### PR TITLE
medbot injection message now only bold red for target. 

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -219,8 +219,7 @@
 	if(open && !locked)
 		if(user) user << "<span class='warning'>You short out [src]'s reagent synthesis circuits.</span>"
 		spawn(0)
-			for(var/mob/O in hearers(src, null))
-				O.show_message(""<span class='userdanger'>[src] buzzes oddly!</span>", 1)
+			src.visible_message("<span class='userdanger'>[src] buzzes oddly!</span>", 1)
 		flick("medibot_spark", src)
 		src.patient = null
 		if(user) src.oldpatient = user

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -220,7 +220,7 @@
 		if(user) user << "<span class='warning'>You short out [src]'s reagent synthesis circuits.</span>"
 		spawn(0)
 			for(var/mob/O in hearers(src, null))
-				O.show_message("\red <B>[src] buzzes oddly!</B>", 1)
+				O.show_message(""<span class='userdanger'>[src] buzzes oddly!</span>", 1)
 		flick("medibot_spark", src)
 		src.patient = null
 		if(user) src.oldpatient = user
@@ -425,7 +425,9 @@
 		return
 	else
 		src.icon_state = "medibots"
-		visible_message("\red <B>[src] is trying to inject [src.patient]!</B>")
+		C.visible_message("<span class='danger'>[src] is trying to inject [src.patient]!</span>", \
+			<span class='userdanger'>[src] is trying to inject [src.patient]!</span>")
+		
 		spawn(30)
 			if ((get_dist(src, src.patient) <= 1) && (src.on))
 				if((reagent_id == "internal_beaker") && (src.reagent_glass) && (src.reagent_glass.reagents.total_volume))
@@ -433,7 +435,8 @@
 					src.reagent_glass.reagents.reaction(src.patient, 2)
 				else
 					src.patient.reagents.add_reagent(reagent_id,src.injection_amount)
-				visible_message("\red <B>[src] injects [src.patient] with the syringe!</B>")
+				C.visible_message("<span class='danger'>[src] injects [src.patient] with the syringe!</span>", \
+					<span class='userdanger'>[src] injects [src.patient] with the syringe!</span>")
 
 			src.icon_state = "medibot[src.on]"
 			src.currently_healing = 0
@@ -457,7 +460,7 @@
 
 /obj/machinery/bot/medbot/explode()
 	src.on = 0
-	visible_message("\red <B>[src] blows apart!</B>", 1)
+	visible_message("<span class='userdanger'>[src] blows apart!</span>", 1)
 	var/turf/Tsec = get_turf(src)
 
 	new /obj/item/weapon/storage/firstaid(Tsec)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -425,7 +425,7 @@
 	else
 		src.icon_state = "medibots"
 		C.visible_message("<span class='danger'>[src] is trying to inject [src.patient]!</span>", \
-			<span class='userdanger'>[src] is trying to inject [src.patient]!</span>")
+			"<span class='userdanger'>[src] is trying to inject [src.patient]!</span>")
 		
 		spawn(30)
 			if ((get_dist(src, src.patient) <= 1) && (src.on))
@@ -435,7 +435,7 @@
 				else
 					src.patient.reagents.add_reagent(reagent_id,src.injection_amount)
 				C.visible_message("<span class='danger'>[src] injects [src.patient] with the syringe!</span>", \
-					<span class='userdanger'>[src] injects [src.patient] with the syringe!</span>")
+					"<span class='userdanger'>[src] injects [src.patient] with the syringe!</span>")
 
 			src.icon_state = "medibot[src.on]"
 			src.currently_healing = 0


### PR DESCRIPTION
- adding span classes everywhere
- bold red message when the player is the one being injected/trying to be injected by medibot, otherwise just red message for other players.
- Replace one show_message with visible_message.
