### PR TITLE
Disposal units mob restrictions for stuffing other mobs.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -143,6 +143,7 @@
 				V.show_message("[usr] starts climbing into the disposal.", 3)
 			if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 				if(target.anchored) return
+				if(!ishuman(user) && !ismonkey(user)) return
 				V.show_message("[usr] starts stuffing [target.name] into the disposal.", 3)
 		if(!do_after(usr, 20))
 			return


### PR DESCRIPTION
Only monkeys and humans can stuff mobs into disposal units now. I'm not really happy by adding these checks but OH WELL.
