### PR TITLE
Removes e-chair toggle verb. Fixes #4853

### DIFF
--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -28,6 +28,11 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!usr || !isturf(usr.loc))
+		return
+	if(usr.stat || usr.restrained())
+		return
+
 	if(on)
 		on = 0
 		icon_state = "echair0"

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -2,7 +2,6 @@
 	name = "electric chair"
 	desc = "Looks absolutely SHOCKING!"
 	icon_state = "echair0"
-	var/on = 0
 	var/obj/item/assembly/shock_kit/part = null
 	var/last_time = 1.0
 
@@ -23,25 +22,6 @@
 		return
 	return
 
-/obj/structure/stool/bed/chair/e_chair/verb/toggle()
-	set name = "Toggle Electric Chair"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr || !isturf(usr.loc))
-		return
-	if(usr.stat || usr.restrained())
-		return
-
-	if(on)
-		on = 0
-		icon_state = "echair0"
-	else
-		on = 1
-		icon_state = "echair1"
-	usr << "<span class='notice'>You switch [on ? "on" : "off"] [src].</span>"
-	return
-
 /obj/structure/stool/bed/chair/e_chair/rotate()
 	..()
 	overlays.Cut()
@@ -49,8 +29,6 @@
 	return
 
 /obj/structure/stool/bed/chair/e_chair/proc/shock()
-	if(!on)
-		return
 	if(last_time + 50 > world.time)
 		return
 	last_time = world.time


### PR DESCRIPTION
They're practically useless, acted as a safety switch for the signaler not to work. If you need safety, switch signaler channel and code.
