### PR TITLE
Nerfs manifested ghosts

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -407,7 +407,7 @@ var/list/sacrificed = list()
 			"\red You hear liquid flowing.")
 			D.real_name = "[pick(first_names_male)] [pick(last_names)]"
 			D.universal_speak = 1
-			D.status_flags &= ~GODMODE
+			D.status_flags = CANSTUN|CANWEAKEN|CANPARALYSE|CANPUSH
 
 			D.key = ghost.key
 


### PR DESCRIPTION
Manifested ghosts can now be stunned.
Fixes #2934.
God forbid anyone ever gives humans status flags that would need to be copy-pasted here.

Alternative fix: make manifested ghosts be humans instead of dummies. This would mean you could capture the soul of a manifested ghost. 
