### PR TITLE
Remove Valve

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -17,7 +17,6 @@
 <A href='?src=\ref[src];make=0;dir=1'>Pipe</A><BR>
 <A href='?src=\ref[src];make=1;dir=5'>Bent Pipe</A><BR>
 <A href='?src=\ref[src];make=5;dir=1'>Manifold</A><BR>
-<A href='?src=\ref[src];make=8;dir=1'>Manual Valve</A><BR>
 <A href='?src=\ref[src];make=18;dir=1'>Digital Valve</A><BR>
 <b>Devices:</b><BR>
 <A href='?src=\ref[src];make=4;dir=1'>Connector</A><BR>


### PR DESCRIPTION
Removes manual valves from the pipe dispenser menu.

Digital valves are functionally identical to manual valves, the only difference is DigiVals can be used by silicons whereas ManVals can not.

In other words, Manual Valves literal reason to exist is round start meta to prevent AI plasma floods.
