### PR TITLE
You can use a pill on a mining rig while it is equipped to inject the contents into yourself

### DIFF
--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -97,12 +97,24 @@
 /obj/item/clothing/suit/space/rig/mining
 	icon_state = "rig-mining"
 	name = "mining hardsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
+	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating, and an auto-injector for use with pills."
 	item_state = "mining_hardsuit"
 	armor = list(melee = 40, bullet = 5, laser = 10,energy = 5, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/pickaxe)
 
-
+/obj/item/clothing/suit/space/rig/mining/attackby(obj/item/I as obj, mob/user as mob)
+	if(istype(I, /obj/item/weapon/reagent_containers/pill) && isliving(loc))
+		var/obj/item/weapon/reagent_containers/pill/P = I
+		var/mob/living/L = loc
+		user.unEquip(P)
+		loc << "<span class='notice'>You insert [I] into the suit and feel a tiny prick.</span>"
+		if(P.reagents.total_volume)
+			P.reagents.reaction(L, INGEST)
+			P.reagents.trans_to(L, P.reagents.total_volume)
+		qdel(P)
+		return
+	else
+		..()
 
 //Syndicate rig
 /obj/item/clothing/head/helmet/space/rig/syndi


### PR DESCRIPTION
Using a pill on a mining rig while you are wearing it now injects the contents of the pill into you and disposes of the pill. 

This was mostly to get around the fact that you can no longer chomp on stim pills while in a vaccuum due to recent changes (I mean, taking off your helmet AND mask to take a pill is a bit...), making them a fairly pointless mining item, this fixes that; But has other uses potentially for other servers (Starving or Dehydrated due to cave-in? Nutriment and water pills! Muh immersion!)
