### PR TITLE
Entered() cleanup

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -8,19 +8,6 @@
 
 /var/list/meteorsC = list(/obj/effect/meteor/dust) //for space dust event
 
-/*
-/proc/meteor_wave(var/number = 50) //this proc's unused now.
-	if(!ticker || wavesecret)
-		return
-
-	wavesecret = 1
-	for(var/i = 0 to number)
-		spawn(rand(10,100))
-			spawn_meteor()
-	spawn(meteor_wave_delay)
-		wavesecret = 0
-
-*/
 /proc/spawn_meteors(var/number = 10, var/list/meteortypes)
 	for(var/i = 0; i < number; i++)
 		spawn_meteor(meteortypes)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -88,15 +88,13 @@
 	removeVerb(/obj/mecha/verb/disconnect_from_port)
 	removeVerb(/atom/movable/verb/pull)
 	log_message("[src.name] created.")
-	loc.Entered(src)
 	mechas_list += src //global mech list
 	return
 
 /obj/mecha/Destroy()
 	go_out()
 	for(var/mob/M in src) //Let's just be ultra sure
-		M.loc = get_turf(src)
-		M.loc.Entered(M)
+		M.Move(loc)
 
 	if(prob(30))
 		explosion(get_turf(loc), 0, 0, 1, 3)
@@ -1052,8 +1050,6 @@
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src
 		src.verbs -= /obj/mecha/verb/eject
-		src.Entered(mmi_as_oc)
-		src.Move(src.loc)
 		src.icon_state = initial(icon_state)
 		dir = dir_in
 		src.log_message("[mmi_as_oc] moved in as pilot.")

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -17,10 +17,7 @@
 
 /obj/mecha/working/ripley/Destroy()
 	for(var/atom/movable/A in src.cargo)
-		A.loc = get_turf(src)
-		var/turf/T = get_turf(A)
-		if(T)
-			T.Entered(A)
+		A.loc = loc
 		step_rand(A)
 	cargo.Cut()
 	..()
@@ -82,11 +79,8 @@
 		var/obj/O = locate(href_list["drop_from_cargo"])
 		if(O && O in src.cargo)
 			src.occupant_message("<span class='notice'>You unload [O].</span>")
-			O.loc = get_turf(src)
+			O.loc = loc
 			src.cargo -= O
-			var/turf/T = get_turf(O)
-			if(T)
-				T.Entered(O)
 			src.log_message("Unloaded [O]. Cargo compartment capacity: [cargo_capacity - src.cargo.len]")
 	return
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -33,10 +33,7 @@
 			overlays -= wet_overlay
 
 /turf/simulated/Entered(atom/A, atom/OL)
-	if(movement_disabled && usr.ckey != movement_disabled_exception)
-		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
-
+	..()
 	if (istype(A,/mob/living/carbon))
 		var/mob/living/carbon/M = A
 		if(M.lying)	return
@@ -61,6 +58,3 @@
 
 			if(2) //lube
 				M.slip(0, 10, null, (STEP|SLIDE|GALOSHES_DONT_HELP))
-
-
-	..()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -51,7 +51,6 @@
 	inertial_drift(A)
 
 	if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE - 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE - 1))
-		A << "start entered [A.x], [A.y], [A.z]"
 		var/move_to_z = src.z
 		var/safety = 1
 
@@ -84,7 +83,6 @@
 			A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
 
 		if(isliving(A))
-			A << "end entered [A.x], [A.y], [A.z]"
 			var/mob/living/L = A
 			if(L.pulling)
 				var/turf/T = get_step(L.loc,turn(A.dir, 180))

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -15,216 +15,117 @@
 /turf/space/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
 
-/turf/space/attackby(obj/item/C as obj, mob/user as mob)
-
-	if (istype(C, /obj/item/stack/rods))
+/turf/space/attackby(obj/item/C, mob/user)
+	if(istype(C, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = C
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			user << "<span class='warning'>There is already a lattice.</span>"
 			return
-		if (R.use(1))
+		if(R.use(1))
 			user << "<span class='notice'>Constructing support lattice...</span>"
 			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 			ReplaceWithLattice()
 		else
 			user << "<span class='warning'>You need one rod to build lattice.</span>"
-			return
 		return
-
-	if (istype(C, /obj/item/stack/tile/plasteel))
+	if(istype(C, /obj/item/stack/tile/plasteel))
 		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
 		if(L)
 			var/obj/item/stack/tile/plasteel/S = C
-			if (S.use(1))
+			if(S.use(1))
 				qdel(L)
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				user << "<span class='notice'>You build a floor.</span>"
 				S.build(src)
 			else
 				user << "<span class='warning'>You need one floor tile to build a floor.</span>"
-				return
-			return
 		else
 			user << "<span class='danger'>The plating is going to need some support. Place metal rods first.</span>"
-	return
 
-
-// Ported from unstable r355
-
-/turf/space/Entered(atom/movable/A as mob|obj)
-	if(movement_disabled)
-		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
+/turf/space/Entered(atom/movable/A)
 	..()
-	if ((!(A) || src != A.loc))	return
+	if ((!(A) || src != A.loc))
+		return
 
 	inertial_drift(A)
 
-	if(ticker && ticker.mode)
+	if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE - 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE - 1))
+		A << "start entered [A.x], [A.y], [A.z]"
+		var/move_to_z = src.z
+		var/safety = 1
 
-		// Okay, so let's make it so that people can travel z levels but not nuke disks!
-		// if(ticker.mode.name == "nuclear emergency")	return
-		if(A.z > 6) return
-		if (A.x <= TRANSITIONEDGE || A.x >= (world.maxx - TRANSITIONEDGE - 1) || A.y <= TRANSITIONEDGE || A.y >= (world.maxy - TRANSITIONEDGE - 1))
-			if(istype(A, /obj/effect/meteor))
-				qdel(A)
-				return
+		while(move_to_z == src.z)
+			var/move_to_z_str = pickweight(accessable_z_levels)
+			move_to_z = text2num(move_to_z_str)
+			safety++
+			if(safety > 10)
+				break
 
-			var/move_to_z = src.z
-			var/safety = 1
-
-			//Check if it's a mob pulling an object
-			var/atom/movable/was_pulling = null
-			var/mob/living/MOB = null
-			if(isliving(A))
-				MOB = A
-				if(MOB.pulling)
-					was_pulling = MOB.pulling //Store the object to transition later
-
-			while(move_to_z == src.z)
-				var/move_to_z_str = pickweight(accessable_z_levels)
-				move_to_z = text2num(move_to_z_str)
-				safety++
-				if(safety > 10)
-					break
-
-			if(!move_to_z)
-				return
-
-			A.z = move_to_z
-
-			if(src.x <= TRANSITIONEDGE)
-				A.x = world.maxx - TRANSITIONEDGE - 2
-				A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
-
-			else if (A.x >= (world.maxx - TRANSITIONEDGE - 1))
-				A.x = TRANSITIONEDGE + 1
-				A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
-
-			else if (src.y <= TRANSITIONEDGE)
-				A.y = world.maxy - TRANSITIONEDGE -2
-				A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
-
-			else if (A.y >= (world.maxy - TRANSITIONEDGE - 1))
-				A.y = TRANSITIONEDGE + 1
-				A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
-
-			spawn (0)
-				if(was_pulling && MOB) //Carry the object they were pulling over when they transition
-					was_pulling.loc = MOB.loc
-					MOB.start_pulling(was_pulling)
-				if ((A && A.loc))
-					A.loc.Entered(A)
-
-/turf/space/proc/Sandbox_Spacemove(atom/movable/A as mob|obj)
-	var/cur_x
-	var/cur_y
-	var/next_x
-	var/next_y
-	var/target_z
-	var/list/y_arr
-
-	if(src.x <= 1)
-		if(istype(A, /obj/effect/meteor))
-			qdel(A)
+		if(!move_to_z)
 			return
 
-		var/list/cur_pos = src.get_global_map_pos()
-		if(!cur_pos) return
-		cur_x = cur_pos["x"]
-		cur_y = cur_pos["y"]
+		A.z = move_to_z
+
+		if(src.x <= TRANSITIONEDGE)
+			A.x = world.maxx - TRANSITIONEDGE - 2
+			A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
+
+		else if (A.x >= (world.maxx - TRANSITIONEDGE - 1))
+			A.x = TRANSITIONEDGE + 1
+			A.y = rand(TRANSITIONEDGE + 2, world.maxy - TRANSITIONEDGE - 2)
+
+		else if (src.y <= TRANSITIONEDGE)
+			A.y = world.maxy - TRANSITIONEDGE -2
+			A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
+
+		else if (A.y >= (world.maxy - TRANSITIONEDGE - 1))
+			A.y = TRANSITIONEDGE + 1
+			A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
+
+		if(isliving(A))
+			A << "end entered [A.x], [A.y], [A.z]"
+			var/mob/living/L = A
+			if(L.pulling)
+				var/turf/T = get_step(L.loc,turn(A.dir, 180))
+				L.pulling.loc = T
+
+/turf/space/proc/Sandbox_Spacemove(atom/movable/A)
+	var/cur_x
+	var/cur_y
+	var/next_x = src.x
+	var/next_y = src.y
+	var/target_z
+	var/list/y_arr
+	var/list/cur_pos = src.get_global_map_pos()
+	if(!cur_pos)
+		return
+	cur_x = cur_pos["x"]
+	cur_y = cur_pos["y"]
+
+	if(src.x <= 1)
 		next_x = (--cur_x||global_map.len)
 		y_arr = global_map[next_x]
 		target_z = y_arr[cur_y]
-/*
-		//debug
-		world << "Src.z = [src.z] in global map X = [cur_x], Y = [cur_y]"
-		world << "Target Z = [target_z]"
-		world << "Next X = [next_x]"
-		//debug
-*/
-		if(target_z)
-			A.z = target_z
-			A.x = world.maxx - 2
-			spawn (0)
-				if ((A && A.loc))
-					A.loc.Entered(A)
+		next_x = world.maxx - 2
 	else if (src.x >= world.maxx)
-		if(istype(A, /obj/effect/meteor))
-			qdel(A)
-			return
-
-		var/list/cur_pos = src.get_global_map_pos()
-		if(!cur_pos) return
-		cur_x = cur_pos["x"]
-		cur_y = cur_pos["y"]
 		next_x = (++cur_x > global_map.len ? 1 : cur_x)
 		y_arr = global_map[next_x]
 		target_z = y_arr[cur_y]
-/*
-		//debug
-		world << "Src.z = [src.z] in global map X = [cur_x], Y = [cur_y]"
-		world << "Target Z = [target_z]"
-		world << "Next X = [next_x]"
-		//debug
-*/
-		if(target_z)
-			A.z = target_z
-			A.x = 3
-			spawn (0)
-				if ((A && A.loc))
-					A.loc.Entered(A)
+		next_x = 3
 	else if (src.y <= 1)
-		if(istype(A, /obj/effect/meteor))
-			qdel(A)
-			return
-		var/list/cur_pos = src.get_global_map_pos()
-		if(!cur_pos) return
-		cur_x = cur_pos["x"]
-		cur_y = cur_pos["y"]
 		y_arr = global_map[cur_x]
 		next_y = (--cur_y||y_arr.len)
 		target_z = y_arr[next_y]
-/*
-		//debug
-		world << "Src.z = [src.z] in global map X = [cur_x], Y = [cur_y]"
-		world << "Next Y = [next_y]"
-		world << "Target Z = [target_z]"
-		//debug
-*/
-		if(target_z)
-			A.z = target_z
-			A.y = world.maxy - 2
-			spawn (0)
-				if ((A && A.loc))
-					A.loc.Entered(A)
-
+		next_y = world.maxy - 2
 	else if (src.y >= world.maxy)
-		if(istype(A, /obj/effect/meteor))
-			qdel(A)
-			return
-		var/list/cur_pos = src.get_global_map_pos()
-		if(!cur_pos) return
-		cur_x = cur_pos["x"]
-		cur_y = cur_pos["y"]
 		y_arr = global_map[cur_x]
 		next_y = (++cur_y > y_arr.len ? 1 : cur_y)
 		target_z = y_arr[next_y]
-/*
-		//debug
-		world << "Src.z = [src.z] in global map X = [cur_x], Y = [cur_y]"
-		world << "Next Y = [next_y]"
-		world << "Target Z = [target_z]"
-		//debug
-*/
-		if(target_z)
-			A.z = target_z
-			A.y = 3
-			spawn (0)
-				if ((A && A.loc))
-					A.loc.Entered(A)
-	return
+		next_y = 3
+
+	var/turf/T = locate(next_x, next_y, target_z)
+	A.Move(T)
 
 /turf/space/handle_slip()
 	return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -27,10 +27,8 @@
 
 /turf/New()
 	..()
-	for(var/atom/movable/AM as mob|obj in src)
-		spawn( 0 )
-			src.Entered(AM)
-			return
+	for(var/atom/movable/AM in src)
+		Entered(AM)
 	return
 
 // Adds the adjacent turfs to the current atmos processing
@@ -50,9 +48,6 @@
 	return 0
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
-	if(movement_disabled && usr.ckey != movement_disabled_exception)
-		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
 	if (!mover)
 		return 1
 	// First, make sure it can leave its square
@@ -85,28 +80,7 @@
 			return 0
 	return 1 //Nothing found to block so return success!
 
-/turf/Entered(atom/atom as mob|obj)
-	if(movement_disabled)
-		usr << "<span class='danger'>Movement is admin-disabled.</span>" //This is to identify lag problems
-		return
-	..()
-//vvvvv Infared beam stuff vvvvv
-
-	if ((atom && atom.density && !( istype(atom, /obj/effect/beam) )))
-		for(var/obj/effect/beam/i_beam/I in src)
-			spawn( 0 )
-				if (I)
-					I.hit()
-				break
-
-//^^^^^ Infared beam stuff ^^^^^
-
-	if(!istype(atom, /atom/movable))
-		return
-
-	var/atom/movable/M = atom
-
-	var/loopsanity = 100
+/turf/Entered(atom/movable/M)
 	if(ismob(M))
 		var/mob/O = M
 		if(!O.lastarea)
@@ -117,16 +91,13 @@
 			inertial_drift(O)
 		else if(!istype(src, /turf/space))
 			O.inertia_dir = 0
-	..()
-	var/objects = 0
-	for(var/atom/A as mob|obj|turf|area in range(1))
-		if(objects > loopsanity)	break
-		objects++
-		spawn( 0 )
-			if ((A && M))
-				A.HasProximity(M, 1)
-			return
-	return
+
+	var/loopsanity = 100
+	for(var/atom/A in range(1))
+		if(loopsanity == 0)
+			break
+		loopsanity--
+		A.HasProximity(M, 1)
 
 /turf/proc/is_plating()
 	return 0

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -143,7 +143,6 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/kill_pipe_processing
 	src.verbs += /client/proc/kill_air_processing
 	src.verbs += /client/proc/disable_communication
-	src.verbs += /client/proc/disable_movement
 	src.verbs += /client/proc/print_pointers
 	src.verbs += /client/proc/count_movable_instances
 	src.verbs += /client/proc/SDQL2_query
@@ -268,17 +267,3 @@ var/global/say_disabled = 0
 		message_admins("[src.ckey] used 'Disable all communication verbs', killing all communication methods.")
 	else
 		message_admins("[src.ckey] used 'Disable all communication verbs', restoring all communication methods.")
-
-//This proc is intended to detect lag problems relating to movement
-var/global/movement_disabled = 0
-var/global/movement_disabled_exception //This is the client that calls the proc, so he can continue to run around to gauge any change to lag.
-/client/proc/disable_movement()
-	set category = "Mapping"
-	set name = "Disable all movement"
-
-	movement_disabled = !movement_disabled
-	if(movement_disabled)
-		message_admins("[src.ckey] used 'Disable all movement', killing all movement.")
-		movement_disabled_exception = usr.ckey
-	else
-		message_admins("[src.ckey] used 'Disable all movement', restoring all movement.")

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -19,37 +19,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	priority_announce("What the fuck was that?!", "General Alert")
 
 /datum/round_event/immovable_rod/start()
-	var/startx = 0
-	var/starty = 0
-	var/endy = 0
-	var/endx = 0
 	var/startside = pick(cardinal)
-
-	switch(startside)
-		if(NORTH)
-			starty = 187
-			startx = rand(41, 199)
-			endy = 38
-			endx = rand(41, 199)
-		if(EAST)
-			starty = rand(38, 187)
-			startx = 199
-			endy = rand(38, 187)
-			endx = 41
-		if(SOUTH)
-			starty = 38
-			startx = rand(41, 199)
-			endy = 187
-			endx = rand(41, 199)
-		else
-			starty = rand(38, 187)
-			startx = 41
-			endy = rand(38, 187)
-			endx = 199
-
-	//rod time!
-	new /obj/effect/immovablerod(locate(startx, starty, 1), locate(endx, endy, 1))
-
+	var/turf/startT = spaceDebrisStartLoc(startside, 1)
+	var/turf/endT = spaceDebrisFinishLoc(startside, 1)
+	new /obj/effect/immovablerod(startT, endT)
 
 /obj/effect/immovablerod
 	name = "Immovable Rod"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -597,22 +597,6 @@
 /turf/simulated/mineral/updateMineralOverlays()
 	return
 
-
-
 /turf/proc/fullUpdateMineralOverlays()
 	for (var/turf/t in range(1,src))
 		t.updateMineralOverlays()
-
-/turf/simulated/floor/plating/asteroid/Entered(atom/movable/M as mob|obj)
-	..()
-	if(istype(M,/mob/living/silicon/robot))
-		var/mob/living/silicon/robot/R = M
-		if(istype(R.module, /obj/item/weapon/robot_module/miner))
-			if(istype(R.module_state_1,/obj/item/weapon/storage/bag/ore))
-				src.attackby(R.module_state_1,R)
-			else if(istype(R.module_state_2,/obj/item/weapon/storage/bag/ore))
-				src.attackby(R.module_state_2,R)
-			else if(istype(R.module_state_3,/obj/item/weapon/storage/bag/ore))
-				src.attackby(R.module_state_3,R)
-			else
-				return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -108,13 +108,10 @@
 		now_pushing = 1
 
 		if (!AM.anchored)
+			if(pulling == AM)
+				stop_pulling()
 			var/t = get_dir(src, AM)
-			if (istype(AM, /obj/structure/window))
-				if(AM:ini_dir == NORTHWEST || AM:ini_dir == NORTHEAST || AM:ini_dir == SOUTHWEST || AM:ini_dir == SOUTHEAST)
-					for(var/obj/structure/window/win in get_step(AM,t))
-						now_pushing = 0
-						return
-			step(AM, t)
+			AM.Move(get_step(AM, t))
 		now_pushing = 0
 
 /mob/living/carbon/human/Stat()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -330,11 +330,10 @@
 				t7 = null
 	if ((t7 && (pulling && ((get_dist(src, pulling) <= 1 || pulling.loc == loc) && (client && client.moving)))))
 		var/turf/T = loc
-		var/turf/P = pulling.loc
 		. = ..()
 
 		if (pulling && pulling.loc)
-			if(!isturf(pulling.loc) || pulling.loc != P)
+			if(!isturf(pulling.loc))
 				stop_pulling()
 				return
 			else
@@ -362,7 +361,6 @@
 							if (istype(G, /obj/item/weapon/grab))
 								for(var/mob/O in viewers(M, null))
 									O.show_message(text("<span class='danger'>[] has been pulled from []'s grip by []</span>", G.affecting, G.assailant, src), 1)
-								//G = null
 								qdel(G)
 						else
 							ok = 0
@@ -397,17 +395,12 @@
 										if(check_dna_integrity(M)) //blood DNA
 											var/mob/living/carbon/DNA_helper = pulling
 											H.blood_DNA[DNA_helper.dna.unique_enzymes] = DNA_helper.dna.blood_type
-						step(pulling, get_dir(pulling.loc, T))
+						pulling.Move(T)
 						if(M)
 							M.start_pulling(t)
 				else
 					if (pulling)
-						if (istype(pulling, /obj/structure/window))
-							if(pulling:ini_dir == NORTHWEST || pulling:ini_dir == NORTHEAST || pulling:ini_dir == SOUTHWEST || pulling:ini_dir == SOUTHEAST)
-								for(var/obj/structure/window/win in get_step(pulling,get_dir(pulling.loc, T)))
-									stop_pulling()
-					if (pulling)
-						step(pulling, get_dir(pulling.loc, T))
+						pulling.Move(T)
 	else
 		stop_pulling()
 		. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -927,9 +927,7 @@
 
 
 /mob/living/silicon/robot/Move(a, b, flag)
-
 	. = ..()
-
 	if(module)
 		if(module.type == /obj/item/weapon/robot_module/janitor)
 			var/turf/tile = loc
@@ -959,7 +957,16 @@
 								cleaned_human.update_inv_shoes(0)
 							cleaned_human.clean_blood()
 							cleaned_human << "<span class='danger'>[src] cleans your face!</span>"
-		return
+			return
+
+		if(module.type == /obj/item/weapon/robot_module/miner)
+			if(istype(loc, /turf/simulated/floor/plating/asteroid))
+				if(istype(module_state_1,/obj/item/weapon/storage/bag/ore))
+					loc.attackby(module_state_1,src)
+				else if(istype(module_state_2,/obj/item/weapon/storage/bag/ore))
+					loc.attackby(module_state_2,src)
+				else if(istype(module_state_3,/obj/item/weapon/storage/bag/ore))
+					loc.attackby(module_state_3,src)
 
 /mob/living/silicon/robot/proc/self_destruct()
 	if(emagged)


### PR DESCRIPTION
Cleaned up the turf Entered() procs:
-Removed check for infrared beams. (it checked each time that anything moved)
-Removed 'movement_disabled' check, the verb is also completely removed.

For space Entered() turfs:
-Removed check for meteor
Now meteors and immovable rods will use the same proc to determinate their start and finish, while moving they'll check in which z level they are, deleting themselves if they leave it.
-Removed spawn() to move objects being pulled between z levels
Replaced the step() from mob pulling movement code and replaced them with Move()

For asteroid Entered turfs:
-Removed check for mining cyborgs, now it will be next to the janitor borg check to clean the floor.

Mecha code got a small clean, removing the Entered() calls from there.
