### PR TITLE
Cyborg module selection update works with emagged borgs, removes old module selection ui button

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -65,7 +65,8 @@
 #define ui_acti_alt "EAST-1:28,SOUTH:5"	//alternative intent switcher for when the interface is hidden (F12)
 
 #define ui_borg_pull "EAST-2:26,SOUTH+1:7"
-#define ui_borg_panel "EAST-1:28,SOUTH+1:7"
+#define ui_borg_radio "EAST-1:28,SOUTH+1:7"
+#define ui_borg_intents "EAST-2:26,SOUTH:5"
 
 //Upper-middle right (damage indicators)
 #define ui_toxin "EAST-1:28,CENTER+5:27"

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -10,7 +10,7 @@
 	using.name = "radio"
 	using.icon = 'icons/mob/screen_cyborg.dmi'
 	using.icon_state = "radio"
-	using.screen_loc = ui_movi
+	using.screen_loc = ui_borg_radio
 	using.layer = 20
 	adding += using
 
@@ -50,7 +50,7 @@
 	using.name = "act_intent"
 	using.icon = 'icons/mob/screen_cyborg.dmi'
 	using.icon_state = mymob.a_intent
-	using.screen_loc = ui_acti
+	using.screen_loc = ui_borg_intents
 	using.layer = 20
 	adding += using
 	action_intent = using
@@ -75,15 +75,6 @@
 	mymob.hands.icon_state = "nomod"
 	mymob.hands.name = "module"
 	mymob.hands.screen_loc = ui_borg_module
-
-//Module Panel
-	using = new /obj/screen()
-	using.name = "panel"
-	using.icon = 'icons/mob/screen_cyborg.dmi'
-	using.icon_state = "panel"
-	using.screen_loc = ui_borg_panel
-	using.layer = 19
-	adding += using
 
 //Store
 	mymob.throw_icon = new /obj/screen()
@@ -177,6 +168,16 @@
 
 		var/x = -4	//Start at CENTER-4,SOUTH+1
 		var/y = 1
+
+		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
+		//be emagged before they actually select a module. - or some situation can cause them to get a new module
+		// - or some situation might cause them to get de-emagged or something.
+		if(r.emagged)
+			if(!(r.module.emag in r.module.modules))
+				r.module.modules.Add(r.module.emag)
+		else
+			if(r.module.emag in r.module.modules)
+				r.module.modules.Remove(r.module.emag)
 
 		for(var/atom/movable/A in r.module.modules)
 			if( (A != r.module_state_1) && (A != r.module_state_2) && (A != r.module_state_3) )

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -118,6 +118,8 @@
 			if(istype(R) && !R.emagged && R.connected_ai == usr && !R.scrambledcodes && can_control(usr, R))
 				log_game("[key_name(usr)] emagged [R.name] using robotic console!")
 				R.emagged = 1
+				if(R.hud_used)
+					R.hud_used.update_robot_modules_display()  //Shows/hides the emag item if the inventory screen is already open.
 				if(R.mind.special_role)
 					R.verbs += /mob/living/silicon/robot/proc/ResetSecurityCodes
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -491,6 +491,8 @@
 					sleep(6)
 					if(prob(50))
 						emagged = 1
+						if(user.hud_used)
+							user.hud_used.update_robot_modules_display()	//Shows/hides the emag item if the inventory screen is already open.
 						lawupdate = 0
 						connected_ai = null
 						user << "You emag [src]'s interface."


### PR DESCRIPTION
- Emagged borgs' hidden inventory will now become visible in the module selection section.
- Also removed the now outdated module selection UI button and rearranged borg UI buttons to reflect this.
  Screenshot: http://www.ss13.eu/borg_ui_smaller_bottom_right.png
