### PR TITLE
Removes two unused vars of the gamemode datums.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -14,8 +14,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	required_enemies = 1
 	recommended_enemies = 4
 
-	uplink_welcome = "Syndicate Uplink Console:"
-	uplink_uses = 10
 
 	var/const/prob_int_murder_target = 50 // intercept names the assassination target half the time
 	var/const/prob_right_murder_target_l = 25 // lower bound on probability of naming right assassination target

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -30,8 +30,6 @@
 	required_enemies = 6
 	recommended_enemies = 6
 
-	uplink_welcome = "Nar-Sie Uplink Console:"
-	uplink_uses = 10
 
 	var/finished = 0
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -3,9 +3,6 @@
 	config_tag = "extended"
 	required_players = 0
 
-	uplink_welcome = "Syndicate Uplink Console:"
-	uplink_uses = 10
-
 /datum/game_mode/announce()
 	world << "<B>The current game mode is - Extended Role-Playing!</B>"
 	world << "<B>Just have fun and role-play!</B>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -27,8 +27,6 @@
 	var/required_enemies = 0
 	var/recommended_enemies = 0
 	var/pre_setup_before_jobs = 0
-	var/uplink_welcome = "Syndicate Uplink Console:"
-	var/uplink_uses = 10
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
 	var/datum/mind/sacrifice_target = null
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -10,10 +10,6 @@
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
 
-	uplink_welcome = "Crazy AI Uplink Console:"
-	uplink_uses = 10
-
-
 
 	var/AI_win_timeleft = 1800 //started at 1800, in case I change this for testing round end.
 	var/malf_mode_declared = 0

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -5,9 +5,6 @@
 	var/nometeors = 1
 	required_players = 0
 
-	uplink_welcome = "EVIL METEOR Uplink Console:"
-	uplink_uses = 10
-
 
 /datum/game_mode/meteor/announce()
 	world << "<B>The current game mode is - Meteor!</B>"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -11,9 +11,6 @@
 	pre_setup_before_jobs = 1
 	antag_flag = BE_OPERATIVE
 
-	uplink_welcome = "Corporate Backed Uplink Console:"
-	uplink_uses = 10
-
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.
 
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -20,10 +20,6 @@
 	required_enemies = 3
 	recommended_enemies = 3
 
-
-	uplink_welcome = "Revolutionary Uplink Console:"
-	uplink_uses = 10
-
 	var/finished = 0
 	var/checkwin_counter = 0
 	var/const/max_headrevs = 3

--- a/code/game/gamemodes/sandbox/sandbox.dm
+++ b/code/game/gamemodes/sandbox/sandbox.dm
@@ -3,9 +3,6 @@
 	config_tag = "sandbox"
 	required_players = 0
 
-	uplink_welcome = "Syndicate Uplink Console:"
-	uplink_uses = 10
-
 /datum/game_mode/sandbox/announce()
 	world << "<B>The current game mode is - Sandbox!</B>"
 	world << "<B>Build your own station with the sandbox-panel command!</B>"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -16,10 +16,6 @@
 	required_enemies = 1
 	recommended_enemies = 4
 
-
-	uplink_welcome = "Syndicate Uplink Console:"
-	uplink_uses = 10
-
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/scale_modifier = 1 // Used for gamemodes, that are a child of traitor, that need more than the usual.
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -10,9 +10,6 @@
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
 
-	uplink_welcome = "Wizardly Uplink Console:"
-	uplink_uses = 10
-
 	var/finished = 0
 
 /datum/game_mode/wizard/announce()

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -9,8 +9,8 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 var/list/world_uplinks = list()
 
 /obj/item/device/uplink
-	var/welcome 					// Welcoming menu message
-	var/uses 						// Numbers of crystals
+	var/welcome = "Syndicate Uplink Console:"	// Welcoming menu message
+	var/uses = 10								// Numbers of crystals
 	// List of items not to shove in their hands.
 	var/purchase_log = ""
 	var/show_description = null
@@ -22,8 +22,6 @@ var/list/world_uplinks = list()
 /obj/item/device/uplink/New()
 	..()
 	world_uplinks+=src
-	welcome = ticker.mode.uplink_welcome
-	uses = ticker.mode.uplink_uses
 
 /obj/item/device/uplink/Destroy()
 	world_uplinks-=src


### PR DESCRIPTION
Removes two unused vars of the gamemode datums, uplink_welcome and uplink_uses.

uplink_welcome was actually used as a greeting text from uplinks, now they'll always show "Syndicate Uplink Console:". The removed strings weren't nothing important, actually, with the addition of the uplinks in cargo, you were able to metagame the ongoing gamemode.
