### PR TITLE
Make new_players dereference from their mind when observing

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -119,6 +119,7 @@
 				observer.real_name = client.prefs.real_name
 				observer.name = observer.real_name
 				observer.key = key
+				qdel(mind)
 
 				qdel(src)
 				return 1


### PR DESCRIPTION
When observing, that observer would be given their original new_player's mind, but that mind would still have the new_player as its current. This caused the new_player to fail to GC and resulted in the observer's mind's current becoming null.

Fix: Just delete the new_player mind when the player observes. If an admin turns them into a human or whatever, a new mind will be created automatically then.
