### PR TITLE
Shuttle launch timer cannot be shortened when less than 11 seconds are left

### DIFF
--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -8,7 +8,7 @@
 
 	attackby(var/obj/item/weapon/card/W as obj, var/mob/user as mob)
 		if(stat & (BROKEN|NOPOWER))	return
-		if ((!( istype(W, /obj/item/weapon/card) ) || !( ticker ) || emergency_shuttle.location != DOCKED || !( user )))	return
+		if (!( istype(W, /obj/item/weapon/card) ) || !( ticker ) || emergency_shuttle.location != DOCKED || !( user ) || emergency_shuttle.timeleft() < 11)	return
 		if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 			if (istype(W, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = W


### PR DESCRIPTION
Added a check to see if the timer is less than 11 seconds before attempting to change the timer.

No message is give to the player, but since this is such a rare thing it shouldn't matter. Using your ID on the console doesn't give you any feedback while in flight either so whatever.

Also removed an unused pair of "()".

Fixes issue [#2064](https://github.com/tgstation/-tg-station/issues/2064).
