### PR TITLE
Fix for #3036: dead people floating in space randomly

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -144,7 +144,11 @@
 	return 0
 
 /turf/proc/inertial_drift(atom/movable/A as mob|obj)
-	if(!(A.last_move))	return
+	if(!(A.last_move))
+		return
+	for(var/mob/M in range(A, 1))
+		if(M.pulling == A)
+			return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
 		if(M.Process_Spacemove(1))
@@ -152,9 +156,6 @@
 			return
 		spawn(5)
 			if((M && !(M.anchored) && (M.loc == src)))
-				if(M.inertia_dir)
-					step(M, M.inertia_dir)
-					return
 				M.inertia_dir = M.last_move
 				step(M, M.inertia_dir)
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -146,9 +146,8 @@
 /turf/proc/inertial_drift(atom/movable/A as mob|obj)
 	if(!(A.last_move))
 		return
-	for(var/mob/M in range(A, 1))
-		if(M.pulling == A)
-			return
+	if (A.pulledby)
+		return
 	if((istype(A, /mob/) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
 		var/mob/M = A
 		if(M.Process_Spacemove(1))


### PR DESCRIPTION
This does two things: first, if you are being pulled by something, you are not affected by inertial drift, because it's implied that they are holding you. So dead people will no longer fly off in random directions when you pull them into space.

Second, this fixes strange relations between inertia_dir, which is the direction you are floating to, and last_move, which is the last direction you were moving.

Before: if inertia_dir was set, it ignored last_move outright.
Now: inertia_dir is set to last_move.

This means that when you /throw/ someone somewhere in space, and they hit something, they will not suddenly float back because inertia_dir was pointing in the opposite direction of the throw.

Fixes #3036
