### PR TITLE
Linda fixes.

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -200,12 +200,14 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 			T.atmos_adjacent_turfs &= ~counterdir
 
 /atom/movable/proc/air_update_turf(var/command = 0)
-	if(istype(loc,/turf))
-		for(var/turf/T in locs) // used by double wide doors and other nonexistant multitile structures
-			if(command)
-				T.CalculateAdjacentTurfs()
-			if(air_master)
-				air_master.add_to_active(T,command)
+	for(var/turf/T in locs) // used by double wide doors and other nonexistant multitile structures
+		T.air_update_turf(command)
+
+/turf/proc/air_update_turf(var/command = 0)
+	if(command)
+		CalculateAdjacentTurfs()
+	if(air_master)
+		air_master.add_to_active(src,command)
 
 
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -301,7 +301,9 @@
 
 
 /obj/structure/window/Move()
+	density = 0				//CanAtmosPass while moving
 	air_update_turf(1)
+	density = 1
 	..()
 	dir = ini_dir
 	air_update_turf(1)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -131,6 +131,7 @@
 		else
 			ground_zero.assume_air(air_contents)
 			ground_zero.hotspot_expose(1000, 125)
+			ground_zero.air_update_turf()		//you still want to activate in case it has other contents like N2O
 
 	else if(air_contents.temperature > (T0C + 250))
 		strength = (fuel_moles/20)
@@ -142,6 +143,7 @@
 		else
 			ground_zero.assume_air(air_contents)
 			ground_zero.hotspot_expose(1000, 125)
+			ground_zero.air_update_turf()
 
 	else if(air_contents.temperature > (T0C + 100))
 		strength = (fuel_moles/25)
@@ -151,10 +153,12 @@
 		else
 			ground_zero.assume_air(air_contents)
 			ground_zero.hotspot_expose(1000, 125)
+			ground_zero.air_update_turf()
 
 	else
 		ground_zero.assume_air(air_contents)
 		ground_zero.hotspot_expose(1000, 125)
+		ground_zero.air_update_turf()
 
 	if(master)
 		del(master)
@@ -166,3 +170,4 @@
 	if(!T)
 		return
 	T.assume_air(removed)
+	air_update_turf()

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -50,15 +50,20 @@
 
 				var/y_distance = TO.y - FROM.y
 				var/x_distance = TO.x - FROM.x
+				var/list/T_air = list()
 				for (var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
 					if(istype(A, /obj/item/device/radio/beacon)) continue // don't teleport beacons because that's just insanely stupid
 					if(A.anchored && istype(A, /obj/machinery)) continue
 					if(istype(A, /obj/structure/disposalpipe )) continue
 					if(istype(A, /obj/structure/cable )) continue
+					if(istype(A, /obj/structure/window ))		//if move fails do it manualy
+						if(isturf(A.loc) && !(A.loc in T_air) )
+							T_air += A.loc
 
 					var/turf/newloc = locate(A.x + x_distance, A.y + y_distance, TO.z) // calculate the new place
 					if(!A.Move(newloc)) // if the atom, for some reason, can't move, FORCE them to move! :) We try Move() first to invoke any movement-related checks the atom needs to perform after moving
 						A.loc = locate(A.x + x_distance, A.y + y_distance, TO.z)
+
 
 					spawn()
 						if(ismob(A) && !(A in flashers)) // don't flash if we're already doing an effect
@@ -74,4 +79,7 @@
 								sleep(20)
 								M.client.screen -= blueeffect
 								del(blueeffect)
+				for(var/turf/acT in T_air)
+					acT.air_update_turf(1)
+				T_air = null
 			del(newAnomaly)


### PR DESCRIPTION
Added air_update_turf as turf process because its stupid that it doesn't have one already.
Bombs now activate gases properly.
Window gas activation works now.

I'm not sure why this issue https://github.com/tgstation/-tg-station/issues/2035  exists.
It should be handled by the delete process, I cannot reproduce.
The bluespace anomaly https://github.com/tgstation/-tg-station/issues/1553 should work, but if the above has problems, there might be some problems with this also.
