### PR TITLE
Nar-sie change + Construct Names

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -1,7 +1,7 @@
 
 /mob/living/simple_animal/construct
 	name = "Construct"
-	real_name = "Contruct"
+	real_name = "Construct"
 	desc = ""
 	speak_emote = list("hisses")
 	emote_hear = list("wails","screeches")
@@ -25,6 +25,9 @@
 	minbodytemp = 0
 	faction = "cult"
 
+/mob/living/simple_animal/construct/New()
+	name = text("[initial(name)] ([rand(1, 1000)])")
+	real_name = name
 
 /mob/living/simple_animal/construct/Life()
 	..()
@@ -255,7 +258,7 @@
 	var/energy = 0
 	var/max_energy = 1000
 
-/mob/living/simple_animal/constructbehemoth/attackby(var/obj/item/O as obj, var/mob/user as mob)
+/mob/living/simple_animal/construct/behemoth/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(O.force)
 		if(O.force >= 11)
 			var/damage = O.force

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -523,15 +523,14 @@ var/global/list/uneatable = list(
 
 	if(istype(A,/mob/living/))
 		var/mob/living/C = A
-		if(!iscultist(C))//TODO: Make Narsie reward her cultists with transformation into a construct.
-			C.dust()
+		C.dust()
 
 	if(isturf(A))
 		var/turf/T = A
-		if(istype(T, /turf/simulated/floor))
+		if(istype(T, /turf/simulated/floor) && !istype(T, /turf/simulated/floor/engine/cult))
 			if(prob(20)) T.ChangeTurf(/turf/simulated/floor/engine/cult)
 
-		else if(istype(T,/turf/simulated/wall))
+		else if(istype(T,/turf/simulated/wall) && !istype(T, /turf/simulated/wall/cult))
 			if(prob(20)) T.ChangeTurf(/turf/simulated/wall/cult)
 	return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -452,7 +452,7 @@ var/global/list/uneatable = list(
 
 
 /obj/machinery/singularity/narsie //Moving narsie to a child object of the singularity so it can be made to function differently. --NEO
-	name = "Nar-Sie"
+	name = "Nar-sie's Avatar"
 	desc = "Your mind begins to bubble and ooze as it tries to comprehend what it sees."
 	icon = 'icons/obj/magic_terror.dmi'
 	pixel_x = -89
@@ -461,8 +461,8 @@ var/global/list/uneatable = list(
 	contained = 0 //Are we going to move around?
 	dissipate = 0 //Do we lose energy over time?
 	move_self = 1 //Do we move on our own?
-	grav_pull = 10 //How many tiles out do we pull?
-	consume_range = 3 //How many tiles out do we eat
+	grav_pull = 5 //How many tiles out do we pull?
+	consume_range = 6 //How many tiles out do we eat
 
 /obj/machinery/singularity/narsie/large
 	name = "Nar-Sie"
@@ -472,6 +472,7 @@ var/global/list/uneatable = list(
 	pixel_y = -256
 	current_size = 12
 	move_self = 1 //Do we move on our own?
+	grav_pull = 10
 	consume_range = 12 //How many tiles out do we eat
 
 /obj/machinery/singularity/narsie/large/New()
@@ -509,11 +510,9 @@ var/global/list/uneatable = list(
 
 
 /obj/machinery/singularity/narsie/mezzer()
-	for(var/mob/living/carbon/human/M in oviewers(8, src))
+	for(var/mob/living/carbon/M in oviewers(8, src))
 		if(M.stat == CONSCIOUS)
-			if(iscultist(M))
-				continue
-			else
+			if(!iscultist(M))
 				M << "\red You feel your sanity crumble away in an instant as you gaze upon [src.name]..."
 				M.apply_effect(3, STUN)
 
@@ -524,7 +523,7 @@ var/global/list/uneatable = list(
 
 	if(istype(A,/mob/living/))
 		var/mob/living/C = A
-		if(!iscultist(C))//if someone's not a cultist (includes constructs/cult xenos/whatever)
+		if(!iscultist(C))//TODO: Make Narsie reward her cultists with transformation into a construct.
 			C.dust()
 
 	if(isturf(A))

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -476,7 +476,7 @@ var/global/list/uneatable = list(
 
 /obj/machinery/singularity/narsie/large/New()
 	..()
-	world << "<font size='28' color='red'><b>NAR-SIE HAS RISEN</b></font>"
+	world << "<font size='15' color='red'><b>NAR-SIE HAS RISEN</b></font>"
 	if(emergency_shuttle)
 		emergency_shuttle.incall(0.5) // Cannot recall
 
@@ -488,23 +488,52 @@ var/global/list/uneatable = list(
 	if(prob(25))
 		mezzer()
 
-/obj/machinery/singularity/narsie/consume(var/atom/A) //Has its own consume proc because it doesn't need energy and I don't want BoHs to explode it. --NEO
-	if(is_type_in_list(A, uneatable))
-		return 0
-	if (istype(A,/mob/living))//Mobs get gibbed
-		A:gib()
-	else if(istype(A,/obj/))
-		A:ex_act(1.0)
-		if(A) del(A)
+
+/obj/machinery/singularity/narsie/Bump(atom/A)//you dare stand before a god?!
+	godsmack(A)
+	return
+
+/obj/machinery/singularity/narsie/Bumped(atom/A)
+	godsmack(A)
+	return
+
+/obj/machinery/singularity/narsie/proc/godsmack(var/atom/A)
+	if(istype(A,/obj/))
+		var/obj/O = A
+		O.ex_act(1.0)
+		if(O) del(O)
+
 	else if(isturf(A))
 		var/turf/T = A
-		if(T.intact)
-			for(var/obj/O in T.contents)
-				if(O.level != 1)
-					continue
-				if(O.invisibility == 101)
-					src.consume(O)
-		A:ChangeTurf(/turf/space)
+		T.ChangeTurf(/turf/simulated/floor/engine/cult)
+
+
+/obj/machinery/singularity/narsie/mezzer()
+	for(var/mob/living/carbon/human/M in oviewers(8, src))
+		if(M.stat == CONSCIOUS)
+			if(iscultist(M))
+				continue
+			else
+				M << "\red You feel your sanity crumble away in an instant as you gaze upon [src.name]..."
+				M.apply_effect(3, STUN)
+
+
+/obj/machinery/singularity/narsie/consume(var/atom/A)
+	if(is_type_in_list(A, uneatable))
+		return 0
+
+	if(istype(A,/mob/living/))
+		var/mob/living/C = A
+		if(!iscultist(C))//if someone's not a cultist (includes constructs/cult xenos/whatever)
+			C.dust()
+
+	if(isturf(A))
+		var/turf/T = A
+		if(istype(T, /turf/simulated/floor))
+			if(prob(20)) T.ChangeTurf(/turf/simulated/floor/engine/cult)
+
+		else if(istype(T,/turf/simulated/wall))
+			if(prob(20)) T.ChangeTurf(/turf/simulated/wall/cult)
 	return
 
 /obj/machinery/singularity/narsie/ex_act() //No throwing bombs at it either. --NEO


### PR DESCRIPTION
Instead of Del()ing everything and causing a bajillion air leaks like a normal singularity, Nar-sie now converts nearby turfs into cult-style turfs. Objects and walls in Nar-sie's way are destroyed. Non-cultists are turned to dust, cultists are spared.

Constructs now get numbered names, for the sake of telling them apart from another.

http://i.imgur.com/E93rM28.png
