### PR TITLE
Emotes, griefing prevent, improvement

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -32,7 +32,7 @@
 			m_type = 1
 
 		if ("blink_r")
-			message = "<B>[src]</B> blinks rapidly."
+			message = "<B>\red[src]</B> blinks rapidly."
 			m_type = 1
 
 		if ("blush")
@@ -63,7 +63,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strong noise."
+				message = "<B>\red[src]</B> makes a strong noise."
 				m_type = 2
 
 		if ("chuckle")
@@ -82,11 +82,11 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strong noise."
+				message = "<B>[src]</B>\red makes a strong noise."
 				m_type = 2
 
 		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
+			message = "\red<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
 			m_type = 1
 
 		if ("flap")
@@ -98,7 +98,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a weak noise."
+				message = "<B>[src]</B>\red makes a weak noise."
 				m_type = 2
 
 		if ("giggle")
@@ -122,7 +122,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a very loud noise."
+				message = "<B>[src]</B>\red makes a very loud noise."
 				m_type = 2
 
 		if ("shake")
@@ -133,7 +133,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strange noise."
+				message = "<B>[src]</B>\red makes a strange noise."
 				m_type = 2
 
 		if ("sigh")
@@ -170,7 +170,7 @@
 				..(act)
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sigh, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blush, bow-(none)/mob, burp, chuckle, clap, dance, flap, frown, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, sigh, sit, smile, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -30,7 +30,7 @@
 
 		if ("choke")
 			if (miming)
-				message = "<B>[src]</B> clutches \his throat desperately!"
+				message = "\red<B>[src]</B> clutches \his throat desperately!"
 			else
 				..(act)
 
@@ -47,18 +47,18 @@
 
 		if ("collapse")
 			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
+			message = "\red<B>[src]</B> collapses!"
 			m_type = 2
 
 		if ("cough")
 			if (miming)
-				message = "<B>[src]</B> appears to cough!"
+				message = "\red<B>[src]</B> appears to cough!"
 			else
 				if (!muzzled)
-					message = "<B>[src]</B> coughs!"
+					message = "\red<B>[src]</B> coughs!"
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a strong noise."
+					message = "\red<B>[src]</B> makes a strong noise."
 					m_type = 2
 
 		if ("cry")
@@ -123,7 +123,7 @@
 
 		if ("gasp")
 			if (miming)
-				message = "<B>[src]</B> appears to be gasping!"
+				message = "\red<B>[src]</B> appears to be gasping!"
 			else
 				..(act)
 
@@ -135,13 +135,13 @@
 
 		if ("groan")
 			if (miming)
-				message = "<B>[src]</B> appears to groan!"
+				message = "\red<B>[src]</B> appears to groan!"
 			else
 				if (!muzzled)
-					message = "<B>[src]</B> groans!"
+					message = "\red<B>[src]</B> groans!"
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a loud noise."
+					message = "\red<B>[src]</B> makes a loud noise."
 					m_type = 2
 
 		if ("grumble")
@@ -234,7 +234,7 @@
 			m_type = 2
 
 		if ("pale")
-			message = "<B>[src]</B> goes pale for a second."
+			message = "\red<B>[src]</B> goes pale for a second."
 			m_type = 1
 
 		if ("raise")
@@ -260,7 +260,7 @@
 
 		if ("scream")
 			if (miming)
-				message = "<B>[src]</B> acts out a scream!"
+				message = "\red<B>[src]</B> acts out a scream!"
 			else
 				..(act)
 
@@ -290,7 +290,7 @@
 
 		if ("sneeze")
 			if (miming)
-				message = "<B>[src]</B> sneezes."
+				message = "\red<B>[src]</B> sneezes."
 			else
 				..(act)
 
@@ -316,7 +316,7 @@
 				m_type = 2
 
 		if ("help") //This can stay at the bottom.
-			src << "Help for human emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, cry, custom, dance, dap, deathgasp, drool, eyebrow, faint, frown, flap, gasp, giggle, glare-(none)/mob, grin, groan, grumble, handshake, hug-(none)/mob, johnny, jump, laugh, look-(none)/mob, me, moan, mumble, nod, pale, point-(atom), raise, salute, scream, shake, shiver, shrug, sigh, signal-#1-10, smile, sneeze, sniff, snore, stare-(none)/mob, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for human emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blush, bow-(none)/mob, burp, chuckle, clap, cry, custom, dance, dap, eyebrow, frown, flap, giggle, glare-(none)/mob, grin, grumble, handshake, hug-(none)/mob, johnny, jump, laugh, look-(none)/mob, me, moan, mumble, nod, point-(atom), raise, salute, shiver, shrug, sigh, signal-#1-10, smile, sniff, snore, stare-(none)/mob, tremble, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)
@@ -345,4 +345,3 @@
 		else if (m_type & 2)
 			for (var/mob/O in hearers(src.loc, null))
 				O.show_message(message, m_type)
-

--- a/code/modules/mob/living/carbon/metroid/death.dm
+++ b/code/modules/mob/living/carbon/metroid/death.dm
@@ -15,7 +15,7 @@
 	stat = DEAD
 	icon_state = "[colour] baby slime dead"
 	for(var/mob/O in viewers(src, null))
-		O.show_message("<b>The [name]</b> seizes up and falls limp...", 1) //ded -- Urist
+		O.show_message("\red<b>The [name]</b> seizes up and falls limp...", 1) //ded -- Urist
 
 	update_canmove()
 	if(blind)	blind.layer = 0

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -44,7 +44,7 @@
 			m_type = 2
 
 		if ("choke")
-			message = "<B>[src]</B> chokes!"
+			message = "\red<B>[src]</B> chokes!"
 			m_type = 2
 
 		if ("chuckle")
@@ -53,11 +53,11 @@
 
 		if ("collapse")
 			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
+			message = "\red<B>[src]</B> collapses!"
 			m_type = 2
 
 		if ("cough")
-			message = "<B>[src]</B> coughs!"
+			message = "\red<B>[src]</B> coughs!"
 			m_type = 2
 
 		if ("dance")
@@ -66,15 +66,15 @@
 				m_type = 1
 
 		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
+			message = "\red<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
 			m_type = 1
 
 		if ("drool")
-			message = "<B>[src]</B> drools."
+			message = "\red<B>[src]</B> drools."
 			m_type = 1
 
 		if ("faint")
-			message = "<B>[src]</B> faints."
+			message = "\red<B>[src]</B> faints."
 			if(src.sleeping)
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
@@ -90,7 +90,7 @@
 			m_type = 1
 
 		if ("gasp")
-			message = "<B>[src]</B> gasps!"
+			message = "\red<B>[src]</B> gasps!"
 			m_type = 2
 
 		if ("giggle")
@@ -174,7 +174,7 @@
 			m_type = 1
 
 		if ("scream")
-			message = "<B>[src]</B> screams!"
+			message = "\red<B>[src]</B> screams!"
 			m_type = 2
 
 		if ("shake")
@@ -194,7 +194,7 @@
 			m_type = 1
 
 		if ("sneeze")
-			message = "<B>[src]</B> sneezes."
+			message = "\red<B>[src]</B> sneezes."
 			m_type = 2
 
 		if ("sniff")
@@ -252,7 +252,7 @@
 			m_type = 2
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, sigh, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, chuckle, clap, dance, flap, frown, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, shake, sit, sigh, smile, snore, stare-(none)/mob, sulk, sway, tremble, twitch_s, wave, whimper, yawn"
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."


### PR DESCRIPTION
!!NO NEW FEATURES ADDED, IS OK IN CODEFREEZE!!
Changes some emotes with a \red text added and removed from help to prevent misleading players and possible griefing. After all, the game is somewhat realistic, so why not keep the emotes be too.
