### PR TITLE
Cavity implant disk fix, steal objective finding fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -627,6 +627,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 	sleep(max(sleeptime, 15))
 	del(animation)
 
+
 //Will return the contents of an atom recursivly to a depth of 'searchDepth'
 /atom/proc/GetAllContents(searchDepth = 5)
 	var/list/toReturn = list()
@@ -637,6 +638,17 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 			toReturn += part.GetAllContents(searchDepth - 1)
 
 	return toReturn
+
+
+/atom/proc/GetTypeInAllContents(typepath, searchDepth = 5)
+	for(var/atom/part in contents)
+		if(istype(part, typepath))
+			return 1
+		if(part.contents.len && searchDepth)
+			if(part.GetTypeInAllContents(typepath, searchDepth - 1))
+				return 1
+	return 0
+
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(var/atom/source, var/atom/target, var/length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -193,16 +193,6 @@
 	w_class = 5.0
 */
 
-/obj/item/weapon/gift
-	name = "gift"
-	desc = "A wrapped item."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "gift3"
-	var/size = 3.0
-	var/obj/item/gift = null
-	item_state = "gift"
-	w_class = 4.0
-
 /obj/item/weapon/legcuffs
 	name = "legcuffs"
 	desc = "Use this to keep prisoners in line."

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -288,7 +288,7 @@ datum/objective/steal
 	)
 
 	var/global/possible_items_special[] = list(
-		/*"nuclear authentication disk" = /obj/item/weapon/disk/nuclear,*///Broken with the change to nuke disk making it respawn on z level change.
+	//	"nuclear authentication disk" = /obj/item/weapon/disk/nuclear, //Broken with the change to nuke disk making it respawn on z level change.
 		"advanced energy gun" = /obj/item/weapon/gun/energy/gun/nuclear,
 		"diamond drill" = /obj/item/weapon/pickaxe/diamonddrill,
 		"bag of holding" = /obj/item/weapon/storage/backpack/holding,
@@ -334,8 +334,8 @@ datum/objective/steal
 	check_completion()
 		if(!steal_target || !owner.current)	return 0
 		if(!isliving(owner.current))	return 0
-		var/list/all_items = owner.current.get_contents()
-		switch (target_name)
+		var/list/all_items = owner.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
+		switch(target_name)
 			if("28 moles of plasma (full tank)","10 diamonds","50 gold bars","25 refined uranium bars")
 				var/target_amount = text2num(target_name)//Non-numbers are ignored.
 				var/found_amount = 0.0//Always starts as zero.
@@ -344,16 +344,6 @@ datum/objective/steal
 					if(istype(I, steal_target))
 						found_amount += (target_name=="28 moles of plasma (full tank)" ? (I:air_contents:toxins) : (I:amount))
 				return found_amount>=target_amount
-
-			if("50 coins (in bag)")
-				var/obj/item/weapon/moneybag/B = locate() in all_items
-
-				if(B)
-					var/target = text2num(target_name)
-					var/found_amount = 0.0
-					for(var/obj/item/weapon/coin/C in B)
-						found_amount++
-					return found_amount>=target
 
 			if("a functional AI")
 				for(var/obj/item/device/aicard/C in all_items) //Check for ai card

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -185,9 +185,9 @@
 			return
 	var/disky = 0
 	for (var/atom/O in M.contents) //I'm pretty sure this accounts for the maximum amount of container in container stacking. --NeoFite
-		if (istype(O, /obj/item/weapon/storage) || istype(O, /obj/item/weapon/gift))
+		if (istype(O, /obj/item/weapon/storage))
 			for (var/obj/OO in O.contents)
-				if (istype(OO, /obj/item/weapon/storage) || istype(OO, /obj/item/weapon/gift))
+				if (istype(OO, /obj/item/weapon/storage))
 					for (var/obj/OOO in OO.contents)
 						if (istype(OOO, /obj/item/weapon/disk/nuclear))
 							disky = 1
@@ -213,9 +213,9 @@
 	if (istype(M, /obj/item/weapon/storage/backpack/holding))
 		precision = rand(1,100)
 	for (var/atom/O in M.contents) //I'm pretty sure this accounts for the maximum amount of container in container stacking. --NeoFite
-		if (istype(O, /obj/item/weapon/storage) || istype(O, /obj/item/weapon/gift))
+		if (istype(O, /obj/item/weapon/storage))
 			for (var/obj/OO in O.contents)
-				if (istype(OO, /obj/item/weapon/storage) || istype(OO, /obj/item/weapon/gift))
+				if (istype(OO, /obj/item/weapon/storage))
 					for (var/obj/OOO in OO.contents)
 						if (istype(OOO, /obj/item/weapon/storage/backpack/holding))
 							precision = rand(1,100)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -21,17 +21,6 @@
 	pixel_y = rand(-10,10)
 	icon_state = "giftcrate[rand(1,5)]"
 
-
-/obj/item/weapon/gift/attack_self(mob/user as mob)
-	user.drop_item()
-	if(gift)
-		user.put_in_active_hand(gift)
-		gift.add_fingerprint(user)
-	else
-		user << "<span class='notice'>[src] was empty!</span>"
-	del(src)
-
-
 /obj/item/weapon/a_gift/attack_self(mob/M as mob)
 	var/gift_type = pick(/obj/item/weapon/sord,
 		/obj/item/weapon/storage/wallet,

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -53,10 +53,6 @@
 
 	for(var/obj/item/weapon/storage/S in src)
 		L += S.return_inv()
-	for(var/obj/item/weapon/gift/G in src)
-		L += G.gift
-		if(istype(G.gift, /obj/item/weapon/storage))
-			L += G.gift:return_inv()
 	return L
 
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -36,10 +36,10 @@ var/list/mechtoys = list(
 
 //SUPPLY PACKS MOVED TO /code/defines/obj/supplypacks.dm
 
-/obj/structure/plasticflaps //HOW DO YOU CALL THOSE THINGS ANYWAY
-	name = "\improper Plastic flaps"
-	desc = "I definitely cant get past those. No way."
-	icon = 'icons/obj/stationobjs.dmi' //Change this.
+/obj/structure/plasticflaps	//HOW DO YOU CALL THOSE THINGS ANYWAY
+	name = "plastic flaps"
+	desc = "Definitely can't get past those. No way."
+	icon = 'icons/obj/stationobjs.dmi'	//Change this.
 	icon_state = "plasticflaps"
 	density = 0
 	anchored = 1
@@ -72,7 +72,7 @@ var/list/mechtoys = list(
 				del(src)
 
 /obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
-	name = "\improper Airtight plastic flaps"
+	name = "airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
 
 	New() //set the turf below the flaps to block air
@@ -89,7 +89,7 @@ var/list/mechtoys = list(
 		..()
 
 /obj/machinery/computer/supplycomp
-	name = "Supply shuttle console"
+	name = "supply shuttle console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "supply"
 	req_access = list(access_cargo)
@@ -100,7 +100,7 @@ var/list/mechtoys = list(
 	var/can_order_contraband = 0
 
 /obj/machinery/computer/ordercomp
-	name = "Supply ordering console"
+	name = "supply ordering console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "request"
 	circuit = "/obj/item/weapon/circuitboard/ordercomp"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -166,37 +166,11 @@
 
 	if(Storage) //If it called itself
 		L += Storage.return_inv()
-
-		//Leave this commented out, it will cause storage items to exponentially add duplicate to the list
-		//for(var/obj/item/weapon/storage/S in Storage.return_inv()) //Check for storage items
-		//	L += get_contents(S)
-
-		for(var/obj/item/weapon/gift/G in Storage.return_inv()) //Check for gift-wrapped items
-			L += G.gift
-			if(istype(G.gift, /obj/item/weapon/storage))
-				L += get_contents(G.gift)
-
-		for(var/obj/item/smallDelivery/D in Storage.return_inv()) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
 		return L
-
 	else
-
 		L += src.contents
 		for(var/obj/item/weapon/storage/S in src.contents)	//Check for storage items
 			L += get_contents(S)
-
-		for(var/obj/item/weapon/gift/G in src.contents) //Check for gift-wrapped items
-			L += G.gift
-			if(istype(G.gift, /obj/item/weapon/storage))
-				L += get_contents(G.gift)
-
-		for(var/obj/item/smallDelivery/D in src.contents) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
 		return L
 
 /mob/living/proc/check_contents_for(A)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -102,8 +102,7 @@
 			return
 		if(istype(target, /obj/structure/table) || istype(target, /obj/structure/rack) \
 		|| istype(target, /obj/item/smallDelivery) || istype(target,/obj/structure/bigDelivery) \
-		|| istype(target, /obj/item/weapon/gift) || istype(target, /obj/item/weapon/evidencebag) \
-		|| istype(target, /obj/structure/closet/body_bag))
+		|| istype(target, /obj/item/weapon/evidencebag) || istype(target, /obj/structure/closet/body_bag))
 			return
 		if(target.anchored)
 			return

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -24,7 +24,7 @@
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tool)
-		if(IC || tool.w_class > 3 || istype(tool, /obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/organ))
+		if(IC || tool.w_class > 3 || tool.GetTypeInAllContents(/obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/organ))
 			user.visible_message("<span class='notice'>[user] can't seem to fit [tool] in [target]'s [target_zone].</span>")
 			return 0
 		else


### PR DESCRIPTION
Adds GetTypeInAllContents, which should be self-explanatory. It recursively checks for a typepath locating in an atom.
It's used by cavity implants to make sure you can't slip the nuke disk in.

Objective items in a cheesewheel in a book in your backpack will now be located properly by the game.

Removes /obj/item/weapon/gift from the code, as it was completely unused.

Also removes the smallDelivery loop in /mob/proc/get_contents(). It's amazing that proc worked at all, it really doesn't do what it's described as doing. I'm leaving it for now, as the game seems to have gotten on well enough so far, and it'll probably just increase processing for no gain if I fix it.

And finally, unrelated but I thought I'd throw it in (sorry); standardisation of names in supplyshuttle.dm
