### PR TITLE
Fixes some runtimes related to atmos/shuttles

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -901,11 +901,13 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 
 	if(toupdate.len)
 		for(var/turf/simulated/T1 in toupdate)
+			air_master.remove_from_active(T1)
 			T1.CalculateAdjacentTurfs()
 			air_master.add_to_active(T1,1)
 
 	if(fromupdate.len)
 		for(var/turf/simulated/T2 in fromupdate)
+			air_master.remove_from_active(T2)
 			T2.CalculateAdjacentTurfs()
 			air_master.add_to_active(T2,1)
 


### PR DESCRIPTION
Removes the turf from the air controller when any shuttles moves. They are added back afterwards. This will avoid having walls on the active turf list who runtime to hell.

Basically, it removes all the turfs from both sides (where the shuttle was and where it docks) and then tries to add them back normally.
