### PR TITLE
Igniter sparks

### DIFF
--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -5,15 +5,24 @@
 	m_amt = 500
 	g_amt = 50
 	origin_tech = "magnets=1"
+	var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread
 
+
+/obj/item/device/assembly/igniter/New()
+	..()
+	sparks.set_up(2, 0, src)
+	sparks.attach(src)
+
+
+/obj/item/device/assembly/igniter/activate()
+	if(!..())	return 0//Cooldown check
+	var/turf/location = get_turf(loc)
+	if(location)	location.hotspot_expose(1000,1000)
+	sparks.start()
+	return 1
+
+
+/obj/item/device/assembly/igniter/attack_self(mob/user as mob)
 	activate()
-		if(!..())	return 0//Cooldown check
-		var/turf/location = get_turf(loc)
-		if(location)	location.hotspot_expose(1000,1000)
-		return 1
-
-
-	attack_self(mob/user as mob)
-		activate()
-		add_fingerprint(user)
-		return
+	add_fingerprint(user)
+	return


### PR DESCRIPTION
Always bothered me that igniter assemblies didn't spawn sparks.

Added the spark effect to the assembly igniter for pretty shiney sparkies.
Makes the igniter more visible thats its been used instead of the current 'fire spawns at dudes feet if in plasma', also makes them useful for creating signaler alarms - albeit massive fire hazards.
