### PR TITLE
Update for power code to remove some bugs and fix some functionality

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -506,6 +506,10 @@ turf/simulated/floor/proc/update_icon()
 	if(istype(C, /obj/item/weapon/cable_coil))
 		if(is_plating())
 			var/obj/item/weapon/cable_coil/coil = C
+			for(var/obj/structure/cable/LC in src)
+				if((LC.d1==0)||(LC.d2==0))
+					LC.attackby(C,user)
+					return
 			coil.turf_place(src, user)
 		else
 			user << "\red You must remove the plating first."

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -470,7 +470,7 @@
 				del(C)
 				return
 
-		C.denode()// this may have disconnected some cables that terminated on the centre of the turf, disconnect them.
+		C.denode()// this call may have disconnected some cables that terminated on the centre of the turf, if so split the powernets.
 		return
 
 /obj/structure/cable/proc/mergeConnectedNetworks(var/direction)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -468,7 +468,9 @@
 			if (prob(50)) //fail
 				new/obj/item/weapon/cable_coil(C.loc, 2, C.cable_color)
 				del(C)
+				return
 
+		C.denode()// this may have disconnected some cables that terminated on the centre of the turf, disconnect them.
 		return
 
 /obj/structure/cable/proc/mergeConnectedNetworks(var/direction)
@@ -512,12 +514,13 @@
 	for(var/AM in loc)
 		if(istype(AM,/obj/structure/cable))
 			var/obj/structure/cable/C = AM
-			if(C.powernet == powernet)	continue
-			if(C.powernet)
-				merge_powernets(powernet, C.powernet)
-			else
-				C.powernet = powernet
-				powernet.cables += C
+			if(C.d1 == 0 && d1==0) //only connected if they are both "nodes"
+				if(C.powernet == powernet)	continue
+				if(C.powernet)
+					merge_powernets(powernet, C.powernet)
+				else
+					C.powernet = powernet
+					powernet.cables += C
 
 		else if(istype(AM,/obj/machinery/power/apc))
 			var/obj/machinery/power/apc/N = AM

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -172,6 +172,24 @@
 				. += C
 	return .
 
+/obj/machinery/power/proc/get_marked_connections()
+
+	. = list()
+
+	if(!directwired)
+		return get_indirect_connections()
+
+	var/cdir
+
+	for(var/card in cardinal)
+		var/turf/T = get_step(loc,card)
+		cdir = get_dir(T,loc)
+
+		for(var/obj/structure/cable/C in T)
+			if(C.d1 == cdir || C.d2 == cdir)
+				. += C
+	return .
+
 /obj/machinery/power/proc/get_indirect_connections()
 	. = list()
 	for(var/obj/structure/cable/C in loc)


### PR DESCRIPTION
# Functionality
- Cables can now be placed across each other and not connect, just like cables placed in the map editor.
- Alternately by leaving a "node" or "dot" in both cables you can have these cables connect
# Bugs Fixed
- Unconnected cable networks which share the same powernet and power are no longer created when adding cable to nodes or removing nodes on top of smooth cable
# Code changes:
- Adds denode proc that should be called when a wire is added to causing it to no longer be a "node" (i.e. terminates in the centre of the turf)
- Adds propagate_network proc that traverses the graph adding every cable to a new network while removing the old one
- Adds call to denode in the cable_join proc
- Fixes mergeConnectedNetworksOnTurf() to only connect cables that are both nodes
- Adds a get_marked_connections() proc to cable which finds all edges connected to it's endpoints regardless of whether they have a powernet(as opposed to get_connections())
