### PR TITLE
Dummy global list, for recycling and decreasing the amount of del() calls.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -57,6 +57,7 @@ datum/controller/game_controller/New()
 	if(!syndicate_code_response)	syndicate_code_response	= generate_code_phrase()
 	if(!ticker)						ticker = new /datum/controller/gameticker()
 	if(!emergency_shuttle)			emergency_shuttle = new /datum/shuttle_controller/emergency_shuttle()
+	if(!dummy_controller)			dummy_controller = new /datum/dummy_controller()
 
 
 datum/controller/game_controller/proc/setup()

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -162,12 +162,35 @@
 	item_state = "card-id"
 	w_class = 1.0
 
-//TODO: Figure out wtf this is and possibly remove it -Nodrak
+
+var/global/datum/dummy_controller/dummy_controller
+
+/datum/dummy_controller
+	var/list/ready = list()
+	var/list/being_used = list()
+
+/datum/dummy_controller/proc/use(atom/movable/A)
+	var/obj/item/weapon/dummy/D
+	if(ready.len)
+		D = ready[1]
+		ready -= D
+	else
+		D = new()
+	being_used += D
+	D.loc = A.loc
+	return D
+
+/datum/dummy_controller/proc/store(var/obj/item/weapon/dummy/D)
+	D.loc = null
+	being_used -= D
+	ready += D
+
 /obj/item/weapon/dummy
 	name = "dummy"
 	invisibility = 101.0
 	anchored = 1.0
 	flags = TABLEPASS
+
 
 /obj/item/weapon/dummy/ex_act()
 	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -884,7 +884,7 @@ var/using_new_click_proc = 0 //TODO ERRORAGE (This is temporary, while the DblCl
 			// ------- CLICKED OBJECT EXISTS IN GAME WORLD, DISTANCE FROM PERSON TO OBJECT IS 1 SQUARE OR THEY'RE ON THE SAME SQUARE -------
 
 			var/direct = get_dir(usr, src)
-			var/obj/item/weapon/dummy/D = new /obj/item/weapon/dummy( usr.loc )
+			var/obj/item/weapon/dummy/D = dummy_controller.use(src)
 			var/ok = 0
 			if ( (direct - 1) & direct)
 
@@ -978,10 +978,8 @@ var/using_new_click_proc = 0 //TODO ERRORAGE (This is temporary, while the DblCl
 					See the previous More info, for... more info...
 				*/
 
-			//del(D)
-			// Garbage Collect Dummy
-			D.loc = null
-			D = null
+			//store the dummy back for recycling
+			dummy_controller.store(D)
 
 			// ------- DUMMY OBJECT'S SERVED IT'S PURPOSE, IT'S REWARDED WITH A SWIFT DELETE -------
 			if (!( ok ))


### PR DESCRIPTION
Added a global datum that will handle the dummy objects list, so they can be recycled.

This will decrease a lot the amount of atom/movable/del() calls.

THIS NEEDS TO BE TESTED ON A SERVER WITH A DECENT AMOUNT OF PEOPLE, ALL CLICKING AT THE SAME TIME. DO NOT MERGE IF THAT DIDN'T HAPPEN.
