### PR TITLE
Revamps the Chameleon Jumpsuit with four new chameleon items.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -249,10 +249,10 @@ var/list/uplink_items = list()
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"
 
-/datum/uplink_item/stealthy_tools/chameleon_jumpsuit
-	name = "Chameleon Jumpsuit"
-	desc = "A jumpsuit used to imitate the uniforms of Nanotrasen crewmembers."
-	item = /obj/item/clothing/under/chameleon
+/datum/uplink_item/stealthy_tools/chameleon_kit
+	name = "Chameleon Kit"
+	desc = "A kit containing a chameleon jumpsuit, exosuit, helmet, shoes, and backpack, able to alter their appearance to imitate uniforms and armor."
+	item = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	cost = 3
 
 /datum/uplink_item/stealthy_tools/chameleon_stamp

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -154,7 +154,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "Chameleon Kit"
-	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessions sold seperately."
+	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon/New()
 	..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -151,3 +151,16 @@
 	new /obj/item/weapon/implanter/emp/(src)
 	new /obj/item/device/flashlight/emp/(src)
 	return
+
+/obj/item/weapon/storage/box/syndie_kit/chameleon
+	name = "Chameleon Kit"
+	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessions sold seperately."
+
+/obj/item/weapon/storage/box/syndie_kit/chameleon/New()
+	..()
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/head/chameleon(src)
+	new /obj/item/clothing/suit/chameleon(src)
+	new /obj/item/clothing/shoes/chameleon(src)
+	new /obj/item/weapon/storage/backpack/chameleon(src)
+	new /obj/item/weapon/paper/nogloves(src)

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -9,8 +9,8 @@
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
 
-	redcoat
-		item_color = "redcoat"	//Exists for washing machines. Is not different from black shoes in any way.
+/obj/item/clothing/shoes/black/redcoat
+	item_color = "redcoat"	//Exists for washing machines. Is not different from black shoes in any way.
 
 /obj/item/clothing/shoes/brown
 	name = "brown shoes"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -113,7 +113,7 @@
 
 
 /obj/item/clothing/suit/armor/vest/det_suit
-	name = "armor"
+	name = "detective's armor"
 	desc = "An armored vest with a detective's badge on it."
 	icon_state = "detective-armor"
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter,/obj/item/device/detective_scanner,/obj/item/device/taperecorder)

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -1,3 +1,7 @@
+//*****************
+//**Cham Jumpsuit**
+//*****************
+
 /obj/item/clothing/under/chameleon
 //starts off as black
 	name = "black jumpsuit"
@@ -10,53 +14,26 @@
 
 	New()
 		..()
-		for(var/U in typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
-			var/obj/item/clothing/under/V = new U
-			src.clothing_choices += V
-
-		for(var/U in typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
+		var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/cloud,
+			/obj/item/clothing/under/golem, /obj/item/clothing/under/gimmick)//Prevent infinite loops and bad jumpsuits.
+		for(var/U in typesof(/obj/item/clothing/under)-blocked)
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 		return
-
-
-	attackby(obj/item/clothing/under/U as obj, mob/user as mob)
-		..()
-		if(istype(U, /obj/item/clothing/under/chameleon))
-			user << "\red Nothing happens."
-			return
-		if(istype(U, /obj/item/clothing/under))
-			if(src.clothing_choices.Find(U))
-				user << "\red Pattern is already recognised by the suit."
-				return
-			src.clothing_choices += U
-			user << "\red Pattern absorbed by the suit."
-
 
 	emp_act(severity)
 		name = "psychedelic"
 		desc = "Groovy!"
 		icon_state = "psyche"
 		item_color = "psyche"
-		spawn(200)
-			name = "Black Jumpsuit"
-			icon_state = "bl_suit"
-			item_color = "black"
-			desc = null
-		..()
-
 
 	verb/change()
-		set name = "Change Color"
+		set name = "Change Jumpsuit Appearance"
 		set category = "Object"
 		set src in usr
 
-		if(icon_state == "psyche")
-			usr << "\red Your suit is malfunctioning"
-			return
-
-		var/obj/item/clothing/under/A
-		A = input("Select Colour to change it to", "BOOYEA", A) in clothing_choices
+		var/obj/item/clothing/suit/A
+		A = input("Select jumpsuit to change it to", "Chameleon Jumpsuit")as null|anything in clothing_choices
 		if(!A)
 			return
 
@@ -70,12 +47,197 @@
 		item_color = A.item_color
 		usr.update_inv_w_uniform()	//so our overlays update.
 
+//*****************
+//**Chameleon Hat**
+//*****************
 
+/obj/item/clothing/head/chameleon
+	name = "grey cap"
+	icon_state = "greysoft"
+	item_state = "greysoft"
+	item_color = "grey"
+	desc = "It looks like a plain hat, but upon closer inspection, there's an advanced holographic array installed inside. It seems to have a small dial inside."
+	origin_tech = "syndicate=3"
+	var/list/clothing_choices = list()
 
-/obj/item/clothing/under/chameleon/all/New()
-	..()
-	var/blocked = list(/obj/item/clothing/under/chameleon, /obj/item/clothing/under/chameleon/all)
-	//to prevent an infinite loop
-	for(var/U in typesof(/obj/item/clothing/under)-blocked)
-		var/obj/item/clothing/under/V = new U
-		src.clothing_choices += V
+	New()
+		..()
+		var/blocked = list(/obj/item/clothing/head/chameleon, /obj/item/clothing/head/helmet/space/space_ninja,
+			/obj/item/clothing/head/space/golem, /obj/item/clothing/head/justice,)//Prevent infinite loops and bad hats.
+		for(var/U in typesof(/obj/item/clothing/head)-blocked)
+			var/obj/item/clothing/head/V = new U
+			src.clothing_choices += V
+		return
+
+	emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+		name = "grey cap"
+		desc = "It's a baseball hat in a tasteful grey colour."
+		icon_state = "greysoft"
+		item_color = "grey"
+		update_icon()
+
+	verb/change()
+		set name = "Change Hat/Helmet Appearance"
+		set category = "Object"
+		set src in usr
+
+		var/obj/item/clothing/suit/A
+		A = input("Select headwear to change it to", "Chameleon Hat")as null|anything in clothing_choices
+		if(!A)
+			return
+
+		desc = null
+		permeability_coefficient = 0.90
+
+		desc = A.desc
+		name = A.name
+		icon_state = A.icon_state
+		item_state = A.item_state
+		item_color = A.item_color
+		flags_inv = A.flags_inv
+		usr.update_inv_head()	//so our overlays update.
+
+//******************
+//**Chameleon Suit**
+//******************
+
+/obj/item/clothing/suit/chameleon
+	name = "armor"
+	icon_state = "armor"
+	item_state = "armor"
+	desc = "It appears to be a vest of standard armor, except this is embedded with a hidden holographic cloaker, allowing it to change it's appearance, but offering no protection.. It seems to have a small dial inside."
+	origin_tech = "syndicate=3"
+	var/list/clothing_choices = list()
+
+	New()
+		..()
+		var/blocked = list(/obj/item/clothing/suit/chameleon, /obj/item/clothing/suit/space/space_ninja,
+			/obj/item/clothing/suit/golem, /obj/item/clothing/suit/suit, /obj/item/clothing/suit/cyborg_suit, /obj/item/clothing/suit/justice,
+			/obj/item/clothing/suit/greatcoat)//Prevent infinite loops and bad suits.
+		for(var/U in typesof(/obj/item/clothing/suit)-blocked)
+			var/obj/item/clothing/suit/V = new U
+			src.clothing_choices += V
+		return
+
+	emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+		name = "armor"
+		desc = "An armored vest that protects against some damage."
+		icon_state = "armor"
+		item_color = "armor"
+		update_icon()
+
+	verb/change()
+		set name = "Change Exosuit Appearance"
+		set category = "Object"
+		set src in usr
+
+		var/obj/item/clothing/suit/A
+		A = input("Select footwear to change it to", "Chameleon Exosuit")as null|anything in clothing_choices
+		if(!A)
+			return
+
+		desc = null
+		permeability_coefficient = 0.90
+
+		desc = A.desc
+		name = A.name
+		icon_state = A.icon_state
+		item_state = A.item_state
+		item_color = A.item_color
+		flags_inv = A.flags_inv
+		usr.update_inv_wear_suit()	//so our overlays update.
+
+//*******************
+//**Chameleon Shoes**
+//*******************
+/obj/item/clothing/shoes/chameleon
+	name = "black shoes"
+	icon_state = "black"
+	item_state = "black"
+	item_color = "black"
+	desc = "They're comfy black shoes, with clever Syndicate cloaking technology built in. It seems to have a small dial on the back of each shoe."
+	origin_tech = "syndicate=3"
+	var/list/clothing_choices = list()
+
+	New()
+		..()
+		var/blocked = list(/obj/item/clothing/shoes/chameleon, /obj/item/clothing/shoes/space_ninja,
+			/obj/item/clothing/shoes/golem, /obj/item/clothing/shoes/syndigaloshes, /obj/item/clothing/shoes/cyborg)//prevent infinite loops and bad shoes.
+		for(var/U in typesof(/obj/item/clothing/shoes)-blocked)
+			var/obj/item/clothing/shoes/V = new U
+			src.clothing_choices += V
+		return
+
+	emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+		name = "black shoes"
+		desc = "A pair of black shoes."
+		icon_state = "black"
+		item_state = "black"
+		item_color = "black"
+		update_icon()
+
+	verb/change()
+		set name = "Change Footwear Appearance"
+		set category = "Object"
+		set src in usr
+
+		var/obj/item/clothing/shoes/A
+		A = input("Select footwear to change it to", "Chameleon Shoes")as null|anything in clothing_choices
+		if(!A)
+			return
+
+		desc = null
+		permeability_coefficient = 0.90
+
+		desc = A.desc
+		name = A.name
+		icon_state = A.icon_state
+		item_state = A.item_state
+		item_color = A.item_color
+		usr.update_inv_shoes()	//so our overlays update.
+
+//**********************
+//**Chameleon Backpack**
+//**********************
+/obj/item/weapon/storage/backpack/chameleon
+	name = "backpack"
+	icon_state = "backpack"
+	item_state = "backpack"
+	desc = "A backpack outfitted with cloaking tech. It seems to have a small dial inside, kept away from the storage."
+	origin_tech = "syndicate=3"
+	var/list/clothing_choices = list()
+
+	New()
+		..()
+		var/blocked = list(/obj/item/weapon/storage/backpack/chameleon, /obj/item/weapon/storage/backpack/satchel/withwallet,)
+		for(var/U in typesof(/obj/item/weapon/storage/backpack)-blocked)//Prevent infinite loops and bad backpacks.
+			var/obj/item/weapon/storage/backpack/V = new U
+			src.clothing_choices += V
+		return
+
+	emp_act(severity) //Because we don't have psych for all slots right now but still want a downside to EMP.  In this case your cover's blown.
+		name = "backpack"
+		desc = "You wear this on your back and put items into it."
+		icon_state = "backpack"
+		item_state = "backpack"
+		update_icon()
+
+	verb/change()
+		set name = "Change Backpack Appearance"
+		set category = "Object"
+		set src in usr
+
+		var/obj/item/weapon/storage/backpack/A
+		A = input("Select backpack to change it to", "Chameleon Backpack")as null|anything in clothing_choices
+		if(!A)
+			return
+
+		desc = null
+		permeability_coefficient = 0.90
+
+		desc = A.desc
+		name = A.name
+		icon_state = A.icon_state
+		item_state = A.item_state
+		item_color = A.item_color
+		usr.update_inv_back()	//so our overlays update.

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -347,3 +347,7 @@
 
 /obj/item/weapon/paper/crumpled/bloody
 	icon_state = "scrap_bloodied"
+
+/obj/item/weapon/paper/nogloves
+	name = "No gloves included."
+	info = "We're sorry, but we could not provide Chameleon Gloves due to a conflict with several space wizards rumored to steal suns for fun.<BR>However, spy specialists say that dying your gloves will work.  Find some crayons and gloves to dye.<BR>Good luck, agent.<BR><BR><I>- Anonymous MI13 Representive"


### PR DESCRIPTION
The chameleon jumpsuit is one of the most underused items, as disguises are really hard to pull off.  This will help to make part of it just a bit easier.
- Replaced the chameleon jumpsuit in the uplink with a kit.  This kit has the jumpsuit, a new chameleon backpack, exosuit, helmet, and shoes.  It also comes with a piece of paper explaining why gloves aren't included.
- The new chameleon items work just like the jumpsuit does.  You can change their appearances to look like almost anything that's available in the code.  Exceptions being unfinished things, ninja stuff, and golem stuff.
- It costs 3 telecrystals.  This price is based around that fact that if someone wants a really good disguise, they'll also need to buy a voice changer (4tc) and an agent ID (2tc), totally 9tc all together.  Maybe they'll buy the stamp.
- Changes the way the chameleon slot items will choose what to pick as an option to turn into.  It's now a list of excluded items instead of a pile of paths for allowed items.  This results in both a lot of more options to choose from and makes it easier to maintain, as when a new bag/jumpsuit/etc gets added, it'll be added to the list automatically.
- I also tided up a single case of existing code not using the full path declaration.

Thanks to YotaXP, Cheridan, Nodrak, Aranclanos, some guy named 'nope' and coderbus in general for runtime stopping and helping with the dreaded undefined error.
