### PR TITLE
Changes the initialism for stat collecting on summon magic to SU

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -253,7 +253,7 @@
 							max_uses--
 							temp = "You have cast summon guns."
 						if("summonmagic")
-							feedback_add_details("wizard_spell_learned","SM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
+							feedback_add_details("wizard_spell_learned","SU") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							H.rightandwrong(1)
 							max_uses--
 							temp = "You have cast summon magic."


### PR DESCRIPTION
Because SM was taken by smoke. On the stat page this will result in smoke being overreported until a full month after this change has been live on both servers. WHOOPS!

For judgement purposes you can probably assume that nearly all "smoke" spells on the stat page are actually summon magic, because who the hell takes smoke?
