### PR TITLE
Fixes medals changing size on mob attachment

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -170,18 +170,18 @@ BLIND     // can't see anything
 	attachTie(I, user)
 	..()
 
-/obj/item/clothing/under/proc/attachTie(obj/item/I, mob/user)
+/obj/item/clothing/under/proc/attachTie(obj/item/I, mob/user, notifyAttach = 1)
 	if(istype(I, /obj/item/clothing/tie))
 		if(hastie)
 			if(user)
 				user << "<span class='warning'>[src] already has an accessory.</span>"
-			return
+			return 0
 		else
 			if(user)
 				user.drop_item()
 			hastie = I
 			I.loc = src
-			if(user)
+			if(user && notifyAttach)
 				user << "<span class='notice'>You attach [I] to [src].</span>"
 			I.transform *= 0.5	//halve the size so it doesn't overpower the under
 			I.pixel_x += 8
@@ -194,7 +194,7 @@ BLIND     // can't see anything
 				var/mob/living/carbon/human/H = loc
 				H.update_inv_w_uniform(0)
 
-			return
+			return 1
 
 
 /obj/item/clothing/under/examine()

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -96,19 +96,12 @@
 
 		if(M.w_uniform)
 			var/obj/item/clothing/under/U = M.w_uniform
-			if(!U.hastie) //Check if he is not already wearing an accessory
-				user.drop_item()
-				U.hastie = src
-				src.loc = U
-
+			if(U.attachTie(src, user, 0)) //Attach it, do not notify the user of the attachment
 				if(user == M)
 					user << "<span class='notice'>You attach [src] to [U].</span>"
 				else
 					user.visible_message("<span class='notice'>[user] pins \the [src] on [M]'s chest.</span>", \
 										 "<span class='notice'>You pin \the [src] on [M]'s chest.</span>")
-				M.update_inv_w_uniform(0)
-
-			else user << "<span class='warning'>\The [U] already has an accessory.</span>"
 
 		else user << "<span class='warning'>Medals can only be pinned on jumpsuits.</span>"
 	else ..()


### PR DESCRIPTION
-Fixes the medal by changing the code for the attachment via attacking a mob. I made it use the proper function instead of attempting to use unique invalid code. Added a new parameter to the tie function, which I am not very happy about, that squelches the prompt to the user about attaching the object to the mob. I did this as I wanted the code to fit the previous functionality, and this seemed like an okay solution

This fixes the core issue, where unique code was being used to attach the medal to the mob, without doing any scaling or displaying, so the assumption of the attach/deattach procs were broken and therefore produced a large medal.

Tested and works in these cases, (I also attached a black tie to the own mob successfully, including the prompt that is squelched by mob attachment).
also this basically shows nothing, but i am trying all cases of attaching medals and removing them
![dreamseeker 2014-08-15 01-23-24-56](https://cloud.githubusercontent.com/assets/3866862/3924219/16430184-23db-11e4-9cbf-ddcaae591cae.gif)
