### PR TITLE
Toggling vending machine's voice now works

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -282,7 +282,7 @@
 	if((href_list["vend"]) && (vend_ready))
 		if(panel_open)
 			usr << "<span class='notice'>The vending machine cannot dispense products while its service panel is open!</span>"
-		return
+			return
 
 		if((!allowed(usr)) && !emagged && scan_id)	//For SECURE VENDING MACHINES YEAH
 			usr << "<span class='warning'>Access denied.</span>"	//Unless emagged of course

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -266,9 +266,6 @@
 			usr << "<span class='notice'>The vending machine refuses to interface with you, as you are not in its target demographic!</span>"
 			return
 
-	if(panel_open)
-		usr << "<span class='notice'>The vending machine cannot dispense products while its service panel is open!</span>"
-		return
 	if(href_list["remove_coin"])
 		if(!coin)
 			usr << "<span class='notice'>There is no coin in this machine.</span>"
@@ -283,6 +280,9 @@
 
 	usr.set_machine(src)
 	if((href_list["vend"]) && (vend_ready))
+		if(panel_open)
+			usr << "<span class='notice'>The vending machine cannot dispense products while its service panel is open!</span>"
+		return
 
 		if((!allowed(usr)) && !emagged && scan_id)	//For SECURE VENDING MACHINES YEAH
 			usr << "<span class='warning'>Access denied.</span>"	//Unless emagged of course


### PR DESCRIPTION
Fixes #1938

Moved service check to when an item is actually being vended. The voice speaker toggle and removing coin now works when the service panel is open. This check is kind of redundant since the interface hides objects to vend when the panel is open, but just in case.
