### PR TITLE
ID computer: Manage positions for latejoiners

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -16,7 +16,7 @@
 	//Cooldown for closing positions in seconds
 	//if set to -1: No cooldown... probably a bad idea
 	//if set to 0: Not able to close "original" positions. You can only close positions that you have opened before
-	var/close_position_cooldown = 0
+	var/close_position_cooldown = 280
 	//Keeps track of the time
 	var/time_last_closed_position = 0
 	//Jobs you cannot open new positions for

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -139,7 +139,6 @@
 						dat += "<a href='?src=\ref[src];choice=make_job_available'>Open Position</a><br>"
 					else
 						dat += "<b>There are too many positions for this job.</b><br>"
-						usr << "?src=\ref[src];choice=make_job_available"
 
 				else
 					dat += "<b>You cannot open positions for this job.</b><br>"


### PR DESCRIPTION
First time I used git, probably did something horribly wrong. 

Details in first post @  http://forums.nanotrasen.com/viewtopic.php?f=16&t=12490&p=195140#p195140

I have disabled the ability to close original positions since you were worried about "lelassistants" griefing. You can now only close positions that you have opened before. The maximum amount of open positions scales with the station's population, so you won't see 50 clown positions
