### PR TITLE
Removes Departmental Security (To an extent)

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -150,16 +150,19 @@
 	spawn_positions = 5
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
-	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue)
-	minimal_access = list(access_security, access_sec_doors, access_brig, access_court) //But see /datum/job/warden/get_access()
+	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_construction, access_engine,
+	access_mailsorting, access_mining, access_medical, access_research)
+	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_construction, access_engine,
+	access_mailsorting, access_mining, access_medical, access_research, access_maint_tunnels) //But see /datum/job/warden/get_access()
 	minimal_player_age = 7
 
 
 /datum/job/officer/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
+	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
 	if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(H), slot_back)
 	if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_sec(H), slot_back)
-	assign_sec_to_department(H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/security(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
@@ -178,94 +181,6 @@
 	L.implanted = 1
 	return 1
 
-/datum/job/officer/get_access()
-	var/list/L = list()
-	L = ..() | check_config_for_sec_maint()
-	return L
-	
-var/list/sec_departments = list("engineering", "supply", "medical", "science")
 
-/datum/job/officer/proc/assign_sec_to_department(var/mob/living/carbon/human/H)
-	if(!H) return 0
-	if(!sec_departments.len)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
-	else
-		var/department = pick(sec_departments)
-		sec_departments -= department
-		var/dep_access = null
-		var/destination = null
-		switch(department)
-			if("supply")
-				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/cargo(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/supply(H), slot_ears)
-				dep_access = list(access_mailsorting, access_mining)
-				destination = /area/security/checkpoint/supply
-			if("engineering")
-				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/engine(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/engi(H), slot_ears)
-				dep_access = list(access_construction, access_engine)
-				destination = /area/security/checkpoint/engineering
-			if("medical")
-				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/med(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/med(H), slot_ears)
-				dep_access = list(access_medical)
-				destination = /area/security/checkpoint/medical
-			if("science")
-				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/science(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/sci(H), slot_ears)
-				dep_access = list(access_research)
-				destination = /area/security/checkpoint/science
-		var/teleport = 0
-		if(!config.sec_start_brig)
-			if(destination)
-				if(!ticker || ticker.current_state <= GAME_STATE_SETTING_UP)
-					teleport = 1
-		if(teleport)
-			var/turf/T
-			var/safety = 0
-			while(safety < 25)
-				T = safepick(get_area_turfs(destination))
-				if(T && !H.Move(T))
-					safety += 1
-					continue
-				else
-					break
-		H << "<b>You have been assigned to [department]!</b>"
-		access += dep_access
-	
-/obj/item/device/radio/headset/headset_sec/department/New()
-	wires = new(src)
-	secure_radio_connections = new
 
-	if(radio_controller)
-		initialize()
-	recalculateChannels()
 
-/obj/item/device/radio/headset/headset_sec/department/engi
-	keyslot1 = new /obj/item/device/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/device/encryptionkey/headset_eng
-
-/obj/item/device/radio/headset/headset_sec/department/supply
-	keyslot1 = new /obj/item/device/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/device/encryptionkey/headset_cargo
-
-/obj/item/device/radio/headset/headset_sec/department/med
-	keyslot1 = new /obj/item/device/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/device/encryptionkey/headset_med
-
-/obj/item/device/radio/headset/headset_sec/department/sci
-	keyslot1 = new /obj/item/device/encryptionkey/headset_sec
-	keyslot2 = new /obj/item/device/encryptionkey/headset_sci
-
-/obj/item/clothing/under/rank/security/cargo/New()
-	attachTie(new /obj/item/clothing/tie/armband/cargo)
-
-/obj/item/clothing/under/rank/security/engine/New()
-	attachTie(new /obj/item/clothing/tie/armband/engine)
-
-/obj/item/clothing/under/rank/security/science/New()
-	attachTie(new /obj/item/clothing/tie/armband/science)
-
-/obj/item/clothing/under/rank/security/med/New()
-	attachTie(new /obj/item/clothing/tie/armband/medblue)


### PR DESCRIPTION
From this thread: http://www.ss13.eu/phpbb/viewtopic.php?f=42&t=4046

This will be my most controversial pull request to date.

The situation is inane, for three months Sec Dept access has been broken..

Let that sink in, three months. THREE MONTHS. If this was any other job it would have been fixed within days.

Officers are trapped in their departments or worse. Also Sec Maint was revoked recently which adds even more bullshit to the stress of Security players.

This removes Departmental Security to an extent, the following changes are..
- All Security Officer have basic access to all departments
- Security Officers spawn on the brig
- Sec Officers have default Maint access.

This should also mean Officers now have actual access to departments that works! If it does not work, then we will know the problem is not on our end.

Thank you.
