### PR TITLE
NanoUI mob transformation runtime fix

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -66,6 +66,9 @@ datum/mind
 				current.verbs -= /datum/changeling/proc/EvolutionMenu
 			current.mind = null
 
+			nanomanager.user_transferred(current, new_character)
+
+
 		if(key)
 			if(new_character.key != key)					//if we're transfering into a body with a key associated which is not ours
 				new_character.ghostize(1)						//we'll need to ghostize so that key isn't mobless.
@@ -74,8 +77,6 @@ datum/mind
 
 		if(new_character.mind)								//disassociate any mind currently in our new body's mind variable
 			new_character.mind.current = null
-
-		nanomanager.user_transferred(current, new_character)
 
 		current = new_character								//associate ourself with our new body
 		new_character.mind = src							//and associate our new body with ourself


### PR DESCRIPTION
NanoUIs will now only transfer their mob UI list on a mob transformation if the old mob exists. No extra checks, just better placement for the NanoUI user_transfered() proc call.

This will fix some runtimes.
