### PR TITLE
Cc mining

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -156,22 +156,22 @@
 	anchored = 1.0
 	var/obj/item/weapon/card/id/inserted_id
 	var/list/prize_list = list(
-		new /datum/data/mining_equipment("Chili",               /obj/item/weapon/reagent_containers/food/snacks/hotchili,          100),
-		new /datum/data/mining_equipment("Cigar",               /obj/item/clothing/mask/cigarette/cigar/havana,                    100),
-		new /datum/data/mining_equipment("Whiskey",             /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,    150),
-		new /datum/data/mining_equipment("Soap",                /obj/item/weapon/soap/nanotrasen, 						           150),
-		new /datum/data/mining_equipment("Stimulant pills",     /obj/item/weapon/storage/pill_bottle/stimulant, 				   350),
-		new /datum/data/mining_equipment("Alien toy",           /obj/item/clothing/mask/facehugger/toy, 		                   250),
+		new /datum/data/mining_equipment("Chili",               /obj/item/weapon/reagent_containers/food/snacks/hotchili,          200),
+		new /datum/data/mining_equipment("Cigar",               /obj/item/clothing/mask/cigarette/cigar/havana,                    200),
+		new /datum/data/mining_equipment("Whiskey",             /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,    300),
+		new /datum/data/mining_equipment("Soap",                /obj/item/weapon/soap/nanotrasen, 						           350),
+		new /datum/data/mining_equipment("Stimulant pills",     /obj/item/weapon/storage/pill_bottle/stimulant, 				   1000),
+		new /datum/data/mining_equipment("Alien toy",           /obj/item/clothing/mask/facehugger/toy, 		                   500),
 		new /datum/data/mining_equipment("Laser pointer",       /obj/item/device/laser_pointer, 				                   500),
 		new /datum/data/mining_equipment("Point card",    		/obj/item/weapon/card/mining_point_card,               			   500),
-		new /datum/data/mining_equipment("Lazarus injector",    /obj/item/weapon/lazarus_injector,                                1000),
+		new /datum/data/mining_equipment("Lazarus injector",    /obj/item/weapon/lazarus_injector,                                2000),
 		new /datum/data/mining_equipment("Space cash",    		/obj/item/weapon/spacecash/c1000,                    			  5000),
-		new /datum/data/mining_equipment("Sonic jackhammer",    /obj/item/weapon/pickaxe/jackhammer,                               500),
-		new /datum/data/mining_equipment("Mining drone",        /mob/living/simple_animal/hostile/mining_drone/,                   500),
-		new /datum/data/mining_equipment("Jaunter",             /obj/item/device/wormhole_jaunter,                                 200),
-		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                        750),
-		new /datum/data/mining_equipment("Kinetic accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,                  1000),
-		new /datum/data/mining_equipment("Jetpack",             /obj/item/weapon/tank/jetpack/carbondioxide/mining,               2000),
+		new /datum/data/mining_equipment("Sonic jackhammer",    /obj/item/weapon/pickaxe/jackhammer,                               1000),
+		new /datum/data/mining_equipment("Mining drone",        /mob/living/simple_animal/hostile/mining_drone/,                   1000),
+		new /datum/data/mining_equipment("Jaunter",             /obj/item/device/wormhole_jaunter,                                 500),
+		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                        1200),
+		new /datum/data/mining_equipment("Kinetic accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,                  2000),
+		new /datum/data/mining_equipment("Jetpack",             /obj/item/weapon/tank/jetpack/carbondioxide/mining,               4000),
 		)
 
 /datum/data/mining_equipment/

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -72,8 +72,8 @@
 /turf/simulated/mineral/random
 	name = "Mineral deposit"
 	icon_state = "rock"
-	var/mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 5, "Gold" = 15, "Silver" = 35, "Plasma" = 40, "Iron" = 50, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
-	var/mineralChance = 30  //means 10% chance of this plot changing to a mineral deposit
+	var/mineralSpawnChanceList = list("Uranium" = 15, "Diamond" = 5, "Gold" = 10, "Silver" = 15, "Plasma" = 25, "Iron" = 30, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
+	var/mineralChance = 20  //means 10% chance of this plot changing to a mineral deposit
 
 /turf/simulated/mineral/random/New()
 	..()
@@ -108,8 +108,8 @@
 
 /turf/simulated/mineral/random/high_chance
 	icon_state = "rock_highchance"
-	mineralChance = 40
-	mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 10, "Gold" = 15, "Silver" = 35, "Plasma" = 45, "Iron" = 50)
+	mineralChance = 25
+	mineralSpawnChanceList = list("Uranium" = 20, "Diamond" = 5, "Gold" = 10, "Silver" = 25, "Plasma" = 35, "Iron" = 50)
 
 /turf/simulated/mineral/random/high_chance/New()
 	icon_state = "rock"
@@ -117,8 +117,8 @@
 
 /turf/simulated/mineral/random/low_chance
 	icon_state = "rock_lowchance"
-	mineralChance = 30
-	mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 10, "Gold" = 15, "Silver" = 35, "Plasma" = 45, "Iron" = 50, "Gibtonite" = 4)
+	mineralChance = 10
+	mineralSpawnChanceList = list("Uranium" = 10, "Gold" = 10, "Silver" = 10, "Plasma" = 20, "Iron" = 45, "Gibtonite" = 4)
 
 /turf/simulated/mineral/random/low_chance/New()
 	icon_state = "rock"
@@ -127,7 +127,7 @@
 /turf/simulated/mineral/uranium
 	name = "Uranium deposit"
 	mineralName = "Uranium"
-	spreadChance = 20
+	spreadChance = 15
 	spread = 5
 	hidden = 1
 	scan_state = "rock_Uranium"
@@ -136,7 +136,7 @@
 	name = "Iron deposit"
 	icon_state = "rock_Iron"
 	mineralName = "Iron"
-	spreadChance = 40
+	spreadChance = 35
 	spread = 1
 	hidden = 0
 
@@ -151,7 +151,7 @@
 /turf/simulated/mineral/gold
 	name = "Gold deposit"
 	mineralName = "Gold"
-	spreadChance = 20
+	spreadChance = 15
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Gold"
@@ -159,7 +159,7 @@
 /turf/simulated/mineral/silver
 	name = "Silver deposit"
 	mineralName = "Silver"
-	spreadChance = 25
+	spreadChance = 15
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Silver"
@@ -168,7 +168,7 @@
 	name = "Plasma deposit"
 	icon_state = "rock_Plasma"
 	mineralName = "Plasma"
-	spreadChance = 30
+	spreadChance = 25
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Plasma"
@@ -178,7 +178,7 @@
 	icon_state = "rock_Clown"
 	mineralName = "Clown"
 	mineralAmt = 3
-	spreadChance = 20
+	spreadChance = 25
 	spread = 0
 	hidden = 0
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -72,7 +72,7 @@
 /turf/simulated/mineral/random
 	name = "Mineral deposit"
 	icon_state = "rock"
-	var/mineralSpawnChanceList = list("Uranium" = 1, "Diamond" = 1, "Gold" = 1, "Silver" = 1, "Plasma" = 1, "Iron" = 50, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
+	var/mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 5, "Gold" = 15, "Silver" = 35, "Plasma" = 40, "Iron" = 50, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 10  //means 10% chance of this plot changing to a mineral deposit
 
 /turf/simulated/mineral/random/New()
@@ -108,7 +108,7 @@
 
 /turf/simulated/mineral/random/high_chance
 	icon_state = "rock_highchance"
-	mineralChance = 25
+	mineralChance = 40
 	mineralSpawnChanceList = list("Uranium" = 35, "Diamond" = 10, "Gold" = 35, "Silver" = 35, "Plasma" = 35, "Iron" = 50)
 
 /turf/simulated/mineral/random/high_chance/New()
@@ -117,8 +117,8 @@
 
 /turf/simulated/mineral/random/low_chance
 	icon_state = "rock_lowchance"
-	mineralChance = 5
-	mineralSpawnChanceList = list("Uranium" = 1, "Diamond" = 1, "Gold" = 1, "Silver" = 1, "Plasma" = 1, "Iron" = 50, "Gibtonite" = 4)
+	mineralChance = 30
+	mineralSpawnChanceList = list("Uranium" = 35, "Diamond" = 10, "Gold" = 35, "Silver" = 35, "Plasma" = 45, "Iron" = 50, "Gibtonite" = 4)
 
 /turf/simulated/mineral/random/low_chance/New()
 	icon_state = "rock"
@@ -127,8 +127,8 @@
 /turf/simulated/mineral/uranium
 	name = "Uranium deposit"
 	mineralName = "Uranium"
-	spreadChance = 5
-	spread = 1
+	spreadChance = 20
+	spread = 5
 	hidden = 1
 	scan_state = "rock_Uranium"
 
@@ -136,14 +136,14 @@
 	name = "Iron deposit"
 	icon_state = "rock_Iron"
 	mineralName = "Iron"
-	spreadChance = 20
+	spreadChance = 40
 	spread = 1
 	hidden = 0
 
 /turf/simulated/mineral/diamond
 	name = "Diamond deposit"
 	mineralName = "Diamond"
-	spreadChance = 0
+	spreadChance = 5
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Diamond"
@@ -151,7 +151,7 @@
 /turf/simulated/mineral/gold
 	name = "Gold deposit"
 	mineralName = "Gold"
-	spreadChance = 5
+	spreadChance = 20
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Gold"
@@ -159,7 +159,7 @@
 /turf/simulated/mineral/silver
 	name = "Silver deposit"
 	mineralName = "Silver"
-	spreadChance = 5
+	spreadChance = 25
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Silver"
@@ -168,7 +168,7 @@
 	name = "Plasma deposit"
 	icon_state = "rock_Plasma"
 	mineralName = "Plasma"
-	spreadChance = 5
+	spreadChance = 30
 	spread = 1
 	hidden = 1
 	scan_state = "rock_Plasma"
@@ -178,7 +178,7 @@
 	icon_state = "rock_Clown"
 	mineralName = "Clown"
 	mineralAmt = 3
-	spreadChance = 0
+	spreadChance = 20
 	spread = 0
 	hidden = 0
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -178,7 +178,7 @@
 	icon_state = "rock_Clown"
 	mineralName = "Clown"
 	mineralAmt = 3
-	spreadChance = 25
+	spreadChance = 0
 	spread = 0
 	hidden = 0
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -73,7 +73,7 @@
 	name = "Mineral deposit"
 	icon_state = "rock"
 	var/mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 5, "Gold" = 15, "Silver" = 35, "Plasma" = 40, "Iron" = 50, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
-	var/mineralChance = 10  //means 10% chance of this plot changing to a mineral deposit
+	var/mineralChance = 30  //means 10% chance of this plot changing to a mineral deposit
 
 /turf/simulated/mineral/random/New()
 	..()
@@ -109,7 +109,7 @@
 /turf/simulated/mineral/random/high_chance
 	icon_state = "rock_highchance"
 	mineralChance = 40
-	mineralSpawnChanceList = list("Uranium" = 35, "Diamond" = 10, "Gold" = 35, "Silver" = 35, "Plasma" = 35, "Iron" = 50)
+	mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 10, "Gold" = 15, "Silver" = 35, "Plasma" = 45, "Iron" = 50)
 
 /turf/simulated/mineral/random/high_chance/New()
 	icon_state = "rock"
@@ -118,7 +118,7 @@
 /turf/simulated/mineral/random/low_chance
 	icon_state = "rock_lowchance"
 	mineralChance = 30
-	mineralSpawnChanceList = list("Uranium" = 35, "Diamond" = 10, "Gold" = 35, "Silver" = 35, "Plasma" = 45, "Iron" = 50, "Gibtonite" = 4)
+	mineralSpawnChanceList = list("Uranium" = 25, "Diamond" = 10, "Gold" = 15, "Silver" = 35, "Plasma" = 45, "Iron" = 50, "Gibtonite" = 4)
 
 /turf/simulated/mineral/random/low_chance/New()
 	icon_state = "rock"


### PR DESCRIPTION
Changes mining so it is more enjoyable for players of "old mining"

-distributes the var's more evenly for ores
-puts diamonds only on the west side of the asteroid (the one with monsters)
-allows for more "veins" within the asteroid
-changes the costs of mining equipment to scale with the increased amount of ore.
