### PR TITLE
Fixes target names not being updated on change, reduces some duplicated ...

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -277,7 +277,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					if(!search_id)	break
 					search_pda = 0
 
-		for(var/datum/mind/T in ticker.mode.traitors)
+		for(var/datum/mind/T in ticker.minds)
 			for(var/datum/objective/obj in T.objectives)
 				// Only update if this player is a target
 				if(obj.target && obj.target.current.real_name == name)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -236,7 +236,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 
 
-//This will update a mob's name, real_name, mind.name, data_core records, pda and id
+//This will update a mob's name, real_name, mind.name, data_core records, pda, id and traitor text
 //Calling this proc without an oldname will only update the mob and skip updating the pda, id and records ~Carn
 /mob/proc/fully_replace_character_name(var/oldname,var/newname)
 	if(!newname)	return 0
@@ -276,6 +276,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					PDA.name = "PDA-[newname] ([PDA.ownjob])"
 					if(!search_id)	break
 					search_pda = 0
+
+		for(var/datum/mind/T in ticker.mode.traitors)
+			for(var/datum/objective/obj in T.objectives)
+				// Only update if this player is a target
+				if(obj.target && obj.target.current.real_name == name)
+					obj.update_explanation_text()
+
 	return 1
 
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -19,6 +19,7 @@ datum/objective
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)
+		update_explanation_text()
 
 
 	proc/find_target_by_role(role, role_type=0)//Option sets either to check assigned role or special role. Default to assigned.
@@ -26,25 +27,22 @@ datum/objective
 			if((possible_target != owner) && ishuman(possible_target.current) && ((role_type ? possible_target.special_role : possible_target.assigned_role) == role) )
 				target = possible_target
 				break
+		update_explanation_text()
 
+	proc/update_explanation_text()
+		//Default does nothing, override where needed
 
 
 datum/objective/assassinate
+	var/target_role_type=0
+
 	find_target()
 		..()
-		if(target && target.current)
-			explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
-		else
-			explanation_text = "Free Objective"
 		return target
 
-
 	find_target_by_role(role, role_type=0)
+		target_role_type = role_type
 		..(role, role_type)
-		if(target && target.current)
-			explanation_text = "Assassinate [target.current.real_name], the [!role_type ? target.assigned_role : target.special_role]."
-		else
-			explanation_text = "Free Objective"
 		return target
 
 
@@ -55,25 +53,25 @@ datum/objective/assassinate
 			return 0
 		return 1
 
-
-
-datum/objective/mutiny
-	find_target()
+	update_explanation_text()
 		..()
 		if(target && target.current)
-			explanation_text = "Assassinate [target.current.real_name], the [target.assigned_role]."
+			explanation_text = "Assassinate [target.current.real_name], the [!target_role_type ? target.assigned_role : target.special_role]."
 		else
 			explanation_text = "Free Objective"
-		return target
 
+datum/objective/mutiny
+	var/target_role_type=0
+
+	find_target()
+		..()
+		return target
 
 	find_target_by_role(role, role_type=0)
+		target_role_type = role_type
 		..(role, role_type)
-		if(target && target.current)
-			explanation_text = "Assassinate [target.current.real_name], the [!role_type ? target.assigned_role : target.special_role]."
-		else
-			explanation_text = "Free Objective"
 		return target
+
 
 	check_completion()
 		if(target && target.current)
@@ -85,24 +83,25 @@ datum/objective/mutiny
 			return 0
 		return 1
 
-
-datum/objective/debrain//I want braaaainssss
-	find_target()
+	update_explanation_text()
 		..()
 		if(target && target.current)
-			explanation_text = "Steal the brain of [target.current.real_name]."
+			explanation_text = "Assassinate [target.current.real_name], the [!target_role_type ? target.assigned_role : target.special_role]."
 		else
 			explanation_text = "Free Objective"
-		return target
 
+datum/objective/debrain//I want braaaainssss
+	var/target_role_type=0
+
+	find_target()
+		..()
+		return target
 
 	find_target_by_role(role, role_type=0)
+		target_role_type = role_type
 		..(role, role_type)
-		if(target && target.current)
-			explanation_text = "Steal the brain of [target.current.real_name] the [!role_type ? target.assigned_role : target.special_role]."
-		else
-			explanation_text = "Free Objective"
 		return target
+
 
 	check_completion()
 		if(!target)//If it's a free objective.
@@ -118,24 +117,25 @@ datum/objective/debrain//I want braaaainssss
 				return 1
 		return 0
 
-
-datum/objective/protect//The opposite of killing a dude.
-	find_target()
+	update_explanation_text()
 		..()
 		if(target && target.current)
-			explanation_text = "Protect [target.current.real_name], the [target.assigned_role]."
+			explanation_text = "Steal the brain of [target.current.real_name], the [!target_role_type ? target.assigned_role : target.special_role]."
 		else
 			explanation_text = "Free Objective"
-		return target
 
+datum/objective/protect//The opposite of killing a dude.
+	var/target_role_type=0
+
+	find_target()
+		..()
+		return target
 
 	find_target_by_role(role, role_type=0)
+		target_role_type = role_type
 		..(role, role_type)
-		if(target && target.current)
-			explanation_text = "Protect [target.current.real_name], the [!role_type ? target.assigned_role : target.special_role]."
-		else
-			explanation_text = "Free Objective"
 		return target
+
 
 	check_completion()
 		if(!target)			//If it's a free objective.
@@ -146,6 +146,12 @@ datum/objective/protect//The opposite of killing a dude.
 			return 1
 		return 0
 
+	update_explanation_text()
+		..()
+		if(target && target.current)
+			explanation_text = "Protect [target.current.real_name], the [!target_role_type ? target.assigned_role : target.special_role]."
+		else
+			explanation_text = "Free Objective"
 
 datum/objective/hijack
 	explanation_text = "Hijack the emergency shuttle by escaping alone."


### PR DESCRIPTION
Fixes #100
Adds proc to update explanation_text referring to the player's target, meaning clown or any other changed character's name will appear correctly when their real name update proc is called.

It won't work with cult, but as far as I understand it only heads are candidates for targets, so the issue shouldn't affect this gamemode.
