### PR TITLE
Works with falsewalls and plasma asay logs.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -990,6 +990,8 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/plasma/attackby(C as obj, mob/user as mob)
 	if(C)
+		message_admins("Plasma airlock ignited by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("Plasma airlock ignited by [user.ckey]([user]) in ([x],[y],[z])")
 		ignite(is_hot(C))
 	..()
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -205,8 +205,6 @@ move an amendment</a> to the drawing.</p>
 		return BORDER_2NDTILE
 	if (locate(/obj/structure/falsewall) in T2)
 		return BORDER_2NDTILE
-	if (locate(/obj/structure/falserwall) in T2)
-		return BORDER_2NDTILE
 
 	return BORDER_NONE
 

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/turf/walls.dmi'
 	var/mineral = "metal"
 	var/opening = 0
+	density = 1
 
 /obj/structure/falsewall/New()
 	relativewall_neighbours()
@@ -15,17 +16,14 @@
 
 /obj/structure/falsewall/Destroy()
 
-	var/temploc = src.loc
+	var/temploc = loc
+	loc = null
 
-	spawn(10)
-		for(var/turf/simulated/wall/W in range(temploc,1))
-			W.relativewall()
+	for(var/turf/simulated/wall/W in range(temploc,1))
+		W.relativewall()
 
-		for(var/obj/structure/falsewall/W in range(temploc,1))
-			W.relativewall()
-
-		for(var/obj/structure/falserwall/W in range(temploc,1))
-			W.relativewall()
+	for(var/obj/structure/falsewall/W in range(temploc,1))
+		W.relativewall()
 	..()
 
 
@@ -45,14 +43,10 @@
 		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
 			if(src.mineral == W.mineral)
 				junction |= get_dir(src,W)
-	for(var/obj/structure/falserwall/W in orange(src,1))
-		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
-			if(src.mineral == W.mineral)
-				junction |= get_dir(src,W)
 	icon_state = "[mineral][junction]"
 	return
 
-/obj/structure/falsewall/attack_hand(mob/user as mob)
+/obj/structure/falsewall/attack_hand(mob/user)
 	if(opening)
 		return
 
@@ -60,7 +54,7 @@
 		opening = 1
 		icon_state = "[mineral]fwall_open"
 		flick("[mineral]fwall_opening", src)
-		sleep(15)
+		sleep(4)
 		src.density = 0
 		SetOpacity(0)
 		opening = 0
@@ -69,20 +63,19 @@
 		flick("[mineral]fwall_closing", src)
 		icon_state = "[mineral]0"
 		density = 1
-		sleep(15)
+		sleep(4)
 		SetOpacity(1)
 		src.relativewall()
 		opening = 0
 
 /obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
-	..()
 	if(density)
 		icon_state = "[mineral]0"
 		src.relativewall()
 	else
 		icon_state = "[mineral]fwall_open"
 
-/obj/structure/falsewall/proc/ChangeToWall(var/delete = 1)
+/obj/structure/falsewall/proc/ChangeToWall(delete = 1)
 	var/turf/T = get_turf(src)
 	if(!mineral || mineral == "metal")
 		T.ChangeTurf(/turf/simulated/wall)
@@ -92,68 +85,59 @@
 		qdel(src)
 	return T
 
-/obj/structure/falsewall/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/falsewall/attackby(obj/item/weapon/W, mob/user)
 	if(opening)
-		user << "\red You must wait until the door has stopped moving."
+		user << "<span class='warning'>You must wait until the door has stopped moving.</span>"
 		return
 
 	if(density)
 		var/turf/T = get_turf(src)
 		if(T.density)
-			user << "\red The wall is blocked!"
+			user << "<span class='warning'>[src] is blocked!</span>"
 			return
 		if(istype(W, /obj/item/weapon/screwdriver))
-			user.visible_message("[user] tightens some bolts on the wall.", "You tighten the bolts on the wall.")
+			if (!istype(T, /turf/simulated/floor))
+				user << "<span class='warning'>[src] bolts must be tightened on the floor!</span>"
+				return
+			user.visible_message("<span class='notice'>[user] tightens some bolts on the wall.</span>", "<span class='warning'>You tighten the bolts on the wall.</span>")
 			ChangeToWall()
-
-		if( istype(W, /obj/item/weapon/weldingtool) )
+		if(istype(W, /obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
-			if( WT:welding )
-				ChangeToWall(0)
-				if(mineral != "plasma")//Stupid shit keeps me from pushing the attackby() to plasma walls -Sieve
-					T = get_turf(src)
-					T.attackby(W,user)
-				qdel(src)
+			if(WT.remove_fuel(0,user))
+				dismantle(user)
 	else
-		user << "\blue You can't reach, close it first!"
+		user << "<span class='warning'>You can't reach, close it first!</span>"
 
-	if( istype(W, /obj/item/weapon/pickaxe/plasmacutter) || istype(W, /obj/item/weapon/pickaxe/diamonddrill) || istype(W, /obj/item/weapon/melee/energy/blade))
-		ChangeToWall(0)
-		if(mineral != "plasma")
-			var/turf/T = get_turf(src)
-			T.attackby(W,user)
-		qdel(src)
+	if(istype(W, /obj/item/weapon/pickaxe/plasmacutter) || istype(W, /obj/item/weapon/pickaxe/diamonddrill) || istype(W, /obj/item/weapon/melee/energy/blade))
+		dismantle()
 
-
-/obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
-	..()
-	if(density)
-		icon_state = "[mineral]0"
-		src.relativewall()
+/obj/structure/falsewall/proc/dismantle(mob/user)
+	user.visible_message("<span class='notice'>[user] dismantles the false wall.</span>", "<span class='warning'>You dismantle the false wall.</span>")
+	new /obj/structure/girder/displaced(loc)
+	if(mineral == "metal")
+		if(istype(src, /obj/structure/falsewall/reinforced))
+			new /obj/item/stack/sheet/plasteel(loc)
+			new /obj/item/stack/sheet/plasteel(loc)
+		else
+			new /obj/item/stack/sheet/metal(loc)
+			new /obj/item/stack/sheet/metal(loc)
 	else
-		icon_state = "[mineral]fwall_open"
+		var/P = text2path("/obj/item/stack/sheet/mineral/[mineral]")
+		new P(loc)
+		new P(loc)
+	playsound(src, 'sound/items/Welder.ogg', 100, 1)
+	qdel(src)
 
 /*
  * False R-Walls
  */
 
-/obj/structure/falserwall
+/obj/structure/falsewall/reinforced
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to seperate rooms."
-	icon = 'icons/turf/walls.dmi'
 	icon_state = "r_wall"
-	density = 1
-	opacity = 1
-	anchored = 1
-	var/mineral = "metal"
-	var/opening = 0
 
-/obj/structure/falserwall/New()
-	relativewall_neighbours()
-	..()
-
-
-/obj/structure/falserwall/attack_hand(mob/user as mob)
+/obj/structure/falsewall/reinforced/attack_hand(mob/user)
 	if(opening)
 		return
 
@@ -162,7 +146,7 @@
 		// Open wall
 		icon_state = "frwall_open"
 		flick("frwall_opening", src)
-		sleep(15)
+		sleep(5)
 		density = 0
 		SetOpacity(0)
 		opening = 0
@@ -171,12 +155,26 @@
 		icon_state = "r_wall"
 		flick("frwall_closing", src)
 		density = 1
-		sleep(15)
+		sleep(5)
 		SetOpacity(1)
 		relativewall()
 		opening = 0
 
-/obj/structure/falserwall/relativewall()
+/obj/structure/falsewall/reinforced/ChangeToWall(delete = 1)
+	var/turf/T = get_turf(src)
+	T.ChangeTurf(/turf/simulated/wall/r_wall)
+	if(delete)
+		qdel(src)
+	return T
+
+/obj/structure/falsewall/reinforced/update_icon()
+	if(density)
+		icon_state = "rwall0"
+		src.relativewall()
+	else
+		icon_state = "frwall_open"
+
+/obj/structure/falsewall/reinforced/relativewall()
 
 	if(!density)
 		icon_state = "frwall_open"
@@ -192,57 +190,8 @@
 		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
 			if(src.mineral == W.mineral)
 				junction |= get_dir(src,W)
-	for(var/obj/structure/falserwall/W in orange(src,1))
-		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
-			if(src.mineral == W.mineral)
-				junction |= get_dir(src,W)
 	icon_state = "rwall[junction]"
 	return
-
-
-
-/obj/structure/falserwall/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(opening)
-		user << "\red You must wait until the door has stopped moving."
-		return
-
-	if(istype(W, /obj/item/weapon/screwdriver))
-		var/turf/T = get_turf(src)
-		user.visible_message("[user] tightens some bolts on the r wall.", "You tighten the bolts on the wall.")
-		T.ChangeTurf(/turf/simulated/wall) //Intentionally makes a regular wall instead of an r-wall (no cheap r-walls for you).
-		qdel(src)
-
-	if( istype(W, /obj/item/weapon/weldingtool) )
-		var/obj/item/weapon/weldingtool/WT = W
-		if( WT.remove_fuel(0,user) )
-			var/turf/T = get_turf(src)
-			T.ChangeTurf(/turf/simulated/wall)
-			T = get_turf(src)
-			T.attackby(W,user)
-			qdel(src)
-
-	else if( istype(W, /obj/item/weapon/pickaxe/plasmacutter) )
-		var/turf/T = get_turf(src)
-		T.ChangeTurf(/turf/simulated/wall)
-		T = get_turf(src)
-		T.attackby(W,user)
-		qdel(src)
-
-	//DRILLING
-	else if (istype(W, /obj/item/weapon/pickaxe/diamonddrill))
-		var/turf/T = get_turf(src)
-		T.ChangeTurf(/turf/simulated/wall)
-		T = get_turf(src)
-		T.attackby(W,user)
-		qdel(src)
-
-	else if( istype(W, /obj/item/weapon/melee/energy/blade) )
-		var/turf/T = get_turf(src)
-		T.ChangeTurf(/turf/simulated/wall)
-		T = get_turf(src)
-		T.attackby(W,user)
-		qdel(src)
-
 
 /*
  * Uranium Falsewalls
@@ -256,11 +205,11 @@
 	var/active = null
 	var/last_event = 0
 
-/obj/structure/falsewall/uranium/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/structure/falsewall/uranium/attackby(obj/item/weapon/W, mob/user)
 	radiate()
 	..()
 
-/obj/structure/falsewall/uranium/attack_hand(mob/user as mob)
+/obj/structure/falsewall/uranium/attack_hand(mob/user)
 	radiate()
 	..()
 
@@ -303,6 +252,24 @@
 	desc = "A wall with plasma plating. This is definately a bad idea."
 	icon_state = ""
 	mineral = "plasma"
+
+/obj/structure/falsewall/plasma/attackby(obj/item/weapon/W, mob/user)
+	if(is_hot(W) > 300)
+		message_admins("Plasma falsewall ignited by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("Plasma falsewall ignited by [user.ckey]([user]) in ([x],[y],[z])")
+		burnbabyburn()
+		return
+	..()
+
+/obj/structure/falsewall/plasma/proc/burnbabyburn(user)
+	playsound(src, 'sound/items/Welder.ogg', 100, 1)
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 400)
+	new /obj/structure/girder/displaced(loc)
+	qdel(src)
+
+/obj/structure/falsewall/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > 300)
+		burnbabyburn()
 
 //-----------wtf?-----------start
 /obj/structure/falsewall/clown

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -9,6 +9,7 @@
 	var/mineral = "metal"
 	var/opening = 0
 	density = 1
+	opacity = 1
 
 /obj/structure/falsewall/New()
 	relativewall_neighbours()
@@ -50,28 +51,32 @@
 	if(opening)
 		return
 
+	opening = 1
 	if(density)
-		opening = 1
-		icon_state = "[mineral]fwall_open"
-		flick("[mineral]fwall_opening", src)
+		do_the_flick()
 		sleep(4)
-		src.density = 0
+		density = 0
 		SetOpacity(0)
-		opening = 0
+		update_icon(0)
 	else
-		opening = 1
-		flick("[mineral]fwall_closing", src)
-		icon_state = "[mineral]0"
+		do_the_flick()
 		density = 1
 		sleep(4)
 		SetOpacity(1)
-		src.relativewall()
-		opening = 0
+		update_icon()
+	opening = 0
 
-/obj/structure/falsewall/update_icon()//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
+/obj/structure/falsewall/proc/do_the_flick()
+	if(density)
+		flick("[mineral]fwall_opening", src)
+	else
+		flick("[mineral]fwall_closing", src)
+
+/obj/structure/falsewall/update_icon(relativewall = 1)//Calling icon_update will refresh the smoothwalls if it's closed, otherwise it will make sure the icon is correct if it's open
 	if(density)
 		icon_state = "[mineral]0"
-		src.relativewall()
+		if(relativewall)
+			relativewall()
 	else
 		icon_state = "[mineral]fwall_open"
 
@@ -137,29 +142,6 @@
 	desc = "A huge chunk of reinforced metal used to seperate rooms."
 	icon_state = "r_wall"
 
-/obj/structure/falsewall/reinforced/attack_hand(mob/user)
-	if(opening)
-		return
-
-	if(density)
-		opening = 1
-		// Open wall
-		icon_state = "frwall_open"
-		flick("frwall_opening", src)
-		sleep(5)
-		density = 0
-		SetOpacity(0)
-		opening = 0
-	else
-		opening = 1
-		icon_state = "r_wall"
-		flick("frwall_closing", src)
-		density = 1
-		sleep(5)
-		SetOpacity(1)
-		relativewall()
-		opening = 0
-
 /obj/structure/falsewall/reinforced/ChangeToWall(delete = 1)
 	var/turf/T = get_turf(src)
 	T.ChangeTurf(/turf/simulated/wall/r_wall)
@@ -167,7 +149,13 @@
 		qdel(src)
 	return T
 
-/obj/structure/falsewall/reinforced/update_icon()
+/obj/structure/falsewall/reinforced/do_the_flick()
+	if(density)
+		flick("frwall_opening", src)
+	else
+		flick("frwall_closing", src)
+
+/obj/structure/falsewall/reinforced/update_icon(relativewall = 1)
 	if(density)
 		icon_state = "rwall0"
 		src.relativewall()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -74,7 +74,7 @@
 				if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
 					if(!anchored)
 						if(S.amount < 2)
-							user << "<span class='warning>You need at least two sheets to create a false wall.</span>"
+							user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
 							return
 						S.use(2)
 						user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
@@ -98,7 +98,7 @@
 				if(/obj/item/stack/sheet/plasteel)
 					if(!anchored)
 						if(S.amount < 2)
-							user << "<span class='warning>You need at least two sheets to create a false wall.</span>"
+							user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
 							return
 						S.use(2)
 						user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
@@ -134,7 +134,9 @@
 			if(S.sheettype)
 				var/M = S.sheettype
 				if(!anchored)
-					if(S.amount < 2) return
+					if(S.amount < 2)
+						user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
+						return
 					S.use(2)
 					user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
 					var/F = text2path("/obj/structure/falsewall/[M]")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -73,7 +73,9 @@
 
 				if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
 					if(!anchored)
-						if(S.amount < 2) return
+						if(S.amount < 2)
+							user << "<span class='warning>You need at least two sheets to create a false wall.</span>"
+							return
 						S.use(2)
 						user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
 						var/obj/structure/falsewall/F = new (loc)
@@ -95,10 +97,12 @@
 
 				if(/obj/item/stack/sheet/plasteel)
 					if(!anchored)
-						if(S.amount < 2) return
+						if(S.amount < 2)
+							user << "<span class='warning>You need at least two sheets to create a false wall.</span>"
+							return
 						S.use(2)
 						user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
-						var/obj/structure/falserwall/FW = new (loc)
+						var/obj/structure/falsewall/reinforced/FW = new (loc)
 						transfer_fingerprints_to(FW)
 						qdel(src)
 					else

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -19,172 +19,172 @@
 	var/openSound = 'sound/effects/stonedoor_openclose.ogg'
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 
-	New(location)
-		..()
-		icon_state = mineralType
-		name = "[mineralType] door"
-		air_update_turf(1)
+/obj/structure/mineral_door/New(location)
+	..()
+	icon_state = mineralType
+	name = "[mineralType] door"
+	air_update_turf(1)
+	return
+
+/obj/structure/mineral_door/Destroy()
+	density = 0
+	air_update_turf(1)
+	..()
+
+/obj/structure/mineral_door/Move()
+	var/turf/T = loc
+	..()
+	move_update_air(T)
+
+/obj/structure/mineral_door/Bumped(atom/user)
+	..()
+	if(!state)
+		return TryToSwitchState(user)
+	return
+
+/obj/structure/mineral_door/attack_ai(mob/user) //those aren't machinery, they're just big fucking slabs of a mineral
+	if(isAI(user)) //so the AI can't open it
 		return
-
-	Destroy()
-		density = 0
-		air_update_turf(1)
-		..()
-
-	Move()
-		var/turf/T = loc
-		..()
-		move_update_air(T)
-
-	Bumped(atom/user)
-		..()
-		if(!state)
+	else if(isrobot(user)) //but cyborgs can
+		if(get_dist(user,src) <= 1) //not remotely though
 			return TryToSwitchState(user)
-		return
 
-	attack_ai(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
-		if(isAI(user)) //so the AI can't open it
-			return
-		else if(isrobot(user)) //but cyborgs can
-			if(get_dist(user,src) <= 1) //not remotely though
-				return TryToSwitchState(user)
+/obj/structure/mineral_door/attack_paw(mob/user)
+	return TryToSwitchState(user)
 
-	attack_paw(mob/user as mob)
-		return TryToSwitchState(user)
+/obj/structure/mineral_door/attack_hand(mob/user)
+	return TryToSwitchState(user)
 
-	attack_hand(mob/user as mob)
-		return TryToSwitchState(user)
+/obj/structure/mineral_door/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(air_group) return 0
+	if(istype(mover, /obj/effect/beam))
+		return !opacity
+	return !density
 
-	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-		if(air_group) return 0
-		if(istype(mover, /obj/effect/beam))
-			return !opacity
-		return !density
+/obj/structure/mineral_door/CanAtmosPass()
+	return !density
 
-	CanAtmosPass()
-		return !density
-
-	proc/TryToSwitchState(atom/user)
-		if(isSwitchingStates) return
-		if(ismob(user))
-			var/mob/M = user
-			if(world.time - user.last_bumped <= 60) return //NOTE do we really need that?
-			if(M.client)
-				if(iscarbon(M))
-					var/mob/living/carbon/C = M
-					if(!C.handcuffed)
-						SwitchState()
-				else
+/obj/structure/mineral_door/proc/TryToSwitchState(atom/user)
+	if(isSwitchingStates) return
+	if(ismob(user))
+		var/mob/M = user
+		if(world.time - user.last_bumped <= 60) return //NOTE do we really need that?
+		if(M.client)
+			if(iscarbon(M))
+				var/mob/living/carbon/C = M
+				if(!C.handcuffed)
 					SwitchState()
-		else if(istype(user, /obj/mecha))
-			SwitchState()
+			else
+				SwitchState()
+	else if(istype(user, /obj/mecha))
+		SwitchState()
 
-	proc/SwitchState()
-		if(state)
-			Close()
-		else
-			Open()
+/obj/structure/mineral_door/proc/SwitchState()
+	if(state)
+		Close()
+	else
+		Open()
 
-	proc/Open()
-		isSwitchingStates = 1
-		playsound(loc, openSound, 100, 1)
-		flick("[mineralType]opening",src)
-		sleep(10)
-		density = 0
-		opacity = 0
-		state = 1
-		air_update_turf(1)
-		update_icon()
-		isSwitchingStates = 0
-
-		if(close_delay != -1)
-			spawn(close_delay)
-				if(!isSwitchingStates && state == 1)
-					Close()
-
-	proc/Close()
-		var/turf/T = get_turf(src)
-		for(var/mob/living/L in T)
-			return
-		isSwitchingStates = 1
-		playsound(loc, closeSound, 100, 1)
-		flick("[mineralType]closing",src)
-		sleep(10)
-		density = 1
-		opacity = 1
-		state = 0
-		air_update_turf(1)
-		update_icon()
-		isSwitchingStates = 0
-
+/obj/structure/mineral_door/proc/Open()
+	isSwitchingStates = 1
+	playsound(loc, openSound, 100, 1)
+	flick("[mineralType]opening",src)
+	sleep(10)
+	density = 0
+	opacity = 0
+	state = 1
+	air_update_turf(1)
 	update_icon()
-		if(state)
-			icon_state = "[mineralType]open"
-		else
-			icon_state = mineralType
+	isSwitchingStates = 0
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(istype(W,/obj/item/weapon/pickaxe))
-			var/obj/item/weapon/pickaxe/digTool = W
-			user << "You start digging the [name]."
-			if(do_after(user,digTool.digspeed*hardness) && src)
-				user << "You finished digging."
-				Dismantle()
-		else if(istype(W,/obj/item/weapon)) //not sure, can't not just weapons get passed to this proc?
-			hardness -= W.force/100
-			user << "You hit the [name] with your [W.name]!"
-			CheckHardness()
-		else
-			attack_hand(user)
+	if(close_delay != -1)
+		spawn(close_delay)
+			if(!isSwitchingStates && state == 1)
+				Close()
+
+/obj/structure/mineral_door/proc/Close()
+	var/turf/T = get_turf(src)
+	for(var/mob/living/L in T)
 		return
+	isSwitchingStates = 1
+	playsound(loc, closeSound, 100, 1)
+	flick("[mineralType]closing",src)
+	sleep(10)
+	density = 1
+	opacity = 1
+	state = 0
+	air_update_turf(1)
+	update_icon()
+	isSwitchingStates = 0
 
+/obj/structure/mineral_door/update_icon()
+	if(state)
+		icon_state = "[mineralType]open"
+	else
+		icon_state = mineralType
 
-	bullet_act(var/obj/item/projectile/Proj)
-		hardness -= Proj.damage
-		..()
+/obj/structure/mineral_door/attackby(obj/item/weapon/W, mob/user)
+	if(istype(W,/obj/item/weapon/pickaxe))
+		var/obj/item/weapon/pickaxe/digTool = W
+		user << "You start digging the [name]."
+		if(do_after(user,digTool.digspeed*hardness) && src)
+			user << "You finished digging."
+			Dismantle()
+	else if(istype(W,/obj/item/weapon)) //not sure, can't not just weapons get passed to this proc?
+		hardness -= W.force/100
+		user << "You hit the [name] with your [W.name]!"
 		CheckHardness()
-		return
+	else
+		attack_hand(user)
+	return
 
 
-	proc/CheckHardness()
-		if(hardness <= 0)
-			Dismantle(1)
+/obj/structure/mineral_door/bullet_act(obj/item/projectile/Proj)
+	hardness -= Proj.damage
+	..()
+	CheckHardness()
+	return
 
-	proc/Dismantle(devastated = 0)
-		if(!devastated)
-			if (mineralType == "metal")
-				var/ore = /obj/item/stack/sheet/metal
-				for(var/i = 1, i <= oreAmount, i++)
-					new ore(get_turf(src))
-			else
-				var/ore = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
-				for(var/i = 1, i <= oreAmount, i++)
-					new ore(get_turf(src))
+
+/obj/structure/mineral_door/proc/CheckHardness()
+	if(hardness <= 0)
+		Dismantle(1)
+
+/obj/structure/mineral_door/proc/Dismantle(devastated = 0)
+	if(!devastated)
+		if (mineralType == "metal")
+			var/ore = /obj/item/stack/sheet/metal
+			for(var/i = 1, i <= oreAmount, i++)
+				new ore(get_turf(src))
 		else
-			if (mineralType == "metal")
-				var/ore = /obj/item/stack/sheet/metal
-				for(var/i = 3, i <= oreAmount, i++)
-					new ore(get_turf(src))
-			else
-				var/ore = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
-				for(var/i = 3, i <= oreAmount, i++)
-					new ore(get_turf(src))
-		qdel(src)
+			var/ore = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
+			for(var/i = 1, i <= oreAmount, i++)
+				new ore(get_turf(src))
+	else
+		if (mineralType == "metal")
+			var/ore = /obj/item/stack/sheet/metal
+			for(var/i = 3, i <= oreAmount, i++)
+				new ore(get_turf(src))
+		else
+			var/ore = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
+			for(var/i = 3, i <= oreAmount, i++)
+				new ore(get_turf(src))
+	qdel(src)
 
-	ex_act(severity = 1)
-		switch(severity)
-			if(1)
+/obj/structure/mineral_door/ex_act(severity = 1)
+	switch(severity)
+		if(1)
+			Dismantle(1)
+		if(2)
+			if(prob(20))
 				Dismantle(1)
-			if(2)
-				if(prob(20))
-					Dismantle(1)
-				else
-					hardness--
-					CheckHardness()
-			if(3)
-				hardness -= 0.1
+			else
+				hardness--
 				CheckHardness()
-		return
+		if(3)
+			hardness -= 0.1
+			CheckHardness()
+	return
 
 
 
@@ -211,28 +211,28 @@
 /obj/structure/mineral_door/transparent
 	opacity = 0
 
-	Close()
-		..()
-		opacity = 0
+/obj/structure/mineral_door/transparent/Close()
+	..()
+	opacity = 0
 
 /obj/structure/mineral_door/transparent/plasma
 	mineralType = "plasma"
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		if(istype(W,/obj/item/weapon/weldingtool))
-			var/obj/item/weapon/weldingtool/WT = W
-			if(WT.remove_fuel(0, user))
-				TemperatureAct(100)
-		..()
+/obj/structure/mineral_door/transparent/plasma/attackby(obj/item/weapon/W, mob/user)
+	if(is_hot(W))
+		message_admins("Plasma mineral door ignited by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("Plasma mineral door ignited by [user.ckey]([user]) in ([x],[y],[z])")
+		TemperatureAct(100)
+	..()
 
-	temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-		if(exposed_temperature > 300)
-			TemperatureAct(exposed_temperature)
+/obj/structure/mineral_door/transparent/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > 300)
+		TemperatureAct(exposed_temperature)
 
-	proc/TemperatureAct(temperature)
-		atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 500)
-		hardness = 0
-		CheckHardness()
+/obj/structure/mineral_door/transparent/plasma/proc/TemperatureAct(temperature)
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 500)
+	hardness = 0
+	CheckHardness()
 
 /obj/structure/mineral_door/transparent/diamond
 	mineralType = "diamond"
@@ -244,11 +244,11 @@
 	openSound = 'sound/effects/doorcreaky.ogg'
 	closeSound = 'sound/effects/doorcreaky.ogg'
 
-	Dismantle(devastated = 0)
-		if(!devastated)
-			for(var/i = 1, i <= oreAmount, i++)
-				new/obj/item/stack/sheet/wood(get_turf(src))
-		qdel(src)
+/obj/structure/mineral_door/wood/Dismantle(devastated = 0)
+	if(!devastated)
+		for(var/i = 1, i <= oreAmount, i++)
+			new/obj/item/stack/sheet/wood(get_turf(src))
+	qdel(src)
 
 /obj/structure/mineral_door/resin
 	mineralType = "resin"
@@ -257,14 +257,14 @@
 	openSound = 'sound/effects/attackblob.ogg'
 	closeSound = 'sound/effects/attackblob.ogg'
 
-	TryToSwitchState(atom/user)
-		if(isalien(user))
-			return ..()
+/obj/structure/mineral_door/resin/TryToSwitchState(atom/user)
+	if(isalien(user))
+		return ..()
 
-	Dismantle(devastated = 0)
-		qdel(src)
+/obj/structure/mineral_door/resin/Dismantle(devastated = 0)
+	qdel(src)
 
-	CheckHardness()
-		playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
-		..()
+/obj/structure/mineral_door/resin/CheckHardness()
+	playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
+	..()
 

--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -15,9 +15,6 @@
 		for(var/obj/structure/falsewall/W in orange(src,1))
 			if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
 				junction |= get_dir(src,W)
-		for(var/obj/structure/falserwall/W in orange(src,1))
-			if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
-				junction |= get_dir(src,W)
 
 /* Commenting this out for now until we figure out what to do with shuttle smooth walls, if anything.
    As they are now, they sort of work screwy and may need further coding. Or just be scrapped.*/
@@ -38,11 +35,12 @@
 	if(istype(src,/turf/simulated/wall))
 		var/turf/simulated/wall/wall = src
 		wall.icon_state = "[wall.walltype][junction]"
-	else if (istype(src,/obj/structure/falserwall))
-		src.icon_state = "rwall[junction]"
 	else if (istype(src,/obj/structure/falsewall))
-		var/obj/structure/falsewall/fwall = src
-		fwall.icon_state = "[fwall.mineral][junction]"
+		if(istype(src,/obj/structure/falsewall/reinforced))
+			icon_state = "rwall[junction]"
+		else
+			var/obj/structure/falsewall/fwall = src
+			fwall.icon_state = "[fwall.mineral][junction]"
 /*	else if(istype(src,/turf/simulated/shuttle/wall))
 		var/newicon = icon;
 		var/newiconstate = icon_state;
@@ -83,8 +81,6 @@
 	for(var/obj/structure/falsewall/W in range(src,1))
 		W.relativewall()
 		W.update_icon()//Refreshes the wall to make sure the icons don't desync
-	for(var/obj/structure/falserwall/W in range(src,1))
-		W.relativewall()
 	return
 
 /turf/simulated/wall/New()
@@ -142,10 +138,6 @@
 			if(src.mineral == W.mineral)//Only 'like' walls connect -Sieve
 				junction |= get_dir(src,W)
 	for(var/obj/structure/falsewall/W in orange(src,1))
-		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
-			if(src.mineral == W.mineral)
-				junction |= get_dir(src,W)
-	for(var/obj/structure/falserwall/W in orange(src,1))
 		if(abs(src.x-W.x)-abs(src.y-W.y)) //doesn't count diagonal walls
 			if(src.mineral == W.mineral)
 				junction |= get_dir(src,W)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -86,6 +86,8 @@
 
 /turf/simulated/wall/mineral/plasma/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+		message_admins("Plasma wall ignited by [key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("Plasma wall ignited by [user.ckey]([user]) in ([x],[y],[z])")
 		ignite(is_hot(W))
 		return
 	..()


### PR DESCRIPTION
Removed a spawn() from the Destroy() proc of falsewalls.
Removed the falserwall type, now reinforced walls are a subtype of falsewalls.
Due to that, removed a bunch of copypasted code.
Falsewalls now spawn closed.
Falsewalls open/close timers are now proper, regarding their animation times.
You can't use a screwdriver on falsewalls while they aren't on a floor. (excluding shuttle floors)
Fixed #2338
Plasma falsewalls will now ignite.
Added a feedback message when you don't have enough sheets to create a falsewall.
Admin logs for igniting plasma walls, falsewalls, doors and airlocks.
Stadarized mineral_doors.dm.
