### PR TITLE
>Using spawn() on turf procs

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -25,6 +25,8 @@
 		overlays += wet_overlay
 
 	spawn(rand(790, 820)) // Purely so for visual effect
+		if(!istype(src, /turf/simulated)) //Because turfs don't get deleted, they change, adapt, transform, evolve and deform. they are one and they are all.
+			return
 		if(wet > wet_setting) return
 		wet = 0
 		if(wet_overlay)


### PR DESCRIPTION
Because turfs don't give a fuck, added a sanity check when the spawn() of MakeSlippery() is engaged. Turfs can change but the procs won't stop.
