### PR TITLE
Infini-baton Fix

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -32,9 +32,9 @@
 
 /obj/item/weapon/melee/baton/proc/deductcharge(var/chrgdeductamt)
 	if(bcell)
-		bcell.use(chrgdeductamt)
-
-		if(bcell.charge < chrgdeductamt)
+		if(bcell.use(chrgdeductamt))
+			return 1
+		else
 			status = 0
 			update_icon()
 			return 0


### PR DESCRIPTION
You can no longer create batons with functionally infinite charge, by first rigging the cell and then hitting someone to blow it up.
