### PR TITLE
Emagged cleanbots now spew foam instead of spawning gibs!

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -25,8 +25,6 @@
 	health = 25
 	maxhealth = 25
 	var/cleaning = 0
-	var/screwloose = 0
-	var/oddbutton = 0
 	var/blood = 1
 	var/list/target_types = list()
 	var/obj/effect/decal/cleanable/target
@@ -92,12 +90,12 @@ text("<A href='?src=\ref[src];operation=start'>[src.on ? "On" : "Off"]</A>"))
 		dat += text({"<BR>Cleans Blood: []<BR>"}, text("<A href='?src=\ref[src];operation=blood'>[src.blood ? "Yes" : "No"]</A>"))
 		dat += text({"<BR>Patrol station: []<BR>"}, text("<A href='?src=\ref[src];operation=patrol'>[src.should_patrol ? "Yes" : "No"]</A>"))
 	//	dat += text({"<BR>Beacon frequency: []<BR>"}, text("<A href='?src=\ref[src];operation=freq'>[src.beacon_freq]</A>"))
-	if(src.open && !src.locked)
+/*	if(src.open && !src.locked)
 		dat += text({"
 Odd looking screw twiddled: []<BR>
 Weird button pressed: []"},
 text("<A href='?src=\ref[src];operation=screw'>[src.screwloose ? "Yes" : "No"]</A>"),
-text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"]</A>"))
+text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"]</A>"))*/
 
 	user << browse("<HEAD><TITLE>Cleaner v1.0 controls</TITLE></HEAD>[dat]", "window=autocleaner")
 	onclose(user, "autocleaner")
@@ -127,18 +125,17 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			if (freq > 0)
 				src.beacon_freq = freq
 			src.updateUsrDialog()
-		if("screw")
+/*		if("screw")
 			src.screwloose = !src.screwloose
 			usr << "<span class='notice>You twiddle the screw.</span>"
 			src.updateUsrDialog()
 		if("oddbutton")
 			src.oddbutton = !src.oddbutton
 			usr << "<span class='notice'>You press the weird button.</span>"
-			src.updateUsrDialog()
+			src.updateUsrDialog() */
 		if("hack")
-			if(!src.oddbutton)
-				src.emagged = 2 //Cleanbots are odd, this is here to ensure the "compromised" status updates properly.
-				src.oddbutton = 1
+			if(!src.emagged)
+				src.emagged = 2
 				src.hacked = 1
 				usr << "<span class='warning'>You corrupt [src]'s cleaning software.</span>"
 			else if(!src.hacked)
@@ -146,7 +143,6 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			else
 				src.hacked = 0
 				src.emagged = 0
-				src.oddbutton = 0
 				usr << "<span class='notice'>[src]'s software has been reset!</span>"
 			src.updateUsrDialog()
 
@@ -168,9 +164,8 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 /obj/machinery/bot/cleanbot/Emag(mob/user as mob)
 	..()
 	if(open && !locked)
-		if(user) user << "<span class='notice'>The [src] buzzes and beeps.</span>"
-		src.oddbutton = 1
-		src.screwloose = 1
+		if(user) user << "<span class='notice'>[src] buzzes and beeps.</span>"
+		src.emagged = 2
 
 /obj/machinery/bot/cleanbot/process()
 	set background = BACKGROUND_ENABLED
@@ -181,17 +176,18 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 		return
 	var/list/cleanbottargets = list()
 
-	if(!src.screwloose && !src.oddbutton && prob(5))
+	if(!src.emagged && prob(5))
 		visible_message("[src] makes an excited beeping booping sound!")
 
-	if(src.screwloose && prob(5))
+	if(src.emagged && prob(10)) //Wets floors randomly
 		if(istype(loc,/turf/simulated))
 			var/turf/simulated/T = src.loc
 			T.MakeSlippery()
 
-	if(src.oddbutton && prob(5))
+	if(src.emagged && prob(5)) //Spawns foam!
 		visible_message("<span class='danger'>[src] whirs and bubbles violently, before releasing a plume of froth!</span>")
 		new /obj/effect/effect/foam(src.loc)
+		
 	if(!src.target || src.target == null)
 		for (var/obj/effect/decal/cleanable/D in view(7,src))
 			for(var/T in src.target_types)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -190,10 +190,8 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 			T.MakeSlippery()
 
 	if(src.oddbutton && prob(5))
-		visible_message("Something flies out of [src]. He seems to be acting oddly.")
-		var/obj/effect/decal/cleanable/blood/gibs/gib = new /obj/effect/decal/cleanable/blood/gibs(src.loc)
-		//gib.streak(list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
-		src.oldtarget = gib
+		visible_message("<span class='danger'>[src] whirs and bubbles violently, before releasing a plume of froth!</span>")
+		new /obj/effect/effect/foam(src.loc)
 	if(!src.target || src.target == null)
 		for (var/obj/effect/decal/cleanable/D in view(7,src))
 			for(var/T in src.target_types)
@@ -322,7 +320,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 /obj/machinery/bot/cleanbot/proc/clean(var/obj/effect/decal/cleanable/target)
 	src.anchored = 1
 	src.icon_state = "cleanbot-c"
-	visible_message("\red [src] begins to clean up [target]")
+	visible_message("<span class='danger'>[src] begins to clean up [target]</span>")
 	src.cleaning = 1
 	spawn(50)
 		src.cleaning = 0
@@ -333,7 +331,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 
 /obj/machinery/bot/cleanbot/explode()
 	src.on = 0
-	src.visible_message("\red <B>[src] blows apart!</B>", 1)
+	src.visible_message("<span class='danger'><B>[src] blows apart!</B></span>", 1)
 	var/turf/Tsec = get_turf(src)
 
 	new /obj/item/weapon/reagent_containers/glass/bucket(Tsec)


### PR DESCRIPTION
Emagged cleanbots will now release foam that will slip anyone caught in it!
This is the same effect generated by AI liquid dispensers.

EDIT: They will now have an increased chance to wet a tile!

Reasoning for this Pull Request:
The cleanbot's emag effect was completely worthless. It spawned gibs randomly and occasionally wet a tile. That is it. What made things worse is that after doing so, it would proceed to clean up the gibs as in a dog eating its own vomit.

This PR seeks to make the cleanbot more "fun" to emag. It will give an actual reason to bother doing it, and may prove useful to clever traitors and the clown!

Also in the PR: Converts the "/red" text to span classes.
