### PR TITLE
Security Officers spawn with Black Gloves

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -169,6 +169,7 @@ Security Officer
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 	H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_s_store)
 	H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_l_store)
 


### PR DESCRIPTION
AKA: The final phase of the militarization of SS13's Security Force.

Does what it says on the tin, Sec Officers will now spawn wearing a pair of Black Gloves. This accomplishes two things.

1: Completes the tacticool appearance of Officers.
2: Helps the Detective in forensics.
