### PR TITLE
Food crate update and supply shuttle computer tweak

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -43,9 +43,11 @@
 	name = "Food crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/flour,
 					/obj/item/weapon/reagent_containers/food/drinks/milk,
-					/obj/item/weapon/reagent_containers/food/drinks/milk,
+					/obj/item/weapon/reagent_containers/food/drinks/soymilk,
 					/obj/item/weapon/storage/fancy/egg_box,
 					/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+					/obj/item/weapon/reagent_containers/food/condiment/sugar,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/monkey,
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -551,7 +551,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		var/timeout = world.time + 600
 		var/reason = copytext(sanitize(input(usr,"Reason:","Why do you require this item?","") as null|text),1,MAX_MESSAGE_LEN)
 		if(world.time > timeout)	return
-		if(!reason)	return
+//		if(!reason)	return
 
 		var/idname = "*None Provided*"
 		var/idrank = "*None Provided*"


### PR DESCRIPTION
Changed food crate to include all of chef's basic ingredients. Changed supply shuttle console to no longer require a reason while ordering.  The requests console is unchanged and must have something in the reason field.
