### PR TITLE
Improved Singularity Ex_act()

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -54,20 +54,21 @@ var/global/list/uneatable = list(
 /obj/machinery/singularity/blob_act(severity)
 	return
 
-
 /obj/machinery/singularity/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			if(prob(25))
-				investigate_log("has been destroyed by an explosion.","singulo")
+			if(current_size <= 3)
+				investigate_log("has been destroyed by a heavy explosion.","singulo")
 				qdel(src)
 				return
 			else
-				energy += 50
-		if(2.0 to 3.0)
-			energy += round((rand(20,60)/2),1)
-			return
+				energy -= round(((energy+1)/2),1)
+		if(2.0)
+			energy -= round(((energy+1)/3),1)
+		if(3.0)
+			energy -= round(((energy+1)/4),1)
 	return
+
 
 /obj/machinery/singularity/bullet_act(obj/item/projectile/P)
 	return 0 //Will there be an impact? Who knows.  Will we see it? No.


### PR DESCRIPTION
Hey, guys? How do you kill a singularity? You blow it up, right??

Except not, since as it turns out, that doesn't work at all...
In the old code, only a heavy explosion could destroy a singularity, and only at a 25% chance (lol rng)
Bomb cap is 3,5,7 right now, which means that if a singularity was past stage 2, the bomb wouldn't be able to reach the 'middle' to blow it up.
Any explosion that didn't kill the singularity outright actually make it STRONGER.

This is intended to make blowing up singularities work more like people expect them to. A light explosion will cut out a 4th of its energy, a moderate will cut a 3rd, and a heavy explosion will destroy a smaller singularity or will cut its energy in half.
It SOUNDS like a lot, but consider that:
*The explosion has to reach the center of the singularity
*The singularity can recover from it pretty easily by eating more stuff
*Explosions strong enough to do this aren't easy to come by, and are harder to activate without the singularity eating them outright.
