### PR TITLE
Fix for #2660: clowns killing themselves with toy dualsabers

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -213,9 +213,10 @@ obj/item/weapon/twohanded/
 
 /obj/item/weapon/twohanded/dualsaber/attack(target as mob, mob/living/user as mob)
 	..()
-	if((CLUMSY in user.mutations) && (wielded) &&prob(40))
+	if((CLUMSY in user.mutations) && (wielded) && prob(40))
 		user << "\red You twirl around a bit before losing your balance and impaling yourself on the [src]."
-		user.take_organ_damage(20,25)
+		if (force_wielded)
+			user.take_organ_damage(20,25)
 		return
 	if((wielded) && prob(50))
 		spawn(0)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -214,7 +214,7 @@ obj/item/weapon/twohanded/
 /obj/item/weapon/twohanded/dualsaber/attack(target as mob, mob/living/user as mob)
 	..()
 	if((CLUMSY in user.mutations) && (wielded) && prob(40))
-		Impale(user)
+		impale(user)
 		return
 	if((wielded) && prob(50))
 		spawn(0)
@@ -222,7 +222,7 @@ obj/item/weapon/twohanded/
 				user.dir = i
 				sleep(1)
 
-/obj/item/weapon/twohanded/dualsaber/proc/Impale(mob/living/user as mob)
+/obj/item/weapon/twohanded/dualsaber/proc/impale(mob/living/user as mob)
 	user << "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on the [src].</span>"
 	if (force_wielded)
 		user.take_organ_damage(20,25)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -214,15 +214,20 @@ obj/item/weapon/twohanded/
 /obj/item/weapon/twohanded/dualsaber/attack(target as mob, mob/living/user as mob)
 	..()
 	if((CLUMSY in user.mutations) && (wielded) && prob(40))
-		user << "\red You twirl around a bit before losing your balance and impaling yourself on the [src]."
-		if (force_wielded)
-			user.take_organ_damage(20,25)
+		Impale(user)
 		return
 	if((wielded) && prob(50))
 		spawn(0)
 			for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))
 				user.dir = i
 				sleep(1)
+
+/obj/item/weapon/twohanded/dualsaber/proc/Impale(mob/living/user as mob)
+	user << "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on the [src].</span>"
+	if (force_wielded)
+		user.take_organ_damage(20,25)
+	else
+		user.adjustStaminaLoss(25)
 
 /obj/item/weapon/twohanded/dualsaber/IsShield()
 	if(wielded)


### PR DESCRIPTION
Clowns no longer kill themselves with dual toy swords, instead they receive holodamage. Fixes #2660

And a span class.
