### PR TITLE
active_diseases list cleans up on disease cure

### DIFF
--- a/code/datums/disease.dm
+++ b/code/datums/disease.dm
@@ -204,7 +204,7 @@ var/list/diseases = typesof(/datum/disease) - /datum/disease
 
 /datum/disease/proc/GetDiseaseID()
 	return src.type
-/*
+
 /datum/disease/Del()
 	active_diseases.Remove(src)
-*/
+	..()


### PR DESCRIPTION
Makes the _active_diseases_ global list clean up again when a disease is cured.

Right now, it's keeping pointers to null objects.
