### PR TITLE
Shunted AI tracking.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -483,7 +483,6 @@
 	return
 
 
-
 /obj/machinery/power/apc/interact(mob/user)
 	if(!user)
 		return
@@ -783,7 +782,6 @@
 	else if (href_list["occupyapc"])
 		malfoccupy(usr)
 
-
 	else if (href_list["deoccupyapc"])
 		malfvacate()
 
@@ -816,6 +814,10 @@
 	src.occupant.verbs += /datum/game_mode/malfunction/proc/takeover
 	src.occupant.cancel_camera()
 
+	for(var/obj/item/weapon/pinpointer/point in world)
+		point.the_disk = src //the pinpointer will detect the shunted AI
+
+
 /obj/machinery/power/apc/proc/malfvacate(var/forced)
 	if(!src.occupant)
 		return
@@ -831,6 +833,9 @@
 			src.occupant.loc = src.loc
 			src.occupant.death()
 			src.occupant.gib()
+
+	for(var/obj/item/weapon/pinpointer/point in world)
+		point.the_disk = null //the pinpointer will go back to pointing at the nuke disc.
 
 
 /obj/machinery/power/apc/proc/ion_act()


### PR DESCRIPTION
-When an AI shunts into an APC, the pinpointer will begin tracking it. When the AI returns to its core, the pinpointer will go back to locating the nuke disc.
