### PR TITLE
Print SQL connection errors to world log

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -283,6 +283,7 @@ proc/setup_database_connection()
 		failed_db_connections = 0	//If this connection succeeded, reset the failed connections counter.
 	else
 		failed_db_connections++		//If it failed, increase the failed connections counter.
+		world.log << "SQL error: " + dbcon.ErrorMsg()
 
 	return .
 


### PR DESCRIPTION
I had some fun with not being able to connect to any database, while the same settings worked querying the database from a bash console.

This (very small) commit prints the dbcon.ErrorMsg() to the world.log file to aid with database connection-issue debugging.

offtopic: Turns out DreamMaker was looking for libmysql.so which didn't exist on my debian squeeze installation. However libmysql.so.5 existed so I created a libmysql.so symlink and was finally able to connect.
