### PR TITLE
Various Fixes

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -84,7 +84,7 @@
 		src << "<span class='warning'>This creature's DNA is ruined beyond useability!</span>"
 		return
 
-	if(!G.state > GRAB_NECK)
+	if(G.state <= GRAB_NECK)
 		src << "<span class='warning'>We must have a tighter grip to absorb this creature.</span>"
 		return
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -310,7 +310,7 @@ var/list/sacrificed = list()
 			var/S=0
 			for(var/obj/effect/rune/R in orange(rad,src))
 				if(R!=src)
-					R.invisibility=101
+					R.invisibility=INVISIBILITY_OBSERVER
 				S=1
 			if(S)
 				if(istype(src,/obj/effect/rune))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -27,6 +27,7 @@
 	var/light_disabled = 0
 	var/alarm_on = 0
 	var/busy = 0
+	var/emped = 0  //Number of consecutive EMP's on this camera
 
 /obj/machinery/camera/New()
 	wires = new(src)
@@ -59,13 +60,17 @@
 			stat |= EMPED
 			SetLuminosity(0)
 			triggerCameraAlarm()
+			emped = emped+1  //Increase the number of consecutive EMP's
+			var/thisemp = emped //Take note of which EMP this proc is for
 			spawn(900)
-				network = previous_network
-				icon_state = initial(icon_state)
-				stat &= ~EMPED
-				cancelCameraAlarm()
-				if(can_use())
-					cameranet.addCamera(src)
+				if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
+					network = previous_network
+					icon_state = initial(icon_state)
+					stat &= ~EMPED
+					cancelCameraAlarm()
+					if(can_use())
+						cameranet.addCamera(src)
+					emped = 0 //Resets the consecutive EMP count
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -24,7 +24,7 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	var/subspace_transmission = 0
 	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
 	var/maxf = 1499
-	var/emped = 0	// since radios don't use machinery stat binary flags they get a seperate variable
+	var/emped = 0	//Highjacked to track the number of consecutive EMPs on the radio, allowing consecutive EMP's to stack properly.
 //			"Example" = FREQ_LISTENING|FREQ_BROADCASTING
 	flags = FPRINT | CONDUCT | TABLEPASS
 	slot_flags = SLOT_BELT
@@ -667,8 +667,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 	else return
 
 /obj/item/device/radio/emp_act(severity)
-	if (emped == 1) //
-		return
+	emped++ //There's been an EMP; better count it
+	var/curremp = emped //Remember which EMP this was
 	if (listening && ismob(loc))	// if the radio is turned on and on someone's person they notice
 		loc << "<span class='warning'>\The [src] overloads.</span>"
 	broadcasting = 0
@@ -677,10 +677,10 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 		channels[ch_name] = 0
 	on = 0
 	spawn(200)
-		emped = 0
-		if (!istype(src, /obj/item/device/radio/intercom)) // intercoms will turn back on on their own
-			on = 1
-	emped = 1
+		if(emped == curremp) //Don't fix it if it's been EMP'd again
+			emped = 0
+			if (!istype(src, /obj/item/device/radio/intercom)) // intercoms will turn back on on their own
+				on = 1
 	..()
 
 ///////////////////////////////


### PR DESCRIPTION
Allows ghosts, seers, and reveal runes to see hidden runes, fixing Issue #512, fixes the issue with consecutive camera EMP's at Issue #731 and a similar issue for radios, and fixes a broken check for ling absorb introduced with the grab overhaul.
