### PR TITLE
canUseTopic()

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -233,7 +233,7 @@ Class Procs:
 	return 1
 
 /mob/living/silicon/robot/canUseTopic()
-	if(stat || lockcharge || stunned)
+	if(stat || lockcharge || stunned || weakened)
 		return
 	return 1
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -202,29 +202,40 @@ Class Procs:
 	..()
 	if(!interact_offline && stat & (NOPOWER|BROKEN))
 		return 1
-	if(usr.restrained() || usr.lying || usr.stat)
+	if(!usr.canUseTopic(src))
 		return 1
-	if(!(ishuman(usr) || issilicon(usr)))
-		usr << "<span class='notice'>You don't have the dexterity to do this!</span>"
-		return 1
-
-	var/norange = 0
-	if(istype(usr, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = usr
-		if(istype(H.l_hand, /obj/item/tk_grab))
-			norange = 1
-		else if(istype(H.r_hand, /obj/item/tk_grab))
-			norange = 1
-
-	if(!norange)
-		if(!issilicon(usr))
-			if(!in_range(src, usr))
-				return 1
-			if(!isturf(loc))
-				return 1
-
 	add_fingerprint(usr)
 	return 0
+
+/mob/proc/canUseTopic() //TODO: once finished, place these procs on the respective mob files
+	return
+
+/mob/dead/observer/canUseTopic()
+	if(check_rights(R_ADMIN))
+		return
+
+/mob/living/canUseTopic()
+	src << "<span class='notice'>You don't have the dexterity to do this!</span>"
+	return
+
+/mob/living/carbon/human/canUseTopic(atom/movable/M)
+	if(restrained() || lying || stat || stunned || weakened)
+		return
+	if(!in_range(M, src))
+		return
+	if(!isturf(M.loc) && M.loc != src)
+		return
+	return 1
+
+/mob/living/silicon/ai/canUseTopic()
+	if(stat)
+		return
+	return 1
+
+/mob/living/silicon/robot/canUseTopic()
+	if(stat || lockcharge || stunned)
+		return
+	return 1
 
 /obj/machinery/attack_ai(mob/user as mob)
 	if(isrobot(user))

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -174,7 +174,7 @@
 
 
 /datum/song/Topic(href, href_list)
-	if(!in_range(instrumentObj, usr) || (issilicon(usr) && instrumentObj.loc != usr) || !isliving(usr) || !usr.canmove || usr.restrained())
+	if(usr.canUseTopic(src))
 		usr << browse(null, "window=instrument")
 		usr.unset_machine()
 		return


### PR DESCRIPTION
Creates canUseTopic(), a mob proc contained for the moment in the machinery.dm

The Topic() proc of machinery will use this.
The first non-machinery item to use this will be the violin and piano.
There are plans to make admin observers use this, to make AIs don't be able to use Topic() when they lose power (doing that currently will break gameplay) and make all items use the canUseTopic() proc if needed.
I just wanted to pull the fix for the piano and violin quick, the rest is a todo.

Fixes issue https://github.com/tgstation/-tg-station/issues/2471
