### PR TITLE
Gives Lawyer a sec headset

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -324,6 +324,7 @@ var/global/lawyer = 0//Checks for another lawyer
 		else
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/lawyer/purpsuit(H), slot_w_uniform)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/lawyer/purpjacket(H), slot_wear_suit)
+		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/device/pda/lawyer(H), slot_belt)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/briefcase(H), slot_l_hand)


### PR DESCRIPTION
The Idea is that now lawyers will be in the loop as to what is going on in the brig. Considering most time now as lawyer is wasted begging security for the reason their client is in jail, i don't know why this wasn't done sooner.
It is also a reason to be a traitor lawyer due to legal access to sec channel.

If this gets pulled I will edit the wiki to reflect this.

As for those two PRs did by accident, my bad.
![phoenix_coffee_to_face_2](https://f.cloud.github.com/assets/6406147/2156777/1f6feafa-9467-11e3-9657-1ad1e7614bad.gif)
