### PR TITLE
Bugfix For Mechs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -966,7 +966,9 @@
 	visible_message("<span class='notice'>[user] starts to climb into [src.name]")
 
 	if(enter_after(40,user))
-		if(!src.occupant)
+		if(src.health <= 0)
+			user << "You cannot get in the [src.name], it has been destroyed."
+		else if(!src.occupant)
 			moved_inside(user)
 		else if(src.occupant!=user)
 			user << "[src.occupant] was faster. Try better next time, loser."


### PR DESCRIPTION
Added in a check to see if the mech a player is trying to enter has a health value greater than 0. This fixes a bug whereby if a player is entering a mech as it is destroyed, their mob gets deleted and the player loses connection to the server. Reconnecting to the server allows this player to rejoin the game, but as a new person.
