### PR TITLE
Surgery bugfix without other commits.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1018,9 +1018,10 @@ var/using_new_click_proc = 0 //TODO ERRORAGE (This is temporary, while the DblCl
 
 			if (W)
 				// ------- YOU HAVE AN ITEM IN YOUR HAND - HANDLE ATTACKBY AND AFTERATTACK -------
+				var/ignoreAA = 0 //Ignore afterattack(). Surgery uses this.
 				if (t5)
-					src.attackby(W, usr)
-				if (W)
+					ignoreAA = src.attackby(W, usr)
+				if (W && !ignoreAA)
 					W.afterattack(src, usr, (t5 ? 1 : 0), params)
 
 			else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -488,7 +488,7 @@
 			if(user.a_intent == "help")
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(user, src))
-						return
+						return 1
 
 	..()
 


### PR DESCRIPTION
Fixes items calling their afterattack() proc when they are used on surgeries, for example, inserting a syringe inside of a person and then starting to inject the contents of the syringe on said person.

afak, surgeries can't be handled on the afterattack() of the different surgery tools because of cavity implants, so this is a semi-decent fix that can be used for future features too. But I do not like touching this code. I appreciate any feedback about this.
