### PR TITLE
Fixes a dreadful typo I made in #3949

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -77,7 +77,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 		var/mob/living/carbon/human/H = user
 
-		if((invocation_type == "whisper" || invocation_type == "shout") && !H.is_muzzled())
+		if((invocation_type == "whisper" || invocation_type == "shout") && H.is_muzzled())
 			user << "<span class='notice'>You can't get the words out!</span>"
 			return 0
 


### PR DESCRIPTION
Wizards couldn't cast spells _unless_ they were muzzled...  My bad.
