### PR TITLE
Photocopier runtimes fix.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -24,7 +24,7 @@
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 	var/greytoggle = "Greyscale"
 	var/mob/living/ass = null
-
+	var/busy = 0
 
 /obj/machinery/photocopier/attack_ai(mob/user)
 	return attack_hand(user)
@@ -63,7 +63,7 @@
 	if(href_list["copy"])
 		if(copy)
 			for(var/i = 0, i < copies, i++)
-				if(toner > 0)
+				if(toner > 0 && !busy && copy)
 					var/obj/item/weapon/paper/c = new /obj/item/weapon/paper (loc)
 					if(toner > 10)	//lots of toner, make it dark
 						c.info = "<font color = #101010>"
@@ -78,13 +78,15 @@
 					c.fields = copy.fields
 					c.updateinfolinks()
 					toner--
+					busy = 1
 					sleep(15)
+					busy = 0
 				else
 					break
 			updateUsrDialog()
 		else if(photocopy)
 			for(var/i = 0, i < copies, i++)
-				if(toner >= 5)  //Was set to = 0, but if there was say 3 toner left and this ran, you would get -2 which would be weird for ink
+				if(toner >= 5 && !busy && photocopy)  //Was set to = 0, but if there was say 3 toner left and this ran, you would get -2 which would be weird for ink
 					var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)
 					var/icon/I = icon(photocopy.icon, photocopy.icon_state)
 					var/icon/img = icon(photocopy.img)
@@ -109,8 +111,9 @@
 					p.pixel_x = rand(-10, 10)
 					p.pixel_y = rand(-10, 10)
 					p.blueprints = photocopy.blueprints //a copy of a picture is still good enough for the syndicate
-
+					busy = 1
 					sleep(15)
+					busy = 0
 				else
 					break
 		else if(ass) //ASS COPY. By Miauw
@@ -118,7 +121,7 @@
 				var/icon/temp_img
 				if(ishuman(ass) && (ass.get_item_by_slot(slot_w_uniform) || ass.get_item_by_slot(slot_wear_suit)))
 					usr << "<span class='notice'>You feel kind of silly copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "their"] clothes on.</span>"
-				else if(toner >= 5 && check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
+				else if(toner >= 5 && !busy && check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
 					if(isalien(ass) || istype(ass,/mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.
 						temp_img = icon("icons/ass/assalien.png")
 					else if(ishuman(ass)) //Suit checks are in check_ass
@@ -141,7 +144,9 @@
 					ic.Blend(small_img,ICON_OVERLAY, 10, 13)
 					p.icon = ic
 					toner -= 5
+					busy = 1
 					sleep(15)
+					busy = 0
 				else
 					break
 		updateUsrDialog()
@@ -176,7 +181,7 @@
 			updateUsrDialog()
 	else if(href_list["aipic"])
 		if(!istype(usr,/mob/living/silicon/ai)) return
-		if(toner >= 5)
+		if(toner >= 5 && !busy)
 			var/list/nametemp = list()
 			var/find
 			var/datum/picture/selection
@@ -201,7 +206,9 @@
 			p.pixel_x = rand(-10, 10)
 			p.pixel_y = rand(-10, 10)
 			toner -= 5	 //AI prints color pictures only, thus they can do it more efficiently
+			busy = 1
 			sleep(15)
+			busy = 0
 		updateUsrDialog()
 	else if(href_list["colortoggle"])
 		if(greytoggle == "Greyscale")


### PR DESCRIPTION
Added some checks on the photocopier after the sleeps to avoid runtimes and made a new var "busy" to avoid exploits that ignored the wait times.
