### PR TITLE
Adds a timer when drawing blood from other people.

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -72,6 +72,11 @@
 						if(NOCLONE in T.mutations)	//target done been et, no more blood in him
 							user << "<span class='notice'>You are unable to locate any blood.</span>"
 							return
+						if(target != user)
+							target.visible_message("<span class='danger'>[user] is trying to take a blood sample from  [target]!</span>", \
+											"<span class='userdanger'>[user] is trying to take a blood sample from [target]!</span>")
+							if(!do_mob(user, target)) 
+								return
 						B.holder = src
 						B.volume = amount
 						//set reagent data


### PR DESCRIPTION
Taking a blood sample with a syringe is now similar to injecting with a syringe. It takes time and a message appears when you try to do it (unless the user targets themself).

Fixes #3621
