### PR TITLE
Made door crushing better. Ready to merge. 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -996,17 +996,7 @@ About the new airlock wires panel:
 				close()
 			return
 
-	for(var/mob/living/M in get_turf(src))
-		if(isrobot(M))
-			M.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-		else
-			M.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-			M.SetStunned(5)
-			M.SetWeakened(5)
-			M.emote("scream")
-		var/turf/location = src.loc
-		if(istype(location, /turf/simulated))
-			location.add_blood(M)
+	crush()
 
 	use_power(50)
 	if(istype(src, /obj/machinery/door/airlock/glass))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -237,6 +237,19 @@
 	update_freelok_sight()
 	return
 
+/obj/machinery/door/proc/crush()
+	for(var/mob/living/L in get_turf(src))
+		if(isrobot(L))
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
+		else
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
+			L.SetStunned(5)
+			L.SetWeakened(5)
+			L.emote("scream")
+			var/turf/location = src.loc
+			if(istype(location, /turf/simulated)) //Robots don't have blood
+				location.add_blood(L)
+
 /obj/machinery/door/proc/requiresID()
 	return 1
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -239,7 +239,7 @@
 
 /obj/machinery/door/proc/crush()
 	for(var/mob/living/L in get_turf(src))
-		else if(isalien(L))  //For xenos
+		if(isalien(L))  //For xenos
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 1.5) //Xenos go into crit after aproximately the same amount of crushes as humans.
 			L.emote("roar")
 		else if(ishuman(L)) //For humans

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -239,16 +239,21 @@
 
 /obj/machinery/door/proc/crush()
 	for(var/mob/living/L in get_turf(src))
-		if(isrobot(L))
-			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-		else
-			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-			L.SetStunned(5)
-			L.SetWeakened(5)
+		else if(isalien(L))  //For xenos
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 1.5) //Xenos go into crit after aproximately the same amount of crushes as humans.
+			L.emote("roar")
+		else if(ishuman(L)) //For humans
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE) 
 			L.emote("scream")
-			var/turf/location = src.loc
-			if(istype(location, /turf/simulated)) //Robots don't have blood
-				location.add_blood(L)
+			L.Weaken(5)
+		else if(ismonkey(L)) //For monkeys
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
+			L.Weaken(5)
+		else //for simple_animals & borgs
+			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
+		var/turf/location = src.loc
+		if(istype(location, /turf/simulated)) //add_blood doesn't work for borgs/xenos, but add_blood_floor does.
+			location.add_blood_floor(L)
 
 /obj/machinery/door/proc/requiresID()
 	return 1

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -66,6 +66,7 @@
 
 	operating = 1
 	flick("closing", src)
+	crush()
 	icon_state = "closed"
 	density = 1
 	explosion_resistance = initial(explosion_resistance)


### PR DESCRIPTION
Fixes #661 and is better than #821.

Again because git is a steaming pile of shit.

New proc of /obj/machinery/door: crush(). Crushes any mob on the tile. Called right after initiating the closing animation for poddoors and shutters and on the normal location for airlocks.
