### PR TITLE
Removes the hashnames from humans turned monkey (Attempt the THIRD)

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -298,7 +298,7 @@
 //////////////////////////////////////////////////////////// Monkey Block
 	if(blocks[RACEBLOCK])
 		if(istype(M, /mob/living/carbon/human))	// human > monkey
-			var/mob/living/carbon/monkey/O = M.monkeyize(TR_KEEPITEMS | TR_HASHNAME | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
+			var/mob/living/carbon/monkey/O = M.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
 			if(connected) //inside dna thing
 				var/obj/machinery/dna_scannernew/C = connected
 				O.loc = C

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -171,7 +171,7 @@
 	changeling.geneticdamage = 3
 	src << "<span class='warning'>Our genes cry out!</span>"
 
-	var/mob/living/carbon/monkey/O = monkeyize(TR_KEEPITEMS | TR_HASHNAME | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPSE | TR_KEEPSRC)
+	var/mob/living/carbon/monkey/O = monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPSE | TR_KEEPSRC)
 
 	O.make_changeling(1)
 	O.verbs += /mob/living/carbon/proc/changeling_human_form


### PR DESCRIPTION
This deals with humans using ling powers or DNA injectors to become things like "Monkey (42A0)" and such

Calling out over the radio "LOOK FOR THE MONKEY WITH THE FOUR LETTER NAME/NAME WITH LETTERS IN IT" is shitty and meta. Humans shouldn't be able to tell at a glace that a monkey is actually a player unless it ACTS like a player. Let people try some reverse Turing test shit and mimic a computer controlled monkey.

Note: This is a remake of an earlier request (#1028) that was in ITSELF a remake of an even earlier request (#1003). I am sorry for burning these numbers.
