### PR TITLE
Adds syndicate implant kit to the traitor uplink.

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -23,10 +23,11 @@
 #define BORGXRAY  4
 
 // for secHUDs and medHUDs and variants. The number is the location of the image on the list hud_list of humans.
-#define HEALTH_HUD		1 // dead, alive, sick, health status
-#define STATUS_HUD		2 // a simple line rounding the mob's number health
-#define ID_HUD			3 // the job asigned to your ID
-#define WANTED_HUD		4 // wanted, released, parroled, security status
-#define IMPLOYAL_HUD	5 // loyality implant
-#define IMPCHEM_HUD		6 // chemical implant
-#define IMPTRACK_HUD	7 // tracking implant
+#define HEALTH_HUD			1 // dead, alive, sick, health status
+#define STATUS_HUD			2 // a simple line rounding the mob's number health
+#define ID_HUD				3 // the job asigned to your ID
+#define WANTED_HUD			4 // wanted, released, parroled, security status
+#define IMPLOYAL_HUD		5 // loyality implant
+#define IMPCHEM_HUD			6 // chemical implant
+#define IMPTRACK_HUD		7 // tracking implant
+#define IMPSYNDICATE_HUD	8 // syndicate implant

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -294,6 +294,11 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	cost = 10
 
+/datum/uplink_item/implants/syndicate
+	name = "Syndicate Implant"
+	desc ="An implant injected into the body, which can be detected with the included syndicateHUD. Only useful if you want other syndicates with the same gear to be able to recognize you, and vice versa."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_syndicate
+	cost = 1
 
 // POINTLESS BADASSERY
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -204,3 +204,7 @@
 		source.mind.store_memory("EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 		source << "The implanted EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
 		return 1
+
+/obj/item/weapon/implant/syndicate
+	name ="syndicate"
+	desc ="The syndicate version of the loyalty implant."

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -75,3 +75,11 @@
 	imp = new /obj/item/weapon/implant/emp(src)
 	..()
 	update_icon()
+
+/obj/item/weapon/implanter/syndicate
+	name ="implanter-syndicate"
+
+/obj/item/weapon/implanter/syndicate/New()
+	imp = new /obj/item/weapon/implant/syndicate(src)
+	..()
+	update_icon()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -92,6 +92,18 @@
 	O.update_icon()
 	return
 
+/obj/item/weapon/storage/box/syndie_kit/imp_syndicate
+	name = "Syndicate Implant (with injector and syndiHUD)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_syndicate/New()
+	..()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/syndicate(O)
+	O.update_icon()
+	new /obj/item/clothing/glasses/sunglasses/syndicatehud(src)
+	return
+
+
 /*/obj/item/weapon/storage/box/syndie_kit/imp_compress
 	name = "Compressed Matter Implant (with injector)"
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -128,10 +128,25 @@
 			user << "<span class='warning'>It is already emagged!</span>" */ //Fuck emags
 
 /obj/item/clothing/glasses/sunglasses/sechud/emp_act(severity)
+	hud_emp_act()
+
+
+/obj/item/clothing/glasses/sunglasses/syndicatehud // concealed as sunglasses
+	var/obj/item/clothing/glasses/hud/syndicate/hud = null
+	origin_tech = "syndicate=1"
+
+	New()
+		..()
+		src.hud = new/obj/item/clothing/glasses/hud/syndicate(src)
+		return
+
+/obj/item/clothing/glasses/sunglasses/syndicatehud/emp_act(severity)
+	hud_emp_act()
+
+obj/item/clothing/glasses/sunglasses/proc/hud_emp_act()
 	if(emagged == 0)
 		emagged = 1
 		desc = desc + " The display flickers slightly."
-
 
 /obj/item/clothing/glasses/thermal
 	name = "Optical Thermal Scanner"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -140,3 +140,28 @@
 					else
 						continue
 				C.images += holder
+
+
+/*
+ * Syndicate hud shows 'T' icon for characters that have a syndicate implant in them
+ */
+/obj/item/clothing/glasses/hud/syndicate
+
+/obj/item/clothing/glasses/hud/syndicate/process_hud(var/mob/M)
+	if(!M)	return
+	if(!M.client)	return
+	var/client/C = M.client
+	var/image/holder
+	for(var/mob/living/carbon/human/perp in view(M))
+
+		for(var/obj/item/weapon/implant/I in perp)
+			if(I.implanted)
+				if(istype(I,/obj/item/weapon/implant/syndicate))
+					holder = perp.hud_list[IMPSYNDICATE_HUD]
+					holder.icon_state = "hudtraitor"
+				else
+					continue
+				C.images += holder
+				break
+
+

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -26,7 +26,7 @@
 	internal_organs += new /obj/item/organ/heart
 	internal_organs += new /obj/item/organ/brain
 
-	for(var/i=0;i<7;i++) // 2 for medHUDs and 5 for secHUDs
+	for(var/i=0;i<8;i++) // 2 for medHUDs, 5 for secHUDs, 1 for syndicateHud
 		hud_list += image('icons/mob/hud.dmi', src, "hudunknown")
 
 	..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -932,6 +932,8 @@
 	proc/handle_regular_hud_updates()
 		if(!client)	return 0
 
+
+		// Remove hud icons (medical hud, security hud, syndicate hud)
 		for(var/image/hud in client.images)
 			if(copytext(hud.icon_state,1,4) == "hud") //ugly, but icon comparison is worse, I believe
 				client.images.Remove(hud)
@@ -1094,6 +1096,11 @@
 						var/obj/item/clothing/glasses/sunglasses/sechud/O = glasses
 						if(O.hud)		O.hud.process_hud(src)
 						if(!druggy)		see_invisible = SEE_INVISIBLE_LIVING
+					else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/syndicatehud))
+						var/obj/item/clothing/glasses/sunglasses/syndicatehud/O = glasses
+						if(O.hud)		O.hud.process_hud(src)
+						if(!druggy)		see_invisible = SEE_INVISIBLE_LIVING
+
 
 				else if(istype(glasses, /obj/item/clothing/glasses/hud))
 					var/obj/item/clothing/glasses/hud/O = glasses


### PR DESCRIPTION
The set costs 1 telecrystal and contains a syndicate implant and a syndicateHUD. SyndicateHUD detects the implant and shows the traitor hud icon above the implanted person's head. Adds the option for traitors to recognize each other by spending one telecrystal.

SyndicateHUD is concealed as sunglasses and has level 1 illegal origin tech.
