### PR TITLE
Windoor fix

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -90,19 +90,6 @@
 			user.visible_message("<span class='warning'>[user] forces the door to open with \his [src]!</span>", "<span class='warning'>We force the door to open.</span>", "<span class='warning'>You hear a metal screeching sound.</span>")
 			A.open(1)
 
-	else if(istype(target, /obj/machinery/door/window))
-		var/obj/machinery/door/window/W = target
-
-		if(!W.requiresID() || W.allowed(user)) 
-			return
-
-		if(!(W.stat & NOPOWER))
-			user << "<span class='notice'>[W]'s motors resist our efforts to force it.</span>"
-			return
-		else
-			user.visible_message("<span class='warning'>[user] forces the door to open with \his [src]!</span>", "<span class='warning'>We force the door to open.</span>", "<span class='warning'>You hear a glass screeching sound.</span>")
-			W.open(1)
-
 //Space Suit & Helmet
 /obj/effect/proc_holder/changeling/organic_space_suit
 	name = "Organic Space Suit"

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -90,6 +90,19 @@
 			user.visible_message("<span class='warning'>[user] forces the door to open with \his [src]!</span>", "<span class='warning'>We force the door to open.</span>", "<span class='warning'>You hear a metal screeching sound.</span>")
 			A.open(1)
 
+	else if(istype(target, /obj/machinery/door/window))
+		var/obj/machinery/door/window/W = target
+
+		if(!W.requiresID() || W.allowed(user)) 
+			return
+
+		if(!(W.stat & NOPOWER))
+			user << "<span class='notice'>[W]'s motors resist our efforts to force it.</span>"
+			return
+		else
+			user.visible_message("<span class='warning'>[user] forces the door to open with \his [src]!</span>", "<span class='warning'>We force the door to open.</span>", "<span class='warning'>You hear a glass screeching sound.</span>")
+			W.open(1)
+
 //Space Suit & Helmet
 /obj/effect/proc_holder/changeling/organic_space_suit
 	name = "Organic Space Suit"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -25,23 +25,31 @@
 	playsound(src, "shatter", 70, 1)
 	..()
 
+
+/obj/machinery/door/window/proc/open_and_close()
+	open()
+	if(src.check_access(null))
+		sleep(50)
+	else //secure doors close faster
+		sleep(20)
+	close()
+
 /obj/machinery/door/window/Bumped(atom/movable/AM as mob|obj)
-	if(operating)
+	if( operating || !src.density )
 		return
 	if (!( ismob(AM) ))
 		var/obj/machinery/bot/bot = AM
 		if(istype(bot))
-			if(density && src.check_access(bot.botcard))
-				open()
-				sleep(50)
-				close()
+			if(src.check_access(bot.botcard))
+				open_and_close()
+			else
+				flick(text("[]deny", src.base_state), src)
 		else if(istype(AM, /obj/mecha))
 			var/obj/mecha/mecha = AM
-			if(density)
-				if(mecha.occupant && src.allowed(mecha.occupant))
-					open()
-					sleep(50)
-					close()
+			if(mecha.occupant && src.allowed(mecha.occupant))
+				open_and_close()
+			else
+				flick(text("[]deny", src.base_state), src)
 		return
 	if (!( ticker ))
 		return
@@ -51,21 +59,16 @@
 	return
 
 /obj/machinery/door/windoor/bumpopen(mob/user as mob)
-	if(operating)
+	if( operating || !src.density )
 		return
 	src.add_fingerprint(user)
 	if(!src.requiresID())
 		user = null
 
-	if(density & allowed(user))
-			open()
-			if(src.check_access(null))
-				sleep(50)
-			else //secure doors close faster
-				sleep(20)
-			close()
-		else
-			flick(text("[]deny", src.base_state), src)
+	if(allowed(user))
+			open_and_close()
+	else
+		flick(text("[]deny", src.base_state), src)
 	return
 
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -183,18 +183,36 @@
 /obj/machinery/door/window/attack_ai(mob/user as mob)
 	return src.attack_hand(user)
 
-/obj/machinery/door/window/attack_paw(mob/user as mob)
-	if(istype(user, /mob/living/carbon/alien/humanoid) || istype(user, /mob/living/carbon/slime/))
-		if(src.operating)
-			return
-		user.changeNext_move(8)
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		user.visible_message("<span class='danger'>[user] smashes against the [src.name].</span>", \
-					"<span class='userdanger'>[user] smashes against the [src.name].</span>")
-		take_damage(25)
-	else
-		return src.attack_hand(user)
+/obj/machinery/door/window/proc/attack_generic(mob/user as mob, damage = 0)
+	if(src.operating)
+		return
+	user.changeNext_move(8)
+	playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+	user.visible_message("<span class='danger'>[user] smashes against the [src.name].</span>", \
+				"<span class='userdanger'>[user] smashes against the [src.name].</span>")
+	take_damage(damage)
 
+/obj/machinery/door/window/attack_alien(mob/user as mob)
+	if(islarva(user))
+		return
+	attack_generic(user, 25)
+
+/obj/machinery/door/window/attack_animal(mob/user as mob)
+	if(!isanimal(user))
+		return
+	var/mob/living/simple_animal/M = user
+	if(M.melee_damage_upper <= 0)
+		return
+	attack_generic(M, M.melee_damage_upper)
+
+
+/obj/machinery/door/window/attack_slime(mob/living/carbon/slime/user as mob)
+	if(!user.is_adult)
+		return
+	attack_generic(user, 25)
+
+/obj/machinery/door/window/attack_paw(mob/user as mob)
+		return src.attack_hand(user)
 
 /obj/machinery/door/window/attack_hand(mob/user as mob)
 	return src.attackby(user, user)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -223,7 +223,7 @@
 		return 1
 
 	//If it's a weapon, smash windoor. Unless it's a crowbar, an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
-	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card)) && !istype(I, /obj/item/weapon/crowbar)
+	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card) && !istype(I, /obj/item/weapon/crowbar))
 		user.changeNext_move(8)
 		var/aforce = I.force
 		if(I.damtype == BRUTE || I.damtype == BURN)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -58,7 +58,7 @@
 		bumpopen(M)
 	return
 
-/obj/machinery/door/windoor/bumpopen(mob/user as mob)
+/obj/machinery/door/window/bumpopen(mob/user as mob)
 	if( operating || !src.density )
 		return
 	src.add_fingerprint(user)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -221,8 +221,9 @@
 		visible_message("<span class='danger'>\The [src] has been hit by [user] with [I].</span>")
 		if (src.health <= 0)
 			new /obj/item/weapon/shard(src.loc)
-			var/obj/item/stack/cable_coil/CC = new /obj/item/stack/cable_coil(src.loc)
-			CC.amount = 2
+			new /obj/item/weapon/shard(src.loc)
+			new /obj/item/stack/rods(src.loc, 2)
+			new /obj/item/stack/cable_coil(src.loc, 2)
 			src.density = 0
 			qdel(src)
 		return

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -99,8 +99,11 @@
 		return 0
 	if (!ticker)
 		return 0
+	if(!forced)
+		if(stat & NOPOWER)
+			return 0
 	if(forced < 2)
-		if( (stat & NOPOWER) || emagged )
+		if(emagged)
 			return 0
 	if(!src.operating) //in case of emag
 		src.operating = 1
@@ -122,8 +125,11 @@
 /obj/machinery/door/window/close(var/forced=0)
 	if (src.operating)
 		return 0
+	if(!forced)
+		if(stat & NOPOWER)
+			return 0
 	if(forced < 2)
-		if(emagged || (stat & NOPOWER))
+		if(emagged)
 			return 0
 	src.operating = 1
 	flick(text("[]closing", src.base_state), src)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -239,8 +239,8 @@
 			qdel(src)
 		return
 	
-	if(istype(I, /obj/item/weapon/crowbar)
-		if(stat & NOPOWER))
+	if(istype(I, /obj/item/weapon/crowbar))
+		if(stat & NOPOWER)
 			if(src.density)
 				open(2)
 			else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -206,6 +206,8 @@
 	//Emags and ninja swords? You may pass.
 	if (src.density && (istype(I, /obj/item/weapon/card/emag)||istype(I, /obj/item/weapon/melee/energy/blade)))
 		src.operating = -1
+		flick("[src.base_state]spark", src)
+		sleep(6)
 		if(istype(I, /obj/item/weapon/melee/energy/blade))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)
@@ -213,9 +215,10 @@
 			playsound(src.loc, "sparks", 50, 1)
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message("\blue The glass door was sliced open by [user]!")
-		flick("[src.base_state]spark", src)
-		sleep(6)
-		open(2)
+			open(2)
+			emagged = 1
+			return 1
+		open()
 		emagged = 1
 		return 1
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -66,7 +66,7 @@
 		user = null
 
 	if(allowed(user))
-			open_and_close()
+		open_and_close()
 	else
 		flick(text("[]deny", src.base_state), src)
 	return
@@ -100,7 +100,7 @@
 	if (!ticker)
 		return 0
 	if(forced < 2)
-		if(stat & NOPOWER) || emagged)
+		if( (stat & NOPOWER) || emagged )
 			return 0
 	if(!src.operating) //in case of emag
 		src.operating = 1


### PR DESCRIPTION
- fixes #3584
- unpowered windoors stop functioning but can be forced open with eblade, and forced open or closed with crowbar, fireaxe and armblade.
- mobs bumping open windoors leave fingerprints.
- Destroying windoor now drops 2 glass shards, 2 rods, 2 cable pieces.
- mechas & bots w/o access trigger the deny animation when bumping the windoor
- secure windoors close faster when bumped open by mecha/bot (same as mobs).
- Adding span class stuff.
- Simple animals,  adult aliens and  adult slimes can attack windoors. Fixes #3783
