### PR TITLE
Showers wet the floor

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -156,7 +156,11 @@
 	add_fingerprint(M)
 	if(on)
 		for (var/atom/movable/G in loc)
-			Crossed(G)
+			wash(G)
+	else
+		if(istype(loc, /turf/simulated))
+			var/turf/simulated/tile = loc
+			tile.MakeSlippery()
 
 
 /obj/machinery/shower/attackby(obj/item/I, mob/user)
@@ -206,9 +210,10 @@
 /obj/machinery/shower/Crossed(atom/movable/O)
 	..()
 	wash(O)
-	if(ismob(O))
-		mobpresent += 1
-		check_heat(O)
+	if(iscarbon(O) && on)
+		var/mob/living/carbon/M=O
+		M.slip(4,2,null,NO_SLIP_WHEN_WALKING)
+
 
 
 /obj/machinery/shower/Uncrossed(atom/movable/O)
@@ -220,7 +225,9 @@
 //Yes, showers are super powerful as far as washing goes.
 /obj/machinery/shower/proc/wash(atom/movable/O)
 	if(!on) return
-
+	if(ismob(O))
+		mobpresent += 1
+		check_heat(O)
 	if(isliving(O))
 		var/mob/living/L = O
 		L.ExtinguishMob()
@@ -304,6 +311,7 @@
 	if(!on || !mobpresent) return
 	for(var/mob/living/carbon/C in loc)
 		check_heat(C)
+
 
 
 /obj/machinery/shower/proc/check_heat(mob/M)


### PR DESCRIPTION
Fixes #4248 

Showers wet the floor when turned off and slip when they are on. This way the floor is not made slippery every tick in process().
