### PR TITLE
Disabled the game using "set background" by making all instances of it use a define

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -16,7 +16,7 @@ datum/controller/air_system
 
 
 /datum/controller/air_system/proc/setup()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	world << "\red \b Processing Geometry..."
 	sleep(1)
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -195,7 +195,7 @@
 
 /proc/get_mobs_in_radio_ranges(var/list/obj/item/device/radio/radios)
 
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	. = list()
 	// Returns a list of mobs who can hear any of the radios given in @radios

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -9,6 +9,10 @@
 								1 to use the default behaviour;
 								2 for preloading absolutely everything;
 								*/
+
+#define BACKGROUND_ENABLED 0    // The default value for all uses of set background. Set background can cause gradual lag and is recommended you only turn this on if necessary.
+								// 1 will enable set background. 0 will disable set background.
+
 //ADMIN STUFF
 #define ROUNDSTART_LOGOUT_REPORT_TIME	6000 //Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
 

--- a/code/controllers/failsafe.dm
+++ b/code/controllers/failsafe.dm
@@ -22,7 +22,7 @@ var/datum/controller/failsafe/Failsafe
 /datum/controller/failsafe/proc/process()
 	processing = 1
 	spawn(0)
-		set background = 1
+		set background = BACKGROUND_ENABLED
 		while(1)	//more efficient than recursivly calling ourself over and over. background = 1 ensures we do not trigger an infinite loop
 			if(!master_controller)		new /datum/controller/game_controller()	//replace the missing master_controller! This should never happen.
 			if(!lighting_controller)	new /datum/controller/lighting()		//replace the missing lighting_controller

--- a/code/controllers/lighting_controller.dm
+++ b/code/controllers/lighting_controller.dm
@@ -34,7 +34,7 @@ datum/controller/lighting/New()
 datum/controller/lighting/proc/process()
 	processing = 1
 	spawn(0)
-		set background = 1
+		set background = BACKGROUND_ENABLED
 		while(1)
 			if(processing && (world.cpu <= max_cpu_use))
 				iteration++
@@ -68,7 +68,7 @@ datum/controller/lighting/proc/process()
 datum/controller/lighting/proc/Initialize(var/z_level)
 	processing = 0
 	spawn(-1)
-		set background = 1
+		set background = BACKGROUND_ENABLED
 		for(var/i=1, i<=lights.len, i++)
 			var/datum/light_source/L = lights[i]
 			if(L.check())

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -108,7 +108,7 @@ datum/controller/game_controller/proc/setup_objects()
 datum/controller/game_controller/proc/process()
 	processing = 1
 	spawn(0)
-		set background = 1
+		set background = BACKGROUND_ENABLED
 		while(1)	//far more efficient than recursively calling ourself
 			if(!Failsafe)	new /datum/controller/failsafe()
 

--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -148,7 +148,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 	proc/process()
 
 		spawn(0)
-			set background = 1
+			set background = BACKGROUND_ENABLED
 			while(1)
 				if(processing)
 					iteration++

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1507,7 +1507,7 @@ proc/process_ghost_teleport_locs()
 				Obj << mysound
 
 	proc/process()
-		set background = 1
+		set background = BACKGROUND_ENABLED
 
 		var/sound/S = null
 		var/sound_delay = 0

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -65,7 +65,7 @@
 
 /obj/effect/blob/proc/Pulse(var/pulse = 0, var/origin_dir = 0)//Todo: Fix spaceblob expand
 
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	PulseAnimation()
 

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -158,7 +158,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		src.screwloose = 1
 
 /obj/machinery/bot/cleanbot/process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(!src.on)
 		return

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -220,7 +220,7 @@ Auto Patrol: []"},
 		mode = SECBOT_IDLE
 
 /obj/machinery/bot/ed209/process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (!src.on)
 		return

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -163,7 +163,7 @@
 			src.updateUsrDialog()
 
 /obj/machinery/bot/floorbot/process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(!src.on)
 		return

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -232,7 +232,7 @@
 		src.icon_state = "medibot[src.on]"
 
 /obj/machinery/bot/medbot/process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(!src.on)
 		src.stunned = 0

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -192,7 +192,7 @@ Auto Patrol: []"},
 		mode = SECBOT_IDLE
 
 /obj/machinery/bot/secbot/process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(!src.on)
 		return

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -378,7 +378,7 @@
 /obj/machinery/porta_turret/process()
 	//the main machinery process
 
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(cover == null && anchored)	//if it has no cover and is anchored
 		if(stat & BROKEN)	//if the turret is borked

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -164,7 +164,7 @@
 
 
 /obj/structure/alien/weeds/proc/Life()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	var/turf/U = get_turf(src)
 
 	if(istype(U, /turf/space))

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -41,7 +41,7 @@
 		Spread()
 
 /obj/effect/glowshroom/proc/Spread()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	for(var/i=1,i<=yield,i++)
 		if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
@@ -80,7 +80,7 @@
 			child.desc = "This is a [child.generation]\th generation glowshroom!"//I added this for testing, but I figure I'll leave it in.
 
 /obj/effect/glowshroom/proc/CalcDir(turf/location = loc)
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	var/direction = 16
 
 	for(var/wallDir in cardinal)

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -1451,7 +1451,7 @@ ________________________________________________________________________________
 //=======//PROCESS PROCS//=======//
 
 /obj/item/clothing/suit/space/space_ninja/proc/ntick(mob/living/carbon/human/U = affecting)
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	//Runs in the background while the suit is initialized.
 	spawn while(cell.charge>=0)
@@ -2075,7 +2075,7 @@ ________________________________________________________________________________
 	return
 
 /obj/item/clothing/suit/space/space_ninja/proc/ai_holo_process()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	spawn while(hologram&&s_initialized&&AI)//Suit on and there is an AI present.
 		if(!s_initialized||get_dist(affecting,hologram.loc)>3)//Once suit is de-initialized or hologram reaches out of bounds.

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -10,7 +10,7 @@
 
 /mob/living/carbon/alien/humanoid/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (notransform)
 		return

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -7,7 +7,7 @@
 
 /mob/living/carbon/alien/larva/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (notransform)
 		return

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/brain/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	..()
 
 	if(stat != DEAD)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -36,7 +36,7 @@
 
 /mob/living/carbon/human/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (notransform)	return
 	if(!loc)			return	// Fixing a null error that occurs when the mob isn't found in the world -- TLE

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -9,7 +9,7 @@
 
 /mob/living/carbon/slime/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (src.notransform)
 		return

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -11,7 +11,7 @@
 
 /mob/living/carbon/monkey/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	if (notransform)	return
 	..()
 

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -68,7 +68,7 @@
 
 /datum/camerachunk/proc/update()
 
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	var/list/newVisibleTurfs = list()
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/robot/Life()
 	set invisibility = 0
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if (src.notransform)
 		return

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -113,7 +113,7 @@
 
 
 /obj/machinery/computer/gravity_control_computer/Topic(href, href_list)
-	set background = 1
+	set background = BACKGROUND_ENABLED
 
 	if(..())
 		return

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -208,7 +208,7 @@ var/global/list/uneatable = list(
 
 
 /obj/machinery/singularity/proc/eat()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	if(defer_powernet_rebuild != 2)
 		defer_powernet_rebuild = 1
 	// Let's just make this one loop.
@@ -589,7 +589,7 @@ var/global/list/uneatable = list(
 	grav_pull = 0
 
 /obj/machinery/singularity/narsie/wizard/eat()
-	set background = 1
+	set background = BACKGROUND_ENABLED
 	if(defer_powernet_rebuild != 2)
 		defer_powernet_rebuild = 1
 	for(var/atom/X in orange(consume_range,src))

--- a/code/world.dm
+++ b/code/world.dm
@@ -195,7 +195,7 @@
 #define INACTIVITY_KICK	6000	//10 minutes in ticks (approx.)
 /world/proc/KickInactiveClients()
 	spawn(-1)
-		set background = 1
+		set background = BACKGROUND_ENABLED
 		while(1)
 			sleep(INACTIVITY_KICK)
 			for(var/client/C in clients)


### PR DESCRIPTION
... , which can be changed in code/_compile_options.dm

Testing has revealed that it reduces the sluggishness of the game, though it will slightly spike from lag when the singularity is loose, but will eventually return to normal. Thanks to ChuckTheSheep for suggesting it.

Server owners who want to keep set background enabled can do so by changing the define.
