### PR TITLE
Fixes make_powernets proc

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -216,7 +216,8 @@
 
 	for(var/obj/structure/cable/PC in cable_list)
 		if(!PC.powernet)
-			PC.powernet = new()
+			var/datum/powernet/NewPN = new()
+			NewPN.add_cable(PC)
 			propagate_network(PC,PC.powernet)
 
 //remove the old powernet and replace it with a new one throughout the network.


### PR DESCRIPTION
The _make_powernets_ proc was not adding the first cable found to the cable list of a newly created powernet (the one from which was propagated the network). This would cause problems when merging two powernets.

This wasn't detected until now because :
- _make_powernets_ is only called at initialization or by the admin verb,
- the powernets work perfectly... until you merged two and it forgot to merge the unreferenced cable.

Fixes #4011.

**_Note**_ : The node cable under the right SMES in Electrical Maintenance is pointed east instead of west. The SMES is then unable to output power without rewiring.
Is someone making map changes (Ikarrus ?) and can fix that, or should I do it ?
