### PR TITLE
ID Card computer character limit fix.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -336,7 +336,7 @@
 			if (authenticated)
 				var/t1 = href_list["assign_target"]
 				if(t1 == "Custom")
-					var/temp_t = copytext(sanitize(input("Enter a custom job assignment.","Assignment")),1,MAX_MESSAGE_LEN)
+					var/temp_t = copytext(sanitize(input("Enter a custom job assignment.","Assignment")),1,MAX_NAME_LEN)
 					if(temp_t)
 						t1 = temp_t
 				else
@@ -358,7 +358,7 @@
 				var/t2 = modify
 				//var/t1 = input(usr, "What name?", "ID computer", null)  as text
 				if ((authenticated && modify == t2 && (in_range(src, usr) || (istype(usr, /mob/living/silicon))) && istype(loc, /turf)))
-					modify.registered_name = href_list["reg"]
+					modify.registered_name = copytext(sanitize(href_list["reg"]),1,MAX_NAME_LEN)
 		if ("mode")
 			mode = text2num(href_list["mode_target"])
 


### PR DESCRIPTION
Made the ID name and custom job title use MAX_NAME_LEN (26) instead of 1024.

The ID name will now be sanitized.
Fixes #703
