### PR TITLE
Attempt 2: Stun Batons can now go on your belt.

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -101,8 +101,11 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
-	storage_slots = 4
+	storage_slots = 5
+	max_w_class = 3 //Because the baton wouldn't fit otherwise. - Neerti
 	can_hold = list(
+		"/obj/item/weapon/baton",
+		"/obj/item/weapon/classic_baton",
 		"/obj/item/weapon/grenade/flashbang",
 		"/obj/item/weapon/reagent_containers/spray/pepper",
 		"/obj/item/weapon/handcuffs",


### PR DESCRIPTION
Same deal as last time, nothing new, but there's an increased demand for this change on the forums.  I feel the fear of a sec officer getting four batons isn't really a big deal since,
- Having four batons doesn't give you much of an advantage since it takes forever to deplete the charge on one anyways.
- You deprive yourself of being able to carry extra flashbangs, cuffs, flashes, or even _DONUTS_ on your belt.
- You can already carry four flashbangs.  Four cuffs.  Four flashes.   Oh wait, in your backpack you could carry half of the armory!
- A snowflake check for an extra baton is just silly.

Forums: http://www.ss13.eu/phpbb/viewtopic.php?f=5&t=3324
Old PR: #1453
