### PR TITLE
Voicechanger fix

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -125,7 +125,7 @@
 	//U << text("Now tracking [] on camera.", target.name)
 	//if (U.machine == null)
 	//	U.machine = U
-	U << "Now tracking [target.name] on camera."
+	U << "Now tracking [target.get_visible_name()] on camera."
 
 	spawn (0)
 		while (U.cameraFollow == target)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -33,7 +33,7 @@
 	return if_no_id
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
-/mob/living/carbon/human/proc/get_visible_name()
+/mob/living/carbon/human/get_visible_name()
 	var/face_name = get_face_name("")
 	var/id_name = get_id_name("")
 	if(face_name)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -553,3 +553,7 @@
 						CM.legcuffed.loc = usr.loc
 						CM.legcuffed = null
 						CM.update_inv_legcuffed(0)
+
+
+/mob/living/proc/get_visible_name()
+	return name


### PR DESCRIPTION
Fixes AI seeing the real name of a person speaking over radio using a voice changer. (Fixes #1977) Now they see their visible name (unknown or whatever is on their id etc)
