### PR TITLE
Runtime fix for ninja steal objective.

### DIFF
--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -102,6 +102,7 @@
 					if(2)	//steal
 						var/datum/objective/steal/O = new /datum/objective/steal()
 						O.set_target(pick(O.possible_items_special))
+						O.owner = Mind
 						Mind.objectives += O
 
 					if(3)	//protect/kill


### PR DESCRIPTION
The steal objective from ninjas who are spawned by events will now have the var owner properly set, avoiding runtimes at roundend.
