### PR TITLE
Makes opaque structures and space vines update surrounding lights when destroyed

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -16,3 +16,8 @@ obj/structure/ex_act(severity)
 				return
 		if(3.0)
 			return
+
+obj/structure/Destroy()
+	if(opacity)
+		UpdateAffectingLights()
+	..()


### PR DESCRIPTION
Fixes #4971 (mineral doors, and more generally every opaque structures were affected by this issue).

_Edit_ : did the same with spacevines.
Some full path convert while i was at it too.
