### PR TITLE
Fixes wizards/wraiths dissapearing at using ethereal jaunt while buckled

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -27,6 +27,8 @@
 			animation.icon_state = "liquify"
 			animation.layer = 5
 			animation.master = holder
+			if(target.buckled)
+				target.buckled.unbuckle()
 			if(phaseshift == 1)
 				animation.dir = target.dir
 				flick("phase_shift",animation)


### PR DESCRIPTION
Using ethereal jaunt will now unbuckle you to avoid being deleted with the holder at failing the move() call.
