### PR TITLE
Quickened Spells (ready to merge edition)

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -26,8 +26,9 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/range = 7 //the range of the spell; outer radius for aoe spells
 	var/message = "" //whatever it says to the guy affected by it
 	var/selection_type = "view" //can be "range" or "view"
-	var/spell_level = 1 //if a spell can be taken multiple times, this raises
-	var/level_max = 1 //The max possible level_max is 5, but most spells cap lower for balancing reasons
+	var/spell_level = 0 //if a spell can be taken multiple times, this raises
+	var/level_max = 4 //The max possible level_max is 4
+	var/cooldown_min = 0 //This defines what spell quickened four timeshas as a cooldown. Make sure to set this for every spell
 
 	var/overlay = 0
 	var/overlay_icon = 'icons/obj/wizard.dmi'

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -26,6 +26,8 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/range = 7 //the range of the spell; outer radius for aoe spells
 	var/message = "" //whatever it says to the guy affected by it
 	var/selection_type = "view" //can be "range" or "view"
+	var/spell_level = 1 //if a spell can be taken multiple times, this raises
+	var/level_max = 1 //The max possible level_max is 5, but most spells cap lower for balancing reasons
 
 	var/overlay = 0
 	var/overlay_icon = 'icons/obj/wizard.dmi'

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -8,6 +8,7 @@
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
+	level_max = 3
 	include_user = 1
 	centcom_cancast = 0 //Prevent people from getting to centcom
 

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -8,7 +8,7 @@
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
-	level_max = 3
+	cooldown_min = 100 //50 deciseconds reduction per rank
 	include_user = 1
 	centcom_cancast = 0 //Prevent people from getting to centcom
 

--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -10,6 +10,7 @@
 	invocation = "KN'A FTAGHU, PUCK 'BTHNK!"
 	invocation_type = "shout"
 	range = 7
+	level_max = 5
 	selection_type = "range"
 	var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 

--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -10,7 +10,7 @@
 	invocation = "KN'A FTAGHU, PUCK 'BTHNK!"
 	invocation_type = "shout"
 	range = 7
-	level_max = 5
+	cooldown_min = 30 //30 deciseconds reduction per rank
 	selection_type = "range"
 	var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -8,6 +8,7 @@
 	invocation = "AULIE OXIN FIERA"
 	invocation_type = "whisper"
 	range = 3
+	level_max = 2
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets)
 	for(var/turf/T in targets)

--- a/code/datums/spells/knock.dm
+++ b/code/datums/spells/knock.dm
@@ -8,7 +8,7 @@
 	invocation = "AULIE OXIN FIERA"
 	invocation_type = "whisper"
 	range = 3
-	level_max = 2
+	cooldown_min = 20 //20 deciseconds reduction per rank
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/cast(list/targets)
 	for(var/turf/T in targets)

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -8,7 +8,7 @@
 	invocation = "GIN'YU CAPAN"
 	invocation_type = "whisper"
 	range = 1
-	level_max = 3
+	cooldown_min = 200 //100 deciseconds reduction per rank
 	var/list/protected_roles = list("Wizard","Changeling","Cultist") //which roles are immune to the spell
 	var/list/compatible_mobs = list(/mob/living/carbon/human,/mob/living/carbon/monkey) //which types of mobs are affected by the spell. NOTE: change at your own risk
 	var/base_spell_loss_chance = 20 //base probability of the wizard losing a spell in the process

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -8,6 +8,7 @@
 	invocation = "GIN'YU CAPAN"
 	invocation_type = "whisper"
 	range = 1
+	level_max = 3
 	var/list/protected_roles = list("Wizard","Changeling","Cultist") //which roles are immune to the spell
 	var/list/compatible_mobs = list(/mob/living/carbon/human,/mob/living/carbon/monkey) //which types of mobs are affected by the spell. NOTE: change at your own risk
 	var/base_spell_loss_chance = 20 //base probability of the wizard losing a spell in the process

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -8,7 +8,7 @@
 	invocation = "FORTI GY AMA"
 	invocation_type = "shout"
 	range = 7
-	cooldown_min = 75 //19 deciseconds reduction per rank
+	cooldown_min = 90 //15 deciseconds reduction per rank
 
 	max_targets = 0
 
@@ -221,7 +221,7 @@
 	invocation = "STAUN EI"
 	invocation_type = "shout"
 	amt_stunned = 2//just exists to make sure the statue "catches" them
-	cooldown_min = 100 //125 deciseconds reduction per rank
+	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	summon_type = "/obj/structure/closet/statue"
 

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -8,6 +8,7 @@
 	invocation = "FORTI GY AMA"
 	invocation_type = "shout"
 	range = 7
+	level_max = 2
 
 	max_targets = 0
 
@@ -53,6 +54,7 @@
 	invocation = "EI NATH"
 	invocation_type = "shout"
 	range = 1
+	level_max = 3
 
 	destroys = "gib_brain"
 
@@ -70,6 +72,7 @@
 	invocation_type = "none"
 	range = -1
 	include_user = 1
+	level_max = 5
 
 	smoke_spread = 2
 	smoke_amt = 10
@@ -83,6 +86,7 @@
 	invocation_type = "shout"
 	range = -1
 	include_user = 1
+	level_max = 4
 
 	emp_heavy = 6
 	emp_light = 10
@@ -98,6 +102,7 @@
 	invocation_type = "none"
 	range = -1
 	include_user = 1
+	level_max = 5
 
 	smoke_spread = 1
 	smoke_amt = 10
@@ -118,6 +123,7 @@
 	invocation_type = "shout"
 	range = -1
 	include_user = 1
+	level_max = 3
 
 	smoke_spread = 1
 	smoke_amt = 5
@@ -132,6 +138,7 @@
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "whisper"
 	range = 0
+	level_max = 5
 
 	summon_type = list("/obj/effect/forcefield")
 	summon_lifespan = 300
@@ -189,6 +196,7 @@
 	invocation = "STI KALY"
 	invocation_type = "whisper"
 	message = "\blue Your eyes cry out in pain!"
+	level_max = 5
 
 	starting_spells = list("/obj/effect/proc_holder/spell/targeted/inflict_handler/blind","/obj/effect/proc_holder/spell/targeted/genetic/blind")
 
@@ -211,6 +219,7 @@
 	invocation = "STAUN EI"
 	invocation_type = "shout"
 	amt_stunned = 2//just exists to make sure the statue "catches" them
+	level_max = 4
 
 	summon_type = "/obj/structure/closet/statue"
 
@@ -224,6 +233,7 @@
 	invocation = "ONI SOMA"
 	invocation_type = "shout"
 	range = 20
+	level_max = 3
 
 	proj_icon_state = "fireball"
 	proj_name = "a fireball"

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -8,7 +8,7 @@
 	invocation = "FORTI GY AMA"
 	invocation_type = "shout"
 	range = 7
-	level_max = 2
+	cooldown_min = 75 //19 deciseconds reduction per rank
 
 	max_targets = 0
 
@@ -43,6 +43,7 @@
 
 	mutations = list(LASER, HULK)
 	duration = 300
+	cooldown_min = 300 //25 deciseconds reduction per rank
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/disintegrate
 	name = "Disintegrate"
@@ -54,7 +55,7 @@
 	invocation = "EI NATH"
 	invocation_type = "shout"
 	range = 1
-	level_max = 3
+	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	destroys = "gib_brain"
 
@@ -72,7 +73,7 @@
 	invocation_type = "none"
 	range = -1
 	include_user = 1
-	level_max = 5
+	cooldown_min = 20 //25 deciseconds reduction per rank
 
 	smoke_spread = 2
 	smoke_amt = 10
@@ -86,7 +87,7 @@
 	invocation_type = "shout"
 	range = -1
 	include_user = 1
-	level_max = 4
+	cooldown_min = 200 //50 deciseconds reduction per rank
 
 	emp_heavy = 6
 	emp_light = 10
@@ -102,7 +103,8 @@
 	invocation_type = "none"
 	range = -1
 	include_user = 1
-	level_max = 5
+	cooldown_min = 5 //4 deciseconds reduction per rank
+
 
 	smoke_spread = 1
 	smoke_amt = 10
@@ -123,7 +125,7 @@
 	invocation_type = "shout"
 	range = -1
 	include_user = 1
-	level_max = 3
+	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	smoke_spread = 1
 	smoke_amt = 5
@@ -138,7 +140,7 @@
 	invocation = "TARCOL MINTI ZHERI"
 	invocation_type = "whisper"
 	range = 0
-	level_max = 5
+	cooldown_min = 50 //12 deciseconds reduction per rank
 
 	summon_type = list("/obj/effect/forcefield")
 	summon_lifespan = 300
@@ -196,7 +198,7 @@
 	invocation = "STI KALY"
 	invocation_type = "whisper"
 	message = "\blue Your eyes cry out in pain!"
-	level_max = 5
+	cooldown_min = 50 //12 deciseconds reduction per rank
 
 	starting_spells = list("/obj/effect/proc_holder/spell/targeted/inflict_handler/blind","/obj/effect/proc_holder/spell/targeted/genetic/blind")
 
@@ -219,7 +221,7 @@
 	invocation = "STAUN EI"
 	invocation_type = "shout"
 	amt_stunned = 2//just exists to make sure the statue "catches" them
-	level_max = 4
+	cooldown_min = 100 //125 deciseconds reduction per rank
 
 	summon_type = "/obj/structure/closet/statue"
 
@@ -233,7 +235,7 @@
 	invocation = "ONI SOMA"
 	invocation_type = "shout"
 	range = 20
-	level_max = 3
+	cooldown_min = 20 //10 deciseconds reduction per rank
 
 	proj_icon_state = "fireball"
 	proj_name = "a fireball"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -162,20 +162,20 @@
 						else
 							aspell.name = initial(aspell.name)
 							aspell.spell_level++
-							aspell.charge_max = initial(aspell.charge_max) / aspell.spell_level
+							aspell.charge_max = round(initial(aspell.charge_max) - aspell.spell_level * (initial(aspell.charge_max) - aspell.cooldown_min)/ aspell.level_max)
 							if(aspell.charge_max < aspell.charge_counter)
 								aspell.charge_counter = aspell.charge_max
 							switch(aspell.spell_level)
-								if(2)
+								if(1)
 									temp = "You have improved [aspell.name] into Efficient [aspell.name]."
 									aspell.name = "Efficient [aspell.name]"
-								if(3)
+								if(2)
 									temp = "You have further improved [aspell.name] into Quickened [aspell.name]."
 									aspell.name = "Quickened [aspell.name]"
-								if(4)
+								if(3)
 									temp = "You have further improved [aspell.name] into Free [aspell.name]."
 									aspell.name = "Free [aspell.name]"
-								if(5)
+								if(4)
 									temp = "You have further improved [aspell.name] into Instant [aspell.name]."
 									aspell.name = "Instant [aspell.name]"
 							if(aspell.spell_level >= aspell.level_max)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -153,11 +153,33 @@
 				var/list/available_spells = list(magicmissile = "Magic Missile", fireball = "Fireball", disintegrate = "Disintegrate", disabletech = "Disable Tech", smoke = "Smoke", blind = "Blind", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate", etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", fleshtostone = "Flesh to Stone", summonguns = "Summon Guns", staffchange = "Staff of Change", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation")
 				var/already_knows = 0
 				for(var/obj/effect/proc_holder/spell/aspell in H.spell_list)
-					if(available_spells[href_list["spell_choice"]] == aspell.name)
+					if(available_spells[href_list["spell_choice"]] == initial(aspell.name))
 						already_knows = 1
-						temp = "You already know that spell."
-						uses++
-						break
+						if(aspell.spell_level >= aspell.level_max)
+							temp = "This spell cannot be improved further."
+							uses++
+							break
+						else
+							aspell.name = initial(aspell.name)
+							aspell.spell_level++
+							aspell.charge_max = initial(aspell.charge_max) / aspell.spell_level
+							if(aspell.charge_max < aspell.charge_counter)
+								aspell.charge_counter = aspell.charge_max
+							switch(aspell.spell_level)
+								if(2)
+									temp = "You have improved [aspell.name] into Efficient [aspell.name]."
+									aspell.name = "Efficient [aspell.name]"
+								if(3)
+									temp = "You have further improved [aspell.name] into Quickened [aspell.name]."
+									aspell.name = "Quickened [aspell.name]"
+								if(4)
+									temp = "You have further improved [aspell.name] into Free [aspell.name]."
+									aspell.name = "Free [aspell.name]"
+								if(5)
+									temp = "You have further improved [aspell.name] into Instant [aspell.name]."
+									aspell.name = "Instant [aspell.name]"
+							if(aspell.spell_level >= aspell.level_max)
+								temp += " This spell cannot be strengthened any further."
 			/*
 			*/
 				if(!already_knows)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,16 +51,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
-
-<div class='commit sansserif'>
-	<h2 class='date'>13 September 2013</h2>
-	<h3 class='author'>Incoming updated:</h3>
-	<ul class='changes bgimages16'>
-		<li class='rscadd'>Wizards have become craftier in preparing their spells efficiently. Be on the lookout for improved versions of existing spells!</li>
-	</ul>
-</div>
-
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 <div class='commit sansserif'>
 	<h2 class='date'>3 September 2013</h2>
 	<h3 class='author'>Cael_Aislinn updated:</h3>
@@ -134,8 +125,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 </div>
 
 
-<!-- #ADDTOCHANGELOGMARKER# -->
-
+<!-- #ADDTOCHANGELOGMARKER# -->
 <div class='commit sansserif'>
 	<h2 class='date'>12 August 2013</h2>
 	<h3 class='author'>Giacom updated:</h3>
@@ -201,7 +191,6 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	</ul>
 </div>
 
-
 <div class='commit sansserif'>	
 	<h2 class='date'>21 July 2013</h2>
 	<h3 class='author'>Cheridan updated:</h3>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -51,7 +51,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>13 September 2013</h2>
+	<h3 class='author'>Incoming updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Wizards have become craftier in preparing their spells efficiently. Be on the lookout for improved versions of existing spells!</li>
+	</ul>
+</div>
+
 <div class='commit sansserif'>
 	<h2 class='date'>3 September 2013</h2>
 	<h3 class='author'>Cael_Aislinn updated:</h3>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -125,7 +125,8 @@ should be listed in the changelog upon commit tho. Thanks. -->
 </div>
 
 
-<!-- #ADDTOCHANGELOGMARKER# -->
+<!-- #ADDTOCHANGELOGMARKER# -->
+
 <div class='commit sansserif'>
 	<h2 class='date'>12 August 2013</h2>
 	<h3 class='author'>Giacom updated:</h3>
@@ -191,6 +192,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	</ul>
 </div>
 
+
 <div class='commit sansserif'>	
 	<h2 class='date'>21 July 2013</h2>
 	<h3 class='author'>Cheridan updated:</h3>


### PR DESCRIPTION
Pull had to be remade to be pull-able after I cocked things up, remind me never to premake a changelog text again

old pull with all discussion https://github.com/tgstation/-tg-station/pull/1367

---

It is now possible for wizards to use their spell book to purchase cooldown reductions for their spells. Each reduction costs a spell book charge and will be properly refunded if spells are unlearned.

The reduction will will follow a linear progression, with each rank giving as much as the one before it. The final cooldown is set via the variable cooldown_min

Each spell can be raised to use all five points these values are open to discussion:

Magic Missile: 1.5 second cooldown reduction per upgrade with a minimum 9 second cast time
Fireball: 1 second cooldown reduction per upgrade with a minimum 2 second cast time
Disintegrate: 10 second cooldown reduction per upgrade with a minimum 20 second cast time
Disable Tech: 5 second cooldown reduction per upgrade with a minimum 20 second cast time
Smoke: 2.5 second cooldown reduction per upgrade with a minimum 2 second cast time
Blind: 1.2 second cooldown reduction per upgrade with a minimum 5 second cast time
Mindswap: 10 second cooldown reduction per upgrade with a minimum 20 second cast time
Forcewall: 1.2 second cooldown reduction per upgrade with a minimum 5 second cast time
Blink: .4 second cooldown reduction per upgrade with a minimum .5 second cast time
Teleport: 10 second cooldown reduction per upgrade with a minimum 20 second cast time
Mutate: 2.5 second cooldown reduction per upgrade with a minimum 30 second cast time
Ethereal Jaunt: 5 second cooldown reduction per upgrade with a minimum 30 second cast time
Knock: 2 second cooldown reduction per upgrade with a minimum 20 second cast time
Curse of the Horsemen: 3 second cooldown reduction per upgrade with a minimum 3 second cast time
Flesh to Stone: 10 second cooldown reduction per upgrade with a minimum 20 second cast time
Summon Guns and all artifacts: not affected
