### PR TITLE
Cyborgs choosing their name at round start.

### DIFF
--- a/code/defines/procs/helpers.dm
+++ b/code/defines/procs/helpers.dm
@@ -683,6 +683,31 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		M.real_name = newname
 		M.name = newname
 
+/proc/robotname(var/mob/M as mob) //Same as ainame, but for cyborgs
+	var/randomname = M.name
+	var/time_passed = world.time//Pretty basic but it'll do. It's still possible to bypass this by return robotname().
+	var/newname = input(M,"You are a Cyborg. Would you like to change your name to something else?", "Name change",randomname)
+	if((world.time-time_passed)>200)//If more than 20 game seconds passed.
+		M << "You took too long to decide. Default name selected."
+		return
+
+	if (length(newname) == 0)
+		newname = randomname
+
+	if (newname)
+		if ((newname == "Unknown") || (newname == "floor") || (newname == "wall") || (newname == "r-wall"))//Keeping this here to prevent dumb.
+			M << "Don't do that."
+			return robotname(M)
+		for (var/mob/living/silicon/ai/A in world)
+			if (A.real_name == newname&&newname!=randomname)
+				M << "There's already a cyborg with that name."
+				return robotname(M)
+		if (length(newname) >= 26)
+			newname = copytext(newname, 1, 26)
+		newname = dd_replacetext(newname, ">", "'")
+		M.real_name = newname
+		M.name = newname
+
 /proc/clname(var/mob/M as mob) //--All praise goes to NEO|Phyte, all blame goes to DH, and it was Cindi-Kate's idea
 	var/randomname = pick(clown_names)
 	var/newname = input(M,"You are the clown. Would you like to change your name to something else?", "Name change",randomname)

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -20,6 +20,7 @@
 	faction = "Station"
 	total_positions = 0
 	spawn_positions = 1
+	supervisors = "your laws and the AI"
 
 
 	equip(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -436,7 +436,7 @@
 			else if(src.health < config.health_threshold_crit)
 				if(src.health <= 20 && prob(1)) spawn(0) emote("gasp")
 
-				//if(!src.rejuv) src.oxyloss++
+				if(!src.rejuv) src.oxyloss++ //Oxagen deprevation when in crit.
 				if(!src.reagents.has_reagent("inaprovaline")) src.adjustOxyLoss(1)
 
 				if(src.stat != 2)	src.stat = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,4 +1,3 @@
-
 /mob/living/silicon/robot/New(loc,var/syndie = 0)
 	spark_system = new /datum/effect/effect/system/spark_spread()
 	spark_system.set_up(5, 0, src)
@@ -9,9 +8,11 @@
 		modtype = "robot"
 		updateicon()
 //		syndicate = syndie
-		if(real_name == "Cyborg")
-			real_name += " [pick(rand(1, 999))]"
+
+		if(!real_name)//The cyborg should always get a name, even if one was not chosen.
+			real_name = "Cyborg [pick(rand(1, 999))]"
 			name = real_name
+
 	spawn (4)
 		if (client)
 			connected_ai = activeais()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -175,7 +175,6 @@
 
 	O.gender = gender
 	O.invisibility = 0
-	O.name = "Cyborg"
 	O.real_name = "Cyborg"
 	O.lastKnownIP = client.address ? client.address : null
 	if (mind)
@@ -205,6 +204,7 @@
 	O.mmi.transfer_identity(src)//Does not transfer key/client.
 
 	spawn(0)//To prevent the proc from returning null.
+		robotname(O)//This proc names our new cyborg buddy
 		del(src)
 	return O
 
@@ -296,30 +296,6 @@
 
 		new_metroid.a_intent = "hurt"
 		new_metroid << "<B>You are now a baby Metroid.</B>"
-	spawn(0)//To prevent the proc from returning null.
-		del(src)
-	return
-
-/mob/living/carbon/human/proc/corgize()
-	if (monkeyizing)
-		return
-	for(var/obj/item/W in src)
-		drop_from_slot(W)
-	update_clothing()
-	monkeyizing = 1
-	canmove = 0
-	icon = null
-	invisibility = 101
-	for(var/t in organs)
-		del(t)
-
-	var/mob/living/simple_animal/corgi/new_corgi = new /mob/living/simple_animal/corgi (loc)
-
-	new_corgi.mind_initialize(src)
-	new_corgi.key = key
-
-	new_corgi.a_intent = "hurt"
-	new_corgi << "<B>You are now a Corgi!.</B>"
 	spawn(0)//To prevent the proc from returning null.
 		del(src)
 	return


### PR DESCRIPTION
-Cyborgs can now choose their name at round start. Roboticists still have to name endoskeletons manually.
-Gave cyborgs a supervisor (fixes the line cyborgs get 'You answer directly to .')
-Uncommented the line preventing monkeys from taking oxyloss damage in crit.

Signed-off-by: Matt mjohnson88@hotmail.com
