### PR TITLE
Small atmos-related fixes

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -24,6 +24,8 @@ datum/controller/air_system
 
 	setup_allturfs()
 
+	global_activeturfs = active_turfs.len
+
 	world << "\red \b Geometry processed in [(world.timeofday-start_time)/10] seconds!"
 
 /datum/controller/air_system/proc/process()

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -41,6 +41,9 @@ datum/controller/game_controller/New()
 
 	createRandomZlevel()			//probably shouldn't be here!
 
+	for(var/i=0, i<max_secret_rooms, i++)
+		make_mining_asteroid_secret()
+
 	if(!events)
 		new /datum/controller/event()
 
@@ -67,9 +70,6 @@ datum/controller/game_controller/proc/setup()
 	setup_objects()
 	setupgenetics()
 	setupfactions()
-
-	for(var/i=0, i<max_secret_rooms, i++)
-		make_mining_asteroid_secret()
 
 	spawn(0)
 		if(ticker)
@@ -129,6 +129,7 @@ datum/controller/game_controller/proc/process()
 					last_thing_processed = air_master.type
 					air_master.process()
 					air_cost = (world.timeofday - timer) / 10
+					global_activeturfs = air_master.active_turfs.len
 
 				sleep(breather_ticks)
 

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -82,7 +82,7 @@
 		var/datum/gas_mixture/adding = new
 		var/datum/gas/sleeping_agent/trace_gas = new
 
-		trace_gas.moles = 2000
+		trace_gas.moles = 6000
 		adding.trace_gases += trace_gas
 		adding.temperature = T20C
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -5,6 +5,7 @@ var/global/obj/effect/overlay/plmaster = null
 var/global/obj/effect/overlay/slmaster = null
 
 
+var/global/list/global_activeturfs
 var/global/list/machines = list()
 var/global/list/processing_objects = list()
 var/global/list/active_diseases = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -643,7 +643,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 			if(master_controller)
 				stat(null,"MasterController-[last_tick_duration] ([master_controller.processing?"On":"Off"]-[controller_iteration])")
-				stat(null,"Air-[master_controller.air_cost]\t#[air_master.active_turfs.len]")
+				stat(null,"Air-[master_controller.air_cost]\t#[global_activeturfs]")
 				stat(null,"Sun-[master_controller.sun_cost]")
 				stat(null,"Mob-[master_controller.mobs_cost]\t#[mob_list.len]")
 				stat(null,"Dis-[master_controller.diseases_cost]\t#[active_diseases.len]")


### PR DESCRIPTION
-the number of active turfs on the status tab will be refreshed and the end of each tick and when the air controller setup finishes.
-mining rooms will be generated before the air controller is created
-changed the total of moles of the NO2 turfs from 2000 to 6000 to compensate the replacement of the canister that spawns like 36000 moles on top of it for a normal canister. I'm talking about the NO2 canister inside of the chamber in atmos. (I will replace the canister in another pull request)
