### PR TITLE
Adds name/appearance bans. They're based on jobban code, but prevent the...

### DIFF
--- a/code/__DEFINES.dm
+++ b/code/__DEFINES.dm
@@ -328,6 +328,7 @@ var/static/list/scarySounds = list('sound/weapons/thudswoosh.ogg','sound/weapons
 #define BANTYPE_JOB_PERMA	3
 #define BANTYPE_JOB_TEMP	4
 #define BANTYPE_ANY_FULLBAN	5 //used to locate stuff to unban.
+#define BANTYPE_APPEARANCE	6
 
 #define SEE_INVISIBLE_MINIMUM 5
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -27,6 +27,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 			bantype_pass = 1
 		if(BANTYPE_APPEARANCE)
 			bantype_str = "APPEARANCE_BAN"
+			duration = -1
 			bantype_pass = 1
 	if( !bantype_pass ) return
 	if( !istext(reason) ) return

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -25,6 +25,9 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 		if(BANTYPE_JOB_TEMP)
 			bantype_str = "JOB_TEMPBAN"
 			bantype_pass = 1
+		if(BANTYPE_APPEARANCE)
+			bantype_str = "APPEARANCE_BAN"
+			bantype_pass = 1
 	if( !bantype_pass ) return
 	if( !istext(reason) ) return
 	if( !isnum(duration) ) return
@@ -106,6 +109,9 @@ datum/admins/proc/DB_ban_unban(var/ckey, var/bantype, var/job = "")
 				bantype_pass = 1
 			if(BANTYPE_JOB_TEMP)
 				bantype_str = "JOB_TEMPBAN"
+				bantype_pass = 1
+			if(BANTYPE_APPEARANCE)
+				bantype_str = "APPEARANCE_BAN"
 				bantype_pass = 1
 			if(BANTYPE_ANY_FULLBAN)
 				bantype_str = "ANY"
@@ -291,6 +297,7 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 	output += "<option value='[BANTYPE_TEMP]'>TEMPBAN</option>"
 	output += "<option value='[BANTYPE_JOB_PERMA]'>JOB PERMABAN</option>"
 	output += "<option value='[BANTYPE_JOB_TEMP]'>JOB TEMPBAN</option>"
+	output += "<option value='[BANTYPE_APPEARANCE]'>APPEARANCE BAN</option>"
 	output += "</select></td>"
 	output += "<td><b>Ckey:</b> <input type='text' name='dbbanaddckey'></td></tr>"
 	output += "<tr><td><b>Duration:</b> <input type='text' name='dbbaddduration'></td>"
@@ -378,6 +385,8 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 					typedesc = "<b>JOBBAN</b><br><font size='2'>([job])"
 				if("JOB_TEMPBAN")
 					typedesc = "<b>TEMP JOBBAN</b><br><font size='2'>([job])<br>([duration] minutes<br>Expires [expiration]"
+				if("APPEARANCE_BAN")
+					typedesc = "<b>APPEARANCE/NAME BAN</b>"
 
 			output += "<tr bgcolor='[dcolor]'>"
 			output += "<td align='center'>[typedesc]</td>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -50,6 +50,7 @@ var/global/floorIsLava = 0
 	body += "<A href='?_src_=holder;warn=[M.ckey]'>Warn</A> | "
 	body += "<A href='?src=\ref[src];newban=\ref[M]'>Ban</A> | "
 	body += "<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> | "
+	body += "<A href='?src=\ref[src];appearanceban=\ref[M]'>Appearance Ban</A> | "
 	body += "<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> "
 
 	if(M.client)

--- a/code/modules/admin/banappearance.dm
+++ b/code/modules/admin/banappearance.dm
@@ -59,7 +59,7 @@ DEBUG
 			return
 
 		//appearance bans
-		var/DBQuery/query = dbcon.NewQuery("SELECT ckey, job FROM erro_ban WHERE bantype = 'APPEARANCE_BAN' AND isnull(unbanned)")
+		var/DBQuery/query = dbcon.NewQuery("SELECT ckey FROM erro_ban WHERE bantype = 'APPEARANCE_BAN' AND NOT unbanned = 1")
 		query.Execute()
 
 		while(query.NextRow())

--- a/code/modules/admin/banappearance.dm
+++ b/code/modules/admin/banappearance.dm
@@ -1,0 +1,109 @@
+//ban people from using custom names and appearances. that'll show 'em.
+
+var/appearanceban_runonce	//Updates legacy bans with new info
+var/appearance_keylist[0]	//to store the keys
+
+/proc/appearance_fullban(mob/M, reason)
+	if (!M || !M.key) return
+	appearance_keylist.Add(text("[M.ckey] ## [reason]"))
+	appearance_savebanfile()
+
+/proc/appearance_client_fullban(ckey)
+	if (!ckey) return
+	appearance_keylist.Add(text("[ckey]"))
+	appearance_savebanfile()
+
+//returns a reason if M is banned, returns 0 otherwise
+/proc/appearance_isbanned(mob/M)
+	if(M)
+		for(var/s in appearance_keylist)
+			if(findtext(s, "[M.ckey]") == 1)
+				var/startpos = findtext(s, "## ") + 3
+				if(startpos && startpos < length(s))
+					var/text = copytext(s, startpos, 0)
+					if(text)
+						return text
+				return "Reason Unspecified"
+	return 0
+
+/*
+DEBUG
+/mob/verb/list_all_appearances()
+	set name = "list all appearances"
+
+	for(var/s in appearance_keylist)
+		world << s
+
+/mob/verb/reload_appearances()
+	set name = "reload appearances"
+
+	appearance_loadbanfile()
+*/
+
+/proc/appearance_loadbanfile()
+	if(config.ban_legacy_system)
+		var/savefile/S=new("data/appearance_full.ban")
+		S["keys[0]"] >> appearance_keylist
+		log_admin("Loading appearance_rank")
+		S["runonce"] >> appearanceban_runonce
+
+		if (!length(appearance_keylist))
+			appearance_keylist=list()
+			log_admin("appearance_keylist was empty")
+	else
+		if(!establish_db_connection())
+			world.log << "Database connection failed. Reverting to the legacy ban system."
+			diary << "Database connection failed. Reverting to the legacy ban system."
+			config.ban_legacy_system = 1
+			appearance_loadbanfile()
+			return
+
+		//appearance bans
+		var/DBQuery/query = dbcon.NewQuery("SELECT ckey, job FROM erro_ban WHERE bantype = 'APPEARANCE_BAN' AND isnull(unbanned)")
+		query.Execute()
+
+		while(query.NextRow())
+			var/ckey = query.item[1]
+
+			appearance_keylist.Add("[ckey]")
+
+/proc/appearance_savebanfile()
+	var/savefile/S=new("data/appearance_full.ban")
+	S["keys[0]"] << appearance_keylist
+
+/proc/appearance_unban(mob/M)
+	appearance_remove("[M.ckey]")
+	appearance_savebanfile()
+
+
+/proc/appearance_updatelegacybans()
+	if(!appearanceban_runonce)
+		log_admin("Updating appearancefile!")
+		// Updates bans.. Or fixes them. Either way.
+		for(var/T in appearance_keylist)
+			if(!T)	continue
+		appearanceban_runonce++	//don't run this update again
+
+
+/proc/appearance_remove(X)
+	for (var/i = 1; i <= length(appearance_keylist); i++)
+		if( findtext(appearance_keylist[i], "[X]") )
+			appearance_keylist.Remove(appearance_keylist[i])
+			appearance_savebanfile()
+			return 1
+	return 0
+
+/*
+proc/DB_ban_isappearancebanned(var/playerckey)
+	establish_db_connection()
+	if(!dbcon.IsConnected())
+		return
+
+	var/sqlplayerckey = sql_sanitize_text(ckey(playerckey))
+
+	var/DBQuery/query = dbcon.NewQuery("SELECT id FROM erro_ban WHERE CKEY = '[sqlplayerckey]' AND ((bantype = 'APPEARANCE_BAN') OR (bantype = 'APPEARANCE_TEMPBAN' AND expiration_time > Now())) AND unbanned != 1")
+	query.Execute()
+	while(query.NextRow())
+		return 1
+	return 0
+*/

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -360,9 +360,56 @@
 
 	/////////////////////////////////////new ban stuff
 
-	else if(href_list["jobban2"])
-//		if(!check_rights(R_BAN))	return
+	else if(href_list["appearanceban"])
+		if(!check_rights(R_BAN))
+			return
+		var/mob/M = locate(href_list["appearanceban"])
+		if(!ismob(M))
+			usr << "This can only be used on instances of type /mob"
+			return
+		if(!M.ckey)	//sanity
+			usr << "This mob has no ckey"
+			return
 
+		var/banreason = appearance_isbanned(M)
+		if(banreason)
+	/*		if(!config.ban_legacy_system)
+				usr << "Unfortunately, database based unbanning cannot be done through this panel"
+				DB_ban_panel(M.ckey)
+				return	*/
+			switch(alert("Reason: '[banreason]' Remove appearance ban?","Please Confirm","Yes","No"))
+				if("Yes")
+					ban_unban_log_save("[key_name(usr)] removed [key_name(M)]'s appearance ban")
+					log_admin("[key_name(usr)] removed [key_name(M)]'s appearance ban")
+					feedback_inc("ban_appearance_unban", 1)
+					DB_ban_unban(M.ckey, BANTYPE_APPEARANCE)
+					appearance_unban(M)
+					message_admins("\blue [key_name_admin(usr)] removed [key_name_admin(M)]'s appearance ban", 1)
+					M << "\red<BIG><B>[usr.client.ckey] has removed your appearance ban.</B></BIG>"
+
+		else switch(alert("Appearance ban [M.ckey]?",,"Yes","No", "Cancel"))
+			if("Yes")
+				var/reason = input(usr,"Reason?","reason","Metafriender") as text|null
+				if(!reason)
+					return
+				ban_unban_log_save("[key_name(usr)] appearance banned [key_name(M)]. reason: [reason]")
+				log_admin("[key_name(usr)] appearance banned [key_name(M)]. \nReason: [reason]")
+				feedback_inc("ban_appearance",1)
+				DB_ban_record(BANTYPE_APPEARANCE, M, -1, reason)
+				appearance_fullban(M, "[reason]; By [usr.ckey] on [time2text(world.realtime)]")
+				notes_add(M.ckey, "Appearance banned - [reason]")
+				message_admins("\blue [key_name_admin(usr)] appearance banned [key_name_admin(M)]", 1)
+				M << "\red<BIG><B>You have been appearance banned by [usr.client.ckey].</B></BIG>"
+				M << "\red <B>The reason is: [reason]</B>"
+				M << "\red Appearance ban can be lifted only upon request."
+				if(config.banappeals)
+					M << "\red To try to resolve this matter head to [config.banappeals]"
+				else
+					M << "\red No ban appeals URL has been set."
+			if("No")
+				return
+
+	else if(href_list["jobban2"])
 		var/mob/M = locate(href_list["jobban2"])
 		if(!ismob(M))
 			usr << "This can only be used on instances of type /mob"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -132,8 +132,10 @@ datum/preferences
 
 				dat += "<center><h2>Occupation Choices</h2>"
 				dat += "<a href='?_src_=prefs;preference=job;task=menu'>Set Occupation Preferences</a><br></center>"
-				dat += "<h2>Indentity</h2>"
+				dat += "<h2>Identity</h2>"
 				dat += "<table width='100%'><tr><td width='75%' valign='top'>"
+				if(appearance_isbanned(user))
+					dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
 				dat += "<a href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
 				dat += "<a href='?_src_=prefs;preference=name'>Always Random Name: [be_random_name ? "Yes" : "No"]</a><BR>"
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -308,7 +308,7 @@
 		var/mob/living/carbon/human/new_character = new(loc)
 		new_character.lastarea = get_area(loc)
 
-		if(ticker.random_players)
+		if(ticker.random_players || appearance_isbanned(new_character))
 			new_character.gender = pick(MALE, FEMALE)
 			client.prefs.real_name = random_name()
 			client.prefs.randomize_appearance_for(new_character)

--- a/code/world.dm
+++ b/code/world.dm
@@ -31,6 +31,7 @@
 	if(config.usewhitelist)
 		load_whitelist()
 	jobban_loadbanfile()
+	appearance_loadbanfile()
 	jobban_updatelegacybans()
 	LoadBans()
 	investigate_reset()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -611,6 +611,7 @@
 #include "code\modules\admin\admin_memo.dm"
 #include "code\modules\admin\admin_ranks.dm"
 #include "code\modules\admin\admin_verbs.dm"
+#include "code\modules\admin\banappearance.dm"
 #include "code\modules\admin\banjob.dm"
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"


### PR DESCRIPTION
... banned player from using their preset names and appearances.

Also corrects a spelling error (Indentity) in the char prefs panel.

So, I've tested this reasonably thoroughly, unbans and rebans in one round, over multiple rounds, over multiple rounds while flipping between SQL and legacy banning. It seems pretty solid. Yell if I need to update anything. :+1: 
