### PR TITLE
Resolves #230

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -39,14 +39,15 @@
 		for(var/mob/living/silicon/ai/A in src)
 			dat += "Stored AI: [A.name]<br>System integrity: [(A.health+100)/2]%<br>"
 
+			if (A.laws.zeroth)
+				laws += "0: [A.laws.zeroth]<BR>"
+
 			for (var/index = 1, index <= A.laws.ion.len, index++)
 				var/law = A.laws.ion[index]
 				if (length(law) > 0)
 					var/num = ionnum()
-					laws += "[num]. [law]"
+					laws += "[num]. [law]<BR>"
 
-			if (A.laws.zeroth)
-				laws += "0: [A.laws.zeroth]<BR>"
 
 			var/number = 1
 			for (var/index = 1, index <= A.laws.inherent.len, index++)


### PR DESCRIPTION
Resolves #230. The output for hacked laws, which are treated by the code as an ion law, was not being outputted in the format which is standard in other law outputs. This fixes that.
