### PR TITLE
Removed intercept metas.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -15,7 +15,6 @@
 /datum/game_mode
 	var/name = "invalid"
 	var/config_tag = null
-	var/intercept_hacked = 0
 	var/votable = 1
 	var/probability = 1
 	var/station_was_nuked = 0 //see nuclearbomb.dm and malfunction.dm
@@ -176,15 +175,14 @@
 
 	var/list/possible_modes = list()
 	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "malf", "changeling", "cult")
-	possible_modes -= "[ticker.mode]" //remove current gamemode, it will be readded later if not malf and AI not intercepting the report
+	possible_modes -= "[ticker.mode]" //remove current gamemode to prevent it from being randomly deleted, it will be readded later
 
 	var/number = pick(1, 2)
 	var/i = 0
 	for(i = 0, i < number, i++) //remove 1 or 2 possibles modes from the list
 		possible_modes.Remove(pick(possible_modes))
 
-	if(!intercept_hacked) //if not malf and AI not intercepting the report
-		possible_modes[rand(1, possible_modes.len)] = "[ticker.mode]" //replace a random game mode with the current one
+	possible_modes[rand(1, possible_modes.len)] = "[ticker.mode]" //replace a random game mode with the current one
 
 	possible_modes = shuffle(possible_modes) //shuffle the list to prevent meta
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -176,15 +176,17 @@
 
 	var/list/possible_modes = list()
 	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "malf", "changeling", "cult")
-	var/number = pick(2, 3)
+	possible_modes -= "[ticker.mode]" //remove current gamemode, it will be readded later if not malf and AI not intercepting the report
+
+	var/number = pick(1, 2)
 	var/i = 0
-	for(i = 0, i < number, i++)
+	for(i = 0, i < number, i++) //remove 1 or 2 possibles modes from the list
 		possible_modes.Remove(pick(possible_modes))
 
-	if(!intercept_hacked)
-		possible_modes.Insert(rand(possible_modes.len), "[ticker.mode]")
+	if(!intercept_hacked) //if not malf and AI not intercepting the report
+		possible_modes[rand(possible_modes.len)] = "[ticker.mode]" //replace a random game mode with the current one
 
-	shuffle(possible_modes)
+	possible_modes = shuffle(possible_modes) //shuffle the list to prevent meta
 
 	var/datum/intercept_text/i_text = new /datum/intercept_text
 	for(var/A in possible_modes)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -184,7 +184,7 @@
 		possible_modes.Remove(pick(possible_modes))
 
 	if(!intercept_hacked) //if not malf and AI not intercepting the report
-		possible_modes[rand(possible_modes.len)] = "[ticker.mode]" //replace a random game mode with the current one
+		possible_modes[rand(1, possible_modes.len)] = "[ticker.mode]" //replace a random game mode with the current one
 
 	possible_modes = shuffle(possible_modes) //shuffle the list to prevent meta
 

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -284,22 +284,6 @@
 			src << "<span class='notice'>Overcurrent applied to the powernet.</span>"
 		else src << "<span class='notice'>Out of uses.</span>"
 
-/datum/AI_Module/small/interhack
-	module_name = "Hack intercept"
-	mod_pick_name = "interhack"
-	description = "Hacks the status update from Centcom, removing any information about malfunctioning electrical systems."
-	cost = 15
-	one_time = 1
-
-	power_type = /mob/living/silicon/ai/proc/interhack
-
-/mob/living/silicon/ai/proc/interhack()
-	set category = "Malfunction"
-	set name = "Hack intercept"
-	src.verbs -= /mob/living/silicon/ai/proc/interhack
-	ticker.mode:hack_intercept()
-	src << "<span class='notice'>Status update intercepted and modified.</span>"
-
 /datum/AI_Module/small/reactivate_camera
 	module_name = "Reactivate camera"
 	mod_pick_name = "recam"

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -104,11 +104,6 @@
 	malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
 	return
 
-
-/datum/game_mode/malfunction/proc/hack_intercept()
-	intercept_hacked = 1
-
-
 /datum/game_mode/malfunction/process()
 	if (apcs >= 3 && malf_mode_declared)
 		AI_win_timeleft -= ((apcs/6)*last_tick_duration) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite


### PR DESCRIPTION
Removed the currently introduced intercept meta (#3792, oh the irony).
Comments added to prevent this from happening again.

The report generation now goes this way :
- we remove the current game mode from the list of all possibles game modes,
- we remove 1 or 2 random game modes,
- then we _replace_ (not insert) a random game mode in the list with the current game mode (so that we always have 4 or 5 modes in the list),
- we shuffle the list, to prevent meta (with the current mode being the only one randomly placed).

Fixes #3854.

**Edit :** Following the below comments, removed the Malf AI _Intercept Hack_ module altogether.
