### PR TITLE
Fixes #3565. Added a "put_in_hand_check" which returns 1 if the item can be equipped ...

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -20,8 +20,8 @@
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(var/obj/item/W)
-	if(lying && !(W.flags&ABSTRACT))			return 0
-	if(!istype(W))		return 0
+	if(!put_in_hand_check(W))
+		return 0
 	if(!l_hand)
 		W.loc = src		//TODO: move to equipped?
 		l_hand = W
@@ -37,8 +37,8 @@
 
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_r_hand(var/obj/item/W)
-	if(lying && !(W.flags&ABSTRACT))			return 0
-	if(!istype(W))		return 0
+	if(!put_in_hand_check(W))
+		return 0
 	if(!r_hand)
 		W.loc = src
 		r_hand = W
@@ -51,6 +51,10 @@
 		return 1
 	return 0
 
+/mob/proc/put_in_hand_check(var/obj/item/W)
+	if(lying && !(W.flags&ABSTRACT))			return 0
+	if(!istype(W))		return 0
+	return 1
 
 //Puts the item into our active hand if possible. returns 1 on success.
 /mob/proc/put_in_active_hand(var/obj/item/W)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -299,3 +299,6 @@
                                                 return
                         step(AM, t)
                 now_pushing = null
+
+/mob/living/silicon/put_in_hand_check()
+	return 0


### PR DESCRIPTION
...in the hand. Replaced the duplicated checks in "put_in_l/r_hand" with it.

Silicons override the check and return 0. Fixes #3565
