### PR TITLE
Changes and fixes to how gamemodes and antags are chosen.

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -9,8 +9,12 @@ var/list/blob_nodes = list()
 /datum/game_mode/blob
 	name = "blob"
 	config_tag = "blob"
+	antag_flag = BE_ALIEN
 
 	required_players = 30
+	required_enemies = 1
+	recommended_enemies = 1
+	pre_setup_before_jobs = 1
 
 	restricted_jobs = list("Cyborg", "AI")
 
@@ -28,26 +32,19 @@ var/list/blob_nodes = list()
 	var/list/infected_crew = list()
 
 /datum/game_mode/blob/pre_setup()
-
-	var/list/possible_blobs = get_players_for_role(BE_ALIEN)
-
-	// stop setup if no possible traitors
-	if(!possible_blobs.len)
-		return 0
-
 	cores_to_spawn = max(round(num_players()/players_per_core, 1), 1)
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
 
 	for(var/j = 0, j < cores_to_spawn, j++)
-		if (!possible_blobs.len)
+		if (!antag_candidates.len)
 			break
-		var/datum/mind/blob = pick(possible_blobs)
+		var/datum/mind/blob = pick(antag_candidates)
 		infected_crew += blob
 		blob.special_role = "Blob"
 		log_game("[blob.key] (ckey) has been selected as a Blob")
-		possible_blobs -= blob
+		antag_candidates -= blob
 
 	if(!infected_crew.len)
 		return 0

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -7,6 +7,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 /datum/game_mode/changeling
 	name = "changeling"
 	config_tag = "changeling"
+	antag_flag = BE_CHANGELING
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15
@@ -47,8 +48,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
-	var/list/datum/mind/possible_changelings = get_players_for_role(BE_CHANGELING)
-
 	var/num_changelings = 1
 
 	if(config.changeling_scaling_coeff)
@@ -56,16 +55,16 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount))
 
-	for(var/datum/mind/player in possible_changelings)
+	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing robots from the list
 			if(player.assigned_role == job)
-				possible_changelings -= player
+				antag_candidates -= player
 
-	if(possible_changelings.len>0)
+	if(antag_candidates.len>0)
 		for(var/i = 0, i < num_changelings, i++)
-			if(!possible_changelings.len) break
-			var/datum/mind/changeling = pick(possible_changelings)
-			possible_changelings -= changeling
+			if(!antag_candidates.len) break
+			var/datum/mind/changeling = pick(antag_candidates)
+			antag_candidates -= changeling
 			changelings += changeling
 			modePlayer += changelings
 		return 1

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -4,15 +4,23 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 20
-	required_enemies = 2
+	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 
+	var/list/possible_changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off
 
 /datum/game_mode/traitor/changeling/announce()
 	world << "<B>The current game mode is - Traitor+Changeling!</B>"
 	world << "<B>There are alien creatures on the station along with some syndicate operatives out for their own gain! Do not let the changelings or the traitors succeed!</B>"
 
+/datum/game_mode/traitor/changeling/can_start()
+	if(!..())
+		return 0
+	possible_changelings = get_players_for_role(BE_CHANGELING)
+	if(possible_changelings.len < required_enemies)
+		return 0
+	return 1
 
 /datum/game_mode/traitor/changeling/pre_setup()
 	if(config.protect_roles_from_antagonist)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -19,6 +19,7 @@
 /datum/game_mode/cult
 	name = "cult"
 	config_tag = "cult"
+	antag_flag = BE_CULTIST
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	protected_jobs = list()
 	required_players = 15
@@ -41,8 +42,6 @@
 	var/eldergod = 1 //for the summon god objective
 
 	var/const/acolytes_needed = 5 //for the survive objective
-	var/const/min_cultists_to_start = 3
-	var/const/max_cultists_to_start = 4
 	var/acolytes_survived = 0
 
 
@@ -62,21 +61,20 @@
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
-	var/list/cultists_possible = get_players_for_role(BE_CULTIST)
-	for(var/datum/mind/player in cultists_possible)
+	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing heads and such from the list
 			if(player.assigned_role == job)
-				cultists_possible -= player
+				antag_candidates -= player
 
-	for(var/cultists_number = 1 to max_cultists_to_start)
-		if(!cultists_possible.len)
+	for(var/cultists_number = 1 to recommended_enemies)
+		if(!antag_candidates.len)
 			break
-		var/datum/mind/cultist = pick(cultists_possible)
-		cultists_possible -= cultist
+		var/datum/mind/cultist = pick(antag_candidates)
+		antag_candidates -= cultist
 		cult += cultist
 		log_game("[cultist.key] (ckey) has been selected as a cultist")
 
-	return (cult.len>0)
+	return (cult.len>=required_enemies)
 
 
 /datum/game_mode/cult/post_setup()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -21,13 +21,16 @@
 	var/station_was_nuked = 0 //see nuclearbomb.dm and malfunction.dm
 	var/explosion_in_progress = 0 //sit back and relax
 	var/list/datum/mind/modePlayer = new
+	var/list/datum/mind/antag_candidates = list()	// List of possible starting antags goes here
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/required_players = 0
 	var/required_enemies = 0
 	var/recommended_enemies = 0
+	var/pre_setup_before_jobs = 0
 	var/uplink_welcome = "Syndicate Uplink Console:"
 	var/uplink_uses = 10
+	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
 
 // Items removed from above:
 /*
@@ -45,9 +48,12 @@
 	for(var/mob/new_player/player in player_list)
 		if((player.client)&&(player.ready))
 			playerC++
-	if(playerC >= required_players)
-		return 1
-	return 0
+	if(playerC < required_players)
+		return 0
+	antag_candidates = get_players_for_role(antag_flag)
+	if(antag_candidates.len < required_enemies)
+		return 0
+	return 1
 
 
 ///pre_setup()
@@ -203,7 +209,7 @@
 		set_security_level(SEC_LEVEL_BLUE)
 
 
-/datum/game_mode/proc/get_players_for_role(var/role, override_jobbans=1)
+/datum/game_mode/proc/get_players_for_role(var/role)
 	var/list/players = list()
 	var/list/candidates = list()
 	var/list/drafted = list()
@@ -264,13 +270,13 @@
 
 		else												// Not enough scrubs, ABORT ABORT ABORT
 			break
-
+/*
 	if(candidates.len < recommended_enemies && override_jobbans) //If we still don't have enough people, we're going to start drafting banned people.
 		for(var/mob/new_player/player in players)
 			if (player.client && player.ready)
 				if(jobban_isbanned(player, "Syndicate") || jobban_isbanned(player, roletext)) //Nodrak/Carn: Antag Job-bans
 					drafted += player.mind
-
+*/
 	if(restricted_jobs)
 		for(var/datum/mind/player in drafted)				// Remove people who can't be an antagonist
 			for(var/job in restricted_jobs)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -70,27 +70,30 @@ var/global/datum/controller/gameticker/ticker
 			world << "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby."
 			return 0
 		if(secret_force_mode != "secret")
-			var/datum/game_mode/M = config.pick_mode(secret_force_mode)
-			if(M.can_start())
-				src.mode = config.pick_mode(secret_force_mode)
-		job_master.ResetOccupations()
+			for (var/datum/game_mode/M in runnable_modes)
+				if (M.name == secret_force_mode)
+					src.mode = M
+					break
+			if	(!src.mode)
+				message_admins("\blue Unable to force secret [secret_force_mode].", 1)
 		if(!src.mode)
 			src.mode = pickweight(runnable_modes)
-		if(src.mode)
-			var/mtype = src.mode.type
-			src.mode = new mtype
+
 	else
 		src.mode = config.pick_mode(master_mode)
-	if (!src.mode.can_start())
-		world << "<B>Unable to start [mode.name].</B> Not enough players, [mode.required_players] players needed. Reverting to pre-game lobby."
-		del(mode)
-		current_state = GAME_STATE_PREGAME
-		job_master.ResetOccupations()
-		return 0
+		if (!src.mode.can_start())
+			world << "<B>Unable to start [mode.name].</B> Not enough players, [mode.required_players] players and [mode.required_enemies] eligible antagonists needed. Reverting to pre-game lobby."
+			del(mode)
+			current_state = GAME_STATE_PREGAME
+			job_master.ResetOccupations()
+			return 0
 
 	//Configure mode and assign player to special mode stuff
-	job_master.DivideOccupations() //Distribute jobs
-	var/can_continue = src.mode.pre_setup()//Setup special modes
+	var/can_continue = 0
+	if (src.mode.pre_setup_before_jobs)	can_continue = src.mode.pre_setup()
+	job_master.DivideOccupations() 				//Distribute jobs
+	if (!src.mode.pre_setup_before_jobs)	can_continue = src.mode.pre_setup()
+
 	if(!can_continue)
 		del(mode)
 		current_state = GAME_STATE_PREGAME

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -4,9 +4,11 @@
 /datum/game_mode/malfunction
 	name = "AI malfunction"
 	config_tag = "malfunction"
-	required_players = 20
+	antag_flag = BE_MALF
+	required_players = 20 //##values changed for debugging, if you see this in a PR, tell me, then laugh at me.
 	required_enemies = 1
 	recommended_enemies = 1
+	pre_setup_before_jobs = 1
 
 	uplink_welcome = "Crazy AI Uplink Console:"
 	uplink_uses = 10
@@ -26,15 +28,35 @@
 	world << "<B>The AI on the satellite has malfunctioned and must be destroyed.</B>"
 	world << "The AI satellite is deep in space and can only be accessed with the use of a teleporter! You have [AI_win_timeleft/60] minutes to disable it."
 
+/datum/game_mode/malfunction/can_start()
+	//Triumvirate?
+	if (ticker.triai == 1)
+		required_enemies = 3
+	required_players = max(required_enemies+1, required_players) //to prevent issues if players are set too low
+	return ..()
+
+/datum/game_mode/malfunction/get_players_for_role(var/role = BE_MALF)
+	for(var/mob/new_player/player in player_list)
+		if(player.client && player.ready)
+			if(player.client.prefs.be_special & BE_MALF)
+				if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, "AI"))
+					antag_candidates += player.mind
+	antag_candidates = shuffle(antag_candidates)
+	return antag_candidates
 
 /datum/game_mode/malfunction/pre_setup()
-	for(var/mob/new_player/player in player_list)
-		if(player.mind && player.mind.assigned_role == "AI")
-			malf_ai+=player.mind
-			log_game("[malf_ai.key] (ckey) has been selected as a malf AI")
-	if(malf_ai.len)
-		return 1
-	return 0
+	var/datum/mind/chosen_ai
+	for(var/i = required_enemies, i > 0, i--)
+		chosen_ai=pick(antag_candidates)
+		malf_ai += chosen_ai
+		antag_candidates -= malf_ai
+	if (malf_ai.len < required_enemies)
+		return 0
+	for(var/datum/mind/ai_mind in malf_ai)
+		ai_mind.assigned_role = "MODE" //So they aren't chosen for other jobs.
+		ai_mind.special_role = "malfunctioning AI"//So they actually have a special role/N
+		log_game("[ai_mind.key] (ckey) has been selected as a malf AI")
+	return 1
 
 
 /datum/game_mode/malfunction/post_setup()

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -8,6 +8,8 @@
 	required_players = 20 // 20 players - 5 players to be the nuke ops = 15 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
+	pre_setup_before_jobs = 1
+	antag_flag = BE_OPERATIVE
 
 	uplink_welcome = "Corporate Backed Uplink Console:"
 	uplink_uses = 40
@@ -20,45 +22,32 @@
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 
-
 /datum/game_mode/nuclear/announce()
 	world << "<B>The current game mode is - Nuclear Emergency!</B>"
 	world << "<B>A [syndicate_name()] Strike Force is approaching [station_name()]!</B>"
 	world << "A nuclear explosive was being transported by Nanotrasen to a military base. The transport ship mysteriously lost contact with Space Traffic Control (STC). About that time a strange disk was discovered around [station_name()]. It was identified by Nanotrasen as a nuclear auth. disk and now Syndicate Operatives have arrived to retake the disk and detonate SS13! Also, most likely Syndicate star ships are in the vicinity so take care not to lose the disk!\n<B>Syndicate</B>: Reclaim the disk and detonate the nuclear bomb anywhere on SS13.\n<B>Personnel</B>: Hold the disk and <B>escape with the disk</B> on the shuttle!"
 
-/datum/game_mode/nuclear/can_start()//This could be better, will likely have to recode it later
-	if(!..())
-		return 0
-
-	var/list/possible_syndicates = get_players_for_role(BE_OPERATIVE)
+/datum/game_mode/nuclear/pre_setup()
 	var/agent_number = 0
-
-	if(possible_syndicates.len < 1)
-		return 0
-
-	if(possible_syndicates.len > agents_possible)
+	if(antag_candidates.len > agents_possible)
 		agent_number = agents_possible
 	else
-		agent_number = possible_syndicates.len
+		agent_number = antag_candidates.len
 
 	var/n_players = num_players()
 	if(agent_number > n_players)
 		agent_number = n_players/2
 
 	while(agent_number > 0)
-		var/datum/mind/new_syndicate = pick(possible_syndicates)
+		var/datum/mind/new_syndicate = pick(antag_candidates)
 		syndicates += new_syndicate
-		possible_syndicates -= new_syndicate //So it doesn't pick the same guy each time.
+		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
 		agent_number--
 
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = "MODE" //So they aren't chosen for other jobs.
 		synd_mind.special_role = "Syndicate"//So they actually have a special role/N
 		log_game("[synd_mind.key] (ckey) has been selected as a nuclear operative")
-	return 1
-
-
-/datum/game_mode/nuclear/pre_setup()
 	return 1
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -14,6 +14,7 @@
 /datum/game_mode/revolution
 	name = "revolution"
 	config_tag = "revolution"
+	antag_flag = BE_REV
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
 	required_players = 20
 	required_enemies = 3
@@ -44,28 +45,26 @@
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
-	var/list/datum/mind/possible_headrevs = get_players_for_role(BE_REV)
-
 	var/head_check = 0
 	for(var/mob/new_player/player in player_list)
 		if(player.mind.assigned_role in command_positions)
 			head_check = 1
 			break
 
-	for(var/datum/mind/player in possible_headrevs)
+	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing heads and such from the list
 			if(player.assigned_role == job)
-				possible_headrevs -= player
+				antag_candidates -= player
 
 	for (var/i=1 to max_headrevs)
-		if (possible_headrevs.len==0)
+		if (antag_candidates.len==0)
 			break
-		var/datum/mind/lenin = pick(possible_headrevs)
-		possible_headrevs -= lenin
+		var/datum/mind/lenin = pick(antag_candidates)
+		antag_candidates -= lenin
 		head_revolutionaries += lenin
 		log_game("[lenin.key] (ckey) has been selected as a head rev")
 
-	if((head_revolutionaries.len==0)||(!head_check))
+	if((head_revolutionaries.len < required_enemies)||(!head_check))
 		return 0
 
 	return 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -6,6 +6,7 @@
 /datum/game_mode/traitor
 	name = "traitor"
 	config_tag = "traitor"
+	antag_flag = BE_TRAITOR
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")//AI", Currently out of the list as malf does not work for shit
 	required_players = 0
@@ -32,12 +33,6 @@
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
-	var/list/possible_traitors = get_players_for_role(BE_TRAITOR)
-
-	// stop setup if no possible traitors
-	if(!possible_traitors.len)
-		return 0
-
 	var/num_traitors = 1
 
 	if(config.traitor_scaling_coeff)
@@ -45,22 +40,22 @@
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
 
-	for(var/datum/mind/player in possible_traitors)
+	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)
 			if(player.assigned_role == job)
-				possible_traitors -= player
+				antag_candidates -= player
 
 	for(var/j = 0, j < num_traitors, j++)
-		if (!possible_traitors.len)
+		if (!antag_candidates.len)
 			break
-		var/datum/mind/traitor = pick(possible_traitors)
+		var/datum/mind/traitor = pick(antag_candidates)
 		traitors += traitor
 		traitor.special_role = traitor_name
 		log_game("[traitor.key] (ckey) has been selected as a [traitor_name]")
-		possible_traitors.Remove(traitor)
+		antag_candidates.Remove(traitor)
 
 
-	if(!traitors.len)
+	if(traitors.len < required_enemies)
 		return 0
 	return 1
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -4,9 +4,11 @@
 /datum/game_mode/wizard
 	name = "wizard"
 	config_tag = "wizard"
+	antag_flag = BE_WIZARD
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
+	pre_setup_before_jobs = 1
 
 	uplink_welcome = "Wizardly Uplink Console:"
 	uplink_uses = 10
@@ -16,19 +18,13 @@
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
-
 /datum/game_mode/wizard/announce()
 	world << "<B>The current game mode is - Wizard!</B>"
 	world << "<B>There is a \red SPACE WIZARD\black on the station. You can't let him achieve his objective!</B>"
 
+/datum/game_mode/wizard/pre_setup()
 
-/datum/game_mode/wizard/can_start()//This could be better, will likely have to recode it later
-	if(!..())
-		return 0
-	var/list/datum/mind/possible_wizards = get_players_for_role(BE_WIZARD)
-	if(possible_wizards.len==0)
-		return 0
-	var/datum/mind/wizard = pick(possible_wizards)
+	var/datum/mind/wizard = pick(antag_candidates)
 	wizards += wizard
 	modePlayer += wizard
 	wizard.assigned_role = "MODE" //So they aren't chosen for other jobs.
@@ -36,12 +32,8 @@
 	if(wizardstart.len == 0)
 		wizard.current << "<B>\red A starting location for you could not be found, please report this bug!</B>"
 		return 0
-	return 1
-
-
-/datum/game_mode/wizard/pre_setup()
-	for(var/datum/mind/wizard in wizards)
-		wizard.current.loc = pick(wizardstart)
+	for(var/datum/mind/wiz in wizards)
+		wiz.current.loc = pick(wizardstart)
 
 	return 1
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -144,29 +144,24 @@ var/global/datum/controller/occupations/job_master
 		var/datum/job/job = GetJob("AI")
 		if(!job)	return 0
 		if((job.title == "AI") && (config) && (!config.allow_ai))	return 0
+		if(ticker.mode.name == "AI malfunction")	// malf. AIs are pre-selected before jobs
+			for (var/datum/mind/mAI in ticker.mode.malf_ai)
+				AssignRole(mAI.current, "AI")
+				ai_selected++
+			if(ai_selected)	return 1
+			return 0
 
 		for(var/i = job.total_positions, i > 0, i--)
 			for(var/level = 1 to 3)
 				var/list/candidates = list()
-				if(ticker.mode.name == "AI malfunction")//Make sure they want to malf if its malf
-					candidates = FindOccupationCandidates(job, level, BE_MALF)
-				else
-					candidates = FindOccupationCandidates(job, level)
+				candidates = FindOccupationCandidates(job, level)
 				if(candidates.len)
 					var/mob/new_player/candidate = pick(candidates)
 					if(AssignRole(candidate, "AI"))
 						ai_selected++
 						break
-			//Malf NEEDS an AI so force one if we didn't get a player who wanted it
-			if((ticker.mode.name == "AI malfunction")&&(!ai_selected))
-				unassigned = shuffle(unassigned)
-				for(var/mob/new_player/player in unassigned)
-					if(jobban_isbanned(player, "AI"))	continue
-					if(AssignRole(player, "AI"))
-						ai_selected++
-						break
-			if(ai_selected)	return 1
-			return 0
+		if(ai_selected)	return 1
+		return 0
 
 
 /** Proc DivideOccupations

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -30,3 +30,4 @@ rockdtben = Game Master
 sieve = Game Master
 aranclanos = Game Master
 intigracy = Game Master
+dumpdavidson = Game Master


### PR DESCRIPTION
Antags that are unrelated to the jobs and malfunctioning AI (Malf, Blob, Nuke, Wizard) are now chosen prior to job selection. This means you will have an equal chance to be a malf. AI if you have that turned on (Fix to issue #1127).
Fix to rare cases in which you would have a game start with less then three head revs or cultists (game will go back to lobby in this case).
People jobbanned from a certain antag position are now never considered for it.
can_start() is no longer directly called if the mode is secret since get_runnable_modes() does that for you anyway.
Added a message for admins if forcing the secret game mode was not successful.
Rounds with an AI triumvirate will now require at least 3 people with the setting on to start as malfunction mode.
edit: also sets me in admins.txt

What could still be done:
Move all antag selections prior to job selection for truly equal opportunity murderboner.
Proper enforcement of player antag preferences (currently any gamemode beside malf will select players without the special role candidacy on as a last resort).
