### PR TITLE
Addressed hulk speach inconsistant punctuation and cable coil problem

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -104,7 +104,7 @@
 
 		if ((HULK in mutations) && health >= 25 && length(message))
 			if(copytext(message, 1, 2) != "*")
-				message = "[uppertext(message)]!!" //because I don't know how to code properly in getting vars from other files -Bro
+				message = "[uppertext(replacetext(message, ".", "!"))]!!" //because I don't know how to code properly in getting vars from other files -Bro
 
 	..(message)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -297,15 +297,16 @@
 			return
 
 		if( (C.amount + src.amount <= MAXCOIL) )
-			src.use(src.amount) // make sure this one cleans up right
-			C.give(src.amount) // give it cable
 			user << "You join the cable coils together."
+			C.give(src.amount) // give it cable
+			src.use(src.amount) // make sure this one cleans up right
 			return
 
 		else
-			user << "You transfer [MAXCOIL - C.amount] length\s of cable from one coil to the other."
-			src.use(MAXCOIL - C.amount)
-			C.give(MAXCOIL - C.amount)
+			var/amt = MAXCOIL - C.amount
+			user << "You transfer [amt] length\s of cable from one coil to the other."
+			C.give(amt)
+			src.use(amt)
 			return
 
 /obj/item/weapon/cable_coil/proc/use(var/used)


### PR DESCRIPTION
- Made hulk speech change all .'s into !'s to be consistent with added !'s. #496
- Rearranged cable coil transfer to use of cable last since the proc silently returns if src is deleted. This might've cropped up when pete and I changed the code at the same time, oops. #500
