### PR TITLE
Fixes 'Camera Bug' item and makes it a viable tool.

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -287,6 +287,27 @@ proc/listclearnulls(list/list)
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
+//Mergesort: any value in a list, preserves key=value structure
+/proc/sortAssoc(var/list/L)
+	if(L.len < 2)
+		return L
+	var/middle = L.len / 2 + 1 // Copy is first,second-1
+	return mergeAssoc(sortAssoc(L.Copy(0,middle)), sortAssoc(L.Copy(middle))) //second parameter null = to end of list
+
+/proc/mergeAssoc(var/list/L, var/list/R)
+	var/Li=1
+	var/Ri=1
+	var/list/result = new()
+	while(Li <= L.len && Ri <= R.len)
+		if(sorttext(L[Li], R[Ri]) < 1)
+			result += R&R[Ri++]
+		else
+			result += L&L[Li++]
+
+	if(Li <= L.len)
+		return (result + L.Copy(Li, 0))
+	return (result + R.Copy(Ri, 0))
+
 
 //Converts a bitfield to a list of numbers (or words if a wordlist is provided)
 /proc/bitfield2list(bitfield = 0, list/wordlist)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -167,6 +167,10 @@ var/list/uplink_items = list()
 	item = /obj/item/device/chameleon
 	cost = 4
 
+/datum/uplink_item/stealthy_tools/camera_bug
+	name = "Camera Bug"
+	item = /obj/item/device/camera_bug
+	cost = 2
 
 // DEVICE AND TOOLS
 

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -419,42 +419,6 @@
 	icon_state = "power_mod"
 	desc = "Charging circuits for power cells."
 
-
-/obj/item/device/camera_bug
-	name = "camera bug"
-	icon = 'icons/obj/device.dmi'
-	icon_state = "flash"
-	w_class = 1.0
-	item_state = "electronic"
-	throw_speed = 4
-	throw_range = 20
-
-/obj/item/weapon/camera_bug/attack_self(mob/usr as mob)
-	var/list/cameras = new/list()
-	for (var/obj/machinery/camera/C in cameranet.cameras)
-		if (C.bugged && C.status)
-			cameras.Add(C)
-	if (length(cameras) == 0)
-		usr << "\red No bugged functioning cameras found."
-		return
-
-	var/list/friendly_cameras = new/list()
-
-	for (var/obj/machinery/camera/C in cameras)
-		friendly_cameras.Add(C.c_tag)
-
-	var/target = input("Select the camera to observe", null) as null|anything in friendly_cameras
-	if (!target)
-		return
-	for (var/obj/machinery/camera/C in cameras)
-		if (C.c_tag == target)
-			target = C
-			break
-	if (usr.stat == 2) return
-
-	usr.client.eye = target
-
-
 /obj/item/weapon/syntiflesh
 	name = "syntiflesh"
 	desc = "Meat that appears...strange..."

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -16,7 +16,7 @@
 	anchored = 1.0
 	var/panel_open = 0 // 0 = Closed / 1 = Open
 	var/invuln = null
-	var/bugged = 0
+	var/obj/item/device/camera_bug/bug = null
 	var/obj/item/weapon/camera_assembly/assembly = null
 
 	//OTHER
@@ -42,6 +42,11 @@
 		if(C != src && C.c_tag == src.c_tag && tempnetwork.len)
 			world.log << "[src.c_tag] [src.x] [src.y] [src.z] conflicts with [C.c_tag] [C.x] [C.y] [C.z]"
 	*/
+	..()
+
+/obj/machinery/camera/Del()
+	if(istype(bug))
+		bug.bugged_cameras -= src.c_tag
 	..()
 
 /obj/machinery/camera/emp_act(severity)
@@ -150,12 +155,14 @@
 		if (!src.can_use())
 			user << "\blue Camera non-functional"
 			return
-		if (src.bugged)
+		if(istype(src.bug))
 			user << "\blue Camera bug removed."
-			src.bugged = 0
+			src.bug.bugged_cameras -= src.c_tag
+			src.bug = null
 		else
 			user << "\blue Camera bugged."
-			src.bugged = 1
+			src.bug = W
+			src.bug.bugged_cameras[src.c_tag] = src
 	else if(istype(W, /obj/item/weapon/melee/energy/blade))//Putting it here last since it's a special case. I wonder if there is a better way to do these than type casting.
 		deactivate(user,2)//Here so that you can disconnect anyone viewing the camera, regardless if it's on or off.
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -62,12 +62,10 @@
 				if(can_use())
 					cameranet.addCamera(src)
 			for(var/mob/O in mob_list)
-				if (istype(O.machine, /obj/machinery/computer/security))
-					var/obj/machinery/computer/security/S = O.machine
-					if (S.current == src)
-						O.unset_machine()
-						O.reset_view(null)
-						O << "The screen bursts into static."
+				if (O.client && O.client.eye == src)
+					O.unset_machine()
+					O.reset_view(null)
+					O << "The screen bursts into static."
 			..()
 
 
@@ -138,19 +136,17 @@
 			P = W
 			itemname = P.name
 			info = P.notehtml
-		U << "You hold \a [itemname] up to the camera ..."
+		U << "You hold \the [itemname] up to the camera ..."
 		for(var/mob/O in player_list)
 			if(istype(O, /mob/living/silicon/ai))
 				var/mob/living/silicon/ai/AI = O
 				if(U.name == "Unknown") AI << "<b>[U]</b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
 				else AI << "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[U]'>[U]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
 				AI.last_paper_seen = "<HTML><HEAD><TITLE>[itemname]</TITLE></HEAD><BODY><TT>[info]</TT></BODY></HTML>"
-			else if (istype(O.machine, /obj/machinery/computer/security))
-				var/obj/machinery/computer/security/S = O.machine
-				if (S.current == src)
-					O << "[U] holds \a [itemname] up to one of the cameras ..."
-					O << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
-	else if (istype(W, /obj/item/weapon/camera_bug))
+			else if (O.client && O.client.eye == src)
+				O << "[U] holds \a [itemname] up to one of the cameras ..."
+				O << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
+	else if (istype(W, /obj/item/device/camera_bug))
 		if (!src.can_use())
 			user << "\blue Camera non-functional"
 			return
@@ -198,12 +194,10 @@
 	//Apparently, this will disconnect anyone even if the camera was re-activated.
 	//I guess that doesn't matter since they can't use it anyway?
 	for(var/mob/O in player_list)
-		if (istype(O.machine, /obj/machinery/computer/security))
-			var/obj/machinery/computer/security/S = O.machine
-			if (S.current == src)
-				O.unset_machine()
-				O.reset_view(null)
-				O << "The screen bursts into static."
+		if (O.client && O.client.eye == src)
+			O.unset_machine()
+			O.reset_view(null)
+			O << "The screen bursts into static."
 
 /obj/machinery/camera/proc/triggerCameraAlarm()
 	alarm_on = 1

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -1,0 +1,50 @@
+/obj/item/device/camera_bug
+	name = "camera bug"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "mindflash2"
+	w_class = 1.0
+	item_state = "electronic"
+	throw_speed = 4
+	throw_range = 20
+	var/obj/machinery/camera/current
+
+/obj/item/device/camera_bug/attack_self(mob/user as mob)
+	var/list/friendly_cameras = new/list()
+	var/turf/T = get_turf(loc)
+	for (var/obj/machinery/camera/C in cameranet.cameras)
+		if (C.bugged && C.status && C.z == T.z)
+			friendly_cameras[C.c_tag] = C
+	if (friendly_cameras.len == 0)
+		user << "\red No bugged functioning cameras found."
+		return
+
+	var/target = "Cancel"
+	while(target)
+		target = input("Select the camera to observe", "Cancel") as null|anything in friendly_cameras + "Cancel"
+		var/obj/machinery/camera/C = friendly_cameras[target]
+		if ( !C || loc != user || user.stat || user.blinded || !user.canmove )
+			user.unset_machine()
+			user.reset_view(null)
+			return
+
+		T = get_turf(loc)
+		if(T.z != C.z)
+			user << "\red You've lost the signal."
+			current = null
+			user.reset_view(null)
+			attack_self(user)
+			return
+
+		if( !C.can_use() )
+			user << "\red Something's wrong with that camera.  You can't get a feed."
+		else
+
+			current = C
+			user.set_machine(src)
+			user.reset_view(C)
+
+
+/obj/item/device/camera_bug/check_eye(var/mob/user as mob)
+	if (user.stat || loc != user || !user.canmove || user.blinded || !current || !current.can_use())
+		return null
+	return 1

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -311,17 +311,23 @@
 	var/static/list/expandables = list(
 		/obj/item/weapon/research = ADMIN_BUG, // could have been anything spawn-only
 
-		// these are so hackish I am sorry
-		/obj/item/weapon/card/emag = UNIVERSAL_BUG,
-		/obj/item/weapon/cell = SABOTAGE_BUG,
-		/obj/item/device/analyzer = NETWORK_BUG,
-		/obj/item/device/pda = ADVANCED_BUG,
+		// these are all so hackish I am sorry
 
+		/obj/item/device/analyzer = UNIVERSAL_BUG,
 		/obj/item/weapon/stock_parts/subspace/analyzer = UNIVERSAL_BUG,
+
+		/obj/item/device/assembly/igniter = SABOTAGE_BUG,
+		/obj/item/device/assembly/infra = SABOTAGE_BUG, // ir blaster to disable camera
 		/obj/item/weapon/stock_parts/subspace/amplifier = SABOTAGE_BUG,
+
+		/obj/item/device/radio = NETWORK_BUG,
+		/obj/item/device/assembly/signaler = NETWORK_BUG,
 		/obj/item/weapon/stock_parts/subspace/transmitter = NETWORK_BUG,
+
+		/obj/item/device/detective_scanner = ADVANCED_BUG,
+		/obj/item/device/paicard = ADVANCED_BUG,
 		/obj/item/weapon/stock_parts/scanning_module = ADVANCED_BUG
-	)
+		)
 
 	for(var/entry in expandables)
 		if(istype(W,entry))

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -1,50 +1,279 @@
 /obj/item/device/camera_bug
 	name = "camera bug"
+	desc = "For illicit snooping through the camera network."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "mindflash2"
 	w_class = 1.0
 	item_state = "electronic"
 	throw_speed = 4
 	throw_range = 20
-	var/obj/machinery/camera/current
+	var/obj/machinery/camera/current = null
+	var/list/bugged_cameras = list()
+	var/skip_bugcheck = 0
+
+/obj/item/device/camera_bug/proc/get_cameras()
+	return bugged_cameras
+
+/obj/item/device/camera_bug/proc/format_list(var/list/cameras)
+	if(!cameras || !cameras.len)
+		usr << "No bugged cameras found."
+		usr << browse(null,"window=camerabug")
+		return
+	var/html = "<h3>Select a camera:</h3><hr>"
+	for(var/entry in cameras)
+		var/obj/machinery/camera/C = cameras[entry]
+		html += "<a href='?src=\ref[src];view=\ref[C]'>[entry]</a><br>"
+	return html
 
 /obj/item/device/camera_bug/attack_self(mob/user as mob)
-	var/list/friendly_cameras = new/list()
-	var/turf/T = get_turf(loc)
-	for (var/obj/machinery/camera/C in cameranet.cameras)
-		if (C.bugged && C.status && C.z == T.z)
-			friendly_cameras[C.c_tag] = C
-	if (friendly_cameras.len == 0)
-		user << "\red No bugged functioning cameras found."
-		return
+	interact()
 
-	var/target = "Cancel"
-	while(target)
-		target = input("Select the camera to observe", "Cancel") as null|anything in friendly_cameras + "Cancel"
-		var/obj/machinery/camera/C = friendly_cameras[target]
-		if ( !C || loc != user || user.stat || user.blinded || !user.canmove )
-			user.unset_machine()
-			user.reset_view(null)
-			return
+/obj/item/device/camera_bug/interact()
+	var/datum/browser/popup = new(usr, "camerabug","Camera Bug",nref=src)
+	popup.set_content(format_list(get_cameras()))
+	popup.open()
 
-		T = get_turf(loc)
-		if(T.z != C.z)
-			user << "\red You've lost the signal."
-			current = null
-			user.reset_view(null)
-			attack_self(user)
-			return
-
-		if( !C.can_use() )
-			user << "\red Something's wrong with that camera.  You can't get a feed."
-		else
-
+/obj/item/device/camera_bug/Topic(var/href,var/list/href_list)
+	if("close" in href_list)
+		usr.reset_view(null)
+		usr.unset_machine()
+		return // I do not
+	if("view" in href_list)
+		var/obj/machinery/camera/C = locate(href_list["view"])
+		if(istype(C))
+			if(!C.can_use())
+				usr << "\red Something's wrong with that camera.  You can't get a feed."
+				return
+			var/turf/T = get_turf(loc)
+			if(!T || C.z != T.z)
+				usr << "\red You can't get a signal."
+				return
 			current = C
-			user.set_machine(src)
-			user.reset_view(C)
+			if(src.check_eye(usr))
+				usr.set_machine(src)
+				usr.reset_view(C)
+			else
+				usr.unset_machine()
+				usr.reset_view(null)
 
+	interact()
 
 /obj/item/device/camera_bug/check_eye(var/mob/user as mob)
 	if (user.stat || loc != user || !user.canmove || user.blinded || !current || !current.can_use())
+		user.reset_view(null)
+		user.unset_machine()
 		return null
+
+	var/turf/T = get_turf(user.loc)
+	if(T.z != current.z || (!skip_bugcheck && current.bug != src))
+		user << "You've lost the signal."
+		current = null
+		user.reset_view(null)
+		user.unset_machine()
+		return null
+
 	return 1
+
+/obj/item/device/camera_bug/universal
+	desc = "For illicit snooping through the camera network.  Has multiple micro-antennae."
+	skip_bugcheck = 1
+	var/last_update = 0
+
+/obj/item/device/camera_bug/universal/get_cameras()
+	bugged_cameras = list()
+	for(var/obj/machinery/camera/C in cameranet.cameras)
+		if(C.bug)
+			bugged_cameras[C.c_tag] = C
+	return bugged_cameras
+
+/obj/item/device/camera_bug/sabotage
+	desc = "For illicit snooping through the camera network.  Has a suspicious button on the side."
+/obj/item/device/camera_bug/sabotage/format_list(var/list/cameras)
+	if(!cameras || !cameras.len)
+		usr << "No bugged cameras found."
+		return
+	var/html = "<h3>Select a camera:</h3><hr>"
+	for(var/entry in cameras)
+		var/obj/machinery/camera/C = cameras[entry]
+		html += "<a href='?src=\ref[src];view=\ref[C]'>[entry]</a> <a href='?src=\ref[src];emp=\ref[C]'>\[Disable\]</a><br>"
+	return html
+/obj/item/device/camera_bug/sabotage/Topic(var/href,var/href_list)
+	if("emp" in href_list)
+		var/obj/machinery/camera/C = locate(href_list["emp"])
+		if(istype(C) && C.bug == src)
+			C.emp_act(1)
+			C.bug = null
+			bugged_cameras -= C.c_tag
+		interact()
+		return
+	..(href,href_list)
+
+
+/obj/item/device/camera_bug/networked
+	desc = "For illicit snooping through the camera network.  Has a single large antenna."
+	skip_bugcheck = 1
+	var/last_update = 0
+
+/obj/item/device/camera_bug/networked/get_cameras()
+	if(!bugged_cameras.len || (world.time > (last_update + 50)))
+		bugged_cameras = list()
+		for(var/obj/machinery/camera/C in cameranet.cameras)
+			if("SS13" in C.network)
+				bugged_cameras[C.c_tag] = C
+	return bugged_cameras
+
+
+/obj/item/device/camera_bug/tracker
+	desc = "For illicit snooping through the camera network.  Has an unusually large screen."
+	/*
+		Mode 0: No tracking - normal but with report button
+		Mode 1: Monitor one camera - reports
+		Mode 2: Track one target
+	*/
+	var/mode = 0
+	var/last_tracked = 0
+
+	var/refresh_interval = 100
+
+	var/tracked_name = null
+	var/atom/tracking = null
+
+	var/last_found = null
+	var/last_seen = null
+
+	var/tmp/list/seen_list = null
+
+/obj/item/device/camera_bug/tracker/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/item/device/camera_bug/tracker/format_list(var/list/cameras)
+	var/dat = ""
+	switch(mode)
+		if(0)
+			if(!cameras || !cameras.len)
+				usr << "No bugged cameras found."
+				return
+			var/html = "<h3>Select a camera:</h3><hr>"
+			for(var/entry in cameras)
+				var/obj/machinery/camera/C = cameras[entry]
+				html += "<a href='?src=\ref[src];view=\ref[C]'>[entry]</a> <a href='?src=\ref[src];monitor=\ref[C]'>\[Monitor\]</a><br>"
+			return html
+		if(1)
+			if(current)
+				dat = "Analyzing Camera '[current.c_tag]' <a href='?\ref[src];mode=0'>\[Select Camera\]</a><br>"
+				dat += camera_report()
+			else
+				dat = "No camera selected. <a href='?\ref[src];mode=0'>\[Select Camera\]</a><br>"
+		if(2)
+			if(tracking)
+				dat += "Tracking '[tracked_name]'  <a href='?\ref[src];mode=0'>\[Cancel Tracking\]</a><br>"
+				if(last_found)
+					var/time_diff = round((world.time - last_seen) / 600)
+					var/obj/machinery/camera/C = bugged_cameras[last_found]
+					var/outstring
+					if(C)
+						outstring = "<a href='?\ref[src];view=\ref[C]'>[last_found]</a>"
+					else
+						outstring = last_found
+					if(!time_diff)
+						dat += "Last seen near [outstring] (now)<br>"
+					else
+						dat += "Last seen near [outstring] ([time_diff] minute\s ago)<br>"
+				else
+					dat += "Not yet seen."
+			else
+				mode = 0
+				return .()
+	return dat
+
+/obj/item/device/camera_bug/tracker/proc/camera_report()
+	// this should only be called if current exists
+	var/dat = ""
+	if(current && current.can_use())
+		var/list/seen = current.can_see()
+		seen_list = seen
+		var/list/names = list()
+		for(var/obj/machinery/singularity/S in seen) // god help you if you see more than one
+			if(S.name in names)
+				names[S.name]++
+				dat += "[S.name] ([names[S.name]])"
+			else
+				names[S.name] = 1
+				dat += "[S.name]"
+			var/stage = round(S.current_size / 2)+1
+			dat += " (Stage [stage])"
+			dat += " <a href='?\ref[src];track=\ref[S]'>\[Track\]</a><br>"
+
+		for(var/obj/mecha/M in seen)
+			if(M.name in names)
+				names[M.name]++
+				dat += "[M.name] ([names[M.name]])"
+			else
+				names[M.name] = 1
+				dat += "[M.name]"
+			dat += " <a href='?\ref[src];track=\ref[M]'>\[Track\]</a><br>"
+
+
+		for(var/mob/living/M in seen)
+			if(M.name in names)
+				names[M.name]++
+				dat += "[M.name] ([names[M.name]])"
+			else
+				names[M.name] = 1
+				dat += "[M.name]"
+			if(M.buckled && !M.lying)
+				dat += " (Sitting)"
+			if(M.lying)
+				dat += " (Laying down)"
+			dat += " <a href='?\ref[src];track=\ref[M]'>\[Track\]</a><br>"
+		if(length(dat) == 0)
+			dat += "No motion detected."
+		return dat
+	else
+		return "Camera Offline<br>"
+
+/obj/item/device/camera_bug/tracker/process()
+	if(mode == 0 || (world.time < (last_tracked + refresh_interval)))
+		return
+	last_tracked = world.time
+	if(mode==2) // search for user
+		// Note that it will be tricked if your name appears to change.
+		// This is not optimal but it is better than tracking you relentlessly despite everything.
+		if(!tracking || tracking.name != tracked_name)
+			updateDialog()
+			return
+
+		var/list/tracking_cams = list()
+		var/list/b_cams = get_cameras()
+		for(var/entry in b_cams)
+			tracking_cams += b_cams[entry]
+		var/list/target_region = view(tracking)
+
+		for(var/obj/machinery/camera/C in (target_region & tracking_cams))
+			if(C.can_use())
+				last_found = C.c_tag
+				last_seen = world.time
+				updateUsrDialog()
+				return
+	updateDialog()
+
+/obj/item/device/camera_bug/tracker/Topic(var/href,var/list/href_list)
+	if("mode" in href_list)
+		mode = text2num(href_list["mode"])
+	if("monitor" in href_list)
+		var/obj/machinery/camera/C = locate(href_list["monitor"])
+		if(C)
+			current = C
+			usr.reset_view(null)
+			mode = 1
+			interact()
+	if("track" in href_list)
+		var/atom/A = locate(href_list["track"])
+		if(A)
+			tracking = A
+			tracked_name = A.name
+			last_found = current.c_tag
+			last_seen = world.time
+			mode = 2
+	..(href,href_list)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -425,6 +425,7 @@
 #include "code\game\objects\items\toys.dm"
 #include "code\game\objects\items\trash.dm"
 #include "code\game\objects\items\devices\aicard.dm"
+#include "code\game\objects\items\devices\camera_bug.dm"
 #include "code\game\objects\items\devices\chameleonproj.dm"
 #include "code\game\objects\items\devices\flash.dm"
 #include "code\game\objects\items\devices\flashlight.dm"


### PR DESCRIPTION
Camera bug acts as a mini-camera computer with access to all bugged cameras; it now works correctly and is no longer split into two items.

Adjusts camera checks to determine who is looking through them; instead of checking their machine, it now checks the client eye.

Adds camera bug to the uplink list with a cost of 2TC.
