### PR TITLE
Fixes #4073

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -515,10 +515,6 @@
 
 // Harvest an animal's delicious byproducts
 /mob/living/simple_animal/proc/harvest()
-	new meat_type (get_turf(src))
-	if(prob(95))
-		qdel(src)
-		return
 	gib()
 	return
 


### PR DESCRIPTION
*Removes the 95% probability chance of any attempt to harvest meat from various simple animals to fail after dropping one meat. This also means the gib animation will always properly play (provided it exists).

*Fixes #4073

*Meat spawning removed from harvest(), it's always been handled in gib. Harvest still exists due to some overrides on how it works for certain animals (mostly spiders)

*Fixes #4073

*Keeps me marginally relevant ヽ༼ຈل͜ຈ༽ﾉ

*Fixes #4073
