### PR TITLE
Fragile thrown food items use del instead of qdel.  Fixes issue #3561

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -586,7 +586,9 @@
 		..()
 		new/obj/effect/decal/cleanable/tomato_smudge(src.loc)
 		src.visible_message("<span class='notice'>The [src.name] has been squashed.</span>","<span class='moderate'>You hear a smack.</span>")
-		qdel(src)
+		for(var/atom/A in get_turf(hit_atom))
+			src.reagents.reaction(A)
+		del(src) // Not qdel, because it'll hit other mobs then the floor for runtimes.
 		return
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/killertomato
@@ -628,7 +630,7 @@
 	src.reagents.reaction(get_turf(hit_atom))
 	for(var/atom/A in get_turf(hit_atom))
 		src.reagents.reaction(A)
-	qdel(src)
+	del(src) // Not qdel, because it'll hit other mobs then the floor for runtimes.
 	return
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato
@@ -651,7 +653,7 @@
 	src.reagents.reaction(get_turf(hit_atom))
 	for(var/atom/A in get_turf(hit_atom))
 		src.reagents.reaction(A)
-	qdel(src)
+	del(src) // Not qdel, because it'll hit other mobs then the floor for runtimes.
 	return
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluetomato/Crossed(AM as mob|obj)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -437,7 +437,7 @@
 		..()
 		new/obj/effect/decal/cleanable/egg_smudge(src.loc)
 		reagents.reaction(hit_atom, TOUCH)
-		qdel(src)
+		del(src) // Not qdel, because it'll hit other mobs then the floor for runtimes.
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(istype( W, /obj/item/toy/crayon ))
@@ -786,7 +786,8 @@
 /obj/item/weapon/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
 	..()
 	new/obj/effect/decal/cleanable/pie_smudge(src.loc)
-	qdel(src)
+	reagents.reaction(hit_atom, TOUCH)
+	del(src) // Not qdel, because it'll hit other mobs then the floor for runtimes.
 
 /obj/item/weapon/reagent_containers/food/snacks/berryclafoutis
 	name = "berry clafoutis"


### PR DESCRIPTION
This affects tomatoes, blue tomatoes, blood tomatoes, eggs, and pies.  Pies and tomatoes now also apply reagents like the other thrown foods.
