### PR TITLE
Admin "Show Crew Manifest" verb 'fix'

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2076,9 +2076,8 @@
 			if("manifest")
 				var/dat = "<B>Showing Crew Manifest.</B><HR>"
 				dat += "<table cellspacing=5><tr><th>Name</th><th>Position</th></tr>"
-				for(var/mob/living/carbon/human/H in mob_list)
-					if(H.ckey)
-						dat += text("<tr><td>[]</td><td>[]</td></tr>", H.name, H.get_assignment())
+				for(var/datum/data/record/t in data_core.general)
+					dat += text("<tr><td>[]</td><td>[]</td></tr>", t.fields["name"], t.fields["rank"])
 				dat += "</table>"
 				usr << browse(dat, "window=manifest;size=440x410")
 			if("DNA")


### PR DESCRIPTION
Makes the admin "Show Crew Manifest" verb inside the secrets window actually show the Crew Manifest, instead of the old dumb way of just looking at whatever ID human players are holding.
