### PR TITLE
Fixes and some minor changes regarding teleports/portals code.

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,7 +1,9 @@
 //wrapper
 /proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
-	new /datum/teleport/instant/science(arglist(args))
-	return
+	var/datum/teleport/instant/science/D = new
+	if(D.start(arglist(args)))
+		return 1
+	return 0
 
 /datum/teleport
 	var/atom/movable/teleatom //atom to teleport
@@ -14,172 +16,160 @@
 	var/force_teleport = 1 //if false, teleport will use Move() proc (dense objects will prevent teleportation)
 
 
-	New(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
-		..()
-		if(!Init(arglist(args)))
-			return 0
-		return 1
+/datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
+	if(!Init(arglist(args)))
+		return 0
+	return 1
 
-	proc/Init(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
-		if(!setTeleatom(ateleatom))
-			return 0
-		if(!setDestination(adestination))
-			return 0
-		if(!setPrecision(aprecision))
-			return 0
-		setEffects(aeffectin,aeffectout)
-		setForceTeleport(afteleport)
-		setSounds(asoundin,asoundout)
-		return 1
+/datum/teleport/proc/Init(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
+	if(!setTeleatom(ateleatom))
+		return 0
+	if(!setDestination(adestination))
+		return 0
+	if(!setPrecision(aprecision))
+		return 0
+	setEffects(aeffectin,aeffectout)
+	setForceTeleport(afteleport)
+	setSounds(asoundin,asoundout)
+	return 1
 
-	//must succeed
-	proc/setPrecision(aprecision)
-		if(isnum(aprecision))
-			precision = aprecision
-			return 1
+//must succeed
+/datum/teleport/proc/setPrecision(aprecision)
+	if(isnum(aprecision))
+		precision = aprecision
+		return 1
+	return 0
+
+//must succeed
+/datum/teleport/proc/setDestination(atom/adestination)
+	if(istype(adestination))
+		destination = adestination
+		return 1
+	return 0
+
+//must succeed in most cases
+/datum/teleport/proc/setTeleatom(atom/movable/ateleatom)
+	if(istype(ateleatom, /obj/effect) && !istype(ateleatom, /obj/effect/dummy/chameleon))
+		qdel(ateleatom)
+		return 0
+	if(istype(ateleatom))
+		teleatom = ateleatom
+		return 1
+	return 0
+
+//custom effects must be properly set up first for instant-type teleports
+//optional
+/datum/teleport/proc/setEffects(datum/effect/effect/system/aeffectin=null,datum/effect/effect/system/aeffectout=null)
+	effectin = istype(aeffectin) ? aeffectin : null
+	effectout = istype(aeffectout) ? aeffectout : null
+	return 1
+
+//optional
+/datum/teleport/proc/setForceTeleport(afteleport)
+	force_teleport = afteleport
+	return 1
+
+//optional
+/datum/teleport/proc/setSounds(asoundin=null,asoundout=null)
+	soundin = isfile(asoundin) ? asoundin : null
+	soundout = isfile(asoundout) ? asoundout : null
+	return 1
+
+//placeholder
+/datum/teleport/proc/teleportChecks()
+	return 1
+
+/datum/teleport/proc/playSpecials(atom/location,datum/effect/effect/system/effect,sound)
+	if(location)
+		if(effect)
+			spawn(-1)
+				src = null
+				effect.attach(location)
+				effect.start()
+		if(sound)
+			spawn(-1)
+				src = null
+				playsound(location,sound,60,1)
+	return
+
+//do the monkey dance
+/datum/teleport/proc/doTeleport()
+
+	var/turf/destturf
+	var/turf/curturf = get_turf(teleatom)
+	var/area/destarea = get_area(destination)
+	if(precision)
+		var/list/posturfs = circlerangeturfs(destination,precision)
+		destturf = safepick(posturfs)
+	else
+		destturf = get_turf(destination)
+
+	if(!destturf || !curturf)
 		return 0
 
-	//must succeed
-	proc/setDestination(atom/adestination)
-		if(istype(adestination))
-			destination = adestination
-			return 1
-		return 0
+	playSpecials(curturf,effectin,soundin)
 
-	//must succeed in most cases
-	proc/setTeleatom(atom/movable/ateleatom)
-		if(istype(ateleatom, /obj/effect) && !istype(ateleatom, /obj/effect/dummy/chameleon))
-			qdel(ateleatom)
-			return 0
-		if(istype(ateleatom))
-			teleatom = ateleatom
-			return 1
-		return 0
-
-	//custom effects must be properly set up first for instant-type teleports
-	//optional
-	proc/setEffects(datum/effect/effect/system/aeffectin=null,datum/effect/effect/system/aeffectout=null)
-		effectin = istype(aeffectin) ? aeffectin : null
-		effectout = istype(aeffectout) ? aeffectout : null
-		return 1
-
-	//optional
-	proc/setForceTeleport(afteleport)
-		force_teleport = afteleport
-		return 1
-
-	//optional
-	proc/setSounds(asoundin=null,asoundout=null)
-		soundin = isfile(asoundin) ? asoundin : null
-		soundout = isfile(asoundout) ? asoundout : null
-		return 1
-
-	//placeholder
-	proc/teleportChecks()
-		return 1
-
-	proc/playSpecials(atom/location,datum/effect/effect/system/effect,sound)
-		if(location)
-			if(effect)
-				spawn(-1)
-					src = null
-					effect.attach(location)
-					effect.start()
-			if(sound)
-				spawn(-1)
-					src = null
-					playsound(location,sound,60,1)
-		return
-
-	//do the monkey dance
-	proc/doTeleport()
-
-		var/turf/destturf
-		var/turf/curturf = get_turf(teleatom)
-		var/area/destarea = get_area(destination)
-		if(precision)
-			var/list/posturfs = circlerangeturfs(destination,precision)
-			destturf = safepick(posturfs)
-		else
-			destturf = get_turf(destination)
-
-		if(!destturf || !curturf)
-			return 0
-
-		playSpecials(curturf,effectin,soundin)
-
-		if(force_teleport)
-			teleatom.forceMove(destturf)
+	if(force_teleport)
+		teleatom.forceMove(destturf)
+		playSpecials(destturf,effectout,soundout)
+	else
+		if(teleatom.Move(destturf))
 			playSpecials(destturf,effectout,soundout)
-		else
-			if(teleatom.Move(destturf))
-				playSpecials(destturf,effectout,soundout)
 
-		destarea.Entered(teleatom)
+	destarea.Entered(teleatom)
 
-		return 1
+	return 1
 
-	proc/teleport()
-		if(teleportChecks())
-			return doTeleport()
-		return 0
+/datum/teleport/proc/teleport()
+	if(teleportChecks())
+		return doTeleport()
+	return 0
 
 /datum/teleport/instant //teleports when datum is created
 
-	New(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
+	start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
 		if(..())
-			teleport()
-		return
+			if(teleport())
+				return 1
+		return 0
 
 
 /datum/teleport/instant/science
 
-	setEffects(datum/effect/effect/system/aeffectin,datum/effect/effect/system/aeffectout)
-		if(aeffectin==null || aeffectout==null)
-			var/datum/effect/effect/system/spark_spread/aeffect = new
-			aeffect.set_up(5, 1, teleatom)
-			effectin = effectin || aeffect
-			effectout = effectout || aeffect
-			return 1
+/datum/teleport/instant/science/setEffects(datum/effect/effect/system/aeffectin,datum/effect/effect/system/aeffectout)
+	if(aeffectin==null || aeffectout==null)
+		var/datum/effect/effect/system/spark_spread/aeffect = new
+		aeffect.set_up(5, 1, teleatom)
+		effectin = effectin || aeffect
+		effectout = effectout || aeffect
+		return 1
+	else
+		return ..()
+
+/datum/teleport/instant/science/setPrecision(aprecision)
+	..()
+	if(istype(teleatom, /obj/item/weapon/storage/backpack/holding))
+		precision = rand(1,100)
+
+	var/list/bagholding = teleatom.search_contents_for(/obj/item/weapon/storage/backpack/holding)
+	if(bagholding.len)
+		precision = max(rand(1,100)*bagholding.len,100)
+		if(istype(teleatom, /mob/living))
+			var/mob/living/MM = teleatom
+			MM << "<span class='warning'>The bluespace interface on your bag of holding interferes with the teleport!</span>"
+	return 1
+
+/datum/teleport/instant/science/teleportChecks()
+	if(istype(teleatom, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
+		teleatom.visible_message("<span class='warning'>The portal rejects [teleatom]!</span>")
+		return 0
+
+	if(!isemptylist(teleatom.search_contents_for(/obj/item/weapon/disk/nuclear)))
+		if(istype(teleatom, /mob/living))
+			var/mob/living/MM = teleatom
+			MM.visible_message("<span class='warning'>The portal rejects [MM]!","<span class='warning'>The nuclear disk that you're carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
 		else
-			return ..()
+			teleatom.visible_message("<span class='warning'>The portal rejects [teleatom]!</span>")
+		return 0
 
-	setPrecision(aprecision)
-		..()
-		if(istype(teleatom, /obj/item/weapon/storage/backpack/holding))
-			precision = rand(1,100)
-
-		var/list/bagholding = teleatom.search_contents_for(/obj/item/weapon/storage/backpack/holding)
-		if(bagholding.len)
-			precision = max(rand(1,100)*bagholding.len,100)
-			if(istype(teleatom, /mob/living))
-				var/mob/living/MM = teleatom
-				MM << "\red The Bluespace interface on your Bag of Holding interferes with the teleport!"
-		return 1
-
-	teleportChecks()
-		if(istype(teleatom, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
-			teleatom.visible_message("\red <B>The [teleatom] bounces off of the portal!</B>")
-			return 0
-
-		if(!isemptylist(teleatom.search_contents_for(/obj/item/weapon/disk/nuclear)))
-			if(istype(teleatom, /mob/living))
-				var/mob/living/MM = teleatom
-				MM.visible_message("\red <B>The [MM] bounces off of the portal!</B>","\red Something you are carrying seems to be unable to pass through the portal. Better drop it if you want to go through.")
-			else
-				teleatom.visible_message("\red <B>The [teleatom] bounces off of the portal!</B>")
-			return 0
-
-		if(destination.z == 2) //centcom z-level
-			if(istype(teleatom, /obj/mecha))
-				var/obj/mecha/MM = teleatom
-				MM.occupant << "\red <B>The mech would not survive the jump to a location so far away!</B>"
-				return 0
-			if(!isemptylist(teleatom.search_contents_for(/obj/item/weapon/storage/backpack/holding)))
-				teleatom.visible_message("\red <B>The Bag of Holding bounces off of the portal!</B>")
-				return 0
-
-
-		if(destination.z == 7) //Away mission z-levels
-			return 0
-		return 1
+	return 1

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -12,8 +12,12 @@
 
 /obj/machinery/computer/teleporter/New()
 	src.id = "[rand(1000, 9999)]"
+	link_power_station()
 	..()
 	return
+
+/obj/machinery/computer/teleporter/initialize()
+	link_power_station()
 
 /obj/machinery/computer/teleporter/proc/link_power_station()
 	if(power_station)
@@ -198,6 +202,9 @@
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
 	RefreshParts()
 
+/obj/machinery/teleport/hub/initialize()
+	link_power_station()
+
 /obj/machinery/teleport/hub/RefreshParts()
 	var/A = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
@@ -282,6 +289,10 @@
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(null)
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	RefreshParts()
+	link_console_and_hub()
+
+/obj/machinery/teleport/station/initialize()
+	link_console_and_hub()
 
 /obj/machinery/teleport/station/RefreshParts()
 	var/E

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -221,10 +221,9 @@
 	return power_station
 
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
-	spawn()
-		if(power_station && power_station.engaged && !panel_open)
-			teleport(M)
-			use_power(5000)
+	if(power_station && power_station.engaged && !panel_open)
+		teleport(M)
+		use_power(5000)
 	return
 
 /obj/machinery/teleport/hub/attackby(obj/item/W, mob/user)
@@ -244,18 +243,16 @@
 		visible_message("<span class='notice'>Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
 	if (istype(M, /atom/movable))
-		if(prob(30 - (accurate * 10))) //oh dear a problem
-			do_teleport(M, com.target)
-			if(ishuman(M))//don't remove people from the round randomly you jerks
-				var/mob/living/carbon/human/human = M
-				if(human.dna && !human.dna.mutantrace)
-					M  << "<span class='danger'>You hear a buzzing in your ears.</span>"
-					human.dna.mutantrace = "fly"
-					human.update_body()
-					human.update_hair()
-				human.apply_effect((rand(120 - accurate * 40, 180 - accurate * 60)), IRRADIATE, 0)
-		else
-			do_teleport(M, com.target)
+		if(do_teleport(M, com.target))
+			if(prob(30 - (accurate * 10))) //oh dear a problem
+				if(ishuman(M))//don't remove people from the round randomly you jerks
+					var/mob/living/carbon/human/human = M
+					if(human.dna && !human.dna.mutantrace)
+						M  << "<span class='danger'>You hear a buzzing in your ears.</span>"
+						human.dna.mutantrace = "fly"
+						human.update_body()
+						human.update_hair()
+					human.apply_effect((rand(120 - accurate * 40, 180 - accurate * 60)), IRRADIATE, 0)
 	return
 
 /obj/machinery/teleport/hub/update_icon()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -420,7 +420,6 @@
 		P.target = target_turf
 		P.creator = null
 		P.icon = 'icons/obj/objects.dmi'
-		P.failchance = 0
 		P.icon_state = "anom"
 		P.name = "wormhole"
 		var/turf/T = get_turf(target)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -333,8 +333,7 @@
 		if(istype(O, /obj/effect/portal)) //derpfix
 			src.anchored = 0
 			O.Crossed(src)
-			spawn(0)//countering portal teleport spawn(0), hurr
-				src.anchored = 1
+			src.anchored = 1
 		else if(!O.anchored)
 			step(obstacle,src.dir)
 		else //I have no idea why I disabled this

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -5,22 +5,15 @@
 	icon_state = "portal"
 	density = 1
 	unacidable = 1//Can't destroy energy portals.
-	var/failchance = 5
 	var/obj/item/target = null
 	var/creator = null
 	anchored = 1.0
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
-	spawn(0)
-		src.teleport(M)
-		return
-	return
+	src.teleport(M)
 
 /obj/effect/portal/Crossed(AM as mob|obj)
-	spawn(0)
-		src.teleport(AM)
-		return
-	return
+	src.teleport(AM)
 
 /obj/effect/portal/New(loc, turf/target, creator, lifespan=300)
 	portals += src
@@ -52,9 +45,5 @@
 		qdel(src)
 		return
 	if (istype(M, /atom/movable))
-		if(prob(failchance)) //oh dear a problem, put em in deep space
-			src.icon_state = "portal1"
-			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)
-		else
-			do_teleport(M, target, 1) ///You will appear adjacent to the beacon
+		do_teleport(M, target, 1) ///You will appear adjacent to the beacon
 

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -51,7 +51,6 @@
 	desc = "It looks highly unstable; It could close at any moment."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "anom"
-	failchance = 0
 
 /obj/effect/portal/wormhole/attack_hand(mob/user)
 	teleport(user)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -347,20 +347,20 @@
 	if(istype(M, /obj/effect))
 		return
 	if(istype(M, /atom/movable))
-		do_teleport(M, target, 6)
-		if(isliving(M))
-			var/mob/living/L = M
-			L.Weaken(3)
-			if(ishuman(L))
-				shake_camera(L, 20, 1)
-				spawn(20)
-					if(L)
-						L.visible_message("<span class='danger'>[L.name] vomits from travelling through the [src.name]!</span>")
-						L.nutrition -= 20
-						L.adjustToxLoss(-3)
-						var/turf/T = get_turf(L)
-						T.add_vomit_floor(L)
-						playsound(L, 'sound/effects/splat.ogg', 50, 1)
+		if(do_teleport(M, target, 6))
+			if(isliving(M))
+				var/mob/living/L = M
+				L.Weaken(3)
+				if(ishuman(L))
+					shake_camera(L, 20, 1)
+					spawn(20)
+						if(L)
+							L.visible_message("<span class='danger'>[L.name] vomits from travelling through the [src.name]!</span>")
+							L.nutrition -= 20
+							L.adjustToxLoss(-3)
+							var/turf/T = get_turf(L)
+							T.add_vomit_floor(L)
+							playsound(L, 'sound/effects/splat.ogg', 50, 1)
 
 /**********************Resonator**********************/
 


### PR DESCRIPTION
Gameplay changes:
hand-teleporter portals won't have a chance to fail anymore and you can teleport to an away mission.

Full stuff:
Made the teleporters (the one with the computer, power station and portal) link eachother at roundstart with initialize(). And also at New() because why not.
If you try to use the teleporter and the teleport was rejected for any reason (like having a nuclear disk), you won't get the chance to get a random damage from the teleport.
Fixes issue #2236.
Removed some spawn() calls.
Removed the chance of fail from the portal effects (the blue portals made with hand teleporters).
The portal datums will now return 0 if the teleport failed, and now use a new proc, start(), instead of New() to handle themselves.
Standarized teleport.dm from the helper_datums folder.
Removed the checks for centcomm z level and away missions z level for teleports. Now you can go there.
changed the /red messages from the teleports datum to span classes.
The "[something] bounces off of the portal!" were replaced for "The portal rejects [something]".
Removed an extra "the" on those messages.
