### PR TITLE
Fixes Solar Control Computer direction being erased in auto tracking (fix #3528)

### DIFF
--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -61,7 +61,8 @@
 		// Solar Control
 		else if(istype(M, /obj/machinery/power/solar_control))
 			var/obj/machinery/power/solar_control/C = M
-			C.tracker_update() //update manual tracker
+			if(C.track == 1) //if manual tracking...
+				C.tracker_update() //...update the position (not passing an angle, it is handled internally for manual tracking)
 
 		// Solar Panel
 		else if(istype(M, /obj/machinery/power/solar))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -375,7 +375,7 @@ var/list/solars_list = list()
 	if(stat & (NOPOWER | BROKEN))
 		return
 
-	if(track==1 && trackrate)
+	if(track==1 && trackrate) //manual tracking and set a rotation speed
 		if(nexttime <= world.time) //every time we need to increase/decrease the angle by 1°...
 			targetdir = (targetdir + trackrate/abs(trackrate) + 360) % 360 	//... do it
 			nexttime += 36000/abs(trackrate) //reset the counter for the next 1°
@@ -388,10 +388,10 @@ var/list/solars_list = list()
 /obj/machinery/power/solar_control/proc/tracker_update(var/angle)
 	if(stat & (NOPOWER | BROKEN) || track == 0)
 		return
-	if (track == 2)
+	if (track == 2) // auto-tracking (called by tracker.dm /set_angle)
 		cdir = angle
-	else if (track == 1 && trackrate) //if manual tracking...
-		cdir = targetdir			  //...the current direction is the targetted one (and rotates panels to it)
+	else if (trackrate) //else we're manual tracking. If we set a rotation speed...
+		cdir = targetdir //...the current direction is the targetted one (and rotates panels to it)
 	set_panels(cdir)
 	src.updateDialog()
 


### PR DESCRIPTION
Fixes #3528.

The  Sun Controller was updating the Solar Control Computer panels direction every sun update, _regardless of the current tracking mode_ (when it was only supposed to do so for manual tracking).
Depending of the position of the auto-tracker and the computer in the _solar_list_, the angle previously set by auto-tracking could then be erased.

The Sun Controller now checks if a Computer is in manual mode before updating the manual tracking.
