### PR TITLE
Chemmaster 3000 close button fixed

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -258,7 +258,7 @@
 			loaded_pill_bottle.loc = src.loc
 			loaded_pill_bottle = null
 	else if(href_list["close"])
-		usr << browse(null, "window=chemmaster")
+		usr << browse(null, "window=chem_master")
 		usr.unset_machine()
 		return
 


### PR DESCRIPTION
...en the [close] button is pressed.  Previously when the [close] button was pressed it would do nothing and the interface window had to be closed via the window controls.
