### PR TITLE
Fixes slipping when lying down

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -845,15 +845,10 @@ steam.start() -- spawns the effect
 		return
 
 	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP))
-			return
-
-		M.stop_pulling()
-		M << "\blue You slipped on the foam!"
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(5)
-		M.Weaken(2)
+		var/mob/living/carbon/M = AM
+		var/stun = 5
+		var/weaken = 2
+		M.slip(stun, weaken, src)
 
 
 /datum/effect/effect/system/foam_spread

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -846,7 +846,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		M.slip(5, 2, src, 1)
+		M.slip(5, 2, src, 2)
 
 
 /datum/effect/effect/system/foam_spread

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -846,9 +846,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		var/stun = 5
-		var/weaken = 2
-		M.slip(stun, weaken, src)
+		M.slip(5, 2, src, 1)
 
 
 /datum/effect/effect/system/foam_spread

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -962,12 +962,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		var/stun = 8
-		var/weaken = 5
-		if(M.slip(stun, weaken, src))
+		if(M.slip(8, 5, src))
 			if (ishuman(M) && (M.real_name != src.owner))
-				if (istype(src.cartridge, /obj/item/weapon/cartridge/clown) && src.cartridge:honk_charges < 5)
-					src.cartridge:honk_charges++
+				if (istype(src.cartridge, /obj/item/weapon/cartridge/clown))
+					var/obj/item/weapon/cartridge/clown/cart = src.cartridge
+					if(cart.honk_charges < 5)
+						cart.honk_charges++
 
 
 //AI verb and proc for sending PDA messages.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -959,20 +959,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	..()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
+
 	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if ((istype(M, /mob/living/carbon/human) && (istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP)) || M.m_intent == "walk")
-			return
-
-		if ((istype(M, /mob/living/carbon/human) && (M.real_name != src.owner) && (istype(src.cartridge, /obj/item/weapon/cartridge/clown))))
-			if (src.cartridge:honk_charges < 5)
-				src.cartridge:honk_charges++
-
-		M.stop_pulling()
-		M << "\blue You slipped on the PDA!"
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(8)
-		M.Weaken(5)
+		var/mob/living/carbon/M = AM
+		var/stun = 8
+		var/weaken = 5
+		if(M.slip(stun, weaken, src))
+			if (ishuman(M) && (M.real_name != src.owner))
+				if (istype(src.cartridge, /obj/item/weapon/cartridge/clown) && src.cartridge:honk_charges < 5)
+					src.cartridge:honk_charges++
 
 
 //AI verb and proc for sending PDA messages.

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -9,12 +9,9 @@
  * Banana Peals
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		var/stun = 4
-		var/weaken = 2
-		M.slip(stun, weaken, src)
+		M.slip(4, 2, src)
 
 
 /*
@@ -23,9 +20,7 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		var/stun = 3
-		var/weaken = 2
-		M.slip(stun, weaken, src)
+		M.slip(3, 2, src)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -9,31 +9,23 @@
  * Banana Peals
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
-			return
 
-		M.stop_pulling()
-		M << "\blue You slipped on the [name]!"
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(4)
-		M.Weaken(2)
+	if (istype(AM, /mob/living/carbon))
+		var/mob/living/carbon/M = AM
+		var/stun = 4
+		var/weaken = 2
+		M.slip(stun, weaken, src)
+
 
 /*
  * Soap
  */
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
-			return
-
-		M.stop_pulling()
-		M << "\blue You slipped on the [name]!"
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(3)
-		M.Weaken(2)
+		var/mob/living/carbon/M = AM
+		var/stun = 3
+		var/weaken = 2
+		M.slip(stun, weaken, src)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -55,12 +55,12 @@
 
 		switch (src.wet)
 			if(1) //wet floor
-				if(!M.slip(8, 5))
+				if(!M.slip(8, 5, null, 1))
 					M.inertia_dir = 0
 				return
 
 			if(2) //lube
-				if(M.slip(12, 10, null, 2)) // not all mobs slip
-					M.take_organ_damage(2) // Was 5 -- TLE
+				M.slip(12, 10, null, 3)
+
 
 	..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -55,24 +55,12 @@
 
 		switch (src.wet)
 			if(1) //wet floor
-				var/stun = 8
-				var/weaken = 5
-				if(M.slip(stun, weaken))
-					step(M, M.dir)
-				else
+				if(!M.slip(8, 5))
 					M.inertia_dir = 0
 				return
 
 			if(2) //lube
-				var/stun = 12
-				var/weaken = 10
-				var/lube = 1
-				if(M.slip(stun, weaken, null, lube)) // you drop items in your hands here
-					step(M, M.dir)
-					spawn(1) step(M, M.dir)
-					spawn(2) step(M, M.dir)
-					spawn(3) step(M, M.dir)
-					spawn(4) step(M, M.dir)
+				if(M.slip(12, 10, null, 2)) // not all mobs slip
 					M.take_organ_damage(2) // Was 5 -- TLE
 
 	..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -54,41 +54,25 @@
 					playsound(src, "clownstep", 20, 1)
 
 		switch (src.wet)
-			if(1)
-				if(istype(M, /mob/living/carbon/human)) // Added check since monkeys don't have shoes
-					if ((M.m_intent == "run") && !(istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP))
-						M.stop_pulling()
-						step(M, M.dir)
-						M << "\blue You slipped on the wet floor!"
-						playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-						M.Stun(8)
-						M.Weaken(5)
-					else
-						M.inertia_dir = 0
-						return
-				else if(!istype(M, /mob/living/carbon/slime))
-					if (M.m_intent == "run")
-						M.stop_pulling()
-						step(M, M.dir)
-						M << "\blue You slipped on the wet floor!"
-						playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-						M.Stun(8)
-						M.Weaken(5)
-					else
-						M.inertia_dir = 0
-						return
+			if(1) //wet floor
+				var/stun = 8
+				var/weaken = 5
+				if(M.slip(stun, weaken))
+					step(M, M.dir)
+				else
+					M.inertia_dir = 0
+				return
 
-			if(2) //lube		//can cause infinite loops - needs work
-				if(!istype(M, /mob/living/carbon/slime))
-					M.stop_pulling()
+			if(2) //lube
+				var/stun = 12
+				var/weaken = 10
+				var/lube = 1
+				if(M.slip(stun, weaken, null, lube)) // you drop items in your hands here
 					step(M, M.dir)
 					spawn(1) step(M, M.dir)
 					spawn(2) step(M, M.dir)
 					spawn(3) step(M, M.dir)
 					spawn(4) step(M, M.dir)
 					M.take_organ_damage(2) // Was 5 -- TLE
-					M << "\blue You slipped on the floor!"
-					playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-					M.Weaken(10)
 
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,11 +1,3 @@
-
-/mob/living/carbon/Life()
-	.=..()
-	if(recently_slipped)
-		recently_slipped=max(0, recently_slipped-1)
-		if(weakened && recently_slipped==0)
-			recently_slipped = 1
-
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,3 +1,11 @@
+
+/mob/living/carbon/Life()
+	.=..()
+	if(recently_slipped)
+		recently_slipped=max(0, recently_slipped-1)
+		if(weakened && recently_slipped==0)
+			recently_slipped = 1
+
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -8,6 +8,8 @@
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
 
+	var/recently_slipped = 0 // used in mob_movement.dm
+
 //inventory slots
 	var/obj/item/back = null
 	var/obj/item/clothing/mask/wear_mask = null

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -443,3 +443,23 @@
 	else
 		step(pulling, get_dir(pulling.loc, A))
 	return
+
+/mob/proc/slip(var/s_amount, var/w_amount, var/obj/O, var/lube) // used in banana peels, soaps, clown pda
+	if (iscarbon(src) && !lying && canmove) // only carbons slip.
+		if (isslime(src)) // except slimes don't. TODO: reconsider if aliens should slip or not
+			return 0
+		if (ishuman(src) && (isobj(src:shoes) && src:shoes.flags&NOSLIP) && !lube) //lube wins galoshes
+			return 0
+		if (src.m_intent=="walk" && !lube)
+			return 0
+
+		src.stop_pulling()
+		if(O)
+			src << "<span class='danger'>You slipped on the [O.name]!</span>"
+		else
+			src << "<span class='danger'>You slipped!</span>"
+		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+		src.Stun(s_amount)
+		src.Weaken(w_amount)
+		return 1
+	return 0 // no success. Used in clown pda and wet floors

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -444,24 +444,30 @@
 		step(pulling, get_dir(pulling.loc, A))
 	return
 
-/mob/proc/slip(var/s_amount, var/w_amount, var/obj/O, var/lube) // used in banana peels, soaps, clown pda
-	if (iscarbon(src) && !lying && canmove) // only carbons slip.
-		if (!(status_flags & CANWEAKEN)) // except not all carbons
-			return 0
-		if (HULK in src.mutations && !lube) // lube wins hulk
-			return 0
-		if (ishuman(src) && (isobj(src:shoes) && src:shoes.flags&NOSLIP) && !lube) //lube wins galoshes
-			return 0
-		if (src.m_intent=="walk" && !lube) // lube wins walking
+/mob/proc/slip(var/s_amount, var/w_amount, var/obj/O, var/lube) // lube=1 slips when walking, lube=2 is for lube
+	if (iscarbon(src)) // only carbons slip.
+		if (ishuman(src))
+			var/mob/living/carbon/human/shoe_wearer = src
+			if(isobj(shoe_wearer.shoes) && shoe_wearer.shoes.flags&NOSLIP && lube!=2) //lube wins galoshes
+				return 0
+		if (src.m_intent=="walk" && lube==0)
 			return 0
 
-		src.stop_pulling()
-		if(O)
-			src << "<span class='danger'>You slipped on the [O.name]!</span>"
-		else
-			src << "<span class='danger'>You slipped!</span>"
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		src.Stun(s_amount)
-		src.Weaken(w_amount)
+		if((!lying && canmove) || !(src.flags&CANWEAKEN)) //this spams a lot for aliens, hulks and slimes, but how to check if they have been slipped recently?
+			src.stop_pulling()
+			if(O)
+				src << "<span class='danger'>You slipped on the [O.name]!</span>"
+			else
+				src << "<span class='danger'>You slipped!</span>"
+			playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+			src.Stun(s_amount)
+			src.Weaken(w_amount)
+			if(lube)
+				step(src, src.dir)
+		if(lube==2) // Wheeeeeeeeeee!
+			spawn(1) step(src, src.dir)
+			spawn(2) step(src, src.dir)
+			spawn(3) step(src, src.dir)
+			spawn(4) step(src, src.dir)
 		return 1
 	return 0 // no success. Used in clown pda and wet floors

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -467,7 +467,9 @@
 			step(C, C.dir) //slide to the next wet floor, ad infinitum
 			return 1
 
-		if(!C.recently_slipped)
+
+		// here is where we slip: only if you haven't been recently slipped, and are standing
+		if(!C.recently_slipped && !lying)
 			C.stop_pulling()
 			if(O)
 				C << "<span class='danger'>You slipped on the [O.name]!</span>"
@@ -475,7 +477,9 @@
 				C << "<span class='danger'>You slipped!</span>"
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 			C.Stun(s_amount)
-			C.recently_slipped = w_amount
+			C.recently_slipped = 1
+			spawn (w_amount*10)
+				C.recently_slipped = 0
 			if(can_not_weaken || lube==1 || lube==3)
 				step(C, C.dir) //loop back to wet floors
 			if(lube!=3)
@@ -488,7 +492,9 @@
 			spawn(4)
 				step(C, C.dir)
 				C.Weaken(w_amount) //weaken after the last step. Slide may or may not be over yet.
-				C.recently_slipped = w_amount
+				C.recently_slipped = 1
+				spawn (w_amount*10)
+					C.recently_slipped = 0
 			C.take_organ_damage(2) // Was 5 -- TLE
 		return 1
 	return 0 // no success. Used in clown pda and wet floors

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -446,11 +446,13 @@
 
 /mob/proc/slip(var/s_amount, var/w_amount, var/obj/O, var/lube) // used in banana peels, soaps, clown pda
 	if (iscarbon(src) && !lying && canmove) // only carbons slip.
-		if (isslime(src)) // except slimes don't. TODO: reconsider if aliens should slip or not
+		if (!(status_flags & CANWEAKEN)) // except not all carbons
+			return 0
+		if (HULK in src.mutations && !lube) // lube wins hulk
 			return 0
 		if (ishuman(src) && (isobj(src:shoes) && src:shoes.flags&NOSLIP) && !lube) //lube wins galoshes
 			return 0
-		if (src.m_intent=="walk" && !lube)
+		if (src.m_intent=="walk" && !lube) // lube wins walking
 			return 0
 
 		src.stop_pulling()


### PR DESCRIPTION
edit after 4th commit: no nerfs, fixes the bug, sliding on wet floor works correctly, no spam for mobs you can't weaken.
- you can no longer slip people who are already lying down (#1784)
- nerfs lube. You can no longer be slipped x times in a row. Spacing people by lubing the whole hallway to escape doesn't work.
- when you are slipped by lube, you drop your items a few tiles before the turf where you end up sliding to. I can look into changing this if requested, but it will take a more hacky approach.
- slimes and aliens don't slip, hulks only slip on lube
- walking on cleaner foam doesn’t slip you any more
