### PR TITLE
Blob balance changes based on observations.

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -47,7 +47,7 @@
 		for(var/i = 1; i < 8; i += i)
 			Pulse(0, i)
 		for(var/b_dir in alldirs)
-			if(!prob(10))
+			if(!prob(5))
 				continue
 			var/obj/effect/blob/normal/B = locate() in get_step(src, b_dir)
 			if(B)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_idle"
 	desc = "Some blob creature thingy"
-	health = 100
+	health = 75
 	fire_resist = 2
 
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -15,7 +15,7 @@
 
 /mob/camera/blob/verb/transport_core()
 	set category = "Blob"
-	set name = "Return to Core"
+	set name = "Jump to Core"
 	set desc = "Transport back to your core."
 
 	if(blob_core)
@@ -24,7 +24,7 @@
 /mob/camera/blob/verb/jump_to_node()
 	set category = "Blob"
 	set name = "Jump to Node"
-	set desc = "Transport back to your core."
+	set desc = "Transport back to a selected node."
 
 	if(blob_nodes.len)
 		var/list/nodes = list()
@@ -66,7 +66,7 @@
 
 /mob/camera/blob/verb/create_resource()
 	set category = "Blob"
-	set name = "Create Resource Blob (40)"
+	set name = "Create Resource Blob (50)"
 	set desc = "Create a resource tower which will generate points for you."
 
 
@@ -89,7 +89,7 @@
 		src << "There is a resource blob nearby, move more than 3 tiles away from it!"
 		return
 
-	if(!can_buy(40))
+	if(!can_buy(50))
 		return
 
 
@@ -121,8 +121,8 @@
 		src << "Unable to use this blob, find a normal one."
 		return
 
-	for(var/obj/effect/blob/node/blob in orange(4))
-		src << "There is another node nearby, move more than 4 tiles away from it!"
+	for(var/obj/effect/blob/node/blob in orange(5))
+		src << "There is another node nearby, move more than 5 tiles away from it!"
 		return
 
 	if(!can_buy(60))
@@ -153,8 +153,8 @@
 		src << "Unable to use this blob, find a normal one."
 		return
 
-	for(var/obj/effect/blob/factory/blob in orange(6))
-		src << "There is a factory blob nearby, move more than 6 tiles away from it!"
+	for(var/obj/effect/blob/factory/blob in orange(7))
+		src << "There is a factory blob nearby, move more than 7 tiles away from it!"
 		return
 
 	if(!can_buy(60))
@@ -166,7 +166,7 @@
 
 /mob/camera/blob/verb/revert()
 	set category = "Blob"
-	set name = "Remove Blob (0)"
+	set name = "Remove Blob"
 	set desc = "Removes a blob."
 
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -7,9 +7,8 @@
 	density = 0
 	opacity = 0
 	anchored = 1
-	var/active = 1
 	var/health = 30
-	var/brute_resist = 5
+	var/brute_resist = 4
 	var/fire_resist = 1
 
 
@@ -107,7 +106,7 @@
 
 
 	ex_act(severity)
-		var/damage = 50
+		var/damage = 150
 		health -= ((damage/brute_resist) - (severity * 5))
 		update_icon()
 		return
@@ -154,6 +153,7 @@
 /obj/effect/blob/normal
 	icon_state = "blob"
 	luminosity = 0
+	health = 20
 
 	Delete()
 		src.loc = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -457,6 +457,8 @@
 
 /mob/living/simple_animal/adjustBruteLoss(damage)
 	health = Clamp(health - damage, 0, maxHealth)
+	if(health < 1)
+		Die()
 
 /mob/living/simple_animal/proc/SA_attackable(target)
 	if (isliving(target))


### PR DESCRIPTION
- Increased the cost of resource blobs. Blobs were too easily getting a good income and starting a steamroll of the crew.
- Increased the distance of the factory blob and the node blob. This will help encourage the blob to expand more and that if the crew keeps the blob contained then it'll be able to keep it weak.
- Slightly lowered the health of the shield blob. Shields were too useful and too strong, instead of making them more expensive I lowered the health by a little.
- Increased the damage taken from bombs. I previously decreased the damage the blob took from bombs but it seemed too much.
- Reduced the health of normal blobs so lasers one shot them. To keep the game aggressive on the crew and to encourage the blob to create more shield blobs to protect key blob pieces (factories, resources, nodes).
- Lowered the chance for the core to regenerate shield blobs. They spawned too fast.
- Corrected the wording on some verbs.
- Fixed simple animals, such as blob spores, from not dying straight away.
