### PR TITLE
Fix pressing ready button multiple times when connecting causing the button state to flip back and forth

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -24,7 +24,7 @@
 
 		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 			if(!ready)	output += "<p><a href='byond://?src=\ref[src];ready=1'>Declare Ready</A></p>"
-			else	output += "<p><b>You are ready</b> <a href='byond://?src=\ref[src];ready=2'>Cancel</A></p>"
+			else	output += "<p><b>You are ready</b> <a href='byond://?src=\ref[src];ready=0'>Cancel</A></p>"
 
 		else
 			output += "<p><a href='byond://?src=\ref[src];late_join=1'>Join Game!</A></p>"
@@ -94,7 +94,7 @@
 			return 1
 
 		if(href_list["ready"])
-			ready = !ready
+			ready = text2num(href_list["ready"])
 
 		if(href_list["refresh"])
 			src << browse(null, "window=playersetup") //closes the player setup window


### PR DESCRIPTION
Repro: join, tap the ready button twice. Once you finish connecting it will toggle to ready and back again.
