### PR TITLE
Fixes #2967 Blobs prevent supply shuttle from moving

### DIFF
--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -210,6 +210,8 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 			return 1
 		if(istype(A,/obj/item/device/radio/beacon))
 			return 1
+		if(istype(A,/obj/effect/blob))
+			return 1
 
 		for(var/i=1, i<=A.contents.len, i++)
 			var/atom/B = A.contents[i]

--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -212,6 +212,8 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 			return 1
 		if(istype(A,/obj/effect/blob))
 			return 1
+		if(istype(A,/obj/effect/spider/spiderling))
+			return 1
 
 		for(var/i=1, i<=A.contents.len, i++)
 			var/atom/B = A.contents[i]


### PR DESCRIPTION
Fixes #2967

If Centcom can detect a blob on the station and stop the escape shuttle they should be able to do it with the supply shuttle as well.

Should work fine but will test when I get home.
