### PR TITLE
[RFC] Powernets refactoring

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -1,19 +1,32 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-
 /datum/powernet
 	var/list/cables = list()	// all cables & junctions
 	var/list/nodes = list()		// all APCs & sources
 
-	var/newload = 0
-	var/load = 0
-	var/newavail = 0
-	var/avail = 0
-	var/viewload = 0
-	var/number = 0
-	var/perapc = 0			// per-apc avilability
-	var/netexcess = 0
+	var/newload = 0				// increased by every machines each tick then becomes...
+	var/load = 0				// ...the current load on the powernet
+	var/newavail = 0			// increased by every machines each tick then becomes...
+	var/avail = 0				//...the current available power in the powernet
+	var/viewload = 0			//the load as it appears on the power console (gradually updated)
+	var/number = 0				//Unused //TODEL
+	var/perapc = 0				// per-apc avilability
+	var/netexcess = 0			//excess power on the powernet (typically avail-load)
+
+/*Powernet procs :
+
+In modules/power/power.dm :
+
+/datum/powernet/New()
+/datum/powernet/Destroy()
+/datum/powernet/proc/is_empty()
+/datum/powernet/proc/remove_cable(var/obj/structure/cable/C)
+/datum/powernet/proc/add_cable(var/obj/structure/cable/C)
+/datum/powernet/proc/remove_machine(var/obj/machinery/power/M)
+/datum/powernet/proc/add_machine(var/obj/machinery/power/M)
+/datum/powernet/proc/reset()
+/datum/powernet/proc/get_electrocute_damage()
 
 
+*/
 
 /datum/debug
 	var/list/debuglist

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1,38 +1,37 @@
-// attach a wire to a power machine - leads from the turf you are standing on
+///////////////////////////////
+//CABLE STRUCTURE
+///////////////////////////////
 
-/obj/machinery/power/attackby(obj/item/weapon/W, mob/user)
 
-	if(istype(W, /obj/item/stack/cable_coil))
+////////////////////////////////
+// Definitions
+////////////////////////////////
 
-		var/obj/item/stack/cable_coil/coil = W
+/* Cable directions (d1 and d2)
 
-		var/turf/T = user.loc
 
-		if(T.intact || !istype(T, /turf/simulated/floor))
-			return
+  9   1   5
+	\ | /
+  8 - 0 - 4
+	/ | \
+  10  2   6
 
-		if(get_dist(src, user) > 1)
-			return
-
-		if(!directwired)		// only for attaching to directwired machines
-			return
-
-		coil.turf_place(T, user)
-		return
-	else
-		..()
-	return
+If d1 = 0 and d2 = 0, there's no cable
+If d1 = 0 and d2 = dir, it's a O-X cable, getting from the center of the tile to dir (knot cable)
+If d1 = dir1 and d2 = dir2, it's a full X-X cable, getting from dir1 to dir2
+By design, d1 is the smallest direction and d2 is the highest
+*/
 
 /obj/structure/cable
-	level = 1
+	level = 1 //is underfloor
 	anchored =1
 	var/datum/powernet/powernet
 	name = "power cable"
 	desc = "A flexible superconducting cable for heavy-duty power transfer"
 	icon = 'icons/obj/power_cond/power_cond_red.dmi'
 	icon_state = "0-1"
-	var/d1 = 0
-	var/d2 = 1
+	var/d1 = 0   // cable direction 1 (see above)
+	var/d2 = 1   // cable direction 2 (see above)
 	layer = 2.44 //Just below unary stuff, which is at 2.45 and above pipes, which are at 2.4
 	var/cable_color = "red"
 
@@ -65,7 +64,6 @@
 	icon = 'icons/obj/power_cond/power_cond_white.dmi'
 
 // the power cable object
-
 /obj/structure/cable/New()
 	..()
 
@@ -81,16 +79,20 @@
 	var/turf/T = src.loc			// hide if turf is not intact
 
 	if(level==1) hide(T.intact)
-	cable_list += src
+	cable_list += src //add it to the global cable list
 
 
 /obj/structure/cable/Destroy()					// called when a cable is deleted
-//	if(!defer_powernet_rebuild)					// set if network will be rebuilt manually
 	if(powernet)
-		powernet.cut_cable(src)				// update the powernets
-	cable_list -= src
-	..()													// then go ahead and delete the cable
+		cut_cable_from_powernet()				// update the powernets
+	cable_list -= src							//remove it from global cable list
+	..()										// then go ahead and delete the cable
 
+///////////////////////////////////
+// General procedures
+///////////////////////////////////
+
+//If underfloor, hide the cable
 /obj/structure/cable/hide(var/i)
 
 	if(level == 1 && istype(loc, /turf))
@@ -108,9 +110,15 @@
 /obj/structure/cable/proc/get_powernet()			//TODO: remove this as it is obsolete
 	return powernet
 
+//Telekinesis has no effect on a cable
 /obj/structure/cable/attack_tk(mob/user)
 	return
 
+// Items usable on a cable :
+//   - Wirecutters : cut it duh !
+//   - Cable coil : merge cables
+//   - Multitool : get the power currently passing through the cable
+//
 /obj/structure/cable/attackby(obj/item/W, mob/user)
 
 	var/turf/T = src.loc
@@ -142,10 +150,8 @@
 
 	else if(istype(W, /obj/item/device/multitool))
 
-		var/datum/powernet/PN = get_powernet()		// find the powernet
-
-		if(PN && (PN.avail > 0))		// is it powered?
-			user << "\red [PN.avail]W in power network."
+		if(powernet && (powernet.avail > 0))		// is it powered?
+			user << "\red [powernet.avail]W in power network."
 
 		else
 			user << "\red The cable is not powered."
@@ -159,7 +165,6 @@
 	src.add_fingerprint(user)
 
 // shock the user with probability prb
-
 /obj/structure/cable/proc/shock(mob/user, prb, var/siemens_coeff = 1.0)
 	if(!prob(prb))
 		return 0
@@ -171,6 +176,7 @@
 	else
 		return 0
 
+//explosion handling
 /obj/structure/cable/ex_act(severity)
 	switch(severity)
 		if(1.0)
@@ -186,9 +192,216 @@
 				qdel(src)
 	return
 
-// the cable coil object, used for laying cable
+obj/structure/cable/proc/cableColor(var/colorC)
+	var/color_n = "red"
+	if(colorC)
+		color_n = colorC
+	cable_color = color_n
+	switch(colorC)
+		if("red")
+			icon = 'icons/obj/power_cond/power_cond_red.dmi'
+		if("yellow")
+			icon = 'icons/obj/power_cond/power_cond_yellow.dmi'
+		if("green")
+			icon = 'icons/obj/power_cond/power_cond_green.dmi'
+		if("blue")
+			icon = 'icons/obj/power_cond/power_cond_blue.dmi'
+		if("pink")
+			icon = 'icons/obj/power_cond/power_cond_pink.dmi'
+		if("orange")
+			icon = 'icons/obj/power_cond/power_cond_orange.dmi'
+		if("cyan")
+			icon = 'icons/obj/power_cond/power_cond_cyan.dmi'
+		if("white")
+			icon = 'icons/obj/power_cond/power_cond_white.dmi'
+
+////////////////////////////////////////////
+// Power related
+///////////////////////////////////////////
+
+obj/structure/cable/proc/add_avail(var/amount)
+	if(powernet)
+		powernet.newavail += amount
+
+obj/structure/cable/proc/add_load(var/amount)
+	if(powernet)
+		powernet.newload += amount
+
+obj/structure/cable/proc/surplus()
+	if(powernet)
+		return powernet.avail-powernet.load
+	else
+		return 0
+
+obj/structure/cable/proc/avail()
+	if(powernet)
+		return powernet.avail
+	else
+		return 0
+
+/////////////////////////////////////////////////
+// Cable laying helpers
+////////////////////////////////////////////////
+
+// merge with the powernets of power objects in the given direction
+/obj/structure/cable/proc/mergeConnectedNetworks(var/direction)
+	var/turf/TB
+	var/fdir = (!direction)? 0 : turn(direction, 180) //flip the direction, to match with the source position on its turf
+	if(!(d1 == direction || d2 == direction)) //if the cable is not pointed in this direction, do nothing
+		return
+	TB = get_step(src, direction)
+
+	for(var/obj/structure/cable/C in TB)
+
+		if(!C)
+			continue
+
+		if(src == C)
+			continue
+
+		if(C.d1 == fdir || C.d2 == fdir) //we've got a matching cable in the neighbor turf
+			if(!C.powernet) //if the matching cable somehow got no powernet, make him one (should not happen for cables)
+				var/datum/powernet/newPN = new()
+				newPN.add_cable(C)
+
+			if(powernet) //if we already have a powernet, then merge the two powernets
+				merge_powernets(powernet,C.powernet)
+			else
+				C.powernet.add_cable(src) //else, we simply connect to the matching cable powernet
+
+// merge with the powernets of power objects in the source turf
+/obj/structure/cable/proc/mergeConnectedNetworksOnTurf()
+	if(!powernet) //if we somehow have no powernet, make one (should not happen for cables)
+		var/datum/powernet/newPN = new()
+		newPN.add_cable(src)
+
+	for(var/AM in loc)
+		if(istype(AM,/obj/structure/cable))
+			var/obj/structure/cable/C = AM
+			if(C.d1 == 0 && d1==0) //only connected if they are both "nodes"
+				if(C.powernet == powernet)	continue
+				if(C.powernet)
+					merge_powernets(powernet, C.powernet)
+				else
+					powernet.add_cable(C) //the cable was powernetless, let's just add it to our powernet
+
+		else if(istype(AM,/obj/machinery/power/apc))
+			var/obj/machinery/power/apc/N = AM
+			if(!N.terminal)	continue // APC are connected through their terminal
+			if(N.terminal.powernet)
+				merge_powernets(powernet, N.terminal.powernet)
+			else
+				powernet.add_machine(N.terminal)
+
+		else if(istype(AM,/obj/machinery/power)) //other power machines
+			var/obj/machinery/power/M = AM
+			if(M.powernet == powernet)	continue
+			if(M.powernet)
+				merge_powernets(powernet, M.powernet)
+			else
+				powernet.add_machine(M)
+
+//////////////////////////////////////////////
+// Powernets handling helpers
+//////////////////////////////////////////////
+
+/obj/structure/cable/proc/get_connections()
+	. = list()	// this will be a list of all connected power objects without a powernet
+	var/turf/T = loc
+
+	if(d1)	T = get_step(src, d1)
+	if(T)	. += power_list(T, src, d1, 1) //only returns these with no powernets
+
+	T = get_step(src, d2)
+	if(T)	. += power_list(T, src, d2, 1) //only returns these with no powernets
+
+	return .
+
+// will get both marked and unmarked connections (i.e with or without powernets)
+/obj/structure/cable/proc/get_marked_connections()
+	. = list()	// this will be a list of all connected power objects
+	var/turf/T = loc
+
+	if(d1)	T = get_step(src, d1)
+	if(T)	. += power_list(T, src, d1, 0)
+
+	T = get_step(src, d2)
+	if(T)	. += power_list(T, src, d2, 0)
+
+	return .
+
+//should be called after placing a cable which extends another cable, creating a "smooth" cable that no longer terminates in the centre of a turf.
+//needed as this can, unlike other placements, disconnect cables
+/obj/structure/cable/proc/denode()
+	var/turf/T1 = loc
+	if(!T1) return
+
+	var/list/powerlist = power_list(T1,src,0,0) //find the other cables that ended in the centre of the turf, with or without a powernet
+	if(powerlist.len>0)
+		var/datum/powernet/PN = new()
+		propagate_network(powerlist[1],PN) //propagates the new powernet beginning at the source cable
+
+		if(PN.is_empty()) //can happen with machines made nodeless when smoothing cables
+			qdel(PN)
+
+// cut the cable's powernet at this cable and updates the powergrid
+/obj/structure/cable/proc/cut_cable_from_powernet()
+	var/turf/T1 = loc
+	if(!T1)	return
+
+	var/turf/T2
+	if(d2)	T2 = get_step(T1, d2)
+	if(d1)	T1 = get_step(T1, d1)
+
+
+	var/list/P_list = power_list(T1, src, d1,0,cable_only = 1)	// what joins on to cut cable...
+	P_list += power_list(T2, src, d2,0, cable_only = 1) //...in both directions
+
+
+	if(P_list.len == 0)//if nothing in both list, then the cable was a lone cable, just delete it and its powernet
+		powernet.remove_cable(src)
+
+		for(var/obj/machinery/power/P in T1)//check if it was powering a machine
+			if(!P.connect_to_network()) //can't find a node cable on a the turf to connect to
+				P.disconnect_from_network() //remove from current network (and delete powernet)
+		return
+
+
+	var/i
+	var/obj/structure/cable/Cable_i
+
+	//removes every adjacents cables, from the powernet, except the first found (to save processing)
+	//that way we'll know if there was a loop somewhere
+	for (i = 2, i <= P_list.len, i++)
+		Cable_i = P_list[i]
+		powernet.remove_cable(Cable_i)
+
+	// remove the cut cable from its turf and powernet, so that it doesn't get count in propagate_network worklist
+	loc = null
+	powernet.remove_cable(src) //remove the cut cable from its powernet
+
+	for (i = 2, i <= P_list.len, i++) // propagate network to every powernetless adjacents cables
+		Cable_i = P_list[i]
+		if(Cable_i.powernet == null) //if not null, there was a loop and the cable is already part of a powernet
+			var/datum/powernet/newPN = new()
+			propagate_network(P_list[i], newPN)
+
+	// Disconnect machines connected to nodes
+	if(d1 == 0) // if we cut a node (O-X) cable
+		for(var/obj/machinery/power/P in T1)
+			if(!P.connect_to_network()) //can't find a node cable on a the turf to connect to
+				P.disconnect_from_network() //remove from current network
+
+///////////////////////////////////////////////
+// The cable coil object, used for laying cable
+///////////////////////////////////////////////
+
+////////////////////////////////
+// Definitions
+////////////////////////////////
 
 #define MAXCOIL 30
+
 /obj/item/stack/cable_coil
 	name = "cable coil"
 	icon = 'icons/obj/power.dmi'
@@ -214,6 +427,20 @@
 			viewers(user) << "<span class='suicide'>[user] is strangling \himself with the [src.name]! It looks like \he's trying to commit suicide.</span>"
 		return(OXYLOSS)
 
+/obj/item/stack/cable_coil/New(loc, amount = MAXCOIL, var/param_color = null)
+	..()
+	src.amount = amount
+	if (param_color)
+		item_color = param_color
+	pixel_x = rand(-2,2)
+	pixel_y = rand(-2,2)
+	update_icon()
+
+///////////////////////////////////
+// General procedures
+///////////////////////////////////
+
+//you can use wires to heal robotics
 /obj/item/stack/cable_coil/attack(mob/living/carbon/human/H, mob/user)
 	if(!istype(H))
 		return ..()
@@ -226,14 +453,6 @@
 	else
 		return ..()
 
-/obj/item/stack/cable_coil/New(loc, amount = MAXCOIL, var/param_color = null)
-	..()
-	src.amount = amount
-	if (param_color)
-		item_color = param_color
-	pixel_x = rand(-2,2)
-	pixel_y = rand(-2,2)
-	update_icon()
 
 /obj/item/stack/cable_coil/update_icon()
 	if (!item_color)
@@ -248,6 +467,7 @@
 		icon_state = "coil_[item_color]"
 		name = "cable coil"
 
+
 /obj/item/stack/cable_coil/examine()
 	set src in view(1)
 
@@ -257,6 +477,7 @@
 		usr << "A piece of power cable."
 	else
 		usr << "A coil of power cable. There are [amount] lengths of cable in the coil."
+
 
 /obj/item/stack/cable_coil/verb/make_restraint()
 	set name = "Make Cable Restraints"
@@ -276,6 +497,9 @@
 		usr << "\blue You cannot do that."
 	..()
 
+// Items usable on a cable coil :
+//   - Wirecutters : cut them duh !
+//   - Cable coil : merge cables
 /obj/item/stack/cable_coil/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if( istype(W, /obj/item/weapon/wirecutters) && src.amount > 1)
@@ -304,6 +528,7 @@
 			src.use(amt)
 			return
 
+//remove cables from the stack
 /obj/item/stack/cable_coil/use(var/used)
 	if(src.amount < used)
 		return 0
@@ -318,6 +543,7 @@
 		update_icon()
 		return 1
 
+//add cables to the stack
 /obj/item/stack/cable_coil/proc/give(var/extra)
 	if(amount + extra > MAXCOIL)
 		amount = MAXCOIL
@@ -325,14 +551,16 @@
 		amount += extra
 	update_icon()
 
+///////////////////////////////////////////////
+// Cable laying procedures
+//////////////////////////////////////////////
+
 // called when cable_coil is clicked on a turf/simulated/floor
-
 /obj/item/stack/cable_coil/proc/turf_place(turf/simulated/floor/F, mob/user)
-
 	if(!isturf(user.loc))
 		return
 
-	if(get_dist(F,user) > 1)
+	if(get_dist(F,user) > 1) //too far
 		user << "You can't lay cable at a place that far away."
 		return
 
@@ -357,32 +585,30 @@
 
 		C.cableColor(item_color)
 
-		C.d1 = 0
+		//set up the new cable
+		C.d1 = 0 //it's a O-X node cable
 		C.d2 = dirn
 		C.add_fingerprint(user)
 		C.updateicon()
 
-		C.powernet = new()
-		powernets += C.powernet
-		C.powernet.cables += C
+		//create a new powernet with the cable, if needed it will be merged later
+		var/datum/powernet/PN = new()
+		PN.add_cable(C)
 
-		C.mergeConnectedNetworks(C.d2)
-		C.mergeConnectedNetworksOnTurf()
+		C.mergeConnectedNetworks(C.d2) //merge the powernet with adjacents powernets
+		C.mergeConnectedNetworksOnTurf() //merge the powernet with on turf powernets
 
 
 		use(1)
+
 		if (C.shock(user, 50))
 			if (prob(50)) //fail
 				new/obj/item/stack/cable_coil(C.loc, 1, C.cable_color)
 				qdel(C)
-		//src.laying = 1
-		//last = C
-
 
 // called when cable_coil is click on an installed obj/cable
-
+// or click on a turf that already contains a "node" cable
 /obj/item/stack/cable_coil/proc/cable_join(obj/structure/cable/C, mob/user)
-
 	var/turf/U = user.loc
 	if(!isturf(U))
 		return
@@ -397,12 +623,14 @@
 		return
 
 
-	if(U == T)		// do nothing if we clicked a cable we're standing on
-		return		// may change later if can think of something logical to do
+	if(U == T) //if clicked on the turf we're standing on, try to put a cable in the direction we're facing
+		turf_place(T,user)
+		return
 
 	var/dirn = get_dir(C, user)
 
-	if(C.d1 == dirn || C.d2 == dirn)		// one end of the clicked cable is pointing towards us
+	// one end of the clicked cable is pointing towards us
+	if(C.d1 == dirn || C.d2 == dirn)
 		if(U.intact)						// can't place a cable if the floor is complete
 			user << "You can't lay cable there unless the floor tiles are removed."
 			return
@@ -425,19 +653,24 @@
 			NC.add_fingerprint()
 			NC.updateicon()
 
-			if(C.powernet)
-				NC.powernet = C.powernet
-				NC.powernet.cables += NC
-				NC.mergeConnectedNetworks(NC.d2)
-				NC.mergeConnectedNetworksOnTurf()
+			//create a new powernet with the cable, if needed it will be merged later
+			var/datum/powernet/newPN = new()
+			newPN.add_cable(NC)
+
+			NC.mergeConnectedNetworks(NC.d2) //merge the powernet with adjacents powernets
+			NC.mergeConnectedNetworksOnTurf() //merge the powernet with on turf powernets
+
 			use(1)
+
 			if (NC.shock(user, 50))
 				if (prob(50)) //fail
 					new/obj/item/stack/cable_coil(NC.loc, 1, NC.cable_color)
 					qdel(NC)
 
 			return
-	else if(C.d1 == 0)		// exisiting cable doesn't point at our position, so see if it's a stub
+
+	// exisiting cable doesn't point at our position, so see if it's a stub
+	else if(C.d1 == 0)
 							// if so, make it a full cable pointing from it's old direction to our dirn
 		var/nd1 = C.d2	// these will be the new directions
 		var/nd2 = dirn
@@ -465,11 +698,12 @@
 		C.updateicon()
 
 
-		C.mergeConnectedNetworks(C.d1)
-		C.mergeConnectedNetworks(C.d2)
+		C.mergeConnectedNetworks(C.d1) //merge the powernets...
+		C.mergeConnectedNetworks(C.d2) //...in the two new cable directions
 		C.mergeConnectedNetworksOnTurf()
 
 		use(1)
+
 		if (C.shock(user, 50))
 			if (prob(50)) //fail
 				new/obj/item/stack/cable_coil(C.loc, 2, C.cable_color)
@@ -479,116 +713,9 @@
 		C.denode()// this call may have disconnected some cables that terminated on the centre of the turf, if so split the powernets.
 		return
 
-/obj/structure/cable/proc/mergeConnectedNetworks(var/direction)
-	var/turf/TB
-	if(!(d1 == direction || d2 == direction))
-		return
-	TB = get_step(src, direction)
-
-	for(var/obj/structure/cable/TC in TB)
-
-		if(!TC)
-			continue
-
-		if(src == TC)
-			continue
-
-		var/fdir = (!direction)? 0 : turn(direction, 180)
-
-		if(TC.d1 == fdir || TC.d2 == fdir)
-
-			if(!TC.powernet)
-				TC.powernet = new()
-				powernets += TC.powernet
-				TC.powernet.cables += TC
-
-			if(powernet)
-				merge_powernets(powernet,TC.powernet)
-			else
-				powernet = TC.powernet
-				powernet.cables += src
-
-
-
-
-/obj/structure/cable/proc/mergeConnectedNetworksOnTurf()
-	if(!powernet)
-		powernet = new()
-		powernets += powernet
-		powernet.cables += src
-
-	for(var/AM in loc)
-		if(istype(AM,/obj/structure/cable))
-			var/obj/structure/cable/C = AM
-			if(C.d1 == 0 && d1==0) //only connected if they are both "nodes"
-				if(C.powernet == powernet)	continue
-				if(C.powernet)
-					merge_powernets(powernet, C.powernet)
-				else
-					C.powernet = powernet
-					powernet.cables += C
-
-		else if(istype(AM,/obj/machinery/power/apc))
-			var/obj/machinery/power/apc/N = AM
-			if(!N.terminal)	continue
-			if(N.terminal.powernet)
-				merge_powernets(powernet, N.terminal.powernet)
-			else
-				N.terminal.powernet = powernet
-				powernet.nodes[N.terminal] = N.terminal
-
-		else if(istype(AM,/obj/machinery/power))
-			var/obj/machinery/power/M = AM
-			if(M.powernet == powernet)	continue
-			if(M.powernet)
-				merge_powernets(powernet, M.powernet)
-			else
-				M.powernet = powernet
-				powernet.nodes[M] = M
-
-
-obj/structure/cable/proc/cableColor(var/colorC)
-	var/color_n = "red"
-	if(colorC)
-		color_n = colorC
-	cable_color = color_n
-	switch(colorC)
-		if("red")
-			icon = 'icons/obj/power_cond/power_cond_red.dmi'
-		if("yellow")
-			icon = 'icons/obj/power_cond/power_cond_yellow.dmi'
-		if("green")
-			icon = 'icons/obj/power_cond/power_cond_green.dmi'
-		if("blue")
-			icon = 'icons/obj/power_cond/power_cond_blue.dmi'
-		if("pink")
-			icon = 'icons/obj/power_cond/power_cond_pink.dmi'
-		if("orange")
-			icon = 'icons/obj/power_cond/power_cond_orange.dmi'
-		if("cyan")
-			icon = 'icons/obj/power_cond/power_cond_cyan.dmi'
-		if("white")
-			icon = 'icons/obj/power_cond/power_cond_white.dmi'
-
-obj/structure/cable/proc/add_avail(var/amount)
-	if(powernet)
-		powernet.newavail += amount
-
-obj/structure/cable/proc/add_load(var/amount)
-	if(powernet)
-		powernet.newload += amount
-
-obj/structure/cable/proc/surplus()
-	if(powernet)
-		return powernet.avail-powernet.load
-	else
-		return 0
-
-obj/structure/cable/proc/avail()
-	if(powernet)
-		return powernet.avail
-	else
-		return 0
+//////////////////////////////
+// Misc.
+/////////////////////////////
 
 /obj/item/stack/cable_coil/cut
 	item_state = "coil_red2"

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -1,10 +1,17 @@
+//////////////////////////////
+// POWER MACHINERY BASE CLASS
+//////////////////////////////
+
+/////////////////////////////
+// Definitions
+/////////////////////////////
+
 /obj/machinery/power
 	name = null
 	icon = 'icons/obj/power.dmi'
 	anchored = 1.0
 	var/datum/powernet/powernet = null
-	var/directwired = 1		// by default, power machines are connected by a cable in a neighbouring turf
-							// if set to 0, requires a 0-X cable on this turf
+	var/directwired = 1		// TODEL
 	use_power = 0
 	idle_power_usage = 0
 	active_power_usage = 0
@@ -12,6 +19,10 @@
 /obj/machinery/power/Destroy()
 	disconnect_from_network()
 	..()
+
+///////////////////////////////
+// General procedures
+//////////////////////////////
 
 // common helper procs for all power machines
 /obj/machinery/power/proc/add_avail(var/amount)
@@ -39,8 +50,7 @@
 
 // returns true if the area has power on given channel (or doesn't require power).
 // defaults to power_channel
-
-/obj/machinery/proc/powered(var/chan = -1)
+/obj/machinery/proc/powered(var/chan = -1) // defaults to power_channel
 
 	if(!src.loc)
 		return 0
@@ -56,7 +66,6 @@
 	return A.master.powered(chan)	// return power status of the area
 
 // increment the power usage stats for an area
-
 /obj/machinery/proc/use_power(var/amount, var/chan = -1) // defaults to power_channel
 	var/area/A = get_area(src)		// make sure it's in an area
 	if(!A || !isarea(A) || !A.master)
@@ -75,51 +84,119 @@
 		stat |= NOPOWER
 	return
 
+// connect the machine to a powernet if a node cable is present on the turf
+/obj/machinery/power/proc/connect_to_network()
+	var/turf/T = src.loc
+	if(!T || !istype(T))
+		return 0
 
-// the powernet datum
-// each contiguous network of cables & nodes
+	var/obj/structure/cable/C = T.get_cable_node() //check if we have a node cable on the machine turf, the first found is picked
+	if(!C || !C.powernet)
+		return 0
 
+	C.powernet.add_machine(src)
+	return 1
 
-// rebuild all power networks from scratch
+// remove and disconnect the machine from its current powernet
+/obj/machinery/power/proc/disconnect_from_network()
+	if(!powernet)
+		return 0
+	powernet.remove_machine(src)
+	return 1
 
-/proc/makepowernets()
-	for(var/datum/powernet/PN in powernets)
-		del(PN)
-	powernets.Cut()
+// attach a wire to a power machine - leads from the turf you are standing on
+//almost never called, overwritten by all power machines but terminal and generator
+/obj/machinery/power/attackby(obj/item/weapon/W, mob/user)
 
-	for(var/obj/structure/cable/PC in cable_list)
-		if(!PC.powernet)
-			PC.powernet = new()
-			powernets += PC.powernet
-//			if(Debug)	world.log << "Starting mpn at [PC.x],[PC.y] ([PC.d1]/[PC.d2])"
-			powernet_nextlink(PC,PC.powernet)
+	if(istype(W, /obj/item/stack/cable_coil))
 
-//	if(Debug) world.log << "[powernets.len] powernets found"
+		var/obj/item/stack/cable_coil/coil = W
 
-	for(var/obj/structure/cable/C in cable_list)
-		if(!C.powernet)	continue
-		C.powernet.cables += C
+		var/turf/T = user.loc
 
-	for(var/obj/machinery/power/M in machines)
-		M.connect_to_network()
+		if(T.intact || !istype(T, /turf/simulated/floor))
+			return
+
+		if(get_dist(src, user) > 1)
+			return
+
+		coil.turf_place(T, user)
+		return
+	else
+		..()
+	return
+
+///////////////////////////////////////////
+// Powernet handling helpers
+//////////////////////////////////////////
+
+//returns all the cables WITHOUT a powernet in neighbors turfs,
+//pointing towards the turf the machine is located at
+/obj/machinery/power/proc/get_connections()
+
+	. = list()
+
+	var/cdir
+	var/turf/T
+
+	for(var/card in cardinal)
+		T = get_step(loc,card)
+		cdir = get_dir(T,loc)
+
+		for(var/obj/structure/cable/C in T)
+			if(C.powernet)	continue
+			if(C.d1 == cdir || C.d2 == cdir)
+				. += C
+	return .
+
+//returns all the cables in neighbors turfs,
+//pointing towards the turf the machine is located at
+/obj/machinery/power/proc/get_marked_connections()
+
+	. = list()
+
+	var/cdir
+	var/turf/T
+
+	for(var/card in cardinal)
+		T = get_step(loc,card)
+		cdir = get_dir(T,loc)
+
+		for(var/obj/structure/cable/C in T)
+			if(C.d1 == cdir || C.d2 == cdir)
+				. += C
+	return .
+
+//returns all the NODES (O-X) cables WITHOUT a powernet in the turf the machine is located at
+/obj/machinery/power/proc/get_indirect_connections()
+	. = list()
+	for(var/obj/structure/cable/C in loc)
+		if(C.powernet)	continue
+		if(C.d1 == 0) // the cable is a node cable
+			. += C
+	return .
+
+///////////////////////////////////////////
+// GLOBAL PROCS for powernets handling
+//////////////////////////////////////////
 
 
 // returns a list of all power-related objects (nodes, cable, junctions) in turf,
 // excluding source, that match the direction d
 // if unmarked==1, only return those with no powernet
-/proc/power_list(var/turf/T, var/source, var/d, var/unmarked=0)
+/proc/power_list(var/turf/T, var/source, var/d, var/unmarked=0, var/cable_only = 0)
 	. = list()
 	var/fdir = (!d)? 0 : turn(d, 180)			// the opposite direction to d (or 0 if d==0)
 //	world.log << "d=[d] fdir=[fdir]"
 	for(var/AM in T)
 		if(AM == source)	continue			//we don't want to return source
 
-		if(istype(AM,/obj/machinery/power))
+		if(!cable_only && istype(AM,/obj/machinery/power))
 			var/obj/machinery/power/P = AM
 			if(P.powernet == 0)	continue		// exclude APCs which have powernet=0
 
 			if(!unmarked || !P.powernet)		//if unmarked=1 we only return things with no powernet
-				if(P.directwired || (d == 0))
+				if(d == 0)
 					. += P
 
 		else if(istype(AM,/obj/structure/cable))
@@ -131,332 +208,57 @@
 	return .
 
 
-/obj/structure/cable/proc/get_connections()
-	. = list()	// this will be a list of all connected power objects
-	var/turf/T = loc
+// rebuild all power networks from scratch - only called at world creation or by the admin verb
+/proc/makepowernets()
+	for(var/datum/powernet/PN in powernets)
+		del(PN)
+	powernets.Cut()
 
-	if(d1)	T = get_step(src, d1)
-	if(T)	. += power_list(T, src, d1, 1)
-
-	T = get_step(src, d2)
-	if(T)	. += power_list(T, src, d2, 1)
-
-	return .
-
-// will get both marked and unmarked connections
-/obj/structure/cable/proc/get_marked_connections()
-	. = list()	// this will be a list of all connected power objects
-	var/turf/T = loc
-
-	if(d1)	T = get_step(src, d1)
-	if(T)	. += power_list(T, src, d1, 0)
-
-	T = get_step(src, d2)
-	if(T)	. += power_list(T, src, d2, 0)
-
-	return .
-
-/obj/machinery/power/proc/get_connections()
-
-	. = list()
-
-	if(!directwired)
-		return get_indirect_connections()
-
-	var/cdir
-
-	for(var/card in cardinal)
-		var/turf/T = get_step(loc,card)
-		cdir = get_dir(T,loc)
-
-		for(var/obj/structure/cable/C in T)
-			if(C.powernet)	continue
-			if(C.d1 == cdir || C.d2 == cdir)
-				. += C
-	return .
-
-/obj/machinery/power/proc/get_marked_connections()
-
-	. = list()
-
-	if(!directwired)
-		return get_indirect_connections()
-
-	var/cdir
-
-	for(var/card in cardinal)
-		var/turf/T = get_step(loc,card)
-		cdir = get_dir(T,loc)
-
-		for(var/obj/structure/cable/C in T)
-			if(C.d1 == cdir || C.d2 == cdir)
-				. += C
-	return .
-
-/obj/machinery/power/proc/get_indirect_connections()
-	. = list()
-	for(var/obj/structure/cable/C in loc)
-		if(C.powernet)	continue
-		if(C.d1 == 0)
-			. += C
-	return .
-
-
-/proc/powernet_nextlink(var/obj/O, var/datum/powernet/PN)
-	var/list/P = list()
-
-	while(1)
-		if( istype(O,/obj/structure/cable) )
-			var/obj/structure/cable/C = O
-			C.powernet = PN
-			P = C.get_connections()
-
-		else if(O.anchored && istype(O,/obj/machinery/power))
-			var/obj/machinery/power/M = O
-			M.powernet = PN
-			P = M.get_connections()
-
-		else
-			return
-
-		if(P.len == 0)	return
-
-		O = P[1]
-
-		for(var/L = 2 to P.len)
-			powernet_nextlink(P[L], PN)
+	for(var/obj/structure/cable/PC in cable_list)
+		if(!PC.powernet)
+			PC.powernet = new()
+			propagate_network(PC,PC.powernet)
 
 //remove the old powernet and replace it with a new one throughout the network.
 /proc/propagate_network(var/obj/O, var/datum/powernet/PN)
 	//world.log << "propagating new network"
 	var/list/worklist = list()
-	worklist+=O
+	var/list/found_machines = list()
 	var/index = 1
-	while(index<=worklist.len)
-		var/obj/P = worklist[index++]
+	var/obj/P = null
+
+	worklist+=O //start propagating from the passed object
+
+	while(index<=worklist.len) //until we've exhausted all power objects
+		P = worklist[index] //get the next power object found
+		index++
+
 		if( istype(P,/obj/structure/cable))
-			//world.log << "is cable"
 			var/obj/structure/cable/C = P
-			if(C.powernet==PN)
-				//world.log << "already has correct network"
-				continue
-			//world.log << "removing from old powernet[C.powernet]"
-			C.powernet.cables-=C
-			C.powernet = PN
-			PN.cables+=C
-			for(var/obj/newP in C.get_marked_connections())
-				worklist+=newP
-			//world.log << "found [P.len] children"
+			if(C.powernet != PN) //add it to the powernet, if it isn't already there
+				PN.add_cable(C)
+			worklist |= C.get_marked_connections() //get adjacents power objects, with or without a powernet
+
 		else if(P.anchored && istype(P,/obj/machinery/power))
-			//world.log << "is machine"
 			var/obj/machinery/power/M = P
-			if(M.powernet==PN)
-				//world.log << "already has correct network"
-				continue
-			//world.log << "removing from old powernet[M.powernet]"
-			M.powernet.nodes-=M
-			M.powernet = PN
-			PN.nodes+=M
-			for(var/obj/newP in M.get_marked_connections())
-				worklist+=newP
-			//world.log << "found [P.len] children"
+			found_machines |= M //we wait until the powernet is fully propagates to connect the machines
+
 		else
 			continue
-//should be called after placing a cable which extends another cable, creating a "smooth" cable that no longer terminates in the centre of a turf.
-//needed as this can, unlike other placements, disconnect cables
-/obj/structure/cable/proc/denode()
-	//world.log << "denoding"
-	var/turf/T1 = loc
-	if(!T1) return
-	var/list/powerlist = power_list(T1,src,0,0) //find the other cables that ended in the centre of the turf
-	//world.log << "found [powerlist.len] power items, picking the first"
-	var/datum/powernet/oldPN = powernet
-	var/datum/powernet/PN = new()
-	powernets+=PN
-	if(powerlist.len>0)
-		propagate_network(powerlist[1],PN)
-	if(oldPN.cables.len==0&&oldPN.nodes.len==0)
-		//world.log << "There was a loop, so the old powernet was destroyed, removing it"
-		powernets-=oldPN
 
-// cut a powernet at this cable object
-/datum/powernet/proc/cut_cable(var/obj/structure/cable/C)
-	var/turf/T1 = C.loc
-	if(!T1)	return
-	var/node = 0
-	if(C.d1 == 0)
-		node = 1
-
-	var/turf/T2
-	if(C.d2)	T2 = get_step(T1, C.d2)
-	if(C.d1)	T1 = get_step(T1, C.d1)
+	//now that the powernet is set, connect found machines to it
+	for(var/obj/machinery/power/PM in found_machines)
+		if(!PM.connect_to_network()) //couldn't find a node on its turf...
+			PM.disconnect_from_network() //... so disconnect if already on a powernet
 
 
-	var/list/P1 = power_list(T1, C, C.d1)	// what joins on to cut cable in dir1
-	var/list/P2 = power_list(T2, C, C.d2)	// what joins on to cut cable in dir2
-
-//	if(Debug)
-//		for(var/obj/O in P1)
-//			world.log << "P1: [O] at [O.x] [O.y] : [istype(O, /obj/structure/cable) ? "[O:d1]/[O:d2]" : null] "
-//		for(var/obj/O in P2)
-//			world.log << "P2: [O] at [O.x] [O.y] : [istype(O, /obj/structure/cable) ? "[O:d1]/[O:d2]" : null] "
-
-
-	if(P1.len == 0 || P2.len == 0)//if nothing in either list, then the cable was an endpoint no need to rebuild the powernet,
-		cables -= C				//just remove cut cable from the list
-//		if(Debug) world.log << "Was end of cable"
+//Merge two powernets, the bigger (in cable length term) absorbing the other
+/proc/merge_powernets(var/datum/powernet/net1, var/datum/powernet/net2)
+	if(!net1 || !net2) //if one of the powernet doesn't exist, return
 		return
 
-	//null the powernet reference of all cables & nodes in this powernet
-	var/i=1
-	while(i<=cables.len)
-		var/obj/structure/cable/Cable = cables[i]
-		if(Cable)
-			Cable.powernet = null
-			if(Cable == C)
-				cables.Cut(i,i+1)
-				continue
-		i++
-	i=1
-	while(i<=nodes.len)
-		var/obj/machinery/power/Node = nodes[i]
-		if(Node)
-			Node.powernet = null
-		i++
-
-	// remove the cut cable from the network
-//	C.netnum = -1
-
-	C.loc = null
-
-	powernet_nextlink(P1[1], src)		// propagate network from 1st side of cable, using current netnum	//TODO?
-
-	// now test to see if propagation reached to the other side
-	// if so, then there's a loop in the network
-	var/notlooped = 0
-	for(var/O in P2)
-		if( istype(O, /obj/machinery/power) )
-			var/obj/machinery/power/Machine = O
-			if(Machine.powernet != src)
-				notlooped = 1
-				break
-		else if( istype(O, /obj/structure/cable) )
-			var/obj/structure/cable/Cable = O
-			if(Cable.powernet != src)
-				notlooped = 1
-				break
-
-	if(notlooped)
-		// not looped, so make a new powernet
-		var/datum/powernet/PN = new()
-		powernets += PN
-
-//		if(Debug) world.log << "Was not looped: spliting PN#[number] ([cables.len];[nodes.len])"
-
-		i=1
-		while(i<=cables.len)
-			var/obj/structure/cable/Cable = cables[i]
-			if(Cable && !Cable.powernet)	// non-connected cables will have powernet=null, since they weren't reached by propagation
-				Cable.powernet = PN
-				cables.Cut(i,i+1)	// remove from old network & add to new one
-				PN.cables += Cable
-				continue
-			i++
-
-		i=1
-		while(i<=nodes.len)
-			var/obj/machinery/power/Node = nodes[i]
-			if(Node && !Node.powernet)
-				Node.powernet = PN
-				nodes.Cut(i,i+1)
-				PN.nodes[Node] = Node
-				continue
-			i++
-
-	// Disconnect machines connected to nodes
-	if(node)
-		for(var/obj/machinery/power/P in T1)
-			if(P.powernet && !P.powernet.nodes[src])
-				P.disconnect_from_network()
-//		if(Debug)
-//			world.log << "Old PN#[number] : ([cables.len];[nodes.len])"
-//			world.log << "New PN#[PN.number] : ([PN.cables.len];[PN.nodes.len])"
-//
-//	else
-//		if(Debug)
-//			world.log << "Was looped."
-//		//there is a loop, so nothing to be done
-//		return
-
-
-
-/datum/powernet/proc/reset()
-	load = newload
-	newload = 0
-	avail = newavail
-	newavail = 0
-
-
-	viewload = 0.8*viewload + 0.2*load
-
-	viewload = round(viewload)
-
-	var/numapc = 0
-
-	if(nodes && nodes.len)
-		for(var/obj/machinery/power/terminal/term in nodes)
-			if( istype( term.master, /obj/machinery/power/apc ) )
-				numapc++
-
-	if(numapc)
-		perapc = avail/numapc
-
-	netexcess = avail - load
-
-	if( netexcess > 100)		// if there was excess power last cycle
-		if(nodes && nodes.len)
-			for(var/obj/machinery/power/smes/S in nodes)	// find the SMESes in the network
-				if(S.powernet == src)
-					S.restore()				// and restore some of the power that was used
-				else
-					error("[S.name] (\ref[S]) had a [S.powernet ? "different (\ref[S.powernet])" : "null"] powernet to our powernet (\ref[src]).") //this line is a faggot and using the normal ERROR proc breaks it
-					nodes.Remove(S)
-
-/datum/powernet/proc/get_electrocute_damage()
-	switch(avail)/*
-		if (1300000 to INFINITY)
-			return min(rand(70,150),rand(70,150))
-		if (750000 to 1300000)
-			return min(rand(50,115),rand(50,115))
-		if (100000 to 750000-1)
-			return min(rand(35,101),rand(35,101))
-		if (75000 to 100000-1)
-			return min(rand(30,95),rand(30,95))
-		if (50000 to 75000-1)
-			return min(rand(25,80),rand(25,80))
-		if (25000 to 50000-1)
-			return min(rand(20,70),rand(20,70))
-		if (10000 to 25000-1)
-			return min(rand(20,65),rand(20,65))
-		if (1000 to 10000-1)
-			return min(rand(10,20),rand(10,20))*/
-		if (1000000 to INFINITY)
-			return min(rand(50,160),rand(50,160))
-		if (200000 to 1000000)
-			return min(rand(25,80),rand(25,80))
-		if (100000 to 200000)//Ave powernet
-			return min(rand(20,60),rand(20,60))
-		if (50000 to 100000)
-			return min(rand(15,40),rand(15,40))
-		if (1000 to 50000)
-			return min(rand(10,20),rand(10,20))
-		else
-			return 0
-
-//The powernet that calls this proc will consume the other powernet
-/proc/merge_powernets(var/datum/powernet/net1, var/datum/powernet/net2)
-	if(!net1 || !net2)	return
-	if(net1 == net2)	return
+	if(net1 == net2) //don't merge same powernets
+		return
 
 	//We assume net1 is larger. If net2 is in fact larger we are just going to make them switch places to reduce on code.
 	if(net1.cables.len < net2.cables.len)	//net2 is larger than net1. Let's switch them around
@@ -464,55 +266,23 @@
 		net1 = net2
 		net2 = temp
 
+	//we don't use add_cable and add_machine here, because that could
+	//change the size of net2.nodes or net2.cables while in the loop (runtime galore)
 	for(var/i=1,i<=net2.nodes.len,i++)		//merge net2 into net1
-		var/obj/machinery/power/Node = net2.nodes[i]
+		var/obj/machinery/power/Node = net2.nodes[i] //merge power machines
 		if(Node)
 			Node.powernet = net1
 			net1.nodes[Node] = Node
 
 	for(var/i=1,i<=net2.cables.len,i++)
-		var/obj/structure/cable/Cable = net2.cables[i]
+		var/obj/structure/cable/Cable = net2.cables[i] //merge cables
 		if(Cable)
 			Cable.powernet = net1
 			net1.cables += Cable
 
-	del(net2)
+	qdel(net2) //garbage collect the now empty powernet
+
 	return net1
-
-
-/obj/machinery/power/proc/connect_to_network()
-	var/turf/T = src.loc
-	if(!T || !istype(T)) return 0
-	var/obj/structure/cable/C = T.get_cable_node()
-	if(!C || !C.powernet)	return 0
-//	makepowernets() //TODO: find fast way	//EWWWW what are you doing!?
-	powernet = C.powernet
-	powernet.nodes[src] = src
-	return 1
-
-/obj/machinery/power/proc/disconnect_from_network()
-	if(!powernet)
-		//world << " no powernet"
-		return 0
-	powernet.nodes -= src
-	powernet = null
-	//world << "powernet null"
-	return 1
-
-/turf/proc/get_cable_node()
-	if(!istype(src, /turf/simulated/floor))
-		return null
-	for(var/obj/structure/cable/C in src)
-		if(C.d1 == 0)
-			return C
-	return null
-
-/area/proc/get_apc()
-	for(var/area/RA in src.related)
-		var/obj/machinery/power/apc/FINDME = locate() in RA
-		if (FINDME)
-			return FINDME
-
 
 //Determines how strong could be shock, deals damage to mob, uses power.
 //M is a mob who touched wire/whatever
@@ -579,3 +349,143 @@
 		cell.use(drained_energy)
 	return drained_energy
 
+////////////////////////////////////////////
+// POWERNET DATUM PROCS
+// each contiguous network of cables & nodes
+////////////////////////////////////////////
+
+/datum/powernet/New()
+	powernets += src
+
+/datum/powernet/Destroy()
+	powernets -= src
+
+/datum/powernet/proc/is_empty()
+	return !cables.len && !nodes.len
+
+//remove a cable from the current powernet
+//if the powernet is then empty, delete it
+//Warning : this proc DON'T check if the cable exists
+/datum/powernet/proc/remove_cable(var/obj/structure/cable/C)
+	cables -= C
+	C.powernet = null
+	if(is_empty())//the powernet is now empty...
+		qdel(src)///... delete it
+
+//add a cable to the current powernet
+//Warning : this proc DON'T check if the cable exists
+/datum/powernet/proc/add_cable(var/obj/structure/cable/C)
+	if(C.powernet)// if C already has a powernet...
+		if(C.powernet == src)
+			return
+		else
+			C.powernet.remove_cable(C) //..remove it
+	C.powernet = src
+	cables +=C
+
+//remove a power machine from the current powernet
+//if the powernet is then empty, delete it
+//Warning : this proc DON'T check if the machine exists
+/datum/powernet/proc/remove_machine(var/obj/machinery/power/M)
+	nodes -=M
+	M.powernet = null
+	if(is_empty())//the powernet is now empty...
+		qdel(src)///... delete it
+
+
+//add a power machine to the current powernet
+//Warning : this proc DON'T check if the machine exists
+/datum/powernet/proc/add_machine(var/obj/machinery/power/M)
+	if(M.powernet)// if M already has a powernet...
+		if(M.powernet == src)
+			return
+		else
+			M.powernet.remove_machine(M) //..remove it
+	M.powernet = src
+	nodes[M] = M
+
+//handles the power changes in the powernet
+//called every ticks by the powernet controller
+/datum/powernet/proc/reset()
+	load = newload
+	newload = 0
+	avail = newavail
+	newavail = 0
+
+
+	viewload = 0.8*viewload + 0.2*load
+
+	viewload = round(viewload)
+
+	var/numapc = 0
+
+	if(nodes && nodes.len)
+		for(var/obj/machinery/power/terminal/term in nodes)
+			if( istype( term.master, /obj/machinery/power/apc ) )
+				numapc++
+
+	if(numapc)
+		perapc = avail/numapc
+
+	netexcess = avail - load
+
+	if( netexcess > 100)		// if there was excess power last cycle
+		if(nodes && nodes.len)
+			for(var/obj/machinery/power/smes/S in nodes)	// find the SMESes in the network
+				if(S.powernet == src)
+					S.restore()				// and restore some of the power that was used
+				else
+					error("[S.name] (\ref[S]) had a [S.powernet ? "different (\ref[S.powernet])" : "null"] powernet to our powernet (\ref[src]).") //this line is a faggot and using the normal ERROR proc breaks it
+					nodes.Remove(S)
+
+/datum/powernet/proc/get_electrocute_damage()
+	switch(avail)/*
+		if (1300000 to INFINITY)
+			return min(rand(70,150),rand(70,150))
+		if (750000 to 1300000)
+			return min(rand(50,115),rand(50,115))
+		if (100000 to 750000-1)
+			return min(rand(35,101),rand(35,101))
+		if (75000 to 100000-1)
+			return min(rand(30,95),rand(30,95))
+		if (50000 to 75000-1)
+			return min(rand(25,80),rand(25,80))
+		if (25000 to 50000-1)
+			return min(rand(20,70),rand(20,70))
+		if (10000 to 25000-1)
+			return min(rand(20,65),rand(20,65))
+		if (1000 to 10000-1)
+			return min(rand(10,20),rand(10,20))*/
+		if (1000000 to INFINITY)
+			return min(rand(50,160),rand(50,160))
+		if (200000 to 1000000)
+			return min(rand(25,80),rand(25,80))
+		if (100000 to 200000)//Ave powernet
+			return min(rand(20,60),rand(20,60))
+		if (50000 to 100000)
+			return min(rand(15,40),rand(15,40))
+		if (1000 to 50000)
+			return min(rand(10,20),rand(10,20))
+		else
+			return 0
+
+////////////////////////////////////////////////
+// Misc.
+///////////////////////////////////////////////
+
+
+// return a knot cable (O-X) if one is present in the turf
+// null if there's none
+/turf/proc/get_cable_node()
+	if(!istype(src, /turf/simulated/floor))
+		return null
+	for(var/obj/structure/cable/C in src)
+		if(C.d1 == 0)
+			return C
+	return null
+
+/area/proc/get_apc()
+	for(var/area/RA in src.related)
+		var/obj/machinery/power/apc/FINDME = locate() in RA
+		if (FINDME)
+			return FINDME

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -33,10 +33,10 @@ var/list/solars_list = list()
 	solars_list.Remove(src)
 
 /obj/machinery/power/solar/connect_to_network()
-	..()
+	var/to_return = ..()
 	if(powernet) //if connected and not already in solar_list...
 		solars_list |= src			   //... add it
-
+	return to_return
 
 /obj/machinery/power/solar/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)
@@ -287,9 +287,10 @@ var/list/solars_list = list()
 	solars_list.Remove(src)
 
 /obj/machinery/power/solar_control/connect_to_network()
-	..()
+	var/to_return = ..()
 	if(powernet) //if connected and not already in solar_list...
 		solars_list |= src //... add it
+	return to_return
 
 /obj/machinery/power/solar_control/initialize()
 	..()

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -26,9 +26,10 @@
 	solars_list.Remove(src)
 
 /obj/machinery/power/tracker/connect_to_network()
-	..()
+	var/to_return = ..()
 	if(powernet)	//if connected and not already in solar_list...
 		solars_list |= src				//... add it
+	return to_return
 
 /obj/machinery/power/tracker/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)


### PR DESCRIPTION
I started by investigating the powernets odd behavior, but finished by commenting/reorganizing/rewriting a large part of the power code...

I had to make design choices for this one, that have to be approved by the community, so, that's just a RFC for now.
This will get a PR if/when the community is ok with the way i've designed cable laying/machine connecting.

I've compiled a little file with the (not so) new powernets behavior/handling, that can be found here : http://www.sendspace.com/file/5nb2mn
**Alternative cable connection version is available here** : http://www.sendspace.com/file/3qhd5u
Please pardon the guerilla-style Paint illustrations...

The main change is that machines can now only be connected via a node cable on its turf (got rid of the _directwired_ half broken/implemented way of doing)

A quick summary of what was done :
- cleaned, organized and commented a large part of the power code, 
- some new procs handling (powernets creation/destruction, cable adding/removing, machines adding/removing, ...)
- new cable laying possibility : if you click in the turf you're standing on, you'll try to lay a node cable in the direction you're facing,
- cleaned lots of oversights that could (and would) leave empty powernets in the powernets global list
- got rid of the recursive way of propagating networks,
- rewrote the cut_cable and propagate_network procs to correctly updates every connected cables and machines (fix, at last, #1455).

That last one was severely lacking : in fact, each time you cut a cable and there was more than one adjacent cable in a given direction, only the first found was updated (so you'll get cables with null powernet or physically separated cables that were in the same powernet).

There's certainly room for improvement and optimization, but it's working and a good base for anyone wanting to meddle with powernets.
