### PR TITLE
Roman fix for issue #4101 Fixed #4101

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -31,7 +31,6 @@
 	icon_state = "roman"
 	item_color = "roman"
 	item_state = "armor"
-	armor = list(melee = 25, bullet = 0, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/under/waiter
 	name = "waiter's outfit"


### PR DESCRIPTION
This fixes issue #4101 by removing the armor stats from the roman armor jumpsuit which you could get from the costume vendor. Really, 25 brute, 25 laser, 10 taser protection? Fixed #4101 
