### PR TITLE
Prettified emote code, added "*help" to cyborg and slime

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -13,96 +13,123 @@
 	var/message
 
 	switch(act)
-		if("sign")
-			if (!src.restrained())
-				message = text("<B>The alien</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
-				m_type = 1
-		if ("burp")
+		if ("burp") //Alphabetical please.
 			if (!muzzled)
 				message = "<B>[src]</B> burps."
 				m_type = 2
+
 		if ("deathgasp")
 			message = "<B>[src]</B> lets out a waning guttural screech, green blood bubbling from its maw..."
 			m_type = 2
-		if("scratch")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> scratches."
-				m_type = 1
-		if("whimper")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> whimpers."
-				m_type = 2
-		if("roar")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> roars."
-				m_type = 2
-		if("his")
-			if(!muzzled)
-				message = "<B>The [src.name]</B> hisses."
-				m_type = 2
-		if("tail")
-			message = "<B>The [src.name]</B> waves its tail."
-			m_type = 1
-		if("gasp")
-			message = "<B>The [src.name]</B> gasps."
+
+		if ("choke")
+			message = "<B>[src]</B> chokes."
 			m_type = 2
-		if("shiver")
-			message = "<B>The [src.name]</B> shivers."
-			m_type = 2
-		if("drool")
-			message = "<B>The [src.name]</B> drools."
-			m_type = 1
-		if("scretch")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> scretches."
-				m_type = 2
-		if("choke")
-			message = "<B>The [src.name]</B> chokes."
-			m_type = 2
-		if("moan")
-			message = "<B>The [src.name]</B> moans!"
-			m_type = 2
-		if("nod")
-			message = "<B>The [src.name]</B> nods its head."
-			m_type = 1
-		if("sit")
-			message = "<B>The [src.name]</B> sits down."
-			m_type = 1
-		if("sway")
-			message = "<B>The [src.name]</B> sways around dizzily."
-			m_type = 1
-		if("sulk")
-			message = "<B>The [src.name]</B> sulks down sadly."
-			m_type = 1
-		if("twitch")
-			message = "<B>The [src.name]</B> twitches violently."
-			m_type = 1
-		if("dance")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> dances around happily."
-				m_type = 1
-		if("roll")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> rolls."
-				m_type = 1
-		if("shake")
-			message = "<B>The [src.name]</B> shakes its head."
-			m_type = 1
-		if("gnarl")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> gnarls and shows its teeth.."
-				m_type = 2
-		if("jump")
-			message = "<B>The [src.name]</B> jumps!"
-			m_type = 1
-		if("collapse")
+
+		if ("collapse")
 			Paralyse(2)
-			message = text("<B>[]</B> collapses!", src)
+			message = "<B>[src]</B> collapses!"
 			m_type = 2
-		if("help")
-			src << "burp, deathgasp, choke, collapse, dance, drool, gasp, shiver, gnarl, jump, moan, nod, roar, roll, scratch,\nscretch, shake, sign-#, sit, sulk, sway, tail, twitch, whimper"
+
+		if ("dance")
+			if (!src.restrained())
+				message = "<B>[src]</B> dances around happily."
+				m_type = 1
+
+		if ("drool")
+			message = "<B>[src]</B> drools."
+			m_type = 1
+
+		if ("gasp")
+			message = "<B>[src]</B> gasps."
+			m_type = 2
+
+		if ("gnarl")
+			if (!muzzled)
+				message = "<B>[src]</B> gnarls and shows its teeth.."
+				m_type = 2
+
+		if ("hiss")
+			if(!muzzled)
+				message = "<B>[src]</B> hisses."
+				m_type = 2
+
+		if ("jump")
+			message = "<B>[src]</B> jumps!"
+			m_type = 1
+
+		if ("moan")
+			message = "<B>[src]</B> moans!"
+			m_type = 2
+
+		if ("nod")
+			message = "<B>[src]</B> nods its head."
+			m_type = 1
+
+		if ("roar")
+			if (!muzzled)
+				message = "<B>[src]</B> roars."
+				m_type = 2
+
+		if ("roll")
+			if (!src.restrained())
+				message = "<B>[src]</B> rolls."
+				m_type = 1
+
+		if ("scratch")
+			if (!src.restrained())
+				message = "<B>[src]</B> scratches."
+				m_type = 1
+
+		if ("scretch")
+			if (!muzzled)
+				message = "<B>[src]</B> scretches."
+				m_type = 2
+
+		if ("shake")
+			message = "<B>[src]</B> shakes its head."
+			m_type = 1
+
+		if ("shiver")
+			message = "<B>[src]</B> shivers."
+			m_type = 2
+
+		if ("sign")
+			if (!src.restrained())
+				message = text("<B>[src]</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
+				m_type = 1
+
+		if ("sit")
+			message = "<B>[src]</B> sits down."
+			m_type = 1
+
+		if ("sulk")
+			message = "<B>[src]</B> sulks down sadly."
+			m_type = 1
+
+		if ("sway")
+			message = "<B>[src]</B> sways around dizzily."
+			m_type = 1
+
+		if ("tail")
+			message = "<B>[src]</B> waves its tail."
+			m_type = 1
+
+		if ("twitch")
+			message = "<B>[src]</B> twitches violently."
+			m_type = 1
+
+		if ("whimper")
+			if (!muzzled)
+				message = "<B>[src]</B> whimpers."
+				m_type = 2
+
+		if ("help") //This is an exception
+			src << "Help for xenomorph emotes. You can use these emotes with say \"*emote\":\nburp, deathgasp, choke, collapse, dance, drool, gasp, gnarl, hiss, jump, moan, nod, roar, roll, scratch, \nscretch, shake, shiver, sign-#, sit, sulk, sway, tail, twitch, whimper"
+
 		else
-			src << text("Invalid Emote: []", act)
+			src << "\blue Unusable emote '[act]'. Say *help for a list."
+
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")
 		if (act == "roar")

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -12,93 +12,95 @@
 	var/m_type = 1
 	var/message
 
-	switch(act)
-		if("sign")
-			if (!src.restrained())
-				message = text("<B>The alien</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
-				m_type = 1
+	switch(act) //Alphabetically sorted please.
 		if ("burp")
 			if (!muzzled)
 				message = "<B>[src]</B> burps."
 				m_type = 2
-		if("scratch")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> scratches."
-				m_type = 1
-		if("whimper")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> whimpers."
-				m_type = 2
-//		if("roar")
-//			if (!muzzled)
-//				message = "<B>The [src.name]</B> roars." Commenting out since larva shouldn't roar /N
-//				m_type = 2
-		if("tail")
-			message = "<B>The [src.name]</B> waves its tail."
-			m_type = 1
-		if("gasp")
-			message = "<B>The [src.name]</B> gasps."
+		if ("choke")
+			message = "<B>[src]</B> chokes."
 			m_type = 2
-		if("shiver")
-			message = "<B>The [src.name]</B> shivers."
-			m_type = 2
-		if("drool")
-			message = "<B>The [src.name]</B> drools."
-			m_type = 1
-		if("scretch")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> scretches."
-				m_type = 2
-		if("choke")
-			message = "<B>The [src.name]</B> chokes."
-			m_type = 2
-		if("moan")
-			message = "<B>The [src.name]</B> moans!"
-			m_type = 2
-		if("nod")
-			message = "<B>The [src.name]</B> nods its head."
-			m_type = 1
-//		if("sit")
-//			message = "<B>The [src.name]</B> sits down." //Larvan can't sit down, /N
-//			m_type = 1
-		if("sway")
-			message = "<B>The [src.name]</B> sways around dizzily."
-			m_type = 1
-		if("sulk")
-			message = "<B>The [src.name]</B> sulks down sadly."
-			m_type = 1
-		if("twitch")
-			message = "<B>The [src.name]</B> twitches violently."
-			m_type = 1
-		if("dance")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> dances around happily."
-				m_type = 1
-		if("roll")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> rolls."
-				m_type = 1
-		if("shake")
-			message = "<B>The [src.name]</B> shakes its head."
-			m_type = 1
-		if("gnarl")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> gnarls and shows its teeth.."
-				m_type = 2
-		if("jump")
-			message = "<B>The [src.name]</B> jumps!"
-			m_type = 1
-		if("hiss_")
-			message = "<B>The [src.name]</B> hisses softly."
-			m_type = 1
-		if("collapse")
+		if ("collapse")
 			Paralyse(2)
-			message = text("<B>[]</B> collapses!", src)
+			message = "<B>[src]</B> collapses!"
 			m_type = 2
-		if("help")
-			src << "burp, choke, collapse, dance, drool, gasp, shiver, gnarl, jump, moan, nod, roll, scratch,\nscretch, shake, sign-#, sulk, sway, tail, twitch, whimper"
+		if ("dance")
+			if (!src.restrained())
+				message = "<B>[src]</B> dances around happily."
+				m_type = 1
+		if ("drool")
+			message = "<B>[src]</B> drools."
+			m_type = 1
+		if ("gasp")
+			message = "<B>[src]</B> gasps."
+			m_type = 2
+		if ("gnarl")
+			if (!muzzled)
+				message = "<B>[src]</B> gnarls and shows its teeth.."
+				m_type = 2
+		if ("hiss")
+			message = "<B>[src]</B> hisses softly."
+			m_type = 1
+		if ("jump")
+			message = "<B>[src]</B> jumps!"
+			m_type = 1
+		if ("moan")
+			message = "<B>[src]</B> moans!"
+			m_type = 2
+		if ("nod")
+			message = "<B>[src]</B> nods its head."
+			m_type = 1
+//		if ("roar")
+//			if (!muzzled)
+//				message = "<B>[src]</B> roars." Commenting out since larva shouldn't roar /N
+//				m_type = 2
+		if ("roll")
+			if (!src.restrained())
+				message = "<B>[src]</B> rolls."
+				m_type = 1
+		if ("scratch")
+			if (!src.restrained())
+				message = "<B>[src]</B> scratches."
+				m_type = 1
+		if ("scretch")
+			if (!muzzled)
+				message = "<B>[src]</B> scretches."
+				m_type = 2
+		if ("shake")
+			message = "<B>[src]</B> shakes its head."
+			m_type = 1
+		if ("shiver")
+			message = "<B>[src]</B> shivers."
+			m_type = 2
+		if ("sign")
+			if (!src.restrained())
+				message = text("<B>The alien</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
+				m_type = 1
+//		if ("sit")
+//			message = "<B>[src]</B> sits down." //Larvan can't sit down, /N
+//			m_type = 1
+		if ("sulk")
+			message = "<B>[src]</B> sulks down sadly."
+			m_type = 1
+		if ("sway")
+			message = "<B>[src]</B> sways around dizzily."
+			m_type = 1
+		if ("tail")
+			message = "<B>[src]</B> waves its tail."
+			m_type = 1
+		if ("twitch")
+			message = "<B>[src]</B> twitches violently."
+			m_type = 1
+		if ("whimper")
+			if (!muzzled)
+				message = "<B>[src]</B> whimpers."
+				m_type = 2
+
+		if ("help") //"The exception"
+			src << "Help for larva emotes. You can use these emotes with say \"*emote\":\nburp, choke, collapse, dance, drool, gasp, gnarl, hiss, jump, moan, nod, roll, scratch,\nscretch, shake, shiver, sign-#, sulk, sway, tail, twitch, whimper"
+
 		else
-			src << text("Invalid Emote: []", act)
+			src << "\blue Unusable emote '[act]'. Say *help for a list."
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")
 		if (m_type & 1)

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -16,34 +16,43 @@
 			src << "You sound an alarm."
 			message = "<B>[src]</B> sounds an alarm."
 			m_type = 2
+
 		if ("alert")
 			src << "You let out a distressed noise."
 			message = "<B>[src]</B> lets out a distressed noise."
 			m_type = 2
-		if ("notice")
-			src << "You play a loud tone."
-			message = "<B>[src]</B> plays a loud tone."
-			m_type = 2
-		if ("flash")
-			message = "The lights on <B>[src]</B> flash quickly."
-			m_type = 1
-		if ("blink")
-			message = "<B>[src]</B> blinks."
-			m_type = 1
-		if ("whistle")
-			src << "You whistle."
-			message = "<B>[src]</B> whistles."
-			m_type = 2
+
 		if ("beep")
 			src << "You beep."
 			message = "<B>[src]</B> beeps."
 			m_type = 2
+
+		if ("blink")
+			message = "<B>[src]</B> blinks."
+			m_type = 1
+
 		if ("boop")
 			src << "You boop."
 			message = "<B>[src]</B> boops."
 			m_type = 2
+
+		if ("flash")
+			message = "The lights on <B>[src]</B> flash quickly."
+			m_type = 1
+
+		if ("notice")
+			src << "You play a loud tone."
+			message = "<B>[src]</B> plays a loud tone."
+			m_type = 2
+
+		if ("whistle")
+			src << "You whistle."
+			message = "<B>[src]</B> whistles."
+			m_type = 2
+
 		if ("help")
-			src << "alarm,alert,notice,flash,blink,whistle,beep,boop"
+			src << "Help for MMI emotes. You can use these emotes with say \"*emote\":\nalarm, alert, beep, blink, boop, flash, notice, whistle"
+
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -18,7 +18,13 @@
 
 	if(src.stat == 2.0 && (act != "deathgasp"))
 		return
-	switch(act)
+	switch(act) //Please keep this alphabetically ordered when adding or changing emotes.
+		if ("aflap")
+			if (!src.restrained())
+				message = "<B>[src]</B> flaps \his wings ANGRILY!"
+				m_type = 2
+				if(miming)
+					m_type = 1
 		if ("airguitar")
 			if (!src.restrained())
 				message = "<B>[src]</B> is strumming the air and headbanging like a safari chimp."
@@ -32,22 +38,87 @@
 			message = "<B>[src]</B> blinks rapidly."
 			m_type = 1
 
+		if ("blush")
+			message = "<B>[src]</B> blushes."
+			m_type = 1
+
 		if ("bow")
 			if (!src.buckled)
 				var/M = null
 				if (param)
-					for (var/mob/A in view(null, null))
+					for (var/mob/A in view(1, src))
 						if (param == A.name)
 							M = A
 							break
 				if (!M)
 					param = null
-
 				if (param)
 					message = "<B>[src]</B> bows to [param]."
 				else
 					message = "<B>[src]</B> bows."
 			m_type = 1
+
+		if ("choke")
+			if(miming)
+				message = "<B>[src]</B> clutches \his throat desperately!"
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> chokes!"
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a strong noise."
+					m_type = 2
+
+		if ("chuckle")
+			if(miming)
+				message = "<B>[src]</B> appears to chuckle."
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> chuckles."
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a noise."
+					m_type = 2
+
+		if ("clap")
+			if (!src.restrained())
+				message = "<B>[src]</B> claps."
+				m_type = 2
+				if(miming)
+					m_type = 1
+
+		if ("collapse")
+			Paralyse(2)
+			message = "<B>[src]</B> collapses!"
+			m_type = 2
+			if(miming)
+				m_type = 1
+
+		if ("cough")
+			if(miming)
+				message = "<B>[src]</B> appears to cough!"
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> coughs!"
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a strong noise."
+					m_type = 2
+
+		if ("cry")
+			if(miming)
+				message = "<B>[src]</B> cries."
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> cries."
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a weak noise. \He frowns."
+					m_type = 2
 
 		if ("custom")
 			var/input = copytext(sanitize(input("Choose an emote to display.") as text|null),1,MAX_MESSAGE_LEN)
@@ -75,6 +146,203 @@
 					return
 				message = "<B>[src]</B> [input]"
 
+		if ("dap")
+			m_type = 1
+			if (!src.restrained())
+				var/M = null
+				if (param)
+					for (var/mob/A in view(1, src))
+						if (param == A.name)
+							M = A
+							break
+				if (M)
+					message = "<B>[src]</B> gives daps to [M]."
+				else
+					message = "<B>[src]</B> sadly can't find anybody to give daps to, and daps \himself. Shameful."
+
+		if ("deathgasp")
+			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
+			m_type = 1
+
+		if ("drool")
+			message = "<B>[src]</B> drools."
+			m_type = 1
+
+		if ("eyebrow")
+			message = "<B>[src]</B> raises an eyebrow."
+			m_type = 1
+
+		if ("faint")
+			message = "<B>[src]</B> faints."
+			if(src.sleeping)
+				return //Can't faint while asleep
+			src.sleeping += 10 //Short-short nap
+			m_type = 1
+
+		if ("flap")
+			if (!src.restrained())
+				message = "<B>[src]</B> flaps \his wings."
+				m_type = 2
+				if(miming)
+					m_type = 1
+
+		if ("frown")
+			message = "<B>[src]</B> frowns."
+			m_type = 1
+
+		if ("gasp")
+			if(miming)
+				message = "<B>[src]</B> appears to be gasping!"
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> gasps!"
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a weak noise."
+					m_type = 2
+
+		if ("giggle")
+			if(miming)
+				message = "<B>[src]</B> giggles silently!"
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> giggles."
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a noise."
+					m_type = 2
+
+		if ("glare")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(null, null))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> glares at [param]."
+			else
+				message = "<B>[src]</B> glares."
+
+		if ("grin")
+			message = "<B>[src]</B> grins."
+			m_type = 1
+
+		if ("groan")
+			if(miming)
+				message = "<B>[src]</B> appears to groan!"
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> groans!"
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a loud noise."
+					m_type = 2
+
+		if ("grumble")
+			if(miming)
+				message = "<B>[src]</B> grumbles!"
+				m_type = 1
+			if (!muzzled)
+				message = "<B>[src]</B> grumbles!"
+				m_type = 2
+			else
+				message = "<B>[src]</B> makes a noise."
+				m_type = 2
+
+		if ("handshake")
+			m_type = 1
+			if (!src.restrained() && !src.r_hand)
+				var/mob/M = null
+				if (param)
+					for (var/mob/A in view(1, null))
+						if (param == A.name)
+							M = A
+							break
+				if (M == src)
+					M = null
+				if (M)
+					if (M.canmove && !M.r_hand && !M.restrained())
+						message = "<B>[src]</B> shakes hands with [M]."
+					else
+						message = "<B>[src]</B> holds out \his hand to [M]."
+
+		if ("hug")
+			m_type = 1
+			if (!src.restrained())
+				var/M = null
+				if (param)
+					for (var/mob/A in view(1, null))
+						if (param == A.name)
+							M = A
+							break
+				if (M == src)
+					M = null
+				if (M)
+					message = "<B>[src]</B> hugs [M]."
+				else
+					message = "<B>[src]</B> hugs \himself."
+
+		if ("johnny")
+			var/M
+			if (param)
+				M = param
+			if (!M)
+				param = null
+			else
+				if(miming)
+					message = "<B>[src]</B> takes a drag from a cigarette and blows \"[M]\" out in smoke."
+					m_type = 1
+				else
+					message = "<B>[src]</B> says, \"[M], please. He had a family.\" [src.name] takes a drag from a cigarette and blows \his name out in smoke."
+					m_type = 2
+
+		if ("laugh")
+			if(miming)
+				message = "<B>[src]</B> acts out a laugh."
+				m_type = 1
+			else
+				if (!muzzled)
+					message = "<B>[src]</B> laughs."
+					m_type = 2
+				else
+					message = "<B>[src]</B> makes a noise."
+					m_type = 2
+
+		if ("look")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(null, null))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> looks at [param]."
+			else
+				message = "<B>[src]</B> looks."
+			m_type = 1
+
+		if ("moan")
+			if(miming)
+				message = "<B>[src]</B> appears to moan!"
+				m_type = 1
+			else
+				message = "<B>[src]</B> moans!"
+				m_type = 2
+
+		if ("mumble")
+			message = "<B>[src]</B> mumbles!"
+			m_type = 2
+			if(miming)
+				m_type = 1
+
 		if ("me")
 			if(silent)
 				return
@@ -100,208 +368,77 @@
 			else
 				message = "<B>[src]</B> [message]"
 
+		if ("nod")
+			message = "<B>[src]</B> nods."
+			m_type = 1
+
+		if ("pale")
+			message = "<B>[src]</B> goes pale for a second."
+			m_type = 1
+
+		if ("point")
+			if (!src.restrained())
+				var/mob/M = null
+				if (param)
+					for (var/atom/A as mob|obj|turf|area in view(null, null))
+						if (param == A.name)
+							M = A
+							break
+				if (!M)
+					message = "<B>[src]</B> points."
+				else
+					M.point()
+				if (M)
+					message = "<B>[src]</B> points to [M]."
+				else
+			m_type = 1
+
+		if ("raise")
+			if (!src.restrained())
+				message = "<B>[src]</B> raises a hand."
+			m_type = 1
+
 		if ("salute")
 			if (!src.buckled)
 				var/M = null
 				if (param)
-					for (var/mob/A in view(null, null))
+					for (var/mob/A in view(1, src))
 						if (param == A.name)
 							M = A
 							break
 				if (!M)
 					param = null
-
 				if (param)
 					message = "<B>[src]</B> salutes to [param]."
 				else
 					message = "<B>[src]</b> salutes."
 			m_type = 1
 
-		if ("choke")
-			if(miming)
-				message = "<B>[src]</B> clutches his throat desperately!"
+		if ("scream")
+			if (miming)
+				message = "<B>[src]</B> acts out a scream!"
 				m_type = 1
 			else
 				if (!muzzled)
-					message = "<B>[src]</B> chokes!"
+					message = "<B>[src]</B> screams!"
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a strong noise."
+					message = "<B>[src]</B> makes a very loud noise."
 					m_type = 2
 
-		if ("clap")
-			if (!src.restrained())
-				message = "<B>[src]</B> claps."
-				m_type = 2
-				if(miming)
-					m_type = 1
-		if ("flap")
-			if (!src.restrained())
-				message = "<B>[src]</B> flaps \his wings."
-				m_type = 2
-				if(miming)
-					m_type = 1
-
-		if ("aflap")
-			if (!src.restrained())
-				message = "<B>[src]</B> flaps \his wings ANGRILY!"
-				m_type = 2
-				if(miming)
-					m_type = 1
-
-		if ("drool")
-			message = "<B>[src]</B> drools."
+		if ("shake")
+			message = "<B>[src]</B> shakes \his head."
 			m_type = 1
 
-		if ("eyebrow")
-			message = "<B>[src]</B> raises an eyebrow."
-			m_type = 1
-
-		if ("chuckle")
+		if ("shiver")
+			message = "<B>[src]</B> shivers."
+			m_type = 2
 			if(miming)
-				message = "<B>[src]</B> appears to chuckle."
 				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> chuckles."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
 
-		if ("twitch")
-			message = "<B>[src]</B> twitches violently."
+		if ("shrug")
+			message = "<B>[src]</B> shrugs."
 			m_type = 1
-
-		if ("twitch_s")
-			message = "<B>[src]</B> twitches."
-			m_type = 1
-
-		if ("faint")
-			message = "<B>[src]</B> faints."
-			if(src.sleeping)
-				return //Can't faint while asleep
-			src.sleeping += 10 //Short-short nap
-			m_type = 1
-
-		if ("cough")
-			if(miming)
-				message = "<B>[src]</B> appears to cough!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> coughs!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a strong noise."
-					m_type = 2
-
-		if ("frown")
-			message = "<B>[src]</B> frowns."
-			m_type = 1
-
-		if ("nod")
-			message = "<B>[src]</B> nods."
-			m_type = 1
-
-		if ("blush")
-			message = "<B>[src]</B> blushes."
-			m_type = 1
-
-		if ("wave")
-			message = "<B>[src]</B> waves."
-			m_type = 1
-
-		if ("gasp")
-			if(miming)
-				message = "<B>[src]</B> appears to be gasping!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> gasps!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a weak noise."
-					m_type = 2
-
-		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
-			m_type = 1
-
-		if ("giggle")
-			if(miming)
-				message = "<B>[src]</B> giggles silently!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> giggles."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
-
-		if ("glare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> glares at [param]."
-			else
-				message = "<B>[src]</B> glares."
-
-		if ("stare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> stares at [param]."
-			else
-				message = "<B>[src]</B> stares."
-
-		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> looks at [param]."
-			else
-				message = "<B>[src]</B> looks."
-			m_type = 1
-
-		if ("grin")
-			message = "<B>[src]</B> grins."
-			m_type = 1
-
-		if ("cry")
-			if(miming)
-				message = "<B>[src]</B> cries."
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> cries."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a weak noise. \He frowns."
-					m_type = 2
 
 		if ("sigh")
 			if(miming)
@@ -315,101 +452,6 @@
 					message = "<B>[src]</B> makes a weak noise."
 					m_type = 2
 
-		if ("laugh")
-			if(miming)
-				message = "<B>[src]</B> acts out a laugh."
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> laughs."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
-
-		if ("mumble")
-			message = "<B>[src]</B> mumbles!"
-			m_type = 2
-			if(miming)
-				m_type = 1
-
-		if ("grumble")
-			if(miming)
-				message = "<B>[src]</B> grumbles!"
-				m_type = 1
-			if (!muzzled)
-				message = "<B>[src]</B> grumbles!"
-				m_type = 2
-			else
-				message = "<B>[src]</B> makes a noise."
-				m_type = 2
-
-		if ("groan")
-			if(miming)
-				message = "<B>[src]</B> appears to groan!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> groans!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a loud noise."
-					m_type = 2
-
-		if ("moan")
-			if(miming)
-				message = "<B>[src]</B> appears to moan!"
-				m_type = 1
-			else
-				message = "<B>[src]</B> moans!"
-				m_type = 2
-
-		if ("johnny")
-			var/M
-			if (param)
-				M = param
-			if (!M)
-				param = null
-			else
-				if(miming)
-					message = "<B>[src]</B> takes a drag from a cigarette and blows \"[M]\" out in smoke."
-					m_type = 1
-				else
-					message = "<B>[src]</B> says, \"[M], please. He had a family.\" [src.name] takes a drag from a cigarette and blows his name out in smoke."
-					m_type = 2
-
-		if ("point")
-			if (!src.restrained())
-				var/mob/M = null
-				if (param)
-					for (var/atom/A as mob|obj|turf|area in view(null, null))
-						if (param == A.name)
-							M = A
-							break
-
-				if (!M)
-					message = "<B>[src]</B> points."
-				else
-					M.point()
-
-				if (M)
-					message = "<B>[src]</B> points to [M]."
-				else
-			m_type = 1
-
-		if ("raise")
-			if (!src.restrained())
-				message = "<B>[src]</B> raises a hand."
-			m_type = 1
-
-		if("shake")
-			message = "<B>[src]</B> shakes \his head."
-			m_type = 1
-
-		if ("shrug")
-			message = "<B>[src]</B> shrugs."
-			m_type = 1
-
 		if ("signal")
 			if (!src.restrained())
 				var/t1 = round(text2num(param))
@@ -422,20 +464,6 @@
 
 		if ("smile")
 			message = "<B>[src]</B> smiles."
-			m_type = 1
-
-		if ("shiver")
-			message = "<B>[src]</B> shivers."
-			m_type = 2
-			if(miming)
-				m_type = 1
-
-		if ("pale")
-			message = "<B>[src]</B> goes pale for a second."
-			m_type = 1
-
-		if ("tremble")
-			message = "<B>[src]</B> trembles in fear!"
 			m_type = 1
 
 		if ("sneeze")
@@ -468,6 +496,36 @@
 					message = "<B>[src]</B> makes a noise."
 					m_type = 2
 
+		if ("stare")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> stares at [param]."
+			else
+				message = "<B>[src]</B> stares."
+
+		if ("tremble")
+			message = "<B>[src]</B> trembles in fear!"
+			m_type = 1
+
+		if ("twitch")
+			message = "<B>[src]</B> twitches violently."
+			m_type = 1
+
+		if ("twitch_s")
+			message = "<B>[src]</B> twitches."
+			m_type = 1
+
+		if ("wave")
+			message = "<B>[src]</B> waves."
+			m_type = 1
+
 		if ("whimper")
 			if (miming)
 				message = "<B>[src]</B> appears hurt."
@@ -491,76 +549,8 @@
 				if(miming)
 					m_type = 1
 
-		if ("collapse")
-			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
-			m_type = 2
-			if(miming)
-				m_type = 1
-
-		if("hug")
-			m_type = 1
-			if (!src.restrained())
-				var/M = null
-				if (param)
-					for (var/mob/A in view(1, null))
-						if (param == A.name)
-							M = A
-							break
-				if (M == src)
-					M = null
-
-				if (M)
-					message = "<B>[src]</B> hugs [M]."
-				else
-					message = "<B>[src]</B> hugs \himself."
-
-		if ("handshake")
-			m_type = 1
-			if (!src.restrained() && !src.r_hand)
-				var/mob/M = null
-				if (param)
-					for (var/mob/A in view(1, null))
-						if (param == A.name)
-							M = A
-							break
-				if (M == src)
-					M = null
-
-				if (M)
-					if (M.canmove && !M.r_hand && !M.restrained())
-						message = "<B>[src]</B> shakes hands with [M]."
-					else
-						message = "<B>[src]</B> holds out \his hand to [M]."
-
-		if("dap")
-			m_type = 1
-			if (!src.restrained())
-				var/M = null
-				if (param)
-					for (var/mob/A in view(1, null))
-						if (param == A.name)
-							M = A
-							break
-				if (M)
-					message = "<B>[src]</B> gives daps to [M]."
-				else
-					message = "<B>[src]</B> sadly can't find anybody to give daps to, and daps \himself. Shameful."
-
-		if ("scream")
-			if (miming)
-				message = "<B>[src]</B> acts out a scream!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> screams!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a very loud noise."
-					m_type = 2
-
-		if ("help")
-			src << "blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough,\ncry, custom, deathgasp, drool, eyebrow, frown, gasp, giggle, groan, grumble, handshake, hug-(none)/mob, glare-(none)/mob,\ngrin, laugh, look-(none)/mob, moan, mumble, nod, pale, point-atom, raise, salute, shake, shiver, shrug,\nsigh, signal-#1-10, smile, sneeze, sniff, snore, stare-(none)/mob, tremble, twitch, twitch_s, whimper,\nwink, yawn"
+		if ("help") //This can stay at the bottom.
+			src << "Help for human emotes. You can use these emotes with say \"*emote\":\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, choke, chuckle, clap, collapse, \ncough, cry, custom, dap, deathgasp, drool, eyebrow, faint, frown, flap, gasp, giggle, glare-(none)/mob, grin, groan, grumble, handshake, \nhug-(none)/mob, johnny, laugh, look-(none)/mob, moan, mumble, me, nod, pale, point-(atom), raise, \nsalute, scream, shake, shiver, shrug, sigh, signal-#1-10, smile, sneeze, sniff, snore, \nstare-(none)/mob, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."

--- a/code/modules/mob/living/carbon/metroid/emote.dm
+++ b/code/modules/mob/living/carbon/metroid/emote.dm
@@ -12,33 +12,44 @@
 	var/m_type = 1
 	var/message
 
-	switch(act)
-		if("moan")
-			message = "<B>The [src.name]</B> moans."
-			m_type = 2
-		if("shiver")
-			message = "<B>The [src.name]</B> shivers."
-			m_type = 2
-		if("sway")
-			message = "<B>The [src.name]</B> sways around dizzily."
-			m_type = 1
-		if("twitch")
-			message = "<B>The [src.name]</B> twitches."
-			m_type = 1
-		if("vibrate")
-			message = "<B>The [src.name]</B> vibrates!"
-			m_type = 1
-		if("light")
-			message = "<B>The [src.name]</B> lights up for a bit, then stops."
-			m_type = 1
-		if("jiggle")
-			message = "<B>The [src.name]</B> jiggles!"
-			m_type = 1
+	switch(act) //Alphabetical please
 		if("bounce")
 			message = "<B>The [src.name]</B> bounces in place."
 			m_type = 1
+
+		if("jiggle")
+			message = "<B>The [src.name]</B> jiggles!"
+			m_type = 1
+
+		if("light")
+			message = "<B>The [src.name]</B> lights up for a bit, then stops."
+			m_type = 1
+
+		if("moan")
+			message = "<B>The [src.name]</B> moans."
+			m_type = 2
+
+		if("shiver")
+			message = "<B>The [src.name]</B> shivers."
+			m_type = 2
+
+		if("sway")
+			message = "<B>The [src.name]</B> sways around dizzily."
+			m_type = 1
+
+		if("twitch")
+			message = "<B>The [src.name]</B> twitches."
+			m_type = 1
+
+		if("vibrate")
+			message = "<B>The [src.name]</B> vibrates!"
+			m_type = 1
+
+		if ("help") //This is an exception
+			src << "Help for slime emotes. You can use these emotes with say \"*emote\":\nbounce, jiggle, light, moan, shiver, sway, twitch, vibrate"
+
 		else
-			src << text("Invalid Emote: []", act)
+			src << "\blue Unusable emote '[act]'. Say *help for a list."
 	if ((message && src.stat == 0))
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))

--- a/code/modules/mob/living/carbon/monkey/emote.dm
+++ b/code/modules/mob/living/carbon/monkey/emote.dm
@@ -13,95 +13,120 @@
 	var/m_type = 1
 	var/message
 
-	switch(act)
-		if("sign")
-			if (!src.restrained())
-				message = text("<B>The monkey</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
-				m_type = 1
-		if("scratch")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> scratches."
-				m_type = 1
-		if("whimper")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> whimpers."
-				m_type = 2
-		if("roar")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> roars."
-				m_type = 2
-		if("tail")
-			message = "<B>The [src.name]</B> waves his tail."
-			m_type = 1
-		if("gasp")
-			message = "<B>The [src.name]</B> gasps."
+	switch(act) //Ooh ooh ah ah keep this alphabetical ooh ooh ah ah!
+		if ("choke")
+			message = "<B>[src]</B> chokes."
 			m_type = 2
-		if("shiver")
-			message = "<B>The [src.name]</B> shivers."
-			m_type = 2
-		if("drool")
-			message = "<B>The [src.name]</B> drools."
-			m_type = 1
-		if("paw")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> flails his paw."
-				m_type = 1
-		if("scretch")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> scretches."
-				m_type = 2
-		if("choke")
-			message = "<B>The [src.name]</B> chokes."
-			m_type = 2
-		if("moan")
-			message = "<B>The [src.name]</B> moans!"
-			m_type = 2
-		if("nod")
-			message = "<B>The [src.name]</B> nods his head."
-			m_type = 1
-		if("sit")
-			message = "<B>The [src.name]</B> sits down."
-			m_type = 1
-		if("sway")
-			message = "<B>The [src.name]</B> sways around dizzily."
-			m_type = 1
-		if("sulk")
-			message = "<B>The [src.name]</B> sulks down sadly."
-			m_type = 1
-		if("twitch")
-			message = "<B>The [src.name]</B> twitches violently."
-			m_type = 1
-		if("dance")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> dances around happily."
-				m_type = 1
-		if("roll")
-			if (!src.restrained())
-				message = "<B>The [src.name]</B> rolls."
-				m_type = 1
-		if("shake")
-			message = "<B>The [src.name]</B> shakes his head."
-			m_type = 1
-		if("gnarl")
-			if (!muzzled)
-				message = "<B>The [src.name]</B> gnarls and shows his teeth.."
-				m_type = 2
-		if("jump")
-			message = "<B>The [src.name]</B> jumps!"
-			m_type = 1
-		if("collapse")
+
+		if ("collapse")
 			Paralyse(2)
-			message = text("<B>[]</B> collapses!", src)
+			message = "<B>[src]</B> collapses!"
 			m_type = 2
-		if("deathgasp")
-			message = "<b>The [src.name]</b> lets out a faint chimper as it collapses and stops moving..."
+
+		if ("dance")
+			if (!src.restrained())
+				message = "<B>[src]</B> dances around happily."
+				m_type = 1
+
+		if ("deathgasp")
+			message = "<b>[src]</b> lets out a faint chimper as it collapses and stops moving..."
 			m_type = 1
-		if("giggle")
+
+		if ("drool")
+			message = "<B>[src]</B> drools."
+			m_type = 1
+
+		if ("gasp")
+			message = "<B>[src]</B> gasps."
+			m_type = 2
+
+		if ("gnarl")
 			if (!muzzled)
-				message = "<B>The [src.name]</B> giggles happily."
+				message = "<B>[src]</B> gnarls and shows its teeth.."
 				m_type = 2
-		if("help")
-			src << "choke, collapse, dance, deathgasp, drool, gasp, shiver, gnarl, giggle, jump, paw, moan, nod, roar, roll, scratch,\nscretch, shake, sign-#, sit, sulk, sway, tail, twitch, whimper"
+
+		if ("giggle")
+			if (!muzzled)
+				message = "<B>[src]</B> giggles happily."
+				m_type = 2
+
+		if ("jump")
+			message = "<B>[src]</B> jumps!"
+			m_type = 1
+
+		if ("paw")
+			if (!src.restrained())
+				message = "<B>[src]</B> flails its paw."
+				m_type = 1
+
+		if ("moan")
+			message = "<B>[src]</B> moans!"
+			m_type = 2
+
+		if ("nod")
+			message = "<B>[src]</B> nods its head."
+			m_type = 1
+
+		if ("roar")
+			if (!muzzled)
+				message = "<B>[src]</B> roars."
+				m_type = 2
+
+		if ("roll")
+			if (!src.restrained())
+				message = "<B>[src]</B> rolls."
+				m_type = 1
+
+		if ("scratch")
+			if (!src.restrained())
+				message = "<B>[src]</B> scratches."
+				m_type = 1
+
+		if ("scretch")
+			if (!muzzled)
+				message = "<B>[src]</B> scretches."
+				m_type = 2
+
+		if ("shake")
+			message = "<B>[src]</B> shakes its head."
+			m_type = 1
+
+		if ("shiver")
+			message = "<B>[src]</B> shivers."
+			m_type = 2
+
+		if ("sign")
+			if (!src.restrained())
+				message = text("<B>[src]</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
+				m_type = 1
+
+		if ("sit")
+			message = "<B>[src]</B> sits down."
+			m_type = 1
+
+		if ("sulk")
+			message = "<B>[src]</B> sulks down sadly."
+			m_type = 1
+
+		if ("sway")
+			message = "<B>[src]</B> sways around dizzily."
+			m_type = 1
+
+		if ("tail")
+			message = "<B>[src]</B> waves its tail."
+			m_type = 1
+
+		if ("twitch")
+			message = "<B>[src]</B> twitches violently."
+			m_type = 1
+
+		if ("whimper")
+			if (!muzzled)
+				message = "<B>[src]</B> whimpers."
+				m_type = 2
+
+		if ("help") //Ooh ah ooh ooh this is an exception to alphabetical ooh ooh.
+			src << "Help for monkey emotes. You can use these emotes with say \"*emote\":\nchoke, collapse, dance, deathgasp, drool, gasp, gnarl, giggle, jump, paw, moan, nod, roar, roll, scratch, scretch, \nshake, shiver, sign-#, sit, sulk, sway, tail, twitch, whimper"
 		else
 			src << text("Invalid Emote: []", act)
 	if ((message && src.stat == 0))

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -9,51 +9,62 @@
 		act = copytext(act,1,length(act))
 
 	switch(act)
-		if ("salute")
-			if (!src.buckled)
-				var/M = null
-				if (param)
-					for (var/mob/A in view(null, null))
-						if (param == A.name)
-							M = A
-							break
-				if (!M)
-					param = null
+		if ("aflap")
+			if (!src.restrained())
+				message = "<B>[src]</B> flaps \his wings ANGRILY!"
+				m_type = 2
 
-				if (param)
-					message = "<B>[src]</B> salutes to [param]."
-				else
-					message = "<B>[src]</b> salutes."
+		if("beep")
+			var/M = null
+			if(param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if(!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> beeps at [param]."
+			else
+				message = "<B>[src]</B> beeps."
+			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 1
+
 		if ("bow")
 			if (!src.buckled)
 				var/M = null
 				if (param)
-					for (var/mob/A in view(null, null))
+					for (var/mob/A in view(1, src))
 						if (param == A.name)
 							M = A
 							break
 				if (!M)
 					param = null
-
 				if (param)
 					message = "<B>[src]</B> bows to [param]."
 				else
 					message = "<B>[src]</B> bows."
 			m_type = 1
 
+		if("buzz")
+			var/M = null
+			if(param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if(!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> buzzes at [param]."
+			else
+				message = "<B>[src]</B> buzzes."
+			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+			m_type = 1
+
 		if ("clap")
 			if (!src.restrained())
 				message = "<B>[src]</B> claps."
-				m_type = 2
-		if ("flap")
-			if (!src.restrained())
-				message = "<B>[src]</B> flaps \his wings."
-				m_type = 2
-
-		if ("aflap")
-			if (!src.restrained())
-				message = "<B>[src]</B> flaps \his wings ANGRILY!"
 				m_type = 2
 
 		if ("custom")
@@ -70,6 +81,44 @@
 				return
 			message = "<B>[src]</B> [input]"
 
+		if ("deathgasp")
+			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
+			m_type = 1
+
+		if ("flap")
+			if (!src.restrained())
+				message = "<B>[src]</B> flaps \his wings."
+				m_type = 2
+
+		if ("glare")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> glares at [param]."
+			else
+				message = "<B>[src]</B> glares."
+
+		if ("look")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> looks at [param]."
+			else
+				message = "<B>[src]</B> looks."
+			m_type = 1
+
 		if ("me")
 			if (src.client)
 				if(client.prefs.muted & MUTE_IC)
@@ -84,6 +133,57 @@
 			else
 				message = "<B>[src]</B> [message]"
 
+		if ("nod")
+			message = "<B>[src]</B> nods."
+			m_type = 1
+
+		if("ping")
+			var/M = null
+			if(param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if(!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> pings at [param]."
+			else
+				message = "<B>[src]</B> pings."
+			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+			m_type = 1
+
+		if ("salute")
+			if (!src.buckled)
+				var/M = null
+				if (param)
+					for (var/mob/A in view(1, src))
+						if (param == A.name)
+							M = A
+							break
+				if (!M)
+					param = null
+
+				if (param)
+					message = "<B>[src]</B> salutes to [param]."
+				else
+					message = "<B>[src]</b> salutes."
+			m_type = 1
+
+		if ("stare")
+			var/M = null
+			if (param)
+				for (var/mob/A in view(1, src))
+					if (param == A.name)
+						M = A
+						break
+			if (!M)
+				param = null
+			if (param)
+				message = "<B>[src]</B> stares at [param]."
+			else
+				message = "<B>[src]</B> stares."
+
 		if ("twitch")
 			message = "<B>[src]</B> twitches violently."
 			m_type = 1
@@ -92,114 +192,12 @@
 			message = "<B>[src]</B> twitches."
 			m_type = 1
 
-		if ("nod")
-			message = "<B>[src]</B> nods."
-			m_type = 1
-
-		if ("deathgasp")
-			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
-			m_type = 1
-
-		if ("glare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> glares at [param]."
-			else
-				message = "<B>[src]</B> glares."
-
-		if ("stare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> stares at [param]."
-			else
-				message = "<B>[src]</B> stares."
-
-		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-
-			if (!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> looks at [param]."
-			else
-				message = "<B>[src]</B> looks."
-			m_type = 1
-
-		if("beep")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> beeps at [param]."
-			else
-				message = "<B>[src]</B> beeps."
-			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
-			m_type = 1
-
-		if("ping")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> pings at [param]."
-			else
-				message = "<B>[src]</B> pings."
-			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-			m_type = 1
-
-		if("buzz")
-			var/M = null
-			if(param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if(!M)
-				param = null
-
-			if (param)
-				message = "<B>[src]</B> buzzes at [param]."
-			else
-				message = "<B>[src]</B> buzzes."
-			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
-			m_type = 1
+		if ("help")
+			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob, clap, custom, deathgasp, \nflap, glare-(none)/mob, look-(none)/mob, me, nod, ping-(none)/mob, \nsalute-(none)/mob, stare-(none)/mob, twitch, twitch_s,"
 
 		else
-			src << text("Invalid Emote: []", act)
+			src << "\blue Unusable emote '[act]'. Say *help for a list."
+
 	if ((message && src.stat == 0))
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))


### PR DESCRIPTION
Emote code is alphabetized and I hope it stays that way. 
Adds help emotes to slimes and cyborgs.

Fixes #1207
