### PR TITLE
Fixes skeletons unable to play xylophone on their ribcage

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -205,7 +205,7 @@
 					src << "<span class='info'>You're completely exhausted.</span>"
 				else
 					src << "<span class='info'>You feel fatigued.</span>"
-			if(dna && (dna.species == /datum/species/skeleton) && !H.w_uniform && !H.wear_suit)
+			if(dna && dna.species.id && dna.species.id == "skeleton" && !H.w_uniform && !H.wear_suit)
 				H.play_xylophone()
 		else
 			if(ishuman(src))


### PR DESCRIPTION
Corrected the skeleton _species_ check, enabling ribcage playing again (fixes #4594).

Hope the server won't become _2spooky4playing_ now...
