### PR TITLE
Griefprevent, emoteimprove

### DIFF
--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -16,7 +16,7 @@
 	user.update_canmove()
 
 	if(user.stat != DEAD)
-		user.emote("deathgasp")
+		user.emote("dedye")
 		user.tod = worldtime2text()
 
 	spawn(800)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -72,7 +72,7 @@
 	return dat
 
 /obj/item/weapon/implant/explosive/trigger(emote, mob/source)
-	if(emote == "deathgasp")
+	if(emote == "dedye")
 		activate("death")
 
 /obj/item/weapon/implant/explosive/activate(var/cause)
@@ -109,7 +109,7 @@
 	create_reagents(50)
 
 /obj/item/weapon/implant/chem/trigger(emote, mob/source)
-	if(emote == "deathgasp")
+	if(emote == "dedye")
 		activate(reagents.total_volume)
 
 /obj/item/weapon/implant/chem/activate(var/cause)

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -13,8 +13,8 @@
 	var/message
 
 	switch(act) //Alphabetical please
-		if ("deathgasp")
-			message = "<B>[src]</B> lets out a waning guttural screech, green blood bubbling from its maw..."
+		if ("dedye")
+			message = "\red<B>[src]</B> lets out a waning guttural screech, green blood bubbling from its maw..."
 			m_type = 2
 
 		if ("gnarl")

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -32,7 +32,7 @@
 			m_type = 1
 
 		if ("blink_r")
-			message = "<B>[src]</B> blinks rapidly."
+			message = "<B>\red[src]</B> blinks rapidly."
 			m_type = 1
 
 		if ("blush")
@@ -63,7 +63,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strong noise."
+				message = "<B>\red[src]</B> makes a strong noise."
 				m_type = 2
 
 		if ("chuckle")
@@ -82,11 +82,11 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strong noise."
+				message = "<B>[src]</B>\red makes a strong noise."
 				m_type = 2
 
 		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
+			message = "\red<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
 			m_type = 1
 
 		if ("flap")
@@ -98,7 +98,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a weak noise."
+				message = "<B>[src]</B>\red makes a weak noise."
 				m_type = 2
 
 		if ("giggle")
@@ -122,7 +122,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a very loud noise."
+				message = "<B>[src]</B>\red makes a very loud noise."
 				m_type = 2
 
 		if ("shake")
@@ -133,7 +133,7 @@
 			if (!muzzled)
 				..(act)
 			else
-				message = "<B>[src]</B> makes a strange noise."
+				message = "<B>[src]</B>\red makes a strange noise."
 				m_type = 2
 
 		if ("sigh")
@@ -170,7 +170,7 @@
 				..(act)
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sigh, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blush, bow-(none)/mob, burp, chuckle, clap, dance, flap, frown, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, sigh, sit, smile, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -32,7 +32,7 @@
 			m_type = 1
 
 		if ("blink_r")
-			message = "<B>\red[src]</B> blinks rapidly."
+			message = "<B>[src]</B> blinks rapidly."
 			m_type = 1
 
 		if ("blush")
@@ -85,7 +85,7 @@
 				message = "<B>[src]</B>\red makes a strong noise."
 				m_type = 2
 
-		if ("deathgasp")
+		if ("dedye")
 			message = "\red<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
 			m_type = 1
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -26,7 +26,7 @@
 			M.go_out()
 
 	if(!gibbed)
-		emote("deathgasp") //let the world KNOW WE ARE DEAD
+		emote("dedye") //let the world KNOW WE ARE DEAD
 
 		update_canmove()
 		if(client) blind.layer = 0

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -30,7 +30,7 @@
 
 		if ("choke")
 			if (miming)
-				message = "<B>[src]</B> clutches \his throat desperately!"
+				message = "\red<B>[src]</B> clutches \his throat desperately!"
 			else
 				..(act)
 
@@ -47,18 +47,18 @@
 
 		if ("collapse")
 			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
+			message = "\red<B>[src]</B> collapses!"
 			m_type = 2
 
 		if ("cough")
 			if (miming)
-				message = "<B>[src]</B> appears to cough!"
+				message = "\red<B>[src]</B> appears to cough!"
 			else
 				if (!muzzled)
-					message = "<B>[src]</B> coughs!"
+					message = "\red<B>[src]</B> coughs!"
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a strong noise."
+					message = "\red<B>[src]</B> makes a strong noise."
 					m_type = 2
 
 		if ("cry")
@@ -123,7 +123,7 @@
 
 		if ("gasp")
 			if (miming)
-				message = "<B>[src]</B> appears to be gasping!"
+				message = "\red<B>[src]</B> appears to be gasping!"
 			else
 				..(act)
 
@@ -135,13 +135,13 @@
 
 		if ("groan")
 			if (miming)
-				message = "<B>[src]</B> appears to groan!"
+				message = "\red<B>[src]</B> appears to groan!"
 			else
 				if (!muzzled)
-					message = "<B>[src]</B> groans!"
+					message = "\red<B>[src]</B> groans!"
 					m_type = 2
 				else
-					message = "<B>[src]</B> makes a loud noise."
+					message = "\red<B>[src]</B> makes a loud noise."
 					m_type = 2
 
 		if ("grumble")
@@ -234,7 +234,7 @@
 			m_type = 2
 
 		if ("pale")
-			message = "<B>[src]</B> goes pale for a second."
+			message = "\red<B>[src]</B> goes pale for a second."
 			m_type = 1
 
 		if ("raise")
@@ -260,7 +260,7 @@
 
 		if ("scream")
 			if (miming)
-				message = "<B>[src]</B> acts out a scream!"
+				message = "\red<B>[src]</B> acts out a scream!"
 			else
 				..(act)
 
@@ -290,7 +290,7 @@
 
 		if ("sneeze")
 			if (miming)
-				message = "<B>[src]</B> sneezes."
+				message = "\red<B>[src]</B> sneezes."
 			else
 				..(act)
 
@@ -316,7 +316,7 @@
 				m_type = 2
 
 		if ("help") //This can stay at the bottom.
-			src << "Help for human emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, cry, custom, dance, dap, deathgasp, drool, eyebrow, faint, frown, flap, gasp, giggle, glare-(none)/mob, grin, groan, grumble, handshake, hug-(none)/mob, johnny, jump, laugh, look-(none)/mob, me, moan, mumble, nod, pale, point-(atom), raise, salute, scream, shake, shiver, shrug, sigh, signal-#1-10, smile, sneeze, sniff, snore, stare-(none)/mob, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for human emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blush, bow-(none)/mob, burp, chuckle, clap, cry, custom, dance, dap, eyebrow, frown, flap, giggle, glare-(none)/mob, grin, grumble, handshake, hug-(none)/mob, johnny, jump, laugh, look-(none)/mob, me, moan, mumble, nod, point-(atom), raise, salute, shiver, shrug, sigh, signal-#1-10, smile, sniff, snore, stare-(none)/mob, tremble, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)
@@ -345,4 +345,3 @@
 		else if (m_type & 2)
 			for (var/mob/O in hearers(src.loc, null))
 				O.show_message(message, m_type)
-

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -20,7 +20,7 @@
 	if(mind)
 		miming=mind.miming
 
-	if(src.stat == 2.0 && (act != "deathgasp"))
+	if(src.stat == 2.0 && (act != "dedye"))
 		return
 	switch(act) //Please keep this alphabetically ordered when adding or changing emotes.
 		if ("aflap") //Any emote on human that uses miming must be left in, oh well.

--- a/code/modules/mob/living/carbon/metroid/death.dm
+++ b/code/modules/mob/living/carbon/metroid/death.dm
@@ -15,7 +15,7 @@
 	stat = DEAD
 	icon_state = "[colour] baby slime dead"
 	for(var/mob/O in viewers(src, null))
-		O.show_message("<b>The [name]</b> seizes up and falls limp...", 1) //ded -- Urist
+		O.show_message("\red<b>The [name]</b> seizes up and falls limp...", 1) //ded -- Urist
 
 	update_canmove()
 	if(blind)	blind.layer = 0

--- a/code/modules/mob/living/carbon/monkey/emote.dm
+++ b/code/modules/mob/living/carbon/monkey/emote.dm
@@ -14,8 +14,8 @@
 	var/message
 
 	switch(act) //Ooh ooh ah ah keep this alphabetical ooh ooh ah ah!
-		if ("deathgasp")
-			message = "<b>[src]</b> lets out a faint chimper as it collapses and stops moving..."
+		if ("dedye")
+			message = "\red<b>[src]</b> lets out a faint chimper as it collapses and stops moving..."
 			m_type = 1
 
 		if ("gnarl")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -65,7 +65,7 @@
 				message = "<B>[src]</B> dances around happily."
 				m_type = 1
 
-		if ("deathgasp")
+		if ("dedye")
 			message = "\red<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
 			m_type = 1
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -44,7 +44,7 @@
 			m_type = 2
 
 		if ("choke")
-			message = "<B>[src]</B> chokes!"
+			message = "\red<B>[src]</B> chokes!"
 			m_type = 2
 
 		if ("chuckle")
@@ -53,11 +53,11 @@
 
 		if ("collapse")
 			Paralyse(2)
-			message = "<B>[src]</B> collapses!"
+			message = "\red<B>[src]</B> collapses!"
 			m_type = 2
 
 		if ("cough")
-			message = "<B>[src]</B> coughs!"
+			message = "\red<B>[src]</B> coughs!"
 			m_type = 2
 
 		if ("dance")
@@ -66,15 +66,15 @@
 				m_type = 1
 
 		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
+			message = "\red<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
 			m_type = 1
 
 		if ("drool")
-			message = "<B>[src]</B> drools."
+			message = "\red<B>[src]</B> drools."
 			m_type = 1
 
 		if ("faint")
-			message = "<B>[src]</B> faints."
+			message = "\red<B>[src]</B> faints."
 			if(src.sleeping)
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
@@ -90,7 +90,7 @@
 			m_type = 1
 
 		if ("gasp")
-			message = "<B>[src]</B> gasps!"
+			message = "\red<B>[src]</B> gasps!"
 			m_type = 2
 
 		if ("giggle")
@@ -174,7 +174,7 @@
 			m_type = 1
 
 		if ("scream")
-			message = "<B>[src]</B> screams!"
+			message = "\red<B>[src]</B> screams!"
 			m_type = 2
 
 		if ("shake")
@@ -194,7 +194,7 @@
 			m_type = 1
 
 		if ("sneeze")
-			message = "<B>[src]</B> sneezes."
+			message = "\red<B>[src]</B> sneezes."
 			m_type = 2
 
 		if ("sniff")
@@ -252,7 +252,7 @@
 			m_type = 2
 
 		if ("help")
-			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, scream, shake, sit, sigh, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tremble, twitch, twitch_s, wave, whimper, yawn"
+			src << "Help for emotes. You can use these emotes with say \"*emote\":\n\naflap, blush, bow-(none)/mob, burp, chuckle, clap, dance, flap, frown, giggle, glare-(none)/mob, grin, jump, laugh, look, me, nod, point-atom, shake, sit, sigh, smile, snore, stare-(none)/mob, sulk, sway, tremble, twitch_s, wave, whimper, yawn"
 
 		else
 			src << "\blue Unusable emote '[act]'. Say *help for a list."

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -21,7 +21,7 @@
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)	return
 	if(!gibbed)
-		emote("deathgasp")
+		emote("dedye")
 	stat = DEAD
 	update_canmove()
 	if(camera)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -84,8 +84,8 @@
 				return
 			message = "<B>[src]</B> [input]"
 
-		if ("deathgasp")
-			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
+		if ("dedye")
+			message = "\red<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
 			m_type = 1
 
 		if ("flap")


### PR DESCRIPTION
Made some emotes red and removed from help (the ones affected by diseases and near desth shit). Changed deathgasp to dedye to prevent players from using it.
