### PR TITLE
R&D improvements

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -184,16 +184,6 @@
 	..()
 	return
 
-//Re-implemented auto-sync now that it's not ungodly laggy -Sieve
-/obj/machinery/mecha_part_fabricator/process()
-	..()
-	if(async)
-		if(async > 101)//Once every 10 seconds at most
-			sync()
-			async = 1
-		async++
-	return
-
 /obj/machinery/mecha_part_fabricator/proc/operation_allowed(mob/M)
 	if(isrobot(M) || isAI(M))
 		return 1
@@ -579,9 +569,9 @@
 			if("main")
 				left_part = output_available_resources()+"<hr>"
 				left_part += "<a href='?src=\ref[src];sync=1'>Sync with R&D servers</a><hr>"
-				left_part += "<a href='?src=\ref[src];async=1'>Auto-Sync [async ? "Enabled" : "Disabled"]</a><hr>"
+//				left_part += "<a href='?src=\ref[src];async=1'>Auto-Sync [async ? "Enabled" : "Disabled"]</a><hr>"
 				for(var/part_set in part_sets)
-					left_part += "<a href='?src=\ref[src];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=\ref[src];partset_to_queue=[part_set]'>Add all parts to queue\]<br>"
+					left_part += "<a href='?src=\ref[src];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=\ref[src];partset_to_queue=[part_set]'>Add all parts to queue</a>\]<br>"
 			if("parts")
 				left_part += output_parts_list(part_set)
 				left_part += "<hr><a href='?src=\ref[src];screen=main'>Return</a>"
@@ -678,7 +668,7 @@
 		return update_queue_on_page()
 	if(href_list["async"])
 		async = !async
-		return update_queue_on_page()
+		return updateUsrDialog()
 	if(href_list["part_desc"])
 		var/obj/part = filter.getObj("part_desc")
 		if(part)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -579,6 +579,7 @@
 			if("main")
 				left_part = output_available_resources()+"<hr>"
 				left_part += "<a href='?src=\ref[src];sync=1'>Sync with R&D servers</a><hr>"
+				left_part += "<a href='?src=\ref[src];async=1'>Auto-Sync [async ? "Enabled" : "Disabled"]</a><hr>"
 				for(var/part_set in part_sets)
 					left_part += "<a href='?src=\ref[src];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=\ref[src];partset_to_queue=[part_set]'>Add all parts to queue\]<br>"
 			if("parts")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -926,6 +926,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	req_access = null
 	req_access_txt = "29"
 
+/obj/machinery/computer/rdconsole/robotics/initialize()
+	..()
+	for(var/obj/machinery/mecha_part_fabricator/M in area_contents(get_area(src)))
+		M.consoles.Add(src)//Adds itself to the mechfabs internal lists
+	return
+
 /obj/machinery/computer/rdconsole/core
 	name = "Core R&D Console"
 	id = 1

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -116,20 +116,21 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return
 
 //Have it automatically push research to the centcom server so wild griffins can't fuck up R&D's work --NEO
-/obj/machinery/computer/rdconsole/proc/griefProtection()
+//This is really redundant and not needed --Sieve
+/*/obj/machinery/computer/rdconsole/proc/griefProtection()
 	for(var/obj/machinery/r_n_d/server/centcom/C in world)
 		for(var/datum/tech/T in files.known_tech)
 			C.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
 			C.files.AddDesign2Known(D)
-		C.files.RefreshResearch()
+		C.files.RefreshResearch()*/
 
 
 /obj/machinery/computer/rdconsole/New()
 	..()
 	files = new /datum/research(src) //Setup the research data holder.
 	if(!id)
-		for(var/obj/machinery/r_n_d/server/centcom/S in world)
+		for(var/obj/machinery/r_n_d/server/centcom/S in machines)
 			S.initialize()
 			break
 
@@ -186,7 +187,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			screen = 1.2
 			files.AddTech2Known(t_disk.stored)
 			updateUsrDialog()
-			griefProtection() //Update centcom too
+//			griefProtection() //Update centcom too
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
 		t_disk.stored = null
@@ -209,7 +210,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			screen = 1.4
 			files.AddDesign2Known(d_disk.blueprint)
 			updateUsrDialog()
-			griefProtection() //Update centcom too
+//			griefProtection() //Update centcom too
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
 		d_disk.blueprint = null
@@ -300,21 +301,21 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(!sync)
 			usr << "\red You must connect to the network first!"
 		else
-			griefProtection() //Putting this here because I dont trust the sync process
+//			griefProtection() //Putting this here because I dont trust the sync process
 			spawn(30)
 				if(src)
-					for(var/obj/machinery/r_n_d/server/S in world)
+					for(var/obj/machinery/r_n_d/server/S in machines)//No reason to check the entire damn world for machines that are already in a list -Sieve
 						var/server_processed = 0
 						if(S.disabled)
 							continue
-						if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
+						if( ((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom)) && files.checksum != S.files.checksum)
 							for(var/datum/tech/T in files.known_tech)
 								S.files.AddTech2Known(T)
 							for(var/datum/design/D in files.known_designs)
 								S.files.AddDesign2Known(D)
 							S.files.RefreshResearch()
 							server_processed = 1
-						if(((id in S.id_with_download) && !istype(S, /obj/machinery/r_n_d/server/centcom)) || S.hacked)
+						if( (((id in S.id_with_download) && !istype(S, /obj/machinery/r_n_d/server/centcom)) || S.hacked) && files.checksum != S.files.checksum)
 							for(var/datum/tech/T in S.files.known_tech)
 								files.AddTech2Known(T)
 							for(var/datum/design/D in S.files.known_designs)
@@ -550,7 +551,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				linked_imprinter = null
 
 	else if(href_list["reset"]) //Reset the R&D console's database.
-		griefProtection()
+//		griefProtection()
 		var/choice = alert("R&D Console Database Reset", "Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
 			screen = 0.0
@@ -572,7 +573,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	user.set_machine(src)
 	var/dat = ""
-	files.RefreshResearch()
+//	files.RefreshResearch()//WHY
 	switch(screen) //A quick check to make sure you get the right screen when a device is disconnected.
 		if(2 to 2.9)
 			if(screen == 2.3)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -115,17 +115,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				D.linked_console = src
 	return
 
-//Have it automatically push research to the centcom server so wild griffins can't fuck up R&D's work --NEO
-//This is really redundant and not needed --Sieve
-/*/obj/machinery/computer/rdconsole/proc/griefProtection()
-	for(var/obj/machinery/r_n_d/server/centcom/C in world)
-		for(var/datum/tech/T in files.known_tech)
-			C.files.AddTech2Known(T)
-		for(var/datum/design/D in files.known_designs)
-			C.files.AddDesign2Known(D)
-		C.files.RefreshResearch()*/
-
-
 /obj/machinery/computer/rdconsole/New()
 	..()
 	files = new /datum/research(src) //Setup the research data holder.
@@ -136,11 +125,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 /obj/machinery/computer/rdconsole/initialize()
 	SyncRDevices()
-
-/*	Instead of calling this every tick, it is only being called when needed
-/obj/machinery/computer/rdconsole/process()
-	griefProtection()
-*/
 
 /obj/machinery/computer/rdconsole/attackby(var/obj/item/weapon/D as obj, var/mob/user as mob)
 
@@ -187,7 +171,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			screen = 1.2
 			files.AddTech2Known(t_disk.stored)
 			updateUsrDialog()
-//			griefProtection() //Update centcom too
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
 		t_disk.stored = null
@@ -210,7 +193,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			screen = 1.4
 			files.AddDesign2Known(d_disk.blueprint)
 			updateUsrDialog()
-//			griefProtection() //Update centcom too
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
 		d_disk.blueprint = null
@@ -573,7 +555,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	user.set_machine(src)
 	var/dat = ""
-//	files.RefreshResearch()//WHY
 	switch(screen) //A quick check to make sure you get the right screen when a device is disconnected.
 		if(2 to 2.9)
 			if(screen == 2.3)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -51,6 +51,7 @@ research holder datum.
 	var/list/known_tech = list()				//List of locally known tech.
 	var/list/possible_designs = list()		//List of all designs (at base reliability).
 	var/list/known_designs = list()			//List of available designs (at base reliability).
+	var/checksum									//Checksum of contained data
 
 /datum/research/New()		//Insert techs into possible_tech here. Known_tech automatically updated.
 	for(var/T in typesof(/datum/tech) - /datum/tech)
@@ -137,6 +138,7 @@ research holder datum.
 		T = Clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
+	generate_checksum()
 	return
 
 //Refreshes the levels of a given tech.
@@ -158,6 +160,18 @@ research holder datum.
 						D.reliability = min(100, D.reliability + rand(1,3))
 						if(I.crit_fail)
 							D.reliability = min(100, D.reliability + rand(3, 5))
+
+
+//Sieve
+/datum/research/proc/generate_checksum()//Creates what's essentially a checksum to compare data packets
+	var/list/holder = list()
+	for(var/datum/tech/T in known_tech)
+		holder.Add("[T.id][T.level]")//Only adding the relevant bits
+	for(var/datum/design/D in known_designs)
+		holder.Add("[D.id][D.reliability]")
+	checksum = md5(list2params(holder))
+//Problem with this method is that if the entries of the list are re-ordered it will appear different
+//In this usage, it shouldn't be too problematic (List isn't re-ordered for any known reason, and at worst causes extraneous updates)
 
 
 /***************************************************************

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -148,6 +148,7 @@ research holder datum.
 		if(KT.id == ID)
 			if(KT.level <= level)
 				KT.level = max((KT.level + 1), (level - 1))
+	generate_checksum()
 	return
 
 /datum/research/proc/UpdateDesigns(var/obj/item/I, var/list/temp_tech)
@@ -160,6 +161,8 @@ research holder datum.
 						D.reliability = min(100, D.reliability + rand(1,3))
 						if(I.crit_fail)
 							D.reliability = min(100, D.reliability + rand(3, 5))
+	generate_checksum()
+	return
 
 
 //Sieve

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -164,9 +164,8 @@ research holder datum.
 	generate_checksum()
 	return
 
-
-//Sieve
-/datum/research/proc/generate_checksum()//Creates what's essentially a checksum to compare data packets
+//Creates what's essentially a checksum to compare data packets
+/datum/research/proc/generate_checksum()
 	var/list/holder = list()
 	for(var/datum/tech/T in known_tech)
 		holder.Add("[T.id][T.level]")//Only adding the relevant bits

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -60,7 +60,7 @@
 		if((T20C + 20) to (T0C + 70))
 			health = max(0, health - 1)
 	if(health <= 0)
-		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or it's files anwyay.
+		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or its files anwyay.
 							refreshParts and the hasReq procs that get called by this are laggy and do not need to be called by every server on the map every tick */
 		var/updateRD = 0
 		files.known_designs = list()
@@ -95,7 +95,7 @@
 
 //Backup files to centcom to help admins recover data after greifer attacks
 /obj/machinery/r_n_d/server/proc/griefProtection()
-	if(files.checksum != backup.files.checksum)
+	if(backup && files.checksum != backup.files.checksum)
 		for(var/datum/tech/T in files.known_tech)
 			backup.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)
@@ -238,6 +238,7 @@
 	else if(href_list["reset_tech"])
 		var/choice = alert("Technology Data Reset", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
+			temp_server.griefProtection()
 			for(var/datum/tech/T in temp_server.files.known_tech)
 				if(T.id == href_list["reset_tech"])
 					T.level = 1
@@ -247,6 +248,7 @@
 	else if(href_list["reset_design"])
 		var/choice = alert("Design Data Deletion", "Are you sure you want to delete this design? If you still have the prerequisites for the design, it'll reset to its base reliability. Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
+			temp_server.griefProtection()
 			for(var/datum/design/D in temp_server.files.known_designs)
 				if(D.id == href_list["reset_design"])
 					temp_server.files.known_designs -= D

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -60,8 +60,6 @@
 		if((T20C + 20) to (T0C + 70))
 			health = max(0, health - 1)
 	if(health <= 0)
-		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or its files anwyay.
-							refreshParts and the hasReq procs that get called by this are laggy and do not need to be called by every server on the map every tick */
 		var/updateRD = 0
 		files.known_designs = list()
 		for(var/datum/tech/T in files.known_tech)
@@ -95,7 +93,7 @@
 
 //Backup files to centcom to help admins recover data after greifer attacks
 /obj/machinery/r_n_d/server/proc/griefProtection()
-	if(backup && files.checksum != backup.files.checksum)
+	if(backup && files.checksum != backup.files.checksum)//Does absolutely nothing if there's no Centcomm backup
 		for(var/datum/tech/T in files.known_tech)
 			backup.files.AddTech2Known(T)
 		for(var/datum/design/D in files.known_designs)


### PR DESCRIPTION
Made machines using the R&D filesystem use checksums to determine if the data in them has changed before they sync, as opposed to force-syncing every file.
Cut out most of griefProtection() because it was redundant/uneeded not to mention that it won't work at all on the current map due to the lack of a Centcom server. griefProtection() still functions and uses the checksums, but was also made much more efficient
Changed all the "in world" checks to "in machines" because they were all looking for machines anyways.
Gave mechfabs a holder list for consoles instead of iterating through the area every time the button was pressed.
