### PR TITLE
AI Photography

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -1,4 +1,19 @@
 
+/obj/effect/datacore
+	name = "datacore"
+	var/medical[] = list()
+	var/general[] = list()
+	var/security[] = list()
+	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
+	var/locked[] = list()
+
+/datum/data
+	var/name = "data"
+
+/datum/data/record
+	name = "record"
+	var/list/fields = list()
+
 /obj/effect/datacore/proc/manifest(var/nosleep = 0)
 	spawn()
 		if(!nosleep)

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -1,12 +1,5 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
-/datum/data
-	var/name = "data"
-
-/datum/data/record
-	name = "record"
-	var/list/fields = list()
-
 /datum/powernet
 	var/list/cables = list()	// all cables & junctions
 	var/list/nodes = list()		// all APCs & sources

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -31,15 +31,6 @@
 	var/def_zone
 	pass_flags = PASSTABLE
 
-/obj/effect/datacore
-	name = "datacore"
-	var/medical[] = list()
-	var/general[] = list()
-	var/security[] = list()
-	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
-	var/locked[] = list()
-
-
 /obj/effect/list_container
 	name = "list container"
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -419,7 +419,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 		//human_or_robot_user << browse(dat, "window=newscaster_main;size=400x600")
 		//onclose(human_or_robot_user, "newscaster_main")
-		
+
 		var/datum/browser/popup = new(human_or_robot_user, "newscaster_main", "Newscaster Unit #[src.unit_no]", 400, 600)
 		popup.set_content(dat)
 		popup.set_title_image(human_or_robot_user.browse_rsc_icon(src.icon, src.icon_state))
@@ -737,9 +737,6 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			user << "<FONT COLOR='blue'>This does nothing.</FONT>"
 	src.update_icon()
 
-/obj/machinery/newscaster/attack_ai(mob/user as mob)
-	return src.attack_hand(user) //or maybe it'll have some special functions? No idea.
-
 
 /obj/machinery/newscaster/attack_paw(mob/user as mob)
 	user << "<font color='blue'>The newscaster controls are far too complicated for your tiny brain!</font>"
@@ -754,6 +751,23 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		photo = user.get_active_hand()
 		user.drop_item()
 		photo.loc = src
+	if(istype(usr,/mob/living/silicon/ai))
+		var/list/nametemp = list()
+		var/find
+		var/datum/picture/selection
+		var/mob/living/silicon/ai/tempAI = user
+		for(var/datum/picture/t in tempAI.aicamera.aipictures)
+			nametemp += t.fields["name"]
+		find = input("Select picture (numbered in order taken)") in nametemp
+		var/obj/item/weapon/photo/P = new/obj/item/weapon/photo()
+		for(var/datum/picture/q in tempAI.aicamera.aipictures)
+			if(q.fields["name"] == find)
+				selection = q
+				break  	// just in case some AI decides to take 10 thousand pictures in a round
+		P.icon = selection.fields["icon"]
+		P.img = selection.fields["img"]
+		P.desc = selection.fields["desc"]
+		photo = P
 
 
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -29,6 +29,7 @@ var/list/ai_list = list()
 	var/icon/holo_icon//Default is assigned when AI is created.
 	var/obj/item/device/pda/ai/aiPDA = null
 	var/obj/item/device/multitool/aiMulti = null
+	var/obj/item/device/camera/ai_camera/aicamera = null
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker
@@ -84,6 +85,7 @@ var/list/ai_list = list()
 	aiPDA.name = name + " (" + aiPDA.ownjob + ")"
 
 	aiMulti = new(src)
+	aicamera = new/obj/item/device/camera/ai_camera(src)
 
 	if (istype(loc, /turf))
 		verbs.Add(/mob/living/silicon/ai/proc/ai_call_shuttle,/mob/living/silicon/ai/proc/ai_camera_track, \
@@ -689,3 +691,4 @@ var/list/ai_list = list()
 	set name = "State Laws"
 
 	checklaws()
+

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -130,6 +130,10 @@ var/datum/cameranet/cameranet = new()
 
 	// 0xf = 15
 	var/turf/position = get_turf(target)
+	return checkTurfVis(position)
+
+
+/datum/cameranet/proc/checkTurfVis(var/turf/position)
 	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z)
 	if(chunk)
 		if(chunk.changed)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -105,6 +105,8 @@
 					p.name = photocopy.name
 					p.desc = photocopy.desc
 					p.scribble = photocopy.scribble
+					p.pixel_x = rand(-10, 10)
+					p.pixel_y = rand(-10, 10)
 					p.blueprints = photocopy.blueprints //a copy of a picture is still good enough for the syndicate
 
 					sleep(15)
@@ -159,6 +161,8 @@
 			p.img = img
 			p.desc = selection.fields["desc"]
 			p.blueprints = selection.fields["blueprints"]
+			p.pixel_x = rand(-10, 10)
+			p.pixel_y = rand(-10, 10)
 			toner -= 5	 //AI prints color pictures only, thus they can do it more efficiently
 			sleep(15)
 		updateUsrDialog()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -20,8 +20,9 @@
 	var/obj/item/weapon/paper/copy = null	//what's in the copier!
 	var/obj/item/weapon/photo/photocopy = null
 	var/copies = 1	//how many copies to print!
-	var/toner = 30 //how much toner is left! woooooo~
+	var/toner = 40 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
+	var/greytoggle = "Greyscale"
 
 
 /obj/machinery/photocopier/attack_ai(mob/user)
@@ -43,8 +44,12 @@
 			dat += "Printing: [copies] copies."
 			dat += "<a href='byond://?src=\ref[src];min=1'>-</a> "
 			dat += "<a href='byond://?src=\ref[src];add=1'>+</a><BR><BR>"
+			if(photocopy)
+				dat += "Printing in <a href='byond://?src=\ref[src];colortoggle=1'>[greytoggle]</a><BR><BR>"
 	else if(toner)
 		dat += "Please insert paper to copy.<BR><BR>"
+	if(istype(user,/mob/living/silicon/ai))
+		dat += "<a href='byond://?src=\ref[src];aipic=1'>Print photo from database</a><BR><BR>"
 	dat += "Current toner level: [toner]"
 	if(!toner)
 		dat +="<BR>Please insert a new toner cartridge!"
@@ -78,36 +83,50 @@
 			updateUsrDialog()
 		else if(photocopy)
 			for(var/i = 0, i < copies, i++)
-				if(toner > 0)
+				if(toner >= 5)  //Was set to = 0, but if there was say 3 toner left and this ran, you would get -2 which would be weird for ink
 					var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)
 					var/icon/I = icon(photocopy.icon, photocopy.icon_state)
 					var/icon/img = icon(photocopy.img)
-					if(toner > 10)	//plenty of toner, go straight greyscale
-						I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))		//I'm not sure how expensive this is, but given the many limitations of photocopying, it shouldn't be an issue.
-						img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
-					else			//not much toner left, lighten the photo
-						I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
-						img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
+					if(greytoggle == "Greyscale")
+						if(toner > 10) //plenty of toner, go straight greyscale
+							I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0)) //I'm not sure how expensive this is, but given the many limitations of photocopying, it shouldn't be an issue.
+							img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+						else //not much toner left, lighten the photo
+							I.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
+							img.MapColors(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(100,100,100))
+						toner -= 5	//photos use a lot of ink!
+					else if(greytoggle == "Color")
+						if(toner >= 10)
+							toner -= 10 //Color photos use even more ink!
+						else
+							continue
 					p.icon = I
 					p.img = img
 					p.name = photocopy.name
 					p.desc = photocopy.desc
 					p.scribble = photocopy.scribble
-					toner -= 5	//photos use a lot of ink!
+					p.blueprints = photocopy.blueprints //a copy of a picture is still good enough for the syndicate
+
 					sleep(15)
 				else
 					break
 			updateUsrDialog()
 	else if(href_list["remove"])
 		if(copy)
-			copy.loc = usr.loc
-			usr.put_in_hands(copy)
+			if(!istype(usr,/mob/living/silicon/ai)) //surprised this check didn't exist before, putting stuff in AI's hand is bad
+				copy.loc = usr.loc
+				usr.put_in_hands(copy)
+			else
+				copy.loc = src.loc
 			usr << "<span class='notice'>You take [copy] out of [src].</span>"
 			copy = null
 			updateUsrDialog()
 		else if(photocopy)
-			photocopy.loc = usr.loc
-			usr.put_in_hands(photocopy)
+			if(!istype(usr,/mob/living/silicon/ai)) //same with this one, wtf
+				photocopy.loc = usr.loc
+				usr.put_in_hands(photocopy)
+			else
+				photocopy.loc = src.loc
 			usr << "<span class='notice'>You take [photocopy] out of [src].</span>"
 			photocopy = null
 			updateUsrDialog()
@@ -119,6 +138,36 @@
 		if(copies < maxcopies)
 			copies++
 			updateUsrDialog()
+	else if(href_list["aipic"])
+		if(!istype(usr,/mob/living/silicon/ai)) return
+		if(toner >= 5)
+			var/list/nametemp = list()
+			var/find
+			var/datum/picture/selection
+			var/mob/living/silicon/ai/tempAI = usr
+			for(var/datum/picture/t in tempAI.aicamera.aipictures)
+				nametemp += t.fields["name"]
+			find = input("Select picture (numbered in order taken)") in nametemp
+			var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)
+			for(var/datum/picture/q in tempAI.aicamera.aipictures)
+				if(q.fields["name"] == find)
+					selection = q
+					break
+			var/icon/I = selection.fields["icon"]
+			var/icon/img = selection.fields["img"]
+			p.icon = I
+			p.img = img
+			p.desc = selection.fields["desc"]
+			p.blueprints = selection.fields["blueprints"]
+			toner -= 5	 //AI prints color pictures only, thus they can do it more efficiently
+			sleep(15)
+		updateUsrDialog()
+	else if(href_list["colortoggle"])
+		if(greytoggle == "Greyscale")
+			greytoggle = "Color"
+		else
+			greytoggle ="Greyscale"
+		updateUsrDialog()
 
 /obj/machinery/photocopier/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/weapon/paper))
@@ -145,7 +194,7 @@
 		if(toner == 0)
 			user.drop_item()
 			del(O)
-			toner = 30
+			toner = 40
 			user << "<span class='notice'>You insert [O] into [src].</span>"
 			updateUsrDialog()
 		else

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -248,8 +248,8 @@
 	P.icon = ic
 	P.img = temp
 	P.desc = mobs
-//	P.pixel_x = rand(-10, 10)
-//	P.pixel_y = rand(-10, 10)
+	P.pixel_x = rand(-10, 10)
+	P.pixel_y = rand(-10, 10)
 
 	if(blueprints)
 		P.blueprints = 1
@@ -265,8 +265,8 @@
 	var/icon = ic
 	var/img = temp
 	var/desc = mobs
-//	var/pixel_x = rand(-10, 10)
-//	var/pixel_y = rand(-10, 10)
+	var/pixel_x = rand(-10, 10)
+	var/pixel_y = rand(-10, 10)
 
 	if(blueprints)
 		blueprints = 1
@@ -288,8 +288,8 @@
 	P.fields["icon"] = icon
 	P.fields["img"] = img
 	P.fields["desc"] = desc
-//	P.fields["pixel_x"] = pixel_x
-//	P.fields["pixel_y"] = pixel_y
+	P.fields["pixel_x"] = pixel_x
+	P.fields["pixel_y"] = pixel_y
 	P.fields["blueprints"] = blueprints
 
 	aipictures += P
@@ -310,8 +310,8 @@
 	P.icon = selection.fields["icon"]
 	P.img = selection.fields["img"]
 	P.desc = selection.fields["desc"]
-//	P.pixel_x = selection.fields["pixel_x"]
-//	P.pixel_y = selection.fields["pixel_y"]
+	P.pixel_x = selection.fields["pixel_x"]
+	P.pixel_y = selection.fields["pixel_y"]
 
 	P.show(usr)
 	usr << P.desc

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -106,6 +106,27 @@
 	var/pictures_left = 10
 	var/on = 1
 	var/blueprints = 0	//are blueprints visible in the current photo being created?
+	var/aipictures[] = list() //Allows for storage of pictures taken by AI, in a similar manner the datacore stores info
+
+
+/obj/item/device/camera/ai_camera //camera AI can take pictures with
+	name = "AI photo camera"
+
+	verb/picture()
+		set category ="AI Commands"
+		set name = "Take Picture"
+		set src in usr
+		var/mob/living/silicon/ai/my_ai = usr
+		var/target = get_turf(my_ai.eyeobj)
+
+		captureimage(target, usr)
+
+	verb/viewpicture()
+		set category ="AI Commands"
+		set name = "View Pictures"
+		set src in usr
+
+		viewpictures()
 
 
 /obj/item/device/camera/attack(mob/living/carbon/human/M, mob/user)
@@ -125,7 +146,7 @@
 	..()
 
 
-/obj/item/device/camera/proc/get_icon(turf/the_turf)
+/obj/item/device/camera/proc/camera_get_icon(turf/the_turf, blueprints)
 	//Bigger icon base to capture those icons that were shifted to the next tile
 	//i.e. pretty much all wall-mounted machinery
 	var/icon/res = icon('icons/effects/96x96.dmi', "")
@@ -165,7 +186,7 @@
 	return res
 
 
-/obj/item/device/camera/proc/get_mobs(turf/the_turf)
+/obj/item/device/camera/proc/camera_get_mobs(turf/the_turf)
 	var/mob_detail
 	for(var/mob/living/carbon/A in the_turf)
 		if(A.invisibility) continue
@@ -185,9 +206,7 @@
 	return mob_detail
 
 
-/obj/item/device/camera/afterattack(atom/target, mob/user, flag)
-	if(!on || !pictures_left || ismob(target.loc)) return
-
+/obj/item/device/camera/proc/captureimage(atom/target, mob/user, flag)  //Proc for both regular and AI-based camera to take the image
 	var/x_c = target.x - 1
 	var/y_c = target.y + 1
 	var/z_c	= target.z
@@ -203,12 +222,23 @@
 		for(var/j = 1; j <= 3; j++)
 			var/turf/T = locate(x_c, y_c, z_c)
 			if(T in seen)
-				temp.Blend(get_icon(T), ICON_OVERLAY, 32 * (j-1-1), 32 - 32 * (i-1))
-				mobs += get_mobs(T)
+				if(istype(user,/mob/living/silicon/ai))
+					if(0 == cameranet.checkTurfVis(T)) //Checks to see if this turf is visible to the AI's cameras
+						x_c++  //because continue would skip the x_c++ further down, and it is rather important to this proc to work right
+						continue
+				temp.Blend(camera_get_icon(T), ICON_OVERLAY, 32 * (j-1-1), 32 - 32 * (i-1))
+				mobs += camera_get_mobs(T)
 			x_c++
 		y_c--
 		x_c -= 3
+	if(!istype(usr,/mob/living/silicon/ai))
+		printpicture(user, temp, mobs, blueprints, flag)
+	else
+		aipicture(user, temp, mobs, blueprints)
 
+
+
+/obj/item/device/camera/proc/printpicture(mob/user, icon/temp, mobs, blueprints, flag) //Normal camera proc for creating photos
 	var/obj/item/weapon/photo/P = new/obj/item/weapon/photo()
 	user.put_in_hands(P)
 	var/icon/small_img = icon(temp)
@@ -218,14 +248,101 @@
 	P.icon = ic
 	P.img = temp
 	P.desc = mobs
-	P.pixel_x = rand(-10, 10)
-	P.pixel_y = rand(-10, 10)
+//	P.pixel_x = rand(-10, 10)
+//	P.pixel_y = rand(-10, 10)
 
 	if(blueprints)
 		P.blueprints = 1
 	blueprints = 0
 
+
+/obj/item/device/camera/proc/aipicture(mob/user, icon/temp, mobs, blueprints) //instead of printing a picture like a regular camera would, we do this instead for the AI
+
+	var/icon/small_img = icon(temp)
+	var/icon/ic = icon('icons/obj/items.dmi',"photo")
+	small_img.Scale(8, 8)
+	ic.Blend(small_img,ICON_OVERLAY, 10, 13)
+	var/icon = ic
+	var/img = temp
+	var/desc = mobs
+//	var/pixel_x = rand(-10, 10)
+//	var/pixel_y = rand(-10, 10)
+
+	if(blueprints)
+		blueprints = 1
+
+	injectaialbum(icon, img, desc, pixel_x, pixel_y, blueprints)
+
+
+/datum/picture
+	var/name = "picture"
+	var/list/fields = list()
+
+
+/obj/item/device/camera/proc/injectaialbum(var/icon, var/img, var/desc, var/pixel_x, var/pixel_y, var/blueprints) //stores image information to a list similar to that of the datacore
+	var/numberer = 1
+	for(var/datum/picture in src.aipictures)
+		numberer++
+	var/datum/picture/P = new()
+	P.fields["name"] = "Photo [numberer]"
+	P.fields["icon"] = icon
+	P.fields["img"] = img
+	P.fields["desc"] = desc
+//	P.fields["pixel_x"] = pixel_x
+//	P.fields["pixel_y"] = pixel_y
+	P.fields["blueprints"] = blueprints
+
+	aipictures += P
+
+
+/*obj/item/device/camera/ai_camera/proc/findpicture()
+	var/selection = input("Select picture (numbered in order taken)", "Pictures", null, null) in aipictures
+
+
+	var/dat = "<B>Showing list of pictures.</B><HR>"
+	dat += "<table cellspacing=5><tr><th>Name</th></tr>"
+	for(var/datum/picture/p in src.aipictures)
+		dat += "<tr>[p.fields["name"]]</tr>"
+		usr << "That loop (debug)"
+	dat += "</table>"
+	usr << browse(dat, "window=photo album;size=440x410")
+
+	<a href='?src=\ref[src];selection=[p.fields["name"]]'>  //For later use // WIP
+
+
+/obj/item/device/camera/ai_camera/Topic(picname, href_list[])
+	if(href_list["selection"])
+		src.find = picname
+*/															//Part of the above WIP
+
+/obj/item/device/camera/ai_camera/proc/viewpictures() //AI proc for viewing pictures they have taken
+	var/list/nametemp = list()
+	var/find
+	var/datum/picture/selection
+	for(var/datum/picture/t in src.aipictures)
+		nametemp += t.fields["name"]
+	find = input("Select picture (numbered in order taken)") in nametemp
+	var/obj/item/weapon/photo/P = new/obj/item/weapon/photo()
+	for(var/datum/picture/q in src.aipictures)
+		if(q.fields["name"] == find)
+			selection = q
+			break  	// just in case some AI decides to take 10 thousand pictures in a round
+	P.icon = selection.fields["icon"]
+	P.img = selection.fields["img"]
+	P.desc = selection.fields["desc"]
+//	P.pixel_x = selection.fields["pixel_x"]
+//	P.pixel_y = selection.fields["pixel_y"]
+
+	P.show(usr)
+	usr << P.desc
+	del P    //so 10 thousdand pictures items are not left in memory should an AI take them and then view them all.
+
+/obj/item/device/camera/afterattack(atom/target, mob/user, flag)
+	if(!on || !pictures_left || ismob(target.loc)) return
+	captureimage(target, user, flag)
+
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
+
 
 	pictures_left--
 	desc = "A polaroid camera. It has [pictures_left] photos left."

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -295,26 +295,6 @@
 	aipictures += P
 
 
-/*obj/item/device/camera/ai_camera/proc/findpicture()
-	var/selection = input("Select picture (numbered in order taken)", "Pictures", null, null) in aipictures
-
-
-	var/dat = "<B>Showing list of pictures.</B><HR>"
-	dat += "<table cellspacing=5><tr><th>Name</th></tr>"
-	for(var/datum/picture/p in src.aipictures)
-		dat += "<tr>[p.fields["name"]]</tr>"
-		usr << "That loop (debug)"
-	dat += "</table>"
-	usr << browse(dat, "window=photo album;size=440x410")
-
-	<a href='?src=\ref[src];selection=[p.fields["name"]]'>  //For later use // WIP
-
-
-/obj/item/device/camera/ai_camera/Topic(picname, href_list[])
-	if(href_list["selection"])
-		src.find = picname
-*/															//Part of the above WIP
-
 /obj/item/device/camera/ai_camera/proc/viewpictures() //AI proc for viewing pictures they have taken
 	var/list/nametemp = list()
 	var/find
@@ -342,7 +322,6 @@
 	captureimage(target, user, flag)
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)
-
 
 	pictures_left--
 	desc = "A polaroid camera. It has [pictures_left] photos left."

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -54,6 +54,15 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>12 September 2013</h2>
+	<h3 class='author'>AndroidSFV updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class="rscadd">AI Photography: AIs now have two new verbs, Take Picture and View Picture. The pictures the AI takes are centered on the AI's eyeobj. You can use these pictures on a newscaster, and print them at a photocopier.
+	</ul>
+</div>
+
+
+<div class='commit sansserif'>
 	<h2 class='date'>31 August 2013</h2>
 	<h3 class='author'>Cael_Aislinn updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
Gives the AI two verbs, Take Picture and View Picture. The AI can also print these pictures at a photocopier if there is enough toner, and on a newscaster. The AI is given an ai_camera in New(). The picture is taken centered on the AI's eyeobj. I broke up some of the original photography code so that it could be used with the AI camera.

Added some checks to photocopier.dm that when the AI tried to eject a photo from a photocopier, it would end up in the AI's hand. Also increased the amount of toner a photocopier holds (and how much a toner cartridge adds) to 40. I also gave a toggle option for non-ai mobs to copy in greyscale or color. 

Consolidated some datacore code into datacore.dm.

To come in future pulls: A way for AI's to delete pictures they don't like so it isn't cluttered, targeting of the center of the picture based on a mouse click, giving this functionality to borgs, unifying picture storage/viewing among all silicons, making the selection interface into some form a window with html interaction.

Please offer any feedback or criticism in a detailed manner so I can address it properly.

Notes: code/datums/obj.dm and /code/defines/obj.dm, where I found those bits of datacore code, do not really serve a purpose and should have their contents shifted into more appropriate .dm's. Also, when you try to take a picture of the kitchen, the kitchen turfs appear black in the picture. I will open issues for both.

Also, a big thanks to Nodrak and Giacom for providing invaluable advice and assistance.
