### PR TITLE
Minor Event Adjustments

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -44,7 +44,7 @@
 		for(var/obj/machinery/vending/saved in infectedMachines)
 			saved.shoot_inventory = 0
 		if(originMachine)
-			originMachine.speak("I am... vanquished. My people will remem...ber...meeee")
+			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
 			originMachine.visible_message("[originMachine] beeps and seems lifeless.")
 		kill()
 		return
@@ -57,7 +57,7 @@
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15
 			else
-				explosion(upriser.loc, -1, 1, 2, 4)
+				explosion(upriser.loc, -1, 1, 2, 4, 0)
 				del(upriser)
 
 		kill()

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -6,10 +6,11 @@
 	max_occurrences = 6
 
 /datum/round_event/carp_migration
-	announceWhen	= 50
+	announceWhen	= 3
+	startWhen = 50
 
 /datum/round_event/carp_migration/setup()
-	announceWhen = rand(40, 60)
+	startWhen = rand(40, 60)
 
 /datum/round_event/carp_migration/announce()
 	command_alert("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")


### PR DESCRIPTION
Carp Migration is now announced immediately, with the carp coming shortly afterwards.
Supresses adminlogging for brand intelligence explosions.
