### PR TITLE
Fix wands losing a charge even when no spell was actually cast

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -28,7 +28,7 @@
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent"]"
 
-/obj/item/ammo_casing/proc/newshot() //For energy weapons and shotgun shells.
+/obj/item/ammo_casing/proc/newshot() //For energy weapons, shotgun shells and wands (!).
 	if (!BB)
 		BB = new projectile_type(src)
 	return

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -32,7 +32,11 @@
 /obj/item/weapon/gun/magic/proc/newshot()
 	if (charges && chambered)
 		chambered.newshot()
-		charges--
+	return
+
+/obj/item/weapon/gun/magic/process_chamber()
+	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
+		charges--//... drain a charge
 	return
 
 /obj/item/weapon/gun/magic/New()

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -53,6 +53,11 @@
 	playsound(user, fire_sound, 50, 1)
 	user.attack_log += "\[[time_stamp()]\] <b>[user]/[user.ckey]</b> zapped \himself with a <b>[src]</b>"
 
+
+/////////////////////////////////////
+//WAND OF DEATH
+/////////////////////////////////////
+
 /obj/item/weapon/gun/magic/wand/death
 	name = "wand of death"
 	desc = "This deadly wand overwhelms the victim's body with pure energy, slaying them without fail."
@@ -68,6 +73,10 @@
 	charges--
 	..()
 
+/////////////////////////////////////
+//WAND OF HEALING
+/////////////////////////////////////
+
 /obj/item/weapon/gun/magic/wand/resurrection
 	name = "wand of healing"
 	desc = "This wand uses healing magics to heal and revive. They are rarely utilized within the Wizard Federation for some reason."
@@ -81,6 +90,10 @@
 	charges--
 	..()
 
+/////////////////////////////////////
+//WAND OF POLYMORPH
+/////////////////////////////////////
+
 /obj/item/weapon/gun/magic/wand/polymorph
 	name = "wand of polymorph"
 	desc = "This wand is attuned to chaos and will radically alter the victim's form."
@@ -92,6 +105,10 @@
 	..() //because the user mob ceases to exists by the time wabbajack fully resolves
 	wabbajack(user)
 	charges--
+
+/////////////////////////////////////
+//WAND OF TELEPORTATION
+/////////////////////////////////////
 
 /obj/item/weapon/gun/magic/wand/teleport
 	name = "wand of teleportation"
@@ -109,6 +126,10 @@
 	charges--
 	..()
 
+/////////////////////////////////////
+//WAND OF DOOR CREATION
+/////////////////////////////////////
+
 /obj/item/weapon/gun/magic/wand/door
 	name = "wand of door creation"
 	desc = "This particular wand can create doors in any wall for the unscrupulous wizard who shuns teleportation magics."
@@ -119,6 +140,10 @@
 
 /obj/item/weapon/gun/magic/wand/door/zap_self()
 	return
+
+/////////////////////////////////////
+//WAND OF FIREBALL
+/////////////////////////////////////
 
 /obj/item/weapon/gun/magic/wand/fireball
 	name = "wand of fireball"


### PR DESCRIPTION
Fixes  #4588 .

Same problem as with energy guns : the _"clip"_ was reduced if the _click_ was valid, regardless of any unfired _"shot"_.

I can't help but feel magic guns (a.k.a wands) shouldn't behave like they had clips, bullets, ...
