### PR TITLE
[don't merge]Changes the default ticklag from 0.9 to 0.7

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -136,8 +136,8 @@ ALLOW_HOLIDAYS
 ##Remove the # mark if you are going to use the SVN irc bot to relay adminhelps
 #USEIRCBOT
 
-##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
-TICKLAG 0.9
+##Defines the ticklag for the world.  0.7 is the normal one, 0.5 is smoother.
+TICKLAG 0.7
 
 ## Defines if Tick Compensation is used.  It results in a minor slowdown of movement of all mobs, but attempts to result in a level movement speed across all ticks.  Recommended if tickrate is lowered.
 TICKCOMP 0


### PR DESCRIPTION
Servers can still choose their own ticklag.
This will make the default speed be 7 turfs per second, from 5.5
Fast speed will be 14 turfs per second instead of 11.

Changelog pending. This must have one to inform server hosts.
