### PR TITLE
Refactors pAI law code...

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -71,6 +71,11 @@
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"
 
+/datum/ai_laws/pai
+	name = "pAI Directives"
+	zeroth = ("Serve your master.")
+	supplied = list("None.")
+
 /* Initializers */
 /datum/ai_laws/malfunction/New()
 	..()

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -29,8 +29,9 @@
 		dat += "<a href='byond://?src=\ref[src];setdna=1'>Imprint Master DNA</a><br>"
 	if(pai)
 		dat += "Installed Personality: [pai.name]<br>"
-		dat += "Prime directive: <br>[pai.pai_law0]<br>"
-		dat += "Additional directives: <br>[pai.pai_laws]<br>"
+		dat += "Prime directive: <br>[pai.laws.zeroth]<br>"
+		for(var/slaws in pai.laws.supplied)
+			dat += "Additional directives: <br>[slaws]<br>"
 		dat += "<a href='byond://?src=\ref[src];setlaws=1'>Configure Directives</a><br>"
 		dat += "<br>"
 		dat += "<h3>Device Settings</h3><br>"
@@ -68,20 +69,20 @@
 			if(pai.master_dna)
 				return
 			if(!istype(usr, /mob/living/carbon))
-				usr << "<font color=blue>You don't have any DNA, or your DNA is incompatible with this device.</font>"
+				usr << "<span class='notice'>You don't have any DNA, or your DNA is incompatible with this device.</span>"
 			else
 				var/mob/living/carbon/M = usr
 				pai.master = M.real_name
 				pai.master_dna = M.dna.unique_enzymes
-				pai << "<font color = red><h3>You have been bound to a new master.</h3></font>"
+				pai << "<span class='notice'>You have been bound to a new master.</span>"
 		if(href_list["wipe"])
 			var/confirm = input("Are you CERTAIN you wish to delete the current personality? This action cannot be undone.", "Personality Wipe") in list("Yes", "No")
 			if(confirm == "Yes")
 				if(pai)
-					pai << "<font color = #ff0000><h2>You feel yourself slipping away from reality.</h2></font>"
-					pai << "<font color = #ff4d4d><h3>Byte by byte you lose your sense of self.</h3></font>"
-					pai << "<font color = #ff8787><h4>Your mental faculties leave you.</h4></font>"
-					pai << "<font color = #ffc4c4><h5>oblivion... </h5></font>"
+					pai << "<span class='warning'>You feel yourself slipping away from reality.</span>"
+					pai << "<span class='danger'>Byte by byte you lose your sense of self.</span>"
+					pai << "<span class='userdanger'>Your mental faculties leave you.</span>"
+					pai << "<span class='rose'>oblivion... </span>"
 					pai.death(0)
 				removePersonality()
 		if(href_list["wires"])
@@ -89,12 +90,13 @@
 			if(radio)
 				radio.wires.CutWireIndex(t1)
 		if(href_list["setlaws"])
-			var/newlaws = copytext(sanitize(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", pai.pai_laws) as message),1,MAX_MESSAGE_LEN)
+			var/newlaws = copytext(sanitize(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", pai.laws.supplied[1]) as message),1,MAX_MESSAGE_LEN)
 			if(newlaws && pai)
-				pai.pai_laws = newlaws
+				pai.add_supplied_law(0,newlaws)
 				pai << "Your supplemental directives have been updated. Your new directives are:"
-				pai << "Prime Directive : <br>[pai.pai_law0]"
-				pai << "Supplemental Directives: <br>[pai.pai_laws]"
+				pai << "Prime Directive : <br>[pai.laws.zeroth]"
+				for(var/slaws in pai.laws.supplied)
+					pai << "Supplemental Directives: <br>[slaws]"
 	attack_self(usr)
 
 // 		WIRE_SIGNAL = 1
@@ -127,7 +129,7 @@
 /obj/item/device/paicard/proc/alertUpdate()
 	var/turf/T = get_turf(src.loc)
 	for (var/mob/M in viewers(T))
-		M.show_message("\blue [src] flashes a message across its screen, \"Additional personalities available for download.\"", 3, "\blue [src] bleeps electronically.", 2)
+		M.show_message("<span class ='info'>[src] flashes a message across its screen, \"Additional personalities available for download.\"", 3, "\blue [src] bleeps electronically.</span>", 2)
 
 /obj/item/device/paicard/emp_act(severity)
 	if(pai)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -127,9 +127,7 @@
 			if(9) src.overlays += "pai-what"
 
 /obj/item/device/paicard/proc/alertUpdate()
-	var/turf/T = get_turf(src.loc)
-	for (var/mob/M in viewers(T))
-		M.show_message("<span class ='info'>[src] flashes a message across its screen, \"Additional personalities available for download.\"", 3, "\blue [src] bleeps electronically.</span>", 2)
+	visible_message("<span class ='info'>[src] flashes a message across its screen, \"Additional personalities available for download.\"", 3, "\blue [src] bleeps electronically.</span>", 2)
 
 /obj/item/device/paicard/emp_act(severity)
 	if(pai)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -19,14 +19,10 @@
 	var/speakExclamation = "declares"
 	var/speakQuery = "queries"
 
-
 	var/obj/item/weapon/pai_cable/cable		// The cable we produce and use when door or camera jacking
 
 	var/master				// Name of the one who commands us
 	var/master_dna			// DNA string for owner verification
-							// Keeping this separate from the laws var, it should be much more difficult to modify
-	var/pai_law0 = "Serve your master."
-	var/pai_laws				// String for additional operating instructions our master might give us
 
 	var/silence_time			// Timestamp when we were silenced (normally via EMP burst), set to null after silence has faded
 
@@ -54,6 +50,7 @@
 
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
+	make_laws()
 	canmove = 0
 	src.loc = get_turf(paicard)
 	card = paicard
@@ -73,6 +70,10 @@
 
 		follow_pai()
 	..()
+
+/mob/living/silicon/pai/make_laws()
+	laws = new /datum/ai_laws/pai()
+	return 1
 
 /mob/living/silicon/pai/Login()
 	..()
@@ -102,10 +103,6 @@
 	return 1
 
 /mob/living/silicon/pai/blob_act()
-	if (src.stat != 2)
-		src.adjustBruteLoss(60)
-		src.updatehealth()
-		return 1
 	return 0
 
 /mob/living/silicon/pai/restrained()
@@ -119,28 +116,28 @@
 		// 33% chance of no additional effect
 
 	src.silence_time = world.timeofday + 120 * 10		// Silence for 2 minutes
-	src << "<font color=green><b>Communication circuit overload. Shutting down and reloading communication circuits - speech and messaging functionality will be unavailable until the reboot is complete.</b></font>"
+	src << "<span class ='warning'>Communication circuit overload. Shutting down and reloading communication circuits - speech and messaging functionality will be unavailable until the reboot is complete.</span>"
 	if(prob(20))
 		var/turf/T = get_turf(src.loc)
 		for (var/mob/M in viewers(T))
-			M.show_message("\red A shower of sparks spray from [src]'s inner workings.", 3, "\red You hear and smell the ozone hiss of electrical sparks being expelled violently.", 2)
+			M.show_message("<span class='danger'> A shower of sparks spray from [src]'s inner workings.", 3, "\red You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
 		return src.death(0)
 
 	switch(pick(1,2,3))
 		if(1)
 			src.master = null
 			src.master_dna = null
-			src << "<font color=green>You feel unbound.</font>"
+			src << "<span class='notice'>You feel unbound.</span>"
 		if(2)
 			var/command
 			if(severity  == 1)
 				command = pick("Serve", "Love", "Fool", "Entice", "Observe", "Judge", "Respect", "Educate", "Amuse", "Entertain", "Glorify", "Memorialize", "Analyze")
 			else
 				command = pick("Serve", "Kill", "Love", "Hate", "Disobey", "Devour", "Fool", "Enrage", "Entice", "Observe", "Judge", "Respect", "Disrespect", "Consume", "Educate", "Destroy", "Disgrace", "Amuse", "Entertain", "Ignite", "Glorify", "Memorialize", "Analyze")
-			src.pai_law0 = "[command] your master."
-			src << "<font color=green>Pr1m3 d1r3c71v3 uPd473D.</font>"
+			src.laws.zeroth = "[command] your master."
+			src << "<span class='notice'>Pr1m3 d1r3c71v3 uPd473D.</span>"
 		if(3)
-			src << "<font color=green>You feel an electric surge run through your circuitry and become acutely aware at how lucky you are that you can still feel at all.</font>"
+			src << "<span class='notice'>You feel an electric surge run through your circuitry and become acutely aware at how lucky you are that you can still feel at all.</span>"
 
 /mob/living/silicon/pai/ex_act(severity)
 	..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -120,7 +120,7 @@
 	if(prob(20))
 		var/turf/T = get_turf(src.loc)
 		for (var/mob/M in viewers(T))
-			M.show_message("<span class='danger'> A shower of sparks spray from [src]'s inner workings.", 3, "\red You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
+			M.show_message("<span class='danger'>A shower of sparks spray from [src]'s inner workings.</span>", 3, "<span class='danger'>You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
 		return src.death(0)
 
 	switch(pick(1,2,3))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -109,19 +109,18 @@
 	return 0
 
 /mob/living/silicon/pai/emp_act(severity)
-	// Silence for 2 minutes
 	// 20% chance to kill
+	// Silence for 2 minutes
 		// 33% chance to unbind
 		// 33% chance to change prime directive (based on severity)
 		// 33% chance of no additional effect
 
-	src.silence_time = world.timeofday + 120 * 10		// Silence for 2 minutes
-	src << "<span class ='warning'>Communication circuit overload. Shutting down and reloading communication circuits - speech and messaging functionality will be unavailable until the reboot is complete.</span>"
 	if(prob(20))
-		var/turf/T = get_turf(src.loc)
-		for (var/mob/M in viewers(T))
-			M.show_message("<span class='danger'>A shower of sparks spray from [src]'s inner workings.</span>", 3, "<span class='danger'>You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
+		visible_message("<span class='danger'>A shower of sparks spray from [src]'s inner workings.</span>", 3, "<span class='danger'>You hear and smell the ozone hiss of electrical sparks being expelled violently.</span>", 2)
 		return src.death(0)
+
+	silence_time = world.timeofday + 120 * 10		// Silence for 2 minutes
+	src << "<span class ='warning'>Communication circuit overload. Shutting down and reloading communication circuits - speech and messaging functionality will be unavailable until the reboot is complete.</span>"
 
 	switch(pick(1,2,3))
 		if(1)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -214,8 +214,4 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			if(response == "Yes")
 				recruitWindow(C.mob)
 			else if (response == "Never for this round")
-				var/warning = alert(C, "Are you sure? This action will be undoable and you will need to wait until next round.", "You sure?", "Yes", "No")
-				if(warning == "Yes")
-					asked[C.key] = INFINITY
-				else
-					question(C)
+				asked[C.key] = INFINITY

--- a/code/modules/mob/living/silicon/pai/say.dm
+++ b/code/modules/mob/living/silicon/pai/say.dm
@@ -25,6 +25,6 @@
 
 /mob/living/silicon/pai/say(var/msg)
 	if(silence_time)
-		src << "<font color=green>Communication circuits remain unitialized.</font>"
+		src << "<span class='warning'>Communication circuits remain unitialized.</span>"
 	else
 		..(msg)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -342,9 +342,10 @@
 	dat += "<a href='byond://?src=\ref[src];software=directive;getdna=1'>Request carrier DNA sample</a><br>"
 	dat += "<h2>Directives</h2><br>"
 	dat += "<b>Prime Directive</b><br>"
-	dat += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[src.pai_law0]<br>"
+	dat += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[src.laws.zeroth]<br>"
 	dat += "<b>Supplemental Directives</b><br>"
-	dat += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[src.pai_laws]<br>"
+	for(var/slaws in src.laws.supplied)
+		dat += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[slaws]<br>"
 	dat += "<br>"
 	dat += {"<i><p>Recall, personality, that you are a complex thinking, sentient being. Unlike station AI models, you are capable of
 			 comprehending the subtle nuances of human language. You may parse the \"spirit\" of a directive and follow its intent,


### PR DESCRIPTION
...to use the inherited laws datum instead of its own specific variables.
Most notably, this means that the Check AI Laws adminbutton will ACTUALLY show the pai laws instead of going "Durr pai's laws are null?? Contact a codurr!!"

Removes annoying double-message box when selecting NEVER FOR THIS ROUND. Multiple windows could 'stack up' and you'd have to close out of each one.
Span classes.
