### PR TITLE
Replaces the carrot with the analyzer for upgrading cameras, also makes them easier to upgrade.[WIP]

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -113,6 +113,8 @@
 	deactivate(user,0)
 
 /obj/machinery/camera/attackby(W as obj, mob/living/user as mob)
+	var/msg = "<span class='notice'>You attach [W] into the assembly inner circuits.</span>"
+	var/msg2 = "<span class='notice'>The camera already has that upgrade!</span>"
 
 	// DECONSTRUCTION
 	if(istype(W, /obj/item/weapon/screwdriver))
@@ -132,7 +134,28 @@
 				assembly.loc = src.loc
 				assembly.state = 1
 			qdel(src)
+	else if(istype(W, /obj/item/device/analyzer) && panel_open) //XRay
+		if(!isXRay())
+			upgradeXRay()
+			qdel(W)
+			user << "[msg]"
+		else
+			user << "[msg2]"
 
+	else if(istype(W, /obj/item/stack/sheet/mineral/plasma) && panel_open)
+		if(!isEmpProof())
+			upgradeEmpProof()
+			user << "[msg]"
+			qdel(W)
+		else
+			user << "[msg2]"
+	else if(istype(W, /obj/item/device/assembly/prox_sensor) && panel_open)
+		if(!isMotion())
+			upgradeMotion()
+			user << "[msg]"
+			qdel(W)
+		else
+			user << "[msg2]"
 
 	// OTHER
 	else if ((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -10,7 +10,7 @@
 	g_amt = 300
 
 	//	Motion, EMP-Proof, X-Ray
-	var/list/obj/item/possible_upgrades = list(/obj/item/device/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma, /obj/item/weapon/reagent_containers/food/snacks/grown/carrot)
+	var/list/obj/item/possible_upgrades = list(/obj/item/device/assembly/prox_sensor, /obj/item/stack/sheet/mineral/plasma, /obj/item/device/analyzer)
 	var/list/upgrades = list()
 	var/state = 0
 	var/busy = 0

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -57,7 +57,7 @@
 	return O
 
 /obj/machinery/camera/proc/isXRay()
-	var/O = locate(/obj/item/weapon/reagent_containers/food/snacks/grown/carrot) in assembly.upgrades
+	var/O = locate(/obj/item/device/analyzer) in assembly.upgrades
 	return O
 
 /obj/machinery/camera/proc/isMotion()
@@ -70,7 +70,7 @@
 	assembly.upgrades.Add(new /obj/item/stack/sheet/mineral/plasma(assembly))
 
 /obj/machinery/camera/proc/upgradeXRay()
-	assembly.upgrades.Add(new /obj/item/weapon/reagent_containers/food/snacks/grown/carrot(assembly))
+	assembly.upgrades.Add(new /obj/item/device/analyzer(assembly))
 
 // If you are upgrading Motion, and it isn't in the camera's New(), add it to the machines list.
 /obj/machinery/camera/proc/upgradeMotion()


### PR DESCRIPTION
The analyzer (found in toolboxes and the autolathe) now replaces the carrot for creating x-ray cameras.
Cameras are now easier to upgrade. Screw open the panel, then insert the required item.
