### PR TITLE
Items table crafting fixing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -262,6 +262,7 @@
 						while(amt > 0)
 							I = locate(B) in loc
 							Deletion.Add(I)
+							I.loc = null //remove it from the table loc so that we don't locate the same item every time (will be relocated inside the crafted item in construct_item())
 							amt--
 						break item_loop
 		else
@@ -286,6 +287,7 @@
 			if(!istype(B, A))
 				Deletion.Remove(B)
 				qdel(B)
+
 	return Deletion
 
 /obj/structure/table/interact(mob/user)
@@ -295,7 +297,7 @@
 	var/dat = "<h3>Construction menu</h3>"
 	dat += "<div class='statusDisplay'>"
 	if(busy)
-		dat += "Construction inprogress...</div>"
+		dat += "Construction in progress...</div>"
 	else
 		for(var/datum/table_recipe/R in table_recipes)
 			if(check_contents(R))


### PR DESCRIPTION
- Fixes #4820 

For recipes containing _/obj/items_ (meteorshell and pulseshell are, currently, the only recipes containing these), the problem was that, when looking for _n_ items of the same type in the table content, it located _n_ times the same one.

When a corresponding item is found in the table content, it's location is now set to _null_ to prevent that (the item is eventually relocated into the newly craft item further in the code).

_Note that meteorshell is supposed to requires two manipulators, as pulseshell is supposed to requires two advanced capacitors._
- Small typo in construction fixed
