### PR TITLE
Fixed the overeye hair, now it should display properly instead of an 'error' message.

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -74,7 +74,7 @@
 
 /datum/sprite_accessory/hair/over_eye
 	name = "Over Eye"
-	icon_state = "hair_overeye"
+	icon_state = "hair_shortovereye"
 
 /datum/sprite_accessory/hair/long_over_eye
 	name = "Long Over Eye"


### PR DESCRIPTION
Fixed the overeye hair, now it should display properly instead of an 'error' message.
