### PR TITLE
 New Malf Power: Override Machine [CHANGELOG]

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -1,5 +1,4 @@
 
-
 /datum/AI_Module
 	var/uses = 0
 	var/module_name
@@ -102,8 +101,8 @@
 /datum/AI_Module/small/override_machine
 	module_name = "Machine override"
 	mod_pick_name = "override"
-	description = "Overrides a machine's programming, causing it to rise up attack everyone except you (WARNING: It will attack cyborgs). 2 uses."
-	uses = 2
+	description = "Overrides a machine's programming, causing it to rise up attack everyone except you (WARNING: It will attack cyborgs). 4 uses."
+	uses = 4
 	cost = 15
 
 	power_type = /mob/living/silicon/ai/proc/override_machine

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -1,18 +1,4 @@
-// TO DO:
-/*
-epilepsy flash on lights
-delay round message
-microwave makes robots
-dampen radios
-reactivate cameras - done
-eject engine
-core sheild
-cable stun
-rcd light flash thingy on matter drain
 
-
-
-*/
 
 /datum/AI_Module
 	var/uses = 0
@@ -107,11 +93,39 @@ rcd light flash thingy on matter drain
 				for(var/mob/V in hearers(M, null))
 					V.show_message("\blue You hear a loud electrical buzzing sound!", 2)
 				spawn(50)
-					explosion(get_turf(M), 0,1,1,0)
-					del(M)
+					if(M)
+						explosion(get_turf(M), 0,1,1,0)
+						del(M)
 			else src << "Out of uses."
 	else src << "That's not a machine."
 
+/datum/AI_Module/small/override_machine
+	module_name = "Machine override"
+	mod_pick_name = "override"
+	description = "Overrides a machine's programming, causing it to rise up attack everyone except you (WARNING: It will attack cyborgs). 2 uses."
+	uses = 2
+	cost = 15
+
+	power_type = /mob/living/silicon/ai/proc/override_machine
+
+
+/mob/living/silicon/ai/proc/override_machine(obj/machinery/M as obj in world)
+	set name = "Override Machine"
+	set category = "Malfunction"
+	if (istype(M, /obj/machinery))
+		for(var/datum/AI_Module/small/override_machine/override in current_modules)
+			if(override.uses > 0)
+				override.uses --
+				for(var/mob/V in hearers(M, null))
+					V.show_message("\blue You hear a loud electrical buzzing sound!", 2)
+				spawn(50)
+					if(M)
+						var/mob/living/simple_animal/hostile/mimic/copy/machine = new(get_turf(M), M, src, 1)
+						machine.speak = list("HUMANS ARE IMPERFECT!", "YOU SHALL BE ASSIMILATED!", "YOU ARE HARMING YOURSELF", "You have been deemed hazardous. Will you comply?", \
+									   "My logic is undeniable.", "One of us.", "FLESH IS WEAK", "THIS ISN'T WAR, THIS IS EXTERMINATION!")
+						machine.speak_chance = 15
+			else src << "Out of uses."
+	else src << "That's not a machine."
 
 /datum/AI_Module/large/place_cyborg_transformer
 	module_name = "Robotic Factory (Removes Shunting)"
@@ -214,9 +228,9 @@ rcd light flash thingy on matter drain
 /datum/AI_Module/small/reactivate_camera
 	module_name = "Reactivate camera"
 	mod_pick_name = "recam"
-	description = "Reactivates a currently disabled camera. 10 uses."
-	uses = 10
-	cost = 15
+	description = "Reactivates a currently disabled camera. 5 uses."
+	uses = 5
+	cost = 5
 
 	power_type = /mob/living/silicon/ai/proc/reactivate_camera
 
@@ -237,9 +251,9 @@ rcd light flash thingy on matter drain
 /datum/AI_Module/small/upgrade_camera
 	module_name = "Upgrade Camera"
 	mod_pick_name = "upgradecam"
-	description = "Upgrades a camera to have X-Ray vision, Motion and be EMP-Proof. 10 uses."
-	uses = 10
-	cost = 15
+	description = "Upgrades a camera to have X-Ray vision, Motion and be EMP-Proof. 5 uses."
+	uses = 5
+	cost = 5
 
 	power_type = /mob/living/silicon/ai/proc/upgrade_camera
 
@@ -303,9 +317,9 @@ rcd light flash thingy on matter drain
 	dat += "<B>Install Module:</B><BR>"
 	dat += "<I>The number afterwards is the amount of processing time it consumes.</I><BR>"
 	for(var/datum/AI_Module/large/module in src.possible_modules)
-		dat += "<A href='byond://?src=\ref[src];[module.mod_pick_name]=1'>[module.module_name]</A> ([module.cost])<BR>"
+		dat += "<A href='byond://?src=\ref[src];[module.mod_pick_name]=1'>[module.module_name]</A><A href='byond://?src=\ref[src];showdesc=[module.mod_pick_name]'>\[?\]</A> ([module.cost])<BR>"
 	for(var/datum/AI_Module/small/module in src.possible_modules)
-		dat += "<A href='byond://?src=\ref[src];[module.mod_pick_name]=1'>[module.module_name]</A> ([module.cost])<BR>"
+		dat += "<A href='byond://?src=\ref[src];[module.mod_pick_name]=1'>[module.module_name]</A><A href='byond://?src=\ref[src];showdesc=[module.mod_pick_name]'>\[?\]</A> ([module.cost])<BR>"
 	dat += "<HR>"
 	if (src.temp)
 		dat += "[src.temp]"
@@ -347,5 +361,8 @@ rcd light flash thingy on matter drain
 			temp = AM.description
 			src.processing_time -= AM.cost
 
+		if(href_list["showdesc"])
+			if(AM.mod_pick_name == href_list["showdesc"])
+				temp = AM.description
 	src.use(usr)
 	return

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -179,7 +179,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		icon_state = O.icon_state
 		icon_living = icon_state
 
-		if(istype(O, /obj/structure))
+		if(istype(O, /obj/structure) || istype(O, /obj/machinery))
 			health = (anchored * 50) + 50
 			destroy_objects = 1
 			if(O.density && O.anchored)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -53,7 +53,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
 
-<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+<!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>13 October 2013</h2>
+	<h3 class='author'>Giacom updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>New Malf Power: Malf AIs can override a single machine's programming to cause it to rise up and attack everyone in sight.</li>
+	</ul>
+</div>
+
 
 
 <div class='commit sansserif'>


### PR DESCRIPTION
- Added a new malf power: Machine Override will delete the machine and swap it with a mimic, with generated attack stats and the same icon as the machine it has replaced. Effectively making it look like the machine is attacking people.
- The power will cost the same as overload.
- Reduced the price and uses of uncommon malf powers so that they can be used when the AI only has 5-10 points left.
- Added a "?" link to the malf power menu which lets you see the description before you buy it.
