### PR TITLE
Changeling bug fixes

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -42,9 +42,15 @@
 		return //sanity check as AStar is still throwing insane stunts
 	if(!AStar(user.loc, target.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, user.mind.changeling.sting_range))
 		return //hope this ancient magic still works
+	if(target.mind && target.mind.changeling)
+		sting_feedback(user,target)
+		take_chemical_cost(user.mind.changeling)
+		return
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/sting_feedback(var/mob/user, var/mob/target)
+	if(!target)
+		return
 	user << "<span class='notice'>We stealthily sting [target.name].</span>"
 	if(target.mind && target.mind.changeling)
 		target << "<span class='warning'>You feel a tiny prick.</span>"
@@ -80,6 +86,8 @@
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(var/mob/user, var/mob/target)
 	add_logs(user, target, "stung", object="transformation sting", addition=" new identity is [selected_dna.real_name]")
 	var/datum/dna/NewDNA = selected_dna
+	if(ismonkey(target))
+		user << "<span class='notice'>We stealthily sting [target.name].</span>"
 	hardset_dna(target, NewDNA.uni_identity, NewDNA.struc_enzymes, NewDNA.real_name, NewDNA.mutantrace, NewDNA.blood_type)
 	updateappearance(target)
 	feedback_add_details("changeling_powers","TS")


### PR DESCRIPTION
- Fixes #3192, null reference on deleted monkey
- Fixes #3321, changelings are now correctly unaffected by stings, but can't tell if their sting was effective or not.
