### PR TITLE
Adds functionality to empty a transit pod or put mobs in one

### DIFF
--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -130,8 +130,10 @@ obj/structure/ex_act(severity)
 									if(ismob(AM))
 										var/mob/M = AM
 										M.Weaken(5)
+
 					else
 						close_animation()
+			break
 
 
 /obj/structure/transit_tube/station/attackby(obj/item/W, mob/user)
@@ -145,6 +147,7 @@ obj/structure/ex_act(severity)
 					GM.Weaken(5)
 					src.Bumped(GM)
 					del(G)
+				break
 
 /obj/structure/transit_tube/station/proc/open_animation()
 	if(icon_state == "closed")

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -30,6 +30,8 @@
 	enter_delay = 3
 	var/pod_moving = 0
 	var/automatic_launch_time = 100
+	var/cooldown_delay = 30
+	var/launch_cooldown = 0
 
 	var/const/OPEN_DURATION = 6
 	var/const/CLOSE_DURATION = 6
@@ -170,11 +172,11 @@ obj/structure/ex_act(severity)
 /obj/structure/transit_tube/station/proc/launch_pod()
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		if(!pod.moving && pod.dir in directions())
-			spawn(35) //To prevent saxing in the pod, should probably change these to sleep if it doesn't break the tubes
+			spawn(5)
 				pod_moving = 1
 				close_animation()
 				sleep(CLOSE_DURATION + 2)
-				if(icon_state == "closed" && pod)
+				if(icon_state == "closed" && pod && launch_cooldown < world.time)
 					pod.follow_tube()
 
 				pod_moving = 0
@@ -203,6 +205,7 @@ obj/structure/ex_act(severity)
 /obj/structure/transit_tube/station/pod_stopped(obj/structure/transit_tube_pod/pod, from_dir)
 	pod_moving = 1
 	spawn(5)
+		launch_cooldown = world.time + min(cooldown_delay, automatic_launch_time)
 		open_animation()
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -121,7 +121,7 @@ obj/structure/ex_act(severity)
 					open_animation()
 
 				else if(icon_state == "open")
-					if(pod.contents.len && user.loc != pod && intent_numeric(user.a_intent) > 1)
+					if(pod.contents.len && user.loc != pod)
 						user.visible_message("<span class='warning'>[user] starts emptying [pod]'s contents onto the floor!</span>")
 						if(do_after(user, 40)) //So it doesn't default to close_animation() on fail
 							if(pod.loc == loc)
@@ -143,7 +143,7 @@ obj/structure/ex_act(severity)
 			var/mob/GM = G.affecting
 			for(var/obj/structure/transit_tube_pod/pod in loc)
 				pod.visible_message("<span class='warning'>[user] starts putting [GM] into the [pod]!</span>")
-				if(do_after(user, 60))
+				if(do_after(user, 60) && GM && G && G.affecting == GM)
 					GM.Weaken(5)
 					src.Bumped(GM)
 					del(G)


### PR DESCRIPTION
Clicking on a transit station with an empty hand will cause you to attempt to empty the contents of the pod onto the floor, takes 4 seconds

Clicking on a transit station with a grab item in the aggressive state or above will cause you to attempt to stuff the grabbed mob into the pod, takes 6 seconds
EDIT1: Caused stuffing people in pods to stun them for 5 seconds to assist transport of captured persons

Fixes #1997, although the AI will require assistance from a crew member
