### PR TITLE
Stop sounds

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -64,7 +64,8 @@ var/list/admin_verbs_ban = list(
 	)
 var/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,
-	/client/proc/play_sound
+	/client/proc/play_sound,
+	/client/proc/stop_sounds
 	)
 var/list/admin_verbs_fun = list(
 	/client/proc/object_talk,
@@ -208,7 +209,7 @@ var/list/admin_verbs_hideable = list(
 		if(rights & R_REJUVINATE)	verbs += admin_verbs_rejuv
 		if(rights & R_SOUNDS)		verbs += admin_verbs_sounds
 		if(rights & R_SPAWN)		verbs += admin_verbs_spawn
-		
+
 		for(var/path in holder.rank.adds)
 			verbs += path
 		for(var/path in holder.rank.subs)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -25,7 +25,20 @@
 	playsound(get_turf(src.mob), S, 50, 0, 0)
 	feedback_add_details("admin_verb","PLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/stop_sounds()
+	set category = "Debug"
+	set name = "Stop Sounds"
+	if((check_rights(R_SOUNDS)) || (check_rights(R_DEBUG)))
 
+		log_admin("[key_name(src)] stopped all currently playing sounds.")
+		message_admins("[key_name_admin(src)] stopped all currently playing sounds.")
+		for(var/mob/M in player_list)
+			if(M.client)
+				M << sound(null)
+		feedback_add_details("admin_verb","SS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+	else
+		return
 /*
 /client/proc/cuban_pete()
 	set category = "Fun"


### PR DESCRIPTION
Adds a new admin verb in the debug category called Stop Sounds. It can be used to stop all sounds currently playing. Useful if you need to diagnose if the sounds are the cause of lag, or if you play two sounds on top of each other.
