### PR TITLE
Fixes for a disposal runtime everytime something got flushed

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -496,7 +496,12 @@
 	var/tomail = 0 //changes if contains wrapped package
 	var/hasmob = 0 //If it contains a mob
 
+/obj/structure/disposalholder/Destroy()
+	qdel(gas)
+	active = 0
+	..()
 
+/obj/structure/disposalholder
 	// initialize a holder from the contents of a disposal unit
 	proc/init(var/obj/machinery/disposal/D)
 		gas = D.air_contents// transfer gas resv. into holder object
@@ -550,20 +555,13 @@
 	proc/move()
 		var/obj/structure/disposalpipe/last
 		while(active)
-			if(has_fat_guy && prob(2)) // chance of becoming stuck per segment if contains a fat guy
-				active = 0
-				// find the fat guys
-				for(var/mob/living/carbon/human/H in src)
-
-				break
-			sleep(1)		// was 1
 			var/obj/structure/disposalpipe/curr = loc
 			last = curr
 			curr = curr.transfer(src)
-			if(!curr)
+			if(!curr && active)
 				last.expel(src, loc, dir)
 
-			//
+			sleep(1)
 			if(!(count--))
 				active = 0
 		return


### PR DESCRIPTION
http://pastebin.com/tpQWSW9P

Detailed writeup of cause: Disposal holder object was going through the loop, looking for pipes and continuing on. When it hit the outlet, the outlet ejects everything and qdel()'s the disposal holder. Holder continues processing, sees that there's nowhere else to go, and tries to emergency eject. Doing so calls a bunch of loc = null procs that runtime.
Fix: Make the processing part of the disposal holder only continue if it's active. Make the disposal holder inactive as part of Destroy().
