### PR TITLE
Lasers from cyborgs won't get their sprite ruined due to an EMP anymore.

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -60,6 +60,8 @@ obj/item/weapon/gun/energy/laser/retro
 				chambered.newshot()
 	return
 
+/obj/item/weapon/gun/energy/laser/cyborg/emp_act()
+	return
 
 /obj/item/weapon/gun/energy/laser/scatter
 	name = "scatter laser gun"


### PR DESCRIPTION
Fixes issue https://github.com/tgstation/-tg-station/issues/2565
