### PR TITLE
Re-added Syndie Soap

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -126,6 +126,11 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/pen/paralysis
 	cost = 3
 
+/datum/uplink_item/stealthy_weapons/soap
+	name = "Syndicate Soap"
+	item = /obj/item/weapon/soap/syndie
+	cost = 1
+
 /datum/uplink_item/stealthy_weapons/detomatix
 	name = "Detomatix PDA Cartridge"
 	item = /obj/item/weapon/cartridge/syndicate


### PR DESCRIPTION
- Re-added the syndie soap uplink item after it was mistakenly forgotten after the https://github.com/tgstation/-tg-station/pull/194 conversion.
