### PR TITLE
pAI only disposal restriction

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -143,6 +143,7 @@
 				V.show_message("[usr] starts climbing into the disposal.", 3)
 			if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 				if(target.anchored) return
+				if(ispAI(user)) return
 				V.show_message("[usr] starts stuffing [target.name] into the disposal.", 3)
 		if(!do_after(usr, 20))
 			return


### PR DESCRIPTION
An alternative to pull #833 which fixes issue #809.

This alternative only puts a restriction on pAIs shoving things in disposal bins, which was the issue, instead of everything but monkeys and humans, which wasn't the issue.
