### PR TITLE
Adds a chance of syndiborg to the staff of change

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -134,7 +134,10 @@ proc/wabbajack(mob/living/M)
 					new_mob = new /mob/living/carbon/monkey(M.loc)
 					new_mob.universal_speak = 1
 				if("robot")
-					new_mob = new /mob/living/silicon/robot(M.loc)
+					if(prob(30))
+						new_mob = new /mob/living/silicon/robot/syndicate(M.loc)
+					else
+						new_mob = new /mob/living/silicon/robot(M.loc)
 					new_mob.gender = M.gender
 					new_mob.invisibility = 0
 					new_mob.job = "Cyborg"


### PR DESCRIPTION
Odds of syndiborg are 5%, odds of normal borg are now 11.666...%, down from 16.666...%

Syndiborgs spawn with their default lawset, which means that they can (and almost certainly will) try to kill everyone if left to their own devices.

Technically a nerf to the staff of change and likewise a buff to people who get hit by it.
