### PR TITLE
Changes mime abilities into spells

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -6,6 +6,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 /obj/effect/proc_holder/spell
 	name = "Spell"
 	desc = "A wizard spell"
+	panel = "Spells"
 	density = 0
 	opacity = 0
 
@@ -15,14 +16,17 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 	var/charge_max = 100 //recharge time in deciseconds if charge_type = "recharge" or starting charges if charge_type = "charges"
 	var/charge_counter = 0 //can only cast spells if it equals recharge, ++ each decisecond if charge_type = "recharge" or -- each cast if charge_type = "charges"
+	var/still_recharging_msg = "<span class='notice'>The spell is still recharging.</span>"
 
 	var/holder_var_type = "bruteloss" //only used if charge_type equals to "holder_var"
 	var/holder_var_amount = 20 //same. The amount adjusted with the mob's var when the spell is used
 
 	var/clothes_req = 1 //see if it requires clothes
+	var/human_req = 0 //spell can only be cast by humans
 	var/stat_allowed = 0 //see if it requires being conscious/alive, need to set to 1 for ghostpells
 	var/invocation = "HURP DURP" //what is uttered when the wizard casts the spell
-	var/invocation_type = "none" //can be none, whisper and shout
+	var/invocation_emote_self = null
+	var/invocation_type = "none" //can be none, whisper, emote and shout
 	var/range = 7 //the range of the spell; outer radius for aoe spells
 	var/message = "" //whatever it says to the guy affected by it
 	var/selection_type = "view" //can be "range" or "view"
@@ -56,7 +60,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 		switch(charge_type)
 			if("recharge")
 				if(charge_counter < charge_max)
-					user << "<span class='notice'>[name] is still recharging.</span>"
+					user << still_recharging_msg
 					return 0
 			if("charges")
 				if(!charge_counter)
@@ -86,7 +90,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				H << "<span class='notice'>I don't feel strong enough without my hat.</span>"
 				return 0
 	else
-		if(clothes_req)
+		if(clothes_req || human_req)
 			user << "<span class='notice'>This spell can only be casted by humans!</span>"
 			return 0
 
@@ -113,10 +117,13 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				user.whisper(invocation)
 			else
 				user.whisper(replacetext(invocation," ","`"))
+		if("emote")
+			user.visible_message(invocation, invocation_emote_self) //same style as in mob/living/emote.dm
 
 /obj/effect/proc_holder/spell/New()
 	..()
 
+	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
 
 /obj/effect/proc_holder/spell/Click()

--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -14,12 +14,15 @@
 	//should have format of list("emagged" = 1,"name" = "Wizard's Justicebot"), for example
 	var/delay = 1//Go Go Gadget Inheritance
 
+	var/cast_sound = 'sound/items/welder.ogg'
+
 /obj/effect/proc_holder/spell/aoe_turf/conjure/cast(list/targets)
 
 	for(var/turf/T in targets)
 		if(T.density && !summon_ignore_density)
 			targets -= T
-	playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
+
+	playsound(src.loc, cast_sound, 50, 1)
 
 	if(do_after(usr,delay))
 		for(var/i=0,i<summon_amt,i++)

--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -1,0 +1,51 @@
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall
+	name = "Invisible wall"
+	desc = "The mime's performance transmutates into physical reality."
+	school = "mime"
+	panel = "Mime"
+	summon_type = list(/obj/effect/forcefield/mime)
+	invocation_type = "emote"
+	invocation_emote_self = "<span class='notice'>You form a wall in front of yourself.</span>"
+	summon_lifespan = 300
+	charge_max = 300
+	clothes_req = 0
+	range = 0
+	cast_sound = null
+
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall/Click()
+	if(usr)
+		invocation = "<B>[usr.real_name]</B> looks as if a wall is in front of them."
+	else
+		invocation_type ="none"
+	..()
+
+
+/obj/effect/proc_holder/spell/targeted/mime/speak
+	name = "Speech"
+	desc = "Make or break a vow of silence."
+	school = "mime"
+	panel = "Mime"
+	clothes_req = 0
+	human_req = 1
+	charge_max = 3000
+	range = -1
+	include_user = 1
+
+/obj/effect/proc_holder/spell/targeted/mime/speak/Click()
+	if(!usr)
+		return
+	var/mob/living/carbon/human/H = usr
+	if(H.miming)
+		still_recharging_msg = "<span class='notice'>You can't break your vow of silence that fast!</span>"
+	else
+		still_recharging_msg = "<span class='notice'>You'll have to wait before you can give your vow of silence again.</span>"
+	..()
+
+/obj/effect/proc_holder/spell/targeted/mime/speak/cast(list/targets)
+	for(var/mob/living/carbon/human/H in targets)
+		H.miming=!H.miming
+		if(H.miming)
+			H << "<span class='notice'>You make a vow of silence.</span>"
+		else
+			H << "<span class='notice'>You break your vow of silence.</span>"

--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -35,6 +35,8 @@
 /obj/effect/proc_holder/spell/targeted/mime/speak/Click()
 	if(!usr)
 		return
+	if(!ishuman(usr))
+		return
 	var/mob/living/carbon/human/H = usr
 	if(H.miming)
 		still_recharging_msg = "<span class='notice'>You can't break your vow of silence that fast!</span>"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -242,10 +242,8 @@
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_in_backpack)
-		H.verbs += /client/proc/mimespeak
-		H.verbs += /client/proc/mimewall
-		H.mind.special_verbs += /client/proc/mimespeak
-		H.mind.special_verbs += /client/proc/mimewall
+		H.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(H)
+		H.spell_list += new /obj/effect/proc_holder/spell/targeted/mime/speak(H)
 		H.miming = 1
 		H.rename_self("mime")
 		return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -674,11 +674,11 @@ note dizziness decrements automatically in the mob's Life() proc.
 		for(var/obj/effect/proc_holder/spell/S in spell_list)
 			switch(S.charge_type)
 				if("recharge")
-					statpanel("Spells","[S.charge_counter/10.0]/[S.charge_max/10]",S)
+					statpanel("[S.panel]","[S.charge_counter/10.0]/[S.charge_max/10]",S)
 				if("charges")
-					statpanel("Spells","[S.charge_counter]/[S.charge_max]",S)
+					statpanel("[S.panel]","[S.charge_counter]/[S.charge_max]",S)
 				if("holdervar")
-					statpanel("Spells","[S.holder_var_type] [S.holder_var_amount]",S)
+					statpanel("[S.panel]","[S.holder_var_type] [S.holder_var_amount]",S)
 
 
 


### PR DESCRIPTION
- Admins can now give the mime abilities from the 'give spell' menu. Like previous mime abilities, these are not transferred when a mime is cloned. (Fixes #1376)
- code/game/jobs/jobprocs.dm is unused. Waiting for opinions if it should be removed, kept, or moved to unused folder before I touch it.
- mind.special_verbs is now completely unused. Someone might want to remove it or find a use for it.
