### PR TITLE
Light tubes and bulbs brightness

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -650,11 +650,6 @@
 	g_amt = 100
 	brightness = 8
 
-/obj/item/weapon/light/tube/large
-	w_class = 2
-	name = "large light tube"
-	brightness = 15
-
 /obj/item/weapon/light/bulb
 	name = "light bulb"
 	desc = "A replacement light bulb."
@@ -662,20 +657,11 @@
 	base_state = "lbulb"
 	item_state = "contvapour"
 	g_amt = 100
-	brightness = 5
+	brightness = 4
 
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
 	..()
 	shatter()
-
-/obj/item/weapon/light/bulb/fire
-	name = "fire bulb"
-	desc = "A replacement fire bulb."
-	icon_state = "fbulb"
-	base_state = "fbulb"
-	item_state = "egg4"
-	g_amt = 100
-	brightness = 5
 
 // update the icon state and description of the light
 
@@ -694,11 +680,6 @@
 
 /obj/item/weapon/light/New()
 	..()
-	switch(name)
-		if("light tube")
-			brightness = rand(6,9)
-		if("light bulb")
-			brightness = rand(4,6)
 	update()
 
 


### PR DESCRIPTION
Removes the unused large tubes and fire bulbs.
Made light bulbs have 4 brightness and tubes 8 by default, no random variables changing this value.
Fixes issue https://github.com/tgstation/-tg-station/issues/2474
