### PR TITLE
Changes feedback message for NOCLONE in cloner

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -325,10 +325,10 @@
 	if (subject.suiciding == 1)
 		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
 		return
-	if ((!subject.ckey) || (!subject.client))
-		scantemp = "<font class='bad'>Mental interface failure.</font>"
-		return
 	if (NOCLONE in subject.mutations)
+		scantemp = "<font class='bad'>Subject no longer contains the fundamental materials required to create a living clone.</font>"
+		return
+	if ((!subject.ckey) || (!subject.client))
 		scantemp = "<font class='bad'>Mental interface failure.</font>"
 		return
 	if (find_record("ckey", subject.ckey, records))


### PR DESCRIPTION
-When trying to clone a corpse with the NOCLONE flag, it will now give actual feedback that the body cannot be cloned because of lack of DNA.

-Changed the if statement order, which is now slightly important since we want the NOCLONE feedback to fire over the no ckey feedback.

Why is this needed: Because we don't puzzle the geneticist over a corpse that cannot actually ever be cloned. Previously the geneticist might pointlessly try to clone an unclonable body, and since the feedback is same for a body that does not currently have a ckey, the geneticist might constantly try to clone the unclonable body.
