### PR TITLE
Made the code compilable again

### DIFF
--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -5,9 +5,7 @@
 	max_occurrences = 1
 
 /datum/round_event/meteor_wave/meaty/announce()
-	command_alert("Meaty ores have been detected on collision course with the station.", "Oh Crap, Get The Mop.")
-	world << sound('sound/AI/meteors.ogg')
-
+	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh Crap, Get The Mop.",'sound/AI/meteors.ogg')
 
 /datum/round_event/meteor_wave/meaty/tick()
 	if(IsMultiple(activeFor, 3))


### PR DESCRIPTION
The recent meteor update was apparently using the deprecate _command_alert_ proc instead of the current _priority_annonce_ (which also handles sound playing instead of having it separated).
Strangely, quietly ignored by Travis (or built using an outdated branch ?).

Oh, and highly disturbing event when i tested it...
I fear a mop won't suffice !
