### PR TITLE
EMP-kit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -116,9 +116,9 @@ var/list/uplink_items = list()
 	cost = 4
 
 /datum/uplink_item/dangerous/emp
-	name = "A box of 5 EMP Grenades"
-	desc = "Electromagnetic pulse grenades cause transient disturbance on detonation, disabling nearby electronic equipment."
-	item = /obj/item/weapon/storage/box/emps
+	name = "EMP Kit"
+	desc = "A box that contains an EMP grenade, an EMP implant and a short ranged device disguised as a flashlight. Useful to disrupt communication and silicon lifeforms."
+	item = /obj/item/weapon/storage/box/syndie_kit/emp
 	cost = 3
 
 /datum/uplink_item/dangerous/syndicate_minibomb

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -209,3 +209,34 @@
 	m_amt = 0
 	g_amt = 0
 	brightness_on = 6 //luminosity when on
+
+/obj/item/device/flashlight/emp
+	desc = "A hand-held emergency light modified to inflict EMP at short range."
+	origin_tech = "magnets=4;syndicate=5"
+
+	var/emp_charges = 5
+
+/obj/item/device/flashlight/emp/examine()
+	..()
+	usr << "Has [emp_charges] charge\s remaining."
+	return
+
+/obj/item/device/flashlight/emp/attack(mob/living/M as mob, mob/living/user as mob)
+	if(on && user.zone_sel.selecting == "eyes") // call original attack proc only if aiming at the eyes
+		..()
+	return
+
+/obj/item/device/flashlight/emp/afterattack(atom/A as mob|obj, mob/user)
+	if (emp_charges > 0)
+		A.emp_act(1)
+		A.visible_message("<span class='danger'>[user] blinks \the [src] at \the [A].", \
+											"<span class='userdanger'>[user] blinks \the [src] at \the [A].")
+		if(ismob(A))
+			var/mob/M = A
+			M.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> attacked <b>[M]/[M.ckey]</b> with an <b>EMP-light</b>"
+			user.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> attacked <b>[M]/[M.ckey]</b> with an <b>EMP-light</b>"
+			log_attack("<font color='red'>[user] ([user.ckey]) attacked [M] ([M.ckey]) with an EMP-light</font>")
+		emp_charges -= 1
+	else
+		user << "<span class='warning'>The [src] is out of charges!</span>"
+	return

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/grenade/empgrenade
-	name = "classic emp grenade"
+	name = "classic EMP grenade"
 	icon_state = "emp"
 	item_state = "emp"
 	origin_tech = "materials=2;magnets=3"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -179,3 +179,28 @@
 	source.mind.store_memory("An adrenalin implant can be activated by using the pale emote, <B>say *pale</B> to attempt to activate.", 0, 0)
 	source << "<span class='notice'>The implanted adrenalin implant can be activated by using the pale emote, <B>say *pale</B> to attempt to activate.</span>"
 	return 1
+
+
+/obj/item/weapon/implant/emp
+	name = "emp"
+	desc = "Triggers an EMP."
+
+	var/activation_emote = "chuckle"
+	var/uses = 1
+
+/obj/item/weapon/implant/emp/New()
+	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	..()
+	return
+
+/obj/item/weapon/implant/emp/trigger(emote, mob/living/carbon/source as mob)
+	if (src.uses < 1)	return 0
+	if (emote == src.activation_emote)
+		src.uses--
+		empulse(source, 3, 5)
+	return
+
+/obj/item/weapon/implant/emp/implanted(mob/living/carbon/source)
+		source.mind.store_memory("EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
+		source << "The implanted EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
+		return 1

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -66,3 +66,12 @@
 	imp = new /obj/item/weapon/implant/adrenalin(src)
 	..()
 	update_icon()
+
+
+/obj/item/weapon/implanter/emp
+	name = "implanter-EMP"
+
+/obj/item/weapon/implanter/emp/New()
+	imp = new /obj/item/weapon/implant/emp(src)
+	..()
+	update_icon()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -128,3 +128,13 @@
 	new /obj/item/clothing/suit/space/syndicate(src)
 	new /obj/item/clothing/head/helmet/space/syndicate(src)
 	return
+
+/obj/item/weapon/storage/box/syndie_kit/emp
+	name = "EMP kit"
+
+/obj/item/weapon/storage/box/syndie_kit/emp/New()
+	..()
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/implanter/emp/(src)
+	new /obj/item/device/flashlight/emp/(src)
+	return

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,7 +51,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>21 August 2013</h2>
+	<h3 class='author'>Dumpdavidson updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Replaced the EMP grenades from the uplink with an EMP kit. The kit contains a grenade, an implant and a flashlight with 5 uses that can EMP any object or mob in melee range.</li>
+	</ul>
+</div>
+
 
 <div class='commit sansserif'>
 	<h2 class='date'>13 August 2013</h2>


### PR DESCRIPTION
EMP grenades saw nearly no use. They were awkward to use in combat (unlike a flashbang they didn't stop your target from running) and even more awkward for stealth due to the 10 range light EMP setting off cameras. This change intends to offer less "nuclear" options to use EMPs as a traitor. 

Adds EMP-implant. (3 heavy range 5 weak range EMP, useful if a borg stuns you).
Adds EMP-flashlight (5 uses in melee range on any object or mob you click, disables headsets and opens lockers/crates).

Replaced the EMP grenades from the uplink with an EMP kit.
The kit  (3 TK) contains:
1 grenade
1 implant
1 EMP-flashlight
