### PR TITLE
Power distribution tweaking

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -1,15 +1,13 @@
 /datum/powernet
 	var/list/cables = list()	// all cables & junctions
-	var/list/nodes = list()		// all APCs & sources
+	var/list/nodes = list()		// all connected machines
 
-	var/newload = 0				// increased by every machines each tick then becomes...
-	var/load = 0				// ...the current load on the powernet
-	var/newavail = 0			// increased by every machines each tick then becomes...
+	var/load = 0				// the current load on the powernet, increased by each machine at processing
+	var/newavail = 0			// what available power was gathered last tick, then becomes...
 	var/avail = 0				//...the current available power in the powernet
-	var/viewload = 0			//the load as it appears on the power console (gradually updated)
-	var/number = 0				//Unused //TODEL
-	var/perapc = 0				// per-apc avilability
-	var/netexcess = 0			//excess power on the powernet (typically avail-load)
+	var/viewload = 0			// the load as it appears on the power console (gradually updated)
+	var/number = 0				// Unused //TODEL
+	var/netexcess = 0			// excess power on the powernet (typically avail-load)
 
 /*Powernet procs :
 

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -340,7 +340,7 @@
 		power = 1	// IVE GOT THE POWER!
 		if(PN) //runtime errors fixer. They were caused by PN.newload trying to access missing network in case of working on stored power.
 			storedpower += shieldload
-			PN.newload += shieldload //uses powernet power.
+			PN.load += shieldload //uses powernet power.
 //		message_admins("[PN.load]", 1)
 //		use_power(250) //uses APC power
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -111,14 +111,14 @@
 		set_mode(DISCONNECTED)
 		return
 
-	var/datum/powernet/PN = attached.get_powernet()
+	var/datum/powernet/PN = attached.powernet
 	if(PN)
 		SetLuminosity(5)
 
 		// found a powernet, so drain up to max power from it
 
 		var/drained = min ( drain_rate, PN.avail )
-		PN.newload += drained
+		PN.load += drained
 		power_drained += drained
 
 		// if tried to drain more than available on powernet

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -2369,7 +2369,7 @@ ________________________________________________________________________________
 						var/drained = 0
 						if(PN&&do_after(U,10))
 							drained = min(drain, PN.avail)
-							PN.newload += drained
+							PN.load += drained
 							if(drained < drain)//if no power on net, drain apcs
 								for(var/obj/machinery/power/terminal/T in PN.nodes)
 									if(istype(T.master, /obj/machinery/power/apc))
@@ -2415,13 +2415,13 @@ ________________________________________________________________________________
 
 		if("WIRE")
 			var/obj/structure/cable/A = target
-			var/datum/powernet/PN = A.get_powernet()
+			var/datum/powernet/PN = A.powernet
 			while(G.candrain&&!maxcapacity&&!isnull(A))
 				drain = (round((rand(G.mindrain,G.maxdrain))/2))
 				var/drained = 0
 				if(PN&&do_after(U,10))
 					drained = min(drain, PN.avail)
-					PN.newload += drained
+					PN.load += drained
 					if(drained < drain)//if no power on net, drain apcs
 						for(var/obj/machinery/power/terminal/T in PN.nodes)
 							if(istype(T.master, /obj/machinery/power/apc))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -33,7 +33,7 @@
 #define APC_UPDATE_ICON_COOLDOWN 200 // 20 seconds
 
 // the Area Power Controller (APC), formerly Power Distribution Unit (PDU)
-// one per area, needs wire conection to power network
+// one per area, needs wire conection to power network through a terminal
 
 // controls power to devices in that area
 // may be opened to change power cell
@@ -992,7 +992,7 @@
 
 /obj/machinery/power/apc/add_load(var/amount)
 	if(terminal && terminal.powernet)
-		terminal.powernet.newload += amount
+		terminal.powernet.load += amount
 
 /obj/machinery/power/apc/avail()
 	if(terminal)
@@ -1040,32 +1040,28 @@
 	else
 		main_status = 2
 
-	var/perapc = 0
-	if(terminal && terminal.powernet)
-		perapc = terminal.powernet.perapc
-
 	//if(debug)
 	//	world.log << "Status: [main_status] - Excess: [excess] - Last Equip: [lastused_equip] - Last Light: [lastused_light] - Longterm: [longtermpower]"
 
 	if(cell && !shorted)
 
 
-		// draw power from cell as before
+		// draw power from cell as before to power the area
 		var/cellused = min(cell.charge, CELLRATE * lastused_total)	// clamp deduction to a max, amount left in cell
 		cell.use(cellused)
 
-		if(excess > 0 || perapc > lastused_total)		// if power excess, or enough anyway, recharge the cell
-														// by the same amount just used
+		if(excess > lastused_total)		// if power excess recharge the cell
+										// by the same amount just used
 			cell.give(cellused)
 			add_load(cellused/CELLRATE)		// add the load used to recharge the cell
 
 
 		else		// no excess, and not enough per-apc
 
-			if( (cell.charge/CELLRATE+perapc) >= lastused_total)		// can we draw enough from cell+grid to cover last usage?
+			if( (cell.charge/CELLRATE + excess) >= lastused_total)		// can we draw enough from cell+grid to cover last usage?
 
-				cell.charge = min(cell.maxcharge, cell.charge + CELLRATE * perapc)	//recharge with what we can
-				add_load(perapc)		// so draw what we can from the grid
+				cell.charge = min(cell.maxcharge, cell.charge + CELLRATE * excess)	//recharge with what we can
+				add_load(excess)		// so draw what we can from the grid
 				charging = 0
 
 			else	// not enough power available to run the last tick!
@@ -1112,12 +1108,8 @@
 
 		if(chargemode && charging == 1 && operating)
 			if(excess > 0)		// check to make sure we have enough to charge
-				// Max charge is perapc share, capped to cell capacity, or % per second constant (Whichever is smallest)
-/*				var/ch = min(perapc, (cell.maxcharge - cell.charge), (cell.maxcharge*CHARGELEVEL))
-				add_load(ch) // Removes the power we're taking from the grid
-				cell.give(ch) // actually recharge the cell
-*/
-				var/ch = min(perapc*CELLRATE, (cell.maxcharge - cell.charge), (cell.maxcharge*CHARGELEVEL))
+				// Max charge is capped to % per second constant
+				var/ch = min(excess*CELLRATE, cell.maxcharge*CHARGELEVEL)
 				add_load(ch/CELLRATE) // Removes the power we're taking from the grid
 				cell.give(ch) // actually recharge the cell
 
@@ -1126,8 +1118,8 @@
 				chargecount = 0
 
 		// show cell as fully charged if so
-
 		if(cell.charge >= cell.maxcharge)
+			cell.charge = cell.maxcharge
 			charging = 2
 
 		if(chargemode)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -225,7 +225,7 @@ obj/structure/cable/proc/add_avail(var/amount)
 
 obj/structure/cable/proc/add_load(var/amount)
 	if(powernet)
-		powernet.newload += amount
+		powernet.load += amount
 
 obj/structure/cable/proc/surplus()
 	if(powernet)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -1,6 +1,8 @@
 // the SMES
 // stores power
 
+#define SMESRATE 0.05			// rate of internal charge to external power
+
 /obj/machinery/power/smes
 	name = "power storage unit"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
@@ -138,9 +140,6 @@
 /obj/machinery/power/smes/proc/chargedisplay()
 	return round(5.5*charge/capacity)
 
-#define SMESRATE 0.05			// rate of internal charge to external power
-
-
 /obj/machinery/power/smes/process()
 
 	if(stat & BROKEN)	return
@@ -150,6 +149,7 @@
 	var/last_chrg = inputting
 	var/last_onln = outputting
 
+	//inputting
 	if(terminal && input_attempt)
 		input_available = terminal.surplus()
 
@@ -169,7 +169,7 @@
 			if(input_attempt && input_available > 0 && input_available >= input_level)
 				inputting = 1
 
-
+	//outputting
 	if(outputting)
 		output_used = min( charge/SMESRATE, output_level)		//limit output to that stored
 
@@ -193,7 +193,6 @@
 
 // called after all power processes are finished
 // restores charge level to smes if there was excess this ptick
-
 /obj/machinery/power/smes/proc/restore()
 	if(stat & BROKEN)
 		return
@@ -212,19 +211,19 @@
 
 	var/clev = chargedisplay()
 
-	charge += excess * SMESRATE
+	charge += excess * SMESRATE			// restore unused power
 	powernet.netexcess -= excess		// remove the excess from the powernet, so later SMESes don't try to use it
 
 	output_used -= excess
 
-	if(clev != chargedisplay() )
+	if(clev != chargedisplay() ) //if needed updates the icons overlay
 		update_icon()
 	return
 
 
 /obj/machinery/power/smes/add_load(var/amount)
 	if(terminal && terminal.powernet)
-		terminal.powernet.newload += amount
+		terminal.powernet.load += amount
 
 
 /obj/machinery/power/smes/attack_ai(mob/user)


### PR DESCRIPTION
Tweaked the power generation/usage procedure :
- power generation (solars, generators, collectors, etc) and usage (SMES, APC, drains, etc) are handled during machine processing,
- the powernet available power is reset each tick (with whatever power was generated during machines processing). If there was unused power in the net, store it back in the SMES.

Game differences with the previous way of doing :
- the available power is correctly handled each tick.
  Previously, some variables were not correctly reinitialized, causing, for example, the SMES to only load 1 tick on 2, despite the powernet having enough power to do it every tick, (fixes the main issue of #3761).
- consequence :  the SMES and APC are usually (re)charging faster,
- APC now draw power the same way as other machines.
  Previously, perapc available power was split between every APC **before** applying any load on it. So, you could have an heavy loaded powernet that would potentially send power to all APC,
- consequence : we can now have some APC charging but others that don't (if the powernet don't have enough power for all of them).
  Also, a little less processing from powernets.

Fixed #3761
