### PR TITLE
Throwforce buffs

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -190,7 +190,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/syndiecards
 	name = "Syndicate Playing Cards"
-	desc = "A special deck of murder-grade playing cards with a mono-molecular edge and metal reinforcement. They are lethal when thrown, but loose their edge very easily. \
+	desc = "A special deck of murder-grade playing cards with a mono-molecular edge and metal reinforcement. They are lethal when thrown, but lose their edge very easily. \
 	You can also play card games with them."
 	item = /obj/item/toy/cards/deck/syndicate
 	cost = 1

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -188,6 +188,14 @@ var/list/uplink_items = list()
 	if(istype(T))
 		T.TC_cost = cost
 
+/datum/uplink_item/dangerous/syndiecards
+	name = "Syndicate Playing Cards"
+	desc = "A special deck of murder-grade playing cards with a mono-molecular edge and metal reinforcement. They are lethal when thrown, but loose their edge very easily. \
+	You can also play card games with them."
+	item = /obj/item/toy/cards/deck/syndicate
+	cost = 1
+	excludefrom = list(/datum/game_mode/nuclear)
+
 // AMMUNITION
 
 /datum/uplink_item/ammo
@@ -445,14 +453,6 @@ var/list/uplink_items = list()
 	desc = "Syndicate Bundles are specialised groups of items that arrive in a plain box. These items are collectively worth more than 10 telecrystals, but you do not know which specialisation you will receive."
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 10
-	excludefrom = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/badass/syndiecards
-	name = "Syndicate Playing Cards"
-	desc = "A special deck of space-grade playing cards with a mono-molecular edge and metal reinforcement, making them lethal weapons both when wielded as a blade and when thrown. \
-	You can also play card games with them."
-	item = /obj/item/toy/cards/deck/syndicate
-	cost = 1
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/badass/balloon

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -6,7 +6,7 @@
 	w_class = 3.0
 	force = 6.0
 	m_amt = 937.5
-	throwforce = 10.0
+	throwforce = 15
 	throw_speed = 3
 	throw_range = 7
 	flags = CONDUCT

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -915,11 +915,20 @@ obj/item/toy/cards/deck/syndicate
 	deckstyle = "syndicate"
 	card_hitsound = 'sound/weapons/bladeslice.ogg'
 	card_force = 5
-	card_throwforce = 10
+	card_throwforce = 20
 	card_throw_speed = 3
 	card_throw_range = 7
 	card_attack_verb = list("attacked", "sliced", "diced", "slashed", "cut")
 
+obj/item/toy/cards/singlecard/throw_at(atom/target, range, speed, mob/user)
+	..()
+	throwforce = 0
+	force = 0
+
+obj/item/toy/cards/singlecard/attack(mob/M, mob/living/user)
+	..()
+	throwforce = 0
+	force = 0
 
 /obj/item/toy/nuke
 	name = "\improper Nuclear Fission Explosive toy"


### PR DESCRIPTION
Buffs syndie cards to @Rockdtben specifications- to do 5 force and 20 throwforce, but only for the first hit, after which they become useless.

Buffs floortiles back to 15 force as agreed with @hornygranny following the speed/range nerf.
