### PR TITLE
Ends early round syndiebombing

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -55,6 +55,8 @@ var/list/uplink_items = list()
 		feedback_add_details("traitor_uplink_items_bought", "[item]")
 		return new item(loc)
 
+/datum/uplink_item/proc/modify_item(var/obj/I, var/mob/M) //Override this if there's vars on newly spawned items you want to change
+
 /datum/uplink_item/proc/buy(var/obj/item/device/uplink/U, var/mob/user)
 
 	..()
@@ -74,6 +76,8 @@ var/list/uplink_items = list()
 			return 0
 
 		var/obj/I = spawn_item(get_turf(user), U)
+
+		modify_item(I, user)
 
 		if(istype(I, /obj/item) && ishuman(user))
 			var/mob/living/carbon/human/A = user
@@ -387,18 +391,28 @@ var/list/uplink_items = list()
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device pulls the singularity towards it. \
 	Does not work when the singularity is still in containment. A singularity beacon can cause catastrophic damage to a space station, \
 	leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation. \
-	because of the high risk of mass destruction and panic normal agents are not permited to use this beacon for the first 40 minutes of the shift."
+	Except in nuclear operations this beacon will not respond for the first 40 minutes of the shift due to the high risk of station abandonment this item brings."
 	item = /obj/item/device/sbeacondrop
 	cost = 7
+
+/datum/uplink_item/device_tools/singularity_beacon/modify_item(var/obj/I, var/mob/M)
+	var/obj/item/device/sbeacondrop/B = I
+	if(!M.mind || !(M.mind in ticker.mode.syndicates))
+		B.is_time_restricted = 1
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb. \
-	because of the high risk of mass destruction and panic normal agents are not permited to use this beacon for the first 40 minutes of the shift."
+	Except in nuclear operations this beacon will not respond for the first 40 minutes of the shift due to the high risk of station abandonment this item brings."
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 5
 	excludefrom = list(/datum/game_mode/traitor/double_agents)
+
+/datum/uplink_item/device_tools/syndicate_bomb/modify_item(var/obj/I, var/mob/M)
+	var/obj/item/device/sbeacondrop/B = I
+	if(!M.mind || !(M.mind in ticker.mode.syndicates))
+		B.is_time_restricted = 1
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -386,14 +386,16 @@ var/list/uplink_items = list()
 	name = "Singularity Beacon"
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device pulls the singularity towards it. \
 	Does not work when the singularity is still in containment. A singularity beacon can cause catastrophic damage to a space station, \
-	leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation."
+	leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation. \
+	because of the high risk of mass destruction and panic normal agents are not permited to use this beacon for the first 40 minutes of the shift."
 	item = /obj/item/device/sbeacondrop
 	cost = 7
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
-	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
+	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb. \
+	because of the high risk of mass destruction and panic normal agents are not permited to use this beacon for the first 40 minutes of the shift."
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 5
 	excludefrom = list(/datum/game_mode/traitor/double_agents)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -111,10 +111,24 @@
 	origin_tech = "bluespace=1;syndicate=7"
 	w_class = 2
 	var/droptype = /obj/machinery/singularity_beacon/syndicate
+	var/time_avalibility
 
+/obj/item/device/sbeacondrop/New()
+	time_avalibility = round_start_time + 24000 //40 minutes into the round
+	..()
+/obj/item/device/sbeacondrop/examine()
+	..()
+	if(time_avalibility > world.time)
+		var/timer = round((time_avalibility - world.time)/600) //return time to use device in minutes
+		usr << "A digital display on it reads \"[timer]\"."
+	else
+		usr << "A digital display on it blinks zero."
 
 /obj/item/device/sbeacondrop/attack_self(mob/user as mob)
 	if(user)
+		if(time_avalibility > world.time && ticker.mode.syndicates.len == 0)
+			user << "<span class='notice'>The device buzzes quietly. It doesn't seem to be responding right now...</span>"
+			return
 		user << "<span class='notice'>Locked In.</span>"
 		new droptype( user.loc )
 		playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -112,21 +112,23 @@
 	w_class = 2
 	var/droptype = /obj/machinery/singularity_beacon/syndicate
 	var/time_avalibility
+	var/is_time_restricted = 0
 
 /obj/item/device/sbeacondrop/New()
 	time_avalibility = round_start_time + 24000 //40 minutes into the round
 	..()
 /obj/item/device/sbeacondrop/examine()
 	..()
-	if(time_avalibility > world.time)
-		var/timer = round((time_avalibility - world.time)/600) //return time to use device in minutes
-		usr << "A digital display on it reads \"[timer]\"."
-	else
-		usr << "A digital display on it blinks zero."
+	if(is_time_restricted)
+		if(time_avalibility > world.time)
+			var/timer = round((time_avalibility - world.time)/600) //return time to use device in minutes
+			usr << "A digital display on it reads \"[timer]\"."
+		else
+			usr << "A digital display on it blinks zero."
 
 /obj/item/device/sbeacondrop/attack_self(mob/user as mob)
 	if(user)
-		if(time_avalibility > world.time && ticker.mode.syndicates.len == 0)
+		if(is_time_restricted && time_avalibility > world.time)
 			user << "<span class='notice'>The device buzzes quietly. It doesn't seem to be responding right now...</span>"
 			return
 		user << "<span class='notice'>Locked In.</span>"


### PR DESCRIPTION
Restricts the beacon items (singulo beacon and syndicate bomb) from the first 40 minutes of play in traitor. 

Nuke Agents can still use these items at will, but for normal traitors they will be stuck holding the beacon in the meantime. This doesn't affect the beacons you get in bundles, which can still be used whenever. 

The descriptions of the items in the uplink have been altered to reflect this caveat.

Between this and #4681 hopefully #4673 won't be needed anymore
