### PR TITLE
Dynamic maintenance spawn tables

### DIFF
--- a/code/__HELPERS/random.dm
+++ b/code/__HELPERS/random.dm
@@ -1,0 +1,18 @@
+//Return a randomly picked element in a weighted list.
+//
+//structure: elem1,weight1,elem2,weight2,...,elemN,weightN
+//
+/proc/weighted_pick(var/list/weightedlist)
+	if(!weightedlist.len)
+		return
+
+	var/list/picktable
+	for(var/i = 1, i <= weightedlist.len, i+=2)
+		var/entry =  weightedlist[i]
+		var/weight = weightedlist[i+1]
+
+		if(weight > 0)
+			for(var/j = 0, j < weight, j++)
+				picktable += list(entry)
+
+	return pick(picktable)

--- a/code/modules/awaymissions/loot.dm
+++ b/code/modules/awaymissions/loot.dm
@@ -1,17 +1,65 @@
 /obj/effect/spawner/lootdrop
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "x2"
+	color = "yellow"
 	var/lootcount = 1		//how many items will be spawned
 	var/lootdoubles = 0		//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
 
 /obj/effect/spawner/lootdrop/initialize()
 	if(loot && loot.len)
-		for(var/i = lootcount, i > 0, i--)
+		for(var/i = 0, i < lootcount, i++)
 			if(!loot.len) break
-			var/lootspawn = pick(loot)
-			if(!lootdoubles)
-				loot.Remove(lootspawn)
+			var/lootspawn = weighted_pick(loot)
+			if(!lootdoubles && lootspawn)
+				var/j = loot.Find(lootspawn)
+				if(j)
+					loot.Cut(j,j+1)
 
-			new lootspawn(get_turf(src))
+			if(lootspawn)
+				new lootspawn(get_turf(src))
 	qdel(src)
+
+/obj/effect/spawner/lootdrop/armory_contraband
+	name = "armory contraband gun spawner"
+
+	loot = list("/obj/item/weapon/gun/projectile/automatic/pistol",8,
+				"/obj/item/weapon/gun/projectile/shotgun/combat",5,
+				"/obj/item/weapon/gun/projectile/revolver/mateba",1,
+				"/obj/item/weapon/gun/projectile/automatic/deagle",1
+				)
+
+/obj/effect/spawner/lootdrop/extinguisher
+	name = "random fire extinguisher spawner"
+
+	loot = list("/obj/item/weapon/extinguisher",1,
+				"/obj/item/weapon/extinguisher/mini",1,
+				)
+
+/obj/effect/spawner/lootdrop/mask
+	name = "random breathing mask spawner"
+
+	loot = list("/obj/item/clothing/mask/gas",2,
+				"/obj/item/clothing/mask/breath",2,
+				"",1
+				)
+
+/obj/effect/spawner/lootdrop/oxygen
+	name = "random oxygen tank spawner"
+
+	loot = list("/obj/item/weapon/tank/emergency_oxygen",2,
+				"/obj/item/weapon/tank/oxygen",2,
+				"",1
+				)
+
+/obj/effect/spawner/lootdrop/tools
+	name = "random tools spawner"
+
+	loot = list("/obj/item/weapon/crowbar",1,
+				"/obj/item/weapon/screwdriver",1,
+				"/obj/item/weapon/wirecutters",1,
+				"/obj/item/weapon/wrench",1,
+				"/obj/item/weapon/weldingtool",1,
+				"/obj/item/device/multitool",1,
+				"",1
+				)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -39,6 +39,7 @@
 #include "code\__HELPERS\matrices.dm"
 #include "code\__HELPERS\mobs.dm"
 #include "code\__HELPERS\names.dm"
+#include "code\__HELPERS\random.dm"
 #include "code\__HELPERS\sanitize_values.dm"
 #include "code\__HELPERS\text.dm"
 #include "code\__HELPERS\time.dm"


### PR DESCRIPTION
Created a generic weighted_pick() function that takes a strided list as input

Modified the random loot spawner to use it.

Added loot tables for maintenance.

NOTE: Due to the feature freeze, this pull request is ment for discussion and balancing of the tables. Also for adding more tables?

NOTE AGAIN: This breaks the contraband spawner on metastation, i would have fixed it but i don't want to include map changes yet.
