### PR TITLE
Vomit message fix

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -694,8 +694,8 @@
 			if(lastpuke >= 25) // about 25 second delay I guess
 				Stun(5)
 
-				for(var/mob/O in viewers(world.view, src))
-					O.show_message("<span class='danger'>[O] throws up!</span>")
+				visible_message("<span class='danger'>[src] throws up!</span>", \
+						"<span class='userdanger'>[src] throws up!</span>")
 				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
 				var/turf/location = loc


### PR DESCRIPTION
Fixes #4655 .

Also:
- replaces "for(var/mob/0 ... show_message" by "visible_message(...)"
- Vomiting message is now bold red for the source.
