### PR TITLE
Fixes some misc NODROP stuff I think

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -367,6 +367,8 @@
 					return 1
 				return 0
 			if(slot_s_store)
+				if(flags & NODROP) //Suit storage NODROP items drop if you take a suit off, this is to prevent people exploiting this.
+					return 0
 				if(H.s_store)
 					return 0
 				if(!H.wear_suit)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -344,6 +344,8 @@
 					return 0
 				return 1
 			if(slot_l_store)
+				if(flags & NODROP) //Pockets aren't visible, so you can't move NODROP items into them.
+					return 0
 				if(H.l_store)
 					return 0
 				if(!H.w_uniform)
@@ -355,6 +357,8 @@
 				if( w_class <= 2 || (slot_flags & SLOT_POCKET) )
 					return 1
 			if(slot_r_store)
+				if(flags & NODROP)
+					return 0
 				if(H.r_store)
 					return 0
 				if(!H.w_uniform)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -89,7 +89,7 @@
 
 	if(I == wear_suit)
 		if(s_store)
-			unEquip(s_store)
+			unEquip(s_store, 1) //It makes no sense for your suit storage to stay on you if you drop your suit.
 		wear_suit = null
 		update_inv_wear_suit(0)
 	else if(I == w_uniform)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -94,9 +94,9 @@
 		update_inv_wear_suit(0)
 	else if(I == w_uniform)
 		if(r_store)
-			unEquip(r_store)
+			unEquip(r_store, 1) //Again, makes sense for pockets to drop.
 		if(l_store)
-			unEquip(l_store)
+			unEquip(l_store, 1)
 		if(wear_id)
 			unEquip(wear_id)
 		if(belt)


### PR DESCRIPTION
I actually tested this.

NODROP clothing in your hands can now be put into clothing slots (but not pockets or suit storage)
NODROP items on your suit storage will drop when you take the suit storage off because it makes sense.

Apparently you could already put on NODROP clothes and I had no idea.

You can't put NODROP items in your pockets, either. They do drop when you take off your jumpsuit, though. IDs and belts don't drop when you take off your jumpsuit.
