### PR TITLE
Cargo shuttle getting stuck with 'invalid request' bugfix.

### DIFF
--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -525,7 +525,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
 	else if (href_list["viewrequests"])
-		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Current requests: <BR><BR>"
+		temp = "Current requests: <BR><BR>"
 		for(var/S in supply_shuttle.requestlist)
 			var/datum/supply_order/SO = S
 			temp += "#[SO.ordernum] - [SO.object.name] requested by [SO.orderedby]<BR>"
@@ -722,12 +722,11 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 					supply_shuttle.requestlist.Cut(i,i+1)
 					supply_shuttle.points -= P.cost
 					supply_shuttle.shoppinglist += O
-					temp = "Thanks for your order.<BR>"
-					temp += "<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
+					temp = "Thanks for your order."
 				else
-					temp = "Not enough supply points.<BR>"
-					temp += "<BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
+					temp = "Not enough supply points."
 				break
+		temp += "<BR><BR><A href='?src=\ref[src];viewrequests=1'>Back</A> <A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 
 	else if (href_list["vieworders"])
 		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Current approved orders: <BR><BR>"
@@ -748,7 +747,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>Main Menu</A>"
 */
 	else if (href_list["viewrequests"])
-		temp = "<A href='?src=\ref[src];mainmenu=1'>Main Menu</A><BR><BR>Current requests: <BR><BR>"
+		temp = "Current requests: <BR><BR>"
 		for(var/S in supply_shuttle.requestlist)
 			var/datum/supply_order/SO = S
 			temp += "#[SO.ordernum] - [SO.object.name] requested by [SO.orderedby]  [supply_shuttle.moving ? "":supply_shuttle.at_station ? "":"<A href='?src=\ref[src];confirmorder=[SO.ordernum]'>Approve</A> <A href='?src=\ref[src];rreq=[SO.ordernum]'>Remove</A>"]<BR>"


### PR DESCRIPTION
Fixes the cargo computer getting stuck with 'Invalid requests' if the player tried to authorize an order that was already authorized.
Removed two repeated 'main menu' buttons on said computer.
