### PR TITLE
Small revamp of medHUDs and secHUDs. Fixes del() lag (this time 5real).

### DIFF
--- a/code/__DEFINES.dm
+++ b/code/__DEFINES.dm
@@ -433,3 +433,12 @@ var/list/be_special_flags = list(
 	"Monkey" = BE_MONKEY,
 	"Ninja" = BE_NINJA
 	)
+
+// for secHUDs and medHUDs and variants. The number is the location of the image on the list hud_list of humans.
+#define HEALTH_HUD		1 // dead, alive, sick, health status
+#define STATUS_HUD		2 // a simple line rounding the mob's number health
+#define ID_HUD			3 // the job asigned to your ID
+#define WANTED_HUD		4 // wanted, released, parroled, security status
+#define IMPLOYAL_HUD	5 // loyality implant
+#define IMPCHEM_HUD		6 // chemical implant
+#define IMPTRACK_HUD	7 // tracking implant

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -78,7 +78,7 @@
 		if(!M || M.stat || !(M in view(M)))	return
 		if(!M.client)	return
 		var/client/C = M.client
-		var/icon/tempHud = 'icons/mob/hud.dmi'
+		var/image/holder
 		for(var/mob/living/carbon/human/patient in view(M.loc))
 			if(M.see_invisible < patient.invisibility)
 				continue
@@ -88,12 +88,22 @@
 					foundVirus++
 			//if(patient.virus2)
 			//	foundVirus++
-			C.images += image(tempHud,patient,"hud[RoundHealth(patient.health)]")
+
+			holder = patient.hud_list[HEALTH_HUD]
 			if(patient.stat == 2)
-				C.images += image(tempHud,patient,"huddead")
-			else if(patient.status_flags & XENO_HOST)
-				C.images += image(tempHud,patient,"hudxeno")
-			else if(foundVirus)
-				C.images += image(tempHud,patient,"hudill")
+				holder.icon_state = "hudhealth-100"
+				C.images += holder
 			else
-				C.images += image(tempHud,patient,"hudhealthy")
+				holder.icon_state = "hud[RoundHealth(patient.health)]"
+				C.images += holder
+
+			holder = patient.hud_list[STATUS_HUD]
+			if(patient.stat == 2)
+				holder.icon_state = "huddead"
+			else if(patient.status_flags & XENO_HOST)
+				holder.icon_state = "hudxeno"
+			else if(foundVirus)
+				holder.icon_state = "hudill"
+			else
+				holder.icon_state = "hudhealthy"
+			C.images += holder

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -45,22 +45,31 @@
 		if(!M)	return
 		if(!M.client)	return
 		var/client/C = M.client
-		var/icon/tempHud = 'icons/mob/hud.dmi'
+		var/image/holder
 		for(var/mob/living/carbon/human/patient in view(M))
 			var/foundVirus = 0
 			for(var/datum/disease/D in patient.viruses)
 				if(!D.hidden[SCANNER])
 					foundVirus++
 			if(!C) continue
-			C.images += image(tempHud, patient, "hud[RoundHealth(patient.health)]")
+
+			holder = patient.hud_list[HEALTH_HUD]
 			if(patient.stat == 2)
-				C.images += image(tempHud, patient, "huddead")
-			else if(patient.status_flags & XENO_HOST)
-				C.images += image(tempHud, patient, "hudxeno")
-			else if(foundVirus)
-				C.images += image(tempHud, patient, "hudill")
+				holder.icon_state = "hudhealth-100"
 			else
-				C.images += image(tempHud, patient, "hudhealthy")
+				holder.icon_state = "hud[RoundHealth(patient.health)]"
+			C.images += holder
+
+			holder = patient.hud_list[STATUS_HUD]
+			if(patient.stat == 2)
+				holder.icon_state = "huddead"
+			else if(patient.status_flags & XENO_HOST)
+				holder.icon_state = "hudxeno"
+			else if(foundVirus)
+				holder.icon_state = "hudill"
+			else
+				holder.icon_state = "hudhealthy"
+			C.images += holder
 
 
 /obj/item/clothing/glasses/hud/security
@@ -80,42 +89,57 @@
 	if(!M)	return
 	if(!M.client)	return
 	var/client/C = M.client
-	var/icon/tempHud = 'icons/mob/hud.dmi'
+	var/image/holder
 	for(var/mob/living/carbon/human/perp in view(M))
 		if(!C) continue
 		var/perpname = "wot"
+		holder = perp.hud_list[ID_HUD]
 		if(perp.wear_id)
 			var/obj/item/weapon/card/id/I = perp.wear_id.GetID()
 			if(I)
-				C.images += image(tempHud, perp, "hud[ckey(I.GetJobName())]")
 				perpname = I.registered_name
+				holder.icon_state = "hud[ckey(I.GetJobName())]"
+				C.images += holder
 			else
 				perpname = perp.name
-				C.images += image(tempHud, perp, "hudunknown")
+				holder.icon_state = "hudunknown"
+				C.images += holder
 		else
 			perpname = perp.name
-			C.images += image(tempHud, perp, "hudunknown")
+			holder.icon_state = "hudunknown"
+			C.images += holder
 
 		for(var/datum/data/record/E in data_core.general)
 			if(E.fields["name"] == perpname)
+				holder = perp.hud_list[WANTED_HUD]
 				for (var/datum/data/record/R in data_core.security)
 					if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
-						C.images += image(tempHud, perp, "hudwanted")
+						holder.icon_state = "hudwanted"
+						C.images += holder
 						break
 					else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Incarcerated"))
-						C.images += image(tempHud, perp, "hudprisoner")
+						holder.icon_state = "hudprisoner"
+						C.images += holder
 						break
 					else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Parolled"))
-						C.images += image(tempHud, perp, "hudparolled")
+						holder.icon_state = "hudparolled"
+						C.images += holder
 						break
 					else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Released"))
-						C.images += image(tempHud, perp, "hudreleased")
+						holder.icon_state = "hudreleased"
+						C.images += holder
 						break
 		for(var/obj/item/weapon/implant/I in perp)
 			if(I.implanted)
 				if(istype(I,/obj/item/weapon/implant/tracking))
-					C.images += image(tempHud, perp, "hud_imp_tracking")
+					holder = perp.hud_list[IMPTRACK_HUD]
+					holder.icon_state = "hud_imp_tracking"
+					C.images += holder
 				if(istype(I,/obj/item/weapon/implant/loyalty))
-					C.images += image(tempHud, perp, "hud_imp_loyal")
+					holder = perp.hud_list[IMPLOYAL_HUD]
+					holder.icon_state = "hud_imp_loyal"
+					C.images += holder
 				if(istype(I,/obj/item/weapon/implant/chem))
-					C.images += image(tempHud, perp, "hud_imp_chem")
+					holder = perp.hud_list[IMPCHEM_HUD]
+					holder.icon_state = "hud_imp_chem"
+					C.images += holder

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -4,6 +4,7 @@
 	voice_name = "unknown"
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
+	var/list/hud_list = list()
 
 
 /mob/living/carbon/human/dummy
@@ -29,6 +30,9 @@
 	internal_organs += new /obj/item/organ/appendix
 	internal_organs += new /obj/item/organ/heart
 	internal_organs += new /obj/item/organ/brain
+
+	for(var/i=0;i<7;i++) // 2 for medHUDs and 5 for secHUDs
+		hud_list += image('icons/mob/hud.dmi', src, "hudunknown")
 
 	..()
 

--- a/code/modules/mob/living/silicon/pai/hud.dm
+++ b/code/modules/mob/living/silicon/pai/hud.dm
@@ -2,36 +2,53 @@
 	if(client)
 		for(var/image/hud in client.images)
 			if(copytext(hud.icon_state,1,4) == "hud")
-				del(hud)
+				client.images -= hud
 
 /mob/living/silicon/pai/proc/securityHUD()
 	if(client)
-		var/icon/tempHud = 'icons/mob/hud.dmi'
+		var/image/holder
 		var/turf/T = get_turf_or_move(src.loc)
 		for(var/mob/living/carbon/human/perp in view(T))
+			var/perpname = "wot"
+			holder = perp.hud_list[ID_HUD]
 			if(perp.wear_id)
-				client.images += image(tempHud,perp,"hud[ckey(perp:wear_id:GetJobName())]")
-				var/perpname = "wot"
-				if(istype(perp.wear_id,/obj/item/weapon/card/id))
-					perpname = perp.wear_id:registered_name
-				else if(istype(perp.wear_id,/obj/item/device/pda))
-					var/obj/item/device/pda/tempPda = perp.wear_id
-					perpname = tempPda.owner
-				for (var/datum/data/record/E in data_core.general)
-					if (E.fields["name"] == perpname)
-						for (var/datum/data/record/R in data_core.security)
-							if ((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
-								client.images += image(tempHud,perp,"hudwanted")
-								break
-							else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Incarcerated"))
-								client.images += image(tempHud,perp,"hudprisoner")
-								break
+				var/obj/item/weapon/card/id/I = perp.wear_id.GetID()
+				if(I)
+					perpname = I.registered_name
+					holder.icon_state = "hud[ckey(perp:wear_id:GetJobName())]"
+					client.images += holder
+				else
+					perpname = perp.name
+					holder.icon_state = "hudunknown"
+					client.images += holder
 			else
-				client.images += image(tempHud,perp,"hudunknown")
+				holder.icon_state = "hudunknown"
+				client.images += holder
+
+			for(var/datum/data/record/E in data_core.general)
+				if(E.fields["name"] == perpname)
+					holder = perp.hud_list[WANTED_HUD]
+					for (var/datum/data/record/R in data_core.security)
+						if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "*Arrest*"))
+							holder.icon_state = "hudwanted"
+							client.images += holder
+							break
+						else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Incarcerated"))
+							holder.icon_state = "hudprisoner"
+							client.images += holder
+							break
+						else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Parolled"))
+							holder.icon_state = "hudparolled"
+							client.images += holder
+							break
+						else if((R.fields["id"] == E.fields["id"]) && (R.fields["criminal"] == "Released"))
+							holder.icon_state = "hudreleased"
+							client.images += holder
+							break
 
 /mob/living/silicon/pai/proc/medicalHUD()
 	if(client)
-		var/icon/tempHud = 'icons/mob/hud.dmi'
+		var/image/holder
 		var/turf/T = get_turf_or_move(src.loc)
 		for(var/mob/living/carbon/human/patient in view(T))
 
@@ -40,15 +57,24 @@
 				if(!D.hidden[SCANNER])
 					foundVirus = 1
 
-			client.images += image(tempHud,patient,"hud[RoundHealth(patient.health)]")
+			holder = patient.hud_list[HEALTH_HUD]
 			if(patient.stat == 2)
-				client.images += image(tempHud,patient,"huddead")
-			else if(patient.status_flags & XENO_HOST)
-				client.images += image(tempHud,patient,"hudxeno")
-			else if(foundVirus)
-				client.images += image(tempHud,patient,"hudill")
+				holder.icon_state = "hudhealth-100"
+				client.images += holder
 			else
-				client.images += image(tempHud,patient,"hudhealthy")
+				holder.icon_state = "hud[RoundHealth(patient.health)]"
+				client.images += holder
+
+			holder = patient.hud_list[STATUS_HUD]
+			if(patient.stat == 2)
+				holder.icon_state = "huddead"
+			else if(patient.status_flags & XENO_HOST)
+				holder.icon_state = "hudxeno"
+			else if(foundVirus)
+				holder.icon_state = "hudill"
+			else
+				holder.icon_state = "hudhealthy"
+			client.images += holder
 
 /mob/living/silicon/pai/proc/RoundHealth(health)
 	switch(health)


### PR DESCRIPTION
SecHUDs and medHUDs (including pAIs and odyssesus) won't create a fucklod of images per tick and then disposal them, lagging like retards.

Now each human will have a list of the HUD images, that will be refreshed if it's required, lets say, a medic walking near you with a medHUD will refresh both of your medical hud images.
The list, called hud_list, uses seven(for now) defines for all the images, defined in the __DEFINES.dm

I also added a check for not rounding the health bar if the pacient it's dead, fixing some issues with showing dead people in critical or with possitive health.
