### PR TITLE
Microwave fix

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -59,14 +59,15 @@
 ********************/
 
 /obj/machinery/microwave/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(!broken && !dirty && !operating)
+	if(operating)
+		return
+	if(!broken && dirty<100)
 		if(default_deconstruction_screwdriver(user, "mw-o", "mw", O))
 			return
 		if(default_unfasten_wrench(user, O))
 			return
-
-	if(exchange_parts(user, O))
-		return
+		if(exchange_parts(user, O))
+			return
 
 	default_deconstruction_crowbar(O)
 
@@ -171,7 +172,7 @@
 		user << "\red This is ridiculous. You can not fit \the [G.affecting] in this [src]."
 		return 1
 	else
-		user << "\red You have no idea what you can cook with this [O]."
+		user << "\red You have no idea what you can cook with this."
 		return 1
 	src.updateUsrDialog()
 
@@ -190,7 +191,7 @@
 ********************/
 
 /obj/machinery/microwave/interact(mob/user as mob) // The microwave Menu
-	if(panel_open)
+	if(panel_open || !anchored)
 		return
 	var/dat = "<div class='statusDisplay'>"
 	if(src.broken > 0)


### PR DESCRIPTION
- Fixes #2929 , microwave now still deconstructable when not completely dirty. (if you can use it, you can deconstruct it)
- Can no longer use a Rapid Part Exchange Device to upgrade microwave parts if microwave is broken or completely dirty.(if you can't upgrade it manually via deconstruction, you shouldn't be able to upgrade it with the RPED either)
- Broken or dirty microwave can now be unanchored/anchored with wrench.(no reason that it shouldn't be possible)
- Fixes "You have no idea what you can cook with this THE rolling pin." 
- Can no longer add ingredient / clean while microwave is operating.
- Can no longer activate the microwave when unanchored.
