### PR TITLE
Expands the max number of admin permission flags from 16 to 31

### DIFF
--- a/code/__DEFINES.dm
+++ b/code/__DEFINES.dm
@@ -389,7 +389,10 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 
 #define R_MAXPERMISSION 4096 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
-#define R_HOST			65535
+
+//IMPORTANT! The permissions system supports flags up to 2^30 (possibly 2^31), HOWEVER, once the flag 65536
+//starts being used, an edit to rights2text(rights, seperator="") needs to happen! The edit is prepared
+//and commented out. Please uncomment it before assigning that flag. Once you do, delete this note. ~Errorage
 
 //Preference toggles
 #define SOUND_ADMINHELP	1

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -223,7 +223,15 @@ proc/tg_list2text(list/list, glue=",")
 
 
 //Converts a rights bitfield into a string
-/proc/rights2text(rights,seperator="")
+/proc/rights2text(rights, seperator="")
+	/* --UNCOMMENT ONCE PERMISSIONS ABOVE 2^15 START BEING USED!
+	if(rights >= 65536)
+		var/rights_pt2 = rights - 65536
+		if(rights_pt2 & 1) .+= "[seperator]+NUKESERVER"
+		if(rights_pt2 & 2) .+= "[seperator]+DDOSALLPLAYERS"
+		if(rights_pt2 & 4) .+= "[seperator]+SPAWN_RL_SINGULARITY"
+	*/
+
 	if(rights & R_BUILDMODE)	. += "[seperator]+BUILDMODE"
 	if(rights & R_ADMIN)		. += "[seperator]+ADMIN"
 	if(rights & R_BAN)			. += "[seperator]+BAN"
@@ -251,23 +259,23 @@ proc/tg_list2text(list/list, glue=",")
 	var/max = max(red,green,blue)
 	var/min = min(red,green,blue)
 	var/range = max-min
-	
+
 	var/hue=0;var/saturation=0;var/lightness=0;
 	lightness = (max + min)/2
 	if(range != 0)
 		if(lightness < 0.5)	saturation = range/(max+min)
 		else				saturation = range/(2-max-min)
-		
+
 		var/dred = ((max-red)/(6*max)) + 0.5
 		var/dgreen = ((max-green)/(6*max)) + 0.5
 		var/dblue = ((max-blue)/(6*max)) + 0.5
-		
+
 		if(max==red)		hue = dblue - dgreen
 		else if(max==green)	hue = dred - dblue + (1/3)
 		else				hue = dgreen - dred + (2/3)
 		if(hue < 0)			hue++
 		else if(hue > 1)	hue--
-	
+
 	return list(hue, saturation, lightness)
 
 /proc/hsl2rgb(hue, saturation, lightness)
@@ -281,11 +289,11 @@ proc/tg_list2text(list/list, glue=",")
 		if(lightness < 0.5)	b = lightness*(1+saturation)
 		else				b = (lightness+saturation) - (saturation*lightness)
 		a = 2*lightness - b
-		
+
 		red = round(255 * hue2rgb(a, b, hue+(1/3)))
 		green = round(255 * hue2rgb(a, b, hue))
 		blue = round(255 * hue2rgb(a, b, hue-(1/3)))
-	
+
 	return list(red, green, blue)
 
 /proc/hue2rgb(a, b, hue)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -226,7 +226,7 @@ proc/tg_list2text(list/list, glue=",")
 /proc/rights2text(rights, seperator="")
 	/* --UNCOMMENT ONCE PERMISSIONS ABOVE 2^15 START BEING USED!
 	if(rights >= 65536)
-		var/rights_pt2 = rights - 65536
+		var/rights_pt2 = rights / 65536
 		if(rights_pt2 & 1) .+= "[seperator]+NUKESERVER"
 		if(rights_pt2 & 2) .+= "[seperator]+DDOSALLPLAYERS"
 		if(rights_pt2 & 4) .+= "[seperator]+SPAWN_RL_SINGULARITY"

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -172,7 +172,7 @@ datum/controller/vote
 		var/trialmin = 0
 		if(C.holder)
 			admin = 1
-			if(C.holder.rights & R_ADMIN)
+			if(check_rights_for(C, R_ADMIN))
 				trialmin = 1
 		voting |= C
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -313,7 +313,7 @@ datum/mind
 				crystals = suplink.uses
 			if (suplink)
 				text += "|<a href='?src=\ref[src];common=takeuplink'>take</a>"
-				if (usr.client.holder.rights & R_FUN)
+				if (check_rights(R_FUN, 0))
 					text += ", <a href='?src=\ref[src];common=crystals'>[crystals]</a> crystals"
 				else
 					text += ", [crystals] crystals"
@@ -903,7 +903,7 @@ datum/mind
 					memory = null//Remove any memory they may have had.
 					log_admin("[key_name_admin(usr)] removed [current]'s uplink.")
 				if("crystals")
-					if (usr.client.holder.rights & R_FUN)
+					if (check_rights(R_FUN, 0))
 						var/obj/item/device/uplink/hidden/suplink = find_syndicate_uplink()
 						var/crystals
 						if (suplink)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -37,7 +37,7 @@
 			return
 
 	log_ooc("[mob.name]/[key] : [msg]")
-	
+
 	var/keyname = key
 	if(prefs.unlock_content)
 		if(prefs.toggles & MEMBER_PUBLIC)
@@ -47,7 +47,7 @@
 		if(C.prefs.toggles & CHAT_OOC)
 			if(holder)
 				if(!holder.fakekey || C.holder)
-					if(holder.rights & R_ADMIN)
+					if(check_rights_for(src, R_ADMIN))
 						C << "<font color=[config.allow_admin_ooccolor ? prefs.ooccolor :"#b82e00" ]><b><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></b></font>"
 					else
 						C << "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
@@ -68,7 +68,7 @@ var/global/normal_ooc_colour = "#002eb8"
 	set name = "OOC Text Color"
 	set category = "Preferences"
 
-	if(!holder || !(holder.rights & R_ADMIN))
+	if(!holder || check_rights_for(src, R_ADMIN))
 		if(!is_content_unlocked())	return
 
 	var/new_ooccolor = input(src, "Please select your OOC colour.", "OOC colour") as color|null

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -37,9 +37,13 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 				if("stealth")					rights |= R_STEALTH
 				if("rejuv","rejuvinate")		rights |= R_REJUVINATE
 				if("varedit")					rights |= R_VAREDIT
-				if("everything","host","all")	rights |= R_HOST
+				if("everything","host","all")	rights |= ((2 * R_MAXPERMISSION) - 1)
 				if("sound","sounds")			rights |= R_SOUNDS
 				if("spawn","create")			rights |= R_SPAWN
+
+				/* --ONCE FLAGS LARGER OR EQUAL THAN 2^16 = 65536 START BEING USED, USE THIS CODE!
+				if("nukeeverything")			rights += R_NUKEEVERYTHING
+				*/
 
 		admin_ranks[rank] = rights
 		previous_rights = rights

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -50,8 +50,7 @@
 	if(!usr.client)
 		return
 
-	if(!usr.client.holder || !(usr.client.holder.rights & R_PERMISSIONS))
-		usr << "\red You do not have permission to do this!"
+	if (!check_rights(R_PERMISSIONS))
 		return
 
 	establish_db_connection()
@@ -100,8 +99,7 @@
 	if(!usr.client)
 		return
 
-	if(!usr.client.holder || !(usr.client.holder.rights & R_PERMISSIONS))
-		usr << "\red You do not have permission to do this!"
+	if (check_rights(R_PERMISSIONS))
 		return
 
 	establish_db_connection()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -700,7 +700,7 @@
 			return
 
 		if(M != usr)																//we can jobban ourselves
-			if(M.client && M.client.holder && (M.client.holder.rights & R_BAN))		//they can ban too. So we can't ban them
+			if (check_rights_for(M, R_BAN))		//they can ban too. So we can't ban them
 				alert("You cannot perform this action. You must be of a higher administrative rank!")
 				return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,7 +77,7 @@ datum/preferences
 
 		// OOC Metadata:
 	var/metadata = ""
-	
+
 	var/unlock_content = 0
 
 /datum/preferences/New(client/C)
@@ -210,13 +210,13 @@ datum/preferences
 						dat += "<b>Adminhelp Sound:</b> "
 						dat += "<a href='?_src_=prefs;preference=hear_adminhelps'>[(toggles & SOUND_ADMINHELP)?"On":"Off"]</a><br>"
 
-					if(unlock_content || (user.client.holder && (user.client.holder.rights & R_ADMIN)))
+					if(unlock_content || check_rights_for(user, R_ADMIN))
 						dat += "<b>OOC:</b> <span style='border: 1px solid #161616; background-color: [ooccolor];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=ooccolor;task=input'>Change</a><br>"
-					
+
 					if(unlock_content)
 						dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</a><br>"
 						dat += "<b>Ghost Form:</b> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_form]</a><br>"
-						
+
 
 				dat += "</td><td width='300px' height='300px' valign='top'>"
 


### PR DESCRIPTION
- Expands the maximum number of admin permission flags you can have from 16 to 31.
- Standardizes all current permission lookup checks to check_rights() and check_rights_for()

To test: add these debug lines somewhere:

//START COPY PASTE

mob/verb/give_allrights()
    src.client.holder.rights = 393087

mob/verb/hasright()
    var/hi = input(src,"Choose a file to access:","Download",null) as null|num
    var/r = check_rights(hi, 1);
    world << "[r]"

mob/verb/checkrights()
    for(var/i = 0; i < 32; i++)
        var/n = 1 << i
        var/r = check_rights(n , 1);
        world << "has right 2^[i] = [n]? [r]"

//END COPY PASTE

Start the game, run 'give allrights', which doesn't give all rights, but some of the rights. 128 and 131072 are missing. Then you can either run 'hasright' to check whether you have the permissions that correspond to a user defined number, or you can run 'checkrights' to check for all 31 theoretical permissions.
