### PR TITLE
Emagging cyborgs href spoof fix

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -195,9 +195,9 @@
 				usr << "\red Access Denied."
 
 		else if (href_list["magbot"])
-			if(src.allowed(usr))
+			if(issilicon(usr) && is_special_character(usr))
 				var/mob/living/silicon/robot/R = locate(href_list["magbot"])
-				if(R)
+				if(R && !R.emagged)
 					var/choice = input("Are you certain you wish to hack [R.name]?") in list("Confirm", "Abort")
 					if(choice == "Confirm")
 						if(R && istype(R))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -197,7 +197,7 @@
 		else if (href_list["magbot"])
 			if(issilicon(usr) && is_special_character(usr))
 				var/mob/living/silicon/robot/R = locate(href_list["magbot"])
-				if(R && !R.emagged)
+				if(R && !R.emagged && R.connected_ai == usr && !R.scrambledcodes)
 					var/choice = input("Are you certain you wish to hack [R.name]?") in list("Confirm", "Abort")
 					if(choice == "Confirm")
 						if(R && istype(R))


### PR DESCRIPTION
Stops human, non special AI from emagging cyborgs using a spoofed href

Humans with a captains level id would be able to spoof a href that would cause cyborgs to become emagged. This sanity check ensures only the AI that has a special role will be able to use the hack. (It uses the same check that the computer uses to check if the hack button
