### PR TITLE
Added "the" in throwing emote // Grammar Fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -308,7 +308,7 @@
 	//actually throw it!
 	if(item)
 		item.layer = initial(item.layer)
-		src.visible_message("\red [src] has thrown [item].")
+		src.visible_message("\red [src] has thrown the [item].")
 
 		if(!src.lastarea)
 			src.lastarea = get_area(src.loc)


### PR DESCRIPTION
Why add it? Well, it makes it all gramatically correct.

EXAMPLES:

Dick McDickinson has thrown the Alkysine(20u) pill.
Gaffot has thrown the PDA - Gaffot;
Innuendo McNugget has thrown the screwdriver

...and so on. Just a tiny fix.
