### PR TITLE
Gives cyborgs ai click shortcuts, adds some click shortcuts, and gives borgs more meaningful hotkeys

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -141,6 +141,10 @@
 /obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
 	toggle_breaker()
 
+/obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
+	src.enabled = !src.enabled
+	src.updateTurrets()
+
 
 /atom/proc/AIAltClick(var/mob/living/silicon/ai/user)
 	AltClick(user)
@@ -156,6 +160,10 @@
 		// disable/6 is not in Topic; disable/5 disables both temporary and permenant shock
 		Topic("aiDisable=5", list("aiDisable"="5"), 1)
 	return
+
+/obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
+	src.lethal = !src.lethal
+	src.updateTurrets()
 
 //
 // Override TurfAdjacent for AltClicking

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -36,6 +36,9 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] && modifiers["ctrl"])
+		CtrlShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return
@@ -85,6 +88,9 @@
 	than anything else in the game, atoms have separate procs
 	for AI shift, ctrl, and alt clicking.
 */
+
+/mob/living/silicon/ai/CtrlShiftClickOn(var/atom/A)
+	A.AICtrlShiftClick(src)
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	A.AIShiftClick(src)
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
@@ -96,6 +102,17 @@
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
 */
+/atom/proc/AICtrlShiftClick()
+	return
+
+/obj/machinery/door/airlock/AICtrlShiftClick()  // Sets/Unsets Emergency Access Override
+	if(emagged)
+		return
+	if(!emergency)
+		Topic("aiEnable=11", list("aiEnable"="11"), 1) // 1 meaning no window (consistency!)
+	else
+		Topic("aiDisable=11", list("aiDisable"="11"), 1)
+	return
 
 /atom/proc/AIShiftClick()
 	return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -43,6 +43,9 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] && modifiers["ctrl"])
+		CtrlShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return
@@ -258,6 +261,17 @@
 
 /mob/proc/TurfAdjacent(var/turf/T)
 	return T.Adjacent(src)
+
+/*
+	Control+Shift click
+	Unused except for AI
+*/
+/mob/proc/CtrlShiftClickOn(var/atom/A)
+	A.CtrlShiftClick(src)
+	return
+
+/atom/proc/CtrlShiftClick(var/mob/user)
+	return
 
 /*
 	Misc helpers

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -100,6 +100,41 @@
 	cycle_modules()
 	return
 
+//Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
+// for non-doors/apcs
+/mob/living/silicon/robot/ShiftClickOn(var/atom/A)
+	A.BorgShiftClick(src)
+/mob/living/silicon/robot/CtrlClickOn(var/atom/A)
+	A.BorgCtrlClick(src)
+/mob/living/silicon/robot/AltClickOn(var/atom/A)
+	A.BorgAltClick(src)
+
+
+/atom/proc/BorgShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
+	ShiftClick(user)
+
+/obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
+	AIShiftClick()
+
+
+/atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
+	CtrlClick(user)
+
+/obj/machinery/door/airlock/BorgCtrlClick() // Bolts doors. Forwards to AI code.
+	AICtrlClick()
+
+/obj/machinery/power/apc/BorgCtrlClick() // turns off/on APCs. Forwards to AI code.
+	AICtrlClick()
+
+
+/atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
+	AltClick(user)
+	return
+
+/obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
+	AIAltClick()
+
+
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -118,7 +118,7 @@
 	CtrlShiftClick(user)
 
 /obj/machinery/door/airlock/BorgCtrlShiftClick() // Sets/Unsets Emergency Access Override Forwards to AI code.
-	AiCtrlShiftClick()
+	AICtrlShiftClick()
 
 
 /atom/proc/BorgShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -19,6 +19,9 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] && modifiers["ctrl"])
+		CtrlShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
 		return
@@ -102,12 +105,20 @@
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
+/mob/living/silicon/robot/CtrlShiftClickOn(var/atom/A)
+	A.BorgCtrlShiftClick(src)
 /mob/living/silicon/robot/ShiftClickOn(var/atom/A)
 	A.BorgShiftClick(src)
 /mob/living/silicon/robot/CtrlClickOn(var/atom/A)
 	A.BorgCtrlClick(src)
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
 	A.BorgAltClick(src)
+
+/atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
+	CtrlShiftClick(user)
+
+/obj/machinery/door/airlock/BorgCtrlShiftClick() // Sets/Unsets Emergency Access Override Forwards to AI code.
+	AiCtrlShiftClick()
 
 
 /atom/proc/BorgShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -126,6 +126,8 @@
 /obj/machinery/power/apc/BorgCtrlClick() // turns off/on APCs. Forwards to AI code.
 	AICtrlClick()
 
+/obj/machinery/turretid/BorgCtrlClick() //turret control on/off. Forwards to AI code.
+	AICtrlClick()
 
 /atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
 	AltClick(user)
@@ -134,6 +136,8 @@
 /obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
 	AIAltClick()
 
+/obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
+	AIAltClick()
 
 /*
 	As with AI, these are not used in click code,

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -3,4 +3,5 @@
 	regenerate_icons()
 	show_laws(0)
 	if(mind)	ticker.mode.remove_revolutionary(mind)
+	winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
 	return

--- a/code/modules/mob/living/silicon/robot/login.dm
+++ b/code/modules/mob/living/silicon/robot/login.dm
@@ -1,7 +1,11 @@
+
+
 /mob/living/silicon/robot/Login()
 	..()
 	regenerate_icons()
 	show_laws(0)
 	if(mind)	ticker.mode.remove_revolutionary(mind)
+
 	winset(src, null, "mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+
 	return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -125,6 +125,7 @@
 		mmi = null
 	..()
 
+
 /mob/living/silicon/robot/proc/pick_module()
 	if(module)
 		return
@@ -239,6 +240,18 @@
 	set category = "Robot Commands"
 	set name = "Show Alerts"
 	robot_alerts()
+
+//for borg hotkeys, here module refers to borg inv slot, not core module
+/mob/living/silicon/robot/verb/cmd_toggle_module(module as num)
+	set name = "Toggle Module"
+	set hidden = 1
+	toggle_module(module)
+
+/mob/living/silicon/robot/verb/cmd_unequip_module()
+	set name = "Unequip Module"
+	set hidden = 1
+	uneq_active()
+
 
 /mob/living/silicon/robot/proc/robot_alerts()
 	var/dat = "<HEAD><TITLE>Current Station Alerts</TITLE><META HTTP-EQUIV='Refresh' CONTENT='10'></HEAD><BODY>\n"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -47,4 +47,6 @@
 	if(isobj(loc))
 		var/obj/Loc=loc
 		Loc.on_log()
+	//set macro to normal incase it was overriden (like cyborg currently does)
+	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -81,6 +81,47 @@ Any-Mode: (hotkey doesn't need to be on)
 \tEND = throw
 </font>"}
 
+
+	var/borghotkey_mode = {"<font color='purple'>
+Hotkey-Mode: (hotkey-mode must be on)
+\tTAB = toggle hotkey-mode
+\ta = left
+\ts = down
+\td = right
+\tw = up
+\tq = unequip active module
+\tt = say
+\tx = cycle active modules
+\tz = activate held object (or y)
+\tf = cycle-intents-left
+\tg = cycle-intents-right
+\t1 = activate module 1
+\t2 = activate module 2
+\t3 = activate module 3
+\t4 = toggle intents
+</font>"}
+
+	var/borgother = {"<font color='purple'>
+Any-Mode: (hotkey doesn't need to be on)
+\tCtrl+a = left
+\tCtrl+s = down
+\tCtrl+d = right
+\tCtrl+w = up
+\tCtrl+q = unequip active module
+\tCtrl+x = cycle active modules
+\tCtrl+z = activate held object (or Ctrl+y)
+\tCtrl+f = cycle-intents-left
+\tCtrl+g = cycle-intents-right
+\tCtrl+1 = activate module 1
+\tCtrl+2 = activate module 2
+\tCtrl+3 = activate module 3
+\tCtrl+4 = toggle intents
+\tDEL = pull
+\tINS = toggle intents
+\tPGUP = cycle active modules
+\tPGDN = activate held object
+</font>"}
+
 	var/admin = {"<font color='purple'>
 Admin:
 \tF5 = Aghost (admin-ghost)
@@ -88,8 +129,12 @@ Admin:
 \tF7 = admin-pm
 \tF8 = Invisimin
 </font>"}
+	if (isrobot(mob))
+		src << borghotkey_mode
+		src << borgother
+	else
+		src << hotkey_mode
+		src << other
 
-	src << hotkey_mode
-	src << other
 	if(holder)
 		src << admin

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -35,6 +35,21 @@
 	set name = "hotkeys-help"
 	set category = "OOC"
 
+	var/adminhotkeys = {"<font color='purple'>
+Admin:
+\tF5 = Aghost (admin-ghost)
+\tF6 = player-panel-new
+\tF7 = admin-pm
+\tF8 = Invisimin
+</font>"}
+
+	mob.hotkey_help()
+
+	if(holder)
+		src << adminhotkeys
+
+
+/mob/proc/hotkey_help()
 	var/hotkey_mode = {"<font color='purple'>
 Hotkey-Mode: (hotkey-mode must be on)
 \tTAB = toggle hotkey-mode
@@ -81,8 +96,11 @@ Any-Mode: (hotkey doesn't need to be on)
 \tEND = throw
 </font>"}
 
+	src << hotkey_mode
+	src << other
 
-	var/borghotkey_mode = {"<font color='purple'>
+/mob/living/silicon/robot/hotkey_help()
+	var/hotkey_mode = {"<font color='purple'>
 Hotkey-Mode: (hotkey-mode must be on)
 \tTAB = toggle hotkey-mode
 \ta = left
@@ -101,7 +119,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \t4 = toggle intents
 </font>"}
 
-	var/borgother = {"<font color='purple'>
+	var/other = {"<font color='purple'>
 Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+a = left
 \tCtrl+s = down
@@ -122,19 +140,5 @@ Any-Mode: (hotkey doesn't need to be on)
 \tPGDN = activate held object
 </font>"}
 
-	var/admin = {"<font color='purple'>
-Admin:
-\tF5 = Aghost (admin-ghost)
-\tF6 = player-panel-new
-\tF7 = admin-pm
-\tF8 = Invisimin
-</font>"}
-	if (isrobot(mob))
-		src << borghotkey_mode
-		src << borgother
-	else
-		src << hotkey_mode
-		src << other
-
-	if(holder)
-		src << admin
+	src << hotkey_mode
+	src << other

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,3 +1,237 @@
+macro "borghotkeymode"
+	elem 
+		name = "TAB"
+		command = ".winset \"mainwindow.macro=borgmacro hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5\""
+		is-disabled = false
+	elem 
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem 
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem 
+		name = "WEST+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem 
+		name = "NORTH+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem 
+		name = "EAST+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem 
+		name = "SOUTH+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem 
+		name = "1"
+		command = "toggle-module 1"
+		is-disabled = false
+	elem 
+		name = "CTRL+1"
+		command = "toggle-module 1"
+		is-disabled = false
+	elem 
+		name = "2"
+		command = "toggle-module 2"
+		is-disabled = false
+	elem 
+		name = "CTRL+2"
+		command = "toggle-module 2"
+		is-disabled = false
+	elem 
+		name = "3"
+		command = "toggle-module 3"
+		is-disabled = false
+	elem 
+		name = "CTRL+3"
+		command = "toggle-module 3"
+		is-disabled = false
+	elem 
+		name = "4"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+4"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "A+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+A+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "Q"
+		command = "unequip-module"
+		is-disabled = false
+	elem 
+		name = "CTRL+Q"
+		command = "unequip-module"
+		is-disabled = false
+	elem 
+		name = "R"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem "s_key"
+		name = "S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "CTRL+S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "T"
+		command = "say"
+		is-disabled = false
+	elem "w_key"
+		name = "W+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+W+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem 
+		name = "F5"
+		command = "Aghost"
+		is-disabled = false
+	elem 
+		name = "F6"
+		command = "Player-Panel-New"
+		is-disabled = false
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+		is-disabled = false
+	elem 
+		name = "F8"
+		command = "Invisimin"
+		is-disabled = false
+	elem 
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
 macro "macro"
 	elem 
 		name = "TAB"
@@ -355,6 +589,172 @@ macro "hotkeymode"
 		is-disabled = false
 	elem 
 		name = "Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+Z"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem 
+		name = "F5"
+		command = "Aghost"
+		is-disabled = false
+	elem 
+		name = "F6"
+		command = "Player-Panel-New"
+		is-disabled = false
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+		is-disabled = false
+	elem 
+		name = "F8"
+		command = "Invisimin"
+		is-disabled = false
+	elem 
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
+macro "borgmacro"
+	elem 
+		name = "TAB"
+		command = ".winset \"mainwindow.macro=borghotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0\""
+		is-disabled = false
+	elem 
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem 
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem 
+		name = "WEST+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem 
+		name = "NORTH+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem 
+		name = "EAST+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem 
+		name = "SOUTH+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem 
+		name = "CTRL+1"
+		command = "toggle-module 1"
+		is-disabled = false
+	elem 
+		name = "CTRL+2"
+		command = "toggle-module 2"
+		is-disabled = false
+	elem 
+		name = "CTRL+3"
+		command = "toggle-module 3"
+		is-disabled = false
+	elem 
+		name = "CTRL+4"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+A+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "CTRL+Q"
+		command = "unequip-module"
+		is-disabled = false
+	elem 
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "CTRL+W+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "CTRL+Y"
 		command = "Activate-Held-Object"
 		is-disabled = false
 	elem 
@@ -1322,6 +1722,8 @@ window "mapwindow"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
+		letterbox = true
+		zoom = 0
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
@@ -1794,4 +2196,6 @@ window "infowindow"
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 		on-tab = ""
+		prefix-color = none
+		suffix-color = none
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1722,8 +1722,6 @@ window "mapwindow"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
-		letterbox = true
-		zoom = 0
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
@@ -2196,6 +2194,4 @@ window "infowindow"
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 		on-tab = ""
-		prefix-color = none
-		suffix-color = none
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -16,12 +16,8 @@ macro "borghotkeymode"
 		command = ".southeast"
 		is-disabled = false
 	elem 
-		name = "SOUTHWEST"
-		command = ".southwest"
-		is-disabled = false
-	elem 
 		name = "NORTHWEST"
-		command = ".northwest"
+		command = "unequip-module"
 		is-disabled = false
 	elem 
 		name = "CTRL+WEST"
@@ -112,14 +108,6 @@ macro "borghotkeymode"
 		command = ".east"
 		is-disabled = false
 	elem 
-		name = "E"
-		command = "quick-equip"
-		is-disabled = false
-	elem 
-		name = "CTRL+E"
-		command = "quick-equip"
-		is-disabled = false
-	elem 
 		name = "F"
 		command = "a-intent left"
 		is-disabled = false
@@ -142,14 +130,6 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Q"
 		command = "unequip-module"
-		is-disabled = false
-	elem 
-		name = "R"
-		command = ".southwest"
-		is-disabled = false
-	elem 
-		name = "CTRL+R"
-		command = ".southwest"
 		is-disabled = false
 	elem "s_key"
 		name = "S+REP"
@@ -650,12 +630,8 @@ macro "borgmacro"
 		command = ".southeast"
 		is-disabled = false
 	elem 
-		name = "SOUTHWEST"
-		command = ".southwest"
-		is-disabled = false
-	elem 
 		name = "NORTHWEST"
-		command = ".northwest"
+		command = "unequip-module"
 		is-disabled = false
 	elem 
 		name = "CTRL+WEST"
@@ -722,10 +698,6 @@ macro "borgmacro"
 		command = ".east"
 		is-disabled = false
 	elem 
-		name = "CTRL+E"
-		command = "quick-equip"
-		is-disabled = false
-	elem 
 		name = "CTRL+F"
 		command = "a-intent left"
 		is-disabled = false
@@ -736,10 +708,6 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+Q"
 		command = "unequip-module"
-		is-disabled = false
-	elem 
-		name = "CTRL+R"
-		command = ".southwest"
 		is-disabled = false
 	elem 
 		name = "CTRL+S+REP"


### PR DESCRIPTION
Cyborgs get all AI click shorts, but defaults to normal behavior when not triggering an AI click shortcut (shift still inspects, control still drags, alt still searches.)

Added click shortcuts:

Door: 
Control+Shift click: toggles access override.

Turret controls:
Control+click: toggles turrets on/off.
Alt+click: toggles lethal.

Borg hotkeys (macros) changed as follows:

1-3/control+1-3: select/toggle module 1-3 (inventory module, not core module).
q/control+q/end: unequip active module
4/control+4: toggle intent. (mainly because i felt i had to something with 4.)

hotkeys that borgs can't used removed. (throw, equip, etc)

Everything else remains the same, tab still toggles hotkey mode, etc.

hotkey-help updated for borg players to reflect this.

This is my first major pull request, but everything has been unit tested on a clean install. no known bugs.
