### PR TITLE
Tome rework (don't merge)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -606,7 +606,7 @@ datum/mind
 						var/datum/game_mode/cult/cult = ticker.mode
 						if (istype(cult))
 							cult.memorize_cult_objectives(src)
-						message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
+						message_admins("[key_name_admin(usr)] has cult'ed [current].")
 						log_admin("[key_name_admin(usr)] has cult'ed [current].")
 				if("tome")
 					var/mob/living/carbon/human/H = current

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -591,7 +591,7 @@ datum/mind
 						special_role = null
 						var/datum/game_mode/cult/cult = ticker.mode
 						if (istype(cult))
-							cult.memoize_cult_objectives(src)
+							cult.memorize_cult_objectives(src)
 						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
 						memory = ""
 						message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
@@ -605,7 +605,7 @@ datum/mind
 						current << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"
 						var/datum/game_mode/cult/cult = ticker.mode
 						if (istype(cult))
-							cult.memoize_cult_objectives(src)
+							cult.memorize_cult_objectives(src)
 						message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
 						log_admin("[key_name_admin(usr)] has cult'ed [current].")
 				if("tome")
@@ -1055,7 +1055,7 @@ datum/mind
 			current << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"
 			var/datum/game_mode/cult/cult = ticker.mode
 			if (istype(cult))
-				cult.memoize_cult_objectives(src)
+				cult.memorize_cult_objectives(src)
 			else
 				var/explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it."
 				current << "<B>Objective #1</B>: [explanation]"

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -94,9 +94,8 @@
 
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
-		grant_runeword(cult_mind.current)
-		grant_secondword(cult_mind.current)
-		grant_thirdword(cult_mind.current)
+//		grant_runeword(cult_mind.current)
+//		grant_secondword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.current << "\blue You are a member of the cult!"
 		memorize_cult_objectives(cult_mind)
@@ -124,7 +123,9 @@
 		cult_mind.memory += "<B>Objective #[obj_count]</B>: [explanation]<BR>"
 	cult_mind.current << "The Geometer of Blood grants you the knowledge to convert non-believers. (Join Blood Self)"
 	cult_mind.memory += "The Geometer of Blood grants you the knowledge to convert non-believers. (Join Blood Self)<BR>"
-
+	grant_runeword(cult_mind.current,"join")
+	grant_runeword(cult_mind.current,"blood")
+	grant_runeword(cult_mind.current,"self")
 
 /datum/game_mode/proc/equip_cultist(mob/living/carbon/human/mob)
 	if(!istype(mob))
@@ -153,20 +154,19 @@
 		return 1
 
 
+//datum/game_mode/cult/proc/grant_secondword(mob/living/carbon/human/cult_mob, var/word)
+//	if (!word)
+//		if(secondwords.len > 0)
+//			word=pick(secondwords)
+//			secondwords -= word
+//			grant_runeword(cult_mob,word)
+
 /datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if (!word)
-		word="join"
+		if(startwords.len > 0)
+			word=pick(startwords)
+			startwords -= word
 	return ..(cult_mob,word)
-
-/datum/game_mode/cult/proc/grant_secondword(mob/living/carbon/human/cult_mob, var/word)
-	if (!word)
-		word="blood"
-		grant_runeword(cult_mob,word)
-			
-/datum/game_mode/cult/proc/grant_thirdword(mob/living/carbon/human/cult_mob, var/word)
-	if (!word)
-		word="self"
-		grant_runeword(cult_mob,word)
 
 /datum/game_mode/proc/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if(!wordtravel)
@@ -177,14 +177,14 @@
 	switch(word)
 		if("travel")
 			wordexp = "[wordtravel] is travel..."
-		if("blood")
-			wordexp = "[wordblood] is blood..."
-		if("join")
-			wordexp = "[wordjoin] is join..."
+//		if("blood")
+//			wordexp = "[wordblood] is blood..."
+//		if("join")
+//			wordexp = "[wordjoin] is join..."
 		if("hell")
 			wordexp = "[wordhell] is Hell..."
-		if("self")
-			wordexp = "[wordself] is self..."
+//		if("self")
+//			wordexp = "[wordself] is self..."
 		if("see")
 			wordexp = "[wordsee] is see..."
 		if("tech")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -34,7 +34,7 @@
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
 	var/list/startwords = list("blood","join","self","hell")
-	var/list/secondwords = list("travel","see","tech","destroy", "other", "hide")
+	var/list/secondwords = list("blood","join","self","hell"))
 
 	var/list/objectives = list()
 
@@ -95,7 +95,7 @@
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
 		grant_runeword(cult_mind.current)
-//		grant_secondword(cult_mind.current)
+		grant_secondword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.current << "\blue You are a member of the cult!"
 		memorize_cult_objectives(cult_mind)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -95,10 +95,10 @@
 	for(var/datum/mind/cult_mind in cult)
 		equip_cultist(cult_mind.current)
 		grant_runeword(cult_mind.current)
-		grant_secondword(cult_mind.current)
+//		grant_secondword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.current << "\blue You are a member of the cult!"
-		memoize_cult_objectives(cult_mind)
+		memorize_cult_objectives(cult_mind)
 		cult_mind.special_role = "Cultist"
 
 	spawn (rand(waittime_l, waittime_h))
@@ -106,7 +106,7 @@
 	..()
 
 
-/datum/game_mode/cult/proc/memoize_cult_objectives(var/datum/mind/cult_mind)
+/datum/game_mode/cult/proc/memorize_cult_objectives(var/datum/mind/cult_mind)
 	for(var/obj_count = 1,obj_count <= objectives.len,obj_count++)
 		var/explanation
 		switch(objectives[obj_count])
@@ -213,8 +213,8 @@
 
 /datum/game_mode/cult/add_cultist(datum/mind/cult_mind) //INHERIT
 	if (!..(cult_mind))
+		memorize_cult_objectives(cult_mind)
 		return
-	memoize_cult_objectives(cult_mind)
 
 
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = 1)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -177,14 +177,14 @@
 	switch(word)
 		if("travel")
 			wordexp = "[wordtravel] is travel..."
-//		if("blood")
-//			wordexp = "[wordblood] is blood..."
-//		if("join")
-//			wordexp = "[wordjoin] is join..."
+		if("blood")
+			wordexp = "[wordblood] is blood..."
+		if("join")
+			wordexp = "[wordjoin] is join..."
 		if("hell")
 			wordexp = "[wordhell] is Hell..."
-//		if("self")
-//			wordexp = "[wordself] is self..."
+		if("self")
+			wordexp = "[wordself] is self..."
 		if("see")
 			wordexp = "[wordsee] is see..."
 		if("tech")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 /datum/game_mode
 	var/list/datum/mind/cult = list()
 	var/list/allwords = list("travel","self","see","hell","blood","join","tech","destroy", "other", "hide")
-
+	var/list/grantwords = list("travel", "see", "hell", "tech", "destroy", "other", "hide")
 
 /proc/iscultist(mob/living/M as mob)
 	return istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.cult)
@@ -34,8 +34,8 @@
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
 	var/list/startwords = list("blood","join","self","hell")
-	var/list/secondwords = list("blood","join","self","hell"))
-
+	var/list/secondwords = list("travel", "see", "tech", "destroy", "other", "hide")
+	
 	var/list/objectives = list()
 
 	var/eldergod = 1 //for the summon god objective
@@ -96,6 +96,7 @@
 		equip_cultist(cult_mind.current)
 		grant_runeword(cult_mind.current)
 		grant_secondword(cult_mind.current)
+		grant_thirdword(cult_mind.current)
 		update_cult_icons_added(cult_mind)
 		cult_mind.current << "\blue You are a member of the cult!"
 		memorize_cult_objectives(cult_mind)
@@ -121,8 +122,8 @@
 				explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it."
 		cult_mind.current << "<B>Objective #[obj_count]</B>: [explanation]"
 		cult_mind.memory += "<B>Objective #[obj_count]</B>: [explanation]<BR>"
-	cult_mind.current << "The convert rune is join blood self"
-	cult_mind.memory += "The convert rune is join blood self<BR>"
+	cult_mind.current << "The Geometer of Blood grants you the knowledge to convert non-believers. (Join Blood Self)"
+	cult_mind.memory += "The Geometer of Blood grants you the knowledge to convert non-believers. (Join Blood Self)<BR>"
 
 
 /datum/game_mode/proc/equip_cultist(mob/living/carbon/human/mob)
@@ -151,26 +152,27 @@
 		mob.update_icons()
 		return 1
 
-/datum/game_mode/cult/proc/grant_secondword(mob/living/carbon/human/cult_mob, var/word)
-	if (!word)
-		if(secondwords.len > 0)
-			word=pick(secondwords)
-			secondwords -= word
-			grant_runeword(cult_mob,word)
 
 /datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if (!word)
-		if(startwords.len > 0)
-			word=pick(startwords)
-			startwords -= word
+		word="join"
 	return ..(cult_mob,word)
 
+/datum/game_mode/cult/proc/grant_secondword(mob/living/carbon/human/cult_mob, var/word)
+	if (!word)
+		word="blood"
+		grant_runeword(cult_mob,word)
+			
+/datum/game_mode/cult/proc/grant_thirdword(mob/living/carbon/human/cult_mob, var/word)
+	if (!word)
+		word="self"
+		grant_runeword(cult_mob,word)
 
 /datum/game_mode/proc/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if(!wordtravel)
 		runerandom()
 	if (!word)
-		word=pick(allwords)
+		word=pick(grantwords)
 	var/wordexp
 	switch(word)
 		if("travel")
@@ -197,7 +199,7 @@
 //			wordexp = "[wordfree] is free..."
 		if("hide")
 			wordexp = "[wordhide] is hide..."
-	cult_mob << "\red [pick("You remember something from the dark teachings of your master","You hear a dark voice on the wind","Black blood oozes into your vision and forms into symbols","You have a vision of a [pick("crow","raven","vulture","parrot")] it squawks","You catch a brief glimmer of the otherside")]... [wordexp]"
+	cult_mob << "\red [pick("You remember something from the dark teachings of your master","You hear a dark voice on the wind","Black blood oozes into your vision and forms into symbols","You catch a brief glimmer of the otherside")]... [wordexp]"
 	cult_mob.mind.store_memory("<B>You remember that</B> [wordexp]", 0, 0)
 
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -161,12 +161,12 @@
 //			secondwords -= word
 //			grant_runeword(cult_mob,word)
 
-/datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
-	if (!word)
-		if(startwords.len > 0)
-			word=pick(startwords)
-			startwords -= word
-	return ..(cult_mob,word)
+//datum/game_mode/cult/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
+//	if (!word)
+//		if(startwords.len > 0)
+//			word=pick(startwords)
+//			startwords -= word
+//	return ..(cult_mob,word)
 
 /datum/game_mode/proc/grant_runeword(mob/living/carbon/human/cult_mob, var/word)
 	if(!wordtravel)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -194,6 +194,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 		if(word1 == wordjoin && word2 == wordhide && word3 == wordtech)
 			return runestun()
 		else
+			user.take_overall_damage(75, 0)
 			return fizzle()
 
 
@@ -355,7 +356,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				<h3>Teleport self</h3>
 				Teleport rune is a special rune, as it only needs two words, with the third word being destination. Basically, when you have two runes with the same destination, invoking one will teleport you to the other one. If there are more than 2 runes, you will be teleported to a random one. Runes with different third words will create separate networks. You can imbue this rune into a talisman, giving you a great escape mechanism.<br>
 				<h3>Teleport other</h3>
-				Teleport other allows for teleportation for any movable object to another rune with the same third word. You need 3 cultists chanting the invocation for this rune to work.<br>
+				Teleport other allows for teleportation for any movable object to another rune with the same third word. <br>
 				<h3>Summon new tome</h3>
 				Invoking this rune summons a new arcane tome.
 				<h3>Convert a person</h3>
@@ -385,7 +386,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				<h3>Summon cultist</h3>
 				This rune allows you to summon a fellow cultist to your location. The target cultist must be unhandcuffed ant not buckled to anything. You also need to have 3 people chanting at the rune to succesfully invoke it. Invoking it takes heavy strain on the bodies of all chanting cultists.<br>
 				<h3>Free a cultist</h3>
-				This rune unhandcuffs and unbuckles any cultist of your choice, no matter where he is. You need to have 3 people invoking the rune for it to work. Invoking it takes heavy strain on the bodies of all chanting cultists.<br>
+				This rune unhandcuffs and unbuckles any cultist of your choice, no matter where he is. Invoking it takes heavy strain on the bodies of all chanting cultists.<br>
 				<h3>Deafen</h3>
 				This rune temporarily deafens all non-cultists around you.<br>
 				<h3>Blind</h3>
@@ -415,9 +416,9 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 					words[words[number]] = words[number]
 				if("change")
 					words[words[number]] = input("Enter the translation for [words[number]]", "Word notes") in engwords
-					for (var/w in words)
-						if ((words[w] == words[words[number]]) && (w != words[number]))
-							words[w] = w
+					for (var/entry in words)
+						if ((words[entry] == words[words[number]]) && (entry != words[number]))
+							words[entry] = entry
 			notedat = {"
 						<br><b>Word translation notes</b> <br>
 						[words[1]] is <a href='byond://?src=\ref[src];number=1;action=change'>[words[words[1]]]</A> <A href='byond://?src=\ref[src];number=1;action=clear'>Clear</A><BR>
@@ -534,29 +535,62 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			if(usr.get_active_hand() != src)
 				return
 
-			var/w1
-			var/w2
-			var/w3
-			var/list/english = list()
-			for (var/w in words)
-				english+=words[w]
-			if(usr)
-				w1 = input("Write your first rune:", "Rune Scribing") in english
-				for (var/w in words)
-					if (words[w] == w1)
-						w1 = w
-			if(usr)
-				w2 = input("Write your second rune:", "Rune Scribing") in english
-				for (var/w in words)
-					if (words[w] == w2)
-						w2 = w
-			if(usr)
-				w3 = input("Write your third rune:", "Rune Scribing") in english
-				for (var/w in words)
-					if (words[w] == w3)
-						w3 = w
+			var/list/dictionary = list(
+				"convert" = list("join","blood","self"),
+				"wall" = list("destroy","travel","self"),
+				"blood boil" = list("destroy","see","blood"),
+				"blood drain" = list("travel","blood","self"),
+				"raise dead" = list("blood","join","hell"),
+				"summon narsie" = list("hell","join","self"),
+				"communicate" = list("self","other","technology"),
+				"emp" = list("destroy","see","technology"),
+				"manifest" = list("blood","see","travel"),
+				"summon tome" = list("see","blood","hell"),
+				"see invisible" = list("see","hell","join"),
+				"hide" = list("hide","see","blood"),
+				"reveal" = list("blood","see","hide"),
+				"astral journey" = list("hell","travel","self"),
+				"imbue" = list("hell","technology","join"),
+				"sacrifice" = list("hell","blood","join"),
+				"summon cultist" = list("join","other","self"),
+				"free cultist" = list("travel","technology","other"),
+				"deafen" = list("hide","other","see"),
+				"blind" = list("destroy","see","other"),
+				"stun" = list("join","hide","technology"),
+				"armor" = list("hell","destroy","other"),
+				"teleport" = list("travel","self"),
+				"teleport other" = list("travel","other")
+				)
 
-			if(usr.get_active_hand() != src)
+
+			var/list/scribewords = list("none")
+
+			var/list/english = list()
+
+			for (var/entry in words)
+				if (words[entry] != entry)
+					english+=list(words[entry] = entry)
+
+			for (var/entry in dictionary)
+				var/list/required = dictionary[entry]
+				if (length(english&required) == required.len)
+					scribewords += entry
+
+			var/chosen_rune = null
+			
+			
+			if(usr)
+				chosen_rune = input ("Choose a rune to scribe.") in scribewords
+				if (!chosen_rune)
+					return
+				if (chosen_rune == "none")
+					return
+				if (chosen_rune == "teleport")
+					dictionary[chosen_rune] += input ("Choose a destination word") in english
+				if (chosen_rune == "teleport other")
+					dictionary[chosen_rune] += input ("Choose a destination word") in english
+							
+			if(user.get_active_hand() != src)
 				return
 
 			for (var/mob/V in viewers(src))
@@ -569,9 +603,10 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				var/mob/living/carbon/human/H = user
 				var/obj/effect/rune/R = new /obj/effect/rune(user.loc)
 				user << "\red You finish drawing the arcane markings of the Geometer."
-				R.word1 = w1
-				R.word2 = w2
-				R.word3 = w3
+				var/list/required = dictionary[chosen_rune]
+				R.word1 = english[required[1]]
+				R.word2 = english[required[2]]
+				R.word3 = english[required[3]]
 				R.check_icon()
 				R.blood_DNA = list()
 				R.blood_DNA[H.dna.unique_enzymes] = H.dna.blood_type
@@ -590,8 +625,8 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 	//				return
 	//		for(var/mob/M in nearby)
 	//			if(M == user)
-			for(var/w in words)
-				words[w] = T.words[w]
+			for(var/entry in words)
+				words[entry] = T.words[entry]
 			user << "You copy the translation notes from your tome."
 
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -290,6 +290,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			if(word1 == wordtravel && word2 == wordother)
 				icon_state = "1"
 				src.icon += rgb(200, 0, 0)
+				return
 			if(word1 == wordjoin && word2 == wordhide && word3 == wordtech)
 				icon_state = "2"
 				src.icon += rgb(100, 0, 100)
@@ -577,8 +578,8 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 					scribewords += entry
 
 			var/chosen_rune = null
-			
-			
+
+
 			if(usr)
 				chosen_rune = input ("Choose a rune to scribe.") in scribewords
 				if (!chosen_rune)
@@ -589,7 +590,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 					dictionary[chosen_rune] += input ("Choose a destination word") in english
 				if (chosen_rune == "teleport other")
 					dictionary[chosen_rune] += input ("Choose a destination word") in english
-							
+
 			if(user.get_active_hand() != src)
 				return
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -193,8 +193,11 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			return itemport(src.word3)
 		if(word1 == wordjoin && word2 == wordhide && word3 == wordtech)
 			return runestun()
+		if(word1 == worddestr && word2 == wordhell && word3 == wordother)
+			return clown()
 		else
-			user.take_overall_damage(75, 0)
+			user.take_overall_damage(30, 0)
+			user << "\red You feel the life draining from you, as if Lord Nar-Sie is displeased with you."
 			return fizzle()
 
 
@@ -295,6 +298,8 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				icon_state = "2"
 				src.icon += rgb(100, 0, 100)
 				return
+			if(word1 == worddestr && word2 == wordhell && word3 == wordother)
+				icon_state = "[rand(1,6)]"
 			icon_state="[rand(1,6)]" //random shape and color for dummy runes
 			src.icon -= rgb(255,255,255)
 			src.icon += rgb(rand(1,255),rand(1,255),rand(1,255))
@@ -560,7 +565,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				"stun" = list("join","hide","technology"),
 				"armor" = list("hell","destroy","other"),
 				"teleport" = list("travel","self"),
-				"teleport other" = list("travel","other")
+				"teleport other" = list("travel","other"),
 				)
 
 
@@ -585,6 +590,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				if (!chosen_rune)
 					return
 				if (chosen_rune == "none")
+					user << "\red You decide against scribing a rune, perhaps you should take this time to study your notes."
 					return
 				if (chosen_rune == "teleport")
 					dictionary[chosen_rune] += input ("Choose a destination word") in english

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -193,8 +193,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			return itemport(src.word3)
 		if(word1 == wordjoin && word2 == wordhide && word3 == wordtech)
 			return runestun()
-		if(word1 == worddestr && word2 == wordhell && word3 == wordother)
-			return clown()
 		else
 			user.take_overall_damage(30, 0)
 			user << "\red You feel the life draining from you, as if Lord Nar-Sie is displeased with you."
@@ -298,8 +296,6 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				icon_state = "2"
 				src.icon += rgb(100, 0, 100)
 				return
-			if(word1 == worddestr && word2 == wordhell && word3 == wordother)
-				icon_state = "[rand(1,6)]"
 			icon_state="[rand(1,6)]" //random shape and color for dummy runes
 			src.icon -= rgb(255,255,255)
 			src.icon += rgb(rand(1,255),rand(1,255),rand(1,255))
@@ -565,7 +561,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				"stun" = list("join","hide","technology"),
 				"armor" = list("hell","destroy","other"),
 				"teleport" = list("travel","self"),
-				"teleport other" = list("travel","other"),
+				"teleport other" = list("travel","other")
 				)
 
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -77,7 +77,6 @@ var/list/sacrificed = list()
 
 			return fizzle()
 
-
 /////////////////////////////////////////SECOND RUNE
 
 		tomesummon()
@@ -114,6 +113,8 @@ var/list/sacrificed = list()
 					M.mind.special_role = "Cultist"
 					M << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"
 					M << "<font color=\"purple\"><b><i>Assist your new compatriots in their dark dealings. Their goal is yours, and yours is theirs. You serve the Dark One above all else. Bring It back.</b></i></font>"
+					usr << "\red The Geometer of Blood is pleased to see his followers grow in numbers."
+					ticker.mode:grant_runeword(usr)
 					return 1
 				else
 					M << "<font color=\"purple\"><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible truth. The veil of reality has been ripped away and in the festering wound left behind something sinister takes root.</b></i></font>"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1036,3 +1036,4 @@ var/list/sacrificed = list()
 
 			del(src)
 			return
+


### PR DESCRIPTION
Edited pull request with full info for easier reading.

Tomes reworked for user friendliness! A fairly large change to cult.

Tomes no longer make you choose from a list of words three times to form a rune.

Tomes now use the "notes" section to decide whether you can scribe a rune or not, once you've translated the appropriate words into english, the usable runes will be in the list when you choose scribe rune, it will scribe the appropriate word that you translated. I.E. If "Ire" was translated to "join", the first word will be "ire".

On top of removing research (Which people found annoying and or too easy.), converting people now gives you a word.

Cultists start with the three words for "convert" as per discussion below and coderbus.

ISSUE which is why it's (DON'T MERGE) is that the cult doesn't have "Hell" to start, Nar-Nar requires "hell", and in the current grant_runeword code, it's possible for a cultist to get one word repeatedly. This COULD make a summon narnar objective incredibly hard/impossible for some cults. It's usable as-is, but this is something I personally find to be an issue.
