### PR TITLE
Disposals spawning with air.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -27,22 +27,28 @@
 	// find the attached trunk (if present) and init gas resvr.
 /obj/machinery/disposal/New()
 	..()
-	spawn(5)
-		trunk = locate() in src.loc
-		if(!trunk)
-			mode = 0
-			flush = 0
-		else
-			trunk.linked = src	// link the pipe trunk to self
+	trunk = locate() in src.loc
+	if(!trunk)
+		mode = 0
+		flush = 0
+	else
+		trunk.linked = src	// link the pipe trunk to self
 
-		air_contents = new/datum/gas_mixture()
-		//gas.volume = 1.05 * CELLSTANDARD
-		update()
+	air_contents = new/datum/gas_mixture()
+	//gas.volume = 1.05 * CELLSTANDARD
+	update()
 
 /obj/machinery/disposal/Del()
 	for(var/atom/movable/AM in contents)
 		AM.loc = src.loc
 	..()
+
+/obj/machinery/disposal/initialize() //this will remove around 5kpa from a turf, add it to the disposal air and then add it back to the turf, basically it spawns air depending on the turf air.
+	var/atom/L = loc
+	var/datum/gas_mixture/env = L.return_air()
+	var/datum/gas_mixture/removed = env.remove(SEND_PRESSURE)
+	air_contents.merge(removed)
+	env.merge(removed)
 
 	// attack by item places it in to disposal
 /obj/machinery/disposal/attackby(var/obj/item/I, var/mob/user)


### PR DESCRIPTION
Makes disposal start the round with air inside, depending the air of their loc. This will slightly reduce atmos roundstart lag. Around 150~ compare calls per tick for 5 minutes removed.
