### PR TITLE
Slime refactoring fixes

### DIFF
--- a/code/modules/mob/living/carbon/metroid/death.dm
+++ b/code/modules/mob/living/carbon/metroid/death.dm
@@ -5,8 +5,10 @@
 			M.colour = colour
 			M.rabid = 1
 			is_adult = 0
+			maxHealth = 150
+			revive()
 			regenerate_icons()
-			health = maxHealth
+			name = "[colour] [is_adult ? "adult" : "baby"] slime ([rand(1, 1000)])"
 			return
 
 	if(stat == DEAD)	return

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -55,7 +55,8 @@
 		icon_state = "[colour] [is_adult ? "adult" : "baby"] slime"
 		real_name = name
 		slime_mutation = mutation_table(colour)
-		coretype = text2path("/obj/item/slime_extract/[colour]")
+		var/sanitizedcolour = replacetext(colour, " ", "")
+		coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	..()
 
 /mob/living/carbon/slime/regenerate_icons()

--- a/code/modules/mob/living/carbon/metroid/powers.dm
+++ b/code/modules/mob/living/carbon/metroid/powers.dm
@@ -208,7 +208,7 @@
 					M.colour = colour
 				else
 					M.colour = slime_mutation[rand(1,4)]
-				M.nutrition = new_nutrition
+				if(ckey)	M.nutrition = new_nutrition //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel
 				if(i != 1) step_away(M,src)
 				babies += M

--- a/code/modules/mob/living/carbon/metroid/subtypes.dm
+++ b/code/modules/mob/living/carbon/metroid/subtypes.dm
@@ -9,8 +9,8 @@ proc/mutation_table(var/colour)
 			slime_mutation[4] = "purple"
 		//Tier 2
 		if("purple")
-			slime_mutation[1] = "darkpurple"
-			slime_mutation[2] = "darkblue"
+			slime_mutation[1] = "dark purple"
+			slime_mutation[2] = "dark blue"
 			slime_mutation[3] = "green"
 			slime_mutation[4] = "green"
 		if("metal")
@@ -21,20 +21,20 @@ proc/mutation_table(var/colour)
 		if("yellow")
 			slime_mutation[1] = "red"
 			slime_mutation[2] = "red"
-			slime_mutation[3] = "darkpurple"
+			slime_mutation[3] = "dark purple"
 			slime_mutation[4] = "yellow"
 		if("blue")
-			slime_mutation[1] = "darkblue"
+			slime_mutation[1] = "dark blue"
 			slime_mutation[2] = "pink"
 			slime_mutation[3] = "pink"
 			slime_mutation[4] = "silver"
 		//Tier 3
-		if("darkblue")
+		if("dark blue")
 			slime_mutation[1] = "purple"
 			slime_mutation[2] = "cerulean"
 			slime_mutation[3] = "blue"
 			slime_mutation[4] = "cerulean"
-		if("darkpurple")
+		if("dark purple")
 			slime_mutation[1] = "purple"
 			slime_mutation[2] = "sepia"
 			slime_mutation[3] = "orange"
@@ -53,8 +53,8 @@ proc/mutation_table(var/colour)
 		if("pink")
 			slime_mutation[1] = "pink"
 			slime_mutation[2] = "pink"
-			slime_mutation[3] = "lightpink"
-			slime_mutation[4] = "lightpink"
+			slime_mutation[3] = "light pink"
+			slime_mutation[4] = "light pink"
 		if("red")
 			slime_mutation[1] = "red"
 			slime_mutation[2] = "red"


### PR DESCRIPTION
Funfact: before my refactor in #2354 slimes ran different code to reproduce depending on if life() did it automatically or if the reproduce() verb was used. Practically speaking this meant that player slimes and CPU slimes used different code. My pull fixed that, but what I didn't notice is that these two pieces of code weren't exactly identical:

When life did it the new baby slimes had the default nutrition (700)
When reproduce did it the slimes had 90% of the nutrition of the parent each.

Since a parent could store 1200 nutriton every child would usually gain ~1080 nutrition, even though naturally they could only store 1000 by themselves. As a result of this player split CPU baby slimes were never hungry and would evolve as soon as their "tick this up one if the slime is well fed" counter went to 10. My pull gave the player slime split behavior to the pure CPU slimes, meaning that if xenobio didn't act quickly to kill newborn slimes they'd have to deal with adults.

This pull emulates the old "functionality". Baby slimes spawned from CPU slimes will have default nutrition and have to be fed a monkey to evolve, player slimes will have children that may go adult by themselves if the player was thrifty about nutrition usage.

---

Adult slimes who died and split in two as a result weren't surviving, that's been fixed.

---

Dark purple, dark blue, and light pink slimes were broken because of the spaces in their color names. It's been fixed.

Why did no one notice? Probably because they're rarely bred.
