### PR TITLE
Adds cryo verb to eject items inside, non-human occupants are ejected

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -69,10 +69,9 @@
 	..()
 	
 	if(in_range(usr, src))
-		if(contents.len > 0)
-			usr << "You can just about make out some loose objects floating in the murk:"
+		usr << "You can just about make out some loose objects floating in the murk:"
 		for(var/obj/O in src)
-			if(!istype(O, /obj/item/weapon/reagent_containers/glass))
+			if(O != beaker)
 				usr << O.name
 		for(var/mob/M in src)
 			if(M != occupant)
@@ -349,7 +348,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/eject_contents()
 	for(var/obj/O in src)
-		if(!istype(O, /obj/item/weapon/reagent_containers/glass))
+		if(O != beaker)
 			O.loc = get_step(loc, SOUTH)
 	for(var/mob/M in contents) 
 		M.loc = get_step(loc, SOUTH)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -33,6 +33,10 @@
 		updateDialog()
 		return
 
+	for(var/mob/M in contents) 
+		if(M != occupant)
+			M.loc = get_step(loc, SOUTH)
+			update_icon()
 	if(air_contents)
 		temperature_archived = air_contents.temperature
 		heat_gas_contents()
@@ -59,6 +63,17 @@
 	go_out()
 	return
 
+/obj/machinery/atmospherics/unary/cryo_cell/examine()
+	..()
+	
+	if(in_range(usr, src))
+		if(contents.len > 0)
+			usr << "You can just about make out some loose objects floating in the murk:"
+		for(var/obj/O in src)
+			if(!istype(O, /obj/item/weapon/reagent_containers/glass))
+				usr << O.name
+	else
+		usr << "<span class='notice'>Too far away to view contents.</span>"
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
 	ui_interact(user)
@@ -275,9 +290,6 @@
 	if(occupant)
 		usr << "<span class='notice'>[src] is already occupied.</span>"
 		return
-	if(M.abiotic())
-		usr << "<span class='notice'>Subject may not have abiotic items on.</span>"
-		return
 	if(!node)
 		usr << "<span class='notice'>The cell is not correctly connected to its pipe network!</span>"
 		return
@@ -327,3 +339,12 @@
 	if(usr.stat || stat & (NOPOWER|BROKEN))
 		return
 	put_mob(usr)
+
+/obj/machinery/atmospherics/unary/cryo_cell/verb/eject_contents()
+	set name = "Eject contents"
+	set category = "Object"
+	set src in oview(1)
+
+	for(var/obj/O in src)
+		if(!istype(O, /obj/item/weapon/reagent_containers/glass))
+			O.loc = get_step(loc, SOUTH)


### PR DESCRIPTION
Fixes #1363
Cryo tubes now have verbs to "eject contents", which spit out all of the objects that have been dropped or thrown inside of it. Examining the cryo tube up close now lists those contents, if any, as well.
Additionally, the tube will not complain about abiotic contents if the attempted occupant has an item in their hand.

Now for the part I'm not too sure about: Any non-human occupant is immediately spat out upon transformation. The disadvantage is that users have no chance to try and imprison any threats. The plus side is that the code doesn't become butchered and hacky. Please do leave your thoughts regarding this change.

This does NOT fix items and mobs disappearing alongside the cryotube being destroyed, since some confirmation on the expected behaviour would be preferred before anything is implemented.
