### PR TITLE
[MAP] Syringe gun projectiles will now display a message when the shots are deflected by the THICKMATERIAL flag.

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -158,7 +158,7 @@ datum/shuttle_controller
 					captain_announce("The Emergency Shuttle has left the station. Estimate [round(timeleft()/60,1)] minutes until the shuttle docks at Central Command.")
 				else if(location == TRANSIT)
 					move_shuttles()
-					message_admins("Shuttles have attempted to move to Centcom")
+					//message_admins("Shuttles have attempted to move to Centcom")
 					location = ENDGAME
 					online = 0
 					endtime = null

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -104,7 +104,7 @@ BLIND     // can't see anything
 	name = "space helmet"
 	icon_state = "space"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
-	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
+	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
 	item_state = "space"
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -33,7 +33,8 @@
 	desc = "An armored beret commonly used by special operations officers. Uses forcefield technology to protect the head from space."
 	icon_state = "beret_badge"
 	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 30, rad = 30)
-	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | STOPSPRESSUREDMAGE
+	flags = FPRINT | TABLEPASS | STOPSPRESSUREDMAGE
+	flags_inv = 0
 
 
 //NASA Voidsuit

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -1,6 +1,6 @@
 //Captain's Spacesuit
 /obj/item/clothing/head/helmet/space/capspace
-	name = "space helmet"
+	name = "captain's space helmet"
 	icon_state = "capspace"
 	item_state = "capspacehelmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Only for the most fashionable of military figureheads."
@@ -9,15 +9,12 @@
 	armor = list(melee = 65, bullet = 50, laser = 50,energy = 25, bomb = 50, bio = 100, rad = 50)
 
 //Captain's space suit This is not the proper path but I don't currently know enough about how this all works to mess with it.
-/obj/item/clothing/suit/armor/captain
-	name = "Captain's armor"
+/obj/item/clothing/suit/space/captain
+	name = "captain's armor"
 	desc = "A bulky, heavy-duty piece of exclusive Nanotrasen armor. YOU are in charge!"
 	icon_state = "caparmor"
 	item_state = "capspacesuit"
 	w_class = 4
-	gas_transfer_coefficient = 0.01
-	permeability_coefficient = 0.02
-	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs)
 	slowdown = 1.5
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)
@@ -33,7 +30,7 @@
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"
-	desc = "An armored beret commonly used by special operations officers."
+	desc = "An armored beret commonly used by special operations officers. Uses forcefield technology to protect the head from space."
 	icon_state = "beret_badge"
 	armor = list(melee = 65, bullet = 55, laser = 35,energy = 20, bomb = 30, bio = 30, rad = 30)
 	flags = FPRINT | TABLEPASS | HEADCOVERSEYES | BLOCKHAIR | STOPSPRESSUREDMAGE

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -17,6 +17,7 @@
 	w_class = 4
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.02
+	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs)
 	slowdown = 1.5
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -92,7 +92,7 @@
 	item_state = "swat_suit"
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags = FPRINT | TABLEPASS
+	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen)
 	slowdown = 1
@@ -169,6 +169,7 @@
 	w_class = 4//bulky item
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen)
+	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
@@ -182,6 +183,7 @@
 	item_state = "swat_suit"
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.90
+	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 3
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
@@ -189,6 +191,7 @@
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
+	flags = FPRINT | TABLEPASS | THICKMATERIAL
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -83,6 +83,9 @@
 			if(M.can_inject(target_zone = hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				reagents.trans_to(M, reagents.total_volume)
 				return 1
+			else
+				target.visible_message("<span class='danger'>The [name] was deflected!</span>", \
+									   "<span class='userdanger'>You were protected against the [name]!</span>")
 		flags &= ~NOREACT
 		reagents.handle_reactions()
 		return 1

--- a/maps/tgstation.2.1.2.dmm
+++ b/maps/tgstation.2.1.2.dmm
@@ -2818,7 +2818,7 @@
 "bcj" = (/obj/machinery/vending/cigarette,/turf/simulated/floor/wood,/area/bridge/meeting_room)
 "bck" = (/obj/machinery/light,/turf/simulated/floor/bluegrid,/area/turret_protected/ai)
 "bcl" = (/obj/machinery/camera/motion{c_tag = "AI Chamber South"; dir = 1; name = "motion-sensitive security camera"; network = list("RD")},/turf/simulated/floor{icon_state = "dark"},/area/turret_protected/ai)
-"bcm" = (/obj/structure/rack,/obj/item/weapon/tank/jetpack/oxygen,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/armor/captain,/obj/item/clothing/head/helmet/space/capspace,/obj/item/device/radio/intercom{dir = 8; freerange = 1; name = "Station Intercom (Command)"; pixel_x = -28},/turf/simulated/floor/wood,/area/crew_quarters/captain)
+"bcm" = (/obj/structure/rack,/obj/item/weapon/tank/jetpack/oxygen,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/space/captain,/obj/item/clothing/head/helmet/space/capspace,/obj/item/device/radio/intercom{dir = 8; freerange = 1; name = "Station Intercom (Command)"; pixel_x = -28},/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bcn" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bco" = (/obj/machinery/computer/card,/obj/item/weapon/card/id/captains_spare,/turf/simulated/floor/wood,/area/crew_quarters/captain)
 "bcp" = (/obj/structure/table/woodentable,/obj/machinery/recharger,/obj/item/weapon/melee/chainofcommand,/turf/simulated/floor/wood,/area/crew_quarters/captain)


### PR DESCRIPTION
- Fixes the space helmet not having the flag.
- Fixes various coverall armour not having the THICKMATERIAL flag.
- Fixes #2115 and the captain's space suit path was changed to /obj/item/clothing/suit/space/captain from /obj/item/clothing/suit/armor/captain
- Updated the map with the new path.
- Removed a debug message.
