### PR TITLE
Runtime fix for buildmode, throwitem option.

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -254,6 +254,8 @@
 
 		if(4)
 			if(pa.Find("left"))
+				if(isturf(object))
+					return
 				holder.throw_atom = object
 			if(pa.Find("right"))
 				if(holder.throw_atom)


### PR DESCRIPTION
Runtime fix for buildmode, throwitem option, you can't select turfs anymore to throw.
