### PR TITLE
TK ID steal exploit fix.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -292,14 +292,9 @@
 			if (modify)
 				data_core.manifest_modify(modify.registered_name, modify.assignment)
 				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
-				if(ishuman(usr) && in_range(src, usr))
-					modify.loc = usr.loc
-					if(!usr.get_active_hand())
-						usr.put_in_hands(modify)
-					modify = null
-				else
-					modify.loc = loc
-					modify = null
+				modify.loc = loc
+				modify.verb_pickup()
+				modify = null
 			else
 				var/obj/item/I = usr.get_active_hand()
 				if (istype(I, /obj/item/weapon/card/id))
@@ -310,14 +305,9 @@
 
 		if ("scan")
 			if (scan)
-				if(ishuman(usr) && in_range(src, usr))
-					scan.loc = usr.loc
-					if(!usr.get_active_hand())
-						usr.put_in_hands(scan)
-					scan = null
-				else
-					scan.loc = src.loc
-					scan = null
+				scan.loc = src.loc
+				scan.verb_pickup()
+				scan = null
 			else
 				var/obj/item/I = usr.get_active_hand()
 				if (istype(I, /obj/item/weapon/card/id))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -292,7 +292,7 @@
 			if (modify)
 				data_core.manifest_modify(modify.registered_name, modify.assignment)
 				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
-				if(ishuman(usr))
+				if(ishuman(usr) && in_range(src, usr))
 					modify.loc = usr.loc
 					if(!usr.get_active_hand())
 						usr.put_in_hands(modify)
@@ -310,7 +310,7 @@
 
 		if ("scan")
 			if (scan)
-				if(ishuman(usr))
+				if(ishuman(usr) && in_range(src, usr))
 					scan.loc = usr.loc
 					if(!usr.get_active_hand())
 						usr.put_in_hands(scan)


### PR DESCRIPTION
Added a distance check for when you remove an ID of the HoP's computer. If failed, it drops on the computer's location, just like a borg or AI interaction.

Meh.
