### PR TITLE
Fix shower not extinguishing fires

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -152,11 +152,8 @@
 	on = !on
 	update_icon()
 	if(on)
-		if (M.loc == loc)
-			wash(M)
-			check_heat(M)
 		for (var/atom/movable/G in loc)
-			G.clean_blood()
+			Crossed(G)
 
 
 /obj/machinery/shower/attackby(obj/item/I, mob/user)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -59,3 +59,4 @@ hornygranny = Game Master
 yota = Game Master
 firecage = Game Master
 donkieyo = Game Master
+argoneus = Game Master


### PR DESCRIPTION
It extinguished properly when you pulled something under active shower, but not if you activated it with a burning person under it -> The code washed the person activating the shower, thus if there were 2 people under it, it only washed the one that turned it on. What I did was upon activation set Crossed() on every mob under the shower, it seems to work fine now.

Fixed #3571
