### PR TITLE
Changed moneyplants to use the plant's potency...

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -883,7 +883,8 @@
 	icon_state = "spawner"
 	potency = 10
 	New()
-		switch(rand(1,100))//(potency) //It wants to use the default potency instead of the new, so it was always 10. Will try to come back to this later - Cheridan
+		..()
+		switch(potency)
 			if(0 to 10)
 				new/obj/item/weapon/spacecash/(src.loc)
 			if(11 to 20)


### PR DESCRIPTION
... instead of a random value when generating spacecash.

I didn't call spawn(5) in this, just ..().  The ..() in this case is:

```
New(newloc,newpotency)
    if (!isnull(newpotency))
        potency = newpotency
    ..()
    src.pixel_x = rand(-5.0, 5)
    src.pixel_y = rand(-5.0, 5)
```

The spacecash plant uses the default /obj/item/seeds/proc/harvest proc, which calls the edited constructor using "new product(user.loc, potency)".  There's no race condition here, the ..() constructor sets the potency using that argument.

Although, the harvest proc _does_ set the product's potency _again_ after its creation.  In my opinion this is wholly unnecessary, as the product's potency is always set by the constructor call earlier in the proc.  It gives the false impression that there's a race condition, and could possibly result in issues if the product is deleted to quickly (the space cash helper object is deleted after a spawn(5), which ought to be enough time, but still.)  I might want to change how this works later and submit another pull request from this branch.  For now, the only change is to space cash, and it works (:
