### PR TITLE
Fixes attached voice analysers not listening

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -60,7 +60,10 @@
 	if(!attached_device)	return
 	attached_device.HasProximity(AM)
 	return
-
+/obj/item/device/transfer_valve/hear_talk(mob/living/M, msg)
+	if(!attached_device)	return
+	attached_device.hear_talk(M, msg)
+	return
 
 /obj/item/device/transfer_valve/attack_self(mob/user as mob)
 	user.set_machine(src)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -10,15 +10,14 @@
 	var/recorded	//the activation message
 
 	hear_talk(mob/living/M as mob, msg)
-		if(secured)
-			if(listening)
-				recorded = msg
-				listening = 0
-				var/turf/T = get_turf(src)	//otherwise it won't work in hand
-				T.visible_message("\icon[src] beeps, \"Activation message is '[recorded]'.\"")
-			else
-				if(findtext(msg, recorded))
-					pulse(0)
+		if(listening)
+			recorded = msg
+			listening = 0
+			var/turf/T = get_turf(src)	//otherwise it won't work in hand
+			T.visible_message("\icon[src] beeps, \"Activation message is '[recorded]'.\"")
+		else
+			if(findtext(msg, recorded))
+				pulse(0)
 
 	activate()
 		if(secured)


### PR DESCRIPTION
The voice analyser will listen to the keyword now even when not secured
(enabling it to be directly used on grenade casings and tank transfer
valves).

Adds missing related proc to tank transfer valve.
