### PR TITLE
Adds a name and light blue color to AI Private channel on the radio.

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -121,7 +121,7 @@ var/const/MED_FREQ = 1355 //medical, coloured blue in chat window
 var/const/ENG_FREQ = 1357 //engineering, coloured orange in chat window
 var/const/SEC_FREQ = 1359 //security, coloured red in chat window
 var/const/DSQUAD_FREQ = 1441 //death squad frequency, coloured grey in chat window
-var/const/AIPRIV_FREQ = 1447 //AI private, colored light blue in chat window
+var/const/AIPRIV_FREQ = 1447 //AI private, colored magenta in chat window
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -76,6 +76,7 @@ Radio:
 1443 - Confession Intercom
 1349 - Miners
 1347 - Cargo techs
+1447 - AI Private
 
 Devices:
 1451 - tracking implant
@@ -108,6 +109,7 @@ var/list/radiochannels = list(
 	"Syndicate" = 1213,
 	"Supply" = 1347,
 	"Service" = 1349,
+	"AI Private" = 1447,
 )
 //depenging helpers
 var/const/SYND_FREQ = 1213 //nuke op frequency, coloured dark brown in chat window
@@ -119,6 +121,7 @@ var/const/MED_FREQ = 1355 //medical, coloured blue in chat window
 var/const/ENG_FREQ = 1357 //engineering, coloured orange in chat window
 var/const/SEC_FREQ = 1359 //security, coloured red in chat window
 var/const/DSQUAD_FREQ = 1441 //death squad frequency, coloured grey in chat window
+var/const/AIPRIV_FREQ = 1447 //AI private, colored light blue in chat window
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -352,6 +352,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				freq_text = "Service"
 			if(SUPP_FREQ)
 				freq_text = "Supply"
+			if(AIPRIV_FREQ)
+				freq_text = "AI Private"
 		//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
 
 
@@ -386,6 +388,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			part_a = "<span class='suppradio'><span class='name'>"
 		else if (display_freq==DSQUAD_FREQ)
 			part_a = "<span class='dsquadradio'><span class='name'>"
+		else if (display_freq==AIPRIV_FREQ)
+			part_a = "<span class='aiprivradio'><span class='name'>"
 
 		// --- Filter the message; place it in quotes apply a verb ---
 
@@ -647,6 +651,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 				freq_text = "Service"
 			if(SUPP_FREQ)
 				freq_text = "Supply"
+			if(AIPRIV_FREQ)
+				freq_text = "AI Private"
 		//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
 
 
@@ -685,6 +691,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 			part_a = "<span class='suppradio'><span class='name'>"
 		else if (display_freq==DSQUAD_FREQ)
 			part_a = "<span class='dsquadradio'><span class='name'>"
+		else if (display_freq==AIPRIV_FREQ)
+			part_a = "<span class='aiprivradio'><span class='name'>"
 
 		// --- This following recording is intended for research and feedback in the use of department radio channels ---
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -494,6 +494,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 					freq_text = "Service"
 				if(SUPP_FREQ)
 					freq_text = "Supply"
+				if(AIPRIV_FREQ)
+					freq_text = "AI Private"
 			//There's probably a way to use the list var of channels in code\game\communications.dm to make the dept channels non-hardcoded, but I wasn't in an experimentive mood. --NEO
 
 			if(!freq_text)
@@ -520,7 +522,8 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 				part_a = "<span class='suppradio'><span class='name'>"
 			else if (display_freq==DSQUAD_FREQ)
 				part_a = "<span class='dsquadradio'><span class='name'>"
-
+			else if (display_freq==AIPRIV_FREQ)
+				part_a = "<span class='aiprivradio'><span class='name'>"
 			var/quotedmsg = M.say_quote(message)
 
 			//This following recording is intended for research and feedback in the use of department radio channels.

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -34,7 +34,7 @@ em						{font-style: normal;	font-weight: bold;}
 .servradio				{color: #6eaa2c;}
 .syndradio				{color: #6D3F40;}
 .dsquadradio			{color: #686868;}
-.aiprivradio			{color: #6688dd;}
+.aiprivradio			{color: #ff00ff;}
 
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -34,6 +34,7 @@ em						{font-style: normal;	font-weight: bold;}
 .servradio				{color: #6eaa2c;}
 .syndradio				{color: #6D3F40;}
 .dsquadradio			{color: #686868;}
+.aiprivradio			{color: #6688dd;}
 
 .alert					{color: #ff0000;}
 h1.alert, h2.alert		{color: #000000;}


### PR DESCRIPTION
AI Private (144.7) now has its own name and color! 
The purpose of this is to allow the AI to more easily notice the difference between private and public messages.

![screenshot 2014-03-31 00 34 46](https://cloud.githubusercontent.com/assets/4955510/2564193/bd63e680-b898-11e3-8e12-5a82732b8613.png)
