### PR TITLE
Sets screenloc even if no client

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -541,8 +541,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(BACK_LAYER)
 
 	if(back)
+		back.screen_loc = ui_back
 		if(client && hud_used && hud_used.hud_shown)
-			back.screen_loc = ui_back	//TODO
 			client.screen += back
 
 		overlays_standing[BACK_LAYER]	= image("icon"='icons/mob/back.dmi', "icon_state"="[back.icon_state]", "layer"=-BACK_LAYER)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -314,9 +314,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 	if(istype(w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = w_uniform
-		w_uniform.screen_loc = ui_iclothing // Set the item's location on the screen
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += w_uniform				// add the item to the HUD
+			if(hud_used.inventory_shown)			//if the inventory is open ...
+				w_uniform.screen_loc = ui_iclothing //...draw the item in the inventory screen
+			client.screen += w_uniform				//Either way, add the item to the HUD
 
 		var/t_color = w_uniform.item_color
 		if(!t_color)		t_color = icon_state
@@ -351,7 +352,7 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(ID_LAYER)
 	if(wear_id)
 		wear_id.screen_loc = ui_id	//TODO
-		if(client && hud_used && hud_used.hud_shown)
+		if(client && hud_used)
 			client.screen += wear_id
 
 		overlays_standing[ID_LAYER]	= image("icon"='icons/mob/mob.dmi', "icon_state"="id", "layer"=-ID_LAYER)
@@ -362,9 +363,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 /mob/living/carbon/human/update_inv_gloves()
 	remove_overlay(GLOVES_LAYER)
 	if(gloves)
-		gloves.screen_loc = ui_gloves
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += gloves					// add the item to the HUD
+			if(hud_used.inventory_shown)			//if the inventory is open ...
+				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
+			client.screen += gloves					//Either way, add the item to the HUD
 
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
@@ -385,9 +387,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(GLASSES_LAYER)
 
 	if(glasses)
-		glasses.screen_loc = ui_glasses
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += glasses				// add the item to the HUD
+			if(hud_used.inventory_shown)			//if the inventory is open ...
+				glasses.screen_loc = ui_glasses		//...draw the item in the inventory screen
+			client.screen += glasses				//Either way, add the item to the HUD
 
 		overlays_standing[GLASSES_LAYER]	= image("icon"='icons/mob/eyes.dmi', "icon_state"="[glasses.icon_state]", "layer"=-GLASSES_LAYER)
 
@@ -398,9 +401,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(EARS_LAYER)
 
 	if(ears)
-		ears.screen_loc = ui_ears
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += ears					// add the item to the HUD
+			if(hud_used.inventory_shown)			//if the inventory is open ...
+				ears.screen_loc = ui_ears			//...draw the item in the inventory screen
+			client.screen += ears					//Either way, add the item to the HUD
 
 		overlays_standing[EARS_LAYER] = image("icon"='icons/mob/ears.dmi', "icon_state"="[ears.icon_state]", "layer"=-EARS_LAYER)
 
@@ -411,9 +415,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SHOES_LAYER)
 
 	if(shoes)
-		shoes.screen_loc = ui_shoes
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += shoes					// add the item to the HUD
+			if(hud_used.inventory_shown)			//if the inventory is open ...
+				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
+			client.screen += shoes					//Either way, add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/feet.dmi', "icon_state"="[shoes.icon_state]", "layer"=-SHOES_LAYER)
 		overlays_standing[SHOES_LAYER]	= standing
@@ -428,8 +433,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SUIT_STORE_LAYER)
 
 	if(s_store)
-		s_store.screen_loc = ui_sstore1
-		if(client && hud_used && hud_used.hud_shown)
+		s_store.screen_loc = ui_sstore1		//TODO
+		if(client && hud_used)
 			client.screen += s_store
 
 		var/t_state = s_store.item_state
@@ -444,9 +449,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(HEAD_LAYER)
 
 	if(head)
-		head.screen_loc = ui_head
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += head						// add the item to the HUD
+			if(hud_used.inventory_shown)				//if the inventory is open ...
+				head.screen_loc = ui_head		//TODO	//...draw the item in the inventory screen
+			client.screen += head						//Either way, add the item to the HUD
 
 		var/image/standing = image("icon"='icons/mob/head.dmi', "icon_state"="[head.icon_state]", "layer"=-HEAD_LAYER)
 		standing.color = head.color // For now, this is here solely for kitty ears, but everything should do this eventually
@@ -465,7 +471,7 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 	if(belt)
 		belt.screen_loc = ui_belt
-		if(client && hud_used && hud_used.hud_shown)
+		if(client && hud_used)
 			client.screen += belt
 
 		var/t_state = belt.item_state
@@ -480,9 +486,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SUIT_LAYER)
 
 	if(istype(wear_suit, /obj/item/clothing/suit))
-		wear_suit.screen_loc = ui_oclothing
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += wear_suit						// add the item to the HUD
+			if(hud_used.inventory_shown)					//if the inventory is open ...
+				wear_suit.screen_loc = ui_oclothing	//TODO	//...draw the item in the inventory screen
+			client.screen += wear_suit						//Either way, add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/suit.dmi', "icon_state"="[wear_suit.icon_state]", "layer"=-SUIT_LAYER)
 		overlays_standing[SUIT_LAYER]	= standing
@@ -501,12 +508,12 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 /mob/living/carbon/human/update_inv_pockets()
 	if(l_store)
-		l_store.screen_loc = ui_storage1
-		if(client && hud_used && hud_used.hud_shown)
+		l_store.screen_loc = ui_storage1	//TODO
+		if(client && hud_used)
 			client.screen += l_store
 	if(r_store)
-		r_store.screen_loc = ui_storage2
-		if(client && hud_used && hud_used.hud_shown)
+		r_store.screen_loc = ui_storage2	//TODO
+		if(client && hud_used)
 			client.screen += r_store
 
 
@@ -514,9 +521,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(FACEMASK_LAYER)
 
 	if(istype(wear_mask, /obj/item/clothing/mask))
-		wear_mask.screen_loc = ui_mask
 		if(client && hud_used && hud_used.hud_shown)
-			client.screen += wear_mask					// add the item to the HUD
+			if(hud_used.inventory_shown)				//if the inventory is open ...
+				wear_mask.screen_loc = ui_mask	//TODO	//...draw the item in the inventory screen
+			client.screen += wear_mask					//Either way, add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/mask.dmi', "icon_state"="[wear_mask.icon_state]", "layer"=-FACEMASK_LAYER)
 		overlays_standing[FACEMASK_LAYER]	= standing
@@ -533,8 +541,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(BACK_LAYER)
 
 	if(back)
-		back.screen_loc = ui_back
 		if(client && hud_used && hud_used.hud_shown)
+			back.screen_loc = ui_back	//TODO
 			client.screen += back
 
 		overlays_standing[BACK_LAYER]	= image("icon"='icons/mob/back.dmi', "icon_state"="[back.icon_state]", "layer"=-BACK_LAYER)
@@ -590,8 +598,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 		drop_r_hand()
 		return
 	if(r_hand)
+		r_hand.screen_loc = ui_rhand	//TODO
 		if(client)
-			r_hand.screen_loc = ui_rhand	//TODO
 			client.screen += r_hand
 
 		var/t_state = r_hand.item_state
@@ -609,8 +617,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 		drop_l_hand()
 		return
 	if(l_hand)
+		l_hand.screen_loc = ui_lhand	//TODO
 		if(client)
-			l_hand.screen_loc = ui_lhand	//TODO
 			client.screen += l_hand
 
 		var/t_state = l_hand.item_state

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -314,10 +314,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 	if(istype(w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = w_uniform
+		w_uniform.screen_loc = ui_iclothing // Set the item's location on the screen
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				w_uniform.screen_loc = ui_iclothing //...draw the item in the inventory screen
-			client.screen += w_uniform				//Either way, add the item to the HUD
+			client.screen += w_uniform				// add the item to the HUD
 
 		var/t_color = w_uniform.item_color
 		if(!t_color)		t_color = icon_state
@@ -351,8 +350,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 /mob/living/carbon/human/update_inv_wear_id()
 	remove_overlay(ID_LAYER)
 	if(wear_id)
+		wear_id.screen_loc = ui_id	//TODO
 		if(client && hud_used && hud_used.hud_shown)
-			wear_id.screen_loc = ui_id	//TODO
 			client.screen += wear_id
 
 		overlays_standing[ID_LAYER]	= image("icon"='icons/mob/mob.dmi', "icon_state"="id", "layer"=-ID_LAYER)
@@ -363,10 +362,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 /mob/living/carbon/human/update_inv_gloves()
 	remove_overlay(GLOVES_LAYER)
 	if(gloves)
+		gloves.screen_loc = ui_gloves
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
-			client.screen += gloves					//Either way, add the item to the HUD
+			client.screen += gloves					// add the item to the HUD
 
 		var/t_state = gloves.item_state
 		if(!t_state)	t_state = gloves.icon_state
@@ -387,10 +385,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(GLASSES_LAYER)
 
 	if(glasses)
+		glasses.screen_loc = ui_glasses
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				glasses.screen_loc = ui_glasses		//...draw the item in the inventory screen
-			client.screen += glasses				//Either way, add the item to the HUD
+			client.screen += glasses				// add the item to the HUD
 
 		overlays_standing[GLASSES_LAYER]	= image("icon"='icons/mob/eyes.dmi', "icon_state"="[glasses.icon_state]", "layer"=-GLASSES_LAYER)
 
@@ -401,10 +398,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(EARS_LAYER)
 
 	if(ears)
+		ears.screen_loc = ui_ears
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				ears.screen_loc = ui_ears			//...draw the item in the inventory screen
-			client.screen += ears					//Either way, add the item to the HUD
+			client.screen += ears					// add the item to the HUD
 
 		overlays_standing[EARS_LAYER] = image("icon"='icons/mob/ears.dmi', "icon_state"="[ears.icon_state]", "layer"=-EARS_LAYER)
 
@@ -415,10 +411,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SHOES_LAYER)
 
 	if(shoes)
+		shoes.screen_loc = ui_shoes
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)			//if the inventory is open ...
-				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
-			client.screen += shoes					//Either way, add the item to the HUD
+			client.screen += shoes					// add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/feet.dmi', "icon_state"="[shoes.icon_state]", "layer"=-SHOES_LAYER)
 		overlays_standing[SHOES_LAYER]	= standing
@@ -433,8 +428,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SUIT_STORE_LAYER)
 
 	if(s_store)
+		s_store.screen_loc = ui_sstore1
 		if(client && hud_used && hud_used.hud_shown)
-			s_store.screen_loc = ui_sstore1		//TODO
 			client.screen += s_store
 
 		var/t_state = s_store.item_state
@@ -449,10 +444,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(HEAD_LAYER)
 
 	if(head)
+		head.screen_loc = ui_head
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)				//if the inventory is open ...
-				head.screen_loc = ui_head		//TODO	//...draw the item in the inventory screen
-			client.screen += head						//Either way, add the item to the HUD
+			client.screen += head						// add the item to the HUD
 
 		var/image/standing = image("icon"='icons/mob/head.dmi', "icon_state"="[head.icon_state]", "layer"=-HEAD_LAYER)
 		standing.color = head.color // For now, this is here solely for kitty ears, but everything should do this eventually
@@ -470,8 +464,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(BELT_LAYER)
 
 	if(belt)
+		belt.screen_loc = ui_belt
 		if(client && hud_used && hud_used.hud_shown)
-			belt.screen_loc = ui_belt
 			client.screen += belt
 
 		var/t_state = belt.item_state
@@ -486,10 +480,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(SUIT_LAYER)
 
 	if(istype(wear_suit, /obj/item/clothing/suit))
+		wear_suit.screen_loc = ui_oclothing
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)					//if the inventory is open ...
-				wear_suit.screen_loc = ui_oclothing	//TODO	//...draw the item in the inventory screen
-			client.screen += wear_suit						//Either way, add the item to the HUD
+			client.screen += wear_suit						// add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/suit.dmi', "icon_state"="[wear_suit.icon_state]", "layer"=-SUIT_LAYER)
 		overlays_standing[SUIT_LAYER]	= standing
@@ -508,12 +501,12 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 /mob/living/carbon/human/update_inv_pockets()
 	if(l_store)
+		l_store.screen_loc = ui_storage1
 		if(client && hud_used && hud_used.hud_shown)
-			l_store.screen_loc = ui_storage1	//TODO
 			client.screen += l_store
 	if(r_store)
+		r_store.screen_loc = ui_storage2
 		if(client && hud_used && hud_used.hud_shown)
-			r_store.screen_loc = ui_storage2	//TODO
 			client.screen += r_store
 
 
@@ -521,10 +514,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(FACEMASK_LAYER)
 
 	if(istype(wear_mask, /obj/item/clothing/mask))
+		wear_mask.screen_loc = ui_mask
 		if(client && hud_used && hud_used.hud_shown)
-			if(hud_used.inventory_shown)				//if the inventory is open ...
-				wear_mask.screen_loc = ui_mask	//TODO	//...draw the item in the inventory screen
-			client.screen += wear_mask					//Either way, add the item to the HUD
+			client.screen += wear_mask					// add the item to the HUD
 
 		var/image/standing	= image("icon"='icons/mob/mask.dmi', "icon_state"="[wear_mask.icon_state]", "layer"=-FACEMASK_LAYER)
 		overlays_standing[FACEMASK_LAYER]	= standing
@@ -541,8 +533,8 @@ Please contact me on #coderbus IRC. ~Carnie x
 	remove_overlay(BACK_LAYER)
 
 	if(back)
+		back.screen_loc = ui_back
 		if(client && hud_used && hud_used.hud_shown)
-			back.screen_loc = ui_back	//TODO
 			client.screen += back
 
 		overlays_standing[BACK_LAYER]	= image("icon"='icons/mob/back.dmi', "icon_state"="[back.icon_state]", "layer"=-BACK_LAYER)


### PR DESCRIPTION
Sets the screenloc property for items in update_icons even if there's no client at the moment (possibly because the player has lost the connection temporarily).

Fixes #3643.  Thanks to @Menshin for the suggested fix!  I tested this a little and didn't see any side effects.
