### PR TITLE
Pepper Spray Update!

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -56,6 +56,7 @@
 /datum/supply_packs/paper
 	name = "Bureaucracy crate"
 	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
+					/obj/item/device/camera_film,
 					/obj/item/weapon/hand_labeler,
 					/obj/item/hand_labeler_refill,
 					/obj/item/hand_labeler_refill,
@@ -68,7 +69,7 @@
 					/obj/item/weapon/folder/yellow,
 					/obj/item/weapon/clipboard,
 					/obj/item/weapon/clipboard)
-	cost = 25
+	cost = 15
 	containertype = /obj/structure/closet/crate
 	containername = "Bureaucracy crate"
 
@@ -78,23 +79,6 @@
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "monkey crate"
-
-
-/datum/supply_packs/beanbagammo
-	name = "Beanbag shells"
-	contains = list(/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag,
-					/obj/item/ammo_casing/shotgun/beanbag)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "beanbag shells"
 
 /datum/supply_packs/toner
 	name = "Toner Cartridges"
@@ -546,7 +530,7 @@
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs)
+					/obj/item/weapon/storage/box/teargas)
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "weapons crate"
@@ -581,23 +565,16 @@
 	name = "Riot gear crate"
 	contains = list(/obj/item/weapon/melee/baton,
 					/obj/item/weapon/melee/baton,
-					/obj/item/weapon/melee/baton,
-					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/handcuffs,
-					/obj/item/weapon/handcuffs,
-					/obj/item/weapon/handcuffs,
+					/obj/item/weapon/storage/box/teargas,
+					/obj/item/weapon/storage/box/handcuffs,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot,
-					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot)
-	cost = 60
+					/obj/item/clothing/suit/armor/riot,)
+	cost = 45
 	containertype = /obj/structure/closet/crate/secure
 	containername = "riot gear crate"
 	access = access_armory

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -71,7 +71,6 @@
 		new /obj/item/weapon/tank/emergency_oxygen/engi( src )
 		return
 
-
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains white gloves."
@@ -100,7 +99,6 @@
 		new /obj/item/clothing/mask/surgical(src)
 		new /obj/item/clothing/mask/surgical(src)
 		new /obj/item/clothing/mask/surgical(src)
-
 
 /obj/item/weapon/storage/box/syringes
 	name = "syringes"
@@ -145,7 +143,6 @@
 		new /obj/item/weapon/dnainjector/m2h(src)
 		new /obj/item/weapon/dnainjector/m2h(src)
 
-
 /obj/item/weapon/storage/box/blanks
 	name = "box of blank shells"
 	desc = "It has a picture of a gun and several warning symbols on the front."
@@ -159,8 +156,6 @@
 		new /obj/item/ammo_casing/shotgun/blank(src)
 		new /obj/item/ammo_casing/shotgun/blank(src)
 		new /obj/item/ammo_casing/shotgun/blank(src)
-
-
 
 /obj/item/weapon/storage/box/flashbangs
 	name = "box of flashbangs (WARNING)"
@@ -177,6 +172,21 @@
 		new /obj/item/weapon/grenade/flashbang(src)
 		new /obj/item/weapon/grenade/flashbang(src)
 
+/obj/item/weapon/storage/box/teargas
+	name = "box of tear gas grenades (WARNING)"
+	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness and skin irritation.</B>"
+	icon_state = "flashbang"
+
+	New()
+		..()
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+		new /obj/item/weapon/grenade/chem_grenade/teargas(src)
+
 /obj/item/weapon/storage/box/emps
 	name = "emp grenades"
 	desc = "A box with 5 emp grenades."
@@ -189,7 +199,6 @@
 		new /obj/item/weapon/grenade/empgrenade(src)
 		new /obj/item/weapon/grenade/empgrenade(src)
 		new /obj/item/weapon/grenade/empgrenade(src)
-
 
 /obj/item/weapon/storage/box/trackimp
 	name = "tracking implant kit"
@@ -221,7 +230,6 @@
 		new /obj/item/weapon/implanter(src)
 		new /obj/item/weapon/implantpad(src)
 
-
 /obj/item/weapon/storage/box/rxglasses
 	name = "prescription glasses"
 	desc = "This box contains nerd glasses."
@@ -250,7 +258,6 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 		new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 
-
 /obj/item/weapon/storage/box/condimentbottles
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
@@ -264,8 +271,6 @@
 		new /obj/item/weapon/reagent_containers/food/condiment(src)
 		new /obj/item/weapon/reagent_containers/food/condiment(src)
 
-
-
 /obj/item/weapon/storage/box/cups
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
@@ -278,7 +283,6 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/sillycup( src )
-
 
 /obj/item/weapon/storage/box/donkpockets
 	name = "box of donk-pockets"
@@ -305,7 +309,6 @@
 		..()
 		for(var/i = 1; i <= 5; i++)
 			new /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped(src)
-
 
 /obj/item/weapon/storage/box/ids
 	name = "spare IDs"
@@ -336,7 +339,6 @@
 		new /obj/item/weapon/cartridge/security(src)
 		new /obj/item/weapon/cartridge/security(src)
 		new /obj/item/weapon/cartridge/security(src)
-
 
 /obj/item/weapon/storage/box/handcuffs
 	name = "spare handcuffs"
@@ -381,7 +383,6 @@
 		new /obj/item/weapon/storage/pill_bottle( src )
 		new /obj/item/weapon/storage/pill_bottle( src )
 
-
 /obj/item/weapon/storage/box/snappops
 	name = "snap pop box"
 	desc = "Eight wrappers of fun! Ages 8 and up. Not suitable for children."
@@ -393,7 +394,6 @@
 		..()
 		for(var/i=1; i <= storage_slots; i++)
 			new /obj/item/toy/snappop(src)
-
 
 /obj/item/weapon/storage/box/matches
 	name = "matchbox"
@@ -418,7 +418,6 @@
 			processing_objects.Add(W)
 		W.update_icon()
 		return
-
 
 /obj/item/weapon/storage/box/lights
 	name = "replacement bulbs"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1750,7 +1750,7 @@ datum
 		condensedcapsaicin
 			name = "Condensed Capsaicin"
 			id = "condensedcapsaicin"
-			description = "This shit goes in pepperspray."
+			description = "A chemical agent used for self-defense and in police work."
 			reagent_state = LIQUID
 			color = "#B31008" // rgb: 179, 16, 8
 
@@ -1782,26 +1782,29 @@ datum
 							if ( !safe_thing )
 								safe_thing = victim.glasses
 						if ( eyes_covered && mouth_covered )
-							victim << "\red Your [safe_thing] protects you from the pepperspray!"
 							return
 						else if ( mouth_covered )	// Reduced effects if partially protected
-							victim << "\red Your [safe_thing] protect you from most of the pepperspray!"
+							if(prob(5))
+								victim.emote("scream")
 							victim.eye_blurry = max(M.eye_blurry, 3)
 							victim.eye_blind = max(M.eye_blind, 1)
-							victim.Paralyse(1)
+							victim.confused = max(M.confused, 3)
+							victim.damageoverlaytemp = 60
+							victim.Weaken(1)
 							victim.drop_item()
 							return
 						else if ( eyes_covered ) // Eye cover is better than mouth cover
-							victim << "\red Your [safe_thing] protects your eyes from the pepperspray!"
-							victim.emote("scream")
-							victim.eye_blurry = max(M.eye_blurry, 1)
+							victim.eye_blurry = max(M.eye_blurry, 3)
+							victim.damageoverlaytemp = 30
 							return
 						else // Oh dear :D
-							victim.emote("scream")
-							victim << "\red You're sprayed directly in the eyes with pepperspray!"
+							if(prob(5))
+								victim.emote("scream")
 							victim.eye_blurry = max(M.eye_blurry, 5)
 							victim.eye_blind = max(M.eye_blind, 2)
-							victim.Paralyse(1)
+							victim.confused = max(M.confused, 6)
+							victim.damageoverlaytemp = 75
+							victim.Weaken(3)
 							victim.drop_item()
 
 		frostoil

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -449,6 +449,13 @@ datum
 				new /obj/item/stack/sheet/mineral/plasma(location)
 				return
 
+		capsaicincondensation
+			name = "Capsaicincondensation"
+			id = "capsaicincondensation"
+			result = "condensedcapsaicin"
+			required_reagents = list("capsaicin" = 1, "ethanol" = 5)
+			result_amount = 5
+
 		virus_food
 			name = "Virus Food"
 			id = "virusfood"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -49,7 +49,19 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>4 September 2013</h2>
+	<h3 class='author'>Cheridan updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>You can now condense capsaicin into pepper spray with chemistry.</li>
+		<li class='tweak'>Pepper spray made slightly more effective.</li>
+		<li class='tweak'>Teargas grenades can be obtained in Weapons and Riot crates.</li>
+		<li class='tweak'>Riot crate comes with 2 sets of gear instead of 3, made cheaper. Beanbag crate removed entirely. Just make more at the autolathe instead. Bureaucracy crate cheaper, now has film roll. </li>
+	</ul>
+</div>
+
 
 <div class="commit sansserif">
 	<h2 class="date">6 April 2013</h2>


### PR DESCRIPTION
-Capsaicin can be turned into Condensed Capsaicin via chemistry.
-Alters the effect of pepper spray slightly. Changes it from a paralyze(KO) to weaken(stun like batons, etc), and adds slight lingering confuse effect.
-Adds teargas grenades(pepper spray smoke chem grenades), currently obtainable in Weapons crates and Riot crates.

Supplypacks:
-Adds a roll of film to the bureaucracy crate, and made it a little cheaper.
-Removes the beanbag crate entirely, it redundant. Just print out the beanbag shells at the autolathe.
-The previously-overpacked Riot gear crate comes with 1 less set of equipment, but with more handcuffs. Made cheaper to compensate.
