### PR TITLE
Paperwork and Record Console Updates

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -6,6 +6,7 @@
 	var/general[] = list()
 	var/security[] = list()
 	var/securityPrintCount = 0
+	var/securityCrimeCounter = 0
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 
@@ -15,6 +16,55 @@
 /datum/data/record
 	name = "record"
 	var/list/fields = list()
+
+/datum/data/crime
+	name = "crime"
+	var/crimeName = ""
+	var/crimeDetails = ""
+	var/author = ""
+	var/time = ""
+	var/dataId = 0
+
+/obj/effect/datacore/proc/createCrimeEntry(cname = "", cdetails = "", author = "", time = "")
+	var/datum/data/crime/c = new /datum/data/crime
+	c.crimeName = cname
+	c.crimeDetails = cdetails
+	c.author = author
+	c.time = time
+	c.dataId = ++securityCrimeCounter
+	return c
+
+/obj/effect/datacore/proc/addMinorCrime(id = "", var/datum/data/crime/crime)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/crimes = R.fields["mi_crim"]
+			crimes |= crime
+			return
+
+/obj/effect/datacore/proc/removeMinorCrime(id, cDataId)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/crimes = R.fields["mi_crim"]
+			for(var/datum/data/crime/crime in crimes)
+				if(crime.dataId == text2num(cDataId))
+					crimes -= crime
+					return
+
+/obj/effect/datacore/proc/removeMajorCrime(id, cDataId)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/crimes = R.fields["ma_crim"]
+			for(var/datum/data/crime/crime in crimes)
+				if(crime.dataId == text2num(cDataId))
+					crimes -= crime
+					return
+
+/obj/effect/datacore/proc/addMajorCrime(id = "", var/datum/data/crime/crime)
+	for(var/datum/data/record/R in security)
+		if(R.fields["id"] == id)
+			var/list/crimes = R.fields["ma_crim"]
+			crimes |= crime
+			return
 
 /obj/effect/datacore/proc/manifest(var/nosleep = 0)
 	spawn()
@@ -77,10 +127,8 @@ var/record_id_num = 1001
 		S.fields["id"]			= id
 		S.fields["name"]		= H.real_name
 		S.fields["criminal"]	= "None"
-		S.fields["mi_crim"]		= "None"
-		S.fields["mi_crim_d"]	= "No minor crime convictions."
-		S.fields["ma_crim"]		= "None"
-		S.fields["ma_crim_d"]	= "No major crime convictions."
+		S.fields["mi_crim"]		= list()
+		S.fields["ma_crim"]		= list()
 		S.fields["notes"]		= "No notes."
 		security += S
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -2,6 +2,7 @@
 /obj/effect/datacore
 	name = "datacore"
 	var/medical[] = list()
+	var/medicalPrintCount = 0
 	var/general[] = list()
 	var/security[] = list()
 	var/securityPrintCount = 0

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -4,6 +4,7 @@
 	var/medical[] = list()
 	var/general[] = list()
 	var/security[] = list()
+	var/securityPrintCount = 0
 	//This list tracks characters spawned in the world and cannot be modified in-game. Currently referenced by respawn_character().
 	var/locked[] = list()
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -80,8 +80,10 @@
 
 							if(R.fields["m_stat"] == "*Insane*" || R.fields["p_stat"] == "*Deceased*")
 								background = "'background-color:#990000;'"
-							else if(R.fields["p_stat"] == "Physically Unfit" || R.fields["p_stat"] == "*Unconscious*" || R.fields["m_stat"] == "*Unstable*" || R.fields["m_stat"] == "*Watch*")
+							else if(R.fields["p_stat"] == "*Unconscious*" || R.fields["m_stat"] == "*Unstable*")
 								background = "'background-color:#CD6500;'"
+							else if(R.fields["p_stat"] == "Physically Unfit" || R.fields["m_stat"] == "*Watch*")
+								background = "'background-color:#3BB9FF;'"
 							else
 								background = "'background-color:#4F7529;'"
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -466,7 +466,8 @@
 				if (!( src.printing ))
 					src.printing = 1
 					data_core.medicalPrintCount++
-					sleep(50)
+					playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
+					sleep(30)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
 					P.info = "<CENTER><B>Medical Record - (MR-[data_core.medicalPrintCount])</B></CENTER><BR>"
 					if(active1 in data_core.general)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -16,6 +16,15 @@
 	var/temp = null
 	var/printing = null
 
+/obj/machinery/computer/med_data/attackby(obj/item/O as obj, user as mob)
+	if(istype(O, /obj/item/weapon/card/id) && !scan)
+		usr.drop_item()
+		O.loc = src
+		scan = O
+		user << "You insert [O]."
+	else
+		..()
+
 /obj/machinery/computer/med_data/attack_hand(mob/user as mob)
 	if(..())
 		return

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -89,7 +89,7 @@
 
 							dat += text("<tr style=[]><td><A href='?src=\ref[];d_rec=[]'>[]</a></td>", background, src, R.fields["id"], R.fields["name"])
 							dat += text("<td>[]</td>", R.fields["id"])
-							dat += text("<td>F:[]<BR>D:[]</td>", R.fields["fingerprint"], b_dna)
+							dat += text("<td><b>F:</b> []<BR><b>D:</b> []</td>", R.fields["fingerprint"], b_dna)
 							dat += text("<td>[]</td>", blood_type)
 							dat += text("<td>[]</td>", R.fields["p_stat"])
 							dat += text("<td>[]</td></tr>", R.fields["m_stat"])

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -397,9 +397,10 @@
 			else if (href_list["print_p"])
 				if (!( src.printing ))
 					src.printing = 1
+					data_core.medicalPrintCount++
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
-					P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"
+					P.info = "<CENTER><B>Medical Record - (MR-[data_core.medicalPrintCount])</B></CENTER><BR>"
 					if(active1 in data_core.general)
 						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", src.active1.fields["name"], src.active1.fields["id"], src.active1.fields["sex"], src.active1.fields["age"], src.active1.fields["fingerprint"], src.active1.fields["p_stat"], src.active1.fields["m_stat"])
 					else
@@ -413,7 +414,7 @@
 					else
 						P.info += "<B>Medical Record Lost!</B><BR>"
 					P.info += "</TT>"
-					P.name = "paper- 'Medical Record'"
+					P.name = text("MR-[] '[]'", data_core.medicalPrintCount, src.active1.fields["name"])
 					src.printing = null
 
 	src.add_fingerprint(usr)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -106,7 +106,49 @@
 					else
 						dat += "<B>General Record Lost!</B><BR>"
 					if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))
-						dat += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: <A href='?src=\ref[];choice=Edit Field;field=criminal'>[]</A><BR>\n<BR>\nMinor Crimes: <A href='?src=\ref[];choice=Edit Field;field=mi_crim'>[]</A><BR>\nDetails: <A href='?src=\ref[];choice=Edit Field;field=mi_crim_d'>[]</A><BR>\n<BR>\nMajor Crimes: <A href='?src=\ref[];choice=Edit Field;field=ma_crim'>[]</A><BR>\nDetails: <A href='?src=\ref[];choice=Edit Field;field=ma_crim_d'>[]</A><BR>\n<BR>\nImportant Notes:<BR>\n\t<A href='?src=\ref[];choice=Edit Field;field=notes'>[]</A><BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", src, active2.fields["criminal"], src, active2.fields["mi_crim"], src, active2.fields["mi_crim_d"], src, active2.fields["ma_crim"], src, active2.fields["ma_crim_d"], src, active2.fields["notes"])
+						dat += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: <A href='?src=\ref[];choice=Edit Field;field=criminal'>[]</A>",src, active2.fields["criminal"])
+						dat += text("<BR>\n<BR>\nMinor Crimes: <A href='?src=\ref[];choice=Edit Field;field=mi_crim_add'>Add New</A>", src)
+
+
+						dat +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<tr>
+<th>Crime</th>
+<th>Details</th>
+<th>Author</th>
+<th>Time Added</th>
+<th>Del</th>
+</tr>"}
+						for(var/datum/data/crime/c in active2.fields["mi_crim"])
+							dat += "<tr><td>[c.crimeName]</td>"
+							dat += "<td>[c.crimeDetails]</td>"
+							dat += "<td>[c.author]</td>"
+							dat += "<td>[c.time]</td>"
+							dat += "<td><A href='?src=\ref[src];choice=Edit Field;field=mi_crim_delete;cdataid=[c.dataId]'>\[X\]</A></td>"
+							dat += "</tr>"
+						dat += "</table>"
+
+
+						dat += text("<BR>\n<BR>\nMajor Crimes: <A href='?src=\ref[];choice=Edit Field;field=ma_crim_add'>Add New</A>", src)
+
+						dat +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<tr>
+<th>Crime</th>
+<th>Details</th>
+<th>Author</th>
+<th>Time Added</th>
+<th>Del</th>
+</tr>"}
+						for(var/datum/data/crime/c in active2.fields["ma_crim"])
+							dat += "<tr><td>[c.crimeName]</td>"
+							dat += "<td>[c.crimeDetails]</td>"
+							dat += "<td>[c.author]</td>"
+							dat += "<td>[c.time]</td>"
+							dat += "<td><A href='?src=\ref[src];choice=Edit Field;field=ma_crim_delete;cdataid=[c.dataId]'>\[X\]</A></td>"
+							dat += "</tr>"
+						dat += "</table>"
+
+						dat += text("<BR>\n<BR>\nImportant Notes:<BR>\n\t<A href='?src=\ref[];choice=Edit Field;field=notes'>[]</A>", src, active2.fields["notes"])
+						dat += text("<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>")
 						var/counter = 1
 						while(active2.fields[text("com_[]", counter)])
 							dat += text("[]<BR><A href='?src=\ref[];choice=Delete Entry;del_c=[]'>Delete Entry</A><BR><BR>", active2.fields[text("com_[]", counter)], src, counter)
@@ -316,7 +358,42 @@ What a mess.*/
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 					if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))
-						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []<BR>\n<BR>\nMinor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nMajor Crimes: []<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["criminal"], active2.fields["mi_crim"], active2.fields["mi_crim_d"], active2.fields["ma_crim"], active2.fields["ma_crim_d"], active2.fields["notes"])
+						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", active2.fields["criminal"])
+
+						P.info += "<BR>\n<BR>\nMinor Crimes:<BR>\n"
+						P.info +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<tr>
+<th>Crime</th>
+<th>Details</th>
+<th>Author</th>
+<th>Time Added</th>
+</tr>"}
+						for(var/datum/data/crime/c in active2.fields["mi_crim"])
+							P.info += "<tr><td>[c.crimeName]</td>"
+							P.info += "<td>[c.crimeDetails]</td>"
+							P.info += "<td>[c.author]</td>"
+							P.info += "<td>[c.time]</td>"
+							P.info += "</tr>"
+						P.info += "</table>"
+
+						P.info += "<BR>\nMajor Crimes: <BR>\n"
+						P.info +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<tr>
+<th>Crime</th>
+<th>Details</th>
+<th>Author</th>
+<th>Time Added</th>
+</tr>"}
+						for(var/datum/data/crime/c in active2.fields["ma_crim"])
+							P.info += "<tr><td>[c.crimeName]</td>"
+							P.info += "<td>[c.crimeDetails]</td>"
+							P.info += "<td>[c.author]</td>"
+							P.info += "<td>[c.time]</td>"
+							P.info += "</tr>"
+						P.info += "</table>"
+
+
+						P.info += text("<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["notes"])
 						var/counter = 1
 						while(active2.fields[text("com_[]", counter)])
 							P.info += text("[]<BR>", active2.fields[text("com_[]", counter)])
@@ -373,10 +450,8 @@ What a mess.*/
 					R.fields["id"] = active1.fields["id"]
 					R.name = text("Security Record #[]", R.fields["id"])
 					R.fields["criminal"] = "None"
-					R.fields["mi_crim"] = "None"
-					R.fields["mi_crim_d"] = "No minor crime convictions."
-					R.fields["ma_crim"] = "None"
-					R.fields["ma_crim_d"] = "No major crime convictions."
+					R.fields["mi_crim"] = list()
+					R.fields["ma_crim"] = list()
 					R.fields["notes"] = "No notes."
 					data_core.security += R
 					active2 = R
@@ -431,30 +506,34 @@ What a mess.*/
 							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active1 != a1))
 								return
 							active1.fields["age"] = t1
-					if("mi_crim")
-						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please input minor crimes list:", "Secure. records", active2.fields["mi_crim"], null)  as text),1,MAX_MESSAGE_LEN)
-							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
+					if("mi_crim_add")
+						if (istype(active1, /datum/data/record))
+							var/t1 = copytext(sanitize(input("Please input minor crime names:", "Secure. records", "", null)  as text),1,MAX_MESSAGE_LEN)
+							var/t2 = copytext(sanitize(input("Please input minor crime details:", "Secure. records", "", null)  as message),1,MAX_MESSAGE_LEN)
+							if ((!( t1 ) || !( t2 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
-							active2.fields["mi_crim"] = t1
-					if("mi_crim_d")
-						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please summarize minor crimes:", "Secure. records", active2.fields["mi_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
-							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
+							var/crime = data_core.createCrimeEntry(t1, t2, scan.registered_name ? scan.registered_name : "Unknown", worldtime2text())
+							data_core.addMinorCrime(active1.fields["id"], crime)
+					if("mi_crim_delete")
+						if (istype(active1, /datum/data/record))
+							if (href_list["cdataid"])
+								if ((!( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
+									return
+								data_core.removeMinorCrime(active1.fields["id"], href_list["cdataid"])
+					if("ma_crim_add")
+						if (istype(active1, /datum/data/record))
+							var/t1 = copytext(sanitize(input("Please input major crime names:", "Secure. records", "", null)  as text),1,MAX_MESSAGE_LEN)
+							var/t2 = copytext(sanitize(input("Please input major crime details:", "Secure. records", "", null)  as message),1,MAX_MESSAGE_LEN)
+							if ((!( t1 ) || !( t2 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
-							active2.fields["mi_crim_d"] = t1
-					if("ma_crim")
-						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please input major crimes list:", "Secure. records", active2.fields["ma_crim"], null)  as text),1,MAX_MESSAGE_LEN)
-							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
-								return
-							active2.fields["ma_crim"] = t1
-					if("ma_crim_d")
-						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please summarize major crimes:", "Secure. records", active2.fields["ma_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
-							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
-								return
-							active2.fields["ma_crim_d"] = t1
+							var/crime = data_core.createCrimeEntry(t1, t2, scan.registered_name ? scan.registered_name : "Unknown", worldtime2text())
+							data_core.addMajorCrime(active1.fields["id"], crime)
+					if("ma_crim_delete")
+						if (istype(active1, /datum/data/record))
+							if (href_list["cdataid"])
+								if ((!( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
+									return
+								data_core.removeMajorCrime(active1.fields["id"], href_list["cdataid"])
 					if("notes")
 						if (istype(active2, /datum/data/record))
 							var/t1 = copytext(sanitize(input("Please summarize notes:", "Secure. records", active2.fields["notes"], null)  as message),1,MAX_MESSAGE_LEN)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -350,7 +350,8 @@ What a mess.*/
 				if (!( printing ))
 					printing = 1
 					data_core.securityPrintCount++
-					sleep(50)
+					playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
+					sleep(30)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( loc )
 					P.info = "<CENTER><B>Security Record - (SR-[data_core.securityPrintCount])</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -433,25 +433,25 @@ What a mess.*/
 							active1.fields["age"] = t1
 					if("mi_crim")
 						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please input minor disabilities list:", "Secure. records", active2.fields["mi_crim"], null)  as text),1,MAX_MESSAGE_LEN)
+							var/t1 = copytext(sanitize(input("Please input minor crimes list:", "Secure. records", active2.fields["mi_crim"], null)  as text),1,MAX_MESSAGE_LEN)
 							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
 							active2.fields["mi_crim"] = t1
 					if("mi_crim_d")
 						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please summarize minor dis.:", "Secure. records", active2.fields["mi_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
+							var/t1 = copytext(sanitize(input("Please summarize minor crimes:", "Secure. records", active2.fields["mi_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
 							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
 							active2.fields["mi_crim_d"] = t1
 					if("ma_crim")
 						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please input major diabilities list:", "Secure. records", active2.fields["ma_crim"], null)  as text),1,MAX_MESSAGE_LEN)
+							var/t1 = copytext(sanitize(input("Please input major crimes list:", "Secure. records", active2.fields["ma_crim"], null)  as text),1,MAX_MESSAGE_LEN)
 							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
 							active2.fields["ma_crim"] = t1
 					if("ma_crim_d")
 						if (istype(active2, /datum/data/record))
-							var/t1 = copytext(sanitize(input("Please summarize major dis.:", "Secure. records", active2.fields["ma_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
+							var/t1 = copytext(sanitize(input("Please summarize major crimes:", "Secure. records", active2.fields["ma_crim_d"], null)  as message),1,MAX_MESSAGE_LEN)
 							if ((!( t1 ) || !( authenticated ) || usr.stat || usr.restrained() || (!in_range(src, usr) && (!istype(usr, /mob/living/silicon))) || active2 != a2))
 								return
 							active2.fields["ma_crim_d"] = t1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -464,12 +464,41 @@ What a mess.*/
 				G.fields["rank"] = "Unassigned"
 				G.fields["sex"] = "Male"
 				G.fields["age"] = "Unknown"
-				G.fields["fingerprint"] = "Unknown"
+				G.fields["fingerprint"] = "?????"
 				G.fields["p_stat"] = "Active"
 				G.fields["m_stat"] = "Stable"
 				data_core.general += G
 				active1 = G
-				active2 = null
+
+				var/datum/data/record/R = new /datum/data/record()
+				R.fields["name"] = active1.fields["name"]
+				R.fields["id"] = active1.fields["id"]
+				R.name = text("Security Record #[]", R.fields["id"])
+				R.fields["criminal"] = "None"
+				R.fields["mi_crim"] = list()
+				R.fields["ma_crim"] = list()
+				R.fields["notes"] = "No notes."
+				data_core.security += R
+				active2 = R
+
+						//Medical Record
+				var/datum/data/record/M = new /datum/data/record()
+				M.fields["id"]			= active1.fields["id"]
+				M.fields["name"]		= active1.fields["name"]
+				M.fields["blood_type"]	= "?"
+				M.fields["b_dna"]		= "?????"
+				M.fields["mi_dis"]		= "None"
+				M.fields["mi_dis_d"]	= "No minor disabilities have been declared."
+				M.fields["ma_dis"]		= "None"
+				M.fields["ma_dis_d"]	= "No major disabilities have been diagnosed."
+				M.fields["alg"]			= "None"
+				M.fields["alg_d"]		= "No allergies have been detected in this patient."
+				M.fields["cdi"]			= "None"
+				M.fields["cdi_d"]		= "No diseases have been diagnosed at the moment."
+				M.fields["notes"]		= "No notes."
+				data_core.medical += M
+
+
 
 //FIELD FUNCTIONS
 			if ("Edit Field")

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -307,9 +307,10 @@ What a mess.*/
 			if ("Print Record")
 				if (!( printing ))
 					printing = 1
+					data_core.securityPrintCount++
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( loc )
-					P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
+					P.info = "<CENTER><B>Security Record - (SR-[data_core.securityPrintCount])</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
 						P.info += text("Name: [] ID: []<BR>\nSex: []<BR>\nAge: []<BR>\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["sex"], active1.fields["age"], active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
 					else
@@ -323,7 +324,7 @@ What a mess.*/
 					else
 						P.info += "<B>Security Record Lost!</B><BR>"
 					P.info += "</TT>"
-					P.name = "paper - 'Security Record'"
+					P.name = text("SR-[] '[]'", data_core.securityPrintCount, active1.fields["name"])
 					printing = null
 //RECORD DELETE
 			if ("Delete All Records")


### PR DESCRIPTION
- [x] Printed Security Records are now named "SR-[SecPrintNumber] '[NameOfRecordHolder]'"
- [x] Printed Medical Records are now named "MR-[MedPrintNumber] '[NameOfRecordHolder]'"
- [x] Security Record's title on the paper changed from 'Security Record' to 'Security Record - (SR-[SecPrintNumber])'
- [x] Medical Record's title on the paper changed from 'Medical Record' to 'Medical Record - (MR-[MedPrintNumber])'
- [x] Medical Records Console now accepts IDs if you hit them with an ID.
- [x] Medical Records Consoles' List Records menu updated to be more like securities http://i.imgur.com/fBmkq8C.png
- [x] Fix'd some typos in Security Console
- [x] Crime Records are now lists. http://i.imgur.com/c3tLPQ9.png
- [x] Fix new Security Records not having crime status: http://puu.sh/9mfaO/e51ffd2bc1.png
- [x] Fix new Med Records (Blood type looks like crap when empty: http://puu.sh/9mfID/1766d115c7.png
- [x] Play  sound/poster_being_created.ogg while printing (Both Record types)
- [x] Bold F: and D: to distinguish fingerprint from label.
