### PR TITLE
Resolves #636

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -125,6 +125,7 @@
 				var/i = round(O.w_class)
 				if(i in list(1,2,3,4,5))
 					P.icon_state = "deliverycrate[i]"
+					P.w_class = i
 				P.add_fingerprint(usr)
 				O.add_fingerprint(usr)
 				add_fingerprint(usr)


### PR DESCRIPTION
Resolves #636. A wrapped package was ALWAYS using the wrapper's (or something) default w_class of 3. Now, the package inherits the w_class from the object being wrapped.
