### PR TITLE
Fix many messages and sounds

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -60,7 +60,7 @@ obj/item/proc/get_clamped_volume()
 	user.lastattacked = M
 	M.lastattacker = user
 
-	add_logs(user, M, "attacked", object=src.name, addition="(INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+	add_logs(user, M, "attacked", object=src.name, addition="(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 
 	//spawn(1800)            // this wont work right
 	//	M.lastattacker = null

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -33,7 +33,7 @@
 	if(!foldable)
 		return
 	if(contents.len)
-		user << "<span class='notice'>You can't fold it with items still inside.</span>"
+		user << "<span class='notice'>You can't fold this box with items still inside.</span>"
 		return
 	if(!ispath(foldable))
 		return

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -33,6 +33,7 @@
 	if(!foldable)
 		return
 	if(contents.len)
+		user << "<span class='notice'>You can't fold it with items still inside.</span>"
 		return
 	if(!ispath(foldable))
 		return

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -4,11 +4,13 @@
 	icon_state = "briefcase"
 	flags = CONDUCT
 	force = 8.0
+	hitsound = "swing_hit"
 	throw_speed = 2
 	throw_range = 4
 	w_class = 4.0
 	max_w_class = 3
 	max_combined_w_class = 21
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
 /obj/item/weapon/storage/briefcase/New()
 	..()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -153,11 +153,13 @@
 	item_state = "sec-case"
 	desc = "A large briefcase with a digital locking system."
 	force = 8.0
+	hitsound = "swing_hit"
 	throw_speed = 2
 	throw_range = 4
 	w_class = 4.0
 	max_w_class = 3
 	max_combined_w_class = 21
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
 /obj/item/weapon/storage/secure/briefcase/New()
 	..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -172,12 +172,13 @@
 		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 		health -= W.force * 0.1
 	else if(!shock(user, 70))
-		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 		switch(W.damtype)
 			if("fire")
 				health -= W.force
+				playsound(loc, 'sound/items/welder.ogg', 80, 1)
 			if("brute")
 				health -= W.force * 0.1
+				playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	healthcheck()
 	..()
 	return

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -173,12 +173,13 @@
 		health -= W.force * 0.1
 	else if(!shock(user, 70))
 		switch(W.damtype)
-			if("fire")
+			if(BURN)
 				health -= W.force
 				playsound(loc, 'sound/items/welder.ogg', 80, 1)
-			if("brute")
+			if(BRUTE)
 				health -= W.force * 0.1
 				playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
+
 	healthcheck()
 	..()
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -116,12 +116,12 @@
 		if ("help")
 			help_shake_act(M)
 		else
-			if (is_muzzled())
+			if (M.is_muzzled())
 				return
-			if (health > 0)
-				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-						"<span class='userdanger'>[M.name] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
+					"<span class='userdanger'>[M.name] bites [src]!</span>")
+			if (health > -100)
 				adjustBruteLoss(rand(1, 3))
 				updatehealth()
 	return
@@ -134,7 +134,7 @@
 
 	if(M.Victim) return // can't attack while eating!
 
-	if (health > -100)
+	if (stat > -100)
 
 		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
 				"<span class='userdanger'>The [M.name] glomps [src]!</span>")
@@ -307,6 +307,28 @@ In all, this is a lot like the monkey code. /N
 			else
 				M << "<span class='warning'>[name] is too injured for that.</span>"
 	return
+
+
+/mob/living/carbon/alien/humanoid/attack_larva(mob/living/carbon/alien/larva/L as mob)
+
+	switch(L.a_intent)
+		if("help")
+			visible_message("<span class='notice'>[L] rubs its head against [src].</span>")
+
+
+		else
+			if (health > 0)
+				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+				var/damage = rand(1, 3)
+				visible_message("<span class='danger'>[L.name] bites [src]!!</span>", \
+						"<span class='userdanger'>[L.name] bites [src]!!</span>")
+
+				adjustBruteLoss(damage)
+				updatehealth()
+			else
+				L << "<span class='warning'>[name] is too injured for that.</span>"
+	return
+
 
 
 /mob/living/carbon/alien/humanoid/restrained()

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -117,6 +117,8 @@
 	if(M.melee_damage_upper == 0)
 		M.emote("[M.friendly] [src]")
 	else
+		if(M.attack_sound)
+			playsound(loc, M.attack_sound, 50, 1, 1)
 		visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>", \
 				"<span class='userdanger'>[M] [M.attacktext] [src]!</span>")
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
@@ -142,12 +144,12 @@
 		if ("help")
 			help_shake_act(M)
 		else
-			if (is_muzzled())
+			if (M.is_muzzled())
 				return
-			if (health > 0)
-				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-						"<span class='userdanger'>[M.name] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
+					"<span class='userdanger'>[M.name] bites [src]!</span>")
+			if (health > -100)
 				adjustBruteLoss(rand(1, 3))
 				updatehealth()
 	return
@@ -158,13 +160,12 @@
 		M << "You cannot attack people before the game has started."
 		return
 
-	if(M.Victim) return // can't attack while eating!
+	if(M.Victim)
+		return // can't attack while eating!
 
-	if (health > -100)
-
+	if (stat != DEAD)
 		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
 				"<span class='userdanger'>The [M.name] glomps [src]!</span>")
-
 		var/damage = rand(1, 3)
 
 		if(M.is_adult)
@@ -172,9 +173,8 @@
 		else
 			damage = rand(5, 35)
 
+
 		adjustBruteLoss(damage)
-
-
 		updatehealth()
 
 	return
@@ -259,7 +259,7 @@
 		else
 			if (health > 0)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				var/damage = rand(1, 3)
+				var/damage = 1
 				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
 						"<span class='userdanger'>[M.name] bites [src]!</span>")
 				adjustBruteLoss(damage)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -237,6 +237,27 @@
 		if(armor >= 2)	return
 
 
+/mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L as mob)
+
+	switch(L.a_intent)
+		if("help")
+			visible_message("<span class='notice'>[L] rubs its head against [src].</span>")
+
+
+		else
+
+			var/damage = rand(1, 3)
+			visible_message("<span class='danger'>[L] bites [src]!</span>", \
+					"<span class='userdanger'>[L] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+
+			if(stat != DEAD)
+				L.amount_grown = min(L.amount_grown + damage, L.max_grown)
+			var/obj/item/organ/limb/affecting = get_organ(ran_zone(L.zone_sel.selecting))
+			var/armor_block = run_armor_check(affecting, "melee")
+			apply_damage(damage, BRUTE, affecting, armor_block)
+
+
 /mob/living/carbon/human/attack_slime(mob/living/carbon/slime/M as mob)
 	if(M.Victim) return // can't attack while eating!
 

--- a/code/modules/mob/living/carbon/human/human_attackpaw.dm
+++ b/code/modules/mob/living/carbon/human/human_attackpaw.dm
@@ -3,11 +3,12 @@
 	if (M.a_intent == "help")
 		help_shake_act(M)
 	else
-		if (is_muzzled())
+		if (M.is_muzzled())
 			return
 
 		visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
 			"<span class='userdanger'>[M.name] bites [src]!</span>")
+		playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 
 		var/damage = rand(1, 3)
 		var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -74,20 +74,39 @@
 	if (M.a_intent == "help")
 		help_shake_act(M)
 	else
-		if (M.a_intent == "harm" && !is_muzzled())
-			if ((prob(75) && health > 0))
+		if (M.a_intent == "harm" && !M.is_muzzled())
+			if (prob(75))
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				visible_message("<span class='danger'>[M.name] bites [name]!</span>", \
 						"<span class='userdanger'>[M.name] bites [name]!</span>")
 				var/damage = rand(1, 5)
-				adjustBruteLoss(damage)
-				health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
+				if (health > -100)
+					adjustBruteLoss(damage)
+					health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
 				for(var/datum/disease/D in M.viruses)
 					contract_disease(D,1,0)
 			else
 				visible_message("<span class='danger'>[M.name] has attempted to bite [name]!</span>", \
 					"<span class='userdanger'>[M.name] has attempted to bite [name]!</span>")
 	return
+
+/mob/living/carbon/monkey/attack_larva(mob/living/carbon/alien/larva/L as mob)
+
+	switch(L.a_intent)
+		if("help")
+			visible_message("<span class='notice'>[L] rubs its head against [src].</span>")
+
+
+		else
+
+			var/damage = rand(1, 3)
+			visible_message("<span class='danger'>[L] bites [src]!</span>", \
+					"<span class='userdanger'>[L] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+
+			if(stat != DEAD)
+				L.amount_grown = min(L.amount_grown + damage, L.max_grown)
+				adjustBruteLoss(damage)
 
 /mob/living/carbon/monkey/attack_hand(mob/living/carbon/human/M as mob)
 	if (!ticker)
@@ -181,8 +200,9 @@
 				else
 					visible_message("<span class='danger'>[M] has slashed [name]!</span>", \
 							"<span class='userdanger'>[M] has slashed [name]!</span>")
-				adjustBruteLoss(damage)
-				updatehealth()
+				if (stat != DEAD)
+					adjustBruteLoss(damage)
+					updatehealth()
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to lunge at [name]!</span>", \

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -246,20 +246,16 @@
 
 	if (Victim) return // can't attack while eating!
 
+	visible_message("<span class='danger'> The [M.name] has glomped [src]!</span>", \
+			"<span class='userdanger'> The [M.name] has glomped [src]!</span>")
+	var/damage = rand(1, 3)
+	attacked += 5
+	if(M.is_adult)
+		damage = rand(1, 6)
+	else
+		damage = rand(1, 3)
 	if (health > -100)
-
-		visible_message("<span class='danger'> The [M.name] has glomped [src]!</span>", \
-				"<span class='userdanger'> The [M.name] has glomped [src]!</span>")
-		var/damage = rand(1, 3)
-		attacked += 5
-
-		if(M.is_adult)
-			damage = rand(1, 6)
-		else
-			damage = rand(1, 3)
-
 		adjustBruteLoss(damage)
-
 		updatehealth()
 	return
 
@@ -279,7 +275,7 @@
 
 /mob/living/carbon/slime/attack_paw(mob/living/carbon/monkey/M as mob)
 	if(!(istype(M, /mob/living/carbon/monkey)))
-		return // Fix for aliens receiving double messages when attacking other aliens.
+		return // Fix for aliens receiving double messages when attacking slimes.
 
 	if (!ticker)
 		M << "You cannot attack people before the game has started."
@@ -296,16 +292,37 @@
 		if ("help")
 			help_shake_act(M)
 		else
-			if (is_muzzled())
+			if (M.is_muzzled())
 				return
-			if (health > 0)
-				attacked += 10
-				//playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] has attacked [src]!</span>", \
-						"<span class='userdanger'>[M.name] has attacked [src]!</span>")
+
+			attacked += 10
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
+					"<span class='userdanger'>[M.name] bites [src]!</span>")
+			if (health > -100)
 				adjustBruteLoss(rand(1, 3))
 				updatehealth()
 	return
+
+/mob/living/carbon/slime/attack_larva(mob/living/carbon/alien/larva/L as mob)
+
+	switch(L.a_intent)
+
+		if("help")
+			visible_message("<span class='notice'>[L] rubs its head against [src].</span>")
+
+
+		else
+
+			attacked += 10
+			visible_message("<span class='danger'>[L] bites [src]!</span>", \
+					"<span class='userdanger'>[L] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+
+			if(stat != DEAD)
+				var/damage = rand(1, 3)
+				L.amount_grown = min(L.amount_grown + damage, L.max_grown)
+				adjustBruteLoss(damage)
 
 
 /mob/living/carbon/slime/attack_hand(mob/living/carbon/human/M as mob)
@@ -416,8 +433,9 @@
 				visible_message("<span class='danger'>[M] has punched [src]!</span>", \
 						"<span class='userdanger'>[M] has punched [src]!</span>")
 
-				adjustBruteLoss(damage)
-				updatehealth()
+				if (health > -100)
+					adjustBruteLoss(damage)
+					updatehealth()
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to punch [src]!</span>")
@@ -446,13 +464,15 @@
 				var/damage = rand(15, 30)
 				if (damage >= 25)
 					damage = rand(20, 40)
-					visible_message("<span class='danger'>[M] has attacked [name]!</span>", \
-							"<span class='userdanger'>[M] has attacked [name]!</span>")
+					visible_message("<span class='danger'>[M] has slashed [name]!</span>", \
+							"<span class='userdanger'>[M] has slashed [name]!</span>")
 				else
 					visible_message("<span class='danger'>[M] has wounded [name]!</span>", \
 							"<span class='userdanger'>)[M] has wounded [name]!</span>")
-				adjustBruteLoss(damage)
-				updatehealth()
+
+				if (health > -100)
+					adjustBruteLoss(damage)
+					updatehealth()
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to lunge at [name]!</span>", \

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -20,6 +20,7 @@
 	faction = list("neutral")
 	attack_same = 1
 	attacktext = "kicks"
+	attack_sound = 'sound/weapons/punch1.ogg'
 	health = 40
 	melee_damage_lower = 1
 	melee_damage_upper = 2

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -67,6 +67,7 @@
 			visible_message("<span class='danger'>[src] has been attacked with [O] by [user]!</span>")
 		else
 			visible_message("<span class='danger'>[src] blocks [O] with its shield!</span>")
+		playsound(loc, O.hitsound, 25, 1, -1)
 	else
 		usr << "<span class='danger'>This weapon is ineffective, it does no damage.</span>"
 		visible_message("<span class='danger'>[user] gently taps [src] with [O].</span>")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -276,6 +276,7 @@
 		if("help")
 			if (health > 0)
 				visible_message("<span class='notice'> [M] [response_help] [src].</span>")
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		if("grab")
 			if (M == src || anchored)
@@ -292,10 +293,12 @@
 			LAssailant = M
 
 			visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
+			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		if("harm", "disarm")
 			adjustBruteLoss(harm_intent_damage)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
+			playsound(loc, "punch", 25, 1, -1)
 
 	return
 
@@ -326,6 +329,7 @@
 			var/damage = rand(15, 30)
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 					"<span class='userdanger'>[M] has slashed at [src]!</span>")
+			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
 			adjustBruteLoss(damage)
 
 	return
@@ -407,6 +411,7 @@
 				adjustBruteLoss(damage)
 				visible_message("<span class='danger'>[src] has been attacked with [O] by [user]!</span>",\
 								"<span class='userdanger'>[src] has been attacked with [O] by [user]!</span>")
+				playsound(loc, O.hitsound, 25, 1, -1)
 			else
 				visible_message("<span class='danger'>[O] bounces harmlessly off of [src].</span>",\
 								"<span class='userdanger'>[O] bounces harmlessly off of [src].</span>")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -296,10 +296,32 @@
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		if("harm", "disarm")
-			adjustBruteLoss(harm_intent_damage)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
+			adjustBruteLoss(harm_intent_damage)
 
+	return
+
+/mob/living/simple_animal/attack_paw(mob/living/carbon/monkey/M as mob)
+	if(!(istype(M, /mob/living/carbon/monkey)))
+		return // Fix for aliens receiving double messages when attacking simple animals.
+
+	..()
+
+	switch(M.a_intent)
+
+		if ("help")
+			if (health > 0)
+				visible_message("<span class='notice'> [M] [response_help] [src].</span>")
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		else
+			if (M.is_muzzled())
+				return
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
+			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
+						"<span class='userdanger'>[M.name] bites [src]!</span>")
+			if (health > -100)
+				adjustBruteLoss(rand(1, 3))
 	return
 
 /mob/living/simple_animal/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
@@ -346,6 +368,7 @@
 			var/damage = rand(5, 10)
 			visible_message("<span class='danger'>[L] bites [src]!</span>", \
 					"<span class='userdanger'>[L] bites [src]!</span>")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 
 			if(stat != DEAD)
 				L.amount_grown = min(L.amount_grown + damage, L.max_grown)
@@ -359,17 +382,18 @@
 
 	if(M.Victim) return // can't attack while eating!
 
-	visible_message("<span class='danger'>[M.name] glomps [src]!</span>", \
-			"<span class='userdanger'>[M.name] glomps [src]!</span>")
+	if (health > 0)
+		visible_message("<span class='danger'>[M.name] glomps [src]!</span>", \
+				"<span class='userdanger'>[M.name] glomps [src]!</span>")
 
-	var/damage = rand(1, 3)
+		var/damage = rand(1, 3)
 
-	if(M.is_adult)
-		damage = rand(20, 40)
-	else
-		damage = rand(5, 35)
+		if(M.is_adult)
+			damage = rand(20, 40)
+		else
+			damage = rand(5, 35)
 
-	adjustBruteLoss(damage)
+		adjustBruteLoss(damage)
 
 
 	return
@@ -398,26 +422,27 @@
 		else
 			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
 			return
-	else if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+	if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
 		if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
 			harvest()
-	else
-		user.changeNext_move(CLICK_CD_MELEE)
-		if(O.force)
-			if(O.force >= force_threshold)
-				var/damage = O.force
-				if (O.damtype == STAMINA)
-					damage = 0
-				adjustBruteLoss(damage)
-				visible_message("<span class='danger'>[src] has been attacked with [O] by [user]!</span>",\
-								"<span class='userdanger'>[src] has been attacked with [O] by [user]!</span>")
-				playsound(loc, O.hitsound, 25, 1, -1)
-			else
-				visible_message("<span class='danger'>[O] bounces harmlessly off of [src].</span>",\
-								"<span class='userdanger'>[O] bounces harmlessly off of [src].</span>")
+
+	user.changeNext_move(CLICK_CD_MELEE)
+	var/damage = 0
+	if(O.force)
+		if(O.force >= force_threshold)
+			damage = O.force
+			if (O.damtype == STAMINA)
+				damage = 0
+			visible_message("<span class='danger'>[src] has been [O.attack_verb.len ? "[pick(O.attack_verb)]": "attacked"] with [O] by [user]!</span>",\
+							"<span class='userdanger'>[src] has been attacked with [O] by [user]!</span>")
 		else
-			user.visible_message("<span class='warning'>[user] gently taps [src] with [O].</span>",\
+			visible_message("<span class='danger'>[O] bounces harmlessly off of [src].</span>",\
+							"<span class='userdanger'>[O] bounces harmlessly off of [src].</span>")
+		playsound(loc, O.hitsound, 50, 1, -1)
+	else
+		user.visible_message("<span class='warning'>[user] gently taps [src] with [O].</span>",\
 							"<span class='warning'>This weapon is ineffective, it does no damage.</span>")
+	adjustBruteLoss(damage)
 
 /mob/living/simple_animal/movement_delay()
 	var/tally = 0 //Incase I need to add stuff other than "speed" later


### PR DESCRIPTION
- adding message notice when trying to fold a non-empty box.
- Fix one typo in item_attack.dm
- gives attack_verbs and hitsound to briefcase and secure briefcase (lack of sound when attacking)
- Attacking grille with a lit weldingtool plays the correct welding sound.
- Fixes immunity to monkey bites while wearing a muzzle / monkey being able to bite while wearing a muzzle.

(Mob attack messages & sounds)
- Attacking dead simple animal now gives message and sound for human/monkey/larva/humanoid and attack w/ item. (similar to attacking a dead human)
- Fixes finishing blow from human on mouse not giving sound/message.
- Fixes lack of sound when attacking simple_animal/syndicate/melee with an item.
- Gives sound to goat attacks.
- Fixes monkeys not being able to attack simple animals (dead or alive).
- Monkey attack on slime now uses "bite" verb and plays sound.
- Fixes Monkey inability to attack slime, humanoid, monkey, larva unconscious or dead.
- Gives sound to monkey on Human attack.
- Fixes inability of larvas to bite humanoids, slimes, humans.
