### PR TITLE
Vending refill runtimes fix

### DIFF
--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -17,7 +17,7 @@
 /obj/item/weapon/vending_refill/New(amt = -1)
 	..()
 	name = "\improper [machine_name] restocking unit"
-	if(amt > -1)
+	if(isnum(amt) && amt > -1)
 		charges = amt
 
 /obj/item/weapon/vending_refill/examine()


### PR DESCRIPTION
the vending refill objects won't runtime anymore at roundstart if they were placed in the map
