### PR TITLE
Gives all Nuke Ops their own Military PDA.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -13,6 +13,7 @@
 	..()
 	sleep(2)
 	new /obj/item/weapon/tank/jetpack/oxygen/harness(src)
+	new /obj/item/device/pda/syndicate(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/clothing/under/syndicate(src)
 	new /obj/item/clothing/head/helmet/space/rig/syndi(src)
@@ -47,7 +48,6 @@
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/weapon/pinpointer/nukeop(src)
-	new /obj/item/device/pda/syndicate(src)
 	return
 
 /obj/structure/closet/syndicate/resources/


### PR DESCRIPTION
One line of code moved to provide all Nuke Ops with their own military PDA. This means that Nuke Ops can lock the shuttle when they leave, making the whole rules revolving around who can and can't mess with the Syndie shuttle less critical. This is a quick patch; more features will ideally be implemented down the line to deal with that issue.
