### PR TITLE
Small optimizations in air and camera visibility init

### DIFF
--- a/code/FEA/FEA_turf_tile.dm
+++ b/code/FEA/FEA_turf_tile.dm
@@ -262,16 +262,14 @@ turf/simulated
 						//See what kind of border it is
 						if(istype(T,/turf/space))
 							if(parent.space_borders)
-								parent.space_borders -= src
-								parent.space_borders += src
+								parent.space_borders |= src
 							else
 								parent.space_borders = list(src)
 							length_space_border++
 
 						else
 							if(parent.borders)
-								parent.borders -= src
-								parent.borders += src
+								parent.borders |= src
 							else
 								parent.borders = list(src)
 

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -86,6 +86,9 @@
 			continue
 
 		for(var/turf/t in c.can_see())
+			// Possible optimization: if(turfs[t]) here, rather than &= turfs afterwards.
+			// List associations use a tree or hashmap of some sort (alongside the list itself)
+			//  so are surprisingly fast. (significantly faster than var/thingy/x in list, in testing)
 			newVisibleTurfs[t] = t
 
 	// Removes turf that isn't in turfs.
@@ -141,9 +144,8 @@
 		if(c.can_use())
 			cameras += c
 
-	for(var/turf/t in range(CHUNK_SIZE + (CHUNK_SIZE / 6), locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
-		if(t.x >= x && t.y >= y && t.x < x + CHUNK_SIZE && t.y < y + CHUNK_SIZE)
-			turfs[t] = t
+	for(var/turf/t in block(locate(x, y, z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
+		turfs[t] = t
 
 	for(var/camera in cameras)
 		var/obj/machinery/camera/c = camera
@@ -154,6 +156,9 @@
 			continue
 
 		for(var/turf/t in c.can_see())
+			// Possible optimization: if(turfs[t]) here, rather than &= turfs afterwards.
+			// List associations use a tree or hashmap of some sort (alongside the list itself)
+			//  so are surprisingly fast. (significantly faster than var/thingy/x in list, in testing)
 			visibleTurfs[t] = t
 
 	// Removes turf that isn't in turfs.


### PR DESCRIPTION
 Optimizations in insignificant procs (less than 2% of total self time each (according to the june 7 profile), and the changes probably don't have a huge impact on them.

/turf/simulated/proc/update_air_properties()
- Changed border lists to use |= rather than -= then +=.

/datum/camerachunk/New()
- Uses block() rather than range() and a coordinate check

Comment (copied to two places) outlining a potential optimization. (potential as in "needs to be tested whether it actually makes things faster, or creates massive lag")
