### PR TITLE
throw_item() small cleanup.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -370,11 +370,6 @@
 	if(src.client)
 		src.client.screen -= item
 
-	item.loc = src.loc
-
-	if(istype(item, /obj/item))
-		item:dropped(src) // let it know it's been dropped
-
 	//actually throw it!
 	if(item)
 		item.layer = initial(item.layer)


### PR DESCRIPTION
Removed the location change and dropped() call from the throw_item() proc. These thingies are already handled by u_equip(), who is called.

This will fix some runtimes if an item is deleted on their dropped()
