### PR TITLE
Issue 297 Gibbing in pipes fix

### DIFF
--- a/code/game/objects/effects/gibs.dm
+++ b/code/game/objects/effects/gibs.dm
@@ -42,6 +42,9 @@
 				for(var/j = 1, j<= gibamounts[i], j++)
 					var/gibType = gibtypes[i]
 					gib = new gibType(location)
+					if(istype(location,/mob/living/carbon))
+						var/mob/living/carbon/digester = location
+						digester.stomach_contents += gib
 
 					if(viruses.len > 0)
 						for(var/datum/disease/D in viruses)

--- a/code/game/objects/effects/gibs.dm
+++ b/code/game/objects/effects/gibs.dm
@@ -1,14 +1,14 @@
 /proc/gibs(atom/location, var/list/viruses, var/datum/dna/MobDNA)
-	new /obj/effect/gibspawner/generic(get_turf(location),viruses,MobDNA)
+	new /obj/effect/gibspawner/generic(location,viruses,MobDNA)
 
 /proc/hgibs(atom/location, var/list/viruses, var/datum/dna/MobDNA)
-	new /obj/effect/gibspawner/human(get_turf(location),viruses,MobDNA)
+	new /obj/effect/gibspawner/human(location,viruses,MobDNA)
 
 /proc/xgibs(atom/location, var/list/viruses)
-	new /obj/effect/gibspawner/xeno(get_turf(location),viruses)
+	new /obj/effect/gibspawner/xeno(location,viruses)
 
 /proc/robogibs(atom/location, var/list/viruses)
-	new /obj/effect/gibspawner/robot(get_turf(location),viruses)
+	new /obj/effect/gibspawner/robot(location,viruses)
 
 /obj/effect/gibspawner
 	var/sparks = 0 //whether sparks spread on Gib()
@@ -20,8 +20,7 @@
 	New(location, var/list/viruses, var/datum/dna/MobDNA)
 		..()
 
-		if(istype(loc,/turf)) //basically if a badmin spawns it
-			Gib(loc,viruses,MobDNA)
+		Gib(loc,viruses,MobDNA)
 
 	proc/Gib(atom/location, var/list/viruses = list(), var/datum/dna/MobDNA = null)
 		if(gibtypes.len != gibamounts.len || gibamounts.len != gibdirections.len)
@@ -59,7 +58,8 @@
 					else if(istype(src, /obj/effect/gibspawner/human)) // Probably a monkey
 						gib.blood_DNA["Non-human DNA"] = "A+"
 					var/list/directions = gibdirections[i]
-					if(directions.len)
-						gib.streak(directions)
+					if(istype(loc,/turf))
+						if(directions.len)
+							gib.streak(directions)
 
 		del(src)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -161,12 +161,11 @@ Doesn't work on other aliens/AI.*/
 	set desc = "Empties the contents of your stomach"
 	set category = "Alien"
 
-	if(powerc())
-		if(stomach_contents.len)
-			for(var/mob/M in src)
-				if(M in stomach_contents)
-					stomach_contents.Remove(M)
-					M.loc = loc
-					//Paralyse(10)
-			src.visible_message("\green <B>[src] hurls out the contents of their stomach!</B>")
+	if(powerc() && stomach_contents.len)
+		for(var/atom/movable/A in stomach_contents)
+			if(A in stomach_contents)
+				stomach_contents.Remove(A)
+				A.loc = loc
+				//Paralyse(10)
+		src.visible_message("\green <B>[src] hurls out the contents of their stomach!</B>")
 	return

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -100,6 +100,9 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 		new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)	//To get the player's attention
 		if(gib_on_success)
 			affected_mob.gib()
+		if(istype(new_xeno.loc,/mob/living/carbon))
+			var/mob/living/carbon/digester = new_xeno.loc
+			digester.stomach_contents += new_xeno
 		del(src)
 
 /*----------------------------------------


### PR DESCRIPTION
Gibbing in an object or mob now leaves the gibs inside.  This solves issue #297 which was that gibs would explode out of the floor if someone chestburst while travelling through disposals.  (The larva was already handled fine, just the gibs apparently pierced through the floor and pipes.)
The gibs continue travelling through the pipes, and shoot out the exit appropriately.  I didn't have to implement that, in fact this whole thing changed very little code.  I just made the gibs spawn in the pipe instead of the turf.

The  most notable other effect is that someone who gibs in a closet results in a closet full of gibs, instead of gibs spraying out of the closet.

Other notes:
Tested with gibself and facehuggers, works the same with both.
Tested with humans and corgis.  It should work for monkeys and robots too because it's the gibspawner code, which is common to all.
Tested with humans devoured by queens - no gibs escape, the gibs are technically left within the queen mob with no effect.  I didn't test facehugger-induced gibbing inside a queen, but the larva's fate should be the same as before (presumably it is still in the queen's stomach).
There are existing icon update issues with people riding on mulebots, completely unrelated to this PR.
#297
