### PR TITLE
No longer can you make shoecuffs with cable cuffs

### DIFF
--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -94,6 +94,8 @@
 	if ((istype(H, /obj/item/weapon/handcuffs) && !( src.chained )))
 		//H = null
 		if (src.icon_state != "orange") return
+		if(istype(H, /obj/item/weapon/handcuffs/cable))
+			return 0
 		qdel(H)
 		src.chained = 1
 		src.slowdown = 15


### PR DESCRIPTION
You cannot make shoecuffs using cablecuffs.

Fixes #3779 
