### PR TITLE
Unsimulated walls blocking air

### DIFF
--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -4,12 +4,12 @@
 	icon_state = "riveted"
 	opacity = 1
 	density = 1
+	blocks_air = 1
 
 /turf/unsimulated/wall/fakeglass
 	name = "window"
 	icon_state = "fakewindows"
 	opacity = 0
-	blocks_air = 1
 
 /turf/unsimulated/wall/fakedoor
 	name = "Centcom Access"


### PR DESCRIPTION
Made all unsimulated/wall turfs have block_air = 1 instead of only the fakeglass walls
