### PR TITLE
Fireaxe cabinet hacking now fails if player moves away

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -23,11 +23,11 @@
 
 		if (isrobot(usr) || src.locked)
 			if(istype(O, /obj/item/device/multitool))
-				user << "\red Resetting circuitry..."
+				user << "<span class = 'caution'> Resetting circuitry...</span>"
 				playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
 				if(do_after(user, 20))
 					src.locked = 0
-					user << "\blue You disable the locking modules."
+					user << "<span class = 'caution'> You disable the locking modules.</span>"
 					update_icon()
 				return
 			else if(istype(O, /obj/item/weapon))
@@ -41,7 +41,7 @@
 				else
 					playsound(user, 'sound/effects/Glasshit.ogg', 100, 1) //We don't want this playing every time
 				if(W.force < 15)
-					user << "\blue The cabinet's protective glass glances off the hit."
+					user << "<span class = 'warning'> The cabinet's protective glass glances off the hit.</span>"
 				else
 					src.hitstaken++
 					if(src.hitstaken == 4)
@@ -54,12 +54,12 @@
 		if (istype(O, /obj/item/weapon/twohanded/fireaxe) && src.localopened)
 			if(!fireaxe)
 				if(O:wielded)
-					user << "\red Unwield the axe first."
+					user << "<span class = 'warning'> Unwield the axe first.</span>"
 					return
 				fireaxe = O
 				user.drop_item()
 				src.contents += O
-				user << "\blue You place the fire axe back in the [src.name]."
+				user << "<span class = 'caution'> You place the fire axe back in the [src.name].</span>"
 				update_icon()
 			else
 				if(src.smashed)
@@ -82,11 +82,11 @@
 					spawn(10) update_icon()
 					return
 				else
-					user << "\red Resetting circuitry..."
+					user << "<span class = 'caution'> Resetting circuitry...</span>"
 					playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
 					if(do_after(user, 20))
 						src.locked = 1
-						user << "\blue You re-enable the locking modules."
+						user << "<span class = 'caution'> You re-enable the locking modules.</span>"
 					return
 			else
 				localopened = !localopened
@@ -107,13 +107,13 @@
 			hasaxe = 1
 
 		if(src.locked)
-			user <<"\red The cabinet won't budge!"
+			user <<"<span class = 'warning'> The cabinet won't budge!</span>"
 			return
 		if(localopened)
 			if(fireaxe)
 				user.put_in_hands(fireaxe)
 				fireaxe = null
-				user << "\blue You take the fire axe from the [name]."
+				user << "<span class = 'caution'> You take the fire axe from the [name].</span>"
 				src.add_fingerprint(user)
 				update_icon()
 			else
@@ -140,7 +140,7 @@
 	attack_tk(mob/user as mob)
 		if(localopened && fireaxe)
 			fireaxe.loc = loc
-			user << "\blue You telekinetically remove the fire axe."
+			user << "<span class = 'caution'> You telekinetically remove the fire axe.</span>"
 			fireaxe = null
 			update_icon()
 			return
@@ -184,14 +184,14 @@
 
 	attack_ai(mob/user as mob)
 		if(src.smashed)
-			user << "\red The security of the cabinet is compromised."
+			user << "<span class = 'warning'> The security of the cabinet is compromised.</span>"
 			return
 		else
 			locked = !locked
 			if(locked)
-				user << "\red Cabinet locked."
+				user << "<span class = 'caution'> Cabinet locked.</span>"
 			else
-				user << "\blue Cabinet unlocked."
+				user << "<span class = 'caution'> Cabinet unlocked.</span>"
 			return
 
 	update_icon() //Template: fireaxe[has fireaxe][is opened][hits taken][is smashed]. If you want the opening or closing animations, add "opening" or "closing" right after the numbers

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -25,10 +25,10 @@
 			if(istype(O, /obj/item/device/multitool))
 				user << "\red Resetting circuitry..."
 				playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
-				sleep(50) // Sleeping time~
-				src.locked = 0
-				user << "\blue You disable the locking modules."
-				update_icon()
+				if(do_after(user, 20))
+					src.locked = 0
+					user << "\blue You disable the locking modules."
+					update_icon()
 				return
 			else if(istype(O, /obj/item/weapon))
 				var/obj/item/weapon/W = O
@@ -83,10 +83,10 @@
 					return
 				else
 					user << "\red Resetting circuitry..."
-					sleep(50)
-					src.locked = 1
-					user << "\blue You re-enable the locking modules."
 					playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
+					if(do_after(user, 20))
+						src.locked = 1
+						user << "\blue You re-enable the locking modules."
 					return
 			else
 				localopened = !localopened


### PR DESCRIPTION
- Removes the ability to run away right after initializing the cabinet hacking with a multitool and still successfully finish the hacking (and seeing the hack message).
- Also, playing the relocking sound at the beginning of the relocking hack instead of the end, just like with the unlocking hack.

edit:
- Changing user messages to use span class stuff instead of \blue.
