### PR TITLE
Nodrop  checks for several machines/structures

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -540,10 +540,10 @@
 		if(src.SUIT)
 			user << "<font color='blue'>The unit already contains a suit.</font>"
 			return
-		user << "You load the [S.name] into the storage compartment."
 		if(!user.drop_item())
 			user << "<span class='notice'>\The [S] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
 			return
+		user << "You load the [S.name] into the storage compartment."
 		S.loc = src
 		src.SUIT = S
 		src.update_icon()
@@ -556,10 +556,10 @@
 		if(src.HELMET)
 			user << "<font color='blue'>The unit already contains a helmet.</font>"
 			return
-		user << "You load the [H.name] into the storage compartment."
 		if(!user.drop_item())
 			user << "<span class='notice'>\The [H] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
 			return
+		user << "You load the [H.name] into the storage compartment."
 		H.loc = src
 		src.HELMET = H
 		src.update_icon()
@@ -572,10 +572,10 @@
 		if(src.MASK)
 			user << "<font color='blue'>The unit already contains a mask.</font>"
 			return
-		user << "You load the [M.name] into the storage compartment."
 		if(!user.drop_item())
 			user << "<span class='notice'>\The [M] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
 			return
+		user << "You load the [M.name] into the storage compartment."
 		M.loc = src
 		src.MASK = M
 		src.update_icon()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -541,7 +541,9 @@
 			user << "<font color='blue'>The unit already contains a suit.</font>"
 			return
 		user << "You load the [S.name] into the storage compartment."
-		user.drop_item()
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [S] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
+			return
 		S.loc = src
 		src.SUIT = S
 		src.update_icon()
@@ -555,7 +557,9 @@
 			user << "<font color='blue'>The unit already contains a helmet.</font>"
 			return
 		user << "You load the [H.name] into the storage compartment."
-		user.drop_item()
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [H] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
+			return
 		H.loc = src
 		src.HELMET = H
 		src.update_icon()
@@ -569,7 +573,9 @@
 			user << "<font color='blue'>The unit already contains a mask.</font>"
 			return
 		user << "You load the [M.name] into the storage compartment."
-		user.drop_item()
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [M] is stuck to your hand, you cannot put it in the Suit Storage Unit!</span>"
+			return
 		M.loc = src
 		src.MASK = M
 		src.update_icon()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -256,6 +256,9 @@
 		if ( istype(W,/obj/item/clothing/head/helmet ) )
 			user << "This item does not fit."
 			return
+		if(W.flags & NODROP) //if "can't drop" item
+			user << "<span class='notice'>\The [W] is stuck to your hand, you cannot put it in the washing machine!</span>"
+			return
 
 		if(contents.len < 5)
 			if ( state in list(1, 3) )

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -190,7 +190,9 @@ LINEN BINS
 		user << "<span class='notice'>You put [I] in [src].</span>"
 		update_icon()
 	else if(amount && !hidden && I.w_class < 4)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
-		user.drop_item()
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [I] is stuck to your hand, you cannot hide it among the sheets!</span>"
+			return
 		I.loc = src
 		hidden = I
 		user << "<span class='notice'>You hide [I] among the sheets.</span>"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -250,7 +250,6 @@
 
 	if(contents.len >= storage_capacity)
 		return -1
-
 	if(include_mobs && isliving(AM))
 		var/mob/living/L = AM
 		if(L.buckled)
@@ -325,7 +324,9 @@
 	if(opened)
 		if(isrobot(user))
 			return
-		user.drop_item()
+		if(!user.drop_item()) //couldn't drop the item
+			user << "<span class='notice'>\The [W] is stuck to your hand, you cannot put it in \the [src]!</span>"
+			return
 		if(W)
 			W.loc = src.loc
 	else if(istype(W, /obj/item/weapon/packageWrap))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -146,7 +146,9 @@ FLOOR SAFES
 	if(open)
 		if(I.w_class + space <= maxspace)
 			space += I.w_class
-			user.drop_item()
+			if(!user.drop_item())
+				user << "<span class='notice'>\The [I] is stuck to your hand, you cannot put it in the safe!</span>"
+				return
 			I.loc = src
 			user << "<span class='notice'>You put [I] in [src].</span>"
 			updateUsrDialog()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -708,7 +708,9 @@ Destroy type values:
 		return
 	if(isrobot(user))
 		return
-	user.drop_item()
+	if(!user.drop_item())
+		user << "<span class='notice'>\The [O] is stuck to your hand, you cannot put it in the rack!</span>"
+		return
 	if (O.loc != src.loc)
 		step(O, get_dir(O, src))
 	return
@@ -722,7 +724,9 @@ Destroy type values:
 
 	if(isrobot(user))
 		return
-	user.drop_item()
+	if(!user.drop_item())
+		user << "<span class='notice'>\The [W] is stuck to your hand, you cannot put it in the rack!</span>"
+		return
 	if(W && W.loc)	W.loc = src.loc
 	return 1
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -89,7 +89,9 @@
 		if(w_items + I.w_class > 5)
 			user << "<span class='notice'>The cistern is full.</span>"
 			return
-		user.drop_item()
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [I] is stuck to your hand, you cannot put it in the cistern!</span>"
+			return
 		I.loc = src
 		w_items += I.w_class
 		user << "<span class='notice'>You carefully place [I] into the cistern.</span>"

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -70,7 +70,10 @@ obj/machinery/seed_extractor/attackby(var/obj/item/O as obj, var/mob/user as mob
 			user << "<span class='notice'>There are no seeds in \the [O.name].</span>"
 		return
 
-	user.drop_item()
+	if(!user.drop_item()) //couldn't drop the item
+		user << "<span class='notice'>\The [O] is stuck to your hand, you cannot put it in the seed extractor!</span>"
+		return
+
 	if(O && O.loc)
 		O.loc = src.loc
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -210,7 +210,9 @@
 	if(carved)
 		if(!store)
 			if(I.w_class < 3)
-				user.drop_item()
+				if(!user.drop_item())
+					user << "<span class='notice'>\The [I] is stuck to your hand, you cannot put it in [title]!</span>"
+					return
 				I.loc = src
 				store = I
 				user << "<span class='notice'>You put [I] in [title].</span>"

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -144,7 +144,9 @@
 
 					if( ! ( item_to_add.type in allowed_types ) )
 						usr << "You set [item_to_add] on [src]'s back, but \he shakes it off!"
-						usr.drop_item()
+						if(!usr.drop_item())
+							usr << "<span class='notice'>\The [item_to_add] is stuck to your hand, you cannot put it on [src]'s back!</span>"
+							return
 						item_to_add.loc = loc
 						if(prob(25))
 							step_rand(item_to_add)
@@ -305,17 +307,21 @@
 
 	if(valid)
 		if(usr)
+			if(!usr.drop_item())
+				usr << "<span class='notice'>\The [item_to_add] is stuck to your hand, you cannot put it on [src]'s head!</span>"
+				return 0
 			usr.visible_message("[usr] puts [item_to_add] on [real_name]'s head.  [src] looks at [usr] and barks once.",
 				"You put [item_to_add] on [real_name]'s head.  [src] gives you a peculiar look, then wags \his tail once and barks.",
 				"You hear a friendly-sounding bark.")
-			usr.drop_item()
 		item_to_add.loc = src
 		src.inventory_head = item_to_add
 		regenerate_icons()
 
 	else
+		if(!usr.drop_item())
+			usr << "<span class='notice'>\The [item_to_add] is stuck to your hand, you cannot put it on [src]'s head!</span>"
+			return 0
 		usr << "You set [item_to_add] on [src]'s head, but \he shakes it off!"
-		usr.drop_item()
 		item_to_add.loc = loc
 		if(prob(25))
 			step_rand(item_to_add)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -117,7 +117,9 @@
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(var/obj/item/I, mob/user)
 	if(isrobot(user))	return //Carn: fix for borgs dropping their modules on conveyor belts
-	user.drop_item()
+	if(!user.drop_item())
+		user << "<span class='notice'>\The [I] is stuck to your hand, you cannot place it on the conveyor!</span>"
+		return
 	if(I && I.loc)	I.loc = src.loc
 	return
 

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -69,9 +69,11 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if (temp_tech.len == 0)
 			user << "<span class='warning'> You cannot deconstruct this item!</span>"
 			return
+		if(!user.drop_item())
+			user << "<span class='notice'>\The [O] is stuck to your hand, you cannot put it in the analyzer!</span>"
+			return
 		busy = 1
 		loaded_item = O
-		user.drop_item()
 		O.loc = src
 		user << "<span class='notice'>You add the [O.name] to the machine!</span>"
 		flick("d_analyzer_la", src)


### PR DESCRIPTION
The _NODROP_  items code is robust.
Unfortunately, the value it returns was not checked by many machines/structures, allowing location changes for these items (prime example : it fixes #3407).

I've so added a check each time it was necessary and tell the player the item is stuck in his hand when it's the case.

The affected machines/structures were :
- crates (and bins, as they are derivated from crates),
- suit storage unit (_potential_)
- washing machines (**confirmed**)
- bedsheets bins (**confirmed**)
- safe (the one in the vault, **confirmed**)
- racks (**confirmed**)
- watercloset's cistern (**confirmed**)
- seed extractor (**confirmed**)
- carved books (**confirmed**)
- corgis (**confirmed**)
- conveyor belts (**confirmed**)
- destructive analyzer (**confirmed**)

I may have missed some, don't hesitate !
