### PR TITLE
Of slimes and commands

### DIFF
--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -437,7 +437,16 @@
 				if (Victim) // We are asked to stop feeding
 					if (Friends[who] > 4)
 						Victim = null
+						Target = null
 						if (Friends[who] < 7)
+							--Friends[who]
+							to_say = "Grrr..." // I'm angry but I do it
+						else
+							to_say = "Fine..."
+				else if (Target) // We are asked to stop chasing
+					if (Friends[who] > 3)
+						Target = null
+						if (Friends[who] < 6)
 							--Friends[who]
 							to_say = "Grrr..." // I'm angry but I do it
 						else


### PR DESCRIPTION
Return of  #3762

Fixes #3739

The issue was that their 'Victim' was cleared, but 'Target' was not, so they released the subject and immediately started to chase them again. The 'stop' command now will also make them stop chasing the target.

They still may retarget the subject, especially if they are hungry, and the target is a monkey, but it doesn't happen always and it doesn't happen instantly. They may also target someone else.
