### PR TITLE
Fixes dodgeballs

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -422,6 +422,7 @@
 	desc = "Used for playing the most violent and degrading of childhood games."
 
 /obj/item/weapon/beach_ball/holoball/dodgeball/throw_impact(atom/hit_atom)
+	..()
 	if((ishuman(hit_atom)))
 		var/mob/living/carbon/M = hit_atom
 		playsound(src, 'sound/items/dodgeball.ogg', 50, 1)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -218,7 +218,7 @@
 
 	if(W.w_class > max_w_class)
 		if(!stop_messages)
-			usr << "<span class='notice'>[W] is too big for this [src].</span>"
+			usr << "<span class='notice'>[W] is too big for [src].</span>"
 		return 0
 
 	var/sum_w_class = W.w_class


### PR DESCRIPTION
Their throw_impact now calls ..() so they can be caught, theoretically deal real impact damage, and they actually give messages on hit.  Fixes #1063, and makes dodgeball not so eerily message-less.

Dodgeballs still deal holodamage and can knock down, even if you catch them, which is realistic and fine.

Also fixes "too large to fit in this the backpack" in storage.dm.
