### PR TITLE
Removed Super Conductivity, fixed Atmos lag

### DIFF
--- a/code/FEA/FEA_airgroup.dm
+++ b/code/FEA/FEA_airgroup.dm
@@ -218,7 +218,7 @@ datum/air_group
 			for(var/T in members)
 				var/turf/simulated/member = T
 				member.hotspot_expose(air.temperature, CELL_VOLUME)
-				member.consider_superconductivity(starting=1)
+				//member.consider_superconductivity(starting=1)
 
 		air.react()
 		return

--- a/code/FEA/FEA_system.dm
+++ b/code/FEA/FEA_system.dm
@@ -89,7 +89,7 @@ datum
 			var/list/turf/simulated/active_singletons = list()
 
 			//Special functions lists
-			var/list/turf/simulated/active_super_conductivity = list()
+			//var/list/turf/simulated/active_super_conductivity = list()
 			var/list/turf/simulated/high_pressure_delta = list()
 
 			//Geometry updates lists
@@ -124,7 +124,7 @@ datum
 					//Used by process()
 					//Warning: Do not call this
 
-				process_super_conductivity()
+				//process_super_conductivity()
 					//Used by process()
 					//Warning: Do not call this
 
@@ -265,7 +265,7 @@ datum
 				process_groups()
 				process_singletons()
 
-				process_super_conductivity()
+				//process_super_conductivity()
 				process_high_pressure_delta()
 
 				if(current_cycle%10==5) //Check for groups of tiles to resume group processing every 10 cycles
@@ -324,10 +324,10 @@ datum
 				for(var/item in active_singletons)
 					item:process_cell()
 
-			process_super_conductivity()
+/*			process_super_conductivity()
 				for(var/turf/simulated/hot_potato in active_super_conductivity)
 					hot_potato.super_conduct()
-
+*/
 			process_high_pressure_delta()
 				for(var/turf/pressurized in high_pressure_delta)
 					pressurized.high_pressure_movements()

--- a/code/FEA/FEA_turf_tile.dm
+++ b/code/FEA/FEA_turf_tile.dm
@@ -376,10 +376,10 @@ turf/simulated
 		if(active_hotspot)
 			if (!active_hotspot.process(possible_fire_spreads))
 				return 0
-
+/*
 		if(air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
 			consider_superconductivity(starting = 1)
-
+*/
 		if(air.check_tile_graphic())
 			update_visuals(air)
 
@@ -478,7 +478,7 @@ turf/simulated
 								share_temperature_mutual_solid(modeled_neighbor, modeled_neighbor.thermal_conductivity)
 					//			world << "SOLID, SOLID"
 
-						modeled_neighbor.consider_superconductivity()
+						//modeled_neighbor.consider_superconductivity()
 
 					else
 						if(air) //Open
@@ -510,7 +510,7 @@ turf/simulated
 
 
 		//Make sure still hot enough to continue conducting heat
-		if(air)
+/*		if(air)
 			if(air.temperature < MINIMUM_TEMPERATURE_FOR_SUPERCONDUCTION)
 				being_superconductive = 0
 				air_master.active_super_conductivity -= src
@@ -521,7 +521,7 @@ turf/simulated
 				being_superconductive = 0
 				air_master.active_super_conductivity -= src
 				return 0
-
+*/
 	proc/mimic_temperature_solid(turf/model, conduction_coefficient)
 		var/delta_temperature = (temperature_archived - model.temperature)
 		if((heat_capacity > 0) && (abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER))
@@ -540,7 +540,7 @@ turf/simulated
 			temperature -= heat/heat_capacity
 			sharer.temperature += heat/sharer.heat_capacity
 
-	proc/consider_superconductivity(starting)
+/*	proc/consider_superconductivity(starting)
 
 		if(being_superconductive || !thermal_conductivity)
 			return 0
@@ -557,7 +557,7 @@ turf/simulated
 		being_superconductive = 1
 
 		air_master.active_super_conductivity += src
-
+*/
 	proc/reset_delay()
 		//sets this turf to process quickly again
 		next_check=0

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -30,7 +30,6 @@
 <BR>
 <B>Special Processing Data</B><BR>
 <B>Hotspot Processing:</B> [hotspots]<BR>
-<B>High Temperature Processing:</B> [air_master.active_super_conductivity.len]<BR>
 <B>High Pressure Processing:</B> [air_master.high_pressure_delta.len] (not yet implemented)<BR>
 <BR>
 <B>Geometry Processing Data</B><BR>


### PR DESCRIPTION
Removed Super Conductivity, a useless and broken proc. Observations have seen firesuits being far more robust, being able to survive being right next to a hotspot, and space having a neutral (Grey) pressure, allowing for someone with oxygen and no suit to run from arrival's airlock to the Chapel Solar before collapsing into critical. It also seems to remove some of the lag bombs have, and the lag hull breaches have, and pressure changes are far faster, too.
