### PR TITLE
Change examine() from an atom verb to a mob verb

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -301,11 +301,10 @@
 		else
 			return ..()
 
-	examine()
-		set src in oview(1)
+	examine(mob/user)
 		..()
 		if(welded)
-			usr << "It seems welded shut."
+			user << "It seems welded shut."
 
 	power_change()
 		if(powered(power_channel))

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -206,8 +206,7 @@
 	return
 /atom/proc/ShiftClick(var/mob/user)
 	if(user.client && user.client.eye == user)
-		examine()
-		user.face_atom(src)
+		user.examinate(src)
 	return
 
 /*

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -55,7 +55,7 @@
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
 /atom/proc/attack_ghost(mob/dead/observer/user as mob)
 	if(user.client && user.client.inquisitive_ghost)
-		examine()
+		user.examinate(src)
 	return
 
 // ---------------------------------------

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -205,19 +205,33 @@ its easier to just keep the beam vertical.
 
 
 //All atoms
-/atom/verb/examine()
-	set name = "Examine"
-	set category = "IC"
-	set src in oview(12)	//make it work from farther away
+/atom/proc/examine(mob/user)
+	//This reformat names to get a/an properly working on item descriptions when they are bloody
+	var/determiner = "This is"
+	if(src.gender == PLURAL)
+		determiner = "These are"
+	var/f_name = "\a [src]."
+	if(src.blood_DNA)
+		if(gender == PLURAL)
+			f_name = "some "
+		else
+			f_name = "a "
+		f_name += "<span class='danger'>bloody</span> [name]!"
 
-	if (!( usr ))
-		return
-	usr << "\icon[src]That's \a [src]." //changed to "That's" from "This is" because "This is some metal sheets" sounds dumb compared to "That's some metal sheets" ~Carn
+	user << "\icon[src][determiner] [f_name]"
+
 	if(desc)
-		usr << desc
+		user << desc
 	// *****RM
-	//usr << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
-	return
+	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
+
+	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
+		user << "It contains:"
+		if(reagents.reagent_list.len)
+			for(var/datum/reagent/R in reagents.reagent_list)
+				user << "[R.volume] units of [R.name]"
+		else
+			user << "Nothing."
 
 /atom/proc/relaymove()
 	return

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -146,11 +146,9 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 		for(var/mob/living/silicon/ai/AI in player_list)
 			AI.client.images += blood
 
-	examine()
-		set src in view(2)
-
-		if(!iscultist(usr))
-			usr << "A strange collection of symbols drawn in blood."
+	examine(mob/user)
+		if(!iscultist(user))
+			user << "A strange collection of symbols drawn in blood."
 			return
 			/* Explosions... really?
 			if(desc && !usr.stat)
@@ -160,9 +158,9 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				qdel(src)
 			*/
 		if(!desc)
-			usr << "A spell circle drawn in blood. It reads: <i>[word1] [word2] [word3]</i>."
+			user << "A spell circle drawn in blood. It reads: <i>[word1] [word2] [word3]</i>."
 		else
-			usr << "Explosive Runes inscription in blood. It reads: <i>[desc]</i>."
+			user << "Explosive Runes inscription in blood. It reads: <i>[desc]</i>."
 
 		return
 
@@ -696,13 +694,12 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			user << "You copy the translation notes from your tome."
 
 
-	examine()
-		set src in usr
+	examine(mob/user)
 		..()
-		if(!iscultist(usr))
-			usr << "An old, dusty tome with frayed edges and a sinister looking cover."
+		if(!iscultist(user))
+			user << "An old, dusty tome with frayed edges and a sinister looking cover."
 		else
-			usr << "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though."
+			user << "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of."
 
 /obj/item/weapon/tome/imbued //admin tome, spawns working runes without waiting
 	w_class = 2.0

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -3,13 +3,6 @@
 	var/imbue = null
 	var/uses = 0
 
-
-	examine()
-		set src in view(2)
-		..()
-		return
-
-
 	attack_self(mob/living/user as mob)
 		if(iscultist(user))
 			var/delete = 1

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -54,11 +54,11 @@
 			the_disk = locate()
 		point_at(the_disk)
 
-	examine()
+	examine(mob/user)
 		..()
 		for(var/obj/machinery/nuclearbomb/bomb in world)
 			if(bomb.timing)
-				usr << "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]"
+				user << "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]"
 
 
 /obj/item/weapon/pinpointer/advpinpointer

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -80,10 +80,9 @@
 		t += "The connect error light is blinking."
 	return t
 
-/obj/machinery/meter/examine()
-	set src in view(3)
+/obj/machinery/meter/examine(mob/user)
 	..()
-	usr << status()
+	user << status()
 
 
 /obj/machinery/meter/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob)

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -41,15 +41,13 @@
 	if(!locked && open)
 		emagged = 2
 
-/obj/machinery/bot/examine()
-	set src in view()
+/obj/machinery/bot/examine(mob/user)
 	..()
 	if (src.health < maxhealth)
 		if (src.health > maxhealth/3)
-			usr << "<span class='warning'>[src]'s parts look loose.</span>"
+			user << "<span class='warning'>[src]'s parts look loose.</span>"
 		else
-			usr << "<span class='danger'>[src]'s parts look very loose!</span>"
-	return
+			user << "<span class='danger'>[src]'s parts look very loose!</span>"
 
 /obj/machinery/bot/attack_alien(var/mob/living/carbon/alien/user as mob)
 	src.health -= rand(15,30)*brute_dam_coeff

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -26,12 +26,11 @@
 	else
 		overlays.Cut()
 
-/obj/machinery/cell_charger/examine()
-	set src in oview(5)
+/obj/machinery/cell_charger/examine(mob/user)
 	..()
-	usr << "There's [charging ? "a" : "no"] cell in the charger."
+	user << "There's [charging ? "a" : "no"] cell in the charger."
 	if(charging)
-		usr << "Current charge: [charging.charge]"
+		user << "Current charge: [charging.charge]"
 
 /obj/machinery/cell_charger/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -85,11 +85,9 @@
 	read_only = !read_only
 	user << "You flip the write-protect tab to [src.read_only ? "protected" : "unprotected"]."
 
-/obj/item/weapon/disk/data/examine()
-	set src in oview(5)
+/obj/item/weapon/disk/data/examine(mob/user)
 	..()
-	usr << "The write-protect tab is set to [src.read_only ? "protected" : "unprotected"]."
-	return
+	user << "The write-protect tab is set to [src.read_only ? "protected" : "unprotected"]."
 
 //Health Tracker Implant
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -85,19 +85,19 @@
 	open_machine()
 	return
 
-/obj/machinery/atmospherics/unary/cryo_cell/examine()
+/obj/machinery/atmospherics/unary/cryo_cell/examine(mob/user)
 	..()
 
-	if(in_range(usr, src))
-		usr << "You can just about make out some loose objects floating in the murk:"
+	if(in_range(user, src))
+		user << "You can just about make out some loose objects floating in the murk:"
 		for(var/obj/O in src)
 			if(O != beaker)
-				usr << O.name
+				user << O.name
 		for(var/mob/M in src)
 			if(M != occupant)
-				usr << M.name
+				user << M.name
 	else
-		usr << "<span class='notice'>Too far away to view contents.</span>"
+		user << "<span class='notice'>Too far away to view contents.</span>"
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
 	ui_interact(user)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -36,11 +36,10 @@
 		else
 			icon_state = "light0"
 
-/obj/machinery/light_switch/examine()
-	set src in oview(1)
+/obj/machinery/light_switch/examine(mob/user)
 	..()
-	if(usr && !usr.stat)
-		usr << "It is [on? "on" : "off"]."
+	if(user && !user.stat)
+		user << "It is [on? "on" : "off"]."
 
 
 /obj/machinery/light_switch/attack_paw(mob/user)

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -19,12 +19,11 @@ var/const/SAFETY_COOLDOWN = 100
 	..()
 	update_icon()
 
-/obj/machinery/recycler/examine()
-	set src in view()
+/obj/machinery/recycler/examine(mob/user)
 	..()
-	usr << "The power light is [(stat & NOPOWER) ? "off" : "on"]."
-	usr << "The safety-mode light is [safety_mode ? "on" : "off"]."
-	usr << "The safety-sensors status light is [emagged ? "off" : "on"]."
+	user << "The power light is [(stat & NOPOWER) ? "off" : "on"]."
+	user << "The safety-mode light is [safety_mode ? "on" : "off"]."
+	user << "The safety-sensors status light is [emagged ? "off" : "on"]."
 
 /obj/machinery/recycler/power_change()
 	..()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -27,18 +27,13 @@
 			overlays  += "sheater-open"
 		return
 
-	examine()
-		set src in oview(12)
-		if (!( usr ))
-			return
+	examine(mob/user)
 		..()
-
-		usr << "The heater is [on ? "on" : "off"] and the hatch is [open ? "open" : "closed"]."
+		user << "The heater is [on ? "on" : "off"] and the hatch is [open ? "open" : "closed"]."
 		if(open)
-			usr << "The power cell is [cell ? "installed" : "missing"]."
+			user << "The power cell is [cell ? "installed" : "missing"]."
 		else
-			usr << "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
-		return
+			user << "The charge meter reads [cell ? round(cell.percent(),1) : 0]%"
 
 	emp_act(severity)
 		if(stat & (BROKEN|NOPOWER))

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -122,12 +122,11 @@
 						line1 = ""
 				update_display(line1, line2)
 
-	examine()
-		set src in view()
+	examine(mob/user)
 		. = ..()
 		switch(mode)
 			if(1,2,4)
-				usr << "The display says:<br>\t<xmp>[message1]</xmp><br>\t<xmp>[message2]</xmp>"
+				user << "The display says:<br>\t<xmp>[message1]</xmp><br>\t<xmp>[message2]</xmp>"
 
 
 	proc/set_message(m1, m2)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -41,9 +41,9 @@
 	..()
 
 
-/obj/machinery/syndicatebomb/examine()
+/obj/machinery/syndicatebomb/examine(mob/user)
 	..()
-	usr << "A digital display on it reads \"[timer]\"."
+	user << "A digital display on it reads \"[timer]\"."
 
 /obj/machinery/syndicatebomb/update_icon()
 	icon_state = "[initial(icon_state)][active ? "-active" : "-inactive"][open_panel ? "-wires" : ""]"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -166,25 +166,24 @@
 	else
 		return 0
 
-/obj/mecha/examine()
-	set src in view()
+/obj/mecha/examine(mob/user)
 	..()
 	var/integrity = health/initial(health)*100
 	switch(integrity)
 		if(85 to 100)
-			usr << "It's fully intact."
+			user << "It's fully intact."
 		if(65 to 85)
-			usr << "It's slightly damaged."
+			user << "It's slightly damaged."
 		if(45 to 65)
-			usr << "It's badly damaged."
+			user << "It's badly damaged."
 		if(25 to 45)
-			usr << "It's heavily damaged."
+			user << "It's heavily damaged."
 		else
-			usr << "It's falling apart."
+			user << "It's falling apart."
 	if(equipment && equipment.len)
-		usr << "It's equipped with:"
+		user << "It's equipped with:"
 		for(var/obj/item/mecha_parts/mecha_equipment/ME in equipment)
-			usr << "\icon[ME] [ME]"
+			user << "\icon[ME] [ME]"
 	return
 
 

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -6,13 +6,6 @@
 	layer = 2.1
 	anchored = 1
 
-
-	examine()
-		set src in view(2)
-		..()
-		return
-
-
 	New(location,main = "#FFFFFF", var/type = "rune")
 		..()
 		loc = location

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -84,9 +84,8 @@
 
 	src.loc = T
 
-/obj/item/examine()
-	set src in view()
-
+/obj/item/examine(mob/user) //This might be spammy. Remove?
+	..()
 	var/size
 	switch(src.w_class)
 		if(1.0)
@@ -104,25 +103,13 @@
 		else
 	//if ((CLUMSY in usr.mutations) && prob(50)) t = "funny-looking"
 
-	//This reformat names to get a/an properly working on item descriptions when they are bloody
-	var/f_name = "\a [src]"
-	if(src.blood_DNA)
-		f_name = "a bloody [name]"
-
-	var/determiner
 	var/pronoun
 	if(src.gender == PLURAL)
-		determiner = "These are"
 		pronoun = "They are"
 	else
-		determiner = "This is"
 		pronoun = "It is"
 
-	usr << "\icon[src][determiner] [f_name]. [pronoun] a [size] item." //e.g. These are some gloves. They are a small item. or This is a toolbox. It is a bulky item.
-
-	if(src.desc)
-		usr << src.desc
-	return
+	user << "[pronoun] a [size] item." //e.g. They are a small item. or It is a bulky item.
 
 /obj/item/attack_hand(mob/user as mob)
 	if (!user) return

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -249,10 +249,6 @@
 		emp_cur_charges = min(emp_cur_charges+1, emp_max_charges)
 		return 1
 
-/obj/item/device/flashlight/emp/examine()
-	..()
-	return
-
 /obj/item/device/flashlight/emp/attack(mob/living/M as mob, mob/living/user as mob)
 	if(on && user.zone_sel.selecting == "eyes") // call original attack proc only if aiming at the eyes
 		..()

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -66,10 +66,9 @@
 	failmsg = "The [name]'s refill light blinks red."
 	..()
 
-/obj/item/device/lightreplacer/examine()
-	set src in view(2)
+/obj/item/device/lightreplacer/examine(mob/user)
 	..()
-	usr << "It has [uses] lights remaining."
+	user << "It has [uses] light\s remaining."
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user)
 	if(istype(W,  /obj/item/weapon/card/emag) && emagged == 0)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -658,15 +658,13 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 		return get_mobs_in_view(canhear_range, src)
 
 
-/obj/item/device/radio/examine()
-	set src in view()
-
+/obj/item/device/radio/examine(mob/user)
 	..()
-	if ((in_range(src, usr) || loc == usr))
+	if ((in_range(src, user) || loc == user))
 		if (b_stat)
-			usr.show_message("\blue \the [src] can be attached and modified!")
+			user.show_message("<span class='notice'>\The [src] can be attached and modified.</span>")
 		else
-			usr.show_message("\blue \the [src] can not be modified or attached!")
+			user.show_message("<span class='notice'>\The [src] can not be modified or attached.</span>")
 	return
 
 /obj/item/device/radio/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -24,10 +24,9 @@
 	update_icon()
 
 
-/obj/item/device/taperecorder/examine()
-	set src in view(1)
+/obj/item/device/taperecorder/examine(mob/user)
 	..()
-	usr << "The wire panel is [open_panel ? "opened" : "closed"]."
+	user << "The wire panel is [open_panel ? "opened" : "closed"]."
 
 
 /obj/item/device/taperecorder/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -26,19 +26,17 @@
 		usr << browse(null, "window=stack")
 	..()
 
-/obj/item/stack/examine()
-	set src in view(1)
+/obj/item/stack/examine(mob/user)
 	..()
 	if(src.singular_name)
 		if(src.amount>1)
-			usr << "There are [src.amount] [src.singular_name]\s in the stack."
+			user << "There are [src.amount] [src.singular_name]\s in the stack."
 		else
-			usr << "There is [src.amount] [src.singular_name] in the stack."
+			user << "There is [src.amount] [src.singular_name] in the stack."
 	else if(src.amount>1)
-		usr << "There are [src.amount] in the stack."
+		user << "There are [src.amount] in the stack."
 	else
-		usr << "There is [src.amount] in the stack."
-	return
+		user << "There is [src.amount] in the stack."
 
 /obj/item/stack/attack_self(mob/user as mob)
 	interact(user)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -109,7 +109,7 @@
  */
 /obj/item/toy/gun
 	name = "cap gun"
-	desc = "There are 0 caps left. Looks almost like the real thing! Ages 8 and up. Please recycle in an autolathe when you're out of caps!"
+	desc = "Looks almost like the real thing! Ages 8 and up. Please recycle in an autolathe when you're out of caps!"
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "revolver"
 	item_state = "gun"
@@ -121,12 +121,9 @@
 	attack_verb = list("struck", "pistol whipped", "hit", "bashed")
 	var/bullets = 7.0
 
-	examine()
-		set src in usr
-
-		src.desc = text("There are [] cap\s left. Looks almost like the real thing! Ages 8 and up.", src.bullets)
+	examine(mob/user)
 		..()
-		return
+		user << "There are [bullets] cap\s left."
 
 	attackby(obj/item/toy/ammo/gun/A as obj, mob/user as mob)
 
@@ -193,11 +190,9 @@
 	attack_verb = list("attacked", "struck", "hit")
 	var/bullets = 5
 
-	examine()
-		set src in view(2)
+	examine(mob/user)
 		..()
-		if (bullets)
-			usr << "\blue It is loaded with [bullets] foam darts!"
+		user << "\blue It is loaded with [bullets] foam dart\s."
 
 	attackby(obj/item/I as obj, mob/user as mob)
 		if(istype(I, /obj/item/toy/ammo/crossbow))
@@ -815,10 +810,9 @@ obj/item/toy/cards/singlecard
 	pixel_x = -5
 
 
-obj/item/toy/cards/singlecard/examine()
-	set src in usr.contents
-	if(ishuman(usr))
-		var/mob/living/carbon/human/cardUser = usr
+obj/item/toy/cards/singlecard/examine(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/cardUser = user
 		if(cardUser.get_item_by_slot(slot_l_hand) == src || cardUser.get_item_by_slot(slot_r_hand) == src)
 			cardUser.visible_message("<span class='notice'>[cardUser] checks \his card.</span>", "<span class='notice'>The card reads: [src.cardname]</span>")
 		else

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -42,10 +42,10 @@
 		else
 			return 1
 
-	examine()
+	examine(mob/user)
 		..()
 		if(!ink)
-			usr << "<span class='notice'>It doesn't have a toner cardridge installed.</span>"
+			user << "<span class='notice'>It doesn't have a toner cardridge installed.</span>"
 			return
 		var/ink_level = "high"
 		if(ink.charges < 1)
@@ -54,7 +54,7 @@
 			ink_level = "low"
 		else if((ink.charges/ink.max_charges) > 1) //Over 100% (admin var edit)
 			ink_level = "dangerously high"
-		usr << "<span class='notice'>Its ink levels look [ink_level].</span>"
+		user << "<span class='notice'>Its ink levels look [ink_level].</span>"
 
 	attackby(obj/item/weapon/W, mob/user)
 		..()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -79,10 +79,10 @@
 	src.add_fingerprint(user)
 	return
 
-/obj/item/weapon/card/id/examine()
+/obj/item/weapon/card/id/examine(mob/user)
 	..()
 	if(mining_points)
-		usr << "There's [mining_points] mining equipment redemption points loaded onto this card."
+		user << "There's [mining_points] mining equipment redemption points loaded onto this card."
 
 /obj/item/weapon/card/id/GetAccess()
 	return access

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -557,6 +557,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		user << "You take the last paper out of the pack, and throw the pack away."
 		qdel(src)
 
-/obj/item/weapon/rollingpaperpack/examine()
+/obj/item/weapon/rollingpaperpack/examine(mob/user)
 	..()
-	usr << "There are [src.papers] left"
+	user << "There are [src.papers] left"

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -36,12 +36,6 @@
 	create_reagents(max_water)
 	reagents.add_reagent("water", max_water)
 
-/obj/item/weapon/extinguisher/examine()
-	set src in usr
-	..()
-	usr << "It contains [src.reagents.total_volume] units of water!"
-	return
-
 /obj/item/weapon/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
 	src.icon_state = "[sprite_name][!safety]"

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -20,8 +20,7 @@
 	create_reagents(1000)
 
 
-/obj/item/weapon/grenade/chem_grenade/examine()
-	set src in usr
+/obj/item/weapon/grenade/chem_grenade/examine(mob/user)
 	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
 	..()
 

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -86,8 +86,7 @@
 	explosion(src.loc,-1,0,2)
 	qdel(src)
 
-/obj/item/weapon/grenade/iedcasing/examine()
-	set src in usr
+/obj/item/weapon/grenade/iedcasing/examine(mob/user)
 	..()
 	if(assembled == 3)
-		usr << "You can't tell when it will explode!"
+		user << "You can't tell when it will explode!"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -45,14 +45,13 @@
 	return*/
 
 
-/obj/item/weapon/grenade/examine()
-	set src in usr
+/obj/item/weapon/grenade/examine(mob/user)
 	..()
 	if(display_timer)
 		if(det_time > 1)
-			usr << "The timer is set to [det_time/10] seconds."
+			user << "The timer is set to [det_time/10] second\s."
 		else
-			usr << "\The [src] is set for instant detonation."
+			user << "\The [src] is set for instant detonation."
 
 
 /obj/item/weapon/grenade/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -24,19 +24,14 @@
 	src.icon_state = "[src.icon_type]box[total_contents]"
 	return
 
-/obj/item/weapon/storage/fancy/examine()
-	set src in oview(1)
+/obj/item/weapon/storage/fancy/examine(mob/user)
 	..()
 	if(contents.len <= 0)
-		usr << "There are no [src.icon_type]s left in the box."
+		user << "There are no [src.icon_type]s left in the box."
 	else if(contents.len == 1)
-		usr << "There is one [src.icon_type] left in the box."
+		user << "There is one [src.icon_type] left in the box."
 	else
-		usr << "There are [src.contents.len] [src.icon_type]s in the box."
-
-	return
-
-
+		user << "There are [src.contents.len] [src.icon_type]s in the box."
 
 /*
  * Donut Box

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -27,10 +27,9 @@
 	max_w_class = 2
 	max_combined_w_class = 14
 
-	examine()
-		set src in oview(1)
+	examine(mob/user)
 		..()
-		usr << text("The service panel is [src.open ? "open" : "closed"].")
+		user << text("The service panel is [src.open ? "open" : "closed"].")
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob)
 		if(locked)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -50,13 +50,12 @@
 	else
 		icon_state = "[initial(name)]"
 
-/obj/item/weapon/melee/baton/examine()
-	set src in view(1)
+/obj/item/weapon/melee/baton/examine(mob/user)
 	..()
 	if(bcell)
-		usr <<"<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>"
+		user <<"<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>"
 	if(!bcell)
-		usr <<"<span class='warning'>The baton does not have a power source installed.</span>"
+		user <<"<span class='warning'>The baton does not have a power source installed.</span>"
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/stock_parts/cell))

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -23,12 +23,11 @@
 		return
 
 
-	examine()
-		set src in usr
+	examine(mob/user)
 		..()
 		if(air_contents.oxygen < 10)
-			usr << text("\red <B>The meter on the [src.name] indicates you are almost out of air!</B>")
-			playsound(usr, 'sound/effects/alert.ogg', 50, 1)
+			user << text("<span class='userdanger'>The meter on the [src.name] indicates you are almost out of air!</span>")
+			playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 
 /obj/item/weapon/tank/oxygen/yellow
@@ -69,12 +68,11 @@
 	icon_state = "oxygen"
 
 
-	examine()
-		set src in usr
+	examine(mob/user)
 		..()
-		if(air_contents.oxygen < 1 && loc==usr)
-			usr << "\red <B>The meter on the [src.name] indicates you are almost out of air!</B>"
-			usr << sound('sound/effects/alert.ogg')
+		if(air_contents.oxygen < 1 && loc==user)
+			user << text("<span class='userdanger'>The meter on the [src.name] indicates you are almost out of air!</span>")
+			playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/air/New()
 	..()
@@ -139,12 +137,11 @@
 		return
 
 
-	examine()
-		set src in usr
+	examine(mob/user)
 		..()
-		if(air_contents.oxygen < 0.2 && loc==usr)
-			usr << text("\red <B>The meter on the [src.name] indicates you are almost out of air!</B>")
-			usr << sound('sound/effects/alert.ogg')
+		if(air_contents.oxygen < 0.2 && loc==user)
+			user << text("<span class='userdanger'>The meter on the [src.name] indicates you are almost out of air!</span>")
+			playsound(user, 'sound/effects/alert.ogg', 50, 1)
 
 /obj/item/weapon/tank/emergency_oxygen/engi
 	name = "extended-capacity emergency oxygen tank"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -36,13 +36,13 @@
 
 	..()
 
-/obj/item/weapon/tank/examine()
+/obj/item/weapon/tank/examine(mob/user)
 	var/obj/icon = src
 	..()
 	if (istype(src.loc, /obj/item/assembly))
 		icon = src.loc
-	if (!in_range(src, usr))
-		if (icon == src) usr << "\blue If you want any more information you'll need to get closer."
+	if (!in_range(src, user))
+		if (icon == src) user << "<span class='notice'>If you want any more information you'll need to get closer.</span>"
 		return
 
 	var/celsius_temperature = src.air_contents.temperature-T0C
@@ -61,9 +61,7 @@
 	else
 		descriptive = "furiously hot"
 
-	usr << "\blue It feels [descriptive]"
-
-	return
+	user << "<span class='notice'>It feels [descriptive].</span>"
 
 /obj/item/weapon/tank/blob_act()
 	if(prob(50))

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -18,14 +18,6 @@
 	..()
 	create_reagents(volume)
 	noz = make_noz()
-	return
-
-/obj/item/weapon/watertank/examine()
-	set src in usr
-	..()
-	for(var/datum/reagent/R in reagents.reagent_list)
-		usr << "[round(R.volume)] units of [R.name] left."
-	return
 
 /obj/item/weapon/watertank/ui_action_click()
 	if (usr.get_item_by_slot(slot_back) == src)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -151,10 +151,9 @@
 	reagents.add_reagent("fuel", max_fuel)
 
 
-/obj/item/weapon/weldingtool/examine()
-	set src in usr
+/obj/item/weapon/weldingtool/examine(mob/user)
 	..()
-	usr << "It contains [get_fuel()]/[max_fuel] units of fuel!"
+	user << "It contains [get_fuel()] unit\s of fuel out of [max_fuel]."
 
 
 /obj/item/weapon/weldingtool/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -20,13 +20,12 @@
 	if(isnum(amt) && amt > -1)
 		charges = amt
 
-/obj/item/weapon/vending_refill/examine()
-	set src in usr
+/obj/item/weapon/vending_refill/examine(mob/user)
 	..()
 	if(charges)
-		usr << "It can restock [charges] item(s)."
+		user << "It can restock [charges] item(s)."
 	else
-		usr << "It's empty!"
+		user << "It's empty!"
 
 //NOTE I decided to go for about 1/3 of a machine's capacity
 

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -163,15 +163,14 @@ LINEN BINS
 	var/obj/item/hidden = null
 
 
-/obj/structure/bedsheetbin/examine()
+/obj/structure/bedsheetbin/examine(mob/user)
 	..()
 	if(amount < 1)
-		usr << "There are no bed sheets in the bin."
-		return
-	if(amount == 1)
-		usr << "There is one bed sheet in the bin."
-		return
-	usr << "There are [amount] bed sheets in the bin."
+		user << "There are no bed sheets in the bin."
+	else if(amount == 1)
+		user << "There is one bed sheet in the bin."
+	else
+		user << "There are [amount] bed sheets in the bin."
 
 
 /obj/structure/bedsheetbin/update_icon()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -20,10 +20,9 @@
 	create_reagents(100)
 
 
-/obj/structure/janitorialcart/examine()
-	set src in usr
+/obj/structure/janitorialcart/examine(mob/user)
 	..()
-	usr << "It contains [reagents.total_volume] unit\s of liquid!"
+	user << "It contains [reagents.total_volume] unit\s of liquid."
 	//everything else is visible, so doesn't need to be mentioned
 
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/weapon/mop, mob/user)
@@ -176,12 +175,10 @@
 	create_reagents(100)
 
 
-/obj/structure/stool/bed/chair/janicart/examine()
-	set src in usr
+/obj/structure/stool/bed/chair/janicart/examine(mob/user)
 	..()
-	usr << "It contains [reagents.total_volume] unit\s of water!"
 	if(mybag)
-		usr << "\A [mybag] is hanging on the [callme]."
+		user << "\A [mybag] is hanging on \the [callme]."
 
 
 /obj/structure/stool/bed/chair/janicart/attackby(obj/item/I, mob/user)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -12,12 +12,6 @@
 /obj/structure/mopbucket/New()
 	create_reagents(100)
 
-
-/obj/structure/mopbucket/examine()
-	set src in usr
-	..()
-	usr << "It contains [reagents.total_volume] unit\s of water!"
-
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/mop))
 		if(reagents.total_volume < 1)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -124,15 +124,13 @@
 		return
 
 
-	examine()
-		set src in view()
+	examine(mob/user)
 		..()
-		if((in_range(src, usr) || loc == usr))
+		if((in_range(src, user) || loc == user))
 			if(secured)
-				usr << "\The [src] is ready!"
+				user << "\The [src] is secured and ready to be used."
 			else
-				usr << "\The [src] can be attached!"
-		return
+				user << "\The [src] can be attached to other things."
 
 
 	attack_self(mob/user as mob)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -11,9 +11,9 @@
 	var/obj/item/device/assembly_holder/bombassembly = null   //The first part of the bomb is an assembly holder, holding an igniter+some device
 	var/obj/item/weapon/tank/bombtank = null //the second part of the bomb is a plasma tank
 
-/obj/item/device/onetankbomb/examine()
+/obj/item/device/onetankbomb/examine(mob/user)
 	..()
-	bombtank.examine()
+	bombtank.examine(user)
 
 /obj/item/device/onetankbomb/update_icon()
 	if(bombtank)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -57,15 +57,13 @@
 			master.update_icon()
 
 
-	examine()
-		set src in view()
+	examine(mob/user)
 		..()
-		if ((in_range(src, usr) || src.loc == usr))
-			if (src.secured)
-				usr << "\The [src] is ready!"
+		if ((in_range(src, user) || src.loc == user))
+			if(secured)
+				user << "\The [src] is secured and ready to be used."
 			else
-				usr << "\The [src] can be attached!"
-		return
+				user << "\The [src] can be attached to other things."
 
 
 	HasProximity(atom/movable/AM as mob|obj)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -7,10 +7,10 @@
 	var/armed = 0
 
 
-	examine()
+	examine(mob/user)
 		..()
 		if(armed)
-			usr << "It looks like it's armed."
+			user << "It looks like it's armed."
 
 	activate()
 		if(..())

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -194,20 +194,19 @@ BLIND     // can't see anything
 			return
 
 
-/obj/item/clothing/under/examine()
-	set src in view()
+/obj/item/clothing/under/examine(mob/user)
 	..()
 	switch(src.sensor_mode)
 		if(0)
-			usr << "Its sensors appear to be disabled."
+			user << "Its sensors appear to be disabled."
 		if(1)
-			usr << "Its binary life sensors appear to be enabled."
+			user << "Its binary life sensors appear to be enabled."
 		if(2)
-			usr << "Its vital tracker appears to be enabled."
+			user << "Its vital tracker appears to be enabled."
 		if(3)
-			usr << "Its vital tracker and tracking beacon appear to be enabled."
+			user << "Its vital tracker and tracking beacon appear to be enabled."
 	if(hastie)
-		usr << "\A [hastie] is attached to it."
+		user << "\A [hastie] is attached to it."
 
 atom/proc/generate_uniform(index,t_color)
 	var/icon/female_uniform_icon	= icon("icon"='icons/mob/uniform.dmi', "icon_state"="[t_color]_s")

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -28,10 +28,9 @@
 	user.update_inv_shoes(0)	//so our mob-overlays update
 
 
-/obj/item/clothing/shoes/magboots/examine()
-	set src in view()
+/obj/item/clothing/shoes/magboots/examine(mob/user)
 	..()
-	usr << "Its mag-pulse traction system appears to be [magpulse ? "enabled" : "disabled"]."
+	user << "Its mag-pulse traction system appears to be [magpulse ? "enabled" : "disabled"]."
 
 
 /obj/item/clothing/shoes/magboots/advance

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -2244,21 +2244,20 @@ ________________________________________________________________________________
 				U.drop_item()
 	return 0
 
-/obj/item/clothing/suit/space/space_ninja/examine()
-	set src in view()
+/obj/item/clothing/suit/space/space_ninja/examine(mob/user)
 	..()
 	if(s_initialized)
-		var/mob/living/carbon/human/U = affecting
-		if(s_control)
-			U << "All systems operational. Current energy capacity: <B>[cell.charge]</B>."
-			if(!kamikaze)
-				U << "The CLOAK-tech device is <B>[s_active?"active":"inactive"]</B>."
+		if(user == affecting)
+			if(s_control)
+				user << "All systems operational. Current energy capacity: <B>[cell.charge]</B>."
+				if(!kamikaze)
+					user << "The CLOAK-tech device is <B>[s_active?"active":"inactive"]</B>."
+				else
+					user << "<span class='userdanger'>KAMIKAZE MODE ENGAGED!</span>"
+				user << "There are <B>[s_bombs]</B> smoke bomb\s remaining."
+				user << "There are <B>[a_boost]</B> adrenaline booster\s remaining."
 			else
-				U << "\red KAMIKAZE MODE ENGAGED!"
-			U << "There are <B>[s_bombs]</B> smoke bombs remaining."
-			U << "There are <B>[a_boost]</B> adrenaline boosters remaining."
-		else
-			U <<  "�rr�R �a��a�� No-�-� f��N� 3RR�r"
+				user <<  "�rr�R �a��a�� No-�-� f��N� 3RR�r"
 
 /*
 ===================================================================================
@@ -2503,12 +2502,10 @@ ________________________________________________________________________________
 	U << "You <b>[candrain?"disable":"enable"]</b> special interaction."
 	candrain=!candrain
 
-/obj/item/clothing/gloves/space_ninja/examine()
-	set src in view()
+/obj/item/clothing/gloves/space_ninja/examine(mob/user)
 	..()
 	if(flags & NODROP)
-		var/mob/living/carbon/human/U = loc
-		U << "The energy drain mechanism is: <B>[candrain?"active":"inactive"]</B>."
+		user << "The energy drain mechanism is: <B>[candrain?"active":"inactive"]</B>."
 
 /*
 ===================================================================================
@@ -2608,8 +2605,7 @@ ________________________________________________________________________________
 			U.sight &= ~SEE_TURFS
 			U << "Switching mode to <B>Scouter</B>."
 
-/obj/item/clothing/mask/gas/voice/space_ninja/examine()
-	set src in view()
+/obj/item/clothing/mask/gas/voice/space_ninja/examine(mob/user)
 	..()
 
 	var/mode
@@ -2622,8 +2618,8 @@ ________________________________________________________________________________
 			mode = "Thermal Scanner"
 		if(3)
 			mode = "Meson Scanner"
-	usr << "<B>[mode]</B> is active."//Leaving usr here since it may be on the floor or on a person.
-	usr << "Voice mimicking algorithm is set <B>[!vchange?"inactive":"active"]</B>."
+	user << "<B>[mode]</B> is active."//Leaving usr here since it may be on the floor or on a person.
+	user << "Voice mimicking algorithm is set <B>[!vchange?"inactive":"active"]</B>."
 
 /*
 ===================================================================================

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -295,9 +295,9 @@
 			user << "<span class='info'>There's no points left on [src].</span>"
 	..()
 
-/obj/item/weapon/card/mining_point_card/examine()
+/obj/item/weapon/card/mining_point_card/examine(mob/user)
 	..()
-	usr << "There's [points] points on the card."
+	user << "There's [points] point\s on the card."
 
 /**********************Jaunter**********************/
 
@@ -436,12 +436,9 @@
 /obj/item/clothing/mask/facehugger/toy
 	desc = "A toy often used to play pranks on other miners by putting it in their beds. It takes a bit to recharge after latching onto something."
 	throwforce = 0
+	real = 0
 	sterile = 1
 	tint = 3 //Makes it feel more authentic when it latches on
-
-/obj/item/clothing/mask/facehugger/toy/examine()//So that giant red text about probisci doesn't show up.
-	if(desc)
-		usr << desc
 
 /obj/item/clothing/mask/facehugger/toy/Die()
 	return
@@ -628,12 +625,12 @@
 	if(!malfunctioning)
 		malfunctioning = 1
 
-/obj/item/weapon/lazarus_injector/examine()
+/obj/item/weapon/lazarus_injector/examine(mob/user)
 	..()
 	if(!loaded)
-		usr << "<span class='info'>[src] is empty.</span>"
+		user << "<span class='info'>[src] is empty.</span>"
 	if(malfunctioning)
-		usr << "<span class='info'>The display on [src] seems to be flickering.</span>"
+		user << "<span class='info'>The display on [src] seems to be flickering.</span>"
 
 /**********************Mining Scanner**********************/
 /obj/item/device/mining_scanner

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -103,10 +103,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/obj/effect/step_trigger/S in locate(x, y, z))	//<-- this is dumb
 		S.Crossed(src)
 
-/mob/dead/observer/examine()
-	if(usr)
-		usr << desc
-
 /mob/dead/observer/can_use_hands()	return 0
 /mob/dead/observer/is_active()		return 0
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -21,7 +21,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 
 	var/sterile = 0
-
+	var/real = 1 //0 for the toy, 1 for real. Sure I could istype, but fuck that.
 	var/strength = 5
 
 	var/attached = 0
@@ -43,16 +43,17 @@ var/const/MAX_ACTIVE_TIME = 400
 	user.unEquip(src)
 	Attach(M)
 
-/obj/item/clothing/mask/facehugger/examine()
+/obj/item/clothing/mask/facehugger/examine(mob/user)
 	..()
+	if(!real)
+		return
 	switch(stat)
 		if(DEAD,UNCONSCIOUS)
-			usr << "\red \b [src] is not moving."
+			user << "<span class='danger'>[src] is not moving.</span>"
 		if(CONSCIOUS)
-			usr << "\red \b [src] seems to be active."
+			user << "<span class='userdanger'>[src] seems to be active!</span>"
 	if (sterile)
-		usr << "\red \b It looks like the proboscis has been removed."
-	return
+		user << "<span class='notice'>It looks like the proboscis has been removed.</span>"
 
 /obj/item/clothing/mask/facehugger/attackby(var/obj/item/O,var/mob/m)
 	if(O.force)

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -33,15 +33,12 @@
 	brainmob << "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>"
 
 
-/obj/item/organ/brain/examine()
-	set src in oview(12)
-	if(!usr)	return
-
+/obj/item/organ/brain/examine(mob/user)
 	..()
 	if(brainmob && brainmob.client)
-		usr << "You can feel the small spark of life still left in this one."
+		user << "You can feel the small spark of life still left in this one."
 	else
-		usr << "This one seems particularly lifeless. Perhaps it will regain some of it's luster later.."
+		user << "This one seems particularly lifeless. Perhaps it will regain some of its luster later."
 
 
 /obj/item/organ/brain/attack(mob/living/carbon/M, mob/user)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,10 +1,4 @@
-/mob/living/carbon/human/examine()
-	set src in view()
-
-	if(!usr || !src)	return
-	if( usr.sdisabilities & BLIND || usr.blinded || usr.stat==UNCONSCIOUS )
-		usr << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
+/mob/living/carbon/human/examine(mob/user)
 
 	var/skipgloves = 0
 	var/skipsuitstorage = 0
@@ -176,7 +170,7 @@
 		else if(istype(wear_id, /obj/item/weapon/card/id)) //just in case something other than a PDA/ID card somehow gets in the ID slot :[
 			var/obj/item/weapon/card/id/idcard = wear_id
 			id = idcard.registered_name
-		if(id && (id != real_name) && (get_dist(src, usr) <= 1) && prob(10))
+		if(id && (id != real_name) && (get_dist(src, user) <= 1) && prob(10))
 			msg += "<span class='warning'>[t_He] [t_is] wearing \icon[wear_id] \a [wear_id] yet something doesn't seem right...</span>\n"
 		else*/
 		msg += "[t_He] [t_is] wearing \icon[wear_id] \a [wear_id].\n"
@@ -253,7 +247,7 @@
 	if(nutrition < 100)
 		msg += "[t_He] [t_is] severely malnourished.\n"
 	else if(nutrition >= 500)
-		if(usr.nutrition < 100)
+		if(user.nutrition < 100)
 			msg += "[t_He] [t_is] plump and delicious looking - Like a fat little piggy. A tasty piggy.\n"
 		else
 			msg += "[t_He] [t_is] quite chubby.\n"
@@ -276,10 +270,10 @@
 			msg += "[t_He] [t_is] repulsively uncanny!\n"
 
 
-	if(istype(usr, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = usr
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
 		if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
-			if(!usr.stat && usr != src) //|| !usr.canmove || usr.restrained()) Fluff: Sechuds have eye-tracking technology and sets 'arrest' to people that the wearer looks and blinks at.
+			if(!user.stat && user != src) //|| !user.canmove || user.restrained()) Fluff: Sechuds have eye-tracking technology and sets 'arrest' to people that the wearer looks and blinks at.
 				var/criminal = "None"
 
 				var/perpname = get_face_name(get_id_name(""))
@@ -292,4 +286,4 @@
 
 	msg += "*---------*</span>"
 
-	usr << msg
+	user << msg

--- a/code/modules/mob/living/carbon/metroid/examine.dm
+++ b/code/modules/mob/living/carbon/metroid/examine.dm
@@ -1,10 +1,4 @@
-/mob/living/carbon/slime/examine()
-	set src in oview()
-
-	if(!usr || !src)	return
-	if( (usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr,/mob/dead/observer) )
-		usr << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
+/mob/living/carbon/slime/examine(mob/user)
 
 	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
 	if (src.stat == DEAD)
@@ -33,5 +27,5 @@
 				msg += "<span class='warning'><B>It is radiating with massive levels of electrical activity!</B></span>\n"
 
 	msg += "*---------*</span>"
-	usr << msg
+	user << msg
 	return

--- a/code/modules/mob/living/carbon/monkey/examine.dm
+++ b/code/modules/mob/living/carbon/monkey/examine.dm
@@ -1,11 +1,4 @@
-/mob/living/carbon/monkey/examine()
-	set src in oview()
-
-	if(!usr || !src)	return
-	if( (usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr,/mob/dead/observer) )
-		usr << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
-
+/mob/living/carbon/monkey/examine(mob/user)
 	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
 
 	if (src.handcuffed)
@@ -47,5 +40,4 @@
 
 	msg += "*---------*</span>"
 
-	usr << msg
-	return
+	user << msg

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -1,11 +1,4 @@
-/mob/living/silicon/ai/examine()
-	set src in oview()
-
-	if(!usr || !src)	return
-	if( (usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr,/mob/dead/observer) )
-		usr << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
-
+/mob/living/silicon/ai/examine(mob/user)
 	var/msg = "<span class='info'>*---------*\nThis is \icon[src] <EM>[src]</EM>!\n"
 	if (src.stat == DEAD)
 		msg += "<span class='deadsay'>It appears to be powered-down.</span>\n"
@@ -27,5 +20,4 @@
 		msg += "</span>"
 	msg += "*---------*</span>"
 
-	usr << msg
-	return
+	user << msg

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -1,27 +1,2 @@
 /mob/living/silicon/pai/examine() //removed as it was pointless...moved to the pai-card instead.
-	/* This is totaly pointless because this mob is contained inside a card!
-	set src in oview()
-
-	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
-	if (src.stat == DEAD)
-		msg += "<span class='deadsay'>It appears to be offline.</span>\n"
-	else
-		msg += "<span class='warning'>"
-		if (src.getBruteLoss())
-			if (src.getBruteLoss() < 30)
-				msg += "It looks slightly dented.\n"
-			else
-				msg += "<B>Its casing appears cracked and broken!</B>\n"
-		if (src.getFireLoss())
-			if (src.getFireLoss() < 30)
-				msg += "It looks slightly charred!\n"
-			else
-				msg += "<B>Its casing is melted and heat-warped!</B>\n"
-		if (src.stat == UNCONSCIOUS)
-			msg += "It doesn't seem to be responding and its text-output is lagging.\n"
-		msg += "</span>"
-	msg += "*---------*</span>"
-
-	usr << msg
-	*/
 	return

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,11 +1,4 @@
-/mob/living/silicon/robot/examine()
-	set src in oview()
-
-	if(!usr || !src)	return
-	if( (usr.sdisabilities & BLIND || usr.blinded || usr.stat) && !istype(usr,/mob/dead/observer) )
-		usr << "<span class='notice'>Something is there but you can't see it.</span>"
-		return
-
+/mob/living/silicon/robot/examine(mob/user)
 	var/msg = "<span class='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
 	var/obj/act_module = get_active_hand()
 	if(act_module)
@@ -41,5 +34,4 @@
 		if(DEAD)			msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>\n"
 	msg += "*---------*</span>"
 
-	usr << msg
-	return
+	user << msg

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -43,9 +43,7 @@
 	qdel(src)
 	return
 
-/mob/living/simple_animal/construct/examine()
-	set src in oview()
-
+/mob/living/simple_animal/construct/examine(mob/user)
 	var/msg = "<span cass='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
 	if (src.health < src.maxHealth)
 		msg += "<span class='warning'>"
@@ -56,8 +54,7 @@
 		msg += "</span>"
 	msg += "*---------*</span>"
 
-	usr << msg
-	return
+	user << msg
 
 /mob/living/simple_animal/construct/Bump(atom/movable/AM as mob|obj, yes)
 	if ((!( yes ) || now_pushing))

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -30,12 +30,12 @@
 	var/image/cap_living = null //Where we store our cap icons so we dont generate them constantly to update our icon
 	var/image/cap_dead = null
 
-/mob/living/simple_animal/hostile/mushroom/examine()
+/mob/living/simple_animal/hostile/mushroom/examine(mob/user)
 	..()
 	if(health >= maxHealth)
-		usr << "<span class='info'>It looks healthy.</span>"
+		user << "<span class='info'>It looks healthy.</span>"
 	else
-		usr << "<span class='info'>It looks like it's been roughed up.</span>"
+		user << "<span class='info'>It looks like it's been roughed up.</span>"
 
 /mob/living/simple_animal/hostile/mushroom/Life()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -249,6 +249,13 @@ var/list/slot_equipment_priority = list( \
 	user << browse(dat, "window=mob\ref[src];size=325x500")
 	onclose(user, "mob\ref[src]")
 
+//mob verbs are faster than object verbs. See http://www.byond.com/forum/?post=1326139&page=2#comment8198716
+/mob/verb/examinate(atom/A as mob|obj|turf in view()) //It used to be oview(12), but I can't really say why
+	set name = "Examine"
+	set category = "IC"
+
+	face_atom(A)
+	A.examine(src)
 
 /mob/verb/mode()
 	set name = "Activate Held Object"

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -103,7 +103,7 @@
 		if(href_list["read"])
 			var/obj/item/weapon/paper/P = locate(href_list["read"])
 			if(istype(P) && P.loc == src)
-				P.examine()
+				usr.examine(P)
 
 		if(href_list["top"])
 			var/obj/item/P = locate(href_list["top"])

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -69,7 +69,7 @@
 		if(href_list["read"])
 			var/obj/item/weapon/paper/P = locate(href_list["read"])
 			if(istype(P) && P.loc == src)
-				P.examine()
+				usr.examine(P)
 
 		//Update everything
 		attack_self(usr)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -48,20 +48,18 @@
 	icon_state = "paper"
 
 
-/obj/item/weapon/paper/examine()
-	set src in oview(1)
-
-	if(is_blind(usr))
+/obj/item/weapon/paper/examine(mob/user)
+	if(is_blind(user))
 		return
-	if(in_range(usr, src))
-		if( !(ishuman(usr) || isobserver(usr) || issilicon(usr)) )
-			usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)]<HR>[stamps]</BODY></HTML>", "window=[name]")
+	if(in_range(user, src))
+		if( !(ishuman(user) || isobserver(user) || issilicon(user)) )
+			user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)]<HR>[stamps]</BODY></HTML>", "window=[name]")
 			onclose(usr, "[name]")
 		else
-			usr << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info]<HR>[stamps]</BODY></HTML>", "window=[name]")
+			user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info]<HR>[stamps]</BODY></HTML>", "window=[name]")
 			onclose(usr, "[name]")
 	else
-		usr << "<span class='notice'>It is too far away.</span>"
+		user << "<span class='notice'>It is too far away.</span>"
 
 
 /obj/item/weapon/paper/verb/rename()
@@ -80,7 +78,7 @@
 
 
 /obj/item/weapon/paper/attack_self(mob/user)
-	examine()
+	user.examine(src)
 	if(rigged && (events.holiday == "April Fool's Day"))
 		if(spam_flag == 0)
 			spam_flag = 1
@@ -252,7 +250,7 @@
 			return
 
 		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
-		
+
 		if(t != null)	//No input from the user means nothing needs to be added
 			if(id!="end")
 				addtofield(text2num(id), t) // He wants to edit a field, let him.

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -74,13 +74,12 @@
 	update_icon()
 
 
-/obj/item/weapon/paper_bin/examine()
-	set src in oview(1)
+/obj/item/weapon/paper_bin/examine(mob/user)
 	..()
 	if(amount)
-		usr << "It contains " + (amount > 1 ? "[amount] papers" : " one paper")+"."
+		user << "It contains " + (amount > 1 ? "[amount] papers" : " one paper")+"."
 	else
-		usr << "It doesn't contain anything."
+		user << "It doesn't contain anything."
 
 
 /obj/item/weapon/paper_bin/update_icon()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -33,7 +33,7 @@
 
 
 /obj/item/weapon/photo/attack_self(mob/user)
-	examine()
+	user.examine(src)
 
 
 /obj/item/weapon/photo/attackby(obj/item/weapon/P, mob/user)
@@ -45,15 +45,12 @@
 	..()
 
 
-/obj/item/weapon/photo/examine()
-	set src in oview(1)
-	if(is_blind(usr))	return
+/obj/item/weapon/photo/examine(mob/user)
+	..()
+	if(is_blind(user))	return
 
-	if(in_range(usr, src))
-		show(usr)
-		usr << desc
-	else
-		usr << "<span class='notice'>It is too far away.</span>"
+	if(in_range(user, src))
+		show(user)
 
 
 /obj/item/weapon/photo/proc/show(mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -184,31 +184,28 @@
 	spawn(5)
 		src.update()
 
-/obj/machinery/power/apc/examine()
-	set src in oview(1)
+/obj/machinery/power/apc/examine(mob/user)
+	..()
+	if(stat & BROKEN)
+		user << "Looks broken."
+		return
+	if(opened)
+		if(has_electronics && terminal)
+			user << "The cover is [opened==2?"removed":"open"] and the power cell is [ cell ? "installed" : "missing"]."
+		else if (!has_electronics && terminal)
+			user << "There are some wires but not any electronics."
+		else if (has_electronics && !terminal)
+			user << "There are lectronics installed but not any wires."
+		else /* if (!has_electronics && !terminal) */
+			user << "There are no electronics nor connected wires."
 
-	if(usr /*&& !usr.stat*/)
-		..()
-		if(stat & BROKEN)
-			usr << "Looks broken."
-			return
-		if(opened)
-			if(has_electronics && terminal)
-				usr << "The cover is [opened==2?"removed":"open"] and the power cell is [ cell ? "installed" : "missing"]."
-			else if (!has_electronics && terminal)
-				usr << "There are some wires but no any electronics."
-			else if (has_electronics && !terminal)
-				usr << "Electronics installed but not wired."
-			else /* if (!has_electronics && !terminal) */
-				usr << "There is no electronics nor connected wires."
-
+	else
+		if (stat & MAINT)
+			user << "The cover is closed. Something wrong with it: it doesn't work."
+		else if (malfhack)
+			user << "The cover is broken. It may be hard to force it open."
 		else
-			if (stat & MAINT)
-				usr << "The cover is closed. Something wrong with it: it doesn't work."
-			else if (malfhack)
-				usr << "The cover is broken. It may be hard to force it open."
-			else
-				usr << "The cover is closed."
+			user << "The cover is closed."
 
 
 // update the APC icon to show the three base states

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -206,6 +206,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
+	singular_name = "cable piece"
 
 	suicide_act(mob/user)
 		if(locate(/obj/structure/stool) in user.loc)
@@ -247,16 +248,6 @@
 	else
 		icon_state = "coil_[item_color]"
 		name = "cable coil"
-
-/obj/item/stack/cable_coil/examine()
-	set src in view(1)
-
-	if(amount == 1)
-		usr << "A short piece of power cable."
-	else if(amount == 2)
-		usr << "A piece of power cable."
-	else
-		usr << "A coil of power cable. There are [amount] lengths of cable in the coil."
 
 /obj/item/stack/cable_coil/verb/make_restraint()
 	set name = "Make Cable Restraints"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -5,9 +5,9 @@
 /obj/item/weapon/stock_parts/cell/New()
 	..()
 	charge = maxcharge
+	desc = "This cell has a power rating of [maxcharge], and you should not swallow it."
 
-	spawn(5)
-		updateicon()
+	updateicon()
 
 /obj/item/weapon/stock_parts/cell/proc/updateicon()
 	overlays.Cut()
@@ -50,13 +50,12 @@
 	return power_used
 
 
-/obj/item/weapon/stock_parts/cell/examine()
-	set src in view(1)
+/obj/item/weapon/stock_parts/cell/examine(mob/user)
 	..()
-	if(usr /*&& !usr.stat*/)
-		usr << "This cell has a power rating of [maxcharge], and you should not swallow it.\nThe charge meter reads [round(src.percent() )]%."
-	if(crit_fail)
-		usr << "\red This power cell seems to be faulty."
+	if(crit_fail || rigged)
+		user << "<span class='danger'>This power cell seems to be faulty!</span>"
+	else
+		user << "The charge meter reads [round(src.percent() )]%."
 
 /obj/item/weapon/stock_parts/cell/attack_self(mob/user as mob)
 	src.add_fingerprint(user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -84,20 +84,15 @@
 	if (fixture_type == "bulb")
 		icon_state = "bulb-construct-stage1"
 
-/obj/machinery/light_construct/examine()
-	set src in view()
+/obj/machinery/light_construct/examine(mob/user)
 	..()
-	if (!(usr in view(2))) return
 	switch(src.stage)
 		if(1)
-			usr << "It's an empty frame."
-			return
+			user << "It's an empty frame."
 		if(2)
-			usr << "It's wired."
-			return
+			user << "It's wired."
 		if(3)
-			usr << "The casing is closed."
-			return
+			user << "The casing is closed."
 
 /obj/machinery/light_construct/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	src.add_fingerprint(user)
@@ -309,19 +304,17 @@
 	update()
 
 // examine verb
-/obj/machinery/light/examine()
-	set src in oview(1)
+/obj/machinery/light/examine(mob/user)
 	..()
-	if(usr && !usr.stat)
-		switch(status)
-			if(LIGHT_OK)
-				usr << "It is turned [on? "on" : "off"]."
-			if(LIGHT_EMPTY)
-				usr << "The [fitting] has been removed."
-			if(LIGHT_BURNED)
-				usr << "The [fitting] is burnt out."
-			if(LIGHT_BROKEN)
-				usr << "The [fitting] has been smashed."
+	switch(status)
+		if(LIGHT_OK)
+			user << "It is turned [on? "on" : "off"]."
+		if(LIGHT_EMPTY)
+			user << "The [fitting] has been removed."
+		if(LIGHT_BURNED)
+			user << "The [fitting] is burnt out."
+		if(LIGHT_BROKEN)
+			user << "The [fitting] has been smashed."
 
 
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -86,13 +86,9 @@ display round(lastgen) and plasmatank amount
 	if(!anchored)
 		return
 
-/obj/machinery/power/port_gen/examine()
-	set src in oview(1)
+/obj/machinery/power/port_gen/examine(mob/user)
 	..()
-	if(active)
-		usr << "It is running."
-	else
-		usr << "It isn't running."
+	user << "It is[active?"n't":""] running."
 
 /obj/machinery/power/port_gen/pacman
 	name = "\improper P.A.C.M.A.N.-type portable generator"
@@ -144,10 +140,10 @@ display round(lastgen) and plasmatank amount
 	power_gen = round(initial(power_gen) * temp_rating * 2)
 	consumption = consumption_coeff
 
-/obj/machinery/power/port_gen/pacman/examine()
+/obj/machinery/power/port_gen/pacman/examine(mob/user)
 	..()
-	usr << "\blue The generator has [sheets] units of [sheet_name] fuel left, producing [power_gen] per cycle."
-	if(crit_fail) usr << "\red The generator seems to have broken down."
+	user << "<span class='notice'>The generator has [sheets] units of [sheet_name] fuel left, producing [power_gen] per cycle.</span>"
+	if(crit_fail) user << "<span class='danger'>The generator seems to have broken down.</span>"
 
 /obj/machinery/power/port_gen/pacman/HasFuel()
 	if(sheets >= 1 / (time_per_sheet / power_output) - sheet_left)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -110,7 +110,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	src.dir = turn(src.dir, 90)
 	return 1
 
-/obj/structure/particle_accelerator/examine()
+/obj/structure/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)
 		if(0)
 			src.desc = text("A [name], looks like it's not attached to the flooring")
@@ -123,7 +123,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			if(powered)
 				src.desc = src.desc_holder
 	..()
-	return
 
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user)
@@ -304,7 +303,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 /obj/machinery/particle_accelerator/update_icon()
 	return
 
-/obj/machinery/particle_accelerator/examine()
+/obj/machinery/particle_accelerator/examine(mob/user)
 	switch(src.construction_state)
 		if(0)
 			src.desc = text("A [name], looks like it's not attached to the flooring")
@@ -317,7 +316,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			if(powered)
 				src.desc = src.desc_holder
 	..()
-	return
 
 
 /obj/machinery/particle_accelerator/attackby(obj/item/W, mob/user)

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -17,10 +17,9 @@
 			max_charges = Ceiling(max_charges / 2)
 	..()
 
-/obj/item/weapon/gun/magic/wand/examine()
+/obj/item/weapon/gun/magic/wand/examine(mob/user)
 	..()
-	usr << "Has [charges] charge\s remaining."
-	return
+	user << "Has [charges] charge\s remaining."
 
 /obj/item/weapon/gun/magic/wand/update_icon()
 	icon_state = "[initial(icon_state)][charges ? "" : "-drained"]"

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -67,10 +67,9 @@
 	return
 
 
-/obj/item/weapon/gun/projectile/examine()
+/obj/item/weapon/gun/projectile/examine(mob/user)
 	..()
-	usr << "Has [get_ammo()] round\s remaining."
-	return
+	user << "Has [get_ammo()] round\s remaining."
 
 /obj/item/weapon/gun/projectile/proc/get_ammo(var/countchambered = 1)
 	var/boolets = 0 //mature var names for mature people

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -44,9 +44,9 @@
 		boolets += magazine.ammo_count(countempties)
 	return boolets
 
-/obj/item/weapon/gun/projectile/revolver/examine()
+/obj/item/weapon/gun/projectile/revolver/examine(mob/user)
 	..()
-	usr << "[get_ammo(0,0)] of those are live rounds."
+	user << "[get_ammo(0,0)] of those are live rounds."
 
 /obj/item/weapon/gun/projectile/revolver/detective
 	desc = "A cheap Martian knock-off of a Smith & Wesson Model 10. Uses .38-Special rounds."

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -46,10 +46,10 @@
 	update_icon()	//I.E. fix the desc
 	return 1
 
-/obj/item/weapon/gun/projectile/shotgun/examine()
+/obj/item/weapon/gun/projectile/shotgun/examine(mob/user)
 	..()
 	if (chambered)
-		usr << "A [chambered.BB ? "live" : "spent"] one is in the chamber."
+		user << "A [chambered.BB ? "live" : "spent"] one is in the chamber."
 
 /obj/item/weapon/gun/projectile/shotgun/combat
 	name = "combat shotgun"

--- a/code/modules/reagents/grenade_launcher.dm
+++ b/code/modules/reagents/grenade_launcher.dm
@@ -12,12 +12,9 @@
 	var/max_grenades = 3
 	m_amt = 2000
 
-	examine()
-		set src in view()
+	examine(mob/user)
 		..()
-		if(!(usr in view(2)) && usr != loc)
-			return
-		usr << "[grenades] / [max_grenades] grenades."
+		user << "[grenades] / [max_grenades] grenades loaded."
 
 	attackby(obj/item/I as obj, mob/user as mob)
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -108,9 +108,10 @@ Borg Hypospray
 	user << "<span class='notice'>[src] is now dispensing '[R.name]'.</span>"
 	return
 
-/obj/item/weapon/reagent_containers/borghypo/examine()
+/obj/item/weapon/reagent_containers/borghypo/examine(mob/user)
+	usr = user
 	..()
-	DescribeContents()
+	DescribeContents()	//Because using the standardized reagents datum was just too cool for whatever fuckwit wrote this
 
 /obj/item/weapon/reagent_containers/borghypo/proc/DescribeContents()
 	var/empty = 1

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -100,20 +100,18 @@
 
 		return
 
-	examine()
-		set src in view()
+	examine(mob/user)
 		..()
-		if (!(usr in range(0)) && usr!=src.loc) return
 		if(!reagents || reagents.total_volume==0)
-			usr << "\blue \The [src] is empty!"
+			user << "<span class='notice'>\The [src] is empty!</span>"
 		else if (reagents.total_volume<=src.volume/4)
-			usr << "\blue \The [src] is almost empty!"
+			user << "<span class='notice'>\The [src] is almost empty!</span>"
 		else if (reagents.total_volume<=src.volume*0.66)
-			usr << "\blue \The [src] is half full!"
+			user << "<span class='notice'>\The [src] is half full!</span>"
 		else if (reagents.total_volume<=src.volume*0.90)
-			usr << "\blue \The [src] is almost full!"
+			user << "<span class='notice'>\The [src] is almost full!</span>"
 		else
-			usr << "\blue \The [src] is full!"
+			user << "<span class='notice'>\The [src] is full!</span>"
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -107,19 +107,16 @@
 	return
 
 
-/obj/item/weapon/reagent_containers/food/snacks/examine()
-	set src in view()
+/obj/item/weapon/reagent_containers/food/snacks/examine(mob/user)
 	..()
-	if(!(usr in range(1)) && usr != loc)
-		return
 	if(bitecount == 0)
 		return
 	else if(bitecount == 1)
-		usr << "[src] was bitten by someone!"
+		user << "[src] was bitten by someone!"
 	else if(bitecount <= 3)
-		usr << "[src] was bitten [bitecount] times!"
+		user << "[src] was bitten [bitecount] times!"
 	else
-		usr << "[src] was bitten multiple times!"
+		user << "[src] was bitten multiple times!"
 
 
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W, mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -32,16 +32,6 @@
 		/mob/living/simple_animal/hostile/retaliate/goat
 	)
 
-	examine()
-		set src in view()
-		..()
-		if(!(usr in view(2)) && usr != loc)
-			return
-		if(reagents && reagents.reagent_list.len)
-			usr << "It contains:"
-			for(var/datum/reagent/R in reagents.reagent_list)
-				usr << "[R.volume] units of [R.name]"
-
 	afterattack(obj/target, mob/user, proximity)
 		if(!proximity) return // not adjacent
 		for(var/type in can_be_placed_into)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -76,14 +76,6 @@
 	spray_currentrange = (spray_currentrange == 1 ? spray_maxrange : 1)
 	user << "<span class='notice'>You [amount_per_transfer_from_this == 10 ? "remove" : "fix"] the nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>"
 
-
-/obj/item/weapon/reagent_containers/spray/examine()
-	set src in usr
-	..()
-	for(var/datum/reagent/R in reagents.reagent_list)
-		usr << "[round(R.volume)] units of [R.name] left."
-	return
-
 /obj/item/weapon/reagent_containers/spray/verb/empty()
 
 	set name = "Empty Spray Bottle"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -39,17 +39,6 @@
 		src.verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
 	..()
 
-/obj/structure/reagent_dispensers/examine()
-	set src in view()
-	..()
-	if (!(usr in view(2)) && usr!=src.loc) return
-	usr << "\blue It contains:"
-	if(reagents && reagents.reagent_list.len)
-		for(var/datum/reagent/R in reagents.reagent_list)
-			usr << "\blue [R.volume] units of [R.name]"
-	else
-		usr << "\blue Nothing."
-
 /obj/structure/reagent_dispensers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
 	set category = "Object"

--- a/code/modules/reagents/syringe_gun.dm
+++ b/code/modules/reagents/syringe_gun.dm
@@ -39,10 +39,9 @@
 	newshot()
 	..()
 
-/obj/item/weapon/gun/syringe/examine()
+/obj/item/weapon/gun/syringe/examine(mob/user)
 	..()
-	usr << "Can hold [max_syringes] syringe\s. Has [syringes.len] syringe\s remaining."
-	return
+	user << "Can hold [max_syringes] syringe\s. Has [syringes.len] syringe\s remaining."
 
 /obj/item/weapon/gun/syringe/attack_self(mob/living/user as mob)
 	if(!syringes.len)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -161,11 +161,9 @@
 		return
 
 
-	examine()
-		if(src in usr)
-			usr << "<span class='notice'>There are [amount] units of package wrap left.</span>"
+	examine(mob/user)
 		..()
-		return
+		user << "<span class='notice'>There are [amount] units of package wrap left.</span>"
 
 
 /obj/item/device/destTagger

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -120,9 +120,10 @@
 /obj/item/weapon/rcs/New()
 	..()
 	processing_objects.Add(src)
-/obj/item/weapon/rcs/examine()
-	desc = "Use this to send crates and closets to cargo telepads. There are [rcharges] charges left."
+
+/obj/item/weapon/rcs/examine(mob/user)
 	..()
+	user << "There are [rcharges] charge\s left."
 
 /obj/item/weapon/rcs/Destroy()
 	processing_objects.Remove(src)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -40,9 +40,9 @@
 		inserted_gps = null
 	..()
 
-/obj/machinery/computer/telescience/examine()
+/obj/machinery/computer/telescience/examine(mob/user)
 	..()
-	usr << "There are [crystals.len ? crystals.len : "no"] bluespace crystals in the crystal slots."
+	user << "There are [crystals.len ? crystals.len : "no"] bluespace crystal\s in the crystal slots."
 
 /obj/machinery/computer/telescience/initialize()
 	..()


### PR DESCRIPTION
Just in time for the feature freeze, a big change that will introduce bugs! Yay!
Mob verb is called verb/examinate(target), which just calls target.examine(user) and face_atom(target)
For explanation why, see http://www.byond.com/forum/?post=1326139&page=2#comment8198716
Long story short, mob verbs are much faster than object verbs. The goal is to make right-click menus populate faster.

Also changes a bunch of examine() procs to get more of them to call the parent. Mostly this affects obj/item/examine().
And also remove a whole shitload of pointless set src in view(2) kind of crap. Also span classes.

I haven't yet tested this thoroughly so DNM. Just tossing this up so other people can yell or w/e.
