### PR TITLE
 Runtime fixes.

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -190,7 +190,7 @@
 		spawn()
 			lines = text2list(t, "\n")
 			if(copytext(lines[1],1,6) == "BPM: ")
-				tempo = 600 / text2num(copytext(lines[1],6))
+				tempo = 600 / max(1, text2num(copytext(lines[1],6)))
 				lines.Cut(1,2)
 			else
 				tempo = 5 // default 120 BPM

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -408,7 +408,7 @@ datum
 						S.start()
 						sleep(10)
 						S.start()
-					if(holder)
+					if(holder && holder.my_atom)
 						holder.clear_reagents()
 				return
 


### PR DESCRIPTION
runtime error: Cannot execute null.on reagent change().
proc name: del reagent (/datum/reagents/proc/del_reagent)
  source file: Chemistry-Holder.dm,308
  usr: null
  src: /datum/reagents (/datum/reagents)
  call stack:
/datum/reagents (/datum/reagents): del reagent("pacid")
/datum/reagents (/datum/reagents): clear reagents()
Chemsmoke (/datum/chemical_reaction/chemsmoke): on reaction(/datum/reagents (/datum/reagents), null)

runtime error: Division by zero
proc name: Topic (/datum/song/Topic)
  source file: musician.dm,193
  usr: Tico-Tico Tambien (/mob/living/carbon/human)
  src: Untitled (/datum/song)
  call stack:
Untitled (/datum/song): Topic("src=[0x210054cd];import=1", /list (/list))
