### PR TITLE
Flashbang twerks

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -7,95 +7,73 @@
 
 /obj/item/weapon/grenade/flashbang/prime()
 	update_mob()
-	for(var/obj/structure/closet/L in view(get_turf(src), null))
-		if(locate(/mob/living/carbon/, L))
-			for(var/mob/living/carbon/M in L)
-				bang(get_turf(src), M)
+	var/flashbang_turf = get_turf(src)
+	for(var/obj/structure/closet/L in view(7, flashbang_turf))
+		for(var/mob/living/M in L)
+			bang(get_turf(M), M)
 
+	for(var/mob/living/M in view(7, flashbang_turf))
+		bang(get_turf(M), M)
 
-	for(var/mob/living/carbon/M in viewers(get_turf(src), null))
-		bang(get_turf(src), M)
-
-	for(var/obj/effect/blob/B in view(8,get_turf(src)))       		//Blob damage here
+	for(var/obj/effect/blob/B in view(8,flashbang_turf))     		//Blob damage here
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
 		B.update_icon()
 	del(src)
 
-/obj/item/weapon/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/carbon/M)
-	// Added a new proc called 'bang' that takes a location and a person to be banged.
-	// Called during the loop that bangs people in lockers/containers and when banging
-	// people in normal view.  Could theroetically be called during other explosions.
-	// -- Polymorph
-	M << "\red <B>BANG</B>"
+/obj/item/weapon/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/M)
+	M << "<span class='warning'>BANG</span>"
 	playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 
 //Checking for protections
 	var/eye_safety = 0
-	var/ear_safety = 0
+	var/ear_safety = 2
+	var/distance = max(1, get_dist(src, T))
+	var/takes_eye_damage = 0
 	if(iscarbon(M))
-		eye_safety = M.eyecheck()
-		if(ishuman(M))
-			if(istype(M:ears, /obj/item/clothing/ears/earmuffs))
-				ear_safety += 2
-			if(HULK in M.mutations)
-				ear_safety += 1
-			if(istype(M:head, /obj/item/clothing/head/helmet))
-				ear_safety += 1
+		var/mob/living/carbon/C = M
+		eye_safety = C.eyecheck()
+		if(ishuman(C))
+			takes_eye_damage = 1
+			var/mob/living/carbon/human/H = C
+			ear_safety = 0
+			if(istype(H.ears, /obj/item/clothing/ears/earmuffs) || istype(H.head, /obj/item/clothing/head/helmet))
+				ear_safety++
+		if(ismonkey(C))
+			ear_safety = 0
+			takes_eye_damage = 1
 
-//Flashing everyone
+//Flash
 	if(eye_safety < 1)
 		flick("e_flash", M.flash)
 		M.eye_stat += rand(1, 3)
-		M.Stun(2)
-		M.Weaken(5)
-
-
-
-//Now applying sound
-	if((get_dist(M, T) <= 2 || src.loc == M.loc || src.loc == M))
-		if(ear_safety > 0)
-			M.Stun(2)
-			M.Weaken(1)
+		M.Stun(max(10/distance, 3))
+		M.Weaken(max(10/distance, 3))
+		if (M.eye_stat >= 20 && takes_eye_damage)
+			M << "<span class='warning'>Your eyes start to burn badly!</span>"
+			M.disabilities |= NEARSIGHTED
+			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+				if (prob(M.eye_stat - 20 + 1))
+					M << "<span class='warning'>You can't see anything!</span>"
+					M.sdisabilities |= BLIND
+//Bang
+	if((src.loc == M) || src.loc == M.loc)//Holding on person or being exactly where lies is significantly more dangerous and voids protection
+		M.Stun(10)
+		M.Weaken(10)
+	if(!ear_safety)
+		M.Stun(max(10/distance, 3))
+		M.Weaken(max(10/distance, 3))
+		M.ear_damage += rand(0, 5)
+		M.ear_deaf = max(M.ear_deaf,15)
+		if (M.ear_damage >= 15)
+			M << "<span class='warning'>Your ears start to ring badly!</span>"
+			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+				if (prob(M.ear_damage - 10 + 5))
+					M << "<span class='warning'>You can't hear anything!</span>"
+					M.sdisabilities |= DEAF
 		else
-			M.Stun(5)
-			M.Weaken(3)
-			if ((prob(14) || (M == src.loc && prob(70))))
-				M.ear_damage += rand(1, 10)
-			else
-				M.ear_damage += rand(0, 5)
-				M.ear_deaf = max(M.ear_deaf,15)
-
-	else if(get_dist(M, T) <= 5)
-		if(!ear_safety)
-			M.Stun(8)
-			M.ear_damage += rand(0, 3)
-			M.ear_deaf = max(M.ear_deaf,10)
-
-	else if(!ear_safety)
-		M.Stun(4)
-		M.ear_damage += rand(0, 1)
-		M.ear_deaf = max(M.ear_deaf,5)
-
-//This really should be in mob not every check
-	if (M.eye_stat >= 20)
-		M << "\red Your eyes start to burn badly!"
-		M.disabilities |= NEARSIGHTED
-		if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-			if (prob(M.eye_stat - 20 + 1))
-				M << "\red You can't see anything!"
-				M.sdisabilities |= BLIND
-	if (M.ear_damage >= 15)
-		M << "\red Your ears start to ring badly!"
-		if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
-			if (prob(M.ear_damage - 10 + 5))
-				M << "\red You can't hear anything!"
-				M.sdisabilities |= DEAF
-	else
-		if (M.ear_damage >= 5)
-			M << "\red Your ears start to ring!"
-	M.update_icons()
-
+			if (M.ear_damage >= 5)
+				M << "<span class='warning'>Your ears start to ring!</span>"
 
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."


### PR DESCRIPTION
-Flashbangs will now stun borgs.
-If you are holding the flashbang on your person when it detonates, or are in the exact tile that the flashbang is on when it detonates, your eye/ear protection is void and you take a significantly longer stun than you would otherwise.
-Flashbangs have a better falloff check than they did previously. 10 on the tile its on, 5 on the tile next to it, 3 everywhere else.
-Added span classes because I know someone will yell at me otherwise
