### PR TITLE
Big red button / syndicate bomb changes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -377,6 +377,7 @@ var/list/uplink_items = list()
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 5
+	excludefrom = list(/datum/game_mode/traitor/double_agents)
 
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -384,6 +384,7 @@ var/list/uplink_items = list()
 	Useful for when speed matters or you wish to synchronize multiple bomb blasts. Be sure to stand clear of the blast radius before using the detonator."
 	item = /obj/item/device/syndicatedetonator
 	cost = 1
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/teleporter
 	name = "Teleporter Circuit Board"


### PR DESCRIPTION
Syndi bombs can only be bought in non double agent rounds.
The big red button is only buyable in nuke-ops.
