### PR TITLE
Fixed #1605 oxyloss from suicide after admin revive.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -275,6 +275,7 @@
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
 	fire_stacks = 0
+	suiciding = 0
 	buckled = initial(src.buckled)
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -51,3 +51,4 @@ vistapowa = Game Master
 miauw62 = Game Master
 kazeespada = Game Master
 rumia29 = Game Master
+bobylein = Game Master


### PR DESCRIPTION
Fixed #1605
Players no longer suffer oxyloss if they suicided and then are revived by admins.
