### PR TITLE
Magic Mania 1.67: Great Balls of Fireballs

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -18,14 +18,24 @@
 /obj/item/projectile/magic/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
-	damage = 25 //The spell fireball additionally does 20 burn, so the wand fireball is marginally less painful
+	damage = 10
 	damage_type = BRUTE
 	nodamage = 0
 	flag = "magic"
 
+/obj/item/projectile/magic/fireball/Range()
+	var/mob/living/L = locate(/mob/living) in (range(src, 1) - firer)
+	if(L && L.stat != DEAD)
+		Bump(L) //Magic Bullet #teachthecontroversy
+		return
+	..()
+
 /obj/item/projectile/magic/fireball/on_hit(var/target)
 	var/turf/T = get_turf(target)
 	explosion(T, -1, 0, 2, 3, 0, flame_range = 2)
+	if(ismob(target)) //multiple flavors of pain
+		var/mob/living/M = target
+		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
 
 /obj/item/projectile/magic/resurrection
 	name = "bolt of resurrection"


### PR DESCRIPTION
Changes the wand of fireball projectile to have the same !!FUN!! proximity detonation properties as the spell version. Slightly moved the damage types from getting hit by the fireball around to better simulate the experience.

Fun fact about spell fireballs: Because the projectile is desiged to explode if it comes within a square of somebody who isn't the wizard direct contact between fireballs and mobs is very rare. This means that while the fireballs are designed to do an extra 25 brute and 20 burn ON CONTACT this usually doesn't happen.

That's why the added damage on the wand here isn't 25/20, because that would actually make it significantly better than the spell.
