### PR TITLE
Fixed the issue where cyborgs could use APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -649,7 +649,7 @@
 	return 1
 
 /obj/machinery/power/apc/proc/validation()
-	return (!locked && !istype(usr, /mob/living/silicon/ai)) || (istype(usr, /mob/living/silicon/ai) && !src.aidisabled)
+	return (!locked && !istype(usr, /mob/living/silicon/ai)) || (istype(usr, /mob/living/silicon) && !src.aidisabled)
 
 /obj/machinery/power/apc/Topic(href, href_list)
 	if(..())


### PR DESCRIPTION
Fixed the validation. Cyborgs can now use APCs, again.
