### PR TITLE
Fixes #4176

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -8,14 +8,10 @@
 /obj/item/weapon/grenade/flashbang/prime()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
-	for(var/obj/structure/closet/L in get_hear(7, flashbang_turf))
-		for(var/mob/living/M in L)
-			bang(get_turf(M), M)
-
-	for(var/mob/living/M in hearers(7, flashbang_turf))
+	for(var/mob/living/M in get_hearers_in_view(7, flashbang_turf))
 		bang(get_turf(M), M)
 
-	for(var/obj/effect/blob/B in view(8,flashbang_turf))     		//Blob damage here
+	for(var/obj/effect/blob/B in get_hear(8,flashbang_turf))     		//Blob damage here
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
 		B.update_icon()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -321,23 +321,13 @@ silicate
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(2, 1, location)
 	s.start()
-	for(var/mob/living/carbon/M in viewers(world.view, location))
-		switch(get_dist(M, location))
-			if(0 to 3)
-				if(hasvar(M, "glasses"))
-					if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
-						continue
-
-				flick("e_flash", M.flash)
-				M.Weaken(5)
-
-			if(4 to 5)
-				if(hasvar(M, "glasses"))
-					if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
-						continue
-
-				flick("e_flash", M.flash)
-				M.Stun(5)
+	for(var/mob/living/carbon/C in get_hearers_in_view(5, location))
+		if(C.eyecheck())
+			continue
+		if(get_dist(C, location) < 4)
+			C.Weaken(5)
+		flick("e_flash", C.flash)
+		C.Stun(5)
 
 /datum/chemical_reaction/napalm
 	name = "Napalm"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -324,9 +324,10 @@ silicate
 	for(var/mob/living/carbon/C in get_hearers_in_view(5, location))
 		if(C.eyecheck())
 			continue
+		flick("e_flash", C.flash)
 		if(get_dist(C, location) < 4)
 			C.Weaken(5)
-		flick("e_flash", C.flash)
+			continue
 		C.Stun(5)
 
 /datum/chemical_reaction/napalm


### PR DESCRIPTION
- Fixes flashpowder only checking for sunglasses protection and not flashing people inside lockers.
  Fix for #4176 .
- simplifiying flashbang's prime() proc.
-  Fixes Blob immunity to flashbangs in the dark.
