### PR TITLE
Linda var removal

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -95,7 +95,7 @@
 		return
 
 	if(location.excited_group)
-		location.excited_group.breakdown = 0
+		location.excited_group.reset_cooldowns()
 
 	if((temperature < FIRE_MINIMUM_TEMPERATURE_TO_EXIST) || (volume <= 1))
 		Kill()

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -287,7 +287,6 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 
 /datum/excited_group
 	var/list/turf_list = list()
-	var/breakdown = 0
 	var/breakdown_cooldown = 0
 
 /datum/excited_group/New()


### PR DESCRIPTION
Removes a now useless var from the atmos excited groups and makes hotspots use the correct proc to reset the breakdown cooldown
