### PR TITLE
onetankbomb fixes

### DIFF
--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -73,6 +73,14 @@
 	if(bombassembly)
 		bombassembly.HasProximity(AM)
 
+/obj/item/device/onetankbomb/HasEntered(atom/movable/AM as mob|obj) //for mousetraps
+	if(bombassembly)
+		bombassembly.HasEntered(AM)
+
+/obj/item/device/onetankbomb/on_found(mob/finder as mob) //for mousetraps
+	if(bombassembly)
+		bombassembly.on_found(finder)
+
 // ---------- Procs below are for tanks that are used exclusively in 1-tank bombs ----------
 
 /obj/item/weapon/tank/proc/bomb_assemble(W,user)	//Bomb assembly proc. This turns assembly+tank into a bomb

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -61,8 +61,11 @@
 		var/turf/T = null
 		if(istype(loc,/turf))
 			T = loc
-		else if (holder && istype(holder.loc,/turf))
-			T = holder.loc
+		else if (holder)
+			if (istype(holder.loc,/turf))
+				T = holder.loc
+			else if (istype(holder.loc.loc,/turf)) //for onetankbombs and other tertiary builds with assemblies
+				T = holder.loc.loc
 		else if(istype(loc,/obj/item/weapon/grenade) && istype(loc.loc,/turf))
 			T = loc.loc
 		if(T)


### PR DESCRIPTION
onetankbombs were not passing stuff to bombassemblys (HasEntered; on_found)

infra sensors were not checking locs high enough up the hierarchy for onetankbombs (and potential future things)

mousetrap/infra - igniter assemblies now trigger onetankbombs correctly
