### PR TITLE
Updates BYOND_MINOR and BYOND_MAJOR vars in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: c
 
 env:
     global:
-    - BYOND_MAJOR="504"
-    - BYOND_MINOR="1232"
+    - BYOND_MAJOR="506"
+    - BYOND_MINOR="1247"
     matrix:
     - DM_MAPFILE="tgstation2"
     - DM_MAPFILE="metastation"


### PR DESCRIPTION
Updates the BYOND_MINOR and BYOND_MAJOR environment variables in .travis.yml, so Travis will start compiling with BYOND 506.1247 instead of BYOND 504.1232.

Head coder(s) should decide whether this gets merged.

---

_Made with the GitHub web editor._
