### PR TITLE
Minor fix omnibus

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -84,7 +84,7 @@
 				if (M.timeofdeath + 6000 < world.time)
 					continue
 			var/turf/T = get_turf(M)
-			if(T)	continue
+			if(!T)	continue
 			if(T.z == 2)	continue
 			var/tmpname = M.real_name
 			if(areaindex[tmpname])

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -218,7 +218,7 @@
 		return 0
 	if(!isturf(O.loc))
 		return 0
-	if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis)
+	if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis || user.lying)
 		return 0
 	if((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1))
 		return 0

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -309,11 +309,6 @@
 			del(src)
 		return
 
-	var/obj/effect/spacevine/vine = locate() in loc
-	if(vine) // don't drop things on tables when trying to attack spacevines
-		vine.attackby(W,user)
-		return
-
 	if(isrobot(user))
 		return
 
@@ -330,7 +325,7 @@
 		return
 
 	user.drop_item(src)
-	return
+	return 1
 
 
 /*
@@ -368,11 +363,6 @@
 		del(src)
 		return
 
-	var/obj/effect/spacevine/vine = locate() in loc
-	if(vine) // don't drop things on tables when trying to attack spacevines
-		vine.attackby(W,user)
-		return
-
 	if(isrobot(user))
 		return
 	if(istype(W, /obj/item/weapon/melee/energy/blade))
@@ -389,7 +379,7 @@
 
 	user.drop_item(src)
 	//if(W && W.loc)	W.loc = src.loc
-	return
+	return 1
 
 
 /*
@@ -418,11 +408,6 @@
 		G.affecting.Weaken(5)
 		visible_message("\red [G.assailant] puts [G.affecting] on the table.")
 		del(W)
-		return
-
-	var/obj/effect/spacevine/vine = locate() in loc
-	if(vine) // don't drop things on tables when trying to attack spacevines
-		vine.attackby(W,user)
 		return
 
 	if (istype(W, /obj/item/weapon/weldingtool))
@@ -475,7 +460,7 @@
 
 	user.drop_item(src)
 	//if(W && W.loc)	W.loc = src.loc
-	return
+	return 1
 
 
 /*
@@ -539,16 +524,11 @@
 		del(src)
 		return
 
-	var/obj/effect/spacevine/vine = locate() in loc
-	if(vine) // don't drop things on racks when trying to attack spacevines
-		vine.attackby(W,user)
-		return
-
 	if(isrobot(user))
 		return
 	user.drop_item()
 	if(W && W.loc)	W.loc = src.loc
-	return
+	return 1
 
 /obj/structure/rack/meteorhit(obj/O as obj)
 	del(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -284,6 +284,9 @@
 /obj/structure/table/attackby(obj/item/weapon/W, mob/user)
 	if (istype(W, /obj/item/weapon/grab) && get_dist(src, user) < 2)
 		var/obj/item/weapon/grab/G = W
+		if(G.affecting.buckled)
+			user << "<span class='notice'>[G.affecting] is buckled to [G.affecting.buckled]!</span>"
+			return
 		if(G.state < GRAB_AGGRESSIVE)
 			user << "<span class='notice'>You need a better grip to do that!</span>"
 			return
@@ -306,6 +309,11 @@
 			del(src)
 		return
 
+	var/obj/effect/spacevine/vine = locate() in loc
+	if(vine) // don't drop things on tables when trying to attack spacevines
+		vine.attackby(W,user)
+		return
+
 	if(isrobot(user))
 		return
 
@@ -322,7 +330,6 @@
 		return
 
 	user.drop_item(src)
-	//if(W && W.loc)	W.loc = src.loc // Unnecessary -  see: mob/proc/drop_item(atom)    - Doohl
 	return
 
 
@@ -339,6 +346,9 @@
 
 	if (istype(W, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = W
+		if(G.affecting.buckled)
+			user << "<span class='notice'>[G.affecting] is buckled to [G.affecting.buckled]!</span>"
+			return
 		if(G.state < GRAB_AGGRESSIVE)
 			user << "<span class='notice'>You need a better grip to do that!</span>"
 			return
@@ -357,6 +367,12 @@
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		del(src)
 		return
+
+	var/obj/effect/spacevine/vine = locate() in loc
+	if(vine) // don't drop things on tables when trying to attack spacevines
+		vine.attackby(W,user)
+		return
+
 	if(isrobot(user))
 		return
 	if(istype(W, /obj/item/weapon/melee/energy/blade))
@@ -390,6 +406,9 @@
 
 	if (istype(W, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = W
+		if(G.affecting.buckled)
+			user << "<span class='notice'>[G.affecting] is buckled to [G.affecting.buckled]!</span>"
+			return
 		if(G.state < GRAB_AGGRESSIVE)
 			user << "<span class='notice'>You need a better grip to do that!</span>"
 			return
@@ -399,6 +418,11 @@
 		G.affecting.Weaken(5)
 		visible_message("\red [G.assailant] puts [G.affecting] on the table.")
 		del(W)
+		return
+
+	var/obj/effect/spacevine/vine = locate() in loc
+	if(vine) // don't drop things on tables when trying to attack spacevines
+		vine.attackby(W,user)
 		return
 
 	if (istype(W, /obj/item/weapon/weldingtool))
@@ -514,6 +538,12 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		del(src)
 		return
+
+	var/obj/effect/spacevine/vine = locate() in loc
+	if(vine) // don't drop things on racks when trying to attack spacevines
+		vine.attackby(W,user)
+		return
+
 	if(isrobot(user))
 		return
 	user.drop_item()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -531,3 +531,8 @@ turf/simulated/floor/proc/update_icon()
 					broken = 0
 				else
 					user << "\blue You need more welding fuel to complete this task."
+	if(istype(C,/obj/item/weapon/scythe))
+		var/obj/effect/spacevine/vine = locate() in src
+		if(vine)
+			vine.attackby(C,user)
+			return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -531,8 +531,3 @@ turf/simulated/floor/proc/update_icon()
 					broken = 0
 				else
 					user << "\blue You need more welding fuel to complete this task."
-	if(istype(C,/obj/item/weapon/scythe))
-		var/obj/effect/spacevine/vine = locate() in src
-		if(vine)
-			vine.attackby(C,user)
-			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -442,7 +442,8 @@ var/global/list/g_fancy_list_of_safe_types = null
 		var/mob/living/carbon/human/H = M
 		var/obj/item/worn = H.wear_id
 		var/obj/item/weapon/card/id/id = null
-		if(worn) id = worn.GetID()
+		if(worn)
+			id = worn.GetID()
 		if(id)
 			id.icon_state = "gold"
 			id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
@@ -463,7 +464,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 					worn.update_icon()
 			else
 				H.equip_to_slot(id,slot_wear_id)
-				// otherwise leave it on the floor
+
 	else
 		alert("Invalid mob")
 	feedback_add_details("admin_verb","GFA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -445,8 +445,33 @@ var/global/list/g_fancy_list_of_safe_types = null
 			if(istype(H.wear_id, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = H.wear_id
 				id = pda.id
-			id.icon_state = "gold"
-			id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+				if(!id)
+					pda.id = new /obj/item/weapon/card/id(pda)
+					pda.id.icon_state = "gold"
+					pda.id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+					pda.id.registered_name = H.real_name
+					pda.id.assignment = "Captain"
+					pda.id.name = "[pda.id.registered_name]'s ID Card ([pda.id.assignment])"
+				else
+					id.icon_state = "gold"
+					id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+			else if(istype(H.wear_id,/obj/item/weapon/storage/wallet))
+				var/obj/item/weapon/storage/wallet/W = H.wear_id
+				id = W.front_id
+				if(!id)
+					id = new /obj/item/weapon/card/id(W)
+					id.icon_state = "gold"
+					id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+					id.registered_name = H.real_name
+					id.assignment = "Captain"
+					id.name = "[id.registered_name]'s ID Card ([id.assignment])"
+					W.front_id = id
+				else
+					id.icon_state = "gold"
+					id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+			else
+				id.icon_state = "gold"
+				id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
 		else
 			var/obj/item/weapon/card/id/id = new/obj/item/weapon/card/id(M);
 			id.icon_state = "gold"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -440,47 +440,30 @@ var/global/list/g_fancy_list_of_safe_types = null
 		return
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		if (H.wear_id)
-			var/obj/item/weapon/card/id/id = H.wear_id
-			if(istype(H.wear_id, /obj/item/device/pda))
-				var/obj/item/device/pda/pda = H.wear_id
-				id = pda.id
-				if(!id)
-					pda.id = new /obj/item/weapon/card/id(pda)
-					pda.id.icon_state = "gold"
-					pda.id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-					pda.id.registered_name = H.real_name
-					pda.id.assignment = "Captain"
-					pda.id.name = "[pda.id.registered_name]'s ID Card ([pda.id.assignment])"
-				else
-					id.icon_state = "gold"
-					id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-			else if(istype(H.wear_id,/obj/item/weapon/storage/wallet))
-				var/obj/item/weapon/storage/wallet/W = H.wear_id
-				id = W.front_id
-				if(!id)
-					id = new /obj/item/weapon/card/id(W)
-					id.icon_state = "gold"
-					id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-					id.registered_name = H.real_name
-					id.assignment = "Captain"
-					id.name = "[id.registered_name]'s ID Card ([id.assignment])"
-					W.front_id = id
-				else
-					id.icon_state = "gold"
-					id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-			else
-				id.icon_state = "gold"
-				id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-		else
-			var/obj/item/weapon/card/id/id = new/obj/item/weapon/card/id(M);
+		var/obj/item/worn = H.wear_id
+		var/obj/item/weapon/card/id/id = null
+		if(worn) id = worn.GetID()
+		if(id)
 			id.icon_state = "gold"
-			id:access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+			id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
+		else
+			id = new /obj/item/weapon/card/id/gold(H.loc)
+			id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
 			id.registered_name = H.real_name
 			id.assignment = "Captain"
 			id.name = "[id.registered_name]'s ID Card ([id.assignment])"
-			H.equip_to_slot_or_del(id, slot_wear_id)
-			H.update_inv_wear_id()
+
+			if(worn)
+				if(istype(worn,/obj/item/device/pda))
+					worn:id = id
+					id.loc = worn
+				else if(istype(worn,/obj/item/weapon/storage/wallet))
+					worn:front_id = id
+					id.loc = worn
+					worn.update_icon()
+			else
+				H.equip_to_slot(id,slot_wear_id)
+				// otherwise leave it on the floor
 	else
 		alert("Invalid mob")
 	feedback_add_details("admin_verb","GFA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -36,6 +36,8 @@
 //Used by throw code to hand over the mob, instead of throwing the grab. The grab is then deleted by the throw code.
 /obj/item/weapon/grab/proc/throw()
 	if(affecting)
+		if(affecting.buckled)
+			return null
 		if(state >= GRAB_AGGRESSIVE)
 			return affecting
 	return null
@@ -78,6 +80,7 @@
 			affecting.drop_item()
 			affecting.hand = h
 			for(var/obj/item/weapon/grab/G in affecting.grabbed_by)
+				if(G == src) continue
 				if(G.state == GRAB_AGGRESSIVE)
 					allow_upgrade = 0
 		if(allow_upgrade)
@@ -106,7 +109,7 @@
 		return
 	if(assailant.next_move > world.time)
 		return
-	if(last_upgrade > world.time + UPGRADE_COOLDOWN)
+	if(world.time < (last_upgrade + UPGRADE_COOLDOWN))
 		return
 	if(!assailant.canmove || assailant.lying)
 		del(src)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -122,10 +122,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W,/obj/item/weapon/storage))
 		..() // -> item/attackby()
-	if(istype(W,/obj/item/weapon/storage))
-		..() // -> item/attackby()
+		return 0
 	if((slices_num <= 0 || !slices_num) || !slice_path)
-		return 1
+		return 0
 	var/inaccurate = 0
 	if( \
 			istype(W, /obj/item/weapon/kitchenknife) || \
@@ -143,7 +142,7 @@
 		inaccurate = 1
 	else if(W.w_class <= 2 && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
 		if(!iscarbon(user))
-			return 1
+			return 0
 		user << "<span class='notice'>You slip [W] inside [src].</span>"
 		user.u_equip(W)
 		if ((user.client && user.s_active != src))
@@ -151,9 +150,10 @@
 		W.dropped(user)
 		add_fingerprint(user)
 		contents += W
-		return
+		return 1 // no afterattack here
 	else
-		return 1
+		return 0 // --- this is everything that is NOT a slicing implement, and which is not being slipped into food; allow afterattack ---
+
 	if ( \
 			!isturf(src.loc) || \
 			!(locate(/obj/structure/table) in src.loc) && \
@@ -162,6 +162,7 @@
 		)
 		user << "<span class='notice'>You cannot slice [src] here! You need a table or at least a tray.</span>"
 		return 1
+
 	var/slices_lost = 0
 	if (!inaccurate)
 		user.visible_message( \
@@ -178,7 +179,7 @@
 	for(var/i=1 to (slices_num-slices_lost))
 		var/obj/slice = new slice_path (src.loc)
 		reagents.trans_to(slice,reagents_per_slice)
-	del(src)
+	del(src) // so long and thanks for all the fish
 
 
 /obj/item/weapon/reagent_containers/food/snacks/Del()


### PR DESCRIPTION
A number of fixes being pushed upstream from Sayustation.

Fixes issues #972/#678, #254, #253.  Prevents you from dropping scythes on tables while attacking space vines.

Fixes a long (forever?) broken functionality of the teleporter, allowing you to teleport to tracking implants.

Minor runtime fix that probably never comes up.

If anything needs to be chopped out, or you need me to merge them into one commit, I can do either.
