### PR TITLE
Stunprod Fix

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -38,7 +38,7 @@
 		if(bcell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
 			status = 0
 			update_icon()
-			usr << "<span class='warning'>[src] is out of charge.</span>"
+			playsound(loc, "sparks", 75, 1, -1)
 		if(bcell.use(chrgdeductamt))
 			return 1
 		else

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -38,7 +38,7 @@
 		if(bcell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
 			status = 0
 			update_icon()
-			user << "<span class='warning'>[src] is out of charge.</span>"
+			usr << "<span class='warning'>[src] is out of charge.</span>"
 		if(bcell.use(chrgdeductamt))
 			return 1
 		else
@@ -62,10 +62,11 @@
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/stock_parts/cell))
+		var/obj/item/weapon/stock_parts/cell/C = W
 		if(bcell)
 			user << "<span class='notice'>[src] already has a cell.</span>"
 		else
-			if(W.maxcharge < hitcost)
+			if(C.maxcharge < hitcost)
 				user << "<span class='notice'>[src] requires a higher capacity cell.</span>"
 				return
 			user.drop_item()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -35,11 +35,13 @@
 
 /obj/item/weapon/melee/baton/proc/deductcharge(var/chrgdeductamt)
 	if(bcell)
+		if(bcell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
+			status = 0
+			update_icon()
+			user << "<span class='warning'>[src] is out of charge.</span>"
 		if(bcell.use(chrgdeductamt))
 			return 1
 		else
-			status = 0
-			update_icon()
 			return 0
 
 /obj/item/weapon/melee/baton/update_icon()
@@ -60,14 +62,17 @@
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/stock_parts/cell))
-		if(!bcell)
+		if(bcell)
+			user << "<span class='notice'>[src] already has a cell.</span>"
+		else
+			if(W.maxcharge < hitcost)
+				user << "<span class='notice'>[src] requires a higher capacity cell.</span>"
+				return
 			user.drop_item()
 			W.loc = src
 			bcell = W
 			user << "<span class='notice'>You install a cell in [src].</span>"
 			update_icon()
-		else
-			user << "<span class='notice'>[src] already has a cell.</span>"
 
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		if(bcell)
@@ -86,13 +91,13 @@
 		status = !status
 		user << "<span class='notice'>[src] is now [status ? "on" : "off"].</span>"
 		playsound(loc, "sparks", 75, 1, -1)
-		update_icon()
 	else
 		status = 0
 		if(!bcell)
 			user << "<span class='warning'>[src] does not have a power source!</span>"
 		else
 			user << "<span class='warning'>[src] is out of charge.</span>"
+	update_icon()
 	add_fingerprint(user)
 
 /obj/item/weapon/melee/baton/attack(mob/M, mob/user)


### PR DESCRIPTION
- Fix icon not updating when turning off baton/stunprod with a total cell charge below the hitcost.
- Baton/stunprod no longer accepts cell with capacity below the hitcost(charge used per stun). Fixes #3123.
- Removes being able to give one last hit (that doesn't even deduct any charge) when the cell charge gets below the hitcost.
- Adds sparks sound when baton/stunprod turns off from being out of charge to warn the player.
