### PR TITLE
Improved eyecheck()

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -26,6 +26,9 @@
 	var/darkness_view = 0//Base human is 2
 	var/invisa_view = 0
 	var/emagged = 0
+	var/flash_protect = 0		//Mal: What level of bright light protection item has. 1 = Flashers, Flashes, & Flashbangs | 2 = Welding | -1 = OH GOD WELDING BURNT OUT MY RETINAS
+	var/tint = 0				//Mal: Sets the item's level of visual impairment tint, normally set to the same as flash_protect
+								//	   but seperated to allow items to protect but not impair vision, like space helmets
 
 /*
 SEE_SELF  // can see self, no matter what
@@ -60,7 +63,8 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/hats.dmi'
 	body_parts_covered = HEAD
 	slot_flags = SLOT_HEAD
-
+	var/flash_protect = 0
+	var/tint = 0
 
 //Mask
 /obj/item/clothing/mask
@@ -68,6 +72,8 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/masks.dmi'
 	body_parts_covered = HEAD
 	slot_flags = SLOT_MASK
+	var/flash_protect = 0
+	var/tint = 0
 
 //Shoes
 /obj/item/clothing/shoes
@@ -110,6 +116,7 @@ BLIND     // can't see anything
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	flash_protect = 2
 
 /obj/item/clothing/suit/space
 	name = "space suit"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -65,6 +65,8 @@
 	icon_state = "sun"
 	item_state = "sunglasses"
 	darkness_view = -1
+	flash_protect = 1
+	tint = 1
 
 /obj/item/clothing/glasses/welding
 	name = "welding goggles"
@@ -73,6 +75,8 @@
 	item_state = "welding-g"
 	action_button_name = "Toggle Welding Goggles"
 	var/up = 0
+	flash_protect = 2
+	tint = 2
 
 /obj/item/clothing/glasses/welding/attack_self()
 	toggle()
@@ -90,12 +94,16 @@
 			flags_inv |= HIDEEYES
 			icon_state = initial(icon_state)
 			usr << "You flip the [src] down to protect your eyes."
+			flash_protect = 2
+			tint = 2
 		else
 			src.up = !src.up
 			src.flags &= ~HEADCOVERSEYES
 			flags_inv &= ~HIDEEYES
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push the [src] up out of your face."
+			flash_protect = 0
+			tint = 0
 
 		usr.update_inv_glasses(0)
 
@@ -146,6 +154,7 @@
 	origin_tech = "magnets=3"
 	vision_flags = SEE_MOBS
 	invisa_view = 2
+	flash_protect = -1
 
 	emp_act(severity)
 		if(istype(src.loc, /mob/living/carbon/human))

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -112,7 +112,9 @@
 	desc = "Covers the eyes, preventing sight."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	vision_flags = BLIND
+//	vision_flags = BLIND	//handled in life.dm/handle_regular_hud_updates()
+	flash_protect = 2
+	tint = 3			// to make them blind
 
 /obj/item/clothing/glasses/sunglasses/big
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Larger than average enhanced shielding blocks many flashes."

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -20,6 +20,8 @@
 	m_amt = 3000
 	g_amt = 1000
 	var/up = 0
+	flash_protect = 2
+	tint = 2
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 	action_button_name = "Toggle Welding Helmet"
@@ -40,12 +42,16 @@
 			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = initial(icon_state)
 			usr << "You flip the [src] down to protect your eyes."
+			flash_protect = 2
+			tint = 2
 		else
 			src.up = !src.up
 			src.flags &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
 			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push the [src] up out of your face."
+			flash_protect = 0
+			tint = 0
 		usr.update_inv_head(0)	//so our mob-overlays update
 
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -9,51 +9,6 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 
-// **** Welding gas mask ****
-
-/obj/item/clothing/mask/gas/welding
-	name = "welding mask"
-	desc = "A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd."
-	icon_state = "death"
-	item_state = "death"
-	m_amt = 3000
-	g_amt = 1000
-	var/up = 0
-	flash_protect = 2
-	tint = 2
-	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-	action_button_name = "Toggle Welding Helmet"
-
-/obj/item/clothing/mask/gas/welding/attack_self()
-	toggle()
-
-
-/obj/item/clothing/mask/gas/welding/verb/toggle()
-	set category = "Object"
-	set name = "Adjust welding mask"
-	set src in usr
-
-	if(usr.canmove && !usr.stat && !usr.restrained())
-		if(src.up)
-			src.up = !src.up
-			src.flags |= (MASKCOVERSEYES)
-			flags_inv |= (HIDEEYES)
-		//	icon_state = initial(icon_state)
-			usr << "You flip the [src] down to protect your eyes."
-			flash_protect = 2
-			tint = 2
-		else
-			src.up = !src.up
-			src.flags &= ~(MASKCOVERSEYES)
-			flags_inv &= ~(HIDEEYES)
-		//	icon_state = "[initial(icon_state)]up"						// i hab only placeholder sprites oh noooess!!!
-			usr << "You push the [src] up out of your face."
-			flash_protect = 0
-			tint = 0
-		usr.update_inv_wear_mask(0)	//so our mob-overlays update
-
-// ********************************************************************
-
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor
 	name = "plague doctor mask"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -9,6 +9,51 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 
+// **** Welding gas mask ****
+
+/obj/item/clothing/mask/gas/welding
+	name = "welding mask"
+	desc = "A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd."
+	icon_state = "death"
+	item_state = "death"
+	m_amt = 3000
+	g_amt = 1000
+	var/up = 0
+	flash_protect = 2
+	tint = 2
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	action_button_name = "Toggle Welding Helmet"
+
+/obj/item/clothing/mask/gas/welding/attack_self()
+	toggle()
+
+
+/obj/item/clothing/mask/gas/welding/verb/toggle()
+	set category = "Object"
+	set name = "Adjust welding mask"
+	set src in usr
+
+	if(usr.canmove && !usr.stat && !usr.restrained())
+		if(src.up)
+			src.up = !src.up
+			src.flags |= (MASKCOVERSEYES)
+			flags_inv |= (HIDEEYES)
+		//	icon_state = initial(icon_state)
+			usr << "You flip the [src] down to protect your eyes."
+			flash_protect = 2
+			tint = 2
+		else
+			src.up = !src.up
+			src.flags &= ~(MASKCOVERSEYES)
+			flags_inv &= ~(HIDEEYES)
+		//	icon_state = "[initial(icon_state)]up"						// i hab only placeholder sprites oh noooess!!!
+			usr << "You push the [src] up out of your face."
+			flash_protect = 0
+			tint = 0
+		usr.update_inv_wear_mask(0)	//so our mob-overlays update
+
+// ********************************************************************
+
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor
 	name = "plague doctor mask"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -204,6 +204,9 @@
 /mob/living/carbon/proc/eyecheck()
 	return 0
 
+/mob/living/carbon/proc/tintcheck()
+	return 0
+
 // ++++ROCKDTBEN++++ MOB PROCS //END
 
 /mob/living/carbon/proc/handle_ventcrawl() // -- TLE -- Merged by Carn

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -544,21 +544,32 @@
 ///Returns a number between -1 to 2
 /mob/living/carbon/human/eyecheck()
 	var/number = 0
-	if(istype(src.head, /obj/item/clothing/head/welding))
-		if(!src.head:up)
-			number += 2
-	if(istype(src.head, /obj/item/clothing/head/helmet/space))
-		number += 2
-	if(istype(src.glasses, /obj/item/clothing/glasses/thermal))
-		number -= 1
-	if(istype(src.glasses, /obj/item/clothing/glasses/sunglasses))
-		number += 1
-	if(istype(src.glasses, /obj/item/clothing/glasses/welding))
-		var/obj/item/clothing/glasses/welding/W = src.glasses
-		if(!W.up)
-			number += 2
+	if(istype(src.head, /obj/item/clothing/head))			//are they wearing something on their head
+		var/obj/item/clothing/head/HFP = src.head			//if yes gets the flash protection value from that item
+		number += HFP.flash_protect
+	if(istype(src.glasses, /obj/item/clothing/glasses))		//glasses
+		var/obj/item/clothing/glasses/GFP = src.glasses
+		number += GFP.flash_protect
+	if(istype(src.wear_mask, /obj/item/clothing/mask))		//mask
+		var/obj/item/clothing/mask/MFP = src.wear_mask
+		number += MFP.flash_protect
 	return number
 
+///tintcheck()
+///Checks eye covering items for visually impairing tinting, such as welding masks
+///Checked in life.dm. 0 & 1 = no impairment, 2 = welding mask overlay, 3 = You can see jack, but you can't see shit.
+/mob/living/carbon/human/tintcheck()
+	var/tinted = 0
+	if(istype(src.head, /obj/item/clothing/head))
+		var/obj/item/clothing/head/HT = src.head
+		tinted += HT.tint
+	if(istype(src.glasses, /obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/GT = src.glasses
+		tinted += GT.tint
+	if(istype(src.wear_mask, /obj/item/clothing/mask))
+		var/obj/item/clothing/mask/MT = src.wear_mask
+		tinted += MT.tint
+	return tinted
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	return 1//Humans can use guns and such

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -21,6 +21,9 @@
 #define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
 #define COLD_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 120K point
 
+#define TINT_IMPAIR 2
+#define TINT_BLIND 3
+
 /mob/living/carbon/human
 	var/oxygen_alert = 0
 	var/toxins_alert = 0
@@ -28,6 +31,8 @@
 	var/pressure_alert = 0
 	var/prev_gender = null // Debug for plural genders
 	var/temperature_alert = 0
+	var/tinttotal = 0				// Total level of visualy impairing items
+
 
 
 /mob/living/carbon/human/Life()
@@ -45,6 +50,8 @@
 	//to find it.
 	blinded = null
 	fire_alert = 0 //Reset this here, because both breathe() and handle_environment() have a chance to set it.
+	tinttotal = tintcheck() //here as both hud updates and status updates call it
+
 
 	//TODO: seperate this out
 	var/datum/gas_mixture/environment = loc.return_air()
@@ -871,9 +878,9 @@
 			else if(eye_blind)			//blindness, heals slowly over time
 				eye_blind = max(eye_blind-1,0)
 				blinded = 1
-			else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold))	//resting your eyes with a blindfold heals blurry eyes faster
+			else if(tinttotal >= TINT_BLIND)		//covering your eyes heals blurry eyes faster
 				eye_blurry = max(eye_blurry-3, 0)
-				blinded = 1
+			//	blinded = 1				//now handled under /handle_regular_hud_updates()
 			else if(eye_blurry)	//blurry eyes heal slowly
 				eye_blurry = max(eye_blurry-1, 0)
 
@@ -1128,11 +1135,11 @@
 					if(260 to 280)			bodytemp.icon_state = "temp-3"
 					else					bodytemp.icon_state = "temp-4"
 
-			var/tint = tintcheck()				// Welding mask overlay check
-			if(tint >= 2 )
+//	This checks how much the mob's eyewear impairs their vision
+			if(tinttotal >= TINT_IMPAIR)
 				if(tinted_weldhelh)
-					if(tint >= 3)
-						blinded = 1				// You get the sudden urge to learn to play keyboard
+					if(tinttotal >= TINT_BLIND)
+						blinded = 1								// You get the sudden urge to learn to play keyboard
 						client.screen += global_hud.darkMask
 					else
 						client.screen += global_hud.darkMask

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -21,8 +21,8 @@
 #define COLD_GAS_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when the current breath's temperature passes the 200K point
 #define COLD_GAS_DAMAGE_LEVEL_3 3 //Amount of damage applied when the current breath's temperature passes the 120K point
 
-#define TINT_IMPAIR 2
-#define TINT_BLIND 3
+#define TINT_IMPAIR 2			//Threshold of tint level to apply weld mask overlay
+#define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 
 /mob/living/carbon/human
 	var/oxygen_alert = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1128,6 +1128,15 @@
 					if(260 to 280)			bodytemp.icon_state = "temp-3"
 					else					bodytemp.icon_state = "temp-4"
 
+			var/tint = tintcheck()				// Welding mask overlay check
+			if(tint >= 2 )
+				if(tinted_weldhelh)
+					if(tint >= 3)
+						blinded = 1				// You get the sudden urge to learn to play keyboard
+						client.screen += global_hud.darkMask
+					else
+						client.screen += global_hud.darkMask
+
 			if(blind)
 				if(blinded)		blind.layer = 18
 				else			blind.layer = 0
@@ -1137,18 +1146,6 @@
 			if(eye_blurry)			client.screen += global_hud.blurry
 			if(druggy)				client.screen += global_hud.druggy
 
-			var/masked = 0
-
-			if( istype(head, /obj/item/clothing/head/welding) )
-				var/obj/item/clothing/head/welding/O = head
-				if(!O.up && tinted_weldhelh)
-					client.screen += global_hud.darkMask
-					masked = 1
-
-			if(!masked && istype(glasses, /obj/item/clothing/glasses/welding) )
-				var/obj/item/clothing/glasses/welding/O = glasses
-				if(!O.up && tinted_weldhelh)
-					client.screen += global_hud.darkMask
 
 			if(eye_stat > 20)
 				if(eye_stat > 30)	client.screen += global_hud.darkMask


### PR DESCRIPTION
Changes flash/welder protection eyecheck() proc from several hard coded item checks to a /var check for eye covering items, reducing the number of IF statements and allowing greater flexibility as child items can have a different protection level to their parent.

Created a new proc tintcheck()
-Items have a separate tint var to allow for items to protect but not impair, such as space helmets.
-tintcheck() adds these up for eye covering locations
-life.dm uses this new proc when checking to apply the welder overlay instead of hardcoded if statements
