### PR TITLE
Fix virus detectability for medbot and medical HUD 

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -52,6 +52,8 @@ var/list/diseases = typesof(/datum/disease) - /datum/disease
 	var/requires = 0
 	var/list/required_limb = list()
 
+	var/const/non_threat = "Non-Threat"
+
 
 /datum/disease/proc/stage_act()
 	var/cure_present = has_cure()

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -182,7 +182,7 @@ var/list/advance_cures = 	list(
 		CRASH("We did not have any symptoms before generating properties.")
 		return
 
-	var/list/properties = list("resistance" = 1, "stealth" = 1, "stage_rate" = 1, "transmittable" = 1, "severity" = 1)
+	var/list/properties = list("resistance" = 1, "stealth" = 1, "stage_rate" = 1, "transmittable" = 1, "severity" = 0)
 
 	for(var/datum/symptom/S in symptoms)
 
@@ -190,7 +190,7 @@ var/list/advance_cures = 	list(
 		properties["stealth"] += S.stealth
 		properties["stage_rate"] += S.stage_speed
 		properties["transmittable"] += S.transmittable
-		properties["severity"] = max(properties["severity"], S.level) // severity is based on the highest level symptom
+		properties["severity"] = max(properties["severity"], S.severity) // severity is based on the highest severity symptom
 
 	return properties
 
@@ -234,7 +234,7 @@ var/list/advance_cures = 	list(
 	switch(level_sev)
 
 		if(-INFINITY to 0)
-			severity = "Non-Threat"
+			severity = non_threat
 		if(1)
 			severity = "Minor"
 		if(2)

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -22,6 +22,7 @@ BONUS
 	stage_speed = -3
 	transmittable = -1
 	level = 4
+	severity = 1
 
 /datum/symptom/beard/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -2
 	transmittable = -4
 	level = 3
+	severity = 3
 
 /datum/symptom/choking/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -3
 	transmittable = 0
 	level = 4
+	severity = 2
 
 
 /datum/symptom/confusion/Activate(var/datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -23,6 +23,7 @@ BONUS
 	stage_speed = 1
 	transmittable = 2
 	level = 1
+	severity = 1
 
 /datum/symptom/cough/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -1
 	transmittable = -3
 	level = 4
+	severity = 3
 
 /datum/symptom/deafness/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -3
 	transmittable = -1
 	level = 4
+	severity = 2
 
 /datum/symptom/dizzy/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = 3
 	transmittable = 2
 	level = 2
+	severity = 2
 
 /datum/symptom/fever/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = 0
 	transmittable = -4
 	level = 6
+	severity = 5
 
 /datum/symptom/flesh_eating/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = 0
 	transmittable = -3
 	level = 6
+	severity = 3
 	var/good_mutations = 0
 	var/archived_dna = null
 
@@ -79,3 +80,4 @@ Bonus
 	transmittable = -7
 	level = 6
 	good_mutations = 1
+	severity = 0

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -3
 	transmittable = -1
 	level = 5
+	severity = 3
 
 /datum/symptom/hallucigen/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -24,6 +24,7 @@ BONUS
 	stage_speed = 2
 	transmittable = 0
 	level = 1
+	severity = 1
 
 /datum/symptom/headache/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -24,6 +24,7 @@ BONUS
 	stage_speed = 3
 	transmittable = 1
 	level = 1
+	severity = 1
 
 /datum/symptom/itching/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -22,6 +22,7 @@ BONUS
 	stage_speed = -1
 	transmittable = 2
 	level = 4
+	severity = 1
 
 /datum/symptom/shedding/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = 2
 	transmittable = 2
 	level = 2
+	severity = 2
 
 /datum/symptom/shivering/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -24,6 +24,7 @@ Bonus
 	stage_speed = 0
 	transmittable = 4
 	level = 1
+	severity = 1
 
 /datum/symptom/sneeze/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -12,8 +12,10 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	var/resistance = 0
 	var/stage_speed = 0
 	var/transmittable = 0
-	// The type level of the symptom. Higher is more lethal and harder to generate.
+	// The type level of the symptom. Higher is harder to generate.
 	var/level = 0
+	// The severity level of the symptom. Higher is more dangerous.
+	var/severity = 0
 	// The hash tag for our diseases, we will add it up with our other symptoms to get a unique id! ID MUST BE UNIQUE!!!
 	var/id = ""
 

--- a/code/datums/diseases/advance/symptoms/visionloss.dm
+++ b/code/datums/diseases/advance/symptoms/visionloss.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -4
 	transmittable = -3
 	level = 5
+	severity = 4
 
 /datum/symptom/visionloss/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/vitiligo.dm
+++ b/code/datums/diseases/advance/symptoms/vitiligo.dm
@@ -22,6 +22,7 @@ BONUS
 	stage_speed = -1
 	transmittable = -2
 	level = 5
+	severity = 1
 
 /datum/symptom/vitiligo/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -3
 	transmittable = -1
 	level = 6
+	severity = 2
 
 /datum/symptom/voice_change/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -27,6 +27,7 @@ Bonus
 	stage_speed = 0
 	transmittable = 1
 	level = 3
+	severity = 4
 
 /datum/symptom/vomit/Activate(var/datum/disease/advance/A)
 	..()
@@ -78,6 +79,7 @@ Bonus
 	stage_speed = -1
 	transmittable = 1
 	level = 4
+	severity = 5
 
 /datum/symptom/vomit/blood/Vomit(var/mob/living/M)
 

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -23,6 +23,7 @@ Bonus
 	stage_speed = -2
 	transmittable = -2
 	level = 4
+	severity = 1
 
 /datum/symptom/weight_gain/Activate(var/datum/disease/advance/A)
 	..()
@@ -64,6 +65,7 @@ Bonus
 	stage_speed = -2
 	transmittable = -2
 	level = 3
+	severity = 1
 
 /datum/symptom/weight_loss/Activate(var/datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -9,7 +9,7 @@
 	permeability_mod = 1
 	contagious_period = 9001 //slightly hacky, but hey! whatever works, right?
 	desc = "If left untreated the subject will become very weak, and may vomit often."
-	severity = "Medium"
+	severity = "Dangerous!"
 	longevity = 1000
 	hidden = list(0, 1)
 	requires = 1
@@ -35,7 +35,8 @@
 			if(prob(1))
 				if (affected_mob.nutrition > 100)
 					affected_mob.Stun(rand(4,6))
-					affected_mob.show_message("<span class='warning'>[affected_mob] throws up!</span>")
+					affected_mob.visible_message("<span class='danger'>[affected_mob] throws up!</span>", \
+												"<span class='userdanger'>[affected_mob] throws up!</span>")
 					playsound(affected_mob.loc, 'sound/effects/splat.ogg', 50, 1)
 					var/turf/location = affected_mob.loc
 					if(istype(location, /turf/simulated))

--- a/code/datums/diseases/brainrot.dm
+++ b/code/datums/diseases/brainrot.dm
@@ -10,7 +10,7 @@
 	curable = 0
 	cure_chance = 15//higher chance to cure, since two reagents are required
 	desc = "This disease destroys the braincells, causing brain fever, brain necrosis and general intoxication."
-	severity = "Major"
+	severity = "Dangerous!"
 	requires = 1
 	required_limb = list(/obj/item/organ/limb/head)
 

--- a/code/datums/diseases/cold9.dm
+++ b/code/datums/diseases/cold9.dm
@@ -8,7 +8,7 @@
 	agent = "ICE9-rhinovirus"
 	affected_species = list("Human")
 	desc = "If left untreated the subject will slow, as if partly frozen."
-	severity = "Moderate"
+	severity = "Medium"
 
 /datum/disease/cold9/stage_act()
 	..()

--- a/code/datums/diseases/fake_gbs.dm
+++ b/code/datums/diseases/fake_gbs.dm
@@ -8,7 +8,7 @@
 	agent = "Gravitokinetic Bipotential SADS-"
 	affected_species = list("Human", "Monkey")
 	desc = "If left untreated death will occur."
-	severity = "Major"
+	severity = "BIOHAZARD THREAT!"
 
 /datum/disease/fake_gbs/stage_act()
 	..()

--- a/code/datums/diseases/fluspanish.dm
+++ b/code/datums/diseases/fluspanish.dm
@@ -9,7 +9,7 @@
 	affected_species = list("Human")
 	permeability_mod = 0.75
 	desc = "If left untreated the subject will burn to death for being a heretic."
-	severity = "Serious"
+	severity = "Dangerous!"
 
 /datum/disease/inquisition/stage_act()
 	..()

--- a/code/datums/diseases/gbs.dm
+++ b/code/datums/diseases/gbs.dm
@@ -10,6 +10,7 @@
 	affected_species = list("Human")
 	curable = 0
 	permeability_mod = 1
+	severity = "BIOHAZARD THREAT!"
 
 /datum/disease/gbs/stage_act()
 	..()

--- a/code/datums/diseases/plasmatoid.dm
+++ b/code/datums/diseases/plasmatoid.dm
@@ -3,3 +3,4 @@
 	max_stages = 4
 	cure = "None"
 	affected_species = list("Monkey", "Human")
+	severity = "Unknown"

--- a/code/datums/diseases/retrovirus.dm
+++ b/code/datums/diseases/retrovirus.dm
@@ -8,7 +8,7 @@
 	agent = ""
 	affected_species = list("Human")
 	desc = "A DNA-altering retrovirus that scrambles the structural and unique enzymes of a host constantly."
-	severity = "Severe"
+	severity = "Dangerous!"
 	permeability_mod = 0.4
 	stage_prob = 2
 	var/SE

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -8,6 +8,7 @@
 	agent = "Unknown"
 	affected_species = list("Human")
 	permeability_mod = 1
+	severity = "BIOHAZARD THREAT!"
 
 /datum/disease/rhumba_beat/stage_act()
 	..()

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -123,7 +123,7 @@
 	cure_chance = 5
 	agent = "R2D2 Nanomachines"
 	desc = "This disease, actually acute nanomachine infection, converts the victim into a cyborg."
-	severity = "BIOHAZARD THREAT!"
+	severity = "Dangerous!"
 	hidden = list(0, 0)
 	stage1	= null
 	stage2	= list("Your joints feel stiff.", "<span class='danger'>Beep...boop..</span>")
@@ -210,7 +210,6 @@
 	cure = "Death"
 	agent = "Fell Doge Majicks"
 	desc = "This disease transforms the victim into a corgi."
-	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)
 	stage1	= list("BARK.")
 	stage2	= list("You feel the need to wear silly hats.")

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -7,7 +7,7 @@
 	cure = "A coder's love (theoretical)."
 	agent = "Shenanigans"
 	affected_species = list("Human", "Monkey", "Alien")
-	severity = "Major"
+	severity = "Harmful"
 	stage_prob = 10
 	hidden = list(1, 1)
 	var/list/stage1 = list("You feel unremarkable.")
@@ -78,7 +78,7 @@
 	curable = 0
 	longevity = 30
 	desc = "Monkeys with this disease will bite humans, causing humans to mutate into a monkey."
-	severity = "Major"
+	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)//Not hidden, with the exception of the starting ape.
 	stage_prob = 4
 	agent = "Kongey Vibrion M-909"
@@ -123,6 +123,7 @@
 	cure_chance = 5
 	agent = "R2D2 Nanomachines"
 	desc = "This disease, actually acute nanomachine infection, converts the victim into a cyborg."
+	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)
 	stage1	= null
 	stage2	= list("Your joints feel stiff.", "<span class='danger'>Beep...boop..</span>")
@@ -130,6 +131,7 @@
 	stage4	= list("<span class='danger'>Your skin feels very loose.</span>", "<span class='danger'>You can feel... something...inside you.</span>")
 	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
 	new_form = /mob/living/silicon/robot
+
 
 /datum/disease/transformation/robot/stage_act()
 	..()
@@ -152,6 +154,8 @@
 	cure_id = list("spaceacillin", "glycerol")
 	cure_chance = 5
 	agent = "Rip-LEY Alien Microbes"
+	desc = "This disease changes the victim into a xenomorph."
+	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)
 	stage1	= null
 	stage2	= list("Your throat feels scratchy.", "<span class='danger'>Kill...</span>")
@@ -179,6 +183,7 @@
 	cure_chance = 80
 	agent = "Advanced Mutation Toxin"
 	desc = "This highly concentrated extract converts anything into more of itself."
+	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)
 	stage1	= list("You don't feel very well.")
 	stage2	= list("You are turning a little green.")
@@ -204,6 +209,8 @@
 	name = "The Barkening"
 	cure = "Death"
 	agent = "Fell Doge Majicks"
+	desc = "This disease transforms the victim into a corgi."
+	severity = "BIOHAZARD THREAT!"
 	hidden = list(0, 0)
 	stage1	= list("BARK.")
 	stage2	= list("You feel the need to wear silly hats.")

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -10,7 +10,7 @@
 	curable = 1
 	permeability_mod = 0.75
 	desc = "Some speculate, that this virus is the cause of Wizard Federation existance. Subjects affected show the signs of mental retardation, yelling obscure sentences or total gibberish. On late stages subjects sometime express the feelings of inner power, and, cite, 'the ability to control the forces of cosmos themselves!' A gulp of strong, manly spirits usually reverts them to normal, humanlike, condition."
-	severity = "Major"
+	severity = "Harmful"
 	requires = 1
 	required_limb = list(/obj/item/organ/limb/head)
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -100,7 +100,8 @@ proc/med_hud_suit_sensors(var/mob/living/carbon/human/patient)
 proc/med_hud_find_virus(var/mob/living/carbon/human/patient)
 	for(var/datum/disease/D in patient.viruses)
 		if(!D.hidden[SCANNER])
-			return 1
+			if(D.severity != D.non_threat)
+				return 1
 
 proc/med_hud_get_health(var/mob/living/carbon/human/patient)
 	var/image/holder = patient.hud_list[HEALTH_HUD]

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -365,7 +365,11 @@
 
 
 	for(var/datum/disease/D in C.viruses)
-		if((D.stage > 1) || (D.spread_type == AIRBORNE))
+		if((D.hidden[SCANNER]) || (D.hidden[PANDEMIC])) //the medibot can't detect viruses that are undetectable to Health Analyzers or Pandemic machines.
+			return 0
+		if(D.severity == D.non_threat) // medibot doesn't try to heal truly harmless viruses
+			return 0
+		if((D.stage > 1) || (D.spread_type == AIRBORNE)) // medibot can't detect a virus in its initial stage unless it spreads airborne.
 
 			if (!C.reagents.has_reagent(src.treatment_virus))
 				return 1 //STOP DISEASE FOREVER
@@ -400,7 +404,10 @@
 	else
 		var/virus = 0
 		for(var/datum/disease/D in C.viruses)
-			virus = 1
+			if((!D.hidden[SCANNER]) && (!D.hidden[PANDEMIC]))    //detectable virus
+				if(D.severity != D.non_threat)      //virus is harmful
+					if((D.stage > 1) || (D.spread_type == AIRBORNE))
+						virus = 1
 
 		if (!reagent_id && (virus))
 			if(!C.reagents.has_reagent(src.treatment_virus))


### PR DESCRIPTION
- Medbots will stop detecting viruses undetectable to Health Analyzers or Pandemic machines.
- Medbots will stop considering 100% harmless(beneficial or neutral symptoms) viruses as a disease to cure.
- gives a severity to all standard diseases.
- gives a severity var to symptoms.
- Players with only harmless beneficial viruses don't appear as ill on medical HUD.

Fixes #3052
