### PR TITLE
Ghosts runtiming with portal hubs

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -86,7 +86,7 @@
 /obj/machinery/teleport/hub/attack_ghost(mob/user as mob)
 	var/atom/l = loc
 	var/obj/machinery/computer/teleporter/com = locate(/obj/machinery/computer/teleporter, locate(l.x - 2, l.y, l.z))
-	if(com.locked)
+	if(com && com.locked)
 		user.loc = get_turf(com.locked)
 
 /obj/effect/portal/attack_ghost(mob/user as mob)


### PR DESCRIPTION
Ghosts won't runtime if they click on the portal while the teleporter computer is gone
