### PR TITLE
Added a batch-script that uploads tgstation.rsc to an external FTP-server

### DIFF
--- a/tools/Upload tgstation.rsc to external FTP/upload_rsc.bat
+++ b/tools/Upload tgstation.rsc to external FTP/upload_rsc.bat
@@ -1,0 +1,20 @@
+@REM Script to easily upload tgstation.rsc to your FTP-server so that clients download it from an
+@REM external webserver instead of from your connection when joining your game server.
+@REM
+@REM Run this script every time you have compiled your code, otherwise joining players will get errors.
+@REM
+@REM Replace USERNAME with your FTP username
+@REM Replace PASSWORD with your FTP password
+@REM Replace FOLDER/FOLDER with the folder on the FTP server where you want to store tgstation.rsc, for example: cd www/rsc
+@REM Replace FTP.DOMAIN.COM with the IP-address or domain name of your FTP server
+@REM Add the URL to the location of tgstation.rsc on your webserver into data\external_rsc_urls.txt
+@REM
+@echo off
+echo user USERNAME> ftpcmd.dat
+echo PASSWORD>> ftpcmd.dat
+echo bin>> ftpcmd.dat
+echo cd FOLDER/FOLDER>> ftpcmd.dat
+echo put ..\..\tgstation.rsc>> ftpcmd.dat
+echo quit>> ftpcmd.dat
+ftp -n -s:ftpcmd.dat FTP.DOMAIN.COM
+del ftpcmd.dat


### PR DESCRIPTION
Added a batch-script to easily upload **tgstation.rsc** to an external FTP-server, for use with **external_rsc_url.txt**.

**Run this script every time you have compiled your code if you are using external_rsc_url.txt, otherwise players will get errors when joining.**
## Edit the batch-script with your login details
- Replace **USERNAME** with your FTP username
- Replace **PASSWORD** with your FTP password
- Replace **FOLDER/FOLDER** with the folder on the FTP server where you want to store **tgstation.rsc**, for example: **cd www/rsc**
- Replace **FTP.DOMAIN.COM** with the IP-address or domain name of your FTP server
- Add the URL to the location of **tgstation.rsc** on your webserver into **data\external_rsc_urls.txt**
