### PR TITLE
Small runtime fix, job preference change before setup

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -427,6 +427,8 @@ datum/preferences
 		return 0
 
 	proc/UpdateJobPreference(mob/user, role, desiredLvl)
+		if(!job_master)
+			return
 		var/datum/job/job = job_master.GetJob(role)
 
 		if(!job)


### PR DESCRIPTION
adds a small check to see if the job controller started up before using buttons related to it and generate runtimes.

Usually these kind of new things are happening due to the amount of time that away missions take to load.
