### PR TITLE
Two EMPs on items being carried by humans fix.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -105,12 +105,6 @@ emp_act
 			return 1
 	return 0
 
-/mob/living/carbon/human/emp_act(severity)
-	for(var/obj/O in src)
-		if(!O)	continue
-		O.emp_act(severity)
-	..()
-
 
 /mob/living/carbon/human/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone)
 	if(!I || !user)	return 0


### PR DESCRIPTION
Removed the emp_act() of humans, mob/living has a better one.
This will stop EMPs affecting twice items on humans.
