### PR TITLE
Malf AIs can now hop from an occupied APC to another, as long as the target APC is within view range.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -735,8 +735,9 @@
 	if(!istype(malf))
 		return
 	if(istype(malf.loc, /obj/machinery/power/apc)) // Already in an APC
-		malf << "<span class='warning'>You must evacuate your current apc first.</span>"
-		return
+		// You need to be able to see the APC in order to hop to it from another APC.
+		if(get_dist(malf.loc, src) < world.view)
+			return
 	if(!malf.can_shunt)
 		malf << "<span class='warning'>You cannot shunt.</span>"
 		return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -737,6 +737,7 @@
 	if(istype(malf.loc, /obj/machinery/power/apc)) // Already in an APC
 		// You need to be able to see the APC in order to hop to it from another APC.
 		if(get_dist(malf.loc, src) < world.view)
+			malf << "<span class='warning'>Target APC out of range of current APC, unable to shunt core processes.</span>"
 			return
 	if(!malf.can_shunt)
 		malf << "<span class='warning'>You cannot shunt.</span>"


### PR DESCRIPTION
 Making it tacticool to hack nearby APCs to further confuse the crew.

The original nerf for APC to APC hopping was before the AIs view was restricted to the APC and before the pinpointer would point to the AI when it shunted/went delta. This is a !FUN! change to make malfunction more dynamic.
