### PR TITLE
Fixes not being able to debrain augmented humans

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -22,7 +22,7 @@
 
 					var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
 
-					if(affecting.status == ORGAN_ROBOTIC) //Cannot operate on Robotic organs - RR
+					if(affecting.status == ORGAN_ROBOTIC && affecting.body_part != HEAD) //Cannot operate on Robotic organs except for the head. - RR
 						continue
 
 				for(var/path in S.species)


### PR DESCRIPTION
Fixes #2423

Yeah this was an Oversight on my part, I made it impossible to perform surgery on augmented limbs due to that having the potential for a lot more issues down the line, Completely forgot to add a way for the Head to get round this check due to brain surgeries not Actually causing issues (This also allows eye surgery to proceed as well, which also causes no issues)
