### PR TITLE
Uplink Update: Added datums for uplink items. This allows you to easily add items to the uplink in a maintainable manner.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -42,7 +42,6 @@ var/list/uplink_items = list()
 	var/item = null
 	var/cost = 0
 	var/last = 0 // Appear last
-	var/abstract = 0
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
@@ -167,7 +166,6 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/device_tools
 	category = "Devices and Tools"
-	abstract = 1
 
 /datum/uplink_item/device_tools/emag
 	name = "Cryptographic Sequencer"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -47,7 +47,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(item)
 		U.uses -= max(cost, 0)
-		feedback_add_details("traitor_uplink_items_bought", item)
+		feedback_add_details("traitor_uplink_items_bought", "[item]")
 		return new item(loc)
 
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -45,9 +45,10 @@ var/list/uplink_items = list()
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
-	U.uses -= max(cost, 0)
-	feedback_add_details("traitor_uplink_items_bought", name)
-	return new item(loc)
+	if(item)
+		U.uses -= max(cost, 0)
+		feedback_add_details("traitor_uplink_items_bought", item)
+		return new item(loc)
 
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1,0 +1,277 @@
+var/list/uplink_items = list()
+
+/proc/get_uplink_items()
+	// If not already initialized..
+	if(!uplink_items.len)
+
+		// Fill in the list	and order it like this:
+		// A keyed list, acting as categories, which are lists to the datum.
+
+		var/list/last = list()
+		for(var/item in typesof(/datum/uplink_item))
+
+			var/datum/uplink_item/I = new item()
+			if(!I.item)
+				continue
+			if(I.gamemodes.len && ticker && !(ticker.mode.name in I.gamemodes))
+				continue
+			if(I.last)
+				last += I
+				continue
+
+			if(!uplink_items[I.category])
+				uplink_items[I.category] = list()
+
+			uplink_items[I.category] += I
+
+		for(var/datum/uplink_item/I in last)
+
+			if(!uplink_items[I.category])
+				uplink_items[I.category] = list()
+
+			uplink_items[I.category] += I
+
+	return uplink_items
+
+// You can change the order of the list by putting datums before/after one another OR
+// you can use the last variable to make sure it appears last, well have the category appear last.
+
+/datum/uplink_item
+	var/name = "item name"
+	var/category = "item category"
+	var/item = null
+	var/cost = 0
+	var/last = 0 // Appear last
+	var/abstract = 0
+	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
+
+/datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
+	U.uses -= max(cost, 0)
+	feedback_add_details("traitor_uplink_items_bought", name)
+	return new item(loc)
+
+/datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
+
+	..()
+	if(!istype(U))
+		return 0
+
+	if (user.stat || user.restrained())
+		return 0
+
+	if (!( istype(user, /mob/living/carbon/human)))
+		return 0
+
+	// If the uplink's holder is in the user's contents
+	if ((U.loc in user.contents || (in_range(U.loc, user) && istype(U.loc.loc, /turf))))
+		user.set_machine(U)
+		if(cost > U.uses)
+			return 0
+
+		var/obj/I = spawn_item(get_turf(user), U)
+
+		if(ishuman(user))
+			var/mob/living/carbon/human/A = user
+			A.put_in_any_hand_if_possible(I)
+			U.purchase_log += "[user] ([user.ckey]) bought [name]."
+
+		U.interact(user)
+		return 1
+	return 0
+
+/*
+//
+//	UPLINK ITEMS
+//
+*/
+
+// DANGEROUS WEAPONS
+
+/datum/uplink_item/dangerous
+	category = "Highly Visible and Dangerous Weapons"
+
+/datum/uplink_item/dangerous/revolver
+	name = "Revolver"
+	item = /obj/item/weapon/gun/projectile
+	cost = 6
+
+/datum/uplink_item/dangerous/ammo
+	name = "Ammo-357"
+	item = /obj/item/ammo_magazine/a357
+	cost = 2
+
+/datum/uplink_item/dangerous/crossbow
+	name = "Energy Crossbow"
+	item = /obj/item/weapon/gun/energy/crossbow
+	cost = 5
+
+/datum/uplink_item/dangerous/sword
+	name = "Energy Sword"
+	item = /obj/item/weapon/melee/energy/sword
+	cost = 4
+
+/datum/uplink_item/dangerous/emp
+	name = "5 EMP Grenades"
+	item = /obj/item/weapon/storage/box/emps
+	cost = 3
+
+
+// STEALTHY WEAPONS
+
+/datum/uplink_item/stealthy_weapons
+	category = "Stealthy and Inconspicuous Weapons"
+
+/datum/uplink_item/stealthy_weapons/para_pen
+	name = "Paralysis Pen"
+	item = /obj/item/weapon/pen/paralysis
+	cost = 3
+
+/datum/uplink_item/stealthy_weapons/detomatix
+	name = "Detomatix PDA Cartridge"
+	item = /obj/item/weapon/cartridge/syndicate
+	cost = 3
+
+
+// STEALTHY TOOLS
+
+/datum/uplink_item/stealthy_tools
+	category = "Stealth and Camouflage Items"
+
+/datum/uplink_item/stealthy_tools/chameleon_jumpsuit
+	name = "Chameleon Jumpsuit"
+	item = /obj/item/clothing/under/chameleon
+	cost = 3
+
+/datum/uplink_item/stealthy_tools/syndigolashes
+	name = "No-Slip Syndicate Shoes"
+	item = /obj/item/clothing/shoes/syndigaloshes
+	cost = 2
+
+/datum/uplink_item/stealthy_tools/agent_card
+	name = "Agent ID Card"
+	item = /obj/item/weapon/card/id/syndicate
+	cost = 2
+
+/datum/uplink_item/stealthy_tools/voice_changer
+	name = "Voice Changer"
+	item = /obj/item/clothing/mask/gas/voice
+	cost = 4
+
+/datum/uplink_item/stealthy_tools/chameleon_proj
+	name = "Chameleon-Projector"
+	item = /obj/item/device/chameleon
+	cost = 4
+
+
+// DEVICE AND TOOLS
+
+/datum/uplink_item/device_tools
+	category = "Devices and Tools"
+	abstract = 1
+
+/datum/uplink_item/device_tools/emag
+	name = "Cryptographic Sequencer"
+	item = /obj/item/weapon/card/emag
+	cost = 3
+
+/datum/uplink_item/device_tools/toolbox
+	name = "Fully Loaded Toolbox"
+	item = /obj/item/weapon/storage/toolbox/syndicate
+	cost = 1
+
+/datum/uplink_item/device_tools/space_suit
+	name = "Space Suit"
+	item = /obj/item/weapon/storage/box/syndie_kit/space
+	cost = 3
+
+/datum/uplink_item/device_tools/thermal
+	name = "Thermal Imaging Glasses"
+	item = /obj/item/clothing/glasses/thermal/syndi
+	cost = 3
+
+/datum/uplink_item/device_tools/binary
+	name = "Binary Translator Key"
+	item = /obj/item/device/encryptionkey/binary
+	cost = 3
+
+/datum/uplink_item/device_tools/hacked_module
+	name = "Hacked AI Upload Module"
+	item = /obj/item/weapon/aiModule/syndicate
+	cost = 7
+
+/datum/uplink_item/device_tools/plastic_explosives
+	name = "C-4 (Destroys Walls)"
+	item = /obj/item/weapon/plastique
+	cost = 2
+
+/datum/uplink_item/device_tools/powersink
+	name = "Powersink (DANGER!)"
+	item = /obj/item/device/powersink
+	cost = 5
+
+/datum/uplink_item/device_tools/singularity_beacon
+	name = "Singularity Beacon (DANGER!)"
+	item = /obj/item/device/sbeacondrop
+	cost = 7
+
+/datum/uplink_item/device_tools/teleporter
+	name = "Teleporter Circuit Board"
+	item = /obj/item/weapon/circuitboard/teleporter
+	cost = 20
+	gamemodes = list("nuclear emergency")
+
+
+// IMPLANTS
+
+/datum/uplink_item/implants
+	category = "Implants"
+
+/datum/uplink_item/implants/freedom
+	name = "Freedom Implant"
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
+	cost = 3
+
+/datum/uplink_item/implants/uplink
+	name = "Uplink Implant (Contains 5 Telecrystals)"
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
+	cost = 10
+
+
+// POINTLESS BADASSERY
+
+/datum/uplink_item/badass
+	category = "(Pointless) Badassery"
+
+/datum/uplink_item/badass/bundle
+	name = "Syndicate Bundle"
+	item = /obj/item/weapon/storage/box/syndicate
+	cost = 10
+
+/datum/uplink_item/badass/balloon
+	name = "For showing that You Are The Boss (Useless Balloon)"
+	item = /obj/item/toy/syndicateballoon
+	cost = 10
+
+/datum/uplink_item/badass/random
+	name = "Random Item (??)"
+	item = /obj/item/weapon/storage/box/syndicate
+	cost = 0
+
+/datum/uplink_item/badass/random/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
+
+	var/list/buyable_items = get_uplink_items()
+	var/list/possible_items = list()
+
+	for(var/category in buyable_items)
+		for(var/datum/uplink_item/I in buyable_items[category])
+			if(I == src)
+				continue
+			if(I.cost > U.uses)
+				continue
+			possible_items += I
+
+	if(possible_items.len)
+		var/datum/uplink_item/I = pick(possible_items)
+		U.uses -= max(0, I.cost)
+		feedback_add_details("traitor_uplink_items_bought","RN")
+		return new I.item(loc)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -55,7 +55,7 @@ var/list/uplink_items = list()
 	if(!istype(U))
 		return 0
 
-	if (user.stat || user.restrained())
+	if (!user || user.stat || user.restrained())
 		return 0
 
 	if (!( istype(user, /mob/living/carbon/human)))
@@ -69,7 +69,7 @@ var/list/uplink_items = list()
 
 		var/obj/I = spawn_item(get_turf(user), U)
 
-		if(ishuman(user))
+		if(istype(I, /obj/item) && ishuman(user))
 			var/mob/living/carbon/human/A = user
 			A.put_in_any_hand_if_possible(I)
 			U.purchase_log += "[user] ([user.ckey]) bought [name]."

--- a/code/game/gamemodes/factions.dm
+++ b/code/game/gamemodes/factions.dm
@@ -118,44 +118,6 @@
 	max_op = 4
 	operative_notes = "We'd like to remind our operatives to keep it professional. You are not here to have a good time, you are here to accomplish your objectives. These vile communists must be stopped at all costs. You may collaborate with any friends of the Syndicate coalition, but keep an eye on any of those Tiger punks if they do show up. You are completely free to accomplish your objectives any way you see fit."
 
-	uplink_contents = {"Highly Visible and Dangerous Weapons;
-/obj/item/weapon/gun/projectile:6:Revolver;
-/obj/item/ammo_magazine/a357:2:Ammo-357;
-/obj/item/weapon/gun/energy/crossbow:5:Energy Crossbow;
-/obj/item/weapon/melee/energy/sword:4:Energy Sword;
-/obj/item/weapon/storage/box/syndicate:10:Syndicate Bundle;
-/obj/item/weapon/storage/box/emps:3:5 EMP Grenades;
-Whitespace:Seperator;
-Stealthy and Inconspicuous Weapons;
-/obj/item/weapon/pen/paralysis:3:Paralysis Pen;
-/obj/item/weapon/soap/syndie:1:Syndicate Soap;
-/obj/item/weapon/cartridge/syndicate:3:Detomatix PDA Cartridge;
-Whitespace:Seperator;
-Stealth and Camouflage Items;
-/obj/item/clothing/under/chameleon:3:Chameleon Jumpsuit;
-/obj/item/clothing/shoes/syndigaloshes:2:No-Slip Syndicate Shoes;
-/obj/item/weapon/card/id/syndicate:2:Agent ID card;
-/obj/item/clothing/mask/gas/voice:4:Voice Changer;
-/obj/item/device/chameleon:4:Chameleon-Projector;
-Whitespace:Seperator;
-Devices and Tools;
-/obj/item/weapon/card/emag:3:Cryptographic Sequencer;
-/obj/item/weapon/storage/toolbox/syndicate:1:Fully Loaded Toolbox;
-/obj/item/weapon/storage/box/syndie_kit/space:3:Space Suit;
-/obj/item/clothing/glasses/thermal/syndi:3:Thermal Imaging Glasses;
-/obj/item/device/encryptionkey/binary:3:Binary Translator Key;
-/obj/item/weapon/aiModule/syndicate:7:Hacked AI Upload Module;
-/obj/item/weapon/plastique:2:C-4 (Destroys walls);
-/obj/item/device/powersink:5:Powersink (DANGER!);
-/obj/item/device/sbeacondrop:7:Singularity Beacon (DANGER!);
-/obj/item/weapon/circuitboard/teleporter:20:Teleporter Circuit Board;
-Whitespace:Seperator;
-Implants;
-/obj/item/weapon/storage/box/syndie_kit/imp_freedom:3:Freedom Implant;
-/obj/item/weapon/storage/box/syndie_kit/imp_uplink:10:Uplink Implant (Contains 5 Telecrystals);
-Whitespace:Seperator;
-(Pointless) Badassery;
-/obj/item/toy/syndicateballoon:10:For showing that You Are The BOSS (Useless Balloon);"}
 
 	// Friendly to everyone. (with Tiger Cooperative too, only because they are a member of the coalition. This is the only reason why the Tiger Cooperative are even allowed in the coalition)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -28,44 +28,6 @@
 	var/recommended_enemies = 0
 	var/uplink_welcome = "Syndicate Uplink Console:"
 	var/uplink_uses = 10
-	var/uplink_items = {"Highly Visible and Dangerous Weapons;
-/obj/item/weapon/gun/projectile:6:Revolver;
-/obj/item/ammo_magazine/a357:2:Ammo-357;
-/obj/item/weapon/gun/energy/crossbow:5:Energy Crossbow;
-/obj/item/weapon/melee/energy/sword:4:Energy Sword;
-/obj/item/weapon/storage/box/syndicate:10:Syndicate Bundle;
-/obj/item/weapon/storage/box/emps:3:5 EMP Grenades;
-Whitespace:Seperator;
-Stealthy and Inconspicuous Weapons;
-/obj/item/weapon/pen/paralysis:3:Paralysis Pen;
-/obj/item/weapon/soap/syndie:1:Syndicate Soap;
-/obj/item/weapon/cartridge/syndicate:3:Detomatix PDA Cartridge;
-Whitespace:Seperator;
-Stealth and Camouflage Items;
-/obj/item/clothing/under/chameleon:3:Chameleon Jumpsuit;
-/obj/item/clothing/shoes/syndigaloshes:2:No-Slip Syndicate Shoes;
-/obj/item/weapon/card/id/syndicate:2:Agent ID card;
-/obj/item/clothing/mask/gas/voice:4:Voice Changer;
-/obj/item/device/chameleon:4:Chameleon-Projector;
-Whitespace:Seperator;
-Devices and Tools;
-/obj/item/weapon/card/emag:3:Cryptographic Sequencer;
-/obj/item/weapon/storage/toolbox/syndicate:1:Fully Loaded Toolbox;
-/obj/item/weapon/storage/box/syndie_kit/space:3:Space Suit;
-/obj/item/clothing/glasses/thermal/syndi:3:Thermal Imaging Glasses;
-/obj/item/device/encryptionkey/binary:3:Binary Translator Key;
-/obj/item/weapon/aiModule/syndicate:7:Hacked AI Upload Module;
-/obj/item/weapon/plastique:2:C-4 (Destroys walls);
-/obj/item/device/powersink:5:Powersink (DANGER!);
-/obj/item/device/sbeacondrop:7:Singularity Beacon (DANGER!);
-/obj/item/weapon/circuitboard/teleporter:20:Teleporter Circuit Board;
-Whitespace:Seperator;
-Implants;
-/obj/item/weapon/storage/box/syndie_kit/imp_freedom:3:Freedom Implant;
-/obj/item/weapon/storage/box/syndie_kit/imp_uplink:10:Uplink Implant (Contains 5 Telecrystals);
-Whitespace:Seperator;
-(Pointless) Badassery;
-/obj/item/toy/syndicateballoon:10:For showing that You Are The BOSS (Useless Balloon);"}
 
 // Items removed from above:
 /*

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -570,9 +570,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					var/t = input(U, "Please enter new ringtone", name, ttone) as text
 					if (in_range(src, U) && loc == U)
 						if (t)
-							if(src.hidden_uplink && hidden_uplink.check_trigger(U, lowertext(t), lowertext(lock_code)))
+							if(src.hidden_uplink && hidden_uplink.check_trigger(U, trim(lowertext(t)), trim(lowertext(lock_code))))
 								U << "The PDA softly beeps."
 								U << browse(null, "window=pda")
+								src.mode = 0
 							else
 								t = copytext(sanitize(t), 1, 20)
 								ttone = t

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -8,20 +8,13 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 
 /obj/item/device/uplink
 	var/welcome 					// Welcoming menu message
-	var/items						// List of items
-	var/item_data					// raw item text
-	var/list/ItemList				// Parsed list of items
 	var/uses 						// Numbers of crystals
 	// List of items not to shove in their hands.
-	var/list/NotInHand = list(/obj/machinery/singularity_beacon/syndicate)
+	var/list/purchase_log = list()
 
 /obj/item/device/uplink/New()
+	..()
 	welcome = ticker.mode.uplink_welcome
-	if(!item_data)
-		items = replacetext(ticker.mode.uplink_items, "\n", "")	// Getting the text string of items
-	else
-		items = replacetext(item_data)
-	ItemList = text2list(src.items, ";")	// Parsing the items text string
 	uses = ticker.mode.uplink_uses
 
 //Let's build a menu!
@@ -33,226 +26,66 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	dat += "<B>Request item:</B><BR>"
 	dat += "<I>Each item costs a number of tele-crystals as indicated by the number following their name.</I><br><BR>"
 
-	var/cost
-	var/item
-	var/name
-	var/path_obj
-	var/path_text
-	var/category_items = 1 //To prevent stupid :P
+	var/list/buyable_items = get_uplink_items()
 
-	for(var/D in ItemList)
-		var/list/O = stringsplit(D, ":")
-		if(O.len != 3)	//If it is not an actual item, make a break in the menu.
-			if(O.len == 1)	//If there is one item, it's probably a title
-				dat += "<b>[O[1]]</b><br>"
-				category_items = 0
-			else	//Else, it's a white space.
-				if(category_items < 1)	//If there were no itens in the last category...
-					dat += "<i>We apologize, as you could not afford anything from this category.</i><br>"
-				dat += "<br>"
-			continue
+	// Loop through categories
+	var/index = 0
+	for(var/category in buyable_items)
 
-		path_text = O[1]
-		cost = text2num(O[2])
+		index++
+		dat += "<b>[category]</b><br>"
 
-		if(cost>uses)
-			continue
+		var/i = 0
 
-		path_obj = text2path(path_text)
+		// Loop through items in category
+		for(var/datum/uplink_item/item in buyable_items[category])
+			i++
+			var/cost_text = ""
+			if(item.cost > 0)
+				cost_text = "([item.cost])"
+			if(item.cost <= uses)
+				dat += "<A href='byond://?src=\ref[src];buy_item=[category]:[i];'>[item.name]</A> [cost_text]<BR>"
+			else
+				dat += "<font color='grey'><i>[item.name] [cost_text]</i></font><BR>"
 
-		// Because we're using strings, this comes up if item paths change.
-		// Failure to handle this error borks uplinks entirely.  -Sayu
-		if(!path_obj)
-			error("Syndicate item is not a valid path: [path_text]")
-		else
-			item = new path_obj()
-			name = O[3]
-			del item
+		// Break up the categories, if it isn't the last.
+		if(buyable_items.len != index)
+			dat += "<br>"
 
-			dat += "<A href='byond://?src=\ref[src];buy_item=[path_text];cost=[cost]'>[name]</A> ([cost])<BR>"
-			category_items++
-
-	dat += "<A href='byond://?src=\ref[src];buy_item=random'>Random Item (??)</A><br>"
 	dat += "<HR>"
 	return dat
 
-//If 'random' was selected
-/obj/item/device/uplink/proc/chooseRandomItem()
-	var/list/randomItems = list()
+// Interaction code. Gathers a list of items purchasable from the paren't uplink and displays it. It also adds a lock button.
+/obj/item/device/uplink/interact(mob/user as mob)
 
-	//Sorry for all the ifs, but it makes it 1000 times easier for other people/servers to add or remove items from this list
-	//Add only items the player can afford:
-	if(uses > 19)
-		randomItems.Add("/obj/item/weapon/circuitboard/teleporter") //Teleporter Circuit Board (costs 20, for nuke ops)
+	var/dat = "<body link='yellow' alink='white' bgcolor='#601414'><font color='white'>"
+	dat += src.generate_menu()
+	dat += "<A href='byond://?src=\ref[src];lock=1'>Lock</a>"
+	dat += "</font></body>"
+	user << browse(dat, "window=hidden")
+	onclose(user, "hidden")
+	return
 
-	if(uses > 9)
-		randomItems.Add("/obj/item/toy/syndicateballoon")//Syndicate Balloon
-		randomItems.Add("/obj/item/weapon/storage/box/syndie_kit/imp_uplink") //Uplink Implanter
-		randomItems.Add("/obj/item/weapon/storage/box/syndicate") //Syndicate bundle
-
-	//if(uses > 8)	//Nothing... yet.
-	//if(uses > 7)	//Nothing... yet.
-
-	if(uses > 6)
-		randomItems.Add("/obj/item/weapon/aiModule/syndicate") //Hacked AI Upload Module
-		randomItems.Add("/obj/item/device/sbeacondrop") //Singularity Beacon
-
-	if(uses > 5)
-		randomItems.Add("/obj/item/weapon/gun/projectile") //Revolver
-
-	if(uses > 4)
-		randomItems.Add("/obj/item/weapon/gun/energy/crossbow") //Energy Crossbow
-		randomItems.Add("/obj/item/device/powersink") //Powersink
-
-	if(uses > 3)
-		randomItems.Add("/obj/item/weapon/melee/energy/sword") //Energy Sword
-		randomItems.Add("/obj/item/clothing/mask/gas/voice") //Voice Changer
-		randomItems.Add("/obj/item/device/chameleon") //Chameleon Projector
-
-	if(uses > 2)
-		randomItems.Add("/obj/item/weapon/storage/box/emps") //EMP Grenades
-		randomItems.Add("/obj/item/weapon/pen/paralysis") //Paralysis Pen
-		randomItems.Add("/obj/item/weapon/cartridge/syndicate") //Detomatix Cartridge
-		randomItems.Add("/obj/item/clothing/under/chameleon") //Chameleon Jumpsuit
-		randomItems.Add("/obj/item/weapon/card/id/syndicate") //Agent ID Card
-		randomItems.Add("/obj/item/weapon/card/emag") //Cryptographic Sequencer
-		randomItems.Add("/obj/item/weapon/storage/box/syndie_kit/space") //Syndicate Space Suit
-		randomItems.Add("/obj/item/device/encryptionkey/binary") //Binary Translator Key
-		randomItems.Add("/obj/item/weapon/storage/box/syndie_kit/imp_freedom") //Freedom Implant
-		randomItems.Add("/obj/item/clothing/glasses/thermal/syndi") //Thermal Imaging Goggles
-
-	if(uses > 1)
-/*
-		var/list/usrItems = usr.get_contents() //Checks to see if the user has a revolver before giving ammo
-		var/hasRevolver = 0
-		for(var/obj/I in usrItems) //Only add revolver ammo if the user has a gun that can shoot it
-			if(istype(I,/obj/item/weapon/gun/projectile))
-				hasRevolver = 1
-
-		if(hasRevolver) randomItems.Add("/obj/item/ammo_magazine/a357") //Revolver ammo
-*/
-		randomItems.Add("/obj/item/ammo_magazine/a357") //Revolver ammo
-		randomItems.Add("/obj/item/clothing/shoes/syndigaloshes") //No-Slip Syndicate Shoes
-		randomItems.Add("/obj/item/weapon/plastique") //C4
-
-	if(uses > 0)
-		randomItems.Add("/obj/item/weapon/soap/syndie") //Syndicate Soap
-		randomItems.Add("/obj/item/weapon/storage/toolbox/syndicate") //Syndicate Toolbox
-
-	if(!randomItems.len)
-		del(randomItems)
-		return 0
-	else
-		var/buyItem = pick(randomItems)
-
-		switch(buyItem) //Ok, this gets a little messy, sorry.
-			if("/obj/item/weapon/circuitboard/teleporter")
-				uses -= 20
-			if("/obj/item/toy/syndicateballoon" , "/obj/item/weapon/storage/box/syndie_kit/imp_uplink" , "/obj/item/weapon/storage/box/syndicate")
-				uses -= 10
-			if("/obj/item/weapon/aiModule/syndicate" , "/obj/item/device/sbeacondrop")
-				uses -= 7
-			if("/obj/item/weapon/gun/projectile")
-				uses -= 6
-			if("/obj/item/weapon/gun/energy/crossbow" , "/obj/item/device/powersink")
-				uses -= 5
-			if("/obj/item/weapon/melee/energy/sword" , "/obj/item/clothing/mask/gas/voice" , "/obj/item/device/chameleon")
-				uses -= 4
-			if("/obj/item/weapon/storage/box/emps" , "/obj/item/weapon/pen/paralysis" , "/obj/item/weapon/cartridge/syndicate" , "/obj/item/clothing/under/chameleon" , \
-			"/obj/item/weapon/card/emag" , "/obj/item/weapon/storage/box/syndie_kit/space" , "/obj/item/device/encryptionkey/binary" , \
-			"/obj/item/weapon/storage/box/syndie_kit/imp_freedom" , "/obj/item/clothing/glasses/thermal/syndi")
-				uses -= 3
-			if("/obj/item/ammo_magazine/a357" , "/obj/item/clothing/shoes/syndigaloshes" , "/obj/item/weapon/plastique", "/obj/item/weapon/card/id/syndicate")
-				uses -= 2
-			if("/obj/item/weapon/soap/syndie" , "/obj/item/weapon/storage/toolbox/syndicate")
-				uses -= 1
-		del(randomItems)
-		return buyItem
-
-/obj/item/device/uplink/proc/handleStatTracking(var/boughtItem)
-//For stat tracking, sorry for making it so ugly
-	if(!boughtItem) return
-
-	switch(boughtItem)
-		if("/obj/item/weapon/circuitboard/teleporter")
-			feedback_add_details("traitor_uplink_items_bought","TP")
-		if("/obj/item/toy/syndicateballoon")
-			feedback_add_details("traitor_uplink_items_bought","BS")
-		if("/obj/item/weapon/storage/box/syndie_kit/imp_uplink")
-			feedback_add_details("traitor_uplink_items_bought","UI")
-		if("/obj/item/weapon/storage/box/syndicate")
-			feedback_add_details("traitor_uplink_items_bought","BU")
-		if("/obj/item/weapon/aiModule/syndicate")
-			feedback_add_details("traitor_uplink_items_bought","AI")
-		if("/obj/item/device/sbeacondrop")
-			feedback_add_details("traitor_uplink_items_bought","SB")
-		if("/obj/item/weapon/gun/projectile")
-			feedback_add_details("traitor_uplink_items_bought","RE")
-		if("/obj/item/weapon/gun/energy/crossbow")
-			feedback_add_details("traitor_uplink_items_bought","XB")
-		if("/obj/item/device/powersink")
-			feedback_add_details("traitor_uplink_items_bought","PS")
-		if("/obj/item/weapon/melee/energy/sword")
-			feedback_add_details("traitor_uplink_items_bought","ES")
-		if("/obj/item/clothing/mask/gas/voice")
-			feedback_add_details("traitor_uplink_items_bought","VC")
-		if("/obj/item/device/chameleon")
-			feedback_add_details("traitor_uplink_items_bought","CP")
-		if("/obj/item/weapon/storage/box/emps")
-			feedback_add_details("traitor_uplink_items_bought","EM")
-		if("/obj/item/weapon/pen/paralysis")
-			feedback_add_details("traitor_uplink_items_bought","PP")
-		if("/obj/item/weapon/cartridge/syndicate")
-			feedback_add_details("traitor_uplink_items_bought","DC")
-		if("/obj/item/clothing/under/chameleon")
-			feedback_add_details("traitor_uplink_items_bought","CJ")
-		if("/obj/item/weapon/card/id/syndicate")
-			feedback_add_details("traitor_uplink_items_bought","AC")
-		if("/obj/item/weapon/card/emag")
-			feedback_add_details("traitor_uplink_items_bought","EC")
-		if("/obj/item/weapon/storage/box/syndie_kit/space")
-			feedback_add_details("traitor_uplink_items_bought","SS")
-		if("/obj/item/device/encryptionkey/binary")
-			feedback_add_details("traitor_uplink_items_bought","BT")
-		if("/obj/item/weapon/storage/box/syndie_kit/imp_freedom")
-			feedback_add_details("traitor_uplink_items_bought","FI")
-		if("/obj/item/clothing/glasses/thermal/syndi")
-			feedback_add_details("traitor_uplink_items_bought","TM")
-		if("/obj/item/ammo_magazine/a357")
-			feedback_add_details("traitor_uplink_items_bought","RA")
-		if("/obj/item/clothing/shoes/syndigaloshes")
-			feedback_add_details("traitor_uplink_items_bought","SH")
-		if("/obj/item/weapon/plastique")
-			feedback_add_details("traitor_uplink_items_bought","C4")
-		if("/obj/item/weapon/soap/syndie")
-			feedback_add_details("traitor_uplink_items_bought","SP")
-		if("/obj/item/weapon/storage/toolbox/syndicate")
-			feedback_add_details("traitor_uplink_items_bought","ST")
 
 /obj/item/device/uplink/Topic(href, href_list)
-
+	..()
 	if (href_list["buy_item"])
-		if(href_list["buy_item"] == "random")
-			var/boughtItem = chooseRandomItem()
-			if(boughtItem)
-				href_list["buy_item"] = boughtItem
-				feedback_add_details("traitor_uplink_items_bought","RN")
-				return 1
-			else
-				return 0
 
-		else
-			if(text2num(href_list["cost"]) > uses) // Not enough crystals for the item
-				return 0
+		var/item = href_list["buy_item"]
+		var/list/split = stringsplit(item, ":") // throw away variable
 
-			//if(usr:mind && ticker.mode.traitors[usr:mind])
-				//var/datum/traitorinfo/info = ticker.mode.traitors[usr:mind]
-				//info.spawnlist += href_list["buy_item"]
+		if(split.len == 2)
+			// Collect category and number
+			var/category = split[1]
+			var/number = text2num(split[2])
 
-			uses -= text2num(href_list["cost"])
-			handleStatTracking(href_list["buy_item"]) //Note: chooseRandomItem handles it's own stat tracking. This proc is not meant for 'random'.
-		return 1
+			var/list/buyable_items = get_uplink_items()
 
+			var/list/uplink = buyable_items[category]
+			if(uplink && uplink.len >= number)
+				var/datum/uplink_item/I = uplink[number]
+				if(I)
+					I.buy(src, usr)
 
 
 // HIDDEN UPLINK - Can be stored in anything but the host item has to have a trigger for it.
@@ -271,14 +104,13 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	name = "Hidden Uplink."
 	desc = "There is something wrong if you're examining this."
 	var/active = 0
-	var/list/purchase_log = list()
 
-// The hidden uplink MUST be inside an obj/item's contents.
-/obj/item/device/uplink/hidden/New()
-	spawn(2)
-		if(!istype(src.loc, /obj/item))
-			del(src)
+/obj/item/device/uplink/hidden/Topic(href, href_list)
 	..()
+	if(href_list["lock"])
+		toggle()
+		usr << browse(null, "window=hidden")
+		return 1
 
 // Toggles the uplink on and off. Normally this will bypass the item's normal functions and go to the uplink menu, if activated.
 /obj/item/device/uplink/hidden/proc/toggle()
@@ -298,43 +130,6 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		trigger(user)
 		return 1
 	return 0
-
-// Interaction code. Gathers a list of items purchasable from the paren't uplink and displays it. It also adds a lock button.
-/obj/item/device/uplink/hidden/interact(mob/user as mob)
-
-	var/dat = "<body link='yellow' alink='white' bgcolor='#601414'><font color='white'>"
-	dat += src.generate_menu()
-	dat += "<A href='byond://?src=\ref[src];lock=1'>Lock</a>"
-	dat += "</font></body>"
-	user << browse(dat, "window=hidden")
-	onclose(user, "hidden")
-	return
-
-// The purchasing code.
-/obj/item/device/uplink/hidden/Topic(href, href_list)
-
-	if (usr.stat || usr.restrained())
-		return
-
-	if (!( istype(usr, /mob/living/carbon/human)))
-		return 0
-
-	if ((usr.contents.Find(src.loc) || (in_range(src.loc, usr) && istype(src.loc.loc, /turf))))
-		usr.set_machine(src)
-		if(href_list["lock"])
-			toggle()
-			usr << browse(null, "window=hidden")
-			return 1
-
-		if(..(href, href_list) == 1)
-			var/path_obj = text2path(href_list["buy_item"])
-			var/obj/I = new path_obj(get_turf(usr))
-			if(ishuman(usr))
-				var/mob/living/carbon/human/A = usr
-				A.put_in_any_hand_if_possible(I)
-			purchase_log += "[usr] ([usr.ckey]) bought [I]."
-	interact(usr)
-	return
 
 // I placed this here because of how relevant it is.
 // You place this in your uplinkable item to check if an uplink is active or not.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -82,6 +82,7 @@
 #include "code\datums\spell.dm"
 #include "code\datums\sun.dm"
 #include "code\datums\supplypacks.dm"
+#include "code\datums\uplink_item.dm"
 #include "code\datums\diseases\appendicitis.dm"
 #include "code\datums\diseases\beesease.dm"
 #include "code\datums\diseases\brainrot.dm"


### PR DESCRIPTION
- Added datums for uplink items. This allows you to easily add items to the uplink in a maintainable manner.
- This fixes the href exploit which allowed traitors to spawn any item they wish, using href spoofing.
- Made the uplink interface still show unbuyable items, but grayed out.
- After unlocking your PDA, it will return to the main menu; this will help stop metagamers.
- Your password will be trimmed, meaning that entering "213 Alpha " will be correct and won't set it as your ringtone.
- Replaced all the old uplink code, which is useless now.
- Changed all the feedback procs to instead use the uplink datum's name. This is important if you are keeping track of stats.
- Moved the bundle uplink item to the "Badass" category.
