### PR TITLE
You can now properly clean your hands of blood. Fixes #2258.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -280,6 +280,12 @@ var/list/blood_splatter_icons = list()
 		overlays += blood_splatter_icon
 	return 1 //we applied blood to the item
 
+/obj/item/clothing/gloves/add_blood(mob/living/carbon/M)
+	if(..() == 0) return 0
+	transfer_blood = rand(2, 4)
+	bloody_hands_mob = M
+	return 1
+
 /turf/simulated/add_blood(mob/living/carbon/M)
 	if(..() == 0)	return 0
 
@@ -291,6 +297,8 @@ var/list/blood_splatter_icons = list()
 /mob/living/carbon/human/add_blood(mob/living/carbon/M)
 	if(..() == 0)	return 0
 	add_blood_list(M)
+	bloody_hands = rand(2, 4)
+	bloody_hands_mob = M
 	update_inv_gloves()	//handles bloody hands overlays and updating
 	return 1 //we applied blood to the item
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -557,3 +557,4 @@
 	. = ..()
 	if(.)
 		transfer_blood = 0
+		bloody_hands_mob = null

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -5,10 +5,10 @@ atom/var/list/suit_fibers
 atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(M.gloves && istype(M.gloves,/obj/item/clothing/))
 		var/obj/item/clothing/gloves/G = M.gloves
-		if(G.transfer_blood) //bloodied gloves transfer blood to touched objects
+		if(G.transfer_blood > 1) //bloodied gloves transfer blood to touched objects
 			if(add_blood(G.bloody_hands_mob)) //only reduces the bloodiness of our gloves if the item wasn't already bloody
 				G.transfer_blood--
-	else if(M.bloody_hands)
+	else if(M.bloody_hands > 1)
 		if(add_blood(M.bloody_hands_mob))
 			M.bloody_hands--
 	if(!suit_fibers) suit_fibers = list()

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -2,7 +2,6 @@
 /mob
 	var/bloody_hands = 0
 	var/mob/living/carbon/human/bloody_hands_mob
-	var/mob/living/carbon/human/track_blood_mob
 
 /obj/item/clothing/gloves
 	var/transfer_blood = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -315,15 +315,16 @@
 
 
 /mob/living/carbon/clean_blood()
-	. = ..()
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.gloves)
 			if(H.gloves.clean_blood())
 				H.update_inv_gloves(0)
 		else
+			..() // Clear the Blood_DNA list
 			if(H.bloody_hands)
 				H.bloody_hands = 0
+				H.bloody_hands_mob = null
 				H.update_inv_gloves(0)
 	update_icons()	//apply the now updated overlays to the mob
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -199,12 +199,8 @@ emp_act
 						if (H.gloves)
 							var/obj/item/clothing/gloves/G = H.gloves
 							G.add_blood(H)
-							G.transfer_blood = 2
-							G.bloody_hands_mob = H
 						else
 							H.add_blood(H)
-							H.bloody_hands = 2
-							H.bloody_hands_mob = H
 						H.update_inv_gloves()	//updates on-mob overlays for bloody hands and/or bloody gloves
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -259,6 +259,7 @@
 	setOxyLoss(0)
 	setCloneLoss(0)
 	setBrainLoss(0)
+	setHalLoss(0)
 	SetParalysis(0)
 	SetStunned(0)
 	SetWeakened(0)


### PR DESCRIPTION
- You can now properly clean your hands of blood. Fixes #2258.
- When you touch an item, to spread the blood, it would take the "bloody_hands" to 0; which is checked if true while you wash your hands. I limited it to only go down to 1, so it will still be true unless you wash your hands.
- Fixed an issue where blood_DNA was being cleared before the blood_hands variable was being set to 0. Now you can properly hide your bloody hands with gloves and when you take them off the hands will still be bloody.
- Removed an unused variable.
- Set the bloody_hands_mob to null where it was appropriate.
- The amount of blood you can transfer to other items, when you touch them, will be a little random for variety.
- Revive() will now heal your hallos damage.
