### PR TITLE
Fixes sec perma being disconnected from the powergrid and scrubber pipe network

### DIFF
--- a/maps/tgstation.2.1.2.dmm
+++ b/maps/tgstation.2.1.2.dmm
@@ -308,7 +308,7 @@
 "afV" = (/turf/simulated/shuttle/wall{icon_state = "swall12"; dir = 2},/area/shuttle/laborcamp/station)
 "afW" = (/turf/simulated/shuttle/wall{icon_state = "swall_s6"; dir = 2},/area/shuttle/laborcamp/station)
 "afX" = (/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/plating,/area/maintenance/fpmaint)
-"afY" = (/obj/machinery/door/airlock/security{name = "Prisoner Processing"; req_access = null; req_access_txt = "2"},/turf/simulated/floor/plating,/area/security/processing)
+"afY" = (/obj/machinery/door/airlock/security{name = "Prisoner Processing"; req_access = null; req_access_txt = "2"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,/turf/simulated/floor,/area/security/processing)
 "afZ" = (/obj/machinery/portable_atmospherics/canister/sleeping_agent,/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/simulated/floor{icon_state = "dark"},/area/security/brig)
 "aga" = (/obj/machinery/door/airlock/security{name = "N2O Storage"; req_access = null; req_access_txt = "3"},/turf/simulated/floor{icon_state = "dark"},/area/security/brig)
 "agb" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 6},/turf/simulated/floor,/area/security/brig)


### PR DESCRIPTION
There was a tile that did not have a power cable connecting the permabrig to powergrid and pipe network.
It was in the new prisoner labor camp shuttle area on the main station. This adds the power cable and pipe
