### PR TITLE
fixes a ton of stuff with parrots

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -30,6 +30,10 @@
 		var/mob/living/carbon/human/H = src.loc
 		if(H.ears == src)
 			return ..(freq, level)
+	else if(istype(src.loc,/mob/living/simple_animal/parrot))
+		var/mob/living/simple_animal/parrot/P = src.loc
+		if(P.ears == src)
+			return ..(freq, level)
 	return -1
 
 /obj/item/device/radio/headset/syndicate

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -119,7 +119,7 @@ var/list/department_radio_keys = list(
 			message_mode = "headset"
 	// Special message handling
 	else if (copytext(message, 1, 2) == ";")
-		if (ishuman(src))
+		if (ishuman(src) || istype(src,/mob/living/simple_animal/parrot/))
 			message_mode = "headset"
 		else if(ispAI(src) || isrobot(src))
 			message_mode = "pAI"

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -103,6 +103,8 @@
 
 	parrot_sleep_dur = parrot_sleep_max //In case someone decides to change the max without changing the duration var
 
+	player_list += src
+
 	verbs.Add(/mob/living/simple_animal/parrot/proc/steal_from_ground, \
 			  /mob/living/simple_animal/parrot/proc/steal_from_mob, \
 			  /mob/living/simple_animal/parrot/verb/drop_held_item_player, \
@@ -248,6 +250,8 @@
 
 //Simple animals
 /mob/living/simple_animal/parrot/attack_animal(mob/living/simple_animal/M as mob)
+	..() //goodbye immortal parrots
+
 	if(client) return
 
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -8,6 +8,13 @@
  *		Sub-types
  */
 
+/*So you want to delete parrots eh?
+heres the locations of their snowflake code:
+lines 294-301 in living/say.dm (speech buffer)
+lines 122 and 135 in living/say.dm (parrots talking into headsets)
+lines 33-36 in radio/headset.dm (parrots hearing headsets)
+*/
+
 /*
  * Defines
  */

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -225,6 +225,8 @@
 	return "says, \"[text]\"";
 
 /mob/living/simple_animal/emote(var/act)
+	if(stat)
+		return
 	if(act)
 		if(act == "scream")	act = "makes a loud and pained whimper" //ugly hack to stop animals screaming when crushed :P
 		for (var/mob/O in viewers(src, null))
@@ -368,22 +370,32 @@
 			var/obj/item/stack/medical/MED = O
 			if(health < maxHealth)
 				if(MED.amount >= 1)
-					adjustBruteLoss(-MED.heal_brute)
-					MED.amount -= 1
-					if(MED.amount <= 0)
-						del(MED)
-					for(var/mob/M in viewers(src, null))
-						if ((M.client && !( M.blinded )))
-							M.show_message("\blue [user] applies [MED] on [src]")
+					if(MED.heal_brute >= 1)
+						adjustBruteLoss(-MED.heal_brute)
+						MED.amount -= 1
+						if(MED.amount <= 0)
+							del(MED)
+						for(var/mob/M in viewers(src, null))
+							if ((M.client && !( M.blinded )))
+								M.show_message("\blue [user] applies [MED] on [src]")
+						return
+					else
+						user << "\blue [MED] won't help at all."
+						return
+			else
+				user << "\blue [src] is at full health."
+				return
 		else
 			user << "\blue [src] is dead, medical items won't bring it back to life."
-	if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+			return
+	else if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
 		if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
 			new meat_type (get_turf(src))
 			if(prob(95))
 				del(src)
 				return
 			gib()
+			return
 	else
 		if(O.force)
 			var/damage = O.force


### PR DESCRIPTION
and also some stuff with simple animals

parrots now eat crackers
parrots now use attack_animal instead of snowflake attack code
parrots toggle between harmless and aggressive, player parrots can do this with a verb
player parrots can use headsets. fixes issue #686
fixes unreported issue of parrots being immune to simple animal attacks

simple_animals now return after using healing items on them, they will also ignore ointment as simple animals only take brute damage. fixes issue #556
simple animals cant emote after death. fixes issue # 557
