### PR TITLE
Mech fabricator fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -1,5 +1,16 @@
 // Areas.dm
 
+// Added to fix mech fabs 05/2013 ~Sayu
+// This is necessary due to lighting subareas.  If you were to go in assuming that things in
+// the same logical /area have the parent /area object... well, you would be mistaken.  If you
+// want to find machines, mobs, etc, in the same logical area, you will need to check all the
+// related areas.  This returns a master contents list to assist in that.
+/proc/area_contents(var/area/A)
+	if(!istype(A)) return null
+	var/list/contents = list()
+	for(var/area/LSA in A.related)
+		contents += LSA.contents
+	return contents
 
 
 // ===

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -496,9 +496,12 @@
 		temp = "Updating local R&D database..."
 		src.updateUsrDialog()
 		sleep(30) //only sleep if called by user
-	for(var/obj/machinery/computer/rdconsole/RDC in get_area(src))
+
+	var/found = 0
+	for(var/obj/machinery/computer/rdconsole/RDC in area_contents(get_area(src)))
 		if(!RDC.sync)
 			continue
+		found = 1
 		for(var/datum/tech/T in RDC.files.known_tech)
 			files.AddTech2Known(T)
 		for(var/datum/design/D in RDC.files.known_designs)
@@ -513,6 +516,9 @@
 			src.updateUsrDialog()
 		if(i || tech_output)
 			src.visible_message("\icon[src] <b>[src]</b> beeps, \"Succesfully synchronized with R&D server. New data processed.\"")
+	if(!silent && !found)
+		temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
+		src.updateUsrDialog()
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(var/obj/item/part as obj,var/resource as text, var/roundto=1)


### PR DESCRIPTION
Mech fabs were looking in their lighting sub-area to connect to equipment in their logical area; if the mech fab and the R&D computer were at different lighting levels, they would cease to be in the same area, making them fail to connect.

This adds a global helper proc to return the contents of a logical area rather than the lighting sub-area, adds that functionality to the mech fab, and makes failing to connect to an R&D computer a recoverable error.
