### PR TITLE
Solar control refactoring

### DIFF
--- a/code/datums/sun.dm
+++ b/code/datums/sun.dm
@@ -46,54 +46,12 @@
 		dx = s/abs(s)
 		dy = c / abs(s)
 
-
-	for(var/obj/machinery/power/M in solars_list)
-
-		if(!M.powernet)
-			solars_list.Remove(M)
+	//now tell the solar control computers to update their status and linked devices
+	for(var/obj/machinery/power/solar_control/SC in solars_list)
+		if(!SC.powernet)
+			solars_list.Remove(SC)
 			continue
-
-		// Solar Tracker
-		if(istype(M, /obj/machinery/power/tracker))
-			var/obj/machinery/power/tracker/T = M
-			T.set_angle(angle)
-
-		// Solar Control
-		else if(istype(M, /obj/machinery/power/solar_control))
-			var/obj/machinery/power/solar_control/C = M
-			if(C.track == 1) //if manual tracking...
-				C.tracker_update() //...update the position (not passing an angle, it is handled internally for manual tracking)
-
-		// Solar Panel
-		else if(istype(M, /obj/machinery/power/solar))
-			var/obj/machinery/power/solar/S = M
-			if(S.control)
-				occlusion(S)
-
-
-// for a solar panel, trace towards sun to see if we're in shadow
-/datum/sun/proc/occlusion(var/obj/machinery/power/solar/S)
-
-	var/ax = S.x		// start at the solar panel
-	var/ay = S.y
-	var/turf/T = null
-
-	for(var/i = 1 to 20)		// 20 steps is enough
-		ax += dx	// do step
-		ay += dy
-
-		T = locate( round(ax,0.5),round(ay,0.5),S.z)
-
-		if(T.x == 1 || T.x==world.maxx || T.y==1 || T.y==world.maxy)		// not obscured if we reach the edge
-			break
-
-		if(T.density)			// if we hit a solid turf, panel is obscured
-			S.obscured = 1
-			return
-
-	S.obscured = 0		// if hit the edge or stepped 20 times, not obscured
-	S.update_solar_exposure()
-
+		SC.update()
 
 
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -10,7 +10,6 @@ var/list/solars_list = list()
 	icon_state = "sp_base"
 	anchored = 1
 	density = 1
-	directwired = 1
 	use_power = 0
 	idle_power_usage = 0
 	active_power_usage = 0
@@ -28,15 +27,22 @@ var/list/solars_list = list()
 	Make(S)
 	connect_to_network()
 
-/obj/machinery/power/solar/disconnect_from_network()
+/obj/machinery/power/solar/Destroy()
+	unset_control() //remove from control computer
 	..()
-	solars_list.Remove(src)
 
-/obj/machinery/power/solar/connect_to_network()
-	var/to_return = ..()
-	if(powernet) //if connected and not already in solar_list...
-		solars_list |= src			   //... add it
-	return to_return
+//set the control of the panel to a given computer if closer than SOLAR_MAX_DIST
+/obj/machinery/power/solar/proc/set_control(var/obj/machinery/power/solar_control/SC)
+	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
+		return 0
+	control = SC
+	return 1
+
+//set the control of the panel to null and removes it from the control list of the previous control computer if needed
+/obj/machinery/power/solar/proc/unset_control()
+	if(control)
+		control.connected_panels.Remove(src)
+	control = null
 
 /obj/machinery/power/solar/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)
@@ -54,7 +60,7 @@ var/list/solars_list = list()
 
 	if(istype(W, /obj/item/weapon/crowbar))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		user << "<span class='notice'>You begin to take the glass off the solar panel...</span>"
+		user.visible_message("<span class='notice'>[user] begins to take the glass off the solar panel.</span>")
 		if(do_after(user, 50))
 			var/obj/item/solar_assembly/S = locate() in src
 			if(S)
@@ -99,7 +105,7 @@ var/list/solars_list = list()
 		src.dir = angle2dir(adir)
 	return
 
-
+//calculates the fraction of the sunlight that the panel recieves
 /obj/machinery/power/solar/proc/update_solar_exposure()
 	if(!sun)
 		return
@@ -123,17 +129,19 @@ var/list/solars_list = list()
 	if(!sun || !control) //if there's no sun or the panel is not linked to a solar control computer, no need to proceed
 		return
 
-	if(obscured)	return
-
-	var/sgen = SOLARGENRATE * sunfrac
-	add_avail(sgen)
-	if(powernet && control)
-		if(powernet.nodes[control])
+	if(powernet)
+		if(powernet == control.powernet)//check if the panel is still connected to the computer
+			if(obscured) //get no light from the sun, so don't generate power
+				return
+			var/sgen = SOLARGENRATE * sunfrac
+			add_avail(sgen)
 			control.gen += sgen
-
+		else //if we're no longer on the same powernet, remove from control computer
+			unset_control()
 
 /obj/machinery/power/solar/proc/broken()
 	stat |= BROKEN
+	unset_control()
 	update_icon()
 	return
 
@@ -173,6 +181,29 @@ var/list/solars_list = list()
 /obj/machinery/power/solar/fake/process()
 	. = PROCESS_KILL
 	return
+
+//trace towards sun to see if we're in shadow
+/obj/machinery/power/solar/proc/occlusion()
+
+	var/ax = x		// start at the solar panel
+	var/ay = y
+	var/turf/T = null
+
+	for(var/i = 1 to 20)		// 20 steps is enough
+		ax += sun.dx	// do step
+		ay += sun.dy
+
+		T = locate( round(ax,0.5),round(ay,0.5),z)
+
+		if(T.x == 1 || T.x==world.maxx || T.y==1 || T.y==world.maxy)		// not obscured if we reach the edge
+			break
+
+		if(T.density)			// if we hit a solid turf, panel is obscured
+			obscured = 1
+			return
+
+	obscured = 0		// if hit the edge or stepped 20 times, not obscured
+	update_solar_exposure()
 
 
 //
@@ -258,7 +289,6 @@ var/list/solars_list = list()
 	icon_state = "solar"
 	anchored = 1
 	density = 1
-	directwired = 1
 	use_power = 1
 	idle_power_usage = 250
 	var/id = 0
@@ -269,6 +299,8 @@ var/list/solars_list = list()
 	var/track = 0			// 0= off  1=timed  2=auto (tracker)
 	var/trackrate = 600		// 300-900 seconds
 	var/nexttime = 0		// time for a panel to rotate of 1° in manual tracking
+	var/obj/machinery/power/tracker/connected_tracker = null
+	var/list/connected_panels = list()
 
 
 /obj/machinery/power/solar_control/New()
@@ -276,6 +308,13 @@ var/list/solars_list = list()
 	if(ticker)
 		initialize()
 	connect_to_network()
+
+/obj/machinery/power/solar_control/Destroy()
+	for(var/obj/machinery/power/solar/M in connected_panels)
+		M.unset_control()
+	if(connected_tracker)
+		connected_tracker.unset_control()
+	..()
 
 /obj/machinery/power/solar_control/disconnect_from_network()
 	..()
@@ -286,6 +325,39 @@ var/list/solars_list = list()
 	if(powernet) //if connected and not already in solar_list...
 		solars_list |= src //... add it
 	return to_return
+
+//search for unconnected panels and trackers in the computer powernet and connect them
+/obj/machinery/power/solar_control/proc/search_for_connected()
+	if(powernet)
+		for(var/obj/machinery/power/M in powernet.nodes)
+			if(istype(M, /obj/machinery/power/solar))
+				var/obj/machinery/power/solar/S = M
+				if(!S.control) //i.e unconnected
+					S.set_control(src)
+					connected_panels |= S
+			else if(istype(M, /obj/machinery/power/tracker))
+				if(!connected_tracker) //if there's already a tracker connected to the computer don't add another
+					var/obj/machinery/power/tracker/T = M
+					if(!T.control) //i.e unconnected
+						connected_tracker = T
+						T.set_control(src)
+
+//called by the sun controller, update the facing angle (either manually or via tracking) and rotates the panels accordingly
+/obj/machinery/power/solar_control/proc/update()
+	if(stat & (NOPOWER | BROKEN))
+		return
+
+	switch(track)
+		if(1)
+			if(trackrate) //we're manual tracking. If we set a rotation speed...
+				cdir = targetdir //...the current direction is the targetted one (and rotates panels to it)
+		if(2) // auto-tracking
+			if(connected_tracker)
+				connected_tracker.set_angle(sun.angle)
+
+	set_panels(cdir)
+	updateDialog()
+
 
 /obj/machinery/power/solar_control/initialize()
 	..()
@@ -313,9 +385,9 @@ var/list/solars_list = list()
 
 /obj/machinery/power/solar_control/interact(mob/user)
 
-	var/t = "Generated power : [round(lastgen)] W<BR>"
-	t += "<B>Orientation</B>: [rate_control(src,"cdir","[cdir]&deg",1,15)] ([angle2text(cdir)])<BR>"
-	t += "Tracking:<div class='statusDisplay'>"
+	var/t = "<B><span class='highlight'>Generated power</span></B> : [round(lastgen)] W<BR>"
+	t += "<B><span class='highlight'>Orientation</span></B>: [rate_control(src,"cdir","[cdir]&deg",1,15)] ([angle2text(cdir)])<BR>"
+	t += "<B><span class='highlight'>Tracking:</B><div class='statusDisplay'>"
 	switch(track)
 		if(0)
 			t += "<span class='linkOn'>Off</span> <A href='?src=\ref[src];track=1'>Timed</A> <A href='?src=\ref[src];track=2'>Auto</A><BR>"
@@ -325,6 +397,13 @@ var/list/solars_list = list()
 			t += "<A href='?src=\ref[src];track=0'>Off</A> <A href='?src=\ref[src];track=1'>Timed</A> <span class='linkOn'>Auto</span><BR>"
 
 	t += "Tracking Rate: [rate_control(src,"tdir","[trackrate] deg/h ([trackrate<0 ? "CCW" : "CW"])",1,30,180)]</div><BR>"
+
+	t += "<B><span class='highlight'>Connected devices:</span></B><div class='statusDisplay'>"
+
+	t += "<A href='?src=\ref[src];search_connected=1'>Search for devices</A><BR>"
+	t += "Solar panels : [connected_panels.len] connected<BR>"
+	t += "Solar tracker : [connected_tracker ? "<span class='good'>Found</span>" : "<span class='bad'>Not found</span>"]</div><BR>"
+
 	t += "<A href='?src=\ref[src];close=1'>Close</A>"
 
 	var/datum/browser/popup = new(user, "solar", name)
@@ -371,26 +450,16 @@ var/list/solars_list = list()
 	if(stat & (NOPOWER | BROKEN))
 		return
 
+	if(connected_tracker) //NOTE : handled here so that we don't add trackers to the processing list
+		if(connected_tracker.powernet != powernet)
+			connected_tracker.unset_control()
+
 	if(track==1 && trackrate) //manual tracking and set a rotation speed
 		if(nexttime <= world.time) //every time we need to increase/decrease the angle by 1°...
 			targetdir = (targetdir + trackrate/abs(trackrate) + 360) % 360 	//... do it
 			nexttime += 36000/abs(trackrate) //reset the counter for the next 1°
 
 	src.updateDialog()
-
-
-// called by solar tracker when sun position changes
-// or called by the sun controller for manual tracking updates
-/obj/machinery/power/solar_control/proc/tracker_update(var/angle)
-	if(stat & (NOPOWER | BROKEN) || track == 0)
-		return
-	if (track == 2) // auto-tracking (called by tracker.dm /set_angle)
-		cdir = angle
-	else if (trackrate) //else we're manual tracking. If we set a rotation speed...
-		cdir = targetdir //...the current direction is the targetted one (and rotates panels to it)
-	set_panels(cdir)
-	src.updateDialog()
-
 
 /obj/machinery/power/solar_control/Topic(href, href_list)
 	if(..())
@@ -416,30 +485,31 @@ var/list/solars_list = list()
 
 	if(href_list["track"])
 		track = text2num(href_list["track"])
-		if(powernet && (track == 2))
-			for(var/obj/machinery/power/tracker/T in powernet.nodes)
-				if(powernet.nodes[T])
-					T.set_angle(sun.angle)
-					break
+		if(track == 2)
+			if(connected_tracker)
+				connected_tracker.set_angle(sun.angle)
+				set_panels(cdir)
 		else if (track == 1) //begin manual tracking
 			src.targetdir = src.cdir
 			if(src.trackrate) nexttime = world.time + 36000/abs(trackrate)
 			set_panels(targetdir)
 
+	if(href_list["search_connected"])
+		src.search_for_connected()
+		if(connected_tracker && track == 2)
+			connected_tracker.set_angle(sun.angle)
+		src.set_panels(cdir)
+
 	src.updateUsrDialog()
 	return
 
-
+//rotates the panel to the passed angle
 /obj/machinery/power/solar_control/proc/set_panels(var/cdir)
-	if(!powernet) return
-	for(var/obj/machinery/power/solar/S in powernet.nodes)
-		if(powernet.nodes[S])
-			if(get_dist(S, src) < SOLAR_MAX_DIST)
-				if(!S.control)
-					S.control = src
-				S.adir = cdir //instantly rotates the panel
-				S.update_icon() //and
-				S.update_solar_exposure() //update it
+
+	for(var/obj/machinery/power/solar/S in connected_panels)
+		S.adir = cdir //instantly rotates the panel
+		S.occlusion()//and
+		S.update_icon() //update it
 
 	update_icon()
 

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -10,26 +10,33 @@
 	icon_state = "tracker"
 	anchored = 1
 	density = 1
-	directwired = 1
 	use_power = 0
 
 	var/id = 0
 	var/sun_angle = 0		// sun angle as set by sun datum
+	var/obj/machinery/power/solar_control/control = null
 
 /obj/machinery/power/tracker/New(var/turf/loc, var/obj/item/solar_assembly/S)
 	..(loc)
 	Make(S)
 	connect_to_network()
 
-/obj/machinery/power/tracker/disconnect_from_network()
+/obj/machinery/power/tracker/Destroy()
+	unset_control() //remove from control computer
 	..()
-	solars_list.Remove(src)
 
-/obj/machinery/power/tracker/connect_to_network()
-	var/to_return = ..()
-	if(powernet)	//if connected and not already in solar_list...
-		solars_list |= src				//... add it
-	return to_return
+//set the control of the tracker to a given computer if closer than SOLAR_MAX_DIST
+/obj/machinery/power/tracker/proc/set_control(var/obj/machinery/power/solar_control/SC)
+	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
+		return 0
+	control = SC
+	return 1
+
+//set the control of the tracker to null and removes it from the previous control computer if needed
+/obj/machinery/power/tracker/proc/unset_control()
+	if(control)
+		control.connected_tracker = null
+	control = null
 
 /obj/machinery/power/tracker/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)
@@ -40,27 +47,21 @@
 	S.loc = src
 	update_icon()
 
-// called by datum/sun/calc_position() as sun's angle changes
+//updates the tracker icon and the facing angle for the control computer
 /obj/machinery/power/tracker/proc/set_angle(var/angle)
 	sun_angle = angle
 
 	//set icon dir to show sun illumination
 	dir = turn(NORTH, -angle - 22.5)	// 22.5 deg bias ensures, e.g. 67.5-112.5 is EAST
 
-	// find all solar controls and update them
-	// currently, just update all controllers in world
-	// ***TODO: better communication system using network
-	if(powernet)
-		for(var/obj/machinery/power/solar_control/C in powernet.nodes)
-			if(powernet.nodes[C])
-				if(get_dist(C, src) < SOLAR_MAX_DIST)
-					C.tracker_update(angle)
+	if(powernet && (powernet == control.powernet)) //update if we're still in the same powernet
+		control.cdir = angle
 
 /obj/machinery/power/tracker/attackby(var/obj/item/weapon/W, var/mob/user)
 
 	if(istype(W, /obj/item/weapon/crowbar))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		user << "<span class='notice'>You begin to take the glass off the solar tracker...</span>"
+		user.visible_message("<span class='notice'>[user] begins to take the glass off the solar tracker.</span>")
 		if(do_after(user, 50))
 			var/obj/item/solar_assembly/S = locate() in src
 			if(S)


### PR DESCRIPTION
Switched the control and handling of the solar panels and trackers to the Solar Control Computers instead of the Sun controller.

**Player-wise :**
You must manually check for connected panels and tracker (yeah one tracker per computer, no need for hoarding) after the wiring.
Some cosmetics adjustments to the computer panel.

**Images :**
![solar_refact_1](https://cloud.githubusercontent.com/assets/7117411/3484755/ee3785e8-03b4-11e4-9e5b-c0b0216cdaba.PNG)
![solar_refact_2](https://cloud.githubusercontent.com/assets/7117411/3484756/eeec6d32-03b4-11e4-8b33-6e28bdd12012.PNG)

**Code-wise :**
- Solar Control Computers now have a list containing all connected panels and a variable with connected tracker. They now handle updating them every sun controller update (~one game minute),
- the manual updating is done so that we don't recheck for new panels/tracker in a powernet each time someone fiddles with the wires,
- panels/tracker is only connected if closer then a set distance (40 squares by default),
- panels/tracker are automatically removed from the controller computer if they arere disconnected (i.e are in another powernet),
- the tracker, if connected, now only set the facing angle of the computer,
- the panels are, then, rotated to this angle and the power generated is updated,
- the solar_list now only contains Solar Control Computers (so instead of going through every panel, trackers and computers each Sun update, we only check for Computers).
  Uncontrolled panels and trackers are now ignored.
- removed listing all nodes in a powernet for trackers/panels/control_computers/etc,
- added procs for handling control setting/unsetting,
- that fix some bugs with not updated/weird behavior of solar panels,
- the check for _if_obscured_ is now a solar panel proc (instead of a Sun datum one),
