### PR TITLE
Runtiming FORTI GY AMA

### DIFF
--- a/code/datums/spells/projectile.dm
+++ b/code/datums/spells/projectile.dm
@@ -60,7 +60,7 @@
 				if(!projectile) // step and step_to sleeps so we'll have to check again.
 					break
 
-				if(!proj_lingering && projectile.loc == current_loc) //if it didn't move since last time
+				if(!target || (!proj_lingering && projectile.loc == current_loc)) //if it didn't move since last time
 					del(projectile)
 					break
 


### PR DESCRIPTION
Added a check for the target of the magic missile between the sleeps. This will stop the runtimes and the MM objects from being stuck in the spot (I think you can pull them though)
