### PR TITLE
Further Ling Tweaks

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -46,11 +46,11 @@
 		return
 
 	if(changeling.absorbedcount < required_dna)
-		src << "<span class='warning'>We require at least [required_dna] samples of compatible DNA.</span>"
+		src << "<span class='warning'>We require at least [required_dna] sample\s of compatible DNA.</span>"
 		return
 
 	if(changeling.chem_charges < required_chems)
-		src << "<span class='warning'>We require at least [required_chems] units of chemicals to do that!</span>"
+		src << "<span class='warning'>We require at least [required_chems] unit\s of chemicals to do that!</span>"
 		return
 
 	if(changeling.geneticdamage > max_genetic_damage)
@@ -115,8 +115,12 @@
 	changeling.absorb_dna(T)
 
 	if(src.nutrition < 400) src.nutrition = min((src.nutrition + T.nutrition), 400)
-	if(T.mind && T.mind.changeling)//If the target was a changeling, suck out their extra juice!
+	if(T.mind && T.mind.changeling)//If the target was a changeling, suck out their extra juice and objective points!
 		changeling.chem_charges += min(T.mind.changeling.chem_charges, changeling.chem_storage)
+		changeling.absorbedcount += T.mind.changeling.absorbedcount
+
+		T.mind.changeling.absorbed_dna.len = 1
+		T.mind.changeling.absorbedcount = 0
 	else
 		changeling.chem_charges += 10
 
@@ -222,7 +226,7 @@
 	set name = "Regenerative Stasis (10)"
 	set desc = "Begin stasis, allowing us to regenerate."
 
-	var/datum/changeling/changeling = changeling_power(10,0,100,DEAD)
+	var/datum/changeling/changeling = changeling_power(10,1,100,DEAD)
 	if(!changeling)	return
 	if(status_flags & FAKEDEATH) return //Make sure we can't stack regenerations and such.
 	changeling.chem_charges -= 10
@@ -252,7 +256,7 @@
 	set name = "Regenerate! (10)"
 	set desc = "Regenerate, healing all damage from our form."
 
-	var/datum/changeling/changeling = changeling_power(10,0,100,DEAD)
+	var/datum/changeling/changeling = changeling_power(10,1,100,DEAD)
 	if(!changeling)	return
 	changeling.chem_charges -= 10
 
@@ -323,18 +327,23 @@
 	if(!changeling)	return 0
 	src.mind.changeling.chem_charges -= 25
 
-	for(var/mob/living/carbon/M in ohearers(4, usr))
-		if(!M.mind || !M.mind.changeling)
-			M.ear_deaf += 30
-			M.confused += 20
-			M.make_jittery(50)
+	for(var/mob/living/M in hearers(4, usr))
+		if(iscarbon(M))
+			if(!M.mind || !M.mind.changeling)
+				M.ear_deaf += 30
+				M.confused += 20
+				M.make_jittery(50)
+			else
+				M << sound('sound/effects/screech.ogg')
+
+		if(issilicon(M))
+			M << sound('sound/weapons/flash.ogg')
+			M.Weaken(rand(5,10))
+
 
 	for(var/obj/machinery/light/L in range(4, usr))
 		L.on = 1
 		L.broken()
-
-	//for(var/obj/structure/window/W in range(2, usr)) //I like the window-breaking, but it makes the ability too 'loud' to fit changelings.
-	//	W.hit(rand(40,100))
 
 	feedback_add_details("changeling_powers","RS")
 	return 1
@@ -343,19 +352,16 @@
 //Makes some spiderlings. Good for setting traps and causing general trouble.
 /mob/living/carbon/proc/changeling_spiders()
 	set category = "Changeling"
-	set name = "Spread Infestation (40)"
+	set name = "Spread Infestation (50)"
 	set desc = "Creates spiderlings."
 
-	var/datum/changeling/changeling = changeling_power(40, 10)
+	var/datum/changeling/changeling = changeling_power(50, 5)
 	if(!changeling)	return 0
-	src.mind.changeling.chem_charges -= 40
+	src.mind.changeling.chem_charges -= 50
 
-	for(var/i=0, i<3, i++)
+	for(var/i=0, i<2, i++)
 		var/obj/effect/spider/spiderling/S = new(src.loc)
-		if(prob(50))//nurses are obnoxious and lay more eggs, let's not have that for now.
-			S.grow_as = /mob/living/simple_animal/hostile/giant_spider/hunter
-		else
-			S.grow_as = /mob/living/simple_animal/hostile/giant_spider
+		S.grow_as = /mob/living/simple_animal/hostile/giant_spider/hunter
 
 	feedback_add_details("changeling_powers","SI")
 	return 1

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -117,15 +117,15 @@ var/list/powerinstances
 
 /datum/power/changeling/shriek
 	name = "Resonant Shriek"
-	desc = "Our lungs and vocal chords shift, allowing us to briefly emit a noise that deafens and confuses humans."
-	helptext = "The high-frequency sounds cannot be heard by humans, but will blow out lights nearby."
+	desc = "Our lungs and vocal chords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded."
+	helptext = "The high-frequency sounds cannot be heard by humans, but will blow out lights nearby. Cyborgs will have their sensors overloaded and become stunned."
 	genomecost = 1
 	verbpath = /mob/living/carbon/proc/changeling_shriek
 
 /datum/power/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires 10 DNA absorptions."
+	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 DNA absorptions."
 	genomecost = 1
 	allowduringlesserform = 1
 	verbpath = /mob/living/carbon/proc/changeling_spiders

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -381,7 +381,7 @@ Nobody takes these seriously anyways -- Ikki
 datum/objective/download
 	proc/gen_amount_goal()
 		target_amount = rand(10,20)
-		explanation_text = "Download [target_amount] research levels."
+		explanation_text = "Download [target_amount] research level\s."
 		return target_amount
 
 
@@ -407,7 +407,7 @@ datum/objective/download
 datum/objective/capture
 	proc/gen_amount_goal()
 		target_amount = rand(5,10)
-		explanation_text = "Accumulate [target_amount] capture points. It is better if they remain relatively unharmed."
+		explanation_text = "Accumulate [target_amount] capture point\s. It is better if they remain relatively unharmed."
 		return target_amount
 
 
@@ -458,7 +458,7 @@ datum/objective/absorb
 						n_p ++
 			target_amount = min(target_amount, n_p)
 
-		explanation_text = "Extract [target_amount] compatible genomes."
+		explanation_text = "Extract [target_amount] compatible genome\s."
 		return target_amount
 
 	check_completion()


### PR DESCRIPTION
-Fixes a bug where a changeling could use revive after being husked by another changeling. The husk also loses his absorb points to the changeling that ate him.
-Fixes some objective text to use appropriate cases when dealing with numbered objectives ("1 genome", "2 genomes", so on)

-Resonant shriek now acts as a "flash" for cyborgs in range, giving changelings an in my opinion much-needed anti-silicon ability. Changelings in the area will also be able to hear the shriek.
-Spread Infestation requires fewer DNA absorptions now, but costs more chems to use and creates 1 fewer spiders.
