### PR TITLE
Minor fix to make mulebot hacking more convenient

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -135,7 +135,7 @@ var/global/mulebot_count = 0
 			)
 		else
 			user << "\blue [src] does not need a repair!"
-	else if (istype(I, /obj/item/device/multitool) || istype(I, /obj/item/weapon/wirecutters))
+	else if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/weapon/wirecutters))
 		if(open)
 			interact(usr, 0)
 	else if(load && ismob(load))  // chance to knock off rider

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -137,7 +137,7 @@ var/global/mulebot_count = 0
 			user << "\blue [src] does not need a repair!"
 	else if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/weapon/wirecutters))
 		if(open)
-			interact(usr, 0)
+			attack_hand(usr)
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1+I.force * 2))
 			unload(0)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -135,6 +135,9 @@ var/global/mulebot_count = 0
 			)
 		else
 			user << "\blue [src] does not need a repair!"
+	else if (istype(I, /obj/item/device/multitool) || istype(I, /obj/item/weapon/wirecutters))
+		if(open)
+			interact(usr, 0)
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1+I.force * 2))
 			unload(0)


### PR DESCRIPTION
**Before**:
1. Unlock controls
2. Open hatch with a screwdriver
3. Click with an empty hand on the bot
4. Switch to multitool or wirecutters
5. Pulse or cut the wires

**Now**:
1. Unlock controls
2. Open hatch with a screwdriver
3. Click directly with multitool or wirecutters
4. Pulse or cut the wires
