### PR TITLE
Supply datums roundstart mass-deletion fix.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -55,12 +55,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	manifest += "<ul>"
 	for(var/path in contains)
 		if(!path)	continue
-		var/atom/movable/AM = new path()
-		manifest += "<li>[AM.name]</li>"
-//		del AM	//just to make sure they're deleted, no longer garbage collected, as there are way to many objects in crates that have other references.
-		qdel(AM) // How about we fix the issues rather than bypass them, mmkay?
+		var/atom/movable/AM = path
+		manifest += "<li>[initial(AM.name)]</li>"
 	manifest += "</ul>"
-
 
 ////// Use the sections to keep things tidy please /Malkevin
 


### PR DESCRIPTION
Supply datums will now use initial() to get the name of the items in their contents, instead of creating and deleting the objects before roundstart.
