### PR TITLE
Stops people from spamming the "summon narsie" rune to summon him more t...

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -146,9 +146,14 @@ var/list/sacrificed = list()
 					M.say("Tok-lyr rqa'nap g[pick("'","`")]lt-ulotf!")
 					cultist_count += 1
 			if(cultist_count >= 9)
-				new /obj/machinery/singularity/narsie/large(src.loc)
+				var/narsie_type = /obj/machinery/singularity/narsie/large
+				// Stops people summoning nar-sie more than once if 2 groups of cultists are on different parts of the station and both summon at the same time.
+				if(locate(narsie_type, machines))
+					return fizzle()
+				new narsie_type(src.loc) // Summon he!
 				if(ticker.mode.name == "cult")
 					ticker.mode:eldergod = 0
+				del(src) // Stops cultists from spamming the rune to summon narsie more than once.
 				return
 			else
 				return fizzle()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -147,9 +147,12 @@ var/list/sacrificed = list()
 					cultist_count += 1
 			if(cultist_count >= 9)
 				var/narsie_type = /obj/machinery/singularity/narsie/large
-				// Stops people summoning nar-sie more than once if 2 groups of cultists are on different parts of the station and both summon at the same time.
-				if(locate(narsie_type, machines))
-					return fizzle()
+				// Moves narsie if he was already summoned.
+				var/obj/him = locate(narsie_type, machines)
+				if(him)
+					him.loc = get_turf(src)
+					return
+				// Otherwise...
 				new narsie_type(src.loc) // Summon he!
 				if(ticker.mode.name == "cult")
 					ticker.mode:eldergod = 0


### PR DESCRIPTION
...han once. Fixes #1680.

When trying to summon narsie, when there already is a narsie, it will instead move the narsie to the new summoning rune.
