### PR TITLE
Fixes #3788 Animals retaliating after death

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -59,7 +59,8 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/Retaliate()
 	..()
-	src.visible_message("\red [src] gets an evil-looking gleam in \his eye.")
+	if(stat == CONSCIOUS)
+		src.visible_message("\red [src] gets an evil-looking gleam in \his eye.")
 
 /mob/living/simple_animal/hostile/retaliate/goat/Move()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -59,8 +59,7 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/Retaliate()
 	..()
-	if(stat == CONSCIOUS)
-		src.visible_message("\red [src] gets an evil-looking gleam in \his eye.")
+	src.visible_message("\red [src] gets an evil-looking gleam in \his eye.")
 
 /mob/living/simple_animal/hostile/retaliate/goat/Move()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -46,4 +46,5 @@
 
 /mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(var/damage)
 	..(damage)
-	Retaliate()
+	if(stat == CONSCIOUS)
+		Retaliate()


### PR DESCRIPTION
Fix for issue #3788. No animals should be able to retaliate anymore if they are dead.
