### PR TITLE
Adds admin list view to secrets tab

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -403,6 +403,7 @@ var/global/floorIsLava = 0
 			<BR>
 			<A href='?src=\ref[src];secretsgeneral=list_job_debug'>Show Job Debug</A><BR>
 			<A href='?src=\ref[src];secretsgeneral=spawn_objects'>Admin Log</A><BR>
+			<A href='?src=\ref[src];secretsgeneral=show_admins'>Show Admin List</A><BR>
 			<BR>
 			"}
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2008,6 +2008,13 @@
 						if(!job)	continue
 						dat += "job: [job.title], current_positions: [job.current_positions], total_positions: [job.total_positions] <BR>"
 					usr << browse(dat, "window=jobdebug;size=600x500")
+			if("show_admins")
+				var/dat = "<B>Current admins:</B><HR>"
+				if(admin_datums)
+					for(var/ckey in admin_datums)
+						var/datum/admins/D = admin_datums[ckey]
+						dat += "[ckey] - [D.rank.name]<br>"
+					usr << browse(dat, "window=showadmins;size=600x500")
 
 	else if(href_list["secretscoder"])
 		if(!check_rights(R_DEBUG))	return


### PR DESCRIPTION
- Added an option to the secrets tab which displays the current list of admins and their ranks.

Screenshot: http://www.ss13.eu/show_admins.png
