### PR TITLE
Admins can now jobban other admins, even if they have +BAN

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -699,11 +699,6 @@
 			usr << "This can only be used on instances of type /mob"
 			return
 
-		if(M != usr)																//we can jobban ourselves
-			if (check_rights_for(M, R_BAN))		//they can ban too. So we can't ban them
-				alert("You cannot perform this action. You must be of a higher administrative rank!")
-				return
-
 		if(!job_master)
 			usr << "Job Master has not been setup!"
 			return


### PR DESCRIPTION
Removed the check in jobbans that prevented admins from banning each other. Everything is already logged up the yinyang, admins are able to regular ban themselves/each other, even perma, and sometimes an admin NEEDS to be jobbanned for something.
