### PR TITLE
The Allow AI config option will now correctly stop players from choosing AI as a job.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -74,7 +74,7 @@
 
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
-	var/allow_ai = 1					// allow ai job
+	var/allow_ai = 0					// allow ai job
 
 	var/traitor_scaling_coeff = 6		//how much does the amount of players get divided by to determine traitors
 	var/changeling_scaling_coeff = 10	//how much does the amount of players get divided by to determine changelings

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -108,3 +108,6 @@
 		return 0
 
 	return max(0, minimal_player_age - C.player_age)
+
+/datum/job/proc/config_check()
+	return 1

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -14,6 +14,11 @@
 		if(!H)	return 0
 		return 1
 
+	config_check()
+		if(config && config.allow_ai)
+			return 1
+		return 0
+
 
 
 /datum/job/cyborg

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -19,6 +19,7 @@ var/global/datum/controller/occupations/job_master
 			var/datum/job/job = new J()
 			if(!job)	continue
 			if(job.faction != faction)	continue
+			if(!job.config_check()) continue
 			occupations += job
 
 
@@ -143,7 +144,6 @@ var/global/datum/controller/occupations/job_master
 		var/ai_selected = 0
 		var/datum/job/job = GetJob("AI")
 		if(!job)	return 0
-		if((job.title == "AI") && (config) && (!config.allow_ai))	return 0
 		if(ticker.mode.name == "AI malfunction")	// malf. AIs are pre-selected before jobs
 			for (var/datum/mind/mAI in ticker.mode.malf_ai)
 				AssignRole(mAI.current, "AI")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -346,6 +346,9 @@ datum/preferences
 			HTML += "<font color=[prefLevelColor]>[prefLevelLabel]</font>"
 			HTML += "</a></td></tr>"
 
+		for(var/i = 1, i < (limit - index), i += 1) // Finish the column so it is even
+			HTML += "<tr bgcolor='[lastJob.selection_color]'><td width='60%' align='right'>&nbsp</td><td>&nbsp</td></tr>"
+
 		HTML += "</td'></tr></table>"
 
 		HTML += "</center></table>"


### PR DESCRIPTION
- The job select screen will now fill in the rest of the last column, so it doesn't look uneven.
- Added a "check_config()" for the job datum. It is used to exclude jobs from the occupation list if it returns false.
