### PR TITLE
Spinning

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -300,13 +300,15 @@
 		if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
 			return 0
 		if(!M.lying)
+			var/olddir = M.dir
+			M.Stun(s_amount)
+			M.Weaken(w_amount)
 			M.stop_pulling()
-			if(lube&STEP)
-				step(M, M.dir)
 			if(lube&SLIDE)
 				for(var/i=1, i<5, i++)
 					spawn (i)
-						step(M, M.dir)
+						step(M, olddir)
+						M.spin(1,1)
 				if(M.lying) //did I fall over?
 					M.adjustBruteLoss(2)
 			if(O)
@@ -314,7 +316,5 @@
 			else
 				M << "<span class='notice'>You slipped!</span>"
 			playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-			M.Stun(s_amount)
-			M.Weaken(w_amount)
 			return 1
 	return 0 // no success. Used in clown pda and wet floors

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -16,9 +16,9 @@
 		else //if(lying != 0)
 			if(lying_prev == 0) //Standing to lying
 				final_pixel_y -= 6
+				if(dir & (EAST|WEST)) //Facing east or west
+					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 
-		if(dir & (EAST|WEST)) //Facing east or west
-			final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 		lying_prev = lying	//so we don't try to animate until there's been another change.
 
 	if(changed)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -543,9 +543,11 @@
 		var/mob/living/carbon/CM = L
 		if(CM.on_fire && CM.canmove)
 			CM.fire_stacks -= 5
-			CM.weakened = 5
+			CM.Weaken(3)
+			CM.spin(32,2)
 			CM.visible_message("<span class='danger'>[CM] rolls on the floor, trying to put themselves out!</span>", \
 				"<span class='notice'>You stop, drop, and roll!</span>")
+			sleep(30)
 			if(fire_stacks <= 0)
 				CM.visible_message("<span class='danger'>[CM] has successfully extinguished themselves!</span>", \
 					"<span class='notice'>You extinguish yourself.</span>")
@@ -560,6 +562,23 @@
 				else
 					cuff_resist(CM.legcuffed, CM)
 
+/mob/living/carbon/proc/spin(spintime, speed)
+	spawn()
+		var/D = dir
+		while(spintime >= speed)
+			sleep(speed)
+			switch(D)
+				if(NORTH)
+					D = EAST
+				if(SOUTH)
+					D = WEST
+				if(EAST)
+					D = SOUTH
+				if(WEST)
+					D = NORTH
+			dir = D
+			spintime -= speed
+	return
 
 /mob/living/proc/get_visible_name()
 	return name

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -645,28 +645,28 @@ var/list/slot_equipment_priority = list( \
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 //Robots and brains have their own version so don't worry about them
 /mob/proc/update_canmove()
-        var/ko = weakened || paralysis || stat || (status_flags & FAKEDEATH)
-        var/bed = !(buckled && istype(buckled, /obj/structure/stool/bed/chair))
-        if(ko || resting || stunned)
-                drop_r_hand()
-                drop_l_hand()
-        else
-                lying = 0
-                canmove = 1
-        if(buckled)
-                lying = 90 * bed
-                anchored = buckled
-        else
-                if((ko || resting) && !lying)
-                        fall(ko)
-        canmove = !(ko || resting || stunned || buckled)
-        density = !lying
-        update_transform()
-        lying_prev = lying
-        if(update_icon) //forces a full overlay update
-                update_icon = 0
-                regenerate_icons()
-        return canmove
+	var/ko = weakened || paralysis || stat || (status_flags & FAKEDEATH)
+	var/bed = !(buckled && istype(buckled, /obj/structure/stool/bed/chair))
+	if(ko || resting || stunned)
+		drop_r_hand()
+		drop_l_hand()
+	else
+		lying = 0
+		canmove = 1
+	if(buckled)
+		lying = 90 * bed
+		anchored = buckled
+	else
+		if((ko || resting) && !lying)
+			fall(ko)
+	canmove = !(ko || resting || stunned || buckled)
+	density = !lying
+	update_transform()
+	lying_prev = lying
+	if(update_icon) //forces a full overlay update
+		update_icon = 0
+		regenerate_icons()
+	return canmove
 
 /mob/proc/fall(var/forced)
 	drop_l_hand()


### PR DESCRIPTION
![posta3](https://cloud.githubusercontent.com/assets/701959/3521719/6636c86a-0743-11e4-8dfd-09dc82dd30db.gif)

Added a spinning visual effect to rolling on the floor to extinguish yourself in case of a fire.
Lube will now make you spin while you're slipping.
Water will make you slip on the spot and won't move you forward.
Fixed the bug of wrong mob directions when buckling them while they are lying down.
