### PR TITLE
Gives Malfuncting AIs the Hostile Lockdown ability!

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -72,9 +72,7 @@
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
 		spawn()
-			if(FA.lockdownbyai == 0)
-				FA.lockdownbyai = 1
-				FA.alarm()
+			FA.alarm()
 	for(var/obj/machinery/door/poddoor/BD in world) //Close blast doors!
 		spawn()
 			BD.close()
@@ -105,9 +103,7 @@
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
 		spawn()
-			if(FA.lockdownbyai == 1)
-				FA.lockdownbyai = 0
-				FA.reset()
+			FA.reset()
 	for(var/obj/machinery/door/poddoor/BD in world) //Open blast doors!
 		spawn()
 			BD.open()

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -80,7 +80,7 @@
 			BD.close()
 	for(var/obj/machinery/door/airlock/AL in world) //shock-bolt airlocks
 		spawn()
-			if(AL.canAIControl())
+			if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
 				AL.locked = 0
 				AL.safe = 0
 				AL.close()
@@ -113,7 +113,7 @@
 			BD.open()
 	for(var/obj/machinery/door/airlock/AL in world) //unbolt and open airlocks
 		spawn()
-			if(AL.canAIControl())
+			if(AL.canAIControl() && !AL.stat)
 
 				AL.locked = 0
 				AL.secondsElectrified = 0

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -67,7 +67,7 @@
 	set name = "Initiate Hostile Lockdown"
 
 	if(usr.stat == 2)
-		usr <<"You cannot disable lockdown because you are dead!"
+		usr <<"You cannot start a lockdown because you are dead!"
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -66,8 +66,8 @@
 	set category = "Malfunction"
 	set name = "Initiate Hostile Lockdown"
 
-	if(usr.stat == 2)
-		usr <<"You cannot start a lockdown because you are dead!"
+	if(src.stat == 2)
+		src <<"You cannot begin a lockdown because you are dead!"
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
@@ -93,14 +93,14 @@
 		C.post_status("alert", "lockdown")
 
 	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
-	usr << "<span class = 'warning'>Lockdown Initiated.</span>"
+	src << "<span class = 'warning'>Lockdown Initiated.</span>"
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"
 	set name = "Disable Lockdown"
 
-	if(usr.stat == 2)
-		usr <<"You cannot disable lockdown because you are dead!"
+	if(src.stat == 2)
+		src <<"You cannot disable lockdown because you are dead!"
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
@@ -121,7 +121,7 @@
 				AL.safe = 1
 				AL.lights = 1
 
-	usr << "<span class = 'notice'>Lockdown Lifted.</span>"
+	src << "<span class = 'notice'>Lockdown Lifted.</span>"
 
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -85,7 +85,7 @@
 					AL.locked = 1 //Bolt it!
 					AL.lights = 0 //Stealth bolt for a classic AI door trap.
 					AL.secondsElectrified = -1  //Shock it!
-			else
+			else if(!D.stat) //So that only powered doors are closed.
 				D.close() //Close ALL the doors!
 
 	var/obj/machinery/computer/communications/C = locate() in machines
@@ -119,7 +119,7 @@
 					AL.open()
 					AL.safe = 1
 					AL.lights = 1 //Essentially reset the airlock to normal.
-			else
+			else if(!D.stat) //Opens only powered doors.
 				D.open() //Open everything!
 
 	src << "<span class = 'notice'>Lockdown Lifted.</span>"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -73,21 +73,20 @@
 	if(malf_cooldown)
 		return
 
-	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
+	var/obj/machinery/door/airlock/AL
+	for(var/obj/machinery/door/D in portals)
 		spawn()
-			FA.alarm()
-	for(var/obj/machinery/door/poddoor/BD in portals) //Close blast doors!
-		spawn()
-			BD.close()
-	for(var/obj/machinery/door/airlock/AL in portals) //shock-bolt airlocks
-		spawn()
-			if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
-				AL.locked = 0
-				AL.safe = 0
-				AL.close()
-				AL.locked = 1
-				AL.lights = 0
-				AL.secondsElectrified = -1
+			if(istype(D, /obj/machinery/door/airlock))
+				AL = D
+				if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
+					AL.locked = 0 //For airlocks that were bolted open.
+					AL.safe = 0 //DOOR CRUSH
+					AL.close()
+					AL.locked = 1 //Bolt it!
+					AL.lights = 0 //Stealth bolt for a classic AI door trap.
+					AL.secondsElectrified = -1  //Shock it!
+			else
+				D.close() //Close ALL the doors!
 
 	var/obj/machinery/computer/communications/C = locate() in machines
 	if(C)
@@ -109,21 +108,19 @@
 	if(malf_cooldown)
 		return
 
-	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
+	var/obj/machinery/door/airlock/AL
+	for(var/obj/machinery/door/D in portals)
 		spawn()
-			FA.reset()
-	for(var/obj/machinery/door/poddoor/BD in portals) //Open blast doors!
-		spawn()
-			BD.open()
-	for(var/obj/machinery/door/airlock/AL in portals) //unbolt and open airlocks
-		spawn()
-			if(AL.canAIControl() && !AL.stat)
-
-				AL.locked = 0
-				AL.secondsElectrified = 0
-				AL.open()
-				AL.safe = 1
-				AL.lights = 1
+			if(istype(D, /obj/machinery/door/airlock))
+				AL = D
+				if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
+					AL.locked = 0
+					AL.secondsElectrified = 0
+					AL.open()
+					AL.safe = 1
+					AL.lights = 1 //Essentially reset the airlock to normal.
+			else
+				D.open() //Open everything!
 
 	src << "<span class = 'notice'>Lockdown Lifted.</span>"
 	malf_cooldown = 1

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -7,7 +7,6 @@
 	var/engaged = 0
 	var/cost = 5
 	var/one_time = 0
-	var/cooldown = 0
 
 	var/power_type
 
@@ -70,16 +69,17 @@
 	if(src.stat == 2)
 		src <<"You cannot begin a lockdown because you are dead!"
 		return
-	if(cooldown)
+
+	if(malf_cooldown)
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
 		spawn()
 			FA.alarm()
-	for(var/obj/machinery/door/poddoor/BD in world) //Close blast doors!
+	for(var/obj/machinery/door/poddoor/BD in portals) //Close blast doors!
 		spawn()
 			BD.close()
-	for(var/obj/machinery/door/airlock/AL in world) //shock-bolt airlocks
+	for(var/obj/machinery/door/airlock/AL in portals) //shock-bolt airlocks
 		spawn()
 			if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
 				AL.locked = 0
@@ -89,15 +89,15 @@
 				AL.lights = 0
 				AL.secondsElectrified = -1
 
-	var/obj/machinery/computer/communications/C = locate() in world
+	var/obj/machinery/computer/communications/C = locate() in machines
 	if(C)
 		C.post_status("alert", "lockdown")
 
 	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
 	src << "<span class = 'warning'>Lockdown Initiated.</span>"
-	cooldown = 1
-	spawn(30) 
-	cooldown = 0
+	malf_cooldown = 1
+	spawn(30)
+	malf_cooldown = 0
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"
@@ -106,16 +106,16 @@
 	if(src.stat == 2)
 		src <<"You cannot disable lockdown because you are dead!"
 		return
-	if(cooldown)
+	if(malf_cooldown)
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
 		spawn()
 			FA.reset()
-	for(var/obj/machinery/door/poddoor/BD in world) //Open blast doors!
+	for(var/obj/machinery/door/poddoor/BD in portals) //Open blast doors!
 		spawn()
 			BD.open()
-	for(var/obj/machinery/door/airlock/AL in world) //unbolt and open airlocks
+	for(var/obj/machinery/door/airlock/AL in portals) //unbolt and open airlocks
 		spawn()
 			if(AL.canAIControl() && !AL.stat)
 
@@ -126,9 +126,9 @@
 				AL.lights = 1
 
 	src << "<span class = 'notice'>Lockdown Lifted.</span>"
-	cooldown = 1
-	spawn(30) 
-	cooldown = 0
+	malf_cooldown = 1
+	spawn(30)
+	malf_cooldown = 0
 
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -7,6 +7,7 @@
 	var/engaged = 0
 	var/cost = 5
 	var/one_time = 0
+	var/cooldown = 0
 
 	var/power_type
 
@@ -69,6 +70,8 @@
 	if(src.stat == 2)
 		src <<"You cannot begin a lockdown because you are dead!"
 		return
+	if(cooldown)
+		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //activate firealarms
 		spawn()
@@ -92,6 +95,9 @@
 
 	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
 	src << "<span class = 'warning'>Lockdown Initiated.</span>"
+	cooldown = 1
+	spawn(30) 
+	cooldown = 0
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"
@@ -99,6 +105,8 @@
 
 	if(src.stat == 2)
 		src <<"You cannot disable lockdown because you are dead!"
+		return
+	if(cooldown)
 		return
 
 	for(var/obj/machinery/firealarm/FA in machines) //deactivate firealarms
@@ -118,6 +126,9 @@
 				AL.lights = 1
 
 	src << "<span class = 'notice'>Lockdown Lifted.</span>"
+	cooldown = 1
+	spawn(30) 
+	cooldown = 0
 
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -57,7 +57,7 @@
 	module_name = "Hostile Station Lockdown"
 	mod_pick_name = "lockdown"
 	description = "Take control of the airlock, blast door and fire control networks, locking them down. Caution! This command also electrifies all airlocks."
-	cost = 40
+	cost = 20
 	one_time = 1
 
 	power_type = /mob/living/silicon/ai/proc/lockdown

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -87,7 +87,6 @@
 				AL.locked = 1
 				AL.lights = 0
 				AL.secondsElectrified = -1
-				AL.lockdownbyai = 1
 
 	var/obj/machinery/computer/communications/C = locate() in world
 	if(C)
@@ -114,17 +113,14 @@
 			BD.open()
 	for(var/obj/machinery/door/airlock/AL in world) //unbolt and open airlocks
 		spawn()
-			if(AL.canAIControl() && AL.lockdownbyai == 1)
+			if(AL.canAIControl())
 
 				AL.locked = 0
 				AL.secondsElectrified = 0
 				AL.open()
 				AL.safe = 1
 				AL.lights = 1
-				AL.lockdownbyai = 0
 
-//	src.verbs -= /mob/living/silicon/ai/proc/disablelockdown
-//	src.verbs += /mob/living/silicon/ai/proc/lockdown
 	usr << "<span class = 'notice'>Lockdown Lifted.</span>"
 
 /datum/AI_Module/large/disable_rcd

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -27,6 +27,7 @@
 		explosion_resistance = 0
 	update_freelook_sight()
 	air_update_turf(1)
+	portals += src
 	return
 
 
@@ -34,6 +35,7 @@
 	density = 0
 	air_update_turf(1)
 	update_freelook_sight()
+	portals -= src
 	..()
 	return
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -39,6 +39,7 @@ var/list/ai_list = list()
 
 	var/control_disabled = 0 // Set to 1 to stop AI from interacting via Click()
 	var/malfhacking = 0 // More or less a copy of the above var, so that malf AIs can hack and still get new cyborgs -- NeoFite
+	var/malf_cooldown = 0 //Cooldown var for malf modules
 
 	var/obj/machinery/power/apc/malfhack = null
 	var/explosive = 0 //does the AI explode when it dies?
@@ -132,7 +133,7 @@ var/list/ai_list = list()
 		return
 
 		//if(icon_state == initial(icon_state))
-	var/icontype = input("Please, select a display!", "AI", null/*, null*/) in list("Clown", "Monochrome", "Blue", "Inverted", "Firewall", "Green", "Red", "Static", "Red October")
+	var/icontype = input("Please, select a display!", "AI", null/*, null*/) in list("Clown", "Monochrome", "Blue", "Inverted", "Firewall", "Green", "Red", "Static", "Red October", "House", "Heartline")
 	if(icontype == "Clown")
 		icon_state = "ai-clown2"
 	else if(icontype == "Monochrome")
@@ -151,6 +152,10 @@ var/list/ai_list = list()
 		icon_state = "ai-static"
 	else if(icontype == "Red October")
 		icon_state = "ai-redoctober"
+	else if(icontype == "House")
+		icon_state = "ai-house"
+	else if(icontype == "Heartline")
+		icon_state = "ai-heartline"
 	//else
 			//usr <<"You can only change your display once!"
 			//return
@@ -240,10 +245,10 @@ var/list/ai_list = list()
 			usr << "Wireless control is disabled!"
 			return
 
-	var/confirm = alert("Are you sure you want to call the shuttle?", "Confirm Shuttle Call", "Yes", "No")
+	var/reason = input(src, "What is the nature of your emergency? ([CALL_SHUTTLE_REASON_LENGTH] characters required.)", "Confirm Shuttle Call") as text
 
-	if(confirm == "Yes")
-		call_shuttle_proc(src)
+	if(length(trim(reason)) > 0)
+		call_shuttle_proc(src, reason)
 
 	// hack to display shuttle timer
 	if(emergency_shuttle.online)


### PR DESCRIPTION
Grants the AI a new ability - Hostile Lockdown, costing 20 CPU time.
- This ability activates all firelocks
- Closes all blast doors and shutters
- Closes and shock-bolts all airlocks that the AI can control, crushing anyone standing in a doorway when it happens.
- Sets the screen display to "Lockdown"
- The lockdown can be reversed using the "Disable Lockdown" verb.
- Lifting the lockdown opens everything that was locked down by the AI. (Airlocks close again shortly after)
- Lifting the lockdown restores airlocks to a safe and functional setting.

Justification for this ability provided here: http://www.ss13.eu/tgdb/latest_stats.html#mode_AI_malfunction

It is my hope that this and further tweaks will help to even out the win/loss rate for the AI during this mode.
