### PR TITLE
Airlocks and Lockers take time to weld and unweld

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -868,7 +868,6 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/attackby(C as obj, mob/user as mob)
-	//world << text("airlock attackby src [] obj [] mob []", src, C, user)
 	if(!istype(usr, /mob/living/silicon))
 		if(src.isElectrified())
 			if(src.shock(user, 75))
@@ -879,12 +878,16 @@ About the new airlock wires panel:
 	src.add_fingerprint(user)
 	if((istype(C, /obj/item/weapon/weldingtool) && !( src.operating ) && src.density))
 		var/obj/item/weapon/weldingtool/W = C
-		if(W.remove_fuel(0,user))
-			if(!src.welded)
-				src.welded = 1
-			else
-				src.welded = null
-			src.update_icon()
+		user << "<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>"
+		if(do_after(user,40,5,1))
+			if(W.remove_fuel(0,user))
+				playsound(loc, 'sound/items/welder.ogg', 50, 1, -6)
+				if(!src.welded)
+					src.welded = 1
+				else
+					src.welded = null
+				user << "<span class='notice'>You [welded ? "welded the airlock shut":"unwelded the airlock"]</span>"
+				src.update_icon()
 			return
 		else
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -879,9 +879,10 @@ About the new airlock wires panel:
 	if((istype(C, /obj/item/weapon/weldingtool) && !( src.operating ) && src.density))
 		var/obj/item/weapon/weldingtool/W = C
 		user << "<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>"
+		playsound(loc, 'sound/items/Welder2.ogg', 40, 1)
 		if(do_after(user,40,5,1))
 			if(W.remove_fuel(0,user))
-				playsound(loc, 'sound/items/welder.ogg', 50, 1, -6)
+				playsound(loc, 'sound/items/welder.ogg', 50, 1)
 				if(!src.welded)
 					src.welded = 1
 				else

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -883,15 +883,13 @@ About the new airlock wires panel:
 		if(do_after(user,40,5,1))
 			if(W.remove_fuel(0,user))
 				playsound(loc, 'sound/items/welder.ogg', 50, 1)
-				if(!src.welded)
-					src.welded = 1
-				else
-					src.welded = null
+				welded = !welded
 				user << "<span class='notice'>You [welded ? "welded the airlock shut":"unwelded the airlock"]</span>"
-				src.update_icon()
-			return
-		else
-			return
+				update_icon()
+				user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>")
+			else
+				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+		return
 	else if(istype(C, /obj/item/weapon/screwdriver))
 		src.p_open = !( src.p_open )
 		user << "<span class='notice'>You [p_open ? "open":"close"] the maintenance panel of the airlock.</span>"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -198,13 +198,18 @@
 		return
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
-		if(!WT.remove_fuel(0,user))
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
-			return
-		src.welded =! src.welded
-		src.update_icon()
-		for(var/mob/M in viewers(src))
-			M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 3, "You hear welding.", 2)
+		user << "<span class='notice'>You begin [welded ? "unwelding":"welding"] the [src]...</span>"
+		playsound(loc, 'sound/items/Welder2.ogg', 40, 1)
+		if(do_after(user,40,5,1))
+			if(WT.remove_fuel(0,user))
+				playsound(loc, 'sound/items/welder.ogg', 50, 1)
+				welded = !welded
+				user << "<span class='notice'>You [welded ? "welded the [src] shut":"unwelded the [src]"]</span>"
+				update_icon()
+				user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>")
+			else
+				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+		return
 	else if(!place(user, W))
 		src.attack_hand(user)
 	return


### PR DESCRIPTION
fixes #3902

Welding and unwelding an airlock or locker takes the same time as removing the airlock electronics.
Sound added to Starting the weld, and ending the weld (the start sound is at 40% because it is LOUD)
Feedback message for the user.
Feedback messages for viewers as welding is a VERY obvious task.
