### PR TITLE
Fixes Issue 112, APCs not charging

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -127,6 +127,8 @@
 					if(A.operating && A.cell)
 						A.cell.charge = max(0, A.cell.charge - 50)
 						power_drained += 50
+						if(A.charging == 2) // If the cell was full
+							A.charging = 1 // It's no longer full
 
 	if(power_drained > max_power * 0.95)
 		playsound(src, 'sound/effects/screech.ogg', 100, 1, 1)


### PR DESCRIPTION
Power sinks were draining cells without telling the APC, resulting in the APC believing itself to be full while empty.
Issue #112 
