### PR TITLE
Broken grilles will not spawn rods when hit

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -120,7 +120,7 @@
 
 //window placing begin
 	else if(istype(W, /obj/item/stack/sheet/rglass) || istype(W, /obj/item/stack/sheet/glass))
-		if(!destroyed)
+		if (!destroyed)
 			var/obj/item/stack/ST = W
 			if (ST.get_amount() < 1)
 				user << "<span class='warning'>You need at least one sheet of glass for that.</span>"
@@ -165,7 +165,7 @@
 				WD.state = 0
 				ST.use(1)
 				user << "<span class='notice'>You place the [WD] on [src].</span>"
-		return
+			return
 //window placing end
 
 	else if(istype(W, /obj/item/weapon/shard))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -120,50 +120,51 @@
 
 //window placing begin
 	else if(istype(W, /obj/item/stack/sheet/rglass) || istype(W, /obj/item/stack/sheet/glass))
-		var/obj/item/stack/ST = W
-		if (ST.get_amount() < 1)
-			user << "<span class='warning'>You need at least one sheet of glass for that.</span>"
-			return
-		var/dir_to_set = 1
-		if(loc == user.loc)
-			dir_to_set = user.dir
-		else
-			if( ( x == user.x ) || (y == user.y) ) //Only supposed to work for cardinal directions.
-				if( x == user.x )
-					if( y > user.y )
-						dir_to_set = 2
-					else
-						dir_to_set = 1
-				else if( y == user.y )
-					if( x > user.x )
-						dir_to_set = 8
-					else
-						dir_to_set = 4
-			else
-				user << "<span class='notice'>You can't reach.</span>"
-				return //Only works for cardinal direcitons, diagonals aren't supposed to work like this.
-		for(var/obj/structure/window/WINDOW in loc)
-			if(WINDOW.dir == dir_to_set)
-				user << "<span class='notice'>There is already a window facing this way there.</span>"
+		if(!destroyed)
+			var/obj/item/stack/ST = W
+			if (ST.get_amount() < 1)
+				user << "<span class='warning'>You need at least one sheet of glass for that.</span>"
 				return
-		user << "<span class='notice'>You start placing the window.</span>"
-		if(do_after(user,20))
-			if(!src) return //Grille destroyed while waiting
+			var/dir_to_set = 1
+			if(loc == user.loc)
+				dir_to_set = user.dir
+			else
+				if( ( x == user.x ) || (y == user.y) ) //Only supposed to work for cardinal directions.
+					if( x == user.x )
+						if( y > user.y )
+							dir_to_set = 2
+						else
+							dir_to_set = 1
+					else if( y == user.y )
+						if( x > user.x )
+							dir_to_set = 8
+						else
+							dir_to_set = 4
+				else
+					user << "<span class='notice'>You can't reach.</span>"
+					return //Only works for cardinal direcitons, diagonals aren't supposed to work like this.
 			for(var/obj/structure/window/WINDOW in loc)
-				if(WINDOW.dir == dir_to_set)//checking this for a 2nd time to check if a window was made while we were waiting.
+				if(WINDOW.dir == dir_to_set)
 					user << "<span class='notice'>There is already a window facing this way there.</span>"
 					return
-			var/obj/structure/window/WD
-			if(istype(W, /obj/item/stack/sheet/rglass))
-				WD = new/obj/structure/window(loc,1) //reinforced window
-			else
-				WD = new/obj/structure/window(loc,0) //normal window
-			WD.dir = dir_to_set
-			WD.ini_dir = dir_to_set
-			WD.anchored = 0
-			WD.state = 0
-			ST.use(1)
-			user << "<span class='notice'>You place the [WD] on [src].</span>"
+			user << "<span class='notice'>You start placing the window.</span>"
+			if(do_after(user,20))
+				if(!src) return //Grille destroyed while waiting
+				for(var/obj/structure/window/WINDOW in loc)
+					if(WINDOW.dir == dir_to_set)//checking this for a 2nd time to check if a window was made while we were waiting.
+						user << "<span class='notice'>There is already a window facing this way there.</span>"
+						return
+				var/obj/structure/window/WD
+				if(istype(W, /obj/item/stack/sheet/rglass))
+					WD = new/obj/structure/window(loc,1) //reinforced window
+				else
+					WD = new/obj/structure/window(loc,0) //normal window
+				WD.dir = dir_to_set
+				WD.ini_dir = dir_to_set
+				WD.anchored = 0
+				WD.state = 0
+				ST.use(1)
+				user << "<span class='notice'>You place the [WD] on [src].</span>"
 		return
 //window placing end
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -178,19 +178,18 @@
 			if("brute")
 				health -= W.force * 0.1
 	healthcheck()
-	..()
+//	..()
 	return
 
 
 /obj/structure/grille/proc/healthcheck()
 	if(health <= 0)
-		var/obj/item/stack/rods/newrods = new(loc)
-		transfer_fingerprints_to(newrods)
-
 		if(!destroyed)
 			icon_state = "brokengrille"
 			density = 0
 			destroyed = 1
+			var/obj/item/stack/rods/newrods = new(loc)
+			transfer_fingerprints_to(newrods)
 
 		else
 			if(health <= -6)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -178,7 +178,7 @@
 			if("brute")
 				health -= W.force * 0.1
 	healthcheck()
-//	..()
+	..()
 	return
 
 


### PR DESCRIPTION
Eh, supposedly fixes https://github.com/tgstation/-tg-station/issues/4181, but now that I think about it, it says girders in the issue, not grilles, which might be a mistake or not. Either way, broken grilles don't spawn rods anymore when hit. healthcheck() was called every time in attackby(), now it will only spawn rod when grille is actually destroyed.

Diff looks weird, I added another check to prevent using glass on broken grille from creating a one-way window, because it's not immulsive, looks silly and you can do that anyway by standing on top of the tile.
