### PR TITLE
Remove some unnecessary code of mine that's causing runtimes

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2,10 +2,6 @@
 	mob_list -= src
 	dead_mob_list -= src
 	living_mob_list -= src
-	if(client)
-		for(var/atom/movable/AM in client.screen)
-			qdel(AM)
-		client.screen = list()
 	qdel(hud_used)
 	if(mind && mind.current == src)
 		spellremove(src)


### PR DESCRIPTION
Should fix this:
The following runtime has occured 716 time(s).
runtime error: wrong type of value for list
proc name: handle regular hud updates (/mob/living/carbon/human/proc/handle_regular_hud_updates)
  source file: life.dm,1188
  usr: null
  src: Butch Adams (/mob/living/carbon/human)

Reason: The global_hud.blurry was getting deleted from people who were getting gibbed or w/e, then people were trying to add global_hud.blurry (which is null) to their screen, which isn't allowed.
