### PR TITLE
Removes lights from the machinery process() list

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -1,8 +1,11 @@
 // channel numbers for power
-#define EQUIP	1
-#define LIGHT	2
-#define ENVIRON	3
-#define TOTAL	4	//for total power used only
+#define EQUIP			1
+#define LIGHT			2
+#define ENVIRON			3
+#define TOTAL			4	//for total power used only
+#define STATIC_EQUIP 	5
+#define STATIC_LIGHT	6
+#define STATIC_ENVIRON	7
 
 
 //bitflags for door switches.

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -271,15 +271,6 @@ datum/controller/game_controller/proc/process_machines()
 					continue
 		machines.Cut(i,i+1)
 
-mob/verb/aranclanos()
-
-	var/list/listita = list()
-	for(var/atom/A in machines)
-		listita[A.type] ++
-		//world << "[A.name]_[A.type]_([A.x], [A.y], [A.z])"
-	for(var/A in listita)
-		world << "[A]: [listita[A]]"
-
 datum/controller/game_controller/proc/process_objects()
 	var/i = 1
 	while(i<=processing_objects.len)

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -271,6 +271,15 @@ datum/controller/game_controller/proc/process_machines()
 					continue
 		machines.Cut(i,i+1)
 
+mob/verb/aranclanos()
+
+	var/list/listita = list()
+	for(var/atom/A in machines)
+		listita[A.type] ++
+		//world << "[A.name]_[A.type]_([A.x], [A.y], [A.z])"
+	for(var/A in listita)
+		world << "[A]: [listita[A]]"
+
 datum/controller/game_controller/proc/process_objects()
 	var/i = 1
 	while(i<=processing_objects.len)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -41,6 +41,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/used_equip = 0
 	var/used_light = 0
 	var/used_environ = 0
+	var/static_equip
+	var/static_light = 0
+	var/static_environ
 
 	var/has_gravity = 0
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -234,8 +234,22 @@
 			used += master.used_environ
 		if(TOTAL)
 			used += master.used_light + master.used_equip + master.used_environ
-
+		if(STATIC_EQUIP)
+			used += master.static_equip
+		if(STATIC_LIGHT)
+			used += master.static_light
+		if(STATIC_ENVIRON)
+			used += master.static_environ
 	return used
+
+/area/proc/addStaticPower(value, powerchannel)
+	switch(powerchannel)
+		if(STATIC_EQUIP)
+			static_equip += value
+		if(STATIC_LIGHT)
+			static_light += value
+		if(STATIC_ENVIRON)
+			static_environ += value
 
 /area/proc/clear_usage()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1018,10 +1018,12 @@
 		use_power(src.environ_consumption, ENVIRON)
 
 	area.calc_lighting() */
-
-	lastused_light = area.usage(LIGHT)
+	lastused_light = area.usage(STATIC_LIGHT)
+	lastused_light += area.usage(LIGHT)
 	lastused_equip = area.usage(EQUIP)
+	lastused_equip += area.usage(STATIC_EQUIP)
 	lastused_environ = area.usage(ENVIRON)
+	lastused_environ += area.usage(STATIC_ENVIRON)
 	area.clear_usage()
 
 	lastused_total = lastused_light + lastused_equip + lastused_environ

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -201,6 +201,7 @@
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	var/on = 0					// 1 if on, 0 if off
 	var/on_gs = 0
+	var/static_power_used = 0
 	var/brightness = 8			// luminosity when on, also used in power calculation
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = 0
@@ -302,6 +303,11 @@
 	active_power_usage = (luminosity * 10)
 	if(on != on_gs)
 		on_gs = on
+		if(on)
+			static_power_used = luminosity * 20 //20W per unit luminosity
+			addStaticPower(static_power_used, STATIC_LIGHT)
+		else
+			removeStaticPower(static_power_used, STATIC_LIGHT)
 
 
 // attempt to set the light's on/off status
@@ -595,14 +601,6 @@
 		broken()
 
 
-// timed process
-// use power
-
-#define LIGHTING_POWER_FACTOR 20		//20W per unit luminosity
-
-/obj/machinery/light/process()//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
-	if(on)
-		use_power(luminosity * LIGHTING_POWER_FACTOR, LIGHT)
 
 // called when area power state changes
 /obj/machinery/light/power_change()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -73,6 +73,15 @@
 		chan = power_channel
 	A.master.use_power(amount, chan)
 
+/obj/machinery/proc/addStaticPower(value, powerchannel)
+	var/area/A = get_area(src)
+	if(!A || !A.master)
+		return
+	A.master.addStaticPower(value, powerchannel)
+
+/obj/machinery/proc/removeStaticPower(value, powerchannel)
+	addStaticPower(-value, powerchannel)
+
 /obj/machinery/proc/power_change()		// called whenever the power settings of the containing area change
 										// by default, check equipment channel & set flag
 										// can override if needed


### PR DESCRIPTION
Adds static power value on areas. These variables should replace machines on the process list, that are only there to consume power.
This commit removes lights from the process list, about 500 of them on the current map.
The purpose of this is to reduce lag from the master controller ticker.
