### PR TITLE
Clickfix

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -9,7 +9,11 @@
 
 	Note that AI have no need for the adjacency proc, and so this proc is a lot cleaner.
 */
-/mob/living/silicon/ai/DblClickOn(var/atom/A)
+/mob/living/silicon/ai/DblClickOn(var/atom/A, params)
+	if(client.buildmode) // comes after object.Click to allow buildmode gui objects to be clicked
+		build_click(src, client.buildmode, params, A)
+		return
+
 	if(control_disabled || stat) return
 	next_move = world.time + 9
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,4 +1,19 @@
-/mob/dead/observer/DblClickOn(var/atom/A)
+/client/var/inquisitive_ghost = 1
+/mob/dead/observer/verb/toggle_inquisition() // warning: unexpected inquisition
+	set name = "Toggle Inquisitiveness"
+	set desc = "Sets whether your ghost examines everything on click by default"
+	set category = "Ghost"
+	if(!client) return
+	client.inquisitive_ghost = !client.inquisitive_ghost
+	if(client.inquisitive_ghost)
+		src << "\blue You will now examine everything you click on."
+	else
+		src << "\blue You will no longer examine things you click on."
+
+/mob/dead/observer/DblClickOn(var/atom/A, var/params)
+	if(client.buildmode)
+		build_click(src, client.buildmode, params, A)
+		return
 	if(can_reenter_corpse && mind && mind.current)
 		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it
 			reenter_corpse()						// (cloning scanner, body bag, closet, mech, etc)
@@ -12,7 +27,10 @@
 	else
 		loc = get_turf(A)
 
-/mob/dead/observer/ClickOn(var/atom/A)
+/mob/dead/observer/ClickOn(var/atom/A, var/params)
+	if(client.buildmode)
+		build_click(src, client.buildmode, params, A)
+		return
 	if(world.time <= next_move) return
 	next_move = world.time + 8
 	// You are responsible for checking config.ghost_interaction when you override this function
@@ -41,8 +59,9 @@
 			following = null
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
-/atom/proc/attack_ghost(mob/user as mob)
-	examine()
+/atom/proc/attack_ghost(mob/dead/observer/user as mob)
+	if(user.client && user.client.inquisitive_ghost)
+		examine()
 	return
 
 // ---------------------------------------

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -495,7 +495,7 @@
 		return
 	if (pulling.anchored)
 		return
-	if (pulling.Adjacent(src))
+	if (!pulling.Adjacent(src))
 		return
 	if (ismob(pulling))
 		var/mob/M = pulling


### PR DESCRIPTION
Buildmode works for adminghosts again, sorry I overlooked that my bad.

Fixes a bug where you could not move pulled objects by clicking the turf, it was basically just a not not included where it belonged.

Adds a verb to toggle observer examination.
