### PR TITLE
[Tumblr] Sausage Party Reduction

### DIFF
--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -344,7 +344,7 @@ ________________________________________________________________________________
 
 /proc/create_space_ninja(spawn_loc)
 	var/mob/living/carbon/human/new_ninja = new(spawn_loc)
-
+	if(prob(50)) new_ninja.gender = "female"
 	var/datum/preferences/A = new()//Randomize appearance for the ninja.
 	A.real_name = "[pick(ninja_titles)] [pick(ninja_names)]"
 	A.copy_to(new_ninja)

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -933,6 +933,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			user << "The rune fizzles uselessly. There is no spirit nearby."
 			return
 		var/mob/living/carbon/human/G = new /mob/living/carbon/human
+		if(prob(50))	G.gender = "female"
 		hardset_dna(G, null, null, null, "adamantine")
 		G.real_name = text("Adamantine Golem ([rand(1, 1000)])")
 		G.equip_to_slot_or_del(new /obj/item/clothing/under/golem(G), slot_w_uniform)


### PR DESCRIPTION
*Lets adamantine golems and ninjas generate female where before they were generated exclusively male.

The ninja spacesuit has a coded in female variant that has existed forever but was not actually used. It only shows up upon suit ACTIVATION because (?:?:?)||i||j4c0d3(?:?:?).

Likewise female adamantine golems have their own sprites and can show up in staff of change shots, but ones generated from the rune were always male.

This does NOT affect admin summoned unknown humans, those are all still male.
