### PR TITLE
Buffed Lamarr at laser tag

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -55,11 +55,13 @@ var/const/MAX_ACTIVE_TIME = 400
 	return
 
 /obj/item/clothing/mask/facehugger/attackby(var/obj/item/O,var/mob/m)
-	if(O.force) Die()
+	if(O.force)
+		Die()
 	return
 
 /obj/item/clothing/mask/facehugger/bullet_act(var/obj/item/projectile/P)
-	if(P.damage) Die()
+	if(P.damage)
+		Die()
 	return
 
 /obj/item/clothing/mask/facehugger/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -54,12 +54,12 @@ var/const/MAX_ACTIVE_TIME = 400
 		usr << "\red \b It looks like the proboscis has been removed."
 	return
 
-/obj/item/clothing/mask/facehugger/attackby()
-	Die()
+/obj/item/clothing/mask/facehugger/attackby(var/obj/item/O,var/mob/m)
+	if(O.force) Die()
 	return
 
-/obj/item/clothing/mask/facehugger/bullet_act()
-	Die()
+/obj/item/clothing/mask/facehugger/bullet_act(var/obj/item/projectile/P)
+	if(P.damage) Die()
 	return
 
 /obj/item/clothing/mask/facehugger/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)


### PR DESCRIPTION
Facehuggers no longer die to zero-damage weapons and projectiles, like
pens and laser tag beams.
