### PR TITLE
Makes camera lights not broken

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -18,7 +18,6 @@
 	var/invuln = null
 	var/obj/item/device/camera_bug/bug = null
 	var/obj/item/weapon/camera_assembly/assembly = null
-	var/light_on = 0
 
 	//OTHER
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -18,6 +18,7 @@
 	var/invuln = null
 	var/obj/item/device/camera_bug/bug = null
 	var/obj/item/weapon/camera_assembly/assembly = null
+	var/light_on = 0
 
 	//OTHER
 
@@ -339,3 +340,13 @@
 		return 1
 	busy = 0
 	return 0
+
+/obj/machinery/camera/proc/toggle_light()
+	light_on = !light_on
+	
+	if (light_on)
+		SetLuminosity(AI_CAMERA_LUMINOSITY)
+	else
+		SetLuminosity(0)
+
+	return light_on

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -341,12 +341,10 @@
 	busy = 0
 	return 0
 
-/obj/machinery/camera/proc/toggle_light()
-	light_on = !light_on
-	
-	if (light_on)
+/obj/machinery/camera/proc/check_AI_light(var/mob/living/silicon/ai/AI)
+	if ((src in range(6, AI.eyeobj)) && AI.camera_light_on && !light_disabled)
 		SetLuminosity(AI_CAMERA_LUMINOSITY)
+		spawn (5)
+			check_AI_light(AI)
 	else
 		SetLuminosity(0)
-
-	return light_on

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -340,11 +340,3 @@
 		return 1
 	busy = 0
 	return 0
-
-/obj/machinery/camera/proc/check_AI_light(var/mob/living/silicon/ai/AI)
-	if ((src in range(6, AI.eyeobj)) && AI.camera_light_on && !light_disabled)
-		SetLuminosity(AI_CAMERA_LUMINOSITY)
-		spawn (5)
-			check_AI_light(AI)
-	else
-		SetLuminosity(0)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -427,6 +427,8 @@ var/list/ai_list = list()
 		updatehealth()
 
 /mob/living/silicon/ai/reset_view(atom/A)
+	if (camera_light_on)
+		light_cameras()
 	if(istype(A,/obj/machinery/camera))
 		current = A
 	..()
@@ -638,6 +640,11 @@ var/list/ai_list = list()
 
 	if (!camera_light_on)
 		src << "Camera lights deactivated."
+
+		for (var/obj/machinery/camera/C in lit_cameras)
+			C.SetLuminosity(0)
+			lit_cameras = list()
+
 		return
 
 	light_cameras()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -46,7 +46,6 @@ var/list/ai_list = list()
 
 	var/mob/living/silicon/ai/parent = null
 
-	var/camera_light_on = 0	//Defines if the AI toggled the light on the camera it's looking through.
 	var/datum/trackable/track = null
 
 	var/last_paper_seen = null
@@ -426,14 +425,9 @@ var/list/ai_list = list()
 		updatehealth()
 
 /mob/living/silicon/ai/reset_view(atom/A)
-	if(current)
-		current.SetLuminosity(0)
 	if(istype(A,/obj/machinery/camera))
 		current = A
 	..()
-	if(istype(A,/obj/machinery/camera))
-		if(camera_light_on)	A.SetLuminosity(AI_CAMERA_LUMINOSITY)
-		else				A.SetLuminosity(0)
 
 
 /mob/living/silicon/ai/proc/switchCamera(var/obj/machinery/camera/C)
@@ -634,41 +628,11 @@ var/list/ai_list = list()
 		return
 	apc.malfvacate()
 
-//Toggles the luminosity and applies it by re-entereing the camera.
 /mob/living/silicon/ai/proc/toggle_camera_light()
 	if(stat != CONSCIOUS)
 		return
-
-	camera_light_on = !camera_light_on
-	src << "Camera lights [camera_light_on ? "activated" : "deactivated"]."
-	if(!camera_light_on)
-		if(src.current)
-			src.current.SetLuminosity(0)
-	else
-		src.lightNearbyCamera()
-
-
-
-// Handled camera lighting, when toggled.
-// It will get the nearest camera from the eyeobj, lighting it.
-
-/mob/living/silicon/ai/proc/lightNearbyCamera()
-	if(camera_light_on && camera_light_on < world.timeofday)
-		if(src.current)
-			var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
-			if(camera && src.current != camera)
-				src.current.SetLuminosity(0)
-				if(!camera.light_disabled)
-					src.current = camera
-					src.current.SetLuminosity(AI_CAMERA_LUMINOSITY)
-				else
-					src.current = null
-			else if(isnull(camera))
-				src.current.SetLuminosity(0)
-				src.current = null
-		else
-			var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
-			if(camera && !camera.light_disabled)
-				src.current = camera
-				src.current.SetLuminosity(AI_CAMERA_LUMINOSITY)
-		camera_light_on = world.timeofday + 1 * 20 // Update the light every 2 seconds.
+	var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
+	if (camera)
+		var/t = camera.toggle_light()
+		src << "Camera lights [t ? "activated" : "deactivated"]."
+	return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -45,6 +45,7 @@ var/list/ai_list = list()
 	var/explosive = 0 //does the AI explode when it dies?
 
 	var/mob/living/silicon/ai/parent = null
+	var/camera_light_on = 0
 
 	var/datum/trackable/track = null
 
@@ -631,8 +632,30 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/proc/toggle_camera_light()
 	if(stat != CONSCIOUS)
 		return
-	var/obj/machinery/camera/camera = near_range_camera(src.eyeobj)
-	if (camera)
-		var/t = camera.toggle_light()
-		src << "Camera lights [t ? "activated" : "deactivated"]."
+
+	camera_light_on = !camera_light_on
+
+	if (!camera_light_on)
+		src << "Camera lights deactivated."
+		return
+
+	light_cameras()
+
+	src << "Camera lights activated."
 	return
+
+/mob/living/silicon/ai/proc/light_cameras()
+	if (!camera_light_on)
+		return
+
+	for(var/obj/machinery/camera/C in range(7, src.eyeobj))
+		if (!C.can_use())
+			continue
+		if (C.luminosity > 0)
+			continue
+		if (C.light_disabled)
+			continue
+		C.check_AI_light(src)
+
+	spawn (5)
+		light_cameras()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -90,6 +90,8 @@
 
 	//user.unset_machine() //Uncomment this if it causes problems.
 	//user.lightNearbyCamera()
+	if (user.camera_light_on)
+		user.light_cameras()
 
 
 // Return to the Core.


### PR DESCRIPTION
Aka OfCamerasAndLights

Removes the HORRIBLE MESS that is a leftover from the time before time.

Now, when you press on 'toggle camera lights' button, you light up all cameras near your eye, and it updates when you move your eye.
