### PR TITLE
Adds container resist proc

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -358,6 +358,7 @@
 	var/mob/living/user = usr
 	var/breakout_time = 2
 	if(open || !locked)	//Open and unlocked, no need to escape
+		open = 1
 		return
 	user.next_move = world.time + 100
 	user.last_special = world.time + 100
@@ -373,9 +374,6 @@
 		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
 		user << "<span class='notice'>You successfully break out of [src]!</span>"
 
-		if(istype(loc, /obj/structure/bigDelivery))
-			var/obj/structure/bigDelivery/BD = loc
-			BD.attack_hand(user)
 		open()
 
 /obj/machinery/dna_scannernew/proc/close()

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -354,6 +354,30 @@
 	if(open)	return close()
 	else		return open()
 
+/obj/machinery/dna_scannernew/container_resist()
+	var/mob/living/user = usr
+	var/breakout_time = 2
+	if(open || !locked)	//Open and unlocked, no need to escape
+		return
+	user.next_move = world.time + 100
+	user.last_special = world.time + 100
+	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
+	for(var/mob/O in viewers(src))
+		O << "<span class='warning'>You hear a metallic creaking from [src]!</span>"
+
+	if(do_after(user,(breakout_time*60*10))) //minutes * 60seconds * 10deciseconds
+		if(!user || user.stat != CONSCIOUS || user.loc != src || open || !locked)
+			return
+
+		locked = 0
+		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>", \
+				"<span class='notice'>You successfully break out of [src]!</span>")
+
+		if(istype(loc, /obj/structure/bigDelivery))
+			var/obj/structure/bigDelivery/BD = loc
+			BD.attack_hand(user)
+		open()
+
 /obj/machinery/dna_scannernew/proc/close()
 	if(open)
 		open = 0

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -370,8 +370,8 @@
 			return
 
 		locked = 0
-		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>", \
-				"<span class='notice'>You successfully break out of [src]!</span>")
+		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
+		user << "<span class='notice'>You successfully break out of [src]!</span>"
 
 		if(istype(loc, /obj/structure/bigDelivery))
 			var/obj/structure/bigDelivery/BD = loc

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -65,6 +65,8 @@
 
 		dat += "<A href='?src=\ref[src];refresh=1'>Scan</A>"
 
+		dat += "<A href='?src=\ref[src];eject=1'>Eject occupant</A>"
+
 		dat += "<h3>Injector</h3>"
 		if(occupant)
 			dat += "<A href='?src=\ref[src];inap=1'>Inject Inaprovaline</A>"
@@ -92,7 +94,11 @@
 		return
 	usr.set_machine(src)
 	if(connected && connected.occupant)
-		if(connected.occupant.health > 0)
+		if(href_list["eject"])
+			connected.eject()
+			updateUsrDialog()
+			return
+		else if(connected.occupant.health > 0)
 			if(href_list["inap"])
 				connected.inject_inap(usr)
 			if(href_list["stox"])
@@ -294,14 +300,10 @@
 		var/units = round(occupant.reagents.get_reagent_amount("dexalin"))
 		user << "<span class='notice'>Occupant now has [units] unit\s of dexalin in their bloodstream.</span>"
 
+/obj/machinery/sleeper/container_resist()
+	eject()
 
-/obj/machinery/sleeper/verb/eject()
-	set name = "Eject occupant"
-	set category = "Object"
-	set src in oview(1)
-	if(usr.stat || isslime(usr) || ispAI(usr))
-		return
-	icon_state = "sleeper-open"
+/obj/machinery/sleeper/proc/eject()
 	go_out()
 	add_fingerprint(usr)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -60,8 +60,8 @@
 	return 0
 
 
-/obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user)
-	if(user.stat)
+/obj/machinery/atmospherics/unary/cryo_cell/container_resist()
+	if(usr.stat)
 		return
 	go_out()
 	return

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -65,7 +65,7 @@
 /obj/machinery/gibber/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/gibber/relaymove(mob/user as mob)
+/obj/machinery/gibber/container_resist()
 	src.go_out()
 	return
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -419,15 +419,26 @@
 	return
 
 
-/obj/machinery/suit_storage_unit/verb/get_out()
-	set name = "Eject Suit Storage Unit"
-	set category = "Object"
-	set src in oview(1)
+/obj/machinery/suit_storage_unit/container_resist()
+	var/mob/living/user = usr
+	if(islocked)
+		user.next_move = world.time + 100
+		user.last_special = world.time + 100
+		var/breakout_time = 2
+		user << "<span class='notice'>You start kicking against the doors to escape! (This will take about [breakout_time] minutes.)</span>"
+		visible_message("You see [user] kicking against the doors of the [src]!")
+		if(do_after(user,(breakout_time*60*10)))
+			if(!user || user.stat != CONSCIOUS || user.loc != src || isopen || !islocked)
+				return
+			else
+				isopen = 1
+				islocked = 0
+				visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
 
-	if (usr.stat != 0)
-		return
-	src.eject_occupant(usr)
-	add_fingerprint(usr)
+		else
+			return
+	src.eject_occupant(user)
+	add_fingerprint(user)
 	src.updateUsrDialog()
 	src.update_icon()
 	return

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -210,6 +210,9 @@
 			return 1
 		return
 
+	container_resist()
+		go_out()
+
 /datum/global_iterator/mech_sleeper
 
 	process(var/obj/item/mecha_parts/mecha_equipment/tool/sleeper/S)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1086,6 +1086,9 @@
 	add_fingerprint(usr)
 	return
 
+/obj/mecha/container_resist()
+	go_out()
+
 
 /obj/mecha/proc/go_out()
 	if(!src.occupant) return

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -191,8 +191,22 @@
 	icon_state = "cocoon1"
 	health = 60
 
-	New()
+/obj/effect/spider/cocoon/New()
 		icon_state = pick("cocoon1","cocoon2","cocoon3")
+
+/obj/effect/spider/cocoon/container_resist()
+	var/mob/living/user = usr
+	var/breakout_time = 2
+	user.next_move = world.time + 100
+	user.last_special = world.time + 100
+	user << "<span class='notice'>You struggle against the tight bonds! (This will take about [breakout_time] minutes.)</span>"
+	visible_message("You see something struggling and writhing in the [src]!")
+	if(do_after(user,(breakout_time*60*10)))
+		if(!user || user.stat != CONSCIOUS || user.loc != src)
+			return
+		Del()
+
+
 
 /obj/effect/spider/cocoon/Del()
 	src.visible_message("\red \The [src] splits open.")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -93,6 +93,9 @@
 /obj/proc/interact(mob/user)
 	return
 
+/obj/proc/container_resist()
+	return
+
 /obj/proc/update_icon()
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -287,3 +287,34 @@
 			overlays += "welded"
 	else
 		icon_state = icon_opened
+
+/obj/structure/closet/container_resist()
+	var/mob/living/user = usr
+	var/breakout_time = 2 //2 minutes by default
+	if(istype(user.loc, /obj/structure/closet/critter) && !welded)
+		breakout_time = 0.75 //45 seconds if it's an unwelded critter crate
+
+	if(opened || (!welded && !locked))
+		return  //Door's open, not locked or welded, no point in resisting.
+
+	//okay, so the closet is either welded or locked... resist!!!
+	user.next_move = world.time + 100
+	user.last_special = world.time + 100
+	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
+	for(var/mob/O in viewers(src))
+		O << "<span class='warning'>[src] begins to shake violently!</span>"
+
+	if(do_after(user,(breakout_time*60*10))) //minutes * 60seconds * 10deciseconds
+		if(!user || user.stat != CONSCIOUS || user.loc != src || opened || (!locked && !welded))
+			return
+		//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
+
+		welded = 0 //applies to all lockers lockers
+		locked = 0 //applies to critter crates and secure lockers only
+		broken = 1 //applies to secure lockers only
+		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>", \
+						"<span class='notice'>You successfully break out of [src]!</span>")
+		if(istype(loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
+			var/obj/structure/bigDelivery/BD = loc
+			BD.attack_hand(user)
+		open()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -312,8 +312,8 @@
 		welded = 0 //applies to all lockers lockers
 		locked = 0 //applies to critter crates and secure lockers only
 		broken = 1 //applies to secure lockers only
-		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>", \
-						"<span class='notice'>You successfully break out of [src]!</span>")
+		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
+		user << "<span class='notice'>You successfully break out of [src]!</span>"
 		if(istype(loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
 			var/obj/structure/bigDelivery/BD = loc
 			BD.attack_hand(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -314,7 +314,4 @@
 		broken = 1 //applies to secure lockers only
 		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
 		user << "<span class='notice'>You successfully break out of [src]!</span>"
-		if(istype(loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
-			var/obj/structure/bigDelivery/BD = loc
-			BD.attack_hand(user)
 		open()

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -148,3 +148,6 @@
 	dump_contents()
 	visible_message("\red [src] shatters!. ")
 	del(src)
+
+/obj/structure/closet/statue/container_resist()
+	return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -101,9 +101,7 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/structure/morgue/relaymove(mob/user as mob)
-	if (user.stat)
-		return
+/obj/structure/morgue/container_resist()
 	src.connected = new /obj/structure/m_tray( src.loc )
 	step(src.connected, EAST)
 	src.connected.layer = OBJ_LAYER
@@ -271,9 +269,7 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/structure/crematorium/relaymove(mob/user as mob)
-	if (user.stat || locked)
-		return
+/obj/structure/crematorium/container_resist()
 	src.connected = new /obj/structure/c_tray( src.loc )
 	step(src.connected, SOUTH)
 	src.connected.layer = OBJ_LAYER

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -464,8 +464,9 @@
 
 	//Breaking out of a container (Locker, sleeper, cryo...)
 	else if(loc && istype(loc, /obj) && !isturf(loc))
-		var/obj/C = loc
-		C.container_resist(L)
+		if(L.stat == CONSCIOUS && !L.stunned && !L.weakened && !L.paralysis)
+			var/obj/C = loc
+			C.container_resist(L)
 
 	//Stop drop and roll & Handcuffs
 	else if(iscarbon(L))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -462,37 +462,10 @@
 		else
 			L.buckled.manual_unbuckle(L)
 
-	//Breaking out of a locker?
-	else if(loc && istype(loc, /obj/structure/closet))
-		var/obj/structure/closet/C = L.loc
-		var/breakout_time = 2 //2 minutes by default
-		if(istype(L.loc, /obj/structure/closet/critter) && !C.welded)
-			breakout_time = 0.75 //45 seconds if it's an unwelded critter crate
-
-		if(C.opened || (!C.welded && !C.locked))
-			return	//Door's open, not locked or welded, no point in resisting.
-
-		//okay, so the closet is either welded or locked... resist!!!
-		usr.next_move = world.time + 100
-		L.last_special = world.time + 100
-		L << "<span class='notice'>You lean on the back of [C] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
-		for(var/mob/O in viewers(C))
-			O << "<span class='warning'>[C] begins to shake violently!</span>"
-
-		if(do_after(usr,(breakout_time*60*10))) //minutes * 60seconds * 10deciseconds
-			if(!C || !L || L.stat != CONSCIOUS || L.loc != C || C.opened || (!C.locked && !C.welded))
-				return
-			//we check after a while whether there is a point of resisting anymore and whether the user is capable of resisting
-
-			C.welded = 0 //applies to all lockers lockers
-			C.locked = 0 //applies to critter crates and secure lockers only
-			C.broken = 1 //applies to secure lockers only
-			L.visible_message("<span class='danger'>[L] successfully broke out of [C]!</span>", \
-							"<span class='notice'>You successfully break out of [C]!</span>")
-			if(istype(C.loc, /obj/structure/bigDelivery)) //Do this to prevent contents from being opened into nullspace (read: bluespace)
-				var/obj/structure/bigDelivery/BD = C.loc
-				BD.attack_hand(usr)
-			C.open()
+	//Breaking out of a container (Locker, sleeper, cryo...)
+	else if(loc && istype(loc, /obj) && !isturf(loc))
+		var/obj/C = loc
+		C.container_resist(L)
 
 	//Stop drop and roll & Handcuffs
 	else if(iscarbon(L))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -193,11 +193,11 @@
 /obj/machinery/disposal/alter_health()
 	return get_turf(src)
 
-// attempt to move while inside
-/obj/machinery/disposal/relaymove(mob/user as mob)
-	if(user.stat || src.flushing)
+// resist to escape the bin
+/obj/machinery/disposal/container_resist()
+	if(src.flushing)
 		return
-	src.go_out(user)
+	go_out(usr)
 	return
 
 // leave the disposal


### PR DESCRIPTION
Fixes #135

Living mobs now call an /obj/container_resist() proc when they resist and their location is not turf, therefore allowing handling of mobs attempting to escape various containers, including lockers, cryo-tubes and Odysseus sleepers. Cryo-tube now only allows escape by resisting rather than moving, although it is currently instant, instead of the wait when you eject the whole contents with the verb.

Feel free to suggest anything else that needs handling or adding for resist escape.
