### PR TITLE
Fixes reactive armor issues with buckled users

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -99,6 +99,8 @@ emp_act
 			if(!turfs.len) turfs += pick(/turf in orange(6))
 			var/turf/picked = pick(turfs)
 			if(!isturf(picked)) return
+			if(buckled)
+				buckled.unbuckle()
 			src.loc = picked
 			return 1
 	return 0


### PR DESCRIPTION
The reactive armor will now unbuckle the person if this was buckled, just like on the wizard spells.
