### PR TITLE
Mobs on Fire - Atmos interaction and Bodytemp Damage tweaks

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -57,6 +57,7 @@
 /obj/effect/hotspot/New()
 	..()
 	air_master.hotspots += src
+	perform_exposure()
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/simulated/floor/location = loc
@@ -80,7 +81,6 @@
 	for(var/atom/item in loc)
 		if(item) // It's possible that the item is deleted in temperature_expose
 			item.fire_act(null, temperature, volume)
-
 	return 0
 
 
@@ -175,3 +175,7 @@
 	air_update_turf()
 	return
 
+/obj/effect/hotspot/HasEntered(mob/living/L)
+	..()
+	if(isliving(L))
+		L.fire_act()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -1,6 +1,6 @@
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
-#define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point
-#define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 1000K point
+#define HEAT_DAMAGE_LEVEL_2 3 //Amount of damage applied when your body temperature passes the 400K point
+#define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 460K point and you are on fire
 
 /mob/living/carbon/alien
 	name = "alien"
@@ -103,12 +103,16 @@
 			if(360 to 400)
 				apply_damage(HEAT_DAMAGE_LEVEL_1, BURN)
 				fire_alert = max(fire_alert, 2)
-			if(400 to 1000)
+			if(400 to 460)
 				apply_damage(HEAT_DAMAGE_LEVEL_2, BURN)
 				fire_alert = max(fire_alert, 2)
-			if(1000 to INFINITY)
-				apply_damage(HEAT_DAMAGE_LEVEL_3, BURN)
-				fire_alert = max(fire_alert, 2)
+			if(460 to INFINITY)
+				if(on_fire)
+					apply_damage(HEAT_DAMAGE_LEVEL_3, BURN)
+					fire_alert = max(fire_alert, 2)
+				else
+					apply_damage(HEAT_DAMAGE_LEVEL_2, BURN)
+					fire_alert = max(fire_alert, 2)
 	return
 
 /mob/living/carbon/alien/proc/handle_mutations_and_radiation()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -5,8 +5,8 @@
 #define HUMAN_CRIT_MAX_OXYLOSS ( (last_tick_duration) /3) //The amount of damage you'll get when in critical condition. We want this to be a 5 minute deal = 300s. There are 100HP to get through, so (1/3)*last_tick_duration per second. Breaths however only happen every 4 ticks.
 
 #define HEAT_DAMAGE_LEVEL_1 2 //Amount of damage applied when your body temperature just passes the 360.15k safety point
-#define HEAT_DAMAGE_LEVEL_2 4 //Amount of damage applied when your body temperature passes the 400K point
-#define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 1000K point
+#define HEAT_DAMAGE_LEVEL_2 3 //Amount of damage applied when your body temperature passes the 400K point
+#define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 460K point and you are on fire
 
 #define COLD_DAMAGE_LEVEL_1 0.5 //Amount of damage applied when your body temperature just passes the 260.15k safety point
 #define COLD_DAMAGE_LEVEL_2 1.5 //Amount of damage applied when your body temperature passes the 200K point
@@ -476,12 +476,16 @@
 				if(360 to 400)
 					apply_damage(HEAT_DAMAGE_LEVEL_1, BURN)
 					fire_alert = max(fire_alert, 2)
-				if(400 to 1000)
+				if(400 to 460)
 					apply_damage(HEAT_DAMAGE_LEVEL_2, BURN)
 					fire_alert = max(fire_alert, 2)
-				if(1000 to INFINITY)
-					apply_damage(HEAT_DAMAGE_LEVEL_3, BURN)
-					fire_alert = max(fire_alert, 2)
+				if(460 to INFINITY)
+					if(on_fire)
+						apply_damage(HEAT_DAMAGE_LEVEL_3, BURN)
+						fire_alert = max(fire_alert, 2)
+					else
+						apply_damage(HEAT_DAMAGE_LEVEL_2, BURN)
+						fire_alert = max(fire_alert, 2)
 
 		else if(bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
 			fire_alert = max(fire_alert, 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -263,8 +263,8 @@
 	ear_deaf = 0
 	ear_damage = 0
 	heal_overall_damage(1000, 1000)
+	ExtinguishMob()
 	fire_stacks = 0
-	on_fire = 0 
 	buckled = initial(src.buckled)
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
@@ -494,7 +494,7 @@
 				BD.attack_hand(usr)
 			C.open()
 
-	//Stop drop and roll & Handcuffs 
+	//Stop drop and roll & Handcuffs
 	else if(iscarbon(L))
 		var/mob/living/carbon/CM = L
 		if(CM.on_fire && CM.canmove)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -77,16 +77,16 @@
 
 //Mobs on Fire
 /mob/living/proc/IgniteMob()
-	if(fire_stacks > 0)
+	if(fire_stacks > 0 && !on_fire)
 		on_fire = 1
-		luminosity += 3
+		src.SetLuminosity(src.luminosity + 3)
 		update_fire()
 
 /mob/living/proc/ExtinguishMob()
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
-		luminosity -= 3
+		src.SetLuminosity(src.luminosity - 3)
 		update_fire()
 
 /mob/living/proc/update_fire()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -79,12 +79,14 @@
 /mob/living/proc/IgniteMob()
 	if(fire_stacks > 0)
 		on_fire = 1
+		luminosity += 3
 		update_fire()
 
 /mob/living/proc/ExtinguishMob()
 	if(on_fire)
 		on_fire = 0
 		fire_stacks = 0
+		luminosity -= 3
 		update_fire()
 
 /mob/living/proc/update_fire()
@@ -107,8 +109,7 @@
 	location.hotspot_expose(700, 50, 1)
 
 /mob/living/fire_act()
-	adjust_fire_stacks(5)
-	if(fire_stacks > 9 && !on_fire)
-		IgniteMob()
+	adjust_fire_stacks(0.5)
+	IgniteMob()
 
 //Mobs on Fire end

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -474,3 +474,7 @@
 
 /mob/living/simple_animal/update_fire()
 	return
+/mob/living/simple_animal/IgniteMob()
+	return
+/mob/living/simple_animal/ExtinguishMob()
+	return


### PR DESCRIPTION
Changes to the Mobs on Fire system and Atmos fire:
- You now catch on fire immediately if you enter a hotspot or a hotspot is generated on top of you. This gives you +(0.5) fire stacks (The cap is 20). Remember, resisting will remove 5 stacks, so you could get through about 10 tiles unprotected without suffering too much damage.

Thoughts behind this: fire_act() used to only be called on every tick, meaning you could run through fire constantly without repercussions unless a tick managed to catch you while you were still in fire. Now, fire is an actual obstacle, and crossing it should be met with consideration to where you are and where you want to be.
- Changes to the burn damage levels: Bodytemp of 400-460 has been reduced to 3 from 4, making hot air less lethal to the player. However, being on fire is significantly more lethal.

Thoughts behind this: On current live, it's about 60 seconds of being on fire to go into crit, which wasn't supposed to happen, I accidently made it very weak when I changed something else. After this change, it's about 37 seconds to crit from full health. Taking away Burn Damage level 3 from body temperature and requiring you to be on fire to hit it is due to the fact that you will effectively never hit 1000 bodytemp without dying in the process. Humans can gain 30 temp per tick, max, according to the default compile options, so you'd die on the way there, making the temperature damage level completely worthless and unaccessed by anyone, so I took it for Fire.
- You now illuminate your surroundings when you are on fire

Requested feature.
