### PR TITLE
Hydroponics fixes, #2992, #3002, chemicals, attackby()

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -20,14 +20,12 @@
 	icon = 'icons/obj/harvest.dmi'
 	potency = -1
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/New(newloc,newpotency)
-	if (!isnull(newpotency))
-		potency = newpotency
+/obj/item/weapon/reagent_containers/food/snacks/grown/New(newloc, newpotency = 50)
 	..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
-	transform *= TransformUsingVariable(potency, 100, 0.5) //Makes the resulting produce's sprite larger or smaller based on potency!
+	transform *= TransformUsingVariable(newpotency, 100, 0.5) //Makes the resulting produce's sprite larger or smaller based on potency!
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attackby(var/obj/item/O as obj, var/mob/user as mob)
@@ -84,11 +82,10 @@
 	trash = /obj/item/weapon/grown/corncob
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment",1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherries
 	seed = "/obj/item/seeds/cherryseed"
@@ -97,12 +94,11 @@
 	icon_state = "cherry"
 	gender = PLURAL
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/cherries
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 15), 1))
-			reagents.add_reagent("sugar", 1+round((potency / 15), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 15), 1))
+		reagents.add_reagent("sugar", 1+round((potency / 15), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/poppy
 	seed = "/obj/item/seeds/poppyseed"
@@ -112,12 +108,11 @@
 	slot_flags = SLOT_HEAD
 	potency = 30
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/poppy
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			reagents.add_reagent("bicaridine", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 3, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		reagents.add_reagent("bicaridine", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 3, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
 	seed = "obj/item/seeds/harebellseed"
@@ -127,11 +122,10 @@
 	slot_flags = SLOT_HEAD
 	potency = 1
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 3, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 3, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato
 	seed = "/obj/item/seeds/potatoseed"
@@ -140,11 +134,10 @@
 	icon_state = "potato"
 	potency = 25
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/potato
-	New()
+	New(var/loc, var/potency = 10)
 		..()
 		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			bitesize = reagents.total_volume
+		bitesize = reagents.total_volume
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
@@ -165,12 +158,11 @@
 	desc = "Nutritious!"
 	icon_state = "grapes"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/no_raisin
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			reagents.add_reagent("sugar", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("sugar", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/greengrapes
 	seed = "/obj/item/seeds/greengrapeseed"
@@ -179,12 +171,11 @@
 	icon_state = "greengrapes"
 	potency = 25
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/no_raisin
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			reagents.add_reagent("kelotane", 3+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("kelotane", 3+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cabbage
 	seed = "/obj/item/seeds/cabbageseed"
@@ -193,11 +184,10 @@
 	icon_state = "cabbage"
 	potency = 25
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/cabbage
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = reagents.total_volume
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = reagents.total_volume
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries
 	seed = "/obj/item/seeds/berryseed"
@@ -205,11 +195,10 @@
 	desc = "Nutritious!"
 	icon_state = "berrypile"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/berries
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/glowberries
 	seed = "/obj/item/seeds/glowberryseed"
@@ -219,12 +208,11 @@
 	var/brightness_on = 2 //luminosity when on
 	icon_state = "glowberrypile"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/glowberries
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", round((potency / 10), 1))
-			reagents.add_reagent("uranium", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", round((potency / 10), 1))
+		reagents.add_reagent("uranium", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/glowberries/Del()
 	if(istype(loc,/mob))
@@ -246,12 +234,11 @@
 	icon_state = "cocoapod"
 	potency = 50
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/cocoapod
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			reagents.add_reagent("coco", 4+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("coco", 4+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/sugarcane
 	seed = "/obj/item/seeds/sugarcaneseed"
@@ -260,10 +247,9 @@
 	icon_state = "sugarcane"
 	potency = 50
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/sugarcane
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("sugar", 4+round((potency / 5), 1))
+		reagents.add_reagent("sugar", 4+round((potency / 5), 1))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/poisonberries
 	seed = "/obj/item/seeds/poisonberryseed"
@@ -273,12 +259,11 @@
 	gender = PLURAL
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/poisonberries
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("toxin", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("toxin", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/deathberries
 	seed = "/obj/item/seeds/deathberryseed"
@@ -288,13 +273,12 @@
 	gender = PLURAL
 	potency = 50
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/deathberries
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("toxin", 3+round(potency / 3, 1))
-			reagents.add_reagent("lexorin", 1+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("toxin", 3+round(potency / 3, 1))
+		reagents.add_reagent("lexorin", 1+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris
 	seed = "/obj/item/seeds/ambrosiavulgaris"
@@ -304,15 +288,14 @@
 	slot_flags = SLOT_HEAD
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("space_drugs", 1+round(potency / 8, 1))
-			reagents.add_reagent("kelotane", 1+round(potency / 8, 1))
-			reagents.add_reagent("bicaridine", 1+round(potency / 10, 1))
-			reagents.add_reagent("toxin", 1+round(potency / 10, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("space_drugs", 1+round(potency / 8, 1))
+		reagents.add_reagent("kelotane", 1+round(potency / 8, 1))
+		reagents.add_reagent("bicaridine", 1+round(potency / 10, 1))
+		reagents.add_reagent("toxin", 1+round(potency / 10, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus
 	seed = "/obj/item/seeds/ambrosiadeus"
@@ -322,15 +305,14 @@
 	slot_flags = SLOT_HEAD
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("bicaridine", 1+round(potency / 8, 1))
-			reagents.add_reagent("synaptizine", 1+round(potency / 8, 1))
-			reagents.add_reagent("hyperzine", 1+round(potency / 10, 1))
-			reagents.add_reagent("space_drugs", 1+round(potency / 10, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("bicaridine", 1+round(potency / 8, 1))
+		reagents.add_reagent("synaptizine", 1+round(potency / 8, 1))
+		reagents.add_reagent("hyperzine", 1+round(potency / 10, 1))
+		reagents.add_reagent("space_drugs", 1+round(potency / 10, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple
 	seed = "/obj/item/seeds/appleseed"
@@ -339,12 +321,11 @@
 	icon_state = "apple"
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/apple
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.maximum_volume = 20
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = reagents.maximum_volume // Always eat the apple in one
+		reagents.maximum_volume = 20
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = reagents.maximum_volume // Always eat the apple in one
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
 	seed = "/obj/item/seeds/poisonedappleseed"
@@ -353,12 +334,11 @@
 	icon_state = "apple"
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.maximum_volume = 20
-			reagents.add_reagent("cyanide", 1+round((potency / 5), 1))
-			bitesize = reagents.maximum_volume // Always eat the apple in one
+		reagents.maximum_volume = 20
+		reagents.add_reagent("cyanide", 1+round((potency / 5), 1))
+		bitesize = reagents.maximum_volume // Always eat the apple in one
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/goldapple
 	seed = "/obj/item/seeds/goldappleseed"
@@ -367,12 +347,11 @@
 	icon_state = "goldapple"
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/goldapple
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			reagents.add_reagent("gold", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("gold", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/goldapple/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -388,11 +367,10 @@
 	potency = 10
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/watermelonslice
 	slices_num = 5
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 6), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 6), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin
 	seed = "/obj/item/seeds/pumpkinseed"
@@ -401,11 +379,10 @@
 	icon_state = "pumpkin"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 6), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 6), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -423,11 +400,10 @@
 	icon_state = "lime"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/lime
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/lemon
 	seed = "/obj/item/seeds/lemonseed"
@@ -436,11 +412,10 @@
 	icon_state = "lemon"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/lemon
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/orange
 	seed = "/obj/item/seeds/orangeseed"
@@ -449,11 +424,10 @@
 	icon_state = "orange"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/orange
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/whitebeet
 	seed = "/obj/item/seeds/whitebeetseed"
@@ -462,12 +436,11 @@
 	icon_state = "whitebeet"
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/whitebeet
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", round((potency / 20), 1))
-			reagents.add_reagent("sugar", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", round((potency / 20), 1))
+		reagents.add_reagent("sugar", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana
 	seed = "/obj/item/seeds/bananaseed"
@@ -479,11 +452,10 @@
 	trash = /obj/item/weapon/grown/bananapeel
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/banana
 
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("banana", 1+round((potency / 10), 1))
-			bitesize = 5
+		reagents.add_reagent("banana", 1+round((potency / 10), 1))
+		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/chili
 	seed = "/obj/item/seeds/chiliseed"
@@ -491,12 +463,11 @@
 	desc = "It's spicy! Wait... IT'S BURNING ME!!"
 	icon_state = "chilipepper"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/chili
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
-			reagents.add_reagent("capsaicin", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
+		reagents.add_reagent("capsaicin", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/chili/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -510,13 +481,12 @@
 	icon_state = "ghostchilipepper"
 	var/mob/held_mob
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chilli
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
-			reagents.add_reagent("capsaicin", 8+round(potency / 2, 1))
-			reagents.add_reagent("condensedcapsaicin", 4+round(potency / 4, 1))
-			bitesize = 1+round(reagents.total_volume / 4, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
+		reagents.add_reagent("capsaicin", 8+round(potency / 2, 1))
+		reagents.add_reagent("condensedcapsaicin", 4+round(potency / 4, 1))
+		bitesize = 1+round(reagents.total_volume / 4, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chilli/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -547,11 +517,10 @@
 	desc = "Maybe there's a chicken inside?"
 	icon_state = "eggplant"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/eggplant
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/soybeans
 	seed = "/obj/item/seeds/soyaseed"
@@ -560,11 +529,10 @@
 	gender = PLURAL
 	icon_state = "soybeans"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/soybeans
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans
 	seed = "/obj/item/seeds/koiseed"
@@ -572,12 +540,11 @@
 	desc = "Something about these seems fishy."
 	icon_state = "koibeans"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 30), 1))
-			reagents.add_reagent("carpotoxin", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 30), 1))
+		reagents.add_reagent("carpotoxin", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/moonflower
 	seed = "/obj/item/seeds/moonflowerseed"
@@ -585,12 +552,11 @@
 	desc = "Store in a location at least 50 yards away from werewolves."
 	icon_state = "moonflower"
 	slot_flags = SLOT_HEAD
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			reagents.add_reagent("moonshine", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		reagents.add_reagent("moonshine", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato
 	seed = "/obj/item/seeds/tomatoseed"
@@ -599,11 +565,10 @@
 	icon_state = "tomato"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/tomato
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 	throw_impact(atom/hit_atom)
 		..()
@@ -618,11 +583,10 @@
 	desc = "I say to-mah-to, you say tom-mae-to... OH GOD IT'S EATING MY LEGS!!"
 	icon_state = "killertomato"
 	potency = 10
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/killertomato/attack_self(mob/user as mob)
 	if(istype(user.loc,/turf/space))
@@ -639,12 +603,11 @@
 	icon_state = "bloodtomato"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/bloodtomato
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
-			reagents.add_reagent("blood", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 10), 1))
+		reagents.add_reagent("blood", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bloodtomato/throw_impact(atom/hit_atom)
 	..()
@@ -663,12 +626,11 @@
 	icon_state = "bluetomato"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			reagents.add_reagent("lube", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		reagents.add_reagent("lube", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato/throw_impact(atom/hit_atom)
 	..()
@@ -699,22 +661,20 @@
 	gender = PLURAL
 	icon_state = "wheat"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/wheat
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grass
 	seed = "/obj/item/seeds/grassseed"
 	name = "grass"
 	desc = "Green and lush."
 	icon_state = "grassclump"
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grass/attack_self(mob/user as mob)
 	user << "<span class='notice'>You prepare the astroturf.</span>"
@@ -732,12 +692,11 @@
 	name = "kudzu pod"
 	desc = "<I>Pueraria Virallis</I>: An invasive species with vines that rapidly creep and wrap around whatever they contact."
 	icon_state = "kudzupod"
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			reagents.add_reagent("anti_toxin", 1+round((potency / 25), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		reagents.add_reagent("anti_toxin", 1+round((potency / 25), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper
 	seed = "/obj/item/seeds/icepepperseed"
@@ -746,12 +705,11 @@
 	icon_state = "icepepper"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			reagents.add_reagent("frostoil", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		reagents.add_reagent("frostoil", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -765,12 +723,11 @@
 	icon_state = "carrot"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/carrot
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			reagents.add_reagent("imidazoline", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		reagents.add_reagent("imidazoline", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi
 	seed = "/obj/item/seeds/reishimycelium"
@@ -779,13 +736,12 @@
 	icon_state = "reishi"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("anti_toxin", 3+round(potency / 3, 1))
-			reagents.add_reagent("stoxin", 3+round(potency / 3, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("anti_toxin", 3+round(potency / 3, 1))
+		reagents.add_reagent("stoxin", 3+round(potency / 3, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -800,13 +756,12 @@
 	icon_state = "amanita"
 	potency = 10
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/amanita
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("amatoxin", 3+round(potency / 3, 1))
-			reagents.add_reagent("mushroomhallucinogen", 1+round(potency / 25, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("amatoxin", 3+round(potency / 3, 1))
+		reagents.add_reagent("mushroomhallucinogen", 1+round(potency / 25, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/amanita/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -821,13 +776,12 @@
 	icon_state = "angel"
 	potency = 35
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/angel
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			reagents.add_reagent("amatoxin", 13+round(potency / 3, 1))
-			reagents.add_reagent("mushroomhallucinogen", 1+round(potency / 25, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		reagents.add_reagent("amatoxin", 13+round(potency / 3, 1))
+		reagents.add_reagent("mushroomhallucinogen", 1+round(potency / 25, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/angel/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -842,12 +796,11 @@
 	icon_state = "libertycap"
 	potency = 15
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/libertycap
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
-			reagents.add_reagent("mushroomhallucinogen", 3+round(potency / 5, 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 50), 1))
+		reagents.add_reagent("mushroomhallucinogen", 3+round(potency / 5, 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/libertycap/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	. = ..()
@@ -860,22 +813,20 @@
 	desc = "<I>Plumus Hellmus</I>: Plump, soft and s-so inviting~"
 	icon_state = "plumphelmet"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/plumphelmet
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 2+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 2+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/walkingmushroom
 	seed = "/obj/item/seeds/walkingmushroom"
 	name = "walking mushroom"
 	desc = "<I>Plumus Locomotus</I>: The beginning of the great walk."
 	icon_state = "walkingmushroom"
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 2+round((potency / 10), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 2+round((potency / 10), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/walkingmushroom/attack_self(mob/user as mob)
 	if(istype(user.loc,/turf/space))
@@ -896,11 +847,10 @@
 	desc = "<I>Cantharellus Cibarius</I>: These jolly yellow little shrooms sure look tasty!"
 	icon_state = "chanterelle"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/chanterelle
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 25), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom
 	seed = "/obj/item/seeds/glowshroom"
@@ -908,7 +858,7 @@
 	desc = "<I>Mycena Bregprox</I>: This species of mushroom glows in the dark."
 	icon_state = "glowshroom"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom
-	New()
+	New(var/loc, var/potency = 10)
 		..()
 		if(lifespan == 0) //basically, if you're spawning these via admin or on the map, then set up some default stats.
 			lifespan = 120
@@ -916,10 +866,10 @@
 			maturation = 15
 			production = 1
 			yield = 3
+			src.potency = 30
 			potency = 30
 			plant_type = 2
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("radium", 1+round((potency / 20), 1))
+		reagents.add_reagent("radium", 1+round((potency / 20), 1))
 		if(istype(src.loc,/mob))
 			pickup(src.loc)//adjusts the lighting on the mob
 		else
@@ -958,7 +908,7 @@
 	desc = "Green and lush."
 	icon_state = "spawner"
 	potency = 10
-	New()
+	New(var/loc, var/potency = 10)
 		..()
 		switch(potency)
 			if(0 to 10)
@@ -988,12 +938,11 @@
 	potency = 20
 	origin_tech = "bluespace=3"
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacetomato
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
-			reagents.add_reagent("singulo", 1+round((potency / 5), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("nutriment", 1+round((potency / 20), 1))
+		reagents.add_reagent("singulo", 1+round((potency / 5), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/gatfruit
 	seed = "/obj/item/seeds/gatfruit"
@@ -1003,14 +952,13 @@
 	potency = 60
 	origin_tech = "combat=3"
 	trash = /obj/item/weapon/gun/projectile/revolver
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("sulfur", 1+round((potency / 10), 1))
-			reagents.add_reagent("carbon", 1+round((potency / 10), 1))
-			reagents.add_reagent("nitrogen", 1+round((potency / 15), 1))
-			reagents.add_reagent("potassium", 1+round((potency / 20), 1))
-			bitesize = 1+round(reagents.total_volume / 2, 1)
+		reagents.add_reagent("sulfur", 1+round((potency / 10), 1))
+		reagents.add_reagent("carbon", 1+round((potency / 10), 1))
+		reagents.add_reagent("nitrogen", 1+round((potency / 15), 1))
+		reagents.add_reagent("potassium", 1+round((potency / 20), 1))
+		bitesize = 1+round(reagents.total_volume / 2, 1)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/coffee_arabica
@@ -1020,10 +968,9 @@
 	icon_state = "coffee_arabica"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/coffee_arabica
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("coffeepowder", 1+round((potency / 10), 2))
+		reagents.add_reagent("coffeepowder", 1+round((potency / 10), 2))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/coffee_robusta
 	seed = "/obj/item/seeds/coffee_robusta_seed"
@@ -1032,11 +979,10 @@
 	icon_state = "coffee_robusta"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/coffee_robusta
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("coffeepowder", 1+round((potency / 10), 2))
-			reagents.add_reagent("hyperzine", 1+round((potency / 20), 1))
+		reagents.add_reagent("coffeepowder", 1+round((potency / 10), 2))
+		reagents.add_reagent("hyperzine", 1+round((potency / 20), 1))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco
 	seed = "/obj/item/seeds/tobacco_seed"
@@ -1054,10 +1000,9 @@
 	icon_state = "stobacco_leaves"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco_space
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("dexalin", 1+round((potency / 20), 1))
+		reagents.add_reagent("dexalin", 1+round((potency / 20), 1))
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tea_aspera
@@ -1067,10 +1012,9 @@
 	icon_state = "tea_aspera_leaves"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/tea_aspera
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("teapowder", 1+round((potency / 10), 2))
+		reagents.add_reagent("teapowder", 1+round((potency / 10), 2))
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tea_astra
@@ -1080,8 +1024,7 @@
 	icon_state = "tea_astra_leaves"
 	potency = 20
 	dried_type = /obj/item/weapon/reagent_containers/food/snacks/grown/tea_astra
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("teapowder", 1+round((potency / 10), 2))
-			reagents.add_reagent("kelotane", 1+round((potency / 20), 1))
+		reagents.add_reagent("teapowder", 1+round((potency / 10), 2))
+		reagents.add_reagent("kelotane", 1+round((potency / 20), 1))

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -17,8 +17,6 @@
 	var/plant_type = 0
 
 /obj/item/weapon/grown/New(newloc,newpotency)
-	if (!isnull(newpotency))
-		potency = newpotency
 	..()
 	pixel_x = rand(-5.0, 5)
 	pixel_y = rand(-5.0, 5)
@@ -113,12 +111,11 @@
 	plant_type = 0
 	seed = "/obj/item/seeds/novaflower"
 	attack_verb = list("seared", "heated", "whacked", "steamed")
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("capsaicin", round(potency, 1))
-			force = round((5+potency/5), 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("capsaicin", round(potency, 1))
+		force = round((5+potency/5), 1)
 
 /obj/item/weapon/grown/nettle // -- Skie
 	desc = "It's probably <B>not</B> wise to touch it with bare hands..."
@@ -135,12 +132,11 @@
 	plant_type = 1
 	origin_tech = "combat=1"
 	seed = "/obj/item/seeds/nettleseed"
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("sacid", round(potency, 1))
-			force = round((5+potency/5), 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("sacid", round(potency, 1))
+		force = round((5+potency/5), 1)
 
 /obj/item/weapon/grown/deathnettle // -- Skie
 	desc = "The \red glowing \black nettle incites \red<B> rage</B>\black in you just from looking at it!"
@@ -158,12 +154,11 @@
 	seed = "/obj/item/seeds/deathnettleseed"
 	origin_tech = "combat=3"
 	attack_verb = list("stung")
-	New()
+	New(var/loc, var/potency = 10)
 		..()
-		spawn(5)	//So potency can be set in the proc that creates these crops
-			reagents.add_reagent("nutriment", 1)
-			reagents.add_reagent("pacid", round(potency, 1))
-			force = round((5+potency/2.5), 1)
+		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("pacid", round(potency, 1))
+		force = round((5+potency/2.5), 1)
 
 	suicide_act(mob/user)
 		viewers(user) << "<span class='suicide'>[user] is eating some of the [src.name]! It looks like \he's trying to commit suicide.</span>"

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -96,7 +96,7 @@
 	icon_state = "bottle16"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("eznutriment", 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/nutrient/l4z
 	name = "bottle of Left 4 Zed"
@@ -104,8 +104,7 @@
 	icon_state = "bottle18"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 28)
-		reagents.add_reagent("radium", 2)
+		reagents.add_reagent("left4zednutriment", 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/nutrient/rh
 	name = "bottle of Robust Harvest"
@@ -113,5 +112,4 @@
 	icon_state = "bottle15"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("diethylamine", 10)
+		reagents.add_reagent("robustharvestnutriment", 30)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -404,13 +404,13 @@ obj/machinery/hydroponics/proc/applyChemicals(var/datum/reagents/S)
 	// Requires 5 mutagen to possibly change species.// Poor man's mutagen.
 	if(S.has_reagent("mutagen", 5) || S.has_reagent("radium", 10) || S.has_reagent("uranium", 10))
 		switch(rand(100))
-			if(91  to 100)	plantdies()
-			if(81  to 90)	mutatespecie()
-			if(66	to 80)	hardmutate()
-			if(41  to 65)	mutate()
-			if(21  to 41)	usr << "The plants don't seem to react..."
-			if(11	to 20)	mutateweed()
-			if(1   to 10)	mutatepest()
+			if(91 to 100)	plantdies()
+			if(81 to 90)	mutatespecie()
+			if(66 to 80)	hardmutate()
+			if(41 to 65)	mutate()
+			if(21 to 41)	usr << "The plants don't seem to react..."
+			if(11 to 20)	mutateweed()
+			if(1 to 10)		mutatepest()
 			else 			usr << "Nothing happens..."
 
 	// 2 or 1 units is enough to change the yield and other stats.// Can change the yield and other stats, but requires more than mutagen
@@ -427,7 +427,7 @@ obj/machinery/hydroponics/proc/applyChemicals(var/datum/reagents/S)
 		adjustHealth(-round(S.get_reagent_amount("radium")*1))
 		adjustToxic(round(S.get_reagent_amount("radium")*3)) // Radium is harsher (OOC: also easier to produce)
 
-	//Nutriments
+	// Nutriments
 	if(S.has_reagent("eznutriment", 1))
 		yieldmod = 1
 		mutmod = 1
@@ -600,9 +600,10 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 				if(syr.reagents.total_volume <= 0)
 					syr.mode = 0
 					syr.update_icon()
-			else if(istype(reagent_source, /obj/item/weapon/reagent_containers/spray/))		//Reminder: fix droppers
+			else if(istype(reagent_source, /obj/item/weapon/reagent_containers/spray/))
 				visi_msg="[user] sprays [target] with [reagent_source]"
 				playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
+				irrigate = 1
 			else if(reagent_source.amount_per_transfer_from_this) // Droppers, cans, beakers, what have you.
 				visi_msg="[user] uses [reagent_source] on [target]"
 				irrigate = 1
@@ -699,7 +700,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			S.handle_item_insertion(G, 1)
 
 	else if(istype(O, /obj/item/weapon/wrench) && unwrenchable)
-		if(anchored==2)
+		if(anchored == 2)
 			user << "Unscrew the hoses first!"
 			return
 
@@ -713,14 +714,13 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			user << "You unwrench [src]."
 
 	else if(istype(O, /obj/item/weapon/screwdriver) && unwrenchable) //THIS NEED TO BE DONE DIFFERENTLY, SOMEONE REFACTOR THE TRAY CODE ALREADY
-
 		if(anchored)
-			if(anchored==2)
+			if(anchored == 2)
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				anchored = 1
 				user << "You unscrew the [src]'s hoses."
 
-			else if(anchored==1)
+			else if(anchored == 1)
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 				anchored = 2
 				user << "You screw in the [src]'s hoses."
@@ -762,7 +762,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 /obj/item/seeds/proc/getYield()
 	var/obj/machinery/hydroponics/parent = loc
 	if (parent.yieldmod == 0)
-		return max(yield, 1)
+		return min(yield, 1)//1 if above zero, 0 otherwise
 	return (yield * parent.yieldmod)
 
 /obj/item/seeds/proc/harvest(mob/user = usr)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -10,6 +10,8 @@
 	var/maxnutri = 10		//The maximum nutrient of water in the tray
 	var/pestlevel = 0		//The amount of pests in the tray (max 10)
 	var/weedlevel = 0		//The amount of weeds in the tray (max 10)
+	var/yieldmod = 1		//Nutriment's effect on yield
+	var/mutmod = 1			//Nutriment's effect on mutations
 	var/toxic = 0			//Toxicity in the tray?
 	var/age = 0				//Current age
 	var/dead = 0			//Is it dead?
@@ -178,13 +180,7 @@ obj/machinery/hydroponics/process()
 
 			// Harvest code
 			if(age > myseed.production && (age - lastproduce) > myseed.production && (!harvest && !dead))
-				if(prob(85))
-					mutate()
-				else if(prob(30))
-					hardmutate()
-				else if(prob(5))
-					mutatespecie()
-
+				nutrimentMutation()
 				if(myseed && myseed.yield != -1) // Unharvestable shouldn't be harvested
 					harvest = 1
 				else
@@ -208,7 +204,24 @@ obj/machinery/hydroponics/process()
 			update_icon()
 	return
 
-
+obj/machinery/hydroponics/proc/nutrimentMutation()
+	if (mutmod == 0)
+		return
+	if (mutmod == 1)
+		if(prob(80))		//80%
+			mutate()
+		else if(prob(75))	//15%
+			hardmutate()
+		return
+	if (mutmod == 2)
+		if(prob(50))		//50%
+			mutate()
+		else if(prob(75))	//37.5%
+			hardmutate()
+		else if(prob(10))	//1/80
+			mutatespecie()
+		return
+	return
 
 obj/machinery/hydroponics/update_icon()
 
@@ -386,6 +399,176 @@ obj/machinery/hydroponics/proc/mutatepest()
 	else
 		usr << "The pests seem to behave oddly, but quickly settle down..."
 
+obj/machinery/hydroponics/proc/applyChemicals(var/datum/reagents/S)
+
+	// Requires 5 mutagen to possibly change species.// Poor man's mutagen.
+	if(S.has_reagent("mutagen", 5) || S.has_reagent("radium", 10) || S.has_reagent("uranium", 10))
+		switch(rand(100))
+			if(91  to 100)	plantdies()
+			if(81  to 90)	mutatespecie()
+			if(66	to 80)	hardmutate()
+			if(41  to 65)	mutate()
+			if(21  to 41)	usr << "The plants don't seem to react..."
+			if(11	to 20)	mutateweed()
+			if(1   to 10)	mutatepest()
+			else 			usr << "Nothing happens..."
+
+	// 2 or 1 units is enough to change the yield and other stats.// Can change the yield and other stats, but requires more than mutagen
+	else if(S.has_reagent("mutagen", 2) || S.has_reagent("radium", 5) || S.has_reagent("uranium", 5))
+		hardmutate()
+	else if(S.has_reagent("mutagen", 1) || S.has_reagent("radium", 2) || S.has_reagent("uranium", 2))
+		mutate()
+
+	// After handling the mutating, we now handle the damage from adding crude radioactives...
+	if(S.has_reagent("uranium", 1))
+		adjustHealth(-round(S.get_reagent_amount("uranium")*1))
+		adjustToxic(round(S.get_reagent_amount("uranium")*2))
+	if(S.has_reagent("radium", 1))
+		adjustHealth(-round(S.get_reagent_amount("radium")*1))
+		adjustToxic(round(S.get_reagent_amount("radium")*3)) // Radium is harsher (OOC: also easier to produce)
+
+	//Nutriments
+	if(S.has_reagent("eznutriment", 1))
+		yieldmod = 1
+		mutmod = 1
+		adjustNutri(round(S.get_reagent_amount("eznutriment")*1))
+
+	if(S.has_reagent("left4zednutriment", 1))
+		yieldmod = 0
+		mutmod = 2
+		adjustNutri(round(S.get_reagent_amount("left4zednutriment")*1))
+
+	if(S.has_reagent("robustharvestnutriment", 1))
+		yieldmod = 2
+		mutmod = 0
+		adjustNutri(round(S.get_reagent_amount("robustharvestnutriment")*1))
+
+	// Antitoxin binds shit pretty well. So the tox goes significantly down
+	if(S.has_reagent("anti_toxin", 1))
+		adjustToxic(-round(S.get_reagent_amount("anti_toxin")*2))
+
+	// NIGGA, YOU JUST WENT ON FULL RETARD.
+	if(S.has_reagent("toxin", 1))
+		adjustToxic(round(S.get_reagent_amount("toxin")*2))
+
+	// Milk is good for humans, but bad for plants. The sugars canot be used by plants, and the milk fat fucks up growth. Not shrooms though. I can't deal with this now...
+	if(S.has_reagent("milk", 1))
+		adjustNutri(round(S.get_reagent_amount("milk")*0.1))
+		adjustWater(round(S.get_reagent_amount("milk")*0.9))
+
+	// Beer is a chemical composition of alcohol and various other things. It's a shitty nutrient but hey, it's still one. Also alcohol is bad, mmmkay?
+	if(S.has_reagent("beer", 1))
+		adjustHealth(-round(S.get_reagent_amount("beer")*0.05))
+		adjustNutri(round(S.get_reagent_amount("beer")*0.25))
+		adjustWater(round(S.get_reagent_amount("beer")*0.7))
+
+	// You're an idiot for thinking that one of the most corrosive and deadly gasses would be beneficial
+	if(S.has_reagent("fluorine", 1))
+		adjustHealth(-round(S.get_reagent_amount("fluorine")*2))
+		adjustToxic(round(S.get_reagent_amount("flourine")*2.5))
+		adjustWater(-round(S.get_reagent_amount("flourine")*0.5))
+		adjustWeeds(-rand(1,4))
+
+	// You're an idiot for thinking that one of the most corrosive and deadly gasses would be beneficial
+	if(S.has_reagent("chlorine", 1))
+		adjustHealth(-round(S.get_reagent_amount("chlorine")*1))
+		adjustToxic(round(S.get_reagent_amount("chlorine")*1.5))
+		adjustWater(-round(S.get_reagent_amount("chlorine")*0.5))
+		adjustWeeds(-rand(1,3))
+
+	// White Phosphorous + water -> phosphoric acid. That's not a good thing really. Phosphoric salts are beneficial though. And even if the plant suffers, in the long run the tray gets some nutrients. The benefit isn't worth that much.
+	if(S.has_reagent("phosphorus", 1))
+		adjustHealth(-round(S.get_reagent_amount("phosphorus")*0.75))
+		adjustNutri(round(S.get_reagent_amount("phosphorus")*0.1))
+		adjustWater(-round(S.get_reagent_amount("phosphorus")*0.5))
+		adjustWeeds(-rand(1,2))
+
+	// Plants should not have sugar, they can't use it and it prevents them getting water/ nutients, it is good for mold though...
+	if(S.has_reagent("sugar", 1))
+		adjustWeeds(rand(1,2))
+		adjustPests(rand(1,2))
+		adjustNutri(round(S.get_reagent_amount("sugar")*0.1))
+
+	// It is water!
+	if(S.has_reagent("water", 1))
+		adjustWater(round(S.get_reagent_amount("water")*1))
+
+	// Holy water. Mostly the same as water, it also heals the plant a little with the power of the spirits~
+	if(S.has_reagent("holywater", 1))
+		adjustWater(round(S.get_reagent_amount("holywater")*1))
+		adjustHealth(round(S.get_reagent_amount("holywater")*0.1))
+
+	// A variety of nutrients are dissolved in club soda, without sugar. These nutrients include carbon, oxygen, hydrogen, phosphorous, potassium, sulfur and sodium, all of which are needed for healthy plant growth.
+	if(S.has_reagent("sodawater", 1))
+		adjustWater(round(S.get_reagent_amount("sodawater")*1))
+		adjustHealth(round(S.get_reagent_amount("sodawater")*0.1))
+		adjustNutri(round(S.get_reagent_amount("sodawater")*0.1))
+
+	// Man, you guys are retards
+	if(S.has_reagent("sacid", 1))
+		adjustHealth(-round(S.get_reagent_amount("sacid")*1))
+		adjustToxic(round(S.get_reagent_amount("sacid")*1.5))
+		adjustWeeds(-rand(1,2))
+
+	// SERIOUSLY
+	if(S.has_reagent("pacid", 1))
+		adjustHealth(-round(S.get_reagent_amount("pacid")*2))
+		adjustToxic(round(S.get_reagent_amount("pacid")*3))
+		adjustWeeds(-rand(1,4))
+
+	// Plant-B-Gone is just as bad
+	if(S.has_reagent("plantbgone", 1))
+		adjustHealth(-round(S.get_reagent_amount("plantbgone")*2))
+		adjustToxic(-round(S.get_reagent_amount("plantbgone")*3))
+		adjustWeeds(-rand(4,8))
+
+	//Weed Spray
+	if(S.has_reagent("weedkiller", 1))
+		adjustToxic(round(S.get_reagent_amount("weedkiller")*0.5))
+		//old toxicity was 4, each spray is default 10 (minimal of 5) so 5 and 2.5 are the new ammounts
+		adjustWeeds(-rand(1,2))
+
+	//Pest Spray
+	if(S.has_reagent("pestkiller", 1))
+		adjustToxic(round(S.get_reagent_amount("pestkiller")*0.5))
+		adjustPests(-rand(1,2))
+
+	// Healing
+	if(S.has_reagent("cryoxadone", 1))
+		adjustHealth(round(S.get_reagent_amount("cryoxadone")*3))
+		adjustToxic(-round(S.get_reagent_amount("cryoxadone")*3))
+
+	// Ammonia is bad ass.
+	if(S.has_reagent("ammonia", 1))
+		adjustHealth(round(S.get_reagent_amount("ammonia")*0.5))
+		adjustNutri(round(S.get_reagent_amount("ammonia")*1))
+		adjustSYield(round(S.get_reagent_amount("ammonia")*0.01))
+
+	// This is more bad ass, and pests get hurt by the corrosive nature of it, not the plant.
+	if(S.has_reagent("diethylamine", 1))
+		adjustHealth(round(S.get_reagent_amount("diethylamine")*1))
+		adjustNutri(round(S.get_reagent_amount("diethylamine")*2))
+		adjustSYield(round(S.get_reagent_amount("diethylamine")*0.02))
+		adjustPests(-rand(1,2))
+
+	// Compost, effectively
+	if(S.has_reagent("nutriment", 1))
+		adjustHealth(round(S.get_reagent_amount("nutriment")*0.5))
+		adjustNutri(round(S.get_reagent_amount("nutriment")*1))
+
+	// The best stuff there is. For testing/debugging.
+	if(S.has_reagent("adminordrazine", 1))
+		adjustWater(round(S.get_reagent_amount("adminordrazine")*1))
+		adjustHealth(round(S.get_reagent_amount("adminordrazine")*1))
+		adjustNutri(round(S.get_reagent_amount("adminordrazine")*1))
+		adjustPests(-rand(1,5))
+		adjustWeeds(-rand(1,5))
+	if(S.has_reagent("adminordrazine", 5))
+		switch(rand(100))
+			if(66  to 100)	mutatespecie()
+			if(33	to 65)	mutateweed()
+			if(1   to 32)	mutatepest()
+			else 			usr << "Nothing happens..."
 
 obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
@@ -396,7 +579,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 		if(istype(reagent_source, /obj/item/weapon/reagent_containers/syringe))
 			var/obj/item/weapon/reagent_containers/syringe/syr = reagent_source
 			if(syr.mode != 1)
-				user << "You can't get any extract out of this plant."
+				user << "You can't get any extract out of this plant."		//That. Gives me an idea...
 				return
 
 		if(!reagent_source.reagents.total_volume)
@@ -406,6 +589,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 		var/list/trays = list(src)//makes the list just this in cases of syringes and compost etc
 		var/target = myseed ? myseed.plantname : src
 		var/visi_msg = ""
+		var/irrigate = 0	//How am I supposed to irrigate pill contents?
 
 		if(istype(reagent_source, /obj/item/weapon/reagent_containers/food/snacks) || istype(reagent_source, /obj/item/weapon/reagent_containers/pill))
 			visi_msg="[user] composts [reagent_source], spreading it through [target]"
@@ -416,18 +600,20 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 				if(syr.reagents.total_volume <= 0)
 					syr.mode = 0
 					syr.update_icon()
-			else if(istype(reagent_source, /obj/item/weapon/reagent_containers/spray/))
+			else if(istype(reagent_source, /obj/item/weapon/reagent_containers/spray/))		//Reminder: fix droppers
 				visi_msg="[user] sprays [target] with [reagent_source]"
 				playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
 			else if(reagent_source.amount_per_transfer_from_this) // Droppers, cans, beakers, what have you.
 				visi_msg="[user] uses [reagent_source] on [target]"
+				irrigate = 1
 			// Beakers, bottles, buckets, etc.  Can't use is_open_container though.
 			if(istype(reagent_source, /obj/item/weapon/reagent_containers/glass/))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 
-		if(reagent_source.amount_per_transfer_from_this>30 && reagent_source.reagents.total_volume>=reagent_source.amount_per_transfer_from_this)
-			trays=FindConnected()
-			visi_msg+=" setting off the irrigation system"
+		if(irrigate && reagent_source.amount_per_transfer_from_this > 30 && reagent_source.reagents.total_volume >= reagent_source.amount_per_transfer_from_this)
+			trays = FindConnected()
+			if (trays.len > 1)
+				visi_msg += " setting off the irrigation system"
 
 		if(visi_msg)
 			visible_message("<span class='notice'>[visi_msg].</span>")
@@ -444,185 +630,14 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			if(istype(reagent_source, /obj/item/weapon/reagent_containers/food/snacks) || istype(reagent_source, /obj/item/weapon/reagent_containers/pill))
 				del(reagent_source)
 
-
-
-			// Requires 5 mutagen to possibly change species.
-			if(S.has_reagent("mutagen", 5))
-				switch(rand(100))
-					if(91  to 100)	H.plantdies()
-					if(81  to 90)  H.mutatespecie()
-					if(66	to 80)	H.hardmutate()
-					if(41  to 65)  H.mutate()
-					if(21  to 41)  user << "The plants don't seem to react..."
-					if(11	to 20)  H.mutateweed()
-					if(1   to 10)  H.mutatepest()
-					else 			user << "Nothing happens..."
-
-			// 2 or 1 units is enough to change the yield and other stats.
-			else if(S.has_reagent("mutagen", 2))
-				H.hardmutate()
-			else if(S.has_reagent("mutagen", 1))
-				H.mutate()
-
-			// Antitoxin binds shit pretty well. So the tox goes significantly down
-			if(S.has_reagent("anti_toxin", 1))
-				H.adjustToxic(-round(S.get_reagent_amount("anti_toxin")*2))
-
-			// NIGGA, YOU JUST WENT ON FULL RETARD.
-			if(S.has_reagent("toxin", 1))
-				H.adjustToxic(round(S.get_reagent_amount("toxin")*2))
-
-			// Milk is good for humans, but bad for plants. The sugars canot be used by plants, and the milk fat fucks up growth. Not shrooms though. I can't deal with this now...
-			if(S.has_reagent("milk", 1))
-				H.adjustNutri(round(S.get_reagent_amount("milk")*0.1))
-				H.adjustWater(round(S.get_reagent_amount("milk")*0.9))
-
-			// Beer is a chemical composition of alcohol and various other things. It's a shitty nutrient but hey, it's still one. Also alcohol is bad, mmmkay?
-			if(S.has_reagent("beer", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("beer")*0.05))
-				H.adjustNutri(round(S.get_reagent_amount("beer")*0.25))
-				H.adjustWater(round(S.get_reagent_amount("beer")*0.7))
-
-			// You're an idiot for thinking that one of the most corrosive and deadly gasses would be beneficial
-			if(S.has_reagent("fluorine", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("fluorine")*2))
-				H.adjustToxic(round(S.get_reagent_amount("flourine")*2.5))
-				H.adjustWater(-round(S.get_reagent_amount("flourine")*0.5))
-				H.adjustWeeds(-rand(1,4))
-
-			// You're an idiot for thinking that one of the most corrosive and deadly gasses would be beneficial
-			if(S.has_reagent("chlorine", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("chlorine")*1))
-				H.adjustToxic(round(S.get_reagent_amount("chlorine")*1.5))
-				H.adjustWater(-round(S.get_reagent_amount("chlorine")*0.5))
-				H.adjustWeeds(-rand(1,3))
-
-			// White Phosphorous + water -> phosphoric acid. That's not a good thing really. Phosphoric salts are beneficial though. And even if the plant suffers, in the long run the tray gets some nutrients. The benefit isn't worth that much.
-			if(S.has_reagent("phosphorus", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("phosphorus")*0.75))
-				H.adjustNutri(round(S.get_reagent_amount("phosphorus")*0.1))
-				H.adjustWater(-round(S.get_reagent_amount("phosphorus")*0.5))
-				H.adjustWeeds(-rand(1,2))
-
-			// Plants should not have sugar, they can't use it and it prevents them getting water/ nutients, it is good for mold though...
-			if(S.has_reagent("sugar", 1))
-				H.adjustWeeds(rand(1,2))
-				H.adjustPests(rand(1,2))
-				H.adjustNutri(round(S.get_reagent_amount("sugar")*0.1))
-
-			// It is water!
-			if(S.has_reagent("water", 1))
-				H.adjustWater(round(S.get_reagent_amount("water")*1))
-
-			// Holy water. Mostly the same as water, it also heals the plant a little with the power of the spirits~
-			if(S.has_reagent("holywater", 1))
-				H.adjustWater(round(S.get_reagent_amount("holywater")*1))
-				H.adjustHealth(round(S.get_reagent_amount("holywater")*0.1))
-
-			// A variety of nutrients are dissolved in club soda, without sugar. These nutrients include carbon, oxygen, hydrogen, phosphorous, potassium, sulfur and sodium, all of which are needed for healthy plant growth.
-			if(S.has_reagent("sodawater", 1))
-				H.adjustWater(round(S.get_reagent_amount("sodawater")*1))
-				H.adjustHealth(round(S.get_reagent_amount("sodawater")*0.1))
-				H.adjustNutri(round(S.get_reagent_amount("sodawater")*0.1))
-
-			// Man, you guys are retards
-			if(S.has_reagent("sacid", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("sacid")*1))
-				H.adjustToxic(round(S.get_reagent_amount("sacid")*1.5))
-				H.adjustWeeds(-rand(1,2))
-
-			// SERIOUSLY
-			if(S.has_reagent("pacid", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("pacid")*2))
-				H.adjustToxic(round(S.get_reagent_amount("pacid")*3))
-				H.adjustWeeds(-rand(1,4))
-
-			// Plant-B-Gone is just as bad
-			if(S.has_reagent("plantbgone", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("plantbgone")*2))
-				H.adjustToxic(-round(S.get_reagent_amount("plantbgone")*3))
-				H.adjustWeeds(-rand(4,8))
-
-			//Weed Spray
-			if(S.has_reagent("weedkiller", 1))
-				H.adjustToxic(round(S.get_reagent_amount("weedkiller")*0.5))
-				//old toxicity was 4, each spray is default 10 (minimal of 5) so 5 and 2.5 are the new ammounts
-				H.adjustWeeds(-rand(1,2))
-
-			//Pest Spray
-			if(S.has_reagent("pestkiller", 1))
-				H.adjustToxic(round(S.get_reagent_amount("pestkiller")*0.5))
-				H.adjustPests(-rand(1,2))
-
-			// Healing
-			if(S.has_reagent("cryoxadone", 1))
-				H.adjustHealth(round(S.get_reagent_amount("cryoxadone")*3))
-				H.adjustToxic(-round(S.get_reagent_amount("cryoxadone")*3))
-
-			// Ammonia is bad ass.
-			if(S.has_reagent("ammonia", 1))
-				H.adjustHealth(round(S.get_reagent_amount("ammonia")*0.5))
-				H.adjustNutri(round(S.get_reagent_amount("ammonia")*1))
-				H.adjustSYield(round(S.get_reagent_amount("ammonia")*0.01))
-
-			// This is more bad ass, and pests get hurt by the corrosive nature of it, not the plant.
-			if(S.has_reagent("diethylamine", 1))
-				H.adjustHealth(round(S.get_reagent_amount("diethylamine")*1))
-				H.adjustNutri(round(S.get_reagent_amount("diethylamine")*2))
-				H.adjustSYield(round(S.get_reagent_amount("diethylamine")*0.02))
-				H.adjustPests(-rand(1,2))
-
-
-			// Compost, effectively
-			if(S.has_reagent("nutriment", 1))
-				H.adjustHealth(round(S.get_reagent_amount("nutriment")*0.5))
-				H.adjustNutri(round(S.get_reagent_amount("nutriment")*1))
-
-			// Poor man's mutagen.
-			if(S.has_reagent("radium", 10) || S.has_reagent("uranium", 10))
-				switch(rand(100))
-					if(91  to 100)	H.plantdies()
-					if(81  to 90)  H.mutatespecie()
-					if(66	to 80)	H.hardmutate()
-					if(41  to 65)  H.mutate()
-					if(21  to 41)  user << "The plants don't seem to react..."
-					if(11	to 20)  H.mutateweed()
-					if(1   to 10)  H.mutatepest()
-					else 			user << "Nothing happens..."
-			// Can change the yield and other stats, but requires more than mutagen
-			else if(S.has_reagent("radium", 5) || S.has_reagent("uranium", 5))
-				H.hardmutate()
-			else if(S.has_reagent("radium", 2) || S.has_reagent("uranium", 2))
-				H.mutate()
-
-			// After handling the mutating, we now handle the damage from adding crude radioactives...
-			if(S.has_reagent("uranium", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("uranium")*1))
-				H.adjustToxic(round(S.get_reagent_amount("uranium")*2))
-			if(S.has_reagent("radium", 1))
-				H.adjustHealth(-round(S.get_reagent_amount("radium")*1))
-				H.adjustToxic(round(S.get_reagent_amount("radium")*3)) // Radium is harsher (OOC: also easier to produce)
-
-			// The best stuff there is. For testing/debugging.
-			if(S.has_reagent("adminordrazine", 1))
-				H.adjustWater(round(S.get_reagent_amount("adminordrazine")*1))
-				H.adjustHealth(round(S.get_reagent_amount("adminordrazine")*1))
-				H.adjustNutri(round(S.get_reagent_amount("adminordrazine")*1))
-				H.adjustPests(-rand(1,5))
-				H.adjustWeeds(-rand(1,5))
-			if(S.has_reagent("adminordrazine", 5))
-				switch(rand(100))
-					if(66  to 100)  H.mutatespecie()
-					if(33	to 65)  H.mutateweed()
-					if(1   to 32)  H.mutatepest()
-					else 			user << "Nothing happens..."
+			H.applyChemicals(S)
 
 			S.clear_reagents()
 			del(S)
 			H.update_icon()
 		return 1
 
-	else if( istype(O, /obj/item/seeds/) )
+	else if(istype(O, /obj/item/seeds/))
 		if(!planted)
 			user.unEquip(O)
 			user << "You plant [O]."
@@ -744,11 +759,17 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			user << "[src] is filled with tiny worms!"
 		user << "" // Empty line for readability.
 
+/obj/item/seeds/proc/getYield()
+	var/obj/machinery/hydroponics/parent = loc
+	if (parent.yieldmod == 0)
+		return max(yield, 1)
+	return (yield * parent.yieldmod)
+
 /obj/item/seeds/proc/harvest(mob/user = usr)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
 	var/t_amount = 0
 
-	while(t_amount < yield)
+	while(t_amount < getYield())
 		var/obj/item/weapon/reagent_containers/food/snacks/grown/t_prod = new product(user.loc, potency) // User gets a consumable
 		if(!t_prod)	return
 		t_prod.seed = type
@@ -777,7 +798,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
 	var/t_amount = 0
 
-	while ( t_amount < (yield * parent.yieldmod ))
+	while (t_amount < getYield())
 		var/obj/item/weapon/reagent_containers/food/snacks/grown/t_prod = new product(user.loc, potency) // User gets a consumable
 
 		t_prod.seed = type
@@ -796,7 +817,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
 	var/t_amount = 0
 
-	while(t_amount < yield)
+	while(t_amount < getYield())
 		var/obj/item/weapon/grown/t_prod = new product(user.loc, potency) // User gets a consumable -QualityVan
 		t_prod.seed = type
 		t_prod.lifespan = lifespan
@@ -814,7 +835,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
 	var/t_amount = 0
 
-	while(t_amount < yield)
+	while(t_amount < getYield())
 		var/obj/item/weapon/grown/t_prod = new product(user.loc, potency) // User gets a consumable -QualityVan
 		t_prod.seed = type
 		t_prod.lifespan = lifespan
@@ -832,7 +853,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/machinery/hydroponics/parent = loc //for ease of access
 	var/t_amount = 0
 
-	while(t_amount < yield)
+	while(t_amount < getYield())
 		new product(user.loc)
 		t_amount++
 
@@ -888,7 +909,7 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 
 	else //else, one packet of seeds. maybe two
 		var/seed_count = 1
-		if(prob(yield * 20))
+		if(prob(getYield() * 20))
 			seed_count++
 		for(var/i=0,i<seed_count,i++)
 			var/obj/item/seeds/replicapod/harvestseeds = new /obj/item/seeds/replicapod(user.loc)
@@ -934,10 +955,10 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	lastproduce = age
 	if(istype(myseed,/obj/item/seeds/replicapod/))
 		user << "You harvest from the [myseed.plantname]."
-	else if(myseed.yield <= 0)
+	else if(myseed.getYield() <= 0)
 		user << "<span class='warning'>You fail to harvest anything useful.</span>"
 	else
-		user << "You harvest [myseed.yield] items from the [myseed.plantname]."
+		user << "You harvest [myseed.getYield()] items from the [myseed.plantname]."
 	if(myseed.oneharvest)
 		del(myseed)
 		planted = 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2652,6 +2652,44 @@ datum
 				..()
 				return
 
+//////////////////////////////////Hydroponics stuff///////////////////////////////
+
+		eznutriment
+			name = "E-Z-Nutrient"
+			id = "eznutriment"
+			description = "Cheap and extremely common type of plant nutriment."
+			reagent_state = LIQUID
+			color = "#376400" // RBG: 50, 100, 0
+
+			on_mob_life(var/mob/living/M as mob)
+				if(prob(10)) M.adjustToxLoss(1)
+				..()
+				return
+
+		left4zednutriment
+			name = "Left 4 Zed"
+			id = "left4zednutriment"
+			description = "Unstable nutriment that makes plants mutate more often than usual."
+			reagent_state = LIQUID
+			color = "#1A1E4D" // RBG: 26, 30, 77
+
+			on_mob_life(var/mob/living/M as mob)
+				if(prob(25)) M.adjustToxLoss(1)
+				..()
+				return
+
+		robustharvestnutriment
+			name = "Robust Harvest"
+			id = "robustharvestnutriment"
+			description = "Very potent nutriment that prevents plants from mutating."
+			reagent_state = LIQUID
+			color = "#9D9D00" // RBG: 157, 157, 0
+
+			on_mob_life(var/mob/living/M as mob)
+				if(prob(15)) M.adjustToxLoss(1)
+				..()
+				return
+
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
 
 		atomicbomb

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -26,6 +26,8 @@
 		/obj/machinery/computer/pandemic,
 		/obj/item/weapon/storage/secure/safe,
 		/obj/machinery/disposal,
+		/obj/machinery/hydroponics,
+		/obj/machinery/biogenerator,
 		/mob/living/simple_animal/cow,
 		/mob/living/simple_animal/hostile/retaliate/goat
 	)


### PR DESCRIPTION
Tray's chemical procession is made into a separate proc. Attackby is a bit less horrible.
Nutriments again affect plant's mutations and yield. They are now actual chemicals. Slightly poisonous, too.
Containers will no longer splash their contents at trays and biogenerators (fixes #2992 and #3022).
Almost all spawn() removed from grown creation. Yay.
Irrigation won't start with pills (and syringes, and growns), or when tray is not connected.
