### PR TITLE
MY EYES!

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -514,12 +514,7 @@
 		if(M.stat != 2)
 			M << "\red Your eyes start to bleed profusely!"
 		if(prob(50))
-			if(M.stat != 2)
-				M << "\red You drop what you're holding and clutch at your eyes!"
-				M.drop_item()
 			M.eye_blurry += 10
-			M.Paralyse(1)
-			M.Weaken(4)
 		if (prob(M.eye_stat - 10 + 1))
 			if(M.stat != 2)
 				M << "\red You go blind!"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -19,14 +19,28 @@
 	name = "Sand"
 	icon_state = "Glass ore"
 	origin_tech = "materials=1"
+	w_class = 2 //sand is smaller than other ores(also: POCKET SAND!).
 
-	attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
-		var/location = get_turf(user)
-		for(var/obj/item/weapon/ore/glass/sandToConvert in location)
-			new /obj/item/stack/sheet/mineral/sandstone(location)
-			del(sandToConvert)
+/obj/item/weapon/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
+	var/location = get_turf(user)
+	for(var/obj/item/weapon/ore/glass/sandToConvert in location)
 		new /obj/item/stack/sheet/mineral/sandstone(location)
-		del(src)
+		del(sandToConvert)
+	new /obj/item/stack/sheet/mineral/sandstone(location)
+	del(src)
+
+/obj/item/weapon/ore/glass/throw_impact(atom/hit_atom)//POCKET SAND!
+	if(ishuman(hit_atom))
+		var/mob/living/carbon/human/H = hit_atom
+		if(( \
+			(H.head && H.head.flags & HEADCOVERSEYES) || \
+			(H.wear_mask && H.wear_mask.flags & MASKCOVERSEYES) || \
+			(H.glasses && H.glasses.flags & GLASSESCOVERSEYES) \
+		))
+			H <<"<span class='warning'>The sand harmlessly hits your eye protection.</span>"
+		else
+			H.apply_effect(rand(2,3), EYE_BLUR)
+			H << "<span class='warning'>You got sand in your eyes!</span>"
 
 /obj/item/weapon/ore/plasma
 	name = "Plasma ore"


### PR DESCRIPTION
Adds pocket sand! Sand has been made smaller to fit into pockets and you can throw it at people to make their vision blurry.

Screwdrivers and forks lost their disarm. However, they still have their blind. Reason:It was inconsistent with damage across the game. A character who can take a bullet to the skull without flinching should not clutch their eyes just because of a screwdriver.
