### PR TITLE
Reduced adminhelp delay to 10 seconds

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -20,8 +20,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	//remove out adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp
-	spawn(1200)
-		src.verbs += /client/verb/adminhelp	// 2 minute cool-down for adminhelps
+	spawn(100)
+		src.verbs += /client/verb/adminhelp	// 10 second cool-down for adminhelps
 
 	//clean the input msg
 	if(!msg)	return


### PR DESCRIPTION
Reason: 2 minutes is actually quite annoying if you ask me, and 10 seconds should do the job while both preventing spam and not forcing one to wait too long. After all, even if someone abuses this there is always the mute button.

Also, typo in commit name. Must say 10 instead of 15 seconds.
