### PR TITLE
Fixes #1006 the invisible UI object bug

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -341,7 +341,7 @@ var/global/datum/controller/occupations/job_master
 		spawnId(H,rank)
 
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_ears)
-//		H.update_icons()
+		H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
 		return 1
 
 


### PR DESCRIPTION
This isn't a good fix, but the real fix would require massive changes to human/update_icons.dm. NOPE.avi. If you're feeling antsy, PM me.

To reproduce the problem every round, in mob.dm change update_icon = 1 to 0.
