### PR TITLE
Fixes #3532 (force secret only works if game mode is in random pool)

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -65,19 +65,19 @@ var/round_start_time = 0
 		src.hide_mode = 1
 	var/list/datum/game_mode/runnable_modes
 	if((master_mode=="random") || (master_mode=="secret"))
-		runnable_modes = config.get_runnable_modes()
-		if (runnable_modes.len==0)
-			current_state = GAME_STATE_PREGAME
-			world << "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby."
-			return 0
-		if(secret_force_mode != "secret")
-			for (var/datum/game_mode/M in runnable_modes)
-				if (M.config_tag && M.config_tag == secret_force_mode)
-					src.mode = M
-					break
-			if	(!src.mode)
-				message_admins("\blue Unable to force secret [secret_force_mode].", 1)
+		if((master_mode=="secret") && (secret_force_mode != "secret"))
+			var/datum/game_mode/smode = config.pick_mode(secret_force_mode)
+			if (!smode.can_start())
+				message_admins("\blue Unable to force secret [secret_force_mode]. [smode.required_players] players and [smode.required_enemies] eligible antagonists needed.", 1)
+			else
+				src.mode = smode
+
 		if(!src.mode)
+			runnable_modes = config.get_runnable_modes()
+			if (runnable_modes.len==0)
+				current_state = GAME_STATE_PREGAME
+				world << "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby."
+				return 0
 			src.mode = pickweight(runnable_modes)
 
 	else


### PR DESCRIPTION
Fixes #3532

Basically, if the game mode selected wasn't in the config for random modes, it couldn't be used with force secret.

This logic is shit because force secret is used as select game mode, but without announcing it to the peeps, and since you can select game modes not in the config, you should be able to do so as well when forcing secret.

From looking at the old code, i think they were trying to select just modes that the player count was right for, but choosing from runnable_modes also limits it to modes in the config, and extended isn't always in there.

The rest of the logic is the same, if secret is forced, and the game mode fails/can't run, it just reverts to normal random secret, while letting the admins know why it failed.
