### PR TITLE
Quick_equip() dropping items fix.

### DIFF
--- a/code/modules/mob/screen.dm
+++ b/code/modules/mob/screen.dm
@@ -358,11 +358,13 @@
 		if(!I)
 			H << "<span class='notice'>You are not holding anything to equip.</span>"
 			return
-
-		H.drop_from_inventory(I)
-		H.equip_to_appropriate_slot(I)
-		H.update_hud()
-
+		if(H.equip_to_appropriate_slot(I))
+			if(hand)
+				update_inv_l_hand(0)
+			else
+				update_inv_r_hand(0)
+		else
+			H << "\red You are unable to equip that."
 
 /mob/living/verb/resist()
 	set name = "Resist"


### PR DESCRIPTION
Using the quick_equip() verb will no longer make you drop your item. It will also stop udpdating all your HUD, instead, it will only update the overlay of your active hand. All other HUD and overlay updates are already handled on the item movements.

If there's no slot available it will show the "You are unable to equip that" message.
Fixes issue #713
