### PR TITLE
Fixed problems with placing atmos machines connecting to the wrong thing.

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -60,7 +60,14 @@ obj/machinery/atmospherics/binary
 		..()
 
 	initialize()
-		if(node1 && node2) return
+		if(node1)
+			node1.disconnect(src)
+			del(network1)
+			node1 = null
+		if(node2)
+			node2.disconnect(src)
+			del(network2)
+			node2 = null
 
 		var/node2_connect = dir
 		var/node1_connect = turn(dir, 180)

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -77,7 +77,10 @@
 		..()
 
 	initialize()
-		if(node) return
+		if(node)
+			node.disconnect(src)
+			del(network)
+			node = null
 
 		var/node_connect = dir
 

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -34,9 +34,9 @@ Filter types:
 				radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
 
 	New()
+		..()
 		if(radio_controller)
 			initialize()
-		..()
 
 	update_icon()
 		if(stat & NOPOWER)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -72,7 +72,18 @@ obj/machinery/atmospherics/trinary
 		..()
 
 	initialize()
-		if(node1 && node2 && node3) return
+		if(node1)
+			node1.disconnect(src)
+			del(network1)
+			node1 = null
+		if(node2)
+			node2.disconnect(src)
+			del(network2)
+			node2 = null
+		if(node3)
+			node3.disconnect(src)
+			del(network3)
+			node3 = null
 
 		var/node1_connect = turn(dir, -180)
 		var/node2_connect = turn(dir, -90)

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -40,7 +40,10 @@
 		..()
 
 	initialize()
-		if(node) return
+		if(node)
+			node.disconnect(src)
+			del(network)
+			node = null
 
 		var/node_connect = dir
 

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -43,6 +43,7 @@
 			icon_state = "in"
 
 	New()
+		..()
 		initial_loc = get_area(loc)
 		if (initial_loc.master)
 			initial_loc = initial_loc.master
@@ -53,7 +54,6 @@
 		if(ticker && ticker.current_state == 3)//if the game is running
 			src.initialize()
 			src.broadcast_status()
-		..()
 
 	high_volume
 		name = "Large Air Vent"

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -25,7 +25,9 @@
 	var/area_uid
 	var/radio_filter_out
 	var/radio_filter_in
+
 	New()
+		..()
 		initial_loc = get_area(loc)
 		if (initial_loc.master)
 			initial_loc = initial_loc.master
@@ -36,7 +38,6 @@
 		if(ticker && ticker.current_state == 3)//if the game is running
 			src.initialize()
 			src.broadcast_status()
-		..()
 
 	update_icon()
 		if(node && on && !(stat & (NOPOWER|BROKEN)))

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -28,12 +28,12 @@ obj/machinery/atmospherics/valve
 			icon_state = "valve[open]"
 
 	New()
+		..()
 		switch(dir)
 			if(NORTH || SOUTH)
 				initialize_directions = NORTH|SOUTH
 			if(EAST || WEST)
 				initialize_directions = EAST|WEST
-		..()
 
 	network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 


### PR DESCRIPTION
- Fixed #242 and #292, at least for the main tests as interpreted (and definitely fixed problems that were even obvious just from the code).
  - The main problem was the machine would get spawned pointing south, and then rotated and initialize() would be called to update its connections. This was directly contrary to initialize()'s implementation which returned if the machine was already connected. In fact, this seems to be the sole purpose and use of initialize() being a seperate proc, to update the machine connections, etc, so I changed the implementation to actually disconnect the old ones and reconnect it, rather than aborting.
  - Also, some machines randomly called the base's New() at the end of their New(), even though they assumed things that happened in the base's New() already happened, so I moved the New()'s ..() to the beginning on those classes.
