### PR TITLE
Fixes #2503 - Mechs Vs. Wand of death

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -433,6 +433,7 @@
 	stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
 /mob/living/simple_animal/proc/Die()
+	health = 0 // so /mob/living/simple_animal/Life() doesn't magically revive them - RR
 	dead_mob_list += src
 	icon_state = icon_dead
 	stat = DEAD

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -433,12 +433,21 @@
 	stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
 /mob/living/simple_animal/proc/Die()
-	health = 0 // so /mob/living/simple_animal/Life() doesn't magically revive them - RR
+	health = 0 // so /mob/living/simple_animal/Life() doesn't magically revive them
 	dead_mob_list += src
 	icon_state = icon_dead
 	stat = DEAD
 	density = 0
 	return
+
+/mob/living/simple_animal/death(gibbed)
+	if(stat == DEAD)
+		return
+
+	if(!gibbed)
+		visible_message("<span class='danger'>\the [src] stops moving...</span>")
+
+	Die()
 
 /mob/living/simple_animal/ex_act(severity)
 	..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -9,10 +9,14 @@
 /obj/item/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
-	damage = 9001
-	damage_type = OXY
-	nodamage = 0
-	flag = "magic"
+
+/obj/item/projectile/magic/death/on_hit(var/target)
+	if(ismob(target))
+		var/mob/M = target
+		M.death()
+	if(isanimal(target))
+		var/mob/living/simple_animal/SA = target
+		SA.Die()
 
 /obj/item/projectile/magic/fireball
 	name = "bolt of fireball"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -13,10 +13,7 @@
 /obj/item/projectile/magic/death/on_hit(var/target)
 	if(ismob(target))
 		var/mob/M = target
-		M.death()
-	if(isanimal(target))
-		var/mob/living/simple_animal/SA = target
-		SA.Die()
+		M.death(0)
 
 /obj/item/projectile/magic/fireball
 	name = "bolt of fireball"


### PR DESCRIPTION
Also changed simple_animal/Die() because if you use a mob's death() proc it won't be cancelled out by that mob's life() except simple_animal life() will actually bring the mob back to life if you just flat out use Die() on the mob.

Removed some Variables on the death projectile due to this rework making them fine to just be inherited from the normal magic projectile.

Fixes #2503 
