### PR TITLE
Automatic shuttle calls changes/fixes

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -16,6 +16,7 @@ var/global/list/chemical_reagents_list				//list of all /datum/reagent datums in
 var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgeries_list = list()				//list of all surgeries by name, associated with their path.
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
+var/global/list/shuttle_caller_list = list()		//list of all communication consoles and AIs, for automatic shuttle calls when there are none.
 
 var/global/list/portals = list()					//for use by portals
 

--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -41,6 +41,9 @@ datum/shuttle_controller
 		if(direction == 1)
 			var/timeleft = timeleft()
 			if(timeleft >= 600)
+				online = 0
+				direction = 1
+				endtime = null
 				return
 			captain_announce("The emergency shuttle has been recalled.")
 			world << sound('sound/AI/shuttlerecalled.ogg')

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -112,11 +112,13 @@ var/list/ai_list = list()
 
 			job = "AI"
 	ai_list += src
+	shuttle_caller_list += src
 	..()
 	return
 
 /mob/living/silicon/ai/Del()
 	ai_list -= src
+	shuttle_caller_list -= src
 	..()
 
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -11,38 +11,28 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
-	var/callshuttle = 0
+	var/callshuttle = 1
 
-	for(var/obj/machinery/computer/communications/commconsole in world)
-		if(commconsole.z == 2)
-			continue
-		if(istype(commconsole.loc,/turf))
+	for(var/SC in shuttle_caller_list)
+		if(istype(SC,/mob/living/silicon/ai))
+			var/mob/living/silicon/ai/AI = SC
+			if(AI.stat && !AI.client)
+				continue
+		var/turf/T = get_turf(SC)
+		if(T && T.z == 1)
+			callshuttle = 0 //if there's an alive AI or a communication console on the station z level, we don't call the shuttle
 			break
-		callshuttle++
-
-	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if(commboard.z == 2)
-			continue
-		if(istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage))
-			break
-		callshuttle++
-
-	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(shuttlecaller.z == 2)
-			continue
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
-			break
-		callshuttle++
 
 	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" /* DEATH SQUADS || sent_strike_team*/)
 		callshuttle = 0
 
-	if(callshuttle == 3) //if all three conditions are met
-		emergency_shuttle.incall(2)
-		log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-		message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
-		world << sound('sound/AI/shuttlecalled.ogg')
+	if(callshuttle)
+		if(!emergency_shuttle.online && emergency_shuttle.direction == 1) //we don't call the shuttle if it's already coming
+			emergency_shuttle.incall(2.5) //25 minutes! If they want to recall, they have 20 minutes to do so
+			log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
+			message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
+			captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
+			world << sound('sound/AI/shuttlecalled.ogg')
 
 	if(explosive)
 		spawn(10)


### PR DESCRIPTION
The automatic shuttle call will now be triggered if there are no communi...cations console on the station z level or an active AI. The shuttle will not have the standard 10 minutes to arrive, instead, it will take 25 minutes, so they have 20 minutes to recall.

Instead of taking a loop on world, there's a new list, shuttle_caller_list, it includes all communication consoles and AIs.

Fixed some weird things regarding recalling the shuttle if the arriving time of the shuttle was bigger than 10 minutes.
