### PR TITLE
Repairs and Expands the Staff of Change

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -254,6 +254,7 @@
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)	return
 	adjustBruteLoss(Proj.damage)
+	Proj.on_hit(src, 0)
 	return 0
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M as mob)

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -45,7 +45,7 @@
 				new_mob.job = "Cyborg"
 				var/mob/living/silicon/robot/Robot = new_mob
 				Robot.mmi = new /obj/item/device/mmi(new_mob)
-				if(!isanimal(M) && !isrobot(M))	Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
+				Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
 			if("slime")
 				if(prob(50))		new_mob = new /mob/living/carbon/slime/adult(M.loc)
 				else				new_mob = new /mob/living/carbon/slime(M.loc)
@@ -91,7 +91,7 @@
 				var/mob/living/carbon/human/H = new_mob
 				ready_dna(H)
 				if(H.dna)
-					H.dna.mutantrace = pick("lizard","golem","slime","plant","fly","plant","shadow","adamantine","skeleton",8;"")
+					H.dna.mutantrace = pick("lizard","golem","slime","plant","fly","shadow","adamantine","skeleton",8;"")
 					H.update_body()
 			else
 				return

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -33,7 +33,7 @@
 
 		var/mob/living/new_mob
 
-		var/randomize = pick("monkey","robot","slime","xeno","human")
+		var/randomize = pick("monkey","robot","slime","xeno","human","animal")
 		switch(randomize)
 			if("monkey")
 				new_mob = new /mob/living/carbon/monkey(M.loc)
@@ -45,7 +45,7 @@
 				new_mob.job = "Cyborg"
 				var/mob/living/silicon/robot/Robot = new_mob
 				Robot.mmi = new /obj/item/device/mmi(new_mob)
-				Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
+				if(!isanimal(M) && !isrobot(M))	Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
 			if("slime")
 				if(prob(50))		new_mob = new /mob/living/carbon/slime/adult(M.loc)
 				else				new_mob = new /mob/living/carbon/slime(M.loc)
@@ -64,6 +64,24 @@
 					if("Drone")		new_mob = new /mob/living/carbon/alien/humanoid/drone(M.loc)
 					else			new_mob = new /mob/living/carbon/alien/larva(M.loc)
 				new_mob.universal_speak = 1*/
+			if("animal")
+				var/animal = pick("parrot","corgi","crab","pug","cat","carp","bear","mushroom","tomato","mouse","chicken","cow","lizard","chick")
+				switch(animal)
+					if("parrot")	new_mob = new /mob/living/simple_animal/parrot(M.loc)
+					if("corgi")		new_mob = new /mob/living/simple_animal/corgi(M.loc)
+					if("crab")		new_mob = new /mob/living/simple_animal/crab(M.loc)
+					if("pug")		new_mob = new /mob/living/simple_animal/pug(M.loc)
+					if("cat")		new_mob = new /mob/living/simple_animal/cat(M.loc)
+					if("carp")		new_mob = new /mob/living/simple_animal/hostile/carp(M.loc)
+					if("bear")		new_mob = new /mob/living/simple_animal/hostile/bear(M.loc)
+					if("mushroom")	new_mob = new /mob/living/simple_animal/mushroom(M.loc)
+					if("tomato")	new_mob = new /mob/living/simple_animal/tomato(M.loc)
+					if("mouse")		new_mob = new /mob/living/simple_animal/mouse(M.loc)
+					if("chicken")	new_mob = new /mob/living/simple_animal/chicken(M.loc)
+					if("cow")		new_mob = new /mob/living/simple_animal/cow(M.loc)
+					if("lizard")	new_mob = new /mob/living/simple_animal/lizard(M.loc)
+					else			new_mob = new /mob/living/simple_animal/chick(M.loc)
+					new_mob.universal_speak = 1
 			if("human")
 				new_mob = new /mob/living/carbon/human(M.loc)
 
@@ -71,8 +89,10 @@
 				A.copy_to(new_mob)
 
 				var/mob/living/carbon/human/H = new_mob
+				ready_dna(H)
 				if(H.dna)
-					H.dna.mutantrace = pick("lizard","golem","slime","plant",4;"")
+					H.dna.mutantrace = pick("lizard","golem","slime","plant","fly","plant","shadow","adamantine","skeleton",8;"")
+					H.update_body()
 			else
 				return
 


### PR DESCRIPTION
*Staff of change now has a ~17% chance of turning you into a simple animal, all have been tested to make sure they're properly controllable.
*Staff of change now works on simple animals, adding on_hit doesn't double up damage on simple animals or try to inflict non-brute damage because it's hardcoded to avoid inflicting damage to animals in the generic projectile. Special projectile effects seem to work fine (in that they still don't really do anything special but don't runtime) on animals
*Mutant races were not updating properly thanks the DNA revamp, so that's been fixed and expanded to include all current races.
*Transfering identity for MMI's in newly created robots has been disabled for animal -> robot because it doesn't work properly for them, robot -> robot also apparently NEVER worked and has likewise been disabled.
