### PR TITLE
Fixed players being unable to auto-reconnect to the server on Reboot(), because of duplicate keys.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -166,8 +166,8 @@
 	for(var/client/C in clients)
 		if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 			C << link("byond://[config.server]")
-		else
-			C << link("byond://[world.address]:[world.port]")
+
+	// Note: all clients automatically connect to the world after it restarts
 
 	..(reason)
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -107,6 +107,7 @@ GUEST_BAN
 # USEWHITELIST
 
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
+# Don't set this to the same server, BYOND will automatically restart players to the server when it has restarted.
 # SERVER ss13.example.com:2506
 
 ## forum address


### PR DESCRIPTION
Reboot() will automatically reconnect players to the server.
"config.server" should only be used for redirecting players to a different server, for whatever reason.
