### PR TITLE
Double agents round-end message small change.

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -35,7 +35,7 @@
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = traitor
 		kill_objective.target = target_list[traitor]
-		kill_objective.explanation_text = "Assassinate [kill_objective.target.current.real_name], the [kill_objective.target.special_role]."
+		kill_objective.explanation_text = "Assassinate [kill_objective.target.current.real_name], the [kill_objective.target.assigned_role], the double agent."
 		traitor.objectives += kill_objective
 
 		// Escape


### PR DESCRIPTION
Changed the wording on the round-end messages of double agents, now clowns and mime won't have different text than the rest.
Fixes #2322
