### PR TITLE
Balance changes to the sleepy pen.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -241,7 +241,7 @@ var/list/uplink_items = list()
 	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a strong anaesthetic and a chemical that is capable of blocking the movement of the vocal chords. \
 	The pen holds one dose of the mixture, and cannot be refilled."
 	item = /obj/item/weapon/pen/sleepy
-	cost = 3
+	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/soap

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -37,6 +37,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/cart = "" //A place to stick cartridge menu information
 	var/detonate = 1 // Can the PDA be blown up?
 	var/hidden = 0 // Is the PDA hidden from the PDA list?
+	var/emped = 0
 
 	var/obj/item/weapon/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
 	var/ownjob = null //related to above
@@ -730,6 +731,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	var/datum/signal/signal = src.telecomms_process()
 
+	if(emped)
+		t = Gibberish(t, 100)
+
 	var/useTC = 0
 	if(signal)
 		if(signal.data["done"])
@@ -1071,6 +1075,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/emp_act(severity)
 	for(var/atom/A in src)
 		A.emp_act(severity)
+	emped += 1
+	spawn(200 * severity)
+		emped -= 1
 
 /proc/get_viewable_pdas()
 	. = list()

--- a/code/modules/mob/living/carbon/say.dm
+++ b/code/modules/mob/living/carbon/say.dm
@@ -5,7 +5,7 @@
 	
 	return message
 
-/mob/living/carbon/can_speak_vocal(message)
-	if(!..() || silent)
+/mob/living/carbon/can_speak_basic(message)
+	if(silent)
 		return 0
-	return 1
+	return ..()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -179,6 +179,9 @@ var/list/department_radio_keys = list(
 	if(!message || message == "")
 		return
 
+	if(silent)
+		return
+
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			src << "<span class='danger'>You cannot speak in IC (muted).</span>"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -177,32 +177,29 @@ var/list/department_radio_keys = list(
 
 /mob/living/proc/can_speak_basic(message) //Check BEFORE handling of xeno and ling channels
 	if(!message || message == "")
-		return
-
-	if(silent)
-		return
+		return 0
 
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			src << "<span class='danger'>You cannot speak in IC (muted).</span>"
-			return
+			return 0
 		if(client.handle_spam_prevention(message,MUTE_IC))
-			return
+			return 0
 	
 	return 1
 
 /mob/living/proc/can_speak_vocal(message) //Check AFTER handling of xeno and ling channels
 	if(!message)
-		return
+		return 0
 
 	if(sdisabilities & MUTE)
-		return
-	
+		return 0
+
 	if(is_muzzled())
-		return
-	
+		return 0
+
 	if(!IsVocal())
-		return
+		return 0
 
 	return 1
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -69,7 +69,8 @@
 
 
 /obj/item/weapon/pen/sleepy/New()
-	create_reagents(60)
+	create_reagents(55)
 	reagents.add_reagent("stoxin", 30)
-	reagents.add_reagent("mutetoxin", 30)
+	reagents.add_reagent("mutetoxin", 15)
+	reagents.add_reagent("tirizene", 10)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1719,12 +1719,27 @@ datum/reagent/toxin/teapowder
 datum/reagent/toxin/mutetoxin //the new zombie powder.
 	name = "Mute Toxin"
 	id = "mutetoxin"
+	description = "A toxin that temporarily paralyzes the vocal cords."
 	reagent_state = LIQUID
 	color = "#F0F8FF" // rgb: 240, 248, 255
 	toxpwr = 0
 
-datum/reagent/toxin/on_mob_life(mob/living/carbon/M)
-	M.silent += 2 * REM + 1 //If this var is increased by one or less, it will have no effect since silent is decreased right after reagents are handled in Life(). Hence the + 1.
+datum/reagent/toxin/mutetoxin/on_mob_life(mob/living/carbon/M)
+	M.silent += REM + 1 //If this var is increased by one or less, it will have no effect since silent is decreased right after reagents are handled in Life(). Hence the + 1.
+	..()
+
+datum/reagent/toxin/staminatoxin
+	name = "Tirizene"
+	id = "tirizene"
+	description = "A toxin that affects the stamina of a person when injected into the bloodstream."
+	reagent_state = LIQUID
+	color = "#6E2828"
+	data = 13
+	toxpwr = 0
+
+datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/M)
+	M.adjustStaminaLoss(REM * data)
+	data = max(data - 1, 3)
 	..()
 
 /////////////////////////Coloured Crayon Powder////////////////////////////

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -386,6 +386,7 @@ silicate
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = null
 	secondary = 1
+
 /datum/chemical_reaction/chemsmoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect/effect/system/chem_smoke_spread/S = new /datum/effect/effect/system/chem_smoke_spread
@@ -449,6 +450,7 @@ silicate
 	result = null
 	required_reagents = list("iron" = 5, "frostoil" = 5, "plasma" = 20)
 	result_amount = 1
+
 /datum/chemical_reaction/plasmasolidification/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)
 	new /obj/item/stack/sheet/mineral/plasma(location)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -938,6 +938,7 @@
 #include "code\modules\mob\living\carbon\carbon_defines.dm"
 #include "code\modules\mob\living\carbon\emote.dm"
 #include "code\modules\mob\living\carbon\inventory.dm"
+#include "code\modules\mob\living\carbon\say.dm"
 #include "code\modules\mob\living\carbon\update_icons.dm"
 #include "code\modules\mob\living\carbon\alien\alien.dm"
 #include "code\modules\mob\living\carbon\alien\alien_defense.dm"


### PR DESCRIPTION
- Sleepy pen contains less mutetoxin
- Mutetoxin is less powerful
- Sleepy pen contains a new reagent: Tirizene
- This reagent inflicts stamina damage (it inflicts more damage when it has recently been injected)
- It can't be made right now because it'd be very hard to balance
- PDAs can now be EMP'd, turning all of their messages into gibberish.
- Fixes a fairly critical bug where silent was not checked in saycode (;_;7)
