### PR TITLE
Fixes an href exploit with cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -875,7 +875,7 @@
 
 	if (href_list["act"])
 		var/obj/item/O = locate(href_list["act"])
-		if(O.loc != src.module)
+		if(!(locate(O) in src.module.modules) && O != src.module.emag)
 			return
 		if(activated(O))
 			src << "Already activated"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -855,6 +855,9 @@
 
 /mob/living/silicon/robot/Topic(href, href_list)
 	..()
+	if(usr && (src != usr))
+		return
+
 	if (href_list["mach_close"])
 		var/t1 = text("window=[href_list["mach_close"]]")
 		unset_machine()
@@ -872,6 +875,8 @@
 
 	if (href_list["act"])
 		var/obj/item/O = locate(href_list["act"])
+		if(O.loc != src.module)
+			return
 		if(activated(O))
 			src << "Already activated"
 			return


### PR DESCRIPTION
Steps to replicate exploit
Open up the modules window to obtain your memory reference. Obtain the memory reference of the object of your desire. Then do byond://?src=[yourmemref];act=[objmemref]

This works because currently there is no check for the object being activated.
