### PR TITLE
Removes the hashnames from humans turned monkey

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -39,7 +39,7 @@
 			L[DNA_FACIAL_HAIR_COLOR_BLOCK] = sanitize_hexcolor(H.f_color)
 			L[DNA_SKIN_TONE_BLOCK] = construct_block(skin_tones.Find(H.skin_tone), skin_tones.len)
 			L[DNA_EYE_COLOR_BLOCK] = sanitize_hexcolor(H.eye_color)
-		
+
 	for(var/i=1, i<=DNA_UNI_IDENTITY_BLOCKS, i++)
 		if(L[i])	. += L[i]
 		else		. += random_string(DNA_BLOCK_SIZE,hex_characters)
@@ -70,32 +70,32 @@
 		return
 	if(!owner.dna)
 		owner.dna = new /datum/dna()
-	
+
 	if(real_name)
 		owner.real_name = real_name
 		owner.dna.generate_unique_enzymes(owner)
-	
+
 	if(blood_type)
 		owner.dna.b_type = blood_type
-	
+
 	if(ui)
 		owner.dna.uni_identity = ui
 		updateappearance(owner)
-	
+
 	var/update_mutantrace = (mutantrace != owner.dna.mutantrace)
 	owner.dna.mutantrace = mutantrace
 	if(update_mutantrace && istype(owner, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = owner
 		H.update_body()
 		H.update_hair()
-	
+
 	if(se)
 		owner.dna.struc_enzymes = se
 		domutcheck(owner)
-	
+
 	check_dna_integrity(owner)
 	return owner.dna
-	
+
 /proc/check_dna_integrity(mob/living/carbon/character)
 	if(!istype(character))
 		return
@@ -103,9 +103,9 @@
 		if(ready_dna(character))
 			return character.dna
 		return
-	
+
 	if(length(character.dna.uni_identity) != DNA_UNI_IDENTITY_BLOCKS*DNA_BLOCK_SIZE)
-		character.dna.uni_identity = character.dna.generate_uni_identity(character)	
+		character.dna.uni_identity = character.dna.generate_uni_identity(character)
 	if(length(character.dna.struc_enzymes)!= DNA_STRUC_ENZYMES_BLOCKS*DNA_BLOCK_SIZE)
 		character.dna.struc_enzymes = character.dna.generate_struc_enzymes()
 	if(!character.dna.real_name || length(character.dna.unique_enzymes) != DNA_UNIQUE_ENZYMES_LEN)
@@ -202,7 +202,7 @@
 /proc/updateappearance(mob/living/carbon/C)
 	if(!check_dna_integrity(C))
 		return 0
-	
+
 	var/structure = C.dna.uni_identity
 	C.gender = (deconstruct_block(getblock(structure, DNA_GENDER_BLOCK), 2)-1) ? FEMALE : MALE
 	if(istype(C, /mob/living/carbon/human))
@@ -236,7 +236,7 @@
 		blocks[i] = (deconstruct_block(getblock(M.dna.struc_enzymes, i), GOOD_MUTATION_DIFFICULTY) == GOOD_MUTATION_DIFFICULTY)
 	for(var/i in op_se_blocks)		//Overpowered mutations...extra difficult to obtain
 		blocks[i] = (deconstruct_block(getblock(M.dna.struc_enzymes, i), OP_MUTATION_DIFFICULTY) == OP_MUTATION_DIFFICULTY)
-	
+
 	if(blocks[NEARSIGHTEDBLOCK])
 		M.disabilities |= NEARSIGHTED
 		M << "\red Your eyes feel strange."
@@ -298,7 +298,7 @@
 //////////////////////////////////////////////////////////// Monkey Block
 	if(blocks[RACEBLOCK])
 		if(istype(M, /mob/living/carbon/human))	// human > monkey
-			var/mob/living/carbon/monkey/O = M.monkeyize(TR_KEEPITEMS | TR_HASHNAME | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
+			var/mob/living/carbon/monkey/O = M.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
 			O.take_overall_damage(40, 0)
 			O.adjustToxLoss(20)
 			if(connected) //inside dna thing
@@ -356,7 +356,7 @@
 /obj/machinery/dna_scannernew/proc/toggle_open()
 	if(open)	return close()
 	else		return open()
-	
+
 /obj/machinery/dna_scannernew/proc/close()
 	if(open)
 		open = 0
@@ -371,7 +371,7 @@
 			C.stop_pulling()
 			break
 		icon_state = initial(icon_state) + (occupant ? "_occupied" : "")
-		
+
 		// search for ghosts, if the corpse is empty and the scanner is connected to a cloner
 		if(occupant)
 			if(locate(/obj/machinery/computer/cloning, get_step(src, NORTH)) \
@@ -385,9 +385,9 @@
 							if(ghost.can_reenter_corpse)
 								ghost << "<b><font color = #330033><font size = 3>Your corpse has been placed into a cloning scanner. Return to your body if you want to be resurrected/cloned!</b> (Verbs -> Ghost -> Re-enter corpse)</font color>"
 							break
-		
+
 		return 1
-		
+
 /obj/machinery/dna_scannernew/proc/open()
 	if(!open)
 		if(locked)
@@ -471,7 +471,7 @@
 	density = 1
 	var/radduration = 2
 	var/radstrength = 1
-	
+
 	var/list/buffer[NUMBER_OF_BUFFERS]
 
 	var/injectorready = 0	//Quick fix for issue 286 (screwdriver the screen twice to restore injector)	-Pete
@@ -613,7 +613,7 @@
 				occupant_status = "<span class='bad'>Invalid DNA structure</span>"
 		else
 			occupant_status = "<span class='bad'>No subject detected</span>"
-		
+
 		if(connected.locked)
 			scanner_status = "<span class='bad'>Locked</span>"
 		else
@@ -621,7 +621,7 @@
 	else
 		occupant_status = "<span class='bad'>Error: Undefined</span>"
 		scanner_status = "<span class='bad'>Error: No scanner detected</span>"
-	
+
 	var/status = "<div class='statusDisplay'>Scanner Status: [scanner_status]<br>Subject Status: [occupant_status]<br>"
 	var/stddev = radstrength*RADIATION_STRENGTH_MULTIPLIER
 	status += "Emitter Array Output Level: [radstrength] <i>Mutation: (-[stddev]<->+[stddev])=68% (-[2*stddev]<->+[2*stddev])=95%</i><br>"
@@ -633,7 +633,7 @@
 		if(0.5 to 0.75)			chance_to_hit = "55-68%"
 		else					chance_to_hit = "<38%"
 	status += "Emitter Array Pulse Duration: [radduration] <i>Accuracy: ([chance_to_hit])</i></div>"
-	
+
 	var/buttons = "<a href='?src=\ref[src];'>Scan</a> "
 	if(connected)		buttons += "<a href='?src=\ref[src];task=togglelock;'>Toggle Bolts</a> <a href='?src=\ref[src];task=toggleopen;'>[connected.open ? "Close" : "Open"] Scanner</a> "
 	else				buttons += "<span class='linkOff'>Toggle Bolts</span> <span class='linkOff'>Open Scanner</span> "
@@ -645,7 +645,7 @@
 	else							buttons += "<a href='?src=\ref[src];task=screen;text=buffer;'>Buffers</a> "
 	buttons += "<br><a href='?src=\ref[src];task=setstrength;num=[radstrength-1];'>--</a> <a href='?src=\ref[src];task=setstrength;'>Emitter Array Output Level</a> <a href='?src=\ref[src];task=setstrength;num=[radstrength+1];'>++</a>"
 	buttons += "<br><a href='?src=\ref[src];task=setduration;num=[radduration-1];'>--</a> <a href='?src=\ref[src];task=setduration;'>Emitter Array Pulse Duration</a> <a href='?src=\ref[src];task=setduration;num=[radduration+1];'>++</a>"
-	
+
 	switch(current_screen)
 		if("working")
 			temp_html += "<h3>System Busy</h3>"
@@ -655,7 +655,7 @@
 			temp_html += "<h3>Buffer Menu</h3>"
 			temp_html += status
 			temp_html += buttons
-			
+
 			if(istype(buffer))
 				for(var/i=1, i<=buffer.len, i++)
 					temp_html += "<br>Slot [i]: "
@@ -714,16 +714,16 @@
 			temp_html += "<h3>Main Menu</h3>"
 			temp_html += status
 			temp_html += buttons
-			
+
 			var/max_line_len = 10*DNA_BLOCK_SIZE
-			
+
 			temp_html += "<div class='line'><div class='statusLabel'>Unique Enzymes :</div><div class='statusValue'><span class='highlight'>"
 			if(viable_occupant)
 				temp_html += "[viable_occupant.dna.unique_enzymes]"
 			else
 				temp_html += " - "
 			temp_html += "</span></div></div><br>"
-			
+
 			temp_html += "<div class='line'><div class='statusLabel'>Unique Identifier:</div><div class='statusValue'><span class='highlight'>"
 			if(viable_occupant)
 				var/len = length(viable_occupant.dna.uni_identity)
@@ -736,7 +736,7 @@
 			else
 				temp_html += " - "
 			temp_html += "</span></div></div><br>"
-			
+
 			temp_html += "<div class='line'><div class='statusLabel'>Structural Enzymes:</div><div class='statusValue'><span class='highlight'>"
 			if(viable_occupant)
 				var/len = length(viable_occupant.dna.struc_enzymes)
@@ -752,7 +752,7 @@
 
 	popup.set_content(temp_html)
 	popup.open()
-	
+
 
 /obj/machinery/computer/scan_consolenew/Topic(href, href_list)
 	if(..())
@@ -766,7 +766,7 @@
 
 	add_fingerprint(usr)
 	usr.set_machine(src)
-	
+
 	var/mob/living/carbon/viable_occupant
 	if(connected)
 		viable_occupant = connected.occupant
@@ -889,13 +889,13 @@
 
 				var/locked_state = connected.locked
 				connected.locked = 1
-				
+
 				current_screen = "working"
 				ShowInterface(usr)
-				
+
 				sleep(radduration*10)
 				current_screen = "mainmenu"
-				
+
 				if(viable_occupant && connected && connected.occupant==viable_occupant)
 					viable_occupant.radiation += RADIATION_IRRADIATION_MULTIPLIER*radduration*radstrength
 					switch(href_list["task"])
@@ -903,42 +903,42 @@
 							var/len = length(viable_occupant.dna.uni_identity)
 							num = Wrap(num, 1, len+1)
 							num = randomize_radiation_accuracy(num, radduration, len)
-							
+
 							var/block = round((num-1)/DNA_BLOCK_SIZE)+1
 							var/subblock = num - block*DNA_BLOCK_SIZE
 							last_change = "UI #[block]-[subblock]; "
-							
+
 							var/hex = copytext(viable_occupant.dna.uni_identity, num, num+1)
 							last_change += "[hex]"
 							hex = scramble(hex, radstrength, radduration)
 							last_change += "->[hex]"
-							
+
 							viable_occupant.dna.uni_identity = copytext(viable_occupant.dna.uni_identity, 1, num) + hex + copytext(viable_occupant.dna.uni_identity, num+1, 0)
 							updateappearance(viable_occupant)
 						if("pulsese")
 							var/len = length(viable_occupant.dna.struc_enzymes)
 							num = Wrap(num, 1, len+1)
 							num = randomize_radiation_accuracy(num, radduration, len)
-							
+
 							var/block = round((num-1)/DNA_BLOCK_SIZE)+1
 							var/subblock = num - block*DNA_BLOCK_SIZE
 							last_change = "SE #[block]-[subblock]; "
-							
+
 							var/hex = copytext(viable_occupant.dna.struc_enzymes, num, num+1)
 							last_change += "[hex]"
 							hex = scramble(hex, radstrength, radduration)
 							last_change += "->[hex]"
-							
+
 							viable_occupant.dna.struc_enzymes = copytext(viable_occupant.dna.struc_enzymes, 1, num) + hex + copytext(viable_occupant.dna.struc_enzymes, num+1, 0)
 							domutcheck(viable_occupant, connected)
 				else
 					current_screen = "mainmenu"
-				
+
 				if(connected)
 					connected.locked = locked_state
 
 	ShowInterface(usr,last_change)
-	
+
 
 /////////////////////////// DNA MACHINES
 #undef INJECTOR_TIMEOUT

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -205,7 +205,7 @@
 	changeling.geneticdamage = 30
 	src << "<span class='warning'>Our genes cry out!</span>"
 
-	var/mob/living/carbon/monkey/O = monkeyize(TR_KEEPITEMS | TR_HASHNAME | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPSE | TR_KEEPSRC)
+	var/mob/living/carbon/monkey/O = monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPSE | TR_KEEPSRC)
 
 	O.make_changeling(1)
 	O.verbs += /mob/living/carbon/proc/changeling_lesser_transform


### PR DESCRIPTION
This deals with humans using ling powers or DNA injectors to become things like "Monkey (42A0)" and such

Calling out over the radio "LOOK FOR THE MONKEY WITH THE FOUR LETTER NAME/NAME WITH LETTERS IN IT" is shitty and meta. Humans shouldn't be able to tell at a glace that a monkey is actually a player unless it ACTS like a player. Let people try some reverse Turing test shit and mimic a computer controlled monkey.
