### PR TITLE
Fix for #2933

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -127,7 +127,10 @@
 
 	//done throwing, either because it hit something or it finished moving
 	src.throwing = 0
-	if(isobj(src)) src.throw_impact(get_turf(src))
+	if(isobj(src))
+		src.throw_impact(get_turf(src))
+	
+	return 1
 
 
 //Overlays


### PR DESCRIPTION
- Fixes #2933 (Throwing a die no longer causes it to roll).

I'm adding "return 1" at the end of throw_at() proc in atoms_movable.dm so that the "if(!..())" of throw_at() proc in dice.dm doesn't return true all the time.
