### PR TITLE
Separate Continuous-Round Configs

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -79,7 +79,9 @@
 	var/traitor_scaling = 0 			//if amount of traitors scales based on amount of players
 	var/protect_roles_from_antagonist = 0// If security and such can be tratior/cult/other
 	var/allow_latejoin_antagonists = 0 // If late-joining players can be traitor/changeling
-	var/continous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
+	var/continuous_round_rev = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
+	var/continuous_round_wiz = 0
+	var/continuous_round_malf = 0
 
 	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 	var/alert_desc_blue_upto = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
@@ -315,8 +317,12 @@
 					config.jobs_have_maint_access	|= EVERYONE_HAS_MAINT_ACCESS
 				if("gateway_delay")
 					config.gateway_delay			= text2num(value)
-				if("continuous_rounds")
-					config.continous_rounds			= 1
+				if("continuous_round_rev")
+					config.continuous_round_rev			= 1
+				if("continuous_round_wiz")
+					config.continuous_round_wiz			= 1
+				if("continuous_round_malf")
+					config.continuous_round_malf			= 1
 				if("ghost_interaction")
 					config.ghost_interaction		= 1
 				if("traitor_scaling")

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -134,7 +134,7 @@
 	if (station_captured && !to_nuke_or_not_to_nuke)
 		return 1
 	if (is_malf_ai_dead())
-		if(config.continous_rounds)
+		if(config.continuous_round_malf)
 			if(emergency_shuttle)
 				emergency_shuttle.always_fake_recall = 0
 			malf_mode_declared = 0

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -168,7 +168,7 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
-	if(config.continous_rounds)
+	if(config.continuous_round_rev)
 		if(finished != 0)
 			if(emergency_shuttle)
 				emergency_shuttle.always_fake_recall = 0

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -183,7 +183,7 @@
 
 /datum/game_mode/wizard/check_finished()
 
-	if(config.continous_rounds)
+	if(config.continuous_round_wiz)
 		return ..()
 
 	var/wizards_alive = 0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -92,7 +92,10 @@ PROBABILITY SANDBOX 0
 ## Uncomment to make rounds which end instantly (Rev, Wizard, Malf) continue until
 ## the shuttle is called or the station is nuked.
 ## Malf and Rev will let the shuttle be called when the antags/protags are dead.
-#CONTINUOUS_ROUNDS
+#CONTINUOUS_ROUND_REV
+#CONTINUOUS_ROUND_WIZ
+#CONTINUOUS_ROUND_MALF
+
 
 ## Uncomment to scale the number of antagonists to crew population. Doesn't
 ## affect all gamemodes.


### PR DESCRIPTION
Separates the continuous round config options to be round-specific. For example, one can config wizard rounds to not end upon the wizard's death, while Rev rounds will still end upon one side's defeat.
