### PR TITLE
/tg/station Atom/Movable Pool + Pooling of Emitter beams and Say() Virtualspeakers

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -213,7 +213,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	var/list/radios = list()
 
-	var/atom/movable/virtualspeaker/virt = new(null)
+	var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker,null)
 	virt.name = name
 	virt.job = job
 	virt.languages = AM.languages
@@ -295,7 +295,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.messages += blackbox_msg
 
 	spawn(50)
-		qdel(virt)
+		PlaceInPool(virt)
 
 /proc/Broadcast_SimpleMessage(var/source, var/frequency, var/text, var/data, var/mob/M, var/compression, var/level)
 

--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -55,6 +55,7 @@ var/global/list/GlobalPool = list()
 	var/atom/movable/AM = pick_n_take(GlobalPool[get_type])
 	if(AM)
 		AM.ResetVars()
+		AM.New()
 		if(new_loc)
 			AM.loc = new_loc
 		return AM

--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -21,14 +21,21 @@ var/global/list/GlobalPool = list()
 //Goes into the pool
 
 /proc/PoolOrNew(var/get_type,var/new_loc)
-	if(!get_type || !new_loc)
+	if(!get_type)
 		return
 
-	var/atom/movable/AM = GetFromPool(get_type,new_loc)
+	var/atom/movable/AM
+	if(new_loc)
+		AM = GetFromPool(get_type,new_loc)
+	else
+		AM = GetFromPool(get_type,null)
 
 	if(!AM)
 		if(ispath(get_type))
-			AM = new get_type (new_loc)
+			if(new_loc)
+				AM = new get_type (new_loc)
+			else
+				AM = new get_type (null)
 
 	if(AM)
 		return AM
@@ -36,7 +43,7 @@ var/global/list/GlobalPool = list()
 
 
 /proc/GetFromPool(var/get_type,var/new_loc)
-	if(!get_type || !new_loc)
+	if(!get_type)
 		return 0
 
 	if(isnull(GlobalPool[get_type]))
@@ -48,7 +55,8 @@ var/global/list/GlobalPool = list()
 	var/atom/movable/AM = pick_n_take(GlobalPool[get_type])
 	if(AM)
 		AM.ResetVars()
-		AM.loc = new_loc
+		if(new_loc)
+			AM.loc = new_loc
 		return AM
 	return 0
 

--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -1,0 +1,84 @@
+
+/*
+/tg/station13 /atom/movable Pool:
+---------------------------------
+By RemieRichards
+
+Creation/Deletion is laggy, so let's reduce reuse and recycle!
+
+Locked to /atom/movable and it's subtypes due to Loc being a const var on /atom
+being read&write on /movable due to how they... move.
+
+*/
+
+var/global/list/GlobalPool = list()
+
+//You'll be using this proc 90% of the time.
+//It grabs a type from the pool if it can
+//And if it can't, it creates one
+//The pool is flexible and will expand to fit
+//The newley created atom when it eventually
+//Goes into the pool
+
+/proc/PoolOrNew(var/get_type,var/new_loc)
+	if(!get_type || !new_loc)
+		return
+
+	var/atom/movable/AM = GetFromPool(get_type,new_loc)
+
+	if(!AM)
+		if(ispath(get_type))
+			AM = new get_type (new_loc)
+
+	if(AM)
+		return AM
+
+
+
+/proc/GetFromPool(var/get_type,var/new_loc)
+	if(!get_type || !new_loc)
+		return 0
+
+	if(isnull(GlobalPool[get_type]))
+		return 0
+
+	if(length(GlobalPool[get_type]) == 0)
+		return 0
+
+	var/atom/movable/AM = pick_n_take(GlobalPool[get_type])
+	if(AM)
+		AM.ResetVars()
+		AM.loc = new_loc
+		return AM
+	return 0
+
+
+
+/proc/PlaceInPool(var/atom/movable/AM)
+	if(!istype(AM))
+		return
+
+	if(AM in GlobalPool[AM.type])
+		return
+
+	AM.ResetVars()
+
+	if(!GlobalPool[AM.type])
+		GlobalPool[AM.type] = list()
+
+	GlobalPool[AM.type] += AM
+
+
+
+/atom/movable/proc/ResetVars()
+	var/list/excluded = list("loc", "locs", "parent_type", "vars", "verbs", "type")
+
+	for(var/V in vars)
+		if(V in excluded)
+			continue
+
+		vars[V] = initial(vars[V])
+
+	vars["loc"] = null
+
+

--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -7,7 +7,7 @@ By RemieRichards
 Creation/Deletion is laggy, so let's reduce reuse and recycle!
 
 Locked to /atom/movable and it's subtypes due to Loc being a const var on /atom
-being read&write on /movable due to how they... move.
+but being read&write on /movable due to how they... move.
 
 */
 
@@ -17,7 +17,7 @@ var/global/list/GlobalPool = list()
 //It grabs a type from the pool if it can
 //And if it can't, it creates one
 //The pool is flexible and will expand to fit
-//The newley created atom when it eventually
+//The new created atom when it eventually
 //Goes into the pool
 
 /proc/PoolOrNew(var/get_type,var/new_loc)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -119,13 +119,17 @@
 		else
 			src.fire_delay = rand(20,100)
 			src.shot_number = 0
-		var/obj/item/projectile/beam/emitter/A = new /obj/item/projectile/beam/emitter( src.loc )
+
+		var/obj/item/projectile/beam/emitter/A = PoolOrNew(/obj/item/projectile/beam/emitter,src.loc)
+
+		A.dir = src.dir
 		playsound(src.loc, 'sound/weapons/emitter.ogg', 25, 1)
+
 		if(prob(35))
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(5, 1, src)
 			s.start()
-		A.dir = src.dir
+
 		switch(dir)
 			if(NORTH)
 				A.yo = 20

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -50,9 +50,12 @@
 	var/forcedodge = 0
 
 
+
 /obj/item/projectile/proc/delete()
 	// Garbage collect the projectiles
 	loc = null
+
+
 
 /obj/item/projectile/proc/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
 	if(!isliving(target))	return 0
@@ -67,8 +70,8 @@
 	else
 		return 50 //if the projectile doesn't do damage, play its hitsound at 50% volume
 
-/obj/item/projectile/Bump(atom/A as mob|obj|turf|area)
 
+/obj/item/projectile/Bump(atom/A as mob|obj|turf|area)
 	if(A == firer)
 		loc = A.loc
 		return 0 //cannot shoot yourself
@@ -120,8 +123,7 @@
 				permutated.Add(A)
 				return 0
 
-			density = 0
-			invisibility = 101
+
 			delete()
 			return 0
 	return 1
@@ -141,9 +143,9 @@
 		delete()
 		return
 	kill_count--
-	spawn while(src && src.loc)
+	spawn while(loc)
 		if((!( current ) || loc == current))
-			current = locate(min(max(x + xo, 1), world.maxx), min(max(y + yo, 1), world.maxy), z)
+			current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
 		if((x == 1 || x == world.maxx || y == 1 || y == world.maxy))
 			delete()
 			return

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -54,6 +54,8 @@
 	icon_state = "emitter"
 	damage = 30
 
+/obj/item/projectile/beam/emitter/delete() //what projectiles use to set loc = null
+	PlaceInPool(src)
 
 /obj/item/projectile/lasertag
 	name = "laser tag beam"

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -304,9 +304,7 @@ datum/signal
 
 		//SAY REWRITE RELATED CODE.
 		//This code is a little hacky, but it *should* work. Even though it'll result in a virtual speaker referencing another virtual speaker. vOv
-		//var/atom/movable/virtualspeaker/virt = new(null) //REMIE POOL
 		var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker,null)
-		world << "Virtual speaker collected/created from pool |Telecomms.dm|"
 		virt.name = source
 		virt.job = job
 		virt.faketrack = 1

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -301,10 +301,12 @@ datum/signal
 
 		if(!job)
 			job = "Unknown"
-		
+
 		//SAY REWRITE RELATED CODE.
 		//This code is a little hacky, but it *should* work. Even though it'll result in a virtual speaker referencing another virtual speaker. vOv
-		var/atom/movable/virtualspeaker/virt = new(null)
+		//var/atom/movable/virtualspeaker/virt = new(null) //REMIE POOL
+		var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker,null)
+		world << "Virtual speaker collected/created from pool |Telecomms.dm|"
 		virt.name = source
 		virt.job = job
 		virt.faketrack = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -662,6 +662,7 @@
 #include "code\game\objects\structures\transit_tubes\station.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube_pod.dm"
+#include "code\game\pooling\atom_pool.dm"
 #include "code\game\turfs\simulated.dm"
 #include "code\game\turfs\turf.dm"
 #include "code\game\turfs\unsimulated.dm"


### PR DESCRIPTION
What it says on the tin.
Pools /atom/movable (and subtypes) rather than creating and deleting them.
(locked to /atom/movable as "loc" is a read only var on /atom, but is read&write on /atom/movable)

<B>USES ADDED IN PR:</B>
- Emitter Projectiles (Credit @d3athrow for help debugging their process())
- Miauw's Say() Virtualspeakers

<B>HOW TO USE:</B>
Creation:
`var/atom/movable/AM = new /atom/movable (loc)`
Replaced with:
`var/atom/movable/AM = PoolOrNew(/atom/movable, loc)`
Deletion:
`del(AM)` or `qdel(AM)`
Replaced with:
`PlaceInPool(AM)`

Which will first attempt to grab something from the pool, and if that fails, will simply create the object normally, which can later on itself join the pool. This results in a dynamic pool of object which should reduce the number of created/delete objects that use the Pool.
