### PR TITLE
Bot intelligence

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -178,8 +178,7 @@
 // Returns true if a link between A and B is blocked
 // Movement through doors allowed if ID has access
 /proc/LinkBlockedWithAccess(turf/A, turf/B, obj/item/weapon/card/id/ID)
-
-	if (A == null || B == null) return 1
+	if (!A || !B) return 1
 	if (get_dist(A,B) > 1) return 1
 
 	for (var/obj/O in B)
@@ -201,20 +200,20 @@
 
 		//windows
 		if (istype(D, /obj/machinery/door/window))
-			if(dir && D.dir)
-				passable = !D.check_access(ID)
+			if((dir & D.dir) && !D.check_access(ID))
+				return 1
 		//doors
 		else
 			if (D.stat && D.density)	//door is broken and shut, so the bot can't open it
 				return 1
 			else if (istype(D, /obj/machinery/door/airlock))
 				var/obj/machinery/door/airlock/A = D
-				if (A.locked || A.welded)
+				if (A.locked || A.welded || !A.check_access(ID))
 					return 1			//bots can't open bolted/welded airlocks
 				else passable = D.check_access(ID)
-			else if (istype(D, /obj/machinery/door/firedoor))
-				if(dir && D.dir)
-					passable = !D.density	//bots can't open closed firedoors. Doesn't matter if they're welded.
-			else if (istype(D, /obj/machinery/door/poddoor)) //blast door in-game
-				passable = !D.density
-	return passable
+			else if (istype(D, /obj/machinery/door/firedoor) && D.density)
+				if (!(istype(D, /obj/machinery/door/firedoor/border_only) && !(dir & D.dir)))
+					return 1	//bots can't open closed firedoors. Doesn't matter if they're welded.
+			else if (istype(D, /obj/machinery/door/poddoor) && D.density) //blast door in-game
+				return 1
+	return 0


### PR DESCRIPTION
Bots are dumb! When a bot tries to go somewhere, here's a (partial?) list of things they think are passable:
- closed doors with no power
- welded doors
- bolted doors
- doors they're not allowed to go through
- closed firedoors
- closed blastdoors

This change lets the stupid bot know those aren't worth trying. No more beepsky swinging back and forth across two broken doors! Less mulebots vanishing into the ether! Etc!

On the other hand... seeing as how often doors fail this means bots might start spending a lot more time in maintenance corridors, which has potential downsides (mulebots getting in the way is the first one that came to mind, or bots wasting time hiding in remote places instead of having fun). And obviously they won't know about doors that break mid-journey, though they'll go around fine once they hit them. I'd prefer to just have bots lose maintenance access if that kind of thing is a problem but I'm not going to fight terribly hard for this commit if the change isn't worth it.

Since disease also uses the A-star proc, this also means that firedoors and blastdoors will stop the spread of sickness. Doors with ID requirements already did, and working doors without ID requirements are still 'porous', but that can be changed if people want - plus chances are people anywhere near those would get sick anyway.

No graphs this time, sorry!
