### PR TITLE
Improvements to debug verbs del-all and spawn.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -714,12 +714,9 @@ var/global/floorIsLava = 0
 
 	if(!check_rights(R_SPAWN))	return
 
-	var/list/types = typesof(/atom)
-	var/list/matches = new()
-
-	for(var/path in types)
-		if(findtext("[path]", object))
-			matches += path
+	var/list/matches = get_fancy_list_of_types()
+	if (!isnull(object) && object!="")
+		matches = filter_fancy_list(matches, object)
 
 	if(matches.len==0)
 		return
@@ -731,6 +728,7 @@ var/global/floorIsLava = 0
 		chosen = input("Select an atom type", "Spawn Atom", matches[1]) as null|anything in matches
 		if(!chosen)
 			return
+	chosen = matches[chosen]
 
 	new chosen(usr.loc)
 


### PR DESCRIPTION
Long paths are shortened, del-all got filter like spawn had.
Long lists of paths are cached.
Screenshot:
![shorten_spawn](https://f.cloud.github.com/assets/3857380/275495/5f7e959a-908c-11e2-88d4-0742db43df68.png)
