### PR TITLE
Attacking unanchored windows with a wrench turns them into stacks of glass

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -170,6 +170,16 @@
 		state = 1 - state
 		playsound(loc, 'sound/items/Crowbar.ogg', 75, 1)
 		user << (state ? "<span class='notice'>You have pried the window into the frame.</span>" : "<span class='notice'>You have pried the window out of the frame.</span>")
+	else if(istype(I, /obj/item/weapon/wrench) && !anchored)
+		/var/glass_type
+		if(reinf)
+			glass_type = /obj/item/stack/sheet/rglass
+		else
+			glass_type = /obj/item/stack/sheet/glass
+		new glass_type(user.loc)
+		if(is_fulltile())//fulltiles drop two panes
+			new glass_type(user.loc)
+		del(src)
 	else
 		if(I.damtype == BRUTE || I.damtype == BURN)
 			hit(I.force)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -179,7 +179,8 @@
 		new glass_type(user.loc)
 		if(is_fulltile())//fulltiles drop two panes
 			new glass_type(user.loc)
-		del(src)
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+		src.Del(1)
 	else
 		if(I.damtype == BRUTE || I.damtype == BURN)
 			hit(I.force)
@@ -291,12 +292,13 @@
 	return
 
 
-/obj/structure/window/Del()
+/obj/structure/window/Del(quiet)
 	density = 0
 	air_update_turf(1)
-	playsound(src, "shatter", 70, 1)
+	if(!quiet)playsound(src, "shatter", 70, 1)
 	update_nearby_icons()
 	loc = null //garbage collect
+	..()
 
 
 /obj/structure/window/Move()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -298,7 +298,6 @@
 	if(!quiet)playsound(src, "shatter", 70, 1)
 	update_nearby_icons()
 	loc = null //garbage collect
-	..()
 
 
 /obj/structure/window/Move()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -171,7 +171,7 @@
 		playsound(loc, 'sound/items/Crowbar.ogg', 75, 1)
 		user << (state ? "<span class='notice'>You have pried the window into the frame.</span>" : "<span class='notice'>You have pried the window out of the frame.</span>")
 	else if(istype(I, /obj/item/weapon/wrench) && !anchored)
-		/var/glass_type
+		var/glass_type
 		if(reinf)
 			glass_type = /obj/item/stack/sheet/rglass
 		else


### PR DESCRIPTION
# Functionality
- You can turn unanchored windows (ones that you can pull and push) back into panes of glass by attacking with a wrench. It makes no sense that the construction of a window is a one way process. Currently you can achieve this by smashing the window then welding the glass back together.
# Code changes:
- Added an "if istype(wrench)" condition to attackby for windows that drops one or two sheets of glass or reinforced glass based on the type of window. Only if the window is not anchored.
