### PR TITLE
Fixes issue #2316 Mulebots picking up crates through plastic flaps.

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -416,9 +416,6 @@ var/global/mulebot_count = 0
 
 	if(get_dist(C, src) > 1 || load || !on)
 		return
-	for(var/obj/structure/plasticflaps/P in src.loc)//Takes flaps into account
-		if(!CanPass(C,P))
-			return
 	mode = 1
 
 	// if a create, close before loading


### PR DESCRIPTION
Mulebots will be able to pick up crates through plastic flaps again.
