### PR TITLE
[Changelog] Forces links to open in browser window

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -3,6 +3,7 @@
 <head>
   <title>/tg/ Station 13 Changelog</title>
   <link rel="stylesheet" type="text/css" href="changelog.css">
+  <base target="_blank" />
   <script type='text/javascript'>
   
 	function changeText(tagID, newText, linkTagID){


### PR DESCRIPTION
... so it's no longer in BYOND's built-in IE version 0.5 and supports all the useful functions of a real browser like forwards/back buttons and webpages made in this century.
