### PR TITLE
Removes intercept meta

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -176,7 +176,6 @@
 
 	var/list/possible_modes = list()
 	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "malf", "changeling", "cult")
-	possible_modes -= "[ticker.mode]"
 	var/number = pick(2, 3)
 	var/i = 0
 	for(i = 0, i < number, i++)


### PR DESCRIPTION
The intercept list no longer removes the current mode's blurb, meaning
it is no longer a list of modes that weren't selected.

Personally, I am DISGUSTED by this OUTRAGEOUS oversight.
