### PR TITLE
Sec belts can now hold batons!

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -102,8 +102,11 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
-	storage_slots = 4
+	storage_slots = 5
+	max_w_class = 3 //Because the baton wouldn't fit otherwise. - Neerti
 	can_hold = list(
+		"/obj/item/weapon/melee/baton",
+		"/obj/item/weapon/melee/classic_baton",
 		"/obj/item/weapon/grenade/flashbang",
 		"/obj/item/weapon/reagent_containers/spray/pepper",
 		"/obj/item/weapon/handcuffs",


### PR DESCRIPTION
The sec belt, commonly used to hold cuffs, flashbangs, and other security things (like donuts and any glasses, bet you didn't know that, I didn't) can now hold all three kinds of batons, the stun baton, prod, and the classic baton found on the derelict.

To accommodate the baton going on the belt, since sec usually already has their belt (and hands on a metaphorical level) full, the belt now has five slots instead of four.

Since the standard sec armor and HoS's coat can hold tasers/eguns already, this should help keep the baton fairly close at hand without adding clutter to their bag.  Also I'm pretty sure somewhere it says it's 'standard procedure' to have your baton on the belt (and not in your hand).
