### PR TITLE
Big Blob Fixes

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -56,6 +56,9 @@
 		..()
 		adjustBruteLoss(Clamp(0.01 * exposed_temperature, 1, 5))
 
+	blob_act()
+		return
+
 	New(loc, var/obj/effect/blob/factory/linked_node)
 		if(istype(linked_node))
 			factory = linked_node

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -94,7 +94,7 @@
 
 
 	B.change_to(/obj/effect/blob/resource)
-	var/obj/effect/blob/resource/R = locate(/obj/effect/blob/resource)
+	var/obj/effect/blob/resource/R = locate() in T
 	if(R)
 		R.overmind = src
 


### PR DESCRIPTION
Fixes the resource node not correctly setting the overmind blob in it's variable.
Fixes blob spores dying from a blob_act().
