### PR TITLE
* Properly renamed Soporific to Sleep Toxins, because that is what it is...

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -57,7 +57,7 @@
 			if(occupant.reagents)
 				//Left the text()s for readability.
 				dat += text("<div class='line'><div class='statusLabel'>Inaprovaline:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("inaprovaline"), 0.1))
-				dat += text("<div class='line'><div class='statusLabel'>Soporific:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("stoxin"), 0.1))
+				dat += text("<div class='line'><div class='statusLabel'>Sleep Toxin:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("stoxin"), 0.1))
 				dat += text("<div class='line'><div class='statusLabel'>Dermaline:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("dermaline"), 0.1))
 				dat += text("<div class='line'><div class='statusLabel'>Bicaridine:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("bicaridine"), 0.1))
 				dat += text("<div class='line'><div class='statusLabel'>Dexalin:</div><div class='statusValue'>[] units</div></div>", round(occupant.reagents.get_reagent_amount("dexalin"), 0.1))
@@ -71,12 +71,12 @@
 		else
 			dat += "<span class='linkOff'>Inject Inaprovaline</span>"
 		if(occupant && occupant.health > 0)
-			dat += {"<BR><A href='?src=\ref[src];stox=1'>Inject Soporific</A>
+			dat += {"<BR><A href='?src=\ref[src];stox=1'>Inject Sleep Toxin</A>
 					<BR><A href='?src=\ref[src];derm=1'>Inject Dermaline</A>
 					<BR><A href='?src=\ref[src];bic=1'>Inject Bicaridine</A>
 					<BR><A href='?src=\ref[src];dex=1'>Inject Dexalin</A>"}
 		else
-			dat += {"<BR><span class='linkOff'>Inject Soporific</span>
+			dat += {"<BR><span class='linkOff'>Inject Sleep Toxin</span>
 					<BR><span class='linkOff'>Inject Dermaline</span>
 					<BR><span class='linkOff'>Inject Bicaridine</span>
 					<BR><span class='linkOff'>Inject Dexalin</span>"}
@@ -268,7 +268,7 @@
 		if(occupant.reagents.get_reagent_amount("stoxin") + 20 < 41)
 			occupant.reagents.add_reagent("stoxin", 20)
 		var/units = round(occupant.reagents.get_reagent_amount("stoxin"))
-		user << "<span class='notice'>Occupant now has [units] unit\s of soporifics in their bloodstream.</span>"
+		user << "<span class='notice'>Occupant now has [units] unit\s of sleep toxins in their bloodstream.</span>"
 
 
 /obj/machinery/sleeper/proc/inject_dermaline(mob/user)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -358,39 +358,6 @@ datum
 				..()
 				return
 
-		srejuvenate
-			name = "Soporific Rejuvenant"
-			id = "stoxin2"
-			description = "Put people to sleep, and heals them."
-			reagent_state = LIQUID
-			color = "#C8A5DC" // rgb: 200, 165, 220
-
-			on_mob_life(var/mob/living/M as mob)
-				if(!M) M = holder.my_atom
-				if(!data) data = 1
-				data++
-				if(M.losebreath >= 10)
-					M.losebreath = max(10, M.losebreath-10)
-				holder.remove_reagent(src.id, 0.2)
-				switch(data)
-					if(1 to 15)
-						M.eye_blurry = max(M.eye_blurry, 10)
-					if(15 to 25)
-						M.drowsyness  = max(M.drowsyness, 20)
-					if(25 to INFINITY)
-						M.sleeping += 1
-						M.adjustOxyLoss(-M.getOxyLoss())
-						M.SetWeakened(0)
-						M.SetStunned(0)
-						M.SetParalysis(0)
-						M.dizziness = 0
-						M.drowsyness = 0
-						M.stuttering = 0
-						M.confused = 0
-						M.jitteriness = 0
-				..()
-				return
-
 		inaprovaline
 			name = "Inaprovaline"
 			id = "inaprovaline"


### PR DESCRIPTION
... and it confused people who would make their patients sleep because they think it's medicine.
- Removed the actual Soporific because it was unused, non-makable and pretty useless. (A chemical which removes stuns but puts you to sleep.... yeah)
