### PR TITLE
Fixed the adjacent proc to correctly process diagonals checks (fix #3519)

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -41,8 +41,8 @@
 
 	// Diagonal case
 	var/in_dir = get_dir(T0,src) // eg. northwest (1+8) = 9 (00001001)
-	var/d1 = in_dir&3		     // eg. west	  (1+8)&3 (0000 0011) = 1 (0000 0001)
-	var/d2 = in_dir&12			 // eg. north	  (1+8)&12 (0000 1100) = 8 (0000 1000)
+	var/d1 = in_dir&3		     // eg. north	  (1+8)&3 (0000 0011) = 1 (0000 0001)
+	var/d2 = in_dir&12			 // eg. west	  (1+8)&12 (0000 1100) = 8 (0000 1000)
 
 	for(var/d in list(d1,d2))
 		if(!T0.ClickCross(d, border_only = 1))

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -49,7 +49,7 @@
 			continue // could not leave T0 in that direction
 
 		var/turf/T1 = get_step(T0,d)
-		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0), border_only = 0) || !T1.ClickCross(get_dir(T1,src), border_only = 0))
+		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) | get_dir(T1,src), border_only = 0)) //let's check both directions at once
 			continue // couldn't enter or couldn't leave T1
 
 		if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
@@ -112,8 +112,8 @@
 			continue // throwpass is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags&ON_BORDER) // windows have throwpass but are on border, check them first
-			if( O.dir == target_dir || (O.dir in list(5,6,9,10)) ) // full tile windows are just diagonals mechanically
-				return 0
+			if( O.dir & target_dir || O.dir & (O.dir-1) ) // full tile windows are just diagonals mechanically
+				return 0								  //O.dir&(O.dir-1) is false for any cardinal direction, but true for diagonal ones
 
 		else if( !border_only ) // dense, not on border, cannot pass over
 			return 0

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -27,32 +27,36 @@
 */
 /turf/Adjacent(var/atom/neighbor, var/atom/target = null)
 	var/turf/T0 = get_turf(neighbor)
-	if(T0 == src)
+
+	if(T0 == src) //same turf
 		return 1
-	if(get_dist(src,T0) > 1)
+
+	if(get_dist(src,T0) > 1) //too far
 		return 0
 
+	// Non diagonal case
 	if(T0.x == x || T0.y == y)
 		// Check for border blockages
 		return T0.ClickCross(get_dir(T0,src), border_only = 1) && src.ClickCross(get_dir(src,T0), border_only = 1, target_atom = target)
 
-	// Not orthagonal
-	var/in_dir = get_dir(neighbor,src) // eg. northwest (1+8)
-	var/d1 = in_dir&(in_dir-1)		// eg west		(1+8)&(8) = 8
-	var/d2 = in_dir - d1			// eg north		(1+8) - 8 = 1
+	// Diagonal case
+	var/in_dir = get_dir(T0,src) // eg. northwest (1+8) = 9 (00001001)
+	var/d1 = in_dir&3		     // eg. west	  (1+8)&3 (0000 0011) = 1 (0000 0001)
+	var/d2 = in_dir&12			 // eg. north	  (1+8)&12 (0000 1100) = 8 (0000 1000)
 
 	for(var/d in list(d1,d2))
 		if(!T0.ClickCross(d, border_only = 1))
 			continue // could not leave T0 in that direction
 
 		var/turf/T1 = get_step(T0,d)
-		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0) & get_dir(T1,src), border_only = 0))
+		if(!T1 || T1.density || !T1.ClickCross(get_dir(T1,T0), border_only = 0) || !T1.ClickCross(get_dir(T1,src), border_only = 0))
 			continue // couldn't enter or couldn't leave T1
 
 		if(!src.ClickCross(get_dir(src,T1), border_only = 1, target_atom = target))
 			continue // could not enter src
 
 		return 1 // we don't care about our own density
+
 	return 0
 
 /*
@@ -104,15 +108,17 @@
 */
 /turf/proc/ClickCross(var/target_dir, var/border_only, var/target_atom = null)
 	for(var/obj/O in src)
-		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
+		if( !O.density || O == target_atom || O.throwpass) //check if there's a dense object present on the turf
+			continue // throwpass is used for anything you can click through (or the firedoor special case, see above)
 
 		if( O.flags&ON_BORDER) // windows have throwpass but are on border, check them first
-			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
+			if( O.dir == target_dir || (O.dir in list(5,6,9,10)) ) // full tile windows are just diagonals mechanically
 				return 0
 
 		else if( !border_only ) // dense, not on border, cannot pass over
 			return 0
 	return 1
+
 /*
 	Aside: throwpass does not do what I thought it did originally, and is only used for checking whether or not
 	a thrown object should stop after already successfully entering a square.  Currently the throw code involved


### PR DESCRIPTION
Corrected the _adjacent_ proc to do _What It Says on the Tin_ (that fixes #3519) : 

> Adjacency (to turf):
> - If you are in the same turf, always true
> - If you are vertically/horizontally adjacent, ensure there are no dense border objects (e.g windows, fire doors, ...) 
> - If you are diagonally adjacent, ensure you can pass through at least one of the mutually adjacent square.
>   - Passing through in this case ignores anything with the throwpass flag, such as racks, and morgue trays _(that's only used in an hack for the firedoors)_

Examples of correct diagonal checks working :
![reachable](https://cloud.githubusercontent.com/assets/7117411/2796297/3829884a-cc0b-11e3-8885-84dc9254a2e3.png)
- case 1 : both ways to the radio are blocked by closed windows, so we can't reach it
- case 2 : one of the windows is open (density = 0), so there's a path to the radio : _grab it_ !
- case 3 : never realized it, but this configuration prevents you from getting the rods...

I found the name of the proc to be a little misleading : it should be view as something like _can_reach_.
Even the adjacent.dm intro comment goes that way

> Adjacency proc for determining touch range
> 
> This is mostly to determine if a user can enter a square for the purposes of touching something.
> Examples include reaching a square diagonally or reaching something on the other side of a glass window.
