### PR TITLE
Lemon-Lime added to vending machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -91,7 +91,7 @@
 
 		var/atom/temp = new typepath(null)
 		var/datum/data/vending_product/R = new /datum/data/vending_product()
-		R.product_name = temp.name
+		R.product_name = initial(temp.name)
 		R.product_path = typepath
 		R.amount = amount
 		R.display_color = pick("red","blue","green")

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -466,7 +466,8 @@
 	product_ads = "Refreshing!;Hope you're thirsty!;Over 1 million drinks sold!;Thirsty? Why not cola?;Please, have a drink!;Drink up!;The best drinks in space."
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola = 10,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_mountain_wind = 10,
 					/obj/item/weapon/reagent_containers/food/drinks/soda_cans/dr_gibb = 10,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/starkist = 10,
-					/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_up = 10)
+					/obj/item/weapon/reagent_containers/food/drinks/soda_cans/space_up = 10,
+					/obj/item/weapon/reagent_containers/food/drinks/soda_cans/lemon_lime = 10)
 	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/soda_cans/thirteenloko = 5)
 
 //This one's from bay12

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -321,7 +321,7 @@
 		..()
 		reagents.add_reagent("sodawater", 50)
 
-/obj/item/weapon/reagent_containers/food/drinks/soda_cans/lemon_line
+/obj/item/weapon/reagent_containers/food/drinks/soda_cans/lemon_lime
 	name = "Lemon-Lime"
 	desc = "You wanted ORANGE. It gave you Lemon Lime."
 	icon_state = "lemon-lime"

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -322,11 +322,12 @@
 		reagents.add_reagent("sodawater", 50)
 
 /obj/item/weapon/reagent_containers/food/drinks/soda_cans/lemon_lime
-	name = "Lemon-Lime"
+	name = "Orange"
 	desc = "You wanted ORANGE. It gave you Lemon Lime."
 	icon_state = "lemon-lime"
 	New()
 		..()
+		name = "Lemon-Lime"
 		reagents.add_reagent("lemon_lime", 30)
 		src.pixel_x = rand(-10.0, 10)
 		src.pixel_y = rand(-10.0, 10)


### PR DESCRIPTION
Added Lemon-Lime cans to vending machines, because... I'm not aware of any reason for them not to be there. And you can use them in Snow Whites!

Changed a typo in the object path as well, but this only affects Meta's map, who is aware of this change and will adjust his future maps accordingly.
