### PR TITLE
Shower logging and prints

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -153,6 +153,7 @@
 /obj/machinery/shower/attack_hand(mob/M)
 	on = !on
 	update_icon()
+	add_fingerprint(M)
 	if(on)
 		for (var/atom/movable/G in loc)
 			Crossed(G)
@@ -171,7 +172,7 @@
 					watertemp = "boiling"
 				if("boiling")
 					watertemp = "normal"
-			user.visible_message("<span class='notice'>[user] adjusts the shower with the [I].</span>", "<span class='notice'>You adjust the shower with the [I].</span>")
+			user.visible_message("<span class='notice'>[user] adjusts the shower with the [I].</span>", "<span class='notice'>You adjust the shower with the [I] to [watertemp] temperature.</span>")
 			log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
 			add_hiddenprint(user)
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -172,6 +172,8 @@
 				if("boiling")
 					watertemp = "normal"
 			user.visible_message("<span class='notice'>[user] adjusts the shower with the [I].</span>", "<span class='notice'>You adjust the shower with the [I].</span>")
+			log_game("[key_name(user)] has wrenched a shower to [watertemp] at ([x],[y],[z])")
+			add_hiddenprint(user)
 
 
 /obj/machinery/shower/update_icon()	//this is terribly unreadable, but basically it makes the shower mist up


### PR DESCRIPTION
The shower will now both log it and add hidden fingerprints when you wrench it to change the temperature.

Fixes #4247 

Shower now leaves fingerprints when turning it on and off

Shower also now gives a better message when you wrench the temperature, informing you if its hot, cold, or normal.
