### PR TITLE
Hydroponics fixes, icons and irrigation

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -71,7 +71,7 @@
 
 		for(var/step_dir in cardinal)
 			var/obj/machinery/hydroponics/h = locate() in get_step(a, step_dir)
-			if(h && h.anchored==2 && !(h in connected) && !(h in processing_atoms))
+			if(h && h.anchored==1 && h.density && !(h in connected) && !(h in processing_atoms)) // Soil plots aren't dense, and don't get this feature.
 				processing_atoms += h
 
 		processing_atoms -= a
@@ -597,9 +597,8 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			if(istype(reagent_source, /obj/item/weapon/reagent_containers/syringe/))
 				var/obj/item/weapon/reagent_containers/syringe/syr = reagent_source
 				visi_msg="[user] injects [target] with [syr]"
-				if(syr.reagents.total_volume <= 0)
+				if(syr.reagents.total_volume <= syr.amount_per_transfer_from_this)
 					syr.mode = 0
-					syr.update_icon()
 			else if(istype(reagent_source, /obj/item/weapon/reagent_containers/spray/))
 				visi_msg="[user] sprays [target] with [reagent_source]"
 				playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
@@ -611,10 +610,10 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			if(istype(reagent_source, /obj/item/weapon/reagent_containers/glass/))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 
-		if(irrigate && reagent_source.amount_per_transfer_from_this > 30 && reagent_source.reagents.total_volume >= reagent_source.amount_per_transfer_from_this)
+		if(irrigate && reagent_source.amount_per_transfer_from_this > 30 && reagent_source.reagents.total_volume >= 30)
 			trays = FindConnected()
 			if (trays.len > 1)
-				visi_msg += " setting off the irrigation system"
+				visi_msg += ", setting off the irrigation system"
 
 		if(visi_msg)
 			visible_message("<span class='notice'>[visi_msg].</span>")
@@ -636,6 +635,8 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			S.clear_reagents()
 			del(S)
 			H.update_icon()
+		if(reagent_source) // If the source wasn't composted and destroyed
+			reagent_source.update_icon()
 		return 1
 
 	else if(istype(O, /obj/item/seeds/))

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -6,84 +6,84 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
-	var/filled = 0
 
-	afterattack(obj/target, mob/user , proximity)
-		if(!proximity) return
-		if(!target.reagents) return
+/obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
+	if(!proximity) return
+	if(!target.reagents) return
 
-		if(filled)
-			if(target.reagents.total_volume >= target.reagents.maximum_volume)
-				user << "<span class='notice'>[target] is full.</span>"
-				return
+	if(reagents.total_volume > 0)
+		if(target.reagents.total_volume >= target.reagents.maximum_volume)
+			user << "<span class='notice'>[target] is full.</span>"
+			return
 
-			if(!target.is_open_container() && !ismob(target) && !istype(target,/obj/item/weapon/reagent_containers/food) && !istype(target, /obj/item/clothing/mask/cigarette)) //You can inject humans and food but you cant remove the shit.
-				user << "<span class='notice'>You cannot directly fill [target].</span>"
-				return
+		if(!target.is_open_container() && !ismob(target) && !istype(target,/obj/item/weapon/reagent_containers/food) && !istype(target, /obj/item/clothing/mask/cigarette)) //You can inject humans and food but you cant remove the shit.
+			user << "<span class='notice'>You cannot directly fill [target].</span>"
+			return
 
-			var/trans = 0
+		var/trans = 0
 
-			if(ismob(target))
-				if(istype(target , /mob/living/carbon/human))
-					var/mob/living/carbon/human/victim = target
+		if(ismob(target))
+			if(istype(target , /mob/living/carbon/human))
+				var/mob/living/carbon/human/victim = target
 
-					var/obj/item/safe_thing = null
-					if(victim.wear_mask)
-						if(victim.wear_mask.flags & MASKCOVERSEYES)
-							safe_thing = victim.wear_mask
-					if(victim.head)
-						if(victim.head.flags & MASKCOVERSEYES)
-							safe_thing = victim.head
-					if(victim.glasses)
-						if(!safe_thing)
-							safe_thing = victim.glasses
+				var/obj/item/safe_thing = null
+				if(victim.wear_mask)
+					if(victim.wear_mask.flags & MASKCOVERSEYES)
+						safe_thing = victim.wear_mask
+				if(victim.head)
+					if(victim.head.flags & MASKCOVERSEYES)
+						safe_thing = victim.head
+				if(victim.glasses)
+					if(!safe_thing)
+						safe_thing = victim.glasses
 
-					if(safe_thing)
-						if(!safe_thing.reagents)
-							safe_thing.create_reagents(100)
-						trans = reagents.trans_to(safe_thing, amount_per_transfer_from_this)
+				if(safe_thing)
+					if(!safe_thing.reagents)
+						safe_thing.create_reagents(100)
+					trans = reagents.trans_to(safe_thing, amount_per_transfer_from_this)
 
-						target.visible_message("<span class='danger'>[user] tries to squirt something into [target]'s eyes, but fails!</span>", \
-												"<span class='userdanger'>[user] tries to squirt something into [target]'s eyes, but fails!</span>")
-						spawn(5)
-							reagents.reaction(safe_thing, TOUCH)
+					target.visible_message("<span class='danger'>[user] tries to squirt something into [target]'s eyes, but fails!</span>", \
+											"<span class='userdanger'>[user] tries to squirt something into [target]'s eyes, but fails!</span>")
+					spawn(5)
+						reagents.reaction(safe_thing, TOUCH)
 
-						user << "<span class='notice'>You transfer [trans] unit\s of the solution.</span>"
-						if(reagents.total_volume<=0)
-							filled = 0
-							icon_state = "dropper[filled]"
-						return
+					user << "<span class='notice'>You transfer [trans] unit\s of the solution.</span>"
+					update_icon()
+					return
 
-				target.visible_message("<span class='danger'>[user] squirts something into [target]'s eyes!</span>", \
-										"<span class='userdanger'>[user] squirts something into [target]'s eyes!</span>")
-				reagents.reaction(target, TOUCH)
-				var/mob/M = target
-				var/R
-				if(reagents)
-					for(var/datum/reagent/A in src.reagents.reagent_list)
-						R += A.id + " ("
-						R += num2text(A.volume) + "),"
-				add_logs(user, M, "squirted", object="[R]")
+			target.visible_message("<span class='danger'>[user] squirts something into [target]'s eyes!</span>", \
+									"<span class='userdanger'>[user] squirts something into [target]'s eyes!</span>")
+			reagents.reaction(target, TOUCH)
+			var/mob/M = target
+			var/R
+			if(reagents)
+				for(var/datum/reagent/A in src.reagents.reagent_list)
+					R += A.id + " ("
+					R += num2text(A.volume) + "),"
+			add_logs(user, M, "squirted", object="[R]")
 
-			trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
-			user << "<span class='notice'>You transfer [trans] unit\s of the solution.</span>"
-			if(reagents.total_volume<=0)
-				filled = 0
-				icon_state = "dropper[filled]"
+		trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
+		user << "<span class='notice'>You transfer [trans] unit\s of the solution.</span>"
+		update_icon()
 
-		else
+	else
 
-			if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
-				user << "<span class='notice'>You cannot directly remove reagents from [target].</span>"
-				return
+		if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
+			user << "<span class='notice'>You cannot directly remove reagents from [target].</span>"
+			return
 
-			if(!target.reagents.total_volume)
-				user << "<span class='notice'>[target] is empty.</span>"
-				return
+		if(!target.reagents.total_volume)
+			user << "<span class='notice'>[target] is empty.</span>"
+			return
 
-			var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 
-			user << "<span class='notice'>You fill [src] with [trans] unit\s of the solution.</span>"
+		user << "<span class='notice'>You fill [src] with [trans] unit\s of the solution.</span>"
 
-			filled = 1
-			icon_state = "dropper[filled]"
+		update_icon()
+
+/obj/item/weapon/reagent_containers/dropper/update_icon()
+	if(reagents.total_volume<=0)
+		icon_state = "dropper0"
+	else
+		icon_state = "dropper1"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
   <title>/tg/ Station 13 Changelog</title>
@@ -53,6 +53,18 @@ should be listed in the changelog upon commit tho. Thanks. -->
 <!-- You can simply add changelogs using AddToChangelog.exe -->
 
 <!-- DO NOT REMOVE OR MOVE THIS COMMENT! THIS MUST BE THE LAST NON-EMPTY LINE BEFORE THE LOGS #ADDTOCHANGELOGMARKER# -->
+
+<div class='commit sansserif'>
+	<h2 class='date'>1 July 2014</h2>
+	<h3 class='author'>Rolan7 updated:</h3>
+	<ul class='changes bgimages16'>
+		<li class='rscadd'>Fixed the irrigation system in hydroponics trays.  Adding at least 30 units of liquid at once will activate the system, sharing the reagents between all connected trays.</li>
+		<li class='bugfix'>Changelings can communicate while muzzled or monkified, and being monkified doesn't stop them from taking human form.</li>
+		<li class='bugfix'>Mimes cannot break the laws of physics unless their vow is currently active.</li>
+		<li class='rscadd'>Trays are rewritten to make sense and so borgs can actually use them.  Service borgs can discretely carry small objects, hint hint.  The items are easily knocked out of them.</li>
+	</ul>
+</div>
+
 <div class='commit sansserif'>
 	<h2 class='date'>20 June 2014</h2>
 	<h3 class='author'>Ikarrus updated:</h3>


### PR DESCRIPTION
Syringes will switch to draw mode if emptied into plots.
All reagent containers have icon updated after plot-use, including droppers.
Droppers updated to use update_icon instead of that "filled" variable.

The above fix issue #3879

Typo in irrigation fixed, allowing liquid > 30 units to be spread amongst connected trays.
Changelog updated, including some things from previous PRs which I didn't add at the time.
