### PR TITLE
Resin walls and weeds cannot be mash-attacked.

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -111,6 +111,7 @@
 
 
 /obj/structure/alien/resin/attack_alien(mob/user)
+	user.changeNext_move(8)
 	if(islarva(user))
 		return
 	user.visible_message("<span class='danger'>[user] claws at the resin!</span>")
@@ -122,6 +123,7 @@
 
 
 /obj/structure/alien/resin/attackby(obj/item/I, mob/user)
+	user.changeNext_move(8)
 	health -= I.force
 	playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
 	healthcheck()
@@ -196,6 +198,7 @@
 
 
 /obj/structure/alien/weeds/attackby(obj/item/I, mob/user)
+	user.changeNext_move(8)
 	if(I.attack_verb.len)
 		visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] with [I] by [user].</span>")
 	else


### PR DESCRIPTION
Adds a delay to attacking resin walls (and weeds, but idk if those really need it), for much the same reasons as was done for mechas in #3821.
