### PR TITLE
temperature gun fix

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -109,6 +109,5 @@
 	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
 	icon_state = "yellow slime extract" //"potato_battery"
 	maxcharge = 10000
-	maxcharge = 10000
 	m_amt = 0
 	g_amt = 0

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -9,7 +9,7 @@
 	origin_tech = "combat=3;materials=4;powerstorage=3;magnets=2"
 
 	projectile_type = "/obj/item/projectile/temp"
-	cell_type = "/obj/item/weapon/cell/crap"
+	cell_type = "/obj/item/weapon/cell/high"
 
 
 	New()


### PR DESCRIPTION
gives temperature guns a high capacity cell. fixes #265
the reason for this is that temperature guns are powerstorage 3, so i gave them a powerstorage 2 cell

removes a duplicated line in power_cells.dm
