### PR TITLE
Ensures the preservation of mimes' uniqueness

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -238,9 +238,9 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_in_backpack)
-		H.verbs += /client/proc/mimespeak
+		//H.verbs += /client/proc/mimespeak
 		H.verbs += /client/proc/mimewall
-		H.mind.special_verbs += /client/proc/mimespeak
+		//H.mind.special_verbs += /client/proc/mimespeak
 		H.mind.special_verbs += /client/proc/mimewall
 		H.miming = 1
 		return 1

--- a/code/game/jobs/jobprocs.dm
+++ b/code/game/jobs/jobprocs.dm
@@ -28,6 +28,7 @@
 
 ////////////////////////
 
+/*
 /client/proc/mimespeak()
 	set category = "Mime"
 	set name = "Speech"
@@ -44,3 +45,5 @@
 		spawn(3000)
 			H.miming = 1
 	return
+
+	*/


### PR DESCRIPTION
- Removes mimes' ability to speak. Clowns cannot break their clumsy nature, so mimes should not be able to break their silence.

(Mimes originally had this verb because the job assignment algorithm could only be used to define three job choice preferences, meaning you were often assigned a job you really didn't like to play. The speech thing was added for people who did not want to play with the limitaiton. Since the job assignment algorithm was fixed, this is no longer an issue, and the problem-patch is no longer needed.)
