### PR TITLE
Compare mob facing helper proc [Review and discuss before merge]

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1261,7 +1261,7 @@ proc/check_target_facings(mob/living/initator, mob/living/target)
 	/*This can be used to add additional effects on interactions between mobs depending on how the mobs are facing each other, such as adding a crit damage to blows to the back of a guy's head.
 	Given how click code currently works (Nov '13), the initiating mob will be facing the target mob most of the time
 	That said, this proc should not be used if the change facing proc of the click code is overriden at the same time*/
-	if(!ismob(target) || target.lying || istype(target, /mob/living/silicon/pai))
+	if(!ismob(target) || target.lying)
 	//Make sure we are not doing this for things that can't have a logical direction to the players given that the target would be on their side
 		return
 	if(initator.dir == target.dir) //mobs are facing the same direction

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1261,7 +1261,7 @@ proc/check_target_facings(mob/living/initator, mob/living/target)
 	/*This can be used to add additional effects on interactions between mobs depending on how the mobs are facing each other, such as adding a crit damage to blows to the back of a guy's head.
 	Given how click code currently works (Nov '13), the initiating mob will be facing the target mob most of the time
 	That said, this proc should not be used if the change facing proc of the click code is overriden at the same time*/
-	if(!ismob(target) || !isliving(target) || target.stat || target.lying || target.weakened || target.stunned || target.paralysis || target.resting || target.sleeping || (target.status_flags & FAKEDEATH) || istype(target, /mob/living/silicon/pai))
+	if(!ismob(target) || !isliving(target) || target.lying || istype(target, /mob/living/silicon/pai))
 	//Make sure we are not doing this for things that can't have a logical direction to the players given that the target would be on their side
 		return
 	if(initator.dir == target.dir) //mobs are facing the same direction

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1256,3 +1256,17 @@ var/list/WALLITEMS = list(
 	else
 		user << "\blue [target] is empty!"
 	return
+
+proc/check_target_facings(mob/living/initator, mob/living/target)
+	/*This can be used to add additional effects on interactions between mobs depending on how the mobs are facing each other, such as adding a crit damage to blows to the back of a guy's head.
+	Given how click code currently works (Nov '13), the initiating mob will be facing the target mob most of the time
+	That said, this proc should not be used if the change facing proc of the click code is overriden at the same time*/
+	if(!ismob(target) || !isliving(target) || target.stat || target.lying || target.weakened || target.stunned || target.paralysis || target.resting || target.sleeping || (target.status_flags & FAKEDEATH) || istype(target, /mob/living/silicon/pai))
+	//Make sure we are not doing this for things that can't have a logical direction to the players given that the target would be on their side
+		return
+	if(initator.dir == target.dir) //mobs are facing the same direction
+		return 1
+	if(initator.dir + 4 == target.dir || initator.dir - 4 == target.dir) //mobs are facing each other
+		return 2
+	if(initator.dir + 2 == target.dir || initator.dir - 2 == target.dir || initator.dir + 6 == target.dir || initator.dir - 6 == target.dir) //Initating mob is looking at the target, while the target mob is looking in a direction perpendicular to the 1st
+		return 3

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1261,7 +1261,7 @@ proc/check_target_facings(mob/living/initator, mob/living/target)
 	/*This can be used to add additional effects on interactions between mobs depending on how the mobs are facing each other, such as adding a crit damage to blows to the back of a guy's head.
 	Given how click code currently works (Nov '13), the initiating mob will be facing the target mob most of the time
 	That said, this proc should not be used if the change facing proc of the click code is overriden at the same time*/
-	if(!ismob(target) || !isliving(target) || target.lying || istype(target, /mob/living/silicon/pai))
+	if(!ismob(target) || target.lying || istype(target, /mob/living/silicon/pai))
 	//Make sure we are not doing this for things that can't have a logical direction to the players given that the target would be on their side
 		return
 	if(initator.dir == target.dir) //mobs are facing the same direction


### PR DESCRIPTION
This new proc compares the direction two mobs are facing when it is called, giving unique returns if the mobs are facing the same direction, facing opposite directions, or one facing perpendicular to the other. 

This proc would allow adding unique effects on interact on facing, such as giving a higher chance to stun if you target the head and hit someone from behind with a toolbox, or a higher chance of blinding someone with a laser pointer if the two mobs are facing one another.

I have not implemented a current use for this proc yet, nor have I extensively tested it's function.

I do need feedback on my exclusion if statement, because I feel I may have been excessive in what is being checked for. 
