### PR TITLE
Humanize() runtimes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -825,7 +825,8 @@ datum/mind
 							log_admin("[key_name(usr)] attempting to humanize [key_name(current)]")
 							message_admins("\blue [key_name_admin(usr)] attempting to humanize [key_name_admin(current)]")
 							H = M.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
-							src = H.mind
+							if(H)
+								src = H.mind
 
 		else if (href_list["silicon"])
 			switch(href_list["silicon"])

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -309,7 +309,7 @@
 	else
 		if(istype(M, /mob/living/carbon/monkey))	// monkey > human,
 			var/mob/living/carbon/human/O = M.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS)
-			if(connected) //inside dna thing
+			if(O && connected) //inside dna thing
 				var/obj/machinery/dna_scannernew/C = connected
 				O.loc = C
 				C.occupant = O

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -213,7 +213,8 @@
 
 	var/mob/living/carbon/human/O = humanize((TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPSRC),chosen_dna.real_name)
 
-	O.make_changeling()
+	if(O)
+		O.make_changeling()
 	feedback_add_details("changeling_powers","LFT")
 	. = 1
 	del(src)


### PR DESCRIPTION
Added some sanity check for when the humanize() proc call finishes. This proc includes a sleep() and it might return nothing of the mob is deleted before the sleep ends.

Others way to engage the issue wouldn't be fair.
