### PR TITLE
Mop cleaning with fuel fix.

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -19,12 +19,13 @@
 
 
 obj/item/weapon/mop/proc/clean(turf/simulated/A)
+	if(reagents.has_reagent("water", 1))
+		A.clean_blood()
+		for(var/obj/effect/O in A)
+			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+				del(O)
 	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
-	A.clean_blood()
-	for(var/obj/effect/O in A)
-		if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
-			del(O)
 
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user)


### PR DESCRIPTION
The mop will now check for water to clean the floor. This will stop people from cleaning the floor with fuel, avoiding the slippery floors.
