### PR TITLE
Modifies how far a corpse has to be from a blob for zombies to occur.

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -79,7 +79,7 @@
 /mob/living/simple_animal/hostile/blobspore/Life()
 
 	if(!is_zombie && isturf(src.loc))
-		for(var/mob/living/carbon/human/H in src.loc) //Only for people in the same tile
+		for(var/mob/living/carbon/human/H in oview(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == DEAD)
 				Zombify(H)
 				break


### PR DESCRIPTION
Initially it was bugged to be anywhere in the same area.
Then it was only the tile under the blob.
Now, thanks to standing corpses and rally spores not always rallying a spore to the exact place you click, it's the same tile or one tile adjacent.
