### PR TITLE
Napalm works again, which fixes incendiary grenades.

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -222,14 +222,16 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 	if(text == "fire")
 		G.toxins = amount
 		G.temperature = 1000
+	else if(text == "toxins")
+		G.toxins = amount
 	else if(text == "n2o")
 		var/datum/gas/sleeping_agent/T = new
 		T.moles = amount
-		G += T
-	else if(text == "fuel")
-		var/datum/gas/volatile_fuel/T
+		G.trace_gases += T
+	else if(text == "fuel") // Not working at the moment, use fire instead
+		var/datum/gas/volatile_fuel/T = new
 		T.moles = amount
-		G += T
+		G.trace_gases += T
 
 	air.merge(G)
 	air_master.add_to_active(src, 0)

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -235,7 +235,7 @@ var/const/SPAWN_AIR = 256
 	if(flag & SPAWN_HEAT)
 		G.temperature += 1000
 	if(flag & SPAWN_COLD)
-		G.temperature -= 1000
+		G.temperature = max(1, G.temperature - 1000)
 
 	if(flag & SPAWN_TOXINS)
 		G.toxins += amount

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -214,7 +214,6 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 	T.atmos_spawn_air(text, amount)
 
 var/const/SPAWN_HEAT = 1
-var/const/SPAWN_COLD = 2
 
 var/const/SPAWN_TOXINS = 4
 var/const/SPAWN_OXYGEN = 8
@@ -233,8 +232,6 @@ var/const/SPAWN_AIR = 256
 
 	if(flag & SPAWN_HEAT)
 		G.temperature += 1000
-	if(flag & SPAWN_COLD)
-		G.temperature = max(1, G.temperature - 1000)
 
 	if(flag & SPAWN_TOXINS)
 		G.toxins += amount

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -213,25 +213,51 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 		return
 	T.atmos_spawn_air(text, amount)
 
-/turf/simulated/proc/atmos_spawn_air(var/text, var/amount)
+var/const/SPAWN_HEAT = 1
+var/const/SPAWN_COLD = 2
+
+var/const/SPAWN_TOXINS = 4
+var/const/SPAWN_OXYGEN = 8
+var/const/SPAWN_CO2 = 16
+var/const/SPAWN_NITROGEN = 32
+
+var/const/SPAWN_N2O = 64
+var/const/SPAWN_FUEL = 128
+
+var/const/SPAWN_AIR = 256
+
+/turf/simulated/proc/atmos_spawn_air(var/flag, var/amount)
 	if(!text || !amount || !air)
 		return
 
 	var/datum/gas_mixture/G = new
 
-	if(text == "fire")
-		G.toxins = amount
-		G.temperature = 1000
-	else if(text == "toxins")
-		G.toxins = amount
-	else if(text == "n2o")
+	if(flag & SPAWN_HEAT)
+		G.temperature += 1000
+	if(flag & SPAWN_COLD)
+		G.temperature -= 1000
+
+	if(flag & SPAWN_TOXINS)
+		G.toxins += amount
+	if(flag & SPAWN_OXYGEN)
+		G.oxygen += amount
+	if(flag & SPAWN_CO2)
+		G.carbon_dioxide += amount
+	if(flag & SPAWN_NITROGEN)
+		G.nitrogen += amount
+
+	if(flag & SPAWN_N2O)
 		var/datum/gas/sleeping_agent/T = new
-		T.moles = amount
+		T.moles += amount
 		G.trace_gases += T
-	else if(text == "fuel") // Not working at the moment, use fire instead
+	if(flag & SPAWN_FUEL) // Not working at the moment, use SPAWN_TOXINS | SPAWN_HEAT instead.
 		var/datum/gas/volatile_fuel/T = new
-		T.moles = amount
+		T.moles += amount
 		G.trace_gases += T
+
+	if(flag & SPAWN_AIR)
+		G.oxygen += MOLES_O2STANDARD * amount
+		G.nitrogen += MOLES_N2STANDARD * amount
 
 	air.merge(G)
 	air_master.add_to_active(src, 0)

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -222,7 +222,6 @@ var/const/SPAWN_CO2 = 16
 var/const/SPAWN_NITROGEN = 32
 
 var/const/SPAWN_N2O = 64
-var/const/SPAWN_FUEL = 128
 
 var/const/SPAWN_AIR = 256
 
@@ -248,10 +247,6 @@ var/const/SPAWN_AIR = 256
 
 	if(flag & SPAWN_N2O)
 		var/datum/gas/sleeping_agent/T = new
-		T.moles += amount
-		G.trace_gases += T
-	if(flag & SPAWN_FUEL) // Not working at the moment, use SPAWN_TOXINS | SPAWN_HEAT instead.
-		var/datum/gas/volatile_fuel/T = new
 		T.moles += amount
 		G.trace_gases += T
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -235,7 +235,7 @@
 		PlasmaBurn(exposed_temperature)
 
 /obj/machinery/door/airlock/plasma/proc/PlasmaBurn(temperature)
-	atmos_spawn_air("fire", 500)
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 500)
 	new/obj/structure/door_assembly/door_assembly_0( src.loc )
 	del (src)
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -118,7 +118,7 @@
 	..()
 	var/turf/simulated/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("fire", 3)
+		T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 3)
 
 /////////////////////
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -51,7 +51,7 @@
 		del(src)
 
 /obj/effect/mine/proc/triggerplasma(obj)
-	atmos_spawn_air("fire", 360)
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 360)
 	spawn(0)
 		del(src)
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -218,7 +218,7 @@
 			TemperatureAct(exposed_temperature)
 
 	proc/TemperatureAct(temperature)
-		atmos_spawn_air("fire", 500)
+		atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 500)
 		hardness = 0
 		CheckHardness()
 

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -94,7 +94,7 @@
 	spawn(2)
 	new /obj/structure/girder(src)
 	src.ChangeTurf(/turf/simulated/floor)
-	atmos_spawn_air("fire", 400)
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 400)
 
 /turf/simulated/wall/mineral/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
 	if(exposed_temperature > 300)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1856,8 +1856,8 @@ datum
 				if(volume >= 5)
 					for(var/mob/living/carbon/slime/M in T)
 						M.adjustToxLoss(rand(15,30))
-					if(istype(T))
-						T.atmos_spawn_air(SPAWN_COLD)
+					//if(istype(T))
+					//	T.atmos_spawn_air(SPAWN_COLD)
 
 		sodiumchloride
 			name = "Table Salt"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1329,12 +1329,12 @@ datum
 					if (egg.grown)
 						egg.Hatch()*/
 				if((!O) || (!volume))	return 0
-				O.atmos_spawn_air("toxins", volume)
+				O.atmos_spawn_air(SPAWN_TOXINS, volume)
 
 			reaction_turf(var/turf/simulated/T, var/volume)
 				src = null
 				if(istype(T))
-					T.atmos_spawn_air("toxins", volume)
+					T.atmos_spawn_air(SPAWN_TOXINS, volume)
 				return
 
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with plasma is stronger than fuel!

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1329,12 +1329,12 @@ datum
 					if (egg.grown)
 						egg.Hatch()*/
 				if((!O) || (!volume))	return 0
-				O.atmos_spawn_air("fuel", 5)
+				O.atmos_spawn_air("toxins", volume)
 
 			reaction_turf(var/turf/simulated/T, var/volume)
 				src = null
 				if(istype(T))
-					T.atmos_spawn_air("fuel", 5)
+					T.atmos_spawn_air("toxins", volume)
 				return
 
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with plasma is stronger than fuel!

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1853,8 +1853,11 @@ datum
 				return
 
 			reaction_turf(var/turf/simulated/T, var/volume)
-				for(var/mob/living/carbon/slime/M in T)
-					M.adjustToxLoss(rand(15,30))
+				if(volume >= 5)
+					for(var/mob/living/carbon/slime/M in T)
+						M.adjustToxLoss(rand(15,30))
+					if(istype(T))
+						T.atmos_spawn_air(SPAWN_COLD)
 
 		sodiumchloride
 			name = "Table Salt"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -350,7 +350,7 @@ datum
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/turf/simulated/T = get_turf(holder.my_atom)
 				if(istype(T))
-					T.atmos_spawn_air("fire", created_volume)
+					T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, created_volume)
 				holder.del_reagent(id)
 				return
 
@@ -1222,7 +1222,7 @@ datum
 				sleep(50)
 				var/turf/simulated/T = get_turf(holder.my_atom)
 				if(istype(T))
-					T.atmos_spawn_air("fire", 50)
+					T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 50)
 
 //Yellow
 		slimeoverload

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -348,10 +348,10 @@ datum
 			required_reagents = list("aluminum" = 1, "plasma" = 1, "sacid" = 1 )
 			result_amount = 1
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-				var/turf/simulated/T = get_turf(src)
+				var/turf/simulated/T = get_turf(holder.my_atom)
 				if(istype(T))
 					T.atmos_spawn_air("fire", created_volume)
-				holder.del_reagent("napalm")
+				holder.del_reagent(id)
 				return
 
 		/*
@@ -1220,7 +1220,7 @@ datum
 				for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 					O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
 				sleep(50)
-				var/turf/simulated/T = get_turf(src)
+				var/turf/simulated/T = get_turf(holder.my_atom)
 				if(istype(T))
 					T.atmos_spawn_air("fire", 50)
 


### PR DESCRIPTION
- Stopped the fuel and n20 option, in spawn_air, from runtiming.
- Added toxins as a spawn_air option.
- Removed all use of the fuel option and replaced it with toxins, since fuel does not work with LINDA anymore.
- Made spawn_air use flags and added HEAT, COLD, TOXINS, OXYGEN, CO2, NITROGEN, N2O, FUEL and AIR flags. You can use them in conjunction by doing "SPAWN_HEAT | SPAWN_TOXINS" for fire.
