### PR TITLE
Fixes medical scrubs not having bio armor

### DIFF
--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -85,6 +85,8 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."
 	icon_state = "scrubsblue"
 	item_color = "scrubsblue"
+	permeability_coefficient = 0.50
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	flags = FPRINT | TABLEPASS
 
 /obj/item/clothing/under/rank/medical/green
@@ -92,6 +94,8 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in dark green."
 	icon_state = "scrubsgreen"
 	item_color = "scrubsgreen"
+	permeability_coefficient = 0.50
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	flags = FPRINT | TABLEPASS
 
 /obj/item/clothing/under/rank/medical/purple
@@ -99,6 +103,8 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in deep purple."
 	icon_state = "scrubspurple"
 	item_color = "scrubspurple"
+	permeability_coefficient = 0.50
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	flags = FPRINT | TABLEPASS
 
 


### PR DESCRIPTION
The title basically.
Everything, absolutely everything on the medsci uniform list has at least 10 bio armor, except the three Medical Scrubs.
Even the description of the item says it has it.
"It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."

Also added permeability_coefficient = 0.50 like the rest of the medical jumpsuits had.
