### PR TITLE
fixing the cure description for Pierrot's Throat.

### DIFF
--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -2,7 +2,7 @@
 	name = "Pierrot's Throat"
 	max_stages = 4
 	spread = "Airborne"
-	cure = "Banana"
+	cure = "Banana products, especially banana bread."
 	cure_id = "banana"
 	cure_chance = 75
 	agent = "H0NI<42 Virus"

--- a/code/datums/diseases/pierrot_throat.dm
+++ b/code/datums/diseases/pierrot_throat.dm
@@ -2,7 +2,7 @@
 	name = "Pierrot's Throat"
 	max_stages = 4
 	spread = "Airborne"
-	cure = "A whole banana."
+	cure = "Banana"
 	cure_id = "banana"
 	cure_chance = 75
 	agent = "H0NI<42 Virus"


### PR DESCRIPTION
Fixes #2188

The possible cure will now simply reads as "Banana" (similar format as the cure of other diseases) so that people don't think the cure is to eat a single banana anymore.
