### PR TITLE
AI/Borg blob candidate fix, secret mode forcing fix

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -35,6 +35,10 @@ var/list/blob_nodes = list()
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
+	for(var/datum/mind/player in antag_candidates)
+		for(var/job in restricted_jobs)//Removing robots from the list
+			if(player.assigned_role == job)
+				antag_candidates -= player
 
 	for(var/j = 0, j < cores_to_spawn, j++)
 		if (!antag_candidates.len)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -71,7 +71,7 @@ var/global/datum/controller/gameticker/ticker
 			return 0
 		if(secret_force_mode != "secret")
 			for (var/datum/game_mode/M in runnable_modes)
-				if (M.name == secret_force_mode)
+				if (M.config_tag && M.config_tag == secret_force_mode)
 					src.mode = M
 					break
 			if	(!src.mode)


### PR DESCRIPTION
Correctly fixes AI/Cyborg blobs this time
Unlike other game modes blob didn't manually remove the restricted jobs from the possible antag lists in pre_setup().

Fix to #1600
