### PR TITLE
Suicides and Logouts are now stored on the Database [NEEDS TESTING]

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,3 +13,20 @@ UPDATE erro_library SET deleted = 1 WHERE id = someid
 (Replace someid with the id of the book you want to soft delete.)
 
 ----------------------------------------------------
+
+12 August 2014, by RemieRichards
+
+Added the table TG_logout_and_suicides.
+It records whenever someone logs out or commits suicide.
+
+fields:
+- id //Logout/Suicide's ID
+- userID //User who "owns" the Logout/Suicide
+- datetime //Time of day the Logout/Suicide occurred
+- roundtime //Roundtime the Logout/Suicide occurred
+- isAntag //If they were an Antag at the time of Logout/Suicide
+- typeLS //Type of Logout/Suicide, it's either "Logout" or "Suicide"
+
+
+
+

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -107,6 +107,26 @@ CREATE TABLE `erro_ban` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `TG_logouts_and_suicides`
+-- By RemieRichards
+-- 
+
+DROP TABLE IF EXISTS `TG_logouts_and_suicides`; 
+/*!40101 SET @saved_cs_client	= @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `TG_logouts_and_suicides` (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`userID` int(11) NOT NULL,
+	`datetime` datetime DEFAULT NULL,
+	`roundtime` int(11) DEFAULT NULL,
+	`isAntag` BOOLEAN DEFAULT NULL,
+	`typeLS` varchar(32) NOT NULL,
+	PRIMARY KEY(`id`)
+	FOREIGN KEY(`userID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `erro_connection_log`
 --
 

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -35,3 +35,8 @@
 #define R_SPAWN			4096
 
 #define R_MAXPERMISSION 4096 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+
+
+//Logout/Suicide logging defines
+#define LOGOUT	"Logout"
+#define SUICIDE "Suicide"

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -71,6 +71,7 @@
 							"\red <b>[src] is holding \his breath! It looks like \he's trying to commit suicide.</b>"))
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
+		DB_add_logout_suicide_record(SUICIDE)
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -22,6 +22,7 @@
 			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
 			return
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
@@ -71,7 +72,6 @@
 							"\red <b>[src] is holding \his breath! It looks like \he's trying to commit suicide.</b>"))
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
-		DB_add_logout_suicide_record(SUICIDE)
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1
@@ -92,6 +92,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		viewers(loc) << "\red <b>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</b>"
 		spawn(50)
 			death(0)
@@ -119,6 +120,7 @@
 			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
 			return
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
 		viewers(src) << "\red <b>[src] is attempting to bite \his tongue. It looks like \he's trying to commit suicide.</b>"
 		adjustOxyLoss(max(175- getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -139,6 +141,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		viewers(src) << "\red <b>[src] is powering down. It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -159,6 +162,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		viewers(src) << "\red <b>[src] is powering down. It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -173,6 +177,7 @@
 		card.removePersonality()
 		for (var/mob/M in viewers(loc))
 			M.show_message("\blue [src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"", 3, "\blue [src] bleeps electronically.", 2)
+		DB_add_logout_suicide_record(SUICIDE)
 		death(0)
 	else
 		src << "Aborting suicide attempt."
@@ -192,6 +197,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		viewers(src) << "\red <b>[src] is thrashing wildly! It looks like \he's trying to commit suicide.</b>"
 		//put em at -175
 		adjustOxyLoss(max(175 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
@@ -212,6 +218,7 @@
 
 	if(confirm == "Yes")
 		suiciding = 1
+		DB_add_logout_suicide_record(SUICIDE)
 		setOxyLoss(100)
 		adjustBruteLoss(100 - getBruteLoss())
 		setToxLoss(100)

--- a/code/modules/admin/DB ban/DB_helpers.dm
+++ b/code/modules/admin/DB ban/DB_helpers.dm
@@ -3,7 +3,7 @@
 Table needs to be a string corresponding to one of our SQL tables see the SQL.schema file for them.
 */
 
-/proc/DB_get_ID_from_table(var/mob/M, var/table) //finds an ID corresponding to M, in table
+/proc/DB_get_ID_from_table(var/mob/M, var/table, var/allow_multiples) //finds an ID corresponding to M, in table
 	establish_db_connection()
 	if(!dbcon.IsConnected())
 		return "<span class='warning'>Database connection failed.</span>"
@@ -26,7 +26,7 @@ Table needs to be a string corresponding to one of our SQL tables see the SQL.sc
 	if(id_number == 0) //No matches
 		return "<span class='warning'>Database find failed due to no matches fitting the search criteria.</span>"
 
-	if(id_number > 1) //Too many matches
+	if(!allow_multiples && id_number > 1) //Too many matches
 		return "<span class='warning'>Database find failed due to multiple matches fitting the search criteria.</span>"
 
 	if(istext(id))

--- a/code/modules/admin/DB ban/DB_helpers.dm
+++ b/code/modules/admin/DB ban/DB_helpers.dm
@@ -1,0 +1,37 @@
+
+/*
+Table needs to be a string corresponding to one of our SQL tables see the SQL.schema file for them.
+*/
+
+/proc/DB_get_ID_from_table(var/mob/M, var/table) //finds an ID corresponding to M, in table
+	establish_db_connection()
+	if(!dbcon.IsConnected())
+		return "<span class='warning'>Database connection failed.</span>"
+
+	if(!M || M.ckey)
+		return "<span class='warning'>No Mob or Mob Ckey.</span>"
+
+	if(!table)
+		return "<span class='warning'>No table specified, This is a code issue.</span>"
+
+	var/sql_find = "SELECT id FROM [table] WHERE ckey = '[M.ckey]'"
+	var/id
+	var/id_number = 0
+	var/DBQuery/query = dbcon.NewQuery(sql_find)
+	query.Execute()
+	while(query.NextRow())
+		id = query.item[1]
+		id_number++
+
+	if(id_number == 0) //No matches
+		return "<span class='warning'>Database find failed due to no matches fitting the search criteria.</span>"
+
+	if(id_number > 1) //Too many matches
+		return "<span class='warning'>Database find failed due to multiple matches fitting the search criteria.</span>"
+
+	if(istext(id))
+		id = text2num(id)
+	if(!isnum(id))
+		return "<span class='warning'>Database find failed due to an ID mismatch. Contact the database admin.</span>"
+
+	return id

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -140,7 +140,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 /mob/proc/DB_add_logout_suicide_record(var/typeLS)
 	var/id = DB_get_ID_from_table(src,"erro_ban")
-	if(!id)
+	if(!id || !isnum(id))
 		return
 
 	if(!typeLS)
@@ -156,7 +156,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 /datum/admins/proc/DB_access_logouts_suicides(var/mob/M) //Not used yet, still WIP.
 	var/id = DB_get_ID_from_table(M,"erro_ban")
-	if(!id || !isnum(id))
+	if(!id)
 		return
 
 	if(!isnum(id)) //ID not a number, ID must be an error message

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -139,7 +139,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 
 /mob/proc/DB_add_logout_suicide_record(var/typeLS)
-	var/id = DB_get_ID_from_table(src,"erro_connection_log")
+	var/id = DB_get_ID_from_table(src,"erro_connection_log",0)
 	if(!id || !isnum(id))
 		return
 
@@ -155,7 +155,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 
 /datum/admins/proc/DB_access_logouts_suicides(var/mob/M) //Not used yet, still WIP.
-	var/id = DB_get_ID_from_table(M,"erro_connection_log")
+	var/id = DB_get_ID_from_table(M,"erro_connection_log",1)
 	if(!id)
 		return
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -139,7 +139,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 
 /mob/proc/DB_add_logout_suicide_record(var/typeLS)
-	var/id = DB_get_ID_from_table(src,"erro_ban")
+	var/id = DB_get_ID_from_table(src,"erro_connection_log")
 	if(!id || !isnum(id))
 		return
 
@@ -155,7 +155,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 
 
 /datum/admins/proc/DB_access_logouts_suicides(var/mob/M) //Not used yet, still WIP.
-	var/id = DB_get_ID_from_table(M,"erro_ban")
+	var/id = DB_get_ID_from_table(M,"erro_connection_log")
 	if(!id)
 		return
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -138,6 +138,41 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 			del(banned_mob.client)
 
 
+/mob/proc/DB_add_logout_suicide_record(var/typeLS)
+	var/id = DB_get_ID_from_table(src,"erro_ban")
+	if(!id)
+		return
+
+	if(!typeLS)
+		return
+
+	var/roundtime = world.time
+	var/isAntag = "[(mind && mind.special_role) ? 1 : 0]"
+
+	var/sql = "INSERT INTO TG_logout_and_suicides (`id`,`userID`,`datetime`,`roundtime`,`isAntag`,`typeLS`) VALUES (null, [id], Now(),[roundtime],[isAntag],'[typeLS]')"
+	var/DBQuery/logout_suicide_record = dbcon.NewQuery(sql)
+	logout_suicide_record.Execute()
+
+
+/datum/admins/proc/DB_access_logouts_suicides(var/mob/M) //Not used yet, still WIP.
+	var/id = DB_get_ID_from_table(M,"erro_ban")
+	if(!id || !isnum(id))
+		return
+
+	if(!isnum(id)) //ID not a number, ID must be an error message
+		usr << id
+		return
+
+	var/logout_suicide = "SELECT id FROM TG_logouts_and_suicides WHERE userID = [id]"
+	var/DBQuery/find = dbcon.NewQuery(logout_suicide)
+	find.Execute()
+	usr << "ID: [find.item[1]]"
+	usr << "Datetime:[find.item[3]]"
+	usr << "Roundtime:[find.item[4]] (miliseconds)"
+	usr << "Is Antag: [(find.item[5] == 1) ? "True":"False"]"
+	usr << "Type: [find.item[6]]"
+
+
 datum/admins/proc/DB_ban_unban(var/ckey, var/bantype, var/job = "")
 
 	if(!check_rights(R_BAN))	return

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -28,6 +28,10 @@
 
 
 				send2irc("Server", "[cheesy_message]")
+
+
+	DB_add_logout_suicide_record(LOGOUT)
+
 	..()
 
 	if(isobj(loc))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -701,6 +701,7 @@
 #include "code\modules\admin\player_notes.dm"
 #include "code\modules\admin\player_panel.dm"
 #include "code\modules\admin\topic.dm"
+#include "code\modules\admin\DB ban\DB_helpers.dm"
 #include "code\modules\admin\DB ban\functions.dm"
 #include "code\modules\admin\permissionverbs\permissionedit.dm"
 #include "code\modules\admin\verbs\adminhelp.dm"


### PR DESCRIPTION
Related to https://github.com/tgstation/-tg-station/pull/4306 
Rock suggested these be added to the Database as an Administrative tool.
Rock is extremely busy so I attempted it myself, this is the result.

Disclaimer:
- SQL is not a language I am brilliant with
- I was unable to test ANY of this due to my computer refusing to setup the SQL servers (even localhost) required to test

DB_add_logout_suicide_record(var/typeLS) is setup to work on Logout and Suicide, using the 2 defines setup for this (They are strings as they are stored in the table for DB_access_logouts_suicides(var/mob/M) and admin use)

DB_access_logouts_suicides(var/mob/M) is a WIP proc and has not been setup to be used anywhere.
Due to lack of SQL knowledge it is cobbled together to the best of my abilities, hence my not using it until someone skilled/knowledgeable can confirm it's safe/functional
