### PR TITLE
Mineral boxes, ore locations fix

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,7 +10,8 @@
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
-		src.contents += W;
+		user.drop_item()
+		W.loc = src
 	if (istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		S.hide_from(usr)


### PR DESCRIPTION
Mineral boxes will now handle properly the movements of the mineral ores when a player click on them with one.

Fixes issue #2352
