### PR TITLE
Uranium powered collectors

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -217,6 +217,9 @@
 /obj/machinery/door/airlock/uranium/proc/radiate()
 	for(var/mob/living/L in range (3,src))
 		L.apply_effect(15,IRRADIATE,0)
+	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
+		if(get_dist(R, src) <= 2)
+			R.receive_pulse(100)
 	return
 
 /obj/machinery/door/airlock/plasma

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -59,6 +59,9 @@
 				L.apply_effect(12,IRRADIATE,0)
 			for(var/turf/simulated/wall/mineral/uranium/T in range(3,src))
 				T.radiate()
+			for(var/obj/machinery/power/rad_collector/R in rad_collectors)
+				if(get_dist(R, src) <= 2)
+					R.receive_pulse(100)
 			last_event = world.time
 			active = null
 			return


### PR DESCRIPTION
Walls and doors within two tiles of a charged collector will generate ~17000W each pulse by the uranium. Increasing the number of walls or doors only increases the rate of pulse. I'm not sure what the minimum cooldown on the pulse is, but this generates a really small amount of power so a large bank would be needed to charge a SMES.

Code shamelessly copypasted and edited from singularity because it works.
