### PR TITLE
Firefighting crates

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -105,6 +105,24 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	containername = "internals crate"
 
+/datum/supply_packs/emergency/firefighting
+	name = "Firefighting Crate"
+	contains = list(/obj/item/clothing/suit/fire/firefighter,
+					/obj/item/clothing/suit/fire/firefighter,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/gas,
+					/obj/item/device/flashlight,
+					/obj/item/device/flashlight,
+					/obj/item/weapon/tank/oxygen/red,
+					/obj/item/weapon/tank/oxygen/red,
+					/obj/item/weapon/extinguisher,
+					/obj/item/weapon/extinguisher,
+					/obj/item/clothing/head/hardhat/red,
+					/obj/item/clothing/head/hardhat/red)
+	cost = 10
+	containertype = /obj/structure/closet/crate
+	containername = "firefighting crate"
+
 /datum/supply_packs/emergency/weedcontrol
 	name = "Weed Control Crate"
 	contains = list(/obj/item/weapon/scythe,


### PR DESCRIPTION
In case of plasma infernos or incendiary shootouts you can now order firefighting crates via Cargo which contain two sets of the contents within fire safety closets that are on short supply aboard the station. They are located in the emergency section on supply consoles and cost 10 supply points.
