### PR TITLE
Fixed an oversight in Wizard-Spell targeting code

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -249,7 +249,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				//targets += input("Choose the target for the spell.", "Targeting") as mob in possible_targets
 				//Adds a safety check post-input to make sure those targets are actually in range.
 				var/mob/M = input("Choose the target for the spell.", "Targeting") as mob in possible_targets
-				if(M in range(range, user)) targets += M
+				if(M in view_or_range(range, user, selection_type)) targets += M
 		
 		else
 			var/list/possible_targets = list()

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -246,7 +246,11 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 						continue
 					possible_targets += M
 
-				targets += input("Choose the target for the spell.", "Targeting") as mob in possible_targets
+				//targets += input("Choose the target for the spell.", "Targeting") as mob in possible_targets
+				//Adds a safety check post-input to make sure those targets are actually in range.
+				var/mob/M = input("Choose the target for the spell.", "Targeting") as mob in possible_targets
+				if(M in range(range, user)) targets += M
+		
 		else
 			var/list/possible_targets = list()
 			for(var/mob/living/target in view_or_range(range, user, selection_type))


### PR DESCRIPTION
Added an extra safety check to check if targets selected via inputs were actually in range. Previously someone could open a bunch of inputs and activate them from what ever range.
