### PR TITLE
Resolves #3371 by opening borg chargers affected by explosions.

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -66,6 +66,11 @@
 	open_machine()
 	..(severity)
 
+/obj/machinery/recharge_station/ex_act(severity)
+	if(occupier)
+		open_machine()
+	..(severity)
+
 /obj/machinery/recharge_station/attack_paw(user as mob)
 	return attack_hand(user)
 


### PR DESCRIPTION
The main example is borgs getting blown, though other explosions will knock them open as well.  They're explosions, after all.  With this change the charger isn't left on, charging nothing, and even if the explosion destroys the charger the MMI is still dropped (as normal for blown, non-emagged borgs).

![battle no-moon zeta 2014-04-27 020354](https://cloud.githubusercontent.com/assets/1363783/2810570/6877cde0-cdd2-11e3-9356-77649d13488e.png)
