### PR TITLE
Fixes runtimes generated by the pai mob when it tries to click on things

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -188,6 +188,9 @@
 	src.unset_machine()
 	src:cameraFollow = null
 
+/mob/living/silicon/pai/UnarmedAttack(var/atom/A)//Stops runtimes due to attack_animal being the default
+	return
+
 //Addition by Mord_Sith to define AI's network change ability
 /*
 /mob/living/silicon/pai/proc/pai_network_change()


### PR DESCRIPTION
Evidently the default UnarmedAttack called by the on click code is attack_animal. This just makes the pAI verison return instead, stopping it from generating runtimes due to attack_animal checking for vars the pAI doesn't have.
