### PR TITLE
You will fall over in zero gravity, again, but you won't make a noise.

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -235,8 +235,5 @@
 					A.loc.Entered(A)
 	return
 
-turf/space/handle_fall()
-	return
-
 /turf/space/handle_slip()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -293,28 +293,30 @@
 	faller.lying = pick(90, 270)
 	if(!forced)
 		return
-	playsound(src, "bodyfall", 50, 1)
+	if(has_gravity(src))
+		playsound(src, "bodyfall", 50, 1)
 
 /turf/handle_slip(mob/slipper, s_amount, w_amount, obj/O, lube)
-	var/mob/living/carbon/M = slipper
-	if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
-		return 0
-	if(!M.lying)
-		M.stop_pulling()
-		if(lube&STEP)
-			step(M, M.dir)
-		if(lube&SLIDE)
-			for(var/i=1, i<5, i++)
-				spawn (i)
-					step(M, M.dir)
-			if(M.lying) //did I fall over?
-				M.adjustBruteLoss(2)
-		if(O)
-			M << "<span class='notice'>You slipped on the [O.name]!</span>"
-		else
-			M << "<span class='notice'>You slipped!</span>"
-		playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(s_amount)
-		M.Weaken(w_amount)
-		return 1
+	if(has_gravity(src))
+		var/mob/living/carbon/M = slipper
+		if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
+			return 0
+		if(!M.lying)
+			M.stop_pulling()
+			if(lube&STEP)
+				step(M, M.dir)
+			if(lube&SLIDE)
+				for(var/i=1, i<5, i++)
+					spawn (i)
+						step(M, M.dir)
+				if(M.lying) //did I fall over?
+					M.adjustBruteLoss(2)
+			if(O)
+				M << "<span class='notice'>You slipped on the [O.name]!</span>"
+			else
+				M << "<span class='notice'>You slipped!</span>"
+			playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+			M.Stun(s_amount)
+			M.Weaken(w_amount)
+			return 1
 	return 0 // no success. Used in clown pda and wet floors

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -22,12 +22,12 @@
 	F << "<small>[time2text(world.timeofday,"hh:mm")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>"
 
 //ADMINVERBS
-/client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo","wires","telesci") )
+/client/proc/investigate_show( subject in list("hrefs","notes","ntsl","singulo","wires","telesci", "gravity") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)	return
 	switch(subject)
-		if("singulo", "ntsl", "wires", "telesci")			//general one-round-only stuff
+		if("singulo", "ntsl", "wires", "telesci", "gravity")			//general one-round-only stuff
 			var/F = investigate_subject2file(subject)
 			if(!F)
 				src << "<font color='red'>Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed.</font>"

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -119,6 +119,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	var/broken_state = 0
 
 /obj/machinery/gravity_generator/main/Destroy() // If we somehow get deleted, remove all of our other parts.
+	investigate_log("was destroyed!", "gravity")
 	on = 0
 	update_list()
 	for(var/obj/machinery/gravity_generator/part/O in parts)
@@ -156,6 +157,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	breaker = 0
 	set_power()
 	set_state(0)
+	investigate_log("has broken down.", "gravity")
 
 /obj/machinery/gravity_generator/main/set_fix()
 	..()
@@ -239,6 +241,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 
 	if(href_list["gentoggle"])
 		breaker = !breaker
+		investigate_log("was toggled [breaker ? "<font color='green'>ON</font>" : "<font color='red'>OFF</font>"] by [usr.key].", "gravity")
 		set_power()
 		src.updateUsrDialog()
 
@@ -246,6 +249,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 
 /obj/machinery/gravity_generator/main/power_change()
 	..()
+	investigate_log("has [stat & NOPOWER ? "lost" : "regained"] power.", "gravity")
 	set_power()
 
 /obj/machinery/gravity_generator/main/get_status()
@@ -267,6 +271,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 		new_state = 1
 
 	charging_state = new_state ? POWER_UP : POWER_DOWN // Startup sequence animation.
+	investigate_log("is now [charging_state == POWER_UP ? "charging" : "discharging"].", "gravity")
 	update_icon()
 
 // Set the state of the gravity.
@@ -276,12 +281,17 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	use_power = on ? 2 : 1
 	// Sound the alert if gravity was just enabled or disabled.
 	var/alert = 0
+	var/area/area = get_area(src)
 	if(new_state) // If we turned on
 		if(gravity_in_level() == 0)
 			alert = 1
+			investigate_log("was brought online and is now producing gravity for this level.", "gravity")
+			message_admins("The gravity generator was brought online. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[area.name]</a>)")
 	else
 		if(gravity_in_level() == 1)
 			alert = 1
+			investigate_log("was brought offline and there is now no gravity for this level.", "gravity")
+			message_admins("The gravity generator was brought offline with no backup generator. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>[area.name]</a>)")
 
 	update_icon()
 	update_list()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -90,6 +90,14 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	update_list()
 
 //
+// Generator an admin can spawn
+//
+
+/obj/machinery/gravity_generator/main/station/admin/New()
+	..()
+	initialize()
+
+//
 // Main Generator with the main code
 //
 


### PR DESCRIPTION
This was important because it told players whether someone was stunned or dead, when it was changed it just added confusion.

Misc:
- You can no longer slip in zero g.
- Added an admin subtype of the gravity generator which admins can spawn to create a pre-setup gravity generator.
- Added admin logs to the gravity generator.
