### PR TITLE
AI restoration console shows ion laws

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -51,6 +51,12 @@
 		if (src.occupier.laws.zeroth)
 			laws += "<b>0:</b> [src.occupier.laws.zeroth]<BR>"
 
+		for (var/index = 1, index <= src.occupier.laws.ion.len, index++)
+			var/law = src.occupier.laws.ion[index]
+			if (length(law) > 0)
+				var/num = ionnum()
+				laws += "<b>[num]:</b> [law]<BR>"
+
 		var/number = 1
 		for (var/index = 1, index <= src.occupier.laws.inherent.len, index++)
 			var/law = src.occupier.laws.inherent[index]


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/4572

The only thing is, it randomizes "number" on ion laws every tick. I figured it's not a big deal and looks kind of neat.
