### PR TITLE
Runtime fix for buildmode, type path inputs by the user being incorrect.

### DIFF
--- a/code/WorkInProgress/buildmode.dm
+++ b/code/WorkInProgress/buildmode.dm
@@ -145,10 +145,11 @@
 					return
 				if(2)
 					objholder = input(usr,"Enter typepath:" ,"Typepath","/obj/structure/closet")
+					var/P = text2path(objholder)
 					var/list/removed_paths = list("/obj/effect/bhole")
-					if(objholder in removed_paths)
-						alert("That path is not allowed.")
+					if((objholder in removed_paths) || !ispath(P))
 						objholder = "/obj/structure/closet"
+						alert("That path is not allowed.")
 					else if (dd_hasprefix(objholder, "/mob") && !check_rights(R_DEBUG,0))
 						objholder = "/obj/structure/closet"
 				if(3)


### PR DESCRIPTION
Runtime fix for buildmode type path inputs, incorrect paths are now rejected.
