### PR TITLE
Bugfix for items calling afterattack() on surgeries.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1018,9 +1018,10 @@ var/using_new_click_proc = 0 //TODO ERRORAGE (This is temporary, while the DblCl
 
 			if (W)
 				// ------- YOU HAVE AN ITEM IN YOUR HAND - HANDLE ATTACKBY AND AFTERATTACK -------
+				var/ignoreAA = 0 //Ignore afterattack(). Surgery uses this.
 				if (t5)
-					src.attackby(W, usr)
-				if (W)
+					ignoreAA = src.attackby(W, usr)
+				if (W && !ignoreAA)
 					W.afterattack(src, usr, (t5 ? 1 : 0), params)
 
 			else

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -161,12 +161,12 @@ var/global/datum/controller/gameticker/ticker
 		var/obj/structure/stool/bed/temp_buckle = new(src)
 		//Incredibly hackish. It creates a bed within the gameticker (lol) to stop mobs running around
 		if(station_missed)
-			for(var/mob/living/M in living_mob_list)
+			for(var/mob/M in mob_list)
 				M.buckled = temp_buckle				//buckles the mob so it can't do anything
 				if(M.client)
 					M.client.screen += cinematic	//show every client the cinematic
 		else	//nuke kills everyone on z-level 1 to prevent "hurr-durr I survived"
-			for(var/mob/living/M in living_mob_list)
+			for(var/mob/M in mob_list)
 				M.buckled = temp_buckle
 				if(M.client)
 					M.client.screen += cinematic
@@ -174,12 +174,10 @@ var/global/datum/controller/gameticker/ticker
 				switch(M.z)
 					if(0)	//inside a crate or something
 						var/turf/T = get_turf(M)
-						if(T && T.z==1)				//we don't use M.death(0) because it calls a for(/mob) loop and
-							M.health = 0
-							M.stat = DEAD
+						if(T && T.z==1)
+							M.death(0)
 					if(1)	//on a z-level 1 turf.
-						M.health = 0
-						M.stat = DEAD
+						M.death(0)
 
 		//Now animate the cinematic
 		switch(station_missed)
@@ -233,9 +231,6 @@ var/global/datum/controller/gameticker/ticker
 						flick("station_explode_fade_red", cinematic)
 						world << sound('sound/effects/explosionfar.ogg')
 						cinematic.icon_state = "summary_selfdes"
-				for(var/mob/living/M in living_mob_list)
-					if(M.loc.z == 1)
-						M.death()//No mercy
 		//If its actually the end of the round, wait for it to end.
 		//Otherwise if its a verb it will continue on afterwards.
 		sleep(300)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -159,7 +159,6 @@ var/global/datum/controller/gameticker/ticker
 		cinematic.screen_loc = "1,0"
 
 		var/obj/structure/stool/bed/temp_buckle = new(src)
-		//Incredibly hackish. It creates a bed within the gameticker (lol) to stop mobs running around
 		if(station_missed)
 			for(var/mob/M in mob_list)
 				M.buckled = temp_buckle				//buckles the mob so it can't do anything
@@ -170,14 +169,10 @@ var/global/datum/controller/gameticker/ticker
 				M.buckled = temp_buckle
 				if(M.client)
 					M.client.screen += cinematic
-
-				switch(M.z)
-					if(0)	//inside a crate or something
-						var/turf/T = get_turf(M)
-						if(T && T.z==1)
-							M.death(0)
-					if(1)	//on a z-level 1 turf.
-						M.death(0)
+				if(M.stat != DEAD)
+					var/turf/T = get_turf(M)
+					if(T && T.z==1)
+						M.death(0) //no mercy
 
 		//Now animate the cinematic
 		switch(station_missed)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -179,7 +179,8 @@ var/bomb_set
 	src.yes_code = 0
 	src.safety = 1
 	src.icon_state = "nuclearbomb3"
-	playsound(src,'sound/machines/Alarm.ogg',100,0,5)
+	for(var/mob/M in player_list)
+		M << 'sound/machines/Alarm.ogg'
 	if (ticker && ticker.mode)
 		ticker.mode.explosion_in_progress = 1
 	sleep(100)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -33,7 +33,7 @@
 	var/gun_charge = 0		// the charge of the gun inserted
 	var/projectile = null	//holder for bullettype
 	var/eprojectile = null//holder for the shot when emagged
-	var/reqpower = 200 //holder for power needed
+	var/reqpower = 500 //holder for power needed
 	var/sound = null//So the taser can have sound
 	var/iconholder = null//holder for the icon_state. 1 for orange sprite, null for blue.
 	var/egun = null//holder to handle certain guns switching bullettypes

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -33,9 +33,9 @@
 	var/gun_charge = 0		// the charge of the gun inserted
 	var/projectile = null	//holder for bullettype
 	var/eprojectile = null//holder for the shot when emagged
-	var/reqpower = 0 //holder for power needed
+	var/reqpower = 200 //holder for power needed
 	var/sound = null//So the taser can have sound
-	var/iconholder = null//holder for the icon_state
+	var/iconholder = null//holder for the icon_state. 1 for orange sprite, null for blue.
 	var/egun = null//holder to handle certain guns switching bullettypes
 
 	var/obj/machinery/porta_turret_cover/cover = null	// the cover that is covering this turret
@@ -68,18 +68,16 @@
 		if(!installation)// if for some reason the turret has no gun (ie, admin spawned) it resorts to basic taser shots
 			projectile = /obj/item/projectile/energy/electrode//holder for the projectile, here it is being set
 			eprojectile = /obj/item/projectile/beam//holder for the projectile when emagged, if it is different
-			reqpower = 200
 			sound = 1
-			iconholder = 1
 		else
-			var/obj/item/weapon/gun/energy/E=new installation
-					// All energy-based weapons are applicable
+			var/obj/item/weapon/gun/energy/E=new installation // All energy-based weapons are applicable
+			projectile = E.projectile_type
+			eprojectile = projectile
+
 			switch(E.type)
+
 				if(/obj/item/weapon/gun/energy/laser/bluetag)
-					projectile = /obj/item/projectile/bluetag
 					eprojectile = /obj/item/projectile/omnitag//This bolt will stun ERRYONE with a vest
-					iconholder = null
-					reqpower = 100
 					lasercolor = "b"
 					req_access = list(access_maint_tunnels,access_clown,access_mime)
 					check_records = 0
@@ -90,10 +88,7 @@
 					shot_delay = 30
 
 				if(/obj/item/weapon/gun/energy/laser/redtag)
-					projectile = /obj/item/projectile/redtag
 					eprojectile = /obj/item/projectile/omnitag
-					iconholder = null
-					reqpower = 100
 					lasercolor = "r"
 					req_access = list(access_maint_tunnels,access_clown,access_mime)
 					check_records = 0
@@ -102,79 +97,41 @@
 					stun_all = 0
 					check_anomalies = 0
 					shot_delay = 30
+					iconholder = 1
 
 				if(/obj/item/weapon/gun/energy/laser/practice)
-					projectile = /obj/item/projectile/practice
+					iconholder = 1
 					eprojectile = /obj/item/projectile/beam
-					iconholder = null
-					reqpower = 100
 
-				if(/obj/item/weapon/gun/energy/pulse_rifle)
-					projectile = /obj/item/projectile/beam/pulse
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 700
-
-				if(/obj/item/weapon/gun/energy/staff)
-					projectile = /obj/item/projectile/change
-					eprojectile = projectile
+				if(/obj/item/weapon/gun/energy/laser/practice/sc_laser)
 					iconholder = 1
-					reqpower = 700
+					eprojectile = /obj/item/projectile/beam
 
-				if(/obj/item/weapon/gun/energy/ionrifle)
-					projectile = /obj/item/projectile/ion
-					eprojectile = projectile
+				if(/obj/item/weapon/gun/energy/laser/retro)
 					iconholder = 1
-					reqpower = 700
 
-				if(/obj/item/weapon/gun/energy/taser)
-					projectile = /obj/item/projectile/energy/electrode
-					eprojectile = projectile
+				if(/obj/item/weapon/gun/energy/laser/retro/sc_retro)
 					iconholder = 1
-					reqpower = 200
 
-				if(/obj/item/weapon/gun/energy/stunrevolver)
-					projectile = /obj/item/projectile/energy/electrode
-					eprojectile = projectile
+				if(/obj/item/weapon/gun/energy/laser/captain)
 					iconholder = 1
-					reqpower = 200
 
 				if(/obj/item/weapon/gun/energy/lasercannon)
-					projectile = /obj/item/projectile/beam/heavylaser
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 600
-
-				if(/obj/item/weapon/gun/energy/decloner)
-					projectile = /obj/item/projectile/energy/declone
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 600
-
-				if(/obj/item/weapon/gun/energy/crossbow/largecrossbow)
-					projectile = /obj/item/projectile/energy/bolt/large
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 125
-
-				if(/obj/item/weapon/gun/energy/crossbow)
-					projectile = /obj/item/projectile/energy/bolt
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 50
-
-				if(/obj/item/weapon/gun/energy/laser)
-					projectile = /obj/item/projectile/beam
-					eprojectile = projectile
-					iconholder = null
-					reqpower = 500
-
-				else // Energy gun shots
-					projectile = /obj/item/projectile/energy/electrode// if it hasn't been emagged, it uses normal taser shots
-					eprojectile = /obj/item/projectile/beam//If it has, going to kill mode
 					iconholder = 1
+
+				if(/obj/item/weapon/gun/energy/taser)
+					eprojectile = /obj/item/projectile/beam
+
+				if(/obj/item/weapon/gun/energy/stunrevolver)
+					eprojectile = /obj/item/projectile/beam
+
+				if(/obj/item/weapon/gun/energy/gun)
+					eprojectile = /obj/item/projectile/beam//If it has, going to kill mode
 					egun = 1
-					reqpower = 200
+
+				if(/obj/item/weapon/gun/energy/gun/nuclear)
+					eprojectile = /obj/item/projectile/beam//If it has, going to kill mode
+					egun = 1
 
 	Del()
 		// deletes its own cover with it
@@ -269,11 +226,11 @@ Status: []<BR>"},
 	else
 		if( powered() )
 			if (on)
-				if (installation == /obj/item/weapon/gun/energy/laser || installation == /obj/item/weapon/gun/energy/pulse_rifle)
-					// laser guns and pulse rifles have an orange icon
+				if (iconholder)
+					// lasers have a orange icon
 					icon_state = "[lasercolor]orange_target_prism"
 				else
-					// anything else has a blue icon
+					// almost everything has a blue icon
 					icon_state = "[lasercolor]target_prism"
 			else
 				icon_state = "[lasercolor]grey_target_prism"
@@ -641,9 +598,9 @@ Status: []<BR>"},
 	// any emagged turrets will shoot extremely fast! This not only is deadly, but drains a lot power!
 
 	if(iconholder)
-		icon_state = "[lasercolor]target_prism"
-	else
 		icon_state = "[lasercolor]orange_target_prism"
+	else
+		icon_state = "[lasercolor]target_prism"
 	if(sound)
 		playsound(src.loc, 'sound/weapons/Taser.ogg', 75, 1)
 	var/obj/item/projectile/A
@@ -750,6 +707,7 @@ Status: []<BR>"},
 		if(3)
 			if(istype(W, /obj/item/weapon/gun/energy)) // the gun installation part
 
+				if(isrobot(user))	return
 				var/obj/item/weapon/gun/energy/E = W // typecasts the item to an energy gun
 				installation = W.type // installation becomes W.type
 				gun_charge = E.power_supply.charge // the gun's charge is stored in src.gun_charge

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -488,7 +488,7 @@
 			if(user.a_intent == "help")
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(user, src))
-						return
+						return 1
 
 	..()
 


### PR DESCRIPTION
Fixes items calling their afterattack() proc when they are used on surgeries, for example, inserting a syringe inside of a person and then starting to inject the contents of the syringe on said person.

afaik, surgeries can't be handled on the afterattack() of the different surgery tools because of cavity implants, so this is a semi-decent fix that can be used for future features too. But I do not like touching this code. I appreciate any feedback about this.
