### PR TITLE
Fixes infinite slime nutrition exploit

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -253,7 +253,7 @@
 
 /mob/living/carbon/slime/proc/handle_nutrition()
 
-	if (prob(15))
+	if(prob(15))
 		nutrition -= 1 + is_adult
 
 	if(nutrition <= 0)
@@ -270,6 +270,18 @@
 			Reproduce()
 		else
 			Evolve()
+
+/mob/living/carbon/slime/proc/add_nutrition(var/nutrition_to_add = 0, var/lastnut = 0)
+	nutrition = min((nutrition + nutrition_to_add), get_max_nutrition())
+	if(nutrition >= (lastnut + 50))
+		if(prob(80))
+			lastnut = nutrition
+			powerlevel++
+			if(powerlevel > 10)
+				powerlevel = 10
+				adjustToxLoss(-10)
+
+
 
 /mob/living/carbon/slime/proc/handle_targets()
 	if(Tempstun)

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -3,11 +3,11 @@
 	set desc = "This will let you feed on any valid creature in the surrounding area. This should also be used to halt the feeding process."
 	if(Victim)
 		Feedstop()
-		return
+		return 0
 
 	if(stat)
 		src << "<i>I must be conscious to do this...</i>"
-		return
+		return 0
 
 	var/list/choices = list()
 	for(var/mob/living/C in view(1,src))
@@ -15,31 +15,31 @@
 			choices += C
 
 	var/mob/living/M = input(src,"Who do you wish to feed on?") in null|choices
-	if(!M) return
+	if(!M) return 0
 	if(Adjacent(M))
 
-		if(!istype(src, /mob/living/carbon/brain))
-			if(!istype(M, /mob/living/carbon/slime))
-				if(stat != 2)
-					if(health > -70)
-
-						for(var/mob/living/carbon/slime/met in view())
-							if(met.Victim == M && met != src)
-								src << "<i>The [met.name] is already feeding on this subject...</i>"
-								return
-						src << "\blue <i>I have latched onto the subject and begun feeding...</i>"
-						M << "\red <b>The [src.name] has latched onto your head!</b>"
-						Feedon(M)
-
-					else
-						src << "<i>This subject does not have a strong enough life energy...</i>"
-				else
-					src << "<i>This subject does not have an edible life energy...</i>"
-			else
-				src << "<i>I must not feed on my brothers...</i>"
-		else
+		if(istype(M, /mob/living/carbon/brain))
 			src << "<i>This subject does not have an edible life energy...</i>"
+			return 0
 
+		if(istype(M, /mob/living/carbon) && (M.health < -70))
+			src << "<i>This subject does not have a strong enough life energy...</i>"
+			return 0
+
+		if(istype(M, /mob/living/simple_animal) && (M.health < 1))//animals don't go into crit, stupid; fixes infinite energy exploit
+			src << "<i>This subject does not have a strong enough life energy...</i>"
+			return 0
+
+		for(var/mob/living/carbon/slime/met in view())
+			if(met.Victim == M && met != src)
+				src << "<i>The [met.name] is already feeding on this subject...</i>"
+				return 0
+
+		src << "\blue <i>I have latched onto the subject and begun feeding...</i>"
+		M << "\red <b>The [src.name] has latched onto your head!</b>"
+
+		Feedon(M)
+		return 1
 
 
 /mob/living/carbon/slime/proc/Feedon(var/mob/living/M)
@@ -49,62 +49,59 @@
 	anchored = 1
 	var/lastnut = nutrition
 	var/fed_succesfully = 0
+	var/health_minimum = -70
+
 	if(is_adult)
 		icon_state = "[colour] adult slime eat"
 	else
 		icon_state = "[colour] baby slime eat"
 
-	while(Victim && M.health > -70 && stat != 2)
+
+	if(istype(Victim, /mob/living/simple_animal))
+		health_minimum = 0
+
+	while(Victim && Victim.health > health_minimum && stat != 2)
 		canmove = 0
 
-		if(Adjacent(M))
+		if(Adjacent(Victim))
 			loc = M.loc
 
-			if(prob(15) && M.client && istype(M, /mob/living/carbon))
-				M << "<span class='danger'>[pick("You can feel your body becoming weak!", \
-				"You feel like you're about to die!", \
-				"You feel every part of your body screaming in agony!", \
-				"A low, rolling pain passes through your body!", \
-				"Your body feels as if it's falling apart!", \
-				"You feel extremely weak!", \
-				"A sharp, deep pain bathes every inch of your body!")]</span>"
-
-			if(istype(M, /mob/living/carbon))
+			if(istype(Victim, /mob/living/carbon))
 				Victim.adjustCloneLoss(rand(5,6))
 				Victim.adjustToxLoss(rand(1,2))
 				if(Victim.health <= 0)
 					Victim.adjustToxLoss(rand(2,4))
 
+				if(prob(15) && Victim.client)
+					Victim << "<span class='danger'>[pick("You can feel your body becoming weak!", \
+					"You feel like you're about to die!", \
+					"You feel every part of your body screaming in agony!", \
+					"A low, rolling pain passes through your body!", \
+					"Your body feels as if it's falling apart!", \
+					"You feel extremely weak!", \
+					"A sharp, deep pain bathes every inch of your body!")]</span>"
+
 				fed_succesfully = 1
 
-			else if(istype(M, /mob/living/simple_animal))
+			else if(health_minimum == 0) //we already know it's a simple_animal from above
 				Victim.adjustBruteLoss(is_adult ? rand(7, 15) : rand(4, 12))
 				fed_succesfully = 1
 
 			else
-				if(prob(25))
-					src << "<span class='warning'>[pick("This subject is incompatable", \
-					"This subject does not have a life energy", "This subject is empty", \
-					"I am not satisified", "I can not feed from this subject", \
-					"I do not feel nourished", "This subject is not food")]...</span>"
+				src << "<span class='warning'>[pick("This subject is incompatable", \
+				"This subject does not have a life energy", "This subject is empty", \
+				"I am not satisified", "I can not feed from this subject", \
+				"I do not feel nourished", "This subject is not food")]...</span>"
 
 			if(fed_succesfully)
-				//I have no idea why this is not in handle_nutrition()
-				nutrition += rand(15,30)
-				if(nutrition >= lastnut + 50)
-					if(prob(80))
-						lastnut = nutrition
-						powerlevel++
-						if(powerlevel > 10)
-							powerlevel = 10
-							adjustToxLoss(-10)
+				add_nutrition(rand(15,30), lastnut)
 
 				//Heal yourself.
 				adjustOxyLoss(-10)
 				adjustBruteLoss(-10)
 				adjustFireLoss(-10)
 				adjustCloneLoss(-10)
-				
+
 				updatehealth()
 				if(Victim)
 					Victim.updatehealth()
@@ -114,7 +111,7 @@
 		else
 			break
 
-	if(stat == 2)
+	if(stat == 2) //why the fuck are you doing icon updating here
 		if(!is_adult)
 			icon_state = "[colour] baby slime dead"
 
@@ -128,7 +125,7 @@
 	anchored = 0
 
 	if(M)
-		if(M.health <= -70)
+		if(M.health < health_minimum)
 			M.canmove = 0
 			if(!client)
 				if(Victim && !rabid && !attacked)
@@ -145,13 +142,16 @@
 				if(prob(85))
 					rabid = 1 // UUUNNBGHHHH GONNA EAT JUUUUUU
 
-			if(client) src << "<i>This subject does not have a strong enough life energy anymore...</i>"
+			if(client)
+				src << "<i>This subject does not have a strong enough life energy anymore...</i>"
 		else
 			M.canmove = 1
 
-			if(client) src << "<i>I have stopped feeding...</i>"
+			if(client)
+				src << "<i>I have stopped feeding...</i>"
 	else
-		if(client) src << "<i>I have stopped feeding...</i>"
+		if(client)
+			src << "<i>I have stopped feeding...</i>"
 
 	Victim = null
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "grey baby slime"
 	pass_flags = PASSTABLE
-	voice_message = "skree!"
+	voice_message = "bleb!"
 	say_message = "hums"
 	ventcrawler = 2
 	var/is_adult = 0


### PR DESCRIPTION
fixes #4086 
Cleans up a disgusting if else pyramid.
Fixes an issue where the upper limit on nutrition did nothing at all.

I'm very upset at whoever added the feature to eat simple_animals.
