### PR TITLE
Reload admins usable by anyone with adminrank

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -12,7 +12,8 @@ var/list/admin_verbs_default = list(
 	/client/proc/toggleprayers,			/*toggles prayers on/off*/
 	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
-	/client/proc/secrets
+	/client/proc/secrets,
+	/client/proc/reload_admins
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/player_panel,			/*shows an interface for all players, with links to various panels (old style)*/
@@ -109,7 +110,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_debug_mob_lists,
 	/client/proc/cmd_admin_delete,
 	/client/proc/cmd_debug_del_all,
-	/client/proc/reload_admins,
 	/client/proc/restart_controller,
 	/client/proc/enable_debug_verbs,
 	/client/proc/callproc

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -87,9 +87,9 @@
 
 /client/proc/reload_admins()
 	set name = "Reload Admins"
-	set category = "Debug"
+	set category = "Admin"
 
-	if(!check_rights(R_SERVER))	return
+	if(!src.holder)	return
 
 	message_admins("[key_name_admin(usr)] manually reloaded admins")
 	load_admins()


### PR DESCRIPTION
Because it's really annoying to be a trialmin/coder/observer with a de-adminned game master and no way to get them back if they're needed.
