### PR TITLE
Removes the huge damage taken from monkey <--> human transformations.

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -299,8 +299,6 @@
 	if(blocks[RACEBLOCK])
 		if(istype(M, /mob/living/carbon/human))	// human > monkey
 			var/mob/living/carbon/monkey/O = M.monkeyize(TR_KEEPITEMS | TR_HASHNAME | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
-			O.take_overall_damage(40, 0)
-			O.adjustToxLoss(20)
 			if(connected) //inside dna thing
 				var/obj/machinery/dna_scannernew/C = connected
 				O.loc = C
@@ -310,8 +308,6 @@
 	else
 		if(istype(M, /mob/living/carbon/monkey))	// monkey > human,
 			var/mob/living/carbon/human/O = M.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
-			O.take_overall_damage(40, 0)
-			O.adjustToxLoss(20)
 			if(connected) //inside dna thing
 				var/obj/machinery/dna_scannernew/C = connected
 				O.loc = C


### PR DESCRIPTION
This damage had  been set at 40 brute and 20 tox dealt at time of transformation in either direction.

This is a big part of why unstable mutagen attacks are so ridiculously effective.
This damage is taken on top of any additional tox damage the chem is giving you, which is significant in itself.

This does not affect other kinds of monkification (admin buttons, ling lesser forms) that never had this damage to begin with
