### PR TITLE
proc/inherit_role()

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -66,6 +66,7 @@
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(T)
 	C.prefs.copy_to(M)
 	M.key = C.key
+	inherit_role(usr,M)
 	M << "<B>You are the [usr.real_name]'s apprentice! You are bound by magic contract to follow their orders and help them in accomplishing their goals."
 	switch(type)
 		if("destruction")
@@ -96,13 +97,13 @@
 	M.mind.name = newname
 	M.real_name = newname
 	M.name = newname
-	var/datum/objective/protect/new_objective = new /datum/objective/protect
+	/*var/datum/objective/protect/new_objective = new /datum/objective/protect
 	new_objective.owner = M:mind
 	new_objective:target = usr:mind
 	new_objective.explanation_text = "Protect [usr.real_name], the wizard."
 	M.mind.objectives += new_objective
 	ticker.mode.traitors += M.mind
-	M.mind.special_role = "apprentice"
+	M.mind.special_role = "apprentice"*/
 	M << sound('sound/effects/magic.ogg')
 
 /obj/item/weapon/antag_spawner/contract/equip_antag(mob/target as mob)
@@ -140,7 +141,8 @@
 	S.start()
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot/syndicate(T)
 	R.key = C.key
-	ticker.mode.syndicates += R.mind
+	inherit_role(usr,R)
+	/*ticker.mode.syndicates += R.mind
 	ticker.mode.update_synd_icons_added(R.mind)
 	R.mind.special_role = "syndicate"
-	R.faction = list("syndicate")
+	R.faction = list("syndicate")*/

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -170,12 +170,13 @@ proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/targ
 	var/mob/living/simple_animal/construct/newstruct = new ctype(get_turf(target))
 	newstruct.faction |= "\ref[stoner]"
 	newstruct.key = target.key
-	if(stoner && iscultist(stoner) || cultoverride)
+	inherit_role(stoner,newstruct)
+	/*if(stoner && iscultist(stoner) || cultoverride)
 		if(ticker.mode.name == "cult")
 			ticker.mode:add_cultist(newstruct.mind)
 		else
 			ticker.mode.cult+=newstruct.mind
-		ticker.mode.update_cult_icons_added(newstruct.mind)
+		ticker.mode.update_cult_icons_added(newstruct.mind)*/
 	newstruct << newstruct.playstyle_string
 	newstruct << "<B>You are still bound to serve your creator, follow their orders and help them complete their goals at all costs.</B>"
 	newstruct.cancel_camera()
@@ -198,8 +199,9 @@ proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/targ
 	S.real_name = "Shade of [T.real_name]"
 	S.key = T.key
 	S.faction |= "\ref[U]" //Add the master as a faction, allowing inter-mob cooperation
-	if(iscultist(U))
-		ticker.mode.add_cultist(S.mind,2)
+	inherit_role(U,S)
+	/*if(iscultist(U))
+		ticker.mode.add_cultist(S.mind,2)*/
 	S.cancel_camera()
 	C.icon_state = "soulstone2"
 	C.name = "Soul Stone: [S.real_name]"

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -214,6 +214,7 @@
 				M.Friends = Friends.Copy()
 				babies += M
 				feedback_add_details("slime_babies_born","slimebirth_[replacetext(M.colour," ","_")]")
+				inherit_role(src,M)
 
 			var/mob/living/carbon/slime/new_slime = pick(babies)
 			new_slime.a_intent = "harm"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -925,6 +925,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		G.loc = src.loc
 		G.key = ghost.key
 		G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost."
+		inherit_role(user,G)
 		qdel(src)
 
 /mob/living/carbon/slime/getTrail()


### PR DESCRIPTION
Designed a proc that gives mobs that are the creations of antags antag status themselves. They don't always become the SAME antag because that doesn't always make sense (like a ling who makes a golem wouldn't make the golem a ling). All the same it clearly delineates "yes you were made by an antag and have antag status" and "no you're still station aligned because that idiot lost his soul stones to the clown". It also means that there won't be any problems with a station aligned shade having cult vision, because it won't anymore if it's truly station aligned.

I'm still testing this a bit so I've only commented out the code instead of removing it wholesale, I will once I'm sure all the functionality is replicated properly.

Currently this replaces the normal methods for soul stoning, constructing, golem summoning, slime splitting, and syndiborg/apprentice summoning. There might be other places it could be used. I was debating on if it should work on pAIs among other things.

Fixes #4276, probably some others too
