### PR TITLE
Runtime fix for wirecutter attack()

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -113,7 +113,7 @@
 		item_state = "cutters_yellow"
 
 /obj/item/weapon/wirecutters/attack(mob/living/carbon/C, mob/user)
-	if(C.handcuffed && istype(C.handcuffed, /obj/item/weapon/handcuffs/cable))
+	if(istype(C) && C.handcuffed && istype(C.handcuffed, /obj/item/weapon/handcuffs/cable))
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		C.handcuffed.loc = null	//garbage collector awaaaaay
 		C.handcuffed = null


### PR DESCRIPTION
Runtime fix for wirecutters attack(), they now make sure that the objective is a mob/living/carbon before trying to remove any kind of cablecuffs.
