### PR TITLE
Fix for being unable to unwrench vents

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -275,6 +275,9 @@
 		return
 
 	attackby(obj/item/W, mob/user)
+		if (istype(W, /obj/item/weapon/wrench)&& !(stat & NOPOWER) && on)
+			user << "\red You cannot unwrench this [src], turn it off first."
+			return 1
 		if(istype(W, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
 			if (WT.remove_fuel(0,user))
@@ -295,6 +298,9 @@
 			else
 				user << "\blue You need more welding fuel to complete this task."
 				return 1
+		else
+			return ..()
+
 	examine()
 		set src in oview(1)
 		..()
@@ -307,14 +313,6 @@
 		else
 			stat |= NOPOWER
 		update_icon()
-
-	attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)
-		if (!istype(W, /obj/item/weapon/wrench))
-			return ..()
-		if (!(stat & NOPOWER) && on)
-			user << "\red You cannot unwrench this [src], turn it off first."
-			return 1
-		return ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/Del()
 	if(initial_loc)


### PR DESCRIPTION
# Bugs Fixed
- You can now unwrench vents, detaching them from the floor.
# Code changes:
- Merged two attackby procs into one with no logical changes.
- added a return ..() to the attackby proc to call the general atmospherics proc for attackby which deals with unwrenching.
