### PR TITLE
Fixes #4338 multiple weed nodes on turf

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -23,6 +23,10 @@ Doesn't work on other aliens/AI.*/
 	set desc = "Plants some alien weeds"
 	set category = "Alien"
 
+	if(locate(/obj/structure/alien/weeds/node) in get_turf(src))
+		src << "There's already a weed node here."
+		return
+
 	if(powerc(50,1))
 		adjustToxLoss(-50)
 		for(var/mob/O in viewers(src, null))


### PR DESCRIPTION
Fixes #4338. Prevents placing a weed node on turf which already has one.
