### PR TITLE
Correcting emote overlooks due to merge from master

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -55,24 +55,20 @@
 					message = "<B>[src]</B> bows."
 			m_type = 1
 
-
 		if ("burp")
 			if (!muzzled)
-				message = "<B>[src]</B> burps."
-				m_type = 2
+				..(act)
 
 		if ("choke")
 			if (!muzzled)
-				message = "<B>[src]</B> chokes!"
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a strong noise."
 				m_type = 2
 
 		if ("chuckle")
 			if (!muzzled)
-				message = "<B>[src]</B> chuckles."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
@@ -82,38 +78,15 @@
 				message = "<B>[src]</B> claps."
 				m_type = 2
 
-		if ("collapse")
-			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
-			m_type = 2
-
 		if ("cough")
 			if (!muzzled)
-				message = "<B>[src]</B> coughs!"
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a strong noise."
 				m_type = 2
 
-		if ("dance")
-			if (!src.restrained())
-				message = "<B>[src]</B> dances around happily."
-				m_type = 1
-
-
 		if ("deathgasp")
 			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
-			m_type = 1
-
-		if ("drool")
-			message = "<B>[src]</B> drools."
-			m_type = 1
-
-		if ("faint")
-			message = "<B>[src]</B> faints."
-			if(src.sleeping)
-				return //Can't faint while asleep
-			src.sleeping += 10 //Short-short nap
 			m_type = 1
 
 		if ("flap")
@@ -121,109 +94,33 @@
 				message = "<B>[src]</B> flaps \his wings."
 				m_type = 2
 
-		if ("frown")
-			message = "<B>[src]</B> frowns."
-			m_type = 1
-
 		if ("gasp")
 			if (!muzzled)
-				message = "<B>[src]</B> gasps!"
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a weak noise."
 				m_type = 2
 
 		if ("giggle")
 			if (!muzzled)
-				message = "<B>[src]</B> giggles."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
-
-		if ("glare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(1, src))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> glares at [param]."
-			else
-				message = "<B>[src]</B> glares."
-
-		if ("grin")
-			message = "<B>[src]</B> grins."
-			m_type = 1
-
-		if ("jump")
-			message = "<B>[src]</B> jumps!"
-			m_type = 1
 
 		if ("laugh")
 			if (!muzzled)
-				message = "<B>[src]</B> laughs."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 
-		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(1, src))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> looks at [param]."
-			else
-				message = "<B>[src]</B> looks."
-			m_type = 1
-
-		if ("me")
-			if (src.client)
-				if(client.prefs.muted & MUTE_IC)
-					src << "You cannot send IC messages (muted)."
-					return
-				if (src.client.handle_spam_prevention(message,MUTE_IC))
-					return
-			if (stat)
-				return
-			if(!(message))
-				return
-			else
-				message = "<B>[src]</B> [message]"
-
 		if ("nod")
-			message = "<B>[src]</B> nods /his head."
-			m_type = 1
-
-		if ("point")
-			if (!src.restrained())
-				var/mob/M = null
-				if (param)
-					for (var/atom/A as mob|obj|turf|area in view(1, src))
-						if (param == A.name)
-							M = A
-							break
-				if (!M)
-					message = "<B>[src]</B> points."
-				else
-					M.point()
-				if (M)
-					message = "<B>[src]</B> points to [M]."
-				else
+			message = "<B>[src]</B> nods."
 			m_type = 1
 
 		if ("scream")
 			if (!muzzled)
-				message = "<B>[src]</B> screams!"
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a very loud noise."
 				m_type = 2
@@ -232,18 +129,9 @@
 			message = "<B>[src]</B> shakes \his head."
 			m_type = 1
 
-		if ("sit")
-			message = "<B>[src]</B> sits down."
-			m_type = 1
-
-		if ("smile")
-			message = "<B>[src]</B> smiles."
-			m_type = 1
-
 		if ("sneeze")
 			if (!muzzled)
-				message = "<B>[src]</B> sneezes."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a strange noise."
 				m_type = 2
@@ -254,54 +142,14 @@
 
 		if ("snore")
 			if (!muzzled)
-				message = "<B>[src]</B> snores."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
 
-		if ("stare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(1, src))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> stares at [param]."
-			else
-				message = "<B>[src]</B> stares."
-
-		if ("sulk")
-			message = "<B>[src]</B> sulks down sadly."
-			m_type = 1
-
-		if ("sway")
-			message = "<B>[src]</B> sways around dizzily."
-			m_type = 1
-
-		if ("tremble")
-			message = "<B>[src]</B> trembles in fear!"
-			m_type = 1
-
-		if ("twitch")
-			message = "<B>[src]</B> twitches violently."
-			m_type = 1
-
-		if ("twitch_s")
-			message = "<B>[src]</B> twitches."
-			m_type = 1
-
-		if ("wave")
-			message = "<B>[src]</B> waves."
-			m_type = 1
-
 		if ("whimper")
 			if (!muzzled)
-				message = "<B>[src]</B> whimpers."
-				m_type = 2
+				..(act)
 			else
 				message = "<B>[src]</B> makes a weak noise."
 				m_type = 2
@@ -312,8 +160,7 @@
 
 		if ("yawn")
 			if (!muzzled)
-				message = "<B>[src]</B> yawns."
-				m_type = 2
+				..(act)
 
 		if ("help")
 			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -27,28 +27,18 @@
 					m_type = 1
 
 		if ("choke")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> clutches \his throat desperately!"
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> chokes!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a strong noise."
-					m_type = 2
+				..(act)
 
 		if ("chuckle")
 			if(miming)
 				message = "<B>[src]</B> appears to chuckle."
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> chuckles."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
+				..(act)
 
 		if ("clap")
 			if (!src.restrained())
@@ -65,7 +55,7 @@
 				m_type = 1
 
 		if ("cough")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> appears to cough!"
 				m_type = 1
 			else
@@ -77,7 +67,7 @@
 					m_type = 2
 
 		if ("cry")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> cries."
 				m_type = 1
 			else
@@ -86,30 +76,6 @@
 					m_type = 2
 				else
 					message = "<B>[src]</B> makes a weak noise. \He frowns."
-					m_type = 2
-
-		if ("choke")
-			if(miming)
-				message = "<B>[src]</B> clutches \his throat desperately!"
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> chokes!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a strong noise."
-					m_type = 2
-
-		if ("chuckle")
-			if(miming)
-				message = "<B>[src]</B> appears to chuckle."
-				m_type = 1
-			else
-				if (!muzzled)
-					message = "<B>[src]</B> chuckles."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
 					m_type = 2
 
 		if ("clap")
@@ -131,12 +97,7 @@
 				message = "<B>[src]</B> appears to cough!"
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> coughs!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a strong noise."
-					m_type = 2
+				..(act)
 
 		if ("cry")
 			if(miming)
@@ -202,35 +163,21 @@
 					m_type = 1
 
 		if ("gasp")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> appears to be gasping!"
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> gasps!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a weak noise."
-					m_type = 2
+				..(act)
 
 		if ("giggle")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> giggles silently!"
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> giggles."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
-
-		if ("grin")
-			message = "<B>[src]</B> grins."
-			m_type = 1
+				..(act)
 
 		if ("groan")
-			if(miming)
+			if (miming)
 				message = "<B>[src]</B> appears to groan!"
 				m_type = 1
 			else
@@ -242,14 +189,13 @@
 					m_type = 2
 
 		if ("grumble")
-			if(miming)
-				message = "<B>[src]</B> grumbles!"
-				m_type = 1
 			if (!muzzled)
 				message = "<B>[src]</B> grumbles!"
-				m_type = 2
 			else
 				message = "<B>[src]</B> makes a noise."
+			if (miming)
+				m_type = 1
+			else
 				m_type = 2
 
 		if ("handshake")
@@ -316,21 +262,6 @@
 					else
 						message = "<B>[src]</B> holds out \his hand to [M]."
 
-		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(1, src))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> looks at [param]."
-			else
-				message = "<B>[src]</B> looks."
-			m_type = 1
-
 		if ("me")
 			if(silent)
 				return
@@ -356,21 +287,6 @@
 			else
 				message = "<B>[src]</B> [message]"
 
-		if ("look")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(null, null))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> looks at [param]."
-			else
-				message = "<B>[src]</B> looks."
-			m_type = 1
-
 		if ("moan")
 			if(miming)
 				message = "<B>[src]</B> appears to moan!"
@@ -384,10 +300,6 @@
 			m_type = 2
 			if(miming)
 				m_type = 1
-
-		if ("nod")
-			message = "<B>[src]</B> nods."
-			m_type = 1
 
 		if ("pale")
 			message = "<B>[src]</B> goes pale for a second."
@@ -419,24 +331,11 @@
 				message = "<B>[src]</B> acts out a scream!"
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> screams!"
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a very loud noise."
-					m_type = 2
+				..(act)
 
 		if ("shiver")
 			message = "<B>[src]</B> shivers."
-			m_type = 2
-			if(miming)
-				m_type = 1
-
-		if ("shiver")
-			message = "<B>[src]</B> shivers."
-			m_type = 2
-			if(miming)
-				m_type = 1
+			m_type = 1
 
 		if ("shrug")
 			message = "<B>[src]</B> shrugs."
@@ -447,12 +346,7 @@
 				message = "<B>[src]</B> sighs."
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> sighs."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a weak noise."
-					m_type = 2
+				..(act)
 
 		if ("signal")
 			if (!src.restrained())
@@ -469,12 +363,7 @@
 				message = "<B>[src]</B> sneezes."
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> sneezes."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a strange noise."
-					m_type = 2
+				..(act)
 
 		if ("sniff")
 			message = "<B>[src]</B> sniffs."
@@ -487,54 +376,14 @@
 				message = "<B>[src]</B> sleeps soundly."
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> snores."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a noise."
-					m_type = 2
-
-		if ("stare")
-			var/M = null
-			if (param)
-				for (var/mob/A in view(1, src))
-					if (param == A.name)
-						M = A
-						break
-			if (!M)
-				param = null
-			if (param)
-				message = "<B>[src]</B> stares at [param]."
-			else
-				message = "<B>[src]</B> stares."
-
-		if ("tremble")
-			message = "<B>[src]</B> trembles in fear!"
-			m_type = 1
-
-		if ("twitch")
-			message = "<B>[src]</B> twitches violently."
-			m_type = 1
-
-		if ("twitch_s")
-			message = "<B>[src]</B> twitches."
-			m_type = 1
-
-		if ("wave")
-			message = "<B>[src]</B> waves."
-			m_type = 1
+				..(act)
 
 		if ("whimper")
 			if (miming)
 				message = "<B>[src]</B> appears hurt."
 				m_type = 1
 			else
-				if (!muzzled)
-					message = "<B>[src]</B> whimpers."
-					m_type = 2
-				else
-					message = "<B>[src]</B> makes a weak noise."
-					m_type = 2
+				..(act)
 
 		if ("yawn")
 			if (!muzzled)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -65,7 +65,6 @@
 				message = "<B>[src]</B> dances around happily."
 				m_type = 1
 
-
 		if ("deathgasp")
 			message = "<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
 			m_type = 1
@@ -154,7 +153,7 @@
 				message = "<B>[src]</B> [message]"
 
 		if ("nod")
-			message = "<B>[src]</B> nods its head."
+			message = "<B>[src]</B> nods."
 			m_type = 1
 
 		if ("point")
@@ -244,16 +243,12 @@
 			message = "<B>[src]</B> whimpers."
 			m_type = 2
 
-		if ("wink")
-			message = "<B>[src]</B> winks."
-			m_type = 1
-
 		if ("yawn")
 			message = "<B>[src]</B> yawns."
 			m_type = 2
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, yawn"
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."


### PR DESCRIPTION
When I merged master into [#1245](https://github.com/tgstation/-tg-station/issues/1245) to resolve conflicts, I didn't notice that
the merge did some unintended things, like duplicating conditionals.

These have been corrected, and I also made more things call `..(act)` so that
there is less duplicate code in different emote procs.

This is the last fix I swear :frowning: 
