### PR TITLE
Gibbing borgs explode violently

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -972,6 +972,10 @@
 
 /mob/living/silicon/robot/proc/self_destruct()
 	gib()
+	if(emagged)
+		explosion(src.loc,1,2,4,flame_range = 2)
+	else
+		explosion(src.loc,-1,0,2)
 	return
 
 /mob/living/silicon/robot/proc/UnlinkSelf()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -971,11 +971,11 @@
 		return
 
 /mob/living/silicon/robot/proc/self_destruct()
-	gib()
 	if(emagged)
 		explosion(src.loc,1,2,4,flame_range = 2)
 	else
 		explosion(src.loc,-1,0,2)
+	gib()
 	return
 
 /mob/living/silicon/robot/proc/UnlinkSelf()


### PR DESCRIPTION
Normal borg explosions cause minor tile damage, knocks people down.
If emagged, they explode with same intensity as syndie mini-bombs, eat your heart out Xanatos.
