### PR TITLE
Pinpointer fix.

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -29,12 +29,16 @@
 		if(!target)
 			icon_state = "pinonnull"
 			return
-		if(target.z != loc.z)
+
+		var/turf/T = get_turf(target)
+		var/turf/L = get_turf(src)
+
+		if(T.z != L.z)
 			icon_state = "pinonnull"
 		else
-			dir = get_dir(src, target)
-			switch(get_dist(src, target))
-				if(0)
+			dir = get_dir(L, T)
+			switch(get_dist(L, T))
+				if(-1)
 					icon_state = "pinondirect"
 				if(1 to 8)
 					icon_state = "pinonclose"


### PR DESCRIPTION
Made the pinpointer use the get_turf() procs, they'll now point to the correct location instead of giving you a giant angry question mark, unless the pinpointer turf location is in another Z level than the target.
