### PR TITLE
Increase Chem Dispenser window height

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -113,7 +113,7 @@
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, ui_key)
 	if (!ui)
 		// the ui does not exist, so we'll create a new one
-		ui = new(user, src, ui_key, "chem_dispenser.tmpl", "Chem Dispenser 5000", 370, 585)
+		ui = new(user, src, ui_key, "chem_dispenser.tmpl", "Chem Dispenser 5000", 370, 590)
 		// When the UI is first opened this is the data it will use
 		ui.set_initial_data(data)
 		ui.open()


### PR DESCRIPTION
Increasing the height gets rid of the scroll bar and thus increases the width, so the chemicals form 3 columns and the amount selection boxes do not overflow. 
