### PR TITLE
Batons will now only take ten seconds to recharge fully.

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -80,7 +80,7 @@
 		if(istype(charging, /obj/item/weapon/melee/baton))
 			var/obj/item/weapon/melee/baton/B = charging
 			if(B.bcell)
-				if(B.bcell.give(175))
+				if(B.bcell.give(1500)) //Because otherwise it takes two minutes to fully charge due to 15k cells. - Neerti
 					icon_state = "recharger1"
 					use_power(200)
 				else


### PR DESCRIPTION
Increased the rate the recharger recharges the cell inside the baton to 1500 per second, which makes it complete charging in ten seconds, assuming no lag (impossible).

Tasers and other eguns are unaffected.
