### PR TITLE
Fixes the Hijack Objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -164,6 +164,10 @@ datum/objective/hijack
 		if(issilicon(owner.current))
 			return 0
 		var/area/shuttle = locate(/area/shuttle/escape/centcom)
+
+		if(!(get_turf(owner.current) in shuttle))
+			return 0
+
 		var/list/protected_mobs = list(/mob/living/silicon/ai, /mob/living/silicon/pai)
 		for(var/mob/living/player in player_list)
 			if(player.type in protected_mobs)	continue


### PR DESCRIPTION
The objective did not check if the owner of the objective was on the
shuttle, only if other people were. So as long as the shuttle was empty they succeeded on that objective.
