### PR TITLE
Station name roundstart runtime

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -47,16 +47,17 @@ var/religion_name = null
 	if (station_name)
 		return station_name
 
-	var/short_name = pick("Station", "Fortress", "Frontier", "Suffix", "Death-trap", "Space-hulk", "Lab", "Hazard","Spess Junk", "Fishery", "No-Moon", "Tomb", "Crypt", "Hut", "Monkey", "Bomb", "Trade Post", "Fortress", "Village", "Town", "City", "Edition", "Hive", "Complex", "Base", "Facility", "Depot", "Outpost", "Installation", "Drydock", "Observatory", "Array", "Relay", "Monitor", "Platform", "Construct", "Hangar", "Prison", "Center", "Port", "Waystation", "Factory", "Waypoint", "Stopover", "Hub", "HQ", "Office", "Object", "Fortification", "Colony", "Planet-Cracker", "Roost", "Fat Camp")
+	if(events)
+		var/short_name = pick("Station", "Fortress", "Frontier", "Suffix", "Death-trap", "Space-hulk", "Lab", "Hazard","Spess Junk", "Fishery", "No-Moon", "Tomb", "Crypt", "Hut", "Monkey", "Bomb", "Trade Post", "Fortress", "Village", "Town", "City", "Edition", "Hive", "Complex", "Base", "Facility", "Depot", "Outpost", "Installation", "Drydock", "Observatory", "Array", "Relay", "Monitor", "Platform", "Construct", "Hangar", "Prison", "Center", "Port", "Waystation", "Factory", "Waypoint", "Stopover", "Hub", "HQ", "Office", "Object", "Fortification", "Colony", "Planet-Cracker", "Roost", "Fat Camp")
 
-	station_name = new_station_name()
+		station_name = new_station_name()
 
-	if (config && config.server_name)
-		world.name = "[config.server_name]: [short_name]"
-	else
-		world.name = station_name
+		if (config && config.server_name)
+			world.name = "[config.server_name]: [short_name]"
+		else
+			world.name = station_name
 
-	return station_name
+		return station_name
 
 /proc/new_station_name()
 	var/random = rand(1,5)


### PR DESCRIPTION
Observing before the round stops loading won't generate runtimes anymore by ghosts making querys for the station's name.

The station name will wait warmly and finally be created properly by the master controller.
