### PR TITLE
Changes a few runes for ease of use and making useless runes useful.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -532,8 +532,8 @@ var/list/sacrificed = list()
 			for(var/datum/mind/H in ticker.mode.cult)
 				if (H.current)
 					H.current << "\red \b [input]"
-				if (/obj/item/weapon/paper/talisman)
-					return 1
+			if (/obj/item/weapon/paper/talisman)
+				return 1
 			return 0
 
 /////////////////////////////////////////FIFTEENTH RUNE
@@ -753,7 +753,7 @@ var/list/sacrificed = list()
 			for(var/mob/living/carbon/C in orange(1,src))
 				if(iscultist(C) && !C.stat)
 					users+=C
-			if(users.len>=3)
+			if(users.len>=1)
 				var/mob/living/carbon/cultist = input("Choose the one who you want to free", "Followers of Geometer") as null|anything in (cultists - users)
 				if(!cultist)
 					return fizzle()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -61,7 +61,7 @@ var/list/sacrificed = list()
 			for(var/mob/living/carbon/C in orange(1,src))
 				if(iscultist(C) && !C.stat)
 					culcount++
-			if(usr.loc==src.loc)
+			if(user.loc==src.loc)
 				return fizzle()
 			if(culcount>=1)
 				user.say("Sas[pick("'","`")]so c'arta forbici tarem!")
@@ -532,9 +532,7 @@ var/list/sacrificed = list()
 			for(var/datum/mind/H in ticker.mode.cult)
 				if (H.current)
 					H.current << "\red \b [input]"
-			if (/obj/item/weapon/paper/talisman)
-				return 1
-			return 0
+			return 1
 
 /////////////////////////////////////////FIFTEENTH RUNE
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -61,7 +61,9 @@ var/list/sacrificed = list()
 			for(var/mob/living/carbon/C in orange(1,src))
 				if(iscultist(C) && !C.stat)
 					culcount++
-			if(culcount>=3)
+			if(usr.loc==src.loc)
+				return fizzle()
+			if(culcount>=1)
 				user.say("Sas[pick("'","`")]so c'arta forbici tarem!")
 				user.visible_message("\red You feel air moving from the rune - like as it was swapped with somewhere else.", \
 				"\red You feel air moving from the rune - like as it was swapped with somewhere else.", \
@@ -530,8 +532,9 @@ var/list/sacrificed = list()
 			for(var/datum/mind/H in ticker.mode.cult)
 				if (H.current)
 					H.current << "\red \b [input]"
-			del(src)
-			return 1
+				if (/obj/item/weapon/paper/talisman)
+					return 1
+			return 0
 
 /////////////////////////////////////////FIFTEENTH RUNE
 


### PR DESCRIPTION
"Teleport Other" no longer requires 3 cultists standing around it to use, can not no longer teleport the user.

Communicate rune no longer deletes on first use, talismans are still only usable one time.

Free Cultist no longer requires 3 cultists to use. (This rune was pretty useless, and still is. Should probably replace it.)

Edit: Did fix an indentation issue pointed out by Sayu that had broken communication, tested and everything is working as intended.
