### PR TITLE
Access Cleanup

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -42,8 +42,6 @@
 /var/const/access_cmo = 40
 /var/const/access_qm = 41
 /var/const/access_court = 42
-/var/const/access_clown = 43
-/var/const/access_mime = 44
 /var/const/access_surgery = 45
 /var/const/access_theatre = 46
 /var/const/access_research = 47
@@ -204,13 +202,13 @@
 	            access_teleporter, access_eva, access_heads, access_captain, access_all_personal_lockers,
 	            access_tech_storage, access_chapel_office, access_atmospherics, access_kitchen,
 	            access_bar, access_janitor, access_crematorium, access_robotics, access_cargo, access_construction,
-	            access_hydroponics, access_library, access_lawyer, access_virology, access_cmo, access_qm, access_clown, access_mime, access_surgery,
+	            access_hydroponics, access_library, access_lawyer, access_virology, access_cmo, access_qm, access_surgery,
 	            access_theatre, access_research, access_mining, access_mailsorting,
 	            access_heads_vault, access_mining_station, access_xenobiology, access_ce, access_hop, access_hos, access_RC_announce,
 	            access_keycard_auth, access_tcomsat, access_gateway)
 
 /proc/get_all_centcom_access()
-	return list(access_cent_general, access_cent_thunder, access_cent_specops, access_cent_medical, access_cent_living, access_cent_storage, access_cent_teleporter, access_cent_creed, access_cent_captain)
+	return list(access_cent_general, access_cent_thunder, access_cent_specops, access_cent_medical, access_cent_living, access_cent_storage, access_cent_teleporter, access_cent_captain)
 
 /proc/get_all_syndicate_access()
 	return list(access_syndicate)
@@ -230,7 +228,7 @@
 		if(5) //command
 			return list(access_heads, access_RC_announce, access_keycard_auth, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_gateway, access_all_personal_lockers, access_heads_vault, access_hop, access_captain)
 		if(6) //station general
-			return list(access_kitchen,access_bar, access_hydroponics, access_janitor, access_chapel_office, access_crematorium, access_library, access_theatre, access_lawyer, access_clown, access_mime)
+			return list(access_kitchen,access_bar, access_hydroponics, access_janitor, access_chapel_office, access_crematorium, access_library, access_theatre, access_lawyer)
 		if(7) //supply
 			return list(access_mailsorting, access_mining, access_mining_station, access_cargo, access_qm)
 
@@ -338,10 +336,6 @@
 			return "CMO Office"
 		if(access_qm)
 			return "Quartermaster"
-		if(access_clown)
-			return "HONK! Access"
-		if(access_mime)
-			return "Silent Access"
 		if(access_surgery)
 			return "Surgery"
 		if(access_theatre)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -60,13 +60,13 @@
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 	minimal_access = list(access_security, access_sec_doors, access_court,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
 
 	equip(var/mob/living/carbon/human/H)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -186,8 +186,8 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	access = list(access_clown, access_theatre, access_maint_tunnels)
-	minimal_access = list(access_clown, access_theatre)
+	access = list(access_theatre, access_maint_tunnels)
+	minimal_access = list(access_theatre)
 
 
 	equip(var/mob/living/carbon/human/H)
@@ -218,8 +218,8 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	access = list(access_mime, access_theatre, access_maint_tunnels)
-	minimal_access = list(access_mime, access_theatre)
+	access = list(access_theatre, access_maint_tunnels)
+	minimal_access = list(access_theatre)
 
 
 	equip(var/mob/living/carbon/human/H)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -88,7 +88,7 @@
 			shot_delay = 6//Longer shot delay because JESUS CHRIST
 			check_records = 0//Don't actively target people set to arrest
 			arrest_type = 1//Don't even try to cuff
-			req_access = list(access_maint_tunnels,access_clown,access_mime)
+			req_access = list(access_maint_tunnels, access_theatre)
 			arrest_type = 1
 			if((lasercolor == "b") && (name == "ED-209 Security Robot"))//Picks a name if there isn't already a custome one
 				name = pick("BLUE BALLER","SANIC","BLUE KILLDEATH MURDERBOT")

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -48,8 +48,6 @@ for reference:
 	access_cmo = 40
 	access_qm = 41
 	access_court = 42
-	access_clown = 43
-	access_mime = 44
 
 */
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -8,7 +8,7 @@
 	m_amt = 50
 	g_amt = 50
 
-	req_access = list(access_engine)
+	req_access = list(access_maint_tunnels)
 
 	var/list/conf_access = null
 	var/last_configurator = null

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -74,7 +74,7 @@
 			if(/obj/item/weapon/gun/energy/laser/bluetag)
 				eprojectile = /obj/item/projectile/omnitag	//This bolt will stun ERRYONE with a vest
 				lasercolor = "b"
-				req_access = list(access_maint_tunnels,access_clown,access_mime)
+				req_access = list(access_maint_tunnels, access_theatre)
 				check_records = 0
 				criminals = 0
 				auth_weapons = 1
@@ -85,7 +85,7 @@
 			if(/obj/item/weapon/gun/energy/laser/redtag)
 				eprojectile = /obj/item/projectile/omnitag
 				lasercolor = "r"
-				req_access = list(access_maint_tunnels,access_clown,access_mime)
+				req_access = list(access_maint_tunnels, access_theatre)
 				check_records = 0
 				criminals = 0
 				auth_weapons = 1

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -9,7 +9,7 @@
 	damage_absorption = list("brute"=1.2,"fire"=1.5,"bullet"=1,"laser"=1,"energy"=1,"bomb"=1)
 	max_temperature = 25000
 	infra_luminosity = 5
-	operation_req_access = list(access_clown)
+	operation_req_access = list(access_theatre)
 	wreckage = /obj/structure/mecha_wreckage/honker
 	add_req_access = 0
 	max_equip = 3


### PR DESCRIPTION
HONK! Access and Mime Access merged into Theatre access. They were used interchangably in most cases, with the exception being the Honker mech which is a joke item anyway.

Airlock Electronics now require only maintenance access instead of engine access.
