### PR TITLE
Rotate medical/security hud sprites when humans fall down

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -62,7 +62,6 @@
 			for(var/datum/disease/D in patient.viruses)
 				if(!D.hidden[SCANNER])
 					foundVirus++
-			if(!C) continue
 
 			holder = patient.hud_list[HEALTH_HUD]
 			if(patient.stat == 2)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -28,7 +28,9 @@
 	internal_organs += new /obj/item/organ/brain
 
 	for(var/i=0;i<7;i++) // 2 for medHUDs and 5 for secHUDs
-		hud_list += image('icons/mob/hud.dmi', src, "hudunknown")
+		var/image/I = image('icons/mob/hud.dmi', src, "hudunknown")
+		I.transform = matrix(-lying, MATRIX_ROTATE)
+		hud_list += I
 
 	..()
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -123,6 +123,16 @@ Please contact me on #coderbus IRC. ~Carnie x
 	update_transform()
 
 
+/mob/living/carbon/human/update_transform()
+	if(lying != lying_prev)
+		for(var/i = 1, i <= hud_list.len, i++)
+			var/image/HUD_image = hud_list[i]
+			if(HUD_image)
+				var/image_rotation = -lying - -lying_prev
+				var/matrix/anti_transform = turn(HUD_image.transform, image_rotation)
+				animate(HUD_image, transform = anti_transform, time = 2, easing = BOUNCE_EASING|EASE_OUT)
+	..()
+
 //DAMAGE OVERLAYS
 //constructs damage icon for each organ from mask * damage field and saves it in our overlays_ lists
 /mob/living/carbon/human/update_damage_overlays()


### PR DESCRIPTION
Doesn't do anything about those retarded cult/rev/nuke op icons, but that's for another day.
Fixes half of #2512
