### PR TITLE
Make holograms GC correctly.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -106,6 +106,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/proc/clear_holo()
 //	hologram.SetLuminosity(0)//Clear lighting.	//handled by the lighting controller when its ower is deleted
 	qdel(hologram)//Get rid of hologram.
+	hologram = null
 	if(master.current == src)
 		master.current = null
 	master = null//Null the master, since no-one is using it now.


### PR DESCRIPTION
The hologram was getting deleted every tick, which caused the timer to reset, which blocked anything else from ever getting tested or force del()'d. Basically, it caused the whole Garbage Controller to stop working.
