### PR TITLE
Runtime fixes

### DIFF
--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -25,3 +25,8 @@
 
 	user.set_machine(src)
 	song.interact(user)
+
+/obj/item/device/violin/Del()
+	if(song)
+		del(song)
+	..()

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -333,3 +333,8 @@
 				src.anchored = 1
 	else
 		..()
+
+/obj/structure/piano/Del()
+	if(song)
+		del(song)
+	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -401,7 +401,7 @@
 				return
 			gib()
 			return
-	else
+	else if(O)
 		if(O.force)
 			var/damage = O.force
 			if (O.damtype == HALLOSS)

--- a/maps/RandomZLevels/stationCollision.dmm
+++ b/maps/RandomZLevels/stationCollision.dmm
@@ -218,7 +218,7 @@
 "ej" = (/turf/simulated/floor{dir = 1; icon_state = "blue"},/area/awaymission/northblock)
 "ek" = (/turf/simulated/floor{dir = 5; icon_state = "blue"},/area/awaymission/northblock)
 "el" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/airless{icon_state = "damaged3"},/area/awaymission/northblock)
-"em" = (/obj/structure/window/reinforced,/obj/machinery/computer/aiupload,/turf/simulated/floor{icon_state = "showroomfloor"},/area/awaymission/research)
+"em" = (/obj/structure/window/reinforced,/obj/machinery/computer/upload/ai,/turf/simulated/floor{icon_state = "showroomfloor"},/area/awaymission/research)
 "en" = (/obj/structure/window/reinforced,/obj/machinery/door/window/brigdoor/eastleft,/turf/simulated/floor{icon_state = "showroomfloor"},/area/awaymission/research)
 "eo" = (/obj/machinery/atmospherics/unary/cold_sink/freezer{current_temperature = 80},/turf/simulated/floor{icon_state = "showroomfloor"},/area/awaymission/research)
 "ep" = (/obj/machinery/atmospherics/unary/vent_pump,/turf/simulated/floor{icon_state = "showroomfloor"},/area/awaymission/research)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1132,4 +1132,10 @@
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
 #include "maps\tgstation.2.1.2.dmm"
+#include "maps\RandomZLevels\Academy.dm"
+#include "maps\RandomZLevels\blackmarketpackers.dm"
+#include "maps\RandomZLevels\challenge.dm"
+#include "maps\RandomZLevels\spacebattle.dm"
+#include "maps\RandomZLevels\stationCollision.dm"
+#include "maps\RandomZLevels\wildwest.dm"
 // END_INCLUDE


### PR DESCRIPTION
Ticked the away mission code files and made them work properly
Made instruments delete their song datums rather than let those datums keep trying to access vars of the now-null instrument. Also means they'll stop playing.
Simple animals were runtiming if they got hit by something, but that something was out of the mob's hands by the time the attack proc was ran. Edge case!
