### PR TITLE
Fixes issue #555

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -119,7 +119,8 @@
 		if(istype(the_target, /obj/mecha) && search_objects < 2)
 			var/obj/mecha/M = the_target
 			if(M.occupant)//Just so we don't attack empty mechs
-				return 1
+				if(CanAttack(M.occupant))
+					return 1
 	return 0
 
 /mob/living/simple_animal/hostile/proc/GiveTarget(var/new_target)//Step 4, give us our selected target

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -52,6 +52,7 @@
 	cap_living.color = cap_color
 	cap_dead.color = cap_color
 	UpdateMushroomCap()
+	health = maxHealth
 	..()
 
 /mob/living/simple_animal/hostile/mushroom/adjustBruteLoss(var/damage)//Possibility to flee from a fight just to make it more visually interesting

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1007,7 +1007,15 @@ datum
 					/mob/living/simple_animal/hostile/syndicate/ranged/space,
 					/mob/living/simple_animal/hostile/alien/queen/large,
 					/mob/living/simple_animal/hostile/retaliate,
-					/mob/living/simple_animal/hostile/retaliate/clown
+					/mob/living/simple_animal/hostile/retaliate/clown,
+					/mob/living/simple_animal/hostile/mushroom,
+					/mob/living/simple_animal/hostile/asteroid,
+					/mob/living/simple_animal/hostile/asteroid/basilisk,
+					/mob/living/simple_animal/hostile/asteroid/goldgrub,
+					/mob/living/simple_animal/hostile/asteroid/goliath,
+					/mob/living/simple_animal/hostile/asteroid/hivelord,
+					/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
+					/mob/living/simple_animal/hostile/carp/holocarp
 					)//exclusion list for things you don't want the reaction to create.
 				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
@@ -1071,28 +1079,17 @@ datum
 					/mob/living/simple_animal/hostile/syndicate/ranged/space,
 					/mob/living/simple_animal/hostile/alien/queen/large,
 					/mob/living/simple_animal/hostile/retaliate,
-					/mob/living/simple_animal/hostile/retaliate/clown
+					/mob/living/simple_animal/hostile/retaliate/clown,
+					/mob/living/simple_animal/hostile/mushroom,
+					/mob/living/simple_animal/hostile/asteroid,
+					/mob/living/simple_animal/hostile/asteroid/basilisk,
+					/mob/living/simple_animal/hostile/asteroid/goldgrub,
+					/mob/living/simple_animal/hostile/asteroid/goliath,
+					/mob/living/simple_animal/hostile/asteroid/hivelord,
+					/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
+					/mob/living/simple_animal/hostile/carp/holocarp
 					)//exclusion list for things you don't want the reaction to create.
 				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-
-				var/message = "A gold slime reaction has occured"
-
-				var/atom/A = holder.my_atom
-				if(A)
-					var/turf/T = get_turf(A)
-					var/area/my_area = get_area(T)
-					message += " in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>)"
-					message += " (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"
-
-					var/mob/M = get(A, /mob)
-					if(M)
-						message += " - Carried By: [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
-					else
-						message += " - Last Fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
-				else
-					message += "."
-
-				message_admins(message, 0, 1)
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1075,25 +1075,6 @@ datum
 					)//exclusion list for things you don't want the reaction to create.
 				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
-				var/message = "A gold slime reaction has occured"
-
-				var/atom/A = holder.my_atom
-				if(A)
-					var/turf/T = get_turf(A)
-					var/area/my_area = get_area(T)
-					message += " in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>)"
-					message += " (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"
-
-					var/mob/M = get(A, /mob)
-					if(M)
-						message += " - Carried By: [M.real_name] ([M.key]) (<A HREF='?_src_=holder;adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)"
-					else
-						message += " - Last Fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
-				else
-					message += "."
-
-				message_admins(message, 0, 1)
-
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
 				for(var/mob/living/carbon/human/M in viewers(get_turf(holder.my_atom), null))


### PR DESCRIPTION
Fixes #555 
Hostile mobs will now run CanAttack() on the occupant of a mech to determine if they will attack it or not.
Fixes walking shrooms not having full health when spawned due to their health randomization on New()
Adds asteroid mobs and mushrooms and holocarp to the blocked list of gold slime reactions
Removes pointless logging on friendly gold slime reactions now that they can't possibly ever be used for griff
