### PR TITLE
Fixed toolbox parent object giving error

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -15,9 +15,6 @@
 
 	New()
 		..()
-		if (src.type == /obj/item/weapon/storage/toolbox)
-			world << "BAD: [src] ([src.type]) spawned at [src.x] [src.y] [src.z]"
-			del(src)
 
 /obj/item/weapon/storage/toolbox/emergency
 	name = "emergency toolbox"


### PR DESCRIPTION
Fixes #1754

It's not really an abstract class and works perfectly fine as a generic toolbox, so removed printing error and deleting itself.
