### PR TITLE
Securer secure crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -170,6 +170,7 @@
 	var/emag = "securecrateemag"
 	var/broken = 0
 	var/locked = 1
+	health = 1000
 
 /obj/structure/closet/crate/hydroponics
 	name = "Hydroponics crate"


### PR DESCRIPTION
Increased the health of secure crates by a factor of ten.

Originally I was going to null out the projectile proc and add an emp_act instead, but one already exists.
The increased health of the secure crate will allow them to still be broken open from gun fire, but will make it inconvenient enough to dissuade cargo arming up every round, hopefully... (it will take 17 buckshot or 50 lasers to break open a crate)
