### PR TITLE
Removes log_adminwarn

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -63,10 +63,6 @@
 	if (config.log_adminchat)
 		diary << "\[[time_stamp()]]ADMINSAY: [text]"
 
-/proc/log_adminwarn(text)
-	if (config.log_adminwarn)
-		diary << "\[[time_stamp()]]ADMINWARN: [text]"
-
 /proc/log_pda(text)
 	if (config.log_pda)
 		diary << "\[[time_stamp()]]PDA: [text]"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -23,7 +23,6 @@
 	var/log_emote = 0					// log emotes
 	var/log_attack = 0					// log attack messages
 	var/log_adminchat = 0				// log admin chat messages
-	var/log_adminwarn = 0				// log warnings admins get about bomb construction and such
 	var/log_pda = 0						// log pda messages
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
 	var/sql_enabled = 0					// for sql switching
@@ -212,8 +211,6 @@
 					config.log_emote = 1
 				if("log_adminchat")
 					config.log_adminchat = 1
-				if("log_adminwarn")
-					config.log_adminwarn = 1
 				if("log_pda")
 					config.log_pda = 1
 				if("log_hrefs")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -6,7 +6,6 @@ var/global/floorIsLava = 0
 ////////////////////////////////
 /proc/message_admins(var/msg)
 	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
-	log_adminwarn(msg)
 	admins << msg
 
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -59,9 +59,6 @@ LOG_LAW
 ## log all Topic() calls (for use by coders in tracking down Topic issues)
 # LOG_HREFS
 
-## log admin warning messages
-##LOG_ADMINWARN  ## Also duplicates a bunch of other messages.
-
 ## disconnect players who did nothing during 10 minutes
 # KICK_INACTIVE
 


### PR DESCRIPTION
This was functionally the same as log_admin but with broken html formatting

Only used in one place and is disabled by default and on SoS's config

Basically no reason to have this as well as log_admin
