### PR TITLE
Grenades: small standardization and mob sprite updates.

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -157,6 +157,8 @@
 
 	playsound(loc, 'sound/effects/bamf.ogg', 50, 1)
 
+	update_mob()
+
 	for(var/obj/item/weapon/reagent_containers/glass/G in beakers)
 		G.reagents.trans_to(src, G.reagents.total_volume)
 
@@ -207,6 +209,8 @@
 		return
 
 	playsound(loc, 'sound/effects/bamf.ogg', 50, 1)
+
+	update_mob()
 
 	if(valid_core)
 		for(var/obj/item/weapon/reagent_containers/glass/G in beakers)

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -4,9 +4,8 @@
 	item_state = "emp"
 	origin_tech = "materials=2;magnets=3"
 
-	prime()
-		..()
-		if(empulse(src, 4, 10))
-			del(src)
-		return
+/obj/item/weapon/grenade/empgrenade/prime()
+	update_mob()
+	empulse(src, 4, 10)
+	del(src)
 

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -5,98 +5,97 @@
 	origin_tech = "materials=2;combat=1"
 	var/banglet = 0
 
-	prime()
-		..()
-		for(var/obj/structure/closet/L in view(get_turf(src), null))
-			if(locate(/mob/living/carbon/, L))
-				for(var/mob/living/carbon/M in L)
-					bang(get_turf(src), M)
+/obj/item/weapon/grenade/flashbang/prime()
+	update_mob()
+	for(var/obj/structure/closet/L in view(get_turf(src), null))
+		if(locate(/mob/living/carbon/, L))
+			for(var/mob/living/carbon/M in L)
+				bang(get_turf(src), M)
 
 
-		for(var/mob/living/carbon/M in viewers(get_turf(src), null))
-			bang(get_turf(src), M)
+	for(var/mob/living/carbon/M in viewers(get_turf(src), null))
+		bang(get_turf(src), M)
 
-		for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
-			var/damage = round(30/(get_dist(B,get_turf(src))+1))
-			B.health -= damage
-			B.update_icon()
-		del(src)
-		return
+	for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
+		var/damage = round(30/(get_dist(B,get_turf(src))+1))
+		B.health -= damage
+		B.update_icon()
+	del(src)
 
-	proc/bang(var/turf/T , var/mob/living/carbon/M)						// Added a new proc called 'bang' that takes a location and a person to be banged.
-		if (locate(/obj/item/weapon/cloaking_device, M))			// Called during the loop that bangs people in lockers/containers and when banging
-			for(var/obj/item/weapon/cloaking_device/S in M)			// people in normal view.  Could theroetically be called during other explosions.
-				S.active = 0										// -- Polymorph
-				S.icon_state = "shield0"
+/obj/item/weapon/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/carbon/M)						// Added a new proc called 'bang' that takes a location and a person to be banged.
+	if (locate(/obj/item/weapon/cloaking_device, M))			// Called during the loop that bangs people in lockers/containers and when banging
+		for(var/obj/item/weapon/cloaking_device/S in M)			// people in normal view.  Could theroetically be called during other explosions.
+			S.active = 0										// -- Polymorph
+			S.icon_state = "shield0"
 
-		M << "\red <B>BANG</B>"
-		playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
+	M << "\red <B>BANG</B>"
+	playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 
 //Checking for protections
-		var/eye_safety = 0
-		var/ear_safety = 0
-		if(iscarbon(M))
-			eye_safety = M.eyecheck()
-			if(ishuman(M))
-				if(istype(M:ears, /obj/item/clothing/ears/earmuffs))
-					ear_safety += 2
-				if(HULK in M.mutations)
-					ear_safety += 1
-				if(istype(M:head, /obj/item/clothing/head/helmet))
-					ear_safety += 1
+	var/eye_safety = 0
+	var/ear_safety = 0
+	if(iscarbon(M))
+		eye_safety = M.eyecheck()
+		if(ishuman(M))
+			if(istype(M:ears, /obj/item/clothing/ears/earmuffs))
+				ear_safety += 2
+			if(HULK in M.mutations)
+				ear_safety += 1
+			if(istype(M:head, /obj/item/clothing/head/helmet))
+				ear_safety += 1
 
 //Flashing everyone
-		if(eye_safety < 1)
-			flick("e_flash", M.flash)
-			M.eye_stat += rand(1, 3)
-			M.Stun(2)
-			M.Weaken(10)
+	if(eye_safety < 1)
+		flick("e_flash", M.flash)
+		M.eye_stat += rand(1, 3)
+		M.Stun(2)
+		M.Weaken(10)
 
 
 
 //Now applying sound
-		if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
-			if(ear_safety > 0)
-				M.Stun(2)
-				M.Weaken(1)
+	if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
+		if(ear_safety > 0)
+			M.Stun(2)
+			M.Weaken(1)
+		else
+			M.Stun(10)
+			M.Weaken(3)
+			if ((prob(14) || (M == src.loc && prob(70))))
+				M.ear_damage += rand(1, 10)
 			else
-				M.Stun(10)
-				M.Weaken(3)
-				if ((prob(14) || (M == src.loc && prob(70))))
-					M.ear_damage += rand(1, 10)
-				else
-					M.ear_damage += rand(0, 5)
-					M.ear_deaf = max(M.ear_deaf,15)
+				M.ear_damage += rand(0, 5)
+				M.ear_deaf = max(M.ear_deaf,15)
 
-		else if(get_dist(M, T) <= 5)
-			if(!ear_safety)
-				M.Stun(8)
-				M.ear_damage += rand(0, 3)
-				M.ear_deaf = max(M.ear_deaf,10)
+	else if(get_dist(M, T) <= 5)
+		if(!ear_safety)
+			M.Stun(8)
+			M.ear_damage += rand(0, 3)
+			M.ear_deaf = max(M.ear_deaf,10)
 
-		else if(!ear_safety)
-			M.Stun(4)
-			M.ear_damage += rand(0, 1)
-			M.ear_deaf = max(M.ear_deaf,5)
+	else if(!ear_safety)
+		M.Stun(4)
+		M.ear_damage += rand(0, 1)
+		M.ear_deaf = max(M.ear_deaf,5)
 
 //This really should be in mob not every check
-		if (M.eye_stat >= 20)
-			M << "\red Your eyes start to burn badly!"
-			M.disabilities |= NEARSIGHTED
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-				if (prob(M.eye_stat - 20 + 1))
-					M << "\red You can't see anything!"
-					M.sdisabilities |= BLIND
-		if (M.ear_damage >= 15)
-			M << "\red Your ears start to ring badly!"
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-				if (prob(M.ear_damage - 10 + 5))
-					M << "\red You can't hear anything!"
-					M.sdisabilities |= DEAF
-		else
-			if (M.ear_damage >= 5)
-				M << "\red Your ears start to ring!"
-		M.update_icons()
+	if (M.eye_stat >= 20)
+		M << "\red Your eyes start to burn badly!"
+		M.disabilities |= NEARSIGHTED
+		if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+			if (prob(M.eye_stat - 20 + 1))
+				M << "\red You can't see anything!"
+				M.sdisabilities |= BLIND
+	if (M.ear_damage >= 15)
+		M << "\red Your ears start to ring badly!"
+		if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+			if (prob(M.ear_damage - 10 + 5))
+				M << "\red You can't hear anything!"
+				M.sdisabilities |= DEAF
+	else
+		if (M.ear_damage >= 5)
+			M << "\red Your ears start to ring!"
+	M.update_icons()
 
 
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
@@ -106,6 +105,7 @@
 	icon_state = "clusterbang"
 
 /obj/item/weapon/grenade/flashbang/clusterbang/prime()
+	update_mob()
 	var/numspawned = rand(4,8)
 	var/again = 0
 	for(var/more = numspawned,more > 0,more--)
@@ -124,7 +124,6 @@
 			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	spawn(0)
 		del(src)
-		return
 
 /obj/item/weapon/grenade/flashbang/clusterbang/segment
 	desc = "A smaller segment of a clusterbang. Better run."
@@ -135,7 +134,6 @@
 /obj/item/weapon/grenade/flashbang/clusterbang/segment/New()//Segments should never exist except part of the clusterbang, since these immediately 'do their thing' and asplode
 	icon_state = "clusterbang_segment_active"
 	active = 1
-	banglet = 1
 	var/stepdist = rand(1,4)//How far to step
 	var/temploc = src.loc//Saves the current location to know where to step away from
 	walk_away(src,temploc,stepdist)//I must go, my people need me
@@ -145,6 +143,7 @@
 	..()
 
 /obj/item/weapon/grenade/flashbang/clusterbang/segment/prime()
+	update_mob()
 	var/numspawned = rand(4,8)
 	for(var/more = numspawned,more > 0,more--)
 		if(prob(35))
@@ -156,17 +155,15 @@
 			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	spawn(0)
 		del(src)
-		return
 
 /obj/item/weapon/grenade/flashbang/cluster/New()//Same concept as the segments, so that all of the parts don't become reliant on the clusterbang
-	spawn(0)
-		icon_state = "flashbang_active"
-		active = 1
-		banglet = 1
-		var/stepdist = rand(1,3)
-		var/temploc = src.loc
-		walk_away(src,temploc,stepdist)
-		var/dettime = rand(15,60)
-		spawn(dettime)
-		prime()
 	..()
+	icon_state = "flashbang_active"
+	active = 1
+	banglet = 1
+	var/stepdist = rand(1,3)
+	var/temploc = src.loc
+	walk_away(src,temploc,stepdist)
+	var/dettime = rand(15,60)
+	spawn(dettime)
+	prime()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -69,18 +69,15 @@
 				var/mob/living/carbon/C = user
 				C.throw_mode_on()
 			spawn(det_time)
-				if(user)
-					user.drop_item()
 				prime()
-				return
-	return
 
 
 /obj/item/weapon/grenade/proc/prime()
-//	playsound(loc, 'sound/items/Welder2.ogg', 25, 1)
-	var/turf/T = get_turf(src)
-	if(T)
-		T.hotspot_expose(700,125)
+
+/obj/item/weapon/grenade/proc/update_mob()
+	if(ismob(loc))
+		var/mob/M = loc
+		M.drop_from_inventory(src)
 
 
 /obj/item/weapon/grenade/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -100,12 +97,10 @@
 				user << "<span class='notice'>You set the [name] for instant detonation.</span>"
 		add_fingerprint(user)
 	..()
-	return
 
 /obj/item/weapon/grenade/attack_hand()
 	walk(src, null, null)
 	..()
-	return
 
 /obj/item/weapon/grenade/attack_paw(mob/user as mob)
 	return attack_hand(user)

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -9,27 +9,27 @@
 	slot_flags = SLOT_BELT
 	var/datum/effect/effect/system/bad_smoke_spread/smoke
 
-	New()
-		..()
-		src.smoke = new /datum/effect/effect/system/bad_smoke_spread
-		src.smoke.attach(src)
+/obj/item/weapon/grenade/smokebomb/New()
+	..()
+	src.smoke = new /datum/effect/effect/system/bad_smoke_spread
+	src.smoke.attach(src)
 
-	prime()
-		playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-		src.smoke.set_up(10, 0, usr.loc)
-		spawn(0)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
-			sleep(10)
-			src.smoke.start()
+/obj/item/weapon/grenade/smokebomb/prime()
+	update_mob()
+	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
+	src.smoke.set_up(10, 0, usr.loc)
+	spawn(0)
+		src.smoke.start()
+		sleep(10)
+		src.smoke.start()
+		sleep(10)
+		src.smoke.start()
+		sleep(10)
+		src.smoke.start()
 
-		for(var/obj/effect/blob/B in view(8,src))
-			var/damage = round(30/(get_dist(B,src)+1))
-			B.health -= damage
-			B.update_icon()
-		sleep(80)
-		del(src)
-		return
+	for(var/obj/effect/blob/B in view(8,src))
+		var/damage = round(30/(get_dist(B,src)+1))
+		B.health -= damage
+		B.update_icon()
+	sleep(80)
+	del(src)

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -9,27 +9,26 @@
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
 
-	prime()													// Prime now just handles the two loops that query for people in lockers and people who can see it.
+/obj/item/weapon/grenade/spawnergrenade/prime()			// Prime now just handles the two loops that query for people in lockers and people who can see it.
+	update_mob()
+	if(spawner_type && deliveryamt)
+		// Make a quick flash
+		var/turf/T = get_turf(src)
+		playsound(T, 'sound/effects/phasein.ogg', 100, 1)
+		for(var/mob/living/carbon/human/M in viewers(T, null))
+			if(M:eyecheck() <= 0)
+				flick("e_flash", M.flash) // flash dose faggots
 
-		if(spawner_type && deliveryamt)
-			// Make a quick flash
-			var/turf/T = get_turf(src)
-			playsound(T, 'sound/effects/phasein.ogg', 100, 1)
-			for(var/mob/living/carbon/human/M in viewers(T, null))
-				if(M:eyecheck() <= 0)
-					flick("e_flash", M.flash) // flash dose faggots
+		for(var/i=1, i<=deliveryamt, i++)
+			var/atom/movable/x = new spawner_type
+			x.loc = T
+			if(prob(50))
+				for(var/j = 1, j <= rand(1, 3), j++)
+					step(x, pick(NORTH,SOUTH,EAST,WEST))
 
-			for(var/i=1, i<=deliveryamt, i++)
-				var/atom/movable/x = new spawner_type
-				x.loc = T
-				if(prob(50))
-					for(var/j = 1, j <= rand(1, 3), j++)
-						step(x, pick(NORTH,SOUTH,EAST,WEST))
+			// Spawn some hostile syndicate critters
 
-				// Spawn some hostile syndicate critters
-
-		del(src)
-		return
+	del(src)
 
 /obj/item/weapon/grenade/spawnergrenade/manhacks
 	name = "manhack delivery grenade"

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -6,8 +6,7 @@
 	item_state = "flashbang"
 	origin_tech = "materials=3;magnets=4;syndicate=4"
 
-	prime()
-		explosion(src.loc,1,2,4)
-		del(src)
-
-		return
+/obj/item/weapon/grenade/syndieminibomb/prime()
+	update_mob()
+	explosion(src.loc,1,2,4)
+	del(src)


### PR DESCRIPTION
Made a new proc for grenades, update_mob(), it will be called in all the different prime() procs. This will drop the grenade of a mob and update his sprite, using the proper inventory proc. It will be only triggered if the loc is a mob.
Standardized all the grenades files
Grenades will no longer make you drop your items when they are triggered if you activated them.
