### PR TITLE
Empty staves whizzle instead of *click*

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -34,6 +34,10 @@
 		proj.silenced = silenced
 		return
 
+	proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
+       	user << "<span class='warning'>*click*</span>"
+       	return
+
 
 	emp_act(severity)
 		for(var/obj/O in contents)
@@ -78,7 +82,7 @@
 		if(!special_check(user))
 			return
 		if(!load_into_chamber())
-			user << "<span class='warning'>*click*</span>"
+			shoot_with_empty_chamber(user)
 			return
 
 		if(!in_chamber)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -35,8 +35,8 @@
 		return
 
 	proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-       	user << "<span class='warning'>*click*</span>"
-       	return
+		user << "<span class='warning'>*click*</span>"
+		return
 
 
 	emp_act(severity)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -35,14 +35,8 @@
 		return
 
 	proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-<<<<<<< HEAD
 		user << "<span class='warning'>*click*</span>"
 		return
-=======
-       	user << "<span class='warning'>*click*</span>"
-       	return
->>>>>>> cec73fb2af4eb69f5a60f1e26871ec2f587dd3a1
-
 
 	emp_act(severity)
 		for(var/obj/O in contents)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -64,6 +64,11 @@ obj/item/weapon/gun/energy/staff
 	update_icon()
 		return
 
+	shoot_with_empty_chamber(mob/living/user as mob|obj)
+       user << "<span class='warning'>The [name] whizzles quietly.<span>"
+       return
+
+
 /obj/item/weapon/gun/energy/staff/animate
 	name = "staff of animation"
 	desc = "An artefact that spits bolts of life-force which causes objects which are hit by it to animate and come to life! This magic doesn't affect machines."

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -65,8 +65,8 @@ obj/item/weapon/gun/energy/staff
 		return
 
 	shoot_with_empty_chamber(mob/living/user as mob|obj)
-       user << "<span class='warning'>The [name] whizzles quietly.<span>"
-       return
+		user << "<span class='warning'>The [name] whizzles quietly.<span>"
+		return
 
 
 /obj/item/weapon/gun/energy/staff/animate

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -65,14 +65,8 @@ obj/item/weapon/gun/energy/staff
 		return
 
 	shoot_with_empty_chamber(mob/living/user as mob|obj)
-<<<<<<< HEAD
 		user << "<span class='warning'>The [name] whizzles quietly.<span>"
 		return
-=======
-       user << "<span class='warning'>The [name] whizzles quietly.<span>"
-       return
->>>>>>> cec73fb2af4eb69f5a60f1e26871ec2f587dd3a1
-
 
 /obj/item/weapon/gun/energy/staff/animate
 	name = "staff of animation"


### PR DESCRIPTION
Added a proc to change the fluff text for staves when they run out of charges. Instead of clicking, they whizzle. Fixes #1629

If you wanted to, you could add visible_message() or play a sound effect, but I didn't want to.
