### PR TITLE
New names of medbot and securitron assemblies.

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -49,7 +49,7 @@
 	treatment_tox = "anti_toxin"
 
 /obj/item/weapon/firstaid_arm_assembly
-	name = "first aid/robot arm assembly"
+	name = "incomplete medibot assembly."
 	desc = "A first aid kit with a robot arm permanently grafted to it."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "firstaid_arm"

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -71,8 +71,8 @@
 	declare_arrests = 0
 
 /obj/item/weapon/secbot_assembly
-	name = "helmet/signaler assembly"
-	desc = "Some sort of bizarre assembly."
+	name = "incomplete securitron assembly"
+	desc = "Some sort of bizarre assembly made from a proximity sensor, helmet, and signaler."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "helmet_signaler"
 	item_state = "helmet"


### PR DESCRIPTION
This basically renamed the securitron assembly to "incomplete securitron assembly" and the medbot assembly to "incomplete medibot assembly" so the names doesnt look like paths.

Fixes #1776
