### PR TITLE
Fixed issue #2436 (Classic baton stuns borgs)

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -40,21 +40,25 @@
 		return
 	add_logs(user, M, "attacked", object="[src.name]")
 
+	if(isrobot(M)) // Don't stun borgs, fix for issue #2436
+		..()
+		return
+	if(!isliving(M)) // Don't stun nonhuman things
+		return
+
 	if(user.a_intent == "harm")
 		if(!..()) return
 		playsound(loc, "swing_hit", 50, 1, -1)
 		if(M.stuttering < 8 && !(HULK in M.mutations))
 			M.stuttering = 8
-		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
-			M.Stun(8)
-			M.Weaken(8)
+		M.Stun(8)
+		M.Weaken(8)
 		M.visible_message("<span class='danger'>[M] has been beaten with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been beaten with [src] by [user]!</span>")
 	else
 		playsound(loc, 'sound/weapons/Genhit.ogg', 50, 1, -1)
-		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
-			M.Stun(5)
-			M.Weaken(5)
+		M.Stun(5)
+		M.Weaken(5)
 		M.visible_message("<span class='danger'>[M] has been stunned with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been stunned with [src] by [user]!</span>")
 

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -46,19 +46,15 @@
 		if(M.stuttering < 8 && !(HULK in M.mutations))
 			M.stuttering = 8
 		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
-		{
 			M.Stun(8)
 			M.Weaken(8)
-		}
 		M.visible_message("<span class='danger'>[M] has been beaten with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been beaten with [src] by [user]!</span>")
 	else
 		playsound(loc, 'sound/weapons/Genhit.ogg', 50, 1, -1)
 		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
-		{
 			M.Stun(5)
 			M.Weaken(5)
-		}
 		M.visible_message("<span class='danger'>[M] has been stunned with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been stunned with [src] by [user]!</span>")
 

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -45,14 +45,20 @@
 		playsound(loc, "swing_hit", 50, 1, -1)
 		if(M.stuttering < 8 && !(HULK in M.mutations))
 			M.stuttering = 8
-		M.Stun(8)
-		M.Weaken(8)
+		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
+		{
+			M.Stun(8)
+			M.Weaken(8)
+		}
 		M.visible_message("<span class='danger'>[M] has been beaten with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been beaten with [src] by [user]!</span>")
 	else
 		playsound(loc, 'sound/weapons/Genhit.ogg', 50, 1, -1)
-		M.Stun(5)
-		M.Weaken(5)
+		if(!istype(M, /mob/living/silicon/robot)) // Don't stun borgs, fix for issue #2436
+		{
+			M.Stun(5)
+			M.Weaken(5)
+		}
 		M.visible_message("<span class='danger'>[M] has been stunned with [src] by [user]!</span>", \
 							"<span class='userdanger'>[M] has been stunned with [src] by [user]!</span>")
 


### PR DESCRIPTION
Fixed issue 2436 (https://github.com/tgstation/-tg-station/issues/2436 - Classic baton stuns borgs).

Tested locally on both regular borgs and syndieborgs.

Did NOT change flavor text when someone hits a borg with the classic baton with the "help" intent, so it will still show up as "Borg has been stunned with Classic Baton by Human!". Can easily change it by adding the current message in between the curly brackets and some new text in an else clause.
