### PR TITLE
Prevents the Detomatix PDA Cartridge from appearing in Double Agents

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -139,6 +139,7 @@ var/list/uplink_items = list()
 	name = "Detomatix PDA Cartridge"
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 3
+	gamemodes = list("revolution", "traitor+changeling", "traitor", "wizard", "nuclear emergency", "traitor", "AI malfunction", "changeling", "meteor", "cult", "blob", "sandbox", "extended")
 
 
 // STEALTHY TOOLS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -15,6 +15,8 @@ var/list/uplink_items = list()
 				continue
 			if(I.gamemodes.len && ticker && !(ticker.mode.name in I.gamemodes))
 				continue
+			if(I.exclude_gamemodes.len && ticker && ticker.mode.name in I.gamemodes)
+				continue
 			if(I.last)
 				last += I
 				continue
@@ -43,6 +45,7 @@ var/list/uplink_items = list()
 	var/cost = 0
 	var/last = 0 // Appear last
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
+	var/list/exclude_gamemodes = list() //Empty list means it is in all the gamemodes, you should never need both of these vars for one item.
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(item)
@@ -139,7 +142,7 @@ var/list/uplink_items = list()
 	name = "Detomatix PDA Cartridge"
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 3
-	gamemodes = list("revolution", "traitor+changeling", "wizard", "nuclear emergency", "traitor", "AI malfunction", "changeling", "meteor", "cult", "blob", "sandbox", "extended")
+	exclude_gamemodes = list("double agents")
 
 
 // STEALTHY TOOLS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -13,7 +13,7 @@ var/list/uplink_items = list()
 			var/datum/uplink_item/I = new item()
 			if(!I.item)
 				continue
-			if(I.gamemodes.len && ticker && !(ticker.mode.name in I.gamemodes))
+			if(I.include_gamemodes.len && ticker && !(ticker.mode.name in I.gamemodes))
 				continue
 			if(I.exclude_gamemodes.len && ticker && ticker.mode.name in I.gamemodes)
 				continue
@@ -44,8 +44,8 @@ var/list/uplink_items = list()
 	var/item = null
 	var/cost = 0
 	var/last = 0 // Appear last
-	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
-	var/list/exclude_gamemodes = list() //Empty list means it is in all the gamemodes, you should never need both of these vars for one item.
+	var/list/include_gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
+	var/list/exclude_gamemodes = list() // Empty list means it is in all the gamemodes, you should never need both of these vars for one item.
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(item)
@@ -244,7 +244,7 @@ var/list/uplink_items = list()
 	name = "Teleporter Circuit Board"
 	item = /obj/item/weapon/circuitboard/teleporter
 	cost = 20
-	gamemodes = list("nuclear emergency")
+	include_gamemodes = list("nuclear emergency")
 
 
 // IMPLANTS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -139,7 +139,7 @@ var/list/uplink_items = list()
 	name = "Detomatix PDA Cartridge"
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 3
-	gamemodes = list("revolution", "traitor+changeling", "traitor", "wizard", "nuclear emergency", "traitor", "AI malfunction", "changeling", "meteor", "cult", "blob", "sandbox", "extended")
+	gamemodes = list("revolution", "traitor+changeling", "wizard", "nuclear emergency", "traitor", "AI malfunction", "changeling", "meteor", "cult", "blob", "sandbox", "extended")
 
 
 // STEALTHY TOOLS


### PR DESCRIPTION
Reasoning: You know your target has a traitor PDA, blow it up before they can spend their points and your target is suddenly a lot more vulnerable and they're SoL on traitor gear.

Haven't seen this happen in game, but if it ever becomes prevalent (especially now that I've mentioned it) you'd see half the double agents if not more having to play without gear against better armed opponents, which is no good.
