### PR TITLE
fixed reinforced tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -295,7 +295,7 @@
 	var/dat = "<h3>Construction menu</h3>"
 	dat += "<div class='statusDisplay'>"
 	if(busy)
-		dat += "Construction inprogress...</div>"
+		dat += "Construction in progress...</div>"
 	else
 		for(var/datum/table_recipe/R in table_recipes)
 			if(check_contents(R))
@@ -585,8 +585,14 @@
 		return
 
 	if (istype(I, /obj/item/weapon/wrench))
-		table_destroy(2, user)
-		return
+		if(istype(src, /obj/structure/table/reinforced))
+			var/obj/structure/table/reinforced/RT = src
+			if(RT.status == 1)
+				table_destroy(2, user)
+				return
+		else
+			table_destroy(2, user)
+			return
 
 	if (istype(I, /obj/item/weapon/storage/bag/tray))
 		var/obj/item/weapon/storage/bag/tray/T = I
@@ -632,24 +638,13 @@ Destroy type values:
 		return
 
 	if(destroy_type == 2)
-		if(istype(src, /obj/structure/table/reinforced))
-			var/obj/structure/table/reinforced/RT = src
-			if(RT.status == 1)
-				user << "<span class='notice'>Now disassembling the reinforced table</span>"
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				if (do_after(user, 50))
-					new parts( src.loc )
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					qdel(src)
-				return
-		else
-			user << "<span class='notice'>Now disassembling table</span>"
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			if (do_after(user, 50))
-				new parts( src.loc )
-				playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				qdel(src)
-			return
+		user << "<span class='notice'>Now disassembling the [src.name]</span>"
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		if (do_after(user, 50))
+			new parts( src.loc )
+			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+			qdel(src)
+		return
 
 
 
@@ -805,4 +800,3 @@ Destroy type values:
 		qdel(src)
 /obj/structure/rack/attack_tk() // no telehulk sorry
 	return
-


### PR DESCRIPTION
Fixes #3320

Fixes not being able to place wrenches on (unweakened) reinforced
tables. The `return` statement in the conditional for the wrench in
`attackby` was preventing control from reaching the conditional later on
that places the wrench on the table. The conditional for the wrench now
checks if it can destroy the table, and if not it continues down to
where it is then placed on the table. `table_destroy` is now guaranteed to
destroy the table. Also removed the now redundant check in `table_destroy`
and made it more portable between different kinds of tables. Also fixed
an obvious typo.
