### PR TITLE
Replaces HasEntered() with Crossed() and reduces redundant checks on turf/Enter()

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -175,7 +175,7 @@
 	air_update_turf()
 	return
 
-/obj/effect/hotspot/HasEntered(mob/living/L)
+/obj/effect/hotspot/Crossed(mob/living/L)
 	..()
 	if(isliving(L))
 		L.fire_act()

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -207,7 +207,7 @@
 		icon_state = "beartrap[armed]"
 		user << "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"]</span>"
 
-/obj/item/weapon/legcuffs/beartrap/HasEntered(AM as mob|obj)
+/obj/item/weapon/legcuffs/beartrap/Crossed(AM as mob|obj)
 	if(armed)
 		if(ishuman(AM))
 			if(isturf(src.loc))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -91,9 +91,6 @@
 /atom/proc/CheckExit()
 	return 1
 
-/atom/proc/HasEntered(atom/movable/AM as mob|obj)
-	return
-
 /atom/proc/HasProximity(atom/movable/AM as mob|obj)
 	return
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -23,6 +23,11 @@
 		src.last_move = get_dir(A, src.loc)
 	return
 
+// Previously known as HasEntered()
+// This is automatically called when something enters your square
+/atom/movable/Crossed(atom/movable/AM)
+	return
+
 /atom/movable/Bump(var/atom/A as mob|obj|turf|area, yes)
 	if(src.throwing)
 		src.throw_impact(A)
@@ -41,6 +46,8 @@
 			loc.Exited(src)
 		loc = destination
 		loc.Entered(src)
+		for(var/atom/movable/AM in loc)
+			AM.Crossed(src)
 		return 1
 	return 0
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -50,7 +50,7 @@
 		return
 	return
 
-/obj/effect/gateway/HasEntered(AM as mob|obj)
+/obj/effect/gateway/Crossed(AM as mob|obj)
 	spawn(0)
 		return
 	return

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -730,7 +730,7 @@ var/global/mulebot_count = 0
 	return get_turf(src)
 
 
-// called from mob/living/carbon/human/HasEntered()
+// called from mob/living/carbon/human/Crossed()
 // when mulebot is in the same loc
 /obj/machinery/bot/mulebot/proc/RunOver(var/mob/living/carbon/human/H)
 	src.visible_message("\red [src] drives over [H]!")

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -116,7 +116,7 @@
 
 /*
 //Allow you to push disposal pipes into it (for those with density 1)
-/obj/machinery/pipedispenser/disposal/HasEntered(var/obj/structure/disposalconstruct/pipe as obj)
+/obj/machinery/pipedispenser/disposal/Crossed(var/obj/structure/disposalconstruct/pipe as obj)
 	if(istype(pipe) && !pipe.anchored)
 		del(pipe)
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -49,7 +49,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 /obj/machinery/recycler/Bumped(var/atom/movable/AM)
 
-	// HasEntered didn't like people lying down.
+	// Crossed didn't like people lying down.
 	if(stat & (BROKEN|NOPOWER))
 		return
 	if(safety_mode)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -33,7 +33,7 @@
 	if(cooldown == 1)
 		return
 
-	// HasEntered didn't like people lying down.
+	// Crossed didn't like people lying down.
 	if(ishuman(AM))
 		// Only humans can enter from the west side, while lying down.
 		var/move_dir = get_dir(loc, AM.loc)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -330,7 +330,7 @@
 		var/obj/O = obstacle
 		if(istype(O, /obj/effect/portal)) //derpfix
 			src.anchored = 0
-			O.HasEntered(src)
+			O.Crossed(src)
 			spawn(0)//countering portal teleport spawn(0), hurr
 				src.anchored = 1
 		else if(!O.anchored)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -375,7 +375,7 @@ steam.start() -- spawns the effect
 	return 1
 
 
-/obj/effect/effect/bad_smoke/HasEntered(mob/living/carbon/M as mob )
+/obj/effect/effect/bad_smoke/Crossed(mob/living/carbon/M as mob )
 	..()
 	if(istype(M, /mob/living/carbon))
 		if (M.internal != null && M.wear_mask && (M.wear_mask.flags & MASKINTERNALS))
@@ -465,7 +465,7 @@ steam.start() -- spawns the effect
 
 	return
 
-/obj/effect/effect/chem_smoke/HasEntered(mob/living/carbon/M as mob )
+/obj/effect/effect/chem_smoke/Crossed(mob/living/carbon/M as mob )
 	..()
 	reagents.reaction(M)
 
@@ -598,7 +598,7 @@ steam.start() -- spawns the effect
 					M.coughedtime = 0
 	return
 
-/obj/effect/effect/sleep_smoke/HasEntered(mob/living/carbon/M as mob )
+/obj/effect/effect/sleep_smoke/Crossed(mob/living/carbon/M as mob )
 	..()
 	if(istype(M, /mob/living/carbon))
 		if (M.internal != null && M.wear_mask && (M.wear_mask.flags & MASKINTERNALS))
@@ -840,7 +840,7 @@ steam.start() -- spawns the effect
 			delete()
 
 
-/obj/effect/effect/foam/HasEntered(var/atom/movable/AM)
+/obj/effect/effect/foam/Crossed(var/atom/movable/AM)
 	if(metal)
 		return
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -12,7 +12,7 @@
 /obj/effect/mine/New()
 	icon_state = "uglyminearmed"
 
-/obj/effect/mine/HasEntered(AM as mob|obj)
+/obj/effect/mine/Crossed(AM as mob|obj)
 	Bumped(AM)
 
 /obj/effect/mine/Bumped(mob/M as mob|obj)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -16,7 +16,7 @@
 		return
 	return
 
-/obj/effect/portal/HasEntered(AM as mob|obj)
+/obj/effect/portal/Crossed(AM as mob|obj)
 	spawn(0)
 		src.teleport(AM)
 		return

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -9,7 +9,7 @@
 /obj/effect/step_trigger/proc/Trigger(var/atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/HasEntered(H as mob|obj)
+/obj/effect/step_trigger/Crossed(H as mob|obj)
 	..()
 	if(!H)
 		return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -967,7 +967,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		src.id.loc = get_turf(src.loc)
 	..()
 
-/obj/item/device/pda/clown/HasEntered(AM as mob|obj) //Clown PDA is slippery.
+/obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
 		if ((istype(M, /mob/living/carbon/human) && (istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP)) || M.m_intent == "walk")

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -304,7 +304,7 @@
 			del(src)
 	..()
 
-/obj/item/weapon/shard/HasEntered(var/mob/AM)
+/obj/item/weapon/shard/Crossed(var/mob/AM)
 	if(istype(AM))
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 		if(ishuman(AM))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -443,7 +443,7 @@
 		playsound(src, 'sound/effects/snap.ogg', 50, 1)
 		del(src)
 
-/obj/item/toy/snappop/HasEntered(H as mob|obj)
+/obj/item/toy/snappop/Crossed(H as mob|obj)
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		if(M.m_intent == "run")

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -8,7 +8,7 @@
 /*
  * Banana Peals
  */
-/obj/item/weapon/bananapeel/HasEntered(AM as mob|obj)
+/obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
 		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
@@ -23,7 +23,7 @@
 /*
  * Soap
  */
-/obj/item/weapon/soap/HasEntered(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
+/obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
 		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -75,7 +75,7 @@
 	else if(src.throwing == 0) //Dice was thrown and is coming to rest
 		src.loc.visible_message("<span class='notice'>[src] rolls to a stop, landing on [result]. [comment]</span>")
 
-/obj/item/weapon/dice/d4/HasEntered(var/mob/living/carbon/human/H)
+/obj/item/weapon/dice/d4/Crossed(var/mob/living/carbon/human/H)
 	if(istype(H) && !H.shoes)
 		H << "<span class='userdanger'>You step on the D4!</span>"
 		H.apply_damage(4,BRUTE,(pick("l_leg", "r_leg")))

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -128,9 +128,9 @@
 	if(nadeassembly)
 		nadeassembly.HasProximity(AM)
 
-/obj/item/weapon/grenade/chem_grenade/HasEntered(atom/movable/AM)
+/obj/item/weapon/grenade/chem_grenade/Crossed(atom/movable/AM)
 	if(nadeassembly)
-		nadeassembly.HasEntered(AM)
+		nadeassembly.Crossed(AM)
 
 /obj/item/weapon/grenade/chem_grenade/on_found(mob/finder)
 	if(nadeassembly)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -14,6 +14,17 @@
 	var/damtype = "brute"
 	var/force = 0
 
+/obj/New()
+	..()
+	if(flags&ON_BORDER && isturf(loc))
+		var/turf/T = loc
+		T.border_objects += src
+/obj/Del()
+	if(flags&ON_BORDER && isturf(loc))
+		var/turf/T = loc
+		T.border_objects -= src
+	..()
+
 /obj/proc/process()
 	processing_objects.Remove(src)
 	return 0

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -14,17 +14,6 @@
 	var/damtype = "brute"
 	var/force = 0
 
-/obj/New()
-	..()
-	if(flags&ON_BORDER && isturf(loc))
-		var/turf/T = loc
-		T.border_objects += src
-/obj/Del()
-	if(flags&ON_BORDER && isturf(loc))
-		var/turf/T = loc
-		T.border_objects -= src
-	..()
-
 /obj/proc/process()
 	processing_objects.Remove(src)
 	return 0

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -287,3 +287,12 @@
 			overlays += "welded"
 	else
 		icon_state = icon_opened
+
+// Objects that try to exit a locker by stepping were doing so successfully,
+// and due to an oversight in turf/Enter() were going through walls.  That
+// should be independently resolved, but this is also an interesting twist.
+/obj/structure/closet/Exit(atom/movable/AM)
+	open()
+	if(AM.loc == src) return 0
+	return 1
+

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -201,7 +201,7 @@
 				ismist = 0
 
 
-/obj/machinery/shower/HasEntered(atom/movable/O)
+/obj/machinery/shower/Crossed(atom/movable/O)
 	..()
 	wash(O)
 	if(ismob(O))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -128,14 +128,6 @@
 			M:inertia_dir = 0
 	..()
 	var/objects = 0
-	for(var/atom/A as mob|obj|turf|area in src)
-		if(objects > loopsanity)	break
-		objects++
-		spawn( 0 )
-			if ((A && M))
-				A.HasEntered(M, 1)
-			return
-	objects = 0
 	for(var/atom/A as mob|obj|turf|area in range(1))
 		if(objects > loopsanity)	break
 		objects++

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -73,9 +73,9 @@
 	if(bombassembly)
 		bombassembly.HasProximity(AM)
 
-/obj/item/device/onetankbomb/HasEntered(atom/movable/AM as mob|obj) //for mousetraps
+/obj/item/device/onetankbomb/Crossed(atom/movable/AM as mob|obj) //for mousetraps
 	if(bombassembly)
-		bombassembly.HasEntered(AM)
+		bombassembly.Crossed(AM)
 
 /obj/item/device/onetankbomb/on_found(mob/finder as mob) //for mousetraps
 	if(bombassembly)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -75,11 +75,11 @@
 			a_right.HasProximity(AM)
 
 
-	HasEntered(atom/movable/AM as mob|obj)
+	Crossed(atom/movable/AM as mob|obj)
 		if(a_left)
-			a_left.HasEntered(AM)
+			a_left.Crossed(AM)
 		if(a_right)
-			a_right.HasEntered(AM)
+			a_right.Crossed(AM)
 
 	on_found(mob/finder as mob)
 		if(a_left)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -261,7 +261,7 @@
 	hit()
 	return
 
-/obj/effect/beam/i_beam/HasEntered(atom/movable/AM as mob|obj)
+/obj/effect/beam/i_beam/Crossed(atom/movable/AM as mob|obj)
 	if(istype(AM, /obj/effect/beam))
 		return
 	spawn(0)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -96,7 +96,7 @@
 		..()
 
 
-	HasEntered(var/atom/movable/AM as mob|obj)
+	Crossed(var/atom/movable/AM as mob|obj)
 		if(armed)
 			if(ishuman(AM))
 				var/mob/living/carbon/H = AM

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -250,7 +250,7 @@ proc/check_panel(mob/M)
 
 		return
 
-	HasEntered(var/mob/M, somenumber)
+	Crossed(var/mob/M, somenumber)
 		if(M == my_target)
 			step_away(src,my_target,2)
 			if(prob(30))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -677,7 +677,7 @@
 	del(src)
 	return
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato/HasEntered(AM as mob|obj)
+/obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/M =	AM
 		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -87,7 +87,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(NewLoc)
 		loc = NewLoc
 		for(var/obj/effect/step_trigger/S in NewLoc)
-			S.HasEntered(src)
+			S.Crossed(src)
 
 		return
 	loc = get_turf(src) //Get out of closets and such as a ghost
@@ -101,7 +101,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		x--
 
 	for(var/obj/effect/step_trigger/S in locate(x, y, z))	//<-- this is dumb
-		S.HasEntered(src)
+		S.Crossed(src)
 
 /mob/dead/observer/examine()
 	if(usr)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -70,7 +70,7 @@ var/const/MAX_ACTIVE_TIME = 400
 /obj/item/clothing/mask/facehugger/equipped(mob/M)
 	Attach(M)
 
-/obj/item/clothing/mask/facehugger/HasEntered(atom/target)
+/obj/item/clothing/mask/facehugger/Crossed(atom/target)
 	HasProximity(target)
 	return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -363,7 +363,7 @@
 
 // called when something steps onto a human
 // this could be made more general, but for now just handle mulebot
-/mob/living/carbon/human/HasEntered(var/atom/movable/AM)
+/mob/living/carbon/human/Crossed(var/atom/movable/AM)
 	var/obj/machinery/bot/mulebot/MB = AM
 	if(istype(MB))
 		MB.RunOver(src)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -40,7 +40,7 @@
 	M.icon_state = src.icon_dead
 	del (src)
 
-/mob/living/simple_animal/mouse/HasEntered(AM as mob|obj)
+/mob/living/simple_animal/mouse/Crossed(AM as mob|obj)
 	if( ishuman(AM) )
 		if(!stat)
 			var/mob/M = AM

--- a/maps/RandomZLevels/wildwest.dm
+++ b/maps/RandomZLevels/wildwest.dm
@@ -144,7 +144,7 @@
 /obj/effect/meatgrinder/New()
 	icon_state = "blobpod"
 
-/obj/effect/meatgrinder/HasEntered(AM as mob|obj)
+/obj/effect/meatgrinder/Crossed(AM as mob|obj)
 	Bumped(AM)
 
 /obj/effect/meatgrinder/Bumped(mob/M as mob|obj)


### PR DESCRIPTION
In an effort to reduce redundant code in object movement two changes have been made:
- atom/HasEntered() is replaced with atom/movable/Crossed(), a byond builtin that is already being called from standard Move() code
- During turf/Enter(), the contents of the tiles are checked only once, using a temporary list to cut down on redundant checks.

This should reduce lag a bit when lots of objects are moving on top of lots of other objects (singulo, mining)

Also I dunno if the whole pushing people into walls trick was ever fixed but this should fix it if not, turf/Enter() allowed things to enter unconditionally if they were not on a turf (before checking their own density even).  I see that bug with sayustation cluster grenades, when they step out of a closet they go through walls easily (allowing you to get parrots into all sorts of places)
