### PR TITLE
Fixes the AI restorer eating the AI

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -13,10 +13,20 @@
 
 
 /obj/machinery/computer/aifixer/attackby(I as obj, user as mob)
+	if(occupant && istype(I, /obj/item/weapon/screwdriver))
+		if(stat & (NOPOWER|BROKEN))
+			user << "\red The screws on the [name]'s screen won't budge."
+		else
+			user << "\red The screws on the [name]'s screen won't budge and it emits a warning beep."
+		return
 
 	if(istype(I, /obj/item/device/aicard))
 		var/obj/item/device/aicard/AIcard = I
 		if(stat & (NOPOWER|BROKEN))
+			if(occupant)
+				AIcard.transfer_ai("AIFIXER","AICARD",src,user)
+				overlays.Cut()
+				return
 			user << "This terminal isn't functioning right now, get it working!"
 			return
 		AIcard.transfer_ai("AIFIXER","AICARD",src,user)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -15,9 +15,9 @@
 /obj/machinery/computer/aifixer/attackby(I as obj, user as mob)
 	if(occupant && istype(I, /obj/item/weapon/screwdriver))
 		if(stat & (NOPOWER|BROKEN))
-			user << "\red The screws on the [name]'s screen won't budge."
+			user << "\red The screws on [name]'s screen won't budge."
 		else
-			user << "\red The screws on the [name]'s screen won't budge and it emits a warning beep."
+			user << "\red The screws on [name]'s screen won't budge and it emits a warning beep."
 		return
 
 	if(istype(I, /obj/item/device/aicard))

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -15,9 +15,9 @@
 /obj/machinery/computer/aifixer/attackby(I as obj, user as mob)
 	if(occupant && istype(I, /obj/item/weapon/screwdriver))
 		if(stat & (NOPOWER|BROKEN))
-			user << "\red The screws on [name]'s screen won't budge."
+			user << "<span class='warning'>The screws on [name]'s screen won't budge.</span>"
 		else
-			user << "\red The screws on [name]'s screen won't budge and it emits a warning beep."
+			user << "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep.</span>"
 		return
 
 	if(istype(I, /obj/item/device/aicard))


### PR DESCRIPTION
Fixes the AI restorer eating the AI, it can't be deconstructed with one in it and you can remove an AI from it regardless of power or cracked screen. (Can't put one in under these conditions though.)

Fixes #2511
