### PR TITLE
Fixes 1653.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -139,7 +139,7 @@
 				return
 			step_towards(src, current)
 			sleep(1)
-			if(!bumped && !isturf(original))
+			if(!bumped && (ismob(original) || istype(original, /obj/machinery/bot)))
 				if(loc == get_turf(original))
 					if(!(original in permutated))
 						Bump(original)


### PR DESCRIPTION
 The only non dense atoms that projectiles will collide with are now mobs and bots that have been aimed at.
