### PR TITLE
SMES constructible terminals

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -383,7 +383,7 @@
 	if (istype(W, /obj/item/weapon/crowbar) && opened)
 		if (has_electronics==1)
 			if (terminal)
-				user << "\red Disconnect wires first."
+				user << "<span class='alert'>Disconnect wires first.</span>"
 				return
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
 			user << "You are trying to remove the power control board..." //lpeters - fixed grammar issues
@@ -391,13 +391,13 @@
 				has_electronics = 0
 				if ((stat & BROKEN) || malfhack)
 					user.visible_message(\
-						"\red [user.name] has broken the power control board inside [src.name]!",\
+						"<span class='alert'>[user.name] has broken the power control board inside [src.name]!</span>",\
 						"You broke the charred power control board and remove the remains.",
 						"You hear a crack!")
 					//ticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
 				else
 					user.visible_message(\
-						"\red [user.name] has removed the power control board from [src.name]!",\
+						"<span class='alert'>[user.name] has removed the power control board from [src.name]!</span>",\
 						"You remove the power control board.")
 					new /obj/item/weapon/module/power_control(loc)
 		else if (opened!=2) //cover isn't removed
@@ -405,7 +405,7 @@
 			update_icon()
 	else if (istype(W, /obj/item/weapon/crowbar) && !((stat & BROKEN) || malfhack) )
 		if(coverlocked && !(stat & MAINT))
-			user << "\red The cover is locked and cannot be opened."
+			user << "<span class='alert'>The cover is locked and cannot be opened.</span>"
 			return
 		else
 			opened = 1
@@ -416,20 +416,20 @@
 			return
 		else
 			if (stat & MAINT)
-				user << "\red There is no connector for your power cell."
+				user << "<span class='alert'>There is no connector for your power cell.</span>"
 				return
 			user.drop_item()
 			W.loc = src
 			cell = W
 			user.visible_message(\
-				"\red [user.name] has inserted the power cell to [src.name]!",\
+				"<span class='alert'>[user.name] has inserted the power cell to [src.name]!</span>",\
 				"You insert the power cell.")
 			chargecount = 0
 			update_icon()
 	else if	(istype(W, /obj/item/weapon/screwdriver))	// haxing
 		if(opened)
 			if (cell)
-				user << "\red Close the APC first." //Less hints more mystery!
+				user << "<span class='alert'>Close the APC first.</span>" //Less hints more mystery!
 				return
 			else
 				if (has_electronics==1 && terminal)
@@ -443,7 +443,7 @@
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 					user << "You unfasten the electronics."
 				else /* has_electronics==0 */
-					user << "\red There is nothing to secure."
+					user << "<span class='alert'>There is nothing to secure.</span>"
 					return
 				update_icon()
 		else if(emagged)
@@ -468,7 +468,7 @@
 				user << "You [ locked ? "lock" : "unlock"] the APC interface."
 				update_icon()
 			else
-				user << "\red Access denied."
+				user << "<span class='alert'>Access denied.</span>"
 	else if (istype(W, /obj/item/weapon/card/emag) && !(emagged || malfhack))		// trying to unlock with an emag card
 		if(opened)
 			user << "You must close the cover to swipe an ID card."
@@ -486,18 +486,19 @@
 					update_icon()
 				else
 					user << "You fail to [ locked ? "unlock" : "lock"] the APC interface."
+
 	else if (istype(W, /obj/item/stack/cable_coil) && !terminal && opened && has_electronics!=2)
-		if (src.loc:intact)
-			user << "\red You must remove the floor plating in front of the APC first."
+		var/turf/T = get_turf(src)
+		if (T.intact)
+			user << "<span class='alert'> You must remove the floor plating in front of the APC first.</span>"
 			return
 		var/obj/item/stack/cable_coil/C = W
 		if(C.amount < 10)
-			user << "\red You need more wires."
+			user << "<span class='alert'> You need more wires.</span>"
 			return
 		user << "You start adding cables to the APC frame..."
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 20) && C.amount >= 10)
-			var/turf/T = get_turf(src)
 			var/obj/structure/cable/N = T.get_cable_node()
 			if (prob(50) && electrocute_mob(usr, N, N))
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -506,13 +507,15 @@
 				return
 			C.use(10)
 			user.visible_message(\
-				"\red [user.name] has added cables to the APC frame!",\
+				"<span class='alert'> [user.name] has added cables to the APC frame!</span>",\
 				"You add cables to the APC frame.")
 			make_terminal()
 			terminal.connect_to_network()
+
 	else if (istype(W, /obj/item/weapon/wirecutters) && terminal && opened && has_electronics!=2)
-		if (src.loc:intact)
-			user << "\red You must remove the floor plating in front of the APC first."
+		var/turf/T = get_turf(src)
+		if (T.intact)
+			user << "<span class='alert'> You must remove the floor plating in front of the APC first.</span>"
 			return
 		user << "You begin to cut the cables..."
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -524,7 +527,7 @@
 				return
 			new /obj/item/stack/cable_coil(loc,10)
 			user.visible_message(\
-				"\red [user.name] cut the cables and dismantled the power terminal.",\
+				"<span class='alert'>[user.name] cut the cables and dismantled the power terminal.</span>",\
 				"You cut the cables and dismantle the power terminal.")
 			qdel(terminal)
 	else if (istype(W, /obj/item/weapon/module/power_control) && opened && has_electronics==0 && !((stat & BROKEN) || malfhack))
@@ -535,12 +538,12 @@
 			user << "You place the power control board inside the frame."
 			qdel(W)
 	else if (istype(W, /obj/item/weapon/module/power_control) && opened && has_electronics==0 && ((stat & BROKEN) || malfhack))
-		user << "\red You cannot put the board inside, the frame is damaged."
+		user << "<span class='alert'>You cannot put the board inside, the frame is damaged.</span>"
 		return
 	else if (istype(W, /obj/item/weapon/weldingtool) && opened && has_electronics==0 && !terminal)
 		var/obj/item/weapon/weldingtool/WT = W
 		if (WT.get_fuel() < 3)
-			user << "\blue You need more welding fuel to complete this task."
+			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return
 		user << "You start welding the APC frame..."
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
@@ -549,15 +552,15 @@
 			if (emagged || malfhack || (stat & BROKEN) || opened==2)
 				new /obj/item/stack/sheet/metal(loc)
 				user.visible_message(\
-					"\red [src] has been cut apart by [user.name] with the weldingtool.",\
+					"<span class='alert'>[src] has been cut apart by [user.name] with the weldingtool.</span>",\
 					"You disassembled the broken APC frame.",\
-					"\red You hear welding.")
+					"<span class='alert'>You hear welding.</span>")
 			else
 				new /obj/item/apc_frame(loc)
 				user.visible_message(\
-					"\red [src] has been cut from the wall by [user.name] with the weldingtool.",\
+					"<span class='alert'>[src] has been cut from the wall by [user.name] with the weldingtool.</span>",\
 					"You cut the APC frame from the wall.",\
-					"\red You hear welding.")
+					"<span class='alert'>You hear welding.</span>")
 			qdel(src)
 			return
 	else if (istype(W, /obj/item/apc_frame) && opened && emagged)
@@ -565,7 +568,7 @@
 		if (opened==2)
 			opened = 1
 		user.visible_message(\
-			"\red [user.name] has replaced the damaged APC frontal panel with a new one.",\
+			"<span class='alert'>[user.name] has replaced the damaged APC frontal panel with a new one.</span>",\
 			"You replace the damaged APC frontal panel with a new one.")
 		qdel(W)
 		update_icon()
@@ -576,7 +579,7 @@
 		user << "You begin to replace the damaged APC frame..."
 		if(do_after(user, 50))
 			user.visible_message(\
-				"\red [user.name] has replaced the damaged APC frame with new one.",\
+				"<span class='alert'>[user.name] has replaced the damaged APC frame with new one.</span>",\
 				"You replace the damaged APC frame with new one.")
 			qdel(W)
 			stat &= ~BROKEN
@@ -592,8 +595,8 @@
 				&& W.w_class >= 3.0 \
 				&& prob(20) )
 			opened = 2
-			user.visible_message("\red The APC cover was knocked down with the [W.name] by [user.name]!", \
-				"\red You knock down the APC cover with your [W.name]!", \
+			user.visible_message("<span class='alert'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
+				"<span class='alert'>You knock down the APC cover with your [W.name]!</span>", \
 				"You hear bang")
 			update_icon()
 		else
@@ -603,8 +606,8 @@
 				(istype(W, /obj/item/device/multitool) || \
 				istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/assembly/signaler)))
 				return src.attack_hand(user)
-			user.visible_message("\red The [src.name] has been hit with the [W.name] by [user.name]!", \
-				"\red You hit the [src.name] with your [W.name]!", \
+			user.visible_message("<span class='alert'> The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
+				"<span class='alert'> You hit the [src.name] with your [W.name]!</span>", \
 				"You hear bang")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
@@ -622,7 +625,7 @@
 			cell.updateicon()
 
 			src.cell = null
-			user.visible_message("\red [user.name] removes the power cell from [src.name]!", "You remove the power cell.")
+			user.visible_message("<span class='alert'>[user.name] removes the power cell from [src.name]!</span>", "You remove the power cell.")
 			//user << "You remove the power cell."
 			charging = 0
 			src.update_icon()
@@ -635,7 +638,7 @@
 /obj/machinery/power/apc/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(!user)
 		return
-	user.visible_message("\red [user.name] slashes at the [src.name]!", "\blue You slash at the [src.name]!")
+	user.visible_message("<span class='alert'>[user.name] slashes at the [src.name]!</span>", "<span class='notice'>You slash at the [src.name]!</span>")
 	playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 
 	var/allcut = wires.IsAllCut()
@@ -643,12 +646,12 @@
 	if(beenhit >= pick(3, 4) && wiresexposed != 1)
 		wiresexposed = 1
 		src.update_icon()
-		src.visible_message("\red The [src.name]'s cover flies open, exposing the wires!")
+		src.visible_message("<span class='alert'>The [src.name]'s cover flies open, exposing the wires!</span>")
 
 	else if(wiresexposed == 1 && allcut == 0)
 		wires.CutAll()
 		src.update_icon()
-		src.visible_message("\red The [src.name]'s wires are shredded!")
+		src.visible_message("<span class='alert'>The [src.name]'s wires are shredded!</span>")
 	else
 		beenhit += 1
 	return
@@ -767,20 +770,20 @@
 
 /obj/machinery/power/apc/proc/can_use(mob/user as mob, var/loud = 0) //used by attack_hand() and Topic()
 	if (user.stat)
-		user << "\red You must be conscious to use this [src]!"
+		user << "<span class='alert'>You must be conscious to use this [src]!</span>"
 		return 0
 	if(!user.client)
 		return 0
 	if ( ! (istype(user, /mob/living/carbon/human) || \
 			istype(user, /mob/living/silicon) || \
 			istype(user, /mob/living/carbon/monkey)) )
-		user << "\red You don't have the dexterity to use this [src]!"
+		user << "<span class='alert'>You don't have the dexterity to use this [src]!</span>"
 		return 0
 	if(user.restrained())
-		user << "\red You must have free hands to use this [src]"
+		user << "<span class='alert'>You must have free hands to use this [src]!</span>"
 		return 0
 	if(user.lying)
-		user << "\red You must stand to use this [src]!"
+		user << "<span class='alert'>You must stand to use this [src]!</span>"
 		return 0
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
@@ -794,7 +797,7 @@
 			)                                                            \
 		)
 			if(!loud)
-				user << "\red \The [src] have AI control disabled!"
+				user << "<span class='alert'>\The [src] have AI control disabled!</span>"
 			return 0
 	else
 		if ((!in_range(src, user) || !istype(src.loc, /turf)))
@@ -804,10 +807,10 @@
 	if (istype(H))
 		if(H.getBrainLoss() >= 60)
 			for(var/mob/M in viewers(src, null))
-				M << "\red [H] stares cluelessly at [src] and drools."
+				M << "<span class='alert'>[H] stares cluelessly at [src] and drools.</span>"
 			return 0
 		else if(prob(H.getBrainLoss()))
-			user << "\red You momentarily forget how to use [src]."
+			user << "<span class='alert'>You momentarily forget how to use [src].</span>"
 			return 0
 	return 1
 
@@ -953,7 +956,7 @@
 						point.the_disk = A //The pinpointer tracks the AI back into its core.
 
 	else
-		src.occupier << "\red Primary core damaged, unable to return core processes."
+		src.occupier << "<span class='alert'>Primary core damaged, unable to return core processes.</span>"
 		if(forced)
 			src.occupier.loc = src.loc
 			src.occupier.death()
@@ -981,7 +984,7 @@
 				s.set_up(3, 1, src)
 				s.start()
 				for(var/mob/M in viewers(src))
-					M.show_message("\red The [src.name] suddenly lets out a blast of smoke and some sparks!", 3, "\red You hear sizzling electronics.", 2)
+					M.show_message("<span class='alert'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", 3, "<span class='alert'>You hear sizzling electronics.</span>", 2)
 
 
 /obj/machinery/power/apc/surplus()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -68,10 +68,12 @@
 	capacity = C / (15000) * 1e6
 
 /obj/machinery/power/smes/attackby(obj/item/I, mob/user)
+	//opening using screwdriver
 	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
 		update_icon()
 		return
 
+	//changing direction using wrench
 	if(default_change_direction_wrench(user, I))
 		terminal = null
 		var/turf/T = get_step(src, dir)
@@ -94,9 +96,83 @@
 		update_icon()
 		return
 
+	//exchanging parts using the RPE
 	if(exchange_parts(user, I))
 		return
 
+	//building and linking a terminal
+	if(istype(I, /obj/item/stack/cable_coil))
+		var/dir = get_dir(user,src)
+		if(dir & (dir-1))//we don't want diagonal click
+			return
+
+		if(terminal) //is there already a terminal ?
+			user << "<span class='alert'>This SMES already have a power terminal!</span>"
+			return
+
+		if(!panel_open) //is the panel open ?
+			user << "<span class='alert'>You must open the maintenance panel first!</span>"
+			return
+
+		var/turf/T = get_turf(user)
+		if (T.intact) //is the floor plating removed ?
+			user << "<span class='alert'>You must first remove the floor plating!</span>"
+			return
+
+
+		var/obj/item/stack/cable_coil/C = I
+		if(C.amount < 10)
+			user << "<span class='alert'>You need more wires.</span>"
+			return
+
+		user << "You start building the power terminal..."
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+
+		if(do_after(user, 20) && C.amount >= 10)
+			var/obj/structure/cable/N = T.get_cable_node() //get the connecting node cable, if there's one
+			if (prob(50) && electrocute_mob(usr, N, N)) //animate the electrocution if uncautious and unlucky
+				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+				s.set_up(5, 1, src)
+				s.start()
+				return
+
+			C.use(10)
+			user.visible_message(\
+				"<span class='alert'>[user.name] has build a power terminal!</span>",\
+				"You build the power terminal.")
+
+			//build the terminal and link it to the network
+			make_terminal(T)
+			terminal.connect_to_network()
+		return
+
+	//disassembling the terminal
+	if(istype(I, /obj/item/weapon/wirecutters) && terminal && panel_open)
+		var/turf/T = get_turf(terminal)
+		if (T.intact) //is the floor plating removed ?
+			user << "<span class='alert'>You must first expose the power terminal!</span>"
+			return
+
+		user << "You begin to dismantle the power terminal..."
+		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+
+		if(do_after(user, 50))
+			if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal)) //animate the electrocution if uncautious and unlucky
+				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+				s.set_up(5, 1, src)
+				s.start()
+				return
+
+			//give the wires back and delete the terminal
+			new /obj/item/stack/cable_coil(T,10)
+			user.visible_message(\
+				"<span class='alert'>[user.name] cuts the cables and dismantles the power terminal.</span>",\
+				"You cut the cables and dismantle the power terminal.")
+			inputting = 0 //stop inputting, since we have don't have a terminal anymore
+			qdel(terminal)
+			return
+
+	//crowbarring it !
 	default_deconstruction_crowbar(I)
 
 /obj/machinery/power/smes/Destroy()
@@ -114,6 +190,12 @@
 		terminal.master = null
 		terminal = null
 
+// create a terminal object pointing towards the SMES
+// wires will attach to this
+/obj/machinery/power/smes/proc/make_terminal(var/turf/T)
+	terminal = new/obj/machinery/power/terminal(T)
+	terminal.dir = get_dir(T,src)
+	terminal.master = src
 
 /obj/machinery/power/smes/update_icon()
 	overlays.Cut()


### PR DESCRIPTION
Added a way to construct or dismantle terminals for SMES.

**Construction :**
- you must be north, south, east or west of the SMES (diagonal is not allowed, because we've got no sprites for diagonals terminals),
- the floor plating must be removed,
- the maintenance panel of the SMES must be open,
- you must have at least 10 lengths of cable

**Deconstruction :**
- the terminal must be exposed (plating removed),
- the maintenance panel of the SMES must be open,
- you must use wirecutters

There's a chance for electrocution if unprotected for both actions.

The code is heavily inspired by the APC one.
I was going to do a standard function for all power machines, but realized only SMES and APC possess a _terminal_ variable.
Given the APC code is somewhat different from the SMES one (e.g the terminal is on the same tile as the APC, as opposed to an adjacent one), that would have involved special cases in a function only used by two objects.

Also, "span classed" the _apc.dm_ file while i was at it.
