### PR TITLE
Galoshes A: Janitor spawns with them on his feet

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -265,7 +265,7 @@
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/galoshes(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/device/pda/janitor(H), slot_belt)
 		return 1
 

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -74,7 +74,7 @@
 	new /obj/item/weapon/caution(src)
 	new /obj/item/device/lightreplacer(src)
 	new /obj/item/weapon/storage/bag/trash(src)
-	new /obj/item/clothing/shoes/galoshes(src)
+	new /obj/item/clothing/shoes/black(src)
 
 /*
  * Lawyer


### PR DESCRIPTION
Swaps the janitor's spawning footwear to galoshes, the ones in his locker are replaced with black shoes.

This means that the Janitor, and any additional Janitors, will start the game with their galoshes on (see below), but it does mean that if the HoP makes an existing crew member a janitor they won't be able to get galoshes and people can't steal them, but it does mean the amount of galoshes in game is controled.

The reason for this change is because the HoP can increase the number of Janitors on station (which is a good thing for them to do because one janitor can't keep the station clean), however the new janitors are at a disadvantage because they can never get a pair of no slip galoshes and Aran made it so only water can clean stuff via mopping, not even space cleaner works.
