### PR TITLE
Jobcode refactoring

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -280,7 +280,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				var/obj/item/device/pda/PDA = A
 				if(PDA.owner == oldname)
 					PDA.owner = newname
-					PDA.name = "PDA-[newname] ([PDA.ownjob])"
+					PDA.update_label()
 					if(!search_id)	break
 					search_pda = 0
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -272,7 +272,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				var/obj/item/weapon/card/id/ID = A
 				if(ID.registered_name == oldname)
 					ID.registered_name = newname
-					ID.name = "[newname]'s ID Card ([ID.assignment])"
+					ID.update_label()
 					if(!search_pda)	break
 					search_id = 0
 

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -205,7 +205,7 @@ datum/hSB
 					ID.registered_name = usr.real_name
 					ID.assignment = "Sandbox"
 					ID.access = get_all_accesses()
-					ID.name = "[ID.registered_name]'s ID Card ([ID.assignment])"
+					ID.update_label()
 
 				//
 				// RCD - starts with full clip

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -10,7 +10,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 
-/datum/job/assistant/equip(var/mob/living/carbon/human/H)
+/datum/job/assistant/equip_items(var/mob/living/carbon/human/H)
 	if(!H)	return 0
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -1,3 +1,6 @@
+/*
+Assistant
+*/
 /datum/job/assistant
 	title = "Assistant"
 	flag = ASSISTANT
@@ -11,10 +14,8 @@
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 
 /datum/job/assistant/equip_items(var/mob/living/carbon/human/H)
-	if(!H)	return 0
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-	return 1
 
 /datum/job/assistant/get_access()
 	if(config.jobs_have_maint_access & ASSISTANTS_HAVE_MAINT_ACCESS) //Config has assistant maint access set

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -1,3 +1,6 @@
+/*
+Captain
+*/
 /datum/job/captain
 	title = "Captain"
 	flag = CAPTAIN
@@ -7,42 +10,49 @@
 	spawn_positions = 1
 	supervisors = "Nanotrasen officials and Space law"
 	selection_color = "#ccccff"
-	idtype = /obj/item/weapon/card/id/gold
 	req_admin_notify = 1
-	access = list() 			//See get_access()
-	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 
+	default_id = /obj/item/weapon/card/id/gold
+	default_pda = /obj/item/device/pda/heads/captain
+	default_headset = /obj/item/device/radio/headset/heads/captain
+	default_backpack = /obj/item/weapon/storage/backpack/captain
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_cap
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/captain(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/captain(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_cap(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
+	access = list() 			//See get_access()
+	minimal_access = list() 	//See get_access()
+
+/datum/job/captain/equip_items(var/mob/living/carbon/human/H)
+	var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
 		U.hastie = new /obj/item/clothing/tie/medal/gold/captain(U)
-		H.equip_to_slot_or_del(U, slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/captain(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/capcarapace(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/caphat(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
+	H.equip_to_slot_or_del(U, slot_w_uniform)
+
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/capcarapace(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/caphat(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
+
+	//Equip ID box
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_l_hand)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
+
+	//Implant him
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
-		world << "<b>[H.real_name] is the captain!</b>"
-		return 1
 
-	get_access()
-		return get_all_accesses()
+	world << "<b>[H.real_name] is the captain!</b>"
 
+	return 1
 
+/datum/job/captain/get_access()
+	return get_all_accesses()
 
+/*
+Head of Personnel
+*/
 /datum/job/hop
 	title = "Head of Personnel"
 	flag = HOP
@@ -52,9 +62,13 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#ddddff"
-	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
 	minimal_player_age = 10
+
+	default_id = /obj/item/weapon/card/id/silver
+	default_pda = /obj/item/device/pda/heads/hop
+	default_headset = /obj/item/device/radio/headset/heads/hop
+
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
@@ -69,18 +83,14 @@
 			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
 
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/hop(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/head_of_personnel(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/hop(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/hopcap(H), slot_head)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
-		return 1
+/datum/job/hop/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/head_of_personnel(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/hopcap(H), slot_head)
+
+	//Equip ID box
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H), slot_l_hand)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
+	return 1

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -14,7 +14,7 @@ Captain
 	minimal_player_age = 14
 
 	default_id = /obj/item/weapon/card/id/gold
-	default_pda = /obj/item/device/pda/heads/captain
+	default_pda = /obj/item/device/pda/captain
 	default_headset = /obj/item/device/radio/headset/heads/captain
 	default_backpack = /obj/item/weapon/storage/backpack/captain
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_cap
@@ -24,7 +24,7 @@ Captain
 
 /datum/job/captain/equip_items(var/mob/living/carbon/human/H)
 	var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
-		U.hastie = new /obj/item/clothing/tie/medal/gold/captain(U)
+	U.hastie = new /obj/item/clothing/tie/medal/gold/captain(U)
 	H.equip_to_slot_or_del(U, slot_w_uniform)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/capcarapace(H), slot_wear_suit)
@@ -40,8 +40,8 @@ Captain
 
 	//Implant him
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+	L.imp_in = H
+	L.implanted = 1
 
 	world << "<b>[H.real_name] is the captain!</b>"
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -12,7 +12,7 @@
 	minimal_access = list(access_bar, access_mineral_storeroom)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
 		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
@@ -53,7 +53,7 @@
 	minimal_access = list(access_kitchen, access_morgue)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chef(H), slot_w_uniform)
@@ -78,7 +78,7 @@
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/hydroponics(H), slot_w_uniform)
@@ -105,7 +105,7 @@
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo(H), slot_ears)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargo(H), slot_w_uniform)
@@ -131,7 +131,7 @@
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo(H), slot_ears)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
@@ -155,7 +155,7 @@
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo (H), slot_ears)
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial (H), slot_back)
@@ -191,7 +191,7 @@
 	minimal_access = list(access_theatre)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.fully_replace_character_name(H.real_name, pick(clown_names))
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/clown(H), slot_back)
@@ -224,7 +224,7 @@
 	minimal_access = list(access_theatre)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/mime(H), slot_back)
 		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
@@ -265,7 +265,7 @@
 	minimal_access = list(access_janitor, access_maint_tunnels)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
@@ -289,7 +289,7 @@
 	minimal_access = list(access_library)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/red(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/device/pda/librarian(H), slot_belt)
@@ -315,7 +315,7 @@ var/global/lawyer = 0//Checks for another lawyer
 	minimal_access = list(access_lawyer, access_court, access_sec_doors)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
 		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -182,7 +182,6 @@ Shaft Miner
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/ore(H), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/mining_voucher(H), slot_in_backpack)
 
-//TODO: Make sure shaftminer without backpack get shit properly
 /*
 Clown
 */
@@ -202,15 +201,12 @@ Clown
 	access = list(access_theatre, access_maint_tunnels)
 	minimal_access = list(access_theatre)
 
-//TODO: Make sure clown gets his survival box
 /datum/job/clown/equip_backpack(var/mob/living/carbon/human/H)
 	var/obj/item/weapon/storage/backpack/BPK = new default_backpack(H)
 
 	new default_storagebox(BPK)
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/banana(BPK, 50)
-	new /obj/item/weapon/bikehorn(BPK)
 	new /obj/item/weapon/stamp/clown(BPK)
-	new /obj/item/toy/crayon/rainbow(BPK)
 	new /obj/item/weapon/reagent_containers/spray/waterflower(BPK)
 
 	H.equip_to_slot_or_del(BPK, slot_back)
@@ -221,6 +217,8 @@ Clown
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H), slot_l_store)
+	H.equip_to_slot_or_del(new /obj/item/toy/crayon/rainbow(H), slot_r_store)
 
 	H.mutations.Add(CLUMSY)
 	H.rename_self("clown")
@@ -317,7 +315,6 @@ Librarian
 /*
 Lawyer
 */
-//TODO: Make sure lawyers get proper suits
 /datum/job/lawyer
 	title = "Lawyer"
 	flag = LAWYER

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -1,4 +1,6 @@
-//Food
+/*
+Bartender
+*/
 /datum/job/bartender
 	title = "Bartender"
 	flag = BARTENDER
@@ -8,38 +10,47 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/bar
+	default_headset = /obj/item/device/radio/headset/headset_srv
+
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_mineral_storeroom)
 	minimal_access = list(access_bar, access_mineral_storeroom)
 
+/datum/job/bartender/equip_backpack(var/mob/living/carbon/human/H)
+	switch(H.backbag)
+		if(1) //No backpack or satchel
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/bartender(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/bar(H), slot_belt)
+			var/obj/item/weapon/storage/box/box = new default_storagebox(H)
+			new /obj/item/ammo_casing/shotgun/beanbag(box)
+			new /obj/item/ammo_casing/shotgun/beanbag(box)
+			new /obj/item/ammo_casing/shotgun/beanbag(box)
+			new /obj/item/ammo_casing/shotgun/beanbag(box)
+			H.equip_to_slot_or_del(box, slot_r_hand)
 
-		if(H.backbag == 1)
-			var/obj/item/weapon/storage/box/survival/Barpack = new /obj/item/weapon/storage/box/survival(H)
-			H.equip_to_slot_or_del(Barpack, slot_r_hand)
-			new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-			new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-			new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-			new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
+		if(2) // Backpack
+			var/obj/item/weapon/storage/backpack/BPK = new default_backpack(H)
+			new default_storagebox(BPK)
+			H.equip_to_slot_or_del(BPK, slot_back,1)
+		if(3) //Satchel
+			var/obj/item/weapon/storage/backpack/BPK = new default_satchel(H)
+			new default_storagebox(BPK)
+			H.equip_to_slot_or_del(BPK, slot_back,1)
 
-		return 1
+/datum/job/bartender/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/bartender(H), slot_w_uniform)
 
+	if(H.backbag != 1)
+		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), slot_in_backpack)
 
-
+/*
+Chef
+*/
 /datum/job/chef
 	title = "Chef"
 	flag = CHEF
@@ -49,22 +60,22 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/chef
+	default_headset = /obj/item/device/radio/headset/headset_srv
+
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
 	minimal_access = list(access_kitchen, access_morgue)
 
+/datum/job/chef/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chef(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/chef(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/chefhat(H), slot_head)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chef(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/chef(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/chefhat(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/chef(H), slot_belt)
-		return 1
-
-
-
+/*
+Botanist
+*/
 /datum/job/hydro
 	title = "Botanist"
 	flag = BOTANIST
@@ -74,24 +85,23 @@
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/botanist
+	default_headset = /obj/item/device/radio/headset/headset_srv
+
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	minimal_access = list(access_hydroponics, access_morgue) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 
+/datum/job/hydro/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/hydroponics(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/botanic_leather(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/apron(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/device/analyzer/plant_analyzer(H), slot_s_store)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/hydroponics(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/botanic_leather(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/apron(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/device/analyzer/plant_analyzer(H), slot_s_store)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/botanist(H), slot_belt)
-		return 1
-
-
-
-//Cargo
+/*
+Quartermaster
+*/
 /datum/job/qm
 	title = "Quartermaster"
 	flag = QUARTERMASTER
@@ -101,23 +111,22 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/quartermaster
+	default_headset = /obj/item/device/radio/headset/headset_cargo
+
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 
+/datum/job/qm/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargo(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
+	H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargo(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/quartermaster(H), slot_belt)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
-		H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
-		return 1
-
-
-
+/*
+Cargo Technician
+*/
 /datum/job/cargo_tech
 	title = "Cargo Technician"
 	flag = CARGOTECH
@@ -127,21 +136,20 @@
 	spawn_positions = 2
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/cargo
+	default_headset = /obj/item/device/radio/headset/headset_cargo
+
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 
+/datum/job/cargo_tech/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/cargo(H), slot_belt)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		return 1
-
-
-
+/*
+Shaft Miner
+*/
 /datum/job/mining
 	title = "Shaft Miner"
 	flag = MINER
@@ -151,33 +159,33 @@
 	spawn_positions = 3
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/shaftminer
+	default_headset = /obj/item/device/radio/headset/headset_cargo
+	default_backpack = /obj/item/weapon/storage/backpack/industrial
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_eng
+	default_storagebox = /obj/item/weapon/storage/box/engineer
+
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station)
 	minimal_access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 
+/datum/job/mining/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/miner(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_cargo (H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_eng(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/miner(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/shaftminer(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/crowbar(H), slot_l_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/ore(H), slot_l_store)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/crowbar(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/ore(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/mining_voucher(H), slot_in_backpack)
-		return 1
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/weapon/crowbar(H), slot_l_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/ore(H), slot_l_store)
+		H.equip_to_slot_or_del(new /obj/item/weapon/mining_voucher(H), slot_r_store)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/crowbar(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/ore(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/weapon/mining_voucher(H), slot_in_backpack)
 
-
-
-
+//TODO: Make sure shaftminer without backpack get shit properly
+/*
+Clown
+*/
 /datum/job/clown
 	title = "Clown"
 	flag = CLOWN
@@ -187,30 +195,39 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/clown
+	default_backpack = /obj/item/weapon/storage/backpack/clown
+
 	access = list(access_theatre, access_maint_tunnels)
 	minimal_access = list(access_theatre)
 
+//TODO: Make sure clown gets his survival box
+/datum/job/clown/equip_backpack(var/mob/living/carbon/human/H)
+	var/obj/item/weapon/storage/backpack/BPK = new default_backpack(H)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.fully_replace_character_name(H.real_name, pick(clown_names))
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/clown(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/clown(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), slot_wear_mask)
-		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/snacks/grown/banana(H, 50), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/weapon/stamp/clown(H), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/toy/crayon/rainbow(H), slot_in_backpack)
-		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/spray/waterflower(H), slot_in_backpack)
-		H.mutations.Add(CLUMSY)
-		H.rename_self("clown")
-		return 1
+	new default_storagebox(BPK)
+	new /obj/item/weapon/reagent_containers/food/snacks/grown/banana(BPK, 50)
+	new /obj/item/weapon/bikehorn(BPK)
+	new /obj/item/weapon/stamp/clown(BPK)
+	new /obj/item/toy/crayon/rainbow(BPK)
+	new /obj/item/weapon/reagent_containers/spray/waterflower(BPK)
 
+	H.equip_to_slot_or_del(BPK, slot_back)
 
+/datum/job/clown/equip_items(var/mob/living/carbon/human/H)
+	H.fully_replace_character_name(H.real_name, pick(clown_names)) // Give him a temporary random name to prevent identity revealing
 
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/clown(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/clown_shoes(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), slot_wear_mask)
+
+	H.mutations.Add(CLUMSY)
+	H.rename_self("clown")
+
+/*
+Mime
+*/
 /datum/job/mime
 	title = "Mime"
 	flag = MIME
@@ -220,38 +237,38 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/mime
+
 	access = list(access_theatre, access_maint_tunnels)
 	minimal_access = list(access_theatre)
 
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/mime(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/mime(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/mime(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/white(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/mime(H), slot_wear_mask)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/beret(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/suspenders(H), slot_wear_suit)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-			H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_l_store)
-			H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_l_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_in_backpack)
-		if(H.mind)
-			H.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null)
-			H.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/mime/speak(null)
-			H.mind.miming = 1
-		H.rename_self("mime")
-		return 1
+/datum/job/mime/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/mime(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/white(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/mime(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/beret(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/suspenders(H), slot_wear_suit)
 
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_l_store)
+		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_l_hand)
+	else
+		H.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(H), slot_in_backpack)
 
+	if(H.mind)
+		H.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null)
+		H.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/mime/speak(null)
+		H.mind.miming = 1
 
+	H.rename_self("mime")
+
+/*
+Janitor
+*/
 /datum/job/janitor
 	title = "Janitor"
 	flag = JANITOR
@@ -261,21 +278,20 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/janitor
+	default_headset = /obj/item/device/radio/headset/headset_srv
+
 	access = list(access_janitor, access_maint_tunnels)
 	minimal_access = list(access_janitor, access_maint_tunnels)
 
+/datum/job/janitor/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_srv(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/janitor(H), slot_belt)
-		return 1
-
-
-
-//More or less assistants
+/*
+Librarian
+*/
 /datum/job/librarian
 	title = "Librarian"
 	flag = LIBRARIAN
@@ -285,23 +301,23 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/librarian
+
 	access = list(access_library, access_maint_tunnels)
 	minimal_access = list(access_library)
 
+/datum/job/librarian/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/red(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/books(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/weapon/barcodescanner(H), slot_r_store)
+	H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/red(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/librarian(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/bag/books(H), slot_l_hand)
-		H.equip_to_slot_or_del(new /obj/item/weapon/barcodescanner(H), slot_r_store)
-		H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
-		return 1
-
-
-
-var/global/lawyer = 0//Checks for another lawyer
+/*
+Lawyer
+*/
+//TODO: Make sure lawyers get proper suits
 /datum/job/lawyer
 	title = "Lawyer"
 	flag = LAWYER
@@ -311,29 +327,24 @@ var/global/lawyer = 0//Checks for another lawyer
 	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+	var/global/lawyers = 0 //Counts lawyer amount
+
+	default_pda = /obj/item/device/pda/lawyer
+	default_headset = /obj/item/device/radio/headset/headset_sec
+
 	access = list(access_lawyer, access_court, access_sec_doors, access_maint_tunnels)
 	minimal_access = list(access_lawyer, access_court, access_sec_doors)
 
+/datum/job/lawyer/equip_items(var/mob/living/carbon/human/H)
+	lawyers += 1
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		if(!lawyer)
-			lawyer = 1
-			H.equip_to_slot_or_del(new /obj/item/clothing/under/lawyer/bluesuit(H), slot_w_uniform)
-			H.equip_to_slot_or_del(new /obj/item/clothing/suit/lawyer/bluejacket(H), slot_wear_suit)
-		else
-			H.equip_to_slot_or_del(new /obj/item/clothing/under/lawyer/purpsuit(H), slot_w_uniform)
-			H.equip_to_slot_or_del(new /obj/item/clothing/suit/lawyer/purpjacket(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/lawyer(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/briefcase(H), slot_l_hand)
-		H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
+	if(lawyers%2 != 0)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/lawyer/bluesuit(H), slot_w_uniform)
+		H.equip_to_slot_or_del(new /obj/item/clothing/suit/lawyer/bluejacket(H), slot_wear_suit)
+	else
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/lawyer/purpsuit(H), slot_w_uniform)
+		H.equip_to_slot_or_del(new /obj/item/clothing/suit/lawyer/purpjacket(H), slot_wear_suit)
 
-		return 1
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/briefcase(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -1,4 +1,7 @@
 //Due to how large this one is it gets its own file
+/*
+Chaplain
+*/
 /datum/job/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN
@@ -8,6 +11,9 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
+
+	default_pda = /obj/item/device/pda/chaplain
+
 	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 
@@ -74,10 +80,7 @@
 		usr << browse(null, "window=editicon") // Close window
 
 /datum/job/chaplain/equip_items(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chaplain(H), slot_w_uniform)
-	H.equip_to_slot_or_del(new /obj/item/device/pda/chaplain(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 
 	var/obj/item/weapon/storage/bible/B = new /obj/item/weapon/storage/bible/booze(H)
@@ -142,4 +145,3 @@
 		dat += "</table></body></html>"
 
 		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
-	return 1

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -73,7 +73,7 @@
 
 		usr << browse(null, "window=editicon") // Close window
 
-/datum/job/chaplain/equip(var/mob/living/carbon/human/H)
+/datum/job/chaplain/equip_items(var/mob/living/carbon/human/H)
 	if(!H)	return 0
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chaplain(H), slot_w_uniform)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -20,7 +20,7 @@
 	minimal_player_age = 7
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/ce(H), slot_ears)
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial (H), slot_back)
@@ -53,7 +53,7 @@
 
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_eng(H), slot_ears)
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial(H), slot_back)
@@ -85,7 +85,7 @@
 	minimal_access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction)
 
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_eng(H), slot_ears)
 		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -1,3 +1,6 @@
+/*
+Chief Engineer
+*/
 /datum/job/chief_engineer
 	title = "Chief Engineer"
 	flag = CHIEF
@@ -7,8 +10,17 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#ffeeaa"
-	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
+	minimal_player_age = 7
+
+	default_id = /obj/item/weapon/card/id/silver
+	default_pda = /obj/item/device/pda/heads/ce
+	default_pda_slot = slot_l_store
+	default_headset = /obj/item/device/radio/headset/heads/ce
+	default_backpack = /obj/item/weapon/storage/backpack/industrial
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_eng
+	default_storagebox = /obj/item/weapon/storage/box/engineer
+
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
@@ -17,28 +29,17 @@
 			            access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_mineral_storeroom)
-	minimal_player_age = 7
 
+/datum/job/chief_engineer/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chief_engineer(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/white(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/ce(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_eng(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chief_engineer(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/ce(H), slot_l_store)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat/white(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
-		return 1
-
-
-
+/*
+Station Engineer
+*/
 /datum/job/engineer
 	title = "Station Engineer"
 	flag = ENGINEER
@@ -48,30 +49,29 @@
 	spawn_positions = 5
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
-	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_tcomsat)
-	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_tcomsat)
 
+	default_pda = /obj/item/device/pda/engineering
+	default_pda_slot = slot_l_store
+	default_headset = /obj/item/device/radio/headset/headset_eng
+	default_backpack = /obj/item/weapon/storage/backpack/industrial
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_eng
+	default_storagebox = /obj/item/weapon/storage/box/engineer
 
+	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
+									access_external_airlocks, access_construction, access_atmospherics, access_tcomsat)
+	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
+									access_external_airlocks, access_construction, access_tcomsat)
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_eng(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/industrial(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_eng(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/engineer(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/orange(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/device/t_scanner(H), slot_r_store)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/engineering(H), slot_l_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
-		return 1
+/datum/job/engineer/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/engineer(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/orange(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/hardhat(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/device/t_scanner(H), slot_r_store)
 
-
-
+/*
+Atmospheric Technician
+*/
 /datum/job/atmos
 	title = "Atmospheric Technician"
 	flag = ATMOSTECH
@@ -81,22 +81,18 @@
 	spawn_positions = 2
 	supervisors = "the chief engineer"
 	selection_color = "#fff5cc"
-	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
+
+	default_pda = /obj/item/device/pda/atmos
+	default_pda_slot = slot_l_store
+	default_headset = /obj/item/device/radio/headset/headset_eng
+	default_storagebox = /obj/item/weapon/storage/box/engineer
+
+	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
+									access_external_airlocks, access_construction, access_atmospherics)
 	minimal_access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction)
 
-
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_eng(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/atmospheric_technician(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/atmos(H), slot_l_store)
-		H.equip_to_slot_or_del(new /obj/item/device/analyzer(H), slot_r_store)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/atmostech/(H), slot_belt)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
-		return 1
+/datum/job/atmos/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/atmospheric_technician(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/device/analyzer(H), slot_r_store)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/atmostech/(H), slot_belt)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -79,9 +79,6 @@
 	C.registered_name = H.real_name
 	C.assignment = H.job
 	C.update_label()
-
-	world << "Equip ID [C]"
-
 	H.equip_to_slot_or_del(C, slot_wear_id)
 
 	//Equip PDA
@@ -89,9 +86,6 @@
 	PDA.owner = H.real_name
 	PDA.ownjob = H.job
 	PDA.update_label()
-
-	world << "Equip PDA [PDA]"
-
 	H.equip_to_slot_or_del(PDA, default_pda_slot)
 
 	//Equip headset

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -70,23 +70,29 @@
 	//Equip backpack
 	equip_backpack(H)
 
+	//Equip the rest of the gear
+	equip_items(H)
+
 	//Equip ID
-	var/obj/item/weapon/card/id/C = new src.default_id(H)
-	C.access = src.get_access()
+	var/obj/item/weapon/card/id/C = new default_id(H)
+	C.access = get_access()
 	C.registered_name = H.real_name
 	C.assignment = H.job
 	C.update_label()
+
+	world << "Equip ID [C]"
+
 	H.equip_to_slot_or_del(C, slot_wear_id)
 
 	//Equip PDA
-	var/obj/item/device/pda/PDA = new src.default_pda(H)
+	var/obj/item/device/pda/PDA = new default_pda(H)
 	PDA.owner = H.real_name
 	PDA.ownjob = H.job
 	PDA.update_label()
-	H.equip_to_slot_or_del(PDA, default_pda_slot)
 
-	//Equip the rest of the gear
-	equip_items(H)
+	world << "Equip PDA [PDA]"
+
+	H.equip_to_slot_or_del(PDA, default_pda_slot)
 
 	//Equip headset
 	H.equip_to_slot_or_del(new src.default_headset(H), slot_ears)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -43,6 +43,7 @@
 	var/default_headset		= /obj/item/device/radio/headset
 	var/default_backpack	= /obj/item/weapon/storage/backpack
 	var/default_satchel		= /obj/item/weapon/storage/backpack/satchel_norm
+	var/default_storagebox= /obj/item/weapon/storage/box/survival
 
 //Only override this proc
 /datum/job/proc/equip_items(var/mob/living/carbon/human/H)
@@ -51,14 +52,14 @@
 /datum/job/proc/equip_backpack(var/mob/living/carbon/human/H)
 	switch(H.backbag)
 		if(1) //No backpack or satchel
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
+			H.equip_to_slot_or_del(new default_storagebox(H), slot_r_hand)
 		if(2) // Backpack
 			var/obj/item/weapon/storage/backpack/BPK = new default_backpack(H)
-			new /obj/item/weapon/storage/box/survival(BPK)
+			new default_storagebox(BPK)
 			H.equip_to_slot_or_del(BPK, slot_back,1)
 		if(3) //Satchel
 			var/obj/item/weapon/storage/backpack/BPK = new default_satchel(H)
-			new /obj/item/weapon/storage/box/survival(BPK)
+			new default_storagebox(BPK)
 			H.equip_to_slot_or_del(BPK, slot_back,1)
 
 //But don't override this
@@ -71,17 +72,17 @@
 
 	//Equip ID
 	var/obj/item/weapon/card/id/C = new src.default_id(H)
-		C.access = src.get_access()
-		C.registered_name = H.real_name
-		C.assignment = H.job
-		C.update_label()
+	C.access = src.get_access()
+	C.registered_name = H.real_name
+	C.assignment = H.job
+	C.update_label()
 	H.equip_to_slot_or_del(C, slot_wear_id)
 
 	//Equip PDA
 	var/obj/item/device/pda/PDA = new src.default_pda(H)
-		PDA.owner = H.real_name
-		PDA.ownjob = H.job
-		PDA.update_label()
+	PDA.owner = H.real_name
+	PDA.ownjob = H.job
+	PDA.update_label()
 	H.equip_to_slot_or_del(PDA, default_pda_slot)
 
 	//Equip the rest of the gear

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -29,8 +29,6 @@
 	//Sellection screen color
 	var/selection_color = "#ffffff"
 
-	//the type of the ID the player will have
-	var/idtype = /obj/item/weapon/card/id
 
 	//If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
 	var/req_admin_notify
@@ -38,7 +36,60 @@
 	//If you have the use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/minimal_player_age = 0
 
+	//Job specific items
+	var/default_id				= /obj/item/weapon/card/id //this is just the looks of it
+	var/default_pda				= /obj/item/device/pda
+	var/default_pda_slot	= slot_belt
+	var/default_headset		= /obj/item/device/radio/headset
+	var/default_backpack	= /obj/item/weapon/storage/backpack
+	var/default_satchel		= /obj/item/weapon/storage/backpack/satchel_norm
+
+//Only override this proc
+/datum/job/proc/equip_items(var/mob/living/carbon/human/H)
+
+//Or this proc
+/datum/job/proc/equip_backpack(var/mob/living/carbon/human/H)
+	switch(H.backbag)
+		if(1) //No backpack or satchel
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
+		if(2) // Backpack
+			var/obj/item/weapon/storage/backpack/BPK = new default_backpack(H)
+			new /obj/item/weapon/storage/box/survival(BPK)
+			H.equip_to_slot_or_del(BPK, slot_back,1)
+		if(3) //Satchel
+			var/obj/item/weapon/storage/backpack/BPK = new default_satchel(H)
+			new /obj/item/weapon/storage/box/survival(BPK)
+			H.equip_to_slot_or_del(BPK, slot_back,1)
+
+//But don't override this
 /datum/job/proc/equip(var/mob/living/carbon/human/H)
+	if(!H)
+		return 0
+
+	//Equip backpack
+	equip_backpack(H)
+
+	//Equip ID
+	var/obj/item/weapon/card/id/C = new src.default_id(H)
+		C.access = src.get_access()
+		C.registered_name = H.real_name
+		C.assignment = H.job
+		C.update_label()
+	H.equip_to_slot_or_del(C, slot_wear_id)
+
+	//Equip PDA
+	var/obj/item/device/pda/PDA = new src.default_pda(H)
+		PDA.owner = H.real_name
+		PDA.ownjob = H.job
+		PDA.update_label()
+	H.equip_to_slot_or_del(PDA, default_pda_slot)
+
+	//Equip the rest of the gear
+	equip_items(H)
+
+	//Equip headset
+	H.equip_to_slot_or_del(new src.default_headset(H), slot_ears)
+
 	return 1
 
 /datum/job/proc/apply_fingerprints(var/mob/living/carbon/human/H)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -1,3 +1,6 @@
+/*
+Chief Medical Officer
+*/
 /datum/job/cmo
 	title = "Chief Medical Officer"
 	flag = CMO
@@ -7,35 +10,33 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#ffddf0"
-	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
+	minimal_player_age = 7
+
+	default_id = /obj/item/weapon/card/id/silver
+	default_pda = /obj/item/device/pda/heads/cmo
+	default_headset = /obj/item/device/radio/headset/heads/cmo
+	default_backpack = /obj/item/weapon/storage/backpack/medic
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_med
+
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors)
-	minimal_player_age = 7
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/cmo(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/medic (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chief_medical_officer(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/cmo(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/cmo(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(H), slot_l_hand)
-		H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		return 1
+/datum/job/cmo/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chief_medical_officer(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/cmo(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 
 
-
+/*
+Medical Doctor
+*/
 /datum/job/doctor
 	title = "Medical Doctor"
 	flag = DOCTOR
@@ -45,30 +46,25 @@
 	spawn_positions = 3
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+
+	default_pda = /obj/item/device/pda/medical
+	default_headset = /obj/item/device/radio/headset/headset_med
+	default_backpack = /obj/item/weapon/storage/backpack/medic
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_med
+
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 	minimal_access = list(access_medical, access_morgue, access_surgery)
 
+/datum/job/doctor/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/medic (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/medical(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(H), slot_l_hand)
-		H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		return 1
-
-
-
-//Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
+/*
+Chemist
+*/
 /datum/job/chemist
 	title = "Chemist"
 	flag = CHEMIST
@@ -78,21 +74,21 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+
+	default_pda = /obj/item/device/pda/chemist
+	default_headset = /obj/item/device/radio/headset/headset_med
+
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_chemistry, access_mineral_storeroom)
 
+/datum/job/chemist/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chemist(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/chemist(H), slot_wear_suit)
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chemist(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/chemist(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/chemist(H), slot_wear_suit)
-		return 1
-
-
-
+/*
+Geneticist
+*/
 /datum/job/geneticist
 	title = "Geneticist"
 	flag = GENETICIST
@@ -102,22 +98,22 @@
 	spawn_positions = 2
 	supervisors = "the chief medical officer and research director"
 	selection_color = "#ffeef0"
+
+	default_pda = /obj/item/device/pda/geneticist
+	default_headset = /obj/item/device/radio/headset/headset_medsci
+
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_research)
 
+/datum/job/geneticist/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/geneticist(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/genetics(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_medsci(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/geneticist(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/geneticist(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/genetics(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
-		return 1
-
-
-
+/*
+Virologist
+*/
 /datum/job/virologist
 	title = "Virologist"
 	flag = VIROLOGIST
@@ -127,25 +123,19 @@
 	spawn_positions = 1
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
+
+	default_pda = /obj/item/device/pda/viro
+	default_headset = /obj/item/device/radio/headset/headset_med
+	default_backpack = /obj/item/weapon/storage/backpack/medic
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_med
+
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_virology, access_mineral_storeroom)
 
-
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/medic (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_med(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/virologist(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/viro(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(H), slot_wear_mask)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/virologist(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		return 1
-
+/datum/job/virologist/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/virologist(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(H), slot_wear_mask)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/virologist(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -1,3 +1,6 @@
+/*
+Research Director
+*/
 /datum/job/rd
 	title = "Research Director"
 	flag = RD
@@ -7,8 +10,13 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#ffddff"
-	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
+	minimal_player_age = 7
+
+	default_id = /obj/item/weapon/card/id/silver
+	default_pda = /obj/item/device/pda/heads/rd
+	default_headset = /obj/item/device/radio/headset/heads/rd
+
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
@@ -19,21 +27,17 @@
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom,
 			            access_tech_storage)
-	minimal_player_age = 7
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/rd(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/research_director(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/rd(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
-		H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
-		return 1
+/datum/job/rd/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/research_director(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
 
-
-
+/*
+Scientist
+*/
 /datum/job/scientist
 	title = "Scientist"
 	flag = SCIENTIST
@@ -43,23 +47,21 @@
 	spawn_positions = 3
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
+
+	default_pda = /obj/item/device/pda/toxins
+	default_headset = /obj/item/device/radio/headset/headset_sci
+
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_mineral_storeroom)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology, access_mineral_storeroom)
 
+/datum/job/scientist/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/scientist(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/science(H), slot_wear_suit)
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/scientist(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/toxins(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat/science(H), slot_wear_suit)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(H), slot_wear_mask)
-//		H.equip_to_slot_or_del(new /obj/item/weapon/tank/oxygen(H), slot_l_hand)
-		return 1
-
-
-
+/*
+Roboticist
+*/
 /datum/job/roboticist
 	title = "Roboticist"
 	flag = ROBOTICIST
@@ -69,22 +71,15 @@
 	spawn_positions = 1
 	supervisors = "research director"
 	selection_color = "#ffeeff"
-	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
-	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+	default_pda = /obj/item/device/pda/roboticist
+	default_headset = /obj/item/device/radio/headset/headset_sci
+
+	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_mineral_storeroom)
+	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research, access_mineral_storeroom)
+
+/datum/job/roboticist/equip_items(var/mob/living/carbon/human/H)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/roboticist(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/roboticist(H), slot_belt)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/labcoat(H), slot_wear_suit)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/toolbox/mechanical(H), slot_l_hand)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		return 1

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -179,8 +179,6 @@ Security Officer
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton/loaded(H), slot_in_backpack)
 
-	//TODO: Make sure security officers get shit properly when no backpack
-
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
 	L.implanted = 1
@@ -222,7 +220,7 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/science(H), slot_w_uniform)
 				default_headset = /obj/item/device/radio/headset/headset_sec/department/sci
 				dep_access = list(access_research)
-				destination = /area/security/checkpoint/science // TODO: Make sure correct headsets are handed out
+				destination = /area/security/checkpoint/science
 		var/teleport = 0
 		if(!config.sec_start_brig)
 			if(destination)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -4,6 +4,9 @@
 		return list(access_maint_tunnels)
 	return list()
 
+/*
+Head of Shitcurity
+*/
 /datum/job/hos
 	title = "Head of Security"
 	flag = HOS
@@ -13,8 +16,15 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#ffdddd"
-	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
+	minimal_player_age = 14
+
+	default_id = /obj/item/weapon/card/id/silver
+	default_pda = /obj/item/device/pda/heads/hos
+	default_headset = /obj/item/device/radio/headset/heads/hos
+	default_backpack = /obj/item/weapon/storage/backpack/security
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
+
 	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
@@ -23,35 +33,28 @@
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway)
-	minimal_player_age = 14
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security (H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_sec(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/hos(H), slot_ears)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/head_of_security(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/heads/hos(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/hos(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/HoS(H), slot_head)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(H), slot_wear_mask) //Grab one from the armory you donk
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(H), slot_glasses)
-		H.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(H), slot_s_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_l_store)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
+/datum/job/hos/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/head_of_security(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/hos(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/HoS(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(H), slot_glasses)
+	H.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(H), slot_s_store)
+
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_l_store)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
+
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
-		return 1
 
-
-
+/*
+Warden
+*/
 /datum/job/warden
 	title = "Warden"
 	flag = WARDEN
@@ -61,40 +64,42 @@
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue)
-	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court) //But see /datum/job/warden/get_access()
 	minimal_player_age = 7
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_sec(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/warden(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/warden(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/warden(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/warden(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(H), slot_glasses)
-//		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(H), slot_wear_mask) //Grab one from the armory you donk
-		H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
-		if(H.backbag == 1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_l_hand)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
+	default_pda = /obj/item/device/pda/warden
+	default_headset = /obj/item/device/radio/headset/headset_sec
+	default_backpack = /obj/item/weapon/storage/backpack/security
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
+
+	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue)
+	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court) //See /datum/job/warden/get_access()
+
+/datum/job/warden/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/warden(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/warden(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/warden(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(H), slot_glasses)
+	H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
+
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_l_hand)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
+
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
-		return 1
 
 /datum/job/warden/get_access()
 	var/list/L = list()
 	L = ..() | check_config_for_sec_maint()
 	return L
 
+/*
+Detective
+*/
 /datum/job/detective
 	title = "Detective"
 	flag = DETECTIVE
@@ -104,43 +109,39 @@
 	spawn_positions = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
-	access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
-	minimal_access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
 	minimal_player_age = 7
 
+	default_pda = /obj/item/device/pda/detective
+	default_headset = /obj/item/device/radio/headset/headset_sec
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
-		if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-		if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/det(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/detective(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/det_hat(H), slot_head)
-		var/obj/item/clothing/mask/cigarette/CIG = new /obj/item/clothing/mask/cigarette(H)
-		CIG.light("")
-		H.equip_to_slot_or_del(CIG, slot_wear_mask)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/suit/det_suit(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/weapon/lighter/zippo(H), slot_l_store)
+	access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
+	minimal_access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court)
 
-		if(H.backbag == 1)//Why cant some of these things spawn in his office?
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/evidence(H), slot_l_hand)
-			H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_r_store)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/evidence(H), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_in_backpack)
+/datum/job/detective/equip_items(var/mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/under/det(H), slot_w_uniform)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/det_hat(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/det_suit(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/lighter/zippo(H), slot_l_store)
+	var/obj/item/clothing/mask/cigarette/cig = new /obj/item/clothing/mask/cigarette(H)
+		cig.light("")
+	H.equip_to_slot_or_del(cig, slot_wear_mask)
 
-		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
+	if(H.backbag == 1)//Why cant some of these things spawn in his office?
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/evidence(H), slot_l_hand)
+		H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_r_store)
+	else
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/evidence(H), slot_in_backpack)
+		H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_in_backpack)
+
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
-		return 1
 
-
-
+/*
+Security Officer
+*/
 /datum/job/officer
 	title = "Security Officer"
 	flag = OFFICER
@@ -150,34 +151,38 @@
 	spawn_positions = 5
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#ffeeee"
-	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue)
-	minimal_access = list(access_security, access_sec_doors, access_brig, access_court) //But see /datum/job/warden/get_access()
 	minimal_player_age = 7
 	var/list/dep_access = null
 
+	default_pda = /obj/item/device/pda/security
+	default_headset = /obj/item/device/radio/headset/headset_sec
+	default_backpack = /obj/item/weapon/storage/backpack/security
+	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
 
-/datum/job/officer/equip(var/mob/living/carbon/human/H)
-	if(!H)	return 0
-	if(H.backbag == 2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(H), slot_back)
-	if(H.backbag == 3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_sec(H), slot_back)
+	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue)
+	minimal_access = list(access_security, access_sec_doors, access_brig, access_court) //But see /datum/job/warden/get_access()
+
+/datum/job/officer/equip_items(var/mob/living/carbon/human/H)
 	assign_sec_to_department(H)
+
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
-	H.equip_to_slot_or_del(new /obj/item/device/pda/security(H), slot_belt)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet(H), slot_head)
 	H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_s_store)
 	H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
+
 	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_l_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_r_store)
+		H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton/loaded(H), slot_l_hand)
 	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/baton/loaded(H), slot_in_backpack)
+
+	//TODO: Make sure security officers get shit properly when no backpack
+
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-	L.imp_in = H
-	L.implanted = 1
-	return 1
+		L.imp_in = H
+		L.implanted = 1
 
 /datum/job/officer/get_access()
 	var/list/L = list()
@@ -186,14 +191,12 @@
 	L |= ..() | check_config_for_sec_maint()
 	dep_access = null;
 	return L
-	
+
 var/list/sec_departments = list("engineering", "supply", "medical", "science")
 
 /datum/job/officer/proc/assign_sec_to_department(var/mob/living/carbon/human/H)
-	if(!H) return 0
 	if(!sec_departments.len)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security(H), slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_ears)
 	else
 		var/department = pick(sec_departments)
 		sec_departments -= department
@@ -201,24 +204,24 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 		switch(department)
 			if("supply")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/cargo(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/supply(H), slot_ears)
+				default_headset = /obj/item/device/radio/headset/headset_sec/department/supply
 				dep_access = list(access_mailsorting, access_mining)
 				destination = /area/security/checkpoint/supply
 			if("engineering")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/engine(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/engi(H), slot_ears)
+				default_headset = /obj/item/device/radio/headset/headset_sec/department/engi
 				dep_access = list(access_construction, access_engine)
 				destination = /area/security/checkpoint/engineering
 			if("medical")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/med(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/med(H), slot_ears)
+				default_headset = /obj/item/device/radio/headset/headset_sec/department/med
 				dep_access = list(access_medical)
 				destination = /area/security/checkpoint/medical
 			if("science")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security/science(H), slot_w_uniform)
-				H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec/department/sci(H), slot_ears)
+				default_headset = /obj/item/device/radio/headset/headset_sec/department/sci
 				dep_access = list(access_research)
-				destination = /area/security/checkpoint/science
+				destination = /area/security/checkpoint/science // TODO: Make sure correct headsets are handed out
 		var/teleport = 0
 		if(!config.sec_start_brig)
 			if(destination)
@@ -236,7 +239,7 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 					break
 		H << "<b>You have been assigned to [department]!</b>"
 		return
-	
+
 /obj/item/device/radio/headset/headset_sec/department/New()
 	wires = new(src)
 	secure_radio_connections = new

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -49,8 +49,8 @@ Head of Shitcurity
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+	L.imp_in = H
+	L.implanted = 1
 
 /*
 Warden
@@ -89,8 +89,8 @@ Warden
 		H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+	L.imp_in = H
+	L.implanted = 1
 
 /datum/job/warden/get_access()
 	var/list/L = list()
@@ -124,8 +124,9 @@ Detective
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/det_suit(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/weapon/lighter/zippo(H), slot_l_store)
+
 	var/obj/item/clothing/mask/cigarette/cig = new /obj/item/clothing/mask/cigarette(H)
-		cig.light("")
+	cig.light("")
 	H.equip_to_slot_or_del(cig, slot_wear_mask)
 
 	if(H.backbag == 1)//Why cant some of these things spawn in his office?
@@ -136,8 +137,8 @@ Detective
 		H.equip_to_slot_or_del(new /obj/item/device/detective_scanner(H), slot_in_backpack)
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+	L.imp_in = H
+	L.implanted = 1
 
 /*
 Security Officer
@@ -181,8 +182,8 @@ Security Officer
 	//TODO: Make sure security officers get shit properly when no backpack
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
-		L.imp_in = H
-		L.implanted = 1
+	L.imp_in = H
+	L.implanted = 1
 
 /datum/job/officer/get_access()
 	var/list/L = list()

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -1,3 +1,6 @@
+/*
+AI
+*/
 /datum/job/ai
 	title = "AI"
 	flag = AI
@@ -10,17 +13,18 @@
 	req_admin_notify = 1
 	minimal_player_age = 30
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
+/datum/job/ai/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+	return 1
+
+/datum/job/ai/config_check()
+	if(config && config.allow_ai)
 		return 1
+	return 0
 
-	config_check()
-		if(config && config.allow_ai)
-			return 1
-		return 0
-
-
-
+/*
+Cyborg
+*/
 /datum/job/cyborg
 	title = "Cyborg"
 	flag = CYBORG
@@ -32,6 +36,9 @@
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
 
-	equip_items(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		return 1
+/datum/job/cyborg/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+
+	H.Robotize()
+
+	return 1

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -10,7 +10,7 @@
 	req_admin_notify = 1
 	minimal_player_age = 30
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		return 1
 
@@ -32,6 +32,6 @@
 	selection_color = "#ddffdd"
 	minimal_player_age = 21
 
-	equip(var/mob/living/carbon/human/H)
+	equip_items(var/mob/living/carbon/human/H)
 		if(!H)	return 0
 		return 1

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -366,16 +366,13 @@ var/global/datum/controller/occupations/job_master
 			C.assignment = rank
 			C.update_label()
 			H.equip_to_slot_or_del(C, slot_wear_id)
-	/*	if(prob(50))
-			H.equip_to_slot_or_del(new /obj/item/weapon/pen(H), slot_r_store)
-		else
-			H.equip_to_slot_or_del(new /obj/item/weapon/pen/blue(H), slot_r_store)*/
+
 		H.equip_to_slot_or_del(new /obj/item/device/pda(H), slot_belt)
 		if(locate(/obj/item/device/pda,H))//I bet this could just use locate.  It can --SkyMarshal
 			var/obj/item/device/pda/pda = locate(/obj/item/device/pda,H)
 			pda.owner = H.real_name
 			pda.ownjob = C.assignment
-			pda.name = "PDA-[H.real_name] ([pda.ownjob])"
+			pda.update_label()
 		return 1
 
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -294,6 +294,7 @@ var/global/datum/controller/occupations/job_master
 
 		H.job = rank
 
+		//If we joined at roundstart we should be positioned at our workstation
 		if(!joined_late)
 			var/obj/S = null
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -306,13 +307,14 @@ var/global/datum/controller/occupations/job_master
 			if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
 				H.loc = S.loc
 
+		if(H.mind)
+			H.mind.assigned_role = rank
+
 		if(job)
 			job.equip(H)
 			job.apply_fingerprints(H)
 
-		if(H.mind)
-			H.mind.assigned_role = rank
-
+/*
 			switch(rank)
 				if("Cyborg")
 					H.Robotize()
@@ -330,29 +332,33 @@ var/global/datum/controller/occupations/job_master
 							var/obj/item/weapon/storage/backpack/BPK = new/obj/item/weapon/storage/backpack/satchel_norm(H)
 							new /obj/item/weapon/storage/box/survival(BPK)
 							H.equip_to_slot_or_del(BPK, slot_back,1)
-
+*/
 		H << "<B>You are the [rank].</B>"
 		H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
 		if(job.req_admin_notify)
 			H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
 
-		spawnId(H,rank)
+		//spawnId(H,rank)
 
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_ears)
+		//H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_ears)
 		H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
 		return 1
 
 
+/*
 	proc/spawnId(var/mob/living/carbon/human/H, rank)
 		if(!H)	return 0
-		var/obj/item/weapon/card/id/C = null
+		//var/obj/item/weapon/card/id/C = null
 
+		//Try to find the datum related to this job
 		var/datum/job/job = null
 		for(var/datum/job/J in occupations)
 			if(J.title == rank)
 				job = J
 				break
 
+		if(job)
+			job.equip(
 		if(job)
 			if(job.title == "Cyborg")
 				return
@@ -373,6 +379,7 @@ var/global/datum/controller/occupations/job_master
 			pda.owner = H.real_name
 			pda.ownjob = C.assignment
 			pda.update_label()
+*/
 		return 1
 
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -9,441 +9,365 @@ var/global/datum/controller/occupations/job_master
 	var/list/job_debug = list()
 
 
-	proc/SetupOccupations(var/faction = "Station")
-		occupations = list()
-		var/list/all_jobs = typesof(/datum/job)
-		if(!all_jobs.len)
-			world << "\red \b Error setting up jobs, no job datums found"
-			return 0
-		for(var/J in all_jobs)
-			var/datum/job/job = new J()
-			if(!job)	continue
-			if(job.faction != faction)	continue
-			if(!job.config_check()) continue
-			occupations += job
-
-
-		return 1
-
-
-	proc/Debug(var/text)
-		if(!Debug2)	return 0
-		job_debug.Add(text)
-		return 1
-
-
-	proc/GetJob(var/rank)
-		if(!rank)	return null
-		for(var/datum/job/J in occupations)
-			if(!J)	continue
-			if(J.title == rank)	return J
-		return null
-
-
-	proc/AssignRole(var/mob/new_player/player, var/rank, var/latejoin = 0)
-		Debug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
-		if(player && player.mind && rank)
-			var/datum/job/job = GetJob(rank)
-			if(!job)	return 0
-			if(jobban_isbanned(player, rank))	return 0
-			if(!job.player_old_enough(player.client)) return 0
-			var/position_limit = job.total_positions
-			if(!latejoin)
-				position_limit = job.spawn_positions
-			if((job.current_positions < position_limit) || position_limit == -1)
-				Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
-				player.mind.assigned_role = rank
-				unassigned -= player
-				job.current_positions++
-				return 1
-		Debug("AR has failed, Player: [player], Rank: [rank]")
+/datum/controller/occupations/proc/SetupOccupations(var/faction = "Station")
+	occupations = list()
+	var/list/all_jobs = typesof(/datum/job)
+	if(!all_jobs.len)
+		world << "\red \b Error setting up jobs, no job datums found"
 		return 0
 
+	for(var/J in all_jobs)
+		var/datum/job/job = new J()
+		if(!job)	continue
+		if(job.faction != faction)	continue
+		if(!job.config_check()) continue
+		occupations += job
 
-	proc/FindOccupationCandidates(datum/job/job, level, flag)
-		Debug("Running FOC, Job: [job], Level: [level], Flag: [flag]")
-		var/list/candidates = list()
-		for(var/mob/new_player/player in unassigned)
-			if(jobban_isbanned(player, job.title))
-				Debug("FOC isbanned failed, Player: [player]")
-				continue
-			if(!job.player_old_enough(player.client))
-				Debug("FOC player not old enough, Player: [player]")
-				continue
-			if(flag && (!player.client.prefs.be_special & flag))
-				Debug("FOC flag failed, Player: [player], Flag: [flag], ")
-				continue
-			if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
-				Debug("FOC pass, Player: [player], Level:[level]")
-				candidates += player
-		return candidates
-
-	proc/GiveRandomJob(var/mob/new_player/player)
-		Debug("GRJ Giving random job, Player: [player]")
-		for(var/datum/job/job in shuffle(occupations))
-			if(!job)
-				continue
-
-			if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
-				continue
-
-			if(job in command_positions) //If you want a command position, select it!
-				continue
-
-			if(jobban_isbanned(player, job.title))
-				Debug("GRJ isbanned failed, Player: [player], Job: [job.title]")
-				continue
-
-			if(!job.player_old_enough(player.client))
-				Debug("GRJ player not old enough, Player: [player]")
-				continue
-
-			if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
-				Debug("GRJ Random job given, Player: [player], Job: [job]")
-				AssignRole(player, job.title)
-				unassigned -= player
-				break
-
-	proc/ResetOccupations()
-		for(var/mob/new_player/player in player_list)
-			if((player) && (player.mind))
-				player.mind.assigned_role = null
-				player.mind.special_role = null
-		SetupOccupations()
-		unassigned = list()
-		return
+	return 1
 
 
-	///This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until it locates a head or runs out of levels to check
-	proc/FillHeadPosition()
-		for(var/level = 1 to 3)
-			for(var/command_position in command_positions)
-				var/datum/job/job = GetJob(command_position)
-				if(!job)	continue
-				var/list/candidates = FindOccupationCandidates(job, level)
-				if(!candidates.len)	continue
-				var/mob/new_player/candidate = pick(candidates)
-				if(AssignRole(candidate, command_position))
-					return 1
-		return 0
+/datum/controller/occupations/proc/Debug(var/text)
+	if(!Debug2)	return 0
+	job_debug.Add(text)
+	return 1
 
 
-	///This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
-	proc/CheckHeadPositions(var/level)
+/datum/controller/occupations/proc/GetJob(var/rank)
+	if(!rank)	return null
+	for(var/datum/job/J in occupations)
+		if(!J)	continue
+		if(J.title == rank)	return J
+	return null
+
+
+/datum/controller/occupations/proc/AssignRole(var/mob/new_player/player, var/rank, var/latejoin = 0)
+	Debug("Running AR, Player: [player], Rank: [rank], LJ: [latejoin]")
+	if(player && player.mind && rank)
+		var/datum/job/job = GetJob(rank)
+		if(!job)	return 0
+		if(jobban_isbanned(player, rank))	return 0
+		if(!job.player_old_enough(player.client)) return 0
+		var/position_limit = job.total_positions
+		if(!latejoin)
+			position_limit = job.spawn_positions
+		if((job.current_positions < position_limit) || position_limit == -1)
+			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
+			player.mind.assigned_role = rank
+			unassigned -= player
+			job.current_positions++
+			return 1
+	Debug("AR has failed, Player: [player], Rank: [rank]")
+	return 0
+
+
+/datum/controller/occupations/proc/FindOccupationCandidates(datum/job/job, level, flag)
+	Debug("Running FOC, Job: [job], Level: [level], Flag: [flag]")
+	var/list/candidates = list()
+	for(var/mob/new_player/player in unassigned)
+		if(jobban_isbanned(player, job.title))
+			Debug("FOC isbanned failed, Player: [player]")
+			continue
+		if(!job.player_old_enough(player.client))
+			Debug("FOC player not old enough, Player: [player]")
+			continue
+		if(flag && (!player.client.prefs.be_special & flag))
+			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
+			continue
+		if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
+			Debug("FOC pass, Player: [player], Level:[level]")
+			candidates += player
+	return candidates
+
+/datum/controller/occupations/proc/GiveRandomJob(var/mob/new_player/player)
+	Debug("GRJ Giving random job, Player: [player]")
+	for(var/datum/job/job in shuffle(occupations))
+		if(!job)
+			continue
+
+		if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
+			continue
+
+		if(job in command_positions) //If you want a command position, select it!
+			continue
+
+		if(jobban_isbanned(player, job.title))
+			Debug("GRJ isbanned failed, Player: [player], Job: [job.title]")
+			continue
+
+		if(!job.player_old_enough(player.client))
+			Debug("GRJ player not old enough, Player: [player]")
+			continue
+
+		if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
+			Debug("GRJ Random job given, Player: [player], Job: [job]")
+			AssignRole(player, job.title)
+			unassigned -= player
+			break
+
+/datum/controller/occupations/proc/ResetOccupations()
+	for(var/mob/new_player/player in player_list)
+		if((player) && (player.mind))
+			player.mind.assigned_role = null
+			player.mind.special_role = null
+	SetupOccupations()
+	unassigned = list()
+	return
+
+
+//This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until´
+//it locates a head or runs out of levels to check
+//This is basically to ensure that there's atleast a few heads in the round
+/datum/controller/occupations/proc/FillHeadPosition()
+	for(var/level = 1 to 3)
 		for(var/command_position in command_positions)
 			var/datum/job/job = GetJob(command_position)
 			if(!job)	continue
 			var/list/candidates = FindOccupationCandidates(job, level)
 			if(!candidates.len)	continue
 			var/mob/new_player/candidate = pick(candidates)
-			AssignRole(candidate, command_position)
-		return
+			if(AssignRole(candidate, command_position))
+				return 1
+	return 0
 
 
-	proc/FillAIPosition()
-		var/ai_selected = 0
-		var/datum/job/job = GetJob("AI")
-		if(!job)	return 0
-		if(ticker.mode.name == "AI malfunction")	// malf. AIs are pre-selected before jobs
-			for (var/datum/mind/mAI in ticker.mode.malf_ai)
-				AssignRole(mAI.current, "AI")
-				ai_selected++
-			if(ai_selected)	return 1
-			return 0
+//This proc is called at the start of the level loop of DivideOccupations() and will cause head jobs to be checked before any other jobs of the same level
+//This is also to ensure we get as many heads as possible
+/datum/controller/occupations/proc/CheckHeadPositions(var/level)
+	for(var/command_position in command_positions)
+		var/datum/job/job = GetJob(command_position)
+		if(!job)	continue
+		var/list/candidates = FindOccupationCandidates(job, level)
+		if(!candidates.len)	continue
+		var/mob/new_player/candidate = pick(candidates)
+		AssignRole(candidate, command_position)
+	return
 
-		for(var/i = job.total_positions, i > 0, i--)
-			for(var/level = 1 to 3)
-				var/list/candidates = list()
-				candidates = FindOccupationCandidates(job, level)
-				if(candidates.len)
-					var/mob/new_player/candidate = pick(candidates)
-					if(AssignRole(candidate, "AI"))
-						ai_selected++
-						break
+
+/datum/controller/occupations/proc/FillAIPosition()
+	var/ai_selected = 0
+	var/datum/job/job = GetJob("AI")
+	if(!job)	return 0
+	if(ticker.mode.name == "AI malfunction")	// malf. AIs are pre-selected before jobs
+		for (var/datum/mind/mAI in ticker.mode.malf_ai)
+			AssignRole(mAI.current, "AI")
+			ai_selected++
 		if(ai_selected)	return 1
 		return 0
+
+	for(var/i = job.total_positions, i > 0, i--)
+		for(var/level = 1 to 3)
+			var/list/candidates = list()
+			candidates = FindOccupationCandidates(job, level)
+			if(candidates.len)
+				var/mob/new_player/candidate = pick(candidates)
+				if(AssignRole(candidate, "AI"))
+					ai_selected++
+					break
+	if(ai_selected)	return 1
+	return 0
 
 
 /** Proc DivideOccupations
  *  fills var "assigned_role" for all ready players.
  *  This proc must not have any side effect besides of modifying "assigned_role".
  **/
-	proc/DivideOccupations()
-		//Setup new player list and get the jobs list
-		Debug("Running DO")
-		SetupOccupations()
+/datum/controller/occupations/proc/DivideOccupations()
+	//Setup new player list and get the jobs list
+	Debug("Running DO")
+	SetupOccupations()
 
-		//Holder for Triumvirate is stored in the ticker, this just processes it
-		if(ticker)
-			for(var/datum/job/ai/A in occupations)
-				if(ticker.triai)
-					A.spawn_positions = 3
+	//Holder for Triumvirate is stored in the ticker, this just processes it
+	if(ticker)
+		for(var/datum/job/ai/A in occupations)
+			if(ticker.triai)
+				A.spawn_positions = 3
 
-		//Get the players who are ready
-		for(var/mob/new_player/player in player_list)
-			if(player.ready && player.mind && !player.mind.assigned_role)
-				unassigned += player
+	//Get the players who are ready
+	for(var/mob/new_player/player in player_list)
+		if(player.ready && player.mind && !player.mind.assigned_role)
+			unassigned += player
 
-		Debug("DO, Len: [unassigned.len]")
-		if(unassigned.len == 0)	return 0
+	Debug("DO, Len: [unassigned.len]")
+	if(unassigned.len == 0)	return 0
 
-		//Shuffle players and jobs
-		unassigned = shuffle(unassigned)
+	//Shuffle players and jobs
+	unassigned = shuffle(unassigned)
 
-		HandleFeedbackGathering()
+	HandleFeedbackGathering()
 
-		//People who wants to be assistants, sure, go on.
-		Debug("DO, Running Assistant Check 1")
-		var/datum/job/assist = new /datum/job/assistant()
-		var/list/assistant_candidates = FindOccupationCandidates(assist, 3)
-		Debug("AC1, Candidates: [assistant_candidates.len]")
-		for(var/mob/new_player/player in assistant_candidates)
-			Debug("AC1 pass, Player: [player]")
-			AssignRole(player, "Assistant")
-			assistant_candidates -= player
-		Debug("DO, AC1 end")
+	//People who wants to be assistants, sure, go on.
+	Debug("DO, Running Assistant Check 1")
+	var/datum/job/assist = new /datum/job/assistant()
+	var/list/assistant_candidates = FindOccupationCandidates(assist, 3)
+	Debug("AC1, Candidates: [assistant_candidates.len]")
+	for(var/mob/new_player/player in assistant_candidates)
+		Debug("AC1 pass, Player: [player]")
+		AssignRole(player, "Assistant")
+		assistant_candidates -= player
+	Debug("DO, AC1 end")
 
-		//Select one head
-		Debug("DO, Running Head Check")
-		FillHeadPosition()
-		Debug("DO, Head Check end")
+	//Select one head
+	Debug("DO, Running Head Check")
+	FillHeadPosition()
+	Debug("DO, Head Check end")
 
-		//Check for an AI
-		Debug("DO, Running AI Check")
-		FillAIPosition()
-		Debug("DO, AI Check end")
+	//Check for an AI
+	Debug("DO, Running AI Check")
+	FillAIPosition()
+	Debug("DO, AI Check end")
 
-		//Other jobs are now checked
-		Debug("DO, Running Standard Check")
+	//Other jobs are now checked
+	Debug("DO, Running Standard Check")
 
 
-		// New job giving system by Donkie
-		// This will cause lots of more loops, but since it's only done once it shouldn't really matter much at all.
-		// Hopefully this will add more randomness and fairness to job giving.
+	// New job giving system by Donkie
+	// This will cause lots of more loops, but since it's only done once it shouldn't really matter much at all.
+	// Hopefully this will add more randomness and fairness to job giving.
 
-		// Loop through all levels from high to low
-		var/list/shuffledoccupations = shuffle(occupations)
-		for(var/level = 1 to 3)
-			//Check the head jobs first each level
-			CheckHeadPositions(level)
+	// Loop through all levels from high to low
+	var/list/shuffledoccupations = shuffle(occupations)
+	for(var/level = 1 to 3)
+		//Check the head jobs first each level
+		CheckHeadPositions(level)
 
-			// Loop through all unassigned players
-			for(var/mob/new_player/player in unassigned)
-
-				// Loop through all jobs
-				for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
-					if(!job)
-						continue
-
-					if(jobban_isbanned(player, job.title))
-						Debug("DO isbanned failed, Player: [player], Job:[job.title]")
-						continue
-
-					if(!job.player_old_enough(player.client))
-						Debug("DO player not old enough, Player: [player], Job:[job.title]")
-						continue
-
-					// If the player wants that job on this level, then try give it to him.
-					if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
-
-						// If the job isn't filled
-						if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
-							Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
-							AssignRole(player, job.title)
-							unassigned -= player
-							break
-
-		// Hand out random jobs to the people who didn't get any in the last check
-		// Also makes sure that they got their preference correct
+		// Loop through all unassigned players
 		for(var/mob/new_player/player in unassigned)
-			if(player.client.prefs.userandomjob)
-				GiveRandomJob(player)
 
-		/*
-		Old job system
-		for(var/level = 1 to 3)
-			for(var/datum/job/job in occupations)
-				Debug("Checking job: [job]")
+			// Loop through all jobs
+			for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
 				if(!job)
 					continue
-				if(!unassigned.len)
-					break
-				if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
-					continue
-				var/list/candidates = FindOccupationCandidates(job, level)
-				while(candidates.len && ((job.current_positions < job.spawn_positions) || job.spawn_positions == -1))
-					var/mob/new_player/candidate = pick(candidates)
-					Debug("Selcted: [candidate], for: [job.title]")
-					AssignRole(candidate, job.title)
-					candidates -= candidate*/
 
-		Debug("DO, Standard Check end")
-
-		Debug("DO, Running AC2")
-
-		// For those who wanted to be assistant if their preferences were filled, here you go.
-		for(var/mob/new_player/player in unassigned)
-			Debug("AC2 Assistant located, Player: [player]")
-			AssignRole(player, "Assistant")
-		return 1
-
-
-	proc/EquipRank(var/mob/living/carbon/human/H, var/rank, var/joined_late = 0)
-		if(!H)	return 0
-		var/datum/job/job = GetJob(rank)
-
-		H.job = rank
-
-		//If we joined at roundstart we should be positioned at our workstation
-		if(!joined_late)
-			var/obj/S = null
-			for(var/obj/effect/landmark/start/sloc in landmarks_list)
-				if(sloc.name != rank)	continue
-				if(locate(/mob/living) in sloc.loc)	continue
-				S = sloc
-				break
-			if(!S)
-				S = locate("start*[rank]") // use old stype
-			if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
-				H.loc = S.loc
-
-		if(H.mind)
-			H.mind.assigned_role = rank
-
-		if(job)
-			job.equip(H)
-			job.apply_fingerprints(H)
-
-/*
-			switch(rank)
-				if("Cyborg")
-					H.Robotize()
-					return 1
-				if("AI","Clown")	//don't need bag preference stuff!
-				else
-					switch(H.backbag)
-						if(1)
-							H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-						if(2)
-							var/obj/item/weapon/storage/backpack/BPK = new/obj/item/weapon/storage/backpack(H)
-							new /obj/item/weapon/storage/box/survival(BPK)
-							H.equip_to_slot_or_del(BPK, slot_back,1)
-						if(3)
-							var/obj/item/weapon/storage/backpack/BPK = new/obj/item/weapon/storage/backpack/satchel_norm(H)
-							new /obj/item/weapon/storage/box/survival(BPK)
-							H.equip_to_slot_or_del(BPK, slot_back,1)
-*/
-		H << "<B>You are the [rank].</B>"
-		H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
-		if(job.req_admin_notify)
-			H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
-
-		//spawnId(H,rank)
-
-		//H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_ears)
-		H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
-		return 1
-
-
-/*
-	proc/spawnId(var/mob/living/carbon/human/H, rank)
-		if(!H)	return 0
-		//var/obj/item/weapon/card/id/C = null
-
-		//Try to find the datum related to this job
-		var/datum/job/job = null
-		for(var/datum/job/J in occupations)
-			if(J.title == rank)
-				job = J
-				break
-
-		if(job)
-			job.equip(
-		if(job)
-			if(job.title == "Cyborg")
-				return
-			else
-				C = new job.idtype(H)
-				C.access = job.get_access()
-		else
-			C = new /obj/item/weapon/card/id(H)
-		if(C)
-			C.registered_name = H.real_name
-			C.assignment = rank
-			C.update_label()
-			H.equip_to_slot_or_del(C, slot_wear_id)
-
-		H.equip_to_slot_or_del(new /obj/item/device/pda(H), slot_belt)
-		if(locate(/obj/item/device/pda,H))//I bet this could just use locate.  It can --SkyMarshal
-			var/obj/item/device/pda/pda = locate(/obj/item/device/pda,H)
-			pda.owner = H.real_name
-			pda.ownjob = C.assignment
-			pda.update_label()
-*/
-		return 1
-
-
-	proc/LoadJobs(jobsfile) //ran during round setup, reads info from jobs.txt -- Urist
-		if(!config.load_jobs_from_txt)
-			return 0
-
-		var/list/jobEntries = file2list(jobsfile)
-
-		for(var/job in jobEntries)
-			if(!job)
-				continue
-
-			job = trim(job)
-			if (!length(job))
-				continue
-
-			var/pos = findtext(job, "=")
-			var/name = null
-			var/value = null
-
-			if(pos)
-				name = copytext(job, 1, pos)
-				value = copytext(job, pos + 1)
-			else
-				continue
-
-			if(name && value)
-				var/datum/job/J = GetJob(name)
-				if(!J)	continue
-				J.total_positions = text2num(value)
-				J.spawn_positions = text2num(value)
-				if(name == "AI" || name == "Cyborg")//I dont like this here but it will do for now
-					J.total_positions = 0
-
-		return 1
-
-
-	proc/HandleFeedbackGathering()
-		for(var/datum/job/job in occupations)
-			var/tmp_str = "|[job.title]|"
-
-			var/level1 = 0 //high
-			var/level2 = 0 //medium
-			var/level3 = 0 //low
-			var/level4 = 0 //never
-			var/level5 = 0 //banned
-			var/level6 = 0 //account too young
-			for(var/mob/new_player/player in player_list)
-				if(!(player.ready && player.mind && !player.mind.assigned_role))
-					continue //This player is not ready
 				if(jobban_isbanned(player, job.title))
-					level5++
+					Debug("DO isbanned failed, Player: [player], Job:[job.title]")
 					continue
-				if(!job.player_old_enough(player.client))
-					level6++
-					continue
-				if(player.client.prefs.GetJobDepartment(job, 1) & job.flag)
-					level1++
-				else if(player.client.prefs.GetJobDepartment(job, 2) & job.flag)
-					level2++
-				else if(player.client.prefs.GetJobDepartment(job, 3) & job.flag)
-					level3++
-				else level4++ //not selected
 
-			tmp_str += "HIGH=[level1]|MEDIUM=[level2]|LOW=[level3]|NEVER=[level4]|BANNED=[level5]|YOUNG=[level6]|-"
-			feedback_add_details("job_preferences",tmp_str)
+				if(!job.player_old_enough(player.client))
+					Debug("DO player not old enough, Player: [player], Job:[job.title]")
+					continue
+
+				// If the player wants that job on this level, then try give it to him.
+				if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
+
+					// If the job isn't filled
+					if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
+						Debug("DO pass, Player: [player], Level:[level], Job:[job.title]")
+						AssignRole(player, job.title)
+						unassigned -= player
+						break
+
+	// Hand out random jobs to the people who didn't get any in the last check
+	// Also makes sure that they got their preference correct
+	for(var/mob/new_player/player in unassigned)
+		if(player.client.prefs.userandomjob)
+			GiveRandomJob(player)
+
+	Debug("DO, Standard Check end")
+
+	Debug("DO, Running AC2")
+
+	// For those who wanted to be assistant if their preferences were filled, here you go.
+	for(var/mob/new_player/player in unassigned)
+		Debug("AC2 Assistant located, Player: [player]")
+		AssignRole(player, "Assistant")
+	return 1
+
+//Gives the player the stuff he should have with his rank
+/datum/controller/occupations/proc/EquipRank(var/mob/living/carbon/human/H, var/rank, var/joined_late = 0)
+	var/datum/job/job = GetJob(rank)
+
+	H.job = rank
+
+	//If we joined at roundstart we should be positioned at our workstation
+	if(!joined_late)
+		var/obj/S = null
+		for(var/obj/effect/landmark/start/sloc in landmarks_list)
+			if(sloc.name != rank)	continue
+			if(locate(/mob/living) in sloc.loc)	continue
+			S = sloc
+			break
+		if(!S)
+			S = locate("start*[rank]") // use old stype
+		if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
+			H.loc = S.loc
+
+	if(H.mind)
+		H.mind.assigned_role = rank
+
+	if(job)
+		job.equip(H)
+		job.apply_fingerprints(H)
+
+	H << "<B>You are the [rank].</B>"
+	H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
+	if(job.req_admin_notify)
+		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
+
+	H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
+	return 1
+
+
+/datum/controller/occupations/proc/LoadJobs(jobsfile) //ran during round setup, reads info from jobs.txt -- Urist
+	if(!config.load_jobs_from_txt)
+		return 0
+
+	var/list/jobEntries = file2list(jobsfile)
+
+	for(var/job in jobEntries)
+		if(!job)
+			continue
+
+		job = trim(job)
+		if (!length(job))
+			continue
+
+		var/pos = findtext(job, "=")
+		var/name = null
+		var/value = null
+
+		if(pos)
+			name = copytext(job, 1, pos)
+			value = copytext(job, pos + 1)
+		else
+			continue
+
+		if(name && value)
+			var/datum/job/J = GetJob(name)
+			if(!J)	continue
+			J.total_positions = text2num(value)
+			J.spawn_positions = text2num(value)
+			if(name == "AI" || name == "Cyborg")//I dont like this here but it will do for now
+				J.total_positions = 0
+
+	return 1
+
+
+/datum/controller/occupations/proc/HandleFeedbackGathering()
+	for(var/datum/job/job in occupations)
+		var/tmp_str = "|[job.title]|"
+
+		var/level1 = 0 //high
+		var/level2 = 0 //medium
+		var/level3 = 0 //low
+		var/level4 = 0 //never
+		var/level5 = 0 //banned
+		var/level6 = 0 //account too young
+		for(var/mob/new_player/player in player_list)
+			if(!(player.ready && player.mind && !player.mind.assigned_role))
+				continue //This player is not ready
+			if(jobban_isbanned(player, job.title))
+				level5++
+				continue
+			if(!job.player_old_enough(player.client))
+				level6++
+				continue
+			if(player.client.prefs.GetJobDepartment(job, 1) & job.flag)
+				level1++
+			else if(player.client.prefs.GetJobDepartment(job, 2) & job.flag)
+				level2++
+			else if(player.client.prefs.GetJobDepartment(job, 3) & job.flag)
+				level3++
+			else level4++ //not selected
+
+		tmp_str += "HIGH=[level1]|MEDIUM=[level2]|LOW=[level3]|NEVER=[level4]|BANNED=[level5]|YOUNG=[level6]|-"
+		feedback_add_details("job_preferences",tmp_str)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -364,7 +364,7 @@ var/global/datum/controller/occupations/job_master
 		if(C)
 			C.registered_name = H.real_name
 			C.assignment = rank
-			C.name = "[C.registered_name]'s ID Card ([C.assignment])"
+			C.update_label()
 			H.equip_to_slot_or_del(C, slot_wear_id)
 	/*	if(prob(50))
 			H.equip_to_slot_or_del(new /obj/item/weapon/pen(H), slot_r_store)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -278,7 +278,7 @@
 		if ("modify")
 			if (modify)
 				data_core.manifest_modify(modify.registered_name, modify.assignment)
-				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
+				modify.update_label()
 				modify.loc = loc
 				modify.verb_pickup()
 				modify = null
@@ -408,7 +408,7 @@
 				P.name = "paper- 'Crew Manifest'"
 				printing = null
 	if (modify)
-		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
+		modify.update_label()
 	updateUsrDialog()
 	return
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -14,7 +14,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	slot_flags = SLOT_ID | SLOT_BELT
 
 	//Main variables
-	var/owner = null
+	var/owner = null // String name of owner
 	var/default_cartridge = 0 // Access level defined by cartridge
 	var/obj/item/weapon/cartridge/cartridge = null //current cartridge
 	var/mode = 0 //Controls what menu the PDA will display. 0 is hub; the rest are either built in or based on cartridge.
@@ -215,6 +215,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(default_cartridge)
 		cartridge = new default_cartridge(src)
 	new /obj/item/weapon/pen(src)
+
+/obj/item/device/pda/proc/update_label()
+	name = "PDA-[owner] ([ownjob])" //Name generalisation
 
 /obj/item/device/pda/proc/can_use(mob/user)
 	if(user && ismob(user))
@@ -472,7 +475,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				id_check(U, 1)
 			if("UpdateInfo")
 				ownjob = id.assignment
-				name = "PDA-[owner] ([ownjob])"
+				update_label()
 			if("Eject")//Ejects the cart, only done from hub.
 				if (!isnull(cartridge))
 					var/turf/T = loc
@@ -848,7 +851,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(!owner)
 			owner = idcard.registered_name
 			ownjob = idcard.assignment
-			name = "PDA-[owner] ([ownjob])"
+			update_label()
 			user << "<span class='notice'>Card scanned.</span>"
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -90,6 +90,27 @@
 /obj/item/weapon/card/id/GetID()
 	return src
 
+/*
+Usage:
+update_label()
+	Sets the id name to whatever registered_name and assignment is
+
+update_label("John Doe", "Clowny")
+	Properly formats the name and occupation and sets the id name to the arguments
+*/
+/obj/item/weapon/card/id/proc/update_label(var/newname, var/newjob)
+	if(newname || newjob)
+		name = text("[][]",
+			(!newname)	? "identification card"	: "[newname]'s ID Card",
+			(!newjob)		? ""										: " ([newjob])"
+		)
+		return
+
+	name = text("[][]",
+		(!registered_name)	? "identification card"	: "[registered_name]'s ID Card",
+		(!assignment)				? ""										: " ([assignment])"
+	)
+
 /obj/item/weapon/card/id/verb/read()
 	set name = "Read ID Card"
 	set category = "Object"
@@ -100,13 +121,11 @@
 
 
 /obj/item/weapon/card/id/silver
-	name = "identification card"
 	desc = "A silver card which shows honour and dedication."
 	icon_state = "silver"
 	item_state = "silver_id"
 
 /obj/item/weapon/card/id/gold
-	name = "identification card"
 	desc = "A golden card which shows power and might."
 	icon_state = "gold"
 	item_state = "gold_id"
@@ -141,7 +160,7 @@
 			src.registered_name = ""
 			return
 		src.assignment = u
-		src.name = "[src.registered_name]'s ID Card ([src.assignment])"
+		update_label()
 		user << "\blue You successfully forge the ID card."
 	else
 		..()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -672,7 +672,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 			var/obj/item/device/pda/P = new(M)
 			P.owner = M.real_name
 			P.ownjob = "Assistant"
-			P.name = "PDA-[M.real_name] (Assistant)"
+			P.update_label()
 			M.equip_to_slot_or_del(P, slot_belt)
 
 
@@ -856,7 +856,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 			var/obj/item/device/pda/heads/pda = new(M)
 			pda.owner = M.real_name
 			pda.ownjob = "Reaper"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
+			pda.update_label()
 
 			M.equip_to_slot_or_del(pda, slot_belt)
 
@@ -927,7 +927,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 			var/obj/item/device/pda/heads/pda = new(M)
 			pda.owner = M.real_name
 			pda.ownjob = "Centcom Official"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
+			pda.update_label()
 
 			M.equip_to_slot_or_del(pda, slot_r_store)
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -470,7 +470,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 			id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
 			id.registered_name = H.real_name
 			id.assignment = "Captain"
-			id.name = "[id.registered_name]'s ID Card ([id.assignment])"
+			id.update_label()
 
 			if(worn)
 				if(istype(worn,/obj/item/device/pda))
@@ -665,9 +665,9 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(M), slot_shoes)
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card (Assistant)"
 			W.assignment = "Assistant"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
 			var/obj/item/device/pda/P = new(M)
 			P.owner = M.real_name
@@ -805,10 +805,10 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(M), slot_r_store)
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card"
 			W.access = get_all_accesses()
 			W.assignment = "Tunnel Clown!"
 			W.registered_name = M.real_name
+			W.update_label(M.real_name)
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 			var/obj/item/weapon/twohanded/fireaxe/fire_axe = new(M)
@@ -861,10 +861,10 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(pda, slot_belt)
 
 			var/obj/item/weapon/card/id/syndicate/W = new(M)
-			W.name = "[M.real_name]'s ID Card"
 			W.access = get_all_accesses()
 			W.assignment = "Reaper"
 			W.registered_name = M.real_name
+			W.update_label(M.real_name)
 			M.equip_to_slot_or_del(W, slot_wear_id)
 // DEATH SQUADS
 		if("death commando")//Was looking to add this for a while.
@@ -904,12 +904,12 @@ var/global/list/g_fancy_list_of_safe_types = null
 			L.implanted = 1
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card"
 			W.icon_state = "centcom"
 			W.access = get_all_accesses()//They get full station access.
 			W.access += get_centcom_access("Death Commando")//Let's add their alloted Centcom access.
 			W.assignment = "Death Commando"
 			W.registered_name = M.real_name
+			W.update_label(M.real_name)
 			M.equip_to_slot_or_del(W, slot_wear_id)
 /*
 		if("syndicate commando")
@@ -934,11 +934,11 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/weapon/clipboard(M), slot_l_hand)
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card (Centcom Official)"
 			W.icon_state = "centcom"
 			W.access = get_centcom_access("Centcom Official")
 			W.assignment = "Centcom Official"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 		if("centcom commander")
@@ -955,12 +955,12 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/ammo_box/a357(M), slot_l_store)
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card (Centcom Commander)"
 			W.icon_state = "centcom"
 			W.access = get_all_accesses()
 			W.access += get_centcom_access("Centcom Commander")
 			W.assignment = "Centcom Commander"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 		if("special ops officer")
@@ -980,12 +980,12 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(M), slot_back)
 
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card (Special Ops Officer)"
 			W.icon_state = "centcom"
 			W.access = get_all_accesses()
 			W.access += get_centcom_access("Special Ops Officer")
 			W.assignment = "Special Ops Officer"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 		if("blue wizard")
@@ -1023,6 +1023,7 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/weapon/staff(M), slot_l_hand)
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(M), slot_back)
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box(M), slot_in_backpack)
+
 		if("soviet admiral")
 			M.equip_to_slot_or_del(new /obj/item/clothing/head/hgpiratecap(M), slot_head)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/swat/combat(M), slot_shoes)
@@ -1033,14 +1034,16 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(M), slot_back)
 			M.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/revolver/mateba(M), slot_belt)
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/soviet(M), slot_w_uniform)
+
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card (Admiral)"
 			W.icon_state = "centcom"
 			W.access = get_all_accesses()
 			W.access += get_centcom_access("Admiral")
 			W.assignment = "Admiral"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
+
 		if("mobster")
 			M.equip_to_slot_or_del(new /obj/item/clothing/head/fedora(M), slot_head)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(M), slot_shoes)
@@ -1049,10 +1052,11 @@ var/global/list/g_fancy_list_of_safe_types = null
 			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(M), slot_glasses)
 			M.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/tommygun(M), slot_r_hand)
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket/really_black(M), slot_w_uniform)
+
 			var/obj/item/weapon/card/id/W = new(M)
-			W.name = "[M.real_name]'s ID Card"
 			W.assignment = "Assistant"
 			W.registered_name = M.real_name
+			W.update_label()
 			M.equip_to_slot_or_del(W, slot_wear_id)
 
 

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -38,12 +38,12 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(H.loc), slot_l_store)
 
 		var/obj/item/weapon/card/id/W = new(H)
-		W.name = "[H.real_name]'s ID Card"
 		W.icon_state = "centcom"
 		W.access = get_all_accesses()
 		W.access += get_all_centcom_access()
 		W.assignment = "Highlander"
 		W.registered_name = H.real_name
+		W.update_label(H.real_name)
 		H.equip_to_slot_or_del(W, slot_wear_id)
 
 	message_admins("\blue [key_name_admin(usr)] used THERE CAN BE ONLY ONE!", 1)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -66,7 +66,6 @@
 		M.equip_to_slot_or_del(new src.corpseback(M), slot_back)
 	if(src.corpseid == 1)
 		var/obj/item/weapon/card/id/W = new(M)
-		W.name = "[M.real_name]'s ID Card ([corpseidjob])"
 		var/datum/job/jobdatum
 		for(var/jobtype in typesof(/datum/job))
 			var/datum/job/J = new jobtype
@@ -83,6 +82,7 @@
 		if(corpseidjob)
 			W.assignment = corpseidjob
 		W.registered_name = M.real_name
+		W.update_label()
 		M.equip_to_slot_or_del(W, slot_wear_id)
 	qdel(src)
 

--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -60,7 +60,6 @@
 		M.equip_to_slot_or_del(new src.corpseback(M), slot_back)
 	if(src.corpseid == 1)
 		var/obj/item/weapon/card/id/W = new(M)
-		W.name = "[M.real_name]'s ID Card"
 		var/datum/job/jobdatum
 		for(var/jobtype in typesof(/datum/job))
 			var/datum/job/J = new jobtype
@@ -77,6 +76,7 @@
 		if(corpseidjob)
 			W.assignment = corpseidjob
 		W.registered_name = M.real_name
+		W.update_label()
 		M.equip_to_slot_or_del(W, slot_wear_id)
 	qdel(src)
 

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -56,3 +56,4 @@ bobylein = Game Master
 sirbayer = Game Master
 hornygranny = Game Master
 yota = Game Master
+donkieyo = Game Master


### PR DESCRIPTION
This PR in words:
- Much item adding has been generalised and added to the parent job equip proc, equip now calls equip_items along with equip_backpack which is the only procs that should be overriden. equip itself gives the player the basic things, ID, PDA and headset.
- Everything have been standardised and all jobs should look the same, codewise
- Bunch of variables have been added to the job datum that lets you change the items handed out in the equip proc, much more cleaner than before
- Best of all, before, everybody received the standard PDA, which was then overridden when equip() was called, so the PDA was quickly removed ontop of the job related one, same with ID, same with headset, (I think) same with backpack. Causing unnecessary lag. This has been removed
- It's generally much more clean and maintainable now, easier for noncodeys to edit
- **Every job now receives what they should, no matter if they have backpack, or no backpack, before if you didn't carry a backpack you could miss out on some good stuff, such as stunbaton for sec or miningvoucher for miners**

In addition to the job refactoring, I have standardised the PDA and ID naming into one proc, instead of it being spread out at over roughly 13 files.

I have tested this as much as I see necessary, but it's a lot of changes and I can't predict or test every inch of it.

**I would love if you guys gave more ideas for refactoring, especially job_controller.dm file since its messy**
