### PR TITLE
Removed environment_smash for a few hostile mobs that don't need it.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -22,6 +22,7 @@
 	health = 40
 	melee_damage_lower = 1
 	melee_damage_upper = 2
+	environment_smash = 0
 	var/datum/reagents/udder = null
 
 /mob/living/simple_animal/hostile/retaliate/goat/New()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -22,6 +22,8 @@
 	pass_flags = PASSTABLE
 	faction = "carp"
 	attack_sound = 'sound/weapons/bite.ogg'
+	environment_smash = 0
+
 
 	//Space bats need no air to fly in.
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -23,6 +23,7 @@
 	melee_damage_upper = 10
 	attacktext = "attacks"
 	attack_sound = 'sound/items/bikehorn.ogg'
+	environment_smash = 0
 
 	min_oxy = 5
 	max_oxy = 0


### PR DESCRIPTION
Pete started a one goat war on his surroundings after the hostile mob overhaul instead of just windows like he used to. He will no longer lash out as his surroundings, and can safely store your goat in a locker to remind him who's the boss around here.

Also, removes environment smash from bats and clowns.
#2735 , fixes #2724
