### PR TITLE
changeling stings more user friendly

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -606,7 +606,11 @@ var/list/datum/dna/hivemind_bank = list()
 	var/list/victims = list()
 	for(var/mob/living/carbon/C in oview(changeling.sting_range))
 		victims += C
-	var/mob/living/carbon/T = input(src, "Who will we sting?") as null|anything in victims
+	var/mob/living/carbon/T
+	if(victims.len == 1)
+		T = victims[1]	// no point in annoying the user if there's only 1 choice
+	else
+		T = input(src, "Who will we sting?") as null|anything in victims
 
 	if(!T) return
 	if(!(T in view(changeling.sting_range))) return

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -49,7 +49,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>5 January 2013</h2>
+	<h3 class='author'>Tastyfish updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='tweak'>Changeling stings that only have one possible target no longer prompt for the 1 choice, they just sting.</li>
+	</ul>
+</div>
+
 
 
 <div class='commit sansserif'>


### PR DESCRIPTION
Made it so that if there is only one valid target for a sting, it doesn't prompt. One of the suggestions from #261.
Open to discussion if the current UI is an intentional slow-down or something.
