### PR TITLE
Removes 'Cancel Camera View' verb for the AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -517,7 +517,7 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/cancel_camera()
 	set category = "AI Commands"
-	set name = "Cancel Camera View"
+	set name = "AI Core"
 
 	//src.cameraFollow = null
 	src.view_core()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -517,7 +517,7 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/cancel_camera()
 	set category = "AI Commands"
-	set name = "AI Core"
+	set name = "Cancel Camera View"
 
 	//src.cameraFollow = null
 	src.view_core()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -92,14 +92,6 @@
 
 
 // Return to the Core.
-
-/mob/living/silicon/ai/verb/core()
-	set category = "AI Commands"
-	set name = "AI Core"
-
-	view_core()
-
-
 /mob/living/silicon/ai/proc/view_core()
 
 	current = null


### PR DESCRIPTION
"Cancel camera view" has _exactly the same effect_. AI has a ton of verbs, and it doesn't need two that do same thing.
