### PR TITLE
Gives escape alive objective better description text.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -205,7 +205,7 @@ datum/objective/block/check_completion()
 
 
 datum/objective/escape
-	explanation_text = "Escape on the shuttle or an escape pod alive."
+	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
 	dangerrating = 5
 
 datum/objective/escape/check_completion()


### PR DESCRIPTION
Basically gives the escape alive objective a better description text. Thus it will now state:

Escape on the shuttle or an escape pod alive and without being in custody.

Fixes #4254
