### PR TITLE
You cannot instant wrench dislodged girders.

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -19,7 +19,8 @@
 			else if(!anchored)
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 				user << "<span class='notice'>Now securing the girder...</span>"
-				if(get_turf(user, 40))
+				if(do_after(user, 40))
+					if(!src) return
 					user << "<span class='notice'>You secured the girder!</span>"
 					var/obj/structure/girder/G = new (loc)
 					transfer_fingerprints_to(G)


### PR DESCRIPTION
Basically you can no longer instantly wrench dislodged girders into place. It takes the same time as it takes to dislodge them.

Fixes #4005 
