### PR TITLE
Resolves #1591

### DIFF
--- a/code/game/machinery/kitchen/icecream_vat.dm
+++ b/code/game/machinery/kitchen/icecream_vat.dm
@@ -216,7 +216,7 @@ var/list/ingredients_source = list(
 	name = "ice cream cone"
 	desc = "Delicious waffle cone, but no ice cream."
 	icon = 'icons/obj/kitchen.dmi'
-	icon_state = "icecream_cone"
+	icon_state = "icecream_cone_waffle" //default for admin-spawned cones, href_list["cone"] should overwrite this all the time
 	layer = 3.1
 	var/ice_creamed = 0
 	var/cone_type


### PR DESCRIPTION
Resolves #1591. Icecream cones had, by default, an icon_state that did not exist. Assigning them one that does should be fine because the proc that calls New() for icecream cones already overwrites it.
