### PR TITLE
This fixes the chameleon projector.

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -14,7 +14,8 @@
 	var/saved_item = /obj/item/weapon/cigbutt
 	var/saved_icon = 'icons/obj/clothing/masks.dmi'
 	var/saved_icon_state = "cigbutt"
-	var/saved_overlays
+	var/saved_overlays = null
+	var/saved_underlays = null
 
 /obj/item/device/chameleon/dropped()
 	disrupt()
@@ -35,6 +36,7 @@
 			saved_icon = target.icon
 			saved_icon_state = target.icon_state
 			saved_overlays = target.overlays
+			saved_underlays = target.underlays
 
 /obj/item/device/chameleon/proc/toggle()
 	if(!can_use || !saved_item) return
@@ -53,7 +55,7 @@
 		var/obj/O = new saved_item(src)
 		if(!O) return
 		var/obj/effect/dummy/chameleon/C = new/obj/effect/dummy/chameleon(usr.loc)
-		C.activate(O, usr, saved_icon, saved_icon_state, saved_overlays, src)
+		C.activate(O, usr, saved_icon, saved_icon_state, saved_overlays, saved_underlays, src)
 		qdel(O)
 		usr << "\blue You activate the [src]."
 		var/obj/effect/overlay/T = new/obj/effect/overlay(get_turf(src))
@@ -89,12 +91,13 @@
 	var/can_move = 1
 	var/obj/item/device/chameleon/master = null
 
-/obj/effect/dummy/chameleon/proc/activate(var/obj/O, var/mob/M, new_icon, new_iconstate, new_overlays, var/obj/item/device/chameleon/C)
+/obj/effect/dummy/chameleon/proc/activate(var/obj/O, var/mob/M, new_icon, new_iconstate, new_overlays, new_underlays, var/obj/item/device/chameleon/C)
 	name = O.name
 	desc = O.desc
 	icon = new_icon
 	icon_state = new_iconstate
 	overlays = new_overlays
+	underlays = new_underlays
 	dir = O.dir
 	M.loc = src
 	master = C


### PR DESCRIPTION
Basically this fixes the issue with the chameleon projector where if you scanned a bomb transfer valve and then turned into it, it didnt show what was on the left side of it, since that was an underlay and the chameleon projector didnt have anything for underlays. 

Also, Cheridan said something about a bug also with the cyborg frames when using the chameleon projector. I do not see any problems with it, but I only tested the code after putting = null. So _shrugs_

Fixes #4508
