### PR TITLE
Fixed various xeno issues.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/alien/humanoid/emote(var/act)
 
+	var/cooldown = 0 //Used to limit *roar and *deathgasp spam.
 	var/param = null
 	if (findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -72,12 +73,12 @@
 
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")
-		if (act == "roar" && xeno_emote_counter <= 0)
+		if (act == "roar")
 			playsound(src.loc, 'sound/voice/hiss5.ogg', 40, 1, 1)
-			xeno_emote_counter = 4
-		if (act == "deathgasp" && xeno_emote_counter <= 0)
+
+		if (act == "deathgasp")
 			playsound(src.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
-			xeno_emote_counter = 4
+
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))
 				O.show_message(message, m_type)

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -72,10 +72,12 @@
 
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")
-		if (act == "roar")
+		if (act == "roar" && xeno_emote_counter <= 0)
 			playsound(src.loc, 'sound/voice/hiss5.ogg', 40, 1, 1)
-		if (act == "deathgasp")
+			xeno_emote_counter = 4
+		if (act == "deathgasp" && xeno_emote_counter <= 0)
 			playsound(src.loc, 'sound/voice/hiss6.ogg', 80, 1, 1)
+			xeno_emote_counter = 4
 		if (m_type & 1)
 			for(var/mob/O in viewers(src, null))
 				O.show_message(message, m_type)

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -1,6 +1,5 @@
 /mob/living/carbon/alien/humanoid/emote(var/act)
 
-	var/cooldown = 0 //Used to limit *roar and *deathgasp spam.
 	var/param = null
 	if (findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -6,7 +6,6 @@
 	fire_alert = 0
 
 	var/temperature_alert = 0
-	var/xeno_emote_counter = 0 //See Life()
 
 
 /mob/living/carbon/alien/humanoid/Life()

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -13,8 +13,6 @@
 	set invisibility = 0
 	set background = 1
 
-	xeno_emote_counter -= 1  //Hack to stop *deathgasp and *roar spam for xenos.
-
 	if (monkeyizing)
 		return
 

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -6,11 +6,14 @@
 	fire_alert = 0
 
 	var/temperature_alert = 0
+	var/xeno_emote_counter = 0 //See Life()
 
 
 /mob/living/carbon/alien/humanoid/Life()
 	set invisibility = 0
 	set background = 1
+
+	xeno_emote_counter -= 1  //Hack to stop *deathgasp and *roar spam for xenos.
 
 	if (monkeyizing)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "alienh_running"
 	icon_living = "alienh_running"
-	icon_dead = "alien_l"
+	icon_dead = "alienh_dead"
 	icon_gib = "syndicate_gib"
 	response_help = "pokes"
 	response_disarm = "shoves"

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -38,7 +38,7 @@
 	name = "alien drone"
 	icon_state = "aliend_running"
 	icon_living = "aliend_running"
-	icon_dead = "aliend_l"
+	icon_dead = "aliend_dead"
 	health = 60
 	melee_damage_lower = 15
 	melee_damage_upper = 15
@@ -47,7 +47,7 @@
 	name = "alien sentinel"
 	icon_state = "aliens_running"
 	icon_living = "aliens_running"
-	icon_dead = "aliens_l"
+	icon_dead = "aliens_dead"
 	health = 120
 	melee_damage_lower = 15
 	melee_damage_upper = 15
@@ -60,7 +60,7 @@
 	name = "alien queen"
 	icon_state = "alienq_running"
 	icon_living = "alienq_running"
-	icon_dead = "alienq_l"
+	icon_dead = "alienq_dead"
 	health = 250
 	maxHealth = 250
 	melee_damage_lower = 15
@@ -83,6 +83,7 @@
 	health = 400
 
 /obj/item/projectile/neurotox
+	name = "neurotoxin"
 	damage = 30
 	icon_state = "toxin"
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -82,7 +82,7 @@
 		return 0
 
 
-	if(health < 1)
+	if(health < 1 && stat != DEAD)
 		Die()
 
 	if(health > maxHealth)
@@ -457,7 +457,7 @@
 
 /mob/living/simple_animal/adjustBruteLoss(damage)
 	health = Clamp(health - damage, 0, maxHealth)
-	if(health < 1)
+	if(health < 1 && stat != DEAD)
 		Die()
 
 /mob/living/simple_animal/proc/SA_attackable(target)


### PR DESCRIPTION
- Fixes ALL simple_animals (not just xenos) dieing whenever they are dead and you hit them again. (Fixed #1444)
- Simple_animal xeno dead sprites are now the same as normal xeno dead sprites.
- *roar and *deathgasp can still be spammed, but a sound is only played every 4 seconds. The actual on-death roar is unaffected.

I'm not sure if there's an issue for *roar and *deathgasp spammability, but if there is please tell me.
