### PR TITLE
Sun and solars

### DIFF
--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -14,19 +14,15 @@
 	rate = rand(50,200)/100			// 50% - 200% of standard rotation
 	if(prob(50))					// same chance to rotate clockwise than counter-clockwise
 		rate = -rate
-	solar_next_update = world.timeofday	// init the timer
+	solar_next_update = world.time	// init the timer
 	angle = rand (0,360)			// the station position to the sun is randomised at round start
 
 // calculate the sun's position given the time of day
 // at the standard rate (100%) the angle is increase/decreased by 6 degrees every minute.
-// a full rotation thus take a (real time) hour in that case
-
+// a full rotation thus take a game hour in that case
 /datum/sun/proc/calc_position()
 
-	if((solar_next_update - world.timeofday) > 131072) //midnight rollover
-		solar_next_update -= MIDNIGHT_ROLLOVER
-
-	if(world.timeofday < solar_next_update) //if less than 60 secondes have passed, do nothing
+	if(world.time < solar_next_update) //if less than 60 game secondes have passed, do nothing
 		return;
 
 	angle = (360 + angle + rate * 6) % 360	 // increase/decrease the angle to the sun, adjusted by the rate

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -13,16 +13,12 @@
 	directwired = 1
 	use_power = 0
 
+	var/id = 0
 	var/sun_angle = 0		// sun angle as set by sun datum
 
 /obj/machinery/power/tracker/New(var/turf/loc, var/obj/item/solar_assembly/S)
 	..(loc)
-	if(!S)
-		S = new /obj/item/solar_assembly(src)
-		S.glass_type = /obj/item/stack/sheet/glass
-		S.tracker = 1
-		S.anchored = 1
-	S.loc = src
+	Make(S)
 	connect_to_network()
 
 /obj/machinery/power/tracker/disconnect_from_network()
@@ -31,7 +27,17 @@
 
 /obj/machinery/power/tracker/connect_to_network()
 	..()
-	solars_list.Add(src)
+	if(powernet && !solars_list.Find(src))	//if connected and not already in solar_list...
+		solars_list.Add(src)				//... add it
+
+/obj/machinery/power/tracker/proc/Make(var/obj/item/solar_assembly/S)
+	if(!S)
+		S = new /obj/item/solar_assembly(src)
+		S.glass_type = /obj/item/stack/sheet/glass
+		S.tracker = 1
+		S.anchored = 1
+	S.loc = src
+	update_icon()
 
 // called by datum/sun/calc_position() as sun's angle changes
 /obj/machinery/power/tracker/proc/set_angle(var/angle)
@@ -49,11 +55,11 @@
 				if(get_dist(C, src) < SOLAR_MAX_DIST)
 					C.tracker_update(angle)
 
-
 /obj/machinery/power/tracker/attackby(var/obj/item/weapon/W, var/mob/user)
 
 	if(istype(W, /obj/item/weapon/crowbar))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+		user << "<span class='notice'>You begin to take the glass off the solar tracker...</span>"
 		if(do_after(user, 50))
 			var/obj/item/solar_assembly/S = locate() in src
 			if(S)

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -27,8 +27,8 @@
 
 /obj/machinery/power/tracker/connect_to_network()
 	..()
-	if(powernet && !solars_list.Find(src))	//if connected and not already in solar_list...
-		solars_list.Add(src)				//... add it
+	if(powernet)	//if connected and not already in solar_list...
+		solars_list |= src				//... add it
 
 /obj/machinery/power/tracker/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)


### PR DESCRIPTION
<h3> Suns and solars tweaking</h3>


I've cleaned up/updated the _sun and solars_ code with the following changes :

<h4> The sun </h4>

- the sun now has a rotation based on _world time_ instead of an internal counter and _realtime_.
  That makes synchronizing easier (since solars are based on _world time_),
- the sun standard rotation rate is a full rotation in one (real time) hour,
- every game minute,  the sun position, the auto/manual tracking and the solars occlusion are updated (yay for synchronizing),
- the sun rotation rate is randomized at round start (50%-200% of standard rotation, i.e from half as slow to twice as fast),
- the sun can rotate clockwise or counter-clockwise,
- the sun starting position is randomized at round start

<h4> Solars </h4>

- Panels instantly rotates to their new position
  (that fixed the bug where the panel would backtrack all the way when finishing a full rotation (e.g 355° to 1°)
- The exposition to the sun of a panel is now correctly calculated (fixed the bug, where
  if the sun was, for example, at 1° and the panel at 359°, no light would arrived to the panel)
- Tweaked manual tracking for better accuracy : the orientation is increased/decrease internally and updated altogether the sun.
- Panels made with reinforced glass now have the double of health
- Added a message notifying the beginning of a solar panel/tracker deconstruction

<h4> Code </h4>
- now checking if the solar panel/tracker/computer is not already in the solars_list before adding it (that should avoid clogging the solars list every time the power nets are remade)

<h4>tl;dr : manual tracking is now possible and solars are now working as intended </h4>
