### PR TITLE
Appropriate mobs not affected by darkness.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -383,13 +383,13 @@
 			sight |= SEE_MOBS
 			sight |= SEE_OBJS
 			see_in_dark = 8
-			see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			see_invisible = SEE_INVISIBLE_MINIMUM
 		else if (stat != 2)
 			sight |= SEE_MOBS
 			sight &= ~SEE_TURFS
 			sight &= ~SEE_OBJS
 			see_in_dark = 4
-			see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			see_invisible = SEE_INVISIBLE_MINIMUM
 
 		if (healths)
 			if (stat != 2)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -298,13 +298,13 @@
 			sight |= SEE_MOBS
 			sight |= SEE_OBJS
 			see_in_dark = 8
-			see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			see_invisible = SEE_INVISIBLE_MINIMUM
 		else if (stat != 2)
 			sight |= SEE_MOBS
 			sight &= ~SEE_TURFS
 			sight &= ~SEE_OBJS
 			see_in_dark = 4
-			see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			see_invisible = SEE_INVISIBLE_MINIMUM
 
 		if (healths)
 			if (stat != 2)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -57,7 +57,7 @@
 			src.sight |= SEE_MOBS
 			src.sight |= SEE_OBJS
 			src.see_in_dark = 8
-			src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			src.see_invisible = SEE_INVISIBLE_MINIMUM
 
 			var/area/home = get_area(src)
 			if(!home)	return//something to do with malf fucking things up I guess. <-- aisat is gone. is this still necessary? ~Carn

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -146,7 +146,7 @@
 		src.sight |= SEE_MOBS
 		src.sight |= SEE_OBJS
 		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		src.see_invisible = SEE_INVISIBLE_MINIMUM
 	else if (src.sight_mode & BORGMESON && src.sight_mode & BORGTHERM)
 		src.sight |= SEE_TURFS
 		src.sight |= SEE_MOBS
@@ -159,13 +159,13 @@
 	else if (src.sight_mode & BORGTHERM)
 		src.sight |= SEE_MOBS
 		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		src.see_invisible = SEE_INVISIBLE_MINIMUM
 	else if (src.stat != 2)
 		src.sight &= ~SEE_MOBS
 		src.sight &= ~SEE_TURFS
 		src.sight &= ~SEE_OBJS
 		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		src.see_invisible = SEE_INVISIBLE_MINIMUM
 
 	for(var/image/hud in client.images)
 		if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe


### PR DESCRIPTION
Gave the mobs, who shouldn't be affected by the darkness, the ability to see clearly in the darkness. These mobs include: AIs, Cyborgs and Xenomorphs.

Player feedback thread: http://ss13.eu/phpbb/viewtopic.php?f=12&t=891

Images for comparison.

Humans
![](http://i.imgur.com/dEnrQwG.png)

Cyborgs
![](http://i.imgur.com/IG6d0js.png)

Xeno (can only see 4 tiles in the dark)
![](http://i.imgur.com/rjIuh01.png)

AI
![](http://i.imgur.com/OMMEaNk.png)
