### PR TITLE
Aliens can now pick up facehuggers again. Fixes Issue #1044

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -27,12 +27,8 @@ var/const/MAX_ACTIVE_TIME = 400
 	var/attached = 0
 
 /obj/item/clothing/mask/facehugger/attack_alien(user as mob) //can be picked up by aliens
-	if(isalien(user))
-		attack_hand(user)
-		return
-	else
-		..()
-		return
+	attack_hand(user)
+	return
 
 /obj/item/clothing/mask/facehugger/attack_hand(user as mob)
 	if((stat == CONSCIOUS && !sterile) && !isalien(user))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -26,7 +26,7 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	var/attached = 0
 
-/obj/item/clothing/mask/facehugger/attack_paw(user as mob) //can be picked up by aliens
+/obj/item/clothing/mask/facehugger/attack_alien(user as mob) //can be picked up by aliens
 	if(isalien(user))
 		attack_hand(user)
 		return


### PR DESCRIPTION
Cause was an errant attack_paw that used to work as a juryrigged solution before attack_alien was a thing.
