### PR TITLE
Logs who RNG picks for antags

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -67,6 +67,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/game_mode/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)
+		log_game("[changeling.key] (ckey) has been selected as a changeling")
 		changeling.current.make_changeling()
 		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -61,12 +61,14 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			possible_changelings -= changeling
 			changelings += changeling
 			modePlayer += changelings
+
 		return 1
 	else
 		return 0
 
 /datum/game_mode/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)
+		log_game("[changeling.key] (ckey) has been selected as a changeling")
 		changeling.current.make_changeling()
 		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -74,6 +74,7 @@
 		var/datum/mind/cultist = pick(cultists_possible)
 		cultists_possible -= cultist
 		cult += cultist
+		log_game("[cultist.key] (ckey) has been selected as a cultist")
 
 	return (cult.len>0)
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -31,6 +31,7 @@
 	for(var/mob/new_player/player in player_list)
 		if(player.mind && player.mind.assigned_role == "AI")
 			malf_ai+=player.mind
+			log_game("[malf_ai.key] (ckey) has been selected as a malf AI")
 	if(malf_ai.len)
 		return 1
 	return 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -54,6 +54,7 @@
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = "MODE" //So they aren't chosen for other jobs.
 		synd_mind.special_role = "Syndicate"//So they actually have a special role/N
+		log_game("[synd_mind.key] (ckey) has been selected as a nuclear operative")
 	return 1
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -63,6 +63,7 @@
 		var/datum/mind/lenin = pick(possible_headrevs)
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
+		log_game("[lenin.key] (ckey) has been selected as a head rev")
 
 	if((head_revolutionaries.len==0)||(!head_check))
 		return 0

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -56,7 +56,9 @@
 		var/datum/mind/traitor = pick(possible_traitors)
 		traitors += traitor
 		traitor.special_role = "traitor"
+		log_game("[traitor.key] (ckey) has been selected as a traitor")
 		possible_traitors.Remove(traitor)
+
 
 	if(!traitors.len)
 		return 0

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -49,6 +49,7 @@
 
 /datum/game_mode/wizard/post_setup()
 	for(var/datum/mind/wizard in wizards)
+		log_game("[wizard.key] (ckey) has been selected as a Wizard")
 		forge_wizard_objectives(wizard)
 		//learn_basic_spells(wizard.current)
 		equip_wizard(wizard.current)


### PR DESCRIPTION
Adds a log to the server log for who is picked to be antags at round start.

Useful for admins who have to investigate stuff from prior rounds.

Please review that I did this in an effective manner.
