### PR TITLE
Attempting to ghost while in critical will now succumb then ghost...

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -71,6 +71,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
+	if(stat != DEAD)
+		succumb()
 	if(stat == DEAD)
 		ghostize(1)
 	else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -12,7 +12,7 @@
 		src.adjustOxyLoss(src.health + 200)
 		src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
 		src << "\blue You have given up life and succumbed to death."
-		src.stat = DEAD
+		death()
 
 
 /mob/living/proc/updatehealth()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -12,7 +12,7 @@
 		src.adjustOxyLoss(src.health + 200)
 		src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
 		src << "\blue You have given up life and succumbed to death."
-
+		src.stat = DEAD
 
 
 /mob/living/proc/updatehealth()


### PR DESCRIPTION
...as a courtesy to streamline their ragequit experience.

What this does is attempt a succumb() when a player uses the ghost verb, so that if a player who is alive but in crit will succumb (which allows them to reenter their body) instead of being asked to live ghost (which will render them still dying but catatonic with a body that can't be entered).

Rules for Succumb/Ghost as of this pull

Succumbing
While Alive outside of crit: Does nothing
While Alive in crit: Kills the body with oxyloss but leaves the player in the body
While Dead: Does nothing
While Ghosted: Does nothing

Ghosting
While Alive outside of crit: Ghosts the player after confirmation, leaving the body unable to be reentered
While Alive in crit: Kills the body with oxyloss, ghosts the player, the body may be reentered
While Dead: Ghosts the player, the body may be reentered
While Ghosted: Reenters the body, if it can be reentered
