### PR TITLE
Strange toolbox, upgrades to gibber

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -9,10 +9,18 @@
 	var/operating = 0 //Is it on?
 	var/dirty = 0 // Does it need cleaning?
 	var/gibtime = 40 // Time from starting until meat appears
-	var/mob/living/occupant // Mob who has been put inside
+	var/mob/living/carbon/occupant // Mob who has been put inside
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 500
+
+	var/require_aggressive_grab = 0
+	var/allow_abiotic = 0
+	var/eject_meat = 1
+	var/xDir=1 // which direction do the meatslabs fly to? 1=west, -1=east
+	var/yDir=0 // recommended values {-1,0,1}
+	var/gibbing_sound='sound/effects/splat.ogg'
+	var/gib_message="<span class='danger'>You hear a loud squelchy grinding sound.</span>"
 
 //auto-gibs anything that bumps into it
 /obj/machinery/gibber/autogibber
@@ -65,42 +73,111 @@
 /obj/machinery/gibber/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/gibber/container_resist()
-	src.go_out()
-	return
-
 /obj/machinery/gibber/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
 		return
 	if(operating)
-		user << "\red It's locked and running"
+		user << "<span class='danger'>It's locked and running</span>"
 		return
 	else
-		src.startgibbing(user)
+		src.start_gibbing(user)
 
-/obj/machinery/gibber/attackby(obj/item/weapon/grab/G as obj, mob/user as mob)
+/obj/machinery/gibber/attackby(obj/item/weapon/grab/G as obj, mob/user as mob, var/location=src)
 	if(src.occupant)
-		user << "\red The gibber is full, empty it first!"
-		return
-	if (!( istype(G, /obj/item/weapon/grab)) || !(istype(G.affecting, /mob/living/carbon/human)))
-		user << "\red This item is not suitable for the gibber!"
-		return
-	if(G.affecting.abiotic(1))
-		user << "\red Subject may not have abiotic items on."
+		user << "<span class='danger'>[src] is full, empty it first!</span>"
 		return
 
-	user.visible_message("\red [user] starts to put [G.affecting] into the gibber!")
+	if(!(istype(G, /obj/item/weapon/grab) && (ismonkey(G.affecting) || ishuman(G.affecting))))
+		user << "<span class='danger'>This item is not suitable for [src]!</span>"
+		return
+
+	if(G.affecting.abiotic(1) && allow_abiotic==0)
+		user << "<span class='danger'>Subject may not have abiotic items on.</span>"
+		return
+
+	if(require_aggressive_grab && G.state<GRAB_AGGRESSIVE)
+		user << "<span class='danger'>You must have a tighter grab on [G.affecting] to do that.</span>"
+		return
+
+	user.visible_message("<span class='danger'>[user] starts to put [G.affecting] into [src]!</span>")
 	src.add_fingerprint(user)
 	if(do_after(user, 30) && G && G.affecting && !occupant)
-		user.visible_message("\red [user] stuffs [G.affecting] into the gibber!")
-		var/mob/M = G.affecting
-		if(M.client)
-			M.client.perspective = EYE_PERSPECTIVE
-			M.client.eye = src
-		M.loc = src
-		src.occupant = M
+		user.visible_message("<span class='danger'>[user] stuffs [G.affecting] into [src]!</span>")
+		put_in_gibber(G.affecting, location)
 		del(G)
 		update_icon()
+		return 1
+
+
+/obj/machinery/gibber/proc/put_in_gibber(var/mob/living/carbon/M, var/location=src) // this is used in hisgrace/proc/eat()
+	if(M.client)
+		M.client.perspective = EYE_PERSPECTIVE
+		M.client.eye = location
+	M.loc = location
+	src.occupant = M
+	return
+
+
+
+/obj/machinery/gibber/proc/start_gibbing(mob/user as mob, var/location=src.loc)
+	if(!src) // This was for debugging but it started working when I put this here so I guess I'll keep it. I don't even.
+		return
+	if(src.operating) //runtime error at this line: no variable null.operating. eh?
+		return
+	if(!src.occupant)
+		visible_message("<span class='danger'>You hear a loud metallic grinding sound.</span>")
+		return
+	if(use_power)
+		use_power(1000)
+	if(gib_message)
+		visible_message(gib_message)
+	src.operating = 1
+	update_icon()
+
+	var/total_slabs = 3
+
+	spawn(gibtime)
+		playsound(location, gibbing_sound, 50, 1)
+		if(allow_abiotic)
+			visible_message("<span class='danger'>[src] spits out the items it could not consume.</danger>")
+			src.occupant.drop_all_items(get_turf(location))
+		if(eject_meat)
+			eject_meat(create_meat(total_slabs))
+		if(user)
+			src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[user]/[user.ckey]</b>" //One shall not simply gib a mob unnoticed!
+			user.attack_log += "\[[time_stamp()]\] Gibbed <b>[src.occupant]/[src.occupant.ckey]</b>"
+			log_attack("\[[time_stamp()]\] <b>[user]/[user.ckey]</b> gibbed <b>[src.occupant]/[src.occupant.ckey]</b>")
+		src.occupant.death(1)
+		src.occupant.ghostize()
+		del(src.occupant)
+		src.operating = 0
+		update_icon()
+
+/obj/machinery/gibber/proc/create_meat(var/total_slabs)
+
+	var/obj/item/weapon/reagent_containers/food/snacks/meat/human/all_meat[total_slabs]
+	for(var/i=1 to total_slabs)
+		var/obj/item/weapon/reagent_containers/food/snacks/meat/human/new_meat
+		if(ishuman(src.occupant))
+			new_meat = new(src, src.occupant, total_slabs)
+		else
+			var/obj/item/weapon/reagent_containers/food/snacks/meat/other=new(src, src.occupant, total_slabs)
+			new_meat = other
+		all_meat[i] = new_meat
+	return all_meat
+
+/obj/machinery/gibber/proc/eject_meat(var/list/allmeat)
+	for (var/i=1 to allmeat.len)
+		var/obj/item/meatslab = allmeat[i]
+		var/turf/Tx = locate(src.x - i*xDir, src.y-i*yDir, src.z)
+		meatslab.loc = src.loc
+		meatslab.throw_at(Tx,i,3)
+		if (!Tx.density)
+			new /obj/effect/decal/cleanable/blood/gibs(Tx,i)
+
+/obj/machinery/gibber/container_resist()
+	src.go_out()
+	return
 
 /obj/machinery/gibber/verb/eject()
 	set category = "Object"
@@ -114,7 +191,7 @@
 	return
 
 /obj/machinery/gibber/proc/go_out()
-	if (!src.occupant)
+	if (!src.occupant || src.operating)
 		return
 	for(var/obj/O in src)
 		O.loc = src.loc
@@ -125,51 +202,3 @@
 	src.occupant = null
 	update_icon()
 	return
-
-
-/obj/machinery/gibber/proc/startgibbing(mob/user as mob)
-	if(src.operating)
-		return
-	if(!src.occupant)
-		visible_message("\red You hear a loud metallic grinding sound.")
-		return
-	use_power(1000)
-	visible_message("\red You hear a loud squelchy grinding sound.")
-	src.operating = 1
-	update_icon()
-	var/sourcename = src.occupant.real_name
-	var/sourcejob = src.occupant.job
-	var/sourcenutriment = src.occupant.nutrition / 15
-	var/sourcetotalreagents = src.occupant.reagents.total_volume
-	var/totalslabs = 3
-
-	var/obj/item/weapon/reagent_containers/food/snacks/meat/human/allmeat[totalslabs]
-	for (var/i=1 to totalslabs)
-		var/obj/item/weapon/reagent_containers/food/snacks/meat/human/newmeat = new
-		newmeat.name = sourcename + newmeat.name
-		newmeat.subjectname = sourcename
-		newmeat.subjectjob = sourcejob
-		newmeat.reagents.add_reagent ("nutriment", sourcenutriment / totalslabs) // Thehehe. Fat guys go first
-		src.occupant.reagents.trans_to (newmeat, round (sourcetotalreagents / totalslabs, 1)) // Transfer all the reagents from the
-		allmeat[i] = newmeat
-
-	src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[user]/[user.ckey]</b>" //One shall not simply gib a mob unnoticed!
-	user.attack_log += "\[[time_stamp()]\] Gibbed <b>[src.occupant]/[src.occupant.ckey]</b>"
-	log_attack("\[[time_stamp()]\] <b>[user]/[user.ckey]</b> gibbed <b>[src.occupant]/[src.occupant.ckey]</b>")
-	src.occupant.death(1)
-	src.occupant.ghostize()
-	del(src.occupant)
-	spawn(src.gibtime)
-		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
-		operating = 0
-		for (var/i=1 to totalslabs)
-			var/obj/item/meatslab = allmeat[i]
-			var/turf/Tx = locate(src.x - i, src.y, src.z)
-			meatslab.loc = src.loc
-			meatslab.throw_at(Tx,i,3)
-			if (!Tx.density)
-				new /obj/effect/decal/cleanable/blood/gibs(Tx,i)
-		src.operating = 0
-		update_icon()
-
-

--- a/code/game/objects/items/weapons/hisgrace.dm
+++ b/code/game/objects/items/weapons/hisgrace.dm
@@ -1,0 +1,193 @@
+/*
+ * Based on Goon's artistic toolbox
+ */
+
+/obj/item/weapon/hisgrace
+
+	var/obj/machinery/gibber/his_grace
+	var/hunger=0
+	var/glomp=0
+	var/eating=0
+	var/mob/living/carbon/champion=null
+	var/bite = 'sound/weapons/bite.ogg'
+	var/make_traitor=1 // 1=only the first person, 2+=anyone who picks up will be made a traitor
+	var/make_psyco=1 // makes you mute-deaf on pick up, shows fluff messages when equipped. 1=show fluff, 2=first person, 3+=anyone who picks up gets mute-deaf
+	var/list/psyco_fluff=list("...feed...me...", "...kill...kill everything...", "...blood...", "...fresh...meat...",
+		 "...me...against...the world...", "..there is...no evil...only...suffering...", "...no evil...",
+		 "...only...suffering...", "...kill...", "...kill...them...all...")
+
+
+/obj/item/weapon/hisgrace/New()
+	..()
+
+	var/obj/item/weapon/storage/toolbox/mechanical/temp = new //don't want to inherit storage properties from toolbox
+	var/list/types = list("icon","icon_state","item_state","flags","force","throwforce","throw_range","throw_speed","w_class","origin_tech","attack_verb")
+	var/list/temp_vars = temp.vars
+	for(var/i=1, i<temp_vars.len, i++)
+		var/a = "[temp_vars[i]]"
+		if(a in types)
+			src.vars[a]=temp_vars[a]
+
+	name="strange toolbox"
+	desc="There is something strange about this toolbox, but you are not sure what it is..."
+
+	his_grace = new()
+	his_grace.name = name
+	his_grace.use_power = 0
+	his_grace.allow_abiotic = 1
+	his_grace.require_aggressive_grab = 1
+	his_grace.eject_meat = 0
+	his_grace.gibbing_sound='sound/items/eatfood.ogg'
+	his_grace.gib_message=null
+	his_grace.gibtime=5
+
+
+/obj/item/weapon/hisgrace/attackby(obj/item/weapon/grab/G as obj, mob/living/user as mob)
+	if(istype(G, /obj/item/weapon/grab))
+		var/is_human=ishuman(G.affecting)
+		if(his_grace.attackby(G,user,src))
+			spawn(his_grace.gibtime)
+				his_grace.start_gibbing(user, src.loc)
+				if(is_human) hunger=0
+				else hunger = max(0, hunger-50) //monkeys aren't as good as humans
+	else if(istype(G, /obj/item/weapon/reagent_containers/food/snacks/meat))
+		user << "<span class='danger'>You feed [G] to [src].</span>"
+		playsound(src.loc, his_grace.gibbing_sound, 50, 1)
+		hunger = hunger - 30
+		del(G)
+	else
+		user << "<span class='userdanger'>You try to put [G] in [src], but [src] bites you instead!</span>"
+		playsound(src.loc, bite, 50, 1)
+		user.take_organ_damage(5)
+		hunger--
+
+
+/obj/item/weapon/hisgrace/pickup(mob/M as mob)
+	..(M)
+	if(!champion)
+		champion = M
+		if(make_traitor)
+			make_traitor()
+		if(make_psyco)
+			make_psyco()
+		if(!(src in processing_objects))
+			processing_objects.Add(src)
+		champion << "<span class='notice'>You feel a sudden surge of power when you pick up [src]!</span>"
+
+/obj/item/weapon/hisgrace/proc/make_traitor()
+	if(is_special_character(champion) || !champion.mind) return
+	ticker.mode.traitors += champion.mind
+	champion.mind.special_role = "Champion of His Grace"
+
+	var/datum/objective/steal/o = new
+	o.target_name = name
+	o.steal_target = /obj/item/weapon/hisgrace
+	o.explanation_text = "Steal [src]."
+	o.owner = champion.mind
+	champion.mind.objectives += o
+
+	var/datum/objective/escape/e = new
+	e.owner = champion.mind
+	champion.mind.objectives += e
+
+	var/i=0
+	for(var/datum/objective/OBJ in champion.mind.objectives)
+		i++
+		champion << "<B>Objective #[i]</B>: [OBJ.explanation_text]"
+
+	if(make_traitor==1)
+		make_traitor--
+
+/obj/item/weapon/hisgrace/proc/make_psyco()
+	if(!(DEAF & champion.sdisabilities))
+		champion.sdisabilities |= DEAF
+	if(!(MUTE & champion.sdisabilities))
+		champion.sdisabilities |= MUTE
+	if(make_psyco==2)
+		make_psyco--
+
+/*
+ * His Grace is active only when equipped. He becomes hungrier and hungrier, starting to nibble and bite
+ * whoever is holding Him. At the peak of His hunger, he will glomp the holder three times before eating them.
+ */
+/obj/item/weapon/hisgrace/process()
+	if(!champion)
+		glomp=0
+		eating=0
+		processing_objects.Remove(src)
+		return
+	if(loc!=champion && loc!=champion.loc)
+		champion = null
+		processing_objects.Remove(src)
+	if(make_psyco && prob(2))
+		champion << "<span class='warning'>"+pick(psyco_fluff)+"</span>"
+	if(hunger<0)
+		hunger=0
+		return
+	if(hunger<100)
+		glomp = 0
+		eating= 0
+	switch(hunger)
+		if(0 to 39)
+			if(prob(8)) growl()
+		if(40 to 69)
+			if(prob(10)) nibble()
+		if(70 to 84)
+			if(prob(15)) bite()
+		if(85 to 99)
+			if(prob(25)) bite()
+		if(100 to INFINITY)
+			if(prob(40)) glomp()
+			if(glomp>=3) eat()
+			return
+	hunger++
+	return
+
+
+/obj/item/weapon/hisgrace/proc/growl(var/mob/living/carbon/user=champion)
+	if(!user) return
+	user.visible_message("<span class='danger'>[src] growls.</span>")
+
+/obj/item/weapon/hisgrace/proc/nibble(var/mob/living/carbon/user=champion)
+	if(!user) return
+	user <<"<span class='userdanger'>[src] nibbles you!</span>"
+	user.take_organ_damage(1)
+	hunger = hunger-1
+
+/obj/item/weapon/hisgrace/proc/bite(var/mob/living/carbon/user=champion)
+	if(!user) return
+	user.visible_message("<span class='danger'>[src] bites [user]!</span>","<span class='userdanger'>[src] bites you!</span>")
+	playsound(src.loc, bite, 50, 1)
+	user.take_organ_damage(2)
+	hunger = hunger-2
+
+/obj/item/weapon/hisgrace/proc/glomp(var/mob/living/carbon/user=champion)
+	if(eating) return
+	if(!user) return
+	user.u_equip(src)
+	user.Weaken(10)
+	user.take_organ_damage(20)
+	playsound(src.loc, bite, 50, 1)
+	user.visible_message("<span class='danger'>[src] glomps [user]!</span>","<span class='userdanger'>[src] glomps you!</span>")
+	glomp++
+
+/obj/item/weapon/hisgrace/proc/eat(var/mob/living/carbon/user=champion)
+	if(eating)
+		return
+	eating = 1
+
+	spawn(30)
+		if(!user)
+			eating=0
+			return
+		user.visible_message("<span class='danger'>[src] eats [user] whole!</span>", "<span class='userdanger'>[src] eats you whole!</span>")
+		his_grace.put_in_gibber(user, src)
+		spawn(his_grace.gibtime)
+			his_grace.occupant.attack_log += "\[[time_stamp()]\] Was eaten by <b>[his_grace]</b>"
+			log_attack("\[[time_stamp()]\] <b>[his_grace]</b> ate <b>[his_grace.occupant]/[his_grace.occupant.ckey]</b>")
+			his_grace.start_gibbing(null, src)
+			hunger = 0
+			glomp  = 0
+			eating = 0
+			return
+

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -75,19 +75,19 @@
 	return 0
 
 
-/mob/proc/drop_from_inventory(var/obj/item/W)
+/mob/proc/drop_from_inventory(var/obj/item/W, var/location=src.loc) //use location when the mob is not on turf
 	if(W)
-		if(client)	client.screen -= W
+		if(!src)
+			return // I do not understand why this starts working after I put in this check.
+		if(src.client)
+			src.client.screen -= W
 		u_equip(W)
 		if(!W) return 1 // self destroying objects (tk, grabs)
-		W.layer = initial(W.layer)
-		W.loc = loc
 
-		var/turf/T = get_turf(loc)
+		var/turf/T = get_turf(location)
 		if(isturf(T))
 			T.Entered(W)
 
-		W.dropped(src)
 		update_icons()
 		return 1
 	return 0
@@ -137,10 +137,23 @@
 	else		return drop_r_hand(Target)
 
 
+/mob/proc/get_implants()
+	var/list/implants = list()
+	for(var/obj/item/weapon/implant/W in src)
+		implants += W
+	return implants
 
+/mob/proc/get_items() // includes items that have been cavity implanted.
+	var/list/items = list()
+	var/list/implants = get_implants()
+	for(var/obj/item/W in (src.contents-implants))
+		items += W
+	return items
 
-
-
+/mob/proc/drop_all_items(var/location=src.loc)
+	var/list/items = get_items()
+	for(var/obj/item/W in items)
+		drop_from_inventory(W, location)
 
 
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -393,3 +393,9 @@
 	if(!ticker.mode.name == "monkey")	return 0
 	return 1
 
+/mob/living/carbon/monkey/abiotic(var/full_body = 0)
+	if(full_body && ((src.l_hand && !( src.l_hand.abstract )) || (src.r_hand && !( src.r_hand.abstract )) || (src.back || src.wear_mask)))
+		return 1
+	else if( (src.l_hand && !src.l_hand.abstract) || (src.r_hand && !src.r_hand.abstract) )
+		return 1
+	return 0

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -3,10 +3,14 @@
 	desc = "A slab of meat"
 	icon_state = "meat"
 	health = 180
-	New()
-		..()
+
+/obj/item/weapon/reagent_containers/food/snacks/meat/New(var/loc, var/mob/flesh, var/total_slabs=3)
+	..(loc)
+	src.bitesize = 3
+	if(!flesh)
 		reagents.add_reagent("nutriment", 3)
-		src.bitesize = 3
+	else
+		add_reagents_from(flesh, total_slabs)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh
@@ -17,6 +21,12 @@
 	name = "-meat"
 	var/subjectname = ""
 	var/subjectjob = null
+
+/obj/item/weapon/reagent_containers/food/snacks/meat/human/New(var/loc, var/mob/living/carbon/human/flesh, var/total_slabs=3)
+	..(loc, flesh, total_slabs)
+	name = flesh.real_name + "-meat"
+	subjectname = flesh.real_name
+	subjectjob = flesh.job
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/monkey
@@ -29,3 +39,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/pug
 	name = "Pug meat"
 	desc = "Tastes like... well you know..."
+
+/obj/item/weapon/reagent_containers/food/snacks/meat/proc/add_reagents_from(var/mob/flesh, var/total_slabs=0)
+	if(!flesh || total_slabs <= 0)
+		return
+	var/sourcenutriment = flesh.nutrition / 15 //probably for the best that not all nutriments are transferred
+	var/sourcetotalreagents = flesh.reagents.total_volume
+	src.reagents.add_reagent ("nutriment", round(sourcenutriment / total_slabs)) // add nutriment
+	flesh.reagents.trans_to (src, round(sourcetotalreagents / total_slabs, 1)) // add reagents


### PR DESCRIPTION
- Adds a new artifact styled weapon called ‘strange toolbox’, based on
  Goon’s artistic toolbox. Basically a portable gibber that will
  eventually eat you unless you feed it. Spawn for +fun or add in your mapping projects. 
- New variables for gibbers: xDir and yDir to change the direction of
  meat slabs ejected (for mappers), allow_abiotic to allow abiotic items,
  require_aggressive_grab to do just that. Doesn't change default gibber performance.
- Gibber accepts monkeys
