### PR TITLE
Increase's jani water tank's starting space cleaner supply

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -1,4 +1,4 @@
-//Hydroponics tank and base code
+	//Hydroponics tank and base code
 /obj/item/weapon/watertank
 	name = "backpack water tank"
 	desc = "A S.U.N.S.H.I.N.E. brand watertank backpack with nozzle to water plants."
@@ -19,7 +19,7 @@
 	create_reagents(volume)
 	noz = make_noz()
 	return
-	
+
 /obj/item/weapon/watertank/examine()
 	set src in usr
 	..()
@@ -38,7 +38,7 @@
 	set name = "Toggle Mister"
 	set category = "Object"
 	on = !on
-	
+
 	var/mob/living/carbon/human/user = usr
 	if(on)
 		//Detach the nozzle into the user's hands
@@ -52,7 +52,7 @@
 		//Remove from their hands and put back "into" the tank
 		remove_noz(user)
 	return
-	
+
 /obj/item/weapon/watertank/proc/make_noz()
 	return new /obj/item/weapon/reagent_containers/spray/mister(src)
 
@@ -102,10 +102,10 @@
 	user << "<span class='notice'>The mister snaps back onto the watertank!</span>"
 	tank.on = 0
 	loc = tank
-	
+
 /obj/item/weapon/reagent_containers/spray/mister/attack_self()
 	return
-	
+
 /proc/check_tank_exists(parent_tank, var/mob/living/carbon/human/M, var/obj/O)
 	if (!parent_tank || !istype(parent_tank, /obj/item/weapon/watertank))	//To avoid weird issues from admin spawns
 		M.unEquip(O)
@@ -120,12 +120,12 @@
 	desc = "A janitorial watertank backpack with nozzle to clean dirt and graffiti."
 	icon_state = "waterbackpackjani"
 	item_state = "waterbackpackjani"
-	
+
 /obj/item/weapon/watertank/janitor/New()
 	..()
-	reagents.add_reagent("cleaner", 250)
-	
-	
+	reagents.add_reagent("cleaner", 500)
+
+
 /obj/item/weapon/reagent_containers/spray/mister/janitor
 	name = "janitor spray nozzle"
 	desc = "A janitorial spray nozzle attached to a watertank, designed to clean up large messes."
@@ -137,11 +137,11 @@
 
 /obj/item/weapon/watertank/janitor/make_noz()
 	return new /obj/item/weapon/reagent_containers/spray/mister/janitor(src)
-	
+
 /obj/item/weapon/reagent_containers/spray/mister/janitor/attack_self(var/mob/user)
 	amount_per_transfer_from_this = (amount_per_transfer_from_this == 10 ? 5 : 10)
 	user << "<span class='notice'>You [amount_per_transfer_from_this == 10 ? "remove" : "fix"] the nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>"
-	
+
 //Atmos tank
 /obj/item/weapon/watertank/atmos
 	name = "backpack water tank"
@@ -149,10 +149,10 @@
 	icon_state = "waterbackpackatmos"
 	item_state = "waterbackpackatmos"
 	volume = 100
-	
+
 /obj/item/weapon/watertank/atmos/make_noz()
 	return new /obj/item/weapon/extinguisher/mini/nozzle(src)
-	
+
 /obj/item/weapon/extinguisher/mini/nozzle
 	name = "fire extinguisher nozzle"
 	desc = "A fire extinguisher nozzle attached to a water tank."
@@ -161,7 +161,7 @@
 	item_state = "misteratmos"
 	safety = 0
 	var/obj/item/weapon/watertank/tank
-	
+
 /obj/item/weapon/extinguisher/mini/nozzle/New(parent_tank)
 	if(check_tank_exists(parent_tank, src))
 		tank = parent_tank
@@ -169,11 +169,11 @@
 		max_water = tank.volume
 		loc = tank
 	return
-		
+
 /obj/item/weapon/extinguisher/mini/nozzle/dropped(mob/user as mob)
 	user << "<span class='notice'>The nozzle snaps back onto the watertank!</span>"
 	tank.on = 0
 	loc = tank
-	
+
 /obj/item/weapon/extinguisher/mini/nozzle/attack_self()
 	return

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -1,4 +1,4 @@
-	//Hydroponics tank and base code
+//Hydroponics tank and base code
 /obj/item/weapon/watertank
 	name = "backpack water tank"
 	desc = "A S.U.N.S.H.I.N.E. brand watertank backpack with nozzle to water plants."


### PR DESCRIPTION
The Janitor's Water Tank Space Cleaner spawn amount is increased from 250 to 500, the highest amount it can carry.

250 units of space cleaner is used up very quickly, and refilling it will usually consume all of chemistry's resources. Giving the janitor more breathing room with the tank would make their life easier.
