### PR TITLE
Fixes and improvements to airlock painters.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1051,9 +1051,10 @@ About the new airlock wires panel:
 	if(istype(C, /obj/item/weapon/airlock_painter))
 		W = C
 	else
+		user << "If you see this, it means airlock/change_paintjob() was called with something other than an airlock painter. Check your code!"
 		return
 
-	if(!W.ink)
+	if(!W.can_use(user))
 		return
 
 	if(glass == 1)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -949,10 +949,7 @@ About the new airlock wires panel:
 					spawn(0)	close(1)
 
 	else if(istype(C, /obj/item/weapon/airlock_painter))
-		var/obj/item/weapon/airlock_painter/WT = C
-		if(WT.ink.charges)
-			src.change_paintjob(user)
-			WT.use()
+		change_paintjob(C, user)
 	else
 		..()
 	return
@@ -1049,30 +1046,46 @@ About the new airlock wires panel:
 	if(!density && !operating && !locked && !welded && autoclose)
 		close()
 
-/obj/machinery/door/airlock/proc/change_paintjob(user)
+/obj/machinery/door/airlock/proc/change_paintjob(obj/item/C as obj, mob/user as mob)
+	var/obj/item/weapon/airlock_painter/W
+	if(istype(C, /obj/item/weapon/airlock_painter))
+		W = C
+	else
+		return
+
+	if(!W.ink)
+		return
+
 	if(glass == 1)
 		//These airlocks have a glass version.
 		var optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining")
 		var paintjob = input(user, "Please select a paintjob for this airlock.") in optionlist
+		if((!in_range(src, usr) && src.loc != usr) || !W.use(user))	return
 		switch(paintjob)
 			if("Default")
 				icon = 'icons/obj/doors/Doorglass.dmi'
 				doortype = 7
+				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Doorengglass.dmi'
 				doortype = 15
+				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmoglass.dmi'
 				doortype = 23
+				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsecglass.dmi'
 				doortype = 16
+				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcomglass.dmi'
 				doortype = 14
+				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormedglass.dmi'
 				doortype = 17
+				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearchglass.dmi'
 				doortype = 21
@@ -1080,44 +1093,57 @@ About the new airlock wires panel:
 			if("Mining")
 				icon = 'icons/obj/doors/Doorminingglass.dmi'
 				doortype = 22
+				heat_proof = 0
 	else
 		//These airlocks have a regular version.
 		var optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining", "Maintenance", "External", "High Security")
 		var paintjob = input(user, "Please select a paintjob for this airlock.") in optionlist
+		if((!in_range(src, usr) && src.loc != usr) || !W.use(user))	return
 		switch(paintjob)
 			if("Default")
 				icon = 'icons/obj/doors/Doorint.dmi'
 				doortype = 0
+				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Dooreng.dmi'
 				doortype = 3
+				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmo.dmi'
 				doortype = 19
+				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsec.dmi'
 				doortype = 2
+				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcom.dmi'
 				doortype = 1
+				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormed.dmi'
 				doortype = 4
+				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearch.dmi'
 				doortype = 20
+				heat_proof = 0
 			if("Mining")
 				icon = 'icons/obj/doors/Doormining.dmi'
 				doortype = 18
+				heat_proof = 0
 			if("Maintenance")
 				icon = 'icons/obj/doors/Doormaint.dmi'
 				doortype = 5
+				heat_proof = 0
 			if("External")
 				icon = 'icons/obj/doors/Doorext.dmi'
 				doortype = 6
+				heat_proof = 0
 			if("High Security")
 				icon = 'icons/obj/doors/hightechsecurity.dmi'
 				doortype = 33
+				heat_proof = 0
 	update_icon()
 
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -948,6 +948,11 @@ About the new airlock wires panel:
 				else
 					spawn(0)	close(1)
 
+	else if(istype(C, /obj/item/weapon/airlock_painter))
+		var/obj/item/weapon/airlock_painter/WT = C
+		if(WT.ink.charges)
+			src.change_paintjob(user)
+			WT.use()
 	else
 		..()
 	return
@@ -1043,3 +1048,76 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/autoclose()
 	if(!density && !operating && !locked && !welded && autoclose)
 		close()
+
+/obj/machinery/door/airlock/proc/change_paintjob(user)
+	if(glass == 1)
+		//These airlocks have a glass version.
+		var optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining")
+		var paintjob = input(user, "Please select a paintjob for this airlock.") in optionlist
+		switch(paintjob)
+			if("Default")
+				icon = 'icons/obj/doors/Doorglass.dmi'
+				doortype = 7
+			if("Engineering")
+				icon = 'icons/obj/doors/Doorengglass.dmi'
+				doortype = 15
+			if("Atmospherics")
+				icon = 'icons/obj/doors/Dooratmoglass.dmi'
+				doortype = 23
+			if("Security")
+				icon = 'icons/obj/doors/Doorsecglass.dmi'
+				doortype = 16
+			if("Command")
+				icon = 'icons/obj/doors/Doorcomglass.dmi'
+				doortype = 14
+			if("Medical")
+				icon = 'icons/obj/doors/Doormedglass.dmi'
+				doortype = 17
+			if("Research")
+				icon = 'icons/obj/doors/Doorresearchglass.dmi'
+				doortype = 21
+				heat_proof = 1
+			if("Mining")
+				icon = 'icons/obj/doors/Doorminingglass.dmi'
+				doortype = 22
+	else
+		//These airlocks have a regular version.
+		var optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining", "Maintenance", "External", "High Security")
+		var paintjob = input(user, "Please select a paintjob for this airlock.") in optionlist
+		switch(paintjob)
+			if("Default")
+				icon = 'icons/obj/doors/Doorint.dmi'
+				doortype = 0
+			if("Engineering")
+				icon = 'icons/obj/doors/Dooreng.dmi'
+				doortype = 3
+			if("Atmospherics")
+				icon = 'icons/obj/doors/Dooratmo.dmi'
+				doortype = 19
+			if("Security")
+				icon = 'icons/obj/doors/Doorsec.dmi'
+				doortype = 2
+			if("Command")
+				icon = 'icons/obj/doors/Doorcom.dmi'
+				doortype = 1
+			if("Medical")
+				icon = 'icons/obj/doors/Doormed.dmi'
+				doortype = 4
+			if("Research")
+				icon = 'icons/obj/doors/Doorresearch.dmi'
+				doortype = 20
+			if("Mining")
+				icon = 'icons/obj/doors/Doormining.dmi'
+				doortype = 18
+			if("Maintenance")
+				icon = 'icons/obj/doors/Doormaint.dmi'
+				doortype = 5
+			if("External")
+				icon = 'icons/obj/doors/Doorext.dmi'
+				doortype = 6
+			if("High Security")
+				icon = 'icons/obj/doors/hightechsecurity.dmi'
+				doortype = 33
+	update_icon()
+
+

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/airlock_painter
 	name = "airlock painter"
-	desc = "This device can change the paintjob of an airlock assembly."
+	desc = "An advanced autopainter preprogrammed with several paintjobs for airlocks. Use it on an airlock during or after construction to change the paintjob."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "paint sprayer"
 	item_state = "paint sprayer"
@@ -15,19 +15,20 @@
 	slot_flags = SLOT_BELT
 
 	var/obj/item/device/toner/ink = null
+	//var/active = 0
 
 	New()
 		ink = new /obj/item/device/toner(src)
 
 	proc/use()
-		if(!ink || ink.charges < 1)
+		if(/*!active ||*/ !ink || ink.charges < 1)
 			return 0
 		else
 			ink.charges--
+			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1)
 			return 1
 
 	examine()
-		set src in usr
 		var/ink_level = "high"
 		if(!ink || ink.charges < 1)
 			ink_level = "empty"
@@ -35,6 +36,17 @@
 			ink_level = "low"
 		else if((ink.charges/ink.max_charges) > 1) //Over 100% (admin var edit)
 			ink_level = "dangerously high"
-		usr << "\icon[src] [src.name] is a small but effective airlock painting tool. Its ink levels look [ink_level]."
+		..()
+		//set src in usr
+		usr << "Its ink levels look [ink_level]."
 		return
 
+	/* Commented out for now. Might remove the comments if people often make mistakes.
+	attack_self(mob/user)
+		if(active)
+			user << "<span class='notice'>You switch [src] off.</span>"
+			active = 0
+		else
+			user << "<span class='notice'>You switch [src] on.</span>"
+			active = 1
+	*/

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -48,13 +48,10 @@
 				user << "<span class='notice'>The airlock painter already contains a toner cardridge.</span>"
 				return
 			user.drop_item()
-			var/obj/item/weapon/airlock_painter/WT = W
-			WT.loc = src
-			ink = WT
+			W.loc = src
+			ink = W
 			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 			user << "<span class='notice'>You install the toner cardridge into the airlock painter.</span>"
-			return
-			user.drop_item()
 
 
 	attack_self(mob/user)

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -19,16 +19,27 @@
 	New()
 		ink = new /obj/item/device/toner(src)
 
+	//This proc doesn't just check if the painter can be used, but also uses it.
+	//Only call this if you are certain that the painter will be used right after this check!
 	proc/use(mob/user as mob)
+		if(can_use(user))
+			ink.charges--
+			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1)
+			return 1
+		else
+			return 0
+
+	//This proc only checks if the painter can be used.
+	//Call this if you don't want the painter to be used right after this check, for example
+	//because you're expecting user input.
+	proc/can_use(mob/user as mob)
 		if(!ink)
 			user << "<span class='notice'>There is no toner cardridge installed installed in \the [name]!</span>"
 			return 0
 		else if(ink.charges < 1)
-			user << "<span class='notice'>\the [name] is out of ink!.</span>"
+			user << "<span class='notice'>\The [name] is out of ink!</span>"
 			return 0
 		else
-			ink.charges--
-			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1)
 			return 1
 
 	examine()

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -38,15 +38,32 @@
 			ink_level = "dangerously high"
 		..()
 		//set src in usr
-		usr << "Its ink levels look [ink_level]."
+		usr << "<span class='notice'>Its ink levels look [ink_level].</span>"
 		return
 
-	/* Commented out for now. Might remove the comments if people often make mistakes.
+	attackby(obj/item/weapon/W, mob/user)
+		..()
+		if(istype(W, /obj/item/device/toner))
+			if(ink)
+				user << "<span class='notice'>The airlock painter already contains a toner cardridge.</span>"
+				return
+			user.drop_item()
+			var/obj/item/weapon/airlock_painter/WT = W
+			WT.loc = src
+			ink = WT
+			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+			user << "<span class='notice'>You install the toner cardridge into the airlock painter.</span>"
+			return
+			user.drop_item()
+
+
 	attack_self(mob/user)
-		if(active)
-			user << "<span class='notice'>You switch [src] off.</span>"
-			active = 0
-		else
-			user << "<span class='notice'>You switch [src] on.</span>"
-			active = 1
-	*/
+		//Change the mode
+		if(ink)
+			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+			var/turf/T = loc
+			if(ismob(T))
+				T = T.loc
+			ink.loc = T
+			ink = null
+			user << "<span class='notice'>You remove the toner cardridge from the airlock painter.</span>"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -312,7 +312,7 @@ obj/structure/door_assembly
 	//Do NOT add your airlock to a list if it does not have a version for that list,
 	//	or you will get broken icons.
 		var/obj/item/weapon/airlock_painter/WT = W
-		if(WT.ink && WT.ink.charges)
+		if(WT.can_use(user))
 			var/icontype
 			var/optionlist
 			if(mineral && mineral == "glass")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -7,14 +7,13 @@ obj/structure/door_assembly
 	density = 1
 	var/state = 0
 	var/mineral = null
-	var/typetext = null
-	var/icontext = null
-	var/base_icon_state = "door_as_0"
-	var/glass_base_icon_state = "door_as_g0"
+	var/typetext = ""
+	var/icontext = ""
+	var/base_icon_state = "door_as_"
+	var/glass_base_icon_state = "door_as_g"
 	var/obj/item/weapon/airlock_electronics/electronics = null
 	var/airlock_type = /obj/machinery/door/airlock //the type path of the airlock once completed
 	var/glass_type = /obj/machinery/door/airlock/glass
-	var/glass = null
 	var/created_name = null
 
 	New()
@@ -27,7 +26,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_com
 		name = "Command Airlock Assembly"
@@ -40,10 +38,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gcom1"
 
 	door_assembly_sec
@@ -57,10 +54,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gsec1"
 
 	door_assembly_eng
@@ -74,10 +70,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_geng1"
 
 	door_assembly_min
@@ -91,10 +86,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gmin1"
 
 	door_assembly_atmo
@@ -108,10 +102,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gatmo1"
 
 	door_assembly_research
@@ -125,10 +118,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gres1"
 
 	door_assembly_science
@@ -142,10 +134,9 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 		glass
-			glass = 1
+			mineral = "glass"
 			icon_state = "door_as_gsci1"
 
 	door_assembly_med
@@ -171,7 +162,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_ext
 		name = "External Airlock Assembly"
@@ -182,7 +172,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_fre
 		name = "Freezer Airlock Assembly"
@@ -193,7 +182,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_hatch
 		name = "Airtight Hatch Assembly"
@@ -204,7 +192,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_mhatch
 		name = "Maintenance Hatch Assembly"
@@ -215,7 +202,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_glass
 		name = "Glass Airlock Assembly"
@@ -299,7 +285,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 	door_assembly_vault
 		name = "Vault Door Assembly"
@@ -310,7 +295,6 @@ obj/structure/door_assembly
 		anchored = 1
 		density = 1
 		state = 1
-		glass = 0
 
 /obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen))
@@ -326,24 +310,12 @@ obj/structure/door_assembly
 	//If your airlock has a glass version, add it to the list with glass versions.
 	//Do NOT add your airlock to a list if it does not have a version for that list,
 	//	or you will get broken icons.
-	//If you do this properly, you can just add the typetext and icontext of your airlock
-	//  to the big switch without having to make exceptions for glass airlocks, it will
-	//  simply be unavailable if the painter is used on an airlock of the wrong type.
-	//If your airlock has both a regular and a glass version, remember to also add the
-	//  icontext as exception in the part of the code that deals with turning a regular
-	//  airlock into a glass airlock, else your airlock can't transition from regular to
-	//  glass and will instead revert back to the white sprite.
-	// |- Ricotez
 		var/obj/item/weapon/airlock_painter/WT = W
 		if(WT.ink.charges)
 			var/icontype
 			var/optionlist
-			var/glasstext = ""
-			var/gicontext = ""
 			if(src.mineral)
 				if(src.mineral == "glass")
-					gicontext = "g"
-					glasstext = "glass_"
 					//These airlocks have a glass version.
 					optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining")
 				else
@@ -354,12 +326,10 @@ obj/structure/door_assembly
 				optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining", "Maintenance", "External", "High Security")
 
 
-			icontype = input(user, "Please select a paintjob for this glass airlock.") in optionlist
+			icontype = input(user, "Please select a paintjob for this airlock.") in optionlist
 			if(!in_range(src, usr) && src.loc != usr)	return
 			switch(icontype)
 				if("Default")
-					if(src.mineral == "glass")
-						glasstext = "glass"
 					typetext = ""
 					icontext = ""
 				if("Engineering")
@@ -392,8 +362,10 @@ obj/structure/door_assembly
 				if("High Security")
 					typetext = "highsecurity"
 					icontext = "highsec"
-			src.airlock_type = text2path("/obj/machinery/door/airlock/[glasstext][typetext]")
-			src.base_icon_state = "door_as_[gicontext][icontext]"
+			src.airlock_type = text2path("/obj/machinery/door/airlock/[typetext]")
+			src.glass_type = text2path("/obj/machinery/door/airlock/glass_[typetext]")
+			src.base_icon_state = "door_as_[icontext]"
+			src.glass_base_icon_state = "door_as_g[icontext]"
 			user << "\blue You change the paintjob on the airlock assembly."
 			WT.use()
 		else
@@ -507,14 +479,18 @@ obj/structure/door_assembly
 						G.use(1)
 						src.mineral = "glass"
 						src.name = "Near finished Window Airlock Assembly"
-						if(icontext in list("eng", "atmo", "sec", "com", "med", "res", "min")) //Make sure this airlock actually has a glass version.
-							src.airlock_type = text2path("/obj/machinery/door/airlock/glass_[typetext]")
+						//This list contains the airlock paintjobs that have a glass version:
+						if(icontext in list("eng", "atmo", "sec", "com", "med", "res", "min"))
+							src.airlock_type = text2path("/obj/machinery/door/airlock/[typetext]")
+							src.glass_type = text2path("/obj/machinery/door/airlock/glass_[typetext]")
 						else
 							//This airlock is default or does not have a glass version, so we revert to the default glass airlock. |- Ricotez
-							src.airlock_type = /obj/machinery/door/airlock/glass
+							src.airlock_type = /obj/machinery/door/airlock
+							src.glass_type = /obj/machinery/door/airlock/glass
 							typetext = ""
 							icontext = ""
-						src.base_icon_state = "door_as_g[icontext]" //this will be applied to the icon_state with the correct state number at the proc's end.
+						src.base_icon_state = "door_as_[icontext]"
+						src.glass_base_icon_state = "door_as_g[icontext]"
 				else if(istype(G, /obj/item/stack/sheet/mineral))
 					var/M = G.sheettype
 					if(G.amount>=2)
@@ -536,22 +512,10 @@ obj/structure/door_assembly
 			if(!src) return
 			user << "\blue You've finished the airlock."
 			var/obj/machinery/door/airlock/door
-			//The below cluster of if-else-statements is a result of the differences between normal
-			//  and mineral doors. |- Ricotez
-			if (mineral)
-				if(mineral == "glass")
-					if(!typetext)
-						airlock_type = /obj/machinery/door/airlock/glass
-					else
-						airlock_type = text2path("/obj/machinery/door/airlock/glass_[typetext]")
-				else
-					airlock_type = text2path("/obj/machinery/door/airlock/[mineral]")
+			if(mineral == "glass")
+				door = new src.glass_type( src.loc )
 			else
-				if(!typetext)
-					airlock_type = /obj/machinery/door/airlock
-				else
-					airlock_type = text2path("/obj/machinery/door/airlock/[typetext]")
-			door = new src.airlock_type( src.loc )
+				door = new src.airlock_type( src.loc )
 			//door.req_access = src.req_access
 			door.electronics = src.electronics
 			door.req_access = src.electronics.conf_access
@@ -561,7 +525,10 @@ obj/structure/door_assembly
 			del(src)
 	else
 		..()
-	icon_state = "[base_icon_state][state]"
+	if(mineral == "glass")
+		icon_state = "[glass_base_icon_state][state]"
+	else
+		icon_state = "[base_icon_state][state]"
 	//This updates the icon_state. They are named as "door_as1_eng" where the 1 in that example
 	//represents what state it's in. So the most generic algorithm for the correct updating of
 	//this is simply to change the number.


### PR DESCRIPTION
-Airlock painters can now be used on finished airlocks to change their paintjob. Keep away from the Clown.
-Airlock painter description up to standards. It still shows the current ink level.
-Fixed a bug with painting airlock assemblies where painted glass airlocks deconstructed to assemblies reconstructed to airlocks would lose their glass status.
-Airlock painters now make a sound (effects/spray2.ogg) when used to paint an airlock.

Second commit:
-You can now remove the toner cardridge from an airlock painter by clicking on the painter in your hand.
-You can now install a toner cardridge into an airlock painter by clicking on it with the toner.

Third commit:
-Removed an unnecessary typecast and duplicate function call from the code.

Fourth commit:  
-Fixed being able to open the paintjob selection window and just walking away to paint the airlock from a distance.
-Fixed a few runtimes that could occur if the toner cardridge were removed while the paintjob selection window is still open.
-If you remove the toner cardridge from the airlock painter, it will now try to be put in your hand before falling to the ground.
I forgot to mention these in the commit itself:
-The heat_proof of an airlock will now be properly set when repainting.
-You can now repaint mineral airlock assemblies.

Fifth commit:
 -The airlock painter now shows a message when initially used on an airlock and out of ink/toner cardridge.
-Codewise the functionality of airlock_painter/use() has been divided between two procs. Use() still works the same, but can_use() only checks if the painter can be used, without draining ink or playing sounds if that's true.
