### PR TITLE
Fixes the ID computer exploit, to bypass the cooldown.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -1,5 +1,9 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
+//Keeps track of the time for the ID console. Having it as a global variable prevents people from dismantling/reassembling it to
+//increase the slots of many jobs.
+var/time_last_changed_position = 0
+
 /obj/machinery/computer/card
 	name = "identification console"
 	desc = "You can use this to change ID's."
@@ -17,8 +21,6 @@
 	//if set to -1: No cooldown... probably a bad idea
 	//if set to 0: Not able to close "original" positions. You can only close positions that you have opened before
 	var/change_position_cooldown = 280
-	//Keeps track of the time
-	var/time_last_changed_position = 0
 	//Jobs you cannot open new positions for
 	var/list/blacklisted = list(
 		"AI",

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -167,7 +167,7 @@ datum/preferences
 				if(config.mutant_races)
 					dat += "<b>Mutant Race:</b><BR><a href='?_src_=prefs;preference=mutant_race;task=input'>[mutant_race]</a><BR>"
 				else
-					dat += "<b>Mutant Race:</b> human<BR>"
+					dat += "<b>Mutant Race:</b> Human<BR>"
 				dat += "<b>Blood Type:</b> [blood_type]<BR>"
 				dat += "<b>Skin Tone:</b><BR><a href='?_src_=prefs;preference=s_tone;task=input'>[skin_tone]</a><BR>"
 				dat += "<b>Underwear:</b><BR><a href ='?_src_=prefs;preference=underwear;task=input'>[underwear]</a><BR>"
@@ -257,7 +257,7 @@ datum/preferences
 		dat += "</center>"
 
 		//user << browse(dat, "window=preferences;size=560x560")
-		var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 580, 580)
+		var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 580, 600)
 		popup.set_content(dat)
 		popup.open(0)
 


### PR DESCRIPTION
Moved the ID computer's time_last_changed_position variable to a global variable, meaning you cannot dismantle and reassemble it to bypass the cooldown.

Made the character setup screen window size bigger to fit in the mutant race option.
Capitalized the default human option.
