### PR TITLE
Disconnects clients who have not joined the round before restarting

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -300,7 +300,7 @@ var/global/datum/controller/gameticker/ticker
 
 				if(!delay_end)
 					sleep(restart_timeout)
-					kick_clients_in_lobby("\red The round came to an end with you in the lobby.")
+					kick_clients_in_lobby("\red The round came to an end with you in the lobby.", 1) //second parameter ensures only afk clients are kicked
 					world.Reboot()
 				else
 					world << "\blue <B>An admin has delayed the round end</B>"

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -300,6 +300,7 @@ var/global/datum/controller/gameticker/ticker
 
 				if(!delay_end)
 					sleep(restart_timeout)
+					kick_clients_in_lobby("\red The round came to an end with you in the lobby.")
 					world.Reboot()
 				else
 					world << "\blue <B>An admin has delayed the round end</B>"

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -221,6 +221,7 @@ var/bomb_set
 					blackbox.save_all_data_to_sql()
 				sleep(300)
 				log_game("Rebooting due to nuclear detonation")
+				kick_clients_in_lobby("\red The round came to an end with you in the lobby.")
 				world.Reboot()
 				return
 	return

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -221,7 +221,7 @@ var/bomb_set
 					blackbox.save_all_data_to_sql()
 				sleep(300)
 				log_game("Rebooting due to nuclear detonation")
-				kick_clients_in_lobby("\red The round came to an end with you in the lobby.")
+				kick_clients_in_lobby("\red The round came to an end with you in the lobby.", 1) //second parameter ensures only afk clients are kicked
 				world.Reboot()
 				return
 	return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -842,10 +842,17 @@ proc/move_ferry()
 	else
 		ferry_location = 1
 
-
-proc/kick_clients_in_lobby(var/message)
+//Kicks all the clients currently in the lobby. The second parameter (kick_only_afk) determins if an is_afk() check is ran, or if all clients are kicked
+//defaults to kicking everyone (afk + non afk clients in the lobby)
+//returns a list of ckeys of the kicked clients
+proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
+	var/list/kicked_client_names = list()
 	for(var/client/C in clients)
 		if(istype(C.mob, /mob/new_player))
+			if(kick_only_afk && !C.is_afk())	//Ignore clients who are not afk
+				continue
 			if(message)
 				C << message
+			kicked_client_names.Add("[C.ckey]")
 			del(C)
+	return kicked_client_names

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -841,3 +841,11 @@ proc/move_ferry()
 		ferry_location = 0
 	else
 		ferry_location = 1
+
+
+proc/kick_clients_in_lobby(var/message)
+	for(var/client/C in clients)
+		if(istype(C.mob, /mob/new_player))
+			if(message)
+				C << message
+			del(C)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -194,7 +194,7 @@
 			<tr id='title_tr'>
 				<td align='center'>
 					<font size='5'><b>Player panel</b></font><br>
-					Hover over a line to see more information - <a href='?_src_=holder;secretsadmin=check_antagonist'>Check antagonists</a> - <a href='?_src_=holder;secretsadmin=kick_all_from_lobby'>Kick everyone in lobby</a>
+					Hover over a line to see more information - <a href='?_src_=holder;secretsadmin=check_antagonist'>Check antagonists</a> - Kick <a href='?_src_=holder;secretsadmin=kick_all_from_lobby;afkonly=0'>everyone</a>/<a href='?_src_=holder;secretsadmin=kick_all_from_lobby;afkonly=1'>AFKers</a> in lobby
 					<p>
 				</td>
 			</tr>

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -194,7 +194,7 @@
 			<tr id='title_tr'>
 				<td align='center'>
 					<font size='5'><b>Player panel</b></font><br>
-					Hover over a line to see more information - <a href='?_src_=holder;secretsadmin=check_antagonist'>Check antagonists</a>
+					Hover over a line to see more information - <a href='?_src_=holder;secretsadmin=check_antagonist'>Check antagonists</a> - <a href='?_src_=holder;secretsadmin=kick_all_from_lobby'>Kick everyone in lobby</a>
 					<p>
 				</td>
 			</tr>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2061,6 +2061,13 @@
 				usr << browse(dat, "window=lawchanges;size=800x500")
 			if("check_antagonist")
 				check_antagonists()
+			if("kick_all_from_lobby")
+				if(ticker && ticker.current_state == GAME_STATE_PLAYING)
+					message_admins("[key_name_admin(usr)] has kicked all clients from the lobby.", 1)
+					log_admin("[key_name(usr)] has kicked all clients from the lobby.")
+					kick_clients_in_lobby("\red The admin [usr.ckey] issued a 'kick all clients from lobby' command.")
+				else
+					usr << "You may only use this when the game is running"
 			if("showailaws")
 				output_ai_laws()
 			if("showgm")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2063,9 +2063,16 @@
 				check_antagonists()
 			if("kick_all_from_lobby")
 				if(ticker && ticker.current_state == GAME_STATE_PLAYING)
-					message_admins("[key_name_admin(usr)] has kicked all clients from the lobby.", 1)
-					log_admin("[key_name(usr)] has kicked all clients from the lobby.")
-					kick_clients_in_lobby("\red The admin [usr.ckey] issued a 'kick all clients from lobby' command.")
+					var/afkonly = text2num(href_list["afkonly"])
+					if(alert("Are you sure you want to kick all [afkonly ? "AFK" : ""] clients from the lobby??","Message","Yes","Cancel") != "Yes")
+						usr << "Kick clients from lobby aborted"
+						return
+					var/list/listkicked = kick_clients_in_lobby("\red The admin [usr.ckey] issued a 'kick all clients from lobby' command.", afkonly)
+					var/strkicked = ""
+					for(var/name in listkicked)
+						strkicked += "[name], "
+					message_admins("[key_name_admin(usr)] has kicked [afkonly ? "all AFK" : "all"] clients from the lobby. [length(listkicked)] clients kicked: [strkicked ? strkicked : "--"]", 1)
+					log_admin("[key_name_admin(usr)] has kicked [afkonly ? "all AFK" : "all"] clients from the lobby. [length(listkicked)] clients kicked: [strkicked ? strkicked : "--"]")
 				else
 					usr << "You may only use this when the game is running"
 			if("showailaws")


### PR DESCRIPTION
- In an effort to decrease the number of unneeded client connections, I've made it so when the round ends, all the clients who are in the lobby get kicked before the restart. This is only effective when rounds end 'organically' (not when restart commands or votes are used, for example). The intention is to prevent people from leaving their computers on and connected indefinitely, because all clients contribute to the total. The assumption is that if you are in the lobby when the round ends, you have not participated in the previous round, meaning you are probably not actually present.
- Also added a button to the player panel, which allows admins to do the same thing. The admin's name is reported to all the kicked clients.

EDITS IN FURTHER COMMITS:
- When clients in the lobby are kicked at round end, only afk clients actually get kicked.
- The admins now have the ability to kick all or just afk clients from the lobby
- When admins use this action, a list of kicked clients is sent to admins and into the log.
- Added a confirmation message to the admin command.
