### PR TITLE
The ethereal jaunt holder object will now eject it's contents when deleted

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -35,11 +35,11 @@
 				animation.dir = target.dir
 				flick("phase_shift",animation)
 				target.loc = holder
-				target.client.eye = holder
 				sleep(jaunt_duration)
 				mobloc = get_turf(target.loc)
 				animation.loc = mobloc
 				target.canmove = 0
+				holder.reappearing = 1
 				sleep(20)
 				animation.dir = target.dir
 				flick("phase_shift2",animation)
@@ -57,7 +57,6 @@
 			else
 				flick("liquify",animation)
 				target.loc = holder
-				target.client.eye = holder
 				var/datum/effect/effect/system/steam_spread/steam = new /datum/effect/effect/system/steam_spread()
 				steam.set_up(10, 0, mobloc)
 				steam.start()
@@ -67,6 +66,7 @@
 				steam.location = mobloc
 				steam.start()
 				target.canmove = 0
+				holder.reappearing = 1
 				sleep(20)
 				flick("reappear",animation)
 				sleep(5)
@@ -86,11 +86,18 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "nothing"
 	var/canmove = 1
+	var/reappearing = 0
 	density = 0
 	anchored = 1
 
+/obj/effect/dummy/spell_jaunt/Del()
+	// Eject contents if deleted somehow
+	for(var/atom/movable/AM in src)
+		AM.loc = get_turf(src)
+	..()
+
 /obj/effect/dummy/spell_jaunt/relaymove(var/mob/user, direction)
-	if (!src.canmove) return
+	if (!src.canmove || reappearing) return
 	var/turf/newLoc = get_step(src,direction)
 	if(!(newLoc.flags & NOJAUNT))
 		loc = newLoc


### PR DESCRIPTION
Ethereal jaunting will no longer let you keep moving while you are reappearing.
