### PR TITLE
Fixed magboots requiring to be turned on and off to correctly set NOSLIP...

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1,7 +1,7 @@
 /atom
 	layer = 2
 	var/level = 2
-	var/flags = null
+	var/flags = 0
 	var/list/fingerprints
 	var/list/fingerprintshidden
 	var/fingerprintslast = null

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -4,7 +4,7 @@
 	icon_state = "magboots0"
 	var/magboot_state = "magboots"
 	var/magpulse = 0
-	var/slowdown_off = 2
+	var/slowdown_active = 2
 	action_button_name = "Toggle Magboots"
 
 
@@ -13,23 +13,20 @@
 	set category = "Object"
 	set src in usr
 	attack_self(usr)
-	
+
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	if(src.magpulse)
 		src.flags &= ~NOSLIP
 		src.slowdown = SHOES_SLOWDOWN
-		src.magpulse = 0
-		icon_state = "[magboot_state]0"
-		user << "You disable the mag-pulse traction system."
 	else
 		src.flags |= NOSLIP
-		src.slowdown = slowdown_off
-		src.magpulse = 1
-		icon_state = "[magboot_state]1"
-		user << "You enable the mag-pulse traction system."
+		src.slowdown = slowdown_active
+	magpulse = !magpulse
+	icon_state = "[magboot_state][magpulse]"
+	user << "You [magpulse ? "enable" : "disable"] the mag-pulse traction system."
 	user.update_inv_shoes(0)	//so our mob-overlays update
-	
+
 
 /obj/item/clothing/shoes/magboots/examine()
 	set src in view()
@@ -38,11 +35,11 @@
 	if(src.flags&NOSLIP)
 		state = "enabled"
 	usr << "Its mag-pulse traction system appears to be [state]."
-	
+
 
 /obj/item/clothing/shoes/magboots/advance
 	desc = "Advanced magnetic boots that have a lighter magnetic pull, placing less burden on the wearer."
 	name = "advanced magboots"
 	icon_state = "advmag0"
 	magboot_state = "advmag"
-	slowdown_off = SHOES_SLOWDOWN
+	slowdown_active = SHOES_SLOWDOWN

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -31,10 +31,7 @@
 /obj/item/clothing/shoes/magboots/examine()
 	set src in view()
 	..()
-	var/state = "disabled"
-	if(src.flags&NOSLIP)
-		state = "enabled"
-	usr << "Its mag-pulse traction system appears to be [state]."
+	usr << "Its mag-pulse traction system appears to be [magpulse ? "enabled" : "disabled"]."
 
 
 /obj/item/clothing/shoes/magboots/advance


### PR DESCRIPTION
... was caused by flags being null, instead of 0.

Refactor'd the magboot code to be more elegant.
