### PR TITLE
Integrated more of security records functionality into SecHUD

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -219,7 +219,9 @@
 						dat += "<br><br><font size='4'><b>Comments/Log</b></font><br>"
 						var/counter = 1
 						while(active2.fields[text("com_[]", counter)])
-							dat += text("[]<BR><A href='?src=\ref[];choice=Delete Entry;del_c=[]'>Delete Entry</A><BR><BR>", active2.fields[text("com_[]", counter)], src, counter)
+							dat += (active2.fields[text("com_[]", counter)] + "<BR>")
+							if(active2.fields[text("com_[]", counter)] != "<B>Deleted</B>")
+								dat += text("<A href='?src=\ref[];choice=Delete Entry;del_c=[]'>Delete Entry</A><BR><BR>", src, counter)
 							counter++
 						dat += text("<A href='?src=\ref[];choice=Add Entry'>Add Entry</A><br><br>", src)
 						dat += text("<A href='?src=\ref[];choice=Delete Record (Security)'>Delete Record (Security Only)</A><br>", src)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -268,7 +268,11 @@
 					if(R)
 						criminal = R.fields["criminal"]
 
-					msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1'>\[[criminal]\]</a>\n"
+					msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];criminal=1;status=1'>\[[criminal]\]</a>\n"
+					msg += "<span class = 'deptradio'>Security record:</span> <a href='?src=\ref[src];criminal=1;view=1'>\[View\]</a> "
+					msg += "<a href='?src=\ref[src];criminal=1;add_crime=1'>\[Add crime\]</a> "
+					msg += "<a href='?src=\ref[src];criminal=1;view_comment=1'>\[View comment log\]</a> "
+					msg += "<a href='?src=\ref[src];criminal=1;add_comment=1'>\[Add comment\]</a>\n"
 
 	msg += "*---------*</span>"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -626,7 +626,7 @@
 
 	//Check for ID
 	var/obj/item/weapon/card/id/idcard = get_idcard()
-	if(judgebot.idcheck && !idcard)
+	if(judgebot.idcheck && !idcard && name=="Unknown")
 		threatcount += 4
 
 	//Check for weapons
@@ -666,7 +666,7 @@
 
 	//Agent cards lower threatlevel.
 	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
-		threatcount -= 2
+		threatcount -= 5
 
 	return threatcount
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -550,7 +550,7 @@
 									while(R.fields[text("com_[]", counter)])
 										counter++
 									R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, worldtime2text(), time2text(world.realtime, "MMM DD"), year_integer+540, t1,)
-									usr << "<span class='notice'>Successfully added comment.</span>
+									usr << "<span class='notice'>Successfully added comment.</span>"
 									return
 					usr << "<span class='warning'>Unable to locate a data core entry for this person.</span>"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -443,7 +443,6 @@
 				src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
 		..()
-		return
 
 
 	if(href_list["criminal"])
@@ -453,38 +452,101 @@
 				if(usr.stat || usr == src) //|| !usr.canmove || usr.restrained()) Fluff: Sechuds have eye-tracking technology and sets 'arrest' to people that the wearer looks and blinks at.
 					return													  //Non-fluff: This allows sec to set people to arrest as they get disarmed or beaten
 				// Checks the user has security clearence before allowing them to change arrest status via hud, comment out to enable all access
-				var/allowed_access = 0
+				var/allowed_access = null
 				var/obj/item/clothing/glasses/G = H.glasses
 				if (!G.emagged)
 					if(H.wear_id)
 						var/list/access = H.wear_id.GetAccess()
 						if(access_sec_doors in access)
-							allowed_access = 1
+							allowed_access = H.get_authentification_name()
 				else
-					allowed_access = 1
+					allowed_access = "@%&ERROR_%$*"
 
 
 				if(!allowed_access)
 					H << "<span class='warning'>ERROR: Invalid Access</span>"
 					return
 
-
-				var/modified = 0
 				var/perpname = get_face_name(get_id_name(""))
 				if(perpname)
 					var/datum/data/record/R = find_record("name", perpname, data_core.security)
 					if(R)
-						var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.fields["criminal"]) in list("None", "*Arrest*", "Incarcerated", "Parolled", "Discharged", "Cancel")
-						if(R)
-							if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
-								if(setcriminal != "Cancel")
-									R.fields["criminal"] = setcriminal
-									modified = 1
+						if(href_list["status"])
+							var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.fields["criminal"]) in list("None", "*Arrest*", "Incarcerated", "Parolled", "Discharged", "Cancel")
+							if(R)
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+									if(setcriminal != "Cancel")
+										R.fields["criminal"] = setcriminal
 
-									spawn()
+										spawn()
 										H.handle_regular_hud_updates()
+								return
 
-				if(!modified)
+						if(href_list["view"])
+							if(R)
+								if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+									usr << "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]"
+									usr << "<b>Minor Crimes:</b>"
+									for(var/datum/data/crime/c in R.fields["mi_crim"])
+										usr << "<b>Crime:</b> [c.crimeName]"
+										usr << "<b>Details:</b> [c.crimeDetails]"
+										usr << "Added by [c.author] at [c.time]"
+										usr << "----------"
+									usr << "<b>Major Crimes:</b>"
+									for(var/datum/data/crime/c in R.fields["ma_crim"])
+										usr << "<b>Crime:</b> [c.crimeName]"
+										usr << "<b>Details:</b> [c.crimeDetails]"
+										usr << "Added by [c.author] at [c.time]"
+										usr << "----------"
+									usr << "<b>Notes:</b> [R.fields["notes"]]"
+
+									//usr << "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>"
+								return
+
+						if(href_list["add_crime"])
+							switch(alert("What crime would you like to add?","Security HUD","Minor Crime","Major Crime","Cancel"))
+								if("Minor Crime")
+									if(R)
+										var/t1 = copytext(sanitize(input("Please input minor crime names:", "Security HUD", "", null)  as text),1,MAX_MESSAGE_LEN)
+										var/t2 = copytext(sanitize(input("Please input minor crime details:", "Security HUD", "", null)  as message),1,MAX_MESSAGE_LEN)
+										if (!t1 || !t2 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+											return
+										var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
+										data_core.addMinorCrime(R.fields["id"], crime)
+										usr << "<span class='notice'>Successfully added a minor crime.</span>"
+										return
+								if("Major Crime")
+									if(R)
+										var/t1 = copytext(sanitize(input("Please input major crime names:", "Security HUD", "", null)  as text),1,MAX_MESSAGE_LEN)
+										var/t2 = copytext(sanitize(input("Please input major crime details:", "Security HUD", "", null)  as message),1,MAX_MESSAGE_LEN)
+										if (!t1 || !t2 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+											return
+										var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
+										data_core.addMajorCrime(R.fields["id"], crime)
+										usr << "<span class='notice'>Successfully added a major crime.</span>"
+										return
+								else return
+
+						if(href_list["view_comment"])
+							if(R)
+								usr << "<b>Comments/Log:</b>"
+								var/counter = 1
+								while(R.fields[text("com_[]", counter)])
+									usr << R.fields[text("com_[]", counter)]
+									usr << "----------"
+									counter++
+								return
+
+						if(href_list["add_comment"])
+							if(R)
+								var/t1 = copytext(sanitize(input("Add Comment:", "Secure. records", null, null)  as message),1,MAX_MESSAGE_LEN)
+								if (!t1 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+									return
+								var/counter = 1
+								while(R.fields[text("com_[]", counter)])
+									counter++
+								R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, worldtime2text(), time2text(world.realtime, "MMM DD"), year_integer+540, t1,)
+								return
 					usr << "<span class='warning'>Unable to locate a data core entry for this person.</span>"
 
 /mob/living/carbon/human/proc/play_xylophone()
@@ -564,7 +626,7 @@
 
 	//Check for ID
 	var/obj/item/weapon/card/id/idcard = get_idcard()
-	if(judgebot.idcheck && !idcard && name=="Unknown")
+	if(judgebot.idcheck && !idcard)
 		threatcount += 4
 
 	//Check for weapons
@@ -604,7 +666,7 @@
 
 	//Agent cards lower threatlevel.
 	if(istype(idcard, /obj/item/weapon/card/id/syndicate))
-		threatcount -= 5
+		threatcount -= 2
 
 	return threatcount
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -484,23 +484,22 @@
 
 						if(href_list["view"])
 							if(R)
-								if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
-									usr << "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]"
-									usr << "<b>Minor Crimes:</b>"
-									for(var/datum/data/crime/c in R.fields["mi_crim"])
-										usr << "<b>Crime:</b> [c.crimeName]"
-										usr << "<b>Details:</b> [c.crimeDetails]"
-										usr << "Added by [c.author] at [c.time]"
-										usr << "----------"
-									usr << "<b>Major Crimes:</b>"
-									for(var/datum/data/crime/c in R.fields["ma_crim"])
-										usr << "<b>Crime:</b> [c.crimeName]"
-										usr << "<b>Details:</b> [c.crimeDetails]"
-										usr << "Added by [c.author] at [c.time]"
-										usr << "----------"
-									usr << "<b>Notes:</b> [R.fields["notes"]]"
-
-									//usr << "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>"
+								if(usr.stat || H.weakened || H.stunned || H.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+									return
+								usr << "<b>Name:</b> [R.fields["name"]]	<b>Criminal Status:</b> [R.fields["criminal"]]"
+								usr << "<b>Minor Crimes:</b>"
+								for(var/datum/data/crime/c in R.fields["mi_crim"])
+									usr << "<b>Crime:</b> [c.crimeName]"
+									usr << "<b>Details:</b> [c.crimeDetails]"
+									usr << "Added by [c.author] at [c.time]"
+									usr << "----------"
+								usr << "<b>Major Crimes:</b>"
+								for(var/datum/data/crime/c in R.fields["ma_crim"])
+									usr << "<b>Crime:</b> [c.crimeName]"
+									usr << "<b>Details:</b> [c.crimeDetails]"
+									usr << "Added by [c.author] at [c.time]"
+									usr << "----------"
+								usr << "<b>Notes:</b> [R.fields["notes"]]"
 								return
 
 						if(href_list["add_crime"])
@@ -509,26 +508,30 @@
 									if(R)
 										var/t1 = copytext(sanitize(input("Please input minor crime names:", "Security HUD", "", null)  as text),1,MAX_MESSAGE_LEN)
 										var/t2 = copytext(sanitize(input("Please input minor crime details:", "Security HUD", "", null)  as message),1,MAX_MESSAGE_LEN)
-										if (!t1 || !t2 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+										if(R)
+											if (!t1 || !t2 || !allowed_access || H.stat || H.weakened || H.stunned || H.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+												return
+											var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
+											data_core.addMinorCrime(R.fields["id"], crime)
+											usr << "<span class='notice'>Successfully added a minor crime.</span>"
 											return
-										var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
-										data_core.addMinorCrime(R.fields["id"], crime)
-										usr << "<span class='notice'>Successfully added a minor crime.</span>"
-										return
 								if("Major Crime")
 									if(R)
 										var/t1 = copytext(sanitize(input("Please input major crime names:", "Security HUD", "", null)  as text),1,MAX_MESSAGE_LEN)
 										var/t2 = copytext(sanitize(input("Please input major crime details:", "Security HUD", "", null)  as message),1,MAX_MESSAGE_LEN)
-										if (!t1 || !t2 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+										if(R)
+											if (!t1 || !t2 || !allowed_access || H.stat || H.weakened || H.stunned || H.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+												return
+											var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
+											data_core.addMajorCrime(R.fields["id"], crime)
+											usr << "<span class='notice'>Successfully added a major crime.</span>"
 											return
-										var/crime = data_core.createCrimeEntry(t1, t2, allowed_access, worldtime2text())
-										data_core.addMajorCrime(R.fields["id"], crime)
-										usr << "<span class='notice'>Successfully added a major crime.</span>"
-										return
 								else return
 
 						if(href_list["view_comment"])
 							if(R)
+								if(H.stat || H.weakened || H.stunned || H.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+									return
 								usr << "<b>Comments/Log:</b>"
 								var/counter = 1
 								while(R.fields[text("com_[]", counter)])
@@ -540,13 +543,15 @@
 						if(href_list["add_comment"])
 							if(R)
 								var/t1 = copytext(sanitize(input("Add Comment:", "Secure. records", null, null)  as message),1,MAX_MESSAGE_LEN)
-								if (!t1 || !R || !allowed_access || usr.stat || usr.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+								if(R)
+									if (!t1 || !allowed_access || H.stat || H.weakened || H.stunned || H.restrained() || !istype(H.glasses, /obj/item/clothing/glasses/hud/security) || !istype(H.glasses, /obj/item/clothing/glasses/hud/security/sunglasses))
+										return
+									var/counter = 1
+									while(R.fields[text("com_[]", counter)])
+										counter++
+									R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, worldtime2text(), time2text(world.realtime, "MMM DD"), year_integer+540, t1,)
+									usr << "<span class='notice'>Successfully added comment.</span>
 									return
-								var/counter = 1
-								while(R.fields[text("com_[]", counter)])
-									counter++
-								R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, worldtime2text(), time2text(world.realtime, "MMM DD"), year_integer+540, t1,)
-								return
 					usr << "<span class='warning'>Unable to locate a data core entry for this person.</span>"
 
 /mob/living/carbon/human/proc/play_xylophone()


### PR DESCRIPTION
Here's the demonstration: http://imgur.com/a/y4Feu

By the way, there are "Unable to locate record" things in that demonstration, they're fixed.

What changed:
- Fixed https://github.com/tgstation/-tg-station/issues/4232
- Fixed "Delete entry" button not disappearing after comment has been deleted.
- You can now (provided you have access) do these things via SecHUD:
  1. View name, criminal status, minor and major crimes and their details, as well as important notes.
  2. View and add comments (Note: it's a bit different from consoles in that the rank of the author is not added, but I figured it's minor)
  3. Add crimes, just like via console

You cannot see general or medical record, rank, age, stuff like that and cannot delete anything. You cannot see fingerprints either. And you cannot edit important notes.

Only status change is available when you're down or restrained. This is for two reasons: it makes sense, because how would you type in anything with your eyes (status change is explained as "blinking" at your target) and also prevents adding comments like "Urist McTraitor killed me in engineering maint".
