### PR TITLE
Smartfridge item name sanitation and unpowered icon fixes

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -16,11 +16,11 @@
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
 	var/item_quants = list()
-/*
+
 /obj/machinery/smartfridge/power_change()
 	..()
 	update_icon()
-*/
+
 /obj/machinery/smartfridge/update_icon()
 	if(!stat)
 		icon_state = icon_on
@@ -135,17 +135,18 @@
 		for (var/O in item_quants)
 			if(item_quants[O] > 0)
 				var/N = item_quants[O]
+				var/itemName = sanitize(O)
 				dat += "<FONT color = 'blue'><B>[capitalize(O)]</B>:"
 				dat += " [N] </font>"
-				dat += "<a href='byond://?src=\ref[src];vend=[O];amount=1'>Vend</A> "
+				dat += "<a href='byond://?src=\ref[src];vend=[itemName];amount=1'>Vend</A> "
 				if(N > 5)
-					dat += "(<a href='byond://?src=\ref[src];vend=[O];amount=5'>x5</A>)"
+					dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=5'>x5</A>)"
 					if(N > 10)
-						dat += "(<a href='byond://?src=\ref[src];vend=[O];amount=10'>x10</A>)"
+						dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=10'>x10</A>)"
 						if(N > 25)
-							dat += "(<a href='byond://?src=\ref[src];vend=[O];amount=25'>x25</A>)"
+							dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=25'>x25</A>)"
 				if(N > 1)
-					dat += "(<a href='?src=\ref[src];vend=[O];amount=[N]'>All</A>)"
+					dat += "(<a href='?src=\ref[src];vend=[itemName];amount=[N]'>All</A>)"
 
 				dat += "<br>"
 


### PR DESCRIPTION
Sanitizes the item names in the smartfridge interface so single-quotes no longer render items un-vendable.  Applies to chem and virology fridges as well.  Fixes #3973 fixes #3377

Also uncomments the power_change method so the fridges use the unpowered sprite when appropriate.
