### PR TITLE
Fixes medbot injection runtime error

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -451,9 +451,10 @@
 
 		spawn(30)
 			if ((get_dist(src, src.patient) <= 1) && (src.on))
-				if((reagent_id == "internal_beaker") && (src.reagent_glass) && (src.reagent_glass.reagents.total_volume))
-					src.reagent_glass.reagents.trans_to(src.patient,src.injection_amount) //Inject from beaker instead.
-					src.reagent_glass.reagents.reaction(src.patient, 2)
+				if(reagent_id == "internal_beaker")
+					if(src.use_beaker && src.reagent_glass && src.reagent_glass.reagents.total_volume)
+						src.reagent_glass.reagents.trans_to(src.patient,src.injection_amount) //Inject from beaker instead.
+						src.reagent_glass.reagents.reaction(src.patient, 2)
 				else
 					src.patient.reagents.add_reagent(reagent_id,src.injection_amount)
 				C.visible_message("<span class='danger'>[src] injects [src.patient] with the syringe!</span>", \


### PR DESCRIPTION
Fixes runtime error when medbot tries to inject a nonexistent reagent called "internal_beaker". Fixes #1709 
