### PR TITLE
Fixes errors caused by copytext being a shit

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -16,7 +16,7 @@
 // Run all strings to be used in an SQL query through this proc first to properly escape out injection attempts.
 /proc/sanitizeSQL(var/t as text)
 	var/sqltext = dbcon.Quote(t);
-	return copytext(sqltext, 2, lentext(sqltext)-1);//Quote() adds quotes around input, we already do that
+	return copytext(sqltext, 2, lentext(sqltext));//Quote() adds quotes around input, we already do that
 
 /*
  * Text sanitization


### PR DESCRIPTION
Basically, copytext's first argument is inclusive, but its 2nd argument isn't.

so copytext("123456789", 2, 8) returns 234567.

When I googled "byond copytext" (to see how it worked in byond and if it used 1 or 0 based indexing) the first link is http://www.byond.com/docs/guide/chap15.html and this does nothing to spell this out.

The reference guide (that i should have used) spells this out more clearly, but it is confusing none the less: http://www.byond.com/docs/ref/info.html#/proc/copytext
