### PR TITLE
Nerf Syndi Crossbow

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -84,7 +84,7 @@
 
 	process()
 		charge_tick++
-		if(charge_tick < 4) return 0
+		if(charge_tick < 9) return 0
 		charge_tick = 0
 		if(!power_supply) return 0
 		power_supply.give(100)


### PR DESCRIPTION
Doubles the time it takes a syndi crossbow to recharge. Presently, it regains 1 shot per 5 process() ticks, which in my testing came out to about 5 seconds, and thus 25 seconds to fully recharge to its max. Given that it also ALWAYS causes a knockdown on what it hits, it is a very effective lockdown weapon instead of the stealth weapon it is (I feel) intended to be. This change simply doubles the time it takes to recharge.
