### PR TITLE
fixes issue #742

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -102,7 +102,11 @@
 	if(iswirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			new /obj/item/stack/rods(loc)
+			if(destroyed)
+				new /obj/item/stack/rods(loc)
+			else
+				new /obj/item/stack/rods(loc)
+				new /obj/item/stack/rods(loc)
 			del(src)
 	else if((isscrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90))


### PR DESCRIPTION
added a quick check to see if the grille was broken when a person uses wirecutters on it.
