### PR TITLE
Admin Log Tweaks

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -233,7 +233,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 0, 2, 3)
+	explosion(T, -1, 0, 2, 3, 0)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -116,7 +116,7 @@ var/savefile/Banlist
 		Banlist["temp"] << temp
 		if (temp)
 			Banlist["minutes"] << bantimestamp
-		notes_add(ckey, "Banned - [reason]")
+		notes_add(ckey, "Banned for [minutes] minutes - [reason]")
 	return 1
 
 /proc/RemoveBan(foldername)

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -22,12 +22,12 @@
 	F << "<small>[time2text(world.timeofday,"hh:mm")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>"
 
 //ADMINVERBS
-/client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo") )
+/client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo", "wires") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)	return
 	switch(subject)
-		if("singulo", "ntsl")			//general one-round-only stuff
+		if("singulo", "ntsl", "wires")			//general one-round-only stuff
 			var/F = investigate_subject2file(subject)
 			if(!F)
 				src << "<font color='red'>Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed.</font>"

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -12,7 +12,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	var/savefile/notesfile = new(NOTESFILE)
 	if(!notesfile)	return "<font color='red'>Error: Cannot access [NOTESFILE]</font>"
 	if(ckey)
-		. = "<b>Notes for <a href='?_src_=holder;notes=show'>[ckey]</a>:</b> <a href='?_src_=holder;notes=add;ckey=[ckey]'>\[+\]</a> <a href='?_src_=holder;notes=remove;ckey=[ckey]'>\[-\]</a><br>"
+		. = "<b>Notes for <a href='?_src_=holder;notes=show'>[ckey]</a>:</b> <a href='?_src_=holder;notes=add;ckey=[ckey]'>\[+\]</a><br>"
 		notesfile.cd = "/[ckey]"
 		var/index = 1
 		while( !notesfile.eof )
@@ -21,7 +21,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 			. += "[note] <a href='?_src_=holder;notes=remove;ckey=[ckey];from=[index]'>\[-\]</a><br>"
 			index++
 	else
-		. = "<b>All Notes:</b> <a href='?_src_=holder;notes=add'>\[+\]</a> <a href='?_src_=holder;notes=remove'>\[-\]</a><br>"
+		. = "<b>All Notes:</b> <a href='?_src_=holder;notes=add'>\[+\]</a><br>"
 		notesfile.cd = "/"
 		for(var/dir in notesfile.dir)
 			. += "<a href='?_src_=holder;notes=show;ckey=[dir]'>[dir]</a><br>"
@@ -83,17 +83,13 @@ datum/admins/proc/notes_gethtml(var/ckey)
 		for( var/note in noteslist )
 			notesfile << note
 
-
 		message_admins("[key_name(usr)] removed a note '[admin_msg]' from [ckey]")
 		log_admin("[key_name(usr)] removed a note '[admin_msg]' from [ckey]")
 
-	else
-		notesfile.cd = "/"
-		if(alert(usr,"Are you sure you want to remove all their notes?","Confirmation","No","Yes - Remove all notes") == "Yes - Remove all notes")
+		if(noteslist.len == 0)
+			notesfile.cd = "/"
 			notesfile.dir.Remove(ckey)
-
-			message_admins("[key_name(usr)] removed all notes from [ckey]")
-			log_admin("[key_name(usr)] removed all notes from [ckey]")
+			message_admins("[ckey] has no notes and was removed from the notes list.")
 	return
 
 #undef NOTESFILE

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -45,11 +45,16 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	notesfile.cd = "/[ckey]"
 	notesfile.eof = 1		//move to the end of the buffer
 	notesfile << "[time2text(world.realtime,"DD-MMM-YYYY")] | [note][(usr && usr.ckey)?" ~[usr.ckey]":""]"
+
+	message_admins("[key_name(usr)] added note '[note]' to [ckey]")
+	log_admin("[key_name(usr)] added note '[note]' to [ckey]")
+
 	return
 
 //handles removing entries from the buffer, or removing the entire directory if no start_index is given
 /proc/notes_remove(var/ckey, var/start_index, var/end_index)
 	var/savefile/notesfile = new(NOTESFILE)
+	var/admin_msg
 	if(!notesfile)	return
 
 	if(!ckey)
@@ -67,17 +72,27 @@ datum/admins/proc/notes_gethtml(var/ckey)
 			var/temp
 			notesfile >> temp
 			if( (start_index <= index) && (index <= end_index) )
+				admin_msg = temp
 				continue
+
 			noteslist += temp
 
 		notesfile.eof = -2		//Move to the start of the buffer and then erase.
 
 		for( var/note in noteslist )
 			notesfile << note
+
+
+		message_admins("[key_name(usr)] removed a note '[admin_msg]' from [ckey]")
+		log_admin("[key_name(usr)] removed a note '[admin_msg]' from [ckey]")
+
 	else
 		notesfile.cd = "/"
 		if(alert(usr,"Are you sure you want to remove all their notes?","Confirmation","No","Yes - Remove all notes") == "Yes - Remove all notes")
 			notesfile.dir.Remove(ckey)
+
+			message_admins("[key_name(usr)] removed all notes from [ckey]")
+			log_admin("[key_name(usr)] removed all notes from [ckey]")
 	return
 
 #undef NOTESFILE

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -31,7 +31,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 //handles adding notes to the end of a ckey's buffer
 //originally had seperate entries such as var/by to record who left the note and when
 //but the current bansystem is a heap of dung.
-/proc/notes_add(var/ckey, var/note)
+/proc/notes_add(var/ckey, var/note, var/lognote = 0)
 	if(!ckey)
 		ckey = ckey(input(usr,"Who would you like to add notes for?","Enter a ckey",null) as text|null)
 		if(!ckey)	return
@@ -46,8 +46,9 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	notesfile.eof = 1		//move to the end of the buffer
 	notesfile << "[time2text(world.realtime,"DD-MMM-YYYY")] | [note][(usr && usr.ckey)?" ~[usr.ckey]":""]"
 
-	message_admins("[key_name(usr)] added note '[note]' to [ckey]")
-	log_admin("[key_name(usr)] added note '[note]' to [ckey]")
+	if(lognote)//don't need an admin log for the notes applied automatically during bans.
+		message_admins("[key_name(usr)] added note '[note]' to [ckey]")
+		log_admin("[key_name(usr)] added note '[note]' to [ckey]")
 
 	return
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -862,7 +862,7 @@
 			if("show")
 				notes_show(ckey)
 			if("add")
-				notes_add(ckey,href_list["text"])
+				notes_add(ckey,href_list["text"], 1)
 				notes_show(ckey)
 			if("remove")
 				notes_remove(ckey,text2num(href_list["from"]),text2num(href_list["to"]))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -138,21 +138,10 @@
 		for(var/mob/O in viewers(src, null))
 			O.show_message("\red [user] cuts the cable.", 1)
 
-		var/message = "A wire has been cut"
-		var/atom/A = user
-		if(A)
-			var/turf/Z = get_turf(A)
-			var/area/my_area = get_area(Z)
-			message += " in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>)"
-			message += " (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"
+		investigate_log("was cut by [key_name(usr, usr.client)] in [user.loc.loc]","wires")
 
-			var/mob/M = get(A, /mob)
-			if(M)
-				message += " - Cut By: [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
-		message_admins(message, 0, 1)
 		del(src)
-
-		return	// not needed, but for clarity
+		return
 
 
 	else if(istype(W, /obj/item/weapon/cable_coil))


### PR DESCRIPTION
-Wire cut logs are now accessed via the Investigate verb, instead of popping up in the admin chat log.
-Wizard Fireball explosions no longer create admin chat log messages either.

-Adding and removing Player Notes is now logged.
-The note that is added automatically to people who get banned, now displays the duration of ban.
