### PR TITLE
Updates admin nicknames, moves list to txt file

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -19,8 +19,9 @@
 
 	if (!msg)
 		return
+	var/nicknames = file2list("config/admin_nicknames.txt")
 
-	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>ADMIN([src.holder.fakekey ? pick("BADMIN", "Fun Police", "Conspiracy", "ERP BLOCKER", "Button Masher", "MissPhaeron", "Turdicide", "hornigranny", "TLC", "scaredofshowers", "SXSI", "HerpEs", "Nerdrak", "Dickarrus", "Wario90900", "Deurpyn", "Fatbeaver", "Arrowage", "Intigaycy", "Hosin Hitter", "Cheridumb", "Petethegoatse", "HotelHabboLover", "Giacunt", "Muskrats", "FickleInspector", "Tankbutt", "Ulisex", "Scrotemis", "Sillnazi", "Stillachair", "cbdsm", "Un_Professional", "Doopenis", "Calasrear", "Quackink ",  "ANyan:3", "Slieve", "Pali-en269", "Teamcreep", "Agoatsie", "Zoomerdik", "LewdMechanic", "NemoPanFried", "LameMontgommery", "EndGameOver", "LocalDingus", "ThoughtlessNaps", "Sewage", "hbgay6969", "Cockdtbent", "Iranclanos", "Liarwhine", "Vagyina", "Nohrape", "Dumboner69", "Gaymarr", "Jesusfraud") : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
+	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>ADMIN([src.holder.fakekey ? pick(nicknames) : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
 
 	for (var/mob/M in player_list)
 		if (istype(M, /mob/new_player))

--- a/config/admin_nicknames.txt
+++ b/config/admin_nicknames.txt
@@ -1,0 +1,2 @@
+Badmin
+<span class='adminooc'>Spanmin</span>


### PR DESCRIPTION
http://tgstation13.org/phpBB/viewtopic.php?f=29&t=1164

Makes the pool of names used by a stealthmin's dsay use an external .txt list.

Updates the pool to the current admins.txt as of 9th August.

See thread linked if you're an admin and want to suggest a change to the list which I'll be sending to SoS when this gets merged.
