### PR TITLE
Rolling chairs fixes.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -8,7 +8,7 @@
 		src.verbs -= /atom/movable/verb/pull
 	..()
 	spawn(3)	//sorry. i don't think there's a better way to do this.
-		handle_rotation()
+		handle_layer()
 	return
 
 /obj/structure/stool/bed/chair/attackby(obj/item/weapon/W as obj, mob/user as mob)
@@ -33,22 +33,27 @@
 		rotate()
 	return
 
-/obj/structure/stool/bed/chair/proc/handle_rotation()	//making this into a seperate proc so office chairs can call it on Move()
-	if(src.dir == NORTH)
+/obj/structure/stool/bed/chair/proc/handle_rotation(direction)	//making this into a seperate proc so office chairs can call it on Move()
+	if(buckled_mob)
+		buckled_mob.buckled = null //Temporary, so Move() succeeds.
+		if(!buckled_mob.Move(direction))
+			buckled_mob.buckled = src
+			dir = buckled_mob.dir
+			return 0
+		buckled_mob.buckled = src //Restoring
+	return 1
+
+/obj/structure/stool/bed/chair/proc/handle_layer()
+	if(dir == NORTH)
 		src.layer = FLY_LAYER
 	else
 		src.layer = OBJ_LAYER
 
+/obj/structure/stool/bed/chair/proc/spin()
+	src.dir = turn(src.dir, 90)
+	handle_layer()
 	if(buckled_mob)
-		if(buckled_mob.loc != src.loc)
-			buckled_mob.buckled = null //Temporary, so Move() succeeds.
-			if(!buckled_mob.Move(loc))
-				unbuckle()
-				buckled_mob = null
-			else
-				buckled_mob.buckled = src //Restoring
-		if(buckled_mob)
-			buckled_mob.dir = dir
+		buckled_mob.dir = dir
 
 /obj/structure/stool/bed/chair/verb/rotate()
 	set name = "Rotate Chair"
@@ -56,18 +61,13 @@
 	set src in oview(1)
 
 	if(config.ghost_interaction)
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
-		return
+		spin()
 	else
 		if(!usr || !isturf(usr.loc))
 			return
 		if(usr.stat || usr.restrained())
 			return
-
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
-		return
+		spin()
 
 /obj/structure/stool/bed/chair/MouseDrop_T(mob/M as mob, mob/user as mob)
 	if(!istype(M)) return
@@ -130,9 +130,10 @@
 /obj/structure/stool/bed/chair/office
 	anchored = 0
 
-/obj/structure/stool/bed/chair/office/Move()
-	..()
-	handle_rotation()
+/obj/structure/stool/bed/chair/office/Move(direction)
+	if(handle_rotation(direction))
+		..()
+	handle_layer()
 
 /obj/structure/stool/bed/chair/office/light
 	icon_state = "officechair_white"


### PR DESCRIPTION
Office/rolling chairs will now work properly when carrying mobs, those will not slip out of the chair, becoming an ungrabless mobs. And the direction of the chair and mob will be better and easier to notice when they bump something.

Their direction changes will work even better if mob movement code finally removes all the spawn() calls. I'm not planning of adding any special code for that here.
Fixes issue #4024 
