### PR TITLE
Makes brooms able to clean.

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -642,9 +642,9 @@ obj/item/weapon/staff/broom/proc/sweep(turf/simulated/A)
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "ectoplasm"
 
-/obj/item/weapon/research//Makes testing much less of a pain -Sieve
+/obj/item/weapon/research //Makes testing much less of a pain -Sieve
 	name = "research"
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "capacitor"
 	desc = "A debug item for research."
-	origin_tech = "materials=8;programming=8;magnets=8;powerstorage=8;bluespace=8;combat=8;biotech=8;syndicate=8"
+	origin_tech = "materials=8;engineering=8;plasmatech=8;powerstorage=8;bluespace=8;biotech=8;combat=8;magnets=8;programming=8;syndicate=8"

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -254,6 +254,24 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "broom"
 
+obj/item/weapon/staff/broom/proc/sweep(turf/simulated/A)
+	for(var/obj/effect/O in A)
+		if(istype(O,/obj/effect/decal/cleanable/ash) || istype(O,/obj/effect/decal/cleanable/dirt) || istype(O,/obj/effect/decal/cleanable/flour) || istype(O,/obj/effect/decal/cleanable/cobweb) || istype(O,/obj/effect/decal/cleanable/cobweb2))
+			qdel(O)
+
+/obj/item/weapon/staff/broom/afterattack(atom/A, mob/user, proximity)
+	if(!proximity) return
+	if(istype(A, /turf/simulated) || istype(A, /obj/effect/decal/cleanable/ash) || istype(A, /obj/effect/decal/cleanable/dirt) || istype(A, /obj/effect/decal/cleanable/flour) || istype(A, /obj/effect/decal/cleanable/cobweb) || istype(A, /obj/effect/decal/cleanable/cobweb2))
+		user.visible_message("<span class='notice'>[user] begins to sweep \the [get_turf(A)].</span>")
+
+		if(do_after(user, 30))
+			if(A)
+				sweep(get_turf(A))
+			user << "<span class='notice'>You have finished sweeping!</span>"
+			return
+	if(istype(A, /obj/effect/decal/cleanable))
+		user << "<span class='notice'>A broom won't clean this mess up.</span>"
+
 /obj/item/weapon/staff/stick
 	name = "stick"
 	desc = "A great tool to drag someone else's drinks across the bar."

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -43,7 +43,7 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 
 
 /obj/effect/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/mop) || istype(I, /obj/item/weapon/soap))
+	if(istype(I, /obj/item/weapon/mop) || istype(I, /obj/item/weapon/soap) || istype(I, /obj/item/weapon/staff/broom))
 		return
 	..()
 


### PR DESCRIPTION
As the title says. Allows the broom to clean like a mop can. It's slightly faster than the mop and doesn't require reagents, but is harder for a janitor to obtain and can only clean dirt, piles of ash, flour, and cobwebs.

Also adds plasmatech and engineering to that research debug/testing item, since it's right there in weapon.dm
