### PR TITLE
Radios more vulnerable to EMP (Issue #711)

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -20,6 +20,11 @@
 	keyslot1 = new /obj/item/device/encryptionkey/
 	recalculateChannels()
 
+/obj/item/device/radio/headset/talk_into(mob/living/M as mob, message, channel)
+	if (!listening)
+		return
+	..()
+
 /obj/item/device/radio/headset/receive_range(freq, level)
 	if(ishuman(src.loc))
 		var/mob/living/carbon/human/H = src.loc

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -60,7 +60,7 @@
 			on = 0
 		else
 			var/area/A = src.loc.loc
-			if(!A || !isarea(A) || !A.master)
+			if(!A || !isarea(A) || !A.master || emped)
 				on = 0
 			else
 				on = A.master.powered(EQUIP) // set "on" to the power status

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -24,6 +24,7 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	var/subspace_transmission = 0
 	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
 	var/maxf = 1499
+	var/emped = 0	// since radios don't use machinery stat binary flags they get a seperate variable
 //			"Example" = FREQ_LISTENING|FREQ_BROADCASTING
 	flags = FPRINT | CONDUCT | TABLEPASS
 	slot_flags = SLOT_BELT
@@ -83,11 +84,14 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 
 	var/dat = ""
 
-	if(!istype(src, /obj/item/device/radio/headset)) //Headsets dont get a mic button
-		dat += "<b>Microphone:</b> [broadcasting ? "<A href='byond://?src=\ref[src];talk=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];talk=1'>Disengaged</A>"]<BR>"
-
-	dat += {"
+	if(!istype(src, /obj/item/device/radio/headset))
+		dat += {"
+				<b>Microphone:</b> [broadcasting ? "<A href='byond://?src=\ref[src];talk=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];talk=1'>Disengaged</A>"]<BR>
 				<b>Speaker:</b> [listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>
+				"}
+	else	//Headsets dont get a mic button, speaker controls both
+		dat += "<b>Power:</b> [listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>"
+	dat += {"
 				<b>Frequency:</b>
 				<A href='byond://?src=\ref[src];freq=-10'>-</A>
 				<A href='byond://?src=\ref[src];freq=-2'>-</A>
@@ -663,14 +667,20 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	else return
 
 /obj/item/device/radio/emp_act(severity)
+	if (emped == 1) //
+		return
 	if (listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
 		loc << "<span class='warning'>\The [src] overloads.</span>"
 	broadcasting = 0
 	listening = 0
-	frequency += pick(-1,1)*2*rand(1,5) // shift the frequency a bit
-	set_frequency(sanitize_frequency(frequency))
 	for (var/ch_name in channels)
 		channels[ch_name] = 0
+	on = 0
+	spawn(200)
+		emped = 0
+		if (!istype(src, /obj/item/device/radio/intercom)) // intercoms will turn back on on their own
+			on = 1
+	emped = 1
 	..()
 
 ///////////////////////////////

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -663,6 +663,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	else return
 
 /obj/item/device/radio/emp_act(severity)
+	if (listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
+		loc << "<span class='warning'>\The [src] overloads.</span>"
 	broadcasting = 0
 	listening = 0
 	frequency += pick(-1,1)*2*rand(1,5) // shift the frequency a bit

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -116,8 +116,7 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 /obj/item/device/radio/proc/text_sec_channel(var/chan_name, var/chan_stat)
 	var/list = !!(chan_stat&FREQ_LISTENING)!=0
 	return {"
-			<B>[chan_name]</B><br>
-			Speaker: <A href='byond://?src=\ref[src];ch_name=[chan_name];listen=[!list]'>[list ? "Engaged" : "Disengaged"]</A><BR>
+			<B>[chan_name]</B>: <A href='byond://?src=\ref[src];ch_name=[chan_name];listen=[!list]'>[list ? "Engaged" : "Disengaged"]</A><BR>
 			"}
 
 /obj/item/device/radio/Topic(href, href_list)
@@ -223,6 +222,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 				//world << "DEBUG: channel=\"[channel]\" switching to \"[channels[1]]\""
 				channel = channels[1]
 			connection = secure_radio_connections[channel]
+			if (!channels[channel]) // if the channel is turned off, don't broadcast
+				return
 		else
 			connection = radio_connection
 			channel = null
@@ -664,6 +665,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 /obj/item/device/radio/emp_act(severity)
 	broadcasting = 0
 	listening = 0
+	frequency += pick(-1,1)*2*rand(1,5) // shift the frequency a bit
+	set_frequency(sanitize_frequency(frequency))
 	for (var/ch_name in channels)
 		channels[ch_name] = 0
 	..()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -53,6 +53,14 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 <div class='commit sansserif'>
+	<h2 class='date'>4 June 2013</h2>
+	<h3 class='author'>Dumpdavidson updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='tweak'>EMPs can now be used to cut off communication: <br>Headsets can no longer broadcast into a channel that is disabled. EMPs will now shift the frequency of a radio.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>25 May 2013</h2>
 	<h3 class='author'>Ikarrus updated:</h3>
 	<ul class='changes bgimages16'>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -56,7 +56,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h2 class='date'>4 June 2013</h2>
 	<h3 class='author'>Dumpdavidson updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='tweak'>EMPs can now be used to cut off communication: <br>Headsets can no longer broadcast into a channel that is disabled. EMPs will now shift the frequency of a radio.</li>
+		<li class='tweak'>Headsets can no longer broadcast into a channel that is disabled.<br>Headsets now have a button to turn off the power instead of the speaker. This button disables all communication functions.<br>EMPs now force affected radios off for about 20 seconds.</li>
 	</ul>
 </div>
 


### PR DESCRIPTION
Department channels that are turned off now cannot be broadcasted into.
EMPs will now shift the frequency of a radio a bit.

This is supposed to fix issue #711 and make EMP a viable option for a traitors or nuke agents that are looking to take someone out without the entire station knowing about it.
