### PR TITLE
Fix Tachyon detector and TTV not being deleted if exploding inside something

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -205,13 +205,16 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		range = min(range, MAX_EX_LIGHT_RANGE)
+		//range = min(range, MAX_EX_LIGHT_RANGE)  ---  handled in explosion.dm and prevented tachyon detectors fromstating true blast
 		var/turf/epicenter = get_turf(loc)
 
 		//world << "\blue Exploding Pressure: [pressure] kPa, intensity: [range]"
 
 		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
-		qdel(src)
+		if(istype(src.loc,/obj/item/device/transfer_valve))
+			qdel(src.loc)
+		else
+			qdel(src)
 
 	else if(pressure > TANK_RUPTURE_PRESSURE)
 		//world << "\blue[x],[y] tank is rupturing: [pressure] kPa, integrity [integrity]"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -205,7 +205,6 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		//range = min(range, MAX_EX_LIGHT_RANGE)  ---  handled in explosion.dm and prevented tachyon detectors fromstating true blast
 		var/turf/epicenter = get_turf(loc)
 
 		//world << "\blue Exploding Pressure: [pressure] kPa, intensity: [range]"


### PR DESCRIPTION
Fixes #2722 (Shoving a TTV in something will let it survive it's own explosion)

```
code/game/objects/items/weapons/tanks/tanks.dm : 214..217
```

Fixes #2977 (Tachyon detector doesn't show true size)

```
code/game/objects/items/weapons/tanks/tanks.dm : 208
```

(These bugfixes are from pull 3417 by Alek2ander , I'm just separating the bugfixes in smaller PRs)
