### PR TITLE
Balance changes to the EMP kit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -137,7 +137,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Kit"
-	desc = "A box that contains an EMP grenade, an EMP implant and a short ranged device disguised as a flashlight. Useful to disrupt communication and silicon lifeforms."
+	desc = "A box that contains two EMP grenades, an EMP implant and a short ranged recharging device disguised as a flashlight. Useful to disrupt communication and silicon lifeforms."
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
 	cost = 3
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -218,17 +218,15 @@
 	var/charge_tick = 0
 
 
-	New()
+/obj/item/device/flashlight/emp/New()
 		..()
 		processing_objects.Add(src)
 
-
-	Del()
+/obj/item/device/flashlight/emp/Del()
 		processing_objects.Remove(src)
 		..()
 
-
-	process()
+/obj/item/device/flashlight/emp/process()
 		charge_tick++
 		if(charge_tick < 10) return 0
 		charge_tick = 0
@@ -248,13 +246,13 @@
 	if(!proximity) return
 	if (emp_cur_charges > 0)
 		emp_cur_charges -= 1
-		A.emp_act(1)
 		A.visible_message("<span class='danger'>[user] blinks \the [src] at \the [A].", \
 											"<span class='userdanger'>[user] blinks \the [src] at \the [A].")
 		if(ismob(A))
 			var/mob/M = A
 			add_logs(user, M, "attacked", object="EMP-light")
 		user << "\The [src] now has [emp_cur_charges] charge\s."
+		A.emp_act(1)
 	else
-		user << "<span class='warning'>The [src] needs time to recharge!</span>"
+		user << "<span class='warning'>\The [src] needs time to recharge!</span>"
 	return

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -183,8 +183,8 @@
 		source.reagents.add_reagent("hyperzine", 10)
 
 /obj/item/weapon/implant/adrenalin/implanted(mob/source)
-	source.mind.store_memory("An adrenal implant can be activated by using the scream emote, <B>say *scream</B> to attempt to activate.", 0, 0)
-	source << "<span class='notice'>The implanted adrenaline implant can be activated by using the scream emote, <B>say *scream</B> to attempt to activate.</span>"
+	source.mind.store_memory("An adrenal implant can be activated [uses] time\s by using the scream emote, <B>say *scream</B> to attempt to activate.", 0, 0)
+	source << "<span class='notice'>The implanted adrenaline implant can be activated [uses] time\s by using the scream emote, <B>say *scream</B> to attempt to activate.</span>"
 	return 1
 
 
@@ -193,7 +193,7 @@
 	desc = "Triggers an EMP."
 
 	var/activation_emote = "chuckle"
-	var/uses = 1
+	var/uses = 2
 
 /obj/item/weapon/implant/emp/New()
 	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
@@ -208,6 +208,6 @@
 	return
 
 /obj/item/weapon/implant/emp/implanted(mob/living/carbon/source)
-		source.mind.store_memory("EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
-		source << "The implanted EMP implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
+		source.mind.store_memory("EMP implant can be activated [uses] time\s by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
+		source << "The implanted EMP implant can be activated [uses] time\s by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
 		return 1

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -148,6 +148,7 @@
 /obj/item/weapon/storage/box/syndie_kit/emp/New()
 	..()
 	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/implanter/emp/(src)
 	new /obj/item/device/flashlight/emp/(src)
 	return


### PR DESCRIPTION
EMP kit got never picked even after my last changes so there's some massive buffs for you. (some feedback from http://www.ss13.eu/phpbb/viewtopic.php?f=10&t=1488)
- EMP-Flashlight now has one charge less but recharges (slower than lasers/energy crossbows do)
- EMP-Flashlight description no longer reveals the nature of the device
- EMP implant now has two uses
- EMP kit now contains two grenades
- EMP and adrenaline implants now inform the user how many charges they contain to begin with (freedom doesn't because it's intentionally random)
- Fixes EMP flashlight sometimes going down to -1 charges.

EMP flashlight doesn't use a cell because cells get affected by EMPs and making a cell immune specifically for this would be silly.
