### PR TITLE
Fixes paper with no input looking populated

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -159,6 +159,9 @@
 
 
 /obj/item/weapon/paper/proc/parsepencode(t, obj/item/weapon/pen/P, mob/user, iscrayon = 0)
+	if(length(t) < 1)		//No input means nothing needs to be parsed
+		return
+
 //	t = copytext(sanitize(t),1,MAX_MESSAGE_LEN)
 
 	t = replacetext(t, "\[center\]", "<center>")
@@ -249,15 +252,16 @@
 			return
 
 		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
+		
+		if(t != null)	//No input from the user means nothing needs to be added
+			if(id!="end")
+				addtofield(text2num(id), t) // He wants to edit a field, let him.
+			else
+				info += t // Oh, he wants to edit to the end of the file, let him.
+				updateinfolinks()
 
-		if(id!="end")
-			addtofield(text2num(id), t) // He wants to edit a field, let him.
-		else
-			info += t // Oh, he wants to edit to the end of the file, let him.
-			updateinfolinks()
-
-		usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info_links]<HR>[stamps]</BODY></HTML>", "window=[name]") // Update the window
-		update_icon()
+			usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info_links]<HR>[stamps]</BODY></HTML>", "window=[name]") // Update the window
+			update_icon()
 
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P, mob/user)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -65,19 +65,20 @@
 			for(var/i = 0, i < copies, i++)
 				if(toner > 0 && !busy && copy)
 					var/obj/item/weapon/paper/c = new /obj/item/weapon/paper (loc)
-					if(toner > 10)	//lots of toner, make it dark
-						c.info = "<font color = #101010>"
-					else			//no toner? shitty copies for you!
-						c.info = "<font color = #808080>"
-					var/copied = html_decode(copy.info)
-					copied = replacetext(copied, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
-					copied = replacetext(copied, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
-					c.info += copied
-					c.info += "</font>"
-					c.name = copy.name
-					c.fields = copy.fields
-					c.updateinfolinks()
-					toner--
+					if(length(copy.info) > 0)	//Only print and add content if the copied doc has words on it
+						if(toner > 10)	//lots of toner, make it dark
+							c.info = "<font color = #101010>"
+						else			//no toner? shitty copies for you!
+							c.info = "<font color = #808080>"
+						var/copied = html_decode(copy.info)
+						copied = replacetext(copied, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
+						copied = replacetext(copied, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+						c.info += copied
+						c.info += "</font>"
+						c.name = copy.name
+						c.fields = copy.fields
+						c.updateinfolinks()
+						toner--
 					busy = 1
 					sleep(15)
 					busy = 0


### PR DESCRIPTION
Fixes #1663

Paper will still show populated paper graphic if a user puts in blank characters like newlines/breaks etc, but I think this should be kept to avoid confusion when editing.
