### PR TITLE
Fixes #3084

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1114,6 +1114,12 @@ datum/mind
 	if(!mind.name)	mind.name = real_name
 	mind.current = src
 
+//VENTCRAWLERS
+/mob/living/mind_initialize()
+	..()
+	if(ventcrawler)
+		add_memory("As [real_name] you can ventcrawl! Use alt+click on vents to quickly travel about the station.")
+
 //HUMAN
 /mob/living/carbon/human/mind_initialize()
 	..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1114,12 +1114,6 @@ datum/mind
 	if(!mind.name)	mind.name = real_name
 	mind.current = src
 
-//VENTCRAWLERS
-/mob/living/mind_initialize()
-	..()
-	if(ventcrawler)
-		add_memory("As [real_name] you can ventcrawl! Use alt+click on vents to quickly travel about the station.")
-
 //HUMAN
 /mob/living/carbon/human/mind_initialize()
 	..()

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -18,6 +18,10 @@
 			if("nuclear emergency")
 				if(mind in ticker.mode:syndicates)
 					ticker.mode.update_all_synd_icons()
+
+	if(ventcrawler)
+		src << "<span class='notice'>You can ventcrawl! Use alt+click on vents to quickly travel about the station.</span>"
+
 	return .
 
 //This stuff needs to be merged from cloning.dm but I'm not in the mood to be shouted at for breaking all the things :< ~Carn


### PR DESCRIPTION
The message will appear on mob creation and also if the player check their notes.

Known thing I can't do anything about: There's no good way to selectively delete memories which may or may not exist on a mob. Someone who gets turned into a lot of ventcrawling mobs (a ling who likes lesser forming, a player slime reproducing) will continue to accrue a new message with each new incarnation. Considering we log multiple times of death in the same fashion I'm calling non-issue.
