### PR TITLE
Adds click cooldown to clicking on mobs Fixes #4812 Take2

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -34,6 +34,7 @@
 
 #define CLICK_CD_MELEE 8
 #define CLICK_CD_RANGE 4
+#define CLICK_CD_HANDCUFFED 10
 //click cooldowns, in tenths of a second
 
 

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -35,6 +35,8 @@
 #define CLICK_CD_MELEE 8
 #define CLICK_CD_RANGE 4
 #define CLICK_CD_HANDCUFFED 10
+#define CLICK_CD_BREAKOUT 100
+#define CLICK_CD_RESIST 20
 //click cooldowns, in tenths of a second
 
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -74,7 +74,7 @@
 		return M.click_action(A,src)
 
 	if(restrained())
-		changeNext_move(10)   //Doing shit in cuffs shall be vey slow
+		changeNext_move(CLICK_CD_HANDCUFFED)   //Doing shit in cuffs shall be vey slow
 		RestrainedClickOn(A)
 		return
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -154,8 +154,6 @@
 	in human click code to allow glove touches only at melee range.
 */
 /mob/proc/UnarmedAttack(var/atom/A, var/proximity_flag)
-	if(ismob(A))
-		changeNext_move(CLICK_CD_MELEE)
 	return
 
 /*

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -101,9 +101,11 @@
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
-			if(ismob(A))
-				changeNext_move(CLICK_CD_MELEE)
 			UnarmedAttack(A)
+
+		//If we click on a mob make sure we add cooldown
+		if(ismob(A))
+			changeNext_move(CLICK_CD_MELEE)
 		return
 
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
@@ -118,15 +120,18 @@
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else
-				if(ismob(A))
-					changeNext_move(CLICK_CD_MELEE)
 				UnarmedAttack(A, 1)
+
+			if(ismob(A))
+				changeNext_move(CLICK_CD_MELEE)
 			return
 		else // non-adjacent click
 			if(W)
 				W.afterattack(A,src,0,params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
+			if(ismob(A))
+				changeNext_move(CLICK_CD_RANGE)
 
 	return
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -11,7 +11,6 @@
 		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
 
 /mob/living/attackby(obj/item/I, mob/user)
-	user.changeNext_move(CLICK_CD_MELEE)
 	I.attack(src, user)
 
 /mob/living/proc/attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone)

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -384,7 +384,7 @@
 		open = 1
 		return
 	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + 100
+	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	user.visible_message("<span class='warning'>You hear a metallic creaking from [src]!</span>")
 

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -383,7 +383,7 @@
 	if(open || !locked)	//Open and unlocked, no need to escape
 		open = 1
 		return
-	user.changeNext_move(100)
+	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	user.visible_message("<span class='warning'>You hear a metallic creaking from [src]!</span>")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -427,7 +427,7 @@
 /obj/machinery/suit_storage_unit/container_resist()
 	var/mob/living/user = usr
 	if(islocked)
-		user.changeNext_move(100)
+		user.changeNext_move(CLICK_CD_BREAKOUT)
 		user.last_special = world.time + 100
 		var/breakout_time = 2
 		user << "<span class='notice'>You start kicking against the doors to escape! (This will take about [breakout_time] minutes.)</span>"

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -428,7 +428,7 @@
 	var/mob/living/user = usr
 	if(islocked)
 		user.changeNext_move(CLICK_CD_BREAKOUT)
-		user.last_special = world.time + 100
+		user.last_special = world.time + CLICK_CD_BREAKOUT
 		var/breakout_time = 2
 		user << "<span class='notice'>You start kicking against the doors to escape! (This will take about [breakout_time] minutes.)</span>"
 		visible_message("You see [user] kicking against the doors of the [src]!")

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -213,7 +213,7 @@
 	var/mob/living/user = usr
 	var/breakout_time = 2
 	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + 100
+	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user << "<span class='notice'>You struggle against the tight bonds! (This will take about [breakout_time] minutes.)</span>"
 	visible_message("You see something struggling and writhing in the [src]!")
 	if(do_after(user,(breakout_time*60*10)))

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -212,7 +212,7 @@
 /obj/effect/spider/cocoon/container_resist()
 	var/mob/living/user = usr
 	var/breakout_time = 2
-	user.changeNext_move(100)
+	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You struggle against the tight bonds! (This will take about [breakout_time] minutes.)</span>"
 	visible_message("You see something struggling and writhing in the [src]!")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -312,7 +312,7 @@
 		return  //Door's open, not locked or welded, no point in resisting.
 
 	//okay, so the closet is either welded or locked... resist!!!
-	user.changeNext_move(100)
+	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + 100
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	for(var/mob/O in viewers(src))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -313,7 +313,7 @@
 
 	//okay, so the closet is either welded or locked... resist!!!
 	user.changeNext_move(CLICK_CD_BREAKOUT)
-	user.last_special = world.time + 100
+	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user << "<span class='notice'>You lean on the back of [src] and start pushing the door open. (this will take about [breakout_time] minutes.)</span>"
 	for(var/mob/O in viewers(src))
 		O << "<span class='warning'>[src] begins to shake violently!</span>"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -510,7 +510,7 @@
 			var/mob/living/carbon/C = L
 			if(C.handcuffed)
 				C.changeNext_move(CLICK_CD_BREAKOUT)
-				C.last_special = world.time + 100
+				C.last_special = world.time + CLICK_CD_BREAKOUT
 				C.visible_message("<span class='warning'>[usr] attempts to unbuckle themself!</span>", \
 							"<span class='notice'>You attempt to unbuckle yourself. (This will take around one minute and you need to stay still.)</span>")
 				spawn(0)
@@ -549,7 +549,7 @@
 		if(CM.canmove && (CM.last_special <= world.time))
 			if(CM.handcuffed || CM.legcuffed)
 				CM.changeNext_move(CLICK_CD_BREAKOUT)
-				CM.last_special = world.time + 100
+				CM.last_special = world.time + CLICK_CD_BREAKOUT
 				if(CM.handcuffed)
 					cuff_resist(CM.handcuffed, CM)
 				else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -476,7 +476,7 @@
 
 	if(!isliving(usr) || usr.next_move > world.time)
 		return
-	usr.changeNext_move(20)
+	usr.changeNext_move(CLICK_CD_RESIST)
 
 	var/mob/living/L = usr
 
@@ -509,7 +509,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			if(C.handcuffed)
-				C.changeNext_move(100)
+				C.changeNext_move(CLICK_CD_BREAKOUT)
 				C.last_special = world.time + 100
 				C.visible_message("<span class='warning'>[usr] attempts to unbuckle themself!</span>", \
 							"<span class='notice'>You attempt to unbuckle yourself. (This will take around one minute and you need to stay still.)</span>")
@@ -548,7 +548,7 @@
 			return
 		if(CM.canmove && (CM.last_special <= world.time))
 			if(CM.handcuffed || CM.legcuffed)
-				CM.changeNext_move(100)
+				CM.changeNext_move(CLICK_CD_BREAKOUT)
 				CM.last_special = world.time + 100
 				if(CM.handcuffed)
 					cuff_resist(CM.handcuffed, CM)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -429,7 +429,6 @@
 		if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
 			harvest()
 
-	user.changeNext_move(CLICK_CD_MELEE)
 	var/damage = 0
 	if(O.force)
 		if(O.force >= force_threshold)


### PR DESCRIPTION
Adds click cooldown for attacking mobs with weapons both close by and at range.
Also makes all the click cooldowns into defines
Resist = 20 - used when resist verb is called
Breakout = 100 - used when breaking out of shit
Handcuffed = 10 - when user is handcuffed

I've pulled out click cooldown changes where they are no longer needed

fixes #4812 
