### PR TITLE
Minor atmos fixes for resin and mineral structures

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -23,6 +23,26 @@
 	anchored = 1
 	var/health = 200
 
+/obj/structure/alien/resin/New(location)
+	..()
+	air_update_turf(1)
+	return
+
+/obj/structure/alien/resin/Del()
+	density = 0
+	air_update_turf(1)
+	..()
+	return
+
+/obj/structure/alien/resin/Move()
+	air_update_turf(1)
+	..()
+	air_update_turf(1)
+	return
+
+/obj/structure/alien/resin/CanAtmosPass()
+	return !density
+	
 /obj/structure/alien/resin/wall
 	name = "resin wall"
 	desc = "Purple slime solidified into a wall."

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -21,10 +21,13 @@
 		icon_state = mineralType
 		name = "[mineralType] door"
 		air_update_turf(1)
+		return
 
 	Del()
+		density = 0
 		air_update_turf(1)
 		..()
+		return
 
 	Move()
 		air_update_turf(1)


### PR DESCRIPTION
Fixes #1195
Resin walls and membranes now block plasma spread. Additionally, mineral walls (including resin doors) no longer keep density = 1 if deleted.
