### PR TITLE
Fixes reagents extra consumption + some cleanup

### DIFF
--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -127,7 +127,7 @@
 			user << "<span class='notice'> You purify [A].</span>"
 			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
 			A.reagents.del_reagent("unholywater")
-			A.reagents.add_reagent("cleaner",unholy2clean)		//it cleans their soul, get it? I'll get my coat...
+			A.reagents.add_reagent("holywater",unholy2clean)
 
 /obj/item/weapon/storage/book/bible/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	playsound(src.loc, "rustle", 50, 1, -5)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -307,12 +307,12 @@ datum/reagent/fuel/unholywater/on_mob_life(var/mob/living/M as mob)
 		M.adjustBruteLoss(2)
 	holder.remove_reagent(src.id, 1)
 
-datum/reagent/plasma/hellwater			//if someone has this in their system they've really pissed off an eldrich god
+datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldrich god
 	name = "Hell Water"
 	id = "hell_water"
 	description = "YOUR FLESH! IT BURNS!"
 
-datum/reagent/plasma/hellwater/on_mob_life(var/mob/living/M as mob)
+datum/reagent/hellwater/on_mob_life(var/mob/living/M as mob)
 	M.fire_stacks = min(5,M.fire_stacks + 3)
 	M.IgniteMob()			//Only problem with igniting people is currently the commonly availible fire suits make you immune to being on fire
 	M.adjustToxLoss(1)
@@ -1199,7 +1199,7 @@ datum/reagent/spaceacillin
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 
-datum/reagent/on_mob_life(var/mob/living/M as mob)//no more mr. panacea
+datum/reagent/spaceacillin/on_mob_life(var/mob/living/M as mob)//no more mr. panacea
 	holder.remove_reagent(src.id, 0.2)
 	..()
 	return


### PR DESCRIPTION
Fixes  #4608
- Also removed the inexistent reagent/plasma subtype of hellwater (i kept hellwater for now, as someone may find a use for it, but there absolutely no way get the reagent in someone...)
- Purifying someone with unholy water in it's body (i.e the chaplain hitting him with the bible) now turns the unholy water to holy water instead of space cleaner (sorry for your joke, whoever did it)
- Unholy water is still a _fuel_ subtype so that it can be lit if somehow extracted from someone
