### PR TITLE
Non-human HUD polishing (stop pulling and intent buttons)

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -72,6 +72,7 @@
 
 	using = new /obj/screen()
 	using.name = "act_intent"
+	using.icon = 'icons/mob/screen_alien.dmi'
 	using.icon_state = mymob.a_intent
 	using.screen_loc = ui_acti
 	using.layer = 20

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -6,6 +6,7 @@
 
 	using = new /obj/screen()
 	using.name = "act_intent"
+	using.icon = 'icons/mob/screen_alien.dmi'
 	using.icon_state = mymob.a_intent
 	using.screen_loc = ui_acti
 	using.layer = 20

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -7,6 +7,7 @@
 
 	using = new /obj/screen()
 	using.name = "act_intent"
+	using.icon = ui_style
 	using.icon_state = mymob.a_intent
 	using.screen_loc = ui_acti
 	using.layer = 20

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -326,8 +326,11 @@
 			else
 				healths.icon_state = "health6"
 
-		if(pullin)	pullin.icon_state = "pull[pulling ? 1 : 0]"
-
+		if(pullin)
+			if(pulling)
+				pullin.icon_state = "pull"
+			else
+				pullin.icon_state = "pull0"
 
 		if (toxin)	toxin.icon_state = "tox[toxins_alert ? 1 : 0]"
 		if (oxygen) oxygen.icon_state = "oxy[oxygen_alert ? 1 : 0]"

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -511,8 +511,11 @@
 		if(pressure)
 			pressure.icon_state = "pressure[pressure_alert]"
 
-		if(pullin)	pullin.icon_state = "pull[pulling ? 1 : 0]"
-
+		if(pullin)
+			if(pulling)
+				pullin.icon_state = "pull"
+			else
+				pullin.icon_state = "pull0"
 
 		if (toxin)	toxin.icon_state = "tox[toxins_alert ? 1 : 0]"
 		if (oxygen) oxygen.icon_state = "oxy[oxygen_alert ? 1 : 0]"


### PR DESCRIPTION
Added a _"stop pulling"_ button to monkey and alien larva HUD and make the _"intent button"_ use the current HUD theme.

Partially fix #3577 (doing so for simple mobs and slimes would involve doing a HUD from scratch for them).

**Monkey (midnight ui used) :** 
![monkey_pullin](https://cloud.githubusercontent.com/assets/7117411/3105609/c4009a42-e674-11e3-96f9-11c1f1908282.png)

**Larva :**
![larva_hud](https://cloud.githubusercontent.com/assets/7117411/3105611/c692bf06-e674-11e3-9819-76ab861b5928.png)

**Alien (intent button) :**
![alien_hud](https://cloud.githubusercontent.com/assets/7117411/3105610/c5982992-e674-11e3-8364-45afd903ba08.png)
