### PR TITLE
Substitute for Muting OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -35,6 +35,10 @@
 			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
+		for(var/word in ooc_filter)
+			if(findtext(msg,word))
+				src << "<B>The word [word] has been filtered from OOC.</B>"
+				return
 
 	log_ooc("[mob.name]/[key] : [msg]")
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -38,6 +38,7 @@
 		for(var/word in ooc_filter)
 			if(findtext(msg,word))
 				src << "<B>The word [word] has been filtered from OOC.</B>"
+				log_ooc("[mob.name]/[key] (Filtered [word]) : [msg]")
 				return
 
 	log_ooc("[mob.name]/[key] : [msg]")

--- a/code/global.dm
+++ b/code/global.dm
@@ -81,6 +81,7 @@ var/tinted_weldhelh = 1
 var/list/jobMax = list()
 var/list/bombers = list(  )
 var/list/admin_log = list (  )
+var/list/ooc_filter = list (  )
 var/list/lastsignalers = list(	)	//keeps last 100 signals here in format: "[src] used \ref[src] @ location [src.loc]: [freq]/[code]"
 var/list/lawchanges = list(  ) //Stores who uploaded laws to which silicon-based lifeform, and what the law was
 var/list/shuttles = list(  )

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -558,6 +558,38 @@ var/global/floorIsLava = 0
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.", 1)
 	feedback_add_details("admin_verb","TDOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/filterooc(word as text)
+	set category = "Server"
+	set desc="Filter what word?"
+	set name="OOC Filter - Add"
+	if(ooc_filter.Find(word))
+		src << "[word] is already filtered."
+		return
+	ooc_filter += word
+	log_admin("[key_name(usr)] filtered [word] from OOC.")
+	message_admins("[key_name(usr)] filtered [word] from OOC.", 1)
+	feedback_add_details("admin_verb", "FOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/unfilterooc(word as text)
+	set category = "Server"
+	set desc="Allow what word?"
+	set name="OOC Filter - Remove"
+	if(ooc_filter.Remove(word))
+		log_admin("[key_name(usr)] allowed [word] in OOC.")
+		message_admins("[key_name(usr)] allowed [word] in OOC.", 1)
+		feedback_add_details("admin_verb", "REMFOOC")
+	else src << "[word] is not filtered."
+
+/datum/admins/proc/clearoocfilter()
+	set category = "Server"
+	set desc="Free Speech"
+	set name="OOC Filter - Clear"
+	ooc_filter = new /list()
+	log_admin("[key_name(usr)] unfiltered OOC.")
+	message_admins("[key_name(usr)] unfiltered OOC.", 1)
+	feedback_add_details("admin_verb", "UNFOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /*
 /datum/admins/proc/toggletraitorscaling()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -23,6 +23,9 @@ var/list/admin_verbs_admin = list(
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
+	/datum/admins/proc/filterooc,		/*filters words from ooc*/
+	/datum/admins/proc/unfilterooc,		/*allows words in ooc*/
+	/datum/admins/proc/clearoocfilter,	/*clears the ooc filter*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/
 	/datum/admins/proc/toggleguests,	/*toggles whether guests can join the current game*/


### PR DESCRIPTION
For consideration:
Allows admins to filter words in OOC on a per-round basis. (The filter list starts empty each round.)
Ideally, this would be used to kill conversations which would previously result in OOC being muted.  Blocked messages, and all filtering/unfiltering is logged, and all admins have access to a filter reset button.
