### PR TITLE
Prevent ghosts seeing admin flag warnings when they click on machines

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -213,7 +213,7 @@ Class Procs:
 	return
 
 /mob/dead/observer/canUseTopic()
-	if(check_rights(R_ADMIN))
+	if(check_rights(R_ADMIN, 0))
 		return
 
 /mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)


### PR DESCRIPTION
This avoids the user seeing a message about lacking admin flags when
they try to use machinery as a ghost

I'm not a hundred percent on this, should we instead improve the message returned by check_rights to be less immersion breaking?
edit: this is an issue with #4485 as well

edit: maybe I should edit the title a few million times more

Fixes #4568 
