### PR TITLE
Fixes various runtimes

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -827,6 +827,7 @@
 				num = Clamp(num, 1, NUMBER_OF_BUFFERS)
 				var/list/buffer_slot = buffer[num]
 				if(istype(buffer_slot))
+					viable_occupant.radiation += rand(15,40)
 					switch(href_list["text"])
 						if("se")
 							if(buffer_slot["SE"])
@@ -843,7 +844,6 @@
 								viable_occupant.dna.unique_enzymes = buffer_slot["UE"]
 								viable_occupant.dna.b_type = buffer_slot["b_type"]
 								updateappearance(viable_occupant)
-					viable_occupant.radiation += rand(15,40)
 		if("injector")
 			if(num && injectorready)
 				num = Clamp(num, 1, NUMBER_OF_BUFFERS)

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -84,8 +84,8 @@
 				for(var/datum/disease/D in O.viruses)
 					if(D.spread_type != SPECIAL)
 						B.data["viruses"] += D.Copy()
+				//if(B.data["blood_DNA"] = copytext(O.dna.unique_enzymes,1,0) //Non-player monkies tend not to have DNA.
 
-				B.data["blood_DNA"] = copytext(O.dna.unique_enzymes,1,0)
 				if(O.resistances&&O.resistances.len)
 					B.data["resistances"] = O.resistances.Copy()
 				bucket_of_blood.reagents.reagent_list += B

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -12,7 +12,7 @@
 	opacity = 0
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel,/obj/item/stack/sheet/metal,/obj/item/stack/rods)
 	var/list/wirecutters_salvage = list(/obj/item/weapon/cable_coil)
-	var/list/crowbar_salvage = list(/obj/item/)
+	var/list/crowbar_salvage = list()
 	var/salvage_num = 5
 
 /obj/structure/mecha_wreckage/gygax/New()

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -12,7 +12,7 @@
 	opacity = 0
 	var/list/welder_salvage = list(/obj/item/stack/sheet/plasteel,/obj/item/stack/sheet/metal,/obj/item/stack/rods)
 	var/list/wirecutters_salvage = list(/obj/item/weapon/cable_coil)
-	var/list/crowbar_salvage
+	var/list/crowbar_salvage = list(/obj/item/)
 	var/salvage_num = 5
 
 /obj/structure/mecha_wreckage/gygax/New()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -383,7 +383,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/weapon/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M, /mob))
+	if(!istype(M,/mob/living/carbon))
 		return
 
 	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_sel.selecting == "mouth" && lit)


### PR DESCRIPTION
Runtimes created when trying to apply radiation to a mob deleted by
monkeyizing, trying to add different types of components to lists of salvage,
attacking non-carbon mobs with lighters, and blending monkies in the
food processor.
