### PR TITLE
LINDA Cryo fix and wide doors

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -199,11 +199,11 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 
 /atom/movable/proc/air_update_turf(var/command = 0)
 	if(istype(loc,/turf))
-		var/turf/T = loc
-		if(command)
-			T.CalculateAdjacentTurfs()
-		if(air_master)
-			air_master.add_to_active(T,command)
+		for(var/turf/T in locs) // used by double wide doors and other nonexistant multitile structures
+			if(command)
+				T.CalculateAdjacentTurfs()
+			if(air_master)
+				air_master.add_to_active(T,command)
 
 
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -224,7 +224,7 @@
 	expel_gas = air_contents.remove(remove_amount)
 	expel_gas.temperature = T20C	//Lets expel hot gas and see if that helps people not die as they are removed
 	loc.assume_air(expel_gas)
-	air_update_turf(1)
+	air_update_turf()
 
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -224,6 +224,7 @@
 	expel_gas = air_contents.remove(remove_amount)
 	expel_gas.temperature = T20C	//Lets expel hot gas and see if that helps people not die as they are removed
 	loc.assume_air(expel_gas)
+	air_update_turf(1)
 
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -97,6 +97,7 @@
 	opacity = 0
 	doortype = 10
 	glass = 1
+	bound_width = 64 // 2x1
 
 /obj/machinery/door/airlock/freezer
 	name = "freezer airlock"


### PR DESCRIPTION
Fixes the lethal cryo problem.  Fixes 2x1 doors so that they can be used, although they are still not on the map.  Tweaks LINDA to properly seal around 2x1 doors as well.
