### PR TITLE
Adds a new option to the Chemmaster 3000 to mass-produce pills

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -388,6 +388,7 @@
 				reagents.clear_reagents()
 				icon_state = "mixer0"
 		else if (href_list["createpill"]) //Also used for condiment packs.
+			if(reagents.total_volume == 0) return
 			if(!condi)
 				var/name = reject_bad_text(input(usr,"Name:","Name your pill!",reagents.get_master_reagent_name()))
 				var/obj/item/weapon/reagent_containers/pill/P
@@ -411,6 +412,26 @@
 				P.name = "[name] pack"
 				P.desc = "A small condiment pack. The label says it contains [name]."
 				reagents.trans_to(P,10)
+
+		else if (href_list["createpills"])
+			if(reagents.total_volume == 0) return
+			if(!condi)
+				var/amount = min(max(round(input(usr, "Amount:", "How many pills?") as num), 1), 10)
+				var/vol_each = min(reagents.total_volume/amount, 50)
+				var/name = reject_bad_text(input(usr,"Name:","Name your pill!", "[reagents.get_master_reagent_name()] ([vol_each]u)"))
+				var/obj/item/weapon/reagent_containers/pill/P
+
+				for(var/i = 0; i < amount; i++)
+					if(loaded_pill_bottle && loaded_pill_bottle.contents.len < loaded_pill_bottle.storage_slots)
+						P = new/obj/item/weapon/reagent_containers/pill(loaded_pill_bottle)
+					else
+						P = new/obj/item/weapon/reagent_containers/pill(src.loc)
+
+					if(!name) name = reagents.get_master_reagent_name()
+					P.name = "[name] pill"
+					P.pixel_x = rand(-7, 7) //random position
+					P.pixel_y = rand(-7, 7)
+					reagents.trans_to(P,vol_each)
 
 		else if (href_list["createbottle"])
 			if(!condi)
@@ -480,6 +501,7 @@
 			dat += "Empty<BR>"
 		if(!condi)
 			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><BR>"
+			dat += "<A href='?src=\ref[src];createpills=1'>Create pills (10 pills max)</A><BR><BR>"
 			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (30 units max)</A>"
 		else
 			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pack (10 units max)</A><BR>"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -390,19 +390,26 @@
 		else if (href_list["createpill"]) //Also used for condiment packs.
 			if(reagents.total_volume == 0) return
 			if(!condi)
-				var/name = reject_bad_text(input(usr,"Name:","Name your pill!",reagents.get_master_reagent_name()))
+				var/amount = 1
+				var/vol_each = min(reagents.total_volume, 50)
+				world << vol_each
+				world << href_list["many"]
+				if(text2num(href_list["many"]))
+					amount = min(max(round(input(usr, "Amount:", "How many pills?") as num), 1), 10)
+					vol_each = min(reagents.total_volume/amount, 50)
+				var/name = reject_bad_text(input(usr,"Name:","Name your pill!", "[reagents.get_master_reagent_name()] ([vol_each]u)"))
 				var/obj/item/weapon/reagent_containers/pill/P
 
-				if(loaded_pill_bottle && loaded_pill_bottle.contents.len < loaded_pill_bottle.storage_slots)
-					P = new/obj/item/weapon/reagent_containers/pill(loaded_pill_bottle)
-				else
-					P = new/obj/item/weapon/reagent_containers/pill(src.loc)
-
-				if(!name) name = reagents.get_master_reagent_name()
-				P.name = "[name] pill"
-				P.pixel_x = rand(-7, 7) //random position
-				P.pixel_y = rand(-7, 7)
-				reagents.trans_to(P,50)
+				for(var/i = 0; i < amount; i++)
+					if(loaded_pill_bottle && loaded_pill_bottle.contents.len < loaded_pill_bottle.storage_slots)
+						P = new/obj/item/weapon/reagent_containers/pill(loaded_pill_bottle)
+					else
+						P = new/obj/item/weapon/reagent_containers/pill(src.loc)
+					if(!name) name = reagents.get_master_reagent_name()
+					P.name = "[name] pill"
+					P.pixel_x = rand(-7, 7) //random position
+					P.pixel_y = rand(-7, 7)
+					reagents.trans_to(P,vol_each)
 			else
 				var/name = reject_bad_text(input(usr,"Name:","Name your bag!",reagents.get_master_reagent_name()))
 				var/obj/item/weapon/reagent_containers/food/condiment/pack/P = new/obj/item/weapon/reagent_containers/food/condiment/pack(src.loc)
@@ -412,26 +419,6 @@
 				P.name = "[name] pack"
 				P.desc = "A small condiment pack. The label says it contains [name]."
 				reagents.trans_to(P,10)
-
-		else if (href_list["createpills"])
-			if(reagents.total_volume == 0) return
-			if(!condi)
-				var/amount = min(max(round(input(usr, "Amount:", "How many pills?") as num), 1), 10)
-				var/vol_each = min(reagents.total_volume/amount, 50)
-				var/name = reject_bad_text(input(usr,"Name:","Name your pill!", "[reagents.get_master_reagent_name()] ([vol_each]u)"))
-				var/obj/item/weapon/reagent_containers/pill/P
-
-				for(var/i = 0; i < amount; i++)
-					if(loaded_pill_bottle && loaded_pill_bottle.contents.len < loaded_pill_bottle.storage_slots)
-						P = new/obj/item/weapon/reagent_containers/pill(loaded_pill_bottle)
-					else
-						P = new/obj/item/weapon/reagent_containers/pill(src.loc)
-
-					if(!name) name = reagents.get_master_reagent_name()
-					P.name = "[name] pill"
-					P.pixel_x = rand(-7, 7) //random position
-					P.pixel_y = rand(-7, 7)
-					reagents.trans_to(P,vol_each)
 
 		else if (href_list["createbottle"])
 			if(!condi)
@@ -500,8 +487,8 @@
 		else
 			dat += "Empty<BR>"
 		if(!condi)
-			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><BR>"
-			dat += "<A href='?src=\ref[src];createpills=1'>Create pills (10 pills max)</A><BR><BR>"
+			dat += "<HR><BR><A href='?src=\ref[src];createpill=1;many=0'>Create pill (50 units max)</A><BR>"
+			dat += "<A href='?src=\ref[src];createpill=1;many=1'>Create pills (10 pills max)</A><BR><BR>"
 			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (30 units max)</A>"
 		else
 			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pack (10 units max)</A><BR>"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -392,8 +392,6 @@
 			if(!condi)
 				var/amount = 1
 				var/vol_each = min(reagents.total_volume, 50)
-				world << vol_each
-				world << href_list["many"]
 				if(text2num(href_list["many"]))
 					amount = min(max(round(input(usr, "Amount:", "How many pills?") as num), 1), 10)
 					vol_each = min(reagents.total_volume/amount, 50)


### PR DESCRIPTION
_Suppose you want to create 10 10u pills_ 
**Before:**
1. Insert beaker into CM 3000
2. Transfer 10 units of reagents to the buffer
3. Select the "Create pill" option
4. Go to step (2) until you get 10 pills 
5. Sigh

**Now:**
1. Insert beaker into CM 3000
2. Transfer 100 units of reagents to the buffer
3. Select the "Create pills" option
4. Type "10"
5. Done

I know the {min,max,round} stuff looks a bit dense but basically it:
- Enforces a non-zero integer between 1 and 10 as input (which means that you can create a minimum of 1 pill and a maximum of 10 pills)
- Keeps the unit count at 50u in case it would be exceeded (eg. by trying to create a single pill with 100u worth of reagents)

Also:
- It also automatically labels the pills with the number of units in each. I can do something similar for the "createpill" option if so desired.
- Prevents empty pills from being created in both "createpill" and "createpills". I can remove that if creating empty pills is a thing.

I'm not that happy about how it looks in the Chemmaster 3000 window, but that should do for now.
