### PR TITLE
Blob Tweakz

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -34,7 +34,13 @@
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 		Delete()
 		return
+	// update_icon is called when health changes so... call update_health in the overmind
+	if(overmind)
+		overmind.update_health()
 	return
+
+/obj/effect/blob/core/RegenHealth()
+	return // Don't regen, we handle it in Life()
 
 /obj/effect/blob/core/Life()
 	if(!overmind)
@@ -44,6 +50,8 @@
 			resource_delay = world.time + 10 // 1 second
 			overmind.add_points(point_rate)
 	health = min(initial(health), health + 1)
+	if(overmind)
+		overmind.update_health()
 	for(var/i = 1; i < 8; i += i)
 		Pulse(0, i)
 	for(var/b_dir in alldirs)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -28,7 +28,7 @@
 	spore_delay = world.time + 100 // 10 seconds
 	PulseAnimation(1)
 	new/mob/living/simple_animal/hostile/blobspore(src.loc, src)
-	return 1
+	return 0
 
 
 /mob/living/simple_animal/hostile/blobspore

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -30,5 +30,5 @@
 
 	if(overmind)
 		overmind.add_points(1)
-	return 1
+	return 0
 

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -25,19 +25,23 @@
 	..()
 	sync_mind()
 	src << "<span class='notice'>You are the overmind!</span>"
-	src << "You are the overmind and can control the blob by placing new blob pieces such as..."
+	src << "You are the overmind and can control the blob! You can expand, which will attack peple, and place new blob pieces such as..."
 	src << "<b>Normal Blob</b> will expand your reach and allow you to upgrade into special blobs that perform certain functions."
 	src << "<b>Shield Blob</b> is a strong and expensive blob which can take more damage. It is fireproof and can block air, use this to protect yourself from station fires."
 	src << "<b>Resource Blob</b> is a blob which will collect more resources for you, try to build these earlier to get a strong income. It will benefit from being near your core or multiple nodes, by having an increased resource rate; put it alone and it won't create resources at all."
 	src << "<b>Node Blob</b> is a blob which will grow, like the core. Unlike the core it won't give you a small income but it can power resource and factory blobs to increase their rate."
 	src << "<b>Factory Blob</b> is a blob which will spawn blob spores which will attack nearby food. Putting this nearby nodes and your core will increase the spawn rate; put it alone and it will not spawn any spores."
 	src << "<b>Shortcuts:</b> CTRL Click = Expand Blob / Middle Mouse Click = Rally Spores / Alt Click = Create Shield"
+	update_health()
 
+/mob/camera/blob/proc/update_health()
+	if(blob_core)
+		hud_used.blobhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#e36600'>[blob_core.health]</font></div>"
 
-mob/camera/blob/Life()
-	hud_used.blobpwrdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#82ed00'>[src.blob_points]</font></div>"
-	hud_used.blobhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#e36600'>[blob_core.health]</font></div>"
-	return
+/mob/camera/blob/proc/add_points(var/points)
+	if(points != 0)
+		blob_points = Clamp(blob_points + points, 0, max_blob_points)
+		hud_used.blobpwrdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#82ed00'>[src.blob_points]</font></div>"
 
 /mob/camera/blob/say(var/message)
 	if (!message)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -25,7 +25,7 @@
 	..()
 	sync_mind()
 	src << "<span class='notice'>You are the overmind!</span>"
-	src << "You are the overmind and can control the blob! You can expand, which will attack peple, and place new blob pieces such as..."
+	src << "You are the overmind and can control the blob! You can expand, which will attack people, and place new blob pieces such as..."
 	src << "<b>Normal Blob</b> will expand your reach and allow you to upgrade into special blobs that perform certain functions."
 	src << "<b>Shield Blob</b> is a strong and expensive blob which can take more damage. It is fireproof and can block air, use this to protect yourself from station fires."
 	src << "<b>Resource Blob</b> is a blob which will collect more resources for you, try to build these earlier to get a strong income. It will benefit from being near your core or multiple nodes, by having an increased resource rate; put it alone and it won't create resources at all."

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -4,12 +4,8 @@
 	if(blob_points < cost)
 		src << "<span class='warning'>You cannot afford this.</span>"
 		return 0
-	blob_points -= cost
+	add_points(-cost)
 	return 1
-
-/mob/camera/blob/proc/add_points(var/points = 0)
-	if(points)
-		blob_points = min(max_blob_points, blob_points + points)
 
 // Power verbs
 
@@ -188,7 +184,7 @@
 
 /mob/camera/blob/verb/expand_blob_power()
 	set category = "Blob"
-	set name = "Expand Blob (5)"
+	set name = "Expand/Attack Blob (5)"
 	set desc = "Attempts to create a new blob in this tile. If the tile isn't clear we will attack it, which might clear it."
 
 	var/turf/T = get_turf(src)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -8,6 +8,7 @@
 	opacity = 0
 	anchored = 1
 	var/health = 30
+	var/health_timestamp = 0
 	var/brute_resist = 4
 	var/fire_resist = 1
 
@@ -52,12 +53,23 @@
 	flick("[icon_state]_glow", src)
 	return
 
+/obj/effect/blob/proc/RegenHealth()
+	// All blobs heal over time when pulsed, but it has a cool down
+	if(health_timestamp > world.time)
+		return 0
+	if(health < initial(health))
+		health++
+		update_icon()
+		health_timestamp = world.time + 10 // 1 seconds
+
 
 /obj/effect/blob/proc/Pulse(var/pulse = 0, var/origin_dir = 0)//Todo: Fix spaceblob expand
 
 	set background = 1
 
 	PulseAnimation()
+
+	RegenHealth()
 
 	if(run_action())//If we can do something here then we dont need to pulse more
 		return
@@ -181,10 +193,10 @@
 	if(health <= 0)
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 		Delete()
-		return
-	if(health <= 15)
+	else if(health <= 15)
 		icon_state = "blob_damaged"
-		return
+	else
+		icon_state = "blob"
 
 /* // Used to create the glow sprites. Remember to set the animate loop to 1, instead of infinite!
 


### PR DESCRIPTION
Blobs will slowly regenerate health when pulsed. They have a second cool down after every pulse to make sure 5 nodes aren't healing them too quickly.

Changed how the overmind hud was updated so that it was more accurate. Instead of updating every life() it will update every time the blob core health changes and every time the resource count changes.

Renamed the expand power to "expand/attack", to make it more clear to new blubbers that you use it to attack people.
