### PR TITLE
Resolves #633

### DIFF
--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -16,7 +16,7 @@
 		var/obj/structure/stool/bed/chair/C = new /obj/structure/stool/bed/chair(loc)
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		C.dir = dir
-		part.loc = loc
+		part.loc = src.loc
 		part.master = null
 		part = null
 		del(src)

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -1,6 +1,7 @@
 /obj/item/assembly/shock_kit
 	name = "electrohelmet assembly"
 	desc = "This appears to be made from both an electropack and a helmet."
+	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "shock_kit"
 	var/obj/item/clothing/head/helmet/part1 = null
 	var/obj/item/device/radio/electropack/part2 = null


### PR DESCRIPTION
Resolves #633. Problem was a null.loc runtime from the chair being disassembled. 

In addition, shock kits were using an incorrect icon path by default. This issue would only have had been observable if attempting to admin spawn or otherwise create the object outside of its normal crafting procedure, such as disassembling the e_chair.
