### PR TITLE
Chameleon Projector Cleanup

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -182,7 +182,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon-Projector"
-	desc = "Projects an image across a user, disguising them as an object scanned with it. The disguised user cannot run. Projectiles pass over them."
+	desc = "Projects an image across a user, disguising them as an object scanned with it, as long as they don't move the projector from their hand. The disguised user cannot run and rojectiles pass over them."
 	item = /obj/item/device/chameleon
 	cost = 4
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -11,72 +11,68 @@
 	origin_tech = "syndicate=4;magnets=4"
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
-	var/saved_item = "/obj/item/weapon/cigbutt"
+	var/saved_item = /obj/item/weapon/cigbutt
 
-	dropped()
-		disrupt()
+/obj/item/device/chameleon/dropped()
+	disrupt()
 
-	attack_self()
-		toggle()
+/obj/item/device/chameleon/equipped()
+	disrupt()
 
-	afterattack(atom/target, mob/user , flag)
+/obj/item/device/chameleon/attack_self()
+	toggle()
+
+/obj/item/device/chameleon/afterattack(atom/target, mob/user , flag)
+	if(!active_dummy)
 		if(istype(target,/obj/item) && !istype(target, /obj/item/weapon/disk/nuclear))
-			playsound(src, 'sound/weapons/flash.ogg', 100, 1, 1)
+			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
 			user << "\blue Scanned [target]."
 			saved_item = target.type
 
-	proc/toggle()
-		if(!can_use || !saved_item) return
-		if(active_dummy)
-			playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
-			for(var/atom/movable/A in active_dummy)
-				A.loc = active_dummy.loc
-				if(ismob(A))
-					if(A:client)
-						A:client:eye = A
-			del(active_dummy)
-			active_dummy = null
-			usr << "\blue You deactivate the [src]."
-			var/obj/effect/overlay/T = new/obj/effect/overlay(get_turf(src))
-			T.icon = 'icons/effects/effects.dmi'
-			flick("emppulse",T)
-			spawn(8) T.delete()
-		else
-			playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
-			var/obj/O = new saved_item(src)
-			if(!O) return
-			var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(usr.loc)
-			C.name = O.name
-			C.desc = O.desc
-			C.icon = O.icon
-			C.icon_state = O.icon_state
-			C.dir = O.dir
-			usr.loc = C
-			C.master = src
-			src.active_dummy = C
-			del(O)
-			usr << "\blue You activate the [src]."
-			var/obj/effect/overlay/T = new/obj/effect/overlay(get_turf(src))
-			T.icon = 'icons/effects/effects.dmi'
-			flick("emppulse",T)
-			spawn(8) T.delete()
+/obj/item/device/chameleon/proc/toggle()
+	if(!can_use || !saved_item) return
+	if(active_dummy)
+		eject_all()
+		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+		del(active_dummy)
+		active_dummy = null
+		usr << "\blue You deactivate the [src]."
+		var/obj/effect/overlay/T = new/obj/effect/overlay(get_turf(src))
+		T.icon = 'icons/effects/effects.dmi'
+		flick("emppulse",T)
+		spawn(8) T.delete()
+	else
+		playsound(get_turf(src), 'sound/effects/pop.ogg', 100, 1, -6)
+		var/obj/O = new saved_item(src)
+		if(!O) return
+		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(usr.loc)
+		C.activate(O, usr, src)
+		del(O)
+		usr << "\blue You activate the [src]."
+		var/obj/effect/overlay/T = new/obj/effect/overlay(get_turf(src))
+		T.icon = 'icons/effects/effects.dmi'
+		flick("emppulse",T)
+		spawn(8) T.delete()
 
-	proc/disrupt()
-		if(active_dummy)
-			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
-			spark_system.set_up(5, 0, src)
-			spark_system.attach(src)
-			spark_system.start()
-			for(var/atom/movable/A in active_dummy)
-				A.loc = active_dummy.loc
-				if(ismob(A))
-					if(A:client)
-						A:client:eye = A
+/obj/item/device/chameleon/proc/disrupt(var/delete_dummy = 1)
+	if(active_dummy)
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
+		spark_system.set_up(5, 0, src)
+		spark_system.attach(src)
+		spark_system.start()
+		eject_all()
+		if(delete_dummy)
 			del(active_dummy)
-			active_dummy = null
-			can_use = 0
-			spawn(100) can_use = 1
+		active_dummy = null
+		can_use = 0
+		spawn(50) can_use = 1
 
+/obj/item/device/chameleon/proc/eject_all()
+	for(var/atom/movable/A in active_dummy)
+		A.loc = active_dummy.loc
+		if(ismob(A))
+			var/mob/M = A
+			M.reset_view(null)
 
 /obj/effect/dummy/chameleon
 	name = ""
@@ -85,38 +81,57 @@
 	anchored = 1
 	var/can_move = 1
 	var/obj/item/device/chameleon/master = null
-	attackby()
-		for(var/mob/M in src)
-			M << "\red Your chameleon-projector deactivates."
-		master.disrupt()
-	attack_hand()
-		for(var/mob/M in src)
-			M << "\red Your chameleon-projector deactivates."
-		master.disrupt()
-	ex_act()
-		for(var/mob/M in src)
-			M << "\red Your chameleon-projector deactivates."
-		master.disrupt()
-	bullet_act()
-		for(var/mob/M in src)
-			M << "\red Your chameleon-projector deactivates."
-		..()
-		master.disrupt()
-	relaymove(var/mob/user, direction)
-		if(istype(loc, /turf/space)) return //No magical space movement!
 
-		if(can_move)
-			can_move = 0
-			switch(usr.bodytemperature)
-				if(300 to INFINITY)
-					spawn(10) can_move = 1
-				if(295 to 300)
-					spawn(13) can_move = 1
-				if(280 to 295)
-					spawn(16) can_move = 1
-				if(260 to 280)
-					spawn(20) can_move = 1
-				else
-					spawn(25) can_move = 1
-			step(src,direction)
-		return
+/obj/effect/dummy/chameleon/proc/activate(var/obj/item/O, var/mob/M, var/obj/item/device/chameleon/C)
+	name = O.name
+	desc = O.desc
+	icon = O.icon
+	icon_state = O.icon_state
+	dir = O.dir
+	M.loc = src
+	master = C
+	master.active_dummy = src
+
+/obj/effect/dummy/chameleon/attackby()
+	for(var/mob/M in src)
+		M << "\red Your chameleon-projector deactivates."
+	master.disrupt()
+
+/obj/effect/dummy/chameleon/attack_hand()
+	for(var/mob/M in src)
+		M << "\red Your chameleon-projector deactivates."
+	master.disrupt()
+
+/obj/effect/dummy/chameleon/ex_act()
+	for(var/mob/M in src)
+		M << "\red Your chameleon-projector deactivates."
+	master.disrupt()
+
+/obj/effect/dummy/chameleon/bullet_act()
+	for(var/mob/M in src)
+		M << "\red Your chameleon-projector deactivates."
+	..()
+	master.disrupt()
+
+/obj/effect/dummy/chameleon/relaymove(var/mob/user, direction)
+	if(istype(loc, /turf/space)) return //No magical space movement!
+
+	if(can_move)
+		can_move = 0
+		switch(user.bodytemperature)
+			if(300 to INFINITY)
+				spawn(10) can_move = 1
+			if(295 to 300)
+				spawn(13) can_move = 1
+			if(280 to 295)
+				spawn(16) can_move = 1
+			if(260 to 280)
+				spawn(20) can_move = 1
+			else
+				spawn(25) can_move = 1
+		step(src, direction)
+	return
+
+/obj/effect/dummy/chameleon/Del()
+	master.disrupt(0)
+	..()


### PR DESCRIPTION
- Cleaned up chameleon projector code. 
- Added a Del() to the projection which will disrupt the chameleon projector, before being deleted by acid or a drill (killing the person inside).
- Made chameleon projectors disrupt if moved from the hand, to make it consistent. Currently you could put them in pockets but if you picked them up it would disrupt. Fixing this would involve changing all use of dropped() so instead I made them disrupt when equipped and, due to how dropped() works, when they switch hands. Lowered the disrupt cooldown to make up for this.
