### PR TITLE
Fixes the names of reagents inside condiment bottles.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -98,10 +98,11 @@
 
 		else
 			name = "misc Condiment Bottle"
+			main_reagent = reagents.get_master_reagent_name()
 			if (reagents.reagent_list.len==1)
-				desc = "Looks like it is [main_reagent], but you are not sure."
+				desc = "Looks like it is [lowertext(main_reagent)], but you are not sure."
 			else
-				desc = "A mixture of various condiments. [main_reagent] is one of them."
+				desc = "A mixture of various condiments. [lowertext(main_reagent)] is one of them."
 			icon_state = "mixedcondiments"
 	else
 		icon_state = "emptycondiment"


### PR DESCRIPTION
Fixes reagent names upon examination of condiment bottles. Previously they were being shown as IDs.

Taking sleep toxins as an example:

**Before:**
Looks like it is stoxin, but you are not sure.

**Now:**
Looks like it is sleep toxin, but you are not sure.
