### PR TITLE
Fixes #3022

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -1,4 +1,3 @@
-
 ////////////////////////////////////////////////////////////////////////////////
 /// (Mixing)Glass.
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,8 +84,11 @@
 			var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 			user << "<span class='notice'>You transfer [trans] unit\s of the solution to [target].</span>"
 
-		//Safety for dumping stuff into a ninja suit. It handles everything through attackby() and this is unnecessary.	//gee thanks noize
+		//Safety for dumping stuff into ninja suits or hydroponics trays. They handle everything through attackby() and this is unnecessary.	//gee thanks noize
 		else if(istype(target, /obj/item/clothing/suit/space/space_ninja))
+			return
+		
+		else if(istype(target, /obj/machinery/hydroponics))
 			return
 
 		else if(reagents.total_volume)


### PR DESCRIPTION
Fixes #3022
Nutrient bottles being left behind are a feature as they're now reagent containers.
This fixes the issue of splashing any reagents left over in the container after transfer.
