### PR TITLE
New player option screen href exploit fix

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -84,6 +84,9 @@
 					if(player.ready)totalPlayersReady++
 
 	Topic(href, href_list[])
+		if(src != usr)
+			return 0
+
 		if(!client)	return 0
 
 		if(href_list["show_preferences"])


### PR DESCRIPTION
Prevents players from modifying another player's preferences and character setup.

Previously players could enter a href and modify anything to do with the new player options screen, including player preferences, character setup, declaring ready etc.

What I thought that would be particularly malicious would be basically wiping the players "special snowflake" by randomizing the name, body and saving the changes.
