### PR TITLE
Fixed Projectiles

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -41,6 +41,7 @@
 				M.take_organ_damage(20)
 
 
+
 /atom/proc/assume_air(datum/air_group/giver)
 	del(giver)
 	return null
@@ -99,8 +100,9 @@
 /atom/proc/emp_act(var/severity)
 	return
 
-/atom/proc/bullet_act(var/obj/item/projectile/Proj)
-	return 0
+/atom/proc/bullet_act(obj/item/projectile/P)
+	P.on_hit(src,0)
+	. = 0
 
 /atom/proc/in_contents_of(container)//can take class or object instance as argument
 	if(ispath(container))
@@ -336,7 +338,7 @@ var/list/blood_splatter_icons = list()
 				blood_splatter_icon = fcopy_rsc(blood_splatter_icon)
 				blood_splatter_icons[index] = blood_splatter_icon
 			overlays += blood_splatter_icon
-			
+
 		//if this blood isn't already in the list, add it
 		if(blood_DNA[M.dna.unique_enzymes])
 			return 0 //already bloodied with this blood. Cannot add more.

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -145,7 +145,7 @@
 
 
 	bullet_act(var/obj/item/projectile/Proj)
-		if(!Proj)	return
+		..()
 		switch(Proj.damage_type)
 		 if(BRUTE)
 			 health -= (Proj.damage/brute_resist)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -938,6 +938,7 @@ steam.start() -- spawns the effect
 		del(src)
 
 	bullet_act()
+		..()
 		if(metal==1 || prob(50))
 			del(src)
 

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -9,12 +9,7 @@
 	unacidable = 1
 
 
-	bullet_act(var/obj/item/projectile/Proj, var/def_zone)
-		var/turf/T = get_turf(src.loc)
-		if(T)
-			for(var/mob/M in T)
-				Proj.on_hit(M,M.bullet_act(Proj, def_zone))
-		return
+
 
 
 ///////////Mimewalls///////////

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -9,6 +9,7 @@
 
 proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, ignorecap = 0)
 	src = null	//so we don't abort once src is deleted
+	epicenter = get_turf(epicenter)
 
 	if(!ignorecap)
 		// Clamp all values to MAX_EXPLOSION_RANGE
@@ -28,7 +29,6 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			return
 
 		var/start = world.timeofday
-		epicenter = get_turf(epicenter)
 		if(!epicenter) return
 
 		if(adminlog)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -94,9 +94,10 @@
 
 /obj/structure/grille/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)	return
+	..()
 	src.health -= Proj.damage*0.2
 	healthcheck()
-	return 0
+	return
 
 /obj/structure/grille/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/wirecutters))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -44,19 +44,6 @@
 /turf/ex_act(severity)
 	return 0
 
-
-/turf/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam/pulse))
-		src.ex_act(2)
-	..()
-	return 0
-
-/turf/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/bullet/gyro))
-		explosion(src, -1, 0, 2)
-	..()
-	return 0
-
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
 		usr << "\red Movement is admin-disabled." //This is to identify lag problems

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -2719,7 +2719,7 @@ It is possible to destroy the net by the occupant or someone else.
 	bullet_act(var/obj/item/projectile/Proj)
 		health -= Proj.damage
 		healthcheck()
-		return 0
+		..()
 
 	ex_act(severity)
 		switch(severity)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -71,6 +71,9 @@ var/global/list/uneatable = list(
 			return
 	return
 
+/obj/machinery/singularity/bullet_act(obj/item/projectile/P)
+	return 0 //Will there be an impact? Who knows.  Will we see it? No.
+
 
 /obj/machinery/singularity/Bump(atom/A)
 	consume(A)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -106,12 +106,6 @@
 					permutated.Add(A)
 					return 0
 
-				if(istype(A,/turf))
-					for(var/obj/O in A)
-						O.bullet_act(src)
-					for(var/mob/M in A)
-						M.bullet_act(src, def_zone)
-
 				density = 0
 				invisibility = 101
 				delete()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -31,6 +31,10 @@
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
+	on_hit(var/atom/target, var/blocked = 0)
+		if(istype(target,/turf/)||istype(target,/obj/structure/))
+			target.ex_act(2)
+		..()
 
 
 /obj/item/projectile/beam/deathlaser

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -78,31 +78,32 @@
 	flag = "energy"
 
 	on_hit(var/atom/target, var/blocked = 0)
-		var/mob/living/carbon/M = target
-		if(check_dna_integrity(M) && M.dna.mutantrace == "plant") //Plantmen possibly get mutated and damaged by the rays.
-			if(prob(15))
-				M.apply_effect((rand(30,80)),IRRADIATE)
-				M.Weaken(5)
-				for (var/mob/V in viewers(src))
-					V.show_message("\red [M] writhes in pain as \his vacuoles boil.", 3, "\red You hear the crunching of leaves.", 2)
-			if(prob(35))
-			//	for (var/mob/V in viewers(src)) //Public messages commented out to prevent possible metaish genetics experimentation and stuff. - Cheridan
-			//		V.show_message("\red [M] is mutated by the radiation beam.", 3, "\red You hear the snapping of twigs.", 2)
-				if(prob(80))
-					randmutb(M)
-					domutcheck(M,null)
+		if(iscarbon(target))
+			var/mob/living/carbon/M = target
+			if(check_dna_integrity(M) && M.dna.mutantrace == "plant") //Plantmen possibly get mutated and damaged by the rays.
+				if(prob(15))
+					M.apply_effect((rand(30,80)),IRRADIATE)
+					M.Weaken(5)
+					for (var/mob/V in viewers(src))
+						V.show_message("\red [M] writhes in pain as \his vacuoles boil.", 3, "\red You hear the crunching of leaves.", 2)
+				if(prob(35))
+				//	for (var/mob/V in viewers(src)) //Public messages commented out to prevent possible metaish genetics experimentation and stuff. - Cheridan
+				//		V.show_message("\red [M] is mutated by the radiation beam.", 3, "\red You hear the snapping of twigs.", 2)
+					if(prob(80))
+						randmutb(M)
+						domutcheck(M,null)
+					else
+						randmutg(M)
+						domutcheck(M,null)
 				else
-					randmutg(M)
-					domutcheck(M,null)
+					M.adjustFireLoss(rand(5,15))
+					M.show_message("\red The radiation beam singes you!")
+				//	for (var/mob/V in viewers(src))
+				//		V.show_message("\red [M] is singed by the radiation beam.", 3, "\red You hear the crackle of burning leaves.", 2)
 			else
-				M.adjustFireLoss(rand(5,15))
-				M.show_message("\red The radiation beam singes you!")
 			//	for (var/mob/V in viewers(src))
-			//		V.show_message("\red [M] is singed by the radiation beam.", 3, "\red You hear the crackle of burning leaves.", 2)
-		else
-		//	for (var/mob/V in viewers(src))
-		//		V.show_message("The radiation beam dissipates harmlessly through [M]", 3)
-			M.show_message("\blue The radiation beam dissipates harmlessly through your body.")
+			//		V.show_message("The radiation beam dissipates harmlessly through [M]", 3)
+				M.show_message("\blue The radiation beam dissipates harmlessly through your body.")
 
 /obj/item/projectile/energy/florayield
 	name = "beta somatoray"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -93,6 +93,7 @@
 
 
 	bullet_act(var/obj/item/projectile/Proj)
+		..()
 		if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
 			message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
 			log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")


### PR DESCRIPTION
Changed atom's bullet_act to call the projectile's on_hit, and changed most bullet_acts to call on_hit as well.  Removed some now-unnecessary snowflake code.

These changes will make projectiles which should affect non-mobs, such as the gyrojet and the ion rifle, work properly.  Inanimate objects can now be empulsed with the ion rifle, whose projectiles used to dissipate on hitting anything but a mob.  Gyrojets now explode on most objects, as opposed to just on walls and mobs, and the snowflake code that made them work on walls is no longer necessary.  The code for pulse rifles' breaking walls has been moved from a check in turf to a check in pulse beams, and has been expanded to include structures, allowing them to (slowly) break girders.  For coders, it means that on_hit is a reliable proc for the effect of a bullet's hitting an object.

While it does mean a number of needless procs of on_hit, it's not too much more proccing than is already done by the gun code, and the removal of the snowflake code that was used to mask the issue, such as the two checks every time a shot hit a wall, should mostly if not more than offset the extra procs.
