### PR TITLE
Fix for infinite loop in powernet_nextlink.

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -183,6 +183,9 @@
 			M.powernet = PN
 			P = M.get_connections()
 
+		else
+			return
+
 		if(P.len == 0)	return
 
 		O = P[1]


### PR DESCRIPTION
If a machine was not anchored, it would repeat forever, doing nothing, since it did not get a new list anywhere in the loop in that case.
Fixed on baystation a while ago.
