### PR TITLE
Overhauled Flashes

### DIFF
--- a/code/datums/diseases/advance/symptoms/visionloss.dm
+++ b/code/datums/diseases/advance/symptoms/visionloss.dm
@@ -32,16 +32,7 @@ Bonus
 			if(1, 2)
 				M << "<span class='notice'>Your eyes itch.</span>"
 			if(3, 4)
-				M << "<span class='notice'>Your eyes ache.</span>"
-				M.eye_blurry = 10
-				M.eye_stat += 1
+				M.damage_eye(8)
 			else
-				M << "<span class='danger'>Your eyes burn horrificly!</span>"
-				M.eye_blurry = 20
-				M.eye_stat += 5
-				if (M.eye_stat >= 10)
-					M.disabilities |= NEARSIGHTED
-					if (prob(M.eye_stat - 10 + 1) && !(M.sdisabilities & BLIND))
-						M << "<span class='danger'>You go blind!</span>"
-						M.sdisabilities |= BLIND
+				M.damage_eye(18)
 	return

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -190,7 +190,7 @@
 				//src.closedoor()
 			if(href_list["fc"])
 				for(var/obj/machinery/flasher/F in targets)
-					F.flash()
+					F.activate()
 		src.add_fingerprint(usr)
 		src.updateUsrDialog()
 		src.update_icon()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -62,42 +62,22 @@
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai()
 	if (src.anchored)
-		return src.flash()
+		return src.activate()
 	else
 		return
 
-/obj/machinery/flasher/proc/flash()
+/obj/machinery/flasher/proc/activate()
 	if (!(powered()) || (isnull(bulb)))
 		return
 
 	if ((bulb.broken) || (src.last_flash && world.time < src.last_flash + 150))
 		return
 
-	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[base_state]_flash", src)
+	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	src.last_flash = world.time
 	use_power(1000)
-
-	for (var/mob/O in viewers(src, null))
-		if (get_dist(src, O) > src.range)
-			continue
-
-		if (istype(O, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = O
-			if(!H.eyecheck() <= 0)
-				continue
-
-		if (istype(O, /mob/living/carbon/alien))//So aliens don't get flashed (they have no external eyes)/N
-			continue
-
-		O.Weaken(strength)
-		if ((O.eye_stat > 15 && prob(O.eye_stat + 50)))
-			flick("e_flash", O:flash)
-			O.eye_stat += rand(1, 2)
-		else
-			if(!O.blinded)
-				flick("flash", O:flash)
-				O.eye_stat += rand(0, 2)
+	flash(src,strength,range)
 
 
 /obj/machinery/flasher/emp_act(severity)
@@ -105,7 +85,7 @@
 		..(severity)
 		return
 	if(prob(75/severity))
-		flash()
+		activate()
 		bulb.broken = 1
 		bulb.icon_state = "flashburnt"
 		src.power_change()
@@ -118,9 +98,9 @@
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
 		if ((M.m_intent != "walk") && (src.anchored))
-			src.flash()
+			src.activate()
 
-/obj/machinery/flasher/portable/flash()
+/obj/machinery/flasher/portable/activate()
 	..()
 	if(prob(4))	//Small chance to burn out on use
 		bulb.broken = 1
@@ -169,7 +149,7 @@
 	for(var/obj/machinery/flasher/M in world)
 		if(M.id == src.id)
 			spawn()
-				M.flash()
+				M.activate()
 
 	sleep(50)
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -119,21 +119,7 @@
 
 		playsound(chassis, 'sound/items/AirHorn.ogg', 100, 1)
 		chassis.occupant_message("<font color='red' size='5'>HONK</font>")
-		for(var/mob/living/carbon/M in ohearers(6, chassis))
-			if(istype(M, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
-					continue
-			M << "<font color='red' size='7'>HONK</font>"
-			M.sleeping = 0
-			M.stuttering += 20
-			M.ear_deaf += 30
-			M.Weaken(3)
-			if(prob(30))
-				M.Stun(10)
-				M.Paralyse(4)
-			else
-				M.make_jittery(500)
+		bang(chassis,"HONK",7,6)
 			/* //else the mousetraps are useless
 			if(istype(M, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M

--- a/code/game/objects/bang.dm
+++ b/code/game/objects/bang.dm
@@ -27,6 +27,7 @@ proc/bangmob(mob/living/carbon/target, var/fluff, intensity)
 			if(istype(target:head, /obj/item/clothing/head/helmet))
 				ear_safety += 1
 		intensity = round(intensity/ear_safety)
+		target.sleeping = max(0,intensity)
 		target.damage_ear(rand(0,intensity))			//First, your ears should hurt.
 		target.Weaken(max(intensity-5,0))			//If it's a strong enough bang, it'll knock people down.
 		target.make_dizzy(max(intensity-3,0)*2)			//It doesn't take a huge sound to make you feel woozy

--- a/code/game/objects/bang.dm
+++ b/code/game/objects/bang.dm
@@ -1,0 +1,37 @@
+proc/bang(var/atom/target, var/fluff, var/intensity = 0, var/range = 0) //Fluff- is it a BANG!, a HONK!, or something else?
+	if(!target)
+		return 0;
+	if(istype(target,/mob))					//We're just banging a mob, not an area
+		return bangmob(target,intensity)			//Bang just that mob.
+	target = get_turf(target)					//We're not banging a mob; prepare to bang an area.
+	for(var/mob/living/carbon/O in range(range,target))
+		if(get_dist(target, O) > range/2) intensity = round(intensity/2)
+		bangmob(O, fluff, intensity)
+	for(var/obj/structure/closet/L in range(range,target))		//Check for closets.  Balance!
+		if(locate(/mob/living/carbon/, L))
+			if(get_dist(target, L) > range/2) intensity = round(intensity/2)
+			for(var/mob/living/carbon/M in L)
+				bang(M,fluff,intensity)
+
+	return 1
+
+
+proc/bangmob(mob/living/carbon/target, var/fluff, intensity)
+	if(istype(target,/mob/living/carbon))
+		var/ear_safety = 1
+		if(istype(target,/mob/living/carbon/human))
+			if(istype(target:ears,/obj/item/clothing/ears/earmuffs))
+				ear_safety += 2
+			if(HULK in target.mutations)
+				ear_safety += 1
+			if(istype(target:head, /obj/item/clothing/head/helmet))
+				ear_safety += 1
+		intensity = round(intensity/ear_safety)
+		target.damage_ear(rand(0,intensity))			//First, your ears should hurt.
+		target.Weaken(max(intensity-5,0))			//If it's a strong enough bang, it'll knock people down.
+		target.make_dizzy(max(intensity-3,0)*2)			//It doesn't take a huge sound to make you feel woozy
+		target.confused += max(intensity-2,0)			//And you'll probably be disoriented briefly
+		target.ear_deaf += round(intensity * 1.5)		//Not to mention, you won't be able to hear for a while.
+		target << "\red <B>[fluff]</B>"
+		return 1
+	return 0

--- a/code/game/objects/flash.dm
+++ b/code/game/objects/flash.dm
@@ -1,20 +1,21 @@
 proc/flash(var/atom/target, var/intensity = 0, var/range = 0, var/mob/user)
 	if(!target)
 		return 0;
-	if(istype(target,/mob))					//We're just flashing a mob, not an area
+	if(istype(target,/mob/living))					//We're just flashing a mob, not an area
 		return flashmob(target,intensity)			//Flash just that mob.
 	target = get_turf(target)					//We're not flashing a mob; prepare to flash an area.
-	for (var/mob/O in viewers(target, null))
-		if (get_dist(src, O) > range || O == user)
+	for (var/mob/living/O in viewers(target, null))
+		if (get_dist(target, O) > range || O == user)
 			continue	//He's out of range, or he's the one who's used the flash; skip him.
 		flashmob(O, intensity)
 	return 1
 
 
-proc/flashmob(mob/target, intensity)
+proc/flashmob(mob/living/target, intensity)
 	if(istype(target,/mob/living/carbon/human) || istype(target,/mob/living/carbon/monkey)) //Monkies and humans should probably be separated from slimes and aliums, but until then, this will have to do.
-		if(target:eyecheck() || target.blinded) return 0 	//He's got protection, or can't see shit.
+		if(target.eyecheck() > 0 || target.blinded) return 0 	//He's got protection, or can't see shit.
 		target.Weaken(intensity)
+		target.damage_eye(round(intensity/2))
 		flick("e_flash", target.flash)
 		if(prob(50))
 			if (locate(/obj/item/weapon/cloaking_device, target))

--- a/code/game/objects/flash.dm
+++ b/code/game/objects/flash.dm
@@ -1,0 +1,29 @@
+proc/flash(var/atom/target, var/intensity = 0, var/range = 0, var/mob/user)
+	if(!target)
+		return 0;
+	if(istype(target,/mob))					//We're just flashing a mob, not an area
+		return flashmob(target,intensity)			//Flash just that mob.
+	target = get_turf(target)					//We're not flashing a mob; prepare to flash an area.
+	for (var/mob/O in viewers(target, null))
+		if (get_dist(src, O) > range || O == user)
+			continue	//He's out of range, or he's the one who's used the flash; skip him.
+		flashmob(O, intensity)
+	return 1
+
+
+proc/flashmob(mob/target, intensity)
+	if(istype(target,/mob/living/carbon/human) || istype(target,/mob/living/carbon/monkey)) //Monkies and humans should probably be separated from slimes and aliums, but until then, this will have to do.
+		if(target:eyecheck() || target.blinded) return 0 	//He's got protection, or can't see shit.
+		target.Weaken(intensity)
+		flick("e_flash", target.flash)
+		if(prob(50))
+			if (locate(/obj/item/weapon/cloaking_device, target))
+				for(var/obj/item/weapon/cloaking_device/S in target)
+					S.active = 0
+					S.icon_state = "shield0"
+		return 1
+	else if(istype(target,/mob/living/silicon/robot))
+		target.Weaken(max(intensity-5,0))	//Robots aren't quite as vulnerable to flashes
+		flick("e_flash", target.flash)
+		return 1
+	return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -644,23 +644,7 @@
 	else
 		M.take_organ_damage(7)
 	M.eye_blurry += rand(3,4)
-	M.eye_stat += rand(2,4)
-	if (M.eye_stat >= 10)
-		M.eye_blurry += 15+(0.1*M.eye_blurry)
-		M.disabilities |= NEARSIGHTED
-		if(M.stat != 2)
-			M << "\red Your eyes start to bleed profusely!"
-		if(prob(50))
-			if(M.stat != 2)
-				M << "\red You drop what you're holding and clutch at your eyes!"
-				M.drop_item()
-			M.eye_blurry += 10
-			M.Paralyse(1)
-			M.Weaken(4)
-		if (prob(M.eye_stat - 10 + 1))
-			if(M.stat != 2)
-				M << "\red You go blind!"
-			M.sdisabilities |= BLIND
+	M.damage_eye(rand(6,12))
 	return
 
 /obj/item/clean_blood()

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -62,42 +62,27 @@
 			user << "<span class='warning'>*click* *click*</span>"
 			return
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
-	var/flashfail = 0
+	var/flashfail = !flash(M,10)
 
-	if(iscarbon(M))
-		var/safety = M:eyecheck()
-		if(safety <= 0)
-			M.Weaken(10)
-			flick("e_flash", M.flash)
-
-			if(ishuman(M) && ishuman(user) && M.stat != DEAD)
-				if(user.mind && user.mind in ticker.mode.head_revolutionaries)
-					if(M.client)
-						if(M.stat == CONSCIOUS)
-							var/revsafe = 0
-							if(isloyal(M))
-								revsafe = 1
-							M.mind_initialize()		//give them a mind datum if they don't have one.
-//							if(M.mind.has_been_rev)
-//								revsafe = 2
-							if(!revsafe)
-								M.mind.has_been_rev = 1
-								ticker.mode.add_revolutionary(M.mind)
-							else if(revsafe == 1)
-								user << "<span class='warning'>Something seems to be blocking the flash!</span>"
-							else
-								user << "<span class='warning'>This mind seems resistant to the flash!</span>"
-						else
-							user << "<span class='warning'>They must be conscious before you can convert them!</span>"
-					else
-						user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
-		else
-			flashfail = 1
-
-	else if(issilicon(M))
-		M.Weaken(rand(5,10))
-	else
-		flashfail = 1
+	if(!flashfail && ishuman(M) && ishuman(user) && M.stat != DEAD)
+		if(user.mind && user.mind in ticker.mode.head_revolutionaries)
+			if(M.client)
+				if(M.stat == CONSCIOUS)
+					var/revsafe = 0
+					for(var/obj/item/weapon/implant/loyalty/L in M)
+						if(L && L.implanted)
+							revsafe = 1
+							break
+					M.mind_initialize()		//give them a mind datum if they don't have one.
+//					if(M.mind.has_been_rev)
+//						revsafe = 2
+					if(!revsafe)
+						M.mind.has_been_rev = 1
+						ticker.mode.add_revolutionary(M.mind)
+					else if(revsafe == 1) user << "<span class='warning'>Something seems to be blocking the flash!</span>"
+					else user << "<span class='warning'>This mind seems resistant to the flash!</span>"
+				else user << "<span class='warning'>They must be conscious before you can convert them!</span>"
+			else user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
 
 	if(isrobot(user))
 		spawn(0)
@@ -158,18 +143,7 @@
 			flick("blspell", animation)
 			sleep(5)
 			del(animation)
-
-	for(var/mob/living/carbon/M in oviewers(3, null))
-		if(prob(50))
-			if (locate(/obj/item/weapon/cloaking_device, M))
-				for(var/obj/item/weapon/cloaking_device/S in M)
-					S.active = 0
-					S.icon_state = "shield0"
-		var/safety = M:eyecheck()
-		if(!safety)
-			if(!M.blinded)
-				flick("flash", M.flash)
-
+	flash(src,0,3,user)
 	return
 
 /obj/item/device/flash/emp_act(severity)
@@ -182,14 +156,9 @@
 				icon_state = "flashburnt"
 				return
 			times_used++
-			if(istype(loc, /mob/living/carbon))
-				var/mob/living/carbon/M = loc
-				var/safety = M.eyecheck()
-				if(safety <= 0)
-					M.Weaken(10)
-					flick("e_flash", M.flash)
-					for(var/mob/O in viewers(M, null))
-						O.show_message("<span class='disarm'>[M] is blinded by the flash!</span>")
+			flash(src,2,5)
+			for(var/mob/O in viewers(src, null))
+				O.show_message("<span class='disarm'>[src] spontaneously activates!</span>")
 	..()
 
 /obj/item/device/flash/synthetic

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -5,93 +5,17 @@
 	origin_tech = "materials=2;combat=1"
 	var/banglet = 0
 
-	prime()
-		..()
-		bang(src,"BANG",10,10)
-		flash(src,10,8)
-
-		for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
-			var/damage = round(30/(get_dist(B,get_turf(src))+1))
-			B.health -= damage
-			B.update_icon()
-		del(src)
-		return
-/*
-	proc/bang(var/turf/T , var/mob/living/carbon/M)						// Added a new proc called 'bang' that takes a location and a person to be banged.
-		if (locate(/obj/item/weapon/cloaking_device, M))			// Called during the loop that bangs people in lockers/containers and when banging
-			for(var/obj/item/weapon/cloaking_device/S in M)			// people in normal view.  Could theroetically be called during other explosions.
-				S.active = 0										// -- Polymorph
-				S.icon_state = "shield0"
-
-		M << "\red <B>BANG</B>"
-		playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
-
-//Checking for protections
-		var/eye_safety = 0
-		var/ear_safety = 0
-		if(iscarbon(M))
-			eye_safety = M.eyecheck()
-			if(ishuman(M))
-				if(istype(M:ears, /obj/item/clothing/ears/earmuffs))
-					ear_safety += 2
-				if(HULK in M.mutations)
-					ear_safety += 1
-				if(istype(M:head, /obj/item/clothing/head/helmet))
-					ear_safety += 1
-
-//Flashing everyone
-		if(eye_safety < 1)
-			flick("e_flash", M.flash)
-			M.eye_stat += rand(1, 3)
-			M.Stun(2)
-			M.Weaken(10)
-
-
-
-//Now applying sound
-		if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
-			if(ear_safety > 0)
-				M.Stun(2)
-				M.Weaken(1)
-			else
-				M.Stun(10)
-				M.Weaken(3)
-				if ((prob(14) || (M == src.loc && prob(70))))
-					M.ear_damage += rand(1, 10)
-				else
-					M.ear_damage += rand(0, 5)
-					M.ear_deaf = max(M.ear_deaf,15)
-
-		else if(get_dist(M, T) <= 5)
-			if(!ear_safety)
-				M.Stun(8)
-				M.ear_damage += rand(0, 3)
-				M.ear_deaf = max(M.ear_deaf,10)
-
-		else if(!ear_safety)
-			M.Stun(4)
-			M.ear_damage += rand(0, 1)
-			M.ear_deaf = max(M.ear_deaf,5)
-
-//This really should be in mob not every check
-		if (M.eye_stat >= 20)
-			M << "\red Your eyes start to burn badly!"
-			M.disabilities |= NEARSIGHTED
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-				if (prob(M.eye_stat - 20 + 1))
-					M << "\red You can't see anything!"
-					M.sdisabilities |= BLIND
-		if (M.ear_damage >= 15)
-			M << "\red Your ears start to ring badly!"
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-				if (prob(M.ear_damage - 10 + 5))
-					M << "\red You can't hear anything!"
-					M.sdisabilities |= DEAF
-		else
-			if (M.ear_damage >= 5)
-				M << "\red Your ears start to ring!"
-		M.update_icons()
-*/
+/obj/item/weapon/grenade/flashbang/prime()
+	..()
+	bang(src,"BANG",10,10)
+	flash(src,10,8)
+	playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
+	for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
+		var/damage = round(30/(get_dist(B,get_turf(src))+1))
+		B.health -= damage
+		B.update_icon()
+	del(src)
+	return
 
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."
@@ -100,6 +24,7 @@
 	icon_state = "clusterbang"
 
 /obj/item/weapon/grenade/flashbang/clusterbang/prime()
+	update_mob()
 	var/numspawned = rand(4,8)
 	var/again = 0
 	for(var/more = numspawned,more > 0,more--)
@@ -118,7 +43,6 @@
 			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	spawn(0)
 		del(src)
-		return
 
 /obj/item/weapon/grenade/flashbang/clusterbang/segment
 	desc = "A smaller segment of a clusterbang. Better run."
@@ -129,7 +53,6 @@
 /obj/item/weapon/grenade/flashbang/clusterbang/segment/New()//Segments should never exist except part of the clusterbang, since these immediately 'do their thing' and asplode
 	icon_state = "clusterbang_segment_active"
 	active = 1
-	banglet = 1
 	var/stepdist = rand(1,4)//How far to step
 	var/temploc = src.loc//Saves the current location to know where to step away from
 	walk_away(src,temploc,stepdist)//I must go, my people need me
@@ -139,6 +62,7 @@
 	..()
 
 /obj/item/weapon/grenade/flashbang/clusterbang/segment/prime()
+	update_mob()
 	var/numspawned = rand(4,8)
 	for(var/more = numspawned,more > 0,more--)
 		if(prob(35))
@@ -150,17 +74,15 @@
 			playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	spawn(0)
 		del(src)
-		return
 
 /obj/item/weapon/grenade/flashbang/cluster/New()//Same concept as the segments, so that all of the parts don't become reliant on the clusterbang
-	spawn(0)
-		icon_state = "flashbang_active"
-		active = 1
-		banglet = 1
-		var/stepdist = rand(1,3)
-		var/temploc = src.loc
-		walk_away(src,temploc,stepdist)
-		var/dettime = rand(15,60)
-		spawn(dettime)
-		prime()
 	..()
+	icon_state = "flashbang_active"
+	active = 1
+	banglet = 1
+	var/stepdist = rand(1,3)
+	var/temploc = src.loc
+	walk_away(src,temploc,stepdist)
+	var/dettime = rand(15,60)
+	spawn(dettime)
+	prime()

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -7,14 +7,8 @@
 
 	prime()
 		..()
-		for(var/obj/structure/closet/L in view(get_turf(src), null))
-			if(locate(/mob/living/carbon/, L))
-				for(var/mob/living/carbon/M in L)
-					bang(get_turf(src), M)
-
-
-		for(var/mob/living/carbon/M in viewers(get_turf(src), null))
-			bang(get_turf(src), M)
+		bang(src,"BANG",10,10)
+		flash(src,10,8)
 
 		for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
 			var/damage = round(30/(get_dist(B,get_turf(src))+1))
@@ -22,7 +16,7 @@
 			B.update_icon()
 		del(src)
 		return
-
+/*
 	proc/bang(var/turf/T , var/mob/living/carbon/M)						// Added a new proc called 'bang' that takes a location and a person to be banged.
 		if (locate(/obj/item/weapon/cloaking_device, M))			// Called during the loop that bangs people in lockers/containers and when banging
 			for(var/obj/item/weapon/cloaking_device/S in M)			// people in normal view.  Could theroetically be called during other explosions.
@@ -97,7 +91,7 @@
 			if (M.ear_damage >= 5)
 				M << "\red Your ears start to ring!"
 		M.update_icons()
-
+*/
 
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -222,14 +222,14 @@
 
 
 //Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. This should probably be renamed to use()
-/obj/item/weapon/weldingtool/proc/remove_fuel(amount = 1, mob/M = null)
+/obj/item/weapon/weldingtool/proc/remove_fuel(amount = 1, mob/living/M = null)
 	if(!welding || !check_fuel())
 		return 0
 	if(get_fuel() >= amount)
 		reagents.remove_reagent("fuel", amount)
 		check_fuel()
 		if(M)
-			eyecheck(M)
+			M.damage_eye(rand(0,10*(2-M.eyecheck())))
 		return 1
 	else
 		if(M)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -201,7 +201,7 @@
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 
-/mob/living/carbon/proc/eyecheck()
+/mob/living/carbon/eyecheck()
 	return 0
 
 /mob/living/carbon/proc/tintcheck()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1152,10 +1152,11 @@
 			if(eye_blurry)			client.screen += global_hud.blurry
 			if(druggy)				client.screen += global_hud.druggy
 
-
+/*			No need for these; damaging eyes adds disabilities.
 			if(eye_stat > 20)
 				if(eye_stat > 30)	client.screen += global_hud.darkMask
 				else				client.screen += global_hud.vimpaired
+*/
 
 			if(machine)
 				if(!machine.check_eye(src))		reset_view(null)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -72,3 +72,37 @@
 	if(eyeblur)		apply_effect(eyeblur, EYE_BLUR, blocked)
 	if(drowsy)		apply_effect(drowsy, DROWSY, blocked)
 	return 1
+
+/mob/living/proc/damage_eye(damage)
+	if(!damage) return
+	eye_stat += damage
+	if(eye_stat < 25)
+		src << "<span class='warning'>Your eyes sting.</span>"
+	else if(eye_stat < 50)
+		src << "<span class='warning'>Your eyes burn.</span>"
+		eye_blurry += rand(3, 6)
+	else if(eye_stat < 75)
+		src << "<span class='warning'>Your eyes can't handle much more of this!</span>"
+	else
+		src << "<span class='warning'>You clutch desperately at your eyes!</span>"
+		Stun(5)
+	if(prob(2*(eye_stat - 28)))
+		sdisabilities |= NEARSIGHTED
+	if(prob(2*(eye_stat - 45)))
+		sdisabilities |= BLIND
+
+
+/mob/living/proc/damage_ear(damage)
+	ear_damage += damage
+	if(ear_damage < 25)
+		src << "<span class='warning'>Your ears hurt.</span>"
+	else if(ear_damage < 50)
+		src << "<span class='warning'>Your ears ring.</span>"
+		ear_deaf += rand(5,10)
+	else if(ear_damage < 75)
+		src << "<span class='warning'>Your ears are filled with a persistent ringing.</span>"
+		ear_deaf += rand(8,16)
+	else
+		src << "<span class='warning'>Your ears pop painfully.</span>"
+		Weaken(5)
+		sdisabilities |= DEAF

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -74,6 +74,9 @@
 //		world << "[src] ~ [src.bodytemperature] ~ [temperature]"
 	return temperature
 
+/mob/living/proc/eyecheck()
+	return 2		//It's probably being called on some slimy tentacle monster with no eyes.
+
 
 // ++++ROCKDTBEN++++ MOB PROCS -- Ask me before touching.
 // Stop! ... Hammertime! ~Carn

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -389,6 +389,7 @@
 #include "code\game\objects\empulse.dm"
 #include "code\game\objects\explosion.dm"
 #include "code\game\objects\explosion_recursive.dm"
+#include "code\game\objects\flash.dm"
 #include "code\game\objects\items.dm"
 #include "code\game\objects\objs.dm"
 #include "code\game\objects\structures.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -386,6 +386,7 @@
 #include "code\game\mecha\medical\odysseus.dm"
 #include "code\game\mecha\working\ripley.dm"
 #include "code\game\mecha\working\working.dm"
+#include "code\game\objects\bang.dm"
 #include "code\game\objects\empulse.dm"
 #include "code\game\objects\explosion.dm"
 #include "code\game\objects\explosion_recursive.dm"


### PR DESCRIPTION
Removed copypasted code from flashers and flashes and replaced it with a
flash proc which takes in a strength, range, target, and user.  It works
for area and target flashes.
Changed flashes and flashers to use the flash proc.  Flashers no longer
affect humans and cyborgs equally; they are weaker against cyborgs in a
similar way to hand flashes.  Hand flashes now stun everyone in a small
area for a short time when empulsed, rather than precisely blinding
their holders.

Also, this will make the flashbulb bit of a RnD replacement I'm working on much, much easier.
