### PR TITLE
Syndicate bomb removal from traitor.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -158,6 +158,7 @@ var/list/uplink_items = list()
 	desc = "The Minibomb is a grenade with a five-second fuse."
 	item = /obj/item/weapon/grenade/syndieminibomb
 	cost = 3
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/viscerators
 	name = "Viscerator Delivery Grenade"
@@ -396,7 +397,7 @@ var/list/uplink_items = list()
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 6
-	excludefrom = list(/datum/game_mode/traitor/double_agents)
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -25,8 +25,7 @@
 			return
 
 		if("screwed")
-			new /obj/item/device/sbeacondrop/bomb(src)
-			new /obj/item/weapon/grenade/syndieminibomb(src)
+			new /obj/item/weapon/storage/box/syndie_kit/emp
 			new /obj/item/device/powersink(src)
 			new /obj/item/clothing/suit/space/syndicate/black/red(src)
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)


### PR DESCRIPTION
Removes syndicate bombs from traitor, they'll only be available at nuke rounds.
Updated the "srewed" traitor bundle, gave it an EMP kit to replace the bomb.
