### PR TITLE
Fixed heater sprites

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -1,7 +1,7 @@
 /obj/machinery/atmospherics/unary/cold_sink/freezer
-	name = "Freezer"
+	name = "freezer"
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "freezer_0"
+	icon_state = "freezer"
 	density = 1
 
 	anchored = 1.0
@@ -32,7 +32,7 @@
 			else
 				icon_state = "freezer"
 		else
-			icon_state = "freezer_0"
+			icon_state = "freezer"
 		return
 
 	attack_ai(mob/user as mob)
@@ -91,7 +91,7 @@
 /obj/machinery/atmospherics/unary/heat_reservoir/heater
 	name = "heater"
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "freezer_0"
+	icon_state = "heater"
 	density = 1
 
 	anchored = 1.0
@@ -118,11 +118,11 @@
 	update_icon()
 		if(src.node)
 			if(src.on)
-				icon_state = "freezer_1"
+				icon_state = "heater_1"
 			else
-				icon_state = "freezer"
+				icon_state = "heater"
 		else
-			icon_state = "freezer_0"
+			icon_state = "heater"
 		return
 
 	attack_ai(mob/user as mob)

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -89,7 +89,7 @@
 
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater
-	name = "Heater"
+	name = "heater"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "heater"
 	density = 1

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -1,7 +1,7 @@
 /obj/machinery/atmospherics/unary/cold_sink/freezer
 	name = "Freezer"
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "freezer_0"
+	icon_state = "freezer"
 	density = 1
 
 	anchored = 1.0
@@ -32,7 +32,7 @@
 			else
 				icon_state = "freezer"
 		else
-			icon_state = "freezer_0"
+			icon_state = "freezer"
 		return
 
 	attack_ai(mob/user as mob)
@@ -89,9 +89,9 @@
 
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater
-	name = "heater"
+	name = "Heater"
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "freezer_0"
+	icon_state = "heater"
 	density = 1
 
 	anchored = 1.0
@@ -118,11 +118,11 @@
 	update_icon()
 		if(src.node)
 			if(src.on)
-				icon_state = "freezer_1"
+				icon_state = "heater_1"
 			else
-				icon_state = "freezer"
+				icon_state = "heater"
 		else
-			icon_state = "freezer_0"
+			icon_state = "heater"
 		return
 
 	attack_ai(mob/user as mob)


### PR DESCRIPTION
Heaters no longer look like freezers, and their first letter is capitalized. I changed some parts about freezers too that should make them appear when editting the map, altough this will probably only work after they're removed and added again on the map.
![2013-07-04 14_05_16-beard relay upsilon](https://f.cloud.github.com/assets/3975713/749280/9ac2a222-e4a6-11e2-906f-5b362d762847.png)
