### PR TITLE
Fix for #4052: Chaplain's bible spawn easily breaks.

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -19,11 +19,6 @@ var/round_start_time = 0
 
 	var/list/datum/mind/minds = list()//The people in the game. Used for objective tracking.
 
-	var/Bible_icon_state	// icon_state the chaplain has chosen for his bible
-	var/Bible_item_state	// item_state the chaplain has chosen for his bible
-	var/Bible_name			// name of the bible
-	var/Bible_deity_name
-
 	var/list/syndicate_coalition = list() // list of traitor-compatible factions
 	var/list/factions = list()			  // list of all factions
 	var/list/availablefactions = list()	  // list of factions with openings

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -2,6 +2,9 @@
 /*
 Chaplain
 */
+
+//CHAPLAIN SETUP MOVED TO /items/weapons/storage/book.dm!
+
 /datum/job/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN
@@ -18,131 +21,12 @@ Chaplain
 	access = list(access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels)
 	minimal_access = list(access_morgue, access_chapel_office, access_crematorium)
 
-	//Pretty bible names
-	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
-
-	//Bible iconstates
-	var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
-	//Bible itemstates
-	var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
-/datum/job/chaplain/proc/setupbiblespecifics(var/obj/item/weapon/storage/book/bible/B, var/mob/living/carbon/human/H)
-	switch(B.icon_state)
-		if("honk1","honk2")
-			new /obj/item/weapon/grown/bananapeel(B)
-			new /obj/item/weapon/grown/bananapeel(B)
-
-			if(B.icon_state == "honk1")
-				H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), slot_wear_mask)
-
-		if("bible")
-			for(var/area/chapel/main/A in world)
-				for(var/turf/T in A.contents)
-					if(T.icon_state == "carpetsymbol")
-						T.dir = 2
-		if("koran")
-			for(var/area/chapel/main/A in world)
-				for(var/turf/T in A.contents)
-					if(T.icon_state == "carpetsymbol")
-						T.dir = 4
-		if("scientology")
-			for(var/area/chapel/main/A in world)
-				for(var/turf/T in A.contents)
-					if(T.icon_state == "carpetsymbol")
-						T.dir = 8
-		if("athiest")
-			for(var/area/chapel/main/A in world)
-				for(var/turf/T in A.contents)
-					if(T.icon_state == "carpetsymbol")
-						T.dir = 10
-
-/datum/job/chaplain/Topic(href, href_list)
-	if(href_list["seticon"])
-		var/iconi = text2num(href_list["seticon"])
-
-		var/biblename = biblenames[iconi]
-		var/obj/item/weapon/storage/book/bible/B = locate(href_list["bible"])
-
-		B.icon_state = biblestates[iconi]
-		B.item_state = bibleitemstates[iconi]
-
-		//Set biblespecific chapels
-		setupbiblespecifics(B, usr)
-
-		usr.put_in_hands(B) // Update inhand icon
-
-		if(ticker)
-			ticker.Bible_icon_state = B.icon_state
-			ticker.Bible_item_state = B.item_state
-			ticker.Bible_name = B.name
-		feedback_set_details("religion_book","[biblename]")
-
-		usr << browse(null, "window=editicon") // Close window
-
 /datum/job/chaplain/equip_items(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chaplain(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
-
-	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
+	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze
+	H.put_in_hands(B)
+	
 	spawn(0)
-		var/religion_name = "Christianity"
-		var/new_religion = copytext(sanitize(input(H, "You are the Chaplain. Would you like to change your religion? Default is Christianity, in SPACE.", "Name change", religion_name)),1,MAX_NAME_LEN)
+		B.attack_self(H)
 
-		if (!new_religion)
-			new_religion = religion_name
-
-		switch(lowertext(new_religion))
-			if("christianity")
-				B.name = pick("The Holy Bible","The Dead Sea Scrolls")
-			if("satanism")
-				B.name = "The Unholy Bible"
-			if("cthulu")
-				B.name = "The Necronomicon"
-			if("islam")
-				B.name = "Quran"
-			if("scientology")
-				B.name = pick("The Biography of L. Ron Hubbard","Dianetics")
-			if("chaos")
-				B.name = "The Book of Lorgar"
-			if("imperium")
-				B.name = "Uplifting Primer"
-			if("toolboxia")
-				B.name = "Toolbox Manifesto"
-			if("homosexuality")
-				B.name = "Guys Gone Wild"
-			if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
-				B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
-				H.setBrainLoss(100) // starts off retarded as fuck
-			if("science")
-				B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
-			else
-				B.name = "The Holy Book of [new_religion]"
-		feedback_set_details("religion_name","[new_religion]")
-
-	spawn(1)
-		var/deity_name = "Space Jesus"
-		var/new_deity = copytext(sanitize(input(H, "Would you like to change your deity? Default is Space Jesus.", "Name change", deity_name)),1,MAX_NAME_LEN)
-
-		if ((length(new_deity) == 0) || (new_deity == "Space Jesus") )
-			new_deity = deity_name
-		B.deity_name = new_deity
-
-		if(ticker)
-			ticker.Bible_deity_name = B.deity_name
-		feedback_set_details("religion_deity","[new_deity]")
-
-		//Open bible selection
-		var/dat = "<html><head><title>Pick Bible Style</title></head><body><center><h2>Pick a bible style</h2></center><table>"
-
-		var/i
-		for(i = 1, i < biblestates.len, i++)
-			var/icon/bibleicon = icon('icons/obj/storage.dmi', biblestates[i])
-
-			var/nicename = biblenames[i]
-			H << browse_rsc(bibleicon, nicename)
-			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=\ref[src];seticon=[i];bible=\ref[B]">[nicename]</a></td></tr>"}
-
-		dat += "</table></body></html>"
-
-		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -7,8 +7,174 @@
 	throw_range = 5
 	w_class = 3.0
 	var/title = "book"
+
 /obj/item/weapon/storage/book/attack_self(mob/user)
 		user << "<span class='notice'>The pages of [title] have been cut out!</span>"
+	
+/obj/item/weapon/storage/book/bible/proc/setupbiblespecifics(var/mob/living/carbon/human/H)
+	switch(icon_state)
+		if("honk1","honk2")
+			new /obj/item/weapon/grown/bananapeel(src)
+			new /obj/item/weapon/grown/bananapeel(src)
+
+			if(icon_state == "honk1")
+				H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(H), slot_wear_mask)
+
+		if("bible")
+			for(var/area/chapel/main/A in world)
+				for(var/turf/T in A.contents)
+					if(T.icon_state == "carpetsymbol")
+						T.dir = 2
+		if("koran")
+			for(var/area/chapel/main/A in world)
+				for(var/turf/T in A.contents)
+					if(T.icon_state == "carpetsymbol")
+						T.dir = 4
+		if("scientology")
+			for(var/area/chapel/main/A in world)
+				for(var/turf/T in A.contents)
+					if(T.icon_state == "carpetsymbol")
+						T.dir = 8
+		if("athiest")
+			for(var/area/chapel/main/A in world)
+				for(var/turf/T in A.contents)
+					if(T.icon_state == "carpetsymbol")
+						T.dir = 10
+
+/obj/item/weapon/storage/book/bible/Topic(href, href_list)
+	if(href_list["seticon"])
+		current_user = null
+
+		if(!set_style)
+			var/iconi = text2num(href_list["seticon"])
+
+			var/biblename = biblenames[iconi]
+			
+			src.icon_state = biblestates[iconi]
+			src.item_state = bibleitemstates[iconi]
+
+			//Set biblespecific chapels
+			setupbiblespecifics(usr)
+
+			if(ticker)
+				ticker.Bible_icon_state = src.icon_state
+				ticker.Bible_item_state = src.item_state
+				ticker.Bible_name = src.name
+			feedback_set_details("religion_book","[biblename]")
+
+			set_style = 1
+
+		usr << browse(null, "window=editicon") // Close window
+
+/obj/item/weapon/storage/book/bible/attack_self(mob/user)
+	if(!istype(user, /mob/living/carbon/human))
+		return
+	
+	if(!set_name)
+		name = "Choose Your Own Religion"
+		// desc = "You're the star of the story!"
+
+	var/mob/living/carbon/human/H = user
+	
+	var/religion_name = "Christianity"
+
+	if(!H.mind && (H.mind.assigned_role == "Chaplain"))
+		H << "\red The book sizzles in your hands."
+		H.take_organ_damage(0,10)
+		return
+
+	if(!set_name)	
+		//Prevent input box spam.
+			
+		// Hacks. Abusing a login event to prevent spammed text boxes
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		var/new_religion = copytext(sanitize(input(H, "You are the Chaplain. Would you like to change your religion? Default is Christianity, in SPACE.", "Name change", religion_name)),1,MAX_NAME_LEN)
+		
+		current_user = null
+
+		// Additional checks against setting values more than once
+		if(!set_name)
+			set_name = 1
+			
+			if (!new_religion)
+				new_religion = religion_name
+
+			switch(lowertext(new_religion))
+				if("christianity")
+					src.name = pick("The Holy Bible","The Dead Sea Scrolls")
+				if("satanism")
+					src.name = "The Unholy Bible"
+				if("cthulu")
+					src.name = "The Necronomicon"
+				if("islam")
+					src.name = "Quran"
+				if("scientology")
+					src.name = pick("The Biography of L. Ron Hubbard","Dianetics")
+				if("chaos")
+					src.name = "The Book of Lorgar"
+				if("imperium")
+					src.name = "Uplifting Primer"
+				if("toolboxia")
+					src.name = "Toolbox Manifesto"
+				if("homosexuality")
+					src.name = "Guys Gone Wild"
+				if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
+					src.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
+					H.setBrainLoss(100) // starts off retarded as fuck
+				if("science")
+					src.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+				else
+					src.name = "The Holy Book of [new_religion]"
+			feedback_set_details("religion_name","[new_religion]")
+
+	if(!set_jesus)
+		var/deity_name = "Space Jesus"
+					
+		// Hacks. Abusing a login event to prevent spammed text boxes
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		var/new_deity = copytext(sanitize(input(H, "Would you like to change your deity? Default is Space Jesus.", "Name change", deity_name)),1,MAX_NAME_LEN)
+		
+		current_user = null
+		
+		// Additional checks against setting values more than once
+		if(!set_jesus)
+			
+			set_jesus = 1
+			
+			if ((length(new_deity) == 0) || (new_deity == "Space Jesus") )
+				new_deity = deity_name
+			deity_name = new_deity
+
+			if(ticker)
+				ticker.Bible_deity_name = deity_name
+			feedback_set_details("religion_deity","[new_deity]")
+	if(!set_style)
+
+		// Hacks. Abusing a login event to prevent spammed web pages
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		//Open bible selection
+		var/dat = "<html><head><title>Pick Bible Style</title></head><body><center><h2>Pick a bible style</h2></center><table>"
+
+		var/i
+		for(i = 1, i < biblestates.len, i++)
+			var/icon/bibleicon = icon('icons/obj/storage.dmi', biblestates[i])
+
+			var/nicename = biblenames[i]
+			H << browse_rsc(bibleicon, nicename)
+			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=\ref[src];seticon=[i];bible=\ref[src]">[nicename]</a></td></tr>"}
+
+		dat += "</table></body></html>"
+
+		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
 
 /obj/item/weapon/storage/book/bible
 	name = "bible"
@@ -17,6 +183,21 @@
 	icon_state ="bible"
 	var/mob/affecting = null
 	var/deity_name = "Christ"
+
+	var/global/current_user
+	var/global/set_name = 0
+	var/global/set_jesus = 0
+	var/global/set_style = 0
+
+	//Pretty bible names
+	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
+
+	//Bible iconstates
+	var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
+	//Bible itemstates
+	var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
 
 /obj/item/weapon/storage/book/bible/booze
 	name = "bible"
@@ -30,9 +211,6 @@
 	new /obj/item/weapon/spacecash(src)
 	new /obj/item/weapon/spacecash(src)
 	new /obj/item/weapon/spacecash(src)
-
-/obj/item/weapon/storage/book/bible/attack_self(mob/user)
-	return
 
 /obj/item/weapon/storage/book/bible/proc/bless(mob/living/carbon/M as mob)
 	if(ishuman(M))

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -7,11 +7,185 @@
 	throw_range = 5
 	w_class = 3.0
 	var/title = "book"
+	hitsound = "punch"
 
 /obj/item/weapon/storage/book/attack_self(mob/user)
 		user << "<span class='notice'>The pages of [title] have been cut out!</span>"
+
+/obj/item/weapon/storage/book/bible
+	name = "bible"
+	desc = "Apply to head repeatedly."
+	icon = 'icons/obj/storage.dmi'
+	icon_state ="bible"
+	var/mob/affecting = null
 	
+	var/global/current_user
+
+	var/global/religion_name
+	var/global/deity_name
+	var/global/bible_name
+	var/global/bible_icon_state
+	var/global/bible_item_state
+
+	//Pretty bible names
+	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
+
+	//Bible iconstates
+	var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
+	//Bible itemstates
+	var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
+
+/obj/item/weapon/storage/book/bible/New()
+	..()
+	setup_name_icon()
+
+/obj/item/weapon/storage/book/bible/proc/setup_name_icon(var/mob/living/carbon/human/H)
+	if(bible_name && bible_icon_state && bible_item_state)
+		if(H && src.name != bible_name)
+			H << "\red The book glows in your hands."
+
+		src.name = bible_name
+		src.icon_state = bible_icon_state
+		src.item_state = bible_item_state
+		if(bible_icon_state == "honk1")
+			hitsound = 'sound/items/bikehorn.ogg'
+	else
+		src.name = "Choose Your Own Religion"
+
+/obj/item/weapon/storage/book/bible/attack_self(mob/user)
+	if(!istype(user, /mob/living/carbon/human))
+		return
+	
+	var/mob/living/carbon/human/H = user
+
+	if(!H)
+		return //How?!
+	
+	var/default_religion_name = "Christianity"
+
+	if(!H.mind && (H.mind.assigned_role == "Chaplain"))
+		H << "\red The book sizzles in your hands."
+		H.take_organ_damage(0,10)
+		return
+
+	if(!religion_name)	
+		//Prevent input box spam.
+			
+		// Hacks. Abusing a login event to prevent spammed text boxes
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		var/new_religion = copytext(sanitize(input(H, "You are the Chaplain. Would you like to change your religion? Default is Christianity, in SPACE.", "Name change", default_religion_name)),1,MAX_NAME_LEN)
+
+		current_user = null
+
+		if(!H)
+			return
+
+		// Additional checks against setting values more than once
+		if(!religion_name)
+			religion_name = new_religion ? new_religion : default_religion_name
+			
+			switch(lowertext(religion_name))
+				if("christianity")
+					bible_name = pick("The Holy Bible","The Dead Sea Scrolls")
+				if("satanism")
+					bible_name = "The Unholy Bible"
+				if("cthulu")
+					bible_name = "The Necronomicon"
+				if("islam")
+					bible_name = "Quran"
+				if("scientology")
+					bible_name = pick("The Biography of L. Ron Hubbard","Dianetics")
+				if("chaos")
+					bible_name = "The Book of Lorgar"
+				if("imperium")
+					bible_name = "Uplifting Primer"
+				if("toolboxia")
+					bible_name = "Toolbox Manifesto"
+				if("homosexuality")
+					bible_name = "Guys Gone Wild"
+				if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
+					bible_name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
+					H.setBrainLoss(100) // starts off retarded as fuck
+				if("science")
+					bible_name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
+				else
+					bible_name = "The Holy Book of [religion_name]"
+
+			feedback_set_details("religion_name","[religion_name]")
+
+	if(!deity_name)
+		var/default_deity_name = "Space Jesus"
+					
+		// Hacks. Abusing a login event to prevent spammed text boxes
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		var/new_deity = copytext(sanitize(input(H, "Would you like to change your deity? Default is Space Jesus.", "Name change", default_deity_name)),1,MAX_NAME_LEN)
+		
+		current_user = null
+
+		// User could be gone
+		if(!H)
+			return		
+		
+		// Additional checks against setting values more than once
+		if(!deity_name)
+			deity_name = new_deity ? new_deity : default_deity_name
+
+		feedback_set_details("religion_deity","[deity_name]")
+
+	if(!bible_icon_state)
+
+		// Hacks. Abusing a login event to prevent spammed web pages
+		if(current_user == H.hud_used)
+			return
+		current_user = H.hud_used
+
+		//Open bible selection
+		var/dat = "<html><head><title>Pick Bible Style</title></head><body><center><h2>Pick a bible style</h2></center><table>"
+
+		var/i
+		for(i = 1, i < biblestates.len, i++)
+			var/icon/bibleicon = icon('icons/obj/storage.dmi', biblestates[i])
+
+			var/nicename = biblenames[i]
+			H << browse_rsc(bibleicon, nicename)
+			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=\ref[src];seticon=[i];bible=\ref[src]">[nicename]</a></td></tr>"}
+
+		dat += "</table></body></html>"
+
+		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
+
+/obj/item/weapon/storage/book/bible/Topic(href, href_list)
+	//JUST A NOTE: IF YOU GET GIBBED WITH THIS OPEN IT WONT EVER GO AWAY :D
+	if(href_list["seticon"])
+		current_user = null
+
+		if(!bible_icon_state)
+			var/iconi = text2num(href_list["seticon"])
+
+			var/biblename = biblenames[iconi]
+			feedback_set_details("religion_book","[biblename]")
+			
+			bible_icon_state = biblestates[iconi]
+			bible_item_state = bibleitemstates[iconi]
+			
+			setup_name_icon(usr)
+
+			//Set biblespecific chapels
+			setupbiblespecifics(usr)
+
+		usr << browse(null, "window=editicon") // Close window
+
 /obj/item/weapon/storage/book/bible/proc/setupbiblespecifics(var/mob/living/carbon/human/H)
+	if(!H)
+		return
+
 	switch(icon_state)
 		if("honk1","honk2")
 			new /obj/item/weapon/grown/bananapeel(src)
@@ -41,187 +215,6 @@
 					if(T.icon_state == "carpetsymbol")
 						T.dir = 10
 
-/obj/item/weapon/storage/book/bible/Topic(href, href_list)
-	if(href_list["seticon"])
-		current_user = null
-
-		if(!set_style)
-			var/iconi = text2num(href_list["seticon"])
-
-			var/biblename = biblenames[iconi]
-			
-			src.icon_state = biblestates[iconi]
-			src.item_state = bibleitemstates[iconi]
-
-			//Set biblespecific chapels
-			setupbiblespecifics(usr)
-
-			if(ticker)
-				ticker.Bible_icon_state = src.icon_state
-				ticker.Bible_item_state = src.item_state
-				ticker.Bible_name = src.name
-			feedback_set_details("religion_book","[biblename]")
-
-			set_style = 1
-
-		usr << browse(null, "window=editicon") // Close window
-
-/obj/item/weapon/storage/book/bible/attack_self(mob/user)
-	if(!istype(user, /mob/living/carbon/human))
-		return
-	
-	if(!set_name)
-		name = "Choose Your Own Religion"
-		// desc = "You're the star of the story!"
-
-	var/mob/living/carbon/human/H = user
-	
-	var/religion_name = "Christianity"
-
-	if(!H.mind && (H.mind.assigned_role == "Chaplain"))
-		H << "\red The book sizzles in your hands."
-		H.take_organ_damage(0,10)
-		return
-
-	if(!set_name)	
-		//Prevent input box spam.
-			
-		// Hacks. Abusing a login event to prevent spammed text boxes
-		if(current_user == H.hud_used)
-			return
-		current_user = H.hud_used
-
-		var/new_religion = copytext(sanitize(input(H, "You are the Chaplain. Would you like to change your religion? Default is Christianity, in SPACE.", "Name change", religion_name)),1,MAX_NAME_LEN)
-		
-		current_user = null
-
-		// Additional checks against setting values more than once
-		if(!set_name)
-			set_name = 1
-			
-			if (!new_religion)
-				new_religion = religion_name
-
-			switch(lowertext(new_religion))
-				if("christianity")
-					src.name = pick("The Holy Bible","The Dead Sea Scrolls")
-				if("satanism")
-					src.name = "The Unholy Bible"
-				if("cthulu")
-					src.name = "The Necronomicon"
-				if("islam")
-					src.name = "Quran"
-				if("scientology")
-					src.name = pick("The Biography of L. Ron Hubbard","Dianetics")
-				if("chaos")
-					src.name = "The Book of Lorgar"
-				if("imperium")
-					src.name = "Uplifting Primer"
-				if("toolboxia")
-					src.name = "Toolbox Manifesto"
-				if("homosexuality")
-					src.name = "Guys Gone Wild"
-				if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
-					src.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
-					H.setBrainLoss(100) // starts off retarded as fuck
-				if("science")
-					src.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
-				else
-					src.name = "The Holy Book of [new_religion]"
-			feedback_set_details("religion_name","[new_religion]")
-
-	if(!set_jesus)
-		var/deity_name = "Space Jesus"
-					
-		// Hacks. Abusing a login event to prevent spammed text boxes
-		if(current_user == H.hud_used)
-			return
-		current_user = H.hud_used
-
-		var/new_deity = copytext(sanitize(input(H, "Would you like to change your deity? Default is Space Jesus.", "Name change", deity_name)),1,MAX_NAME_LEN)
-		
-		current_user = null
-		
-		// Additional checks against setting values more than once
-		if(!set_jesus)
-			
-			set_jesus = 1
-			
-			if ((length(new_deity) == 0) || (new_deity == "Space Jesus") )
-				new_deity = deity_name
-			deity_name = new_deity
-
-			if(ticker)
-				ticker.Bible_deity_name = deity_name
-			feedback_set_details("religion_deity","[new_deity]")
-	if(!set_style)
-
-		// Hacks. Abusing a login event to prevent spammed web pages
-		if(current_user == H.hud_used)
-			return
-		current_user = H.hud_used
-
-		//Open bible selection
-		var/dat = "<html><head><title>Pick Bible Style</title></head><body><center><h2>Pick a bible style</h2></center><table>"
-
-		var/i
-		for(i = 1, i < biblestates.len, i++)
-			var/icon/bibleicon = icon('icons/obj/storage.dmi', biblestates[i])
-
-			var/nicename = biblenames[i]
-			H << browse_rsc(bibleicon, nicename)
-			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=\ref[src];seticon=[i];bible=\ref[src]">[nicename]</a></td></tr>"}
-
-		dat += "</table></body></html>"
-
-		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
-
-/obj/item/weapon/storage/book/bible
-	name = "bible"
-	desc = "Apply to head repeatedly."
-	icon = 'icons/obj/storage.dmi'
-	icon_state ="bible"
-	var/mob/affecting = null
-	var/deity_name = "Christ"
-
-	var/global/current_user
-	var/global/set_name = 0
-	var/global/set_jesus = 0
-	var/global/set_style = 0
-
-	//Pretty bible names
-	var/global/list/biblenames =		list("Bible", "Quran", "Scrapbook", "Burning Bible", "Clown Bible", "Banana Bible", "Creeper Bible", "White Bible", "Holy Light", "The God Delusion", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "Melted Bible", "Necronomicon")
-
-	//Bible iconstates
-	var/global/list/biblestates =		list("bible", "koran", "scrapbook", "burning", "honk1", "honk2", "creeper", "white", "holylight", "atheist", "tome", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
-	//Bible itemstates
-	var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "bible", "bible", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "syringe_kit", "kingyellow", "ithaqua", "scientology", "melted", "necronomicon")
-
-
-/obj/item/weapon/storage/book/bible/booze
-	name = "bible"
-	desc = "To be applied to the head repeatedly."
-	icon_state ="bible"
-
-/obj/item/weapon/storage/book/bible/booze/New()
-	..()
-	new /obj/item/weapon/reagent_containers/food/drinks/beer(src)
-	new /obj/item/weapon/reagent_containers/food/drinks/beer(src)
-	new /obj/item/weapon/spacecash(src)
-	new /obj/item/weapon/spacecash(src)
-	new /obj/item/weapon/spacecash(src)
-
-/obj/item/weapon/storage/book/bible/proc/bless(mob/living/carbon/M as mob)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/heal_amt = 10
-		for(var/obj/item/organ/limb/affecting in H.organs)
-			if(affecting.status == ORGAN_ORGANIC) //No Bible can heal a robotic arm!
-				if(affecting.heal_damage(heal_amt, heal_amt, 0))
-					H.update_damage_overlays(0)
-	return
-
 /obj/item/weapon/storage/book/bible/attack(mob/living/M as mob, mob/living/user as mob)
 
 	var/chaplain = 0
@@ -233,6 +226,7 @@
 	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
 		user << "\red You don't have the dexterity to do this!"
 		return
+
 	if(!chaplain)
 		user << "\red The book sizzles in your hands."
 		user.take_organ_damage(0,10)
@@ -266,27 +260,33 @@
 							for(var/mob/O in viewers(M, null))
 								O.show_message(text("\red <B>[] heals [] with the power of [src.deity_name]!</B>", user, M), 1)
 							M << "\red May the power of [src.deity_name] compel you to be healed!"
-							playsound(src.loc, "punch", 25, 1, -1)
+							playsound(src.loc, hitsound, 25, 1, -1)
 							message_halt = 1
 					else
 						src << "<span class='warning'>[src.deity_name] refuses to heal this metallic taint!</span>"
 						return
-
-
-
-
 		else
 			if(ishuman(M) && !istype(M:head, /obj/item/clothing/head/helmet))
 				M.adjustBrainLoss(10)
 				M << "\red You feel dumber."
 			for(var/mob/O in viewers(M, null))
 				O.show_message(text("\red <B>[] beats [] over the head with []!</B>", user, M, src), 1)
-			playsound(src.loc, "punch", 25, 1, -1)
+			playsound(src.loc, hitsound, 25, 1, -1)
 
 	else if(M.stat == 2)
 		for(var/mob/O in viewers(M, null))
 			O.show_message(text("\red <B>[] smacks []'s lifeless corpse with [].</B>", user, M, src), 1)
-		playsound(src.loc, "punch", 25, 1, -1)
+		playsound(src.loc, hitsound, 25, 1, -1)
+	return
+
+/obj/item/weapon/storage/book/bible/proc/bless(mob/living/carbon/M as mob)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/heal_amt = 10
+		for(var/obj/item/organ/limb/affecting in H.organs)
+			if(affecting.status == ORGAN_ORGANIC) //No Bible can heal a robotic arm!
+				if(affecting.heal_damage(heal_amt, heal_amt, 0))
+					H.update_damage_overlays(0)
 	return
 
 /obj/item/weapon/storage/book/bible/afterattack(atom/A, mob/user as mob, proximity)
@@ -301,12 +301,27 @@
 			var/water2holy = A.reagents.get_reagent_amount("water")
 			A.reagents.del_reagent("water")
 			A.reagents.add_reagent("holywater",water2holy)
+			return
 		if(A.reagents && A.reagents.has_reagent("unholywater")) //yeah yeah, copy pasted code - sue me
 			user << "\blue You purify [A]."
 			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
 			A.reagents.del_reagent("unholywater")
 			A.reagents.add_reagent("cleaner",unholy2clean)		//it cleans their soul, get it? I'll get my coat...
+			return
 
 /obj/item/weapon/storage/book/bible/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	playsound(src.loc, "rustle", 50, 1, -5)
 	..()
+
+	/obj/item/weapon/storage/book/bible/booze
+	name = "bible"
+	desc = "To be applied to the head repeatedly."
+	icon_state ="bible"
+
+/obj/item/weapon/storage/book/bible/booze/New()
+	..()
+	new /obj/item/weapon/reagent_containers/food/drinks/beer(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/beer(src)
+	new /obj/item/weapon/spacecash(src)
+	new /obj/item/weapon/spacecash(src)
+	new /obj/item/weapon/spacecash(src)

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -291,8 +291,16 @@
 
 /obj/item/weapon/storage/book/bible/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity) return
+	
+	//blah
+	usr.changeNext_move(8)
+
 	if (istype(A, /turf/simulated/floor))
 		user << "\blue You hit the floor with the bible."
+
+		//Wanted to put this up above but it was just too annoying.
+		playsound(src.loc, hitsound, 25, 1, -1)
+		
 		if(user.mind && (user.mind.assigned_role == "Chaplain"))
 			call(/obj/effect/rune/proc/revealrunes)(src)
 	if(user.mind && (user.mind.assigned_role == "Chaplain"))

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -279,13 +279,7 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 				screenstate = 5
 			if("6")
 				if(!bibledelay)
-
-					var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible(src.loc)
-					if(ticker && ( ticker.Bible_icon_state && ticker.Bible_item_state) )
-						B.icon_state = ticker.Bible_icon_state
-						B.item_state = ticker.Bible_item_state
-						B.name = ticker.Bible_name
-						B.deity_name = ticker.Bible_deity_name
+					new /obj/item/weapon/storage/book/bible(src.loc)
 
 					bibledelay = 1
 					spawn(60)


### PR DESCRIPTION
I moved the religion setup to be inside bible code. Chaplains start off with the prompt open like old behavior, but if they disconnect, they can continue by just using a bible.

There is some weirdness with (ab)using hud_used. I'm using it as a semi-reliable check to make sure that you don't already have the input prompt open. If I didn't, you could multi-use the book to spam name change prompts. I can't just put a boolean before and after input() because a disconnection crashes the proc.
