### PR TITLE
When the game tries to find players for roles it will now prioritize players who are the least afk

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -280,12 +280,16 @@ proc/isInSight(var/atom/A, var/atom/B)
 
 // Will return a list of active candidates. It increases the buffer 5 times until it finds a candidate which is active within the buffer.
 
-/proc/get_candidates(be_special_flag=0)
-	. = list()
-	for(var/mob/dead/observer/G in player_list)
-		if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-			if(!G.client.is_afk() && (G.client.prefs.be_special & be_special_flag))
-				. += G.client
+/proc/get_candidates(be_special_flag=0, afk_bracket=3000)
+	var/list/candidates = list()
+	// Keep looping until we find a non-afk candidate within the time bracket (we limit the bracket to 10 minutes (6000))
+	while(!candidates.len && afk_bracket < 6000)
+		for(var/mob/dead/observer/G in player_list)
+			if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
+				if(!G.client.is_afk(afk_bracket) && (G.client.prefs.be_special & be_special_flag))
+					candidates += G.client
+		afk_bracket += 600 // Add a minute to the bracket, for every attempt
+	return candidates
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
 	if(!isobj(O))	O = new /obj/screen/text()

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -33,7 +33,7 @@
 			if(temp_vent.network.normal_members.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 
-	var/list/candidates = get_candidates(BE_ALIEN)
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 
 	while(spawncount > 0 && vents.len && candidates.len)
 		var/obj/vent = pick_n_take(vents)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -1,5 +1,6 @@
 // This is to replace the previous datum/disease/alien_embryo for slightly improved handling and maintainability
 // It functions almost identically (see code/datums/diseases/alien_embryo.dm)
+var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 
 /obj/item/alien_embryo
 	name = "alien embryo"
@@ -72,7 +73,7 @@
 				AttemptGrow()
 
 /obj/item/alien_embryo/proc/AttemptGrow(var/gib_on_success = 1)
-	var/list/candidates = get_candidates(BE_ALIEN)
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 	var/client/C = null
 
 	// To stop clientless larva, we will check that our host has a client


### PR DESCRIPTION
For example, it will try to find players that are afk for 5 minutes or lower, if it fails it'll add a minute to the 5 minutes until it finds a candidate or until it reaches 10 minutes.

I changed the get_candidate for aliens so that their 5 minute bracket is instead 45 seconds. This is because a lot of the time larva need to be active ASAP to avoid danger (such as being spawned in dangerous areas) There was a cases of an AFK larva that was very easily killed of, making it fraustrating for the observers watching.
