### PR TITLE
Adds the ability to safely deconstruct cyborgs

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -105,8 +105,7 @@
 		return
 	if(bulb && prob(75/severity))
 		flash()
-		bulb.broken = 1
-		bulb.icon_state = "flashburnt"
+		bulb.burn_out()
 		power_change()
 	..(severity)
 
@@ -123,8 +122,7 @@
 	if(!..())
 		return
 	if(prob(4))	//Small chance to burn out on use
-		bulb.broken = 1
-		bulb.icon_state = "flashburnt"
+		bulb.burn_out()
 		power_change()
 
 /obj/machinery/flasher/portable/attackby(obj/item/weapon/W, mob/user)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -31,6 +31,12 @@
 	last_used = world.time
 	times_used = max(0,round(times_used)) //sanity
 
+/obj/item/device/flash/proc/burn_out(mob/user = null) //Made so you can override it if you want to have an invincible flash from R&D or something.
+	broken = 1
+	icon_state = "flashburnt"
+	if(user)
+		user << "<span class='warning'>The bulb has burnt out!</span>"
+
 
 /obj/item/device/flash/attack(mob/living/M, mob/user)
 	if(!user || !M)	return	//sanity
@@ -53,9 +59,7 @@
 		if(0 to 5)
 			last_used = world.time
 			if(prob(times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
-				broken = 1
-				user << "<span class='warning'>The bulb has burnt out!</span>"
-				icon_state = "flashburnt"
+				burn_out(user)
 				return
 			times_used++
 		else	//can only use it  5 times a minute
@@ -138,9 +142,7 @@
 	switch(times_used)
 		if(0 to 5)
 			if(prob(2*times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
-				broken = 1
-				user << "<span class='warning'>The bulb has burnt out!</span>"
-				icon_state = "flashburnt"
+				burn_out(user)
 				return
 			times_used++
 		else	//can only use it  5 times a minute
@@ -178,8 +180,7 @@
 	switch(times_used)
 		if(0 to 5)
 			if(prob(2*times_used))
-				broken = 1
-				icon_state = "flashburnt"
+				burn_out()
 				return
 			times_used++
 			if(istype(loc, /mob/living/carbon))
@@ -203,13 +204,9 @@
 /obj/item/device/flash/synthetic/attack(mob/living/M, mob/user)
 	..()
 	if(!broken)
-		broken = 1
-		user << "<span class='warning'>The bulb has burnt out!</span>"
-		icon_state = "flashburnt"
+		burn_out(user)
 
 /obj/item/device/flash/synthetic/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	..()
 	if(!broken)
-		broken = 1
-		user << "<span class='warning'>The bulb has burnt out!</span>"
-		icon_state = "flashburnt"
+		burn_out(user)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -205,13 +205,15 @@
 			O.job = "Cyborg"
 
 			O.cell = chest.cell
-			O.cell.loc = O
+			chest.cell.loc = O
+			chest.cell = null
 			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
 			O.mmi = W
 
 			feedback_inc("cyborg_birth",1)
 
-			del(src)
+			src.loc = O
+			O.robot_suit = src
 		else
 			user << "\blue The MMI must go in after everything else!"
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -251,18 +251,20 @@
 /obj/item/robot_parts/head/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 	if(istype(W, /obj/item/device/flash))
+		var/obj/item/device/flash/F = W
 		if(src.flash1 && src.flash2)
 			user << "\blue You have already inserted the eyes!"
 			return
-		else if(src.flash1)
-			user.drop_item()
-			W.loc = src
-			src.flash2 = W
-			user << "\blue You insert the flash into the eye socket!"
+		else if(F.broken)
+			user << "\blue You can't use a broken flash!"
+			return
 		else
 			user.drop_item()
-			W.loc = src
-			src.flash1 = W
+			F.loc = src
+			if(src.flash1)
+				src.flash2 = F
+			else
+				src.flash1 = F
 			user << "\blue You insert the flash into the eye socket!"
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -56,6 +56,7 @@
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 
 	var/obj/item/weapon/tank/internal = null	//Hatred. Used if a borg has a jetpack.
+	var/obj/item/robot_parts/robot_suit/robot_suit = null //Used for deconstruction to remember what the borg was constructed out of..
 
 
 
@@ -491,19 +492,42 @@
 			if(do_after(user, 50))
 				user.visible_message("\red [user] deconstructs [src]!", "\blue You unfasten the securing bolts, and [src] falls to pieces!")
 				var/turf/T = get_turf(src)
-				new /obj/item/robot_parts/robot_suit(T)
-				new /obj/item/robot_parts/l_leg(T)
-				new /obj/item/robot_parts/r_leg(T)
-				new /obj/item/weapon/cable_coil(T, 1)
-				new /obj/item/robot_parts/chest(T)
-				new /obj/item/robot_parts/l_arm(T)
-				new /obj/item/robot_parts/r_arm(T)
-				var/b
-				for(b=0, b!=2, b++)
-					var/obj/item/device/flash/F = new /obj/item/device/flash(T)
-					F.broken = 1
-					F.icon_state = "flashburnt"
-				new /obj/item/robot_parts/head(T)
+				if(robot_suit)
+					robot_suit.loc = T
+					robot_suit.l_leg.loc = T
+					robot_suit.l_leg = null
+					robot_suit.r_leg.loc = T
+					robot_suit.r_leg = null
+					new /obj/item/weapon/cable_coil(T, 1) //The wires break off of the torso from the fall. I'm doing this so that they won't get confused when trying to build another cyborg.
+					robot_suit.chest.loc = T
+					robot_suit.chest.wires = 0.0
+					robot_suit.chest = null
+					robot_suit.l_arm.loc = T
+					robot_suit.l_arm = null
+					robot_suit.r_arm.loc = T
+					robot_suit.r_arm = null
+					robot_suit.head.loc = T
+					robot_suit.head.flash1.loc = T
+					robot_suit.head.flash1.burn_out()
+					robot_suit.head.flash1 = null
+					robot_suit.head.flash2.loc = T
+					robot_suit.head.flash2.burn_out()
+					robot_suit.head.flash2 = null
+					robot_suit.head = null
+					robot_suit.updateicon()
+				else
+					new /obj/item/robot_parts/robot_suit(T)
+					new /obj/item/robot_parts/l_leg(T)
+					new /obj/item/robot_parts/r_leg(T)
+					new /obj/item/weapon/cable_coil(T, 1)
+					new /obj/item/robot_parts/chest(T)
+					new /obj/item/robot_parts/l_arm(T)
+					new /obj/item/robot_parts/r_arm(T)
+					new /obj/item/robot_parts/head(T)
+					var/b
+					for(b=0, b!=2, b++)
+						var/obj/item/device/flash/F = new /obj/item/device/flash(T)
+						F.burn_out()
 				del(src)
 
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -491,44 +491,7 @@
 			playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 			if(do_after(user, 50))
 				user.visible_message("\red [user] deconstructs [src]!", "\blue You unfasten the securing bolts, and [src] falls to pieces!")
-				var/turf/T = get_turf(src)
-				if(robot_suit)
-					robot_suit.loc = T
-					robot_suit.l_leg.loc = T
-					robot_suit.l_leg = null
-					robot_suit.r_leg.loc = T
-					robot_suit.r_leg = null
-					new /obj/item/weapon/cable_coil(T, 1) //The wires break off of the torso from the fall. I'm doing this so that they won't get confused when trying to build another cyborg.
-					robot_suit.chest.loc = T
-					robot_suit.chest.wires = 0.0
-					robot_suit.chest = null
-					robot_suit.l_arm.loc = T
-					robot_suit.l_arm = null
-					robot_suit.r_arm.loc = T
-					robot_suit.r_arm = null
-					robot_suit.head.loc = T
-					robot_suit.head.flash1.loc = T
-					robot_suit.head.flash1.burn_out()
-					robot_suit.head.flash1 = null
-					robot_suit.head.flash2.loc = T
-					robot_suit.head.flash2.burn_out()
-					robot_suit.head.flash2 = null
-					robot_suit.head = null
-					robot_suit.updateicon()
-				else
-					new /obj/item/robot_parts/robot_suit(T)
-					new /obj/item/robot_parts/l_leg(T)
-					new /obj/item/robot_parts/r_leg(T)
-					new /obj/item/weapon/cable_coil(T, 1)
-					new /obj/item/robot_parts/chest(T)
-					new /obj/item/robot_parts/l_arm(T)
-					new /obj/item/robot_parts/r_arm(T)
-					new /obj/item/robot_parts/head(T)
-					var/b
-					for(b=0, b!=2, b++)
-						var/obj/item/device/flash/F = new /obj/item/device/flash(T)
-						F.burn_out()
-				del(src)
+				deconstruct()
 
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
@@ -1088,3 +1051,43 @@
 	set name = "State Laws"
 
 	checklaws()
+
+/mob/living/silicon/robot/proc/deconstruct()
+	var/turf/T = get_turf(src)
+	if(robot_suit)
+		robot_suit.loc = T
+		robot_suit.l_leg.loc = T
+		robot_suit.l_leg = null
+		robot_suit.r_leg.loc = T
+		robot_suit.r_leg = null
+		new /obj/item/weapon/cable_coil(T, 1) //The wires break off of the torso from the fall. I'm doing this so that they won't get confused when trying to build another cyborg.
+		robot_suit.chest.loc = T
+		robot_suit.chest.wires = 0.0
+		robot_suit.chest = null
+		robot_suit.l_arm.loc = T
+		robot_suit.l_arm = null
+		robot_suit.r_arm.loc = T
+		robot_suit.r_arm = null
+		robot_suit.head.loc = T
+		robot_suit.head.flash1.loc = T
+		robot_suit.head.flash1.burn_out()
+		robot_suit.head.flash1 = null
+		robot_suit.head.flash2.loc = T
+		robot_suit.head.flash2.burn_out()
+		robot_suit.head.flash2 = null
+		robot_suit.head = null
+		robot_suit.updateicon()
+	else
+		new /obj/item/robot_parts/robot_suit(T)
+		new /obj/item/robot_parts/l_leg(T)
+		new /obj/item/robot_parts/r_leg(T)
+		new /obj/item/weapon/cable_coil(T, 1)
+		new /obj/item/robot_parts/chest(T)
+		new /obj/item/robot_parts/l_arm(T)
+		new /obj/item/robot_parts/r_arm(T)
+		new /obj/item/robot_parts/head(T)
+		var/b
+		for(b=0, b!=2, b++)
+			var/obj/item/device/flash/F = new /obj/item/device/flash(T)
+			F.burn_out()
+	del(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -482,25 +482,29 @@
 		updateicon()
 
 	else if(istype(W, /obj/item/weapon/wrench) && opened && !cell) //Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
-		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 50))
-			user.visible_message("\red [user] deconstructs [src]!", "\blue You unfasten the securing bolts, and [src] falls to pieces!")
-			var/turf/T = get_turf(src)
-			new /obj/item/robot_parts/robot_suit(T)
-			new /obj/item/robot_parts/l_leg(T)
-			new /obj/item/robot_parts/r_leg(T)
-			new /obj/item/weapon/cable_coil(T, 1)
-			new /obj/item/robot_parts/chest(T)
-			new /obj/item/robot_parts/l_arm(T)
-			new /obj/item/robot_parts/r_arm(T)
-			var/b
-			for(b=0, b!=2, b++)
-				var/obj/item/device/flash/F = new /obj/item/device/flash(T)
-				F.broken = 1
-				F.icon_state = "flashburnt"
-				playsound(F, 'sound/weapons/flash.ogg', 50, 1)
-			new /obj/item/robot_parts/head(T)
-			del(src)
+		if(!lockcharge)
+			user << "\red <b>[src]'s bolts spark! Maybe you should lock them down first!</b>"
+			spark_system.start()
+			return
+		else
+			playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
+			if(do_after(user, 50))
+				user.visible_message("\red [user] deconstructs [src]!", "\blue You unfasten the securing bolts, and [src] falls to pieces!")
+				var/turf/T = get_turf(src)
+				new /obj/item/robot_parts/robot_suit(T)
+				new /obj/item/robot_parts/l_leg(T)
+				new /obj/item/robot_parts/r_leg(T)
+				new /obj/item/weapon/cable_coil(T, 1)
+				new /obj/item/robot_parts/chest(T)
+				new /obj/item/robot_parts/l_arm(T)
+				new /obj/item/robot_parts/r_arm(T)
+				var/b
+				for(b=0, b!=2, b++)
+					var/obj/item/device/flash/F = new /obj/item/device/flash(T)
+					F.broken = 1
+					F.icon_state = "flashburnt"
+				new /obj/item/robot_parts/head(T)
+				del(src)
 
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -608,6 +608,17 @@
 		spark_system.start()
 		return ..()
 
+/mob/living/silicon/robot/verb/unlock_own_panel()
+	set category = "Robot Commands"
+	set name = "Unlock Panel"
+	set desc = "Unlocks your own panel if it is locked. You can not lock it again. A human will have to lock it for you."
+	if(locked)
+		switch(alert("You can not lock your panel again, are you sure?\n      (You can still ask for a human to lock it)", "Unlock Own Panel", "Yes", "No"))
+			if("Yes")
+				locked = 0
+				updateicon()
+				usr << "You unlock your access panel."
+
 /mob/living/silicon/robot/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
 	if (!ticker)
 		M << "You cannot attack people before the game has started."

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -481,6 +481,27 @@
 			user << "Unable to locate a radio."
 		updateicon()
 
+	else if(istype(W, /obj/item/weapon/wrench) && opened && !cell) //Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
+		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
+		if(do_after(user, 50))
+			user.visible_message("\red [user] deconstructs [src]!", "\blue You unfasten the securing bolts, and [src] falls to pieces!")
+			var/turf/T = get_turf(src)
+			new /obj/item/robot_parts/robot_suit(T)
+			new /obj/item/robot_parts/l_leg(T)
+			new /obj/item/robot_parts/r_leg(T)
+			new /obj/item/weapon/cable_coil(T, 1)
+			new /obj/item/robot_parts/chest(T)
+			new /obj/item/robot_parts/l_arm(T)
+			new /obj/item/robot_parts/r_arm(T)
+			var/b
+			for(b=0, b!=2, b++)
+				var/obj/item/device/flash/F = new /obj/item/device/flash(T)
+				F.broken = 1
+				F.icon_state = "flashburnt"
+				playsound(F, 'sound/weapons/flash.ogg', 50, 1)
+			new /obj/item/robot_parts/head(T)
+			del(src)
+
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
 			radio.attackby(W,user)//GTFO, you have your own procs


### PR DESCRIPTION
This is a less destructive way to extract the MMI from a cyborg.
Also, you can no longer use broken flashes for eyes.
### Steps
- 1. Remove the power cell to expose the bolts
  - 1.1 Swipe an authorized ID to unlock the panel (emag works too)
  - 1.2 Crowbar to open the panel
  - 1.3 Bare hands to extract the cell
- 2. Lock down the cyborg to disengage safety protocols
  - Option 1. Cut the lockdown wire
  - Option 2. Use a Robotics console
- 3. Wrench the bolts off for the cyborg to deconstruct
#### Result
- Cyborg falls to pieces
- MMI drops to the ground
- Flashes break from the fall

http://imgur.com/a/O1KWw/

**EDIT:** New verb to allow willing cyborgs to unlock themselves.
