### PR TITLE
Rebalances traitor items.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -339,7 +339,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The emag is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 7
+	cost = 6
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -46,7 +46,8 @@ var/list/uplink_items = list()
 	var/cost = 0
 	var/last = 0 // Appear last
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
-	var/list/excludefrom = list()//Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
+	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
+	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(item)
@@ -105,6 +106,7 @@ var/list/uplink_items = list()
 	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
 	item = /obj/item/weapon/gun/projectile/revolver
 	cost = 13
+	surplus = 50
 
 /datum/uplink_item/dangerous/pistol
 	name = "Stechkin Pistol"
@@ -118,6 +120,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/projectile/automatic/c20r
 	cost = 14
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 40
 
 /datum/uplink_item/dangerous/machinegun
 	name = "L6 Squad Automatic Weapon"
@@ -125,6 +128,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/projectile/automatic/l6_saw
 	cost = 40
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 /datum/uplink_item/dangerous/crossbow
 	name = "Miniature Energy Crossbow"
@@ -133,6 +137,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/energy/crossbow
 	cost = 12
 	excludefrom = list(/datum/game_mode/nuclear)
+	surplus = 50
 
 /datum/uplink_item/dangerous/flamethrower
 	name = "Flamethrower"
@@ -140,6 +145,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/flamethrower/full/tank
 	cost = 11
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 40
 
 /datum/uplink_item/dangerous/sword
 	name = "Energy Sword"
@@ -165,6 +171,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/grenade/spawnergrenade/manhacks
 	cost = 8
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 35
 
 /datum/uplink_item/dangerous/bioterror
 	name = "Biohazardous Chemical Sprayer"
@@ -173,6 +180,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror
 	cost = 20
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 /datum/uplink_item/dangerous/gygax
 	name = "Gygax Exosuit"
@@ -181,6 +189,7 @@ var/list/uplink_items = list()
 	item = /obj/mecha/combat/gygax/dark/loaded
 	cost = 90
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 /datum/uplink_item/dangerous/mauler
 	name = "Mauler Exosuit"
@@ -188,6 +197,7 @@ var/list/uplink_items = list()
 	item = /obj/mecha/combat/marauder/mauler/loaded
 	cost = 140
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 /datum/uplink_item/dangerous/syndieborg
 	name = "Syndicate Cyborg"
@@ -195,6 +205,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/antag_spawner/borg_tele
 	cost = 50
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 //for refunding the syndieborg teleporter
 /datum/uplink_item/dangerous/syndieborg/spawn_item()
@@ -206,6 +217,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo
 	category = "Ammunition"
+	surplus = 40
 
 /datum/uplink_item/ammo/revolver
 	name = "Ammo-357"
@@ -232,6 +244,7 @@ var/list/uplink_items = list()
 	item = /obj/item/ammo_box/magazine/m762
 	cost = 12
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 // STEALTHY WEAPONS
 
@@ -251,6 +264,7 @@ var/list/uplink_items = list()
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. You can also drop it underfoot to slip people."
 	item = /obj/item/weapon/soap/syndie
 	cost = 1
+	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/detomatix
 	name = "Detomatix PDA Cartridge"
@@ -264,6 +278,7 @@ var/list/uplink_items = list()
 	desc = "Fitted for use on the Stetchkin pistol, this suppressor will make its shots quieter when equipped onto it."
 	item = /obj/item/weapon/suppressor
 	cost = 3
+	surplus = 10
 
 // STEALTHY TOOLS
 
@@ -282,6 +297,7 @@ var/list/uplink_items = list()
 	it can also be used in a washing machine to forge clothing."
 	item = /obj/item/weapon/stamp/chameleon
 	cost = 1
+	surplus = 35
 
 /datum/uplink_item/stealthy_tools/syndigolashes
 	name = "No-Slip Brown Shoes"
@@ -312,6 +328,7 @@ var/list/uplink_items = list()
 	desc = "Enables you to bug cameras to view them remotely. Adding particular items to it alters its functions."
 	item = /obj/item/device/camera_bug
 	cost = 2
+	surplus = 90
 
 // DEVICE AND TOOLS
 
@@ -357,6 +374,7 @@ var/list/uplink_items = list()
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. "
 	item = /obj/item/device/encryptionkey/binary
 	cost = 6
+	surplus = 75
 
 /datum/uplink_item/device_tools/ai_detector
 	name = "Artificial Intelligence Detector" // changed name in case newfriends thought it detected disguised ai's
@@ -421,6 +439,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/circuitboard/teleporter
 	cost = 40
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
 
 /datum/uplink_item/device_tools/shield
 	name = "Energy Shield"
@@ -428,6 +447,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/shield/energy
 	cost = 16
 	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 20
 
 
 // IMPLANTS
@@ -447,6 +467,7 @@ var/list/uplink_items = list()
 	The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	cost = 20
+	surplus = 0
 
 /datum/uplink_item/implants/adrenal
 	name = "Adrenal Implant"
@@ -458,6 +479,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"
+	surplus = 0
 
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"
@@ -473,6 +495,7 @@ var/list/uplink_items = list()
 	item = /obj/item/toy/cards/deck/syndicate
 	cost = 1
 	excludefrom = list(/datum/game_mode/nuclear)
+	surplus = 40
 
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"
@@ -504,3 +527,35 @@ var/list/uplink_items = list()
 		U.uses -= max(0, I.cost)
 		feedback_add_details("traitor_uplink_items_bought","RN")
 		return new I.item(loc)
+
+/datum/uplink_item/badass/surplus_crate
+	name = "Syndicate Surplus Crate"
+	desc = "A crate containing 50 telecrystals worth of random syndicate leftovers."
+	cost = 20
+	item = /obj/item/weapon/storage/box/syndicate
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/badass/surplus_crate/spawn_item(turf/loc, obj/item/device/uplink/U)
+	var/obj/structure/closet/crate/C = new(loc)
+	var/list/temp_uplink_list = get_uplink_items()
+	var/list/buyable_items = list()
+	for(var/category in temp_uplink_list)
+		buyable_items += temp_uplink_list[category]
+	var/list/bought_items = list()
+	U.uses -= cost
+	var/remaining_TC = 50
+
+	var/datum/uplink_item/I
+	while(remaining_TC)
+		I = pick(buyable_items)
+		if(!I.surplus)
+			continue
+		if(I.cost > remaining_TC)
+			continue
+		if((I.item in bought_items) && prob(33)) //To prevent people from being flooded with the same thing over and over again.
+			continue
+		bought_items += I.item
+		remaining_TC -= I.cost
+
+	for(var/item in bought_items)
+		new item(C)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -322,7 +322,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The emag is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 6
+	cost = 7
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -104,26 +104,26 @@ var/list/uplink_items = list()
 	name = "Syndicate Revolver"
 	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
 	item = /obj/item/weapon/gun/projectile/revolver
-	cost = 6
+	cost = 13
 
 /datum/uplink_item/dangerous/pistol
 	name = "Stechkin Pistol"
 	desc = "A small, easily concealable handgun that uses 10mm magazines and is compatible with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/pistol
-	cost = 5
+	cost = 9
 
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms-developed submachine gun that fires 12mm automatic rounds with a 20-round magazine."
 	item = /obj/item/weapon/gun/projectile/automatic/c20r
-	cost = 7
+	cost = 14
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/machinegun
 	name = "L6 Squad Automatic Weapon"
 	desc = "A traditionally constructed machine gun made by AA-2531. This deadly weapon has a massive 50-round magazine of 7.62×51mm ammunition."
 	item = /obj/item/weapon/gun/projectile/automatic/l6_saw
-	cost = 20
+	cost = 40
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/crossbow
@@ -131,39 +131,39 @@ var/list/uplink_items = list()
 	desc = "A short bow mounted across a tiller in miniature. Small enough to fit into a pocket or slip into a bag unnoticed. It fires bolts tipped with toxin, a poison collected from an organism. \
 	Its bolts stun enemies for short periods, and replenish automatically."
 	item = /obj/item/weapon/gun/energy/crossbow
-	cost = 5
+	cost = 12
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/flamethrower
 	name = "Flamethrower"
 	desc = "A flamethrower, fueled by a portion of highly flammable biotoxins stolen previously from Nanotrasen stations. Make a statement by roasting the filth in their own greed. Use with caution."
 	item = /obj/item/weapon/flamethrower/full/tank
-	cost = 6
+	cost = 11
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/sword
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/weapon/melee/energy/sword
-	cost = 4
+	cost = 8
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Kit"
 	desc = "A box that contains two EMP grenades, an EMP implant and a short ranged recharging device disguised as a flashlight. Useful to disrupt communication and silicon lifeforms."
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
-	cost = 3
+	cost = 5
 
 /datum/uplink_item/dangerous/syndicate_minibomb
 	name = "Syndicate Minibomb"
 	desc = "The Minibomb is a grenade with a five-second fuse."
 	item = /obj/item/weapon/grenade/syndieminibomb
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/dangerous/viscerators
 	name = "Viscerator Delivery Grenade"
 	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
 	item = /obj/item/weapon/grenade/spawnergrenade/manhacks
-	cost = 4
+	cost = 8
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/bioterror
@@ -171,7 +171,7 @@ var/list/uplink_items = list()
 	desc = "A chemical sprayer that allows a wide dispersal of selected chemicals. Especially tailored by the Tiger Cooperative, the deadly blend it comes stocked with will disorient, damage, and disable your foes... \
 	Use with extreme caution, to prevent exposure to yourself and your fellow operatives."
 	item = /obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror
-	cost = 10
+	cost = 20
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/gygax
@@ -179,21 +179,23 @@ var/list/uplink_items = list()
 	desc = "A lightweight exosuit, painted in a dark scheme. Its speed and equipment selection make it excellent for hit-and-run style attacks. \
 	This model lacks a method of space propulsion, and therefore it is advised to repair the mothership's teleporter if you wish to make use of it."
 	item = /obj/mecha/combat/gygax/dark/loaded
-	cost = 45
+	cost = 90
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/mauler
 	name = "Mauler Exosuit"
 	desc = "A massive and incredibly deadly Syndicate exosuit. Features long-range targetting, thrust vectoring, and deployable smoke."
 	item = /obj/mecha/combat/marauder/mauler/loaded
-	cost = 70
+	cost = 140
 	gamemodes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/dangerous/syndieborg
 	name = "Syndicate Cyborg"
 	desc = "A cyborg designed and programmed for systematic extermination of non-Syndicate personnel."
 	item = /obj/item/weapon/antag_spawner/borg_tele
-	cost = 25
+	cost = 50
 	gamemodes = list(/datum/game_mode/nuclear)
+
 //for refunding the syndieborg teleporter
 /datum/uplink_item/dangerous/syndieborg/spawn_item()
 	var/obj/item/weapon/antag_spawner/borg_tele/T = ..()
@@ -209,13 +211,13 @@ var/list/uplink_items = list()
 	name = "Ammo-357"
 	desc = "A box that contains seven additional rounds for the revolver, made using an automatic lathe."
 	item = /obj/item/ammo_box/a357
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/ammo/smg
 	name = "Ammo-12mm"
 	desc = "A 20-round .45 ACP magazine for use in the C-20r submachine gun."
 	item = /obj/item/ammo_box/magazine/c20m
-	cost = 1
+	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/pistol
@@ -228,7 +230,7 @@ var/list/uplink_items = list()
 	name = "Ammo-7.62×51mm"
 	desc = "A 50-round magazine of 7.62×51mm ammunition for use in the L6 SAW machinegun. By the time you need to use this, you'll already be on a pile of corpses."
 	item = /obj/item/ammo_box/magazine/m762
-	cost = 6
+	cost = 12
 	gamemodes = list(/datum/game_mode/nuclear)
 
 // STEALTHY WEAPONS
@@ -241,7 +243,7 @@ var/list/uplink_items = list()
 	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a strong anaesthetic and a chemical that is capable of blocking the movement of the vocal chords. \
 	The pen holds one dose of the mixture, and cannot be refilled."
 	item = /obj/item/weapon/pen/sleepy
-	cost = 2
+	cost = 4
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/soap
@@ -255,13 +257,13 @@ var/list/uplink_items = list()
 	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. \
 	The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
 	item = /obj/item/weapon/cartridge/syndicate
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Stetchkin Suppressor"
 	desc = "Fitted for use on the Stetchkin pistol, this suppressor will make its shots quieter when equipped onto it."
 	item = /obj/item/weapon/suppressor
-	cost = 2
+	cost = 3
 
 // STEALTHY TOOLS
 
@@ -272,7 +274,7 @@ var/list/uplink_items = list()
 	name = "Chameleon Jumpsuit"
 	desc = "A jumpsuit used to imitate the uniforms of Nanotrasen crewmembers."
 	item = /obj/item/clothing/under/chameleon
-	cost = 3
+	cost = 4
 
 /datum/uplink_item/stealthy_tools/chameleon_stamp
 	name = "Chameleon Stamp"
@@ -285,25 +287,25 @@ var/list/uplink_items = list()
 	name = "No-Slip Brown Shoes"
 	desc = "These allow you to run on wet floors. They do not work on lubricated surfaces."
 	item = /obj/item/clothing/shoes/syndigaloshes
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent Identification card"
 	desc = "Agent cards prevent artificial intelligences from tracking the wearer, and can copy access from other identification cards. The access is cumulative, so scanning one card does not erase the access gained from another."
 	item = /obj/item/weapon/card/id/syndicate
-	cost = 2
+	cost = 3
 
 /datum/uplink_item/stealthy_tools/voice_changer
 	name = "Voice Changer"
 	item = /obj/item/clothing/mask/gas/voice
 	desc = "A conspicuous gas mask that mimics the voice named on your identification card. When no identification is worn, the mask will render your voice unrecognizable."
-	cost = 4
+	cost = 5
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon-Projector"
 	desc = "Projects an image across a user, disguising them as an object scanned with it, as long as they don't move the projector from their hand. The disguised user cannot run and rojectiles pass over them."
 	item = /obj/item/device/chameleon
-	cost = 4
+	cost = 7
 
 /datum/uplink_item/stealthy_tools/camera_bug
 	name = "Camera Bug"
@@ -320,7 +322,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The emag is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"
@@ -333,28 +335,28 @@ var/list/uplink_items = list()
 	desc = "The syndicate medkit is a suspicious black and red. Included is a combat stimulant injector for rapid healing, a medical hud for quick identification of injured comrades, \
 	and other medical supplies helpful for a medical field operative.."
 	item = /obj/item/weapon/storage/firstaid/tactical
-	cost = 5
+	cost = 9
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/space_suit
 	name = "Syndicate Space Suit"
 	desc = "The red and black syndicate space suit is less encumbering than Nanotrasen variants, fits inside bags, and has a weapon slot. Nanotrasen crewmembers are trained to report red space suit sightings."
 	item = /obj/item/weapon/storage/box/syndie_kit/space
-	cost = 3
+	cost = 5
 
 /datum/uplink_item/device_tools/thermal
 	name = "Thermal Imaging Glasses"
 	desc = "These glasses are thermals disguised as engineers' optical meson scanners. \
 	They allow you to see organisms through walls by capturing the upper portion of the infrared light spectrum, emitted as heat and light by objects. \
-	Hotter objects, such as warm bodies, cybernetic organisms and artificial intelligence cores emit more of this light than cooler objects like walls and airlocks."
+	Hotter objects, such as warm bodies, cybernetic organisms and artificial intelligence cores emit more of this light than cooler objects like walls and airlocks." //THEN WHY CANT THEY SEE PLASMA FIRES????
 	item = /obj/item/clothing/glasses/thermal/syndi
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. "
 	item = /obj/item/device/encryptionkey/binary
-	cost = 3
+	cost = 6
 
 /datum/uplink_item/device_tools/ai_detector
 	name = "Artificial Intelligence Detector" // changed name in case newfriends thought it detected disguised ai's
@@ -366,7 +368,7 @@ var/list/uplink_items = list()
 	name = "Hacked AI Law Upload Module"
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 7
+	cost = 14
 
 /datum/uplink_item/device_tools/plastic_explosives
 	name = "Composition C-4"
@@ -380,7 +382,7 @@ var/list/uplink_items = list()
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. \
 	Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
 	item = /obj/item/device/powersink
-	cost = 5
+	cost = 10
 
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Singularity Beacon"
@@ -388,14 +390,14 @@ var/list/uplink_items = list()
 	Does not work when the singularity is still in containment. A singularity beacon can cause catastrophic damage to a space station, \
 	leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation."
 	item = /obj/item/device/sbeacondrop
-	cost = 7
+	cost = 14
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	item = /obj/item/device/sbeacondrop/bomb
-	cost = 6
+	cost = 11
 	excludefrom = list(/datum/game_mode/traitor/double_agents)
 
 /datum/uplink_item/device_tools/rad_laser
@@ -403,28 +405,28 @@ var/list/uplink_items = list()
 	desc = "A radioactive microlaser disguised as a standard Nanotrasen health analyzer. When used, it emits a powerful burst of radiation, which, after a short delay, can incapitate all but the most protected of humanoids. \
 	It has two settings: intensity, which controls the power of the radiation, and wavelength, which controls how long the radiation delay is."
 	item = /obj/item/device/rad_laser
-	cost = 4
+	cost = 6
 
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"
 	desc = "The Syndicate Detonator is a companion device to the Syndicate Bomb. Simply press the included button and an encrypted radio frequency will instruct all live syndicate bombs to detonate. \
 	Useful for when speed matters or you wish to synchronize multiple bomb blasts. Be sure to stand clear of the blast radius before using the detonator."
 	item = /obj/item/device/syndicatedetonator
-	cost = 1
+	cost = 3
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/teleporter
 	name = "Teleporter Circuit Board"
 	desc = "A printed circuit board that completes the teleporter onboard the mothership. Advise you test fire the teleporter before entering it, as malfunctions can occur."
 	item = /obj/item/weapon/circuitboard/teleporter
-	cost = 20
+	cost = 40
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/shield
 	name = "Energy Shield"
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending against other attacks."
 	item = /obj/item/weapon/shield/energy
-	cost = 8
+	cost = 16
 	gamemodes = list(/datum/game_mode/nuclear)
 
 
@@ -437,20 +439,20 @@ var/list/uplink_items = list()
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated using a bodily gesture to attempt to slip restraints."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
-	cost = 3
+	cost = 5
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 5 telecrystals. \
 	The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	cost = 10
+	cost = 20
 
 /datum/uplink_item/implants/adrenal
 	name = "Adrenal Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to inject a chemical cocktail, which has a mild healing effect along with removing all stuns and increasing his speed."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
-	cost = 4
+	cost = 8
 
 // POINTLESS BADASSERY
 
@@ -461,7 +463,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Bundle"
 	desc = "Syndicate Bundles are specialised groups of items that arrive in a plain box. These items are collectively worth more than 10 telecrystals, but you do not know which specialisation you will receive."
 	item = /obj/item/weapon/storage/box/syndicate
-	cost = 10
+	cost = 20
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/badass/syndiecards
@@ -476,7 +478,7 @@ var/list/uplink_items = list()
 	name = "For showing that you are The Boss"
 	desc = "A useless red balloon with the syndicate logo on it, which can blow the deepest of covers."
 	item = /obj/item/toy/syndicateballoon
-	cost = 10
+	cost = 20
 
 /datum/uplink_item/badass/random
 	name = "Random Item"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -210,7 +210,7 @@
 
 	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(synd_mob)
 	U.hidden_uplink.uplink_owner="[synd_mob.key]"
-	U.hidden_uplink.uses = 10
+	U.hidden_uplink.uses = 20
 	synd_mob.equip_to_slot_or_del(U, slot_in_backpack)
 
 	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)

--- a/code/game/machinery/computer/telecrystalconsoles.dm
+++ b/code/game/machinery/computer/telecrystalconsoles.dm
@@ -1,4 +1,4 @@
-#define NUKESCALINGMODIFIER 0.5
+#define NUKESCALINGMODIFIER 1
 
 var/list/possible_uplinker_IDs = list("Alfa","Bravo","Charlie","Delta","Echo","Foxtrot","Zero", "Niner")
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -10,7 +10,7 @@ var/list/world_uplinks = list()
 
 /obj/item/device/uplink
 	var/welcome = "Syndicate Uplink Console:"	// Welcoming menu message
-	var/uses = 10								// Numbers of crystals
+	var/uses = 20								// Numbers of crystals
 	// List of items not to shove in their hands.
 	var/purchase_log = ""
 	var/show_description = null
@@ -209,7 +209,7 @@ var/list/world_uplinks = list()
 /obj/item/device/radio/headset/uplink/New()
 	..()
 	hidden_uplink = new(src)
-	hidden_uplink.uses = 10
+	hidden_uplink.uses = 20
 
 
 

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -6,7 +6,7 @@
 /obj/item/weapon/implant/uplink/New()
 	activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch_s", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
 	hidden_uplink = new(src)
-	hidden_uplink.uses = 5
+	hidden_uplink.uses = 10
 	..()
 	return
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -7,7 +7,9 @@
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/clothing/mask/gas/voice(src)
 			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/weapon/card/id/syndicate(src)
 			new /obj/item/clothing/shoes/syndigaloshes(src)
+			new /obj/item/device/camera_bug(src)
 			return
 
 		if("stealth")
@@ -22,6 +24,7 @@
 			new /obj/item/ammo_box/magazine/m10mm(src)
 			new /obj/item/ammo_box/magazine/m10mm(src)
 			new /obj/item/clothing/under/chameleon(src)
+			new /obj/item/weapon/card/id/syndicate(src)
 			return
 
 		if("screwed")

--- a/html/changelogs/Miauw-PR-4919.yml
+++ b/html/changelogs/Miauw-PR-4919.yml
@@ -1,0 +1,7 @@
+author: Miauw
+
+delete-after: True
+
+changes:
+  - experiment: The amount of TC has been increased to 20, but the price of all items has been doubled as well
+  - experiment: With this, the prices of stealthy items has been slightly decreased and the prices of offensive items slightly increased (+/- 1 TC)


### PR DESCRIPTION
Doubles the prices of items, but also doubles the amount of TC.
Stealthy items have been slightly decreased in price.
Weapons have been slightly increased in price.
Nuke items remain mostly unchanged.
Syndicate bundles were also adjusted.

INTRODUCING: Syndicate Surplus Crates!
50 TC worth of traitor items, weighted away from revolvers, ebows and ammo! (because getting 5 boxes of ammo without any guns sucks)
