### PR TITLE
Robotic Repair Missing fixes [Fixes #2326]

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -163,26 +163,19 @@
 
 
 /obj/item/weapon/weldingtool/attack(mob/living/carbon/human/H, mob/user)
+	var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
 
 	if(istype(H))
-		var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
 		if(affecting.status == ORGAN_ROBOTIC)
 			if(src.remove_fuel(0))
-				if(affecting.brute_dam > 0)
-					affecting.heal_damage(30,0,1)
-					H.update_damage_overlays(0)
-					H.updatehealth()
-					for(var/mob/O in viewers(user, null))
-						O.show_message(text("<span class='notice'>[user] has fixed some of the dents on [H]'s [affecting.getDisplayName()]!</span>"), 1)
-					return
-				else
-					user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"
-					return
+				src.item_heal_robotic(H, user, 30, 0)
+				return
 			else
 				user << "<span class='warning'>Need more welding fuel!</span>"
 				return
 		else
 			return ..()
+
 	else
 		return ..()
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -162,6 +162,31 @@
 	..()
 
 
+/obj/item/weapon/weldingtool/attack(mob/living/carbon/human/H, mob/user)
+
+	if(istype(H))
+		var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
+		if(affecting.status == ORGAN_ROBOTIC)
+			if(src.remove_fuel(0))
+				if(affecting.brute_dam > 0)
+					affecting.heal_damage(30,0,1)
+					H.update_damage_overlays(0)
+					H.updatehealth()
+					for(var/mob/O in viewers(user, null))
+						O.show_message(text("<span class='notice'>[user] has fixed some of the dents on [H]'s [affecting.getDisplayName()]!</span>"), 1)
+					return
+				else
+					user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"
+					return
+			else
+				user << "<span class='warning'>Need more welding fuel!</span>"
+				return
+		else
+			return ..()
+	else
+		return ..()
+
+
 /obj/item/weapon/weldingtool/process()
 	switch(welding)
 		if(0)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -122,43 +122,6 @@ emp_act
 
 	var/obj/item/organ/limb/affecting = get_organ(ran_zone(user.zone_sel.selecting))
 
-//--------------------- Cyber limb stuff ---------------------\\
-
-	if(istype(I, /obj/item/weapon/weldingtool))
-		var/obj/item/weapon/weldingtool/WT = I
-		if(affecting.status == ORGAN_ROBOTIC)
-			if (WT.remove_fuel(0))
-				if(affecting.brute_dam > 0)
-					affecting.heal_damage(30,0,1) //Repair Brute
-					update_damage_overlays(0)
-					updatehealth()
-					for(var/mob/O in viewers(user, null))
-						O.show_message(text("\blue [user] has fixed some of the dents on [src]'s [affecting.getDisplayName()]!"), 1) //Tell everyone [src]'s limb (by its real name) has been repaired
-					return //So we don't attack them as well
-				else
-					user << "<span class='notice'>[src]'s [affecting.getDisplayName()] is already in good condition</span>"
-					return
-			else
-				user << "<span class='warning'>Need more welding fuel!</span>"
-				return
-
-
-	if(istype(I, /obj/item/weapon/cable_coil))
-		var/obj/item/weapon/cable_coil/coil = I
-		if(affecting.status == ORGAN_ROBOTIC)
-			if(affecting.burn_dam > 0)
-				affecting.heal_damage(0,30,1) //Repair Burn
-				updatehealth()
-				coil.use(1)
-				for(var/mob/O in viewers(user, null))
-					O.show_message(text("\blue [user] has fixed some of the burnt wires on [src]'s [affecting.getDisplayName()]!"), 1)
-				return //So we don't attack them as well
-			else
-				user << "<span class='notice'>[src]'s [affecting.getDisplayName()] is already in good condition</span>"
-				return
-
-//-------------------- End of Cyber limb stuff ---------------------\\
-
 	var/hit_area = parse_zone(affecting.name)
 
 	if((user != src) && check_shields(I.force, "the [I.name]"))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -389,9 +389,9 @@
 		var/obj/item/weapon/cable_coil/coil = W
 		adjustFireLoss(-30)
 		updatehealth()
-		coil.use(1)
 		for(var/mob/O in viewers(user, null))
 			O.show_message(text("\red [user] has fixed some of the burnt wires on [src]!"), 1)
+		coil.use(1)
 
 	else if (istype(W, /obj/item/weapon/crowbar))	// crowbar means open or close the cover
 		if(opened)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -220,6 +220,28 @@
 		return(OXYLOSS)
 
 
+/obj/item/weapon/cable_coil/attack(mob/living/carbon/human/H, mob/user)
+
+	if(istype(H))
+		var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
+
+		if(affecting.status == ORGAN_ROBOTIC)
+			if(affecting.burn_dam > 0)
+				affecting.heal_damage(0,30,1)
+				H.updatehealth()
+				src.use(1)
+				for(var/mob/O in viewers(user, null))
+					O.show_message(text("<span class='notice'>[user] has fixed some of the burnt wires on [H]'s [affecting.getDisplayName()]!</span>"), 1)
+				return
+			else
+				user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"
+				return
+		else
+			return ..()
+	else
+		return ..()
+
+
 /obj/item/weapon/cable_coil/New(loc, length = MAXCOIL, var/param_color = null)
 	..()
 	src.amount = length

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -229,9 +229,9 @@
 			if(affecting.burn_dam > 0)
 				affecting.heal_damage(0,30,1)
 				H.updatehealth()
-				src.use(1)
 				for(var/mob/O in viewers(user, null))
 					O.show_message(text("<span class='notice'>[user] has fixed some of the burnt wires on [H]'s [affecting.getDisplayName()]!</span>"), 1)
+				src.use(1)
 				return
 			else
 				user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -221,21 +221,12 @@
 
 
 /obj/item/weapon/cable_coil/attack(mob/living/carbon/human/H, mob/user)
-
+	var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
 	if(istype(H))
-		var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
-
 		if(affecting.status == ORGAN_ROBOTIC)
-			if(affecting.burn_dam > 0)
-				affecting.heal_damage(0,30,1)
-				H.updatehealth()
-				for(var/mob/O in viewers(user, null))
-					O.show_message(text("<span class='notice'>[user] has fixed some of the burnt wires on [H]'s [affecting.getDisplayName()]!</span>"), 1)
-				src.use(1)
-				return
-			else
-				user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"
-				return
+			src.item_heal_robotic(H, user, 0, 30)
+			src.use(1)
+			return
 		else
 			return ..()
 	else

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -151,6 +151,30 @@
 	return update_organ_icon()
 
 
+/obj/item/proc/item_heal_robotic(var/mob/living/carbon/human/H, var/mob/user, var/brute, var/burn)
+	var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
+
+	var/dam //changes repair text based on how much brute/burn was supplied
+
+	if(brute > burn)
+		dam = 1
+	else
+		dam = 0
+
+	if(affecting.status == ORGAN_ROBOTIC)
+		if(brute > 0 && affecting.brute_dam > 0 || burn > 0 && affecting.burn_dam > 0)
+			affecting.heal_damage(brute,burn,1)
+			H.update_damage_overlays(0)
+			H.updatehealth()
+			for(var/mob/O in viewers(user, null))
+				O.show_message(text("<span class='notice'>[user] has fixed some of the [dam ? "dents on" : "burnt wires in"] [H]'s [affecting.getDisplayName()]!</span>"), 1)
+			return
+		else
+			user << "<span class='notice'>[H]'s [affecting.getDisplayName()] is already in good condition</span>"
+			return
+	else
+		return
+
 //Returns total damage...kinda pointless really
 /obj/item/organ/limb/proc/get_damage()
 	return brute_dam + burn_dam


### PR DESCRIPTION
- Moves Robotic repair stuff to the two item's respected attack()'s
- Removed them from the human_defense.dm

Yay for everything I ever added to human_defense being removed because to be fair that was a shit place to put it!

Another Augmentation bug fixed, but when will @Aranclanos love me?

Thanks to @Tenebrosity for reporting this.

Fixed a (most likely) unknown issue with cable coils and messages, it's Del(), proc stopping shenanigans - Thanks @Perakp for pointing it out.
