### PR TITLE
Changes faction to list

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -143,4 +143,4 @@
 	ticker.mode.syndicates += R.mind
 	ticker.mode.update_synd_icons_added(R.mind)
 	R.mind.special_role = "syndicate"
-	R.faction = "syndicate"
+	R.faction = list("syndicate")

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -49,7 +49,7 @@
 	attack_sound = 'sound/weapons/genhit1.ogg'
 	var/obj/effect/blob/factory/factory = null
 	var/is_zombie = 0
-	faction = "blob"
+	faction = list("blob")
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -9,7 +9,7 @@
 	invisibility = INVISIBILITY_OBSERVER
 
 	pass_flags = PASSBLOB
-	faction = "blob"
+	faction = list("blob")
 
 	var/obj/effect/blob/core/blob_core = null // The blob overmind's core
 	var/blob_points = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -217,7 +217,7 @@
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
-	synd_mob.faction = "syndicate"
+	synd_mob.faction |= "syndicate"
 	synd_mob.update_icons()
 	return 1
 

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -168,6 +168,7 @@
 
 proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/target, var/mob/stoner = null, cultoverride = 0)
 	var/mob/living/simple_animal/construct/newstruct = new ctype(get_turf(target))
+	newstruct.faction |= "\ref[stoner]"
 	newstruct.key = target.key
 	if(stoner && iscultist(stoner) || cultoverride)
 		if(ticker.mode.name == "cult")
@@ -196,6 +197,7 @@ proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/targ
 	S.name = "Shade of [T.real_name]"
 	S.real_name = "Shade of [T.real_name]"
 	S.key = T.key
+	S.faction |= "\ref[U]" //Add the master as a faction, allowing inter-mob cooperation
 	if(iscultist(U))
 		ticker.mode.add_cultist(S.mind,2)
 	S.cancel_camera()

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -580,12 +580,12 @@
 	var/list/pos_targets = list()
 	var/target = null
 	for(var/mob/living/M in view(scan_range,src))
-		if(M.stat || faction == M.faction)
+		if(M.stat || faction in M.faction)
 			continue
 		pos_targets += M
 	for(var/obj/mecha/M in oview(scan_range, src))
 		if(M.occupant)
-			if(faction == M.occupant.faction)
+			if(faction in M.occupant.faction)
 				continue
 		if(!M.occupant)
 			continue //Don't shoot at empty mechs.

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -580,7 +580,9 @@
 	var/list/pos_targets = list()
 	var/target = null
 	for(var/mob/living/M in view(scan_range,src))
-		if(M.stat || faction in M.faction)
+		if(M.stat)
+			continue
+		if(faction in M.faction)
 			continue
 		pos_targets += M
 	for(var/obj/mecha/M in oview(scan_range, src))

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -53,7 +53,7 @@
 		for(var/obj/machinery/vending/upriser in infectedMachines)
 			if(prob(70))
 				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
-				M.faction = "profit"
+				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15
 			else

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -457,7 +457,7 @@
 	status_flags = CANSTUN|CANWEAKEN|CANPUSH
 	stop_automated_movement_when_pulled = 1
 	mouse_opacity = 1
-	faction = "neutral"
+	faction = list("neutral")
 	a_intent = "harm"
 	min_oxy = 0
 	max_oxy = 0
@@ -601,12 +601,12 @@
 		if(istype(target, /mob/living/simple_animal))
 			var/mob/living/simple_animal/M = target
 			if(M.stat == DEAD)
-				M.faction = "neutral"
+				M.faction = list("neutral")
 				M.revive()
 				if(istype(target, /mob/living/simple_animal/hostile))
 					var/mob/living/simple_animal/hostile/H = M
 					if(malfunctioning)
-						M.faction = "lazarus"
+						M.faction = list("lazarus")
 						H.friends += user
 						H.attack_same = 1
 						log_game("[user] has revived hostile mob [target] with a malfunctioning lazarus injector")

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -10,7 +10,7 @@
 	icon = 'icons/mob/alien.dmi'
 	gender = NEUTER
 	dna = null
-	faction = "alien"
+	faction = list("alien")
 	ventcrawler = 2
 
 	var/storedPlasma = 250

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1075,7 +1075,7 @@
 	lawupdate = 0
 	scrambledcodes = 1
 	modtype = "Synd"
-	faction = "syndicate"
+	faction = list("syndicate")
 	designation = "Syndicate"
 
 /mob/living/silicon/robot/syndicate/New(loc)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -24,7 +24,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
-	faction = "cult"
+	faction = list("cult")
 	var/list/construct_spells = list()
 	var/playstyle_string = "<B>You are a generic construct! Your job is to not exist.</B>"
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -17,7 +17,8 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
-	faction = "goat"
+	faction = list("neutral")
+	attack_same = 1
 	attacktext = "kicks"
 	health = 40
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -28,7 +28,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
-	faction = "alien"
+	faction = list("alien")
 	status_flags = CANPUSH
 	minbodytemp = 0
 	heat_damage_per_tick = 20

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -38,7 +38,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 
-	faction = "russian"
+	faction = list("russian")
 
 //SPACE BEARS! SQUEEEEEEEE~     OW! FUCK! IT BIT MY HAND OFF!!
 /mob/living/simple_animal/hostile/bear/Hudson

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -35,7 +35,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 
-	faction = "carp"
+	faction = list("carp")
 
 /mob/living/simple_animal/hostile/carp/Process_Spacemove(var/check_drift = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -11,5 +11,5 @@
 	melee_damage_upper = 50
 	attacktext = "chomps"
 	attack_sound = 'sound/weapons/bite.ogg'
-	faction = "creature"
+	faction = list("creature")
 

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -29,7 +29,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	faction = "faithless"
+	faction = list("faithless")
 
 /mob/living/simple_animal/hostile/faithless/Process_Spacemove(var/check_drift = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -30,7 +30,7 @@
 	cold_damage_per_tick = 20
 	var/poison_per_bite = 5
 	var/poison_type = "toxin"
-	faction = "spiders"
+	faction = list("spiders")
 	var/busy = 0
 	pass_flags = PASSTABLE
 	move_to_delay = 6

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -16,7 +16,7 @@
 	attacktext = "claws"
 	projectilesound = 'sound/weapons/Gunshot.ogg'
 	projectiletype = /obj/item/projectile/hivebotbullet
-	faction = "hivebot"
+	faction = list("hivebot")
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile
-	faction = "hostile"
+	faction = list("hostile")
 	stop_automated_movement_when_pulled = 0
 	environment_smash = 1 //Set to 1 to break closets,tables,racks, etc; 2 for walls; 3 for rwalls
 	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
@@ -25,7 +25,6 @@
 	var/list/wanted_objects = list() //A list of objects that will be checked against to attack, should we have search_objects enabled
 	var/stat_attack = 0 //Mobs with stat_attack to 1 will attempt to attack things that are unconscious, Mobs with stat_attack set to 2 will attempt to attack the dead.
 	var/stat_exclusive = 0 //Mobs with this set to 1 will exclusively attack things defined by stat_attack, stat_attack 2 means they will only attack corpses
-	var/attack_faction = null //Put a faction string here to have a mob only ever attack a specific faction
 
 /mob/living/simple_animal/hostile/Life()
 
@@ -107,7 +106,12 @@
 		var/mob/living/L = the_target
 		if(L.stat > stat_attack || L.stat != stat_attack && stat_exclusive == 1)
 			return 0
-		if(L.faction == src.faction && !attack_same || L.faction != src.faction && attack_same == 2 || L.faction != attack_faction && attack_faction)
+		var/faction_check = 0
+		for(var/F in faction)
+			if(F in L.faction)
+				faction_check = 1
+				break
+		if(faction_check && !attack_same || !faction_check && attack_same == 2)
 			return 0
 		if(L in friends)
 			return 0

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -17,7 +17,7 @@
 	melee_damage_upper = 12
 	attacktext = "slams"
 	ventcrawler = 2
-	faction = "plants"
+	faction = list("plants")
 
 	min_oxy = 5
 	max_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -33,7 +33,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	faction = "mimic"
+	faction = list("mimic")
 	move_to_delay = 9
 
 /mob/living/simple_animal/hostile/mimic/FindTarget()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -161,7 +161,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	if(owner != creator)
 		LoseTarget()
 		creator = owner
-		faction = "\ref[owner]"
+		faction |= "\ref[owner]"
 
 /mob/living/simple_animal/hostile/mimic/copy/proc/CheckObject(var/obj/O)
 	if((istype(O, /obj/item) || istype(O, /obj/structure)) && !is_type_in_list(O, protected_objects))
@@ -196,7 +196,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		maxHealth = health
 		if(creator)
 			src.creator = creator
-			faction = "\ref[creator]" // very unique
+			faction = list("\ref[creator]") // very unique
 		if(destroy_original)
 			qdel(O)
 		return 1

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -9,7 +9,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
-	faction = "mining"
+	faction = list("mining")
 	environment_smash = 2
 	minbodytemp = 0
 	heat_damage_per_tick = 20

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -17,7 +17,7 @@
 	melee_damage_upper = 1
 	attack_same = 2
 	attacktext = "chomps"
-	faction = "mushroom"
+	faction = list("mushroom")
 	environment_smash = 0
 	stat_attack = 2
 	mouse_opacity = 1

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -32,7 +32,7 @@
 	var/corpse = /obj/effect/landmark/mobcorpse/pirate
 	var/weapon1 = /obj/item/weapon/melee/energy/sword/pirate
 
-	faction = "pirate"
+	faction = list("pirate")
 
 /mob/living/simple_animal/hostile/pirate/ranged
 	name = "Pirate Gunner"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -20,7 +20,7 @@
 	melee_damage_upper = 5
 	attacktext = "bites"
 	pass_flags = PASSTABLE
-	faction = "carp"
+	faction = list("hostile")
 	attack_sound = 'sound/weapons/bite.ogg'
 	environment_smash = 0
 	ventcrawler = 2

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -31,7 +31,12 @@
 			continue
 		if(isliving(A))
 			var/mob/living/M = A
-			if(!attack_same && M.faction != faction)
+			var/faction_check = 0
+			for(var/F in faction)
+				if(F in M.faction)
+					faction_check = 1
+					break
+			if(faction_check && attack_same || !faction_check)
 				enemies |= M
 		else if(istype(A, /obj/mecha))
 			var/obj/mecha/M = A
@@ -40,7 +45,12 @@
 				enemies |= M.occupant
 
 	for(var/mob/living/simple_animal/hostile/retaliate/H in around)
-		if(!attack_same && !H.attack_same && H.faction == faction)
+		var/retaliate_faction_check = 0
+		for(var/F in faction)
+			if(F in H.faction)
+				retaliate_faction_check = 1
+				break
+		if(retaliate_faction_check && !attack_same && !H.attack_same)
 			H.enemies |= enemies
 	return 0
 

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -30,7 +30,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
-	faction = "russian"
+	faction = list("russian")
 	status_flags = CANPUSH
 
 

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -33,7 +33,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	faction = "statue"
+	faction = list("statue")
 	move_to_delay = 0 // Very fast
 
 	animate_movement = NO_STEPS // Do not animate movement, you jump around as you're a scary statue.

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -31,7 +31,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	unsuitable_atoms_damage = 15
-	faction = "syndicate"
+	faction = list("syndicate")
 	status_flags = CANPUSH
 
 /mob/living/simple_animal/hostile/syndicate/Die()
@@ -147,7 +147,7 @@
 	melee_damage_upper = 15
 	attacktext = "cuts"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	faction = "syndicate"
+	faction = list("syndicate")
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -35,7 +35,7 @@
 	max_n2 = 0
 	minbodytemp = 0
 
-	faction = "carp"
+	faction = list("hostile")
 
 /mob/living/simple_animal/hostile/tree/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -24,7 +24,7 @@
 	speed = -1
 	stop_automated_movement = 1
 	status_flags = 0
-	faction = "cult"
+	faction = list("cult")
 	status_flags = CANPUSH
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -124,7 +124,7 @@
 	var/voice_message = null // When you are not understood by others (replaced with just screeches, hisses, chimpers etc.)
 	var/say_message = null // When you are understood by others. Currently only used by aliens and monkeys in their say_quote procs
 
-	var/faction = "neutral" //Used for checking whether hostile simple animals will attack you, possibly more stuff later
+	var/list/faction = list("neutral") //A list of factions that this mob is currently in, for hostile mob targetting, amongst other things
 	var/move_on_shuttle = 1 // Can move on the shuttle.
 
 //The last mob/living/carbon to push/drag/grab this mob (mostly used by slimes friend recognition)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -237,7 +237,7 @@ proc/wabbajack(mob/living/M)
 			for(var/mob/living/carbon/human/H in change.contents)
 				var/mob/living/simple_animal/hostile/statue/S = new /mob/living/simple_animal/hostile/statue(change.loc, firer)
 				S.name = "statue of [H.name]"
-				S.faction = "\ref[firer]"
+				S.faction = firer.faction
 				S.icon = change.icon
 				if(H.mind)
 					H.mind.transfer_to(S)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -237,7 +237,7 @@ proc/wabbajack(mob/living/M)
 			for(var/mob/living/carbon/human/H in change.contents)
 				var/mob/living/simple_animal/hostile/statue/S = new /mob/living/simple_animal/hostile/statue(change.loc, firer)
 				S.name = "statue of [H.name]"
-				S.faction = firer.faction
+				S.faction = list("\ref[firer]")
 				S.icon = change.icon
 				if(H.mind)
 					H.mind.transfer_to(S)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1055,7 +1055,7 @@ datum/chemical_reaction/pestkiller
 			for(var/i = 1, i <= 5, i++)
 				var/chosen = pick(critters)
 				var/mob/living/simple_animal/hostile/C = new chosen
-				C.faction = "slimesummon"
+				C.faction = list("slimesummon")
 				C.loc = get_turf(holder.my_atom)
 				if(prob(50))
 					for(var/j = 1, j <= rand(1, 3), j++)
@@ -1109,7 +1109,7 @@ datum/chemical_reaction/pestkiller
 
 			var/chosen = pick(critters)
 			var/mob/living/simple_animal/hostile/C = new chosen
-			C.faction = "neutral"
+			C.faction = list("neutral")
 			C.loc = get_turf(holder.my_atom)
 
 //Silver

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1055,7 +1055,7 @@ datum/chemical_reaction/pestkiller
 			for(var/i = 1, i <= 5, i++)
 				var/chosen = pick(critters)
 				var/mob/living/simple_animal/hostile/C = new chosen
-				C.faction = list("slimesummon")
+				C.faction |= "slimesummon"
 				C.loc = get_turf(holder.my_atom)
 				if(prob(50))
 					for(var/j = 1, j <= rand(1, 3), j++)
@@ -1109,7 +1109,7 @@ datum/chemical_reaction/pestkiller
 
 			var/chosen = pick(critters)
 			var/mob/living/simple_animal/hostile/C = new chosen
-			C.faction = list("neutral")
+			C.faction |= "neutral"
 			C.loc = get_turf(holder.my_atom)
 
 //Silver


### PR DESCRIPTION
-Changes factions to list because single factions are dumb and clunky, if you're in at least one of the same factions as the hostile mob, it will ignore you, IE: If you made a mob that was "syndicate" and "neutral" it would ignore people with either "syndicate" or "neutral" in their faction list, but create a mob that just has "syndicate" and it will ignore just syndies while attacking neutrals. This is to stop you from hunting down Nook Ops with Lazarus/GoldSlime/MiningDrones
-Removes the attack_faction from hostile mobs because it wouldve made another list search necessary and nobody uses it anyway
-Makes nook ops both "neutral" and "syndicate" so that mining bots/lazarus mobs/blood slime mobs ignore them, but viscerators do too
-Changes Goats to "neutral" but gives them attack_same = 1, so that the great Mining Drone / Goat wars stop, functionality is otherwise unchanged
-Changes Trees and Bats to "hostile" faction because they were just copypasta'd carp entries and had the "carp" faction as a result

Fixes #3992 
Fixes #2900 
Fixes #4173 
