### PR TITLE
Cyborg light replacer recharging bugfix

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -189,7 +189,7 @@
 				if(istype(O, /obj/item/device/lightreplacer))
 					var/obj/item/device/lightreplacer/LR = O
 					var/i = 1
-					for(1, i < coeff, i++)
+					for(1, i <= coeff, i++)
 						LR.Charge(occupier)
 
 			if(occupier)


### PR DESCRIPTION
The janitor borg light replacers will now recharge in a non-upgraded cyborg recharger.
