### PR TITLE
Watertank nozzles no longer delete

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -17,6 +17,7 @@
 /obj/item/weapon/watertank/New()
 	..()
 	create_reagents(volume)
+	noz = make_noz()
 	return
 	
 /obj/item/weapon/watertank/examine()
@@ -37,36 +38,36 @@
 	set name = "Toggle Mister"
 	set category = "Object"
 	on = !on
-
+	
 	var/mob/living/carbon/human/user = usr
 	if(on)
 		//Detach the nozzle into the user's hands
-		make_noz()
 		var/list/L = list("left hand" = slot_l_hand,"right hand" = slot_r_hand)
 		if(!user.equip_in_one_of_slots(noz, L))
 			on = 0
 			user << "<span class='notice'>You need a free hand to hold the mister!</span>"
+			return
+		noz.loc = user
 	else
 		//Remove from their hands and put back "into" the tank
 		remove_noz(user)
 	return
 	
 /obj/item/weapon/watertank/proc/make_noz()
-	noz = new /obj/item/weapon/reagent_containers/spray/mister(src)
-	return
+	return new /obj/item/weapon/reagent_containers/spray/mister(src)
 
 /obj/item/weapon/watertank/equipped(mob/user, slot)
 	if (slot != slot_back)
 		remove_noz(user)
 
 /obj/item/weapon/watertank/proc/remove_noz(mob/user)
-	if (noz != null)
-		var/mob/living/carbon/human/M = user
+	var/mob/living/carbon/human/M = user
+	if(noz in get_both_hands(M))
 		M.unEquip(noz)
 	return
 
 /obj/item/weapon/watertank/Destroy()
-	if (noz)
+	if (on)
 		var/M = get(noz, /mob)
 		remove_noz(M)
 	..()
@@ -91,23 +92,24 @@
 
 /obj/item/weapon/reagent_containers/spray/mister/New(parent_tank)
 	..()
-	if(check_tank_exists(parent_tank, usr, src))
+	if(check_tank_exists(parent_tank, src))
 		tank = parent_tank
 		reagents = tank.reagents	//This mister is really just a proxy for the tank's reagents
-		return
+		loc = tank
+	return
 
 /obj/item/weapon/reagent_containers/spray/mister/dropped(mob/user as mob)
 	user << "<span class='notice'>The mister snaps back onto the watertank!</span>"
 	tank.on = 0
-	qdel(src)
+	loc = tank
 	
 /obj/item/weapon/reagent_containers/spray/mister/attack_self()
 	return
 	
 /proc/check_tank_exists(parent_tank, var/mob/living/carbon/human/M, var/obj/O)
-	if (!parent_tank || !istype(parent_tank, /obj/item/weapon/watertank) || !M || !istype(M))	//To avoid weird issues from admin spawns
+	if (!parent_tank || !istype(parent_tank, /obj/item/weapon/watertank))	//To avoid weird issues from admin spawns
 		M.unEquip(O)
-		qdel(O)
+		qdel(0)
 		return 0
 	else
 		return 1
@@ -134,8 +136,7 @@
 	possible_transfer_amounts = null
 
 /obj/item/weapon/watertank/janitor/make_noz()
-	noz = new /obj/item/weapon/reagent_containers/spray/mister/janitor(src)
-	return
+	return new /obj/item/weapon/reagent_containers/spray/mister/janitor(src)
 	
 /obj/item/weapon/reagent_containers/spray/mister/janitor/attack_self(var/mob/user)
 	amount_per_transfer_from_this = (amount_per_transfer_from_this == 10 ? 5 : 10)
@@ -150,7 +151,7 @@
 	volume = 100
 	
 /obj/item/weapon/watertank/atmos/make_noz()
-	noz = new /obj/item/weapon/extinguisher/mini/nozzle(src)
+	return new /obj/item/weapon/extinguisher/mini/nozzle(src)
 	
 /obj/item/weapon/extinguisher/mini/nozzle
 	name = "fire extinguisher nozzle"
@@ -162,16 +163,17 @@
 	var/obj/item/weapon/watertank/tank
 	
 /obj/item/weapon/extinguisher/mini/nozzle/New(parent_tank)
-	if(check_tank_exists(parent_tank, usr, src))
+	if(check_tank_exists(parent_tank, src))
 		tank = parent_tank
 		reagents = tank.reagents
 		max_water = tank.volume
+		loc = tank
 	return
 		
 /obj/item/weapon/extinguisher/mini/nozzle/dropped(mob/user as mob)
 	user << "<span class='notice'>The nozzle snaps back onto the watertank!</span>"
 	tank.on = 0
-	qdel(src)
+	loc = tank
 	
 /obj/item/weapon/extinguisher/mini/nozzle/attack_self()
 	return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -414,3 +414,7 @@ proc/is_special_character(mob/M) // returns 1 for special characters and 2 for h
 
 /mob/proc/has_mutation(var/mutation)
 	return mutation in src.mutations ? 1 : 0
+
+/proc/get_both_hands(mob/living/carbon/M)
+	var/list/hands = list(M.l_hand, M.r_hand)
+	return hands


### PR DESCRIPTION
Fixes #3206

Watertank nozzle is no longer created and delete as needed, and instead hops between watertank and mob loc.
Also added helper proc to return both hands of a mob.
