### PR TITLE
A change to how "continuous_round_wiz" works

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -178,6 +178,7 @@
 		return ..()
 
 	var/wizards_alive = 0
+	var/traitors_alive = 0
 	for(var/datum/mind/wizard in wizards)
 		if(!istype(wizard.current,/mob/living/carbon))
 			continue
@@ -185,7 +186,15 @@
 			continue
 		wizards_alive++
 
-	if (wizards_alive)
+	if(!wizards_alive)
+		for(var/datum/mind/traitor in traitors)
+			if(!istype(traitor.current,/mob/living/carbon))
+				continue
+			if(traitor.current.stat==2)
+				continue
+			traitors_alive++
+
+	if (wizards_alive || traitors_alive)
 		return ..()
 	else
 		finished = 1


### PR DESCRIPTION
Currently, if the config option for continuous wizard rounds is off the round will end immediately following the death of the wizard.

With this change after the death of the wizard the game will additionally check to see if the wizard has made any antagonists that are still alive to do things after his death. The round won't end unless these antags don't exist or have all already died as well.

This allows for summon guns/magics survivors to not get blueballed out of antag round because the wizard died quickly. Additionally this allows wizards who made apprentices the chance for them to get the wizard alive again (the new healing apprentice has a staff that can raise the dead who is uniquely suited to this task.) Additionally additionally this allows for a mindswap wizard to not get instantly meta'd out when the round doesn't end when the wizard's head is caved in WITHOUT forcing extended on people.

This change was originally part of the Magic Mania pull, but was removed and placed in its own PR on request.
