### PR TITLE
NTSL Crash Fix

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -4,9 +4,9 @@
 /datum/game_mode/malfunction
 	name = "AI malfunction"
 	config_tag = "malfunction"
-	required_players = 0//20
-	required_enemies = 0//1
-	recommended_enemies = 0//1
+	required_players = 20
+	required_enemies = 1
+	recommended_enemies = 1
 
 	uplink_welcome = "Crazy AI Uplink Console:"
 	uplink_uses = 10

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -115,8 +115,12 @@
 //Servers
 
 /obj/machinery/telecomms/server/presets
-
 	network = "tcommsat"
+
+/obj/machinery/telecomms/server/presets/New()
+	..()
+	name = id
+
 
 /obj/machinery/telecomms/server/presets/science
 	id = "Science Server"

--- a/code/modules/scripting/Errors.dm
+++ b/code/modules/scripting/Errors.dm
@@ -60,6 +60,15 @@
 		New(name, token/t)
 			message="Function '[name]' defined twice."
 
+	ParameterFunction
+		message = "You cannot use a function inside a parameter."
+
+		New(token/t)
+			var/line = "?"
+			if(t)
+				line = t.line
+			message = "[line]: [message]"
+
 /*
 	Class: runtimeError
 	An error thrown by the interpreter in running the script.

--- a/code/modules/scripting/Interpreter/Interaction.dm
+++ b/code/modules/scripting/Interpreter/Interaction.dm
@@ -21,6 +21,7 @@
 			ASSERT(program)
 			src.program 	= program
 			CreateGlobalScope()
+			alertadmins = 0 // reset admin alerts
 
 /*
 	Proc: Run
@@ -29,7 +30,6 @@
 		Run()
 			cur_recursion = 0 // reset recursion
 			cur_statements = 0 // reset CPU tracking
-			alertadmins = 0
 
 			ASSERT(src.program)
 			RunBlock(src.program)

--- a/code/modules/scripting/Interpreter/Interpreter.dm
+++ b/code/modules/scripting/Interpreter/Interpreter.dm
@@ -37,7 +37,7 @@
 		cur_statements=0    // current amount of statements called
 		alertadmins=0		// set to 1 if the admins shouldn't be notified of anymore issues
 		max_iterations=100 	// max number of uninterrupted loops possible
-		max_recursion=50   	// max recursions without returning anything (or completing the code block)
+		max_recursion=10   	// max recursions without returning anything (or completing the code block)
 		cur_recursion=0	   	// current amount of recursion
 /*
 	Var: persist
@@ -85,6 +85,19 @@
 			return S
 
 /*
+	Proc: AlertAdmins
+	Alerts the admins of a script that is bad.
+*/
+		AlertAdmins()
+			if(container && !alertadmins)
+				if(istype(container, /datum/TCS_Compiler))
+					var/datum/TCS_Compiler/Compiler = container
+					var/obj/machinery/telecomms/server/Holder = Compiler.Holder
+					var/message = "Potential crash-inducing NTSL script detected at telecommunications server [Compiler.Holder] ([Holder.x], [Holder.y], [Holder.z])."
+
+					alertadmins = 1
+					message_admins(message, 1)
+/*
 	Proc: RunBlock
 	Runs each statement in a block of code.
 */
@@ -108,15 +121,7 @@
 					cur_statements++
 					if(cur_statements >= max_statements)
 						RaiseError(new/runtimeError/MaxCPU())
-
-						if(container && !alertadmins)
-							if(istype(container, /datum/TCS_Compiler))
-								var/datum/TCS_Compiler/Compiler = container
-								var/obj/machinery/telecomms/server/Holder = Compiler.Holder
-								var/message = "Potential crash-inducing NTSL script detected at telecommunications server [Compiler.Holder] ([Holder.x], [Holder.y], [Holder.z])."
-
-								alertadmins = 1
-								message_admins(message, 1)
+						AlertAdmins()
 						break
 
 					if(istype(S, /node/statement/VariableAssignment))
@@ -179,6 +184,7 @@
 
 			// If recursion gets too high (max 50 nested functions) throw an error
 			if(cur_recursion >= max_recursion)
+				AlertAdmins()
 				RaiseError(new/runtimeError/RecursionLimitReached())
 				return 0
 
@@ -330,4 +336,5 @@
 			else if(!istype(value) && isobject(value))			value = new/node/expression/value/reference(value)
 			//TODO: check for invalid name
 			S.variables["[name]"] = value
+
 

--- a/code/modules/scripting/Parser/Parser.dm
+++ b/code/modules/scripting/Parser/Parser.dm
@@ -174,8 +174,9 @@
 			var/loops = 0
 			for()
 				loops++
-				if(loops>=6000)
-					CRASH("Something TERRIBLE has gone wrong in ParseFunctionStatement ;__;")
+				if(loops>=800)
+					errors +=new/scriptError("Cannot find ending params.")
+					return
 
 				if(!curToken)
 					errors+=new/scriptError/EndOfFile()
@@ -184,6 +185,6 @@
 					curBlock.statements+=stmt
 					NextToken() //Skip close parenthesis
 					return
-				var/node/expression/P=ParseParamExpression()
+				var/node/expression/P=ParseParamExpression(check_functions = 1)
 				stmt.parameters+=P
 				if(istype(curToken, /token/symbol) && curToken.value==",") NextToken()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,7 +51,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>6 August 2013</h2>
+	<h3 class='author'>Giacom updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='bugfix'>NTSL no longer allows you to use a function within another function parameter. This was changed to help prevent server crashes; if your working script no longer compiles this is why.</li>
+	</ul>
+</div>
+
 
 <div class='commit sansserif'>
 	<h2 class='date'>4 August 2013</h2>


### PR DESCRIPTION
- Fixes the NTSL crashing the server by setting the max recursion limit to 10. The problem was that the BYOND recursion limit was being met before the NTSL recursion limit.
- Added admin warning messages for the recursion limit.
- Made the admin warnings only appear for every new program that is loaded, and not for everytime the script runs.
- Made the preset servers set their names to their ID.
- Removed the ability to use functions inside parameters, to prevent recursion crashes.
  - Added an error message for it.
- Added some other crash preventing measures.
