### PR TITLE
Changeling scaling coefficient configuration

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -75,7 +75,7 @@
 	var/allow_ai = 0					// allow ai job
 
 	var/traitor_scaling_coeff = 6		//how much does the amount of players get divided by to determine traitors
-	var/changeling_scaling_coeff = 10	//how much does the amount of players get divided by to determine changelings
+	var/changeling_scaling_coeff = 7	//how much does the amount of players get divided by to determine changelings
 
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
 	var/allow_latejoin_antagonists = 0 // If late-joining players can be traitor/changeling

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -102,7 +102,7 @@ PROBABILITY SANDBOX 0
 ## Used as (Antagonists = Population / Coeff)
 ## Set to 0 to disable scaling and use default numbers instead.
 TRAITOR_SCALING_COEFF 6
-CHANGELING_SCALING_COEFF 10
+CHANGELING_SCALING_COEFF 7
 
 ## Uncomment to prohibit jobs that start with loyalty
 ## implants from being most antagonists.


### PR DESCRIPTION
Changed the default number of changeling scaling coefficient from 10 to 7 in the configuration files.

I know it's a configuration but I feel like due to the changes on changelings (honk) they became more passive and this default number should be changed.
