### PR TITLE
Making round end reports more clear and easy read.

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -43,7 +43,7 @@ datum/game_mode/proc/auto_declare_completion_blob()
 			var/text = "<FONT size = 2><B>The blob[(blob_mode.infected_crew.len > 1 ? "s were" : " was")]:</B></FONT>"
 
 			for(var/datum/mind/blob in blob_mode.infected_crew)
-				text += "<br>[blob.key] was [blob.name]"
+				text += "<br><b>[blob.key]</b> was <b>[blob.name]</b>"
 			world << text
 		return 1
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -40,8 +40,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/const/changeling_amount = 4 //hard limit on changelings if scaling is turned off
 
 /datum/game_mode/changeling/announce()
-	world << "<B>The current game mode is - Changeling!</B>"
-	world << "<B>There are alien changelings on the station. Do not let the changelings succeed!</B>"
+	world << "<b>The current game mode is - Changeling!</b>"
+	world << "<b>There are alien changelings on the station. Do not let the changelings succeed!</b>"
 
 /datum/game_mode/changeling/pre_setup()
 
@@ -131,9 +131,9 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/game_mode/proc/greet_changeling(var/datum/mind/changeling, var/you_are=1)
 	if (you_are)
-		changeling.current << "<B>\red You are a changeling!</B>"
+		changeling.current << "<b>\red You are a changeling!</b>"
 	changeling.current << "<b>\red Use say \":g message\" to communicate with your fellow changelings.</b>"
-	changeling.current << "<B>You must complete the following tasks:</B>"
+	changeling.current << "<b>You must complete the following tasks:</b>"
 
 	if (changeling.current.mind)
 		if (changeling.current.mind.assigned_role == "Clown")
@@ -142,7 +142,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	var/obj_count = 1
 	for(var/datum/objective/objective in changeling.objectives)
-		changeling.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+		changeling.current << "<b>Objective #[obj_count]</b>: [objective.explanation_text]"
 		obj_count++
 	return
 
@@ -170,7 +170,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/game_mode/proc/auto_declare_completion_changeling()
 	if(changelings.len)
-		var/text = "<br><b><FONT size=3><B>The changelings were:</B></FONT>"
+		var/text = "<br><font size=3><b>The changelings were:</b></font>"
 		for(var/datum/mind/changeling in changelings)
 			var/changelingwin = 1
 
@@ -195,19 +195,19 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 				var/count = 1
 				for(var/datum/objective/objective in changeling.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='green'><b>Success!</b></font>"
 						feedback_add_details("changeling_objective","[objective.type]|SUCCESS")
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='red'>Fail.</font>"
 						feedback_add_details("changeling_objective","[objective.type]|FAIL")
 						changelingwin = 0
 					count++
 
 			if(changelingwin)
-				text += "<br><font color='green'><B>The changeling was successful!</B></font>"
+				text += "<br><font color='green'><b>The changeling was successful!</b></font>"
 				feedback_add_details("changeling_success","SUCCESS")
 			else
-				text += "<br><font color='red'><B>The changeling has failed.</B></font>"
+				text += "<br><font color='red'><b>The changeling has failed.</b></font>"
 				feedback_add_details("changeling_success","FAIL")
 			text += "<br>"
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -170,18 +170,18 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 /datum/game_mode/proc/auto_declare_completion_changeling()
 	if(changelings.len)
-		var/text = "<FONT size = 2><B>The changelings were:</B></FONT>"
+		var/text = "<br><b><FONT size=3><B>The changelings were:</B></FONT>"
 		for(var/datum/mind/changeling in changelings)
 			var/changelingwin = 1
 
-			text += "<br>[changeling.key] was [changeling.name] ("
+			text += "<br><b>[changeling.key]</b> was <b>[changeling.name]</b> ("
 			if(changeling.current)
 				if(changeling.current.stat == DEAD)
 					text += "died"
 				else
 					text += "survived"
 				if(changeling.current.real_name != changeling.name)
-					text += " as [changeling.current.real_name]"
+					text += " as <b>[changeling.current.real_name]</b>"
 			else
 				text += "body destroyed"
 				changelingwin = 0
@@ -209,6 +209,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			else
 				text += "<br><font color='red'><B>The changeling has failed.</B></font>"
 				feedback_add_details("changeling_success","FAIL")
+			text += "<br>"
 
 		world << text
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -361,19 +361,20 @@
 
 /datum/game_mode/proc/auto_declare_completion_cult()
 	if( cult.len || (ticker && istype(ticker.mode,/datum/game_mode/cult)) )
-		var/text = "<FONT size = 2><B>The cultists were:</B></FONT>"
+		var/text = "<br><font size=3><b>The cultists were:</b></font>"
 		for(var/datum/mind/cultist in cult)
 
-			text += "<br>[cultist.key] was [cultist.name] ("
+			text += "<br><b>[cultist.key]</b> was <b>[cultist.name]</b> ("
 			if(cultist.current)
 				if(cultist.current.stat == DEAD)
 					text += "died"
 				else
 					text += "survived"
 				if(cultist.current.real_name != cultist.name)
-					text += " as [cultist.current.real_name]"
+					text += " as <b>[cultist.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
+		text += "<br>"
 
 		world << text

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -248,15 +248,15 @@
 	else if (!station_captured &&  malf_dead && !station_was_nuked)
 		feedback_set_details("round_end_result","loss - staff win")
 		world << "<FONT size = 3><B>Human Victory</B></FONT>"
-		world << "<B>The AI has been killed!</B> The staff is victorious."
+		world << "<B>The AI has been destroyed!</B> The staff is victorious."
 
 	else if (!station_captured && !malf_dead && !station_was_nuked && crew_evacuated)
 		feedback_set_details("round_end_result","halfwin - evacuated")
 		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
-		world << "<B>The Corporation has lose [station_name()]! All survived personnel will be fired!</B>"
+		world << "<B>The Corporation has lost [station_name()]! All survived personnel will be fired!</B>"
 
 	else if (!station_captured && !malf_dead && !station_was_nuked && !crew_evacuated)
-		feedback_set_details("round_end_result","nalfwin - interrupted")
+		feedback_set_details("round_end_result","halfwin - interrupted")
 		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
 		world << "<B>Round was mysteriously interrupted!</B>"
 	..()
@@ -265,21 +265,22 @@
 
 /datum/game_mode/proc/auto_declare_completion_malfunction()
 	if( malf_ai.len || istype(ticker.mode,/datum/game_mode/malfunction) )
-		var/text = "<FONT size = 2><B>The malfunctioning AI were:</B></FONT>"
+		var/text = "<br><FONT size=3><B>The malfunctioning AI were:</B></FONT>"
 
 		for(var/datum/mind/malf in malf_ai)
 
-			text += "<br>[malf.key] was [malf.name] ("
+			text += "<br><b>[malf.key]</b> was <b>[malf.name]</b> ("
 			if(malf.current)
 				if(malf.current.stat == DEAD)
 					text += "deactivated"
 				else
 					text += "operational"
 				if(malf.current.real_name != malf.name)
-					text += " as [malf.current.real_name]"
+					text += " as <b>[malf.current.real_name]</b>"
 			else
 				text += "hardware destroyed"
 			text += ")"
+		text += "<br>"
 
 		world << text
 	return 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -298,21 +298,22 @@
 
 /datum/game_mode/proc/auto_declare_completion_nuclear()
 	if( syndicates.len || (ticker && istype(ticker.mode,/datum/game_mode/nuclear)) )
-		var/text = "<FONT size = 2><B>The syndicate operatives were:</B></FONT>"
+		var/text = "<br><FONT size=3><B>The syndicate operatives were:</B></FONT>"
 
 		for(var/datum/mind/syndicate in syndicates)
 
-			text += "<br>[syndicate.key] was [syndicate.name] ("
+			text += "<br><b>[syndicate.key]</b> was <b>[syndicate.name]</b> ("
 			if(syndicate.current)
 				if(syndicate.current.stat == DEAD)
 					text += "died"
 				else
 					text += "survived"
 				if(syndicate.current.real_name != syndicate.name)
-					text += " as [syndicate.current.real_name]"
+					text += " as <b>[syndicate.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
+		text += "<br>"
 
 		world << text
 	return 1

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -355,10 +355,10 @@
 	var/list/targets = list()
 
 	if(head_revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
-		var/text = "<FONT size = 2><B>The head revolutionaries were:</B></FONT>"
+		var/text = "<br><font size=3><b>The head revolutionaries were:</b></font>"
 
 		for(var/datum/mind/headrev in head_revolutionaries)
-			text += "<br>[headrev.key] was [headrev.name] ("
+			text += "<br><b>[headrev.key]</b> was <b>[headrev.name]</b> ("
 			if(headrev.current)
 				if(headrev.current.stat == DEAD)
 					text += "died"
@@ -367,21 +367,22 @@
 				else
 					text += "survived the revolution"
 				if(headrev.current.real_name != headrev.name)
-					text += " as [headrev.current.real_name]"
+					text += " as <b>[headrev.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
 
 			for(var/datum/objective/mutiny/objective in headrev.objectives)
 				targets |= objective.target
+		text += "<br>"
 
 		world << text
 
 	if(revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
-		var/text = "<FONT size = 2><B>The revolutionaries were:</B></FONT>"
+		var/text = "<br><font size=3><b>The revolutionaries were:</b></font>"
 
 		for(var/datum/mind/rev in revolutionaries)
-			text += "<br>[rev.key] was [rev.name] ("
+			text += "<br><b>[rev.key]</b> was <b>[rev.name]</b> ("
 			if(rev.current)
 				if(rev.current.stat == DEAD)
 					text += "died"
@@ -390,23 +391,24 @@
 				else
 					text += "survived the revolution"
 				if(rev.current.real_name != rev.name)
-					text += " as [rev.current.real_name]"
+					text += " as <b>[rev.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
+		text += "<br>"
 
 		world << text
 
 
 	if( head_revolutionaries.len || revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution) )
-		var/text = "<FONT size = 2><B>The heads of staff were:</B></FONT>"
+		var/text = "<br><font size=3><b>The heads of staff were:</b></font>"
 
 		var/list/heads = get_all_heads()
 		for(var/datum/mind/head in heads)
 			var/target = (head in targets)
 			if(target)
 				text += "<font color='red'>"
-			text += "<br>[head.key] was [head.name] ("
+			text += "<br><b>[head.key]</b> was <b>[head.name]</b> ("
 			if(head.current)
 				if(head.current.stat == DEAD)
 					text += "died"
@@ -415,12 +417,13 @@
 				else
 					text += "survived the revolution"
 				if(head.current.real_name != head.name)
-					text += " as [head.current.real_name]"
+					text += " as <b>[head.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
 			if(target)
 				text += "</font>"
+		text += "<br>"
 
 		world << text
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -172,18 +172,18 @@
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)
-		var/text = "<FONT size = 2><B>The [traitor_name]s were:</B></FONT>"
+		var/text = "<br><font size=3><b>The [traitor_name]s were:</b></font>"
 		for(var/datum/mind/traitor in traitors)
 			var/traitorwin = 1
 
-			text += "<br>[traitor.key] was [traitor.name] ("
+			text += "<br><b>[traitor.key]</b> was <b>[traitor.name]</b> ("
 			if(traitor.current)
 				if(traitor.current.stat == DEAD)
 					text += "died"
 				else
 					text += "survived"
 				if(traitor.current.real_name != traitor.name)
-					text += " as [traitor.current.real_name]"
+					text += " as <b>[traitor.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
@@ -212,6 +212,7 @@
 			else
 				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
 				feedback_add_details("traitor_success","FAIL")
+			text += "<br>"
 
 		world << text
 	return 1

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -203,18 +203,18 @@
 
 /datum/game_mode/proc/auto_declare_completion_wizard()
 	if(wizards.len)
-		var/text = "<FONT size = 2><B>The wizards/witches were:</B></FONT>"
+		var/text = "<br><font size=3><b>the wizards/witches were:</b></font>"
 
 		for(var/datum/mind/wizard in wizards)
 
-			text += "<br>[wizard.key] was [wizard.name] ("
+			text += "<br><b>[wizard.key]</b> was <b>[wizard.name]</b> ("
 			if(wizard.current)
 				if(wizard.current.stat == DEAD)
 					text += "died"
 				else
 					text += "survived"
 				if(wizard.current.real_name != wizard.name)
-					text += " as [wizard.current.real_name]"
+					text += " as <b>[wizard.current.real_name]</b>"
 			else
 				text += "body destroyed"
 			text += ")"
@@ -245,6 +245,7 @@
 					if(wizard.current.spell_list.len > i)
 						text += ", "
 					i++
+			text += "<br>"
 
 		world << text
 	return 1


### PR DESCRIPTION
## Making round end reports more clear and easy read by:
- bolding antag IC names and BYOND keys.
- empty line between every traitor/wizard/changeling and every antag type
- slighty larger "headlines"
- fixing spelling/grammatical errors

**Screenshot:**
![Screenshot of round report](https://dl.dropboxusercontent.com/u/1726015/SS13/roundendreport1.gif)
