### PR TITLE
Nar-Sie update

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1172,19 +1172,8 @@ datum/mind
 	..()
 	mind.assigned_role = "Shade"
 
-/mob/living/simple_animal/construct/builder/mind_initialize()
+/mob/living/simple_animal/construct/mind_initialize()
 	..()
-	mind.assigned_role = "Artificer"
+	mind.assigned_role = "[initial(name)]"
 	mind.special_role = "Cultist"
-
-/mob/living/simple_animal/construct/wraith/mind_initialize()
-	..()
-	mind.assigned_role = "Wraith"
-	mind.special_role = "Cultist"
-
-/mob/living/simple_animal/construct/armoured/mind_initialize()
-	..()
-	mind.assigned_role = "Juggernaut"
-	mind.special_role = "Cultist"
-
 

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -191,6 +191,11 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				var/datum/effect/effect/system/bad_smoke_spread/smoke = new /datum/effect/effect/system/bad_smoke_spread()
 				smoke.set_up(smoke_amt, 0, location, smoke_amt == 1 ? 15 : 0) // same here
 				smoke.start()
+			else if(smoke_spread == 3)
+				var/datum/effect/effect/system/sleep_smoke_spread/smoke = new /datum/effect/effect/system/sleep_smoke_spread()
+				smoke.set_up(smoke_amt, 0, location, smoke_amt == 1 ? 15 : 0) // same here
+				smoke.start()
+
 
 /obj/effect/proc_holder/spell/proc/cast(list/targets)
 	return

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -113,8 +113,8 @@
 
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
-	name = "Disabling Smoke"
-	desc = "This spell spawns a cloud of disabling smoke."
+	name = "Paralysing Smoke"
+	desc = "This spell spawns a cloud of paralysing smoke."
 
 	school = "conjuration"
 	charge_max = 200

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -110,3 +110,20 @@
 	invocation_type = "none"
 	proj_lifespan = 10
 	max_targets = 6
+
+
+/obj/effect/proc_holder/spell/targeted/smoke/disable
+	name = "Disabling Smoke"
+	desc = "This spell spawns a cloud of disabling smoke."
+
+	school = "conjuration"
+	charge_max = 200
+	clothes_req = 0
+	invocation = "none"
+	invocation_type = "none"
+	range = -1
+	include_user = 1
+	cooldown_min = 20 //25 deciseconds reduction per rank
+
+	smoke_spread = 3
+	smoke_amt = 10

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -22,13 +22,6 @@
 	transfer_soul("VICTIM", M, user)
 	return
 
-/*/obj/item/device/soulstone/attack(mob/living/simple_animal/shade/M as mob, mob/user as mob)//APPARENTLY THEY NEED THEIR OWN SPECIAL SNOWFLAKE CODE IN THE LIVING ANIMAL DEFINES
-	if(!istype(M, /mob/living/simple_animal/shade))//If target is not a shade
-		return ..()
-	user.attack_log += text("\[[time_stamp()]\] <span class='danger'>Used the [src.name] to capture the soul of [M.name] ([M.ckey])</span>")
-
-	transfer_soul("SHADE", M, user)
-	return*/
 ///////////////////Options for using captured souls///////////////////////////////////////
 
 /obj/item/device/soulstone/attack_self(mob/user)
@@ -44,8 +37,6 @@
 	user << browse(dat, "window=aicard")
 	onclose(user, "aicard")
 	return
-
-
 
 
 /obj/item/device/soulstone/Topic(href, href_list)
@@ -160,52 +151,34 @@
 				var/construct_class = alert(U, "Please choose which type of construct you wish to create.",,"Juggernaut","Wraith","Artificer")
 				switch(construct_class)
 					if("Juggernaut")
-						var/mob/living/simple_animal/construct/armoured/Z = new /mob/living/simple_animal/construct/armoured (get_turf(T.loc))
-						Z.key = A.key
-						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
-							else
-								ticker.mode.cult+=Z.mind
-							ticker.mode.update_cult_icons_added(Z.mind)
-						qdel(T)
-						Z << "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>"
-						Z << "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>"
-						Z.cancel_camera()
-						qdel(C)
+						makeNewConstruct(/mob/living/simple_animal/construct/armoured, T, U)
 
 					if("Wraith")
-						var/mob/living/simple_animal/construct/wraith/Z = new /mob/living/simple_animal/construct/wraith (get_turf(T.loc))
-						Z.key = A.key
-						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
-							else
-								ticker.mode.cult+=Z.mind
-							ticker.mode.update_cult_icons_added(Z.mind)
-						qdel(T)
-						Z << "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</B>"
-						Z << "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>"
-						Z.cancel_camera()
-						qdel(C)
+						makeNewConstruct(/mob/living/simple_animal/construct/wraith, T, U)
 
 					if("Artificer")
-						var/mob/living/simple_animal/construct/builder/Z = new /mob/living/simple_animal/construct/builder (get_turf(T.loc))
-						Z.key = A.key
-						if(iscultist(U))
-							if(ticker.mode.name == "cult")
-								ticker.mode:add_cultist(Z.mind)
-							else
-								ticker.mode.cult+=Z.mind
-							ticker.mode.update_cult_icons_added(Z.mind)
-						qdel(T)
-						Z << "<B>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, use magic missile, repair allied constructs (by clicking on them), </B><I>and most important of all create new constructs</I><B> (Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
-						Z << "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>"
-						Z.cancel_camera()
-						qdel(C)
+						makeNewConstruct(/mob/living/simple_animal/construct/builder, T, U)
+
+				qdel(T)
+				qdel(C)
 			else
 				U << "<span class='userdanger'>Creation failed!</span>: The soul stone is empty! Go kill someone!"
 	return
+
+
+proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/target, var/mob/stoner = null, cultoverride = 0)
+	var/mob/living/simple_animal/construct/newstruct = new ctype(get_turf(target))
+	newstruct.key = target.key
+	if(stoner && iscultist(stoner) || cultoverride)
+		if(ticker.mode.name == "cult")
+			ticker.mode:add_cultist(newstruct.mind)
+		else
+			ticker.mode.cult+=newstruct.mind
+		ticker.mode.update_cult_icons_added(newstruct.mind)
+	newstruct << newstruct.playstyle_string
+	newstruct << "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>"
+	newstruct.cancel_camera()
+
 
 /obj/item/device/soulstone/proc/init_shade(var/obj/item/device/soulstone/C, var/mob/living/carbon/human/T, var/mob/U as mob, var/vic = 0)
 	new /obj/effect/decal/remains/human(T.loc) //Spawns a skeleton

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -582,6 +582,7 @@ steam.start() -- spawns the effect
 	icon = 'icons/effects/96x96.dmi'
 	pixel_x = -32
 	pixel_y = -32
+	color = "#9C3636"
 
 /obj/effect/effect/sleep_smoke/New()
 	..()
@@ -596,7 +597,7 @@ steam.start() -- spawns the effect
 //		if (M.wear_suit, /obj/item/clothing/suit/wizrobe && (M.hat, /obj/item/clothing/head/wizard) && (M.shoes, /obj/item/clothing/shoes/sandal))  // I'll work on it later
 		else
 			M.drop_item()
-			M:sleeping += 1
+			M:sleeping += 5
 			if (M.coughedtime != 1)
 				M.coughedtime = 1
 				M.emote("cough")
@@ -612,7 +613,7 @@ steam.start() -- spawns the effect
 			return
 		else
 			M.drop_item()
-			M:sleeping += 1
+			M:sleeping += 5
 			if (M.coughedtime != 1)
 				M.coughedtime = 1
 				M.emote("cough")

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -9,6 +9,7 @@
 	response_disarm = "flails at"
 	response_harm   = "punches"
 	icon_dead = "shade_dead"
+	icon = 'icons/mob/mob.dmi'
 	speed = 0
 	a_intent = "harm"
 	stop_automated_movement = 1
@@ -25,6 +26,7 @@
 	minbodytemp = 0
 	faction = "cult"
 	var/list/construct_spells = list()
+	var/playstyle_string = "<B>You are a generic construct! Your job is to not exist.</B>"
 
 /mob/living/simple_animal/construct/New()
 	..()
@@ -118,8 +120,7 @@
 /mob/living/simple_animal/construct/armoured
 	name = "Juggernaut"
 	real_name = "Juggernaut"
-	desc = "A possessed suit of armour driven by the will of the restless dead"
-	icon = 'icons/mob/mob.dmi'
+	desc = "A possessed suit of armour driven by the will of the restless dead."
 	icon_state = "behemoth"
 	icon_living = "behemoth"
 	maxHealth = 250
@@ -135,7 +136,8 @@
 	status_flags = 0
 	force_threshold = 11
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall)
-
+	playstyle_string = "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, \
+						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>"
 
 /mob/living/simple_animal/construct/armoured/bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
@@ -174,7 +176,6 @@
 	name = "Wraith"
 	real_name = "Wraith"
 	desc = "A wicked bladed shell contraption piloted by a bound spirit"
-	icon = 'icons/mob/mob.dmi'
 	icon_state = "floating"
 	icon_living = "floating"
 	maxHealth = 75
@@ -186,18 +187,16 @@
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
+	playstyle_string = "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</B>"
 
 
 
 /////////////////////////////Artificer/////////////////////////
 
-
-
 /mob/living/simple_animal/construct/builder
 	name = "Artificer"
 	real_name = "Artificer"
 	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies"
-	icon = 'icons/mob/mob.dmi'
 	icon_state = "artificer"
 	icon_living = "artificer"
 	maxHealth = 50
@@ -215,60 +214,31 @@
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone,
 							/obj/effect/proc_holder/spell/targeted/projectile/magic_missile/lesser)
+	playstyle_string = "<B>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, \
+						use magic missile, repair allied constructs (by clicking on them), \
+						</B><I>and most important of all create new constructs</I><B> \
+						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
 
+/////////////////////////////Harvester/////////////////////////
 
-/////////////////////////////Behemoth/////////////////////////
+/mob/living/simple_animal/construct/harvester
+	name = "Harvester"
+	real_name = "Harvester"
+	desc = "A harbinger of Nar-Sie's enlightenment. It'll be all over soon."
+	icon_state = "harvester"
+	icon_living = "harvester"
+	maxHealth = 60
+	health = 60
+	melee_damage_lower = 1
+	melee_damage_upper = 5
+	attacktext = "prods"
+	speed = 0
+	environment_smash = 1
+	see_in_dark = 7
+	attack_sound = 'sound/weapons/tap.ogg'
+	construct_spells = list(/obj/effect/proc_holder/spell/targeted/smoke/disable)
+	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
+						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
 
-
-/mob/living/simple_animal/construct/behemoth
-	name = "Behemoth"
-	real_name = "Behemoth"
-	desc = "The pinnacle of occult technology, Behemoths are the ultimate weapon in the Cult of Nar-Sie's arsenal."
-	icon = 'icons/mob/mob.dmi'
-	icon_state = "behemoth"
-	icon_living = "behemoth"
-	maxHealth = 750
-	health = 750
-	speak_emote = list("rumbles")
-	response_harm   = "harmlessly punches"
-	harm_intent_damage = 0
-	melee_damage_lower = 50
-	melee_damage_upper = 50
-	attacktext = "brutally crushes"
-	speed = 5
-	environment_smash = 2
-	attack_sound = 'sound/weapons/punch4.ogg'
-	force_threshold = 11
-	var/energy = 0
-	var/max_energy = 1000
-
-
-////////////////Powers//////////////////
-
-
-/*
-/client/proc/summon_cultist()
-	set category = "Behemoth"
-	set name = "Summon Cultist (300)"
-	set desc = "Teleport a cultist to your location"
-	if (istype(usr,/mob/living/simple_animal/constructbehemoth))
-
-		if(usr.energy<300)
-			usr << "\red You do not have enough power stored!"
-			return
-
-		if(usr.stat)
-			return
-
-		usr.energy -= 300
-	var/list/mob/living/cultists = new
-	for(var/datum/mind/H in ticker.mode.cult)
-		if (istype(H.current,/mob/living))
-			cultists+=H.current
-			var/mob/cultist = input("Choose the one who you want to summon", "Followers of Geometer") as null|anything in (cultists - usr)
-			if(!cultist)
-				return
-			if (cultist == usr) //just to be sure.
-				return
-			cultist.loc = usr.loc
-			usr.visible_message("/red [cultist] appears in a flash of red light as [usr] glows with power")*/
+/mob/living/simple_animal/construct/harvester/Process_Spacemove(var/check_drift = 0)
+	return 1

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -473,20 +473,8 @@
 	if(!MP)
 		return 0	//Sanity, this should never happen.
 
-//	if(ispath(MP, /mob/living/simple_animal/space_worm)) //Goodbye Space Worms 2014
-//		return 0 //Unfinished. Very buggy, they seem to just spawn additional space worms everywhere and eating your own tail results in new worms spawning.
-
-	if(ispath(MP, /mob/living/simple_animal/construct/behemoth))
-		return 0 //I think this may have been an unfinished WiP or something. These constructs should really have their own class simple_animal/construct/subtype
-
-	if(ispath(MP, /mob/living/simple_animal/construct/armoured))
-		return 0 //Verbs do not appear for players. These constructs should really have their own class simple_animal/construct/subtype
-
-	if(ispath(MP, /mob/living/simple_animal/construct/wraith))
-		return 0 //Verbs do not appear for players. These constructs should really have their own class simple_animal/construct/subtype
-
-	if(ispath(MP, /mob/living/simple_animal/construct/builder))
-		return 0 //Verbs do not appear for players. These constructs should really have their own class simple_animal/construct/subtype
+	if(ispath(MP, /mob/living/simple_animal/construct))
+		return 0 //Verbs do not appear for players.
 
 //Good mobs!
 	if(ispath(MP, /mob/living/simple_animal/cat))

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,10 +1,5 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
 
-var/global/list/uneatable = list(
-	/turf/space,
-	/obj/effect/overlay
-	)
-
 /obj/machinery/singularity
 	name = "gravitational singularity"
 	desc = "A gravitational singularity."
@@ -32,6 +27,7 @@ var/global/list/uneatable = list(
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/teleport_del = 0
 	var/last_warning
+	var/list/uneatable = list(/turf/space, /obj/effect/overlay)
 
 /obj/machinery/singularity/New(loc, var/starting_energy = 50, var/temp = 0)
 	//CARN: admin-alert for chuckle-fuckery.
@@ -477,6 +473,7 @@ var/global/list/uneatable = list(
 	move_self = 1 //Do we move on our own?
 	grav_pull = 5 //How many tiles out do we pull?
 	consume_range = 6 //How many tiles out do we eat
+	uneatable = list(/turf/space, /obj/effect/overlay, /mob/living/simple_animal/construct)
 
 /obj/machinery/singularity/narsie/large
 	name = "Nar-Sie"
@@ -495,6 +492,11 @@ var/global/list/uneatable = list(
 	world << pick(sound('sound/hallucinations/im_here1.ogg'), sound('sound/hallucinations/im_here2.ogg'))
 	if(emergency_shuttle)
 		emergency_shuttle.incall(0.3) // Cannot recall
+
+
+/obj/machinery/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
+	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 1)
+
 
 /obj/machinery/singularity/narsie/process()
 	eat()
@@ -538,8 +540,11 @@ var/global/list/uneatable = list(
 
 	if(istype(A,/mob/living/))
 		var/mob/living/C = A
+		if(C.client)
+			makeNewConstruct(/mob/living/simple_animal/construct/harvester, C, null, 1)
 		C.spawn_dust()
 		C.gib()
+		return
 
 	if(isturf(A))
 		var/turf/T = A
@@ -550,35 +555,33 @@ var/global/list/uneatable = list(
 			if(prob(20)) T.ChangeTurf(/turf/simulated/wall/cult)
 	return
 
+
 /obj/machinery/singularity/narsie/ex_act() //No throwing bombs at it either. --NEO
 	return
 
+
 /obj/machinery/singularity/narsie/proc/pickcultist() //Narsie rewards his cultists with being devoured first, then picks a ghost to follow. --NEO
 	var/list/cultists = list()
-	for(var/datum/mind/cult_nh_mind in ticker.mode.cult)
-		if(!cult_nh_mind.current)
-			continue
-		if(cult_nh_mind.current.stat)
-			continue
-		var/turf/pos = get_turf(cult_nh_mind.current)
-		if(pos.z != src.z)
-			continue
-		cultists += cult_nh_mind.current
-	if(cultists.len)
-		acquire(pick(cultists))
-		return
-		//If there was living cultists, it picks one to follow.
-	for(var/mob/living/carbon/human/food in living_mob_list)
-		if(food.stat)
-			continue
+	var/list/noncultists = list()
+	for(var/mob/living/carbon/food in living_mob_list) //we don't care about constructs or cult-Ians or whatever. cult-monkeys are fair game i guess
 		var/turf/pos = get_turf(food)
 		if(pos.z != src.z)
 			continue
-		cultists += food
-	if(cultists.len)
-		acquire(pick(cultists))
-		return
-		//no living cultists, pick a living human instead.
+
+		if(iscultist(food))
+			cultists += food
+		else
+			noncultists += food
+
+		if(cultists.len) //cultists get higher priority
+			acquire(pick(cultists))
+			return
+
+		if(noncultists.len)
+			acquire(pick(noncultists))
+			return
+
+	//no living humans, follow a ghost instead.
 	for(var/mob/dead/observer/ghost in player_list)
 		if(!ghost.client)
 			continue
@@ -589,7 +592,7 @@ var/global/list/uneatable = list(
 	if(cultists.len)
 		acquire(pick(cultists))
 		return
-		//no living humans, follow a ghost instead.
+
 
 /obj/machinery/singularity/narsie/proc/acquire(var/mob/food)
 	target << "\blue <b>NAR-SIE HAS LOST INTEREST IN YOU</b>"

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -496,6 +496,7 @@
 
 /obj/machinery/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
 	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 1)
+	new /obj/effect/effect/sleep_smoke(user.loc)
 
 
 /obj/machinery/singularity/narsie/process()


### PR DESCRIPTION
Refactors a good amount of construct code. 

Instead of gibbing people, Nar-Sie will instead convert them into Harvester constructs (like I always intended but never bothered).
Harvesters aren't strong, but can use a version of smoke that knocks people out, letting them be brought back to the Geometer. They can also fly in space.
Ghosts can click on (large) Nar-Sie to become Harvesters.

This happens to fix an issue where Nar-Sie would get soulstoned shades as a target, causing her to hover in one spot for the rest of the round like a nerd.
