### PR TITLE
Re-added reverse pickpocketing. Resolves #792.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -398,10 +398,10 @@ In all, this is a lot like the monkey code. /N
 
 	dat += {"
 	<BR>
-	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
+	<BR><A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
-	user << browse(dat, "window=mob[name];size=325x500")
-	onclose(user, "mob[name]")
+	user << browse(dat, "window=mob\ref[src];size=325x500")
+	onclose(user, "mob\ref[src]")
 
 
 /mob/living/carbon/alien/humanoid/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -495,10 +495,10 @@
 
 	dat += {"
 	<BR>
-	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
+	<BR><A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
-	user << browse(dat, "window=mob[name];size=325x500")
-	onclose(user, "mob[name]")
+	user << browse(dat, "window=mob\ref[src];size=325x500")
+	onclose(user, "mob\ref[src]")
 
 /mob/living/carbon/Topic(href, href_list)
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -377,16 +377,16 @@
 	if(legcuffed)
 		dat += "<BR><A href='?src=\ref[src];item=[slot_legcuffed]'>Legcuffed</A>"
 	if(w_uniform)
-		dat += "<BR><BR><A href='?src=\ref[src];pockets=left'>Left [l_store ? "" : "Empty"] Pocket</A>"
-		dat += " - <A href='?src=\ref[src];pockets=right'>Right [r_store ? "" : "Empty"] Pocket</A>"
+		dat += "<BR><BR><A href='?src=\ref[src];pockets=left'>Left Pocket ([l_store ? "Full" : "Empty"])</A>"
+		dat += " - <A href='?src=\ref[src];pockets=right'>Right Pocket ([r_store ? "Full" : "Empty"])</A>"
 
 	dat += {"
 	<BR>
-	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
+	<BR><A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
 
-	user << browse(dat, "window=mob[name];size=340x480")
-	onclose(user, "mob[name]")
+	user << browse(dat, "window=mob\ref[src];size=340x480")
+	onclose(user, "mob\ref[src]")
 
 
 // called when something steps onto a human

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -238,10 +238,10 @@ var/list/slot_equipment_priority = list( \
 	<HR>
 	<BR><B>Left Hand:</B> <A href='?src=\ref[src];item=[slot_l_hand]'>		[l_hand		? l_hand	: "Nothing"]</A>
 	<BR><B>Right Hand:</B> <A href='?src=\ref[src];item=[slot_r_hand]'>		[r_hand		? r_hand	: "Nothing"]</A>
-	<BR><A href='?src=\ref[user];mach_close=mob[name]'>Close</A>
+	<BR><A href='?src=\ref[user];mach_close=mob\ref[src]'>Close</A>
 	"}
-	user << browse(dat, "window=mob[name];size=325x500")
-	onclose(user, "mob[name]")
+	user << browse(dat, "window=mob\ref[src];size=325x500")
+	onclose(user, "mob\ref[src]")
 
 
 /mob/verb/mode()


### PR DESCRIPTION
- Re-added reverse pickpocketing. Resolves #792.
- Increased the time to empty pockets.
- Split pockets into the left and right pocket slots.
- You can tell if a pocket is empty or full from the strip menu.
- Made the window name be the pointer of the mob, instead of the name, to prevent multiple windows opening when the mob changes name while being stripped.

![](http://i.imgur.com/PWa6zzt.png)
