### PR TITLE
Fix for neurotox machine gun queens

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -72,7 +72,6 @@
 	move_to_delay = 3
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
-	rapid = 1
 	status_flags = 0
 
 /mob/living/simple_animal/hostile/alien/queen/large


### PR DESCRIPTION
Alien queen npcs no longer hold spit speed record. If that's intended effect just close this.
