### PR TITLE
Fixes energy weapons drawing charges on click even when no shot was fire.

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -60,7 +60,7 @@
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	fire_sound = shot.fire_sound
 	if (shot.select_name)
-		user << "\red [src] is now set to [shot.select_name]."
+		user << "<span class='danger'>[src] is now set to [shot.select_name].</span>"
 	update_icon()
 	return
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -33,20 +33,24 @@
 
 
 /obj/item/weapon/gun/energy/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, params)
-	newshot()
+	newshot() //prepare a new shot
 	..()
 
 
 /obj/item/weapon/gun/energy/proc/newshot()
-	if (!ammo_type || !power_supply)	return
+	if (!ammo_type || !power_supply)
+		return
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	if (!power_supply.use(shot.e_cost))	return
-	chambered = shot
-	chambered.newshot()
+	if(power_supply.charge >= shot.e_cost) //if there's enough power in the power_supply cell...
+		chambered = shot //...prepare a new shot based on the current ammo type selected
+		chambered.newshot()
 	return
 
 /obj/item/weapon/gun/energy/process_chamber()
-	chambered = null
+	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
+		var/obj/item/ammo_casing/energy/shot = chambered
+		power_supply.use(shot.e_cost)//... drain the power_supply cell
+	chambered = null //either way, released the prepared shot
 	return
 
 /obj/item/weapon/gun/energy/proc/select_fire(mob/living/user as mob)


### PR DESCRIPTION
The click code was drawing the charge before even checking if the gun could fire.

The new procedure goes as follow :
- the click code goes on until its end (_afterattack_),
- if there's enough energy in the gun cell, a selected mode shot is chambered (laser, electrode, ...),
- the attack/firing code does its things,
- at the end of it, we check if the shot was spent (i.e the actual "bullet" was send). If so, we draw on the gun cell the correct amount of power. If not, we just discard the chambered shot.

Fixes #3910 (and every types of energy guns).

I wish we could overload variables, preventing the two typecasts.

By the way, is there any reason the laser projectile cost only 83 energy on the laser gun, instead of 100 for every others guns that uses lasers (practice, egun, ...) ?
