### PR TITLE
Blob Tweaks

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -10,8 +10,7 @@ var/list/blob_nodes = list()
 	name = "blob"
 	config_tag = "blob"
 
-	required_players = 0
-	required_enemies = 0
+	required_players = 15
 
 	restricted_jobs = list("Cyborg", "AI")
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -20,11 +20,10 @@ var/list/blob_nodes = list()
 	var/declared = 0
 
 	var/cores_to_spawn = 1
-	var/players_per_core = 26
+	var/players_per_core = 30
 
 	var/blob_count = 0
-	var/blobnukecount = 300//Might be a bit low
-	var/blobwincount = 600//Still needs testing
+	var/blobwincount = 500
 
 	var/list/infected_crew = list()
 
@@ -38,7 +37,6 @@ var/list/blob_nodes = list()
 
 	cores_to_spawn = max(round(num_players()/players_per_core, 1), 1)
 
-	blobnukecount = initial(blobnukecount) * cores_to_spawn
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -121,7 +121,7 @@ var/list/blob_nodes = list()
 
 
 			if(blob_client && location)
-				new /obj/effect/blob/core(location, 200, blob_client)
+				new /obj/effect/blob/core(location, 200, blob_client, 2)
 
 		// Stage 0
 		sleep(40)

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -80,6 +80,14 @@ var/list/blob_nodes = list()
 	if(emergency_shuttle)
 		emergency_shuttle.always_fake_recall = 1
 
+	// Disable the blob event for this round.
+	if(events)
+		var/datum/round_event_control/blob/B = locate() in events.control
+		if(B)
+			B.max_occurrences = 0 // disable the event
+	else
+		error("Events variable is null in blob gamemode post setup.")
+
 	spawn(10)
 		start_state = new /datum/station_state()
 		start_state.count()

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_core"
 	health = 200
-	brute_resist = 2
 	fire_resist = 2
 	var/mob/camera/blob/overmind = null // the blob core's overmind
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -7,12 +7,14 @@
 	var/mob/camera/blob/overmind = null // the blob core's overmind
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
 	var/resource_delay = 0
+	var/point_rate = 1
 
-	New(loc, var/h = 200, var/client/new_overmind = null)
+	New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 1)
 		blob_cores += src
 		processing_objects.Add(src)
 		if(!overmind)
 			create_overmind(new_overmind)
+		point_rate = new_rate
 		..(loc, h)
 
 
@@ -40,7 +42,7 @@
 		else
 			if(resource_delay <= world.time)
 				resource_delay = world.time + 10 // 1 second
-				overmind.add_points(2)
+				overmind.add_points(point_rate)
 		health = min(initial(health), health + 1)
 		for(var/i = 1; i < 8; i += i)
 			Pulse(0, i)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_factory"
 	health = 100
-	brute_resist = 1
 	fire_resist = 2
 	var/list/spores = list()
 	var/max_spores = 3

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -65,4 +65,4 @@
 	Die()
 		if(factory)
 			factory.spores -= src
-		..()
+		del(src)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -33,8 +33,8 @@
 	icon_state = "blobpod"
 	icon_living = "blobpod"
 	pass_flags = PASSBLOB
-	health = 50
-	maxHealth = 50
+	health = 40
+	maxHealth = 40
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	attacktext = "hits"

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -33,8 +33,8 @@
 	icon_state = "blobpod"
 	icon_living = "blobpod"
 	pass_flags = PASSBLOB
-	health = 15
-	maxHealth = 15
+	health = 50
+	maxHealth = 50
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	attacktext = "hits"

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_node"
 	health = 100
-	brute_resist = 1
 	fire_resist = 2
 
 

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	health = 30
-	brute_resist = 1
 	fire_resist = 2
 	var/mob/camera/blob/overmind = null
 	var/resource_delay = 0

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -3,9 +3,6 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_idle"
 	desc = "Some blob creature thingy"
-	density = 1
-	opacity = 0
-	anchored = 1
 	health = 100
 	fire_resist = 3
 

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -4,7 +4,7 @@
 	icon_state = "blob_idle"
 	desc = "Some blob creature thingy"
 	health = 100
-	fire_resist = 3
+	fire_resist = 2
 
 
 	update_icon()

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -7,8 +7,7 @@
 	opacity = 0
 	anchored = 1
 	health = 100
-	brute_resist = 1
-	fire_resist = 2
+	fire_resist = 3
 
 
 	update_icon()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -9,7 +9,7 @@
 	anchored = 1
 	var/active = 1
 	var/health = 30
-	var/brute_resist = 4
+	var/brute_resist = 8
 	var/fire_resist = 1
 
 
@@ -81,7 +81,7 @@
 
 	proc/expand(var/turf/T = null, var/prob = 1)
 		if(prob && !prob(health))	return
-		if(istype(T, /turf/space)) 	return
+		if(istype(T, /turf/space) && prob(50)) 	return
 		if(!T)
 			var/list/dirs = list(1,2,4,8)
 			for(var/i = 1 to 4)
@@ -108,15 +108,7 @@
 
 	ex_act(severity)
 		var/damage = 50
-		switch(severity)
-			if(1)
-				src.health -= rand(100,120)
-			if(2)
-				src.health -= rand(60,100)
-			if(3)
-				src.health -= rand(20,60)
-
-		health -= (damage/brute_resist)
+		health -= ((damage/brute_resist) - (severity * 5))
 		update_icon()
 		return
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -81,7 +81,7 @@
 
 	proc/expand(var/turf/T = null, var/prob = 1)
 		if(prob && !prob(health))	return
-		if(istype(T, /turf/space) && prob(50)) 	return
+		if(istype(T, /turf/space) && prob(75)) 	return
 		if(!T)
 			var/list/dirs = list(1,2,4,8)
 			for(var/i = 1 to 4)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -9,7 +9,7 @@
 	anchored = 1
 	var/active = 1
 	var/health = 30
-	var/brute_resist = 8
+	var/brute_resist = 5
 	var/fire_resist = 1
 
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,6 +4,8 @@
 	weight = 5
 	max_occurrences = 1
 
+	earliest_start = 48000 // 1 hour 20 minutes
+
 /datum/round_event/blob
 	announceWhen	= 12
 	endWhen			= 120

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -133,7 +133,7 @@ proc/move_mining_shuttle()
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	if(href_list["move"])
-		if(ticker.mode.name == "blob")
+		if(mining_shuttle_location == 1 && istype(ticker.mode, /datum/game_mode/blob)) // shuttle is on the station, this will mean miners can come back
 			if(ticker.mode:declared)
 				usr << "Under directive 7-10, [station_name()] is quarantined until further notice."
 				return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -238,6 +238,9 @@
 		adjustBruteLoss(60)
 		updatehealth()
 		return 1
+	else
+		gib()
+		return 1
 	return 0
 
 /mob/living/silicon/robot/Stat()


### PR DESCRIPTION
- Blobs can expand into space again but it will be harder to do than on a space tile. EngiBorgs could RCD the floors under the blob to stop it from expanding, which is fatal if it manages to get near the core and open a way to it.
- Dead robots will be gibbed in their blob_act() as their bodies will block the blob.
- Reduced the damage the blob takes from explosions, and increased the brute resistance. Blobs main weakness is fire, not force.
- Made the blob spores into tanks.
- Disabled random blobs in the blob gamemode.
- Added a player limit to the blob gamemode.
- Removed the density from the shield blob, and other variables which are set in the abstract blob.
- Spores will now delete when they die.
- Random even blob will get a core point rate of 1 while the blob gamemode will get 2.
- Raised the amount of time that has to pass before the blob event occurs.
