### PR TITLE
Re-named the verb "Pick Ghost Form" to "Choose Ghost Form". 

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -131,7 +131,7 @@
 
 var/list/ghost_forms = list("ghost","ghostking","ghostian2")
 /client/verb/pick_form()
-	set name = "Pick Ghost Form"
+	set name = "Choose Ghost Form"
 	set category = "Preferences"
 	set desc = "Choose your preferred ghostly appearance."
 	if(!is_content_unlocked())	return


### PR DESCRIPTION
It was interfering with the "pick up" verb which people can easily access by typing "pi" then space. A very minor convenience thing.
