### PR TITLE
Fixes stinging from range pathfinding

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -122,7 +122,8 @@ proc
 		var/closed[] = new()
 		var/path[]
 		start = get_turf(start)
-		if(!start) return 0
+		if(!start)
+			return 0
 
 		open.Enqueue(new /PathNode(start,null,0,call(start,dist)(end)))
 
@@ -166,10 +167,7 @@ proc
 						continue
 
 				open.Enqueue(new /PathNode(d,cur,ng,call(d,dist)(end),cur.nt+1))
-				if(maxnodes && open.L.len > maxnodes)
-					open.L.Cut(open.L.len)
 		}
-
 		var/PathNode/temp
 		while(!open.IsEmpty())
 			temp = open.Dequeue()
@@ -179,6 +177,8 @@ proc
 			temp.bestF = 0
 			closed.Cut(closed.len)
 
+		if(path && maxnodes && path.len > maxnodes+1)
+			return 0
 		if(path)
 			for(var/i = 1; i <= path.len/2; i++)
 				path.Swap(i,path.len-i+1)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -20,7 +20,6 @@
 
 	var/blocks_air = 0
 	var/icon_old = null
-	var/pathweight = 1
 
 	flags = 0
 
@@ -271,8 +270,7 @@
 /turf/proc/Distance(turf/t)
 	if(get_dist(src,t) == 1)
 		var/cost = (src.x - t.x) * (src.x - t.x) + (src.y - t.y) * (src.y - t.y)
-		cost *= (pathweight+t.pathweight)/2
-		return cost
+		return sqrt(cost)
 	else
 		return get_dist(src,t)
 


### PR DESCRIPTION
- Fixes Astar pathfinding being stupid with maxnodes
- Diagonal movement now costs whatever sqrt(2) rounds to.
- Fixes #3665

The problem was giving non-zero maxnodes cut (arbitrarily) the last item from the 'open' node list, where all nodes needed to be gone through. This was broken especially when maxnodes was smaller than the amount of adjacent turfs. Because Astar gives (or atleast should in theory give) the shortest path, it is sufficient to check if the length of this path is bigger than what we wanted it to be.
