### PR TITLE
Prevents voice analyzers using their own speech as input.

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -7,10 +7,13 @@
 	origin_tech = "magnets=1"
 	flags = HEAR
 	var/listening = 0
-	var/recorded	//the activation message
+	var/recorded = "" //the activation message
 
 /obj/item/device/assembly/voice/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-	if(listening)
+	if(speaker == src)
+		return
+
+	if(listening && !radio_freq)
 		recorded = raw_message
 		listening = 0
 		say("Activation message is '[recorded]'.")
@@ -31,7 +34,6 @@
 	if(!user)	return 0
 	activate()
 	return 1
-
 
 /obj/item/device/assembly/voice/toggle_secure()
 	. = ..()


### PR DESCRIPTION
Fixed #4670 
this is my favorite saycode bug so far.
