### PR TITLE
Emergency fix for a projectile runtime

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -146,7 +146,7 @@
 				return
 			step_towards(src, current)
 			sleep(1)
-			if(!bumped && (original.layer>=2.75 || ismob(original)))
+			if(!bumped && ((original && original.layer>=2.75) || ismob(original)))
 				if(loc == get_turf(original))
 					if(!(original in permutated))
 						Bump(original)


### PR DESCRIPTION
Emitters (and probably turrets) never clicked anything so this var is null. Starting the singulo = emitter shots never move and runtime constantly.
