### PR TITLE
Makes decals disappear after an explosion

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -43,6 +43,9 @@
 	icon_state = "xgib1"
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 
+/obj/effect/decal/cleanable/xenoblood/xgibs/ex_act()
+	return
+
 /obj/effect/decal/cleanable/xenoblood/xgibs/up
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibup1","xgibup1","xgibup1")
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -58,6 +58,9 @@
 	icon_state = "gibbl5"
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 
+/obj/effect/decal/cleanable/blood/gibs/ex_act(severity)
+	return
+
 /obj/effect/decal/cleanable/blood/gibs/remove_ex_blood()
     return
 

--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -27,6 +27,9 @@
 			if (step_to(src, get_step(src, direction), 0))
 				break
 
+/obj/effect/decal/cleanable/robot_debris/ex_act()
+	return
+
 /obj/effect/decal/cleanable/robot_debris/limb
 	random_icon_states = list("gibarm", "gibleg")
 

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,7 +1,6 @@
 /obj/effect/decal
 	name = "decal"
 	icon = 'icons/effects/effects.dmi'
-	mouse_opacity = 0
 
 /obj/effect/decal/ex_act(severity)
 		del(src)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,0 +1,7 @@
+/obj/effect/decal
+	name = "decal"
+	icon = 'icons/effects/effects.dmi'
+	mouse_opacity = 0
+
+/obj/effect/decal/ex_act(severity)
+		del(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -429,6 +429,7 @@
 #include "code\game\objects\effects\decals\cleanable.dm"
 #include "code\game\objects\effects\decals\contraband.dm"
 #include "code\game\objects\effects\decals\crayon.dm"
+#include "code\game\objects\effects\decals\decal.dm"
 #include "code\game\objects\effects\decals\misc.dm"
 #include "code\game\objects\effects\decals\remains.dm"
 #include "code\game\objects\effects\decals\Cleanable\aliens.dm"


### PR DESCRIPTION
Fixes runes, dirt, blood, etc remaining and floating in space after an
explosion.
Gibs are excluded from this change.
