### PR TITLE
Adds click cooldown to clicking on mobs Fixes #4812

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -101,9 +101,11 @@
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
-			if(ismob(A))
-				changeNext_move(CLICK_CD_MELEE)
 			UnarmedAttack(A)
+
+		//If we click on a mob make sure we add cooldown
+		if(ismob(A))
+			changeNext_move(CLICK_CD_MELEE)
 		return
 
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
@@ -118,9 +120,10 @@
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else
-				if(ismob(A))
-					changeNext_move(CLICK_CD_MELEE)
 				UnarmedAttack(A, 1)
+
+			if(ismob(A))
+				changeNext_move(CLICK_CD_MELEE)
 			return
 		else // non-adjacent click
 			if(W)


### PR DESCRIPTION
If the click was done with anything in your hands it would not add click cooldown.

I'm not sure if this is fully the correct solution - lots of code seems to just do it in the attackby methods
