### PR TITLE
Removes the null attack_verb from paper.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -18,7 +18,6 @@
 	pressure_resistance = 1
 	slot_flags = SLOT_HEAD
 	body_parts_covered = HEAD
-	attack_verb = list("")
 
 	var/info		//What's actually written on the paper.
 	var/info_links	//A different version of the paper which includes html links at fields and EOF


### PR DESCRIPTION
This should fix the "Victim has been  in the chest with the paper by Attacker!" message.
Resolves issue #238.
