### PR TITLE
jellyburger and slimeburger require 5 flour not 15.

### DIFF
--- a/code/modules/food&drinks/recipes/microwave/recipes_burgers.dm
+++ b/code/modules/food&drinks/recipes/microwave/recipes_burgers.dm
@@ -184,11 +184,11 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/burger/superbite
 
 /datum/recipe/burger/slime
-	reagents = list("slimejelly" = 5, "flour" = 15)
+	reagents = list("slimejelly" = 5, "flour" = 5)
 	items = list()
 	result = /obj/item/weapon/reagent_containers/food/snacks/burger/jelly/slime
 
 /datum/recipe/burger/jelly
-	reagents = list("cherryjelly" = 5, "flour" = 15)
+	reagents = list("cherryjelly" = 5, "flour" = 5)
 	items = list()
 	result = /obj/item/weapon/reagent_containers/food/snacks/burger/jelly/cherry


### PR DESCRIPTION
This changes the recipes of jelly burger and slime burger to require 5 units of flour instead of 15 currently. All burger except the giant one requires 5 flour, not 15. Logically the jelly and slime burger should also require 5 units of flour as they look similar in size to the other '5 flour' burgers..
