### PR TITLE
Automatic shuttle calls 2 the electric boogaloo

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -16,6 +16,7 @@ var/global/list/chemical_reagents_list				//list of all /datum/reagent datums in
 var/global/list/landmarks_list = list()				//list of all landmarks created
 var/global/list/surgeries_list = list()				//list of all surgeries by name, associated with their path.
 var/global/list/mechas_list = list()				//list of all mechs. Used by hostile mobs target tracking.
+var/global/list/shuttle_caller_list = list()  		//list of all communication consoles and AIs, for automatic shuttle calls when there are none.
 
 var/global/list/portals = list()					//for use by portals
 
@@ -44,8 +45,8 @@ var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel")
 	//facial hair
 	init_sprite_accessory_subtypes(/datum/sprite_accessory/facial_hair, facial_hair_styles_list, facial_hair_styles_male_list, facial_hair_styles_female_list)
 	//underwear
-	init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, underwear_all, underwear_m, underwear_f)	
-	
+	init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, underwear_all, underwear_m, underwear_f)
+
 	//Surgeries
 	for(var/path in typesof(/datum/surgery))
 		if(path == /datum/surgery)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -33,6 +33,9 @@
 	var/stat_msg2
 
 
+/obj/machinery/computer/communications/New()
+	shuttle_caller_list += src
+	..()
 
 /obj/machinery/computer/communications/process()
 	if(..())
@@ -498,51 +501,7 @@
 
 
 /obj/machinery/computer/communications/Del()
-
-	for(var/obj/machinery/computer/communications/commconsole in world)
-		if(istype(commconsole.loc,/turf) && commconsole != src)
-			return ..()
-
-	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if(istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage))
-			return ..()
-
-	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
-			return ..()
-
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" /* DEATH SQUADS || sent_strike_team*/)
-		return ..()
-
-	emergency_shuttle.incall(2)
-	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
-	world << sound('sound/AI/shuttlecalled.ogg')
-
+	ai_list -= src
+	emergency_shuttle.autoshuttlecall()
 	..()
 
-/obj/item/weapon/circuitboard/communications/Del()
-
-	for(var/obj/machinery/computer/communications/commconsole in world)
-		if(istype(commconsole.loc,/turf))
-			return ..()
-
-	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if((istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage)) && commboard != src)
-			return ..()
-
-	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
-			return ..()
-
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" /* DEATH SQUADS || sent_strike_team*/)
-		return ..()
-
-	emergency_shuttle.incall(2)
-	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
-	world << sound('sound/AI/shuttlecalled.ogg')
-
-	..()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -501,7 +501,7 @@
 
 
 /obj/machinery/computer/communications/Del()
-	ai_list -= src
+	shuttle_caller_list -= src
 	emergency_shuttle.autoshuttlecall()
 	..()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -120,8 +120,8 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/Del()
 	ai_list -= src
-	emergency_shuttle.autoshuttlecall()
 	shuttle_caller_list -= src
+	emergency_shuttle.autoshuttlecall()
 	..()
 
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -48,7 +48,7 @@ var/list/ai_list = list()
 
 	var/camera_light_on = 0	//Defines if the AI toggled the light on the camera it's looking through.
 	var/datum/trackable/track = null
-	
+
 	var/last_paper_seen = null
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
@@ -114,11 +114,14 @@ var/list/ai_list = list()
 
 			job = "AI"
 	ai_list += src
+	shuttle_caller_list += src
 	..()
 	return
 
 /mob/living/silicon/ai/Del()
 	ai_list -= src
+	emergency_shuttle.autoshuttlecall()
+	shuttle_caller_list -= src
 	..()
 
 

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -11,38 +11,8 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
-	var/callshuttle = 0
-
-	for(var/obj/machinery/computer/communications/commconsole in world)
-		if(commconsole.z == 2)
-			continue
-		if(istype(commconsole.loc,/turf))
-			break
-		callshuttle++
-
-	for(var/obj/item/weapon/circuitboard/communications/commboard in world)
-		if(commboard.z == 2)
-			continue
-		if(istype(commboard.loc,/turf) || istype(commboard.loc,/obj/item/weapon/storage))
-			break
-		callshuttle++
-
-	for(var/mob/living/silicon/ai/shuttlecaller in player_list)
-		if(shuttlecaller.z == 2)
-			continue
-		if(!shuttlecaller.stat && shuttlecaller.client && istype(shuttlecaller.loc,/turf))
-			break
-		callshuttle++
-
-	if(ticker.mode.name == "revolution" || ticker.mode.name == "AI malfunction" /* DEATH SQUADS || sent_strike_team*/)
-		callshuttle = 0
-
-	if(callshuttle == 3) //if all three conditions are met
-		emergency_shuttle.incall(2)
-		log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-		message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.", 1)
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
-		world << sound('sound/AI/shuttlecalled.ogg')
+	ai_list -= src
+	emergency_shuttle.autoshuttlecall()
 
 	if(explosive)
 		spawn(10)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -11,7 +11,7 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
 
-	ai_list -= src
+	shuttle_caller_list -= src
 	emergency_shuttle.autoshuttlecall()
 
 	if(explosive)


### PR DESCRIPTION
The automatic shuttle call will now be triggered if there are no communi...cations console on the station z level or an active AI. The shuttle will not have the standard 10 minutes to arrive, instead, it will take 25 minutes, so they have 20 minutes to recall.

They will use the new proc autoshuttlecall() in the emergency_shuttle controller.

Instead of taking a loop on world, there's a new list, shuttle_caller_list, it includes all communication consoles and AIs.

Fixed some weird things regarding recalling the shuttle if the arriving time of the shuttle was bigger than 10 minutes.
