### PR TITLE
Cargo Overhaul: Phase 1

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -833,6 +833,15 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "cardboard sheets crate"
 	group = supply_materials
 
+/datum/supply_packs/sandstone30
+	name = "30 Sandstone Blocks"
+	contains = list(/obj/item/stack/sheet/mineral/sandstone)
+	amount = 30
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "sandstone blocks crate"
+	group = supply_materials
+/*		// Disabled by request of coderbus
 /datum/supply_packs/wood30
 	name = "25 Wood Planks"
 	contains = list(/obj/item/stack/sheet/wood)
@@ -849,15 +858,6 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 40
 	containertype = /obj/structure/closet/crate
 	containername = "wood planks crate"
-	group = supply_materials
-
-/datum/supply_packs/sandstone30
-	name = "30 Sandstone Blocks"
-	contains = list(/obj/item/stack/sheet/mineral/sandstone)
-	amount = 30
-	cost = 20
-	containertype = /obj/structure/closet/crate
-	containername = "sandstone blocks crate"
 	group = supply_materials
 
 /// Precious materials: these are intentionally priced high to not make mining redundent
@@ -933,7 +933,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate
 	containername = "plasma blocks crate"
 	group = supply_materials
-
+*/
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -43,7 +43,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	var/manifest = ""
 	var/amount = null
 	var/cost = null
-	var/containertype = null
+	var/containertype = /obj/structure/closet/crate
 	var/containername = null
 	var/access = null
 	var/hidden = 0
@@ -67,34 +67,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 //////////////////////////// Emergency ///////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/specialops
-	name = "Special Ops supplies"
-	contains = list(/obj/item/weapon/storage/box/emps,
-					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/grenade/smokebomb,
-					/obj/item/weapon/pen/paralysis,
-					/obj/item/weapon/grenade/chem_grenade/incendiary)
-	cost = 20
-	containertype = /obj/structure/closet/crate
-	containername = "special ops crate"
-	hidden = 1
-	group = supply_emergency
-
-/datum/supply_packs/internals
-	name = "Internals crate"
-	contains = list(/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/mask/gas,
-					/obj/item/weapon/tank/air,
-					/obj/item/weapon/tank/air,
-					/obj/item/weapon/tank/air)
-	cost = 10
+/datum/supply_packs/emergency	// Section header - use these to set default supply group and crate type for sections
+	name = "HEADER"				// Use "HEADER" to denote section headers, this is needed for the supply computers to filter them
 	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
 	group = supply_emergency
 
-/datum/supply_packs/evacuation
+
+/datum/supply_packs/emergency/evac
 	name = "Emergency equipment"
 	contains = list(/obj/machinery/bot/floorbot,
 					/obj/machinery/bot/floorbot,
@@ -115,7 +94,18 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "emergency crate"
 	group = supply_emergency
 
-/datum/supply_packs/weedcontrol
+/datum/supply_packs/emergency/internals
+	name = "Internals crate"
+	contains = list(/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/weapon/tank/air,
+					/obj/item/weapon/tank/air,
+					/obj/item/weapon/tank/air)
+	cost = 10
+	containername = "internals crate"
+
+/datum/supply_packs/emergency/weedcontrol
 	name = "Weed Control Crate"
 	contains = list(/obj/item/weapon/scythe,
 					/obj/item/clothing/mask/gas,
@@ -125,7 +115,19 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "weed control crate"
 	access = access_hydroponics
-	group = supply_emergency
+
+/datum/supply_packs/emergency/specialops
+	name = "Special Ops supplies"
+	contains = list(/obj/item/weapon/storage/box/emps,
+					/obj/item/weapon/grenade/smokebomb,
+					/obj/item/weapon/grenade/smokebomb,
+					/obj/item/weapon/grenade/smokebomb,
+					/obj/item/weapon/pen/paralysis,
+					/obj/item/weapon/grenade/chem_grenade/incendiary)
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "special ops crate"
+	hidden = 1
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -133,188 +135,133 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_packs/security
+	name = "HEADER"
+	containertype = /obj/structure/closet/crate/secure/gear
+	access = access_security
+	group = supply_security
+
+
+/datum/supply_packs/security/supplies
 	name = "Security Supplies crate"
 	contains = list(/obj/item/weapon/storage/box/flashbangs,
 					/obj/item/weapon/storage/box/teargas,
 					/obj/item/weapon/storage/box/flashes,
 					/obj/item/weapon/storage/box/handcuffs)
 	cost = 10
-	containertype = /obj/structure/closet/crate/secure
 	containername = "security supply crate"
-	access = access_security
-	group = supply_security
-
-/////// Implants
-
-/datum/supply_packs/loyalty
-	name = "Loyalty implants crate"
-	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
-	cost = 40
-	containertype = /obj/structure/closet/crate/secure
-	containername = "loyalty implant crate"
-	access = access_armory
-	group = supply_security
-
-/datum/supply_packs/trackingimp
-	name = "Tracking implants crate"
-	contains = list (/obj/item/weapon/storage/box/trackimp)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure
-	containername = "tracking implant crate"
-	access = access_armory
-	group = supply_security
-
-/datum/supply_packs/chemimp
-	name = "Chemical implants crate"
-	contains = list (/obj/item/weapon/storage/box/chemimp)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure
-	containername = "chemical implant crate"
-	access = access_armory
-	group = supply_security
-
 
 ////// Armor: Basic
 
-/datum/supply_packs/helmets
+/datum/supply_packs/security/helmets
 	name = "Helmets crate"
 	contains = list(/obj/item/clothing/head/helmet,
 					/obj/item/clothing/head/helmet,
 					/obj/item/clothing/head/helmet)
 	cost = 10
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "helmet crate"
-	access = access_security
-	group = supply_security
 
-/datum/supply_packs/armor
+/datum/supply_packs/security/armor
 	name = "Armor crate"
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
 	cost = 10
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "armor crate"
-	access = access_security
-	group = supply_security
 
 ////// Weapons: Basic
 
-/datum/supply_packs/baton
+/datum/supply_packs/security/baton
 	name = "Stun Batons crate"
 	contains = list(/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded,
 					/obj/item/weapon/melee/baton/loaded)
 	cost = 10
-	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "stun baton crate"
-	access = access_security
-	group = supply_security
 
-/datum/supply_packs/laser
+/datum/supply_packs/security/laser
 	name = "Lasers crate"
 	contains = list(/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "laser crate"
-	access = access_security
-	group = supply_security
 
-/datum/supply_packs/taser
+/datum/supply_packs/security/taser
 	name = "Stun Guns crate"
 	contains = list(/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/energy/taser,
 					/obj/item/weapon/gun/energy/taser)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "stun gun crate"
-	access = access_security
-	group = supply_security
+
+///// Armory stuff
+
+/datum/supply_packs/security/armory
+	name = "HEADER"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	access = access_armory
 
 ///// Armor: Specialist
 
-/datum/supply_packs/riotshields
-	name = "Riot shields crate"
-	contains = list(/obj/item/weapon/shield/riot,
-					/obj/item/weapon/shield/riot,
-					/obj/item/weapon/shield/riot)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "riot shields crate"
-	access = access_armory
-	group = supply_security
-
-/datum/supply_packs/riot
+/datum/supply_packs/security/armory/riothelmets
 	name = "Riot helmets crate"
 	contains = list(/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "riot helmets crate"
-	access = access_armory
-	group = supply_security
 
-/datum/supply_packs/riot
+/datum/supply_packs/security/armory/riotsuits
 	name = "Riot suits crate"
 	contains = list(/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "riot suits crate"
-	access = access_armory
-	group = supply_security
 
-/datum/supply_packs/bulletarmor
+/datum/supply_packs/security/armory/riotshields
+	name = "Riot shields crate"
+	contains = list(/obj/item/weapon/shield/riot,
+					/obj/item/weapon/shield/riot,
+					/obj/item/weapon/shield/riot)
+	cost = 20
+	containername = "riot shields crate"
+
+/datum/supply_packs/security/armory/bulletarmor
 	name = "Bulletproof armor crate"
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof)
 	cost = 15
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "bulletproof armor crate"
-	access = access_armory
-	group = supply_security
 
-/datum/supply_packs/laserarmor
+/datum/supply_packs/security/armory/laserarmor
 	name = "Ablative armor crate"
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof)		// Only two vests to keep costs down for balance
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "ablative armor crate"
-	access = access_armory
-	group = supply_security
 
 /////// Weapons: Specialist
 
-
-
-/datum/supply_packs/ballistic
+/datum/supply_packs/security/armory/ballistic
 	name = "Combat Shotguns crate"
 	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
 					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
 	cost = 20
-	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "combat shotgun crate"
-	access = access_armory
-	group = supply_security
 
-/datum/supply_packs/expenergy
+/datum/supply_packs/security/armory/expenergy
 	name = "Energy Guns crate"
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)			// Only two guns to keep costs down
 	cost = 25
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "energy gun crate"
-	access = access_armory
-	group = supply_security
 
-/datum/supply_packs/eweapons
+/datum/supply_packs/security/armory/eweapons
 	name = "Incendiary weapons crate"
 	contains = list(/obj/item/weapon/flamethrower/full,
 					/obj/item/weapon/tank/plasma,
@@ -324,36 +271,57 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/grenade/chem_grenade/incendiary,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
 	cost = 15	// its a fecking flamethrower and some plasma, why the shit did this cost so much before!?
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "incendiary weapons crate"
 	access = access_heads
-	group = supply_security
 
-/datum/supply_packs/securitybarriers
+/////// Implants & etc
+
+/datum/supply_packs/security/armory/loyalty
+	name = "Loyalty implants crate"
+	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
+	cost = 40
+	containername = "loyalty implant crate"
+
+/datum/supply_packs/security/armory/trackingimp
+	name = "Tracking implants crate"
+	contains = list (/obj/item/weapon/storage/box/trackimp)
+	cost = 20
+	containername = "tracking implant crate"
+
+/datum/supply_packs/security/armory/chemimp
+	name = "Chemical implants crate"
+	contains = list (/obj/item/weapon/storage/box/chemimp)
+	cost = 20
+	containername = "chemical implant crate"
+
+/datum/supply_packs/security/securitybarriers
 	name = "Security Barriers"
 	contains = list(/obj/machinery/deployable/barrier,
 					/obj/machinery/deployable/barrier,
 					/obj/machinery/deployable/barrier,
 					/obj/machinery/deployable/barrier)
 	cost = 20
-	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "security barriers crate"
-	group = supply_security
 
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/fueltank
+/datum/supply_packs/engineering
+	name = "HEADER"
+	group = supply_engineer
+
+
+/datum/supply_packs/engineering/fueltank
 	name = "Fuel tank crate"
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = 8
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
-	group = supply_engineer
 
-/datum/supply_packs/toolbox		//the most robust crate
+/datum/supply_packs/engineering/tools		//the most robust crate
 	name = "Toolbox crate"
 	contains = list(/obj/item/weapon/storage/toolbox/electrical,
 					/obj/item/weapon/storage/toolbox/electrical,
@@ -362,31 +330,25 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/storage/toolbox/mechanical,
 					/obj/item/weapon/storage/toolbox/mechanical)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "electrical maintenance crate"
-	group = supply_engineer
 
-/datum/supply_packs/powergamermitts
+/datum/supply_packs/engineering/powergamermitts
 	name = "Insulated Gloves crate"
 	contains = list(/obj/item/clothing/gloves/yellow,
 					/obj/item/clothing/gloves/yellow,
 					/obj/item/clothing/gloves/yellow)
 	cost = 20	//Made of pure-grade bullshittinium
-	containertype = /obj/structure/closet/crate
 	containername = "insulated gloves crate"
-	group = supply_engineer
 
-/datum/supply_packs/power
+/datum/supply_packs/engineering/power
 	name = "Powercell crate"
 	contains = list(/obj/item/weapon/cell/high,		//Changed to an extra high powercell because normal cells are useless
 					/obj/item/weapon/cell/high,
 					/obj/item/weapon/cell/high)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "electrical maintenance crate"
-	group = supply_engineer
 
-/datum/supply_packs/engiequipment
+/datum/supply_packs/engineering/engiequipment
 	name = "Engineering Gear crate"
 	contains = list(/obj/item/weapon/storage/belt/utility,
 					/obj/item/weapon/storage/belt/utility,
@@ -401,11 +363,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/head/hardhat)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "engineering gear crate"
-	group = supply_engineer
 
-/datum/supply_packs/solar
+/datum/supply_packs/engineering/solar
 	name = "Solar Pack crate"
 	contains  = list(/obj/item/solar_assembly,
 					/obj/item/solar_assembly,
@@ -432,11 +392,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/tracker_electronics,
 					/obj/item/weapon/paper/solar)
 	cost = 20
-	containertype = /obj/structure/closet/crate
 	containername = "solar pack crate"
-	group = supply_engineer
 
-/datum/supply_packs/engine
+/datum/supply_packs/engineering/engine
 	name = "Emitter crate"
 	contains = list(/obj/machinery/power/emitter,
 					/obj/machinery/power/emitter)
@@ -444,36 +402,30 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate/secure
 	containername = "emitter crate"
 	access = access_ce
-	group = supply_engineer
 
-/datum/supply_packs/engine/field_gen
+/datum/supply_packs/engineering/engine/field_gen
 	name = "Field Generator crate"
 	contains = list(/obj/machinery/field_generator,
 					/obj/machinery/field_generator)
-	containertype = /obj/structure/closet/crate/secure
+	cost = 10
 	containername = "field generator crate"
-	access = access_ce
-	group = supply_engineer
 
-/datum/supply_packs/engine/sing_gen
+/datum/supply_packs/engineering/engine/sing_gen
 	name = "Singularity Generator crate"
 	contains = list(/obj/machinery/the_singularitygen)
-	containertype = /obj/structure/closet/crate/secure
+	cost = 10
 	containername = "singularity generator crate"
-	access = access_ce
-	group = supply_engineer
 
-/datum/supply_packs/engine/collector
+/datum/supply_packs/engineering/engine/collector
 	name = "Collector crate"
 	contains = list(/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
+	cost = 10
 	containername = "collector crate"
-	group = supply_engineer
 
-/datum/supply_packs/engine/PA
+/datum/supply_packs/engineering/engine/PA
 	name = "Particle Accelerator crate"
-	cost = 25
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,
 					/obj/structure/particle_accelerator/particle_emitter/center,
@@ -481,10 +433,8 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/structure/particle_accelerator/particle_emitter/right,
 					/obj/structure/particle_accelerator/power_box,
 					/obj/structure/particle_accelerator/end_cap)
-	containertype = /obj/structure/closet/crate/secure
+	cost = 25
 	containername = "particle accelerator crate"
-	access = access_ce
-	group = supply_engineer
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -492,6 +442,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_packs/medical
+	name = "HEADER"
+	containertype = /obj/structure/closet/crate/medical
+	group = supply_medical
+
+
+/datum/supply_packs/medical/supplies
 	name = "Medical Supplies crate"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
 					/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
@@ -508,51 +464,42 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 20
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical supplies crate"
-	group = supply_medical
 
-/datum/supply_packs/firstaid
+/datum/supply_packs/medical/firstaid
 	name = "First Aid Kits crate"
 	contains = list(/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/regular,
 					/obj/item/weapon/storage/firstaid/regular)
 	cost = 10
-	containertype = /obj/structure/closet/crate/medical
 	containername = "first aid kits crate"
-	group = supply_medical
 
-/datum/supply_packs/firstaidburns
+/datum/supply_packs/medical/firstaidburns
 	name = "Burns Treatment Kits crate"
 	contains = list(/obj/item/weapon/storage/firstaid/fire,
 					/obj/item/weapon/storage/firstaid/fire,
 					/obj/item/weapon/storage/firstaid/fire)
 	cost = 10
-	containertype = /obj/structure/closet/crate/medical
 	containername = "fire first aid kits crate"
-	group = supply_medical
 
-/datum/supply_packs/firstaidtoxins
+/datum/supply_packs/medical/firstaidtoxins
 	name = "Toxin Treatment Kits crate"
 	contains = list(/obj/item/weapon/storage/firstaid/toxin,
 					/obj/item/weapon/storage/firstaid/toxin,
 					/obj/item/weapon/storage/firstaid/toxin)
 	cost = 10
-	containertype = /obj/structure/closet/crate/medical
 	containername = "toxin first aid kits crate"
-	group = supply_medical
 
-/datum/supply_packs/firstaidoxygen
+/datum/supply_packs/medical/firstaidoxygen
 	name = "Oxygen Deprivation Kits crate"
 	contains = list(/obj/item/weapon/storage/firstaid/o2,
 					/obj/item/weapon/storage/firstaid/o2,
 					/obj/item/weapon/storage/firstaid/o2)
 	cost = 10
-	containertype = /obj/structure/closet/crate/medical
 	containername = "oxygen deprivation kits crate"
-	group = supply_medical
 
 
-/datum/supply_packs/virus
+/datum/supply_packs/medical/virus
 	name = "Virus crate"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
 					/obj/item/weapon/reagent_containers/glass/bottle/cold,
@@ -567,39 +514,21 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/storage/box/beakers,
 					/obj/item/weapon/reagent_containers/glass/bottle/mutagen)
 	cost = 25
-	containertype = /obj/structure/closet/crate/secure/weapon
+	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "virus crate"
 	access = access_cmo
-	group = supply_medical
 
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/mecha_ripley
-	name = "Circuit Crate (\"Ripley\" APLU)"
-	contains = list(/obj/item/weapon/book/manual/ripley_build_and_repair,
-					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper APLU \"Ripley\" circuit crate"
-	access = access_robotics
-	group = supply_science
-
-/datum/supply_packs/mecha_odysseus
-	name = "Circuit Crate (\"Odysseus\")"
-	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
-					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure
-	containername = "\improper \"Odysseus\" circuit crate"
-	access = access_robotics
+/datum/supply_packs/science
+	name = "HEADER"
 	group = supply_science
 
 
-/datum/supply_packs/robotics
+/datum/supply_packs/science/robotics
 	name = "Robotics Assembly Crate"
 	contains = list(/obj/item/device/assembly/prox_sensor,
 					/obj/item/device/assembly/prox_sensor,
@@ -609,12 +538,28 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/cell/high,
 					/obj/item/weapon/cell/high)
 	cost = 10
-	containertype = /obj/structure/closet/crate/secure/gear
+	containertype = /obj/structure/closet/crate/secure
 	containername = "robotics assembly crate"
 	access = access_robotics
-	group = supply_science
 
-/datum/supply_packs/plasma
+/datum/supply_packs/science/robotics/mecha_ripley
+	name = "Circuit Crate (\"Ripley\" APLU)"
+	contains = list(/obj/item/weapon/book/manual/ripley_build_and_repair,
+					/obj/item/weapon/circuitboard/mecha/ripley/main, //TEMPORARY due to lack of circuitboard printer
+					/obj/item/weapon/circuitboard/mecha/ripley/peripherals) //TEMPORARY due to lack of circuitboard printer
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper APLU \"Ripley\" circuit crate"
+
+/datum/supply_packs/science/robotics/mecha_odysseus
+	name = "Circuit Crate (\"Odysseus\")"
+	contains = list(/obj/item/weapon/circuitboard/mecha/odysseus/peripherals, //TEMPORARY due to lack of circuitboard printer
+					/obj/item/weapon/circuitboard/mecha/odysseus/main) //TEMPORARY due to lack of circuitboard printer
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
+	containername = "\improper \"Odysseus\" circuit crate"
+
+/datum/supply_packs/science/plasma
 	name = "Plasma assembly crate"
 	contains = list(/obj/item/weapon/tank/plasma,
 					/obj/item/weapon/tank/plasma,
@@ -634,7 +579,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	access = access_tox_storage
 	group = supply_science
 
-/datum/supply_packs/shieldwalls
+/datum/supply_packs/science/shieldwalls
 	name = "Shield Generators"
 	contains = list(/obj/machinery/shieldwallgen,
 					/obj/machinery/shieldwallgen,
@@ -644,14 +589,19 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shield generators crate"
 	access = access_teleporter
-	group = supply_science
 
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Organic /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/food
+/datum/supply_packs/organic
+	name = "HEADER"
+	group = supply_organic
+	containertype = /obj/structure/closet/crate/freezer
+
+
+/datum/supply_packs/organic/food
 	name = "Food crate"
 	contains = list(/obj/item/weapon/reagent_containers/food/drinks/flour,
 					/obj/item/weapon/reagent_containers/food/drinks/milk,
@@ -664,19 +614,15 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
 					/obj/item/weapon/reagent_containers/food/snacks/grown/banana)
 	cost = 10
-	containertype = /obj/structure/closet/crate/freezer
 	containername = "food crate"
-	group = supply_organic
 
-/datum/supply_packs/monkey
+/datum/supply_packs/organic/monkey
 	name = "Monkey crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
 	cost = 20
-	containertype = /obj/structure/closet/crate/freezer
 	containername = "monkey crate"
-	group = supply_organic
 
-/datum/supply_packs/party
+/datum/supply_packs/organic/party
 	name = "Party equipment"
 	contains = list(/obj/item/weapon/storage/box/drinkingglasses,
 					/obj/item/weapon/reagent_containers/food/drinks/shaker,
@@ -689,46 +635,37 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/reagent_containers/food/drinks/beer,
 					/obj/item/weapon/reagent_containers/food/drinks/beer)
 	cost = 20
-	containertype = /obj/structure/closet/crate
 	containername = "party equipment"
-	group = supply_organic
 
 //////// livestock
-/datum/supply_packs/cow
+/datum/supply_packs/organic/cow
 	name = "Cow Crate"
 	cost = 30
 	containertype = /obj/structure/largecrate/cow
 	containername = "cow crate"
-	access = access_hydroponics
-	group = supply_organic
 
-/datum/supply_packs/goat
+/datum/supply_packs/organic/goat
 	name = "Goat Crate"
 	cost = 25
 	containertype = /obj/structure/largecrate/goat
 	containername = "goat crate"
-	access = access_hydroponics
-	group = supply_organic
 
-/datum/supply_packs/chicken
+/datum/supply_packs/organic/chicken
 	name = "Chicken Crate"
 	cost = 20
 	containertype = /obj/structure/largecrate/chick
 	containername = "chicken crate"
-	access = access_hydroponics
-	group = supply_organic
 
-/datum/supply_packs/lisa
+/datum/supply_packs/organic/lisa
 	name = "Corgi Crate"
 	contains = list()
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
 	containername = "corgi crate"
-	group = supply_organic
 
 ////// hippy gear
 
-/datum/supply_packs/hydroponics // -- Skie
+/datum/supply_packs/organic/hydroponics // -- Skie
 	name = "Hydroponics Supply Crate"
 	contains = list(/obj/item/weapon/reagent_containers/spray/plantbgone,
 					/obj/item/weapon/reagent_containers/spray/plantbgone,
@@ -742,10 +679,8 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 15
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "hydroponics crate"
-	access = access_hydroponics
-	group = supply_organic
 
-/datum/supply_packs/seeds
+/datum/supply_packs/organic/hydroponics/seeds
 	name = "Seeds Crate"
 	contains = list(/obj/item/seeds/chiliseed,
 					/obj/item/seeds/berryseed,
@@ -760,12 +695,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/seeds/potatoseed,
 					/obj/item/seeds/sugarcaneseed)
 	cost = 10
-	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "seeds crate"
-	access = access_hydroponics
-	group = supply_organic
 
-/datum/supply_packs/exoticseeds
+/datum/supply_packs/organic/hydroponics/exoticseeds
 	name = "Exotic Seeds Crate"
 	contains = list(/obj/item/seeds/nettleseed,
 					/obj/item/seeds/replicapod,
@@ -778,187 +710,87 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/seeds/bananaseed,
 					/obj/item/seeds/eggyseed)
 	cost = 15
-	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "exotic seeds crate"
-	access = access_hydroponics
-	group = supply_organic
 
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Materials ///////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/metal50
+/datum/supply_packs/materials
+	name = "HEADER"
+	group = supply_materials
+
+
+/datum/supply_packs/materials/metal50
 	name = "50 Metal Sheets"
 	contains = list(/obj/item/stack/sheet/metal)
 	amount = 50
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "metal sheets crate"
-	group = supply_materials
 
-/datum/supply_packs/plasteel20
+/datum/supply_packs/materials/plasteel20
 	name = "20 Plasteel Sheets"
 	contains = list(/obj/item/stack/sheet/plasteel)
 	amount = 20
 	cost = 30
-	containertype = /obj/structure/closet/crate
 	containername = "plasteel sheets crate"
-	group = supply_materials
 
-/datum/supply_packs/plasteel50
+/datum/supply_packs/materials/plasteel50
 	name = "50 Plasteel Sheets"
 	contains = list(/obj/item/stack/sheet/plasteel)
 	amount = 50
 	cost = 50
-	containertype = /obj/structure/closet/crate
 	containername = "plasteel sheets crate"
-	group = supply_materials
 
-/datum/supply_packs/glass50
+/datum/supply_packs/materials/glass50
 	name = "50 Glass Sheets"
 	contains = list(/obj/item/stack/sheet/glass)
 	amount = 50
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "glass sheets crate"
-	group = supply_materials
 
-/datum/supply_packs/cardboard50
+/datum/supply_packs/materials/cardboard50
 	name = "50 Cardboard Sheets"
 	contains = list(/obj/item/stack/sheet/cardboard)
 	amount = 50
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "cardboard sheets crate"
-	group = supply_materials
 
-/datum/supply_packs/sandstone30
+/datum/supply_packs/materials/sandstone30
 	name = "30 Sandstone Blocks"
 	contains = list(/obj/item/stack/sheet/mineral/sandstone)
 	amount = 30
 	cost = 20
-	containertype = /obj/structure/closet/crate
 	containername = "sandstone blocks crate"
-	group = supply_materials
-/*		// Disabled by request of coderbus
-/datum/supply_packs/wood30
-	name = "25 Wood Planks"
-	contains = list(/obj/item/stack/sheet/wood)
-	amount = 25
-	cost = 25
-	containertype = /obj/structure/closet/crate
-	containername = "wood planks crate"
-	group = supply_materials
 
-/datum/supply_packs/wood50
-	name = "50 Wood Planks"
-	contains = list(/obj/item/stack/sheet/wood)
-	amount = 50
-	cost = 40
-	containertype = /obj/structure/closet/crate
-	containername = "wood planks crate"
-	group = supply_materials
-
-/// Precious materials: these are intentionally priced high to not make mining redundent
-
-/datum/supply_packs/silver10
-	name = "10 Silver Ingots"
-	contains = list(/obj/item/stack/sheet/mineral/silver)
-	amount = 10
-	cost = 30
-	containertype = /obj/structure/closet/crate
-	containername = "silver ingots crate"
-	group = supply_materials
-
-/datum/supply_packs/silver20
-	name = "20 Silver Ingots"
-	contains = list(/obj/item/stack/sheet/mineral/silver)
-	amount = 20
-	cost = 45
-	containertype = /obj/structure/closet/crate
-	containername = "silver ingots crate"
-	group = supply_materials
-
-/datum/supply_packs/gold10
-	name = "10 Gold Ingots"
-	contains = list(/obj/item/stack/sheet/mineral/gold)
-	amount = 10
-	cost = 30
-	containertype = /obj/structure/closet/crate
-	containername = "gold ingots crate"
-	group = supply_materials
-
-/datum/supply_packs/gold20
-	name = "20 Gold Ingots"
-	contains = list(/obj/item/stack/sheet/mineral/gold)
-	amount = 20
-	cost = 45
-	containertype = /obj/structure/closet/crate
-	containername = "gold ingots crate"
-	group = supply_materials
-
-/datum/supply_packs/uranium10
-	name = "10 Uranium Blocks"
-	contains = list(/obj/item/stack/sheet/mineral/uranium)
-	amount = 10
-	cost = 30
-	containertype = /obj/structure/closet/crate
-	containername = "uranium blocks crate"
-	group = supply_materials
-
-/datum/supply_packs/uranium20
-	name = "20 Uranium Blocks"
-	contains = list(/obj/item/stack/sheet/mineral/uranium)
-	amount = 20
-	cost = 45
-	containertype = /obj/structure/closet/crate
-	containername = "uranium blocks crate"
-	group = supply_materials
-
-/datum/supply_packs/diamonds10
-	name = "10 Diamonds"
-	contains = list(/obj/item/stack/sheet/mineral/diamond)
-	amount = 10
-	cost = 60		// Damn Space Jews artificially inflating prices
-	containertype = /obj/structure/closet/crate
-	containername = "diamond crate"
-	group = supply_materials
-
-/datum/supply_packs/plasma10
-	name = "10 Plasma Blocks"
-	contains = list(/obj/item/stack/sheet/mineral/plasma)
-	amount = 10
-	cost = 50		// One of the reasons the station exists is to mine this shit, hence the high cost
-	containertype = /obj/structure/closet/crate
-	containername = "plasma blocks crate"
-	group = supply_materials
-*/
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_packs/mule
+/datum/supply_packs/misc
+	name = "HEADER"
+	group = supply_misc
+
+/datum/supply_packs/misc/mule
 	name = "MULEbot Crate"
 	contains = list(/obj/machinery/bot/mulebot)
 	cost = 20
 	containertype = /obj/structure/largecrate/mule
 	containername = "\improper MULEbot Crate"
-	group = supply_misc
 
-/datum/supply_packs/watertank
+/datum/supply_packs/misc/watertank
 	name = "Water tank crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank)
 	cost = 8
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
-	group = supply_misc
 
 
 ///////////// Paper Work
 
-/datum/supply_packs/paper
+/datum/supply_packs/misc/paper
 	name = "Bureaucracy crate"
 	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
 					/obj/item/device/camera_film,
@@ -975,11 +807,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/clipboard,
 					/obj/item/weapon/clipboard)
 	cost = 15
-	containertype = /obj/structure/closet/crate
 	containername = "Bureaucracy crate"
-	group = supply_misc
 
-/datum/supply_packs/toner
+/datum/supply_packs/misc/toner
 	name = "Toner Cartridges"
 	contains = list(/obj/item/device/toner,
 					/obj/item/device/toner,
@@ -988,14 +818,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/device/toner,
 					/obj/item/device/toner)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "toner cartridges"
-	group = supply_misc
 
 
 ///////////// Janitor Supplies
 
-/datum/supply_packs/janitor
+/datum/supply_packs/misc/janitor
 	name = "Janitorial supplies"
 	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
 					/obj/item/weapon/reagent_containers/glass/bucket,
@@ -1011,32 +839,27 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/grenade/chem_grenade/cleaner,
 					/obj/item/weapon/grenade/chem_grenade/cleaner)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "janitorial supplies"
-	group = supply_misc
 
-/datum/supply_packs/janicart
+/datum/supply_packs/misc/janitor/janicart
 	name = "Janitorial Cart crate"
 	contains = list(/obj/structure/janitorialcart)
 	cost = 10
 	containertype = /obj/structure/largecrate
 	containername = "janitorial cart crate"
-	group = supply_misc
 
-/datum/supply_packs/lightbulbs
+/datum/supply_packs/misc/janitor/lightbulbs
 	name = "Replacement lights"
 	contains = list(/obj/item/weapon/storage/box/lights/mixed,
 					/obj/item/weapon/storage/box/lights/mixed,
 					/obj/item/weapon/storage/box/lights/mixed)
 	cost = 10
-	containertype = /obj/structure/closet/crate
 	containername = "replacement lights"
-	group = supply_misc
 
 
 ///////////// Costumes
 
-/datum/supply_packs/costume
+/datum/supply_packs/misc/costume
 	name = "Standard Costume crate"
 	contains = list(/obj/item/weapon/storage/backpack/clown,
 					/obj/item/clothing/shoes/clown_shoes,
@@ -1054,20 +877,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/closet/crate/secure
 	containername = "standard costumes"
 	access = access_theatre
-	group = supply_misc
 
-/datum/supply_packs/wizard
+/datum/supply_packs/misc/wizard
 	name = "Wizard costume"
 	contains = list(/obj/item/weapon/staff,
 					/obj/item/clothing/suit/wizrobe/fake,
 					/obj/item/clothing/shoes/sandal,
 					/obj/item/clothing/head/wizard/fake)
 	cost = 20
-	containertype = /obj/structure/closet/crate
 	containername = "wizard costume crate"
-	group = supply_misc
 
-/datum/supply_packs/randomised
+/datum/supply_packs/misc/randomised
 	var/num_contained = 3 //number of items picked to be contained in a randomised crate
 	contains = list(/obj/item/clothing/head/collectable/chef,
 					/obj/item/clothing/head/collectable/paper,
@@ -1091,23 +911,19 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/head/collectable/petehat)
 	name = "Collectable hat crate!"
 	cost = 200
-	containertype = /obj/structure/closet/crate
 	containername = "Collectable hats crate! Brought to you by Bass.inc!"
-	group = supply_misc
 
-/datum/supply_packs/randomised/New()
+/datum/supply_packs/misc/randomised/New()
 	manifest += "Contains any [num_contained] of:"
 	..()
 
 
-/datum/supply_packs/randomised/contraband
+/datum/supply_packs/misc/randomised/contraband
 	num_contained = 5
 	contains = list(/obj/item/weapon/contraband/poster,
 					/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
 					/obj/item/weapon/lipstick/random)
 	name = "Contraband crate"
 	cost = 30
-	containertype = /obj/structure/closet/crate
 	containername = "crate"	//let's keep it subtle, eh?
 	contraband = 1
-	group = supply_misc

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -5,7 +5,37 @@
 //BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
-var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical","Science","Organic","Materials","Miscellaneous")
+// Supply Groups
+var/const/supply_emergency 	= 1
+var/const/supply_security 	= 2
+var/const/supply_engineer	= 3
+var/const/supply_medical	= 4
+var/const/supply_science	= 5
+var/const/supply_organic	= 6
+var/const/supply_materials 	= 7
+var/const/supply_misc		= 8
+
+var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engineer,supply_medical,supply_science,supply_organic,supply_materials,supply_misc)
+
+/proc/get_supply_group_name(var/cat)
+	switch(cat)
+		if(1)
+			return "Emergency"
+		if(2)
+			return "Security"
+		if(3)
+			return "Engineering"
+		if(4)
+			return "Medical"
+		if(5)
+			return "Science"
+		if(6)
+			return "Food & Livestock"
+		if(7)
+			return "Raw Materials"
+		if(8)
+			return "Miscellaneous"
+
 
 /datum/supply_packs
 	var/name = null
@@ -18,7 +48,8 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	var/access = null
 	var/hidden = 0
 	var/contraband = 0
-	var/group = "Miscellaneous"
+	var/group = supply_misc
+
 
 /datum/supply_packs/New()
 	manifest += "<ul>"
@@ -48,7 +79,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate
 	containername = "special ops crate"
 	hidden = 1
-	group = "Emergency"
+	group = supply_emergency
 
 /datum/supply_packs/internals
 	name = "Internals crate"
@@ -61,7 +92,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/internals
 	containername = "internals crate"
-	group = "Emergency"
+	group = supply_emergency
 
 /datum/supply_packs/evacuation
 	name = "Emergency equipment"
@@ -82,7 +113,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 35
 	containertype = /obj/structure/closet/crate/internals
 	containername = "emergency crate"
-	group = "Emergency"
+	group = supply_emergency
 
 /datum/supply_packs/weedcontrol
 	name = "Weed Control Crate"
@@ -94,7 +125,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "weed control crate"
 	access = access_hydroponics
-	group = "Emergency"
+	group = supply_emergency
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -111,7 +142,9 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "security supply crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
+
+/////// Implants
 
 /datum/supply_packs/loyalty
 	name = "Loyalty implants crate"
@@ -120,7 +153,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "loyalty implant crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/trackingimp
 	name = "Tracking implants crate"
@@ -129,16 +162,16 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "tracking implant crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
-/datum/supply_packs/loyalty
+/datum/supply_packs/chemimp
 	name = "Chemical implants crate"
 	contains = list (/obj/item/weapon/storage/box/chemimp)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
 	containername = "chemical implant crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 
 ////// Armor: Basic
@@ -152,7 +185,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "helmet crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/armor
 	name = "Armor crate"
@@ -163,7 +196,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "armor crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
 
 ////// Weapons: Basic
 
@@ -176,7 +209,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "stun baton crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/laser
 	name = "Lasers crate"
@@ -187,7 +220,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "laser crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/taser
 	name = "Stun Guns crate"
@@ -198,7 +231,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "stun gun crate"
 	access = access_security
-	group = "Security"
+	group = supply_security
 
 ///// Armor: Specialist
 
@@ -211,7 +244,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "riot shields crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/riot
 	name = "Riot helmets crate"
@@ -222,7 +255,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "riot helmets crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/riot
 	name = "Riot suits crate"
@@ -233,7 +266,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "riot suits crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/bulletarmor
 	name = "Bulletproof armor crate"
@@ -244,7 +277,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "bulletproof armor crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/laserarmor
 	name = "Ablative armor crate"
@@ -254,7 +287,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "ablative armor crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /////// Weapons: Specialist
 
@@ -269,7 +302,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "combat shotgun crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/expenergy
 	name = "Energy Guns crate"
@@ -279,7 +312,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "energy gun crate"
 	access = access_armory
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/eweapons
 	name = "Incendiary weapons crate"
@@ -294,7 +327,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "incendiary weapons crate"
 	access = access_heads
-	group = "Security"
+	group = supply_security
 
 /datum/supply_packs/securitybarriers
 	name = "Security Barriers"
@@ -305,7 +338,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "security barriers crate"
-	group = "Security"
+	group = supply_security
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -318,7 +351,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 8
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/toolbox		//the most robust crate
 	name = "Toolbox crate"
@@ -331,7 +364,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "electrical maintenance crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/powergamermitts
 	name = "Insulated Gloves crate"
@@ -341,7 +374,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20	//Made of pure-grade bullshittinium
 	containertype = /obj/structure/closet/crate
 	containername = "insulated gloves crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/power
 	name = "Powercell crate"
@@ -351,7 +384,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "electrical maintenance crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engiequipment
 	name = "Engineering Gear crate"
@@ -370,7 +403,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "engineering gear crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/solar
 	name = "Solar Pack crate"
@@ -401,7 +434,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "solar pack crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engine
 	name = "Emitter crate"
@@ -411,7 +444,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "emitter crate"
 	access = access_ce
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engine/field_gen
 	name = "Field Generator crate"
@@ -420,7 +453,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "field generator crate"
 	access = access_ce
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engine/sing_gen
 	name = "Singularity Generator crate"
@@ -428,7 +461,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "singularity generator crate"
 	access = access_ce
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engine/collector
 	name = "Collector crate"
@@ -436,7 +469,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
 	containername = "collector crate"
-	group = "Engineering"
+	group = supply_engineer
 
 /datum/supply_packs/engine/PA
 	name = "Particle Accelerator crate"
@@ -451,7 +484,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "particle accelerator crate"
 	access = access_ce
-	group = "Engineering"
+	group = supply_engineer
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -475,7 +508,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate/medical
 	containername = "medical supplies crate"
-	group = "Medical"
+	group = supply_medical
 
 /datum/supply_packs/firstaid
 	name = "First Aid Kits crate"
@@ -486,7 +519,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "first aid kits crate"
-	group = "Medical"
+	group = supply_medical
 
 /datum/supply_packs/firstaidburns
 	name = "Burns Treatment Kits crate"
@@ -496,7 +529,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "fire first aid kits crate"
-	group = "Medical"
+	group = supply_medical
 
 /datum/supply_packs/firstaidtoxins
 	name = "Toxin Treatment Kits crate"
@@ -506,7 +539,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "toxin first aid kits crate"
-	group = "Medical"
+	group = supply_medical
 
 /datum/supply_packs/firstaidoxygen
 	name = "Oxygen Deprivation Kits crate"
@@ -516,7 +549,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/medical
 	containername = "oxygen deprivation kits crate"
-	group = "Medical"
+	group = supply_medical
 
 
 /datum/supply_packs/virus
@@ -537,7 +570,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "virus crate"
 	access = access_cmo
-	group = "Medical"
+	group = supply_medical
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -553,7 +586,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper APLU \"Ripley\" circuit crate"
 	access = access_robotics
-	group = "Science"
+	group = supply_science
 
 /datum/supply_packs/mecha_odysseus
 	name = "Circuit Crate (\"Odysseus\")"
@@ -563,7 +596,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper \"Odysseus\" circuit crate"
 	access = access_robotics
-	group = "Science"
+	group = supply_science
 
 
 /datum/supply_packs/robotics
@@ -579,7 +612,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "robotics assembly crate"
 	access = access_robotics
-	group = "Science"
+	group = supply_science
 
 /datum/supply_packs/plasma
 	name = "Plasma assembly crate"
@@ -599,7 +632,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "plasma assembly crate"
 	access = access_tox_storage
-	group = "Science"
+	group = supply_science
 
 /datum/supply_packs/shieldwalls
 	name = "Shield Generators"
@@ -611,7 +644,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shield generators crate"
 	access = access_teleporter
-	group = "Science"
+	group = supply_science
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -633,7 +666,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "food crate"
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/monkey
 	name = "Monkey crate"
@@ -641,7 +674,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "monkey crate"
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/party
 	name = "Party equipment"
@@ -658,7 +691,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "party equipment"
-	group = "Organic"
+	group = supply_organic
 
 //////// livestock
 /datum/supply_packs/cow
@@ -667,7 +700,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/largecrate/cow
 	containername = "cow crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/goat
 	name = "Goat Crate"
@@ -675,7 +708,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/largecrate/goat
 	containername = "goat crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/chicken
 	name = "Chicken Crate"
@@ -683,7 +716,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/largecrate/chick
 	containername = "chicken crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/lisa
 	name = "Corgi Crate"
@@ -691,7 +724,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 50
 	containertype = /obj/structure/largecrate/lisa
 	containername = "corgi crate"
-	group = "Organic"
+	group = supply_organic
 
 ////// hippy gear
 
@@ -710,7 +743,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "hydroponics crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/seeds
 	name = "Seeds Crate"
@@ -730,7 +763,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "seeds crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 /datum/supply_packs/exoticseeds
 	name = "Exotic Seeds Crate"
@@ -748,7 +781,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/hydroponics
 	containername = "exotic seeds crate"
 	access = access_hydroponics
-	group = "Organic"
+	group = supply_organic
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -762,25 +795,25 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "metal sheets crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/plasteel20
 	name = "20 Plasteel Sheets"
 	contains = list(/obj/item/stack/sheet/plasteel)
 	amount = 20
-	cost = 20
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "plasteel sheets crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/plasteel50
 	name = "50 Plasteel Sheets"
 	contains = list(/obj/item/stack/sheet/plasteel)
 	amount = 50
-	cost = 40
+	cost = 50
 	containertype = /obj/structure/closet/crate
 	containername = "plasteel sheets crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/glass50
 	name = "50 Glass Sheets"
@@ -789,7 +822,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "glass sheets crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/cardboard50
 	name = "50 Cardboard Sheets"
@@ -798,106 +831,108 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "cardboard sheets crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/wood30
 	name = "25 Wood Planks"
 	contains = list(/obj/item/stack/sheet/wood)
 	amount = 25
-	cost = 15
+	cost = 25
 	containertype = /obj/structure/closet/crate
 	containername = "wood planks crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/wood50
 	name = "50 Wood Planks"
 	contains = list(/obj/item/stack/sheet/wood)
 	amount = 50
-	cost = 25
+	cost = 40
 	containertype = /obj/structure/closet/crate
 	containername = "wood planks crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/sandstone30
 	name = "30 Sandstone Blocks"
 	contains = list(/obj/item/stack/sheet/mineral/sandstone)
 	amount = 30
-	cost = 10
+	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "sandstone blocks crate"
-	group = "Materials"
+	group = supply_materials
+
+/// Precious materials: these are intentionally priced high to not make mining redundent
 
 /datum/supply_packs/silver10
 	name = "10 Silver Ingots"
 	contains = list(/obj/item/stack/sheet/mineral/silver)
 	amount = 10
-	cost = 20
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "silver ingots crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/silver20
 	name = "20 Silver Ingots"
 	contains = list(/obj/item/stack/sheet/mineral/silver)
 	amount = 20
-	cost = 30
+	cost = 45
 	containertype = /obj/structure/closet/crate
 	containername = "silver ingots crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/gold10
 	name = "10 Gold Ingots"
 	contains = list(/obj/item/stack/sheet/mineral/gold)
 	amount = 10
-	cost = 20
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "gold ingots crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/gold20
 	name = "20 Gold Ingots"
 	contains = list(/obj/item/stack/sheet/mineral/gold)
 	amount = 20
-	cost = 30
+	cost = 45
 	containertype = /obj/structure/closet/crate
 	containername = "gold ingots crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/uranium10
 	name = "10 Uranium Blocks"
 	contains = list(/obj/item/stack/sheet/mineral/uranium)
 	amount = 10
-	cost = 20
+	cost = 30
 	containertype = /obj/structure/closet/crate
 	containername = "uranium blocks crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/uranium20
 	name = "20 Uranium Blocks"
 	contains = list(/obj/item/stack/sheet/mineral/uranium)
 	amount = 20
-	cost = 30
+	cost = 45
 	containertype = /obj/structure/closet/crate
 	containername = "uranium blocks crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/diamonds10
 	name = "10 Diamonds"
 	contains = list(/obj/item/stack/sheet/mineral/diamond)
 	amount = 10
-	cost = 40		// Damn Space Jews artificially inflating prices
+	cost = 60		// Damn Space Jews artificially inflating prices
 	containertype = /obj/structure/closet/crate
 	containername = "diamond crate"
-	group = "Materials"
+	group = supply_materials
 
 /datum/supply_packs/plasma10
 	name = "10 Plasma Blocks"
 	contains = list(/obj/item/stack/sheet/mineral/plasma)
 	amount = 10
-	cost = 30		// One of the reasons the station exists is to mine this shit, hence the high cost
+	cost = 50		// One of the reasons the station exists is to mine this shit, hence the high cost
 	containertype = /obj/structure/closet/crate
 	containername = "plasma blocks crate"
-	group = "Materials"
+	group = supply_materials
 
 
 //////////////////////////////////////////////////////////////////////////////
@@ -910,7 +945,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/largecrate/mule
 	containername = "\improper MULEbot Crate"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/watertank
 	name = "Water tank crate"
@@ -918,7 +953,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 8
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
-	group = "Miscellaneous"
+	group = supply_misc
 
 
 ///////////// Paper Work
@@ -942,7 +977,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 15
 	containertype = /obj/structure/closet/crate
 	containername = "Bureaucracy crate"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/toner
 	name = "Toner Cartridges"
@@ -955,7 +990,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "toner cartridges"
-	group = "Miscellaneous"
+	group = supply_misc
 
 
 ///////////// Janitor Supplies
@@ -978,7 +1013,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "janitorial supplies"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/janicart
 	name = "Janitorial Cart crate"
@@ -986,7 +1021,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/largecrate
 	containername = "janitorial cart crate"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/lightbulbs
 	name = "Replacement lights"
@@ -996,7 +1031,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 10
 	containertype = /obj/structure/closet/crate
 	containername = "replacement lights"
-	group = "Miscellaneous"
+	group = supply_misc
 
 
 ///////////// Costumes
@@ -1019,7 +1054,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate/secure
 	containername = "standard costumes"
 	access = access_theatre
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/wizard
 	name = "Wizard costume"
@@ -1030,7 +1065,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "wizard costume crate"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/randomised
 	var/num_contained = 3 //number of items picked to be contained in a randomised crate
@@ -1058,7 +1093,7 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	cost = 200
 	containertype = /obj/structure/closet/crate
 	containername = "Collectable hats crate! Brought to you by Bass.inc!"
-	group = "Miscellaneous"
+	group = supply_misc
 
 /datum/supply_packs/randomised/New()
 	manifest += "Contains any [num_contained] of:"
@@ -1075,4 +1110,4 @@ var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical"
 	containertype = /obj/structure/closet/crate
 	containername = "crate"	//let's keep it subtle, eh?
 	contraband = 1
-	group = "Miscellaneous"
+	group = supply_misc

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -5,6 +5,8 @@
 //BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
+var/list/all_supply_groups = list("Emergency","Security","Engineering","Medical","Science","Organic","Materials","Miscellaneous")
+
 /datum/supply_packs
 	var/name = null
 	var/list/contains = list()
@@ -16,6 +18,7 @@
 	var/access = null
 	var/hidden = 0
 	var/contraband = 0
+	var/group = "Miscellaneous"
 
 /datum/supply_packs/New()
 	manifest += "<ul>"
@@ -25,6 +28,13 @@
 		manifest += "<li>[AM.name]</li>"
 		AM.loc = null	//just to make sure they're deleted by the garbage collector
 	manifest += "</ul>"
+
+
+////// Use the sections to keep things tidy please /Malkevin
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Emergency ///////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_packs/specialops
 	name = "Special Ops supplies"
@@ -38,77 +48,7 @@
 	containertype = /obj/structure/closet/crate
 	containername = "special ops crate"
 	hidden = 1
-
-/datum/supply_packs/food
-	name = "Food crate"
-	contains = list(/obj/item/weapon/reagent_containers/food/drinks/flour,
-					/obj/item/weapon/reagent_containers/food/drinks/milk,
-					/obj/item/weapon/reagent_containers/food/drinks/soymilk,
-					/obj/item/weapon/storage/fancy/egg_box,
-					/obj/item/weapon/reagent_containers/food/condiment/enzyme,
-					/obj/item/weapon/reagent_containers/food/condiment/sugar,
-					/obj/item/weapon/reagent_containers/food/snacks/meat/monkey,
-					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
-					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
-					/obj/item/weapon/reagent_containers/food/snacks/grown/banana)
-	cost = 10
-	containertype = /obj/structure/closet/crate/freezer
-	containername = "food crate"
-
-/datum/supply_packs/paper
-	name = "Bureaucracy crate"
-	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
-					/obj/item/device/camera_film,
-					/obj/item/weapon/hand_labeler,
-					/obj/item/hand_labeler_refill,
-					/obj/item/hand_labeler_refill,
-					/obj/item/weapon/paper_bin,
-					/obj/item/weapon/pen,
-					/obj/item/weapon/pen/blue,
-					/obj/item/weapon/pen/red,
-					/obj/item/weapon/folder/blue,
-					/obj/item/weapon/folder/red,
-					/obj/item/weapon/folder/yellow,
-					/obj/item/weapon/clipboard,
-					/obj/item/weapon/clipboard)
-	cost = 15
-	containertype = /obj/structure/closet/crate
-	containername = "Bureaucracy crate"
-
-/datum/supply_packs/monkey
-	name = "Monkey crate"
-	contains = list (/obj/item/weapon/storage/box/monkeycubes)
-	cost = 20
-	containertype = /obj/structure/closet/crate/freezer
-	containername = "monkey crate"
-
-/datum/supply_packs/toner
-	name = "Toner Cartridges"
-	contains = list(/obj/item/device/toner,
-					/obj/item/device/toner,
-					/obj/item/device/toner,
-					/obj/item/device/toner,
-					/obj/item/device/toner,
-					/obj/item/device/toner)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "toner cartridges"
-
-/datum/supply_packs/party
-	name = "Party equipment"
-	contains = list(/obj/item/weapon/storage/box/drinkingglasses,
-					/obj/item/weapon/reagent_containers/food/drinks/shaker,
-					/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
-					/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
-					/obj/item/weapon/reagent_containers/food/drinks/ale,
-					/obj/item/weapon/reagent_containers/food/drinks/ale,
-					/obj/item/weapon/reagent_containers/food/drinks/beer,
-					/obj/item/weapon/reagent_containers/food/drinks/beer,
-					/obj/item/weapon/reagent_containers/food/drinks/beer,
-					/obj/item/weapon/reagent_containers/food/drinks/beer)
-	cost = 20
-	containertype = /obj/structure/closet/crate
-	containername = "party equipment"
+	group = "Emergency"
 
 /datum/supply_packs/internals
 	name = "Internals crate"
@@ -121,6 +61,7 @@
 	cost = 10
 	containertype = /obj/structure/closet/crate/internals
 	containername = "internals crate"
+	group = "Emergency"
 
 /datum/supply_packs/evacuation
 	name = "Emergency equipment"
@@ -141,135 +82,7 @@
 	cost = 35
 	containertype = /obj/structure/closet/crate/internals
 	containername = "emergency crate"
-
-/datum/supply_packs/janitor
-	name = "Janitorial supplies"
-	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/reagent_containers/glass/bucket,
-					/obj/item/weapon/mop,
-					/obj/item/weapon/caution,
-					/obj/item/weapon/caution,
-					/obj/item/weapon/caution,
-					/obj/item/weapon/storage/bag/trash,
-					/obj/item/weapon/reagent_containers/spray/cleaner,
-					/obj/item/weapon/reagent_containers/glass/rag,
-					/obj/item/weapon/grenade/chem_grenade/cleaner,
-					/obj/item/weapon/grenade/chem_grenade/cleaner,
-					/obj/item/weapon/grenade/chem_grenade/cleaner,
-					/obj/structure/mopbucket)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "janitorial supplies"
-
-/datum/supply_packs/lightbulbs
-	name = "Replacement lights"
-	contains = list(/obj/item/weapon/storage/box/lights/mixed,
-					/obj/item/weapon/storage/box/lights/mixed,
-					/obj/item/weapon/storage/box/lights/mixed)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "replacement lights"
-
-/datum/supply_packs/costume
-	name = "Standard Costume crate"
-	contains = list(/obj/item/weapon/storage/backpack/clown,
-					/obj/item/clothing/shoes/clown_shoes,
-					/obj/item/clothing/mask/gas/clown_hat,
-					/obj/item/clothing/under/rank/clown,
-					/obj/item/weapon/bikehorn,
-					/obj/item/clothing/under/mime,
-					/obj/item/clothing/shoes/black,
-					/obj/item/clothing/gloves/white,
-					/obj/item/clothing/mask/gas/mime,
-					/obj/item/clothing/head/beret,
-					/obj/item/clothing/suit/suspenders,
-					/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing)
-	cost = 10
-	containertype = /obj/structure/closet/crate/secure
-	containername = "standard costumes"
-	access = access_theatre
-
-/datum/supply_packs/wizard
-	name = "Wizard costume"
-	contains = list(/obj/item/weapon/staff,
-					/obj/item/clothing/suit/wizrobe/fake,
-					/obj/item/clothing/shoes/sandal,
-					/obj/item/clothing/head/wizard/fake)
-	cost = 20
-	containertype = /obj/structure/closet/crate
-	containername = "wizard costume crate"
-
-/datum/supply_packs/mule
-	name = "MULEbot Crate"
-	contains = list(/obj/machinery/bot/mulebot)
-	cost = 20
-	containertype = /obj/structure/largecrate/mule
-	containername = "\improper MULEbot Crate"
-
-/datum/supply_packs/hydroponics // -- Skie
-	name = "Hydroponics Supply Crate"
-	contains = list(/obj/item/weapon/reagent_containers/spray/plantbgone,
-					/obj/item/weapon/reagent_containers/spray/plantbgone,
-					/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
-					/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
-					/obj/item/weapon/hatchet,
-					/obj/item/weapon/minihoe,
-					/obj/item/device/analyzer/plant_analyzer,
-					/obj/item/clothing/gloves/botanic_leather,
-					/obj/item/clothing/suit/apron) // Updated with new things
-	cost = 15
-	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "hydroponics crate"
-	access = access_hydroponics
-
-//farm animals - useless and annoying, but potentially a good source of food
-/datum/supply_packs/cow
-	name = "Cow Crate"
-	cost = 30
-	containertype = /obj/structure/largecrate/cow
-	containername = "cow crate"
-	access = access_hydroponics
-
-/datum/supply_packs/goat
-	name = "Goat Crate"
-	cost = 25
-	containertype = /obj/structure/largecrate/goat
-	containername = "goat crate"
-	access = access_hydroponics
-
-/datum/supply_packs/chicken
-	name = "Chicken Crate"
-	cost = 20
-	containertype = /obj/structure/largecrate/chick
-	containername = "chicken crate"
-	access = access_hydroponics
-
-/datum/supply_packs/lisa
-	name = "Corgi Crate"
-	contains = list()
-	cost = 50
-	containertype = /obj/structure/largecrate/lisa
-	containername = "corgi crate"
-
-/datum/supply_packs/seeds
-	name = "Seeds Crate"
-	contains = list(/obj/item/seeds/chiliseed,
-					/obj/item/seeds/berryseed,
-					/obj/item/seeds/cornseed,
-					/obj/item/seeds/eggplantseed,
-					/obj/item/seeds/tomatoseed,
-					/obj/item/seeds/soyaseed,
-					/obj/item/seeds/wheatseed,
-					/obj/item/seeds/carrotseed,
-					/obj/item/seeds/sunflowerseed,
-					/obj/item/seeds/chantermycelium,
-					/obj/item/seeds/potatoseed,
-					/obj/item/seeds/sugarcaneseed)
-	cost = 10
-	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "seeds crate"
-	access = access_hydroponics
+	group = "Emergency"
 
 /datum/supply_packs/weedcontrol
 	name = "Weed Control Crate"
@@ -277,113 +90,227 @@
 					/obj/item/clothing/mask/gas,
 					/obj/item/weapon/grenade/chem_grenade/antiweed,
 					/obj/item/weapon/grenade/chem_grenade/antiweed)
-	cost = 20
+	cost = 15
 	containertype = /obj/structure/closet/crate/secure/hydrosec
 	containername = "weed control crate"
 	access = access_hydroponics
+	group = "Emergency"
 
-/datum/supply_packs/exoticseeds
-	name = "Exotic Seeds Crate"
-	contains = list(/obj/item/seeds/nettleseed,
-					/obj/item/seeds/replicapod,
-					/obj/item/seeds/replicapod,
-					/obj/item/seeds/replicapod,
-					/obj/item/seeds/plumpmycelium,
-					/obj/item/seeds/libertymycelium,
-					/obj/item/seeds/amanitamycelium,
-					/obj/item/seeds/reishimycelium,
-					/obj/item/seeds/bananaseed,
-					/obj/item/seeds/eggyseed)
-	cost = 15
-	containertype = /obj/structure/closet/crate/hydroponics
-	containername = "exotic seeds crate"
-	access = access_hydroponics
 
-/datum/supply_packs/medical
-	name = "Medical crate"
-	contains = list(/obj/item/weapon/storage/firstaid/regular,
-					/obj/item/weapon/storage/firstaid/fire,
-					/obj/item/weapon/storage/firstaid/toxin,
-					/obj/item/weapon/storage/firstaid/o2,
-					/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
-					/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
-					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-					/obj/item/weapon/storage/box/syringes)
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Security ////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_packs/security
+	name = "Security Supplies crate"
+	contains = list(/obj/item/weapon/storage/box/flashbangs,
+					/obj/item/weapon/storage/box/teargas,
+					/obj/item/weapon/storage/box/flashes,
+					/obj/item/weapon/storage/box/handcuffs)
 	cost = 10
-	containertype = /obj/structure/closet/crate/medical
-	containername = "medical crate"
+	containertype = /obj/structure/closet/crate/secure
+	containername = "security supply crate"
+	access = access_security
+	group = "Security"
+
+/datum/supply_packs/loyalty
+	name = "Loyalty implants crate"
+	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
+	cost = 40
+	containertype = /obj/structure/closet/crate/secure
+	containername = "loyalty implant crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/trackingimp
+	name = "Tracking implants crate"
+	contains = list (/obj/item/weapon/storage/box/trackimp)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "tracking implant crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/loyalty
+	name = "Chemical implants crate"
+	contains = list (/obj/item/weapon/storage/box/chemimp)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "chemical implant crate"
+	access = access_armory
+	group = "Security"
 
 
-/datum/supply_packs/virus
-	name = "Virus crate"
-	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
-					/obj/item/weapon/reagent_containers/glass/bottle/cold,
-					/obj/item/weapon/reagent_containers/glass/bottle/epiglottis_virion,
-					/obj/item/weapon/reagent_containers/glass/bottle/liver_enhance_virion,
-					/obj/item/weapon/reagent_containers/glass/bottle/fake_gbs,
-					/obj/item/weapon/reagent_containers/glass/bottle/magnitis,
-					/obj/item/weapon/reagent_containers/glass/bottle/pierrot_throat,
-					/obj/item/weapon/reagent_containers/glass/bottle/brainrot,
-					/obj/item/weapon/reagent_containers/glass/bottle/hullucigen_virion,
-					/obj/item/weapon/storage/box/syringes,
-					/obj/item/weapon/storage/box/beakers,
-					/obj/item/weapon/reagent_containers/glass/bottle/mutagen)
-	cost = 25
+////// Armor: Basic
+
+/datum/supply_packs/helmets
+	name = "Helmets crate"
+	contains = list(/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet,
+					/obj/item/clothing/head/helmet)
+	cost = 10
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "helmet crate"
+	access = access_security
+	group = "Security"
+
+/datum/supply_packs/armor
+	name = "Armor crate"
+	contains = list(/obj/item/clothing/suit/armor/vest,
+					/obj/item/clothing/suit/armor/vest,
+					/obj/item/clothing/suit/armor/vest)
+	cost = 10
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "armor crate"
+	access = access_security
+	group = "Security"
+
+////// Weapons: Basic
+
+/datum/supply_packs/baton
+	name = "Stun Batons crate"
+	contains = list(/obj/item/weapon/melee/baton/loaded,
+					/obj/item/weapon/melee/baton/loaded,
+					/obj/item/weapon/melee/baton/loaded)
+	cost = 10
 	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "virus crate"
-	access = access_cmo
+	containername = "stun baton crate"
+	access = access_security
+	group = "Security"
 
-/datum/supply_packs/metal50
-	name = "50 Metal Sheets"
-	contains = list(/obj/item/stack/sheet/metal)
-	amount = 50
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "metal sheets crate"
-
-/datum/supply_packs/glass50
-	name = "50 Glass Sheets"
-	contains = list(/obj/item/stack/sheet/glass)
-	amount = 50
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "glass sheets crate"
-
-/datum/supply_packs/electrical
-	name = "Electrical maintenance crate"
-	contains = list(/obj/item/weapon/storage/toolbox/electrical,
-					/obj/item/weapon/storage/toolbox/electrical,
-					/obj/item/clothing/gloves/yellow,
-					/obj/item/clothing/gloves/yellow,
-					/obj/item/weapon/cell,
-					/obj/item/weapon/cell,
-					/obj/item/weapon/cell/high,
-					/obj/item/weapon/cell/high)
+/datum/supply_packs/laser
+	name = "Lasers crate"
+	contains = list(/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/energy/laser)
 	cost = 15
-	containertype = /obj/structure/closet/crate
-	containername = "electrical maintenance crate"
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "laser crate"
+	access = access_security
+	group = "Security"
 
-/datum/supply_packs/mechanical
-	name = "Mechanical maintenance crate"
-	contains = list(/obj/item/weapon/storage/belt/utility/full,
-					/obj/item/weapon/storage/belt/utility/full,
-					/obj/item/weapon/storage/belt/utility/full,
-					/obj/item/clothing/suit/hazardvest,
-					/obj/item/clothing/suit/hazardvest,
-					/obj/item/clothing/suit/hazardvest,
-					/obj/item/clothing/head/welding,
-					/obj/item/clothing/head/welding,
-					/obj/item/clothing/head/hardhat)
-	cost = 10
-	containertype = /obj/structure/closet/crate
-	containername = "mechanical maintenance crate"
+/datum/supply_packs/taser
+	name = "Stun Guns crate"
+	contains = list(/obj/item/weapon/gun/energy/taser,
+					/obj/item/weapon/gun/energy/taser,
+					/obj/item/weapon/gun/energy/taser)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "stun gun crate"
+	access = access_security
+	group = "Security"
 
-/datum/supply_packs/watertank
-	name = "Water tank crate"
-	contains = list(/obj/structure/reagent_dispensers/watertank)
-	cost = 8
-	containertype = /obj/structure/largecrate
-	containername = "water tank crate"
+///// Armor: Specialist
+
+/datum/supply_packs/riotshields
+	name = "Riot shields crate"
+	contains = list(/obj/item/weapon/shield/riot,
+					/obj/item/weapon/shield/riot,
+					/obj/item/weapon/shield/riot)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "riot shields crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/riot
+	name = "Riot helmets crate"
+	contains = list(/obj/item/clothing/head/helmet/riot,
+					/obj/item/clothing/head/helmet/riot,
+					/obj/item/clothing/head/helmet/riot)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "riot helmets crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/riot
+	name = "Riot suits crate"
+	contains = list(/obj/item/clothing/suit/armor/riot,
+					/obj/item/clothing/suit/armor/riot,
+					/obj/item/clothing/suit/armor/riot)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "riot suits crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/bulletarmor
+	name = "Bulletproof armor crate"
+	contains = list(/obj/item/clothing/suit/armor/bulletproof,
+					/obj/item/clothing/suit/armor/bulletproof,
+					/obj/item/clothing/suit/armor/bulletproof)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "bulletproof armor crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/laserarmor
+	name = "Ablative armor crate"
+	contains = list(/obj/item/clothing/suit/armor/laserproof,
+					/obj/item/clothing/suit/armor/laserproof)		// Only two vests to keep costs down for balance
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "ablative armor crate"
+	access = access_armory
+	group = "Security"
+
+/////// Weapons: Specialist
+
+
+
+/datum/supply_packs/ballistic
+	name = "Combat Shotguns crate"
+	contains = list(/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
+					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "combat shotgun crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/expenergy
+	name = "Energy Guns crate"
+	contains = list(/obj/item/weapon/gun/energy/gun,
+					/obj/item/weapon/gun/energy/gun)			// Only two guns to keep costs down
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "energy gun crate"
+	access = access_armory
+	group = "Security"
+
+/datum/supply_packs/eweapons
+	name = "Incendiary weapons crate"
+	contains = list(/obj/item/weapon/flamethrower/full,
+					/obj/item/weapon/tank/plasma,
+					/obj/item/weapon/tank/plasma,
+					/obj/item/weapon/tank/plasma,
+					/obj/item/weapon/grenade/chem_grenade/incendiary,
+					/obj/item/weapon/grenade/chem_grenade/incendiary,
+					/obj/item/weapon/grenade/chem_grenade/incendiary)
+	cost = 15	// its a fecking flamethrower and some plasma, why the shit did this cost so much before!?
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "incendiary weapons crate"
+	access = access_heads
+	group = "Security"
+
+/datum/supply_packs/securitybarriers
+	name = "Security Barriers"
+	contains = list(/obj/machinery/deployable/barrier,
+					/obj/machinery/deployable/barrier,
+					/obj/machinery/deployable/barrier,
+					/obj/machinery/deployable/barrier)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "security barriers crate"
+	group = "Security"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Engineering /////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_packs/fueltank
 	name = "Fuel tank crate"
@@ -391,6 +318,59 @@
 	cost = 8
 	containertype = /obj/structure/largecrate
 	containername = "fuel tank crate"
+	group = "Engineering"
+
+/datum/supply_packs/toolbox		//the most robust crate
+	name = "Toolbox crate"
+	contains = list(/obj/item/weapon/storage/toolbox/electrical,
+					/obj/item/weapon/storage/toolbox/electrical,
+					/obj/item/weapon/storage/toolbox/mechanical,
+					/obj/item/weapon/storage/toolbox/electrical,
+					/obj/item/weapon/storage/toolbox/mechanical,
+					/obj/item/weapon/storage/toolbox/mechanical)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "electrical maintenance crate"
+	group = "Engineering"
+
+/datum/supply_packs/powergamermitts
+	name = "Insulated Gloves crate"
+	contains = list(/obj/item/clothing/gloves/yellow,
+					/obj/item/clothing/gloves/yellow,
+					/obj/item/clothing/gloves/yellow)
+	cost = 20	//Made of pure-grade bullshittinium
+	containertype = /obj/structure/closet/crate
+	containername = "insulated gloves crate"
+	group = "Engineering"
+
+/datum/supply_packs/power
+	name = "Powercell crate"
+	contains = list(/obj/item/weapon/cell/high,		//Changed to an extra high powercell because normal cells are useless
+					/obj/item/weapon/cell/high,
+					/obj/item/weapon/cell/high)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "electrical maintenance crate"
+	group = "Engineering"
+
+/datum/supply_packs/engiequipment
+	name = "Engineering Gear crate"
+	contains = list(/obj/item/weapon/storage/belt/utility,
+					/obj/item/weapon/storage/belt/utility,
+					/obj/item/weapon/storage/belt/utility,
+					/obj/item/clothing/suit/hazardvest,
+					/obj/item/clothing/suit/hazardvest,
+					/obj/item/clothing/suit/hazardvest,
+					/obj/item/clothing/head/welding,
+					/obj/item/clothing/head/welding,
+					/obj/item/clothing/head/welding,
+					/obj/item/clothing/head/hardhat,
+					/obj/item/clothing/head/hardhat,
+					/obj/item/clothing/head/hardhat)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "engineering gear crate"
+	group = "Engineering"
 
 /datum/supply_packs/solar
 	name = "Solar Pack crate"
@@ -421,6 +401,7 @@
 	cost = 20
 	containertype = /obj/structure/closet/crate
 	containername = "solar pack crate"
+	group = "Engineering"
 
 /datum/supply_packs/engine
 	name = "Emitter crate"
@@ -430,6 +411,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "emitter crate"
 	access = access_ce
+	group = "Engineering"
 
 /datum/supply_packs/engine/field_gen
 	name = "Field Generator crate"
@@ -438,6 +420,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "field generator crate"
 	access = access_ce
+	group = "Engineering"
 
 /datum/supply_packs/engine/sing_gen
 	name = "Singularity Generator crate"
@@ -445,6 +428,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "singularity generator crate"
 	access = access_ce
+	group = "Engineering"
 
 /datum/supply_packs/engine/collector
 	name = "Collector crate"
@@ -452,10 +436,11 @@
 					/obj/machinery/power/rad_collector,
 					/obj/machinery/power/rad_collector)
 	containername = "collector crate"
+	group = "Engineering"
 
 /datum/supply_packs/engine/PA
 	name = "Particle Accelerator crate"
-	cost = 40
+	cost = 25
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,
 					/obj/structure/particle_accelerator/particle_emitter/center,
@@ -466,6 +451,98 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "particle accelerator crate"
 	access = access_ce
+	group = "Engineering"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Medical /////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_packs/medical
+	name = "Medical Supplies crate"
+	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+					/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+					/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+					/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+					/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+					/obj/item/weapon/reagent_containers/glass/bottle/toxin,
+					/obj/item/weapon/reagent_containers/glass/bottle/toxin,
+					/obj/item/weapon/reagent_containers/glass/beaker/large,
+					/obj/item/weapon/reagent_containers/glass/beaker/large,
+					/obj/item/weapon/storage/box/beakers,
+					/obj/item/weapon/storage/box/syringes)
+	cost = 20
+	containertype = /obj/structure/closet/crate/medical
+	containername = "medical supplies crate"
+	group = "Medical"
+
+/datum/supply_packs/firstaid
+	name = "First Aid Kits crate"
+	contains = list(/obj/item/weapon/storage/firstaid/regular,
+					/obj/item/weapon/storage/firstaid/regular,
+					/obj/item/weapon/storage/firstaid/regular,
+					/obj/item/weapon/storage/firstaid/regular)
+	cost = 10
+	containertype = /obj/structure/closet/crate/medical
+	containername = "first aid kits crate"
+	group = "Medical"
+
+/datum/supply_packs/firstaidburns
+	name = "Burns Treatment Kits crate"
+	contains = list(/obj/item/weapon/storage/firstaid/fire,
+					/obj/item/weapon/storage/firstaid/fire,
+					/obj/item/weapon/storage/firstaid/fire)
+	cost = 10
+	containertype = /obj/structure/closet/crate/medical
+	containername = "fire first aid kits crate"
+	group = "Medical"
+
+/datum/supply_packs/firstaidtoxins
+	name = "Toxin Treatment Kits crate"
+	contains = list(/obj/item/weapon/storage/firstaid/toxin,
+					/obj/item/weapon/storage/firstaid/toxin,
+					/obj/item/weapon/storage/firstaid/toxin)
+	cost = 10
+	containertype = /obj/structure/closet/crate/medical
+	containername = "toxin first aid kits crate"
+	group = "Medical"
+
+/datum/supply_packs/firstaidoxygen
+	name = "Oxygen Deprivation Kits crate"
+	contains = list(/obj/item/weapon/storage/firstaid/o2,
+					/obj/item/weapon/storage/firstaid/o2,
+					/obj/item/weapon/storage/firstaid/o2)
+	cost = 10
+	containertype = /obj/structure/closet/crate/medical
+	containername = "oxygen deprivation kits crate"
+	group = "Medical"
+
+
+/datum/supply_packs/virus
+	name = "Virus crate"
+	contains = list(/obj/item/weapon/reagent_containers/glass/bottle/flu_virion,
+					/obj/item/weapon/reagent_containers/glass/bottle/cold,
+					/obj/item/weapon/reagent_containers/glass/bottle/epiglottis_virion,
+					/obj/item/weapon/reagent_containers/glass/bottle/liver_enhance_virion,
+					/obj/item/weapon/reagent_containers/glass/bottle/fake_gbs,
+					/obj/item/weapon/reagent_containers/glass/bottle/magnitis,
+					/obj/item/weapon/reagent_containers/glass/bottle/pierrot_throat,
+					/obj/item/weapon/reagent_containers/glass/bottle/brainrot,
+					/obj/item/weapon/reagent_containers/glass/bottle/hullucigen_virion,
+					/obj/item/weapon/storage/box/syringes,
+					/obj/item/weapon/storage/box/beakers,
+					/obj/item/weapon/reagent_containers/glass/bottle/mutagen)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "virus crate"
+	access = access_cmo
+	group = "Medical"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Science /////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_packs/mecha_ripley
 	name = "Circuit Crate (\"Ripley\" APLU)"
@@ -476,6 +553,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper APLU \"Ripley\" circuit crate"
 	access = access_robotics
+	group = "Science"
 
 /datum/supply_packs/mecha_odysseus
 	name = "Circuit Crate (\"Odysseus\")"
@@ -485,6 +563,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "\improper \"Odysseus\" circuit crate"
 	access = access_robotics
+	group = "Science"
 
 
 /datum/supply_packs/robotics
@@ -493,16 +572,14 @@
 					/obj/item/device/assembly/prox_sensor,
 					/obj/item/device/assembly/prox_sensor,
 					/obj/item/weapon/storage/toolbox/electrical,
-					/obj/item/device/flash,
-					/obj/item/device/flash,
-					/obj/item/device/flash,
-					/obj/item/device/flash,
+					/obj/item/weapon/storage/box/flashes,
 					/obj/item/weapon/cell/high,
 					/obj/item/weapon/cell/high)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "robotics assembly crate"
 	access = access_robotics
+	group = "Science"
 
 /datum/supply_packs/plasma
 	name = "Plasma assembly crate"
@@ -522,118 +599,7 @@
 	containertype = /obj/structure/closet/crate/secure/plasma
 	containername = "plasma assembly crate"
 	access = access_tox_storage
-
-/datum/supply_packs/weapons
-	name = "Weapons crate"
-	contains = list(/obj/item/weapon/melee/baton/loaded,
-					/obj/item/weapon/melee/baton/loaded,
-					/obj/item/weapon/gun/energy/laser,
-					/obj/item/weapon/gun/energy/laser,
-					/obj/item/weapon/gun/energy/taser,
-					/obj/item/weapon/gun/energy/taser,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/teargas,
-					/obj/item/device/flash,
-					/obj/item/device/flash,
-					/obj/item/device/flash)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "weapons crate"
-	access = access_security
-
-/datum/supply_packs/eweapons
-	name = "Incendiary weapons crate"
-	contains = list(/obj/item/weapon/flamethrower/full,
-					/obj/item/weapon/tank/plasma,
-					/obj/item/weapon/tank/plasma,
-					/obj/item/weapon/tank/plasma,
-					/obj/item/weapon/grenade/chem_grenade/incendiary,
-					/obj/item/weapon/grenade/chem_grenade/incendiary,
-					/obj/item/weapon/grenade/chem_grenade/incendiary)
-	cost = 25
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "incendiary weapons crate"
-	access = access_heads
-
-/datum/supply_packs/armor
-	name = "Armor crate"
-	contains = list(/obj/item/clothing/head/helmet,
-					/obj/item/clothing/head/helmet,
-					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/suit/armor/vest)
-	cost = 15
-	containertype = /obj/structure/closet/crate/secure
-	containername = "armor crate"
-	access = access_security
-
-/datum/supply_packs/riot
-	name = "Riot gear crate"
-	contains = list(/obj/item/weapon/melee/baton/loaded,
-					/obj/item/weapon/melee/baton/loaded,
-					/obj/item/weapon/shield/riot,
-					/obj/item/weapon/shield/riot,
-					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/storage/box/teargas,
-					/obj/item/weapon/storage/box/handcuffs,
-					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot,
-					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot,)
-	cost = 45
-	containertype = /obj/structure/closet/crate/secure
-	containername = "riot gear crate"
-	access = access_armory
-
-/datum/supply_packs/loyalty
-	name = "Loyalty implant crate"
-	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
-	cost = 60
-	containertype = /obj/structure/closet/crate/secure
-	containername = "loyalty implant crate"
-	access = access_armory
-
-/datum/supply_packs/ballistic
-	name = "Ballistic gear crate"
-	contains = list(/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/weapon/gun/projectile/shotgun/pump/combat,
-					/obj/item/weapon/gun/projectile/shotgun/pump/combat)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "ballistic gear crate"
-	access = access_armory
-
-/datum/supply_packs/expenergy
-	name = "Experimental energy gear crate"
-	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/weapon/gun/energy/gun,
-					/obj/item/weapon/gun/energy/gun)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure
-	containername = "experimental energy gear crate"
-	access = access_armory
-
-/datum/supply_packs/exparmor
-	name = "Experimental armor crate"
-	contains = list(/obj/item/clothing/suit/armor/laserproof,
-					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/head/helmet/riot,
-					/obj/item/clothing/suit/armor/riot)
-	cost = 35
-	containertype = /obj/structure/closet/crate/secure
-	containername = "experimental armor crate"
-	access = access_armory
-
-/datum/supply_packs/securitybarriers
-	name = "Security Barriers"
-	contains = list(/obj/machinery/deployable/barrier,
-					/obj/machinery/deployable/barrier,
-					/obj/machinery/deployable/barrier,
-					/obj/machinery/deployable/barrier)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "security barriers crate"
+	group = "Science"
 
 /datum/supply_packs/shieldwalls
 	name = "Shield Generators"
@@ -645,6 +611,426 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "shield generators crate"
 	access = access_teleporter
+	group = "Science"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Organic /////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_packs/food
+	name = "Food crate"
+	contains = list(/obj/item/weapon/reagent_containers/food/drinks/flour,
+					/obj/item/weapon/reagent_containers/food/drinks/milk,
+					/obj/item/weapon/reagent_containers/food/drinks/soymilk,
+					/obj/item/weapon/storage/fancy/egg_box,
+					/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+					/obj/item/weapon/reagent_containers/food/condiment/sugar,
+					/obj/item/weapon/reagent_containers/food/snacks/meat/monkey,
+					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
+					/obj/item/weapon/reagent_containers/food/snacks/grown/banana,
+					/obj/item/weapon/reagent_containers/food/snacks/grown/banana)
+	cost = 10
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "food crate"
+	group = "Organic"
+
+/datum/supply_packs/monkey
+	name = "Monkey crate"
+	contains = list (/obj/item/weapon/storage/box/monkeycubes)
+	cost = 20
+	containertype = /obj/structure/closet/crate/freezer
+	containername = "monkey crate"
+	group = "Organic"
+
+/datum/supply_packs/party
+	name = "Party equipment"
+	contains = list(/obj/item/weapon/storage/box/drinkingglasses,
+					/obj/item/weapon/reagent_containers/food/drinks/shaker,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
+					/obj/item/weapon/reagent_containers/food/drinks/ale,
+					/obj/item/weapon/reagent_containers/food/drinks/ale,
+					/obj/item/weapon/reagent_containers/food/drinks/beer,
+					/obj/item/weapon/reagent_containers/food/drinks/beer,
+					/obj/item/weapon/reagent_containers/food/drinks/beer,
+					/obj/item/weapon/reagent_containers/food/drinks/beer)
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "party equipment"
+	group = "Organic"
+
+//////// livestock
+/datum/supply_packs/cow
+	name = "Cow Crate"
+	cost = 30
+	containertype = /obj/structure/largecrate/cow
+	containername = "cow crate"
+	access = access_hydroponics
+	group = "Organic"
+
+/datum/supply_packs/goat
+	name = "Goat Crate"
+	cost = 25
+	containertype = /obj/structure/largecrate/goat
+	containername = "goat crate"
+	access = access_hydroponics
+	group = "Organic"
+
+/datum/supply_packs/chicken
+	name = "Chicken Crate"
+	cost = 20
+	containertype = /obj/structure/largecrate/chick
+	containername = "chicken crate"
+	access = access_hydroponics
+	group = "Organic"
+
+/datum/supply_packs/lisa
+	name = "Corgi Crate"
+	contains = list()
+	cost = 50
+	containertype = /obj/structure/largecrate/lisa
+	containername = "corgi crate"
+	group = "Organic"
+
+////// hippy gear
+
+/datum/supply_packs/hydroponics // -- Skie
+	name = "Hydroponics Supply Crate"
+	contains = list(/obj/item/weapon/reagent_containers/spray/plantbgone,
+					/obj/item/weapon/reagent_containers/spray/plantbgone,
+					/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
+					/obj/item/weapon/reagent_containers/glass/bottle/ammonia,
+					/obj/item/weapon/hatchet,
+					/obj/item/weapon/minihoe,
+					/obj/item/device/analyzer/plant_analyzer,
+					/obj/item/clothing/gloves/botanic_leather,
+					/obj/item/clothing/suit/apron) // Updated with new things
+	cost = 15
+	containertype = /obj/structure/closet/crate/hydroponics
+	containername = "hydroponics crate"
+	access = access_hydroponics
+	group = "Organic"
+
+/datum/supply_packs/seeds
+	name = "Seeds Crate"
+	contains = list(/obj/item/seeds/chiliseed,
+					/obj/item/seeds/berryseed,
+					/obj/item/seeds/cornseed,
+					/obj/item/seeds/eggplantseed,
+					/obj/item/seeds/tomatoseed,
+					/obj/item/seeds/soyaseed,
+					/obj/item/seeds/wheatseed,
+					/obj/item/seeds/carrotseed,
+					/obj/item/seeds/sunflowerseed,
+					/obj/item/seeds/chantermycelium,
+					/obj/item/seeds/potatoseed,
+					/obj/item/seeds/sugarcaneseed)
+	cost = 10
+	containertype = /obj/structure/closet/crate/hydroponics
+	containername = "seeds crate"
+	access = access_hydroponics
+	group = "Organic"
+
+/datum/supply_packs/exoticseeds
+	name = "Exotic Seeds Crate"
+	contains = list(/obj/item/seeds/nettleseed,
+					/obj/item/seeds/replicapod,
+					/obj/item/seeds/replicapod,
+					/obj/item/seeds/replicapod,
+					/obj/item/seeds/plumpmycelium,
+					/obj/item/seeds/libertymycelium,
+					/obj/item/seeds/amanitamycelium,
+					/obj/item/seeds/reishimycelium,
+					/obj/item/seeds/bananaseed,
+					/obj/item/seeds/eggyseed)
+	cost = 15
+	containertype = /obj/structure/closet/crate/hydroponics
+	containername = "exotic seeds crate"
+	access = access_hydroponics
+	group = "Organic"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Materials ///////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_packs/metal50
+	name = "50 Metal Sheets"
+	contains = list(/obj/item/stack/sheet/metal)
+	amount = 50
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "metal sheets crate"
+	group = "Materials"
+
+/datum/supply_packs/plasteel20
+	name = "20 Plasteel Sheets"
+	contains = list(/obj/item/stack/sheet/plasteel)
+	amount = 20
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "plasteel sheets crate"
+	group = "Materials"
+
+/datum/supply_packs/plasteel50
+	name = "50 Plasteel Sheets"
+	contains = list(/obj/item/stack/sheet/plasteel)
+	amount = 50
+	cost = 40
+	containertype = /obj/structure/closet/crate
+	containername = "plasteel sheets crate"
+	group = "Materials"
+
+/datum/supply_packs/glass50
+	name = "50 Glass Sheets"
+	contains = list(/obj/item/stack/sheet/glass)
+	amount = 50
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "glass sheets crate"
+	group = "Materials"
+
+/datum/supply_packs/cardboard50
+	name = "50 Cardboard Sheets"
+	contains = list(/obj/item/stack/sheet/cardboard)
+	amount = 50
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "cardboard sheets crate"
+	group = "Materials"
+
+/datum/supply_packs/wood30
+	name = "25 Wood Planks"
+	contains = list(/obj/item/stack/sheet/wood)
+	amount = 25
+	cost = 15
+	containertype = /obj/structure/closet/crate
+	containername = "wood planks crate"
+	group = "Materials"
+
+/datum/supply_packs/wood50
+	name = "50 Wood Planks"
+	contains = list(/obj/item/stack/sheet/wood)
+	amount = 50
+	cost = 25
+	containertype = /obj/structure/closet/crate
+	containername = "wood planks crate"
+	group = "Materials"
+
+/datum/supply_packs/sandstone30
+	name = "30 Sandstone Blocks"
+	contains = list(/obj/item/stack/sheet/mineral/sandstone)
+	amount = 30
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "sandstone blocks crate"
+	group = "Materials"
+
+/datum/supply_packs/silver10
+	name = "10 Silver Ingots"
+	contains = list(/obj/item/stack/sheet/mineral/silver)
+	amount = 10
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "silver ingots crate"
+	group = "Materials"
+
+/datum/supply_packs/silver20
+	name = "20 Silver Ingots"
+	contains = list(/obj/item/stack/sheet/mineral/silver)
+	amount = 20
+	cost = 30
+	containertype = /obj/structure/closet/crate
+	containername = "silver ingots crate"
+	group = "Materials"
+
+/datum/supply_packs/gold10
+	name = "10 Gold Ingots"
+	contains = list(/obj/item/stack/sheet/mineral/gold)
+	amount = 10
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "gold ingots crate"
+	group = "Materials"
+
+/datum/supply_packs/gold20
+	name = "20 Gold Ingots"
+	contains = list(/obj/item/stack/sheet/mineral/gold)
+	amount = 20
+	cost = 30
+	containertype = /obj/structure/closet/crate
+	containername = "gold ingots crate"
+	group = "Materials"
+
+/datum/supply_packs/uranium10
+	name = "10 Uranium Blocks"
+	contains = list(/obj/item/stack/sheet/mineral/uranium)
+	amount = 10
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "uranium blocks crate"
+	group = "Materials"
+
+/datum/supply_packs/uranium20
+	name = "20 Uranium Blocks"
+	contains = list(/obj/item/stack/sheet/mineral/uranium)
+	amount = 20
+	cost = 30
+	containertype = /obj/structure/closet/crate
+	containername = "uranium blocks crate"
+	group = "Materials"
+
+/datum/supply_packs/diamonds10
+	name = "10 Diamonds"
+	contains = list(/obj/item/stack/sheet/mineral/diamond)
+	amount = 10
+	cost = 40		// Damn Space Jews artificially inflating prices
+	containertype = /obj/structure/closet/crate
+	containername = "diamond crate"
+	group = "Materials"
+
+/datum/supply_packs/plasma10
+	name = "10 Plasma Blocks"
+	contains = list(/obj/item/stack/sheet/mineral/plasma)
+	amount = 10
+	cost = 30		// One of the reasons the station exists is to mine this shit, hence the high cost
+	containertype = /obj/structure/closet/crate
+	containername = "plasma blocks crate"
+	group = "Materials"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Miscellaneous ///////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_packs/mule
+	name = "MULEbot Crate"
+	contains = list(/obj/machinery/bot/mulebot)
+	cost = 20
+	containertype = /obj/structure/largecrate/mule
+	containername = "\improper MULEbot Crate"
+	group = "Miscellaneous"
+
+/datum/supply_packs/watertank
+	name = "Water tank crate"
+	contains = list(/obj/structure/reagent_dispensers/watertank)
+	cost = 8
+	containertype = /obj/structure/largecrate
+	containername = "water tank crate"
+	group = "Miscellaneous"
+
+
+///////////// Paper Work
+
+/datum/supply_packs/paper
+	name = "Bureaucracy crate"
+	contains = list(/obj/structure/filingcabinet/chestdrawer/wheeled,
+					/obj/item/device/camera_film,
+					/obj/item/weapon/hand_labeler,
+					/obj/item/hand_labeler_refill,
+					/obj/item/hand_labeler_refill,
+					/obj/item/weapon/paper_bin,
+					/obj/item/weapon/pen,
+					/obj/item/weapon/pen/blue,
+					/obj/item/weapon/pen/red,
+					/obj/item/weapon/folder/blue,
+					/obj/item/weapon/folder/red,
+					/obj/item/weapon/folder/yellow,
+					/obj/item/weapon/clipboard,
+					/obj/item/weapon/clipboard)
+	cost = 15
+	containertype = /obj/structure/closet/crate
+	containername = "Bureaucracy crate"
+	group = "Miscellaneous"
+
+/datum/supply_packs/toner
+	name = "Toner Cartridges"
+	contains = list(/obj/item/device/toner,
+					/obj/item/device/toner,
+					/obj/item/device/toner,
+					/obj/item/device/toner,
+					/obj/item/device/toner,
+					/obj/item/device/toner)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "toner cartridges"
+	group = "Miscellaneous"
+
+
+///////////// Janitor Supplies
+
+/datum/supply_packs/janitor
+	name = "Janitorial supplies"
+	contains = list(/obj/item/weapon/reagent_containers/glass/bucket,
+					/obj/item/weapon/reagent_containers/glass/bucket,
+					/obj/item/weapon/reagent_containers/glass/bucket,
+					/obj/item/weapon/mop,
+					/obj/item/weapon/caution,
+					/obj/item/weapon/caution,
+					/obj/item/weapon/caution,
+					/obj/item/weapon/storage/bag/trash,
+					/obj/item/weapon/reagent_containers/spray/cleaner,
+					/obj/item/weapon/reagent_containers/glass/rag,
+					/obj/item/weapon/grenade/chem_grenade/cleaner,
+					/obj/item/weapon/grenade/chem_grenade/cleaner,
+					/obj/item/weapon/grenade/chem_grenade/cleaner)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "janitorial supplies"
+	group = "Miscellaneous"
+
+/datum/supply_packs/janicart
+	name = "Janitorial Cart crate"
+	contains = list(/obj/structure/janitorialcart)
+	cost = 10
+	containertype = /obj/structure/largecrate
+	containername = "janitorial cart crate"
+	group = "Miscellaneous"
+
+/datum/supply_packs/lightbulbs
+	name = "Replacement lights"
+	contains = list(/obj/item/weapon/storage/box/lights/mixed,
+					/obj/item/weapon/storage/box/lights/mixed,
+					/obj/item/weapon/storage/box/lights/mixed)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "replacement lights"
+	group = "Miscellaneous"
+
+
+///////////// Costumes
+
+/datum/supply_packs/costume
+	name = "Standard Costume crate"
+	contains = list(/obj/item/weapon/storage/backpack/clown,
+					/obj/item/clothing/shoes/clown_shoes,
+					/obj/item/clothing/mask/gas/clown_hat,
+					/obj/item/clothing/under/rank/clown,
+					/obj/item/weapon/bikehorn,
+					/obj/item/clothing/under/mime,
+					/obj/item/clothing/shoes/black,
+					/obj/item/clothing/gloves/white,
+					/obj/item/clothing/mask/gas/mime,
+					/obj/item/clothing/head/beret,
+					/obj/item/clothing/suit/suspenders,
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing)
+	cost = 10
+	containertype = /obj/structure/closet/crate/secure
+	containername = "standard costumes"
+	access = access_theatre
+	group = "Miscellaneous"
+
+/datum/supply_packs/wizard
+	name = "Wizard costume"
+	contains = list(/obj/item/weapon/staff,
+					/obj/item/clothing/suit/wizrobe/fake,
+					/obj/item/clothing/shoes/sandal,
+					/obj/item/clothing/head/wizard/fake)
+	cost = 20
+	containertype = /obj/structure/closet/crate
+	containername = "wizard costume crate"
+	group = "Miscellaneous"
 
 /datum/supply_packs/randomised
 	var/num_contained = 3 //number of items picked to be contained in a randomised crate
@@ -672,6 +1058,7 @@
 	cost = 200
 	containertype = /obj/structure/closet/crate
 	containername = "Collectable hats crate! Brought to you by Bass.inc!"
+	group = "Miscellaneous"
 
 /datum/supply_packs/randomised/New()
 	manifest += "Contains any [num_contained] of:"
@@ -688,3 +1075,4 @@
 	containertype = /obj/structure/closet/crate
 	containername = "crate"	//let's keep it subtle, eh?
 	contraband = 1
+	group = "Miscellaneous"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -172,6 +172,20 @@
 		new /obj/item/weapon/grenade/flashbang(src)
 		new /obj/item/weapon/grenade/flashbang(src)
 
+/obj/item/weapon/storage/box/flashes
+	name = "box of flashbulbs"
+	desc = "<B>WARNING: Flashes can cause serious eye damage, protective eyewear is required.</B>"
+	icon_state = "flashbang"
+
+	New()
+		..()
+		new /obj/item/device/flash(src)
+		new /obj/item/device/flash(src)
+		new /obj/item/device/flash(src)
+		new /obj/item/device/flash(src)
+		new /obj/item/device/flash(src)
+		new /obj/item/device/flash(src)
+
 /obj/item/weapon/storage/box/teargas
 	name = "box of tear gas grenades (WARNING)"
 	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness and skin irritation.</B>"

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -142,6 +142,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	proc/process()
 		for(var/typepath in (typesof(/datum/supply_packs) - /datum/supply_packs))
 			var/datum/supply_packs/P = new typepath()
+			if(P.name == "HEADER") continue		// To filter out group headers
 			supply_packs[P.name] = P
 
 		spawn(0)
@@ -347,8 +348,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 				A:req_access += text2num(SP.access)
 
 			var/list/contains
-			if(istype(SP,/datum/supply_packs/randomised))
-				var/datum/supply_packs/randomised/SPR = SP
+			if(istype(SP,/datum/supply_packs/misc/randomised))
+				var/datum/supply_packs/misc/randomised/SPR = SP
 				contains = list()
 				if(SPR.contains.len)
 					for(var/j=1,j<=SPR.num_contained,j++)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -84,6 +84,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/hacked = 0
 	var/can_order_contraband = 0
+	var/last_viewed_group = "categories"
+
 
 /obj/machinery/computer/ordercomp
 	name = "Supply Ordering Console"
@@ -92,6 +94,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	circuit = "/obj/item/weapon/circuitboard/ordercomp"
 	var/temp = null
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
+	var/last_viewed_group = "categories"
 
 /*
 /obj/effect/marker/supplymarker
@@ -399,7 +402,8 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	else
 		dat += {"Shuttle Location: [supply_shuttle.moving ? "Moving to station ([supply_shuttle.eta] Mins.)":supply_shuttle.at_station ? "Station":"Dock"]<BR>
 		<HR>Supply Points: [supply_shuttle.points]<BR>
-		<BR>\n<A href='?src=\ref[src];order=1'>Request items</A><BR><BR>
+
+		<BR>\n<A href='?src=\ref[src];order=categories'>Request items</A><BR><BR>
 		<A href='?src=\ref[src];vieworders=1'>View approved orders</A><BR><BR>
 		<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR><BR>
 		<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
@@ -407,7 +411,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 	// Removing the old window method but leaving it here for reference
 	//user << browse(dat, "window=computer;size=575x450")
 	//onclose(user, "computer")
-	
+
 	// Added the new browser window method
 	var/datum/browser/popup = new(user, "computer", "Supply Ordering Console", 575, 450)
 	popup.set_content(dat)
@@ -423,12 +427,24 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		usr.set_machine(src)
 
 	if(href_list["order"])
-		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Request what?<BR><BR>Supply Points: [supply_shuttle.points]<BR><HR>"
-		for(var/supply_name in supply_shuttle.supply_packs )
-			var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
-			if(N.hidden || N.contraband) continue																	//Have to send the type instead of a reference to
-			temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"    //the obj because it would get caught by the garbage
-		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
+		if(href_list["order"] == "categories")
+			//all_supply_groups
+			//Request what?
+			last_viewed_group = "categories"
+			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
+			temp += "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>"
+			temp += "<b>Select a category</b><BR><BR>"
+			for(var/supply_group_name in all_supply_groups )
+				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
+		else
+			last_viewed_group = href_list["order"]
+			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
+			temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
+			temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
+			for(var/supply_name in supply_shuttle.supply_packs )
+				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
+				if(N.hidden || N.contraband || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
+				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"		//the obj because it would get caught by the garbage
 
 	else if (href_list["doorder"])
 		if(world.time < reqtime)
@@ -480,7 +496,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		supply_shuttle.requestlist += O
 
 		temp = "Thanks for your request. The cargo team will process it as soon as possible.<BR>"
-		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
+		temp += "<BR><A href='?src=\ref[src];order=[last_viewed_group]'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
 	else if (href_list["vieworders"])
 		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Current approved orders: <BR><BR>"
@@ -519,7 +535,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		dat += {"<BR><B>Supply shuttle</B><HR>
 		\nLocation: [supply_shuttle.moving ? "Moving to station ([supply_shuttle.eta] Mins.)":supply_shuttle.at_station ? "Station":"Away"]<BR>
 		<HR>\nSupply Points: [supply_shuttle.points]<BR>\n<BR>
-		[supply_shuttle.moving ? "\n*Must be away to order items*<BR>\n<BR>":supply_shuttle.at_station ? "\n*Must be away to order items*<BR>\n<BR>":"\n<A href='?src=\ref[src];order=1'>Order items</A><BR>\n<BR>"]
+		[supply_shuttle.moving ? "\n*Must be away to order items*<BR>\n<BR>":supply_shuttle.at_station ? "\n*Must be away to order items*<BR>\n<BR>":"\n<A href='?src=\ref[src];order=categories'>Order items</A><BR>\n<BR>"]
 		[supply_shuttle.moving ? "\n*Shuttle already called*<BR>\n<BR>":supply_shuttle.at_station ? "\n<A href='?src=\ref[src];send=1'>Send away</A><BR>\n<BR>":"\n<A href='?src=\ref[src];send=1'>Send to station</A><BR>\n<BR>"]
 		\n<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];vieworders=1'>View orders</A><BR>\n<BR>
@@ -596,14 +612,33 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 
 	else if (href_list["order"])
 		if(supply_shuttle.moving) return
-		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Supply Points: [supply_shuttle.points]<BR><HR><BR>Request what?<BR><BR>"
+		if(href_list["order"] == "categories")
+			//all_supply_groups
+			//Request what?
+			last_viewed_group = "categories"
+			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
+			temp += "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>"
+			temp += "<b>Select a category</b><BR><BR>"
+			for(var/supply_group_name in all_supply_groups )
+				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
+		else
+			last_viewed_group = href_list["order"]
+			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
+			temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
+			temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
+			for(var/supply_name in supply_shuttle.supply_packs )
+				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
+				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
+				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"		//the obj because it would get caught by the garbage
+
+		/*temp = "Supply points: [supply_shuttle.points]<BR><HR><BR>Request what?<BR><BR>"
 
 		for(var/supply_name in supply_shuttle.supply_packs )
 			var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
 			if(N.hidden && !hacked) continue
 			if(N.contraband && !can_order_contraband) continue
 			temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"    //the obj because it would get caught by the garbage
-		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
+		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"*/
 
 	else if (href_list["doorder"])
 		if(world.time < reqtime)
@@ -655,7 +690,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 		supply_shuttle.requestlist += O
 
 		temp = "Order request placed.<BR>"
-		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A> | <A href='?src=\ref[src];confirmorder=[O.ordernum]'>Authorize Order</A>"
+		temp += "<BR><A href='?src=\ref[src];order=[last_viewed_group]'>Back</A> | <A href='?src=\ref[src];mainmenu=1'>Main Menu</A> | <A href='?src=\ref[src];confirmorder=[O.ordernum]'>Authorize Order</A>"
 
 	else if(href_list["confirmorder"])
 		//Find the correct supply_order datum
@@ -673,10 +708,11 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 					supply_shuttle.points -= P.cost
 					supply_shuttle.shoppinglist += O
 					temp = "Thanks for your order.<BR>"
+					temp += "<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 				else
 					temp = "Not enough supply points.<BR>"
+					temp += "<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 				break
-		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
 	else if (href_list["vieworders"])
 		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Current approved orders: <BR><BR>"
@@ -714,7 +750,7 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 				supply_shuttle.requestlist.Cut(i,i+1)
 				temp = "Request removed.<BR>"
 				break
-		temp += "<BR><A href='?src=\ref[src];viewrequests=1'>OK</A>"
+		temp += "<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
 	else if (href_list["clearreq"])
 		supply_shuttle.requestlist.Cut()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -434,16 +434,17 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp += "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>"
 			temp += "<b>Select a category</b><BR><BR>"
-			for(var/supply_group_name in all_supply_groups )
-				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
+			for(var/cat in all_supply_groups )
+				temp += "<A href='?src=\ref[src];order=[cat]'>[get_supply_group_name(cat)]</A><BR>"
 		else
 			last_viewed_group = href_list["order"]
+			var/cat = text2num(last_viewed_group)
 			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
-			temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
+			temp += "<b>Request from: [get_supply_group_name(cat)]</b><BR><BR>"
 			for(var/supply_name in supply_shuttle.supply_packs )
 				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
-				if(N.hidden || N.contraband || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
+				if(N.hidden || N.contraband || N.group != cat) continue												//Have to send the type instead of a reference to
 				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"		//the obj because it would get caught by the garbage
 
 	else if (href_list["doorder"])
@@ -619,16 +620,17 @@ var/datum/controller/supply_shuttle/supply_shuttle = new()
 			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp += "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><HR><BR><BR>"
 			temp += "<b>Select a category</b><BR><BR>"
-			for(var/supply_group_name in all_supply_groups )
-				temp += "<A href='?src=\ref[src];order=[supply_group_name]'>[supply_group_name]</A><BR>"
+			for(var/cat in all_supply_groups )
+				temp += "<A href='?src=\ref[src];order=[cat]'>[get_supply_group_name(cat)]</A><BR>"
 		else
 			last_viewed_group = href_list["order"]
+			var/cat = text2num(last_viewed_group)
 			temp = "<b>Supply points: [supply_shuttle.points]</b><BR>"
 			temp += "<A href='?src=\ref[src];order=categories'>Back to all categories</A><HR><BR><BR>"
-			temp += "<b>Request from: [last_viewed_group]</b><BR><BR>"
+			temp += "<b>Request from: [get_supply_group_name(cat)]</b><BR><BR>"
 			for(var/supply_name in supply_shuttle.supply_packs )
 				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
-				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != last_viewed_group) continue								//Have to send the type instead of a reference to
+				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != cat) continue		//Have to send the type instead of a reference to
 				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"		//the obj because it would get caught by the garbage
 
 		/*temp = "Supply points: [supply_shuttle.points]<BR><HR><BR>Request what?<BR><BR>"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,7 +51,20 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>10 August 2013</h2>
+	<h3 class='author'>Malkevin updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='wip'>Cargo Overhaul: Phase 1</li>
+		<li class='rscadd'>Ported Bay's cargo computer categoy system</li>
+		<li class='tweak'>Crates have been tweaked significantly. Crates have been reduced to single item types where possible, namely with expensive crates such as weapons and armor. A total of 28 new crates have been added, including chemical and tracking implants, and raw materials can also be bought from cargo for a significant number of points (subject to change)</li>
+		<li class='bugfix'>This was a pretty large edit of repetitive data, so no doubt I've made a mistake or two. Please report any bugs to the usual place</li>
+	</ul>
+</div>
+
+
 <div class='commit sansserif'>
 	<h2 class='date'>6 August 2013</h2>
 	<h3 class='author'>Giacom updated:</h3>


### PR DESCRIPTION
-Ported Bay's cargo computer category system

-Created a box containing six flashes

-Crates have been tweaked significantly. Crates have been reduced to single item types where possible, namely with expensive crates such as weapons and armor. The total number of crates has been increased by 28, new stuff includes chemical and tracking implants, and raw materials can also be bought from cargo for a significant number of points (subject to change)
