### PR TITLE
Changed the default wiki to tgstation13.org/wiki.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -53,7 +53,7 @@
 
 	var/server
 	var/banappeals
-	var/wikiurl = "http://www.ss13.eu/wiki" // Default wiki link.
+	var/wikiurl = "http://www.tgstation13.org/wiki" // Default wiki link.
 	var/forumurl
 
 	var/forbid_singulo_possession = 0

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -713,7 +713,7 @@
 // A book that links to the wiki
 /obj/item/weapon/book/manual/wiki
 	var/page_link = ""
-	window_size = "800x600"
+	window_size = "970x710"
 
 /obj/item/weapon/book/manual/wiki/attack_self()
 	if(!dat)
@@ -728,7 +728,7 @@
 			</head>
 
 			<body>
-			<iframe width='100%' height='97%' src="[config.wikiurl]/index.php?title=[page_link]&printable=yes&remove_links=1&cc=1" frameborder="0" id="main_frame"></iframe>
+			<iframe width='100%' height='97%' src="[config.wikiurl]/[page_link]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
 			</body>
 
 			</html>
@@ -769,7 +769,7 @@
 	icon_state = "book7"
 	author = "University of Bluespace"
 	title = "Teleportation Science - Bluespace for dummies!"
-	page_link = "Telescience"
+	page_link = "Guide_to_telescience"
 
 /obj/item/weapon/book/manual/wiki/engineering_hacking
 	name = "Hacking"

--- a/config/config.txt
+++ b/config/config.txt
@@ -114,7 +114,7 @@ GUEST_BAN
 # FORUMURL http://justanotherday.example.com
 
 ## Wiki address
-# WIKIURL http://www.ss13.eu/wiki/
+# WIKIURL http://www.tgstation13.org/wiki
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://justanotherday.example.com


### PR DESCRIPTION
- Changed the wiki url format to work with the manuals, you can change the config if there are extra parameters, like title.
- Fixed the telescience manual not linking to the telescience guide.
