### PR TITLE
Blob win reported as a win

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -12,7 +12,7 @@
 
 /datum/game_mode/blob/declare_completion()
 	if(blobwincount <= blobs.len)
-		feedback_set_details("round_end_result","loss - blob took over")
+		feedback_set_details("round_end_result","win - blob took over")
 		world << "<FONT size = 3><B>The blob has taken over the station!</B></FONT>"
 		world << "<B>The entire station was eaten by the Blob</B>"
 		log_game("Blob mode completed with a blob victory.")
@@ -24,7 +24,7 @@
 		log_game("Blob mode completed with a tie (station destroyed).")
 
 	else if(!blob_cores.len)
-		feedback_set_details("round_end_result","win - blob eliminated")
+		feedback_set_details("round_end_result","loss - blob eliminated")
 		world << "<FONT size = 3><B>The staff has won!</B></FONT>"
 		world << "<B>The alien organism has been eradicated from the station</B>"
 		log_game("Blob mode completed with a crew victory.")


### PR DESCRIPTION
Blob rounds are now reported as a win if the blob wins and vice versa (just like malf, nuke, rev)
Fixes #1594 
