### PR TITLE
Emagged Cyborgs, when destroyed via the Robotics Console, will not only have a large explosion but their MMI will die with them.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -959,6 +959,8 @@
 
 /mob/living/silicon/robot/proc/self_destruct()
 	if(emagged)
+		if(mmi)
+			del(mmi)
 		explosion(src.loc,1,2,4,flame_range = 2)
 	else
 		explosion(src.loc,-1,0,2)


### PR DESCRIPTION
 This will promote locking down the cyborg, instead, to discover who emagged it via cyborg deconstruction. This commit was brought to you by the feedback thread, which made it happen. http://www.ss13.eu/phpbb/viewtopic.php?f=10&t=2818
