### PR TITLE
Second try at changing the "Coder Secrets" into "General Secrets"

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -399,6 +399,14 @@ var/global/floorIsLava = 0
 
 	var/dat = "<B>The first rule of adminbuse is: you don't talk about the adminbuse.</B><HR>"
 
+	dat +={"
+			<B>General Secrets</B><BR>
+			<BR>
+			<A href='?src=\ref[src];secretsgeneral=list_job_debug'>Show Job Debug</A><BR>
+			<A href='?src=\ref[src];secretsgeneral=spawn_objects'>Admin Log</A><BR>
+			<BR>
+			"}
+
 	if(check_rights(R_ADMIN,0))
 		dat += {"
 			<B>Admin Secrets</B><BR>
@@ -478,11 +486,6 @@ var/global/floorIsLava = 0
 			<A href='?src=\ref[src];secretscoder=maint_access_engiebrig'>Change all maintenance doors to engie/brig access only</A><BR>
 			<A href='?src=\ref[src];secretscoder=maint_access_brig'>Change all maintenance doors to brig access only</A><BR>
 			<A href='?src=\ref[src];secretscoder=infinite_sec'>Remove cap on security officers</A><BR>
-			<BR>
-			<B>Coder Secrets</B><BR>
-			<BR>
-			<A href='?src=\ref[src];secretsadmin=list_job_debug'>Show Job Debug</A><BR>
-			<A href='?src=\ref[src];secretscoder=spawn_objects'>Admin Log</A><BR>
 			<BR>
 			"}
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1358,7 +1358,7 @@
 		else
 			health_description = "This mob type has no health to speak of."
 
-		//Gener
+		//Gender
 		switch(M.gender)
 			if(MALE,FEMALE)	gender_description = "[M.gender]"
 			else			gender_description = "<font color='red'><b>[M.gender]</b></font>"
@@ -2076,16 +2076,6 @@
 				for(var/sig in lawchanges)
 					dat += "[sig]<BR>"
 				usr << browse(dat, "window=lawchanges;size=800x500")
-			if("list_job_debug")
-				var/dat = "<B>Job Debug info.</B><HR>"
-				if(job_master)
-					for(var/line in job_master.job_debug)
-						dat += "[line]<BR>"
-					dat+= "*******<BR><BR>"
-					for(var/datum/job/job in job_master.occupations)
-						if(!job)	continue
-						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.total_positions] <BR>"
-					usr << browse(dat, "window=jobdebug;size=600x500")
 			if("check_antagonist")
 				check_antagonists()
 			if("showailaws")
@@ -2130,10 +2120,8 @@
 			if (ok)
 				world << text("<B>A secret has been activated by []!</B>", usr.key)
 
-	else if(href_list["secretscoder"])
-		if(!check_rights(R_DEBUG))	return
-
-		switch(href_list["secretscoder"])
+	else if(href_list["secretsgeneral"])
+		switch(href_list["secretsgeneral"])
 			if("spawn_objects")
 				var/dat = "<B>Admin Log<HR></B>"
 				for(var/l in admin_log)
@@ -2141,6 +2129,21 @@
 				if(!admin_log.len)
 					dat += "No-one has done anything this round!"
 				usr << browse(dat, "window=admin_log")
+			if("list_job_debug")
+				var/dat = "<B>Job Debug info.</B><HR>"
+				if(job_master)
+					for(var/line in job_master.job_debug)
+						dat += "[line]<BR>"
+					dat+= "*******<BR><BR>"
+					for(var/datum/job/job in job_master.occupations)
+						if(!job)	continue
+						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.total_positions] <BR>"
+					usr << browse(dat, "window=jobdebug;size=600x500")
+
+	else if(href_list["secretscoder"])
+		if(!check_rights(R_DEBUG))	return
+
+		switch(href_list["secretscoder"])
 			if("maint_access_brig")
 				for(var/obj/machinery/door/airlock/maintenance/M in world)
 					if (access_maint_tunnels in M.req_access)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -26,3 +26,4 @@ giacomand - Game Master
 rockdtben - Game Master
 sieve - Game Master
 aranclanos - Game Master
+intigracy - Game Master


### PR DESCRIPTION
Makes the "coder secrets" in secrets panel become general secrets for all admins. Adding myself to admins.txt for test server purposes, in case I ever forget to change it again.

Reasons:
It's very helpful to use the admin log for a quick glance to see who spawned the mateba for the clown, rather than open the serverlog to check.

Plus I see no reason why it should be restricted to coders, considering it's not really at all able to affect the game by admins seeing it.

First PR died due to me forgetting to switch branches before pulling cheridan's changeling stuff. Woops.
