### PR TITLE
Light bulbs dissapearing with TK fix.

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -505,7 +505,7 @@
 	var/obj/item/weapon/light/L = new light_type()
 	L.status = status
 	L.rigged = rigged
-	L.brightness = src.brightness
+	L.brightness = brightness
 
 	// light item inherits the switchcount, then zero it
 	L.switchcount = switchcount
@@ -513,6 +513,7 @@
 
 	L.update()
 	L.add_fingerprint(user)
+	L.loc = loc
 
 	user.put_in_active_hand(L)	//puts it in our active hand
 


### PR DESCRIPTION
Light bulbs will first drop on the floor before being picked up. Because of the TK grab object on their hand, TK users will be unable to pick up the light bulb and it will stay on the floor.
