### PR TITLE
Profiles from client.

### DIFF
--- a/cfg/admin.txt
+++ b/cfg/admin.txt
@@ -1,0 +1,3 @@
+#aranclanoss
+#im a huge faggot
+aranclanos

--- a/cfg/admin.txt
+++ b/cfg/admin.txt
@@ -1,3 +1,12 @@
-#aranclanoss
-#im a huge faggot
+###################################################################################
+# This is a list of ckeys authorized to use client-side debug options:            #
+# Profile, Reboot, Resume, Status, and Trace-client                               #
+# Of these, Profile is the most relevant as it allows you to easily               #
+# retrieve information regarding the game's processing.                           #
+# If a ckey is on this list, and has proper admin privledges,                     #
+# they will be able to right-click the top of the client to access these options. #                                                                                        #
+# Case is not important for ckey.                                                 #
+###################################################################################
 aranclanos
+cheridan
+giacom

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -189,6 +189,8 @@ var/list/admin_verbs_hideable = list(
 
 /client/proc/add_admin_verbs()
 	if(holder)
+		control_freak = CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS
+
 		var/rights = holder.rank.rights
 		verbs += admin_verbs_default
 		if(rights & R_BUILDMODE)	verbs += /client/proc/togglebuildmodeself


### PR DESCRIPTION
Added a new admin txt under the new cfg folder. The ckeys of this list will be able to make profiles on servers that they are admins. We welcome servers to change this list as it is a configuration file. Being on this list does NOT grant you any kind of admin powers.

All admins will now have the control_freak disabled but for skin and macros, to make this work.

The current ckey list serves only as an example.
