### PR TITLE
Gives you a message for how to use your department radio when joining.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -304,6 +304,7 @@ var/global/datum/controller/occupations/job_master
 
 	H << "<b>You are the [rank].</b>"
 	H << "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>"
+	H << "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>"
 	if(job.req_admin_notify)
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
 


### PR DESCRIPTION
When you join, it will give you a message of how to use your department headset right below the message of who you report to.

To speak on your departments radio, use the :h button. To see others, look closely at your headset.

Fixes #4169
