### PR TITLE
Lag spike fix, walls deletion.

### DIFF
--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -97,14 +97,12 @@
 	..()*/
 
 /turf/simulated/wall/Del()
-
-	var/temploc = src.loc
-
 	spawn(10)
-		for(var/turf/simulated/wall/W in range(temploc,1))
+		for(var/turf/simulated/wall/W in range(src,1))
+			world << "asd:[W]([W.x],[W.y],[W.z])"
 			W.relativewall()
 
-		for(var/obj/structure/falsewall/W in range(temploc,1))
+		for(var/obj/structure/falsewall/W in range(src,1))
 			W.relativewall()
 
 	for(var/direction in cardinal)
@@ -114,18 +112,7 @@
 				shroom.icon_state = "glowshroomf"
 				shroom.pixel_x = 0
 				shroom.pixel_y = 0
-
 	..()
-
-/*/turf/simulated/shuttle/wall/Del()
-
-	var/temploc = src.loc
-
-	spawn(10)
-		for(var/turf/simulated/shuttle/wall/W in range(temploc,1))
-			W.relativewall()
-
-	..()*/
 
 /turf/simulated/wall/relativewall()
 	if(istype(src,/turf/simulated/wall/vault)) //HACK!!!

--- a/code/game/smoothwall.dm
+++ b/code/game/smoothwall.dm
@@ -99,7 +99,6 @@
 /turf/simulated/wall/Del()
 	spawn(10)
 		for(var/turf/simulated/wall/W in range(src,1))
-			world << "asd:[W]([W.x],[W.y],[W.z])"
 			W.relativewall()
 
 		for(var/obj/structure/falsewall/W in range(src,1))


### PR DESCRIPTION
Walls deletion will now only update the sprites of the walls near them instead of all the walls of the area.
This will remove the huge lag spike when a wall is deleted in a big area.
