### PR TITLE
Mecha, hud, and click fixes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -55,7 +55,7 @@
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)
 		return
-	
+
 	if(stat || paralysis || stunned || weakened)
 		return
 
@@ -65,6 +65,8 @@
 		return
 
 	if(istype(loc,/obj/mecha))
+		if(!locate(/turf) in list(A,A.loc)) // Prevents inventory from being drilled
+			return
 		var/obj/mecha/M = loc
 		return M.click_action(A,src)
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -294,11 +294,16 @@
 	if( buckled || !A || !x || !y || !A.x || !A.y ) return
 	var/dx = A.x - x
 	var/dy = A.y - y
-	if(!dx && !dy) return
+	if(!dx && !dy) // Wall items are graphically shifted but on the floor
+		if(A.pixel_y > 16)		dir = NORTH
+		else if(A.pixel_y < -16)dir = SOUTH
+		else if(A.pixel_x > 16)	dir = EAST
+		else if(A.pixel_x < -16)dir = WEST
+		return
 
 	if(abs(dx) < abs(dy))
-		if(dy > 0)	usr.dir = NORTH
-		else		usr.dir = SOUTH
+		if(dy > 0)	dir = NORTH
+		else		dir = SOUTH
 	else
-		if(dx > 0)	usr.dir = EAST
-		else		usr.dir = WEST
+		if(dx > 0)	dir = EAST
+		else		dir = WEST

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -46,7 +46,7 @@
 		return 1
 	if(usr.next_move >= world.time)
 		return
-	usr.next_move = world.time + 10
+	usr.next_move = world.time + 6
 
 	if(usr.stat || usr.restrained() || usr.stunned || usr.lying)
 		return 1
@@ -84,6 +84,8 @@
 	if(world.time <= usr.next_move)
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+		return 1
+	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 	if(master)
 		var/obj/item/I = usr.get_active_hand()
@@ -171,6 +173,8 @@
 			usr.hud_used.hidden_inventory_update()
 
 		if("equip")
+			if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
+				return 1
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				H.quick_equip()
@@ -313,6 +317,8 @@
 	if(world.time <= usr.next_move)
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+		return 1
+	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 	switch(name)
 		if("r_hand")

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -31,6 +31,21 @@
 	if(client.buildmode)
 		build_click(src, client.buildmode, params, A)
 		return
+
+	var/list/modifiers = params2list(params)
+	if(modifiers["middle"])
+		MiddleClickOn(A)
+		return
+	if(modifiers["shift"])
+		ShiftClickOn(A)
+		return
+	if(modifiers["alt"])
+		AltClickOn(A)
+		return
+	if(modifiers["ctrl"])
+		CtrlClickOn(A)
+		return
+
 	if(world.time <= next_move) return
 	next_move = world.time + 8
 	// You are responsible for checking config.ghost_interaction when you override this function

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -38,6 +38,7 @@
 	var/datum/effect/effect/system/spark_spread/spark_system = new
 	var/lights = 0
 	var/lights_power = 6
+	var/last_user_hud = 1 // used to show/hide the mecha hud while preserving previous preference
 
 	//inner atmos
 	var/use_internal_tank = 0
@@ -1000,6 +1001,10 @@
 		*/
 		H.stop_pulling()
 		H.forceMove(src)
+		if(H.hud_used)
+			last_user_hud = H.hud_used.hud_shown
+			H.hud_used.hide_hud()
+
 		src.occupant = H
 		src.add_fingerprint(H)
 		src.forceMove(src.loc)
@@ -1145,6 +1150,9 @@
 			src.occupant.client.perspective = MOB_PERSPECTIVE
 		*/
 		src.occupant << browse(null, "window=exosuit")
+		if(src.occupant.hud_used && src.last_user_hud)
+			src.occupant.hud_used.show_hud()
+
 		if(istype(mob_container, /obj/item/device/mmi))
 			var/obj/item/device/mmi/mmi = mob_container
 			if(mmi.brainmob)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -27,6 +27,9 @@
 	if(ishuman(usr) || ismonkey(usr)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 
+		if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
+			return
+
 		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block
 			orient2hud(M)					// dunno why it wasn't before
 			if(M.s_active)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -190,7 +190,7 @@
 		l_hand = null
 	else if(I == r_hand)
 		r_hand = null
-	if(client) client.screen -= I //  will get put back if visible
+	I.screen_loc = null // will get moved if inventory is visible
 
 	switch(slot)
 		if(slot_back)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -244,6 +244,8 @@ var/list/slot_equipment_priority = list( \
 	set category = "Object"
 	set src = usr
 
+	if(istype(loc,/obj/mecha)) return
+
 	if(hand)
 		var/obj/item/W = l_hand
 		if (W)


### PR DESCRIPTION
These are probably late sorry
- Fixes #1487, drilling your inventory
- Fully prevents inventory use while in a mech
- Hides your inventory when you enter a mech, you can reveal it with F12
- Better fix for #1164, the E (quick equip) gui button now works as it should, instead of hiding the newly equipped item
- Ghosts can shift- and alt-click, meaning you can still examine with inquisitive mode turned off, and you can use the new alt panel to look at densely packed squares.  Fixes #1451 
