### PR TITLE
Medibots don't try to heal diseases

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -36,7 +36,6 @@
 	var/treatment_oxy = "tricordrazine"
 	var/treatment_fire = "tricordrazine"
 	var/treatment_tox = "tricordrazine"
-	var/treatment_virus = "spaceacillin"
 	var/shut_up = 0 //self explanatory :)
 
 /obj/machinery/bot/medbot/mysterious
@@ -363,13 +362,6 @@
 	if((C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(src.treatment_tox)))
 		return 1
 
-
-	for(var/datum/disease/D in C.viruses)
-		if((D.stage > 1) || (D.spread_type == AIRBORNE))
-
-			if (!C.reagents.has_reagent(src.treatment_virus))
-				return 1 //STOP DISEASE FOREVER
-
 	return 0
 
 /obj/machinery/bot/medbot/proc/medicate_patient(mob/living/carbon/C as mob)
@@ -398,14 +390,6 @@
 		reagent_id = "toxin"
 
 	else
-		var/virus = 0
-		for(var/datum/disease/D in C.viruses)
-			virus = 1
-
-		if (!reagent_id && (virus))
-			if(!C.reagents.has_reagent(src.treatment_virus))
-				reagent_id = src.treatment_virus
-
 		if (!reagent_id && (C.getBruteLoss() >= heal_threshold))
 			if(!C.reagents.has_reagent(src.treatment_brute))
 				reagent_id = src.treatment_brute


### PR DESCRIPTION
Because it was useless and annoying. Spaceacilin doesn't even do anything, and it meant that they go insane once viro makes a useful disease.
