### PR TITLE
Moves var/sleeping from /mob to /mob/living/carbon.

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -21,16 +21,29 @@
 #define ui_storage1 "9:18,1:5"
 #define ui_storage2 "10:20,1:5"
 
-#define ui_inv1 "6:16,1:5"			//borgs
-#define ui_inv2 "7:16,1:5"			//borgs
-#define ui_inv3 "8:16,1:5"			//borgs
-#define ui_borg_store "9:16,1:5"	//borgs
 
-#define ui_monkey_mask "5:14,1:5"	//monkey
-#define ui_monkey_back "6:15,1:5"	//monkey
+//cyborgs
+#define ui_inv1 "6:16,1:5"
+#define ui_inv2 "7:16,1:5"
+#define ui_inv3 "8:16,1:5"
+#define ui_borg_store "9:16,1:5"
+#define ui_borg_cell "14:28,8:13"	//just above health
+#define ui_borg_health "14:28,6:13"
+#define ui_borg_pull "12:24,2:7"
+#define ui_borg_module "13:26,2:7"
+#define ui_borg_panel "14:28,2:7"
 
+//monkey
+#define ui_monkey_mask "5:14,1:5"
+#define ui_monkey_back "6:15,1:5"
+
+//aliens
 #define ui_alien_storage_l "6:14,1:5"
 #define ui_alien_storage_r "9:18,1:5"
+#define ui_alien_toxin "14:28,13:25"
+#define ui_alien_fire "14:28,12:25"
+#define ui_alien_oxygen "14:28,11:25"
+
 
 //Lower right, persistant menu
 #define ui_drop_throw "14:28,2:7"
@@ -40,9 +53,6 @@
 #define ui_zonesel "14:28,1:5"
 #define ui_acti_alt "14:28,1:5"	//alternative intent switcher for when the interface is hidden (F12)
 
-#define ui_borg_pull "12:24,2:7"
-#define ui_borg_module "13:26,2:7"
-#define ui_borg_panel "14:28,2:7"
 
 //Upper-middle right (damage indicators)
 #define ui_toxin "14:28,13:27"
@@ -50,18 +60,13 @@
 #define ui_oxygen "14:28,11:23"
 #define ui_pressure "14:28,10:21"
 
-#define ui_alien_toxin "14:28,13:25"
-#define ui_alien_fire "14:28,12:25"
-#define ui_alien_oxygen "14:28,11:25"
 
 //Middle right (status indicators)
 #define ui_nutrition "14:28,5:11"
 #define ui_temp "14:28,6:13"
 #define ui_health "14:28,7:15"
 #define ui_internal "14:28,8:17"
-										//borgs
-#define ui_borg_health "14:28,6:13"		//borgs have the health display where humans have the pressure damage indicator.
-#define ui_alien_health "14:28,6:13"	//aliens have the health display where humans have the pressure damage indicator.
+#define ui_alien_health "14:28,6:13"
 
 //Pop-up inventory
 #define ui_shoes "2:8,1:5"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -187,7 +187,7 @@
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise
 		occupant.stat = 1
 		if(occupant.bodytemperature < T0C)
-			occupant.sleeping = max(5, (1 / occupant.bodytemperature)*2000)
+			occupant.SetSleeping(max(5, (1 / occupant.bodytemperature)*2000))
 			occupant.Paralyse(max(5, (1 / occupant.bodytemperature)*3000))
 			if(air_contents.oxygen > 2)
 				if(occupant.getOxyLoss()) occupant.adjustOxyLoss(-1)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -125,7 +125,7 @@
 				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
 					continue
 			M << "<font color='red' size='7'>HONK</font>"
-			M.sleeping = 0
+			M.SetSleeping(0)
 			M.stuttering += 20
 			M.ear_deaf += 30
 			M.Weaken(3)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -586,7 +586,7 @@ steam.start() -- spawns the effect
 //		if (M.wear_suit, /obj/item/clothing/suit/wizrobe && (M.hat, /obj/item/clothing/head/wizard) && (M.shoes, /obj/item/clothing/shoes/sandal))  // I'll work on it later
 		else
 			M.drop_item()
-			M:sleeping += 1
+			M.AdjustSleeping(1)
 			if (M.coughedtime != 1)
 				M.coughedtime = 1
 				M.emote("cough")
@@ -602,7 +602,7 @@ steam.start() -- spawns the effect
 			return
 		else
 			M.drop_item()
-			M:sleeping += 1
+			M.AdjustSleeping(1)
 			if (M.coughedtime != 1)
 				M.coughedtime = 1
 				M.emote("cough")

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -166,12 +166,12 @@ mob/living/carbon/proc/handle_hallucinations()
 			if(71 to 72)
 				//Fake death
 //				src.sleeping_willingly = 1
-				src.sleeping = 20
+				SetSleeping(20)
 				hal_crit = 1
 				hal_screwyhud = 1
 				spawn(rand(50,100))
 //					src.sleeping_willingly = 0
-					src.sleeping = 0
+					SetSleeping(0)
 					hal_crit = 0
 					hal_screwyhud = 0
 	handling_hal = 0

--- a/code/modules/mob/living/blob/blob.dm
+++ b/code/modules/mob/living/blob/blob.dm
@@ -39,7 +39,6 @@
 		AdjustStunned(0)
 		AdjustParalysis(0)
 		AdjustWeakened(0)
-		sleeping = 0
 		if(stat)
 			stat = CONSCIOUS
 		return

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -348,7 +348,7 @@ In all, this is a lot like the monkey code. /N
 	switch(M.a_intent)
 
 		if ("help")
-			sleeping = max(0,sleeping-5)
+			AdjustSleeping(-5)
 			resting = 0
 			AdjustParalysis(-3)
 			AdjustStunned(-3)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -280,7 +280,7 @@
 			drowsyness--
 			eye_blurry = max(2, eye_blurry)
 			if (prob(5))
-				sleeping += 1
+				AdjustSleeping(1)
 				Paralyse(5)
 
 		confused = max(0, confused - 1)
@@ -325,7 +325,7 @@
 				blinded = 1
 				stat = UNCONSCIOUS
 			else if(sleeping)
-				sleeping = max(sleeping-1, 0)
+				AdjustSleeping(-1)
 				blinded = 1
 				stat = UNCONSCIOUS
 				if( prob(10) && health )

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -294,7 +294,7 @@
 	switch(M.a_intent)
 
 		if ("help")
-			sleeping = max(0,sleeping-5)
+			AdjustSleeping(-5)
 			resting = 0
 			AdjustParalysis(-3)
 			AdjustStunned(-3)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -199,7 +199,7 @@
 			drowsyness--
 			eye_blurry = max(2, eye_blurry)
 			if (prob(5))
-				sleeping += 1
+				AdjustSleeping(1)
 				Paralyse(5)
 
 		confused = max(0, confused - 1)
@@ -242,7 +242,7 @@
 				blinded = 1
 				stat = UNCONSCIOUS
 			else if(sleeping)
-				sleeping = max(sleeping-1, 0)
+				AdjustSleeping(-1)
 				blinded = 1
 				stat = UNCONSCIOUS
 				if( prob(10) && health )

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -185,8 +185,8 @@
 					H.w_uniform.add_fingerprint(M)
 
 			if(lying)
-				sleeping = max(0, sleeping - 5)
-				if(sleeping == 0)
+				AdjustSleeping(-5)
+				if(sleeping <= 0)
 					resting = 0
 				M.visible_message("<span class='notice'>[M] shakes [src] trying to get \him up!</span>", \
 								"<span class='notice'>You shake [src] trying to get \him up!</span>")
@@ -531,3 +531,27 @@
 		return
 
 	..(message)
+
+
+/mob/living/carbon/Sleeping(amount)
+	sleeping = max(max(sleeping,amount),0)
+	return
+
+/mob/living/carbon/SetSleeping(amount)
+	sleeping = max(amount,0)
+	return
+
+/mob/living/carbon/AdjustSleeping(amount)
+	sleeping = max(sleeping + amount,0)
+	return
+
+
+/mob/living/carbon/verb/mob_sleep()
+	set name = "Sleep"
+	set category = "IC"
+
+	if(sleeping)
+		src << "<span class='notice'>You are already sleeping.</span>"
+	else
+		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
+			AdjustSleeping(20)	//Short nap

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -14,5 +14,7 @@
 	var/obj/item/back = null
 	var/obj/item/clothing/mask/wear_mask = null
 	var/obj/item/weapon/tank/internal = null
-	
-	var/datum/dna/dna = null//Carbon
+
+	var/datum/dna/dna = null
+
+	var/sleeping = 0

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -179,9 +179,9 @@
 
 		if ("faint")
 			message = "<B>[src]</B> faints."
-			if(src.sleeping)
-				return //Can't faint while asleep
-			src.sleeping += 10 //Short-short nap
+			if(sleeping)
+				return			//Can't faint while asleep
+			AdjustSleeping(10)	//Short-short nap
 			m_type = 1
 
 		if ("cough")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -398,7 +398,7 @@
 				if(SA_pp > SA_para_min) // Enough to make us paralysed for a bit
 					Paralyse(3) // 3 gives them one second to wake up and run away a bit!
 					if(SA_pp > SA_sleep_min) // Enough to make us sleep as well
-						sleeping = max(sleeping+2, 10)
+						SetSleeping(max(sleeping + 2, 10))
 				else if(SA_pp > 0.01)	// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
 					if(prob(20))
 						spawn(0) emote(pick("giggle", "laugh"))
@@ -784,7 +784,7 @@
 			drowsyness--
 			eye_blurry = max(2, eye_blurry)
 			if (prob(5))
-				sleeping += 1
+				AdjustSleeping(1)
 				Paralyse(5)
 
 		confused = max(0, confused - 1)
@@ -855,7 +855,7 @@
 			else if(sleeping)
 				handle_dreams()
 				adjustHalLoss(-5)
-				sleeping = max(sleeping-1, 0)
+				AdjustSleeping(-1)
 				blinded = 1
 				stat = UNCONSCIOUS
 				if( prob(10) && health && !hal_crit )

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -301,7 +301,7 @@
 				if(SA_pp > SA_para_min) // Enough to make us paralysed for a bit
 					Paralyse(3) // 3 gives them one second to wake up and run away a bit!
 					if(SA_pp > SA_sleep_min) // Enough to make us sleep as well
-						sleeping = max(sleeping+2, 10)
+						SetSleeping(max(sleeping + 2, 10))
 				else if(SA_pp > 0.01)	// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
 					if(prob(20))
 						spawn(0) emote(pick("giggle", "laugh"))
@@ -377,7 +377,7 @@
 			drowsyness--
 			eye_blurry = max(2, eye_blurry)
 			if (prob(5))
-				sleeping += 1
+				AdjustSleeping(1)
 				Paralyse(5)
 
 		confused = max(0, confused - 1)
@@ -419,7 +419,7 @@
 				blinded = 1
 				stat = UNCONSCIOUS
 			else if(sleeping)
-				sleeping = max(sleeping-1, 0)
+				AdjustSleeping(-1)
 				blinded = 1
 				stat = UNCONSCIOUS
 				if( prob(10) && health )

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,38 +1,43 @@
 /mob/living/silicon/robot/examine()
 	set src in oview()
 
-	if(!usr || !src)	return
-	if( (usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr,/mob/dead/observer) )
+	if(!usr || !src)
+		return
+	if((usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr, /mob/dead/observer))
 		usr << "<span class='notice'>Something is there but you can't see it.</span>"
 		return
 
-	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
+	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!<br>"
 	msg += "<span class='warning'>"
-	if (src.getBruteLoss())
-		if (src.getBruteLoss() < 60)
-			msg += "It looks slightly dented.\n"
+	if(getBruteLoss())
+		if(getBruteLoss() < 60)
+			msg += "It looks slightly dented.<br>"
 		else
-			msg += "<B>It looks severely dented!</B>\n"
-	if (src.getFireLoss())
-		if (src.getFireLoss() < 60)
-			msg += "It looks slightly charred.\n"
+			msg += "<B>It looks severely dented!</B><br>"
+	if(getFireLoss())
+		if (getFireLoss() < 60)
+			msg += "It looks slightly charred.<br>"
 		else
-			msg += "<B>It looks severely burnt and heat-warped!</B>\n"
-	if (src.health < -50)
-		msg += "It looks barely operational.\n"
+			msg += "<B>It looks severely burnt and heat-warped!</B><br>"
+	if(health < -50)
+		msg += "It looks barely operational.<br>"
 	msg += "</span>"
 
 	if(opened)
-		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
+		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span><br>"
 	else
-		msg += "Its cover is closed.\n"
+		msg += "Its cover is closed.<br>"
 
-	switch(src.stat)
+	switch(stat)
 		if(CONSCIOUS)
-			if(!src.client)	msg += "It appears to be in stand-by mode.\n" //afk
-		if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
-		if(DEAD)			msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>\n"
+			if(!client)
+				msg += "Its cognitive circuits do not appear to be functioning.<br>"
+			else if(resting)
+				msg += "It appears to be in standby mode.<br>"
+		if(UNCONSCIOUS)
+			msg += "<span class='warning'>It doesn't seem to be responding.</span><br>"
+		if(DEAD)
+			msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span><br>"
 	msg += "*---------*</span>"
 
 	usr << msg
-	return

--- a/code/modules/mob/living/silicon/robot/hud.dm
+++ b/code/modules/mob/living/silicon/robot/hud.dm
@@ -60,7 +60,7 @@
 	mymob:cells.icon = 'icons/mob/screen_cyborg.dmi'
 	mymob:cells.icon_state = "charge-empty"
 	mymob:cells.name = "cell"
-	mymob:cells.screen_loc = ui_toxin
+	mymob:cells.screen_loc = ui_borg_cell
 
 //Health
 	mymob.healths = new /obj/screen()
@@ -99,18 +99,6 @@
 	mymob.bodytemp.screen_loc = ui_temp
 
 
-	mymob.oxygen = new /obj/screen()
-	mymob.oxygen.icon = 'icons/mob/screen_cyborg.dmi'
-	mymob.oxygen.icon_state = "oxy0"
-	mymob.oxygen.name = "oxygen"
-	mymob.oxygen.screen_loc = ui_oxygen
-
-	mymob.fire = new /obj/screen()
-	mymob.fire.icon = 'icons/mob/screen_cyborg.dmi'
-	mymob.fire.icon_state = "fire0"
-	mymob.fire.name = "fire"
-	mymob.fire.screen_loc = ui_fire
-
 	mymob.pullin = new /obj/screen()
 	mymob.pullin.icon = 'icons/mob/screen_cyborg.dmi'
 	mymob.pullin.icon_state = "pull0"
@@ -137,7 +125,7 @@
 
 	mymob.client.screen = null
 
-	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.fire, mymob.hands, mymob.healths, mymob:cells, mymob.pullin, mymob.blind, mymob.flash) //, mymob.rest, mymob.sleep, mymob.mach )
+	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.hands, mymob.healths, mymob:cells, mymob.pullin, mymob.blind, mymob.flash)
 	mymob.client.screen += adding + other
 
 	return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -48,8 +48,6 @@
 
 	var/killswitch = 0
 	var/killswitch_time = 60
-	var/weapon_lock = 0
-	var/weaponlock_time = 120
 	var/lawupdate = 1 //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //Boolean of whether the borg is locked down or not
 	var/speed = 0 //Cause sec borgs gotta go fast //No they dont!
@@ -765,10 +763,10 @@
 			return 0
 	return 1
 
-/mob/living/silicon/robot/proc/updateicon()
 
+/mob/living/silicon/robot/proc/updateicon()
 	overlays.Cut()
-	if(stat == 0)
+	if(stat == CONSCIOUS && !resting)
 		overlays += "eyes"
 		if(icon_state == "robot")
 			overlays.Cut()
@@ -798,15 +796,9 @@
 			overlays += "ov-openpanel +c"
 		else
 			overlays += "ov-openpanel -c"
-	return
-
 
 
 /mob/living/silicon/robot/proc/installed_modules()
-	if(weapon_lock)
-		src << "\red Weapon lock active, unable to use modules! Count:[weaponlock_time]"
-		return
-
 	if(!module)
 		pick_module()
 		return
@@ -1005,3 +997,13 @@
 	set name = "State Laws"
 
 	checklaws()
+
+
+/mob/living/silicon/robot/lay_down()
+	set name = "Rest"
+	set category = "IC"
+
+	resting = !resting
+	var/txt = resting ? "going into standby mode" : "waking up from standby mode"
+	visible_message("<span class='notice'>[src] is [txt].</span>", "<span class='notice'>You are now [txt].</span>")
+	updateicon()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -54,7 +54,7 @@ var/next_mob_id = 0
 				if ((type & 1 && sdisabilities & BLIND))
 					return
 	// Added voice muffling for Issue 41.
-	if(stat == UNCONSCIOUS || sleeping > 0)
+	if(stat == UNCONSCIOUS)
 		src << "<I>... You can almost hear someone talking ...</I>"
 	else
 		src << msg
@@ -685,7 +685,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 			lying = 0
 		else
 			lying = 1
-	else if( stat || weakened || paralysis || resting || sleeping || (status_flags & FAKEDEATH) )
+	else if( stat || weakened || paralysis || resting || (status_flags & FAKEDEATH) )
 		lying = 1
 		canmove = 0
 	else if( stunned )
@@ -799,15 +799,12 @@ note dizziness decrements automatically in the mob's Life() proc.
 	return
 
 /mob/proc/Sleeping(amount)
-	sleeping = max(max(sleeping,amount),0)
 	return
 
 /mob/proc/SetSleeping(amount)
-	sleeping = max(amount,0)
 	return
 
 /mob/proc/AdjustSleeping(amount)
-	sleeping = max(sleeping + amount,0)
 	return
 
 /mob/proc/Resting(amount)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -62,8 +62,7 @@
 	var/confused = 0		//Carbon
 	var/antitoxs = null
 	var/plasma = null
-	var/sleeping = 0		//Carbon
-	var/resting = 0			//Carbon
+	var/resting = 0
 	var/lying = 0
 	var/lying_prev = 0
 	var/canmove = 1

--- a/code/modules/mob/screen.dm
+++ b/code/modules/mob/screen.dm
@@ -415,18 +415,6 @@
 	return attack_hand(user)
 
 
-/mob/living/verb/mob_sleep()
-	set name = "Sleep"
-	set category = "IC"
-
-	if(usr.sleeping)
-		usr << "<span class='notice'>You are already sleeping.</span>"
-		return
-	else
-		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
-			usr.sleeping = 20 //Short nap
-
-
 /mob/living/verb/lay_down()
 	set name = "Rest"
 	set category = "IC"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -378,7 +378,7 @@ datum
 					if(15 to 25)
 						M.drowsyness  = max(M.drowsyness, 20)
 					if(25 to INFINITY)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 						M.adjustOxyLoss(-M.getOxyLoss())
 						M.SetWeakened(0)
 						M.SetStunned(0)
@@ -1019,7 +1019,7 @@ datum
 				M.drowsyness = 0
 				M.stuttering = 0
 				M.confused = 0
-				M.sleeping = 0
+				M.SetSleeping(0)
 				M.jitteriness = 0
 				for(var/datum/disease/D in M.viruses)
 					D.spread = "Remissive"
@@ -1404,7 +1404,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				M.adjustOxyLoss(3*REM)
-				M.sleeping += 1
+				M.AdjustSleeping(1)
 				..()
 				return
 
@@ -1542,9 +1542,9 @@ datum
 						M.confused += 2
 						M.drowsyness += 2
 					if(10 to 50)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 					if(51 to INFINITY)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 						M.adjustToxLoss((data - 50)*REM)
 				holder.remove_reagent(src.id, 0.5 * REAGENTS_METABOLISM)
 				..()
@@ -1562,9 +1562,9 @@ datum
 				if(!data) data = 1
 				switch(data)
 					if(1 to 50)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 					if(51 to INFINITY)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 						M.adjustToxLoss(data - 50)
 				data++
 				..()
@@ -2313,7 +2313,7 @@ datum
 				..()
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = max(0,M.sleeping - 2)
+				M.AdjustSleeping(-2)
 				if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = min(310, M.bodytemperature + (25 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)
@@ -2334,7 +2334,7 @@ datum
 				M.dizziness = max(0,M.dizziness-2)
 				M.drowsyness = max(0,M.drowsyness-1)
 				M.jitteriness = max(0,M.jitteriness-3)
-				M.sleeping = max(0,M.sleeping-1)
+				M.AdjustSleeping(-1)
 				if(M.getToxLoss() && prob(20))
 					M.adjustToxLoss(-1)
 				if (M.bodytemperature < 310)  //310 is the normal bodytemp. 310.055
@@ -2353,7 +2353,7 @@ datum
 				..()
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)
@@ -2371,7 +2371,7 @@ datum
 				..()
 				M.dizziness = max(0,M.dizziness-2)
 				M.drowsyness = max(0,M.drowsyness-1)
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				if(M.getToxLoss() && prob(20))
 					M.adjustToxLoss(-1)
 				if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
@@ -2405,7 +2405,7 @@ datum
 				M.druggy = max(M.druggy, 30)
 				M.dizziness +=5
 				M.drowsyness = 0
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.nutrition += 1
@@ -2421,7 +2421,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				M.drowsyness = max(0,M.drowsyness-7)
-				M.sleeping = max(0,M.sleeping-1)
+				M.AdjustSleeping(-1)
 				if (M.bodytemperature > 310)
 					M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)
@@ -2497,7 +2497,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				if (M.bodytemperature > 310)
 					M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				..()
@@ -2527,7 +2527,7 @@ datum
 				..()
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = 0
+				M.SetSleeping(0)
 				if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)
@@ -2547,7 +2547,7 @@ datum
 				..()
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = 0
+				M.SetSleeping(0)
 				if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 					M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)
@@ -2593,7 +2593,7 @@ datum
 				data++
 				switch(data)
 					if(51 to INFINITY)
-						M.sleeping += 1
+						M.AdjustSleeping(1)
 				..()
 				return
 
@@ -2730,7 +2730,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				M.dizziness = max(0,M.dizziness-5)
 				M.drowsyness = max(0,M.drowsyness-3)
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				M.make_jittery(5)
 				..()
 				return
@@ -2749,7 +2749,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				M.drowsyness = max(0,M.drowsyness-7)
-				M.sleeping = max(0,M.sleeping-2)
+				M.AdjustSleeping(-2)
 				if (M.bodytemperature > 310)
 					M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 				M.make_jittery(5)


### PR DESCRIPTION
Updates all cases where sleeping was directly set with the AdjustSleeping() and SetSleeping() procs.

Changed resting on cyborgs to put them in standby mode. Standby mode uses no power, but makes them immobile and blind.
Juggles around the cyborg UI a little bit, removing the non-functional oxygen and fire icons, and moving the cell charge indicator down a bit.

Standardises robot/life.dm, and removes process_locks() and associated vars, which date back to r2 and were unused.
