### PR TITLE
Removes unused variables

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -201,26 +201,6 @@
 						usr.hud_used.move_intent.icon_state = "running"
 				if(istype(usr,/mob/living/carbon/alien/humanoid))
 					usr.update_icons()
-		if("m_intent")
-			if(!usr.m_int)
-				switch(usr.m_intent)
-					if("run")
-						usr.m_int = "13,14"
-					if("walk")
-						usr.m_int = "14,14"
-					if("face")
-						usr.m_int = "15,14"
-			else
-				usr.m_int = null
-		if("walk")
-			usr.m_intent = "walk"
-			usr.m_int = "14,14"
-		if("face")
-			usr.m_intent = "face"
-			usr.m_int = "15,14"
-		if("run")
-			usr.m_intent = "run"
-			usr.m_int = "13,14"
 		if("Reset Machine")
 			usr.unset_machine()
 		if("internal")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -17,9 +17,6 @@
 	// replaced by OPENCONTAINER flags and atom/proc/is_open_container()
 	///Chemistry.
 
-	//Detective Work, used for the duplicate data points kept in the scanners
-	var/list/original_atom
-
 /atom/proc/throw_impact(atom/hit_atom)
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -2,7 +2,6 @@
 	layer = 3
 	var/last_move = null
 	var/anchored = 0
-	// var/elevation = 2    - not used anywhere
 	var/move_speed = 10
 	var/l_move_time = 1
 	var/m_flag = 1

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -1,11 +1,8 @@
 
 /mob
-
 	var/bloody_hands = 0
 	var/mob/living/carbon/human/bloody_hands_mob
-	var/track_blood
 	var/mob/living/carbon/human/track_blood_mob
-	var/track_blood_type
 
 /obj/item/clothing/gloves
 	var/transfer_blood = 0

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -26,12 +26,6 @@
 
 	var/list/surgeries = list()	//a list of surgery datums. generally empty, they're added when the player wants them.
 
-	var/t_plasma = null
-	var/t_oxygen = null
-	var/t_sl_gas = null
-	var/t_n2 = null
-
-
 	var/now_pushing = null
 
 	var/cameraFollow = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -36,7 +36,6 @@
 	var/lastattacker = null
 	var/lastattacked = null
 	var/attack_log = list( )
-	var/already_placed = 0
 	var/obj/machinery/machine = null
 	var/other_mobs = null
 	var/memory = ""
@@ -57,8 +56,6 @@
 	var/ajourn = 0
 	var/druggy = 0			//Carbon
 	var/confused = 0		//Carbon
-	var/antitoxs = null
-	var/plasma = null
 	var/sleeping = 0		//Carbon
 	var/resting = 0			//Carbon
 	var/lying = 0
@@ -80,7 +77,6 @@
 	var/is_dizzy = 0
 	var/is_jittery = 0
 	var/jitteriness = 0//Carbon
-	var/charges = 0
 	var/nutrition = 400//Carbon
 
 	var/overeatduration = 0		// How long this guy is overeating //Carbon
@@ -88,10 +84,8 @@
 	var/stunned = 0
 	var/weakened = 0
 	var/losebreath = 0//Carbon
-	var/intent = null//Living
 	var/shakecamera = 0
 	var/a_intent = "help"//Living
-	var/m_int = null//Living
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null
 	var/obj/structure/stool/bed/buckled = null//Living


### PR DESCRIPTION
original_atom: It seemed to be used for the B12 detective work port. However either the functionality was reverted or made obsolete, regardless this variable has been left over. It is currently only referenced here. 

m_int: Not used or documented at all (what does 13,14 even mean?). I deleted the parts referencing m_int too, I tested if any of the screen objects no longer work, but they all appear to.
THIS IS PROBABLY NEEDS CONFIRMATION THAT IT DOESNT BREAK ANYTHING. It should be fine. I looked at the hud for each mob, it seems to use mov_intent, not run or walk.

track_blood and track_blood_type: Not used anywhere in the code. Might be a mistake to remove but of course doesnt actually affect anything because its not used at all.

t_plasma and other t_gas: Been there since the start, not used and no documentation

already_placed: Been there since the start, not used and no documentation

antitoxs and plasma: Also no documentation and been there since the beginning

charges: Its been there since the start. I... I dont want to even know why this is actually a thing.
