### PR TITLE
Engiborg flamethrower/welder fix.

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -155,29 +155,9 @@
 
 /obj/item/weapon/weldingtool/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/screwdriver))
-		if(welding)
-			user << "<span class='notice'>Turn it off first.</span>"
-			return
-
-		status = !status
-		if(status)
-			user << "<span class='notice'>You resecure [src].</span>"
-		else
-			user << "<span class='notice'>[src] can now be attached and modified.</span>"
-		add_fingerprint(user)
-		return
-
-	if(!status && istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = I
-		R.use(1)
-		var/obj/item/weapon/flamethrower/F = new /obj/item/weapon/flamethrower(user.loc)
-		user.drop_from_inventory(src)
-		loc = F
-		F.weldtool = src
-		add_fingerprint(user)
-		user.put_in_hands(F)
-		return
-
+		flamethrower_screwdriver(I, user)
+	if(istype(I, /obj/item/stack/rods))
+		flamethrower_rods(I, user)
 	..()
 
 
@@ -341,6 +321,27 @@
 		spawn(100)
 			user.disabilities &= ~NEARSIGHTED
 
+/obj/item/weapon/weldingtool/proc/flamethrower_screwdriver(obj/item/I, mob/user)
+	if(welding)
+		user << "<span class='notice'>Turn it off first.</span>"
+		return
+	status = !status
+	if(status)
+		user << "<span class='notice'>You resecure [src].</span>"
+	else
+		user << "<span class='notice'>[src] can now be attached and modified.</span>"
+	add_fingerprint(user)
+
+/obj/item/weapon/weldingtool/proc/flamethrower_rods(obj/item/I, mob/user)
+	if(!status)
+		var/obj/item/stack/rods/R = I
+		R.use(1)
+		var/obj/item/weapon/flamethrower/F = new /obj/item/weapon/flamethrower(user.loc)
+		user.drop_from_inventory(src)
+		loc = F
+		F.weldtool = src
+		add_fingerprint(user)
+		user.put_in_hands(F)
 
 /obj/item/weapon/weldingtool/largetank
 	name = "industrial welding tool"
@@ -348,6 +349,14 @@
 	m_amt = 70
 	g_amt = 60
 	origin_tech = "engineering=2"
+
+/obj/item/weapon/weldingtool/largetank/cyborg
+
+/obj/item/weapon/weldingtool/largetank/cyborg/flamethrower_screwdriver()
+	return
+
+/obj/item/weapon/weldingtool/largetank/cyborg/flamethrower_rods()
+	return
 
 /obj/item/weapon/weldingtool/hugetank
 	name = "upgraded welding tool"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -83,7 +83,7 @@
 		emag = new /obj/item/borg/stun(src)
 		modules += new /obj/item/weapon/rcd/borg(src)
 		modules += new /obj/item/weapon/extinguisher(src)
-		modules += new /obj/item/weapon/weldingtool/largetank(src)
+		modules += new /obj/item/weapon/weldingtool/largetank/cyborg(src)
 		modules += new /obj/item/weapon/screwdriver(src)
 		modules += new /obj/item/weapon/wrench(src)
 		modules += new /obj/item/weapon/crowbar(src)


### PR DESCRIPTION
Fixes engiborgs deleting their own welder by creating a flamethrower.
The attackby() of flamethrowers can lead to flamethrower_screwdriver() and flamethrower_rods(). Two new procs that handle the creation of a flamethrower.
New object /obj/item/weapon/weldingtool/largetank/cyborg. This new object does nothing on the flamethrower creation procs.

I'm not entirely happy about this.
