### PR TITLE
Syringe gun - now 80% more gun! Fixes #1935

### DIFF
--- a/code/modules/reagents/syringe_gun.dm
+++ b/code/modules/reagents/syringe_gun.dm
@@ -1,120 +1,67 @@
-
-
-
 /obj/item/weapon/gun/syringe
 	name = "syringe gun"
-	desc = "A spring loaded rifle designed to fit syringes, designed to incapacitate unruly patients from a distance."
-	icon = 'icons/obj/gun.dmi'
+	desc = "A spring loaded rifle designed to fit syringes, used to incapacitate unruly patients from a distance."
 	icon_state = "syringegun"
 	item_state = "syringegun"
-	w_class = 3.0
+	w_class = 3
 	throw_speed = 2
 	throw_range = 10
-	force = 4.0
-	var/list/syringes = new/list()
-	var/max_syringes = 1
+	force = 4
 	m_amt = 2000
+	clumsy_check = 0
+	fire_sound = 'sound/items/syringeproj.ogg'
+	var/list/syringes = list()
+	var/max_syringes = 1
 
-	examine()
-		set src in view()
-		..()
-		if(!(usr in view(2)) && usr != loc)
-			return
-		usr << "[syringes.len] / [max_syringes] syringes."
+/obj/item/weapon/gun/syringe/process_chambered()
+	if(!syringes.len) return 0
+	
+	var/obj/item/weapon/reagent_containers/syringe/S = syringes[1]
+	
+	if(!S) return 0
+	
+	in_chamber = new /obj/item/projectile/bullet/dart/syringe(src)
+	S.reagents.trans_to(in_chamber, S.reagents.total_volume)
+	in_chamber.name = S.name
+	syringes.Remove(S)
+	
+	del(S)
+	return 1
 
+/obj/item/weapon/gun/syringe/examine()
+	..()
+	usr << "Can hold [max_syringes] syringe\s. Has [syringes.len] syringe\s remaining."
+	return
 
-	attackby(obj/item/I, mob/user)
-		if(istype(I, /obj/item/weapon/reagent_containers/syringe))
-			if(syringes.len < max_syringes)
-				user.drop_item()
-				I.loc = src
-				syringes += I
-				user << "<span class='notice'>You put [I] in [src].</span>"
-				user << "<span class='notice'>[syringes.len] / [max_syringes] syringes.</span>"
-			else
-				usr << "<span class='notice'>[src] cannot hold more syringes.</span>"
+/obj/item/weapon/gun/syringe/attack_self(mob/living/user as mob)
+	if(!syringes.len)
+		user << "<span class='notice'>[src] is empty.</span>"
+		return 0
+	
+	var/obj/item/weapon/reagent_containers/syringe/S = syringes[syringes.len]
+	
+	if(!S) return 0
+	S.loc = user.loc
+	
+	syringes.Remove(S)
+	user << "<span class = 'notice'>You unload [S] from \the [src]!</span>"
+	
+	return 1
 
-
-	afterattack(obj/target, mob/user , flag)
-		if(!isturf(target.loc) || target == user) return
-
-		if(syringes.len)
-			spawn(0) fire_syringe(target,user)
+/obj/item/weapon/gun/syringe/attackby(var/obj/item/A as obj, mob/user as mob, var/show_msg = 1)
+	if(istype(A, /obj/item/weapon/reagent_containers/syringe))
+		if(syringes.len < max_syringes)
+			user.drop_item()
+			user << "<span class='notice'>You load [A] into \the [src]!</span>"
+			syringes.Add(A)
+			A.loc = src
+			return 1
 		else
-			usr << "<span class='notice'>[src] is empty.</span>"
-
-
-	proc/fire_syringe(atom/target, mob/user)
-		if(locate (/obj/structure/table, src.loc))
-			return
-		else
-			var/turf/trg = get_turf(target)
-			var/obj/effect/syringe_gun_dummy/D = new /obj/effect/syringe_gun_dummy(get_turf(src))
-			var/obj/item/weapon/reagent_containers/syringe/S = syringes[1]
-			if(!S || !S.reagents)	//ho boy! wot runtimes!	//haha i love finding my old comments
-				return
-			S.reagents.trans_to(D, S.reagents.total_volume)
-			syringes -= S
-			del(S)
-			D.icon_state = "syringeproj"
-			D.name = "syringe"
-			playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)
-
-			for(var/i=0, i<6, i++)
-				if(!D) break
-				if(D.loc == trg) break
-				step_towards(D,trg)
-
-				if(D)
-					for(var/mob/living/carbon/M in D.loc)
-						if(!istype(M,/mob/living/carbon)) continue
-						if(M == user) continue
-						//Syringe gun attack logging by Yvarov
-						var/R
-						if(D.reagents)
-							for(var/datum/reagent/A in D.reagents.reagent_list)
-								R += A.id + " ("
-								R += num2text(A.volume) + "),"
-						if(ismob(M))
-							M.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>syringegun</b> ([R])"
-							user.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>syringegun</b> ([R])"
-							log_attack("<font color='red'>[user] ([user.ckey]) shot [M] ([M.ckey]) with a syringegun ([R])</font>")
-						else
-							M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT (No longer exists)</b> shot <b>[M]/[M.ckey]</b> with a <b>syringegun</b> ([R])"
-							log_attack("<font color='red'>UNKNOWN shot [M] ([M.ckey]) with a <b>syringegun</b> ([R])</font>")
-						if(D.reagents)
-							D.reagents.trans_to(M, 15)
-						M.visible_message("<span class='danger'>[M] is hit by the syringe!</span>", \
-											"<span class='userdanger'>[M] is hit by the syringe!</span>")
-
-						del(D)
-						break
-				if(D)
-					for(var/atom/A in D.loc)
-						if(A == user) continue
-						if(A.density) del(D)
-
-				sleep(1)
-
-			if(D)
-				spawn(10)
-					del(D)
-
+			usr << "<span class='notice'>[src] cannot hold more syringes.</span>"
+	return 0
 
 /obj/item/weapon/gun/syringe/rapidsyringe
 	name = "rapid syringe gun"
-	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to four syringes."
+	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes."
 	icon_state = "rapidsyringegun"
-	max_syringes = 4
-
-
-/obj/effect/syringe_gun_dummy
-	name = ""
-	desc = ""
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "null"
-	anchored = 1
-	density = 0
-
-	New()
-		create_reagents(15)
+	max_syringes = 6


### PR DESCRIPTION
Syringe gun uses gun code now. Because guns must be guns, not tons of shitty hacky code. This solves all syringe gun's targeting issues (#1935), it works just like any other gun now. Rapid Syringe Gun buffed to 6 syringes because using a rotating revolver-like cylinder only for 4 syringes is pointless.

No path or vars changes, no map or RnD updates needed, syringe projectile was added by me in #1318.

Fixes #1935 
