### PR TITLE
NTSL, parrots, and ID consoles hate apostrophes less.

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,9 +1,12 @@
 //Returns the world time in english
 proc/worldtime2text()
-	return "[round(world.time / 36000)+12]:[(world.time / 600 % 60) < 10 ? add_zero(world.time / 600 % 60, 1) : world.time / 600 % 60]"
+	return gameTimestamp("hh:mm")
 
-proc/time_stamp()
-	return time2text(world.timeofday, "hh:mm:ss")
+proc/time_stamp(var/format = "hh:mm:ss")
+	return time2text(world.timeofday, format)
+
+proc/gameTimestamp(var/format = "hh:mm:ss") // Get the game time in text
+	return time2text(world.time - timezoneOffset + 432000, format)
 
 /* Preserving this so future generations can see how fucking retarded some people are
 proc/time_stamp()

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -5,6 +5,7 @@ var/global/obj/effect/overlay/slmaster = null // atmospheric overlay for sleepin
 // nanomanager, the manager for Nano UIs
 var/datum/nanomanager/nanomanager = new()
 
+var/timezoneOffset = 0 // The difference betwen midnight (of the host computer) and 0 world.ticks.
 
 	// For FTP requests. (i.e. downloading runtime logs.)
 	// However it'd be ok to use for accessing attack logs and such too, which are even laggier.

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -160,21 +160,21 @@
 		var/target_owner
 		var/target_rank
 		if(modify)
-			target_name = modify.name
+			target_name = html_encode(modify.name)
 		else
 			target_name = "--------"
 		if(modify && modify.registered_name)
-			target_owner = modify.registered_name
+			target_owner = html_encode(modify.registered_name)
 		else
 			target_owner = "--------"
 		if(modify && modify.assignment)
-			target_rank = modify.assignment
+			target_rank = html_encode(modify.assignment)
 		else
 			target_rank = "Unassigned"
 
 		var/scan_name
 		if(scan)
-			scan_name = scan.name
+			scan_name = html_encode(scan.name)
 		else
 			scan_name = "--------"
 
@@ -323,9 +323,12 @@
 			if (authenticated)
 				var/t1 = href_list["assign_target"]
 				if(t1 == "Custom")
-					var/temp_t = copytext(sanitize(input("Enter a custom job assignment.","Assignment")),1,MAX_NAME_LEN)
-					if(temp_t)
-						t1 = temp_t
+					var/newJob = reject_bad_name(input("Enter a custom job assignment.", "Assignment", modify ? modify.assignment : "Unassigned"))
+					if(newJob)
+						t1 = newJob
+					else
+						usr << "\red Invalid job name entered."
+						return
 				else
 					var/datum/job/jobdatum
 					for(var/jobtype in typesof(/datum/job))
@@ -345,7 +348,12 @@
 				var/t2 = modify
 				//var/t1 = input(usr, "What name?", "ID computer", null)  as text
 				if ((authenticated && modify == t2 && (in_range(src, usr) || (istype(usr, /mob/living/silicon))) && istype(loc, /turf)))
-					modify.registered_name = copytext(sanitize(href_list["reg"]),1,MAX_NAME_LEN)
+					var/newName = reject_bad_name(href_list["reg"])
+					if(newName)
+						modify.registered_name = newName
+					else
+						usr << "\red Invalid name entered."
+						return
 		if ("mode")
 			mode = text2num(href_list["mode_target"])
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -298,7 +298,7 @@ var/list/department_radio_keys = list(
 			var/mob/living/simple_animal/parrot/P = A
 			if(P.speech_buffer.len >= 10)
 				P.speech_buffer.Remove(pick(P.speech_buffer))
-			P.speech_buffer.Add(message)
+			P.speech_buffer.Add(html_decode(message))
 
 		if(istype(A, /obj/)) //radio in pocket could work, radio in backpack wouldn't --rastaf0
 			var/obj/O = A

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -90,7 +90,7 @@
 
 		// Signal data
 
-		interpreter.SetVar("$content", 	signal.data["message"])
+		interpreter.SetVar("$content", 	html_decode(signal.data["message"]))
 		interpreter.SetVar("$freq"   , 	signal.frequency)
 		interpreter.SetVar("$source" , 	signal.data["name"])
 		interpreter.SetVar("$job"    , 	signal.data["job"])
@@ -207,7 +207,7 @@
 
 		// Time
 		interpreter.SetProc("time", /proc/time)
-		interpreter.SetProc("timestamp", /proc/timestamp)
+		interpreter.SetProc("timestamp", /proc/gameTimestamp)
 
 		// Run the compiled code
 		interpreter.Run()

--- a/code/modules/scripting/Implementations/_Logic.dm
+++ b/code/modules/scripting/Implementations/_Logic.dm
@@ -142,9 +142,6 @@
 /proc/time()
 	return world.timeofday
 
-/proc/timestamp(var/format = "hh:mm:ss") // Get the game time in text
-	return time2text(world.time + 432000, format)
-
 /*
 //Makes a list where all indicies in a string is a seperate index in the list
 // JUST A HELPER DON'T ADD TO NTSCRIPT

--- a/code/world.dm
+++ b/code/world.dm
@@ -52,6 +52,8 @@
 		// dumb and hardcoded but I don't care~
 		config.server_name += " #[(world.port % 1000) / 100]"
 
+	timezoneOffset = text2num(time2text(0,"hh")) * 36000
+
 	makepowernets()
 
 	sun = new /datum/sun()

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -56,6 +56,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>30 November 2013</h2>
+	<h3 class='author'>Yota updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='tweak'>The identification console will now require that ID and job names follow the same restrictions as player names.</li>
+		<li class='bugfix'>NTSL scripts and parrots should now handle apostrophes and such properly.  It&amp;#39;s about time.</li>
+		<li class='bugfix'>NTSL scripts now have a better sense of time.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>27 November 2013</h2>
 	<h3 class='author'>RobRichards updated:</h3>
 	<ul class='changes bgimages16'>


### PR DESCRIPTION
NTSL's timestamp() will fetch the proper station time.

ID consoles enforce standard player name restrictions on the ID name and assignment.

Fixes #690 and #323
