### PR TITLE
Click cooldown removal.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -9,7 +9,7 @@
 #define NOBLUDGEON	4		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define MASKINTERNALS	8	// mask allows internals
 //#define SUITSPACE		8	// suit protects against space
-#define USEDELAY 	16		// For adding extra delay to heavy items, not currently used
+//#define USEDELAY 	16		// For adding extra delay to heavy items, not currently used
 #define NOSHIELD	32		// weapon not affected by shield
 #define CONDUCT		64		// conducts electricity (metal etc.)
 #define ABSTRACT    128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -15,7 +15,6 @@
 		return
 
 	if(control_disabled || stat) return
-	next_move = world.time + 9
 
 	if(ismob(A))
 		ai_actual_track(A)
@@ -51,7 +50,6 @@
 
 	if(world.time <= next_move)
 		return
-	next_move = world.time + 9
 
 	if(aicamera.in_camera_mode)
 		aicamera.camera_mode_off()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -34,9 +34,7 @@
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn( var/atom/A, var/params )
-	world << "<span class='notice'>click start with next_click: [next_click] world.time: [world.time]</span>"
 	if(world.time <= next_click)
-		world << "<span class='alert'>click denied: if(world.time <= next_click) // if([world.time] <= [next_click])</span>"
 		return
 	next_click = world.time + 1
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -56,19 +56,12 @@
 		return
 
 	if(W == A)
-		next_move = world.time + 8
-		if(W.flags&USEDELAY)
-			next_move += 5
-
 		W.attack_self(src)
 		return
 
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)
 	if(A == loc || (A in loc) || (A in contents))
 		// No adjacency checks
-		next_move = world.time + 8
-		if(W.flags&USEDELAY)
-			next_move += 5
 
 		var/resolved = A.attackby(W,src)
 		if(!resolved && A && W)
@@ -81,16 +74,11 @@
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
 	if(isturf(A) || isturf(A.loc))
 		if(A.Adjacent(src)) // see adjacent.dm
-			next_move = world.time + 10
-			if(W.flags&USEDELAY)
-				next_move += 5
-
 			var/resolved = A.attackby(W, src)
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params)
 			return
 		else
-			next_move = world.time + 10
 			W.afterattack(A, src, 0, params)
 			return
 	return

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -46,7 +46,6 @@
 		return 1
 	if(usr.next_move >= world.time)
 		return
-	usr.next_move = world.time + 6
 
 	if(usr.stat || usr.restrained() || usr.stunned || usr.lying)
 		return 1
@@ -91,7 +90,6 @@
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
 			master.attackby(I, usr)
-			usr.next_move = world.time+2
 	return 1
 
 /obj/screen/zone_sel
@@ -297,6 +295,7 @@
 	// We don't even know if it's a middle click
 	if(world.time <= usr.next_move)
 		return 1
+
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
 		return 1
 	if (istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
@@ -306,12 +305,10 @@
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
 				C.activate_hand("r")
-				usr.next_move = world.time+2
 		if("l_hand")
 			if(iscarbon(usr))
 				var/mob/living/carbon/C = usr
 				C.activate_hand("l")
-				usr.next_move = world.time+2
 		if("swap")
 			usr:swap_hand()
 		if("hand")
@@ -320,5 +317,4 @@
 			if(usr.attack_ui(slot_id))
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
-				usr.next_move = world.time+6
 	return 1

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -11,6 +11,7 @@
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 
 /mob/living/attackby(obj/item/I, mob/user)
+	user.changeNext_move(8)
 	I.attack(src, user)
 
 /mob/living/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -46,8 +46,8 @@
 		CtrlClickOn(A)
 		return
 
-	if(world.time <= next_move) return
-	next_move = world.time + 8
+	if(world.time <= next_move)
+		return
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
 	A.attack_ghost(src)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -30,20 +30,9 @@
 	var/obj/item/clothing/gloves/G = gloves
 	if((LASER in mutations) && a_intent == "harm")
 		LaserEyes(A) // moved into a proc below
-
 	else if(istype(G) && G.Touch(A,0)) // for magic gloves
 		return
-
 	else if(TK in mutations)
-		switch(get_dist(src,A))
-			if(1 to 5) // not adjacent may mean blocked by window
-				next_move += 2
-			if(5 to 7)
-				next_move += 5
-			if(8 to 15)
-				next_move += 10
-			if(16 to 128)
-				return
 		A.attack_tk(src)
 
 /*

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -109,19 +109,9 @@ var/const/tk_maxrange = 15
 
 		var/d = get_dist(user, target)
 		if(focus) d = max(d,get_dist(user,focus)) // whichever is further
-		switch(d)
-			if(0)
-				;
-			if(1 to 5) // not adjacent may mean blocked by window
-				if(!proximity)
-					user.next_move += 2
-			if(5 to 7)
-				user.next_move += 5
-			if(8 to tk_maxrange)
-				user.next_move += 10
-			else
-				user << "\blue Your mind won't reach that far."
-				return
+		if(d > tk_maxrange)
+			user << "\blue Your mind won't reach that far."
+			return
 
 		if(!focus)
 			focus_object(target, user)

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -378,7 +378,7 @@
 	if(open || !locked)	//Open and unlocked, no need to escape
 		open = 1
 		return
-	user.next_move = world.time + 100
+	user.changeNext_move(100)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	user.visible_message("<span class='warning'>You hear a metallic creaking from [src]!</span>")

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -120,7 +120,7 @@ var/global/list/autolathe_recipes_hidden = list( \
 	if (stat)
 		return 1
 	if (busy)
-		user << "\red The autolathe is busy. Please wait for completion of previous operation."
+		user << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
 		return 1
 
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
@@ -145,13 +145,13 @@ var/global/list/autolathe_recipes_hidden = list( \
 			return 1
 
 	if (src.m_amount + O.m_amt > max_m_amount)
-		user << "\red The autolathe is full. Please remove metal from the autolathe in order to insert more."
+		user << "<span class=\"alert\">The autolathe is full. Please remove metal from the autolathe in order to insert more.</span>"
 		return 1
 	if (src.g_amount + O.g_amt > max_g_amount)
-		user << "\red The autolathe is full. Please remove glass from the autolathe in order to insert more."
+		user << "<span class=\"alert\">The autolathe is full. Please remove glass from the autolathe in order to insert more.</span>"
 		return 1
 	if (O.m_amt == 0 && O.g_amt == 0)
-		user << "\red This object does not contain significant amounts of metal or glass, or cannot be accepted by the autolathe due to size or hazardous materials."
+		user << "<span class=\"alert\">This object does not contain significant amounts of metal or glass, or cannot be accepted by the autolathe due to size or hazardous materials.</span>"
 		return 1
 
 	var/amount = 1
@@ -227,7 +227,7 @@ var/global/list/autolathe_recipes_hidden = list( \
 						src.g_amount = 0
 					busy = 0
 	else
-		usr << "\red The autolathe is busy. Please wait for completion of previous operation."
+		usr << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
 	src.updateUsrDialog()
 	return
 
@@ -246,27 +246,27 @@ var/global/list/autolathe_recipes_hidden = list( \
 	var/dat
 	if(!panel_open)
 		var/coeff = 2 ** prod_coeff
-		dat = "<div class='statusDisplay'><B>Metal Amount:</B> [src.m_amount] / [max_m_amount] cm<sup>3</sup><BR>"
-		dat += "<B>Glass Amount:</B> [src.g_amount] / [max_g_amount] cm<sup>3</sup><HR>"
+		dat = "<div class='statusDisplay'><b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
+		dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup><hr>"
 		var/list/objs = list()
 		objs += src.L
 		if(src.hacked)
 			objs += src.LL
 		for(var/obj/t in objs)
 			if(disabled || m_amount<t.m_amt || g_amount<t.g_amt)
-				dat += "<span class='linkOff'>[t.name]</span>"
+				dat += replacetext("<span class='linkOff'>[t]</span>", "The ", "")
 			else
-				dat += "<A href='?src=\ref[src];make=\ref[t]'>[t.name]</A>"
+				dat += replacetext("<a href='?src=\ref[src];make=\ref[t]'>[t]</a>", "The ", "")
 
 			if(istype(t, /obj/item/stack))
 				var/obj/item/stack/S = t
 				var/max_multiplier = min(S.max_amount, S.m_amt?round(m_amount/S.m_amt):INFINITY, S.g_amt?round(g_amount/S.g_amt):INFINITY)
 				if (max_multiplier>10 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[10]'>x[10]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[10]'>x[10]</a>"
 				if (max_multiplier>25 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[25]'>x[25]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[25]'>x[25]</a>"
 				if (max_multiplier>1 && !disabled)
-					dat += " <A href='?src=\ref[src];make=\ref[t];multiplier=[max_multiplier]'>x[max_multiplier]</A>"
+					dat += " <a href='?src=\ref[src];make=\ref[t];multiplier=[max_multiplier]'>x[max_multiplier]</a>"
 				dat += " [t.m_amt] m / [t.g_amt] g"
 			else
 				dat += " [t.m_amt/coeff] m / [t.g_amt/coeff] g"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -196,6 +196,7 @@
 
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
 	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
+		user.changeNext_move(8)
 		var/aforce = I.force
 		if(I.damtype == BRUTE || I.damtype == BURN)
 			src.health = max(0, src.health - aforce)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -432,7 +432,7 @@
 /obj/machinery/suit_storage_unit/container_resist()
 	var/mob/living/user = usr
 	if(islocked)
-		user.next_move = world.time + 100
+		user.changeNext_move(100)
 		user.last_special = world.time + 100
 		var/breakout_time = 2
 		user << "<span class='notice'>You start kicking against the doors to escape! (This will take about [breakout_time] minutes.)</span>"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -222,12 +222,12 @@
 	if(premium.len > 0)
 		dat += "<b>Coin slot:</b> "
 		if (coin)
-			dat += "[coin]&nbsp;&nbsp;<a href='byond://?src=\ref[src];remove_coin=1'>Remove</A>"
+			dat += "[coin]&nbsp;&nbsp;<a href='byond://?src=\ref[src];remove_coin=1'>Remove</a>"
 		else
 			dat += "<i>No coin</i>&nbsp;&nbsp;<span class='linkOff'>Remove</span>"
 
 	if(!panel_open)//Vending machines do not dispense items when they are unscrewed
-		dat += "<h3>Select an Item</h3>"
+		dat += "<h3>Select an item</h3>"
 		dat += "<div class='statusDisplay'>"
 		if(product_records.len == 0)
 			dat += "<font color = 'red'>No product loaded!</font>"
@@ -243,10 +243,10 @@
 			for (var/datum/data/vending_product/R in display_records)
 				dat += "<li>"
 				if(R.amount > 0)
-					dat += "<a href='byond://?src=\ref[src];vend=\ref[R]'>Vend</A> "
+					dat += "<a href='byond://?src=\ref[src];vend=\ref[R]'>Vend</a> "
 				else
-					dat += "<span class='linkOff'>Sold Out</span> "
-				dat += "<FONT color = '[R.display_color]'><B>[R.product_name]</B>:</font>"
+					dat += "<span class='linkOff'>Sold out</span> "
+				dat += "<font color = '[R.display_color]'><b>[sanitize(R.product_name)]</b>:</font>"
 				dat += " <b>[R.amount]</b>"
 				dat += "</li>"
 			dat += "</ul>"
@@ -833,9 +833,6 @@
 					/obj/item/weapon/stock_parts/cell = 8, /obj/item/weapon/weldingtool = 8,/obj/item/clothing/head/welding = 8,
 					/obj/item/weapon/light/tube = 10,/obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5,/obj/item/weapon/stock_parts/micro_laser = 5,
 					/obj/item/weapon/stock_parts/matter_bin = 5,/obj/item/weapon/stock_parts/manipulator = 5,/obj/item/weapon/stock_parts/console_screen = 5)
-	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
-	// Another invalid entry, /obj/item/weapon/circuitry.  I don't even know what that would translate to, removed it.
-	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
 
 //This one's from bay12
 /obj/machinery/vending/robotics
@@ -848,5 +845,3 @@
 					/obj/item/weapon/stock_parts/cell/high = 12, /obj/item/device/assembly/prox_sensor = 3,/obj/item/device/assembly/signaler = 3,/obj/item/device/healthanalyzer = 3,
 					/obj/item/weapon/scalpel = 2,/obj/item/weapon/circular_saw = 2,/obj/item/weapon/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/weapon/screwdriver = 5,/obj/item/weapon/crowbar = 5)
-	//everything after the power cell had no amounts, I improvised.  -Sayu
-

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -197,7 +197,7 @@
 /obj/effect/spider/cocoon/container_resist()
 	var/mob/living/user = usr
 	var/breakout_time = 2
-	user.next_move = world.time + 100
+	user.changeNext_move(100)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You struggle against the tight bonds! (This will take about [breakout_time] minutes.)</span>"
 	visible_message("You see something struggling and writhing in the [src]!")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -132,7 +132,6 @@
 	else
 		if(isliving(loc))
 			return
-		user.next_move = max(user.next_move+2,world.time + 2)
 	pickup(user)
 	add_fingerprint(user)
 	user.put_in_active_hand(src)
@@ -154,7 +153,6 @@
 		if(istype(src.loc, /mob/living))
 			return
 		src.pickup(user)
-		user.next_move = max(user.next_move+2,world.time + 2)
 
 	user.put_in_active_hand(src)
 	return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -310,7 +310,7 @@
 		return  //Door's open, not locked or welded, no point in resisting.
 
 	//okay, so the closet is either welded or locked... resist!!!
-	user.next_move = world.time + 100
+	user.changeNext_move(100)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	for(var/mob/O in viewers(src))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -33,6 +33,7 @@
 	attack_hand(user)
 
 /obj/structure/grille/attack_hand(mob/user as mob)
+	user.changeNext_move(8)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	user.visible_message("<span class='warning'>[user] kicks [src].</span>", \
 						 "<span class='warning'>You kick [src].</span>", \
@@ -60,6 +61,7 @@
 		return
 
 /obj/structure/grille/attack_slime(mob/living/carbon/slime/user as mob)
+	user.changeNext_move(8)
 	if(!user.is_adult)	return
 
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
@@ -72,6 +74,7 @@
 	return
 
 /obj/structure/grille/attack_animal(var/mob/living/simple_animal/M as mob)
+	M.changeNext_move(8)
 	if(M.melee_damage_upper == 0)	return
 
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
@@ -104,6 +107,7 @@
 	return
 
 /obj/structure/grille/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	user.changeNext_move(8)
 	if(istype(W, /obj/item/weapon/wirecutters))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -114,6 +114,7 @@
 			R.add_fingerprint(user)
 		del(src)
 	else
+		user.changeNext_move(8)
 		user.visible_message("<span class='notice'>[user] knocks on [src].</span>")
 		add_fingerprint(user)
 		playsound(loc, 'sound/effects/Glasshit.ogg', 50, 1)
@@ -126,6 +127,7 @@
 /obj/structure/window/proc/attack_generic(mob/user as mob, damage = 0)	//used by attack_alien, attack_animal, and attack_slime
 	if(!can_be_reached(user))
 		return
+	user.changeNext_move(8)
 	health -= damage
 	if(health <= 0)
 		user.visible_message("<span class='danger'>[user] smashes through [src]!</span>")
@@ -193,6 +195,7 @@
 		src.Del(1)
 	else
 		if(I.damtype == BRUTE || I.damtype == BURN)
+			user.changeNext_move(8)
 			hit(I.force)
 			if(health <= 7)
 				anchored = 0

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -89,6 +89,7 @@
 		dismantle_wall()
 
 /turf/simulated/wall/attack_paw(mob/user as mob)
+	user.changeNext_move(8)
 	if ((HULK in user.mutations))
 		if (prob(hardness))
 			usr << text("\blue You smash through the wall.")
@@ -102,6 +103,7 @@
 	return src.attack_hand(user)
 
 /turf/simulated/wall/attack_animal(var/mob/living/simple_animal/M)
+	M.changeNext_move(8)
 	if(M.environment_smash >= 2)
 		if(istype(src, /turf/simulated/wall/r_wall))
 			if(M.environment_smash == 3)
@@ -115,6 +117,7 @@
 			return
 
 /turf/simulated/wall/attack_hand(mob/user as mob)
+	user.changeNext_move(8)
 	if (HULK in user.mutations)
 		if (prob(hardness))
 			usr << text("\blue You smash through the wall.")
@@ -132,7 +135,7 @@
 	return
 
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob)
-
+	user.changeNext_move(8)
 	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
 		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -423,7 +423,7 @@
 
 	if(!isliving(usr) || usr.next_move > world.time)
 		return
-	usr.next_move = world.time + 20
+	usr.changeNext_move(20)
 
 	var/mob/living/L = usr
 
@@ -456,7 +456,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			if(C.handcuffed)
-				C.next_move = world.time + 100
+				C.changeNext_move(100)
 				C.last_special = world.time + 100
 				C.visible_message("<span class='warning'>[usr] attempts to unbuckle themself!</span>", \
 							"<span class='notice'>You attempt to unbuckle yourself. (This will take around one minute and you need to stay still.)</span>")
@@ -492,7 +492,7 @@
 				ExtinguishMob()
 			return
 		if(CM.handcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
+			CM.changeNext_move(100)
 			CM.last_special = world.time + 100
 			if(isalienadult(CM) || (HULK in usr.mutations))//Don't want to do a lot of logic gating here.
 				CM.visible_message("<span class='warning'>[CM] is trying to break [CM.handcuffed]!</span>", \
@@ -526,7 +526,7 @@
 						CM.handcuffed = null
 						CM.update_inv_handcuffed(0)
 		else if(CM.legcuffed && CM.canmove && (CM.last_special <= world.time))
-			CM.next_move = world.time + 100
+			CM.changeNext_move(100)
 			CM.last_special = world.time + 100
 			if(isalienadult(CM) || (HULK in usr.mutations))//Don't want to do a lot of logic gating here.
 				CM.visible_message("<span class='warning'>[CM] is trying to break [CM.legcuffed]!</span>", \

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -258,8 +258,6 @@ var/list/slot_equipment_priority = list( \
 		if (W)
 			W.attack_self(src)
 			update_inv_r_hand(0)
-	if(next_move < world.time)
-		next_move = world.time + 2
 	return
 
 /*

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -163,7 +163,7 @@
 					assailant.visible_message("<span class='danger'>[assailant] has tightened \his grip on [affecting]'s neck!</span>")
 					add_logs(assailant, affecting, "strangled")
 
-					assailant.next_move = world.time + 10
+					assailant.changeNext_move(10)
 					affecting.losebreath += 1
 				else
 					assailant.visible_message("<span class='warning'>[assailant] was unable to tighten \his grip on [affecting]'s neck!</span>")

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -10,7 +10,7 @@
 			return 0
 		if(i > 1)
 			newshot()
-	user.next_move = world.time + 4
+	user.changeNext_move(4)
 	update_icon()
 	return 1
 


### PR DESCRIPTION
Removes the click cooldown from almost everything, now it should be always be 0.1 seconds.

Ranged weapons and laser eyes have a cooldown of 0.4.
Grilles, windows and walls have a cooldown of 0.8.
Removes the unused USEDELAY flag.
