### PR TITLE
Vending and autolathe beauty fixes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -120,7 +120,7 @@ var/global/list/autolathe_recipes_hidden = list( \
 	if (stat)
 		return 1
 	if (busy)
-		user << "\red The autolathe is busy. Please wait for completion of previous operation."
+		user << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
 		return 1
 
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
@@ -145,13 +145,13 @@ var/global/list/autolathe_recipes_hidden = list( \
 			return 1
 
 	if (src.m_amount + O.m_amt > max_m_amount)
-		user << "\red The autolathe is full. Please remove metal from the autolathe in order to insert more."
+		user << "<span class=\"alert\">The autolathe is full. Please remove metal from the autolathe in order to insert more.</span>"
 		return 1
 	if (src.g_amount + O.g_amt > max_g_amount)
-		user << "\red The autolathe is full. Please remove glass from the autolathe in order to insert more."
+		user << "<span class=\"alert\">The autolathe is full. Please remove glass from the autolathe in order to insert more.</span>"
 		return 1
 	if (O.m_amt == 0 && O.g_amt == 0)
-		user << "\red This object does not contain significant amounts of metal or glass, or cannot be accepted by the autolathe due to size or hazardous materials."
+		user << "<span class=\"alert\">This object does not contain significant amounts of metal or glass, or cannot be accepted by the autolathe due to size or hazardous materials.</span>"
 		return 1
 
 	var/amount = 1
@@ -227,7 +227,7 @@ var/global/list/autolathe_recipes_hidden = list( \
 						src.g_amount = 0
 					busy = 0
 	else
-		usr << "\red The autolathe is busy. Please wait for completion of previous operation."
+		usr << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
 	src.updateUsrDialog()
 	return
 
@@ -246,8 +246,8 @@ var/global/list/autolathe_recipes_hidden = list( \
 	var/dat
 	if(!panel_open)
 		var/coeff = 2 ** prod_coeff
-		dat = "<div class='statusDisplay'><B>Metal Amount:</B> [src.m_amount] / [max_m_amount] cm<sup>3</sup><BR>"
-		dat += "<B>Glass Amount:</B> [src.g_amount] / [max_g_amount] cm<sup>3</sup><HR>"
+		dat = "<div class='statusDisplay'><b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
+		dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup><hr>"
 		var/list/objs = list()
 		objs += src.L
 		if(src.hacked)
@@ -256,17 +256,17 @@ var/global/list/autolathe_recipes_hidden = list( \
 			if(disabled || m_amount<t.m_amt || g_amount<t.g_amt)
 				dat += replacetext("<span class='linkOff'>[t]</span>", "The ", "")
 			else
-				dat += replacetext("<A href='?src=\ref[src];make=\ref[t]'>[t]</A>", "The ", "")
+				dat += replacetext("<a href='?src=\ref[src];make=\ref[t]'>[t]</a>", "The ", "")
 
 			if(istype(t, /obj/item/stack))
 				var/obj/item/stack/S = t
 				var/max_multiplier = min(S.max_amount, S.m_amt?round(m_amount/S.m_amt):INFINITY, S.g_amt?round(g_amount/S.g_amt):INFINITY)
 				if (max_multiplier>10 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[10]'>x[10]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[10]'>x[10]</a>"
 				if (max_multiplier>25 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[25]'>x[25]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[25]'>x[25]</a>"
 				if (max_multiplier>1 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[max_multiplier]'>x[max_multiplier]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[max_multiplier]'>x[max_multiplier]</a>"
 				dat += " [t.m_amt] m / [t.g_amt] g"
 			else
 				dat += " [t.m_amt/coeff] m / [t.g_amt/coeff] g"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -254,9 +254,9 @@ var/global/list/autolathe_recipes_hidden = list( \
 			objs += src.LL
 		for(var/obj/t in objs)
 			if(disabled || m_amount<t.m_amt || g_amount<t.g_amt)
-				dat += "<span class='linkOff'>[t.name]</span>"
+				dat += replacetext("<span class='linkOff'>[t]</span>", "The ", "")
 			else
-				dat += "<A href='?src=\ref[src];make=\ref[t]'>[t.name]</A>"
+				dat += replacetext("<A href='?src=\ref[src];make=\ref[t]'>[t]</A>", "The ", "")
 
 			if(istype(t, /obj/item/stack))
 				var/obj/item/stack/S = t

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -222,12 +222,12 @@
 	if(premium.len > 0)
 		dat += "<b>Coin slot:</b> "
 		if (coin)
-			dat += "[coin]&nbsp;&nbsp;<a href='byond://?src=\ref[src];remove_coin=1'>Remove</A>"
+			dat += "[coin]&nbsp;&nbsp;<a href='byond://?src=\ref[src];remove_coin=1'>Remove</a>"
 		else
 			dat += "<i>No coin</i>&nbsp;&nbsp;<span class='linkOff'>Remove</span>"
 
 	if(!panel_open)//Vending machines do not dispense items when they are unscrewed
-		dat += "<h3>Select an Item</h3>"
+		dat += "<h3>Select an item</h3>"
 		dat += "<div class='statusDisplay'>"
 		if(product_records.len == 0)
 			dat += "<font color = 'red'>No product loaded!</font>"
@@ -243,10 +243,10 @@
 			for (var/datum/data/vending_product/R in display_records)
 				dat += "<li>"
 				if(R.amount > 0)
-					dat += "<a href='byond://?src=\ref[src];vend=\ref[R]'>Vend</A> "
+					dat += "<a href='byond://?src=\ref[src];vend=\ref[R]'>Vend</a> "
 				else
-					dat += "<span class='linkOff'>Sold Out</span> "
-				dat += "<FONT color = '[R.display_color]'><B>[R.product_name]</B>:</font>"
+					dat += "<span class='linkOff'>Sold out</span> "
+				dat += replacetext("<font color = '[R.display_color]'><b>[R.product_name]</b>:</font>", "ÿ", "")
 				dat += " <b>[R.amount]</b>"
 				dat += "</li>"
 			dat += "</ul>"
@@ -816,8 +816,8 @@
 	icon_state = "engivend"
 	icon_deny = "engivend-deny"
 	req_access_txt = "11" //Engineering Equipment access
-	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/stock_parts/cell/high = 10)
-	contraband = list(/obj/item/weapon/stock_parts/cell/potato = 3)
+	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/cell/high = 10)
+	contraband = list(/obj/item/weapon/cell/potato = 3)
 	premium = list(/obj/item/weapon/storage/belt/utility = 3)
 
 //This one's from bay12
@@ -830,12 +830,9 @@
 	products = list(/obj/item/clothing/under/rank/chief_engineer = 4,/obj/item/clothing/under/rank/engineer = 4,/obj/item/clothing/shoes/orange = 4,/obj/item/clothing/head/hardhat = 4,
 					/obj/item/weapon/storage/belt/utility = 4,/obj/item/clothing/glasses/meson = 4,/obj/item/clothing/gloves/yellow = 4, /obj/item/weapon/screwdriver = 12,
 					/obj/item/weapon/crowbar = 12,/obj/item/weapon/wirecutters = 12,/obj/item/device/multitool = 12,/obj/item/weapon/wrench = 12,/obj/item/device/t_scanner = 12,
-					/obj/item/weapon/stock_parts/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
+					/obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
 					/obj/item/weapon/light/tube = 10,/obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5,/obj/item/weapon/stock_parts/micro_laser = 5,
 					/obj/item/weapon/stock_parts/matter_bin = 5,/obj/item/weapon/stock_parts/manipulator = 5,/obj/item/weapon/stock_parts/console_screen = 5)
-	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
-	// Another invalid entry, /obj/item/weapon/circuitry.  I don't even know what that would translate to, removed it.
-	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
 
 //This one's from bay12
 /obj/machinery/vending/robotics
@@ -845,8 +842,6 @@
 	icon_deny = "robotics-deny"
 	req_access_txt = "29"
 	products = list(/obj/item/clothing/suit/labcoat = 4,/obj/item/clothing/under/rank/roboticist = 4,/obj/item/stack/cable_coil = 4,/obj/item/device/flash = 4,
-					/obj/item/weapon/stock_parts/cell/high = 12, /obj/item/device/assembly/prox_sensor = 3,/obj/item/device/assembly/signaler = 3,/obj/item/device/healthanalyzer = 3,
+					/obj/item/weapon/cell/high = 12, /obj/item/device/assembly/prox_sensor = 3,/obj/item/device/assembly/signaler = 3,/obj/item/device/healthanalyzer = 3,
 					/obj/item/weapon/scalpel = 2,/obj/item/weapon/circular_saw = 2,/obj/item/weapon/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/weapon/screwdriver = 5,/obj/item/weapon/crowbar = 5)
-	//everything after the power cell had no amounts, I improvised.  -Sayu
-

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -246,7 +246,7 @@
 					dat += "<a href='byond://?src=\ref[src];vend=\ref[R]'>Vend</a> "
 				else
 					dat += "<span class='linkOff'>Sold out</span> "
-				dat += replacetext("<font color = '[R.display_color]'><b>[R.product_name]</b>:</font>", "ÿ", "")
+				dat += "<font color = '[R.display_color]'><b>[sanitize(R.product_name)]</b>:</font>"
 				dat += " <b>[R.amount]</b>"
 				dat += "</li>"
 			dat += "</ul>"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -816,8 +816,8 @@
 	icon_state = "engivend"
 	icon_deny = "engivend-deny"
 	req_access_txt = "11" //Engineering Equipment access
-	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/cell/high = 10)
-	contraband = list(/obj/item/weapon/cell/potato = 3)
+	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/device/multitool = 4,/obj/item/weapon/airlock_electronics = 10,/obj/item/weapon/module/power_control = 10,/obj/item/weapon/airalarm_electronics = 10,/obj/item/weapon/stock_parts/cell/high = 10)
+	contraband = list(/obj/item/weapon/stock_parts/cell/potato = 3)
 	premium = list(/obj/item/weapon/storage/belt/utility = 3)
 
 //This one's from bay12
@@ -830,7 +830,7 @@
 	products = list(/obj/item/clothing/under/rank/chief_engineer = 4,/obj/item/clothing/under/rank/engineer = 4,/obj/item/clothing/shoes/orange = 4,/obj/item/clothing/head/hardhat = 4,
 					/obj/item/weapon/storage/belt/utility = 4,/obj/item/clothing/glasses/meson = 4,/obj/item/clothing/gloves/yellow = 4, /obj/item/weapon/screwdriver = 12,
 					/obj/item/weapon/crowbar = 12,/obj/item/weapon/wirecutters = 12,/obj/item/device/multitool = 12,/obj/item/weapon/wrench = 12,/obj/item/device/t_scanner = 12,
-					/obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
+					/obj/item/weapon/stock_parts/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
 					/obj/item/weapon/light/tube = 10,/obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5,/obj/item/weapon/stock_parts/micro_laser = 5,
 					/obj/item/weapon/stock_parts/matter_bin = 5,/obj/item/weapon/stock_parts/manipulator = 5,/obj/item/weapon/stock_parts/console_screen = 5)
 
@@ -842,6 +842,6 @@
 	icon_deny = "robotics-deny"
 	req_access_txt = "29"
 	products = list(/obj/item/clothing/suit/labcoat = 4,/obj/item/clothing/under/rank/roboticist = 4,/obj/item/stack/cable_coil = 4,/obj/item/device/flash = 4,
-					/obj/item/weapon/cell/high = 12, /obj/item/device/assembly/prox_sensor = 3,/obj/item/device/assembly/signaler = 3,/obj/item/device/healthanalyzer = 3,
+					/obj/item/weapon/stock_parts/cell/high = 12, /obj/item/device/assembly/prox_sensor = 3,/obj/item/device/assembly/signaler = 3,/obj/item/device/healthanalyzer = 3,
 					/obj/item/weapon/scalpel = 2,/obj/item/weapon/circular_saw = 2,/obj/item/weapon/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/weapon/screwdriver = 5,/obj/item/weapon/crowbar = 5)


### PR DESCRIPTION
Removes the horrible ÿ produced by /improper from the vending machines.
Removes the 'The ' before every item in the autolathe.
Removed unneeded comments.
Fixed misc capitalization in autolathe.dm and vending.dm.
Span classes!
