### PR TITLE
Surgery fixes

### DIFF
--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -46,10 +46,10 @@
 	if(L)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
-			user.visible_message("<span class='notice'>[user] successfully augments [target]'s [parse_zone(user.zone_sel.selecting)]!</span>")
+			user.visible_message("<span class='notice'>[user] successfully augments [target]'s [target_zone]!</span>")
 			L.loc = get_turf(target)
 			H.organs -= L
-			switch(user.zone_sel.selecting)  //for the surgery to progress this MUST still be the original "location" so it's safe to do this.
+			switch(target_zone)  //for the surgery to progress this MUST still be the original "location" so it's safe to do this.
 				if("r_leg")
 					H.organs += new /obj/item/organ/limb/robot/r_leg(src)
 				if("l_leg")
@@ -70,7 +70,7 @@
 			qdel(tool)
 			H.update_damage_overlays(0)
 			H.update_augments() //Gives them the Cyber limb overlay
-			add_logs(user, target, "augmented", addition="by giving him new [parse_zone(user.zone_sel.selecting)] INTENT: [uppertext(user.a_intent)]")
+			add_logs(user, target, "augmented", addition="by giving him new [target_zone] INTENT: [uppertext(user.a_intent)]")
 	else
-		user.visible_message("<span class='notice'>[user] [target] has no organic [parse_zone(user.zone_sel.selecting)] there!</span>")
+		user.visible_message("<span class='notice'>[user] [target] has no organic [target_zone] there!</span>")
 	return 1

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -49,7 +49,7 @@
 			user.visible_message("<span class='notice'>[user] successfully augments [target]'s [parse_zone(target_zone)]!</span>")
 			L.loc = get_turf(target)
 			H.organs -= L
-			switch(target_zone)  //for the surgery to progress this MUST still be the original "location" so it's safe to do this.
+			switch(target_zone)
 				if("r_leg")
 					H.organs += new /obj/item/organ/limb/robot/r_leg(src)
 				if("l_leg")

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -46,7 +46,7 @@
 	if(L)
 		if(ishuman(target))
 			var/mob/living/carbon/human/H = target
-			user.visible_message("<span class='notice'>[user] successfully augments [target]'s [target_zone]!</span>")
+			user.visible_message("<span class='notice'>[user] successfully augments [target]'s [parse_zone(target_zone)]!</span>")
 			L.loc = get_turf(target)
 			H.organs -= L
 			switch(target_zone)  //for the surgery to progress this MUST still be the original "location" so it's safe to do this.
@@ -72,5 +72,5 @@
 			H.update_augments() //Gives them the Cyber limb overlay
 			add_logs(user, target, "augmented", addition="by giving him new [target_zone] INTENT: [uppertext(user.a_intent)]")
 	else
-		user.visible_message("<span class='notice'>[user] [target] has no organic [target_zone] there!</span>")
+		user.visible_message("<span class='notice'>[user] [target] has no organic [parse_zone(target_zone)] there!</span>")
 	return 1

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -70,7 +70,7 @@
 			qdel(tool)
 			H.update_damage_overlays(0)
 			H.update_augments() //Gives them the Cyber limb overlay
-			add_logs(user, target, "augmented", addition="by giving him new [target_zone] INTENT: [uppertext(user.a_intent)]")
+			add_logs(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else
 		user.visible_message("<span class='notice'>[user] [target] has no organic [parse_zone(target_zone)] there!</span>")
 	return 1

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -29,7 +29,7 @@
 				initiate(user, target, target_zone, tool, surgery)
 				return 1
 			else
-				user << "<span class='notice'>You need to expose [target]'s [target_zone] to perform surgery on it!</span>"
+				user << "<span class='notice'>You need to expose [target]'s [parse_zone(target_zone)] to perform surgery on it!</span>"
 				return 1	//returns 1 so we don't stab the guy in the dick or wherever.
 	return 0
 
@@ -77,7 +77,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.apply_damage(75,"brute","[target_zone]")
-		user.visible_message("<span class='notice'>[user] saws [target]'s [target_zone] open!")
+		user.visible_message("<span class='notice'>[user] saws [target]'s [parse_zone(target_zone)] open!")
 	return 1
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
- Fixes "r_arm" (or equivalent) appearing in two surgery related messages. (fixes #4432 )
- Fixes Robolimb overlay being placed on a limb other than the surgery location during the last step of augment surgery. (fix #1944 )
