### PR TITLE
Runtime fix for building standard airlocks.

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -538,14 +538,17 @@ obj/structure/door_assembly
 			//  and mineral doors. |- Ricotez
 			if (mineral)
 				if(mineral == "glass")
-					if(typetext == "")
+					if(!typetext)
 						airlock_type = /obj/machinery/door/airlock/glass
 					else
 						airlock_type = text2path("/obj/machinery/door/airlock/glass_[typetext]")
 				else
 					airlock_type = text2path("/obj/machinery/door/airlock/[mineral]")
 			else
-				airlock_type = text2path("/obj/machinery/door/airlock/[typetext]")
+				if(!typetext)
+					airlock_type = /obj/machinery/door/airlock
+				else
+					airlock_type = text2path("/obj/machinery/door/airlock/[typetext]")
 			door = new src.airlock_type( src.loc )
 			//door.req_access = src.req_access
 			door.electronics = src.electronics

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -69,7 +69,6 @@
 		buckled_mob << "<span class='danger'>You feel a deep shock course through your body!</span>"
 		sleep(1)
 		buckled_mob.burn_skin(85)
-		buckled_mob.Stun(600)
 	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
 
 	A.power_light = light


### PR DESCRIPTION
Fixes a runtime regarding the construction of standard airlocks.
Changed two if checks [if (var == "")] for [if(!var)].
