### PR TITLE
Emp backpack Icon fix

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -10,9 +10,8 @@
 	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
 
 /obj/item/weapon/gun/energy/emp_act(severity)
-	power_supply.use(round(power_supply.maxcharge / severity))
+	power_supply.use(round(power_supply.charge / severity))
 	update_icon()
-	..()
 
 
 /obj/item/weapon/gun/energy/New()


### PR DESCRIPTION
-Fixes the use() power proc usage in the energy gun's emp_act(). Previously it was trying to pass in the maxcharge of the gun's cell, which caused it to not do anything at all, now it removes all charge from the gun if its a severity 1 emp, half if 2 etc..
-Removes the call to the parent emp_act() proc. The functionality is already done in the energy gun's emp_act() proc.

Fixes #3635
