### PR TITLE
Make grabs GC, fix a grab related runtime

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -38,6 +38,10 @@
 /obj/item/weapon/grab/Destroy()
 	if(affecting)
 		affecting.grabbed_by -= src
+		affecting = null
+	if(assailant)
+		assailant.client.screen -= hud
+		assailant = null
 	qdel(hud)
 	..()
 
@@ -61,7 +65,8 @@
 
 
 /obj/item/weapon/grab/process()
-	confirm()
+	if(!confirm())
+		return 0
 
 	if(assailant.client)
 		assailant.client.screen -= hud


### PR DESCRIPTION
The following runtime has occured 104 time(s).
runtime error: Cannot execute null.s click().
proc name: Click (/obj/screen/grab/Click)
  source file: screen_objects.dm,73
  usr: Reece Eliza (/mob/living/carbon/human)
  src: the reinforce grab (/obj/screen/grab)
