### PR TITLE
F12 feedback text small change

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -298,7 +298,7 @@ datum/hud/New(mob/owner)
 	if(hud_used && client)
 		if(ishuman(src))
 			hud_used.show_hud() //Shows the next hud preset
-			usr << "<span class ='info'>Switched HUD mode.</span>"
+			usr << "<span class ='info'>Switched HUD mode. Press F12 to toggle.</span>"
 		else
 			usr << "<span class ='warning'>Inventory hiding is currently only supported for human mobs, sorry.</span>"
 	else


### PR DESCRIPTION
Changes the message of the F12 button to toggle the HUD, adding a string mentioning that you need to use F12 to use it, in case of pressing it by accident. (Yes it happens)
