### PR TITLE
APC Runtime Fix

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1179,10 +1179,8 @@ var/using_new_click_proc = 0 //TODO ERRORAGE (This is temporary, while the DblCl
 			src.Topic(nhref, params2list(nhref), src, 1)
 
 	else if (istype(src , /obj/machinery/power/apc/))
-		var/nhref = "src=\ref[src];breaker=1"
-		src.Topic(nhref, params2list(nhref), 0)
-
-
+		var/obj/machinery/power/apc/A = src
+		A.toggle_breaker()
 
 	return
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -639,6 +639,8 @@ About the new airlock wires panel:
 
 
 /obj/machinery/door/airlock/Topic(href, href_list, var/nowindow = 0)
+	// If you add an if(..()) check you must first remove the var/nowindow parameter.
+	// Otherwise it will runtime with this kind of error: null.Topic()
 	if(!nowindow)
 		..()
 	if(usr.stat || usr.restrained())

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -693,9 +693,10 @@
 			return 0
 	return 1
 
-/obj/machinery/power/apc/Topic(href, href_list, var/usingUI = 1)
+/obj/machinery/power/apc/Topic(href, href_list)
 	if(..())
 		return
+
 	if(!isrobot(usr))
 		if(!can_use(usr, 1))
 			return
@@ -706,14 +707,7 @@
 		coverlocked = !coverlocked
 
 	else if (href_list["breaker"])
-		operating = !operating
-		if(malfai)
-			if (ticker.mode.config_tag == "malfunction")
-				if (src.z == 1) //if (is_type_in_list(get_area(src), the_station_areas))
-					operating ? ticker.mode:apcs++ : ticker.mode:apcs--
-
-		src.update()
-		update_icon()
+		toggle_breaker()
 
 	else if (href_list["cmode"])
 		chargemode = !chargemode
@@ -786,10 +780,19 @@
 	else if (href_list["deoccupyapc"])
 		malfvacate()
 
-	if(usingUI)
-		src.updateDialog()
+	src.updateDialog()
 
 	return
+
+/obj/machinery/power/apc/proc/toggle_breaker()
+	operating = !operating
+	if(malfai)
+		if (ticker.mode.config_tag == "malfunction")
+			if (src.z == 1) //if (is_type_in_list(get_area(src), the_station_areas))
+				operating ? ticker.mode:apcs++ : ticker.mode:apcs--
+
+	src.update()
+	update_icon()
 
 /obj/machinery/power/apc/proc/malfoccupy(var/mob/living/silicon/ai/malf)
 	if(!istype(malf))


### PR DESCRIPTION
The APC's extra Topic() parameter was causing a runtime to occur when you used ..(). Fixed it by removing the parameter and rearranging the code so it wasn't required. Fixes Issue #1148.

This is just a quick pull request for the annoying runtime I know Aran has been crying over; it will probably be my last for a while.

fk u aran
