### PR TITLE
Latejoin Double Agents [READY]

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -9,8 +9,10 @@
 	traitor_name = "double agent"
 
 	traitors_possible = 8 //hard limit on traitors if scaling is turned off
+	scale_modifier = 1.5 // Nearly twice as many double agents
 
 	var/list/target_list = list()
+	var/list/late_joining_list = list()
 
 /datum/game_mode/traitor/double_agents/announce()
 	world << "<B>The current game mode is - Double Agents!</B>"
@@ -45,5 +47,25 @@
 		..() // Give them standard objectives.
 	return
 
-/datum/game_mode/traitor/double_agents/make_antag_chance(var/mob/living/carbon/human/character)
+/datum/game_mode/traitor/double_agents/add_latejoin_traitor(var/mob/living/carbon/human/character)
+	// As soon as we get 3 or 4 extra latejoin traitors, make them traitors and kill each other.
+	if(late_joining_list.len >= rand(3, 4))
+		// True randomness
+		shuffle(late_joining_list)
+		// Reset the target_list, it'll be used again in force_traitor_objectives
+		target_list = list()
+
+		// Basically setting the target_list for who is killing who
+		var/i = 0
+		for(var/mob/living/carbon/human/traitor in late_joining_list)
+			i++
+			if(i + 1 > traitors.len)
+				i = 0
+			target_list[traitor] = late_joining_list[i + 1]
+
+		// Now, give them their targets
+		for(var/mob/living/carbon/human/traitor in late_joining_list)
+			..(traitor)
+	else
+		late_joining_list += character
 	return // TODO: Have late joining double agents.

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -62,7 +62,7 @@
 		var/i = 0
 		for(var/mob/living/carbon/human/traitor in late_joining_list)
 			i++
-			if(i + 1 > traitors.len)
+			if(i + 1 > late_joining_list.len)
 				i = 0
 			target_list[traitor] = late_joining_list[i + 1]
 
@@ -71,7 +71,7 @@
 			..(traitor)
 	else
 		late_joining_list += character
-	return // TODO: Have late joining double agents.
+	return
 
 /datum/game_mode/traitor/double_agents/proc/check_potential_agents()
 

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -48,6 +48,9 @@
 	return
 
 /datum/game_mode/traitor/double_agents/add_latejoin_traitor(var/mob/living/carbon/human/character)
+
+	check_potential_agents()
+
 	// As soon as we get 3 or 4 extra latejoin traitors, make them traitors and kill each other.
 	if(late_joining_list.len >= rand(3, 4))
 		// True randomness
@@ -69,3 +72,15 @@
 	else
 		late_joining_list += character
 	return // TODO: Have late joining double agents.
+
+/datum/game_mode/traitor/double_agents/proc/check_potential_agents()
+
+	for(var/M in late_joining_list)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.stat != DEAD)
+				if(H.client)
+					continue // It all checks out.
+
+		// If any check fails, remove them from our list
+		late_joining_list -= M

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -9,7 +9,7 @@
 	traitor_name = "double agent"
 
 	traitors_possible = 8 //hard limit on traitors if scaling is turned off
-	scale_modifier = 1.5 // Nearly twice as many double agents
+	scale_modifier = 0.5 // Nearly twice as many double agents
 
 	var/list/target_list = list()
 	var/list/late_joining_list = list()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -21,6 +21,7 @@
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
+	var/scale_modifier = 1 // Used for gamemodes, that are a child of traitor, that need more than the usual.
 
 
 /datum/game_mode/traitor/announce()
@@ -36,6 +37,7 @@
 	var/num_traitors = 1
 
 	if(config.traitor_scaling_coeff)
+		config.traitor_scaling_coeff *= scale_modifier
 		num_traitors = max(1, round((num_players())/(config.traitor_scaling_coeff)))
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
@@ -79,8 +81,12 @@
 		if(character.client.prefs.be_special & BE_TRAITOR)
 			if(!jobban_isbanned(character.client, "traitor") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))
-					character.mind.make_Traitor()
+					add_latejoin_traitor(character)
 	..()
+
+/datum/game_mode/traitor/proc/add_latejoin_traitor(var/mob/living/carbon/human/character)
+	character.mind.make_Traitor()
+
 
 /datum/game_mode/proc/forge_traitor_objectives(var/datum/mind/traitor)
 	if(istype(traitor.current, /mob/living/silicon))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -37,8 +37,7 @@
 	var/num_traitors = 1
 
 	if(config.traitor_scaling_coeff)
-		config.traitor_scaling_coeff *= scale_modifier
-		num_traitors = max(1, round((num_players())/(config.traitor_scaling_coeff)))
+		num_traitors = max(1, round((num_players())/((config.traitor_scaling_coeff * scale_modifier))))
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
 
@@ -75,9 +74,9 @@
 	return 1
 
 /datum/game_mode/traitor/make_antag_chance(var/mob/living/carbon/human/character) //Assigns traitor to latejoiners
-	if(traitors.len >= round(joined_player_list.len / config.traitor_scaling_coeff) + 1) //Caps number of latejoin antagonists
+	if(traitors.len >= round(joined_player_list.len / (config.traitor_scaling_coeff * scale_modifier)) + 1) //Caps number of latejoin antagonists
 		return
-	if (prob(100/config.traitor_scaling_coeff))
+	if (prob(100/(config.traitor_scaling_coeff * scale_modifier)))
 		if(character.client.prefs.be_special & BE_TRAITOR)
 			if(!jobban_isbanned(character.client, "traitor") && !jobban_isbanned(character.client, "Syndicate"))
 				if(!(character.job in ticker.mode.restricted_jobs))


### PR DESCRIPTION
- Late joiners can now be double agents.
- This works by keeping a list of players who are applicable for double agents and then after, a certain number of them are picked, it will tell them all to kill each other.
- Increased the amount of double agents that start in the round (x1.5).
