### PR TITLE
Fix for bolt light sprite on airlocks.

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -192,3 +192,4 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = !A.lights
+			A.update_icon()


### PR DESCRIPTION
Pulsing the bolt light wire with a multitool will now update the sprite of the airlock.
