### PR TITLE
Fixed cable coils disappearing when combined

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -305,7 +305,7 @@
 		//handle mob icon update
 		if(ismob(loc))
 			var/mob/M = loc
-			M.drop_item(src)
+			M.u_equip(src)
 		del(src)
 	else
 		amount -= used


### PR DESCRIPTION
Fixes #1171 and #930
Cable pieces no longer disappear when combining them

Another exciting fix.
