### PR TITLE
Fixed ling regeneration bugs

### DIFF
--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -1,8 +1,9 @@
 /obj/effect/proc_holder/changeling/fakedeath
 	name = "Regenerative Stasis"
 	desc = "We fall into a stasis, allowing us to regenerate."
-	chemical_cost = 10
+	chemical_cost = 20
 	dna_cost = 0
+	req_dna = 1
 	req_stat = DEAD
 	max_genetic_damage = 100
 

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -1,7 +1,6 @@
 /obj/effect/proc_holder/changeling/revive
 	name = "Regenerate"
 	desc = "We regenerate, healing all damage from our form."
-	chemical_cost = 10
 	req_stat = DEAD
 
 //Revive from regenerative stasis


### PR DESCRIPTION
It now requires DNA, preventing infinite genomes, and now correctly
displays the chemical cost, rather than leaving lings thinking that 10
chemicals would be sufficient to revive.
Fixes https://github.com/tgstation/-tg-station/issues/3730, Fixes https://github.com/tgstation/-tg-station/issues/3671
