### PR TITLE
Sandbox Additions & Modifications

### DIFF
--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -1,7 +1,5 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
-// OOC: Subtumaka: i need to go an roll around in pain on the ground for a bit, i forgot i have a hude paper cut and i tried to squeeze a lemon for lemon nande brb
-
 var/hsboxspawn = 1
 
 mob
@@ -65,8 +63,6 @@ datum/hSB
 
 					"Miscellaneous",
 					"Spawn Air Scrubber"				= "hsbscrubber",
-				//	"Spawn Canister..."					= "hsbcanister",
-				// Removed for further redevlopment.
 					"Spawn Welding Fuel Tank"			= "hsbspawn&path=[/obj/structure/reagent_dispensers/fueltank]",
 					"Spawn Water Tank"					= "hsbspawn&path=[/obj/structure/reagent_dispensers/watertank]",
 
@@ -74,8 +70,7 @@ datum/hSB
 					"Spawn Cleanbot"					= "hsbspawn&path=[/obj/machinery/bot/cleanbot]",
 					"Spawn Floorbot"					= "hsbspawn&path=[/obj/machinery/bot/floorbot]",
 					"Spawn Medbot"						= "hsbspawn&path=[/obj/machinery/bot/medbot]",
-				// the following is code built to replace the shit hsbcanister thing and to prevent griff.
-				// note as of 2/12/13: this shit works fine, admin ones need to be fixed.
+
 					"Canisters",
 					"Spawn O2 Canister" 				= "hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/oxygen]",
 					"Spawn Air Canister"				= "hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/air]")
@@ -87,7 +82,6 @@ datum/hSB
 					hsbinfo += "<b>Administration</b><br>"
 					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbtobj'>Toggle Object Spawning</a><br>"
 					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbtac'>Toggle Item Spawn Panel Auto-close</a><br>"
-					// these buttons seem to just be for admin dickery really. might have a use or somethin'.
 					hsbinfo += "<b>Canister Spawning</b><br>"
 					hsbinfo += "<i>Remember, the first rule about adminbuse, is don't talk about the adminbuse</i><br>"
 					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/toxins]'><b>!!!DANGER!!!</b> Spawn Plasma Canister</a><br>"
@@ -186,7 +180,7 @@ datum/hSB
 					hsb.update_icon() // hackish but it wasn't meant to be spawned I guess?
 
 				//
-				// General Purpose Items
+				// Stacked Materials
 				//
 
 				if("hsbrglass")
@@ -229,19 +223,6 @@ datum/hSB
 				if("hsbairlock")
 					new /datum/airlock_maker(usr.loc)
 
-				//
-				// Canister select window
-				//
-			/*
-			code cut for better replacement.
-			uncomment if new code breaks
-				if("hsbcanister")
-					if(!canisterinfo)
-						canisterinfo = "Choose a canister type:<hr>"
-						for(var/O in (typesof(/obj/machinery/portable_atmospherics/canister/) - /obj/machinery/portable_atmospherics/canister/))
-							canisterinfo += "<a href='?src=\ref[src];hsb=hsbspawn&path=[O]'>[O]</a><br>"
-					usr << browse(canisterinfo,"window=sandbox")
-			*/
 				//
 				// Object spawn window
 				//

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -184,7 +184,7 @@ datum/hSB
 				//
 
 				if("hsbrglass")
-					new/obj/item/stack/sheet/rglass{amount=50}(usr.loc) // might work. probably. i dunno.
+					new/obj/item/stack/sheet/rglass{amount=50}(usr.loc)
 
 				if("hsbmetal")
 					new/obj/item/stack/sheet/metal{amount=50}(usr.loc)

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -1,5 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
+// OOC: Subtumaka: i need to go an roll around in pain on the ground for a bit, i forgot i have a hude paper cut and i tried to squeeze a lemon for lemon nande brb
+
 var/hsboxspawn = 1
 
 mob
@@ -49,25 +51,34 @@ datum/hSB
 					"Spawn All-Access ID"				= "hsbaaid",
 
 					"Building Supplies",
+					"Spawn 50 Wood"                     = "hsbwood",
 					"Spawn 50 Metal"					= "hsbmetal",
 					"Spawn 50 Plasteel"					= "hsbplasteel",
+					"Spawn 50 Reinforced Glass"         = "hsbrglass",
 					"Spawn 50 Glass"					= "hsbglass",
 					"Spawn Full Cable Coil"				= "hsbspawn&path=[/obj/item/weapon/cable_coil]",
 					"Spawn Hyper Capacity Power Cell"	= "hsbspawn&path=[/obj/item/weapon/cell/hyper]",
+					"Spawn Inf. Capacity Power Cell"	= "hsbspawn&path=[/obj/item/weapon/cell/infinte]",
 					"Spawn Rapid Construction Device"	= "hsbrcd",
 					"Spawn RCD Ammo"					= "hsb_safespawn&path=[/obj/item/weapon/rcd_ammo]",
 					"Spawn Airlock"						= "hsbairlock",
 
 					"Miscellaneous",
 					"Spawn Air Scrubber"				= "hsbscrubber",
-					"Spawn Canister..."					= "hsbcanister",
+				//	"Spawn Canister..."					= "hsbcanister",
+				// Removed for further redevlopment.
 					"Spawn Welding Fuel Tank"			= "hsbspawn&path=[/obj/structure/reagent_dispensers/fueltank]",
 					"Spawn Water Tank"					= "hsbspawn&path=[/obj/structure/reagent_dispensers/watertank]",
 
 					"Bots",
 					"Spawn Cleanbot"					= "hsbspawn&path=[/obj/machinery/bot/cleanbot]",
 					"Spawn Floorbot"					= "hsbspawn&path=[/obj/machinery/bot/floorbot]",
-					"Spawn Medbot"						= "hsbspawn&path=[/obj/machinery/bot/medbot]")
+					"Spawn Medbot"						= "hsbspawn&path=[/obj/machinery/bot/medbot]",
+				// the following is code built to replace the shit hsbcanister thing and to prevent griff.
+				// note as of 2/12/13: this shit works fine, admin ones need to be fixed.
+					"Canisters",
+					"Spawn O2 Canister" 				= "hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/oxygen]",
+					"Spawn Air Canister"				= "hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/air]")
 
 
 			if(!hsbinfo)
@@ -75,9 +86,17 @@ datum/hSB
 				if(admin)
 					hsbinfo += "<b>Administration</b><br>"
 					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbtobj'>Toggle Object Spawning</a><br>"
-					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbtac'>Toggle Item Spawn Panel Auto-close</a><hr>"
+					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbtac'>Toggle Item Spawn Panel Auto-close</a><br>"
+					// these buttons seem to just be for admin dickery really. might have a use or somethin'.
+					hsbinfo += "<b>Canister Spawning</b><br>"
+					hsbinfo += "<i>Remember, the first rule about adminbuse, is don't talk about the adminbuse</i><br>"
+					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/toxins]'><b>!!!DANGER!!!</b> Spawn Plasma Canister</a><br>"
+					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/carbon_dioxide]'><b>!!!DANGER!!!</b> Spawn CO2 Canister</a><br>"
+					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/nitrogen]'><b>!!!DANGER!!!</b> Spawn Nitrogen Canister</a><br>"
+					hsbinfo += "- <a href='?src=\ref[src];hsb=hsbspawn&path=[/obj/machinery/portable_atmospherics/canister/sleeping_agent]'><b>!!!DANGER!!!</b> Spawn N2O Canister</a><hr>"
 				else
 					hsbinfo += "<i>Some item spawning may be disabled by the administrators.</i><br>"
+					hsbinfo += "<i>Only administrators may spawn dangerous canisters.</i><br>"
 				for(var/T in hrefs)
 					var/href = hrefs[T]
 					if(href)
@@ -124,7 +143,6 @@ datum/hSB
 						world << "<b>\red Sandbox:  \black [usr.key] has added a limiter to object spawning.  The window will now auto-close after use.</b>"
 						config.sandbox_autoclose = 1
 					return
-
 				//
 				// Spacesuit with full air jetpack set as internals
 				//
@@ -167,6 +185,13 @@ datum/hSB
 					var/obj/hsb = new/obj/machinery/portable_atmospherics/scrubber{volume_rate=50*ONE_ATMOSPHERE;on=1}(usr.loc)
 					hsb.update_icon() // hackish but it wasn't meant to be spawned I guess?
 
+				//
+				// General Purpose Items
+				//
+
+				if("hsbrglass")
+					new/obj/item/stack/sheet/rglass{amount=50}(usr.loc) // might work. probably. i dunno.
+
 				if("hsbmetal")
 					new/obj/item/stack/sheet/metal{amount=50}(usr.loc)
 
@@ -175,6 +200,9 @@ datum/hSB
 
 				if("hsbglass")
 					new/obj/item/stack/sheet/glass{amount=50}(usr.loc)
+
+				if("hsbwood")
+					new/obj/item/stack/sheet/wood{amount=50}(usr.loc)
 
 				//
 				// All access ID
@@ -204,13 +232,16 @@ datum/hSB
 				//
 				// Canister select window
 				//
+			/*
+			code cut for better replacement.
+			uncomment if new code breaks
 				if("hsbcanister")
 					if(!canisterinfo)
 						canisterinfo = "Choose a canister type:<hr>"
 						for(var/O in (typesof(/obj/machinery/portable_atmospherics/canister/) - /obj/machinery/portable_atmospherics/canister/))
 							canisterinfo += "<a href='?src=\ref[src];hsb=hsbspawn&path=[O]'>[O]</a><br>"
 					usr << browse(canisterinfo,"window=sandbox")
-
+			*/
 				//
 				// Object spawn window
 				//

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -26,12 +26,14 @@ datum/hSB
 	var/objinfo = null
 	var/canisterinfo = null
 	var/hsbinfo = null
-
+	// This is a list of banned items, they've been banned due to being technical or just for grief.
 	var/global/list/spawn_forbidden = list(
 		/obj/item/weapon/grab, /obj/item/tk_grab, /obj/item/weapon/implant, // not implanter, the actual thing that is inside you
 		/obj/item/assembly,/obj/item/device/onetankbomb, /obj/item/radio, /obj/item/device/pda/ai,
 		/obj/item/device/uplink/hidden, /obj/item/smallDelivery, /obj/item/missile,/obj/item/projectile,
-		/obj/item/borg/sight,/obj/item/borg/overdrive,/obj/item/borg/stun)
+		/obj/item/borg/sight,/obj/item/borg/overdrive,/obj/item/borg/stun,/obj/item/organ,
+		/obj/item/alien_embryo,/obj/item/weapon/robot_module,/obj/item/weapon/storage/secure/safe,
+		/obj/item/weapon/veilrender,/obj/item/device/radio/intercom)
 
 	proc
 		update()
@@ -56,7 +58,7 @@ datum/hSB
 					"Spawn 50 Glass"					= "hsbglass",
 					"Spawn Full Cable Coil"				= "hsbspawn&path=[/obj/item/weapon/cable_coil]",
 					"Spawn Hyper Capacity Power Cell"	= "hsbspawn&path=[/obj/item/weapon/cell/hyper]",
-					"Spawn Inf. Capacity Power Cell"	= "hsbspawn&path=[/obj/item/weapon/cell/infinte]",
+					"Spawn Inf. Capacity Power Cell"	= "hsbspawn&path=[/obj/item/weapon/cell/infinite]",
 					"Spawn Rapid Construction Device"	= "hsbrcd",
 					"Spawn RCD Ammo"					= "hsb_safespawn&path=[/obj/item/weapon/rcd_ammo]",
 					"Spawn Airlock"						= "hsbairlock",

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -56,6 +56,16 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 
 <div class='commit sansserif'>
+	<h2 class='date'>12 March 2013</h2>
+	<h3 class='author'>cookingboy3 updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Added two new buttons to the sandbox panel.</li>
+		<li class='tweak'>Removed canister menu, repaced it with buttons.</li>
+		<li class='tweak'>Players can no longer spawn "dangerous" canisters in sandbox, such as Plasma, N20, CO2, and Nitrogen.</li>
+	</ul>
+</div>
+
+<div class='commit sansserif'>
 	<h2 class='date'>28 November 2013</h2>
 	<h3 class='author'>Malkevin updated:</h3>
 	<ul class='changes bgimages16'>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -59,8 +59,8 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	<h2 class='date'>12 March 2013</h2>
 	<h3 class='author'>cookingboy3 updated:</h3>
 	<ul class='changes bgimages16'>
-		<li class='rscadd'>Added two new buttons to the sandbox panel.</li>
-		<li class='tweak'>Removed canister menu, repaced it with buttons.</li>
+		<li class='rscadd'>Added three new buttons to the sandbox panel.</li>
+		<li class='tweak'>Removed canister menu, replaced it with buttons.</li>
 		<li class='tweak'>Players can no longer spawn "dangerous" canisters in sandbox, such as Plasma, N20, CO2, and Nitrogen.</li>
 	</ul>
 </div>


### PR DESCRIPTION
This update changes the sandbox panel in the following ways:
Dangerous canisters (including Plasma and N2O) can now only be spawned by admins, the buttons will appear under the sandbox toggles.
Along with this, the canister spawn menu was removed, due to it's ability to have players grief badly.
Normal players can still spawn Oxygen and Air canisters.
Added "Spawn 50 Wood", "Spawn 50 Reinforced Glass", and "Spawn Inf. Power Cell" buttons for user convenience.
Added more items to the ban list. They're all technical items or only useful for grief.
