### PR TITLE
3D Sounds + Rewrote the explosion sound to be more optimized and to be more dynamic.

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -47,11 +47,11 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		// Stereo users will also hear the direction of the explosion!
 
 		// Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
-		// 3/7/14 will calculate to 35 + 45
+		// 3/7/14 will calculate to 80 + 35
 
 		var/far_dist = 0
 		far_dist += heavy_impact_range * 5
-		far_dist += devastation_range * 15
+		far_dist += devastation_range * 20
 
 		var/frequency = get_rand_frequency()
 		for(var/mob/M in player_list)
@@ -63,7 +63,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 					// If inside the blast radius + world.view - 2
 					if(dist <= round(max_range + world.view - 2, 1))
 						M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
-					// You hear a far explosion if you're outside the blast radius (*8) Small bombs shouldn't be heard all over the station.
+					// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 					else if(dist <= far_dist)
 						var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
 						far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -43,23 +43,31 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ")
 
-		// Play sounds; since playsound uses range() for each use, we'll try doing it through the player list.
-		// Playsound_local will also have an extra bonus of panning the sound, depending on the source. So stereo users will hear the direction of the explosion
+		// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
+		// Stereo users will also hear the direction of the explosion!
 
+		// Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
+		// 3/7/14 will calculate to 35 + 45
+
+		var/far_dist = 0
+		far_dist += heavy_impact_range * 5
+		far_dist += devastation_range * 15
+
+		var/frequency = get_rand_frequency()
 		for(var/mob/M in player_list)
 			// Double check for client
 			if(M && M.client)
 				var/turf/M_turf = get_turf(M)
-				if(M_turf.z == epicenter.z)
+				if(M_turf && M_turf.z == epicenter.z)
 					var/dist = get_dist(M_turf, epicenter)
 					// If inside the blast radius + world.view - 2
 					if(dist <= round(max_range + world.view - 2, 1))
-						M.playsound_local(epicenter, "explosion", 100, 1)
-					// You hear a far explosion if you're outside the blast radius (*5) Small bombs shouldn't be heard all over the station.
-					else if(dist <= round(max_range * 10, 1))
-						var/far_volume = Clamp(max_range * 10, 30, 60) // Volume is based on explosion size and dist
-						far_volume += (dist > max_range * 2 ? 0 : 40) // add 40 volume if the mob is pretty close to the explosion
-						M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1)
+						M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+					// You hear a far explosion if you're outside the blast radius (*8) Small bombs shouldn't be heard all over the station.
+					else if(dist <= far_dist)
+						var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
+						far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
+						M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
 
 

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -48,7 +48,9 @@
 	// now generate name
 	var/soundfile = "sound/[instrumentDir]/[ascii2text(note+64)][acc][oct].[instrumentExt]"
 	// and play
-	hearers(15, get_turf(instrumentObj)) << sound(soundfile)
+	var/turf/source = get_turf(instrumentObj)
+	for(var/mob/M in hearers(15, source))
+		M.playsound_local(source, file(soundfile), 100, falloff = 2)
 
 /datum/song/proc/updateDialog(mob/user as mob)
 	instrumentObj.updateDialog()		// assumes it's an object in world, override if otherwise

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,73 +1,28 @@
 /proc/playsound(var/atom/source, soundin, vol as num, vary, extrarange as num)
-	//Frequency stuff only works with 45kbps oggs.
 
-	switch(soundin)
-		if ("shatter") soundin = pick('sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg')
-		if ("explosion") soundin = pick('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg')
-		if ("sparks") soundin = pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg','sound/effects/sparks4.ogg')
-		if ("rustle") soundin = pick('sound/effects/rustle1.ogg','sound/effects/rustle2.ogg','sound/effects/rustle3.ogg','sound/effects/rustle4.ogg','sound/effects/rustle5.ogg')
-		if ("punch") soundin = pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg')
-		if ("clownstep") soundin = pick('sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')
-		if ("swing_hit") soundin = pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')
-		if ("hiss") soundin = pick('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
-		if ("pageturn") soundin = pick('sound/effects/pageturn1.ogg', 'sound/effects/pageturn2.ogg','sound/effects/pageturn3.ogg')
-		if ("gunshot") soundin = pick('sound/weapons/Gunshot.ogg', 'sound/weapons/Gunshot2.ogg','sound/weapons/Gunshot3.ogg','sound/weapons/Gunshot4.ogg')
-
-	var/sound/S = sound(soundin)
-	S.wait = 0 //No queue
-	S.channel = 0 //Any channel
-	S.volume = vol
-
-	if (vary)
-		S.frequency = rand(32000, 55000)
+	soundin = get_sfx(soundin) // same sound for everyone
 
 	if(isarea(source))
 		error("[source] is an area and is trying to make the sound: [soundin]")
+		return
 
-	for (var/A in range(world.view+extrarange, source))       // Plays for people in range.
+	var/frequency = get_rand_frequency() // Same frequency for everybody
 
-		if(ismob(A))
-			var/mob/M = A
-			var/mob/M2 = locate(/mob/, M)
-			if (M2 && M2.client)
-				if(M2.ear_deaf <= 0 || !M.ear_deaf)
-					if(isturf(source))
-						var/dx = source.x - M2.x
-						S.pan = max(-100, min(100, dx/8.0 * 100))
+ 	// Looping through the player list has the added bonus of working for mobs inside containers
+	for (var/P in player_list)
+		var/mob/M = P
+		if(!M || !M.client)
+			continue
+		var/turf/T = get_turf(M)
+		if(T && T.z == source.z)
+			if(get_dist(T, source) <= world.view + extrarange)
+				M.playsound_local(source, soundin, vol, vary, frequency)
 
-					M2 << S
+var/const/FALLOFF_SOUNDS = 1
 
-			if (M.client)
-				if(M.ear_deaf <= 0 || !M.ear_deaf)
-					if(isturf(source))
-						var/dx = source.x - M.x
-						S.pan = max(-100, min(100, dx/8.0 * 100))
-
-					M << S
-
-		if(istype(A, /obj/structure/closet))
-			var/obj/O = A
-			for(var/mob/M in O)
-				if (M.client)
-					if(M.ear_deaf <= 0 || !M.ear_deaf)
-						if(isturf(source))
-							var/dx = source.x - M.x
-							S.pan = max(-100, min(100, dx/8.0 * 100))
-
-						M << S
-																		// Now plays for people in lockers!  -- Polymorph
-
-/mob/proc/playsound_local(var/atom/source, soundin, vol as num, vary, extrarange as num)
+/mob/proc/playsound_local(var/atom/source, soundin, vol as num, vary, frequency, falloff)
 	if(!src.client || ear_deaf > 0)	return
-	switch(soundin)
-		if ("shatter") soundin = pick('sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg')
-		if ("explosion") soundin = pick('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg')
-		if ("sparks") soundin = pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg','sound/effects/sparks4.ogg')
-		if ("rustle") soundin = pick('sound/effects/rustle1.ogg','sound/effects/rustle2.ogg','sound/effects/rustle3.ogg','sound/effects/rustle4.ogg','sound/effects/rustle5.ogg')
-		if ("punch") soundin = pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg')
-		if ("clownstep") soundin = pick('sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')
-		if ("swing_hit") soundin = pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')
-		if ("hiss") soundin = pick('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
+	soundin = get_sfx(soundin)
 
 	var/sound/S = sound(soundin)
 	S.wait = 0 //No queue
@@ -75,10 +30,24 @@
 	S.volume = vol
 
 	if (vary)
-		S.frequency = rand(32000, 55000)
+		if(frequency)
+			S.frequency = frequency
+		else
+			S.frequency = get_rand_frequency()
+
 	if(isturf(source))
-		var/dx = source.x - src.x
-		S.pan = max(-100, min(100, dx/8.0 * 100))
+		// 3D sounds, the technology is here!
+		var/turf/T = get_turf(src)
+		var/dx = source.x - T.x // Hearing from the right/left
+		S.x = round(max(-10, min(10, dx)), 1)
+
+		var/dz = source.y - T.y // Hearing from infront/behind
+		S.z = round(max(-10, min(10, dz)), 1)
+
+		// The y value is for above your head, but there is no ceiling in 2d spessmens.
+		S.y = 1
+
+		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
 	src << S
 
@@ -86,3 +55,21 @@
 	if(!ticker || !ticker.login_music)	return
 	if(prefs.toggles & SOUND_LOBBY)
 		src << sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS
+
+/proc/get_rand_frequency()
+	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.
+
+/proc/get_sfx(soundin)
+	if(istext(soundin))
+		switch(soundin)
+			if ("shatter") soundin = pick('sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg')
+			if ("explosion") soundin = pick('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg')
+			if ("sparks") soundin = pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg','sound/effects/sparks4.ogg')
+			if ("rustle") soundin = pick('sound/effects/rustle1.ogg','sound/effects/rustle2.ogg','sound/effects/rustle3.ogg','sound/effects/rustle4.ogg','sound/effects/rustle5.ogg')
+			if ("punch") soundin = pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg')
+			if ("clownstep") soundin = pick('sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')
+			if ("swing_hit") soundin = pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg')
+			if ("hiss") soundin = pick('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
+			if ("pageturn") soundin = pick('sound/effects/pageturn1.ogg', 'sound/effects/pageturn2.ogg','sound/effects/pageturn3.ogg')
+			if ("gunshot") soundin = pick('sound/weapons/Gunshot.ogg', 'sound/weapons/Gunshot2.ogg','sound/weapons/Gunshot3.ogg','sound/weapons/Gunshot4.ogg')
+	return soundin


### PR DESCRIPTION
- 3D sounds! All sounds, which use playsound(), are now 3D. Meaning if you are further away from a source of noise, it will sound quieter and if the source is left of you, you'll hear it more to your left stereo speaker.
- Changed playsound() to use less code. Playsound now loops through the player list, which means you do not have to check inside closets/objects/other mobs to play sounds.
- The piano now uses 3D sounds.
- Explosions that are close to you play the usual sound.
- Explosions which are far away will play explosionfar.ogg, but with volume changed depending on the distance.
- Max cap (3, 7, 14) bombs will play explosionfar.ogg for half of the station (115 tiles).
- A small bomb's sound radius will be much less than max cap bombs, and be quieter (so you can tell the difference).

http://youtu.be/yGi9bglAhlc
