### PR TITLE
Preliminary secondary antag system

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -14,7 +14,7 @@ var/list/blob_nodes = list()
 	required_players = 30
 	required_enemies = 1
 	recommended_enemies = 1
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 25
 
 	restricted_jobs = list("Cyborg", "AI")

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -14,6 +14,8 @@ var/list/blob_nodes = list()
 	required_players = 30
 	required_enemies = 1
 	recommended_enemies = 1
+	secondary_antag = "changeling"
+	secondary_chance = 25
 
 	restricted_jobs = list("Cyborg", "AI")
 
@@ -51,7 +53,7 @@ var/list/blob_nodes = list()
 
 	if(!infected_crew.len)
 		return 0
-
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -126,7 +126,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	if (!(locate(/datum/objective/escape) in changeling.objectives))
 		if(emergency_shuttle)
 			if(emergency_shuttle.always_fake_recall == 1 || config.continuous_round_wiz == 0)//Lets changelings win if they're put into modes where the shuttle never comes
-				var/datum/objective/escapefake/survive_objective = new
+				var/datum/objective/escape/fake/survive_objective = new
 				survive_objective.owner = changeling
 				changeling.objectives += survive_objective
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -67,6 +67,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			antag_candidates -= changeling
 			changelings += changeling
 			modePlayer += changelings
+			..()
 		return 1
 	else
 		return 0
@@ -123,9 +124,16 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			changeling.objectives += debrain_objective
 
 	if (!(locate(/datum/objective/escape) in changeling.objectives))
-		var/datum/objective/escape/escape_objective = new
-		escape_objective.owner = changeling
-		changeling.objectives += escape_objective
+		if(emergency_shuttle)
+			if(emergency_shuttle.always_fake_recall == 1)//Lets changelings win if they're put into modes where the shuttle never comes
+				var/datum/objective/survive/survive_objective = new
+				survive_objective.owner = changeling
+				changeling.objectives += survive_objective
+
+			else
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = changeling
+				changeling.objectives += escape_objective
 
 	return
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -125,8 +125,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	if (!(locate(/datum/objective/escape) in changeling.objectives))
 		if(emergency_shuttle)
-			if(emergency_shuttle.always_fake_recall == 1)//Lets changelings win if they're put into modes where the shuttle never comes
-				var/datum/objective/survive/survive_objective = new
+			if(emergency_shuttle.always_fake_recall == 1 || config.continuous_round_wiz == 0)//Lets changelings win if they're put into modes where the shuttle never comes
+				var/datum/objective/escapefake/survive_objective = new
 				survive_objective.owner = changeling
 				changeling.objectives += survive_objective
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -25,6 +25,8 @@
 	required_players = 15
 	required_enemies = 3
 	recommended_enemies = 4
+	secondary_antag = "changeling"
+	secondary_chance = 50
 
 	uplink_welcome = "Nar-Sie Uplink Console:"
 	uplink_uses = 10
@@ -73,7 +75,7 @@
 		antag_candidates -= cultist
 		cult += cultist
 		log_game("[cultist.key] (ckey) has been selected as a cultist")
-
+	..()
 	return (cult.len>=required_enemies)
 
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -25,7 +25,7 @@
 	required_players = 15
 	required_enemies = 3
 	recommended_enemies = 4
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 50
 
 	uplink_welcome = "Nar-Sie Uplink Console:"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -31,7 +31,7 @@
 	var/uplink_welcome = "Syndicate Uplink Console:"
 	var/uplink_uses = 10
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
-	var/secondary_antag = null 	//keeps track of what additional antag(s) can spawn in a given mode (if any)
+	var/list/secondary_antag = list() 	//keeps track of what additional antag(s) can spawn in a given mode (if any)
 	var/secondary_chance = 0 	//the probability of there being a secondary antag
 	var/secondary_amount = 1 	//the number of secondary antags that will be spawned if they spawn at all
 
@@ -59,9 +59,10 @@
 ///Attempts to select players for special roles the mode might have. Generic Secondary Antags are delt with here
 /datum/game_mode/proc/pre_setup()
 
-	if(secondary_antag && prob(secondary_chance))
+	if(secondary_antag.len > 0 && prob(secondary_chance))
+		var/chosen_secondary_antag = pick(secondary_antag)
 		var/list/secondary_candidates = list()
-		switch(secondary_antag)
+		switch(chosen_secondary_antag)
 			if("changeling")
 				var/datum/game_mode/changeling/temp = new
 				if(config.protect_roles_from_antagonist)
@@ -72,12 +73,14 @@
 					for(var/job in temp.restricted_jobs)
 						if(player.assigned_role == job)
 							secondary_candidates -= player
+			else
+				error("An invalid secondary antag, [chosen_secondary_antag], was specified. Valid secondary antag values are: changeling and the null set")
 
 		if(secondary_candidates.len)
 			var/datum/mind/secondary = null
 			if(secondary_candidates.len < secondary_amount)
 				secondary_amount = secondary_candidates.len
-			switch(secondary_antag)
+			switch(chosen_secondary_antag)
 				if("changeling")
 					for(var/i = 0, i<secondary_amount, i++)
 						secondary = pick(secondary_candidates)

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -9,6 +9,8 @@
 	required_enemies = 1
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
+	secondary_antag = "changeling"
+	secondary_chance = 25
 
 	uplink_welcome = "Crazy AI Uplink Console:"
 	uplink_uses = 10
@@ -56,6 +58,7 @@
 		ai_mind.assigned_role = "MODE" //So they aren't chosen for other jobs.
 		ai_mind.special_role = "malfunctioning AI"//So they actually have a special role/N
 		log_game("[ai_mind.key] (ckey) has been selected as a malf AI")
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -9,7 +9,7 @@
 	required_enemies = 1
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 25
 
 	uplink_welcome = "Crazy AI Uplink Console:"

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -6,7 +6,7 @@
 	var/const/meteordelay = 2000
 	var/nometeors = 1
 	required_players = 0
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 50
 
 	uplink_welcome = "EVIL METEOR Uplink Console:"

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -6,6 +6,8 @@
 	var/const/meteordelay = 2000
 	var/nometeors = 1
 	required_players = 0
+	secondary_antag = "changeling"
+	secondary_chance = 50
 
 	uplink_welcome = "EVIL METEOR Uplink Console:"
 	uplink_uses = 10

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -10,7 +10,7 @@
 	recommended_enemies = 5
 	pre_setup_before_jobs = 1
 	antag_flag = BE_OPERATIVE
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 50
 
 	uplink_welcome = "Corporate Backed Uplink Console:"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -10,6 +10,8 @@
 	recommended_enemies = 5
 	pre_setup_before_jobs = 1
 	antag_flag = BE_OPERATIVE
+	secondary_antag = "changeling"
+	secondary_chance = 50
 
 	uplink_welcome = "Corporate Backed Uplink Console:"
 	uplink_uses = 10
@@ -48,6 +50,7 @@
 		synd_mind.assigned_role = "MODE" //So they aren't chosen for other jobs.
 		synd_mind.special_role = "Syndicate"//So they actually have a special role/N
 		log_game("[synd_mind.key] (ckey) has been selected as a nuclear operative")
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -249,7 +249,16 @@ datum/objective/escape
 		else
 			return 0
 
+datum/objective/escapefake //antimeta for an antagonist that usually needs to escape to win in a roundtype that doesn't allow escape
+	explanation_text = "Escape on the shuttle or an escape pod alive." //looks like escape
 
+	check_completion() //works like survive
+		explanation_text = "Stay alive until the end." //reveals itself no matter what
+		if(!owner.current || owner.current.stat == DEAD || isbrain(owner.current))
+			return 0		//Brains no longer win survive objectives. --NEO
+		if(!is_special_character(owner.current)) //This fails borg'd traitors
+			return 0
+		return 1
 
 datum/objective/survive
 	explanation_text = "Stay alive until the end."
@@ -316,6 +325,8 @@ Nobody takes these seriously anyways -- Ikki
 		steal_target = possible_items[target_name]
 		if (!steal_target )
 			steal_target = possible_items_special[target_name]
+		if(ticker.mode.name == "AI malfunction" && target_name == "a functional AI") //Impossible Objective
+			set_target(pick(possible_items))
 		explanation_text = "Steal [target_name]."
 		return steal_target
 
@@ -362,6 +373,8 @@ Nobody takes these seriously anyways -- Ikki
 					for(var/mob/living/silicon/ai/M in C)
 						if(istype(M, /mob/living/silicon/ai) && M.stat != 2) //See if any AI's are alive inside that card.
 							return 1
+				if(ticker.mode.name == "AI malfunction") //Impossible Objective
+					return 1
 
 			if("the station blueprints")
 				for(var/obj/item/I in all_items)	//the actual blueprints are good too!

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -15,7 +15,7 @@ datum/objective
 	proc/find_target()
 		var/list/possible_targets = list()
 		for(var/datum/mind/possible_target in ticker.minds)
-			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && (possible_target.special_role != "Syndicate") && (possible_target.special_role != "Wizard"))
+			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && (possible_target.assigned_role != "MODE")) //MODE roles are those that start off jobless and off station (Wizards, Nuke Ops, Ninjas).
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)
@@ -249,10 +249,9 @@ datum/objective/escape
 		else
 			return 0
 
-datum/objective/escapefake //antimeta for an antagonist that usually needs to escape to win in a roundtype that doesn't allow escape
-	explanation_text = "Escape on the shuttle or an escape pod alive." //looks like escape
+datum/objective/escape/fake //antimeta for an antagonist that usually needs to escape to win in a roundtype that doesn't allow escape
 
-	check_completion() //works like survive
+	check_completion() //looks like escape, works like survive
 		explanation_text = "Stay alive until the end." //reveals itself no matter what
 		if(!owner.current || owner.current.stat == DEAD || isbrain(owner.current))
 			return 0		//Brains no longer win survive objectives. --NEO
@@ -325,11 +324,10 @@ Nobody takes these seriously anyways -- Ikki
 		steal_target = possible_items[target_name]
 		if (!steal_target )
 			steal_target = possible_items_special[target_name]
-		if(ticker.mode.name == "AI malfunction" && target_name == "a functional AI") //Impossible Objective
+		if(istype("AI malfunction", ticker.mode.name) && istype("a functional AI", target_name)) //Impossible Objective
 			set_target(pick(possible_items))
 		explanation_text = "Steal [target_name]."
 		return steal_target
-
 
 	find_target()
 		return set_target(pick(possible_items))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -15,7 +15,7 @@ datum/objective
 	proc/find_target()
 		var/list/possible_targets = list()
 		for(var/datum/mind/possible_target in ticker.minds)
-			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2))
+			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && (possible_target.special_role != "Syndicate") && (possible_target.special_role != "Wizard"))
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -19,6 +19,8 @@
 	required_players = 20
 	required_enemies = 3
 	recommended_enemies = 3
+	secondary_antag = "changeling"
+	secondary_chance = 50
 
 
 	uplink_welcome = "Revolutionary Uplink Console:"
@@ -66,7 +68,7 @@
 
 	if((head_revolutionaries.len < required_enemies)||(!head_check))
 		return 0
-
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -19,7 +19,7 @@
 	required_players = 20
 	required_enemies = 3
 	recommended_enemies = 3
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 50
 
 

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,6 +5,8 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
+	secondary_antag = "changeling"
+	secondary_chance = 75
 
 	traitor_name = "double agent"
 

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 75
 
 	traitor_name = "double agent"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,8 @@
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
-
+	secondary_antag = "changeling"
+	secondary_chance = 100
 
 	uplink_welcome = "Syndicate Uplink Console:"
 	uplink_uses = 10
@@ -55,11 +56,10 @@
 		log_game("[traitor.key] (ckey) has been selected as a [traitor_name]")
 		antag_candidates.Remove(traitor)
 
-
 	if(traitors.len < required_enemies)
 		return 0
+	..()
 	return 1
-
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in traitors)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,7 +13,7 @@
 	required_enemies = 1
 	recommended_enemies = 4
 	secondary_antag = "changeling"
-	secondary_chance = 100
+	secondary_chance = 75
 
 	uplink_welcome = "Syndicate Uplink Console:"
 	uplink_uses = 10

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 75
 
 	uplink_welcome = "Syndicate Uplink Console:"

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -9,6 +9,8 @@
 	required_enemies = 1
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
+	secondary_antag = "changeling"
+	secondary_chance = 50
 
 	uplink_welcome = "Wizardly Uplink Console:"
 	uplink_uses = 10
@@ -34,7 +36,7 @@
 		return 0
 	for(var/datum/mind/wiz in wizards)
 		wiz.current.loc = pick(wizardstart)
-
+	..()
 	return 1
 
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -9,7 +9,7 @@
 	required_enemies = 1
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
-	secondary_antag = "changeling"
+	secondary_antag = list("changeling")
 	secondary_chance = 50
 
 	uplink_welcome = "Wizardly Uplink Console:"


### PR DESCRIPTION
A single ling can now appear in any game mode as a sole secondary antagonist in addition to the normal antags. The odds of this happening are:

75% chance in traitor and double agents
50% chance in cult, meteor, nuke, revolution, and wizard
25% chance in blob and malf
No chance in lings/Tratorling (since they're already there)

This was intended as a replacement for the ling game mode (and perhaps the traitor+ling game mode as well) as a large group of players have suggested that the defensively oriented newlings cannot or will not effectively terrorize a crew enough to carry a round by themselves without help. The removal of ling mode doesn't have to be done for this update to work, but is merely a suggestion. At the very least the frequency of ling only rounds can be reduced.

Lings that are inserted into roundtypes that don't allow for proper escape will get survival objectives as to not render their greentext impossible.

Secondary antag assignment functions independent of main antag assignment so traitorlings, wizlings, nukelings (just one of them), and revheadlings are all rare possibilities. This respects protected/restricted jobs so there's no chance of buggy Malflings or borglings.

The code has been set up to allow for multiple secondary antags to be added, but no modes will spawn more than one secondary antag right now as a precaution against poor balancing. Likewise it would not be hard to allow different kinds of antags in the secondary antag system, but this has not been added to this commit, again as a precaution on balance.
