### PR TITLE
Removed three useless admin toggle buttons

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -29,9 +29,6 @@
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/allow_vote_mode = 0				// allow votes to change mode
-	var/allow_admin_jump = 1			// allows admin jumping
-	var/allow_admin_spawning = 1		// allows admin item spawning
-	var/allow_admin_rev = 1				// allows admin revives
 	var/vote_delay = 6000				// minimum time between voting sessions (deciseconds, 10 minute default)
 	var/vote_period = 600				// length of voting period (deciseconds, default 1 minute)
 	var/vote_no_default = 0				// vote does not default to nochange/norestart (tbi)
@@ -213,12 +210,6 @@
 					config.allow_vote_restart = 1
 				if("allow_vote_mode")
 					config.allow_vote_mode = 1
-				if("allow_admin_jump")
-					config.allow_admin_jump = 1
-				if("allow_admin_rev")
-					config.allow_admin_rev = 1
-				if("allow_admin_spawning")
-					config.allow_admin_spawning = 1
 				if("no_dead_vote")
 					config.vote_no_dead = 1
 				if("default_no_vote")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -666,6 +666,7 @@ var/global/floorIsLava = 0
 		log_admin("[key_name(usr)] removed the delay.")
 	feedback_add_details("admin_verb","DELAY") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/* //How could this be useful anywhere ever? - Jordie
 /datum/admins/proc/adjump()
 	set category = "Server"
 	set desc="Toggle admin jumping"
@@ -673,6 +674,7 @@ var/global/floorIsLava = 0
 	config.allow_admin_jump = !(config.allow_admin_jump)
 	message_admins("\blue Toggled admin jumping to [config.allow_admin_jump].")
 	feedback_add_details("admin_verb","TJ") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+*/
 
 /datum/admins/proc/adspawn()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -666,32 +666,6 @@ var/global/floorIsLava = 0
 		log_admin("[key_name(usr)] removed the delay.")
 	feedback_add_details("admin_verb","DELAY") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/* //How could this be useful anywhere ever? - Jordie
-/datum/admins/proc/adjump()
-	set category = "Server"
-	set desc="Toggle admin jumping"
-	set name="Toggle Jump"
-	config.allow_admin_jump = !(config.allow_admin_jump)
-	message_admins("\blue Toggled admin jumping to [config.allow_admin_jump].")
-	feedback_add_details("admin_verb","TJ") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-*/
-
-/datum/admins/proc/adspawn()
-	set category = "Server"
-	set desc="Toggle admin spawning"
-	set name="Toggle Spawn"
-	config.allow_admin_spawning = !(config.allow_admin_spawning)
-	message_admins("\blue Toggled admin item spawning to [config.allow_admin_spawning].")
-	feedback_add_details("admin_verb","TAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/datum/admins/proc/adrev()
-	set category = "Server"
-	set desc="Toggle admin revives"
-	set name="Toggle Revive"
-	config.allow_admin_rev = !(config.allow_admin_rev)
-	message_admins("\blue Toggled reviving to [config.allow_admin_rev].")
-	feedback_add_details("admin_verb","TAR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /datum/admins/proc/immreboot()
 	set category = "Server"
 	set desc="Reboots the server post haste"
@@ -714,12 +688,9 @@ var/global/floorIsLava = 0
 	set category = "Admin"
 	set name = "Unprison"
 	if (M.z == 2)
-		if (config.allow_admin_jump)
-			M.loc = pick(latejoin)
-			message_admins("[key_name_admin(usr)] has unprisoned [key_name_admin(M)]", 1)
-			log_admin("[key_name(usr)] has unprisoned [key_name(M)]")
-		else
-			alert("Admin jumping disabled")
+		M.loc = pick(latejoin)
+		message_admins("[key_name_admin(usr)] has unprisoned [key_name_admin(M)]", 1)
+		log_admin("[key_name(usr)] has unprisoned [key_name(M)]")
 	else
 		alert("[M.name] is not prisoned.")
 	feedback_add_details("admin_verb","UP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -97,9 +97,6 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/toggleAI,
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
-	/datum/admins/proc/adrev,
-	/datum/admins/proc/adspawn,
-//	/datum/admins/proc/adjump,
 	/client/proc/toggle_random_events
 	)
 var/list/admin_verbs_debug = list(
@@ -174,9 +171,6 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/immreboot,
 	/client/proc/everyone_random,
 	/datum/admins/proc/toggleAI,
-	/datum/admins/proc/adrev,
-	/datum/admins/proc/adspawn,
-//	/datum/admins/proc/adjump,
 	/client/proc/restart_controller,
 	/client/proc/cmd_admin_list_open_jobs,
 	/client/proc/callproc,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -99,7 +99,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/cmd_debug_del_all,
 	/datum/admins/proc/adrev,
 	/datum/admins/proc/adspawn,
-	/datum/admins/proc/adjump,
+//	/datum/admins/proc/adjump,
 	/client/proc/toggle_random_events
 	)
 var/list/admin_verbs_debug = list(
@@ -176,7 +176,7 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/toggleAI,
 	/datum/admins/proc/adrev,
 	/datum/admins/proc/adspawn,
-	/datum/admins/proc/adjump,
+//	/datum/admins/proc/adjump,
 	/client/proc/restart_controller,
 	/client/proc/cmd_admin_list_open_jobs,
 	/client/proc/callproc,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1093,12 +1093,9 @@
 			usr << "This can only be used on instances of type /mob/living"
 			return
 
-		if(config.allow_admin_rev)
-			L.revive()
-			message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(L)]!", 1)
-			log_admin("[key_name(usr)] healed / Revived [key_name(L)]")
-		else
-			usr << "Admin Rejuvinates have been disabled"
+		L.revive()
+		message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(L)]!", 1)
+		log_admin("[key_name(usr)] healed / Revived [key_name(L)]")
 
 	else if(href_list["makeai"])
 		if(!check_rights(R_SPAWN))	return
@@ -1425,10 +1422,6 @@
 
 	else if(href_list["object_list"])			//this is the laggiest thing ever
 		if(!check_rights(R_SPAWN))	return
-
-		if(!config.allow_admin_spawning)
-			usr << "Spawning of items is not allowed."
-			return
 
 		var/atom/loc = usr.loc
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -6,14 +6,10 @@
 		src << "Only administrators may use this command."
 		return
 
-	if(config.allow_admin_jump)
-		usr.loc = pick(get_area_turfs(A))
-
-		log_admin("[key_name(usr)] jumped to [A]")
-		message_admins("[key_name_admin(usr)] jumped to [A]", 1)
-		feedback_add_details("admin_verb","JA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	usr.loc = pick(get_area_turfs(A))
+	log_admin("[key_name(usr)] jumped to [A]")
+	message_admins("[key_name_admin(usr)] jumped to [A]", 1)
+	feedback_add_details("admin_verb","JA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
@@ -21,13 +17,11 @@
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
-	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
-		message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
-		usr.loc = T
-		feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+
+	log_admin("[key_name(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]")
+	message_admins("[key_name_admin(usr)] jumped to [T.x],[T.y],[T.z] in [T.loc]", 1)
+	usr.loc = T
+	feedback_add_details("admin_verb","JT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
 /client/proc/jumptomob(var/mob/M in mob_list)
@@ -38,19 +32,16 @@
 		src << "Only administrators may use this command."
 		return
 
-	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] jumped to [key_name(M)]")
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-		if(src.mob)
-			var/mob/A = src.mob
-			var/turf/T = get_turf(M)
-			if(T && isturf(T))
-				feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-				A.loc = T
-			else
-				A << "This mob is not located in the game world."
-	else
-		alert("Admin jumping disabled")
+	log_admin("[key_name(usr)] jumped to [key_name(M)]")
+	message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+	if(src.mob)
+		var/mob/A = src.mob
+		var/turf/T = get_turf(M)
+		if(T && isturf(T))
+			feedback_add_details("admin_verb","JM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+			A.loc = T
+		else
+			A << "This mob is not located in the game world."
 
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)
 	set category = "Admin"
@@ -60,17 +51,13 @@
 		src << "Only administrators may use this command."
 		return
 
-	if (config.allow_admin_jump)
-		if(src.mob)
-			var/mob/A = src.mob
-			A.x = tx
-			A.y = ty
-			A.z = tz
-			feedback_add_details("admin_verb","JC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		message_admins("[key_name_admin(usr)] jumped to coordinates [tx], [ty], [tz]")
-
-	else
-		alert("Admin jumping disabled")
+	if(src.mob)
+		var/mob/A = src.mob
+		A.x = tx
+		A.y = ty
+		A.z = tz
+		feedback_add_details("admin_verb","JC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	message_admins("[key_name_admin(usr)] jumped to coordinates [tx], [ty], [tz]")
 
 /client/proc/jumptokey()
 	set category = "Admin"
@@ -80,21 +67,18 @@
 		src << "Only administrators may use this command."
 		return
 
-	if(config.allow_admin_jump)
-		var/list/keys = list()
-		for(var/mob/M in player_list)
-			keys += M.client
-		var/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
-		if(!selection)
-			src << "No keys found."
-			return
-		var/mob/M = selection:mob
-		log_admin("[key_name(usr)] jumped to [key_name(M)]")
-		message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
-		usr.loc = M.loc
-		feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	var/list/keys = list()
+	for(var/mob/M in player_list)
+		keys += M.client
+	var/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
+	if(!selection)
+		src << "No keys found."
+		return
+	var/mob/M = selection:mob
+	log_admin("[key_name(usr)] jumped to [key_name(M)]")
+	message_admins("[key_name_admin(usr)] jumped to [key_name_admin(M)]", 1)
+	usr.loc = M.loc
+	feedback_add_details("admin_verb","JK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Getmob(var/mob/M in mob_list)
 	set category = "Admin"
@@ -103,13 +87,11 @@
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
-	if(config.allow_admin_jump)
-		log_admin("[key_name(usr)] teleported [key_name(M)]")
-		message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
-		M.loc = get_turf(usr)
-		feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+
+	log_admin("[key_name(usr)] teleported [key_name(M)]")
+	message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)]", 1)
+	M.loc = get_turf(usr)
+	feedback_add_details("admin_verb","GM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Getkey()
 	set category = "Admin"
@@ -120,24 +102,21 @@
 		src << "Only administrators may use this command."
 		return
 
-	if(config.allow_admin_jump)
-		var/list/keys = list()
-		for(var/mob/M in player_list)
-			keys += M.client
-		var/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
-		if(!selection)
-			return
-		var/mob/M = selection:mob
+	var/list/keys = list()
+	for(var/mob/M in player_list)
+		keys += M.client
+	var/selection = input("Please, select a player!", "Admin Jumping", null, null) as null|anything in sortKey(keys)
+	if(!selection)
+		return
+	var/mob/M = selection:mob
 
-		if(!M)
-			return
-		log_admin("[key_name(usr)] teleported [key_name(M)]")
-		message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
-		if(M)
-			M.loc = get_turf(usr)
-			feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	else
-		alert("Admin jumping disabled")
+	if(!M)
+		return
+	log_admin("[key_name(usr)] teleported [key_name(M)]")
+	message_admins("[key_name_admin(usr)] teleported [key_name(M)]", 1)
+	if(M)
+		M.loc = get_turf(usr)
+		feedback_add_details("admin_verb","GK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/sendmob(var/mob/M in sortmobs())
 	set category = "Admin"
@@ -147,11 +126,8 @@
 		return
 	var/area/A = input(usr, "Pick an area.", "Pick an area") in return_sorted_areas()
 	if(A)
-		if(config.allow_admin_jump)
-			M.loc = pick(get_area_turfs(A))
-			feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		M.loc = pick(get_area_turfs(A))
+		feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-			log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")
-			message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)] to [A]", 1)
-		else
-			alert("Admin jumping disabled")
+		log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")
+		message_admins("[key_name_admin(usr)] teleported [key_name_admin(M)] to [A]", 1)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -405,13 +405,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!istype(M))
 		alert("Cannot revive a ghost")
 		return
-	if(config.allow_admin_rev)
-		M.revive()
+	M.revive()
 
-		log_admin("[key_name(usr)] healed / revived [key_name(M)]")
-		message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(M)]!", 1)
-	else
-		alert("Admin revive disabled")
+	log_admin("[key_name(usr)] healed / revived [key_name(M)]")
+	message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(M)]!", 1)
 	feedback_add_details("admin_verb","REJU") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_create_centcom_report()


### PR DESCRIPTION
Removing toggle admin jump, spawn and revive buttons.
I can't imagine a scenario where they would be useful; even if on, there's no restrictions on who can toggle them so they could just be turned off.
