### PR TITLE
AI intellicard wireless hotkeys exploit fix

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -32,6 +32,9 @@
 		build_click(src, client.buildmode, params, A)
 		return
 
+	if(control_disabled || stat)
+		return
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"])
 		MiddleClickOn(A)
@@ -46,7 +49,8 @@
 		CtrlClickOn(A)
 		return
 
-	if(control_disabled || stat || world.time <= next_move) return
+	if(world.time <= next_move)
+		return
 	next_move = world.time + 9
 
 	if(aicamera.in_camera_mode)


### PR DESCRIPTION
AIs inside of intellicards will no longer be able to use their hotkeys while their wireless is disabled.

Fixes issue #2357
