### PR TITLE
Re-Adds the Sigh emote, Fixes #1301

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -136,6 +136,13 @@
 				message = "<B>[src]</B> makes a strange noise."
 				m_type = 2
 
+		if ("sigh")
+			if (!muzzled)
+				..(act)
+			else
+				message = "<B>[src]</B> sighs."
+				m_type = 2
+
 		if ("sniff")
 			message = "<B>[src]</B> sniffs."
 			m_type = 2
@@ -163,7 +170,7 @@
 				..(act)
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sigh, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -181,6 +181,10 @@
 			message = "<B>[src]</B> shakes its head."
 			m_type = 1
 
+		if ("sigh")
+			message = "<B>[src]</B> sighs."
+			m_type = 2
+
 		if ("sit")
 			message = "<B>[src]</B> sits down."
 			m_type = 1
@@ -248,7 +252,7 @@
 			m_type = 2
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, sigh, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, yawn"
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."


### PR DESCRIPTION
(Hopefully) Fixes #1301
Re-adds the sigh emote, My guess is it was removed when emote code was cleaned up
(Note I think I may have added sigh to some carbon animals aswell, I don't see a need to remove it, Sighing is just an exhalation of air so animals CAN do it, if it is an issue though I will remove it)

Tested it personally and I can sigh all I wish.
