### PR TITLE
Space, drift, diagonal drift, throws, diagonal throws. Small fix for #4084.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -155,6 +155,9 @@
 			return
 		spawn(5)
 			if((M && !(M.anchored) && (M.loc == src)))
+				if(M.inertia_dir & M.last_move)
+					step(M, M.inertia_dir)
+					return
 				M.inertia_dir = M.last_move
 				step(M, M.inertia_dir)
 	return


### PR DESCRIPTION
Spess is weird. This seems to fix most weirdness with throwing something, being thrown, being thrown and hitting something, slipping, and rarh blargarh rargargarararhblarharh

In essence, inertia_dir can be diagonal, while last_move can't. Previously, it only checked if inertia_dir existed, and ignored last_move if it did, which caused weirdness with being thrown, which didn't update inertia_dir, so you floated randomly once you hit something. Now it will check if inertia_dir is roughly in the same direction as last_move, and if not, then last_move takes priority.

Thing is, if we are floating diagonally, our inertia dir is pointing diagonally, e.g. 9, and last_move is one of straight components of diagonal move, e.g. 8. And since 9 & 8 = 8, it will be OK. But if inertia is, e.g. 9, and last_move is suddenly 4, we obviously were moved by something else and should change direction we are floating... Unless I missed something else, but I think I didn't. I think.

Everything is strange and will need a proper rework eventually.

Fixes #4084.
