### PR TITLE
Headset tweaks

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -19,18 +19,22 @@
 	..()
 	keyslot1 = new /obj/item/device/encryptionkey/
 	recalculateChannels()
+	if(!istype(src.loc,/mob))
+		listening = 0
 
 /obj/item/device/radio/headset/talk_into(mob/living/M as mob, message, channel)
 	if (!listening)
 		return
 	..()
 
+/* damn entitled humans
 /obj/item/device/radio/headset/receive_range(freq, level)
 	if(ishuman(src.loc))
 		var/mob/living/carbon/human/H = src.loc
 		if(H.ears == src)
 			return ..(freq, level)
 	return -1
+*/
 
 /obj/item/device/radio/headset/syndicate
 	origin_tech = "syndicate=3"


### PR DESCRIPTION
Headsets now broadcast to the entire tile regardless of whether they are on your ears.  Previously, they would broadcast to the entire tile ONLY if they were on your ears as a human.  Headsets that are not created on a mob start off.

Partial fix for #686 
