### PR TITLE
Juggernaut Adjustments

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -164,15 +164,16 @@
 
 /mob/living/simple_animal/construct/armoured/bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
-		var/reflectchance = 65 - round(P.damage/3)
+		var/reflectchance = 80 - round(P.damage/3)
 		if(prob(reflectchance))
+			adjustBruteLoss(P.damage * 0.5)
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 							"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")
 
 			// Find a turf near or on the original location to bounce to
 			if(P.starting)
-				var/new_x = P.starting.x + pick(0, 0, -1, 1, -1, 1, -2, 2, -2, 2, -2, 2)
-				var/new_y = P.starting.y + pick(0, 0, -1, 1, -1, 1, -2, 2, -2, 2, -2, 2)
+				var/new_x = P.starting.x + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
+				var/new_y = P.starting.y + pick(0, 0, -1, 1, -2, 2, -2, 2, -2, 2, -3, 3, -3, 3)
 				var/turf/curloc = get_turf(src)
 
 				// redirect the projectile


### PR DESCRIPTION
After finally seeing Juggernauts in action (seeing two of them rape a full escape shuttle) I've realised their laser reflection is a bit much.

-Raised the reflection chance to 80% from 65% -BUT-
-Instead of the reflection nullifying the damage entirely the juggernaut takes half the projectile damage
-Adjusted the weighting on the reflection trajectory, my original intention was meant to be more "ooo sparkley light show, oops sorry dude over there" than "I shoot you, I die"
