### PR TITLE
 * Removing an unneeded exploitable snippet of code. (The game doesn't even use it)

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -142,13 +142,6 @@
 	return ..() //check for shuttle and nuke
 
 
-/datum/game_mode/malfunction/Topic(href, href_list)
-	..()
-	if (href_list["ai_win"])
-		ai_win()
-	return
-
-
 /datum/game_mode/malfunction/proc/takeover()
 	set category = "Malfunction"
 	set name = "System Override"


### PR DESCRIPTION
It's possible to use href exploits to call the gamemode's Topic and cause the round to end.
