### PR TITLE
Multiple machinery fixes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1032,7 +1032,6 @@ FIRE ALARM
 					qdel(src)
 		return
 
-	src.alarm()
 	return
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -342,6 +342,8 @@
 	gameover = 0
 
 /obj/machinery/computer/arcade/orion_trail/attack_hand(mob/user as mob)
+	if(..())
+		return
 	if(fuel <= 0 || food <=0 || settlers.len == 0)
 		gameover = 1
 		event = null

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -11,7 +11,7 @@
 
 /obj/machinery/pipedispenser/attack_hand(user as mob)
 	if(..())
-		return
+		return 1
 	var/dat = {"
 <b>Regular pipes:</b><BR>
 <A href='?src=\ref[src];make=0;dir=1'>Pipe</A><BR>
@@ -46,10 +46,10 @@
 
 /obj/machinery/pipedispenser/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if(!anchored|| !usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
 		usr << browse(null, "window=pipedispenser")
-		return
+		return 1
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	if(href_list["make"])
@@ -149,6 +149,7 @@ Nah
 <A href='?src=\ref[src];dmake=5'>Bin</A><BR>
 <A href='?src=\ref[src];dmake=6'>Outlet</A><BR>
 <A href='?src=\ref[src];dmake=7'>Chute</A><BR>
+<A href='?src=\ref[src];dmake=8'>Sort Junction</A><BR>
 "}
 
 	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
@@ -163,9 +164,6 @@ Nah
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	if(href_list["dmake"])
-		if(!anchored || !usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
-			usr << browse(null, "window=pipedispenser")
-			return
 		if(!wait)
 			var/p_type = text2num(href_list["dmake"])
 			var/obj/structure/disposalconstruct/C = new (src.loc)
@@ -189,6 +187,8 @@ Nah
 				if(7)
 					C.ptype = 8
 					C.density = 1
+				if(8)
+					C.ptype = 9
 			C.add_fingerprint(usr)
 			C.update()
 			wait = 1

--- a/code/modules/food&drinks/kitchen machinery/microwave.dm
+++ b/code/modules/food&drinks/kitchen machinery/microwave.dm
@@ -183,6 +183,8 @@
 	return 0
 
 /obj/machinery/microwave/attack_hand(mob/user as mob)
+	if(..())
+		return
 	user.set_machine(src)
 	interact(user)
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -36,6 +36,8 @@ var/global/list/rad_collectors = list()
 
 
 /obj/machinery/power/rad_collector/attack_hand(mob/user as mob)
+	if(..())
+		return
 	if(anchored)
 		if(!src.locked)
 			toggle_power()


### PR DESCRIPTION
Disposal Pipe Dispenser:
- Monkeys can no longer use it! (just like pipe dispenser)
- Interaction window no longer closes when clicking it while restrained/lying down/out of range.
- Alien/slimes can no longer open the interaction window.
- 'Sort Junction' pipes now available in the dispenser (to replace broken ones).
  
  Fire alarm:
- Can no longer be activated by clicking with an item in hand (alien/monkey exploit).

Radiation Collector Array:
-  Can no longer be toggled as alien/slime or while lying down or with severe brain damage or w/o power.

Orion Trail Arcade:
- clicking a broken orion trail arcade doesn't open the window anymore.

Microwave:
- Can no longer open the microwave interaction window w/o power or as an alien/slime or with brain damage or lying down.
