### PR TITLE
Removes the "SmoothOperator" bundle

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/storage/box/syndicate/
 	New()
 		..()
-		switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "freedom" = 1, "hacker" = 1, "lordsingulo" = 1, "smoothoperator" = 1, "darklord" = 1)))
+		switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "freedom" = 1, "hacker" = 1, "lordsingulo" = 1, "darklord" = 1)))
 			if("bloodyspai")
 				new /obj/item/clothing/under/chameleon(src)
 				new /obj/item/clothing/mask/gas/voice(src)
@@ -56,16 +56,6 @@
 				new /obj/item/clothing/suit/space/syndicate(src)
 				new /obj/item/clothing/head/helmet/space/syndicate(src)
 				new /obj/item/weapon/card/emag(src)
-				return
-
-			if("smoothoperator")
-				new /obj/item/weapon/gun/projectile/automatic/pistol(src)
-				new /obj/item/weapon/silencer(src)
-				new /obj/item/weapon/soap/syndie(src)
-				new /obj/item/weapon/storage/bag/trash(src)
-				new /obj/item/bodybag(src)
-				new /obj/item/clothing/under/suit_jacket(src)
-				new /obj/item/clothing/shoes/laceup(src)
 				return
 
 			if("darklord")


### PR DESCRIPTION
 for being dreadful compared to the other bundles

Bundle included:
*Stetchkin (TC ???): the gun we gave nuke ops to tell them they had to buy their own guns now.  There's no way for a traitor to get more ammo for it
*A silencer (TC 2): makes the gun a normal item (one of its only pluses was it was a small item).
*Syndie Soap (TC 1): slips forever.
*A Trash Bag (TC 0): It's a bulky item so once you take it out of the box you're stuck explaining to everyone why you're carrying a trash bag as not a janitor.
*A Body Bag (TC 0): Ostensibly to drag off corpses without leaving a mess... but then why do they get the soap?
*A Suit (TC 0): Availible for free in the locker room closet
*Lace Up Shoes (TC 0): "Shoot me, I'm valid!"

Since you can't buy a Stetchkin I can't give it an absolute value, except to say that it's worse in almost every respect to the revolver. which is 6.

Even if you are VERY charitable and give it the full 6 valuationyou still have a bundle that awards you less than 10TC of items where every other bundle awards you more than 10TC (that's the point of taking a bundle).

http://www.youtube.com/watch?v=RiMOKmp0uZc
