### PR TITLE
Medal of Captaincy is no longer twice as large.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -25,9 +25,8 @@ Captain
 
 /datum/job/captain/equip_items(var/mob/living/carbon/human/H)
 	var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
-	U.hastie = new /obj/item/clothing/tie/medal/gold/captain(U)
+	U.attachTie(new /obj/item/clothing/tie/medal/gold/captain())
 	H.equip_to_slot_or_del(U, slot_w_uniform)
-
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/capcarapace(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/brown(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/caphat(H), slot_head)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -834,12 +834,13 @@ var/global/list/g_fancy_list_of_safe_types = null
 					carried_item.add_blood(M)//Oh yes, there will be blood...
 
 		if("assassin")
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/suit_jacket(M), slot_w_uniform)
+			var/obj/item/clothing/under/U = new /obj/item/clothing/under/suit_jacket(M)
+			M.equip_to_slot_or_del(U, slot_w_uniform)
+			U.attachTie(new /obj/item/clothing/tie/waistcoat(M))
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(M), slot_shoes)
 			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(M), slot_gloves)
 			M.equip_to_slot_or_del(new /obj/item/device/radio/headset(M), slot_ears)
 			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(M), slot_glasses)
-			M.equip_to_slot_or_del(new /obj/item/clothing/tie/waistcoat(M), slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/weapon/melee/energy/sword(M), slot_l_store)
 
 			var/obj/item/weapon/storage/secure/briefcase/sec_briefcase = new(M)


### PR DESCRIPTION
Fixes issue #2883 and a minor bug where set-equipment wasn't properly equipping "assassins" with waistcoats.  Both cases now use the existing attachTie method, which exists for this reason.

Thanks to Tastyfish for help identifying the actual issue, as #2883 appeared to be resolved at first.
