### PR TITLE
Lootspawner bug fix.

### DIFF
--- a/code/modules/awaymissions/loot.dm
+++ b/code/modules/awaymissions/loot.dm
@@ -8,7 +8,7 @@
 /obj/effect/spawner/lootdrop/initialize()
 	if(loot && loot.len)
 		for(var/i = lootcount, i > 0, i--)
-			if(!loot.len) return
+			if(!loot.len) break
 			var/lootspawn = pick(loot)
 			if(!lootdoubles)
 				loot.Remove(lootspawn)


### PR DESCRIPTION
Fixes a potential issue with lootspawners who have lootcounts longer than their loot list and lootdoubles not enabled.

Of all the things for away missions, these things are well made and deserve more use by mappers.
