### PR TITLE
Labor Camp Tweaks #2

### DIFF
--- a/code/modules/mining/laborcamp/laborminerals.dm
+++ b/code/modules/mining/laborcamp/laborminerals.dm
@@ -1,2 +1,2 @@
 /turf/simulated/mineral/random/labormineral
-	mineralSpawnChanceList = list("Uranium" = 5, "Iron" = 50, "Diamond" = 1, "Gold" = 5, "Silver" = 5, "Plasma" = 25/*, "Adamantine" =5, "Cave" = 1 */) //Don't suffocate the prisoners with caves
+	mineralSpawnChanceList = list("Uranium" = 5, "Iron" = 100, "Diamond" = 1, "Gold" = 5, "Silver" = 5, "Plasma" = 25/*, "Adamantine" =5, "Cave" = 1 */) //Don't suffocate the prisoners with caves

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -52,6 +52,8 @@
 	if(check_auth())
 		dat += text("<A href='?src=\ref[src];choice=station'>Proceed to Station.</A><br>")
 		dat += text("<A href='?src=\ref[src];choice=release'>Open release door.</A><br>")
+	if(machine)
+		dat += text("<HR><b>Mineral Value List:</b><BR>[machine.get_ore_values()]")
 
 
 	user << browse("[dat]", "window=console_stacking_machine")
@@ -117,8 +119,16 @@
 
 
 /obj/machinery/mineral/stacking_machine/laborstacker
-	var/points = 0 //The unclaimed value of ore stacked.  Value for each ore loosely relative to its rarity.  Iron = 1; Diamond = 25.
-	var/list/ore_values = list(("metal" = 1), ("diamond" = 25), ("solid plasma" = 2), ("gold" = 5), ("silver" = 5), ("bananium" = 9999), ("uranium" = 5), ("glass" = 1), ("reinforced glass" = 2), ("plasteel" = 3))
+	var/points = 0 //The unclaimed value of ore stacked.  Value for each ore loosely relative to its rarity.
+	var/list/ore_values = list(("glass" = 1), ("metal" = 2), ("solid plasma" = 2), ("plasteel" = 4), ("reinforced glass" = 4), ("gold" = 5), ("silver" = 5), ("uranium" = 5), ("diamond" = 15), ("bananium" = 50))
+
+/obj/machinery/mineral/stacking_machine/laborstacker/proc/get_ore_values()
+	var/dat = "<table border='0' width='200'>"
+	for(var/ore in ore_values)
+		var/value = ore_values[ore]
+		dat += "<tr><td>[capitalize(ore)]</td><td>[value]</td></tr>"
+	dat += "</table>"
+	return dat
 
 /obj/machinery/mineral/stacking_machine/laborstacker/process_sheet(obj/item/stack/sheet/inp)
 	if(istype(inp))


### PR DESCRIPTION
- Increased the amount of iron that spawns in the labor camp.
- Decreased the amount of points you get from diamond and bananium. Increased the amount of points you get from Iron and alloys. This will make it more consistent on how long your stay would be. Increasing the amount of points you get from iron will help stop the labor camp taking up all your round. Alloys will make them more desirable.
- You can now see which minerals give you which points from the claiming console.
