### PR TITLE
No more getting stuck in the wall

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -27,6 +27,8 @@
 	src.loc = loc
 	src.target = target
 	src.creator = creator
+	for(var/mob/M in src.loc)
+		src.teleport(M)
 	if(lifespan > 0)
 		spawn(lifespan)
 			del(src)


### PR DESCRIPTION
If a hand teleporter portal is forced to spawn on top of you (meaning you're completely encased in impassible material) you will automatically teleport with it.

Previously if this happened to you even if you had the tele you had no way of actually using it as the portal checks only for entering the square, not already being there.
