### PR TITLE
[DO NOT MERGE] Code effeciency project:  Removal of proc/recursive_mob_check from say code

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -167,6 +167,9 @@
 // The old system would loop through lists for a total of 5000 per function call, in an empty server.
 // This new system will loop at around 1000 in an empty server.
 
+//NOPE Recursion can go and fuck itself, we're going to find objects and mobs that can hear and then loop through known clients to see if they are inside any of those objects.
+//Leaving the above proc just incase something else in your codebase uses it, but otherwise I'm pretty sure the above proc won't run anymore.
+
 /proc/get_mobs_in_view(var/R, var/atom/source)
 	// Returns a list of mobs in range of R from source. Used in radio and say code.
 
@@ -178,17 +181,37 @@
 
 	var/list/range = hear(R, T)
 
-	for(var/atom/A in range)
-		if(ismob(A))
-			var/mob/M = A
-			if(M.client)
-				hear += M
-			//world.log << "Start = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])"
-		else if(istype(A, /obj/item/device/radio))
-			hear += A
+	for(var/mob/M in range)
+		hear += M
+		
+	var/list/objects = list()
 
-		if(isobj(A) || ismob(A))
-			hear = recursive_mob_check(A, hear, 3, 1, 0, 1)
+	for(var/obj/O in range)				//Get a list of objects in hearing range.  We'll check to see if any clients have their "eye" set to the object 
+		objects += O
+
+	var/list/hear_and_objects = (hear|objects)
+	for(var/client/C in clients)
+		if(!istype(C) || !C.eye)
+			continue   			//I have no idea when this client check would be needed, but if this runtimes people won't hear anything
+							//So kinda paranoid about runtime avoidance.
+
+
+		if(istype(C.eye, /obj/machinery/camera))
+			continue				//No microphones in cameras if you want people viewing cameras to hear through them remove this check.
+
+		if(C.mob in hear)
+			continue
+
+		if(C.eye in hear_and_objects)
+			hear += C.mob
+			hear_and_objects += C.mob
+			
+		else if(C.mob.loc in hear_and_objects)		//If a mob is inside another mob or object this will pick them up here.
+			hear += C.mob
+			hear_and_objects += C.mob
+		else if(C.mob.loc.loc in hear_and_objects)	//if a mob is inside another mob or object...that is inside another mob or object that can hear, we pick them up here.
+			hear += C.mob				//otherwise they are too deep and won't hear.
+			hear_and_objects += C.mob		//pAI in the hands of a mob, inside of a locker?  They are good.   Inside the backpack on the mob inside the locker?  Deaf.
 
 	return hear
 


### PR DESCRIPTION
Before:  Everytime someone spoke the game would calculate who was all within hearing range as well as objects.  It would then recurse through every mob and obj in that list's .contents variables for more objects and mobs looking for more objects and mobs, then recurse again, and once more.  The reason for this is so that pAI's being held aren't suddenly deaf.

After:  FUCK recursion, we're going to get a list of mobs and objects within hearing range.  Then we're going to loop through the connected clients list and see if they are within any of these objects or mobs.
