### PR TITLE
pAI bioscan runtime fix

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -486,11 +486,11 @@
 		var/mob/living/M = card.loc
 		if(!istype(M, /mob/living))
 			while (!istype(M, /mob/living))
-				M = M.loc
 				if(istype(M, /turf))
 					src.temp = "Error: No biological host found. <br>"
 					src.subscreen = 0
 					return dat
+				M = M.loc
 		dat += {"Bioscan Results for [M]: <br>"
 		Overall Status: [M.stat > 1 ? "dead" : "[M.health]% healthy"] <br>
 		Scan Breakdown: <br>


### PR DESCRIPTION
pAIs won't runtime anymore if they try running a bioscan while lying on the floor
