### PR TITLE
Examine cleaning

### DIFF
--- a/code/WorkInProgress/virus2/isolator.dm
+++ b/code/WorkInProgress/virus2/isolator.dm
@@ -115,6 +115,7 @@
 
 /obj/item/weapon/virusdish
 	name = "Virus containment/growth dish"
+	desc = "This is a virus containment dish"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implantcase-b"
 	var/datum/disease2/disease/virus2 = null
@@ -148,7 +149,7 @@
 		del src
 
 /obj/item/weapon/virusdish/examine()
-	usr << "This is a virus containment dish"
+	..()
 	if(src.info)
 		usr << "It has the following information about its contents"
 		usr << src.info

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -214,7 +214,7 @@ its easier to just keep the beam vertical.
 
 	if (!( usr ))
 		return
-	usr << "That's \a [src]." //changed to "That's" from "This is" because "This is some metal sheets" sounds dumb compared to "That's some metal sheets" ~Carn
+	usr << "\icon[src]That's \a [src]." //changed to "That's" from "This is" because "This is some metal sheets" sounds dumb compared to "That's some metal sheets" ~Carn
 	if(desc)
 		usr << desc
 	// *****RM

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -635,6 +635,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 
 	examine()
 		set src in usr
+		..()
 		if(!iscultist(usr))
 			usr << "An old, dusty tome with frayed edges and a sinister looking cover."
 		else

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -1,5 +1,5 @@
 /obj/machinery/meter
-	name = "meter"
+	name = "gas flow meter"
 	desc = "It measures something."
 	icon = 'icons/obj/meter.dmi'
 	icon_state = "meterX"
@@ -82,10 +82,8 @@
 
 /obj/machinery/meter/examine()
 	set src in view(3)
-
-	var/t = "A gas flow meter. "
-	t += status()
-	usr << t
+	..()
+	usr << status()
 
 
 /obj/machinery/meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -3,7 +3,6 @@
 // can also operate on non-loc area through "otherarea" var
 /obj/machinery/light_switch
 	name = "light switch"
-	desc = "It turns lights on and off. What are you, simple?"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light1"
 	anchored = 1.0
@@ -39,8 +38,9 @@
 
 /obj/machinery/light_switch/examine()
 	set src in oview(1)
+	..()
 	if(usr && !usr.stat)
-		usr << "A light switch. It is [on? "on" : "off"]."
+		usr << "It is [on? "on" : "off"]."
 
 
 /obj/machinery/light_switch/attack_paw(mob/user)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -33,8 +33,7 @@
 		set src in oview(12)
 		if (!( usr ))
 			return
-		usr << "This is \icon[src] \an [src.name]."
-		usr << src.desc
+		..()
 
 		usr << "The heater is [on ? "on" : "off"] and the hatch is [open ? "open" : "closed"]."
 		if(open)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -104,7 +104,14 @@
 			size = "gigantic"
 		else
 	//if ((CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
-	usr << "This is a [src.blood_DNA ? "bloody " : ""]\icon[src][src.name]. It is a [size] item."
+
+	//This reformat names to get a/an properly working on item descriptions when they are bloody
+	var/f_name = "\a [src]"
+	if(src.blood_DNA)
+		f_name = "a bloody [name]"
+
+	usr << "\icon[src]This is [f_name]. It is a [size] item."
+
 	if(src.desc)
 		usr << src.desc
 	return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -38,9 +38,8 @@
 
 /obj/item/weapon/extinguisher/examine()
 	set src in usr
-
-	usr << text("\icon[] [] contains [] units of water left!", src, src.name, src.reagents.total_volume)
 	..()
+	usr << "It contains [src.reagents.total_volume] units of water!"
 	return
 
 /obj/item/weapon/extinguisher/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -22,9 +22,8 @@
 
 /obj/item/weapon/grenade/chem_grenade/examine()
 	set src in usr
+	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
 	..()
-	if(stage == READY && !nadeassembly)
-		usr << "The timer is set to [det_time/10] second\s."
 
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user)
@@ -118,6 +117,7 @@
 			for(var/obj/O in beakers)
 				O.loc = get_turf(src)
 			beakers = list()
+
 
 
 //assembly stuff

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/grenade/empgrenade
 	name = "classic EMP grenade"
+	desc = "It is designed to wreak havok on electronic systems."
 	icon_state = "emp"
 	item_state = "emp"
 	origin_tech = "materials=2;magnets=3"

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -87,7 +87,7 @@
 
 /obj/item/weapon/grenade/iedcasing/examine()
 	set src in usr
-	usr << desc
+	..()
 	if(assembled == 3)
 		usr << "You can't tell when it will explode!" //Stops you from checking the time to detonation unlike regular grenades
 		return

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -28,6 +28,7 @@
 	var/assembled = 0
 	active = 1
 	det_time = 50
+	display_timer = 0
 
 
 
@@ -89,5 +90,4 @@
 	set src in usr
 	..()
 	if(assembled == 3)
-		usr << "You can't tell when it will explode!" //Stops you from checking the time to detonation unlike regular grenades
-		return
+		usr << "You can't tell when it will explode!"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -11,6 +11,7 @@
 	slot_flags = SLOT_BELT
 	var/active = 0
 	var/det_time = 50
+	var/display_timer = 1
 
 /obj/item/weapon/grenade/proc/clown_check(var/mob/living/user)
 	if((CLUMSY in user.mutations) && prob(50))
@@ -47,10 +48,11 @@
 /obj/item/weapon/grenade/examine()
 	set src in usr
 	..()
-	if(det_time > 1)
-		usr << "The timer is set to [det_time/10] seconds."
-		return
-	usr << "\The [src] is set for instant detonation."
+	if(display_timer)
+		if(det_time > 1)
+			usr << "The timer is set to [det_time/10] seconds."
+		else
+			usr << "\The [src] is set for instant detonation."
 
 
 /obj/item/weapon/grenade/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/grenade
 	name = "grenade"
-	desc = "A hand held grenade, with an adjustable timer."
+	desc = "It has an adjustable timer."
 	w_class = 2.0
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "grenade"
@@ -46,7 +46,7 @@
 
 /obj/item/weapon/grenade/examine()
 	set src in usr
-	usr << desc
+	..()
 	if(det_time > 1)
 		usr << "The timer is set to [det_time/10] seconds."
 		return

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -1,5 +1,4 @@
 /obj/item/weapon/grenade/smokebomb
-	desc = "It is set to detonate in 2 seconds."
 	name = "smoke bomb"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "flashbang"

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/grenade/spawnergrenade
-	desc = "It is set to detonate in 5 seconds. It will unleash unleash an unspecified anomaly into the vicinity."
+	desc = "It will unleash unleash an unspecified anomaly into the vicinity."
 	name = "delivery grenade"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "delivery"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -26,7 +26,7 @@
 
 /obj/item/weapon/storage/fancy/examine()
 	set src in oview(1)
-
+	..()
 	if(contents.len <= 0)
 		usr << "There are no [src.icon_type]s left in the box."
 	else if(contents.len == 1)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -37,10 +37,11 @@
 
 /obj/item/weapon/tank/examine()
 	var/obj/icon = src
+	..()
 	if (istype(src.loc, /obj/item/assembly))
 		icon = src.loc
 	if (!in_range(src, usr))
-		if (icon == src) usr << "\blue It's \a \icon[icon][src]! If you want any more information you'll need to get closer."
+		if (icon == src) usr << "\blue If you want any more information you'll need to get closer."
 		return
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
@@ -59,7 +60,7 @@
 	else
 		descriptive = "furiously hot"
 
-	usr << "\blue \The \icon[icon][src] feels [descriptive]"
+	usr << "\blue It feels [descriptive]"
 
 	return
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -150,7 +150,8 @@
 
 /obj/item/weapon/weldingtool/examine()
 	set src in usr
-	usr << "[src] \icon[src] contains [get_fuel()]/[max_fuel] units of fuel!"
+	..()
+	usr << "It contains [get_fuel()]/[max_fuel] units of fuel!"
 
 
 /obj/item/weapon/weldingtool/attackby(obj/item/I, mob/user)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -154,7 +154,7 @@ LINEN BINS
 
 /obj/structure/bedsheetbin
 	name = "linen bin"
-	desc = "A linen bin. It looks rather cosy."
+	desc = "It looks rather cosy."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "linenbin-full"
 	anchored = 1
@@ -164,7 +164,7 @@ LINEN BINS
 
 
 /obj/structure/bedsheetbin/examine()
-	usr << desc
+	..()
 	if(amount < 1)
 		usr << "There are no bed sheets in the bin."
 		return

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -21,8 +21,8 @@
 
 /obj/structure/janitorialcart/examine()
 	set src in usr
-	usr << "[src] \icon[src] contains [reagents.total_volume] unit\s of liquid!"
 	..()
+	usr << "It contains [reagents.total_volume] unit\s of liquid!"
 	//everything else is visible, so doesn't need to be mentioned
 
 
@@ -177,7 +177,8 @@
 
 /obj/structure/stool/bed/chair/janicart/examine()
 	set src in usr
-	usr << "\icon[src] This [callme] contains [reagents.total_volume] unit\s of water!"
+	..()
+	usr << "It contains [reagents.total_volume] unit\s of water!"
 	if(mybag)
 		usr << "\A [mybag] is hanging on the [callme]."
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -15,8 +15,8 @@
 
 /obj/structure/mopbucket/examine()
 	set src in usr
-	usr << "[src] \icon[src] contains [reagents.total_volume] unit\s of water!"
 	..()
+	usr << "It contains [reagents.total_volume] unit\s of water!"
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/mop))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -54,11 +54,6 @@ BLIND     // can't see anything
 	slot_flags = SLOT_GLOVES
 	attack_verb = list("challenged")
 
-/obj/item/clothing/gloves/examine()
-	set src in usr
-	..()
-	return
-
 // Called just before an attack_hand(), in mob/UnarmedAttack()
 /obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity)
 	return 0 // return 1 to cancel attack_hand()

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -60,10 +60,3 @@
 			user.visible_message("[user] finishes wiping off the [A]!")
 			A.clean_blood()
 	return
-
-/obj/item/weapon/reagent_containers/glass/rag/examine()
-	if (!usr)
-		return
-	usr << "That's \a [src]."
-	usr << desc
-	return

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -76,11 +76,11 @@
 
 /obj/item/weapon/paper_bin/examine()
 	set src in oview(1)
-
+	..()
 	if(amount)
-		usr << "<span class='notice'>There " + (amount > 1 ? "are [amount] papers" : "is one paper") + " in the bin.</span>"
+		usr << "It contains " + (amount > 1 ? "[amount] papers" : " one paper")+"."
 	else
-		usr << "<span class='notice'>There are no papers in the bin.</span>"
+		usr << "It doesn't contain anything."
 
 
 /obj/item/weapon/paper_bin/update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -18,6 +18,7 @@
 
 /obj/machinery/power/apc
 	name = "area power controller"
+	desc = "A control terminal for the area electrical systems."
 
 	icon_state = "apc0"
 	anchored = 1
@@ -133,7 +134,7 @@
 	set src in oview(1)
 
 	if(usr /*&& !usr.stat*/)
-		usr << "A control terminal for the area electrical systems."
+		..()
 		if(stat & BROKEN)
 			usr << "Looks broken."
 			return

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -52,11 +52,9 @@
 
 /obj/item/weapon/cell/examine()
 	set src in view(1)
+	..()
 	if(usr /*&& !usr.stat*/)
-		if(maxcharge <= 2500)
-			usr << "[desc]\nThe manufacturer's label states this cell has a power rating of [maxcharge], and that you should not swallow it.\nThe charge meter reads [round(src.percent() )]%."
-		else
-			usr << "This power cell has an exciting chrome finish, as it is an uber-capacity cell type! It has a power rating of [maxcharge]!\nThe charge meter reads [round(src.percent() )]%."
+		usr << "This cell has a power rating of [maxcharge], and you should not swallow it.\nThe charge meter reads [round(src.percent() )]%."
 	if(crit_fail)
 		usr << "\red This power cell seems to be faulty."
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -311,16 +311,17 @@
 // examine verb
 /obj/machinery/light/examine()
 	set src in oview(1)
+	..()
 	if(usr && !usr.stat)
 		switch(status)
 			if(LIGHT_OK)
-				usr << "[desc] It is turned [on? "on" : "off"]."
+				usr << "It is turned [on? "on" : "off"]."
 			if(LIGHT_EMPTY)
-				usr << "[desc] The [fitting] has been removed."
+				usr << "The [fitting] has been removed."
 			if(LIGHT_BURNED)
-				usr << "[desc] The [fitting] is burnt out."
+				usr << "The [fitting] is burnt out."
 			if(LIGHT_BROKEN)
-				usr << "[desc] The [fitting] has been smashed."
+				usr << "The [fitting] has been smashed."
 
 
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -42,7 +42,7 @@ display round(lastgen) and plasmatank amount
 
 //Baseline portable generator. Has all the default handling. Not intended to be used on it's own (since it generates unlimited power).
 /obj/machinery/power/port_gen
-	name = "Portable Generator"
+	name = "portable generator"
 	desc = "A portable generator for emergency backup power"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "portgen0"
@@ -88,13 +88,14 @@ display round(lastgen) and plasmatank amount
 
 /obj/machinery/power/port_gen/examine()
 	set src in oview(1)
+	..()
 	if(active)
-		usr << "\blue The generator is on."
+		usr << "It is running."
 	else
-		usr << "\blue The generator is off."
+		usr << "It isn't running."
 
 /obj/machinery/power/port_gen/pacman
-	name = "P.A.C.M.A.N.-type Portable Generator"
+	name = "\improper P.A.C.M.A.N.-type portable generator"
 	var/sheets = 0
 	var/max_sheets = 100
 	var/sheet_name = ""
@@ -316,7 +317,7 @@ display round(lastgen) and plasmatank amount
 			usr.unset_machine()
 
 /obj/machinery/power/port_gen/pacman/super
-	name = "S.U.P.E.R.P.A.C.M.A.N.-type Portable Generator"
+	name = "\improper S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
 	icon_state = "portgen1"
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
 	power_gen = 15000
@@ -326,7 +327,7 @@ display round(lastgen) and plasmatank amount
 		explosion(src.loc, 3, 3, 3, -1)
 
 /obj/machinery/power/port_gen/pacman/mrs
-	name = "M.R.S.P.A.C.M.A.N.-type Portable Generator"
+	name = "\improper M.R.S.P.A.C.M.A.N.-type portable generator"
 	icon_state = "portgen2"
 	sheet_path = /obj/item/stack/sheet/mineral/diamond
 	power_gen = 40000


### PR DESCRIPTION
I've slightly modified the atom and item code for examine to make them display the icon of the examined object in the text area as some items used to do it (example welder)

I then basically checked the entire sourcecode for examine() overrides that didn't use their superclass to display description text and "fixed" them so they would stop referencing their own name when it was not necessary (i still kept a couple that i felt where still needed).
