### PR TITLE
Pathing optimization

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -224,7 +224,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 				if (!next_dest_loc)
 					next_dest_loc = closest_loc
 				if (next_dest_loc)
-					src.patrol_path = AStar(src.loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=null)
+					src.patrol_path = AStar(src.loc, next_dest_loc, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 120, id=botcard, exclude=null)
 					if(!patrol_path)
 						patrol_path = list()
 		else

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -614,7 +614,7 @@ Auto Patrol: []"},
 // calculates a path to the current destination
 // given an optional turf to avoid
 /obj/machinery/bot/ed209/proc/calc_path(var/turf/avoid = null)
-	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
+	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 120, id=botcard, exclude=avoid)
 	if(!src.path)
 		src.path = list()
 

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -299,7 +299,7 @@
 
 	if(src.patient && src.path.len == 0 && (get_dist(src,src.patient) > 1))
 		spawn(0)
-			src.path = AStar(src.loc, get_turf(src.patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30,id=botcard)
+			src.path = AStar(src.loc, get_turf(src.patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 30,id=botcard)
 			if(!src.path)
 				src.path = list()
 			if(src.path.len == 0)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -646,7 +646,7 @@ var/global/mulebot_count = 0
 // calculates a path to the current destination
 // given an optional turf to avoid
 /obj/machinery/bot/mulebot/proc/calc_path(var/turf/avoid = null)
-	src.path = AStar(src.loc, src.target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 250, id=botcard, exclude=avoid)
+	src.path = AStar(src.loc, src.target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 250, id=botcard, exclude=avoid)
 	if(!src.path)
 		src.path = list()
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -552,7 +552,7 @@ Auto Patrol: []"},
 // calculates a path to the current destination
 // given an optional turf to avoid
 /obj/machinery/bot/secbot/proc/calc_path(var/turf/avoid = null)
-	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
+	src.path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 120, id=botcard, exclude=avoid)
 	if(!src.path)
 		src.path = list()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -293,6 +293,13 @@
 		return cost
 	else
 		return get_dist(src,t)
+
+// This Distance proc assumes that only cardinal movement is
+//  possible. It results in more efficient (CPU-wise) pathing
+//  for bots and anything else that only moves in cardinal dirs.
+/turf/proc/Distance_cardinal(turf/t)
+	return abs(src.x - t.x) + abs(src.y - t.y)
+
 /turf/proc/AdjacentTurfsSpace()
 	var/L[] = new()
 	for(var/turf/t in oview(src,1))


### PR DESCRIPTION
- Added Distance_cardinal proc. Should result in slightly more CPU-efficient pathing when used with CardinalTurfsWithAccess, or other adjacent turf procs that do not return diagonals.
  - Changed calls to AStar that used CardinalTurfsWithAccess to use Distance_cardinal instead of Distance

Overall effect: A bit less CPU used during pathing, if a bot has to path around corners. If a bot doesn't have to path around corners, it should be about as fast as before.

Old screenshots of a quick prototype, when I made the same change to baystation (It mattered much more there, because the current map was the Luna, which was more or less a 3D maze of twisty little passages. On the current TG map, it should only matter if someone builds a wall across beepsky's patrol route):
https://dl.dropbox.com/u/26846767/images/SS13/pathing-curdist3.PNG becomes https://dl.dropbox.com/u/26846767/images/SS13/pathing-altdist3.PNG
https://dl.dropbox.com/u/26846767/images/SS13/pathing-curdist2.PNG becomes https://dl.dropbox.com/u/26846767/images/SS13/pathing-altdist2.PNG
https://dl.dropbox.com/u/26846767/images/SS13/pathing-curdist4.PNG becomes https://dl.dropbox.com/u/26846767/images/SS13/pathing-altdist4.PNG
