### PR TITLE
Changes the mime burger recipe

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -154,7 +154,7 @@
 /datum/recipe/mimeburger
 	reagents = list("flour" = 5)
 	items = list(
-		/obj/item/clothing/head/beret
+		/obj/item/clothing/mask/gas/mime
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/mimeburger
 


### PR DESCRIPTION
Changes the mime burger recipe to require a mime mask instead of a beret.

The beret in the mime burger recipe has always bothered me because unlike the clown wig and mask used in the clown burger recipe that you have to get in a way that's somehow linked to clowns the beret can be found in two different theatre costumes that are unrelated to mimes.

This will reverse the mime burger from being usually easier to make than a clown burger to slightly harder as there is always at least three clown masks in existence at round start on the crashed clown shuttle while there can be no mime masks at all if there is no mime.
