### PR TITLE
Roundstart Logout and suicide Logging and Punishment [Controversial]

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -1,5 +1,11 @@
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
+//Used for detecting Roundstart logouts
+#define ROUNDSTART_END_TIME 6000 //10 minutes in Byond ticks
+#define MIN_ROUNDSTART_LOGOUT_PUNISHMENT 3 //Lowest amount of roundstart logouts to punish with antag candidate shuffles
+#define MAX_ROUNDSTART_LOGOUT_PUNISHMENT 6 //Highest amount of roundstart logouts to punish with antag candidate shuffles
+											//Lowest amount to start preventing antag is MAX_ROUNDSTART_LOGOUT_PUNISHMENT + 1
+
 //Security levels
 #define SEC_LEVEL_GREEN	0
 #define SEC_LEVEL_BLUE	1

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -82,6 +82,7 @@
 
 	var/traitor_objectives_amount = 2
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
+	var/punish_roundstart_logouts = 0	//Used to reduce the antagonist chance of players who frequently logout at roundstart
 	var/allow_latejoin_antagonists = 0 // If late-joining players can be traitor/changeling
 	var/continuous_round_rev = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/continuous_round_wiz = 0
@@ -374,6 +375,8 @@
 
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist	= 1
+				if("punish_roundstart_logouts")
+					config.punish_roundstart_logouts = 1
 				if("allow_latejoin_antagonists")
 					config.allow_latejoin_antagonists	= 1
 				if("allow_random_events")

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -41,6 +41,10 @@ var/list/blob_nodes = list()
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/blob = pick(antag_candidates)
+
+		if(handle_antag_punishments(blob))
+			break
+
 		infected_crew += blob
 		blob.special_role = "Blob"
 		log_game("[blob.key] (ckey) has been selected as a Blob")

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -61,6 +61,10 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		for(var/i = 0, i < num_changelings, i++)
 			if(!antag_candidates.len) break
 			var/datum/mind/changeling = pick(antag_candidates)
+
+			if(handle_antag_punishments(changeling))
+				break
+
 			antag_candidates -= changeling
 			changelings += changeling
 			modePlayer += changelings

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -73,6 +73,10 @@
 		if(!antag_candidates.len)
 			break
 		var/datum/mind/cultist = pick(antag_candidates)
+
+		if(handle_antag_punishments(cultist))
+			break
+
 		antag_candidates -= cultist
 		cult += cultist
 		log_game("[cultist.key] (ckey) has been selected as a cultist")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -414,10 +414,10 @@ proc/display_roundstart_logout_report()
 
 	var/should_break = 0 //This proc goes in the pre_setup() loops
 
-	if(Save_file.roundstart_logout_count && !Mind.current.client.roundstart_punishment_searched)
+	if(Save_file.roundstart_logout_and_suicide_count && !Mind.current.client.roundstart_punishment_searched)
 		log_game("[Mind.key] (ckey) has been searched for roundstart punishment")
 		Mind.current.client.roundstart_punishment_searched++
-		switch(Save_file.roundstart_logout_count)
+		switch(Save_file.roundstart_logout_and_suicide_count)
 			if(MIN_ROUNDSTART_LOGOUT_PUNISHMENT to MAX_ROUNDSTART_LOGOUT_PUNISHMENT)
 				log_game("[Mind.key] (ckey) has been denied an antagonist role and placed back into the candidates pool")
 				should_break++
@@ -430,14 +430,26 @@ proc/display_roundstart_logout_report()
 		return 1
 	return 0
 
+
+//Mob proc for simple updating of roundstart_logout_and_suicide_count
+/mob/proc/update_roundstart_logouts_and_suicides()
+	if(client && client.prefs)
+		var/datum/preferences/Save_file = client.prefs
+		Save_file.roundstart_logout_and_suicide_count++
+		Save_file.save_misc()
+
+
 //Lower's everyone in the game's rounstart_logout_count by 1, as a reward for finishing the round
 //this allows players to earn back normal antag chances
 /proc/handle_roundend_reward()
 	for(var/mob/living/carbon/human/player in player_list)
+		if(player.suiciding)
+			continue
+
 		if(player && player.client && player.client.prefs)
 			var/datum/preferences/Save_file = player.client.prefs
-			Save_file.roundstart_logout_count--
-			if(Save_file.roundstart_logout_count < 0)
-				Save_file.roundstart_logout_count = 0
+			Save_file.roundstart_logout_and_suicide_count--
+			if(Save_file.roundstart_logout_and_suicide_count < 0)
+				Save_file.roundstart_logout_and_suicide_count = 0
 			Save_file.save_misc()
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -392,3 +392,52 @@ proc/display_roundstart_logout_report()
 	for(var/mob/M in mob_list)
 		if(M.client && M.client.holder)
 			M << msg
+
+
+/////////////////////////////////////////////////////////
+//Punishes Roundstart Logouts with reduced antag chance//
+/////////////////////////////////////////////////////////
+
+//Remie's Roundstart Logout Punishment
+
+/datum/game_mode/proc/handle_antag_punishments(var/datum/mind/Mind)
+	if(!istype(Mind))
+		return 1 //No mind, don't antag them
+
+	var/datum/preferences/Save_file = Mind.current.client.prefs
+
+	if(!Save_file)
+		return 1 //No save file, something weird happened
+
+	if(!config.punish_roundstart_logouts)
+		return 0 //So that the punishment is skipped
+
+	var/should_break = 0 //This proc goes in the pre_setup() loops
+
+	if(Save_file.roundstart_logout_count && !Mind.current.client.roundstart_punishment_searched)
+		log_game("[Mind.key] (ckey) has been searched for roundstart punishment")
+		Mind.current.client.roundstart_punishment_searched++
+		switch(Save_file.roundstart_logout_count)
+			if(MIN_ROUNDSTART_LOGOUT_PUNISHMENT to MAX_ROUNDSTART_LOGOUT_PUNISHMENT)
+				log_game("[Mind.key] (ckey) has been denied an antagonist role and placed back into the candidates pool")
+				should_break++
+			if((MAX_ROUNDSTART_LOGOUT_PUNISHMENT + 1) to INFINITY)
+				antag_candidates.Remove(Mind)
+				log_game("[Mind.key] (ckey) has been denied an antagonist role and removed from candidates pool")
+				should_break++
+
+	if(should_break)
+		return 1
+	return 0
+
+//Lower's everyone in the game's rounstart_logout_count by 1, as a reward for finishing the round
+//this allows players to earn back normal antag chances
+/proc/handle_roundend_reward()
+	for(var/mob/living/carbon/human/player in player_list)
+		if(player && player.client && player.client.prefs)
+			var/datum/preferences/Save_file = player.client.prefs
+			Save_file.roundstart_logout_count--
+			if(Save_file.roundstart_logout_count < 0)
+				Save_file.roundstart_logout_count = 0
+			Save_file.save_misc()
+

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -309,8 +309,14 @@ var/round_start_time = 0
 				if(blackbox)
 					blackbox.save_all_data_to_sql()
 
+
 				if(!delay_end)
 					sleep(restart_timeout)
+
+					//Lower's everyone in the game's rounstart_logout_count by 1, as a reward for finishing the round
+					//this allows players to earn back normal antag chances
+					handle_roundend_reward()
+
 					kick_clients_in_lobby("\red The round came to an end with you in the lobby.", 1) //second parameter ensures only afk clients are kicked
 					world.Reboot()
 				else

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -47,6 +47,10 @@
 	var/datum/mind/chosen_ai
 	for(var/i = required_enemies, i > 0, i--)
 		chosen_ai=pick(antag_candidates)
+
+		if(handle_antag_punishments(chosen_ai))
+			break
+
 		malf_ai += chosen_ai
 		antag_candidates -= malf_ai
 	if (malf_ai.len < required_enemies)

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -33,6 +33,10 @@
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/carrier = pick(antag_candidates)
+
+		if(handle_antag_punishments(carrier))
+			break
+
 		carriers += carrier
 		carrier.special_role = "monkey"
 		log_game("[carrier.key] (ckey) has been selected as a Jungle Fever carrier")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -38,6 +38,10 @@
 
 	while(agent_number > 0)
 		var/datum/mind/new_syndicate = pick(antag_candidates)
+
+		if(handle_antag_punishments(new_syndicate))
+			break
+
 		syndicates += new_syndicate
 		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
 		agent_number--

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -58,6 +58,10 @@
 		if (antag_candidates.len==0)
 			break
 		var/datum/mind/lenin = pick(antag_candidates)
+
+		if(handle_antag_punishments(lenin))
+			break
+
 		antag_candidates -= lenin
 		head_revolutionaries += lenin
 		log_game("[lenin.key] (ckey) has been selected as a head rev")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -50,6 +50,10 @@
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/traitor = pick(antag_candidates)
+
+		if(handle_antag_punishments(traitor))
+			break
+
 		traitors += traitor
 		traitor.special_role = traitor_name
 		log_game("[traitor.key] (ckey) has been selected as a [traitor_name]")

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -22,6 +22,10 @@
 /datum/game_mode/wizard/pre_setup()
 
 	var/datum/mind/wizard = pick(antag_candidates)
+
+	if(handle_antag_punishments(wizard))
+		return 0
+
 	wizards += wizard
 	modePlayer += wizard
 	wizard.assigned_role = "MODE" //So they aren't chosen for other jobs.

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -22,6 +22,9 @@
 			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
 			return
 		suiciding = 1
+
+		update_roundstart_logouts_and_suicides()
+
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
@@ -91,10 +94,12 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		viewers(loc) << "\red <b>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</b>"
 		spawn(50)
 			death(0)
 			suiciding = 0
+
 
 /mob/living/carbon/monkey/verb/suicide()
 	set hidden = 1
@@ -118,6 +123,7 @@
 			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
 			return
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
 		viewers(src) << "\red <b>[src] is attempting to bite \his tongue. It looks like \he's trying to commit suicide.</b>"
 		adjustOxyLoss(max(175- getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -138,6 +144,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		viewers(src) << "\red <b>[src] is powering down. It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -158,6 +165,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		viewers(src) << "\red <b>[src] is powering down. It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -172,6 +180,7 @@
 		card.removePersonality()
 		for (var/mob/M in viewers(loc))
 			M.show_message("\blue [src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"", 3, "\blue [src] bleeps electronically.", 2)
+		update_roundstart_logouts_and_suicides()
 		death(0)
 	else
 		src << "Aborting suicide attempt."
@@ -191,6 +200,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		viewers(src) << "\red <b>[src] is thrashing wildly! It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(175 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -211,6 +221,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		update_roundstart_logouts_and_suicides()
 		setOxyLoss(100)
 		adjustBruteLoss(100 - getBruteLoss())
 		setToxLoss(100)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -522,6 +522,13 @@ var/global/floorIsLava = 0
 		if(blackbox)
 			blackbox.save_all_data_to_sql()
 
+		//Lower's everyone in the game's rounstart_logout_count by 1, as a reward for finishing the round
+		//this allows players to earn back normal antag chances
+		handle_roundend_reward()
+
+		if(ticker)
+			ticker.current_state = GAME_STATE_FINISHED
+
 		sleep(50)
 		world.Reboot()
 
@@ -678,6 +685,13 @@ var/global/floorIsLava = 0
 
 	if(blackbox)
 		blackbox.save_all_data_to_sql()
+
+	//Lower's everyone in the game's rounstart_logout_count by 1, as a reward for finishing the round
+	//this allows players to earn back normal antag chances
+	handle_roundend_reward()
+
+	if(ticker)
+		ticker.current_state = GAME_STATE_FINISHED
 
 	world.Reboot()
 

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -39,3 +39,11 @@
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
 	preload_rsc = PRELOAD_RSC
+
+		//////////////////////////////////
+		//Roundstart Antag Chance Checks//
+		//////////////////////////////////
+
+	var/roundstart_punishment_searched = 0 //If you're a good little boy or girl, this will always be 0
+	//This is tied to roundstart_logout_count in a player's savefile, both are used in Game mode code
+	//to reduce a player's chance at antag if they're logging out alot at roundstart

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -165,7 +165,7 @@ var/next_external_rsc = 0
 		return
 
 	if(world.time <= ROUNDSTART_END_TIME)
-		Save_file.roundstart_logout_count++
+		Save_file.roundstart_logout_and_suicide_count++
 		Save_file.save_misc()
 
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -150,8 +150,23 @@ var/next_external_rsc = 0
 		admins -= src
 	directory -= ckey
 	clients -= src
+
+	check_for_roundstart_logout() //Checks for an early logout, and saves the preferences to savefile
+
 	return ..()
 
+
+/client/proc/check_for_roundstart_logout()
+	if(!ticker || ticker.current_state == GAME_STATE_FINISHED)
+		return
+
+	var/datum/preferences/Save_file = prefs
+	if(!Save_file)
+		return
+
+	if(world.time <= ROUNDSTART_END_TIME)
+		Save_file.roundstart_logout_count++
+		Save_file.save_misc()
 
 
 /client/proc/log_client_to_db()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -31,7 +31,7 @@ datum/preferences
 	var/muted = 0
 	var/last_ip
 	var/last_id
-	var/roundstart_logout_count = 0		//Reduced antag chance based on bad behaviour!
+	var/roundstart_logout_and_suicide_count = 0		//Reduced antag chance based on bad behaviour!
 
 
 	//game-preferences

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -31,6 +31,8 @@ datum/preferences
 	var/muted = 0
 	var/last_ip
 	var/last_id
+	var/roundstart_logout_count = 0		//Reduced antag chance based on bad behaviour!
+
 
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
@@ -94,15 +96,21 @@ datum/preferences
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
 				max_save_slots = 8
+
+	var/loaded_misc_successfully = load_misc()
+
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
 		if(load_character())
 			return
+
 	//we couldn't load character data so just randomize the character appearance + name
 	random_character()		//let's create a random character then - rather than a fat, bald and naked man.
 	real_name = random_name(gender)
 	if(!loaded_preferences_successfully)
 		save_preferences()
+	if(!loaded_misc_successfully) //misc stuff failed, make + save defaults
+		save_misc()
 	save_character()		//let's save this new random character so it doesn't keep generating new ones.
 	return
 
@@ -719,10 +727,12 @@ datum/preferences
 					if("save")
 						save_preferences()
 						save_character()
+						save_misc()
 
 					if("load")
 						load_preferences()
 						load_character()
+						load_misc()
 
 					if("changeslot")
 						if(!load_character(text2num(href_list["num"])))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -287,7 +287,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	S["version"] << SAVEFILE_VERSION_MAX
 
-	S["roundstart_logout_count"] << roundstart_logout_count
+	S["roundstart_logout_and_suicide_count"] << roundstart_logout_and_suicide_count
 
 	return 1
 
@@ -302,7 +302,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update == -2)
 		return 0
 
-	S["roundstart_logout_count"] >> roundstart_logout_count
+	S["roundstart_logout_and_suicide_count"] >> roundstart_logout_and_suicide_count
 
 	if(needs_update >= 0)
 		update_preferences(needs_update)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -136,6 +136,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	return 1
 
+
 /datum/preferences/proc/load_character(slot)
 	if(!path)				return 0
 	if(!fexists(path))		return 0
@@ -266,6 +267,45 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_high"]	<< job_engsec_high
 	S["job_engsec_med"]		<< job_engsec_med
 	S["job_engsec_low"]		<< job_engsec_low
+
+	return 1
+
+
+//////////////////////////////////////////////////////////
+// MISC things that need to be persistant in a savefile //
+//////////////////////////////////////////////////////////
+
+//these are seperate to character() and preferences()
+//because I don't want anyone to have to deal with any weirdness
+//that may come from saving character() and prefernces mid round
+
+/datum/preferences/proc/save_misc()
+	if(!path)				return 0
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	S["version"] << SAVEFILE_VERSION_MAX
+
+	S["roundstart_logout_count"] << roundstart_logout_count
+
+	return 1
+
+/datum/preferences/proc/load_misc()
+	if(!path)				return 0
+	if(!fexists(path))		return 0
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	S.cd = "/"
+
+	var/needs_update = savefile_needs_update(S)
+	if(needs_update == -2)
+		return 0
+
+	S["roundstart_logout_count"] >> roundstart_logout_count
+
+	if(needs_update >= 0)
+		update_preferences(needs_update)
 
 	return 1
 


### PR DESCRIPTION
# Main:

Logging out or suiciding before a Defined ROUNDSTART_END_TIME (Defaults to 10 minutes) resorts in a variable on your savefile roundstart_logout_and_suicide_count going up by 1. When rolling for an antagonist role, this is taken into account. if roundstart_logout_and_suicide_count is between 2 defines, a MIN and a MAX the current antag loop ends, and you're placed back into the pool (so you were technically punished, but can still roll a lucky antag). if it's between the MAX and INFINITY you are removed form the candidate list entirely for that round. Admins can bypass this entirely using the usual create antagonist procs.
Whenever you are present for a round end, be in natural or by an Admin, your roundstart_logout_count is reduced by 1, allowing you to "earn" your normal antag rolls back overtime.
# Config:

Logging of Roundstart logouts and suicides always happens, regardless of the config.
Punishment because of Roundstart logouts and suicides is locked to the config

This needs to be added to SoS's game_options.txt (I didn't do this so that it doesn't conflict with his)
## Punish players who frequently log out at roundstart
## (before a specified time, default 10 mins) with reduced antag chances

PUNISH_ROUNDSTART_LOGOUTS

The above defaults to ON, as in punishing the player.
# Extra code stuff:

New save and load procs for preferences, save_misc() and load_misc()
This is because I fear saving someone's normal preferences during a round will cause issues, so I made new procs
# Why:

This is designed to encourage players staying in the round, and to discourage "I didn't get antag? Disconnect" behaviour.

I'm aware of the Feature Freeze, but this will probably need a bit of discussion.
poll: http://tgstation13.org/phpBB/viewtopic.php?f=9&t=1112
