### PR TITLE
Ports Mind Procs from NT

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -29,6 +29,16 @@
 
 */
 
+
+var/const/Changeling = 1
+var/const/Traitor = 2
+var/const/NuclearOp = 3
+var/const/Wizard = 4
+var/const/Cultist = 5
+var/const/Rev = 6
+var/const/Malf = 7
+//remove_antag() constants
+
 datum/mind
 	var/key
 	var/name				//replaces mob/var/original_name
@@ -89,13 +99,13 @@ datum/mind
 	proc/wipe_memory()
 		memory = null
 
+
+/*
+	Removes antag type's references from a mind.
+	objectives, uplinks, powers etc are all handled.
+*/
+
 	proc/remove_antag(specified_antag)
-
-		/*
-		Removes antag type's references from a mind.
-		objectives, uplinks, powers etc are all handled.
-		*/
-
 		special_role = null
 
 		if(objectives.len)
@@ -104,49 +114,43 @@ datum/mind
 				qdel(O)
 
 		switch(specified_antag)
-			if("Changeling")
+			if(Changeling)
 				if(src in ticker.mode.changelings)
 					ticker.mode.changelings -= src
 					current.remove_changeling_powers()
 					if(changeling)
 						qdel(changeling)
 						changeling = null
-
-			if("Traitor")
+			if(Traitor)
 				if(src in ticker.mode.traitors)
 					ticker.mode.traitors -= src
 					if(isAI(current))
 						var/mob/living/silicon/ai/A = current
 						A.set_zeroth_law("")
 						A.show_laws()
-
-			if("NuclearOp")
+			if(NuclearOp)
 				if(src in ticker.mode.syndicates)
 					ticker.mode.syndicates -= src
 					ticker.mode.update_synd_icons_removed(src)
-
-			if("Wizard")
+			if(Wizard)
 				if(src in ticker.mode.wizards)
 					ticker.mode.wizards -= src
 					current.spellremove(current)
-
-			if("Cultist")
+			if(Cultist)
 				if(src in ticker.mode.cult)
 					ticker.mode.cult -= src
 					ticker.mode.update_cult_icons_removed(src)
 					var/datum/game_mode/cult/cult = ticker.mode
 					if(istype(cult))
 						cult.memorize_cult_objectives(src)
-
-			if("Rev")
+			if(Rev)
 				if(src in ticker.mode.revolutionaries)
 					ticker.mode.revolutionaries -= src
 					ticker.mode.update_rev_icons_removed(src)
 				if(src in ticker.mode.head_revolutionaries)
 					ticker.mode.head_revolutionaries -= src
 					ticker.mode.update_rev_icons_removed(src)
-
-			if("Malf")
+			if(Malf)
 				if(src in ticker.mode.malf_ai)
 					ticker.mode.malf_ai -= src
 					var/mob/living/silicon/ai/A = current
@@ -170,13 +174,13 @@ datum/mind
 				R.traitor_frequency = 0.0
 
 	proc/remove_all_antag() //For the Lazy amongst us.
-		remove_antag("Changeling")
-		remove_antag("Traitor")
-		remove_antag("NuclearOp")
-		remove_antag("Wizard")
-		remove_antag("Cultist")
-		remove_antag("Rev")
-		remove_antag("Malf")
+		remove_antag(Changeling)
+		remove_antag(Traitor)
+		remove_antag(NuclearOp)
+		remove_antag(Wizard)
+		remove_antag(Cultist)
+		remove_antag(Rev)
+		remove_antag(Malf)
 
 	proc/show_memory(mob/recipient, window=1)
 		if(!recipient)
@@ -585,7 +589,7 @@ datum/mind
 		else if (href_list["revolution"])
 			switch(href_list["revolution"])
 				if("clear")
-					remove_antag("Rev")
+					remove_antag(Rev)
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-rev'ed [current].")
 					log_admin("[key_name(usr)] has de-rev'ed [current].")
@@ -668,7 +672,7 @@ datum/mind
 		else if (href_list["cult"])
 			switch(href_list["cult"])
 				if("clear")
-					remove_antag("Cultist")
+					remove_antag(Cultist)
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
 					log_admin("[key_name(usr)] has de-cult'ed [current].")
@@ -702,7 +706,7 @@ datum/mind
 		else if (href_list["wizard"])
 			switch(href_list["wizard"])
 				if("clear")
-					remove_antag("Wizard")
+					remove_antag(Wizard)
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
 					log_admin("[key_name(usr)] has de-wizard'ed [current].")
 				if("wizard")
@@ -726,7 +730,7 @@ datum/mind
 		else if (href_list["changeling"])
 			switch(href_list["changeling"])
 				if("clear")
-					remove_antag("Changeling")
+					remove_antag(Changeling)
 					current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
 					log_admin("[key_name(usr)] has de-changeling'ed [current].")
@@ -755,7 +759,7 @@ datum/mind
 		else if (href_list["nuclear"])
 			switch(href_list["nuclear"])
 				if("clear")
-					remove_antag("NuclearOp")
+					remove_antag(NuclearOp)
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
 					log_admin("[key_name(usr)] has de-nuke op'ed [current].")
@@ -804,7 +808,7 @@ datum/mind
 		else if (href_list["traitor"])
 			switch(href_list["traitor"])
 				if("clear")
-					remove_antag("Traitor")
+					remove_antag(Traitor)
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
 					log_admin("[key_name(usr)] has de-traitor'ed [current].")
@@ -876,7 +880,7 @@ datum/mind
 		else if (href_list["silicon"])
 			switch(href_list["silicon"])
 				if("unmalf")
-					remove_antag("Malf")
+					remove_antag(Malf)
 					current << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-malf'ed [current].")
 					log_admin("[key_name(usr)] has de-malf'ed [current].")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -29,16 +29,6 @@
 
 */
 
-
-var/const/Changeling = 1
-var/const/Traitor = 2
-var/const/NuclearOp = 3
-var/const/Wizard = 4
-var/const/Cultist = 5
-var/const/Rev = 6
-var/const/Malf = 7
-//remove_antag() constants
-
 datum/mind
 	var/key
 	var/name				//replaces mob/var/original_name
@@ -105,64 +95,82 @@ datum/mind
 	objectives, uplinks, powers etc are all handled.
 */
 
-	proc/remove_antag(specified_antag)
-		special_role = null
-
+	proc/remove_objectives()
 		if(objectives.len)
 			for(var/datum/objective/O in objectives)
 				objectives -= O
 				qdel(O)
 
-		switch(specified_antag)
-			if(Changeling)
-				if(src in ticker.mode.changelings)
-					ticker.mode.changelings -= src
-					current.remove_changeling_powers()
-					if(changeling)
-						qdel(changeling)
-						changeling = null
-			if(Traitor)
-				if(src in ticker.mode.traitors)
-					ticker.mode.traitors -= src
-					if(isAI(current))
-						var/mob/living/silicon/ai/A = current
-						A.set_zeroth_law("")
-						A.show_laws()
-			if(NuclearOp)
-				if(src in ticker.mode.syndicates)
-					ticker.mode.syndicates -= src
-					ticker.mode.update_synd_icons_removed(src)
-			if(Wizard)
-				if(src in ticker.mode.wizards)
-					ticker.mode.wizards -= src
-					current.spellremove(current)
-			if(Cultist)
-				if(src in ticker.mode.cult)
-					ticker.mode.cult -= src
-					ticker.mode.update_cult_icons_removed(src)
-					var/datum/game_mode/cult/cult = ticker.mode
-					if(istype(cult))
-						cult.memorize_cult_objectives(src)
-			if(Rev)
-				if(src in ticker.mode.revolutionaries)
-					ticker.mode.revolutionaries -= src
-					ticker.mode.update_rev_icons_removed(src)
-				if(src in ticker.mode.head_revolutionaries)
-					ticker.mode.head_revolutionaries -= src
-					ticker.mode.update_rev_icons_removed(src)
-			if(Malf)
-				if(src in ticker.mode.malf_ai)
-					ticker.mode.malf_ai -= src
-					var/mob/living/silicon/ai/A = current
-					A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
-						/datum/game_mode/malfunction/proc/takeover,
-						/datum/game_mode/malfunction/proc/ai_win)
-					A.malf_picker.remove_verbs(A)
-					A.make_laws()
-					qdel(A.malf_picker)
-					A.show_laws()
-					A.icon_state = "ai"
+	proc/remove_changeling()
+		if(src in ticker.mode.changelings)
+			ticker.mode.changelings -= src
+			current.remove_changeling_powers()
+			if(changeling)
+				qdel(changeling)
+				changeling = null
+		special_role = null
+		remove_objectives()
 
+	proc/remove_traitor()
+		if(src in ticker.mode.traitors)
+			ticker.mode.traitors -= src
+			if(isAI(current))
+				var/mob/living/silicon/ai/A = current
+				A.set_zeroth_law("")
+				A.show_laws()
+		special_role = null
+		remove_objectives()
+
+	proc/remove_nukeop()
+		if(src in ticker.mode.syndicates)
+			ticker.mode.syndicates -= src
+			ticker.mode.update_synd_icons_removed(src)
+		special_role = null
+		remove_objectives()
+
+	proc/remove_wizard()
+		if(src in ticker.mode.wizards)
+			ticker.mode.wizards -= src
+			current.spellremove(current)
+		special_role = null
+		remove_objectives()
+
+	proc/remove_cultist()
+		if(src in ticker.mode.cult)
+			ticker.mode.cult -= src
+			ticker.mode.update_cult_icons_removed(src)
+			var/datum/game_mode/cult/cult = ticker.mode
+			if(istype(cult))
+				cult.memorize_cult_objectives(src)
+		special_role = null
+		remove_objectives()
+
+	proc/remove_rev()
+		if(src in ticker.mode.revolutionaries)
+			ticker.mode.revolutionaries -= src
+			ticker.mode.update_rev_icons_removed(src)
+		if(src in ticker.mode.head_revolutionaries)
+			ticker.mode.head_revolutionaries -= src
+			ticker.mode.update_rev_icons_removed(src)
+		special_role = null
+		remove_objectives()
+
+	proc/remove_malf()
+		if(src in ticker.mode.malf_ai)
+			ticker.mode.malf_ai -= src
+			var/mob/living/silicon/ai/A = current
+			A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
+				/datum/game_mode/malfunction/proc/takeover,
+				/datum/game_mode/malfunction/proc/ai_win)
+			A.malf_picker.remove_verbs(A)
+			A.make_laws()
+			qdel(A.malf_picker)
+			A.show_laws()
+			A.icon_state = "ai"
+		special_role = null
+		remove_objectives()
+
+	proc/remove_antag_equip()
 		var/list/Mob_Contents = current.get_contents()
 		for(var/obj/item/I in Mob_Contents)
 			if(istype(I, /obj/item/device/pda))
@@ -174,13 +182,13 @@ datum/mind
 				R.traitor_frequency = 0.0
 
 	proc/remove_all_antag() //For the Lazy amongst us.
-		remove_antag(Changeling)
-		remove_antag(Traitor)
-		remove_antag(NuclearOp)
-		remove_antag(Wizard)
-		remove_antag(Cultist)
-		remove_antag(Rev)
-		remove_antag(Malf)
+		remove_changeling()
+		remove_traitor()
+		remove_nukeop()
+		remove_wizard()
+		remove_cultist()
+		remove_rev()
+		remove_malf()
 
 	proc/show_memory(mob/recipient, window=1)
 		if(!recipient)
@@ -589,7 +597,7 @@ datum/mind
 		else if (href_list["revolution"])
 			switch(href_list["revolution"])
 				if("clear")
-					remove_antag(Rev)
+					remove_rev()
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-rev'ed [current].")
 					log_admin("[key_name(usr)] has de-rev'ed [current].")
@@ -672,7 +680,7 @@ datum/mind
 		else if (href_list["cult"])
 			switch(href_list["cult"])
 				if("clear")
-					remove_antag(Cultist)
+					remove_cultist()
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
 					log_admin("[key_name(usr)] has de-cult'ed [current].")
@@ -706,7 +714,7 @@ datum/mind
 		else if (href_list["wizard"])
 			switch(href_list["wizard"])
 				if("clear")
-					remove_antag(Wizard)
+					remove_wizard()
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
 					log_admin("[key_name(usr)] has de-wizard'ed [current].")
 				if("wizard")
@@ -730,7 +738,7 @@ datum/mind
 		else if (href_list["changeling"])
 			switch(href_list["changeling"])
 				if("clear")
-					remove_antag(Changeling)
+					remove_changeling()
 					current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
 					log_admin("[key_name(usr)] has de-changeling'ed [current].")
@@ -759,7 +767,7 @@ datum/mind
 		else if (href_list["nuclear"])
 			switch(href_list["nuclear"])
 				if("clear")
-					remove_antag(NuclearOp)
+					remove_nukeop()
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
 					log_admin("[key_name(usr)] has de-nuke op'ed [current].")
@@ -808,7 +816,7 @@ datum/mind
 		else if (href_list["traitor"])
 			switch(href_list["traitor"])
 				if("clear")
-					remove_antag(Traitor)
+					remove_traitor()
 					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
 					log_admin("[key_name(usr)] has de-traitor'ed [current].")
@@ -880,7 +888,7 @@ datum/mind
 		else if (href_list["silicon"])
 			switch(href_list["silicon"])
 				if("unmalf")
-					remove_antag(Malf)
+					remove_malf()
 					current << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-malf'ed [current].")
 					log_admin("[key_name(usr)] has de-malf'ed [current].")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -110,6 +110,7 @@ datum/mind
 				changeling = null
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_traitor()
 		if(src in ticker.mode.traitors)
@@ -120,6 +121,7 @@ datum/mind
 				A.show_laws()
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_nukeop()
 		if(src in ticker.mode.syndicates)
@@ -127,6 +129,7 @@ datum/mind
 			ticker.mode.update_synd_icons_removed(src)
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_wizard()
 		if(src in ticker.mode.wizards)
@@ -134,6 +137,7 @@ datum/mind
 			current.spellremove(current)
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_cultist()
 		if(src in ticker.mode.cult)
@@ -144,6 +148,7 @@ datum/mind
 				cult.memorize_cult_objectives(src)
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_rev()
 		if(src in ticker.mode.revolutionaries)
@@ -154,6 +159,7 @@ datum/mind
 			ticker.mode.update_rev_icons_removed(src)
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_malf()
 		if(src in ticker.mode.malf_ai)
@@ -169,6 +175,7 @@ datum/mind
 			A.icon_state = "ai"
 		special_role = null
 		remove_objectives()
+		remove_antag_equip()
 
 	proc/remove_antag_equip()
 		var/list/Mob_Contents = current.get_contents()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -86,6 +86,98 @@ datum/mind
 	proc/store_memory(new_text)
 		memory += "[new_text]<BR>"
 
+	proc/wipe_memory()
+		memory = null
+
+	proc/remove_antag(specified_antag)
+
+		/*
+		Removes antag type's references from a mind.
+		objectives, uplinks, powers etc are all handled.
+		*/
+
+		special_role = null
+
+		if(objectives.len)
+			for(var/datum/objective/O in objectives)
+				objectives -= O
+				qdel(O)
+
+		switch(specified_antag)
+			if("Changeling")
+				if(src in ticker.mode.changelings)
+					ticker.mode.changelings -= src
+					current.remove_changeling_powers()
+					if(changeling)
+						qdel(changeling)
+						changeling = null
+
+			if("Traitor")
+				if(src in ticker.mode.traitors)
+					ticker.mode.traitors -= src
+					if(isAI(current))
+						var/mob/living/silicon/ai/A = current
+						A.set_zeroth_law("")
+						A.show_laws()
+
+			if("NuclearOp")
+				if(src in ticker.mode.syndicates)
+					ticker.mode.syndicates -= src
+					ticker.mode.update_synd_icons_removed(src)
+
+			if("Wizard")
+				if(src in ticker.mode.wizards)
+					ticker.mode.wizards -= src
+					current.spellremove(current)
+
+			if("Cultist")
+				if(src in ticker.mode.cult)
+					ticker.mode.cult -= src
+					ticker.mode.update_cult_icons_removed(src)
+					var/datum/game_mode/cult/cult = ticker.mode
+					if(istype(cult))
+						cult.memorize_cult_objectives(src)
+
+			if("Rev")
+				if(src in ticker.mode.revolutionaries)
+					ticker.mode.revolutionaries -= src
+					ticker.mode.update_rev_icons_removed(src)
+				if(src in ticker.mode.head_revolutionaries)
+					ticker.mode.head_revolutionaries -= src
+					ticker.mode.update_rev_icons_removed(src)
+
+			if("Malf")
+				if(src in ticker.mode.malf_ai)
+					ticker.mode.malf_ai -= src
+					var/mob/living/silicon/ai/A = current
+					A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
+						/datum/game_mode/malfunction/proc/takeover,
+						/datum/game_mode/malfunction/proc/ai_win)
+					A.malf_picker.remove_verbs(A)
+					A.make_laws()
+					qdel(A.malf_picker)
+					A.show_laws()
+					A.icon_state = "ai"
+
+		var/list/Mob_Contents = current.get_contents()
+		for(var/obj/item/I in Mob_Contents)
+			if(istype(I, /obj/item/device/pda))
+				var/obj/item/device/pda/P = I
+				P.lock_code = ""
+
+			else if(istype(I, /obj/item/device/radio))
+				var/obj/item/device/radio/R = I
+				R.traitor_frequency = 0.0
+
+	proc/remove_all_antag() //For the Lazy amongst us.
+		remove_antag("Changeling")
+		remove_antag("Traitor")
+		remove_antag("NuclearOp")
+		remove_antag("Wizard")
+		remove_antag("Cultist")
+		remove_antag("Rev")
+		remove_antag("Malf")
+
 	proc/show_memory(mob/recipient, window=1)
 		if(!recipient)
 			recipient = current
@@ -493,19 +585,10 @@ datum/mind
 		else if (href_list["revolution"])
 			switch(href_list["revolution"])
 				if("clear")
-					if(src in ticker.mode.revolutionaries)
-						ticker.mode.revolutionaries -= src
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
-						ticker.mode.update_rev_icons_removed(src)
-						special_role = null
-					if(src in ticker.mode.head_revolutionaries)
-						ticker.mode.head_revolutionaries -= src
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a head revolutionary!</B></FONT>"
-						ticker.mode.update_rev_icons_removed(src)
-						special_role = null
+					remove_antag("Rev")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a revolutionary!</B></FONT>"
 					message_admins("[key_name_admin(usr)] has de-rev'ed [current].")
 					log_admin("[key_name(usr)] has de-rev'ed [current].")
-
 				if("rev")
 					if(src in ticker.mode.head_revolutionaries)
 						ticker.mode.head_revolutionaries -= src
@@ -585,17 +668,10 @@ datum/mind
 		else if (href_list["cult"])
 			switch(href_list["cult"])
 				if("clear")
-					if(src in ticker.mode.cult)
-						ticker.mode.cult -= src
-						ticker.mode.update_cult_icons_removed(src)
-						special_role = null
-						var/datum/game_mode/cult/cult = ticker.mode
-						if (istype(cult))
-							cult.memorize_cult_objectives(src)
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
-						memory = ""
-						message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
-						log_admin("[key_name(usr)] has de-cult'ed [current].")
+					remove_antag("Cultist")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a cultist!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-cult'ed [current].")
+					log_admin("[key_name(usr)] has de-cult'ed [current].")
 				if("cultist")
 					if(!(src in ticker.mode.cult))
 						ticker.mode.add_cultist(src)
@@ -626,12 +702,9 @@ datum/mind
 		else if (href_list["wizard"])
 			switch(href_list["wizard"])
 				if("clear")
-					if(src in ticker.mode.wizards)
-						ticker.mode.wizards -= src
-						special_role = null
-						current.spellremove(current)
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
-						log_admin("[key_name(usr)] has de-wizard'ed [current].")
+					remove_antag("Wizard")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
+					log_admin("[key_name(usr)] has de-wizard'ed [current].")
 				if("wizard")
 					if(!(src in ticker.mode.wizards))
 						ticker.mode.wizards += src
@@ -653,15 +726,10 @@ datum/mind
 		else if (href_list["changeling"])
 			switch(href_list["changeling"])
 				if("clear")
-					if(src in ticker.mode.changelings)
-						ticker.mode.changelings -= src
-						special_role = null
-						current.remove_changeling_powers()
-						if(changeling)
-							del(changeling)
-						current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
-						log_admin("[key_name(usr)] has de-changeling'ed [current].")
+					remove_antag("Changeling")
+					current << "<FONT color='red' size = 3><B>You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-changeling'ed [current].")
+					log_admin("[key_name(usr)] has de-changeling'ed [current].")
 				if("changeling")
 					if(!(src in ticker.mode.changelings))
 						ticker.mode.changelings += src
@@ -687,15 +755,10 @@ datum/mind
 		else if (href_list["nuclear"])
 			switch(href_list["nuclear"])
 				if("clear")
-					if(src in ticker.mode.syndicates)
-						ticker.mode.syndicates -= src
-						ticker.mode.update_synd_icons_removed(src)
-						special_role = null
-						for (var/datum/objective/nuclear/O in objectives)
-							objectives-=O
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
-						log_admin("[key_name(usr)] has de-nuke op'ed [current].")
+					remove_antag("NuclearOp")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a syndicate operative!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-nuke op'ed [current].")
+					log_admin("[key_name(usr)] has de-nuke op'ed [current].")
 				if("nuclear")
 					if(!(src in ticker.mode.syndicates))
 						ticker.mode.syndicates += src
@@ -741,17 +804,10 @@ datum/mind
 		else if (href_list["traitor"])
 			switch(href_list["traitor"])
 				if("clear")
-					if(src in ticker.mode.traitors)
-						ticker.mode.traitors -= src
-						special_role = null
-						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
-						log_admin("[key_name(usr)] has de-traitor'ed [current].")
-						if(isAI(current))
-							var/mob/living/silicon/ai/A = current
-							A.set_zeroth_law("")
-							A.show_laws()
-
+					remove_antag("Traitor")
+					current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a traitor!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-traitor'ed [current].")
+					log_admin("[key_name(usr)] has de-traitor'ed [current].")
 
 				if("traitor")
 					if(!(src in ticker.mode.traitors))
@@ -820,26 +876,10 @@ datum/mind
 		else if (href_list["silicon"])
 			switch(href_list["silicon"])
 				if("unmalf")
-					if(src in ticker.mode.malf_ai)
-						ticker.mode.malf_ai -= src
-						special_role = null
-
-						var/mob/living/silicon/ai/A = current
-
-						A.verbs.Remove(/mob/living/silicon/ai/proc/choose_modules,
-							/datum/game_mode/malfunction/proc/takeover,
-							/datum/game_mode/malfunction/proc/ai_win)
-
-						A.malf_picker.remove_verbs(A)
-
-						A.make_laws()
-						qdel(A.malf_picker)
-						A.show_laws()
-						A.icon_state = "ai"
-
-						A << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
-						message_admins("[key_name_admin(usr)] has de-malf'ed [A].")
-						log_admin("[key_name(usr)] has de-malf'ed [A].")
+					remove_antag("Malf")
+					current << "\red <FONT size = 3><B>You have been patched! You are no longer malfunctioning!</B></FONT>"
+					message_admins("[key_name_admin(usr)] has de-malf'ed [current].")
+					log_admin("[key_name(usr)] has de-malf'ed [current].")
 
 				if("malf")
 					make_AI_Malf()
@@ -894,37 +934,6 @@ datum/mind
 				obj_count++
 
 		edit_memory()
-/*
-	proc/clear_memory(var/silent = 1)
-		var/datum/game_mode/current_mode = ticker.mode
-
-		// remove traitor uplinks
-		var/list/L = current.get_contents()
-		for (var/t in L)
-			if (istype(t, /obj/item/device/pda))
-				if (t:uplink) qdel(t:uplink)
-				t:uplink = null
-			else if (istype(t, /obj/item/device/radio))
-				if (t:traitorradio) qdel(t:traitorradio)
-				t:traitorradio = null
-				t:traitor_frequency = 0.0
-			else if (istype(t, /obj/item/weapon/SWF_uplink) || istype(t, /obj/item/weapon/syndicate_uplink))
-				if (t:origradio)
-					var/obj/item/device/radio/R = t:origradio
-					R.loc = current.loc
-					R.traitorradio = null
-					R.traitor_frequency = 0.0
-				qdel(t)
-
-		// remove wizards spells
-		//If there are more special powers that need removal, they can be procced into here./N
-		current.spellremove(current)
-
-		// clear memory
-		memory = ""
-		special_role = null
-
-*/
 
 	proc/find_syndicate_uplink()
 		var/list/L = current.get_contents()


### PR DESCRIPTION
ports some mind procs I made ages ago for NT

remove_X() procs remove the specified Antag, their Objectives and their Equipment
remove_all_antag() is for lazy people, might have like, 1 genuine use.
remove_objectives removes antag objectives.
remove_antag_equip() removes the special functions of PDAs and Radios.
wipe_memory() is just a shortcut to memory = null.

Testing: Been live on Artyom and NT for about 1 1/2 months with no issues.
