### PR TITLE
canUseTopic() strip panel, take 2.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -35,3 +35,8 @@
 #define CLICK_CD_MELEE 8
 #define CLICK_CD_RANGE 4
 //click cooldowns, in tenths of a second
+
+
+#define BE_CLOSE 1		//in the case of a silicon, to select if they need to be next to the atom
+#define NO_DEXTERY 1	//if other mobs (monkeys, aliens, etc) can use this
+//used by canUseTopic()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -216,8 +216,12 @@ Class Procs:
 	if(check_rights(R_ADMIN))
 		return
 
-/mob/living/canUseTopic()
-	src << "<span class='notice'>You don't have the dexterity to do this!</span>"
+/mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
+	if(no_dextery)
+		if(be_close && in_range(M, src))
+			return 1
+	else
+		src << "<span class='notice'>You don't have the dexterity to do this!</span>"
 	return
 
 /mob/living/carbon/human/canUseTopic(atom/movable/M)
@@ -229,13 +233,17 @@ Class Procs:
 		return
 	return 1
 
-/mob/living/silicon/ai/canUseTopic()
+/mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat)
+		return
+	if(be_close && !in_range(M, src))
 		return
 	return 1
 
-/mob/living/silicon/robot/canUseTopic()
+/mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat || lockcharge || stunned || weakened)
+		return
+	if(be_close && !in_range(M, src))
 		return
 	return 1
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -345,7 +345,7 @@ In all, this is a lot like the monkey code. /N
 /mob/living/carbon/alien/humanoid/Topic(href, href_list)
 	..()
 	//strip panel
-	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
+	if(canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["pouches"])
 			visible_message("<span class='danger'>[usr] tries to empty [src]'s pouches.</span>", \
 							"<span class='userdanger'>[usr] tries to empty [src]'s pouches.</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -420,7 +420,7 @@
 /mob/living/carbon/Topic(href, href_list)
 	..()
 	//strip panel
-	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
+	if(canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["internal"])
 			var/slot = text2num(href_list["internal"])
 			var/obj/item/ITEM = get_item_by_slot(slot)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -403,7 +403,7 @@
 
 
 /mob/living/carbon/human/Topic(href, href_list)
-	if(!usr.stat && usr.canmove && !usr.restrained() && Adjacent(usr))
+	if(canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
 			if(slot in check_obscured_slots())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -485,7 +485,7 @@ var/list/slot_equipment_priority = list( \
 		if(machine && in_range(src, usr))
 			show_inv(machine)
 
-	if(!usr.stat && usr.canmove && !usr.restrained() && Adjacent(usr))
+	if(canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
 			var/obj/item/what = get_item_by_slot(slot)


### PR DESCRIPTION
The strip panel will now use canUseTopic().
Cyborg and AI canUseTopic() procs will now include a BE_CLOSE variable, just in the case of having to be near the atom.
Added a BE_CLOSE and NO_DEXTERY define, they are both 1.
Third argument for canUseTopic(), dextery check, if a monkey or alien or whatever can perform the action.
