### PR TITLE
Consistency fix for disloged girders securing and building on

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -17,6 +17,9 @@
 				new /obj/item/stack/sheet/metal(get_turf(src))
 				qdel(src)
 		else if(!anchored)
+			if (!istype(src.loc, /turf/simulated/floor))
+				usr << "<span class='danger'>A floor must be present to secure the girder!</span>"
+				return
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			user << "<span class='notice'>Now securing the girder...</span>"
 			if(do_after(user, 40))
@@ -68,6 +71,9 @@
 			qdel(src)
 
 	else if(istype(W, /obj/item/stack/sheet))
+		if (!istype(src.loc, /turf/simulated/floor))
+			usr << "<span class='danger'>The girder is too unstable to build anything!</span>"
+			return
 
 		var/obj/item/stack/sheet/S = W
 		switch(S.type)


### PR DESCRIPTION
Made building on/securing disloged girders consistent with secured girders, by preventing disloged girders from being secured or build on if on a forbidden turf (space, shuttle, ...).

After all, if the floor (or lack of) prevent building a girder, bringing an unsecure disloged one is not going to make it any better.

Fixes #4436 (at least partially)
