### PR TITLE
Fixes the disposal outlet runtiming.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -70,9 +70,6 @@
 
 	src.throwing = 1
 
-	if(usr && HULK in usr.mutations)
-		src.throwing = 2 // really strong throw!
-
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 	var/dx = (target.x > src.x) ? EAST : WEST


### PR DESCRIPTION
The removed code, which was causing the runtime, wasn't even doing anything and was just setting "throwing" to 2 for no reason.

Fixes #2250
