### PR TITLE
Fixes hotkey mode always being set during login. 

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -53,7 +53,7 @@
 // Calling it in the overriden Login, such as /mob/living/Login() doesn't cause this.
 /mob/proc/update_interface()
 	if(client)
-		if(winget(src, "hotkey_toggle", "is-checked"))
+		if(winget(src, "mainwindow.hotkey_toggle", "is-checked") == "true")
 			update_hotkey_mode()
 		else
 			update_normal_mode()


### PR DESCRIPTION
winget() was returning "true", not 1 or 0. It now compares for the string.
