### PR TITLE
Malf timer polishing/fixes

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -118,6 +118,10 @@ var/global/pipe_processing_killed = 0
 			if(!Failsafe)	new /datum/controller/failsafe()
 
 			var/currenttime = world.timeofday
+
+			if((last_tick_timeofday - currenttime) > 1e5) //midnight rollover protection
+				last_tick_timeofday -= MIDNIGHT_ROLLOVER
+
 			last_tick_duration = (currenttime - last_tick_timeofday) / 10
 			last_tick_timeofday = currenttime
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -11,7 +11,7 @@
 	pre_setup_before_jobs = 1
 
 
-	var/AI_win_timeleft = 1800 //started at 1800, in case I change this for testing round end.
+	var/AI_win_timeleft = 5400 //started at 5400, in case I change this for testing round end.
 	var/malf_mode_declared = 0
 	var/station_captured = 0
 	var/to_nuke_or_not_to_nuke = 0
@@ -98,8 +98,8 @@
 	return
 
 /datum/game_mode/malfunction/process()
-	if (apcs >= 3 && malf_mode_declared)
-		AI_win_timeleft -= ((apcs/6)*last_tick_duration) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
+	if ((apcs > 0) && malf_mode_declared)
+		AI_win_timeleft -= apcs * last_tick_duration	//Victory timer de-increments based on how many APCs are hacked
 	..()
 	if (AI_win_timeleft<=0)
 		check_win()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -127,9 +127,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			if(ticker.mode)
 				//world << "DEBUG: ticker not null"
 				if(ticker.mode.name == "AI malfunction")
+					var/datum/game_mode/malfunction/malf = ticker.mode
 					//world << "DEBUG: malf mode ticker test"
-					if(ticker.mode:malf_mode_declared)
-						stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
+					if(malf.malf_mode_declared && (malf.apcs > 0))
+						stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
 		if(emergency_shuttle)
 			if(emergency_shuttle.online && emergency_shuttle.location < 2)
 				var/timeleft = emergency_shuttle.timeleft()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -121,8 +121,9 @@
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
 	if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
-		if(ticker.mode:malf_mode_declared)
-			stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
+		var/datum/game_mode/malfunction/malf = ticker.mode
+		if(malf.malf_mode_declared && (malf.apcs > 0))
+			stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
 	if(emergency_shuttle)
 		if(emergency_shuttle.online && emergency_shuttle.location < 2)
 			var/timeleft = emergency_shuttle.timeleft()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -173,9 +173,8 @@ var/list/ai_list = list()
 		if(ticker.mode.name == "AI malfunction")
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			for (var/datum/mind/malfai in malf.malf_ai)
-				if (mind == malfai)
-					if (malf.apcs >= 3)
-						stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
+				if ((mind == malfai) && (malf.apcs > 0))
+					stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds")
 
 		if(!stat)
 			stat(null, text("System integrity: [(health+100)/2]%"))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -303,11 +303,10 @@
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			for (var/datum/mind/malfai in malf.malf_ai)
 				if(connected_ai)
-					if(connected_ai.mind == malfai)
-						if(malf.apcs >= 3)
-							stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/(malf.apcs/3), 0)] seconds")
-				else if(ticker.mode:malf_mode_declared)
-					stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
+					if((connected_ai.mind == malfai) && (malf.apcs > 0))
+						stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds")
+				else if(malf.malf_mode_declared && (malf.apcs > 0))
+					stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
 
 		if(cell)
 			stat(null, text("Charge Left: [cell.charge]/[cell.maxcharge]"))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -897,11 +897,6 @@
 /obj/machinery/power/apc/proc/toggle_breaker()
 	operating = !operating
 
-	if(malfai)
-		if (ticker.mode.config_tag == "malfunction")
-			if (src.z == 1) //if (is_type_in_list(get_area(src), the_station_areas))
-				operating ? ticker.mode:apcs++ : ticker.mode:apcs--
-
 	src.update()
 	update_icon()
 


### PR DESCRIPTION
**Malf timer polishing and fixes**
- Polished malf timer logic :
  - The time to take control of the station is _5400 / number_of_hacked_apcs_
  - The AI can't start the hostile runtime if less then 3 hacked apcs
  - Once the runtime is started, the amount by which the timer is decreased, is dynamically adjusted by destroyed/hacked apcs (down to 1 APC ; at 0 the hostile runtime is stopped, but can resume).

Note that it's _mainly_ the same logic as before, the implementation being modified.
- toggling an APC breaker won't save you anymore : disposing of an hacked apc is done by deconstructing or blowing (or blobing) it !
- added a protection to prevent division by 0 when all hacked apcs are destroyed
- added a midnight rollover check for the MC _last_tick_duration_ (fixes #4905)
