### PR TITLE
opening/closing powerless machines

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -486,8 +486,6 @@
 	qdel(G)
 
 /obj/machinery/dna_scannernew/attack_hand(mob/user)
-	if(..())
-		return
 	toggle_open(user)
 	add_fingerprint(user)
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -132,42 +132,16 @@
 	open_machine()
 
 /obj/machinery/sleeper/attack_hand(mob/user)
-	if(..())
-		return
-	var/dat = "<h3>Sleeper Status</h3>"
-
-	dat += "<div class='statusDisplay'>"
-	if(!occupant)
-		dat += "Sleeper Unoccupied"
+	if(stat & (BROKEN|NOPOWER))
+		if(state_open)
+			close_machine()
+		else
+			open_machine()
 	else
-		dat += "[occupant.name] => "
-		switch(occupant.stat)	//obvious, see what their status is
-			if(0)
-				dat += "<span class='good'>Conscious</span>"
-			if(1)
-				dat += "<span class='average'>Unconscious</span>"
-			else
-				dat += "<span class='bad'>DEAD</span>"
+		sleeperUI(user)
 
-		dat += "<br />"
-
-		dat +=  "<div class='line'><div class='statusLabel'>Health:</div><div class='progressBar'><div style='width: [occupant.health]%;' class='progressFill good'></div></div><div class='statusValue'>[occupant.health]%</div></div>"
-		dat +=  "<div class='line'><div class='statusLabel'>\> Brute Damage:</div><div class='progressBar'><div style='width: [occupant.getBruteLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getBruteLoss()]%</div></div>"
-		dat +=  "<div class='line'><div class='statusLabel'>\> Resp. Damage:</div><div class='progressBar'><div style='width: [occupant.getOxyLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getOxyLoss()]%</div></div>"
-		dat +=  "<div class='line'><div class='statusLabel'>\> Toxin Content:</div><div class='progressBar'><div style='width: [occupant.getToxLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getToxLoss()]%</div></div>"
-		dat +=  "<div class='line'><div class='statusLabel'>\> Burn Severity:</div><div class='progressBar'><div style='width: [occupant.getFireLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getFireLoss()]%</div></div>"
-
-		dat += "<HR><div class='line'><div class='statusLabel'>Paralysis Summary:</div><div class='statusValue'>[round(occupant.paralysis)]% [occupant.paralysis ? "([round(occupant.paralysis / 4)] seconds left)" : ""]</div></div>"
-		if(occupant.reagents.reagent_list.len)
-			for(var/datum/reagent/R in occupant.reagents.reagent_list)
-				dat += text("<div class='line'><div class='statusLabel'>[R.name]:</div><div class='statusValue'>[] units</div></div>", round(R.volume, 0.1))
-
-	dat += "</div>"
-
-	dat += "<A href='?src=\ref[src];refresh=1'>Scan</A>"
-
-	dat += "<A href='?src=\ref[src];[state_open ? "close=1'>Close</A>" : "open=1'>Open</A>"]"
-
+/obj/machinery/sleeper/proc/sleeperUI(mob/user)
+	var/dat
 	dat += "<h3>Injector</h3>"
 	if(occupant)
 		dat += "<A href='?src=\ref[src];inject=inaprovaline'>Inject Inaprovaline</A>"
@@ -183,6 +157,34 @@
 			var/datum/reagent/C = chemical_reagents_list[re]
 			if(C)
 				dat += "<BR><span class='linkOff'>Inject [C.name]</span>"
+
+	dat += "<h3>Sleeper Status</h3>"
+	dat += "<A href='?src=\ref[src];refresh=1'>Scan</A>"
+	dat += "<A href='?src=\ref[src];[state_open ? "close=1'>Close</A>" : "open=1'>Open</A>"]"
+	dat += "<div class='statusDisplay'>"
+	if(!occupant)
+		dat += "Sleeper Unoccupied"
+	else
+		dat += "[occupant.name] => "
+		switch(occupant.stat)	//obvious, see what their status is
+			if(0)
+				dat += "<span class='good'>Conscious</span>"
+			if(1)
+				dat += "<span class='average'>Unconscious</span>"
+			else
+				dat += "<span class='bad'>DEAD</span>"
+		dat += "<br />"
+		dat +=  "<div class='line'><div class='statusLabel'>Health:</div><div class='progressBar'><div style='width: [occupant.health]%;' class='progressFill good'></div></div><div class='statusValue'>[occupant.health]%</div></div>"
+		dat +=  "<div class='line'><div class='statusLabel'>\> Brute Damage:</div><div class='progressBar'><div style='width: [occupant.getBruteLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getBruteLoss()]%</div></div>"
+		dat +=  "<div class='line'><div class='statusLabel'>\> Resp. Damage:</div><div class='progressBar'><div style='width: [occupant.getOxyLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getOxyLoss()]%</div></div>"
+		dat +=  "<div class='line'><div class='statusLabel'>\> Toxin Content:</div><div class='progressBar'><div style='width: [occupant.getToxLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getToxLoss()]%</div></div>"
+		dat +=  "<div class='line'><div class='statusLabel'>\> Burn Severity:</div><div class='progressBar'><div style='width: [occupant.getFireLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getFireLoss()]%</div></div>"
+
+		dat += "<HR><div class='line'><div class='statusLabel'>Paralysis Summary:</div><div class='statusValue'>[round(occupant.paralysis)]% [occupant.paralysis ? "([round(occupant.paralysis / 4)] seconds left)" : ""]</div></div>"
+		if(occupant.reagents.reagent_list.len)
+			for(var/datum/reagent/R in occupant.reagents.reagent_list)
+				dat += text("<div class='line'><div class='statusLabel'>[R.name]:</div><div class='statusValue'>[] units</div></div>", round(R.volume, 0.1))
+	dat += "</div>"
 
 	var/datum/browser/popup = new(user, "sleeper", "Sleeper Console", 520, 540)	//Set up the popup browser window
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -100,7 +100,13 @@
 		usr << "<span class='notice'>Too far away to view contents.</span>"
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
-	ui_interact(user)
+	if(stat & (NOPOWER|BROKEN))
+		if(state_open == 1)
+			close_machine()
+		else
+			open_machine()
+	else
+		ui_interact(user)
 
 
  /**
@@ -189,7 +195,6 @@
 			on = 1
 
 	if(href_list["open"])
-		on = 0
 		open_machine()
 
 	if(href_list["close"])
@@ -235,6 +240,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/open_machine()
 	if(!state_open && !panel_open)
+		on = 0
 		layer = 3
 		if(occupant)
 			occupant.bodytemperature = Clamp(occupant.bodytemperature, 261, 360)


### PR DESCRIPTION
Sleepers, cryo tubes and DNA scanners now open and close without power by just clicking on them.
Switched the "Sleeper status" and the "Injectors" position of the sleepers UI to stop the missclicks while using the console.
Cryo tubes will turn off automatically if they are open in all cases, they'll stop closing and activate instantly this way.
