### PR TITLE
The max charge of a high capacity power cell was inconsistent.

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -49,7 +49,7 @@
 	name = "high-capacity power cell"
 	origin_tech = "powerstorage=2"
 	icon_state = "hcell"
-	maxcharge = 10000
+	maxcharge = 15000
 	g_amt = 60
 
 /obj/item/weapon/cell/high/empty/New()


### PR DESCRIPTION
Ones prespawned onto the map held 15k charge, new ones spawned were 10k.

This fixes the inconsistency by changing new cells to spawn with 15k max charge
