### PR TITLE
You now have to give a reason for shuttle calls, from the communication console.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -82,6 +82,7 @@
 	var/continuous_round_rev = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/continuous_round_wiz = 0
 	var/continuous_round_malf = 0
+	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
 
@@ -336,6 +337,8 @@
 					config.continuous_round_wiz		= 1
 				if("continuous_round_malf")
 					config.continuous_round_malf	= 1
+				if("shuttle_refuel_delay")
+					config.shuttle_refuel_delay     = text2num(value)
 				if("show_game_type_odds")
 					config.show_game_type_odds		= 1
 				if("ghost_interaction")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -1,4 +1,5 @@
 var/global/datum/controller/gameticker/ticker
+var/round_start_time = 0
 
 #define GAME_STATE_PREGAME		1
 #define GAME_STATE_SETTING_UP	2
@@ -113,6 +114,8 @@ var/global/datum/controller/gameticker/ticker
 		world << "<B>Possibilities:</B> [english_list(modes)]"
 	else
 		src.mode.announce()
+
+	round_start_time = world.time
 
 	supply_shuttle.process() 		//Start the supply shuttle regenerating points
 	master_controller.process()		//Start master_controller.process()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -1,5 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
+var/const/CALL_SHUTTLE_REASON_LENGTH = 12
+
 // The communications computer
 /obj/machinery/computer/communications
 	name = "communications console"
@@ -121,7 +123,7 @@
 				src.state = STATE_CALLSHUTTLE
 		if("callshuttle2")
 			if(src.authenticated)
-				call_shuttle_proc(usr)
+				call_shuttle_proc(usr, href_list["call"])
 				if(emergency_shuttle.online)
 					post_status("shuttle")
 			src.state = STATE_DEFAULT
@@ -245,7 +247,7 @@
 		if("ai-callshuttle")
 			src.aistate = STATE_CALLSHUTTLE
 		if("ai-callshuttle2")
-			call_shuttle_proc(usr)
+			call_shuttle_proc(usr, href_list["ai-callshuttle2"])
 			src.aistate = STATE_DEFAULT
 		if("ai-messagelist")
 			src.aicurrmsg = 0
@@ -315,6 +317,8 @@
 		if(authenticated == 1)
 			authenticated = 2
 		user << "You scramble the communication routing circuits!"
+	else if(istype(I, /obj/item/weapon/card/id))
+		attack_hand(user)
 	else
 		..()
 	return
@@ -378,9 +382,9 @@
 			else
 				dat += "<BR>\[ <A HREF='?src=\ref[src];operation=login'>Log In</A> \]"
 		if(STATE_CALLSHUTTLE)
-			dat += "Are you sure you want to call the shuttle? \[ <A HREF='?src=\ref[src];operation=callshuttle2'>OK</A> | <A HREF='?src=\ref[src];operation=main'>Cancel</A> \]"
+			dat += get_call_shuttle_form()
 		if(STATE_CANCELSHUTTLE)
-			dat += "Are you sure you want to cancel the shuttle? \[ <A HREF='?src=\ref[src];operation=cancelshuttle2'>OK</A> | <A HREF='?src=\ref[src];operation=main'>Cancel</A> \]"
+			dat += get_cancel_shuttle_form()
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"
 			for(var/i = 1; i<=src.messagetitle.len; i++)
@@ -438,7 +442,32 @@
 	popup.open()
 
 
+/obj/machinery/computer/communications/proc/get_call_shuttle_form()
+	var/dat = {"<script type="text/javascript">
+						function getLength(){
+							var reasonField = document.getElementById('reasonfield');
+							if(reasonField.value.length >= [CALL_SHUTTLE_REASON_LENGTH]){
+								reasonField.style.backgroundColor = "#DDFFDD";
+							}
+							else {
+								reasonField.style.backgroundColor = "#FFDDDD";
+							}
+						}
+					</script>"}
 
+	dat += "<form name='callshuttle' action='?src=\ref[src]' method='get' style='display: inline'>"
+	dat += "<input type='hidden' name='src' value='\ref[src]'>"
+	dat += "<input type='hidden' name='operation' value='callshuttle2'>"
+	dat += "<b>Nature of emergency:</b><BR> <input type='text' id='reasonfield' name='call' style='width:250px; background-color:#FFDDDD; onkeydown='getLength() onkeyup='getLength()' onkeypress='getLength()'>"
+	dat += "<BR>Are you sure you want to call the shuttle? \[ <input type='submit' value='Call '></form> \]"
+	return dat
+
+/obj/machinery/computer/communications/proc/get_cancel_shuttle_form()
+	var/dat = "<form name='cancelshuttle' action='?src=\ref[src]' method='get' style='display: inline'>"
+	dat += "<input type='hidden' name='src' value='\ref[src]'>"
+	dat += "<input type='hidden' name='operation' value='cancelshuttle2'>"
+	dat += "<BR>Are you sure you want to cancel the shuttle? \[ <input type='submit' value='Cancel'></form> \]"
+	return dat
 
 /obj/machinery/computer/communications/proc/interact_ai(var/mob/living/silicon/ai/user as mob)
 	var/dat = ""
@@ -457,7 +486,7 @@
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-changeseclevel'>Change Alert Level</A> \]"
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-emergencyaccess'>Emergency Maintenance Access</A> \]"
 		if(STATE_CALLSHUTTLE)
-			dat += "Are you sure you want to call the shuttle? \[ <A HREF='?src=\ref[src];operation=ai-callshuttle2'>OK</A> | <A HREF='?src=\ref[src];operation=ai-main'>Cancel</A> \]"
+			dat += get_call_shuttle_form()
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"
 			for(var/i = 1; i<=src.messagetitle.len; i++)
@@ -510,16 +539,11 @@
 	return dat
 
 
-/proc/call_shuttle_proc(var/mob/user)
+/proc/call_shuttle_proc(var/mob/user, var/call_reason)
 	if ((!( ticker ) || emergency_shuttle.location))
 		return
-/* DEATH SQUADS
-	if(sent_strike_team == 1)
-		user << "Centcom will not allow the shuttle to be called. Consider all contracts terminated."
-		return
-*/
-	if(world.time < 6000)
-		user << "The emergency shuttle is refueling. Please wait another [round((6000-world.time)/600)] minutes before trying again."
+	if(world.time - round_start_time < config.shuttle_refuel_delay)
+		user << "The emergency shuttle is refueling. Please wait another [round((config.shuttle_refuel_delay - round_start_time)/600)] minutes before trying again."
 		return
 
 	if(emergency_shuttle.direction == -1)
@@ -530,13 +554,20 @@
 		user << "The emergency shuttle is already on its way."
 		return
 
+	call_reason = strip_html_simple(trim(call_reason))
+
+	if(length(call_reason) < CALL_SHUTTLE_REASON_LENGTH)
+		user << "You must provide a reason."
+		return
+
 	var/area/signal_origin = get_area(user)
+	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	if (seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
 		emergency_shuttle.incall(0.6, signal_origin)
-		captain_announce("The emergency shuttle has been called. Red Alert state confirmed: Dispatching priority shuttle. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
+		captain_announce("The emergency shuttle has been called. Red Alert state confirmed: Dispatching priority shuttle. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.[emergency_reason]")
 	else
 		emergency_shuttle.incall(1, signal_origin)
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.")
+		captain_announce("The emergency shuttle has been called. It will arrive in [round(emergency_shuttle.timeleft()/60)] minutes.[emergency_reason]")
 
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle.", 1)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -247,7 +247,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		if("ai-callshuttle")
 			src.aistate = STATE_CALLSHUTTLE
 		if("ai-callshuttle2")
-			call_shuttle_proc(usr, href_list["ai-callshuttle2"])
+			call_shuttle_proc(usr, href_list["call"])
 			src.aistate = STATE_DEFAULT
 		if("ai-messagelist")
 			src.aicurrmsg = 0
@@ -441,8 +441,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	popup.set_content(dat)
 	popup.open()
 
-
-/obj/machinery/computer/communications/proc/get_call_shuttle_form()
+/obj/machinery/computer/communications/proc/get_javascript_header(var/form_id)
 	var/dat = {"<script type="text/javascript">
 						function getLength(){
 							var reasonField = document.getElementById('reasonfield');
@@ -453,20 +452,30 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 								reasonField.style.backgroundColor = "#FFDDDD";
 							}
 						}
+						function submit() {
+							document.getElementById('[form_id]').submit();
+						}
 					</script>"}
+	return dat
 
-	dat += "<form name='callshuttle' action='?src=\ref[src]' method='get' style='display: inline'>"
+/obj/machinery/computer/communications/proc/get_call_shuttle_form(var/ai_interface = 0)
+	var/form_id = "callshuttle"
+	var/dat = get_javascript_header(form_id)
+	dat += "<form name='callshuttle' id='[form_id]' action='?src=\ref[src]' method='get' style='display: inline'>"
 	dat += "<input type='hidden' name='src' value='\ref[src]'>"
-	dat += "<input type='hidden' name='operation' value='callshuttle2'>"
+	dat += "<input type='hidden' name='operation' value='[ai_interface ? "ai-callshuttle2" : "callshuttle2"]'>"
 	dat += "<b>Nature of emergency:</b><BR> <input type='text' id='reasonfield' name='call' style='width:250px; background-color:#FFDDDD; onkeydown='getLength() onkeyup='getLength()' onkeypress='getLength()'>"
-	dat += "<BR>Are you sure you want to call the shuttle? \[ <input type='submit' value='Call '></form> \]"
+	dat += "<BR>Are you sure you want to call the shuttle? \[ <a href='#' onclick='submit()'>Call</a> \]"
 	return dat
 
 /obj/machinery/computer/communications/proc/get_cancel_shuttle_form()
-	var/dat = "<form name='cancelshuttle' action='?src=\ref[src]' method='get' style='display: inline'>"
+	var/form_id = "cancelshuttle"
+	var/dat = get_javascript_header(form_id)
+	dat += "<form name='cancelshuttle' id='[form_id]' action='?src=\ref[src]' method='get' style='display: inline'>"
 	dat += "<input type='hidden' name='src' value='\ref[src]'>"
 	dat += "<input type='hidden' name='operation' value='cancelshuttle2'>"
-	dat += "<BR>Are you sure you want to cancel the shuttle? \[ <input type='submit' value='Cancel'></form> \]"
+
+	dat += "<BR>Are you sure you want to cancel the shuttle? \[ <a href='#' onclick='submit()'>Cancel</a> \]"
 	return dat
 
 /obj/machinery/computer/communications/proc/interact_ai(var/mob/living/silicon/ai/user as mob)
@@ -486,7 +495,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-changeseclevel'>Change Alert Level</A> \]"
 			dat += "<BR>\[ <A HREF='?src=\ref[src];operation=ai-emergencyaccess'>Emergency Maintenance Access</A> \]"
 		if(STATE_CALLSHUTTLE)
-			dat += get_call_shuttle_form()
+			dat += get_call_shuttle_form(1)
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"
 			for(var/i = 1; i<=src.messagetitle.len; i++)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -240,10 +240,10 @@ var/list/ai_list = list()
 			usr << "Wireless control is disabled!"
 			return
 
-	var/confirm = alert("Are you sure you want to call the shuttle?", "Confirm Shuttle Call", "Yes", "No")
+	var/reason = input(src, "What is the nature of your emergency? ([CALL_SHUTTLE_REASON_LENGTH] characters required.)", "Confirm Shuttle Call") as text
 
-	if(confirm == "Yes")
-		call_shuttle_proc(src)
+	if(length(trim(reason)) > 0)
+		call_shuttle_proc(src, reason)
 
 	// hack to display shuttle timer
 	if(emergency_shuttle.online)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -105,6 +105,8 @@ PROBABILITY SANDBOX 0
 #CONTINUOUS_ROUND_WIZ
 #CONTINUOUS_ROUND_MALF
 
+## The amount of time it takes for the emergency shuttle to be called, from round start.
+SHUTTLE_REFUEL_DELAY 12000
 
 ## Variables calculate how number of antagonists will scale to population.
 ## Used as (Antagonists = Population / Coeff)


### PR DESCRIPTION
The reason must be over 12 characters.
You can open the communication console UI by using your ID card.
Added a config option for the shuttle refuel delay, defaults to 20 minutes.
Fixed a bug where the refuel delay was counting the pre-game lobby time.

![](http://i.imgur.com/OmslH7y.png)
![](http://i.imgur.com/RdCUmpN.png)
