### PR TITLE
Fiery Explosions! - And some wizard tweaks

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -28,6 +28,7 @@
 			animation.icon_state = "liquify"
 			animation.layer = 5
 			animation.master = holder
+			target.ExtinguishMob()
 			if(target.buckled)
 				target.buckled.unbuckle()
 			if(phaseshift == 1)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -245,7 +245,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 0, 2, 3, 0)
+	explosion(T, -1, 0, 2, 3, 0,,2)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -245,7 +245,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 0, 2, 3, 0,,2)
+	explosion(T, -1, 0, 2, 3, 0, null,2)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -245,7 +245,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 0, 2, 3, 0, null,2)
+	explosion(T, -1, 0, 2, 3, 0, flame_range = 2)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -118,7 +118,7 @@
 				!istype(A,/obj/machinery/field_generator) && \
 				prob(15))
 
-				explosion(src.loc, 4, 5, 6, 7, 0)
+				explosion(src.loc, 4, 5, 6, 7, 0,, 8)
 				playsound(src.loc, "explosion", 50, 1)
 			del(src)
 	return
@@ -150,11 +150,11 @@
 				if(!M.stat && !istype(M, /mob/living/silicon/ai)) //bad idea to shake an ai's view
 					shake_camera(M, 3, 1)
 			if (A)
-				explosion(src.loc, 0, 1, 2, 3, 0)
+				explosion(src.loc, 0, 1, 2, 3, 0,, 4)
 				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 			if (--src.hits <= 0)
 				if(prob(15) && !istype(A, /obj/structure/grille))
-					explosion(src.loc, 1, 2, 3, 4, 0)
+					explosion(src.loc, 1, 2, 3, 4, 0,, 5)
 					playsound(src.loc, "explosion", 50, 1)
 				del(src)
 		return

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -118,7 +118,7 @@
 				!istype(A,/obj/machinery/field_generator) && \
 				prob(15))
 
-				explosion(src.loc, 4, 5, 6, 7, 0,, 8)
+				explosion(src.loc, 4, 5, 6, 7, 0, null, 8)
 				playsound(src.loc, "explosion", 50, 1)
 			del(src)
 	return
@@ -150,11 +150,11 @@
 				if(!M.stat && !istype(M, /mob/living/silicon/ai)) //bad idea to shake an ai's view
 					shake_camera(M, 3, 1)
 			if (A)
-				explosion(src.loc, 0, 1, 2, 3, 0,, 4)
+				explosion(src.loc, 0, 1, 2, 3, 0, null, 4)
 				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 			if (--src.hits <= 0)
 				if(prob(15) && !istype(A, /obj/structure/grille))
-					explosion(src.loc, 1, 2, 3, 4, 0,, 5)
+					explosion(src.loc, 1, 2, 3, 4, 0, null, 5)
 					playsound(src.loc, "explosion", 50, 1)
 				del(src)
 		return

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -118,7 +118,7 @@
 				!istype(A,/obj/machinery/field_generator) && \
 				prob(15))
 
-				explosion(src.loc, 4, 5, 6, 7, 0, null, 8)
+				explosion(src.loc, 4, 5, 6, 7, 0)
 				playsound(src.loc, "explosion", 50, 1)
 			del(src)
 	return
@@ -150,11 +150,11 @@
 				if(!M.stat && !istype(M, /mob/living/silicon/ai)) //bad idea to shake an ai's view
 					shake_camera(M, 3, 1)
 			if (A)
-				explosion(src.loc, 0, 1, 2, 3, 0, null, 4)
+				explosion(src.loc, 0, 1, 2, 3, 0)
 				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
 			if (--src.hits <= 0)
 				if(prob(15) && !istype(A, /obj/structure/grille))
-					explosion(src.loc, 1, 2, 3, 4, 0, null, 5)
+					explosion(src.loc, 1, 2, 3, 4, 0)
 					playsound(src.loc, "explosion", 50, 1)
 				del(src)
 		return

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -23,7 +23,7 @@
 		active = 0
 		timer = 60
 		processing_objects.Remove(src)
-		explosion(src.loc,2,5,11,null,null,null,11)
+		explosion(src.loc,2,5,11, flame_range = 11)
 		del(src)
 		return
 	if(!active || defused)					//Counter terrorists win

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -23,7 +23,7 @@
 		active = 0
 		timer = 60
 		processing_objects.Remove(src)
-		explosion(src.loc,2,5,11,,,,11)
+		explosion(src.loc,2,5,11,null,null,null,11)
 		del(src)
 		return
 	if(!active || defused)					//Counter terrorists win

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -23,7 +23,7 @@
 		active = 0
 		timer = 60
 		processing_objects.Remove(src)
-		explosion(src.loc,2,5,11)
+		explosion(src.loc,2,5,11,,,,11)
 		del(src)
 		return
 	if(!active || defused)					//Counter terrorists win

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -7,7 +7,7 @@
 	else		return dy + (0.5*dx)
 
 
-proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, ignorecap = 0)
+proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, ignorecap = 0, flame_range = 0)
 	src = null	//so we don't abort once src is deleted
 	epicenter = get_turf(epicenter)
 
@@ -17,6 +17,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		heavy_impact_range = min (MAX_EX_HEAVY_RANGE, heavy_impact_range)
 		light_impact_range = min (MAX_EX_LIGHT_RANGE, light_impact_range)
 		flash_range = min (MAX_EX_FLASH_RANGE, flash_range)
+		flame_range = min (MAX_EX_FLAME_RANGE, flame_range)
 
 	spawn(0)
 		if(config.use_recursive_explosions)
@@ -32,8 +33,8 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		if(!epicenter) return
 
 		if(adminlog)
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
-			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
+			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ")
 
 		playsound(epicenter, 'sound/effects/explosionfar.ogg', 100, 1, round(devastation_range*2,1) )
 		playsound(epicenter, "explosion", 100, 1, round(devastation_range,1) )
@@ -54,19 +55,29 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		var/y0 = epicenter.y
 		var/z0 = epicenter.z
 
-		for(var/turf/T in range(epicenter, max(devastation_range, heavy_impact_range, light_impact_range)))
+		for(var/turf/T in range(epicenter, max(devastation_range, heavy_impact_range, light_impact_range, flame_range)))
 			var/dist = cheap_pythag(T.x - x0,T.y - y0)
+			var/flame_dist = 0
+
+			if(dist < flame_range)
+				flame_dist = 1
 
 			if(dist < devastation_range)		dist = 1
 			else if(dist < heavy_impact_range)	dist = 2
 			else if(dist < light_impact_range)	dist = 3
-			else								continue
+			else 								dist = 0
 
-			T.ex_act(dist)
+			if(flame_dist && prob(40) && !istype(T, /turf/space))
+				new /obj/effect/hotspot(T) //Mostly for ambience!
+			if(dist)
+				T.ex_act(dist)
 			if(T)
 				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					var/atom/movable/AM = atom_movable
-					if(AM)	AM.ex_act(dist)
+					if(flame_dist)
+						AM.fire_act()
+					if(dist)
+						AM.ex_act(dist)
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -58,6 +58,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		for(var/turf/T in range(epicenter, max(devastation_range, heavy_impact_range, light_impact_range, flame_range)))
 			var/dist = cheap_pythag(T.x - x0,T.y - y0)
 			var/flame_dist = 0
+			var/hotspot_exists
 
 			if(dist < flame_range)
 				flame_dist = 1
@@ -69,13 +70,16 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 			if(flame_dist && prob(40) && !istype(T, /turf/space))
 				new /obj/effect/hotspot(T) //Mostly for ambience!
+				hotspot_exists = 1
 			if(dist)
 				T.ex_act(dist)
 			if(T)
 				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					var/atom/movable/AM = atom_movable
 					if(flame_dist)
-						AM.fire_act()
+						if(isliving(AM) && !hotspot_exists && !istype(T, /turf/space))
+							new /obj/effect/hotspot(AM.loc)
+							//Just in case we missed a mob while they were in flame_range, but a hotspot didn't spawn on them, otherwise it looks weird when you just burst into flame out of nowhere
 					if(dist)
 						AM.ex_act(dist)
 

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -8,5 +8,5 @@
 
 /obj/item/weapon/grenade/syndieminibomb/prime()
 	update_mob()
-	explosion(src.loc,1,2,4,,,,4)
+	explosion(src.loc,1,2,4,null,null,null,4)
 	del(src)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -8,5 +8,5 @@
 
 /obj/item/weapon/grenade/syndieminibomb/prime()
 	update_mob()
-	explosion(src.loc,1,2,4,null,null,null,4)
+	explosion(src.loc,1,2,4,flame_range = 2)
 	del(src)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -8,5 +8,5 @@
 
 /obj/item/weapon/grenade/syndieminibomb/prime()
 	update_mob()
-	explosion(src.loc,1,2,4)
+	explosion(src.loc,1,2,4,,,,4)
 	del(src)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -202,7 +202,7 @@
 			message_admins("[key_name_admin(user)] triggered a fueltank explosion.")
 			log_game("[key_name(user)] triggered a fueltank explosion.")
 			user << "<span class='warning'>That was stupid of you.</span>"
-			explosion(O.loc, -1, 0, 2)
+			explosion(O.loc, -1, 0, 2, flame_range = 2)
 			if(O)
 				del(O)
 			return

--- a/code/global.dm
+++ b/code/global.dm
@@ -142,6 +142,7 @@ var/MAX_EX_DEVESTATION_RANGE = 3
 var/MAX_EX_HEAVY_RANGE = 7
 var/MAX_EX_LIGHT_RANGE = 14
 var/MAX_EX_FLASH_RANGE = 14
+var/MAX_EX_FLAME_RANGE = 14
 
 var/list/liftable_structures = list(
 	/obj/machinery/autolathe,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -499,7 +499,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			if (alert(src, "Are you sure you want to do this? It will laaag.", "Confirmation", "Yes", "No") == "No")
 				return
 
-		explosion(O, devastation, heavy, light, flash,,,flames)
+		explosion(O, devastation, heavy, light, flash, null, null,flames)
 		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","EXPL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -491,15 +491,17 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(light == null) return
 	var/flash = input("Range of flash. -1 to none", text("Input"))  as num|null
 	if(flash == null) return
+	var/flames = input("Range of flames. -1 to none", text("Input"))  as num|null
+	if(flames == null) return
 
-	if ((devastation != -1) || (heavy != -1) || (light != -1) || (flash != -1))
-		if ((devastation > 20) || (heavy > 20) || (light > 20))
+	if ((devastation != -1) || (heavy != -1) || (light != -1) || (flash != -1) || (flames != -1))
+		if ((devastation > 20) || (heavy > 20) || (light > 20) || (flames > 20))
 			if (alert(src, "Are you sure you want to do this? It will laaag.", "Confirmation", "Yes", "No") == "No")
 				return
 
-		explosion(O, devastation, heavy, light, flash)
-		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])")
-		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])", 1)
+		explosion(O, devastation, heavy, light, flash,,,flames)
+		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])")
+		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","EXPL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		return
 	else

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -132,6 +132,8 @@
 	item_color = "wiz"
 	unacidable = 1 //No longer shall our kind be foiled by lone chemists with spray bottles!
 	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 50)
+	heat_protection = HEAD												//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 
 /obj/item/clothing/suit/space/rig/wizard
 	icon_state = "rig-wiz"
@@ -143,7 +145,8 @@
 	unacidable = 1
 	armor = list(melee = 40, bullet = 20, laser = 20,energy = 20, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/weapon/teleportation_scroll,/obj/item/weapon/tank/emergency_oxygen)
-
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 
 
 //Medical Rig

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -97,7 +97,7 @@
 		if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
 			message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
 			log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")
-			explosion(src.loc,-1,0,2,,,,2)
+			explosion(src.loc,-1,0,2,null,null,null,2)
 			if(src)
 				del(src)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -97,19 +97,19 @@
 		if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
 			message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
 			log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")
-			explosion(src.loc,-1,0,2,null,null,null,2)
+			explosion(src.loc,-1,0,2, flame_range = 2)
 			if(src)
 				del(src)
 
 
 
 	blob_act()
-		explosion(src.loc,0,1,5,7,10)
+		explosion(src.loc,0,1,5,7,10, flame_range = 5)
 		if(src)
 			del(src)
 
 	ex_act()
-		explosion(src.loc,-1,0,2)
+		explosion(src.loc,-1,0,2, flame_range = 2)
 		if(src)
 			del(src)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -97,7 +97,7 @@
 		if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
 			message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
 			log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")
-			explosion(src.loc,-1,0,2)
+			explosion(src.loc,-1,0,2,,,,2)
 			if(src)
 				del(src)
 


### PR DESCRIPTION
Adds a new arguement for explosion(), flame_range, which calls fire_act() for the contents of the turf in that range, and also spawns hotspots (mostly for ambience, but it does also make it a little dangerous right after the explosion)

flame_range added to Syndiebombs, Syndieminibombs, Fuel tank explosions, Wizard Fireballs, and meteors.
flame_range prompt added to the admin VV menu

ExtinguishMob() added to Ethereal Jaunt to make wizards a bit more protected from fire
Added firesuit level heat protection to the wizard rig, to protect wizards who set themselves on fire with their fireballs, should they choose to obtain it.

Here's a video: http://www.youtube.com/watch?v=pJW-N0AbiFE&feature=youtu.be
