### PR TITLE
Fixes tray layer issue

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -306,14 +306,14 @@
 /obj/item/weapon/storage/bag/tray/proc/rebuild_overlays()
 	overlays.Cut()
 	for(var/obj/item/I in contents)
-		overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = 30 + I.layer)
+		overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = -1)
 
 /obj/item/weapon/storage/bag/tray/remove_from_storage(obj/item/W as obj, atom/new_location)
 	..()
 	rebuild_overlays()
 
 /obj/item/weapon/storage/bag/tray/handle_item_insertion(obj/item/I, prevent_warning = 0)
-	overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = 30 + I.layer)
+	overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = -1)
 	..()
 
 


### PR DESCRIPTION
Changes the layer for items on trays to -1.

This fixes issue #1919 where tray contents were showing up above flash overlays, people, and other stuff (despite the tray itself being underneath those things).
