### PR TITLE
Fix not being able to cut cable over space tile

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/turf/space.dmi'
 	name = "\proper space"
 	icon_state = "0"
+	intact = 0
 
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT


### PR DESCRIPTION
Fixes #3129 (Cannot cut wire over space tile)

```
code/game/turfs/space/space.dm
```

(These bugfixes are from pull 3417 by Alek2ander , I'm just separating the bugfixes in smaller PRs)
