### PR TITLE
Fixed grenade casing name not changing

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -3,7 +3,7 @@
 #define READY 2
 
 /obj/item/weapon/grenade/chem_grenade
-	name = "grenade casing"
+	name = "grenade"
 	desc = "A do it yourself grenade casing!"
 	icon_state = "chemg"
 	item_state = "flashbang"
@@ -18,6 +18,7 @@
 
 /obj/item/weapon/grenade/chem_grenade/New()
 	create_reagents(1000)
+	name = initial(name) + " casing" // By adding the " casing" part here we can use initial(name) to get the final name, making it nice to say "large grenade" when it is a large grenade.
 
 
 /obj/item/weapon/grenade/chem_grenade/examine()
@@ -50,12 +51,14 @@
 	if(istype(I, /obj/item/weapon/screwdriver))
 		if(stage == WIRED)
 			if(beakers.len)
-				user << "<span class='notice'>You lock the assembly.</span>"
+				user << "<span class='notice'>You lock the " + initial(name) +" assembly.</span>"
 				playsound(loc, 'sound/items/Screwdriver.ogg', 25, -3)
+				name = initial(name)
+				desc = "A custom made " + initial(name) +"."
 				icon_state = initial(icon_state) +"_locked"
 				stage = READY
 			else
-				user << "<span class='notice'>You need to add at least one beaker before locking the assembly.</span>"
+				user << "<span class='notice'>You need to add at least one beaker before locking the " + initial(name) +" assembly.</span>"
 		else if(stage == READY && !nadeassembly)
 			det_time = det_time == 50 ? 30 : 50	//toggle between 30 and 50
 			user << "<span class='notice'>You modify the time delay. It's set for [det_time / 10] second\s.</span>"
@@ -68,7 +71,7 @@
 			return
 		else
 			if(I.reagents.total_volume)
-				user << "<span class='notice'>You add [I] to the assembly.</span>"
+				user << "<span class='notice'>You add [I] to the " + initial(name) +" assembly.</span>"
 				user.drop_item()
 				I.loc = src
 				beakers += I
@@ -89,34 +92,46 @@
 		assemblyattacher = user.ckey
 
 		stage = WIRED
+		name = "unsecured " + initial(name)
+		desc = "An unsecured " + initial(name) +" assembly."
 		icon_state = initial(icon_state) + "_ass"
-		user << "<span class='notice'>You add [A] to [src]!</span>"
+		user << "<span class='notice'>You add [A] to the " + initial(name) +" assembly!</span>"
 
 	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		C.use(1)
-
+		det_time = 50 // In case the cable_coil was removed and readded.
 		stage = WIRED
+		name = "unsecured " + initial(name)
+		desc = "An unsecured " + initial(name) +" assembly."
 		icon_state = initial(icon_state) + "_ass"
-		user << "<span class='notice'>You rig [src].</span>"
+		user << "<span class='notice'>You rig the " + initial(name) +" assembly.</span>"
 
 	else if(stage == READY && istype(I, /obj/item/weapon/wirecutters))
-		user << "<span class='notice'>You unlock the assembly.</span>"
+		user << "<span class='notice'>You unlock the " + initial(name) +" assembly.</span>"
+		name = "unsecured " + initial(name)
+		desc = "An unsecured " + initial(name) +" assembly."
 		icon_state = initial(icon_state) + "_ass"
 		stage = WIRED
 
 	else if(stage == WIRED && istype(I, /obj/item/weapon/wrench))
-		user << "<span class='notice'>You open the grenade and remove the contents.</span>"
-		icon_state = initial(icon_state)
+		if(beakers.len)
+			for(var/obj/O in beakers)
+				O.loc = get_turf(src)
+			beakers = list()
+			user << "<span class='notice'>You open the " + initial(name) +" assembly and remove the payload.</span>"
+			return // First use of the wrench remove beakers, then use the wrench to remove the activation mechanism.
 		stage = EMPTY
 		if(nadeassembly)
 			nadeassembly.loc = get_turf(src)
 			nadeassembly.master = null
 			nadeassembly = null
-		if(beakers.len)
-			for(var/obj/O in beakers)
-				O.loc = get_turf(src)
-			beakers = list()
+		else // If "nadeassembly = null && stage == WIRED", then it most have been cable_coil that was used.
+			new /obj/item/stack/cable_coil(get_turf(src),1)
+		user << "<span class='notice'>You remove the activation mechanism from the " + initial(name) +" assembly.</span>"
+		name = initial(name) + " casing"
+		desc = initial(desc)
+		icon_state = initial(icon_state)
 
 
 
@@ -190,8 +205,8 @@
 
 //Large chem grenades accept slime cores and use the appropriately.
 /obj/item/weapon/grenade/chem_grenade/large
-	name = "large chem grenade"
-	desc = "An oversized grenade that affects a larger area."
+	name = "large grenade"
+	desc = "An oversized grenade casing."
 	icon_state = "large_grenade"
 	allowed_containers = list(/obj/item/weapon/reagent_containers/glass,/obj/item/weapon/reagent_containers/food/condiment,
 								/obj/item/weapon/reagent_containers/food/drinks)
@@ -217,7 +232,7 @@
 	//make a special case you might as well do it explicitly. -Sayu
 /obj/item/weapon/grenade/chem_grenade/large/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/slime_extract) && stage == WIRED)
-		user << "<span class='notice'>You add [I] to the assembly.</span>"
+		user << "<span class='notice'>You add [I] to the " + initial(name) +" assembly.</span>"
 		user.drop_item()
 		I.loc = src
 		beakers += I

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -18,7 +18,7 @@
 
 /obj/item/weapon/grenade/chem_grenade/New()
 	create_reagents(1000)
-	name = initial(name) + " casing" // By adding the " casing" part here we can use initial(name) to get the final name, making it nice to say "large grenade" when it is a large grenade.
+	name = "[initial(name)] casing" // By adding the " casing" part here we can use initial(name) to get the final name, making it nice to say "large grenade" when it is a large grenade.
 
 
 /obj/item/weapon/grenade/chem_grenade/examine()
@@ -51,14 +51,11 @@
 	if(istype(I, /obj/item/weapon/screwdriver))
 		if(stage == WIRED)
 			if(beakers.len)
-				user << "<span class='notice'>You lock the " + initial(name) +" assembly.</span>"
+				stage_change(READY)
+				user << "<span class='notice'>You lock the [initial(name)] assembly.</span>"
 				playsound(loc, 'sound/items/Screwdriver.ogg', 25, -3)
-				name = initial(name)
-				desc = "A custom made " + initial(name) +"."
-				icon_state = initial(icon_state) +"_locked"
-				stage = READY
 			else
-				user << "<span class='notice'>You need to add at least one beaker before locking the " + initial(name) +" assembly.</span>"
+				user << "<span class='notice'>You need to add at least one beaker before locking the [initial(name)] assembly.</span>"
 		else if(stage == READY && !nadeassembly)
 			det_time = det_time == 50 ? 30 : 50	//toggle between 30 and 50
 			user << "<span class='notice'>You modify the time delay. It's set for [det_time / 10] second\s.</span>"
@@ -71,7 +68,7 @@
 			return
 		else
 			if(I.reagents.total_volume)
-				user << "<span class='notice'>You add [I] to the " + initial(name) +" assembly.</span>"
+				user << "<span class='notice'>You add [I] to the [initial(name)] assembly.</span>"
 				user.drop_item()
 				I.loc = src
 				beakers += I
@@ -91,48 +88,51 @@
 		A.loc = src
 		assemblyattacher = user.ckey
 
-		stage = WIRED
-		name = "unsecured " + initial(name)
-		desc = "An unsecured " + initial(name) +" assembly."
-		icon_state = initial(icon_state) + "_ass"
-		user << "<span class='notice'>You add [A] to the " + initial(name) +" assembly!</span>"
+		stage_change(WIRED)
+		user << "<span class='notice'>You add [A] to the [initial(name)] assembly!</span>"
 
 	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		C.use(1)
 		det_time = 50 // In case the cable_coil was removed and readded.
-		stage = WIRED
-		name = "unsecured " + initial(name)
-		desc = "An unsecured " + initial(name) +" assembly."
-		icon_state = initial(icon_state) + "_ass"
-		user << "<span class='notice'>You rig the " + initial(name) +" assembly.</span>"
+		stage_change(WIRED)
+		user << "<span class='notice'>You rig the [initial(name)] assembly.</span>"
 
 	else if(stage == READY && istype(I, /obj/item/weapon/wirecutters))
-		user << "<span class='notice'>You unlock the " + initial(name) +" assembly.</span>"
-		name = "unsecured " + initial(name)
-		desc = "An unsecured " + initial(name) +" assembly."
-		icon_state = initial(icon_state) + "_ass"
-		stage = WIRED
+		stage_change(WIRED)
+		user << "<span class='notice'>You unlock the [initial(name)] assembly.</span>"
 
 	else if(stage == WIRED && istype(I, /obj/item/weapon/wrench))
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.loc = get_turf(src)
 			beakers = list()
-			user << "<span class='notice'>You open the " + initial(name) +" assembly and remove the payload.</span>"
+			user << "<span class='notice'>You open the [initial(name)] assembly and remove the payload.</span>"
 			return // First use of the wrench remove beakers, then use the wrench to remove the activation mechanism.
-		stage = EMPTY
 		if(nadeassembly)
 			nadeassembly.loc = get_turf(src)
 			nadeassembly.master = null
 			nadeassembly = null
 		else // If "nadeassembly = null && stage == WIRED", then it most have been cable_coil that was used.
 			new /obj/item/stack/cable_coil(get_turf(src),1)
-		user << "<span class='notice'>You remove the activation mechanism from the " + initial(name) +" assembly.</span>"
-		name = initial(name) + " casing"
+		stage_change(EMPTY)
+		user << "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>"
+
+
+/obj/item/weapon/grenade/chem_grenade/stage_change(var/N)
+	stage = N
+	if (stage == EMPTY)
+		name = "[initial(name)] casing"
 		desc = initial(desc)
 		icon_state = initial(icon_state)
-
+	else if (stage == WIRED)
+		name = "unsecured [initial(name)]"
+		desc = "An unsecured [initial(name)] assembly."
+		icon_state = "[initial(name)]_ass"
+	else if (stage == READY)
+		name = initial(name)
+		desc = "A custom made [initial(name)]."
+		icon_state = "[initial(name)]_locked"
 
 
 //assembly stuff
@@ -232,7 +232,7 @@
 	//make a special case you might as well do it explicitly. -Sayu
 /obj/item/weapon/grenade/chem_grenade/large/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/slime_extract) && stage == WIRED)
-		user << "<span class='notice'>You add [I] to the " + initial(name) +" assembly.</span>"
+		user << "<span class='notice'>You add [I] to the [initial(name)] assembly.</span>"
 		user.drop_item()
 		I.loc = src
 		beakers += I

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -119,7 +119,7 @@
 		user << "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>"
 
 
-/obj/item/weapon/grenade/chem_grenade/stage_change(var/N)
+/obj/item/weapon/grenade/chem_grenade/proc/stage_change(var/N)
 	stage = N
 	if (stage == EMPTY)
 		name = "[initial(name)] casing"
@@ -128,11 +128,11 @@
 	else if (stage == WIRED)
 		name = "unsecured [initial(name)]"
 		desc = "An unsecured [initial(name)] assembly."
-		icon_state = "[initial(name)]_ass"
+		icon_state = "[initial(icon_state)]_ass"
 	else if (stage == READY)
 		name = initial(name)
 		desc = "A custom made [initial(name)]."
-		icon_state = "[initial(name)]_locked"
+		icon_state = "[initial(icon_state)]_locked"
 
 
 //assembly stuff


### PR DESCRIPTION
Fixed grenade casing not being renamed to grenade when complete and made all assembly messages refer to the assembly as "grenade assembly" and "large grenade assembly".
- The grenade assembly is called "grenade casing" before anything is done (like it always was)
- The grenade assembly is called "unsecured grenade" when a activation mechanism is added (like before https://github.com/tgstation/-tg-station/commit/f645037dd5ffe491c94f73a39b3aac312e51d579)
- The grenade assembly is called "grenade" when finished (like before  https://github.com/tgstation/-tg-station/commit/f645037dd5ffe491c94f73a39b3aac312e51d579)
- Renamed large chem grenade to "large grenade"
- Made using a wrench on a unsecured grenade remove the payload on the first use, and the activation mechanism on the second use (because we don't want to always remove both at the same time)
- Made cable_coil drop on the floor if it was used as activation mechanism

Fixes https://github.com/tgstation/-tg-station/issues/2378
