### PR TITLE
Malf Runtime Fix

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -111,13 +111,15 @@
 
 	to_nuke_or_not_to_nuke = 1
 	for(var/datum/mind/AI_mind in malf_ai)
-		AI_mind.current << "Congratulations you have taken control of the station."
-		AI_mind.current << "You may decide to blow up the station. You have 60 seconds to choose."
-		AI_mind.current << "You should have a new verb in the Malfunction tab. If you dont - rejoin the game."
-		AI_mind.current.verbs += /datum/game_mode/malfunction/proc/ai_win
+		if(AI_mind.current)
+			AI_mind.current << "Congratulations you have taken control of the station."
+			AI_mind.current << "You may decide to blow up the station. You have 60 seconds to choose."
+			AI_mind.current << "You should have a new verb in the Malfunction tab. If you dont - rejoin the game."
+			AI_mind.current.verbs += /datum/game_mode/malfunction/proc/ai_win
 	spawn (600)
 		for(var/datum/mind/AI_mind in malf_ai)
-			AI_mind.current.verbs -= /datum/game_mode/malfunction/proc/ai_win
+			if(AI_mind.current)
+				AI_mind.current.verbs -= /datum/game_mode/malfunction/proc/ai_win
 		to_nuke_or_not_to_nuke = 0
 	return
 


### PR DESCRIPTION
Fix for the following runtime:

runtime error: Cannot read null.verbs
proc name: capture the station (/datum/game_mode/malfunction/proc/capture_the_station)
  source file: malfunction.dm,120
  usr: null
  src: AI malfunction (/datum/game_mode/malfunction)
  call stack:
AI malfunction (/datum/game_mode/malfunction): capture the station()
