### PR TITLE
removes the crlf bits from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,2 @@
-*.css text eol=crlf
-*.dm text eol=crlf
-*.dme text eol=crlf
-*.dmf text eol=crlf
-*.dmm text eol=crlf
-*.dms text eol=crlf
-*.htm text eol=crlf
-*.html text eol=crlf
-*.js text eol=crlf
-*.py text eol=crlf
-*.txt text eol=crlf
-
 *.dmm merge=merge-dmm
+


### PR DESCRIPTION
that shouldn't have been merged it's horribly broken

Signed-off-by: Mloc-Hibernia colmohici@gmail.com
