### PR TITLE
Adds a new game option: show_game_type_odds

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,6 +81,7 @@
 	var/continuous_round_rev = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/continuous_round_wiz = 0
 	var/continuous_round_malf = 0
+	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 
 	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 	var/alert_desc_blue_upto = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
@@ -317,6 +318,8 @@
 					config.continuous_round_wiz		= 1
 				if("continuous_round_malf")
 					config.continuous_round_malf	= 1
+				if("show_game_type_odds")
+					config.show_game_type_odds		= 1
 				if("ghost_interaction")
 					config.ghost_interaction		= 1
 				if("traitor_scaling_coeff")

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -43,5 +43,10 @@ client/verb/showrevinfo()
 	output += "<b>Current Infomational Settings:</b><br>"
 	output += "Protect Authority Roles From Traitor: [config.protect_roles_from_antagonist]<br>"
 	output += "Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]<br>"
+	if(config.show_game_type_odds)
+		output += "<br><b>Game Type Odds:</b><br>"
+		for(var/i=1,i<=config.probabilities.len,i++)
+			var/p = config.probabilities[i]
+			output += "[p] [config.probabilities[p]]<br>"
 	usr << browse(output,"window=revdata");
 	return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -111,6 +111,9 @@ CHANGELING_SCALING_COEFF 10
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS
 
+## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
+#SHOW_GAME_TYPE_ODDS
+
 ### RANDOM EVENTS ###
 
 ## Comment this to disable random events during the round.


### PR DESCRIPTION
If it's on on the server revision screen below the preexisting information there will be a readout showing the raw chance of each round type occurring. This doesn't tell anyone what the current round type is, it just shows what the odds are.

It defaults to off.
