### PR TITLE
Galoshes B: Janicart crate comes with galoshes

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -857,8 +857,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "janitorial supplies"
 
 /datum/supply_packs/misc/janitor/janicart
-	name = "Janitorial Cart crate"
-	contains = list(/obj/structure/janitorialcart)
+	name = "Janitorial Cart & Galoshes crate"
+	contains = list(/obj/structure/janitorialcart,
+					/obj/item/clothing/shoes/galoshes)
 	cost = 10
 	containertype = /obj/structure/largecrate
 	containername = "janitorial cart crate"


### PR DESCRIPTION
Adds a pair of Galoshes to the Janicart crate

This alternative allows new spawning Janitors to get their noslips, allows HoP assigned Janitors to get their no slips, and maintains the ability for thieving greyshirts to steal the janitors yellow boots, and gives cargo something else to order.

The reason I chucked in a free pair of galoshes into the janicart crate instead of making a new crate is because I see that crate as the new janitor's starter pack, and its also to incentivise that the crate is meant to be ordered for new janitors and not power gaming assholes (although they probably will still do it -meh).

The reason for this change is because the HoP can increase the number of Janitors on station (which is a good thing for them to do because one janitor can't keep the station clean), however the new janitors are at a disadvantage because they can never get a pair of no slip galoshes and Aran made it so only water can clean stuff via mopping, not even space cleaner works.
