### PR TITLE
Creates new "chaos magicarp" that fires a random projectile each time

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -36,5 +36,9 @@
 	health = 50
 
 /mob/living/simple_animal/hostile/carp/ranged/New()
-	projectiletype = pick(typesof(/obj/item/projectile/magic))
+	projectiletype = pick(typesof(initial(projectiletype)))
 	..()
+
+/mob/living/simple_animal/hostile/carp/ranged/Shoot(var/target, var/start, var/user, var/bullet = 0)
+	projectiletype = pick(typesof(initial(projectiletype)))
+	..(target, start, user, bullet)

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -49,6 +49,6 @@
 	maxHealth = 75
 	health = 75
 
-/mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot(var/target, var/start, var/user, var/bullet = 0)
+/mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot()
 	projectiletype = pick(typesof(initial(projectiletype)))
-	..(target, start, user, bullet)
+	..()

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -18,7 +18,10 @@
 /datum/round_event/wizard/magicarp/start()
 	for(var/obj/effect/landmark/C in landmarks_list)
 		if(C.name == "carpspawn")
-			new /mob/living/simple_animal/hostile/carp/ranged(C.loc)
+			if(prob(5))
+				new /mob/living/simple_animal/hostile/carp/ranged/chaos(C.loc)
+			else
+				new /mob/living/simple_animal/hostile/carp/ranged(C.loc)
 
 /mob/living/simple_animal/hostile/carp/ranged
 	name = "magicarp"
@@ -39,6 +42,13 @@
 	projectiletype = pick(typesof(initial(projectiletype)))
 	..()
 
-/mob/living/simple_animal/hostile/carp/ranged/Shoot(var/target, var/start, var/user, var/bullet = 0)
+/mob/living/simple_animal/hostile/carp/ranged/chaos
+	name = "chaos magicarp"
+	desc = "50% carp, 100% magic, 150% horrible."
+	color = "#00FFFF"
+	maxHealth = 75
+	health = 75
+
+/mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot(var/target, var/start, var/user, var/bullet = 0)
 	projectiletype = pick(typesof(initial(projectiletype)))
 	..(target, start, user, bullet)


### PR DESCRIPTION
_This is @Incoming5643's baby. If he doesn't like it then it probably shouldn't be merged._

I added a new mob called "chaos magicarp" which are like normal magicarp, except they have 75 health up from 50 and fire a random magic bolt each time instead of choosing one from the start and sticking with it like the magicarp do.

I also made it randomize from `initial(projectiletype)` instead of directly from `/obj/item/projectile/magic` so someone can make a guncarp in the future without much hassle.

![chaoscarp_graph](https://cloud.githubusercontent.com/assets/5211576/4249710/c0e17a2a-3a7a-11e4-8199-11e27f649eb2.png)
