### PR TITLE
Gives Engiborgs Floortiles

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -243,7 +243,7 @@
 			// ^ makes sinle list of active (occupant.contents) and inactive modules (occupant.module.modules)
 			for(var/obj/O in um)
 				// Engineering
-				if(istype(O,/obj/item/stack/sheet/metal) || istype(O,/obj/item/stack/sheet/rglass) || istype(O,/obj/item/stack/rods) || istype(O,/obj/item/weapon/cable_coil))
+				if(istype(O,/obj/item/stack/sheet/metal) || istype(O,/obj/item/stack/sheet/rglass) || istype(O,/obj/item/stack/rods) || istype(O,/obj/item/weapon/cable_coil)|| istype(O,/obj/item/stack/tile/plasteel))
 					if(O:amount < 50)
 						O:amount += 1
 				// Security

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -13,14 +13,8 @@
 	max_amount = 60
 
 /obj/item/stack/tile/plasteel/cyborg
-	name = "floor tiles"
-	singular_name = "floor tile"
 	desc = "The ground you walk on" //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
-	icon_state = "tile"
-	force = 6.0
-	m_amt = 0
-	throwforce = 15.0
-	flags = FPRINT | TABLEPASS | CONDUCT
+	m_amt = 0 // All other Borg versions of items have no Metal or Glass - RR
 	max_amount = 50
 
 /obj/item/stack/tile/plasteel/New(var/loc, var/amount=null)

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -12,6 +12,17 @@
 	flags = FPRINT | TABLEPASS | CONDUCT
 	max_amount = 60
 
+/obj/item/stack/tile/plasteel/cyborg
+	name = "floor tiles"
+	singular_name = "floor tile"
+	desc = "The ground you walk on" //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
+	icon_state = "tile"
+	force = 6.0
+	m_amt = 0
+	throwforce = 15.0
+	flags = FPRINT | TABLEPASS | CONDUCT
+	max_amount = 50
+
 /obj/item/stack/tile/plasteel/New(var/loc, var/amount=null)
 	..()
 	src.pixel_x = rand(1, 14)
@@ -63,3 +74,6 @@
 //	var/turf/simulated/floor/W = S.ReplaceWithFloor()
 //	W.make_plating()
 	return
+
+
+

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -53,3 +53,15 @@
 	throw_range = 20
 	flags = FPRINT | TABLEPASS | CONDUCT
 	max_amount = 60
+
+
+/obj/item/stack/tile/plasteel/cyborg
+	name = "floor tiles"
+	singular_name = "floor tile"
+	desc = "The ground you walk on" //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
+	icon_state = "tile"
+	force = 6.0
+	m_amt = 0
+	throwforce = 15.0
+	flags = FPRINT | TABLEPASS | CONDUCT
+	max_amount = 50

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -53,15 +53,3 @@
 	throw_range = 20
 	flags = FPRINT | TABLEPASS | CONDUCT
 	max_amount = 60
-
-
-/obj/item/stack/tile/plasteel/cyborg
-	name = "floor tiles"
-	singular_name = "floor tile"
-	desc = "The ground you walk on" //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
-	icon_state = "tile"
-	force = 6.0
-	m_amt = 0
-	throwforce = 15.0
-	flags = FPRINT | TABLEPASS | CONDUCT
-	max_amount = 50

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -108,6 +108,10 @@
 		W.amount = 50
 		modules += W
 
+		var/obj/item/stack/tile/plasteel/cyborg/F = new /obj/item/stack/tile/plasteel/cyborg(src) //"Plasteel" is the normal metal floor tile, Don't be confused - RR
+		F.amount = 50
+		modules += F //'F' for floor tile - RR
+
 
 	respawn_consumable(var/mob/living/silicon/robot/R)
 		var/list/what = list (

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -119,6 +119,7 @@
 			/obj/item/stack/sheet/rglass,
 			/obj/item/stack/rods,
 			/obj/item/weapon/cable_coil,
+			/obj/item/stack/tile/plasteel/cyborg,
 		)
 		for(var/T in what)
 			if(!(locate(T) in modules))


### PR DESCRIPTION
Gives Engiborgs Floortiles, not sure if this is actually an issue but as an Engiborg I hate having to literally beg to get a human to place down the floor tiles I can create with my metal, so now Engiborgs have a floor tile Item.

Notes: 
Yes its a different floor tile item, just like /metal/cyborg its it's own thing.
Yes it replenishes from the Recharger.
I changed the description of the Cyborg floor tile due to cyborg's being unable to throw.
Plasteel is the Normal metal floor tiles, so don't get confused reading the commit.

Forum Thread: http://www.ss13.eu/phpbb/viewtopic.php?f=12&p=43055#p43055

CLEAR TO MERGE! (unless you maintainers now something I don't)
