### PR TITLE
Fix for Cooler circuitboard

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -128,8 +128,11 @@
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/New()
 	..()
 	initialize_directions = dir
+	var/obj/item/weapon/circuitboard/thermomachine/H = new /obj/item/weapon/circuitboard/thermomachine(null)
+	H.build_path = /obj/machinery/atmospherics/unary/heat_reservoir/heater
+	H.name = "circuit board (Heater)"
 	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/thermomachine(null)
+	component_parts += H
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
 	component_parts += new /obj/item/weapon/stock_parts/micro_laser(null)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -277,7 +277,7 @@ to destroy them and players will be able to make replacements.
 							"/obj/item/weapon/stock_parts/console_screen" = 4)
 
 /obj/item/weapon/circuitboard/thermomachine
-	name = "circuit board (Cooler)"
+	name = "circuit board (Freezer)"
 	desc = "Use screwdriver to switch between heating and cooling modes."
 	build_path = /obj/machinery/atmospherics/unary/cold_sink/freezer
 	board_type = "machine"
@@ -296,7 +296,7 @@ to destroy them and players will be able to make replacements.
 			user << "<span class='notice'>You set the board to heating.</span>"
 		else
 			build_path = /obj/machinery/atmospherics/unary/cold_sink/freezer
-			name = "circuit board (Cooler)"
+			name = "circuit board (Freezer)"
 			user << "<span class='notice'>You set the board to cooling.</span>"
 
 /obj/item/weapon/circuitboard/biogenerator


### PR DESCRIPTION
Fixes #3508 and #3620
- Rename the cooler board to Freezer.
- The Heater now contains and drops the thermomachine circuitboard correctly set to "Heater".
