### PR TITLE
Fixes Golems not being able to use internals with their own face

### DIFF
--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -844,16 +844,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	item_state = "golem"
 	siemens_coefficient = 0
 	unacidable = 1
-	flags = ABSTRACT | NODROP
-
-/obj/item/clothing/mask/breath/golem
-	name = "golem's face"
-	desc = "the imposing face of an adamantine golem"
-	icon_state = "golem"
-	item_state = "golem"
-	siemens_coefficient = 0
-	unacidable = 1
-	flags = ABSTRACT | NODROP
+	flags = ABSTRACT | NODROP | MASKINTERNALS | MASKCOVERSMOUTH
 
 
 /obj/item/clothing/gloves/golem


### PR DESCRIPTION
What had happened was when ABSTRACT was introduced the golem face got its own flags, and lost the flags it usually gained from inheritance that it needed to be used as internals (MASKINTERNALS and MASKCOVERSMOUTH). It now has all the flags it used to have.

Also, for no reason, it was defined twice in the exact same manner in a row.

Fixes #2832
