### PR TITLE
Energy Crossbows now play the correct sound

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -93,7 +93,7 @@
 				shake_camera(user, recoil + 1, recoil)
 
 		if(silenced)
-			playsound(user, 'sound/weapons/Gunshot_silenced.ogg', 10, 1)
+			playsound(user, fire_sound, 10, 1)
 		else
 			playsound(user, fire_sound, 50, 1)
 			user.visible_message("<span class='danger'>[user] fires [src]!</span>", "<span class='danger'>You fire [src]!</span>", "You hear a [istype(in_chamber, /obj/item/projectile/beam) ? "laser blast" : "gunshot"]!")

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -116,8 +116,8 @@
 				return
 			user << "<span class='notice'>You unscrew [silenced] from [src].</span>"
 			user.put_in_hands(silenced)
-			var/obj/item/weapon/silencer/silencer = silenced
-			fire_sound = silencer.oldsound
+			var/obj/item/weapon/silencer/S = silenced
+			fire_sound = S.oldsound
 			silenced = 0
 			w_class = 2
 			update_icon()
@@ -133,8 +133,8 @@
 		user.drop_item()
 		user << "<span class='notice'>You screw [I] onto [src].</span>"
 		silenced = I	//dodgy?
-		var/obj/item/weapon/silencer/silencer = I
-		silencer.oldsound = fire_sound
+		var/obj/item/weapon/silencer/S = I
+		S.oldsound = fire_sound
 		fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 		w_class = 3
 		I.loc = src		//put the silencer into the gun

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -8,7 +8,7 @@
 	silenced = 1
 	origin_tech = "combat=2;materials=2;syndicate=8"
 	ammo_type = "/obj/item/ammo_casing/c45"
-
+	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 
 
 /obj/item/weapon/gun/projectile/deagle
@@ -116,6 +116,8 @@
 				return
 			user << "<span class='notice'>You unscrew [silenced] from [src].</span>"
 			user.put_in_hands(silenced)
+			var/obj/item/weapon/silencer/silencer = silenced
+			fire_sound = silencer.oldsound
 			silenced = 0
 			w_class = 2
 			update_icon()
@@ -131,6 +133,9 @@
 		user.drop_item()
 		user << "<span class='notice'>You screw [I] onto [src].</span>"
 		silenced = I	//dodgy?
+		var/obj/item/weapon/silencer/silencer = I
+		silencer.oldsound = fire_sound
+		fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 		w_class = 3
 		I.loc = src		//put the silencer into the gun
 		update_icon()
@@ -150,3 +155,4 @@
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "silencer"
 	w_class = 2
+	var/oldsound = 0 //Stores the true sound the gun made before it was silenced


### PR DESCRIPTION
Changed it so that silenced weapons still play the fire_sound that they
are given

The Silencer now sets the guns fire_sound to the silenced gunshot when attached, and reverts the sound back to the previous fire_sound when removed
