### PR TITLE
Changes to the randomized names for admins using dsay while stealthed

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -20,7 +20,7 @@
 	if (!msg)
 		return
 
-	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>ADMIN([src.holder.fakekey ? pick("BADMIN", "hornigranny", "TLF", "scaredforshadows", "KSI", "Silnazi", "HerpEs", "BJ69", "SpoofedEdd", "Uhangay", "Wario90900", "Regarity", "MissPhareon", "LastFish", "unMportant", "Deurpyn", "Fatbeaver") : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
+	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>ADMIN([src.holder.fakekey ? pick("BADMIN", "Fun Police", "Conspiracy", "ERP BLOCKER", "Button Masher", "MissPhaeron", "Turdicide", "hornigranny", "TLC", "scaredofshowers", "SXSI", "HerpEs", "Nerdrak", "Dickarrus", "Wario90900", "Deurpyn", "Fatbeaver", "Arrowage", "Intigaycy", "Hosin Hitter", "Cheridumb", "Petethegoatse", "HotelHabboLover", "Giacunt", "Muskrats", "FickleInspector", "Tankbutt", "Ulisex", "Scrotemis", "Sillnazi", "Stillachair", "cbdsm", "Un_Professional", "Doopenis", "Calasrear", "Quackink ",  "ANyan:3", "Slieve", "Pali-en269", "Teamcreep", "Agoatsie", "Zoomerdik", "LewdMechanic", "NemoPanFried", "LameMontgommery", "EndGameOver", "LocalDingus", "ThoughtlessNaps", "Sewage", "hbgay6969", "Cockdtbent", "Iranclanos", "Liarwhine", "Vagyina", "Nohrape", "Dumboner69", "Gaymarr", "Jesusfraud") : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
 
 	for (var/mob/M in player_list)
 		if (istype(M, /mob/new_player))


### PR DESCRIPTION
Updated the admin names in deadsay.dm, the ones that randomly show up for stealthed admins when they use the dsay verb. Done because most of the current ones were horribly out of date.

Special thanks to everyone who helped come up with the names!
