### PR TITLE
Removed unnecessary messages when welding

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -293,10 +293,6 @@
 					user.visible_message("[user] unwelds the vent.", "You unweld the vent.", "You hear welding.")
 					welded = 0
 					update_icon()
-			else
-				user << "<span class='notice'>The welding tool needs to be on to start this task.</span>"
-		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return 1
 	else
 		return ..()

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -289,7 +289,8 @@
 			if(istype(P, /obj/item/weapon/weldingtool))
 				var/obj/item/weapon/weldingtool/WT = P
 				if(!WT.remove_fuel(0, user))
-					user << "<span class='warning'>The welding tool must be on to complete this task.</span>"
+					if(!WT.isOn())
+						user << "<span class='warning'>The welding tool must be on to complete this task.</span>"
 					return
 				playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 				user << "<span class='notice'>You start deconstructing the frame.</span>"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -898,8 +898,6 @@ About the new airlock wires panel:
 					user << "<span class='notice'>You [welded ? "welded the airlock shut":"unwelded the airlock"]</span>"
 					update_icon()
 					user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>")
-				else
-					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 		return
 	else if(istype(C, /obj/item/weapon/screwdriver))
 		src.p_open = !( src.p_open )

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -32,7 +32,6 @@
 			else
 				user << "<span class='notice'>You failed to salvage anything valuable from [src].</span>"
 		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return
 
 	if(istype(I, /obj/item/weapon/wirecutters))

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -176,7 +176,6 @@
 			item_heal_robotic(H, user, 30, 0)
 			return
 		else
-			user << "<span class='warning'>Need more welding fuel!</span>"
 			return
 	else
 		return ..()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -457,7 +457,6 @@ obj/structure/door_assembly/New()
 						new M(get_turf(src))
 				qdel(src)
 		else
-			user << "<span class='warning'> You need more welding fuel to dissassemble the airlock assembly.</span>"
 			return
 
 	else if(istype(W, /obj/item/weapon/wrench) && !anchored )

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -59,9 +59,8 @@
 		var/obj/item/weapon/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
 			user << "<span class='notice'>Slicing lattice joints ...</span>"
-		new /obj/item/stack/rods(src.loc)
-		qdel(src)
-
+			new /obj/item/stack/rods(src.loc)
+			qdel(src)
 	return
 
 /obj/structure/lattice/proc/updateOverlays()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -89,7 +89,6 @@ obj/structure/windoor_assembly/Destroy()
 							R.add_fingerprint(user)
 						qdel(src)
 				else
-					user << "<span class='notice'>You need more welding fuel to dissassemble the windoor assembly.</span>"
 					return
 
 			//Wrenching an unsecure assembly anchors it in place. Step 4 complete

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -541,5 +541,3 @@ turf/simulated/floor/proc/update_icon()
 					icon_state = icon_plating
 					burnt = 0
 					broken = 0
-				else
-					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -228,7 +228,6 @@
 				user << "<span class='notice'>You remove the outer plating.</span>"
 				dismantle_wall()
 		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return
 
 	else if( istype(W, /obj/item/weapon/pickaxe/plasmacutter) )

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -102,8 +102,6 @@
 						src.d_state = 3
 						src.icon_state = "r_wall-3"
 						user << "<span class='notice'>You press firmly on the cover, dislodging it.</span>"
-				else
-					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 				return
 
 			if( istype(W, /obj/item/weapon/pickaxe/plasmacutter) )
@@ -166,8 +164,6 @@
 						src.icon_state = "r_wall-6"
 						new /obj/item/stack/rods( src )
 						user << "<span class='notice'>The support rods drop out as you cut them loose from the frame.</span>"
-				else
-					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 				return
 
 			if( istype(W, /obj/item/weapon/pickaxe/plasmacutter) )

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -13,7 +13,7 @@
 		if(W.remove_fuel(15))
 			new refined_type(get_turf(src.loc))
 			qdel(src)
-		else
+		else if(W.isOn())
 			user << "<span class='info'>Not enough fuel to smelt [src].</span>"
 	..()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -412,7 +412,6 @@
 			for(var/mob/O in viewers(user, null))
 				O.show_message(text("<span class='danger'>[user] has fixed some of the dents on [src]!</span>"), 1)
 		else
-			user << "Need more welding fuel!"
 			return
 
 	else if(istype(W, /obj/item/stack/cable_coil) && wiresexposed)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -186,6 +186,8 @@ var/const/GRAV_NEEDS_WRENCH = 3
 					user << "<span class='notice'>You mend the damaged framework.</span>"
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 					broken_state++
+				else if(WT.isOn())
+					user << "<span class='notice'>You don't have enough fuel to mend the damaged framework.</span>"
 		if(GRAV_NEEDS_PLASTEEL)
 			if(istype(I, /obj/item/stack/sheet/plasteel))
 				var/obj/item/stack/sheet/plasteel/PS = I

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -186,8 +186,6 @@
 						state = 2
 						user << "You weld the [src] to the floor."
 						connect_to_network()
-				else
-					user << "<span class='danger'>You need more welding fuel to complete this task.</span>"
 			if(2)
 				if (WT.remove_fuel(0,user))
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
@@ -199,8 +197,6 @@
 						state = 1
 						user << "You cut the [src] free from the floor."
 						disconnect_from_network()
-				else
-					user << "<span class='danger'>You need more welding fuel to complete this task.</span>"
 		return
 
 	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -255,9 +255,6 @@
 
 					qdel(src)
 					return
-			else
-				user << "You need more welding fuel to complete this task."
-				return
 		else
 			user << "You need to attach it to the plating first!"
 			return

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -101,7 +101,6 @@
 					qdel(src)
 				return
 			else
-				user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 				return
 
 	if(istype(I, /obj/item/weapon/melee/energy/blade))
@@ -824,7 +823,6 @@
 				welded()
 				user << "<span class='notice'>You've sliced the disposal pipe.</span>"
 		else
-			user << "<span class='notice'>You need more welding fuel to cut the pipe.</span>"
 			return
 
 // called when pipe is cut with welder
@@ -1141,8 +1139,6 @@
 				welded()
 				user << "<span class='notice'>You've sliced the disposal pipe.</span>"
 		else
-			user << "<span class='notice'>You need more welding fuel to cut the pipe.</span>"
-
 			return
 
 	// would transfer to next pipe segment, but we are in a trunk
@@ -1276,7 +1272,6 @@
 				qdel(src)
 			return
 		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return
 
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -318,7 +318,6 @@
 				qdel(src)
 			return
 		else
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 			return
 
 /obj/machinery/disposal/deliveryChute/process()


### PR DESCRIPTION
It's back. Hopefully this time without issues. I learned how2git after all.
Again, fixed https://github.com/tgstation/-tg-station/issues/4425
Removed unnecessary "Not enough fuel" messages which are handled by remove_fuel itself and were only triggered when welder is off, creating confusion and chaos.
Lattice was actually deleted even when "welded" with welder that is off, not anymore.
