### PR TITLE
Corrects credit-giving in changelog

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -55,7 +55,7 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
 <div class='commit sansserif'>
 	<h2 class='date'>5 march 2014</h2>
-	<h3 class='author'>Drynwyn updated:</h3>
+	<h3 class='author'>Various Coders updated:</h3>
 	<ul class='changes bgimages16'>
 		<li class='rscadd'>Ling rounds are LINGIER, with more lings at a given population.</li>
 		<li class='rscadd'>Many simple animals can ventcrawl, including bats. All ventcrawlers must alt-click to ventcrawl. </li>


### PR DESCRIPTION
Changes credit-giving in changelog from the updater to "various coders." Numbers merged the other one before I could correct it.
