### PR TITLE
Telecomms references manifest for crew's job

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -246,9 +246,23 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 
 		var/jobname // the mob's "job"
 
-		// --- Human: use their actual job ---
+
+		// --- Human: use their job as seen on the crew manifest - makes it unneeded to carry an ID for an AI to see their job
 		if (ishuman(M))
-			jobname = M:get_assignment()
+			var/voice = M.GetVoice() // Why reinvent the wheel when there is a proc that does nice things already
+			var/datum/data/record/findjob
+			for (var/datum/data/record/t in data_core.general)
+				if(t.fields["name"] == voice)
+					findjob = t
+					break
+
+			if(voice != real_name)
+				displayname = voice
+				voicemask = 1
+			if(findjob)
+				jobname = findjob.fields["rank"]
+			else
+				jobname = "Unknown"
 
 		// --- Carbon Nonhuman ---
 		else if (iscarbon(M)) // Nonhuman carbon mob
@@ -269,15 +283,6 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 		// --- Unidentifiable mob ---
 		else
 			jobname = "Unknown"
-
-
-		// --- Modifications to the mob's identity ---
-
-		// The mob is disguising their identity:
-		if (ishuman(M) && M.GetVoice() != real_name)
-			displayname = M.GetVoice()
-			jobname = "Unknown"
-			voicemask = 1
 
 
 


### PR DESCRIPTION
Changes the way telecomms identifies the job of the sender of a radio message. It now references the crew manifest with the voice\* of the sender for their job, instead of looking at whatever ID they are holding for their job.

This should make it a little easier for traitors or lings to impersonate someone else and not get caught by the AI. 
