### PR TITLE
Rework of show-server-revision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 #CONTRIBUTING
 
+##Reporting Issues
+
+See [this page](http://tgstation13.org/wiki/Reporting_Issues) for a guide and format to issue reports.
 
 ##Introduction
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -56,6 +56,7 @@
 	var/wikiurl = "http://www.tgstation13.org/wiki" // Default wiki link.
 	var/forumurl = "http://tgstation13.org/phpBB/index.php" //default forums
 	var/rulesurl = "http://www.tgstation13.org/wiki/Rules" // default rules
+	var/githuburl = "https://www.github.com/tgstation/-tg-station" //default github
 
 	var/forbid_singulo_possession = 0
 	var/useircbot = 0
@@ -247,6 +248,8 @@
 					config.forumurl = value
 				if("rulesurl")
 					config.rulesurl = value
+				if("githuburl")
+					config.githuburl = value
 				if("guest_jobban")
 					config.guest_jobban = 1
 				if("guest_ban")

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -30,7 +30,7 @@ client/verb/showrevinfo()
 
 	if(revdata.revision)
 		src << "<b>Server revision compiled on:</b> [revdata.date]"
-		src << "[config.githuburl]/commit/[revdata.revision]"
+		src << "<a href='[config.githuburl]/commit/[revdata.revision]'>[revdata.revision]</a>"
 	else
 		src << "Revision unknown"
 	src << "<b>Current Infomational Settings:</b><br>Protect Authority Roles From Traitor: [config.protect_roles_from_antagonist]<br>Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]"

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -1,16 +1,11 @@
 var/global/datum/getrev/revdata = new()
 
 /datum/getrev
-	var/project_href
 	var/revision
 	var/date
 	var/showinfo
 
 /datum/getrev/New()
-	if(fexists("config/git_host.txt"))
-		project_href = file2text("config/git_host.txt")
-	else
-		project_href = "https://www.github.com/tgstation/-tg-station"
 	var/list/head_log = file2list(".git/logs/HEAD", "\n")
 	for(var/line=head_log.len, line>=1, line--)
 		if(head_log[line])
@@ -23,42 +18,20 @@ var/global/datum/getrev/revdata = new()
 				if(unix_time)
 					date = unix2date(unix_time)
 			break
-
-	showinfo = "<b>Server Revision:</b> "
-	if(revision)
-		showinfo += "<A href='?src=\ref[src];project_open=1'><BR>[(date ? date : "No Date")]<BR>[revision]</A>"
-	else
-		showinfo += "*unknown*"
-	showinfo += "<p>-<A href='?src=\ref[src];new_issue_open=1'>Report Bugs Here-</A><br><i>Please provide as much info as possible<br>Copy/paste the revision date and hash into your issue report if possible, thanks</i> :)</p>"
-
 	world.log << "Running /tg/ revision:"
 	world.log << date
 	world.log << revision
 	return
 
-/datum/getrev/Topic(href, href_list)
-	..()
-	if(href_list["project_open"])
-		if(alert(usr, "This will open the project in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		usr << link("[project_href]/commit/[revision]")
-	else if(href_list["new_issue_open"])
-		if(alert(usr, "This will open the issue tracker in your browser. Are you sure?",,"Yes","No")=="No")
-			return
-		usr << link("[project_href]/issues/new")
-
-
 client/verb/showrevinfo()
 	set category = "OOC"
 	set name = "Show Server Revision"
-	var/output = revdata.showinfo
-	output += "<b>Current Infomational Settings:</b><br>"
-	output += "Protect Authority Roles From Traitor: [config.protect_roles_from_antagonist]<br>"
-	output += "Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]<br>"
-	if(config.show_game_type_odds)
-		output += "<br><b>Game Type Odds:</b><br>"
-		for(var/i=1,i<=config.probabilities.len,i++)
-			var/p = config.probabilities[i]
-			output += "[p] [config.probabilities[p]]<br>"
-	usr << browse(output,"window=revdata");
+	set desc = "Check the current server code revision"
+
+	if(revdata.revision)
+		src << "<b>Server revision compiled on:</b> [revdata.date]"
+		src << "[config.githuburl]/commit/[revdata.revision]"
+	else
+		src << "Revision unknown"
+	src << "<b>Current Infomational Settings:</b><br>Protect Authority Roles From Traitor: [config.protect_roles_from_antagonist]<br>Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]"
 	return

--- a/config/config.txt
+++ b/config/config.txt
@@ -119,6 +119,9 @@ GUEST_BAN
 ##Rules address
 # RULESURL http://www.tgstation13.org/wiki/Rules
 
+##Github address
+# GITHUBURL https://www.github.com/tgstation/-tg-station
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://justanotherday.example.com
 

--- a/config/git_host.txt
+++ b/config/git_host.txt
@@ -1,1 +1,0 @@
-https://www.github.com/tgstation/-tg-station

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -35,6 +35,30 @@
 		src << "<span class='danger'>The rules URL is not set in the server configuration.</span>"
 	return
 
+/client/verb/github()
+	set name = "Github"
+	set desc = "Visit Github"
+	set hidden = 1
+	if(config.githuburl)
+		if(alert("This will open the Github repository in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link(config.githuburl)
+	else
+		src << "<span class='danger'>The Github URL is not set in the server configuration.</span>"
+	return
+
+/client/verb/reportissue()
+	set name = "Report issue"
+	set desc = "Report an issue"
+	set hidden = 1
+	if(config.githuburl)
+		if(alert("This will open the Github issue reporter in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link("[config.githuburl]/issues/new")
+	else
+		src << "<span class='danger'>The Github URL is not set in the server configuration.</span>"
+	return
+
 /client/verb/hotkeys_help()
 	set name = "hotkeys-help"
 	set category = "OOC"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1827,10 +1827,10 @@ window "rpane"
 		splitter = 50
 		show-splitter = true
 		lock = none
-	elem "rulesb"
+	elem "reportissueb"
 		type = BUTTON
-		pos = 278,0
-		size = 60x16
+		pos = 480,0
+		size = 67x16
 		anchor1 = none
 		anchor2 = none
 		font-family = ""
@@ -1847,17 +1847,17 @@ window "rpane"
 		right-click = false
 		saved-params = "is-checked"
 		on-size = ""
-		text = "Rules"
+		text = "Report Issue"
 		image = ""
-		command = "rules"
+		command = "report-issue"
 		is-flat = false
 		stretch = false
 		is-checked = false
 		group = "rpanemode"
 		button-type = pushbutton
-	elem "changelog"
+	elem "changelogb"
 		type = BUTTON
-		pos = 341,0
+		pos = 336,0
 		size = 67x16
 		anchor1 = none
 		anchor2 = none
@@ -1883,9 +1883,65 @@ window "rpane"
 		is-checked = false
 		group = "rpanemode"
 		button-type = pushbutton
+	elem "rulesb"
+		type = BUTTON
+		pos = 272,0
+		size = 60x16
+		anchor1 = none
+		anchor2 = none
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #000000
+		background-color = none
+		is-visible = true
+		is-disabled = false
+		is-transparent = false
+		is-default = false
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = "is-checked"
+		on-size = ""
+		text = "Rules"
+		image = ""
+		command = "rules"
+		is-flat = false
+		stretch = false
+		is-checked = false
+		group = "rpanemode"
+		button-type = pushbutton
+	elem "githubb"
+		type = BUTTON
+		pos = 408,0
+		size = 67x16
+		anchor1 = none
+		anchor2 = none
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #000000
+		background-color = none
+		is-visible = true
+		is-disabled = false
+		is-transparent = false
+		is-default = false
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = "is-checked"
+		on-size = ""
+		text = "Github"
+		image = ""
+		command = "github"
+		is-flat = false
+		stretch = false
+		is-checked = false
+		group = "rpanemode"
+		button-type = pushbutton
 	elem "forumb"
 		type = BUTTON
-		pos = 215,0
+		pos = 208,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1913,7 +1969,7 @@ window "rpane"
 		button-type = pushbutton
 	elem "wikib"
 		type = BUTTON
-		pos = 152,0
+		pos = 144,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
@@ -1969,7 +2025,7 @@ window "rpane"
 		button-type = pushbox
 	elem "browseb"
 		type = BUTTON
-		pos = 464,0
+		pos = 552,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none


### PR DESCRIPTION
Changes Show-Server-Revision to be a text output containing a link to server's commit that opens in user's default browser.

Adds Github and Report Issue button to UI interface.

Removes git_host.txt and adds github url to config.txt

Adds link to issue format on wiki to contributing.md so it shows up in link given when making new issue.

New show-server-revision (link is a shorter href now but I didn't make a new picture)
![textput](https://cloud.githubusercontent.com/assets/4343468/3658286/a24dd31c-11a1-11e4-8578-bac31b8bfc94.PNG)

New buttons
![buttons](https://cloud.githubusercontent.com/assets/4343468/3658288/a8c20eac-11a1-11e4-9c36-b3031d44d33a.PNG)
