### PR TITLE
Cargo manifests from CentComm may contain errors...

### DIFF
--- a/code/__DEFINES.dm
+++ b/code/__DEFINES.dm
@@ -443,6 +443,9 @@ var/list/be_special_flags = list(
 #define IMPCHEM_HUD		6 // chemical implant
 #define IMPTRACK_HUD	7 // tracking implant
 
+#define MANIFEST_ERROR_NAME		1
+#define MANIFEST_ERROR_COUNT	2
+#define MANIFEST_ERROR_ITEM		4
 //DNA - Because fuck you and your magic numbers being all over the codebase.
 #define DNA_BLOCK_SIZE				3
 

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -46,14 +46,27 @@ var/religion_name = null
 /proc/station_name()
 	if (station_name)
 		return station_name
+	
+	var/short_name = pick("Station", "Fortress", "Frontier", "Suffix", "Death-trap", "Space-hulk", "Lab", "Hazard","Spess Junk", "Fishery", "No-Moon", "Tomb", "Crypt", "Hut", "Monkey", "Bomb", "Trade Post", "Fortress", "Village", "Town", "City", "Edition", "Hive", "Complex", "Base", "Facility", "Depot", "Outpost", "Installation", "Drydock", "Observatory", "Array", "Relay", "Monitor", "Platform", "Construct", "Hangar", "Prison", "Center", "Port", "Waystation", "Factory", "Waypoint", "Stopover", "Hub", "HQ", "Office", "Object", "Fortification", "Colony", "Planet-Cracker", "Roost", "Fat Camp")
 
+	station_name = new_station_name()
+
+	if (config && config.server_name)
+		world.name = "[config.server_name]: [short_name]"
+	else
+		world.name = station_name
+
+	return station_name
+
+/proc/new_station_name()
 	var/random = rand(1,5)
 	var/name = ""
+	var/new_station_name = ""
 
 	//Rare: Pre-Prefix
 	if (prob(10))
 		name = pick("Imperium", "Heretical", "Cuban", "Psychic", "Elegant", "Common", "Uncommon", "Rare", "Unique", "Houseruled", "Religious", "Atheist", "Traditional", "Houseruled", "Mad", "Super", "Ultra", "Secret", "Top Secret", "Deep", "Death", "Zybourne", "Central", "Main", "Government", "Uoi", "Fat", "Automated", "Experimental", "Augmented")
-		station_name = name + " "
+		new_station_name = name + " "
 
 	// Prefix
 	switch(events.holiday)
@@ -61,45 +74,38 @@ var/religion_name = null
 		if(null,"",0)
 			name = pick("", "Stanford", "Dorf", "Alium", "Prefix", "Clowning", "Aegis", "Ishimura", "Scaredy", "Death-World", "Mime", "Honk", "Rogue", "MacRagge", "Ultrameens", "Safety", "Paranoia", "Explosive", "Neckbear", "Donk", "Muppet", "North", "West", "East", "South", "Slant-ways", "Widdershins", "Rimward", "Expensive", "Procreatory", "Imperial", "Unidentified", "Immoral", "Carp", "Ork", "Pete", "Control", "Nettle", "Aspie", "Class", "Crab", "Fist","Corrogated","Skeleton","Race", "Fatguy", "Gentleman", "Capitalist", "Communist", "Bear", "Beard", "Derp", "Space", "Spess", "Star", "Moon", "System", "Mining", "Neckbeard", "Research", "Supply", "Military", "Orbital", "Battle", "Science", "Asteroid", "Home", "Production", "Transport", "Delivery", "Extraplanetary", "Orbital", "Correctional", "Robot", "Hats", "Pizza")
 			if(name)
-				station_name += name + " "
+				new_station_name += name + " "
 
 		//For special days like christmas, easter, new-years etc ~Carn
 		if("Friday the 13th")
 			name = pick("Mike","Friday","Evil","Myers","Murder","Deathly","Stabby")
-			station_name += name + " "
+			new_station_name += name + " "
 			random = 13
 		else
 			//get the first word of the Holiday and use that
 			var/i = findtext(events.holiday," ",1,0)
 			name = copytext(events.holiday,1,i)
-			station_name += name + " "
+			new_station_name += name + " "
 
 	// Suffix
 	name = pick("Station", "Fortress", "Frontier", "Suffix", "Death-trap", "Space-hulk", "Lab", "Hazard","Spess Junk", "Fishery", "No-Moon", "Tomb", "Crypt", "Hut", "Monkey", "Bomb", "Trade Post", "Fortress", "Village", "Town", "City", "Edition", "Hive", "Complex", "Base", "Facility", "Depot", "Outpost", "Installation", "Drydock", "Observatory", "Array", "Relay", "Monitor", "Platform", "Construct", "Hangar", "Prison", "Center", "Port", "Waystation", "Factory", "Waypoint", "Stopover", "Hub", "HQ", "Office", "Object", "Fortification", "Colony", "Planet-Cracker", "Roost", "Fat Camp")
-	station_name += name + " "
+	new_station_name += name + " "
 
 	// ID Number
 	switch(random)
 		if(1)
-			station_name += "[rand(1, 99)]"
+			new_station_name += "[rand(1, 99)]"
 		if(2)
-			station_name += pick("Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa", "Lambda", "Mu", "Nu", "Xi", "Omicron", "Pi", "Rho", "Sigma", "Tau", "Upsilon", "Phi", "Chi", "Psi", "Omega")
+			new_station_name += pick("Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa", "Lambda", "Mu", "Nu", "Xi", "Omicron", "Pi", "Rho", "Sigma", "Tau", "Upsilon", "Phi", "Chi", "Psi", "Omega")
 		if(3)
-			station_name += pick("II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")
+			new_station_name += pick("II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")
 		if(4)
-			station_name += pick("Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-ray", "Yankee", "Zulu")
+			new_station_name += pick("Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-ray", "Yankee", "Zulu")
 		if(5)
-			station_name += pick("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen", "Eighteen", "Nineteen")
+			new_station_name += pick("One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen", "Eighteen", "Nineteen")
 		if(13)
-			station_name += pick("13","XIII","Thirteen")
-
-
-	if (config && config.server_name)
-		world.name = "[config.server_name]: [name]"
-	else
-		world.name = station_name
-
-	return station_name
+			new_station_name += pick("13","XIII","Thirteen")
+	return new_station_name
 
 /proc/world_name(var/name)
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -245,8 +245,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 								if(slip.stamped[i] == /obj/item/weapon/stamp/denied)
 									denied = 1
 							if(slip.erroneous && denied) // Caught a mistake by CentComm (IDEA: maybe CentComm rarely gets offended by this)
-								points += slip.points-5 // For now, give a full refund for paying attention (minus the crate cost)
-								centcomm_message += "<font color=green>+[slip.points-5]</font>: Station correctly denied package [slip.ordernumber]: "
+								points += slip.points-points_per_crate // For now, give a full refund for paying attention (minus the crate cost)
+								centcomm_message += "<font color=green>+[slip.points-points_per_crate]</font>: Station correctly denied package [slip.ordernumber]: "
 								if(slip.erroneous & MANIFEST_ERROR_NAME)
 									centcomm_message += "Destination station incorrect. "
 								else if(slip.erroneous & MANIFEST_ERROR_COUNT)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -119,6 +119,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	var/points_per_slip = 2
 	var/points_per_crate = 5
 	var/plasma_per_point = 5 // 2 plasma for 1 point
+	var/centcomm_message = "" // Remarks from CentComm on how well you checked the last order.
 	//control
 	var/ordernum
 	var/list/shoppinglist = list()
@@ -219,22 +220,55 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		if(!shuttle)	return
 
 		var/plasma_count = 0
+		var/crate_count = 0
 
+		centcomm_message = ""
+		
 		for(var/atom/movable/MA in shuttle)
 			if(MA.anchored)	continue
 
 			// Must be in a crate!
 			if(istype(MA,/obj/structure/closet/crate))
-				points += points_per_crate
+				crate_count++
 				var/find_slip = 1
 
 				for(var/atom in MA)
 					// Sell manifests
 					var/atom/A = atom
 					if(find_slip && istype(A,/obj/item/weapon/paper/manifest))
-						var/obj/item/weapon/paper/slip = A
+						var/obj/item/weapon/paper/manifest/slip = A
+						// TODO: Check for a signature, too.
 						if(slip.stamped && slip.stamped.len) //yes, the clown stamp will work. clown is the highest authority on the station, it makes sense
-							points += points_per_slip
+							// Did they mark it as erroneous?
+							var/denied = 0
+							for(var/i=1,i<=slip.stamped.len,i++)
+								if(slip.stamped[i] == /obj/item/weapon/stamp/denied)
+									denied = 1
+							if(slip.erroneous && denied) // Caught a mistake by CentComm (IDEA: maybe CentComm rarely gets offended by this)
+								points += slip.points-5 // For now, give a full refund for paying attention (minus the crate cost)
+								centcomm_message += "<font color=green>+[slip.points-5]</font>: Station correctly denied package [slip.ordernumber]: "
+								if(slip.erroneous & MANIFEST_ERROR_NAME)
+									centcomm_message += "Destination station incorrect. "
+								else if(slip.erroneous & MANIFEST_ERROR_COUNT)
+									centcomm_message += "Packages incorrectly counted. "
+								else if(slip.erroneous & MANIFEST_ERROR_ITEM)
+									centcomm_message += "Package incomplete. "
+								centcomm_message += "Points refunded.<BR>"
+							else if(!slip.erroneous && !denied) // Approving a proper order awards the relatively tiny points_per_slip
+								points += points_per_slip
+								centcomm_message += "<font color=green>+1</font>: Package [slip.ordernumber] accorded.<BR>"
+							else // You done goofed.
+								if(slip.erroneous)
+									centcomm_message += "<font color=red>+0</font>: Station approved package [slip.ordernumber] despite error: "
+									if(slip.erroneous & MANIFEST_ERROR_NAME)
+										centcomm_message += "Destination station incorrect."
+									else if(slip.erroneous & MANIFEST_ERROR_COUNT)
+										centcomm_message += "Packages incorrectly counted."
+									else if(slip.erroneous & MANIFEST_ERROR_ITEM)
+										centcomm_message += "We found unshipped items on our dock."
+									centcomm_message += "  Be more vigilant.<BR>"
+								else
+									centcomm_message += "<font color=red>+0</font>: Station denied package [slip.ordernumber].  Our records show no fault on our part.<BR>"
 							find_slip = 0
 						continue
 
@@ -245,7 +279,12 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 			del(MA)
 
 		if(plasma_count)
+			centcomm_message += "<font color=green>+[round(plasma_count/plasma_per_point)]</font>: Received [plasma_count] units of exotic material.<BR>"
 			points += round(plasma_count / plasma_per_point)
+		
+		if(crate_count)
+			centcomm_message += "<font color=green>+[round(crate_count*points_per_crate)]</font>: Received [crate_count] crates.<BR>"
+			points += crate_count * points_per_crate
 
 	//Buyin
 	proc/buy()
@@ -279,10 +318,23 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 			//supply manifest generation begin
 
 			var/obj/item/weapon/paper/manifest/slip = new /obj/item/weapon/paper/manifest(A)
+
+			var printed_station_name = world.name // World name is available in the title bar, station_name can be different based on config.
+			if(prob(5))
+				printed_station_name = new_station_name()
+				slip.erroneous |= MANIFEST_ERROR_NAME // They got our station name wrong.  BASTARDS!
+				// IDEA: Have CentComm accidentally send random low-value crates in large orders, give large bonus for returning them intact.
+			var printed_packages_amount = supply_shuttle.shoppinglist.len
+			if(prob(5))
+				printed_packages_amount += rand(1,2) // I considered rand(-2,2), but that could be zero.  Heh.
+				slip.erroneous |= MANIFEST_ERROR_COUNT // They typoed the number of crates in this shipment.  It won't match the other manifests.
+
+			slip.points = SP.cost
+			slip.ordernumber = SO.ordernum
 			slip.info = "<h3>[command_name()] Shipping Manifest</h3><hr><br>"
 			slip.info +="Order #[SO.ordernum]<br>"
-			slip.info +="Destination: [station_name]<br>"
-			slip.info +="[supply_shuttle.shoppinglist.len] PACKAGES IN THIS SHIPMENT<br>"
+			slip.info +="Destination: [printed_station_name]<br>"
+			slip.info +="[printed_packages_amount] PACKAGES IN THIS SHIPMENT<br>"
 			slip.info +="CONTENTS:<br><ul>"
 
 			//spawn the stuff, finish generating the manifest while you're at it
@@ -304,17 +356,24 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 				if(!typepath)	continue
 				var/atom/B2 = new typepath(A)
 				if(SP.amount && B2:amount) B2:amount = SP.amount
-				slip.info += "<li>[B2.name]</li>" //add the item to the manifest
+				slip.info += "<li>[B2.name]</li>" //add the item to the manifest (even if it was misplaced)
+				// If it has multiple items, there's a 1% of each going missing... Not for secure crates or those large wooden ones, though.
+				if(contains.len > 1 && prob(1) && !findtext(SP.containertype,"/secure/") && !findtext(SP.containertype,"/largecrate/")) 
+					slip.erroneous |= MANIFEST_ERROR_ITEM // This item was not included in the shipment!
+					del(B2) // Lost in space... or the loading dock.
 
 			//manifest finalisation
 			slip.info += "</ul><br>"
-			slip.info += "CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>"
+			slip.info += "CHECK CONTENTS AND STAMP BELOW THE LINE TO CONFIRM RECEIPT OF GOODS<hr>" // And now this is actually meaningful.
 
 		supply_shuttle.shoppinglist.Cut()
 		return
 
 /obj/item/weapon/paper/manifest
 	name = "Supply Manifest"
+	var/erroneous = 0
+	var/points = 0
+	var/ordernumber = 0
 
 
 /obj/machinery/computer/ordercomp/attack_ai(var/mob/user as mob)
@@ -457,9 +516,10 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		[supply_shuttle.moving ? "\n*Shuttle already called*<BR>\n<BR>":supply_shuttle.at_station ? "\n<A href='?src=\ref[src];send=1'>Send away</A><BR>\n<BR>":"\n<A href='?src=\ref[src];send=1'>Send to station</A><BR>\n<BR>"]
 		\n<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];vieworders=1'>View orders</A><BR>\n<BR>
-		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
+		\n<A href='?src=\ref[user];mach_close=computer'>Close</A><BR>
+		<HR>\n<B>Central Command messages</B><BR> [supply_shuttle.centcomm_message ? supply_shuttle.centcomm_message : "Glory to Nanotrasen."]"}
 
-	user << browse(dat, "window=computer;size=575x450")
+	user << browse(dat, "window=computer;size=700x450")
 	onclose(user, "computer")
 	return
 

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -268,7 +268,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 										centcomm_message += "We found unshipped items on our dock."
 									centcomm_message += "  Be more vigilant.<BR>"
 								else
-									centcomm_message += "<font color=red>+0</font>: Station denied package [slip.ordernumber].  Our records show no fault on our part.<BR>"
+									points -= slip.points-points_per_crate
+									centcomm_message += "<font color=red>-[slip.points-points_per_crate]</font>: Station denied package [slip.ordernumber].  Our records show no fault on our part.<BR>"
 							find_slip = 0
 						continue
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -52,6 +52,17 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>5 May 2013</h2>
+	<h3 class='author'>Rolan7 updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Cargo manifests from CentComm may contain errors.  Stamp them DENIED for refunds.  Doesn't apply to secure or large crates.  Check the orders console for CentComm feedback.</li>
+	</ul>
+</div>
+
+
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>2 May 2013</h2>
 	<h3 class='author'>Malkevin updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Stamp them DENIED for refunds.  Doesn't apply to secure or large crates.  Feedback shows up in the orders console, including amount of plasma and crates shipped.  Each entry is preceded by color-coded point value.

Possible errors:
Incorrect station name
Incorrect number of packages in shipment
Items missing from the crate

http://kamletos.si/phpbb/viewtopic.php?f=5&t=38
