### PR TITLE
BE_BLOB and easy adminblobing

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -23,5 +23,5 @@
 #define BE_ALIEN		64
 #define BE_PAI			128
 #define BE_CULTIST		256
-#define BE_MONKEY		512
+#define BE_BLOB			512
 #define BE_NINJA		1024

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -39,6 +39,6 @@ var/list/be_special_flags = list(
 	"Alien Lifeform" = BE_ALIEN,
 	"pAI" = BE_PAI,
 	"Cultist" = BE_CULTIST,
-	"Monkey" = BE_MONKEY,
+	"Blob" = BE_BLOB,
 	"Ninja" = BE_NINJA
 	)

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -9,7 +9,7 @@ var/list/blob_nodes = list()
 /datum/game_mode/blob
 	name = "blob"
 	config_tag = "blob"
-	antag_flag = BE_ALIEN
+	antag_flag = BE_BLOB
 
 	required_players = 30
 	required_enemies = 1

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -63,9 +63,9 @@
 	..()
 
 
-/obj/effect/blob/core/proc/create_overmind(var/client/new_overmind)
+/obj/effect/blob/core/proc/create_overmind(var/client/new_overmind, var/override_delay)
 
-	if(overmind_get_delay > world.time)
+	if(overmind_get_delay > world.time && !override_delay)
 		return
 
 	overmind_get_delay = world.time + 300 // 30 seconds
@@ -77,7 +77,7 @@
 	var/list/candidates = list()
 
 	if(!new_overmind)
-		candidates = get_candidates(BE_ALIEN)
+		candidates = get_candidates(BE_BLOB)
 		if(candidates.len)
 			C = pick(candidates)
 	else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -103,7 +103,8 @@ var/global/floorIsLava = 0
 				body += "<A href='?_src_=holder;makeai=\ref[M]'>Make AI</A> | "
 				body += "<A href='?_src_=holder;makerobot=\ref[M]'>Make Robot</A> | "
 				body += "<A href='?_src_=holder;makealien=\ref[M]'>Make Alien</A> | "
-				body += "<A href='?_src_=holder;makeslime=\ref[M]'>Make Slime</A> "
+				body += "<A href='?_src_=holder;makeslime=\ref[M]'>Make Slime</A> | "
+				body += "<A href='?_src_=holder;makeblob=\ref[M]'>Make Blob</A> | "
 
 			//Simple Animals
 			if(isanimal(M))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1132,6 +1132,17 @@
 
 		usr.client.cmd_admin_slimeize(H)
 
+	else if(href_list["makeblob"])
+		if(!check_rights(R_SPAWN))	return
+
+		var/mob/living/carbon/human/H = locate(href_list["makeblob"])
+		if(!istype(H))
+			usr << "This can only be used on instances of type /mob/living/carbon/human"
+			return
+
+		usr.client.cmd_admin_blobize(H)
+
+
 	else if(href_list["makerobot"])
 		if(!check_rights(R_SPAWN))	return
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -159,8 +159,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 	if(istype(M, /mob/living/carbon/human))
 		log_admin("[key_name(src)] has robotized [M.key].")
+		var/mob/living/carbon/human/H = M
 		spawn(10)
-			M:Robotize()
+			H.Robotize()
 
 	else
 		alert("Invalid mob")
@@ -174,8 +175,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 	if(istype(M, /mob/living/carbon/human))
 		log_admin("[key_name(src)] has blobized [M.key].")
+		var/mob/living/carbon/human/H = M
 		spawn(10)
-			M:Blobize()
+			H.Blobize()
 
 	else
 		alert("Invalid mob")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -165,6 +165,22 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	else
 		alert("Invalid mob")
 
+/client/proc/cmd_admin_blobize(var/mob/M in mob_list)
+	set category = "Fun"
+	set name = "Make Blob"
+
+	if(!ticker)
+		alert("Wait until the game starts")
+		return
+	if(istype(M, /mob/living/carbon/human))
+		log_admin("[key_name(src)] has blobized [M.key].")
+		spawn(10)
+			M:Blobize()
+
+	else
+		alert("Invalid mob")
+
+
 /client/proc/cmd_admin_animalize(var/mob/M in mob_list)
 	set category = "Fun"
 	set name = "Make Simple Animal"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -12,10 +12,10 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 	"wizard" = IS_MODE_COMPILED("wizard"),               // 3
 	"malf AI" = IS_MODE_COMPILED("malfunction"),         // 4
 	"revolutionary" = IS_MODE_COMPILED("revolution"),    // 5
-	"alien lifeform" = 1, //always show                 // 6
+	"alien" = 1, //always show                			 // 6
 	"pAI candidate" = 1, // -- TLE                       // 7
 	"cultist" = IS_MODE_COMPILED("cult"),                // 8
-	"infested monkey" = IS_MODE_COMPILED("monkey"),      // 9
+	"blob" = IS_MODE_COMPILED("blob"),					 // 9
 )
 
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -371,6 +371,15 @@
 	. = new_slime
 	del(src)
 
+/mob/living/carbon/human/proc/Blobize()
+	if (notransform)
+		return
+	var/obj/effect/blob/core/new_blob = new /obj/effect/blob/core (loc)
+	new_blob.create_overmind(src.client , 1)
+	gib(src)
+
+
+
 /mob/living/carbon/human/proc/corgize()
 	if (notransform)
 		return


### PR DESCRIPTION
Repurposes the outdated BE_MONKEY into BE_BLOB and separates the alien and blob pools so people can prefer to be one or the other or both or neither. An announcement should be made when this goes live so people are aware they have a new flag to set.

Adds a dedicated button on the player panel so admins can easily turn specific players into blobs.
