### PR TITLE
Chem grenades asay logs improvements

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -535,6 +535,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/key_name_admin(var/whom, var/include_name = 1)
 	return key_name(whom, 1, include_name)
 
+/proc/get_mob_by_ckey(var/key)
+	if(!key)
+		return
+	var/list/mobs = sortmobs()
+	for(var/mob/M in mobs)
+		if(M.ckey == key)
+			return M
+
 // Returns the atom sitting on the turf.
 // For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
 /proc/get_atom_on_turf(var/atom/movable/M)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -55,19 +55,19 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		if(!istype(H.dna, /datum/dna))
 			return 0
 		if(H.gloves)
-			if(fingerprintslast != H.key)
+			if(fingerprintslast != H.ckey)
 				fingerprintshidden += text("\[[time_stamp()]\] (Wearing gloves). Real name: [], Key: []",H.real_name, H.key)
-				fingerprintslast = H.key
+				fingerprintslast = H.ckey
 			return 0
 		if(!( fingerprints ))
-			if(fingerprintslast != H.key)
+			if(fingerprintslast != H.ckey)
 				fingerprintshidden += text("\[[time_stamp()]\] Real name: [], Key: []",H.real_name, H.key)
-				fingerprintslast = H.key
+				fingerprintslast = H.ckey
 			return 1
 	else
-		if(fingerprintslast != M.key)
+		if(fingerprintslast != M.ckey)
 			fingerprintshidden += text("\[[time_stamp()]\] Real name: [], Key: []",M.real_name, M.key)
-			fingerprintslast = M.key
+			fingerprintslast = M.ckey
 	return
 
 //Set ignoregloves to add prints irrespective of the mob having gloves on.
@@ -90,9 +90,9 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		//Now, deal with gloves.
 		if(!ignoregloves)
 			if(H.gloves && H.gloves != src)
-				if(fingerprintslast != H.key)
+				if(fingerprintslast != H.ckey)
 					fingerprintshidden += text("\[[]\](Wearing gloves). Real name: [], Key: []",time_stamp(), H.real_name, H.key)
-					fingerprintslast = H.key
+					fingerprintslast = H.ckey
 				H.gloves.add_fingerprint(M)
 
 			//Deal with gloves the pass finger/palm prints.
@@ -103,9 +103,9 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 					return 0
 
 		//More adminstuffz
-		if(fingerprintslast != H.key)
+		if(fingerprintslast != H.ckey)
 			fingerprintshidden += text("\[[]\]Real name: [], Key: []",time_stamp(), H.real_name, H.key)
-			fingerprintslast = H.key
+			fingerprintslast = H.ckey
 
 		//Make the list if it does not exist.
 		if(!fingerprints)
@@ -120,9 +120,9 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		return 1
 	else
 		//Smudge up dem prints some
-		if(fingerprintslast != M.key)
+		if(fingerprintslast != M.ckey)
 			fingerprintshidden += text("\[[]\]Real name: [], Key: []",time_stamp(), M.real_name, M.key)
-			fingerprintslast = M.key
+			fingerprintslast = M.ckey
 
 	return
 


### PR DESCRIPTION
Makes fingerprintslast use ckey instead of key
Cleans a bit the prime() code, large grenades won't be a huge copypaste anymore
Asay logs will now show up when the grenade is activated instead of used. Only when The grenade is activated by an assembly.
New proc, get_mob_by_ckey(). Give it a ckey and it will return a mob.
