### PR TITLE
Staff of Runtimes

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -97,9 +97,10 @@
 		brainmob.dna = H.dna
 	brainmob.container = src
 
-	var/obj/item/organ/brain/newbrain = H.getorgan(/obj/item/organ/brain)
-	newbrain.loc = src
-	brain = newbrain
+	if(istype(H))
+		var/obj/item/organ/brain/newbrain = H.getorgan(/obj/item/organ/brain)
+		newbrain.loc = src
+		brain = newbrain
 
 	name = "Man-Machine Interface: [brainmob.real_name]"
 	icon_state = "mmi_full"


### PR DESCRIPTION
the transfer_identity() proc of MMIs can now be used by any mob instead of only humans.

This will make the staff of change stop runtiming.
