### PR TITLE
Issue #1012 Fix

### DIFF
--- a/code/modules/surgery/brain_removal.dm
+++ b/code/modules/surgery/brain_removal.dm
@@ -11,14 +11,6 @@
 	time = 64
 	var/obj/item/organ/brain/B = null
 
-/datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		H.apply_damage(75,"brute","head")
-		user.visible_message("<span class='notice'>[user] saws [target]'s skull open!")
-	return 1
-
-
 /datum/surgery_step/extract_brain/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	B = target.getorgan(/obj/item/organ/brain)
 	if(B)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -69,15 +69,10 @@
 	return 1
 
 /datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(surgery.name == "brain removal")
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			H.apply_damage(75,"brute","head")
-			user.visible_message("<span class='notice'>[user] saws [target]'s skull open!")
-	else
+	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		H.apply_damage(75,"brute","chest")
-		user.visible_message("<span class='notice'>[user] saws [target]'s chest open!")
+		H.apply_damage(75,"brute","[target_zone]")
+		user.visible_message("<span class='notice'>[user] saws [target]'s [target_zone] open!")	
 	return 1
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -68,6 +68,15 @@
 	user.visible_message("<span class='notice'>[user] succeeds!</span>")
 	return 1
 
+/datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(surgery.name == "brain removal")
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			H.apply_damage(75,"brute","head")
+			user.visible_message("<span class='notice'>[user] saws [target]'s skull open!")
+	else
+		user.visible_message("<span class='notice'>[user] saws [target]'s chest open!")
+	return 1
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='warning'>[user] screws up!</span>")

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -75,6 +75,8 @@
 			H.apply_damage(75,"brute","head")
 			user.visible_message("<span class='notice'>[user] saws [target]'s skull open!")
 	else
+		var/mob/living/carbon/human/H = target
+		H.apply_damage(75,"brute","chest")
 		user.visible_message("<span class='notice'>[user] saws [target]'s chest open!")
 	return 1
 


### PR DESCRIPTION
Fixes the issue where you would attack someone in the head during the sawing stage of Xenomorph removal, as well as corrects the text. Fixes inconsistency where the Saw step was in brain_removal.dm instead of surgery_step.dm.  Surgery could still use some cleaning up.  
