### PR TITLE
Add logging to failed GC's that result in a del() call

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,5 +1,4 @@
 #define DEBUG					//Enables byond profiling and full runtime logs - note, this may also be defined in your .dme file
-//#define dellogging			//Enables logging of forced del() calls (used for debugging)
 //#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
 								//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
@@ -42,17 +41,6 @@
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5
 #define AI_VOX 1 // Comment out if you don't want VOX to be enabled and have players download the voice sounds.
-
-
-//Additional code for the above flags.
-#ifdef dellogging
-#warn compiling del logging. This will have additional overheads.	//will warn you if compiling with dellogging
-var/list/del_counter = list()
-/proc/log_del(datum/X)
-	if(istype(X)){del_counter[X.type]++;}
-	del(X)
-#define del(X) log_del(X)							//overrides all del() calls with log_del()
-#endif
 
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,5 @@
 #define DEBUG					//Enables byond profiling and full runtime logs - note, this may also be defined in your .dme file
+//#define dellogging			//Enables logging of forced del() calls (used for debugging)
 //#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
 								//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
@@ -41,6 +42,16 @@
 // AI Toggles
 #define AI_CAMERA_LUMINOSITY	5
 #define AI_VOX 1 // Comment out if you don't want VOX to be enabled and have players download the voice sounds.
+
+//Additional code for the above flags.
+#ifdef dellogging
+#warn compiling del logging. This will have additional overheads.	//will warn you if compiling with dellogging
+var/list/del_counter = list()
+/proc/log_del(datum/X)
+	if(istype(X)){del_counter[X.type]++;}
+	del(X)
+#define del(X) log_del(X)							//overrides all del() calls with log_del()
+#endif
 
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/controllers/garbage.dm
+++ b/code/controllers/garbage.dm
@@ -11,6 +11,9 @@ var/datum/controller/garbage_collector/garbage = new()
 								// refID's are associated with the time at which they time out and need to be manually del()
 								// we do this so we aren't constantly locating them and preventing them from being gc'd
 
+	var/list/logging = list()	// list of all types that have failed to GC associated with the number of times that's happened.
+								// the types are stored as strings
+
 /datum/controller/garbage_collector/proc/AddTrash(var/datum/A)
 	if(!istype(A) || !isnull(A.gc_destroyed))
 		return
@@ -37,6 +40,7 @@ var/datum/controller/garbage_collector/garbage = new()
 		if(A && A.gc_destroyed == GCd_at_time) // So if something else coincidently gets the same ref, it's not deleted by mistake
 			// Something's still referring to the qdel'd object.  Kill it.
 			testing("GC: -- \ref[A] | [A.type] was unable to be GC'd and was deleted --")
+			logging["[A.type]"]++
 			del(A)
 			dels++
 //		else

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1137,3 +1137,15 @@ var/global/list/g_fancy_list_of_safe_types = null
 			usr << list2text(clients,",")
 		if("Joined Clients")
 			usr << list2text(joined_player_list,",")
+
+/client/proc/cmd_display_del_log()
+	set category = "Debug"
+	set name = "Display del() Log"
+	set desc = "Displays a list of things that have failed to GC this round"
+
+	var/dat = "<B>List of things that failed to GC this round</B><BR><BR>"
+
+	for(var/path in garbage.logging)
+		dat += "[path] - [garbage.logging[path]] times<BR>"
+
+	usr << browse(dat, "window=dellog")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -148,6 +148,7 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/print_pointers
 	src.verbs += /client/proc/count_movable_instances
 	src.verbs += /client/proc/SDQL2_query
+	src.verbs += /client/proc/cmd_display_del_log
 	//src.verbs += /client/proc/cmd_admin_rejuvenate
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/world.dm
+++ b/code/world.dm
@@ -173,15 +173,6 @@
 				#undef CHAT_PULLR
 
 /world/Reboot(var/reason)
-#ifdef dellogging
-	var/log = file("data/logs/del.log")
-	log << time2text(world.realtime)
-	//mergeSort(del_counter, /proc/cmp_descending_associative)	//still testing the sorting procs. Use notepad++ to sort the resultant logfile for now.
-	for(var/index in del_counter)
-		var/count = del_counter[index]
-		if(count > 10)
-			log << "#[count]\t[index]"
-#endif
 	spawn(0)
 		world << sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')) // random end sounds!! - LastyBatsy
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -173,6 +173,15 @@
 				#undef CHAT_PULLR
 
 /world/Reboot(var/reason)
+#ifdef dellogging
+	var/log = file("data/logs/del.log")
+	log << time2text(world.realtime)
+	//mergeSort(del_counter, /proc/cmp_descending_associative)	//still testing the sorting procs. Use notepad++ to sort the resultant logfile for now.
+	for(var/index in del_counter)
+		var/count = del_counter[index]
+		if(count > 10)
+			log << "#[count]\t[index]"
+#endif
 	spawn(0)
 		world << sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')) // random end sounds!! - LastyBatsy
 


### PR DESCRIPTION
You can view these logs in-game using a debug verb. You have to use the debug-verbs command to see it.

Removed the dellogging compile option. If this is a problem, speak up, but for most users, this new functionality is more useful.
