### PR TITLE
Fixes pAI SecHUDs

### DIFF
--- a/code/modules/mob/living/silicon/pai/hud.dm
+++ b/code/modules/mob/living/silicon/pai/hud.dm
@@ -26,7 +26,7 @@
 						if("Parolled")		holder.icon_state = "hudparolled"
 						if("Discharged")		holder.icon_state = "huddischarged"
 						else
-							return
+							continue
 					client.images += holder
 
 /mob/living/silicon/pai/proc/medicalHUD()


### PR DESCRIPTION
Replaces "return" with "continue" on line 29. "return" was prematurely terminating the loop, causing pAIs to only see one or a few HUD icons at a time.

I plan to extend these HUDs to the AI in the future, after the freeze.
