### PR TITLE
Buffs to the Stechkin Pistol

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -50,6 +50,23 @@
 	ammo_type = "/obj/item/ammo_casing/c9mm"
 	max_ammo = 30
 
+/obj/item/ammo_magazine/mc10mm
+	name = "magazine (10mm)"
+	icon_state = "9x19p"
+	origin_tech = "combat=2"
+	ammo_type = "/obj/item/ammo_casing/c10mm"
+	max_ammo = 8
+	multiple_sprites = 1
+
+/obj/item/ammo_magazine/mc10mm/empty
+	max_ammo = 0
+
+/obj/item/ammo_magazine/c10mm
+	name = "Ammunition Box (10mm)"
+	icon_state = "9mm"
+	origin_tech = "combat=2"
+	ammo_type = "/obj/item/ammo_casing/c10mm"
+	max_ammo = 30
 
 
 /obj/item/ammo_magazine/c45

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -32,6 +32,12 @@
 	projectile_type = "/obj/item/projectile/bullet/weakbullet"
 
 
+/obj/item/ammo_casing/c10mm
+	desc = "A 10mm bullet casing."
+	caliber = "10mm"
+	projectile_type = "/obj/item/projectile/bullet/midbullet3"
+
+
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -86,19 +86,19 @@
 
 /obj/item/weapon/gun/projectile/pistol
 	name = "\improper Stechtkin pistol"
-	desc = "A small, easily concealable gun. Uses 9mm rounds."
+	desc = "A small, easily concealable gun. Uses 10mm rounds."
 	icon_state = "pistol"
 	w_class = 2
 	max_shells = 8
-	caliber = "9mm"
+	caliber = "10mm"
 	silenced = 0
 	origin_tech = "combat=2;materials=2;syndicate=2"
-	ammo_type = "/obj/item/ammo_casing/c9mm"
+	ammo_type = "/obj/item/ammo_casing/c10mm"
 	load_method = 2
 
 /obj/item/weapon/gun/projectile/pistol/New()
 	..()
-	empty_mag = new /obj/item/ammo_magazine/mc9mm/empty(src)
+	empty_mag = new /obj/item/ammo_magazine/mc10mm/empty(src)
 	return
 
 /obj/item/weapon/gun/projectile/pistol/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -21,6 +21,12 @@
 /obj/item/projectile/bullet/midbullet2
 	damage = 25
 
+
+/obj/item/projectile/bullet/midbullet3 //Only used with the Stechkin Pistol - RobRichards
+	damage = 30
+
+
+
 /obj/item/projectile/bullet/suffocationbullet//How does this even work?
 	name = "co bullet"
 	damage = 20


### PR DESCRIPTION
Community Discussion, Stechkin Pistol Sucks.

Discussion Thread: http://www.ss13.eu/phpbb/viewtopic.php?f=10&t=1368

Modified the Stechkin's Damage:

Made a new bullet, midbullet3 (prevents buffing things that ALSO used midbullet2, Like the Stechkin did)
Added bullet types and ammunition for 10mm, (Stechkin was 9mm, More damage = Bigger bullet, Fluff stuff)
Uses the same Icons that 9mm did (lots of ammunition uses these same Icons)

Midbullet3 deals 30 damage, (an Increase of 5 damage per shot from when it used midbullet2)
