### PR TITLE
Runtime fix for the mop

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -34,16 +34,16 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 		user << "<span class='notice'>Your mop is dry!</span>"
 		return
 
-	var/turf/simulated/floor = A
+	var/turf/simulated/turf = A
 	if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
-		floor = A.loc
+		turf = A.loc
 	A = null
 
-	if(istype(floor))
-		user.visible_message("<span class='warning'>[user] begins to clean \the [floor].</span>")
+	if(istype(turf))
+		user.visible_message("<span class='warning'>[user] begins to clean \the [turf].</span>")
 
 		if(do_after(user, 40))
-			clean(floor)
+			clean(turf)
 			user << "<span class='notice'>You have finished mopping!</span>"
 
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -29,16 +29,21 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
-	if(istype(A, /obj/effect/rune) ||istype(A, /turf/simulated) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
-		if(reagents.total_volume < 1)
-			user << "<span class='notice'>Your mop is dry!</span>"
-			return
 
-		user.visible_message("<span class='warning'>[user] begins to clean \the [get_turf(A)].</span>")
+	if(reagents.total_volume < 1)
+		user << "<span class='notice'>Your mop is dry!</span>"
+		return
+
+	var/turf/simulated/floor = A
+	if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+		floor = A.loc
+	A = null
+
+	if(istype(floor))
+		user.visible_message("<span class='warning'>[user] begins to clean \the [floor].</span>")
 
 		if(do_after(user, 40))
-			if(A)
-				clean(get_turf(A))
+			clean(floor)
 			user << "<span class='notice'>You have finished mopping!</span>"
 
 


### PR DESCRIPTION
The following runtime has occured 40 time(s).
runtime error: Cannot execute null.clean blood().
proc name: clean (/obj/item/weapon/mop/proc/clean)
  source file: mop.dm,22
  usr: Xavier Paynter (/mob/living/carbon/human)
  src: the mop (/obj/item/weapon/mop)

Cause: Someone would mop the same vomit/whatever more than once. The first clean would qdel() the vomit, which resulted in the vomit's loc being null. The subsequent moppings would continue and eventually try to call vomit.loc.clean_blood().
