### PR TITLE
Fixes a small bug in ventcrawling

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -386,6 +386,6 @@
 		target_vent = src
 		L << "<span class='warning'> The vent you were heading to appears to be welded.</span>"
 	L.loc = target_vent.loc
-	var/area/new_area = get_area(loc)
+	var/area/new_area = get_area(L.loc)
 	if(new_area)
 		new_area.Entered(L)


### PR DESCRIPTION
Fixes a small bug in ventcrawling that allowed crawlers to avoid things that relied on area.Entered. Mostly the turrets in the AI Core/upload.

Reported: http://www.ss13.eu/phpbb/viewtopic.php?f=42&t=9&start=1900#p126318 
NEXT TIME USE GITHUB.
