### PR TITLE
Made the lobby pre-game countdown timer a configuration option.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -8,6 +8,7 @@
 /datum/configuration
 	var/server_name = null				// server name (for world name / status)
 	var/server_suffix = 0				// generate numeric suffix based on server port
+	var/lobby_countdown = 120			// In between round countdown.
 
 	var/log_ooc = 0						// log OOC channel
 	var/log_access = 0					// log login/logout
@@ -174,6 +175,8 @@
 					config.ban_legacy_system = 1
 				if("use_age_restriction_for_jobs")
 					config.use_age_restriction_for_jobs = 1
+				if("lobby_countdown")
+					config.lobby_countdown = text2num(value)
 				if("log_ooc")
 					config.log_ooc = 1
 				if("log_access")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -5,7 +5,6 @@ var/global/datum/controller/gameticker/ticker
 #define GAME_STATE_PLAYING		3
 #define GAME_STATE_FINISHED		4
 
-
 /datum/controller/gameticker
 	var/const/restart_timeout = 250
 	var/current_state = GAME_STATE_PREGAME
@@ -43,7 +42,11 @@ var/global/datum/controller/gameticker/ticker
 		C.playtitlemusic()
 
 	do
-		pregame_timeleft = 90
+		if(config)
+			pregame_timeleft = config.lobby_countdown
+		else
+			error("configuration was null when retrieving the lobby_countdown value.")
+			pregame_timeleft = 120
 		world << "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>"
 		world << "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds"
 		while(current_state == GAME_STATE_PREGAME)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -63,7 +63,7 @@
 		..()
 
 		statpanel("Lobby")
-		if(client.statpanel=="Lobby" && ticker)
+		if(client.statpanel == "Lobby" && ticker)
 			if(ticker.hide_mode)
 				stat("Game Mode:", "Secret")
 			else

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,6 +1,9 @@
 ## Server name: This appears at the top of the screen in-game. In this case it will read "tgstation: station_name" where station_name is the randomly generated name of the station for the round. Remove the # infront of SERVERNAME and replace 'tgstation' with the name of your choice
 # SERVERNAME tgstation
 
+# Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
+LOBBY_COUNTDOWN 120
+
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 


### PR DESCRIPTION
- Made the lobby pre-game countdown timer a configuration option.
- Changed the default value to 120, from 90, to compensate for BYOND adverts and round restarts closing the client or kicking you randomly.
