### PR TITLE
Increased the cost of the syndicate bomb from 5 to 7.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -229,7 +229,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb (DANGER!)"
 	item = /obj/item/weapon/syndicatebomb
-	cost = 5
+	cost = 7
 
 /datum/uplink_item/device_tools/teleporter
 	name = "Teleporter Circuit Board"


### PR DESCRIPTION
I think the syndicate bomb is just too cheap for what you get. I compared all the items that you could afford after buying one and increased the price to 7 TK.

What you could afford before, after buying one (5TK):
- Ammo
- Energy Crossbow
- Energy Sword
- EMP Grenades
- Minibomb
- Parapen
- Soap
- Detomatix Cartridge
- Cham Jumpsuit
- No-Slip Syndicate Shoes
- Agent ID Card
- Voice Changer
- Cham-Proj
- Camera Bug
- Emag
- Toolbox.
- Space Suit
- Thermals
- Binary Key
- C-4
- PowerSink
- ANOTHER SYNDICATE BOMB
- Freedom Implants

What you can afford after, after buying a bomb (7TK):
- Ammo
- EMP Grenades
- Minibomb
- Parapen
- Soap
- Detomatix
- Cham-Jumpsuit
- No-Slip Shoes
- Agent ID Card
- Camera Bug
- Emag
- Toolbox
- Space Suit
- Thermals
- Binary Key
- C-4
- Freedom Implants
