### PR TITLE
Mech admin logs.

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -79,6 +79,9 @@
 				M.updatehealth()
 			src.occupant_message("You hit [target].")
 			src.visible_message("<font color='red'><b>[src.name] hits [target].</b></font>")
+			occupant.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+			M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [occupant.name] ([occupant.ckey]) with [name] (INTENT: [uppertext(occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+			log_attack("<font color='red'>[occupant.name] ([occupant.ckey]) attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(occupant.a_intent)]) (DAMTYE: [uppertext(src.damtype)])</font>" )
 		else
 			step_away(M,src)
 			src.occupant_message("You push [target] out of the way.")

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -54,6 +54,9 @@
 				M.updatehealth()
 				occupant_message("\red You squeeze [target] with [src.name]. Something cracks.")
 				chassis.visible_message("\red [chassis] squeezes [target].")
+				chassis.occupant.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+				M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [chassis.occupant.name] ([chassis.occupant.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+				log_attack("<font color='red'>[chassis.occupant.name] ([chassis.occupant.ckey]) attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(src.damtype)])</font>" )
 			else
 				step_away(M,chassis)
 				occupant_message("You push [target] out of the way.")
@@ -110,6 +113,11 @@
 									ore.Move(ore_box)
 				else if(target.loc == C)
 					log_message("Drilled through [target]")
+					if(ismob(target))
+						var/mob/M = target
+						chassis.occupant.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+						M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [chassis.occupant.name] ([chassis.occupant.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+						log_attack("<font color='red'>[chassis.occupant.name] ([chassis.occupant.ckey]) attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(src.damtype)])</font>" )
 					target.ex_act(2)
 		return 1
 
@@ -167,6 +175,11 @@
 								ore.Move(ore_box)
 				else if(target.loc == C)
 					log_message("Drilled through [target]")
+					if(ismob(target))
+						var/mob/M = target
+						chassis.occupant.attack_log += "\[[time_stamp()]\]<font color='red'> Attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+						M.attack_log += "\[[time_stamp()]\]<font color='orange'> Attacked by [chassis.occupant.name] ([chassis.occupant.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
+						log_attack("<font color='red'>[chassis.occupant.name] ([chassis.occupant.ckey]) attacked [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(src.damtype)])</font>" )
 					target.ex_act(2)
 		return 1
 
@@ -416,6 +429,9 @@
 		P.failchance = 0
 		P.icon_state = "anom"
 		P.name = "wormhole"
+		var/turf/T = get_turf(target)
+		message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) used a Wormhole Generator in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
+		log_game("[chassis.occupant.ckey]([chassis.occupant]) used a Wormhole Generator in ([T.x],[T.y],[T.z])")
 		do_after_cooldown()
 		src = null
 		spawn(rand(150,300))
@@ -474,6 +490,9 @@
 							sleep(2)
 				set_ready_state(0)
 				chassis.use_power(energy_drain)
+				var/turf/T = get_turf(target)
+				message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) used a Gravitational Catapult in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
+				log_game("[chassis.occupant.ckey]([chassis.occupant]) used a Gravitational Catapult in ([T.x],[T.y],[T.z])")
 				do_after_cooldown()
 		return
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -27,6 +27,7 @@
 		set_ready_state(0)
 		playsound(chassis, fire_sound, 50, 1)
 		var/obj/item/projectile/A = new projectile(curloc)
+		A.firer = chassis.occupant
 		A.original = target
 		A.current = curloc
 		A.yo = targloc.y - curloc.y
@@ -78,9 +79,18 @@
 	icon_state = "pulse1_bl"
 	var/life = 20
 
-	Bump(atom/A)
+	Bump(atom/A) //this is just awful
 		A.bullet_act(src, def_zone)
 		src.life -= 10
+		if(ismob(A))
+			var/mob/M = A
+			if(istype(firer, /mob))
+				M.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
+				firer.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
+				log_attack("<font color='red'>[firer] ([firer.ckey]) shot [M] ([M.ckey]) with a [src]</font>")
+			else
+				M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT (No longer exists)</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
+				log_attack("<font color='red'>UNKNOWN shot [M] ([M.ckey]) with a [src]</font>")
 		if(life <= 0)
 			del(src)
 		return
@@ -147,6 +157,9 @@
 			*/
 		chassis.use_power(energy_drain)
 		log_message("Honked from [src.name]. HONK!")
+		var/turf/T = get_turf(src)
+		message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) used a Mecha Honker in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
+		log_game("[chassis.occupant.ckey]([chassis.occupant]) used a Mecha Honker in ([T.x],[T.y],[T.z])")
 		do_after_cooldown()
 		return
 
@@ -211,6 +224,7 @@
 			playsound(chassis, fire_sound, 80, 1)
 			var/obj/item/projectile/A = new projectile(curloc)
 			src.projectiles--
+			A.firer = chassis.occupant
 			A.original = target
 			A.current = curloc
 			A.yo = targloc.y - curloc.y
@@ -255,6 +269,7 @@
 			playsound(chassis, fire_sound, 50, 1)
 			var/obj/item/projectile/A = new projectile(curloc)
 			src.projectiles--
+			A.firer = chassis.occupant
 			A.original = target
 			A.current = curloc
 			A.yo = targloc.y - curloc.y
@@ -286,6 +301,9 @@
 		M.throw_at(target, missile_range, missile_speed)
 		projectiles--
 		log_message("Fired from [src.name], targeting [target].")
+		var/turf/T = get_turf(src)
+		message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) fired a [src] in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
+		log_game("[chassis.occupant.ckey]([chassis.occupant]) fired a [src] ([T.x],[T.y],[T.z])")
 		do_after_cooldown()
 		return
 
@@ -323,6 +341,9 @@
 		F.throw_at(target, missile_range, missile_speed)
 		projectiles--
 		log_message("Fired from [src.name], targeting [target].")
+		var/turf/T = get_turf(src)
+		message_admins("[key_name(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) fired a [src] in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
+		log_game("[chassis.occupant.ckey]([chassis.occupant]) fired a [src] ([T.x],[T.y],[T.z])")
 		spawn(det_time)
 			F.prime()
 		do_after_cooldown()


### PR DESCRIPTION
Added admin logs for mechs.
Fixed the mech sleeper sprite.

The logs are:
Mob logs for clamp, drill and "empty" hits, and syringe gun and sleeper injected reagents.
Also all the different ranged guns.
Added an admin notice and server log for the honkerblast, wormwhole generator and gravity catapult. These notices have a quick jump to mob, admin-PM and (?) button. They are pretty cool.
