### PR TITLE
Fixes the invisible slimesoup icon.

### DIFF
--- a/code/modules/food&drinks/food/snacks_soup.dm
+++ b/code/modules/food&drinks/food/snacks_soup.dm
@@ -14,7 +14,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/slimesoup
 	name = "slime soup"
 	desc = "If no water is available, you may substitute tears."
-	icon_state = "slimesoup"
+	icon_state = "rorosoup"
 	New()
 		..()
 		eatverb = pick("slurp","sip","suck","inhale","drink")


### PR DESCRIPTION
The slime soup currently has no icon and is invisible because icon_state=slimesoup but the image is called rorosoup.
This PR fixes it.
