### PR TITLE
Powernets machines connection polishing

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -313,7 +313,6 @@
 		var/recalc = 0
 		var/locked = 1
 		var/destroyed = 0
-		var/directwired = 1
 //		var/maxshieldload = 200
 		var/obj/structure/cable/attached		// the attached cable
 		var/storedpower = 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -321,10 +321,14 @@ obj/structure/cable/proc/avail()
 
 // merge with the powernets of power objects in the source turf
 /obj/structure/cable/proc/mergeConnectedNetworksOnTurf()
+	var/list/to_connect = list()
+
 	if(!powernet) //if we somehow have no powernet, make one (should not happen for cables)
 		var/datum/powernet/newPN = new()
 		newPN.add_cable(src)
 
+	//first let's add turf cables to our powernet
+	//then we'll connect machines on turf with a node cable is present
 	for(var/AM in loc)
 		if(istype(AM,/obj/structure/cable))
 			var/obj/structure/cable/C = AM
@@ -338,20 +342,24 @@ obj/structure/cable/proc/avail()
 		else if(istype(AM,/obj/machinery/power/apc))
 			var/obj/machinery/power/apc/N = AM
 			if(!N.terminal)	continue // APC are connected through their terminal
-			if(N.terminal.powernet)
-				merge_powernets(powernet, N.terminal.powernet)
-			else
-				if(!N.terminal.connect_to_network())
-					N.terminal.disconnect_from_network()
+
+			if(N.terminal.powernet == powernet)
+				continue
+
+			to_connect += N.terminal //we'll connect the machines after all cables are merged
 
 		else if(istype(AM,/obj/machinery/power)) //other power machines
 			var/obj/machinery/power/M = AM
-			if(M.powernet == powernet)	continue
-			if(M.powernet)
-				merge_powernets(powernet, M.powernet)
-			else
-				if(!M.connect_to_network())
-					M.disconnect_from_network()
+
+			if(M.powernet == powernet)
+				continue
+
+			to_connect += M //we'll connect the machines after all cables are merged
+
+	//now that cables are done, let's connect found machines
+	for(var/obj/machinery/power/PM in to_connect)
+		if(!PM.connect_to_network())
+			PM.disconnect_from_network() //if we somehow can't connect the machine to the new powernet, remove it from the old nonetheless
 
 //////////////////////////////////////////////
 // Powernets handling helpers

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -341,7 +341,8 @@ obj/structure/cable/proc/avail()
 			if(N.terminal.powernet)
 				merge_powernets(powernet, N.terminal.powernet)
 			else
-				powernet.add_machine(N.terminal)
+				if(!N.terminal.connect_to_network())
+					N.terminal.disconnect_from_network()
 
 		else if(istype(AM,/obj/machinery/power)) //other power machines
 			var/obj/machinery/power/M = AM
@@ -349,7 +350,8 @@ obj/structure/cable/proc/avail()
 			if(M.powernet)
 				merge_powernets(powernet, M.powernet)
 			else
-				powernet.add_machine(M)
+				if(!M.connect_to_network())
+					M.disconnect_from_network()
 
 //////////////////////////////////////////////
 // Powernets handling helpers

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -9,7 +9,6 @@
 	icon_state = "off"
 	density = 1
 	anchored = 0
-	directwired = 0
 	var/t_status = 0
 	var/t_per = 5000
 	var/filter = 1
@@ -48,7 +47,6 @@ display round(lastgen) and plasmatank amount
 	icon_state = "portgen0"
 	density = 1
 	anchored = 0
-	directwired = 0
 	use_power = 0
 
 	var/active = 0

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -11,7 +11,6 @@
 	icon = 'icons/obj/power.dmi'
 	anchored = 1.0
 	var/datum/powernet/powernet = null
-	var/directwired = 1		// TODEL
 	use_power = 0
 	idle_power_usage = 0
 	active_power_usage = 0

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -267,21 +267,13 @@
 		net1 = net2
 		net2 = temp
 
-	//we don't use add_cable and add_machine here, because that could
-	//change the size of net2.nodes or net2.cables while in the loop (runtime galore)
-	for(var/i=1,i<=net2.nodes.len,i++)		//merge net2 into net1
-		var/obj/machinery/power/Node = net2.nodes[i] //merge power machines
-		if(Node)
-			Node.powernet = net1
-			net1.nodes[Node] = Node
+	//merge net2 into net1
+	for(var/obj/structure/cable/Cable in net2.cables) //merge cables
+		net1.add_cable(Cable)
 
-	for(var/i=1,i<=net2.cables.len,i++)
-		var/obj/structure/cable/Cable = net2.cables[i] //merge cables
-		if(Cable)
-			Cable.powernet = net1
-			net1.cables += Cable
-
-	qdel(net2) //garbage collect the now empty powernet
+	for(var/obj/machinery/power/Node in net2.nodes) //merge power machines
+		if(!Node.connect_to_network())
+			Node.disconnect_from_network() //if somehow we can't connect the machine to the new powernet, disconnect it from the old nonetheless
 
 	return net1
 
@@ -401,7 +393,7 @@
 		if(M.powernet == src)
 			return
 		else
-			M.powernet.remove_machine(M) //..remove it
+			M.disconnect_from_network()//..remove it
 	M.powernet = src
 	nodes[M] = M
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -8,7 +8,6 @@ var/global/list/rad_collectors = list()
 	icon_state = "ca"
 	anchored = 0
 	density = 1
-	directwired = 1
 	req_access = list(access_engine_equip)
 //	use_power = 0
 	var/obj/item/weapon/tank/plasma/P = null

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -37,7 +37,6 @@
 	..()
 	if(state == 2 && anchored)
 		connect_to_network()
-		src.directwired = 1
 
 /obj/machinery/power/emitter/Destroy()
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)
@@ -185,7 +184,6 @@
 						state = 2
 						user << "You weld the [src] to the floor."
 						connect_to_network()
-						src.directwired = 1
 				else
 					user << "\red You need more welding fuel to complete this task."
 			if(2)
@@ -199,7 +197,6 @@
 						state = 1
 						user << "You cut the [src] free from the floor."
 						disconnect_from_network()
-						src.directwired = 0
 				else
 					user << "\red You need more welding fuel to complete this task."
 		return

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -11,7 +11,6 @@
 	layer = TURF_LAYER
 	var/obj/machinery/power/master = null
 	anchored = 1
-	directwired = 0		// must have a cable on same turf connecting to terminal
 	layer = 2.6 // a bit above wires
 
 

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -49,7 +49,6 @@
 	density = 1
 	var/opened = 0
 	var/obj/machinery/power/compressor/compressor
-	directwired = 1
 	var/turf/simulated/outturf
 	var/lastgen
 	var/productivity = 1


### PR DESCRIPTION
- Makes machines connecting to powernets correctly call the _connect_to_network_ and _disconnect_from_network_ procs instead of directly adding the machines to the powernets.
- Removed a now unused variable

**Must be merged alongside #4063 (because the variable removed is also in solar panels and tracker)**
Note : _That's why Travis was not happy_
