### PR TITLE
Grants Silicons the ability to hack bots.

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -13,6 +13,7 @@
 	var/brute_dam_coeff = 1.0
 	var/open = 0//Maint panel
 	var/locked = 1
+	var/hacked = 0 //Used to differentiate between being hacked by silicons and emagged by humans.
 	//var/emagged = 0 //Urist: Moving that var to the general /bot tree as it's used by most bots
 
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -156,7 +156,7 @@
 /obj/machinery/bot/proc/hack(mob/user)
 	var/hack
 	if(is_special_character(user) && issilicon(user))
-		hack = "Operating System Inegrity: <A href='?src=\ref[src];operation=hack'>[src.emagged ? "Compromised" : "Normal"]</A><BR>"
+		hack = "Operating System Integrity: <A href='?src=\ref[src];operation=hack'>[src.emagged ? "Compromised" : "Normal"]</A><BR>"
 	return hack
 
 /obj/machinery/bot/attack_ai(mob/user as mob)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -155,8 +155,9 @@
 
 /obj/machinery/bot/proc/hack(mob/user)
 	var/hack
-	if(is_special_character(user) && issilicon(user))
-		hack = "Operating System Integrity: <A href='?src=\ref[src];operation=hack'>[src.emagged ? "Compromised" : "Normal"]</A><BR>"
+	if(issilicon(user))
+		hack += "[src.emagged ? "Software compromised! Unit may exhibit dangerous or erratic behavior." : "Unit operating normally. Release safety lock?"]<BR>"
+		hack += "Harm Prevention Safety System: <A href='?src=\ref[src];operation=hack'>[src.emagged ? "DANGER" : "Engaged"]</A><BR>"
 	return hack
 
 /obj/machinery/bot/attack_ai(mob/user as mob)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -153,6 +153,11 @@
 		if (was_on)
 			turn_on()
 
+/obj/machinery/bot/proc/hack(mob/user)
+	var/hack
+	if(is_special_character(user) && issilicon(user))
+		hack = "Operating System Inegrity: <A href='?src=\ref[src];operation=hack'>[src.emagged ? "Compromised" : "Normal"]</A><BR>"
+	return hack
 
 /obj/machinery/bot/attack_ai(mob/user as mob)
 	src.attack_hand(user)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -110,7 +110,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	src.add_fingerprint(usr)
 	switch(href_list["operation"])
 		if("start")
-			if (src.on)
+			if (src.on && !src.emagged)
 				turn_off()
 			else
 				turn_on()
@@ -139,8 +139,12 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			if(!src.oddbutton)
 				src.emagged = 2 //Cleanbots are odd, this is here to ensure the "compromised" status updates properly.
 				src.oddbutton = 1
+				src.hacked = 1
 				usr << "<span class='warning'>You corrupt [src]'s cleaning software.</span>"
+			else if(!src.hacked)
+				usr << "<span class='userdanger'>[src] does not seem to respond to your repair code!</span>"
 			else
+				src.hacked = 0
 				src.emagged = 0
 				src.oddbutton = 0
 				usr << "<span class='notice'>[src]'s software has been reset!</span>"

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -81,6 +81,7 @@
 
 /obj/machinery/bot/cleanbot/interact(mob/user as mob)
 	var/dat
+	dat += hack(user)
 	dat += text({"
 <TT><B>Automatic Station Cleaner v1.0</B></TT><BR><BR>
 Status: []<BR>
@@ -133,6 +134,12 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		if("oddbutton")
 			src.oddbutton = !src.oddbutton
 			usr << "<span class='notice'>You press the weird button.</span>"
+			src.updateUsrDialog()
+		if("hack")
+			if(!src.oddbutton)
+				src.emagged = 2 //Cleanbots are odd, this is here to ensure the "compromised" status updates properly.
+				src.oddbutton = 1
+				usr << "<span class='warning'>You corrpt [src]'s cleaning software.</span>"
 			src.updateUsrDialog()
 
 /obj/machinery/bot/cleanbot/attackby(obj/item/weapon/W, mob/user as mob)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -140,6 +140,10 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 				src.emagged = 2 //Cleanbots are odd, this is here to ensure the "compromised" status updates properly.
 				src.oddbutton = 1
 				usr << "<span class='warning'>You corrupt [src]'s cleaning software.</span>"
+			else
+				src.emagged = 0
+				src.oddbutton = 0
+				usr << "<span class='notice'>[src]'s software has been reset!</span>"
 			src.updateUsrDialog()
 
 /obj/machinery/bot/cleanbot/attackby(obj/item/weapon/W, mob/user as mob)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -139,7 +139,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			if(!src.oddbutton)
 				src.emagged = 2 //Cleanbots are odd, this is here to ensure the "compromised" status updates properly.
 				src.oddbutton = 1
-				usr << "<span class='warning'>You corrpt [src]'s cleaning software.</span>"
+				usr << "<span class='warning'>You corrupt [src]'s cleaning software.</span>"
 			src.updateUsrDialog()
 
 /obj/machinery/bot/cleanbot/attackby(obj/item/weapon/W, mob/user as mob)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -116,7 +116,7 @@
 	if (.)
 		return
 	var/dat
-
+	dat += hack(user)
 	dat += text({"
 <TT><B>Automatic Security Unit v2.5</B></TT><BR><BR>
 Status: []<BR>
@@ -180,6 +180,11 @@ Auto Patrol: []"},
 			auto_patrol = !auto_patrol
 			mode = SECBOT_IDLE
 			updateUsrDialog()
+		if("hack")
+			if(!src.emagged)
+				src.emagged = 2
+				usr << "<span class='warning'>You disable [src]'s combat inhibitor.</span>"
+			src.updateUsrDialog()
 
 /obj/machinery/bot/ed209/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -184,6 +184,9 @@ Auto Patrol: []"},
 			if(!src.emagged)
 				src.emagged = 2
 				usr << "<span class='warning'>You disable [src]'s combat inhibitor.</span>"
+			else
+				src.emagged = 0
+				usr << "<span class='notice'>You restore [src]'s combat inhibitor.</span>"
 			src.updateUsrDialog()
 
 /obj/machinery/bot/ed209/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -160,7 +160,7 @@ Auto Patrol: []"},
 		else if((lasercolor == "r") && (istype(H.wear_suit, /obj/item/clothing/suit/bluetag)))
 			return
 	if ((href_list["power"]) && (src.allowed(usr)))
-		if (src.on)
+		if (src.on && !src.emagged)
 			turn_off()
 		else
 			turn_on()
@@ -183,9 +183,13 @@ Auto Patrol: []"},
 		if("hack")
 			if(!src.emagged)
 				src.emagged = 2
+				src.hacked = 1
 				usr << "<span class='warning'>You disable [src]'s combat inhibitor.</span>"
+			else if(!src.hacked)
+				usr << "<span class='userdanger'>[src] ignores your attempts to restrict it!</span>"
 			else
 				src.emagged = 0
+				src.hacked = 0
 				usr << "<span class='notice'>You restore [src]'s combat inhibitor.</span>"
 			src.updateUsrDialog()
 

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -150,7 +150,7 @@
 		if("hack")
 			if(!src.emagged)
 				src.emagged = 2
-				usr << "<span class='warning'>You corrpt [src]'s construction protocols.</span>"
+				usr << "<span class='warning'>You corrupt [src]'s construction protocols.</span>"
 			src.updateUsrDialog()
 		if("bridgemode")
 			switch(src.targetdirection)

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -75,6 +75,7 @@
 
 /obj/machinery/bot/floorbot/interact(mob/user as mob)
 	var/dat
+	dat += hack(user)
 	dat += "<TT><B>Automatic Station Floor Repairer v1.0</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];operation=start'>[src.on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel panel is [src.open ? "opened" : "closed"]<BR>"
@@ -145,6 +146,11 @@
 			src.updateUsrDialog()
 		if("make")
 			src.maketiles = !src.maketiles
+			src.updateUsrDialog()
+		if("hack")
+			if(!src.emagged)
+				src.emagged = 2
+				usr << "<span class='warning'>You corrpt [src]'s construction protocols.</span>"
 			src.updateUsrDialog()
 		if("bridgemode")
 			switch(src.targetdirection)

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -134,7 +134,7 @@
 	src.add_fingerprint(usr)
 	switch(href_list["operation"])
 		if("start")
-			if (src.on)
+			if (src.on && !src.emagged)
 				turn_off()
 			else
 				turn_on()
@@ -150,9 +150,13 @@
 		if("hack")
 			if(!src.emagged)
 				src.emagged = 2
+				src.hacked = 1
 				usr << "<span class='warning'>You corrupt [src]'s construction protocols.</span>"
+			else if(!src.hacked)
+				usr << "<span class='userdanger'>[src] is not responding to reset commands!</span>"
 			else
 				src.emagged = 0
+				src.hacked = 0
 				usr << "<span class='notice'>You detect errors in [src] and reset its programming.</span>"
 			src.updateUsrDialog()
 		if("bridgemode")

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -151,6 +151,9 @@
 			if(!src.emagged)
 				src.emagged = 2
 				usr << "<span class='warning'>You corrupt [src]'s construction protocols.</span>"
+			else
+				src.emagged = 0
+				usr << "<span class='notice'>You detect errors in [src] and reset its programming.</span>"
 			src.updateUsrDialog()
 		if("bridgemode")
 			switch(src.targetdirection)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -144,7 +144,7 @@
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	if ((href_list["power"]) && (src.allowed(usr)))
-		if (src.on)
+		if (src.on && !src.emagged)
 			turn_off()
 		else
 			turn_on()
@@ -181,8 +181,12 @@
 	else if (href_list["operation"])
 		if(!src.emagged)
 			src.emagged = 2
+			src.hacked = 1
 			usr << "<span class='warning'>You corrupt [src]'s reagent processor circuits.</span>"
+		else if(!src.hacked)
+			usr << "<span class='userdanger'>[src] seems damaged and does not respond to reprogramming!</span>"
 		else
+			src.hacked = 0
 			src.emagged = 0
 			usr << "<span class='notice'>You reset [src]'s reagent circuits.</span>"
 	src.updateUsrDialog()

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -181,7 +181,10 @@
 	else if (href_list["operation"])
 		if(!src.emagged)
 			src.emagged = 2
-			usr << "<span class='warning'>You reconfigure [src]'s reagent processor circuits.</span>"
+			usr << "<span class='warning'>You corrupt [src]'s reagent processor circuits.</span>"
+		else
+			src.emagged = 0
+			usr << "<span class='notice'>You reset [src]'s reagent circuits.</span>"
 	src.updateUsrDialog()
 	return
 

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -104,6 +104,7 @@
 	if (.)
 		return
 	var/dat
+	dat += hack(user)
 	dat += "<TT><B>Automatic Medical Unit v1.0</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];power=1'>[src.on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel panel is [src.open ? "opened" : "closed"]<BR>"
@@ -177,6 +178,10 @@
 	else if ((href_list["togglevoice"]) && (!src.locked || issilicon(usr)))
 		src.shut_up = !src.shut_up
 
+	else if (href_list["operation"])
+		if(!src.emagged)
+			src.emagged = 2
+			usr << "<span class='warning'>You reconfigure [src]'s reagent processor circuits.</span>"
 	src.updateUsrDialog()
 	return
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -160,6 +160,9 @@ Auto Patrol: []"},
 			if(!src.emagged)
 				src.emagged = 2
 				usr << "<span class='warning'>You overload [src]'s target identification system.</span>"
+			else
+				src.emagged = 0
+				usr << "<span class='notice'>You reboot [src] and restore the target identification.</span>"
 			src.updateUsrDialog()
 
 /obj/machinery/bot/secbot/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -136,7 +136,7 @@ Auto Patrol: []"},
 		return
 	usr.set_machine(src)
 	if((href_list["power"]) && (src.allowed(usr)))
-		if(src.on)
+		if (src.on && !src.emagged)
 			turn_off()
 		else
 			turn_on()
@@ -159,9 +159,13 @@ Auto Patrol: []"},
 		if("hack")
 			if(!src.emagged)
 				src.emagged = 2
+				src.hacked = 1
 				usr << "<span class='warning'>You overload [src]'s target identification system.</span>"
+			else if(!src.hacked)
+				usr << "<span class='userdanger'>[src] refuses to accept your authority!</span>"
 			else
 				src.emagged = 0
+				src.hacked = 0
 				usr << "<span class='notice'>You reboot [src] and restore the target identification.</span>"
 			src.updateUsrDialog()
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -105,7 +105,7 @@
 
 /obj/machinery/bot/secbot/interact(mob/user as mob)
 	var/dat
-
+	dat += hack(user)
 	dat += text({"
 <TT><B>Automatic Security Unit v1.3</B></TT><BR><BR>
 Status: []<BR>
@@ -156,6 +156,11 @@ Auto Patrol: []"},
 			auto_patrol = !auto_patrol
 			mode = SECBOT_IDLE
 			updateUsrDialog()
+		if("hack")
+			if(!src.emagged)
+				src.emagged = 2
+				usr << "<span class='warning'>You overload [src]'s target identification system.</span>"
+			src.updateUsrDialog()
 
 /obj/machinery/bot/secbot/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))


### PR DESCRIPTION
A silicon (AI, cyborgs) is now able to hack any robot through that robot's interface.

A hacked robot behaves mostly as an emagged one does.

Hacked robots cannot be deactivated via interface. If it was manually emagged, it cannot be stopped except by destruction. If a silicon hacked the bot, it must be reset by a silicon before it can be shut down.

Manually emagged robots cannot be restored by silicons. They must be destroyed instead.

The following robots are affected:
- Medibots (including Mysterious versions)
- Securitron
- ED-209 (including laser tag versions!)
- Floorbot
- Cleanbot
