### PR TITLE
Cultist summon rune blurry mobs fix

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -861,7 +861,7 @@ var/list/sacrificed = list()
 					user << "\red You cannot summon the [cultist], for his shackles of blood are strong"
 					return fizzle()
 				cultist.loc = src.loc
-				cultist.lying = 1
+				cultist.Weaken(5)
 				cultist.regenerate_icons()
 				for(var/mob/living/carbon/human/C in orange(1,src))
 					if(iscultist(C) && !C.stat)


### PR DESCRIPTION
Summoning a cultist with the rune will now weaken them instead of changing their lying to 1, making weird blurry mobs.
Fixes issue https://github.com/tgstation/-tg-station/issues/2435
