### PR TITLE
Removing the firedoors from the gameticker process call, 222 less calls.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,6 +22,7 @@
 	power_change()
 		if(powered(power_channel))
 			stat &= ~NOPOWER
+			latetoggle()
 		else
 			stat |= NOPOWER
 		return
@@ -48,19 +49,6 @@
 				return
 		return
 
-
-	process()
-		if(operating || stat & NOPOWER || !nextstate)
-			return
-		switch(nextstate)
-			if(OPEN)
-				open()
-			if(CLOSED)
-				close()
-		nextstate = null
-		return
-
-
 	animate(animation)
 		switch(animation)
 			if("opening")
@@ -82,6 +70,27 @@
 				overlays += "welded_open"
 		return
 
+	open()
+		..()
+		latetoggle()
+		return
+
+	close()
+		..()
+		latetoggle()
+		return
+
+	proc/latetoggle()
+		if(operating || stat & NOPOWER || !nextstate)
+			return
+		switch(nextstate)
+			if(OPEN)
+				nextstate = null
+				open()
+			if(CLOSED)
+				nextstate = null
+				close()
+		return
 
 
 /obj/machinery/door/firedoor/border_only


### PR DESCRIPTION
Removed the process() from firedoors, reducing the amount of machines of the gameticker on 222.

Added the proc latetoggle() for firedoors, it will be called each time that a firedoor closes, open or recovers power. This proc will check if the var "nextstate" is active, to open or close the firedoor.
