### PR TITLE
hand labelers on pill bottles fix.

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -300,10 +300,10 @@
 
 	if(isrobot(user))
 		user << "<span class='notice'>You're a robot. No.</span>"
-		return 1	//Robots can't interact with storage items.
+		return 0	//Robots can't interact with storage items.
 
 	if(!can_be_inserted(W))
-		return 1
+		return 0
 
 	if(istype(W, /obj/item/weapon/tray))	//THIS ISN'T HOW OOP WORKS
 		var/obj/item/weapon/tray/T = W


### PR DESCRIPTION
Makes the attackby() of storage objects return 0 if the can_be_insterted() fails. This will fix hand labelers on pill bottles.

Fixes #1516
