### PR TITLE
Chameleon Stamp

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -162,6 +162,12 @@ var/list/uplink_items = list()
 	item = /obj/item/clothing/under/chameleon
 	cost = 3
 
+/datum/uplink_item/stealthy_tools/chameleon_stamp
+	name = "Chameleon Stamp"
+	desc = "A stamp that can be activated to imitate an official Nanotrasen Stamp™. The disguised stamp will work exactly like the real stamp and will allow you to forge false documents to gain access or equipment; it can also be used in a washing machine to forge clothing."
+	item = /obj/item/weapon/stamp/chameleon
+	cost = 1
+
 /datum/uplink_item/stealthy_tools/syndigolashes
 	name = "No-Slip Brown Shoes"
 	desc = "These allow you to run on wet floors. They do not work on lubricated surfaces."

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -15,12 +15,12 @@
 	attack_verb = list("stamped")
 
 /obj/item/weapon/stamp/qm
-	name = "Quartermaster's rubber stamp"
+	name = "quartermaster's rubber stamp"
 	icon_state = "stamp-qm"
 	color = "cargo"
 
 /obj/item/weapon/stamp/law
-	name = "Law office's rubber stamp"
+	name = "law office's rubber stamp"
 	icon_state = "stamp-law"
 	color = "cargo"
 
@@ -64,6 +64,30 @@
 	icon_state = "stamp-clown"
 	color = "clown"
 
-
 /obj/item/weapon/stamp/attack_paw(mob/user)
 	return attack_hand(user)
+
+// Syndicate stamp to forge documents.
+
+/obj/item/weapon/stamp/chameleon/attack_self(mob/user as mob)
+
+	var/list/stamp_types = typesof(/obj/item/weapon/stamp) - src.type // Get all stamp types except our own
+	var/list/stamps = list()
+
+	// Generate them into a list
+	for(var/stamp_type in stamp_types)
+		var/obj/item/weapon/stamp/S = new stamp_type
+		stamps[capitalize(S.name)] = S
+
+	var/list/show_stamps = list("EXIT" = null) + sortList(stamps) // the list that will be shown to the user to pick from
+
+	var/input_stamp = input(user, "Choose a stamp to disguise as.", "Choose a stamp.") in show_stamps
+
+	if(user && src in user.contents)
+
+		var/obj/item/weapon/stamp/chosen_stamp = stamps[capitalize(input_stamp)]
+
+		if(chosen_stamp)
+			name = chosen_stamp.name
+			icon_state = chosen_stamp.icon_state
+			color = chosen_stamp.color


### PR DESCRIPTION
- Added a new uplink item, the chameleon stamp can be activated to turn into a different stamp; to use for forging documents or for forging clothing.

I left it out of the changelog intentionally.
