### PR TITLE
SMES constructible terminals (reopen)

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -84,12 +84,6 @@
 				user << "<span class='notice'>Terminal found.</span>"
 				break
 		if(!terminal)
-			for(var/obj/structure/cable/C in T)
-				if(C.d1 == turn(dir, 180) || C.d2 == turn(dir, 180))
-					terminal = C
-					user << "<span class='notice'>Cable found.</span>"
-					break
-		if(!terminal)
 			user << "<span class='alert'>No power source found.</span>"
 			return
 		stat &= ~BROKEN


### PR DESCRIPTION
The recent SMES map PR reminds me of my old SMES constructible terminals PR (#3811), that was closed because it was a feature while in feature freeze.

I'm reopening it here so it can be merged/discuted (if i remember correctly, we didn't get to a consensus in #3811).

**Original PR :**

> Added a way to construct or dismantle terminals for SMES.
> **Construction :**
> - you must be north, south, east or west of the SMES (diagonal is not allowed, because we've got no  sprites for diagonals terminals),
> - the floor plating must be removed,
> - the maintenance panel of the SMES must be open,
> - you must have at least 10 lengths of cable
> 
> **Deconstruction :**
> - the terminal must be exposed (plating removed),
> - the maintenance panel of the SMES must be open,
> - you must use wirecutters
> 
> There's a chance for electrocution if unprotected for both actions.
> 
> The code is heavily inspired by the APC one.
> I was going to do a standard function for all power machines, but realized only SMES and APC possess a terminal variable.
> Given the APC code is somewhat different from the SMES one (e.g the terminal is on the same tile as the APC, as opposed to an adjacent one), that would have involved special cases in a function only used by two objects.
