### PR TITLE
Sound runtimes

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -252,13 +252,14 @@
 		for(var/obj/effect/landmark/L in linkedholodeck)
 			if(L.name=="Atmospheric Test Start")
 				spawn(20)
-					var/turf/T = get_turf(L)
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(2, 1, T)
-					s.start()
-					if(T)
-						T.temperature = 5000
-						T.hotspot_expose(50000,50000,1)
+					if(istype(target,/area/holodeck/source_burntest))
+						var/turf/T = get_turf(L)
+						var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+						s.set_up(2, 1, T)
+						s.start()
+						if(T)
+							T.temperature = 5000
+							T.hotspot_expose(50000,50000,1)
 			if(L.name=="Holocarp Spawn")
 				new /mob/living/simple_animal/hostile/carp(L.loc)
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -51,16 +51,16 @@
 	return 0
 
 
-/obj/item/weapon/gun/projectile/shotgun/attack_self(mob/living/user as mob)
+/obj/item/weapon/gun/projectile/shotgun/attack_self(mob/living/user)
 	if(recentpump)	return
-	pump()
+	pump(user)
 	recentpump = 1
 	spawn(10)
 		recentpump = 0
 	return
 
 
-/obj/item/weapon/gun/projectile/shotgun/proc/pump(mob/M as mob)
+/obj/item/weapon/gun/projectile/shotgun/proc/pump(mob/M)
 	playsound(M, 'sound/weapons/shotgunpump.ogg', 60, 1)
 	pumped = 0
 	if(chambered)//We have a shell in the chamber


### PR DESCRIPTION
Sparks won't be spawned in a null location if the holodeck changes the target before their time to spawn. This will stop some runtimes.

Shotguns won't runtime when pumped.
