### PR TITLE
Right clicking a job preference level will now lower it.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -388,7 +388,7 @@ datum/preferences
 		return 0
 
 	proc/GetJobLevel(var/datum/job/job)
-		if (!job || !level) return 0
+		if (!job) return 0
 
 		if (job.flag & (job_civilian_high | job_engsec_high | job_medsci_high))
 			return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -481,9 +481,9 @@ datum/preferences
 					userandomjob = !userandomjob
 					SetChoices(user)
 				if("increaseJobLevel")
-					UpdateJobPreference(user, href_list["text"], 1)
-				if ("decreaseJobLevel")
 					UpdateJobPreference(user, href_list["text"], -1)
+				if ("decreaseJobLevel")
+					UpdateJobPreference(user, href_list["text"], 1)
 				else
 					SetChoices(user)
 			return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -415,7 +415,21 @@ datum/preferences
 			SetChoices(user)
 			return 1
 
-		SetJobPreferenceLevel(job, GetJobLevel(job) + upOrDown)
+
+		var/targetLvl = GetJobLevel(job)
+		if (upOrDown == 1) // increasing from low to high, i.e. lowering the level value
+			if (targetLvl == 0)
+				targetLvl = 3 // low
+			else
+				targetLvl = targetLvl - 1
+		else // decreasing from high to low, i.e. raising the level value
+			if (targetLvl == 3)
+				targetLvl = 0
+			else
+				targetLvl = targetLvl + 1
+
+
+		SetJobPreferenceLevel(job, targetLvl)
 		SetChoices(user)
 
 		return 1
@@ -481,9 +495,9 @@ datum/preferences
 					userandomjob = !userandomjob
 					SetChoices(user)
 				if("increaseJobLevel")
-					UpdateJobPreference(user, href_list["text"], -1)
-				if ("decreaseJobLevel")
 					UpdateJobPreference(user, href_list["text"], 1)
+				if ("decreaseJobLevel")
+					UpdateJobPreference(user, href_list["text"], -1)
 				else
 					SetChoices(user)
 			return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -255,7 +255,7 @@ datum/preferences
 		var/HTML = "<center>"
 		HTML += "<b>Choose occupation chances</b><br>"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=close'>Done</a></center><br>" // Easier to press up here.
-		HTML += "<script type='text/javascript'>function lowerJobPreference(rank) { window.location.href='?_src_=prefs;preference=job;task=lowerInput;text=' + encodeURIComponent(rank); return false; }</script>"
+		HTML += "<script type='text/javascript'>function lowerJobPreference(rank) { window.location.href='?_src_=prefs;preference=job;task=decreaseJobLevel;text=' + encodeURIComponent(rank); return false; }</script>"
 		HTML += "<table width='100%' cellpadding='1' cellspacing='0'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more colomns.
 		HTML += "<table width='100%' cellpadding='1' cellspacing='0'>"
 		var/index = -1
@@ -295,7 +295,7 @@ datum/preferences
 
 			HTML += "</td><td width='40%'>"
 
-			HTML += "<a class='white' href='?_src_=prefs;preference=job;task=input;text=[rank]' oncontextmenu='javascript:return lowerJobPreference(\"[rank]\");'>"
+			HTML += "<a class='white' href='?_src_=prefs;preference=job;task=increaseJobLevel;text=[rank]' oncontextmenu='javascript:return lowerJobPreference(\"[rank]\");'>"
 
 			if(rank == "Assistant")//Assistant is special
 				if(job_civilian_low & ASSISTANT)
@@ -480,10 +480,10 @@ datum/preferences
 				if("random")
 					userandomjob = !userandomjob
 					SetChoices(user)
-				if("input")
-					SetJob(user, href_list["text"])
-				if ("lowerInput")
-					SetLowerJob(user, href_list["text"])
+				if("increaseJobLevel")
+					UpdateJobPreference(user, href_list["text"], 1)
+				if ("decreaseJobLevel")
+					UpdateJobPreference(user, href_list["text"], -1)
 				else
 					SetChoices(user)
 			return 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -254,6 +254,7 @@ datum/preferences
 
 		var/HTML = "<center>"
 		HTML += "<b>Choose occupation chances</b><br>"
+		HTML += "<div align='center'>Left-click to raise an occupation preference, right-click to lower it.<br></div>"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=close'>Done</a></center><br>" // Easier to press up here.
 		HTML += "<script type='text/javascript'>function lowerJobPreference(rank) { window.location.href='?_src_=prefs;preference=job;task=decreaseJobLevel;text=' + encodeURIComponent(rank); return false; }</script>"
 		HTML += "<table width='100%' cellpadding='1' cellspacing='0'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more colomns.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -358,27 +358,60 @@ datum/preferences
 		SetChoices(user)
 		return 1
 
-	proc/RemoveJobFromPreferences(role)
-		var/datum/job/job = job_master.GetJob(role)
-
+	proc/SetJobPreferenceLevel(var/datum/job/job, var/level)
 		if (!job)
 			return 0
+
+		if (level == 1) // set all current high preferred to medium
+			job_civilian_med |= job_civilian_high
+			job_engsec_med |= job_engsec_high
+			job_medsci_med |= job_medsci_high
+			job_civilian_high = 0
+			job_engsec_high = 0
+			job_medsci_high = 0
 
 		if (job.department_flag == CIVILIAN)
 			job_civilian_low &= ~job.flag
 			job_civilian_med &= ~job.flag
 			job_civilian_high &= ~job.flag
-			return CIVILIAN
+
+			switch(level)
+				if (1)
+					job_civilian_high |= job.flag
+				if (2)
+					job_civilian_med |= job.flag
+				if (3)
+					job_civilian_low |= job.flag
+
+			return 1
 		else if (job.department_flag == ENGSEC)
 			job_engsec_low &= ~job.flag
 			job_engsec_med &= ~job.flag
 			job_engsec_high &= ~job.flag
-			return ENGSEC
+
+			switch(level)
+				if (1)
+					job_engsec_high |= job.flag
+				if (2)
+					job_engsec_med |= job.flag
+				if (3)
+					job_engsec_low |= job.flag
+
+			return 1
 		else if (job.department_flag == MEDSCI)
 			job_medsci_low &= ~job.flag
 			job_medsci_med &= ~job.flag
 			job_medsci_high &= ~job.flag
-			return MEDSCI
+
+			switch(level)
+				if (1)
+					job_medsci_high |= job.flag
+				if (2)
+					job_medsci_med |= job.flag
+				if (3)
+					job_medsci_low |= job.flag
+
+			return 1
 
 		return 0
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,7 +51,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>16 June 2013</h2>
+	<h3 class='author'>Khub updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Job preferences menu now not only allows you to left-click the level (i.e. [Medium]) to raise it, but also to right-click it to lower it. That means you don't have to cycle through all the levels to get rid of a [Low].</li>
+	</ul>
+</div>
+
 
 <div class='commit sansserif'>
 	<h2 class='date'>15 June 2013</h2>


### PR DESCRIPTION
It always made me sigh when I wanted to lower a job preference but I needed to click it all the way through - so I decided to implement a right click option. Left clicking the preference (like [Medium]) will raise it like it did before, right clicking will lower it.
I think I also cleaned the code a bit, I had hard times understanding how it works.

First pull request/modification to BYOND code, yey?
