### PR TITLE
APC/airlocks/alarms fixes

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -137,11 +137,11 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			//raises them if they are down (only if power's on)
 			if(!A.locked)
 				A.locked = 1
-				audible_message("You hear a click from the bottom of the door.", null,  1)
+				A.audible_message("You hear a click from the bottom of the door.", null,  1)
 			else
 				if(A.hasPower()) //only can raise bolts if power's on
 					A.locked = 0
-					audible_message("You hear a click from the bottom of the door.", null, 1)
+					A.audible_message("You hear a click from the bottom of the door.", null, 1)
 			A.update_icon()
 
 		if(AIRLOCK_WIRE_BACKUP_POWER1 || AIRLOCK_WIRE_BACKUP_POWER2)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -137,13 +137,11 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			//raises them if they are down (only if power's on)
 			if(!A.locked)
 				A.locked = 1
-				for(var/mob/M in range(1, A))
-					M << "You hear a click from the bottom of the door."
+				audible_message("You hear a click from the bottom of the door.", null,  1)
 			else
 				if(A.hasPower()) //only can raise bolts if power's on
 					A.locked = 0
-					for(var/mob/M in range(1, A))
-						M << "You hear a click from the bottom of the door."
+					audible_message("You hear a click from the bottom of the door.", null, 1)
 			A.update_icon()
 
 		if(AIRLOCK_WIRE_BACKUP_POWER1 || AIRLOCK_WIRE_BACKUP_POWER2)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -795,17 +795,20 @@ table tr:first-child th:first-child { border: none;}
 						user << "<span class='notice'>You [ locked ? "lock" : "unlock"] the Air Alarm interface.</span>"
 						src.updateUsrDialog()
 					else
-						user << "<span class='danger'>Access denied.</span>"
+						user << "<span class='warning'>Access denied.</span>"
 				return
 		if(1)
 			if(istype(W, /obj/item/weapon/crowbar) && wires.wires_status == (2 ** wires.wire_count) - 1)
-				user << "You pry out the circuit."
+				user.visible_message("<span class='warning'>[user.name] removes the air alarm electronics from [src.name]!</span>",\
+									"You start prying out the circuit.")
 				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				spawn(20)
-					new /obj/item/weapon/airalarm_electronics( src.loc )
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					buildstage = 0
-					update_icon()
+				if (do_after(user, 20))
+					if (buildstage ==1)
+						user <<"<span class='notice'>You remove the air alarm electronics.</span>"
+						new /obj/item/weapon/airalarm_electronics( src.loc )
+						playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+						buildstage = 0
+						update_icon()
 				return
 
 			if(istype(W, /obj/item/stack/cable_coil))
@@ -813,14 +816,15 @@ table tr:first-child th:first-child { border: none;}
 				if(cable.get_amount() < 5)
 					user << "<span class='warning'>You need five lengths of cable to wire the fire alarm.</span>"
 					return
-				user << "<span class='notice'>You start wiring the air alarm.</span>"
+				user.visible_message("<span class='warning'>[user.name] wires the air alarm.</span>", \
+									"You start wiring the air alarm.")
 				if (do_after(user, 20))
 					if (cable.get_amount() >= 5 && buildstage == 1)
 						cable.use(5)
-						user << "<span class='notice'>You wire the air alarm.</span>"
-						wires.wires_status = 0
-						buildstage = 2
-						update_icon()
+					user << "<span class='notice'>You wire the air alarm.</span>"
+					wires.wires_status = 0
+					buildstage = 2
+					update_icon()
 				return
 		if(0)
 			if(istype(W, /obj/item/weapon/airalarm_electronics))
@@ -832,7 +836,7 @@ table tr:first-child th:first-child { border: none;}
 				return
 
 			if(istype(W, /obj/item/weapon/wrench))
-				user << "You detach \the [src] from the wall!"
+				user << "<span class='notice'>You detach \the [src] from the wall!</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 				new /obj/item/alarm_frame( user.loc )
 				qdel(src)
@@ -892,14 +896,14 @@ Code shamelessly copied from apc_frame
 	var/turf/loc = get_turf(usr)
 	var/area/A = loc.loc
 	if (!istype(loc, /turf/simulated/floor))
-		usr << "<span class='danger'>Air Alarm cannot be placed on this spot.</span>"
+		usr << "<span class='warning'>Air Alarm cannot be placed on this spot.</span>"
 		return
 	if (A.requires_power == 0 || A.name == "Space")
-		usr << "<span class='danger'>Air Alarm cannot be placed in this area.</span>"
+		usr << "<span class='warning'>Air Alarm cannot be placed in this area.</span>"
 		return
 
 	if(gotwallitem(loc, ndir))
-		usr << "<span class='danger'>There's already an item on this wall!</span>"
+		usr << "<span class='warning'>There's already an item on this wall!</span>"
 		return
 
 	new /obj/machinery/alarm(loc, ndir, 1)
@@ -1011,7 +1015,9 @@ FIRE ALARM
 
 				else if(istype(W, /obj/item/weapon/crowbar))
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-					spawn(20)
+					user.visible_message("<span class='warning'>[user.name] removes the fire alarm electronics from [src.name].</span>", \
+										"You start prying out the circuit.")
+					if(do_after(user, 20))
 						if(buildstage == 1)
 							user << "<span class='notice'>You pry out the circuit!</span>"
 							new /obj/item/weapon/firealarm_electronics(user.loc)
@@ -1025,7 +1031,8 @@ FIRE ALARM
 					update_icon()
 
 				else if(istype(W, /obj/item/weapon/wrench))
-					user.visible_message("<span class='warning'>[user] removes the fire alarm assembly from the wall!</span>", "<span class='warning'>You remove the fire alarm assembly from the wall!</span>")
+					user.visible_message("<span class='warning'>[user] removes the fire alarm assembly from the wall!</span>", \
+										 "<span class='notice'>You remove the fire alarm assembly from the wall!</span>")
 					var/obj/item/firealarm_frame/frame = new /obj/item/firealarm_frame()
 					frame.loc = user.loc
 					playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
@@ -1216,14 +1223,14 @@ Code shamelessly copied from apc_frame
 	var/turf/loc = get_turf(usr)
 	var/area/A = loc.loc
 	if (!istype(loc, /turf/simulated/floor))
-		usr << "<span class='danger'>Fire Alarm cannot be placed on this spot.</span>"
+		usr << "<span class='warning'>Fire Alarm cannot be placed on this spot.</span>"
 		return
 	if (A.requires_power == 0 || A.name == "Space")
-		usr << "<span class='danger'>Fire Alarm cannot be placed in this area.</span>"
+		usr << "<span class='warning'>Fire Alarm cannot be placed in this area.</span>"
 		return
 
 	if(gotwallitem(loc, ndir))
-		usr << "<span class='danger'>There's already an item on this wall!</span>"
+		usr << "<span class='warning'>There's already an item on this wall!</span>"
 		return
 
 	new /obj/machinery/firealarm(loc, ndir, 1)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -799,7 +799,7 @@ table tr:first-child th:first-child { border: none;}
 				return
 		if(1)
 			if(istype(W, /obj/item/weapon/crowbar) && wires.wires_status == (2 ** wires.wire_count) - 1)
-				user.visible_message("<span class='warning'>[user.name] removes the air alarm electronics from [src.name]!</span>",\
+				user.visible_message("<span class='warning'>[user.name] removes the electronics from [src.name].</span>",\
 									"You start prying out the circuit.")
 				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
 				if (do_after(user, 20))
@@ -821,10 +821,10 @@ table tr:first-child th:first-child { border: none;}
 				if (do_after(user, 20))
 					if (cable.get_amount() >= 5 && buildstage == 1)
 						cable.use(5)
-					user << "<span class='notice'>You wire the air alarm.</span>"
-					wires.wires_status = 0
-					buildstage = 2
-					update_icon()
+						user << "<span class='notice'>You wire the air alarm.</span>"
+						wires.wires_status = 0
+						buildstage = 2
+						update_icon()
 				return
 		if(0)
 			if(istype(W, /obj/item/weapon/airalarm_electronics))
@@ -1015,7 +1015,7 @@ FIRE ALARM
 
 				else if(istype(W, /obj/item/weapon/crowbar))
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-					user.visible_message("<span class='warning'>[user.name] removes the fire alarm electronics from [src.name].</span>", \
+					user.visible_message("<span class='warning'>[user.name] removes the electronics from [src.name].</span>", \
 										"You start prying out the circuit.")
 					if(do_after(user, 20))
 						if(buildstage == 1)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -640,7 +640,8 @@ About the new airlock wires panel:
 		if(H.getBrainLoss() >= 60)
 			playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 			if(!istype(H.head, /obj/item/clothing/head/helmet))
-				visible_message("<span class='danger'>[user] headbutts the airlock.</span>")
+				H.visible_message("<span class='danger'>[user] headbutts the airlock.</span>", \
+									"<span class='userdanger'>[user] headbutts the airlock!</span>")
 				var/obj/item/organ/limb/affecting = H.get_organ("head")
 				H.Stun(5)
 				H.Weaken(5)
@@ -888,16 +889,18 @@ About the new airlock wires panel:
 	src.add_fingerprint(user)
 	if((istype(C, /obj/item/weapon/weldingtool) && !( src.operating ) && src.density))
 		var/obj/item/weapon/weldingtool/W = C
-		user << "<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>"
+		user.visible_message("<span class='warning'>[user] is [welded ? "unwelding":"welding"] the airlock.</span>", \
+							"You begin [welded ? "unwelding":"welding"] the airlock...", \
+							"You hear welding.")
 		playsound(loc, 'sound/items/Welder.ogg', 40, 1)
 		if(do_after(user,40,5,1))
 			if(density && !operating)//Door must be closed to weld.
 				if(W.remove_fuel(0,user))
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					welded = !welded
-					user << "<span class='notice'>You [welded ? "welded the airlock shut":"unwelded the airlock"]</span>"
+					user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>", \
+										"<span class='notice'>You've [welded ? "welded the airlock shut":"unwelded the airlock"].</span>")
 					update_icon()
-					user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>")
 		return
 	else if(istype(C, /obj/item/weapon/screwdriver))
 		src.p_open = !( src.p_open )
@@ -920,68 +923,70 @@ About the new airlock wires panel:
 			beingcrowbarred = 0
 		if( beingcrowbarred && (density && welded && !operating && src.p_open && (!hasPower()) && !src.locked) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
+			user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
+								 "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40))
-				switch(src.doortype)
-					if(0) new/obj/structure/door_assembly/door_assembly_0( src.loc )
-					if(1) new/obj/structure/door_assembly/door_assembly_com( src.loc )
-					if(2) new/obj/structure/door_assembly/door_assembly_sec( src.loc )
-					if(3) new/obj/structure/door_assembly/door_assembly_eng( src.loc )
-					if(4) new/obj/structure/door_assembly/door_assembly_med( src.loc )
-					if(5) new/obj/structure/door_assembly/door_assembly_mai( src.loc )
-					if(6) new/obj/structure/door_assembly/door_assembly_ext( src.loc )
-					if(7) new/obj/structure/door_assembly/door_assembly_glass( src.loc )
-					//8 is centcom
-					if(9) new/obj/structure/door_assembly/door_assembly_vault(loc)
-					//10 is double glass door (2x1)
-					//11 is freezer
-					if(12) new/obj/structure/door_assembly/door_assembly_hatch( src.loc )
-					if(13) new/obj/structure/door_assembly/door_assembly_mhatch( src.loc )
-					if(14) new/obj/structure/door_assembly/door_assembly_com/glass( src.loc )
-					if(15) new/obj/structure/door_assembly/door_assembly_eng/glass( src.loc )
-					if(16) new/obj/structure/door_assembly/door_assembly_sec/glass( src.loc )
-					if(17) new/obj/structure/door_assembly/door_assembly_med/glass( src.loc )
-					if(18) new/obj/structure/door_assembly/door_assembly_min( src.loc )
-					if(19) new/obj/structure/door_assembly/door_assembly_atmo( src.loc )
-					if(20) new/obj/structure/door_assembly/door_assembly_research( src.loc )
-					if(21) new/obj/structure/door_assembly/door_assembly_research/glass( src.loc )
-					if(22) new/obj/structure/door_assembly/door_assembly_min/glass( src.loc )
-					if(23) new/obj/structure/door_assembly/door_assembly_atmo/glass( src.loc )
-					if(24) new/obj/structure/door_assembly/door_assembly_gold( src.loc )
-					if(25) new/obj/structure/door_assembly/door_assembly_silver( src.loc )
-					if(26) new/obj/structure/door_assembly/door_assembly_diamond( src.loc )
-					if(27) new/obj/structure/door_assembly/door_assembly_uranium( src.loc )
-					if(28) new/obj/structure/door_assembly/door_assembly_plasma( src.loc )
-					if(29) new/obj/structure/door_assembly/door_assembly_clown( src.loc )
-					if(30) new/obj/structure/door_assembly/door_assembly_sandstone( src.loc )
-					if(31) new/obj/structure/door_assembly/door_assembly_science( src.loc )
-					if(32) new/obj/structure/door_assembly/door_assembly_science/glass( src.loc )
-					if(33) new/obj/structure/door_assembly/door_assembly_highsecurity(src.loc)
-					if(34) new/obj/structure/door_assembly/door_assembly_shuttle(src.loc)
-					if(35) new/obj/structure/door_assembly/door_assembly_wood(src.loc)
-					if(36) new/obj/structure/door_assembly/door_assembly_viro(src.loc)
-					if(37) new/obj/structure/door_assembly/door_assembly_viro/glass(src.loc)
-				if(emagged)
-					user << "<span class='warning'>You discard the damaged electronics.</span>"
+				if(src.loc)
+					switch(src.doortype)
+						if(0) new/obj/structure/door_assembly/door_assembly_0( src.loc )
+						if(1) new/obj/structure/door_assembly/door_assembly_com( src.loc )
+						if(2) new/obj/structure/door_assembly/door_assembly_sec( src.loc )
+						if(3) new/obj/structure/door_assembly/door_assembly_eng( src.loc )
+						if(4) new/obj/structure/door_assembly/door_assembly_med( src.loc )
+						if(5) new/obj/structure/door_assembly/door_assembly_mai( src.loc )
+						if(6) new/obj/structure/door_assembly/door_assembly_ext( src.loc )
+						if(7) new/obj/structure/door_assembly/door_assembly_glass( src.loc )
+						//8 is centcom
+						if(9) new/obj/structure/door_assembly/door_assembly_vault(loc)
+						//10 is double glass door (2x1)
+						//11 is freezer
+						if(12) new/obj/structure/door_assembly/door_assembly_hatch( src.loc )
+						if(13) new/obj/structure/door_assembly/door_assembly_mhatch( src.loc )
+						if(14) new/obj/structure/door_assembly/door_assembly_com/glass( src.loc )
+						if(15) new/obj/structure/door_assembly/door_assembly_eng/glass( src.loc )
+						if(16) new/obj/structure/door_assembly/door_assembly_sec/glass( src.loc )
+						if(17) new/obj/structure/door_assembly/door_assembly_med/glass( src.loc )
+						if(18) new/obj/structure/door_assembly/door_assembly_min( src.loc )
+						if(19) new/obj/structure/door_assembly/door_assembly_atmo( src.loc )
+						if(20) new/obj/structure/door_assembly/door_assembly_research( src.loc )
+						if(21) new/obj/structure/door_assembly/door_assembly_research/glass( src.loc )
+						if(22) new/obj/structure/door_assembly/door_assembly_min/glass( src.loc )
+						if(23) new/obj/structure/door_assembly/door_assembly_atmo/glass( src.loc )
+						if(24) new/obj/structure/door_assembly/door_assembly_gold( src.loc )
+						if(25) new/obj/structure/door_assembly/door_assembly_silver( src.loc )
+						if(26) new/obj/structure/door_assembly/door_assembly_diamond( src.loc )
+						if(27) new/obj/structure/door_assembly/door_assembly_uranium( src.loc )
+						if(28) new/obj/structure/door_assembly/door_assembly_plasma( src.loc )
+						if(29) new/obj/structure/door_assembly/door_assembly_clown( src.loc )
+						if(30) new/obj/structure/door_assembly/door_assembly_sandstone( src.loc )
+						if(31) new/obj/structure/door_assembly/door_assembly_science( src.loc )
+						if(32) new/obj/structure/door_assembly/door_assembly_science/glass( src.loc )
+						if(33) new/obj/structure/door_assembly/door_assembly_highsecurity(src.loc)
+						if(34) new/obj/structure/door_assembly/door_assembly_shuttle(src.loc)
+						if(35) new/obj/structure/door_assembly/door_assembly_wood(src.loc)
+						if(36) new/obj/structure/door_assembly/door_assembly_viro(src.loc)
+						if(37) new/obj/structure/door_assembly/door_assembly_viro/glass(src.loc)
+					if(emagged)
+						user << "<span class='warning'>You discard the damaged electronics.</span>"
+						qdel(src)
+						return
+					user << "<span class='notice'>You removed the airlock electronics!</span>"
+
+					var/obj/item/weapon/airlock_electronics/ae
+					if(!electronics)
+						ae = new/obj/item/weapon/airlock_electronics( src.loc )
+						if(req_one_access)
+							ae.use_one_access = 1
+							ae.conf_access = src.req_one_access
+						else
+							ae.conf_access = src.req_access
+					else
+						ae = electronics
+						electronics = null
+						ae.loc = src.loc
+
 					qdel(src)
 					return
-				user << "<span class='notice'>You removed the airlock electronics!</span>"
-
-				var/obj/item/weapon/airlock_electronics/ae
-				if(!electronics)
-					ae = new/obj/item/weapon/airlock_electronics( src.loc )
-					if(req_one_access)
-						ae.use_one_access = 1
-						ae.conf_access = src.req_one_access
-					else
-						ae.conf_access = src.req_access
-				else
-					ae = electronics
-					electronics = null
-					ae.loc = src.loc
-
-				qdel(src)
-				return
 		else if(hasPower())
 			user << "<span class='warning'> The airlock's motors resist your efforts to force it.</span>"
 		else if(locked)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,7 +39,7 @@
 	var/obj/machinery/door/airlock/closeOther = null
 	var/closeOtherId = null
 	var/lockdownbyai = 0
-	var/doortype = 0
+	var/doortype = null
 	var/justzap = 0
 	var/safe = 1
 	normalspeed = 1
@@ -49,53 +49,53 @@
 
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/Doorcom.dmi'
-	doortype = 1
+	doortype = /obj/structure/door_assembly/door_assembly_com
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/Doorsec.dmi'
-	doortype = 2
+	doortype = /obj/structure/door_assembly/door_assembly_sec
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/Dooreng.dmi'
-	doortype = 3
+	doortype = /obj/structure/door_assembly/door_assembly_eng
 
 /obj/machinery/door/airlock/medical
 	icon = 'icons/obj/doors/Doormed.dmi'
-	doortype = 4
+	doortype = /obj/structure/door_assembly/door_assembly_med
 
 /obj/machinery/door/airlock/maintenance
 	name = "maintenance access"
 	icon = 'icons/obj/doors/Doormaint.dmi'
-	doortype = 5
+	doortype = /obj/structure/door_assembly/door_assembly_mai
 
 /obj/machinery/door/airlock/external
 	name = "external airlock"
 	icon = 'icons/obj/doors/Doorext.dmi'
-	doortype = 6
+	doortype = /obj/structure/door_assembly/door_assembly_ext
 
 /obj/machinery/door/airlock/glass
 	name = "glass airlock"
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	opacity = 0
-	doortype = 7
+	doortype = /obj/structure/door_assembly/door_assembly_glass
 	glass = 1
 
 /obj/machinery/door/airlock/centcom
 	icon = 'icons/obj/doors/Doorele.dmi'
 	opacity = 1
-	doortype = 8
+	doortype = null //(centcom) there's no door assembly sprites for this one.
 
 /obj/machinery/door/airlock/vault
 	name = "vault door"
 	icon = 'icons/obj/doors/vault.dmi'
 	opacity = 1
-	doortype = 9
+	doortype = /obj/structure/door_assembly/door_assembly_vault
 
 /obj/machinery/door/airlock/glass_large
 	name = "glass airlock"
 	icon = 'icons/obj/doors/Door2x1glassfull.dmi'
 	opacity = 0
-	doortype = 10
+	doortype = null //(double glass door) there's no door assembly sprites for this one.
 	glass = 1
 	bound_width = 64 // 2x1
 
@@ -103,67 +103,67 @@
 	name = "freezer airlock"
 	icon = 'icons/obj/doors/Doorfreezer.dmi'
 	opacity = 1
-	doortype = 11
+	doortype = /obj/structure/door_assembly/door_assembly_fre
 
 /obj/machinery/door/airlock/hatch
 	name = "airtight hatch"
 	icon = 'icons/obj/doors/Doorhatchele.dmi'
 	opacity = 1
-	doortype = 12
+	doortype = /obj/structure/door_assembly/door_assembly_hatch
 
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorhatchmaint2.dmi'
 	opacity = 1
-	doortype = 13
+	doortype = /obj/structure/door_assembly/door_assembly_mhatch
 
 /obj/machinery/door/airlock/glass_command
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorcomglass.dmi'
 	opacity = 0
-	doortype = 14
+	doortype = /obj/structure/door_assembly/door_assembly_com/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_engineering
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorengglass.dmi'
 	opacity = 0
-	doortype = 15
+	doortype = /obj/structure/door_assembly/door_assembly_eng/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_security
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorsecglass.dmi'
 	opacity = 0
-	doortype = 16
+	doortype = /obj/structure/door_assembly/door_assembly_sec/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_medical
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doormedglass.dmi'
 	opacity = 0
-	doortype = 17
+	doortype = /obj/structure/door_assembly/door_assembly_med/glass
 	glass = 1
 
 /obj/machinery/door/airlock/mining
 	name = "mining airlock"
 	icon = 'icons/obj/doors/Doormining.dmi'
-	doortype = 18
+	doortype = /obj/structure/door_assembly/door_assembly_min
 
 /obj/machinery/door/airlock/atmos
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/Dooratmo.dmi'
-	doortype = 19
+	doortype = /obj/structure/door_assembly/door_assembly_atmo
 
 /obj/machinery/door/airlock/research
 	icon = 'icons/obj/doors/Doorresearch.dmi'
-	doortype = 20
+	doortype = /obj/structure/door_assembly/door_assembly_research
 
 /obj/machinery/door/airlock/glass_research
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorresearchglass.dmi'
 	opacity = 0
-	doortype = 21
+	doortype = /obj/structure/door_assembly/door_assembly_research/glass
 	glass = 1
 	heat_proof = 1
 
@@ -171,40 +171,40 @@
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Doorminingglass.dmi'
 	opacity = 0
-	doortype = 22
+	doortype = /obj/structure/door_assembly/door_assembly_min/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_atmos
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/Dooratmoglass.dmi'
 	opacity = 0
-	doortype = 23
+	doortype = /obj/structure/door_assembly/door_assembly_atmo/glass
 	glass = 1
 
 /obj/machinery/door/airlock/gold
 	name = "gold airlock"
 	icon = 'icons/obj/doors/Doorgold.dmi'
 	var/mineral = "gold"
-	doortype = 24
+	doortype = /obj/structure/door_assembly/door_assembly_gold
 
 /obj/machinery/door/airlock/silver
 	name = "silver airlock"
 	icon = 'icons/obj/doors/Doorsilver.dmi'
 	var/mineral = "silver"
-	doortype = 25
+	doortype = /obj/structure/door_assembly/door_assembly_silver
 
 /obj/machinery/door/airlock/diamond
 	name = "diamond airlock"
 	icon = 'icons/obj/doors/Doordiamond.dmi'
 	var/mineral = "diamond"
-	doortype = 26
+	doortype = /obj/structure/door_assembly/door_assembly_diamond
 
 /obj/machinery/door/airlock/uranium
 	name = "uranium airlock"
 	desc = "And they said I was crazy."
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	var/mineral = "uranium"
-	doortype = 27
+	doortype = /obj/structure/door_assembly/door_assembly_uranium
 	var/last_event = 0
 
 /obj/machinery/door/airlock/uranium/process()
@@ -224,7 +224,7 @@
 	desc = "No way this can end badly."
 	icon = 'icons/obj/doors/Doorplasma.dmi'
 	var/mineral = "plasma"
-	doortype = 28
+	doortype = /obj/structure/door_assembly/door_assembly_plasma
 
 /obj/machinery/door/airlock/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
@@ -247,49 +247,49 @@
 	desc = "Honkhonkhonk"
 	icon = 'icons/obj/doors/Doorbananium.dmi'
 	var/mineral = "clown"
-	doortype = 29
+	doortype = /obj/structure/door_assembly/door_assembly_clown
 
 /obj/machinery/door/airlock/sandstone
 	name = "sandstone airlock"
 	icon = 'icons/obj/doors/Doorsand.dmi'
 	var/mineral = "sandstone"
-	doortype = 30
+	doortype = /obj/structure/door_assembly/door_assembly_sandstone
 
 /obj/machinery/door/airlock/science
 	icon = 'icons/obj/doors/Doorsci.dmi'
-	doortype = 31
+	doortype = /obj/structure/door_assembly/door_assembly_science
 
 /obj/machinery/door/airlock/glass_science
 	name = "glass airlock"
 	icon = 'icons/obj/doors/Doorsciglass.dmi'
 	opacity = 0
-	doortype = 32
+	doortype = /obj/structure/door_assembly/door_assembly_science/glass
 	glass = 1
 
 /obj/machinery/door/airlock/highsecurity
 	name = "high tech security airlock"
 	icon = 'icons/obj/doors/hightechsecurity.dmi'
-	doortype = 33
+	doortype = /obj/structure/door_assembly/door_assembly_highsecurity
 
 /obj/machinery/door/airlock/shuttle
 	name = "shuttle airlock"
 	icon = 'icons/obj/doors/doorshuttle.dmi'
-	doortype = 34
+	doortype = /obj/structure/door_assembly/door_assembly_shuttle
 
 /obj/machinery/door/airlock/wood
 	name = "wooden airlock"
 	icon = 'icons/obj/doors/Doorwood.dmi'
 	var/mineral = "wood"
-	doortype = 35
+	doortype = /obj/structure/door_assembly/door_assembly_wood
 
 /obj/machinery/door/airlock/virology
 	icon = 'icons/obj/doors/Doorviro.dmi'
-	doortype = 36
+	doortype = /obj/structure/door_assembly/door_assembly_viro
 
 /obj/machinery/door/airlock/glass_virology
 	icon = 'icons/obj/doors/Doorviroglass.dmi'
 	opacity = 0
-	doortype = 37
+	doortype = /obj/structure/door_assembly/door_assembly_viro/glass
 	glass = 1
 
 /*
@@ -927,45 +927,9 @@ About the new airlock wires panel:
 								 "You start to remove electronics from the airlock assembly.")
 			if(do_after(user,40))
 				if(src.loc)
-					switch(src.doortype)
-						if(0) new/obj/structure/door_assembly/door_assembly_0( src.loc )
-						if(1) new/obj/structure/door_assembly/door_assembly_com( src.loc )
-						if(2) new/obj/structure/door_assembly/door_assembly_sec( src.loc )
-						if(3) new/obj/structure/door_assembly/door_assembly_eng( src.loc )
-						if(4) new/obj/structure/door_assembly/door_assembly_med( src.loc )
-						if(5) new/obj/structure/door_assembly/door_assembly_mai( src.loc )
-						if(6) new/obj/structure/door_assembly/door_assembly_ext( src.loc )
-						if(7) new/obj/structure/door_assembly/door_assembly_glass( src.loc )
-						//8 is centcom
-						if(9) new/obj/structure/door_assembly/door_assembly_vault(loc)
-						//10 is double glass door (2x1)
-						//11 is freezer
-						if(12) new/obj/structure/door_assembly/door_assembly_hatch( src.loc )
-						if(13) new/obj/structure/door_assembly/door_assembly_mhatch( src.loc )
-						if(14) new/obj/structure/door_assembly/door_assembly_com/glass( src.loc )
-						if(15) new/obj/structure/door_assembly/door_assembly_eng/glass( src.loc )
-						if(16) new/obj/structure/door_assembly/door_assembly_sec/glass( src.loc )
-						if(17) new/obj/structure/door_assembly/door_assembly_med/glass( src.loc )
-						if(18) new/obj/structure/door_assembly/door_assembly_min( src.loc )
-						if(19) new/obj/structure/door_assembly/door_assembly_atmo( src.loc )
-						if(20) new/obj/structure/door_assembly/door_assembly_research( src.loc )
-						if(21) new/obj/structure/door_assembly/door_assembly_research/glass( src.loc )
-						if(22) new/obj/structure/door_assembly/door_assembly_min/glass( src.loc )
-						if(23) new/obj/structure/door_assembly/door_assembly_atmo/glass( src.loc )
-						if(24) new/obj/structure/door_assembly/door_assembly_gold( src.loc )
-						if(25) new/obj/structure/door_assembly/door_assembly_silver( src.loc )
-						if(26) new/obj/structure/door_assembly/door_assembly_diamond( src.loc )
-						if(27) new/obj/structure/door_assembly/door_assembly_uranium( src.loc )
-						if(28) new/obj/structure/door_assembly/door_assembly_plasma( src.loc )
-						if(29) new/obj/structure/door_assembly/door_assembly_clown( src.loc )
-						if(30) new/obj/structure/door_assembly/door_assembly_sandstone( src.loc )
-						if(31) new/obj/structure/door_assembly/door_assembly_science( src.loc )
-						if(32) new/obj/structure/door_assembly/door_assembly_science/glass( src.loc )
-						if(33) new/obj/structure/door_assembly/door_assembly_highsecurity(src.loc)
-						if(34) new/obj/structure/door_assembly/door_assembly_shuttle(src.loc)
-						if(35) new/obj/structure/door_assembly/door_assembly_wood(src.loc)
-						if(36) new/obj/structure/door_assembly/door_assembly_viro(src.loc)
-						if(37) new/obj/structure/door_assembly/door_assembly_viro/glass(src.loc)
+					if(src.doortype)
+						new src.doortype(src.loc)
+
 					if(emagged)
 						user << "<span class='warning'>You discard the damaged electronics.</span>"
 						qdel(src)
@@ -1132,35 +1096,35 @@ About the new airlock wires panel:
 		switch(paintjob)
 			if("Default")
 				icon = 'icons/obj/doors/Doorglass.dmi'
-				doortype = 7
+				doortype = /obj/structure/door_assembly/door_assembly_glass
 				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Doorengglass.dmi'
-				doortype = 15
+				doortype = /obj/structure/door_assembly/door_assembly_eng/glass
 				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmoglass.dmi'
-				doortype = 23
+				doortype = /obj/structure/door_assembly/door_assembly_atmo/glass
 				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsecglass.dmi'
-				doortype = 16
+				doortype = /obj/structure/door_assembly/door_assembly_sec/glass
 				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcomglass.dmi'
-				doortype = 14
+				doortype = /obj/structure/door_assembly/door_assembly_com/glass
 				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormedglass.dmi'
-				doortype = 17
+				doortype = /obj/structure/door_assembly/door_assembly_med/glass
 				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearchglass.dmi'
-				doortype = 21
+				doortype = /obj/structure/door_assembly/door_assembly_research/glass
 				heat_proof = 1
 			if("Mining")
 				icon = 'icons/obj/doors/Doorminingglass.dmi'
-				doortype = 22
+				doortype = /obj/structure/door_assembly/door_assembly_min/glass
 				heat_proof = 0
 	else
 		//These airlocks have a regular version.
@@ -1170,47 +1134,47 @@ About the new airlock wires panel:
 		switch(paintjob)
 			if("Default")
 				icon = 'icons/obj/doors/Doorint.dmi'
-				doortype = 0
+				doortype = /obj/structure/door_assembly/door_assembly_0
 				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Dooreng.dmi'
-				doortype = 3
+				doortype = /obj/structure/door_assembly/door_assembly_eng
 				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmo.dmi'
-				doortype = 19
+				doortype = /obj/structure/door_assembly/door_assembly_atmo
 				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsec.dmi'
-				doortype = 2
+				doortype = /obj/structure/door_assembly/door_assembly_sec
 				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcom.dmi'
-				doortype = 1
+				doortype = /obj/structure/door_assembly/door_assembly_com
 				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormed.dmi'
-				doortype = 4
+				doortype = /obj/structure/door_assembly/door_assembly_med
 				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearch.dmi'
-				doortype = 20
+				doortype = /obj/structure/door_assembly/door_assembly_research
 				heat_proof = 0
 			if("Mining")
 				icon = 'icons/obj/doors/Doormining.dmi'
-				doortype = 18
+				doortype = /obj/structure/door_assembly/door_assembly_min
 				heat_proof = 0
 			if("Maintenance")
 				icon = 'icons/obj/doors/Doormaint.dmi'
-				doortype = 5
+				doortype = /obj/structure/door_assembly/door_assembly_mai
 				heat_proof = 0
 			if("External")
 				icon = 'icons/obj/doors/Doorext.dmi'
-				doortype = 6
+				doortype = /obj/structure/door_assembly/door_assembly_ext
 				heat_proof = 0
 			if("High Security")
 				icon = 'icons/obj/doors/hightechsecurity.dmi'
-				doortype = 33
+				doortype = /obj/structure/door_assembly/door_assembly_highsecurity
 				heat_proof = 0
 	update_icon()
 

--- a/code/game/machinery/doors/alarmlock.dm
+++ b/code/game/machinery/doors/alarmlock.dm
@@ -3,7 +3,7 @@
 	name = "glass alarm airlock"
 	icon = 'icons/obj/doors/Doorglass.dmi'
 	opacity = 0
-	doortype = 7
+	doortype = /obj/structure/door_assembly/door_assembly_glass
 	glass = 1
 
 	var/datum/radio_frequency/air_connection

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -440,7 +440,8 @@ obj/structure/door_assembly/New()
 	else if(istype(W, /obj/item/weapon/weldingtool) && !anchored )
 		var/obj/item/weapon/weldingtool/WT = W
 		if(WT.remove_fuel(0,user))
-			user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
+			user.visible_message("<span class='warning'>[user] dissassembles the airlock assembly.</span>", \
+								"You start to dissassemble the airlock assembly.")
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 
 			if(do_after(user, 40))
@@ -461,7 +462,9 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/wrench) && !anchored )
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user.visible_message("[user] secures the airlock assembly to the floor.", "You start to secure the airlock assembly to the floor.")
+		user.visible_message("<span class='warning'>[user] secures the airlock assembly to the floor.</span>", \
+							 "You start to secure the airlock assembly to the floor.", \
+							 "You hear wrenching")
 
 		if(do_after(user, 40))
 			if( src.anchored )
@@ -472,7 +475,9 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/wrench) && anchored )
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user.visible_message("[user] unsecures the airlock assembly from the floor.", "You start to unsecure the airlock assembly from the floor.")
+		user.visible_message("<span class='warning'>[user] unsecures the airlock assembly from the floor.</span>", \
+							 "You start to unsecure the airlock assembly from the floor.", \
+							 "You hear wrenching")
 		if(do_after(user, 40))
 			if( !src.anchored )
 				return
@@ -485,7 +490,8 @@ obj/structure/door_assembly/New()
 		if (C.get_amount() < 1)
 			user << "<span class='warning'>You need one length of cable to wire the airlock assembly.</span>"
 			return
-		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
+		user.visible_message("<span class='warning'>[user] wires the airlock assembly.</span>", \
+							"You start to wire the airlock assembly.")
 		if(do_after(user, 40))
 			if(C.get_amount() < 1 || state != 0) return
 			C.use(1)
@@ -495,7 +501,8 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/wirecutters) && state == 1 )
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
+		user.visible_message("<span class='warning'>[user] cuts the wires from the airlock assembly.</span>", \
+							"You start to cut the wires from the airlock assembly.")
 
 		if(do_after(user, 40))
 			if( src.state != 1 )
@@ -507,12 +514,14 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/airlock_electronics) && state == 1 )
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+		user.visible_message("<span class='warning'>[user] installs the electronics into the airlock assembly.</span>", \
+							"You start to install electronics into the airlock assembly.")
 		user.drop_item()
 		W.loc = src
 
 		if(do_after(user, 40))
 			if( src.state != 1 )
+				W.loc = src.loc
 				return
 			user << "<span class='notice'> You've installed the airlock electronics.</span>"
 			src.state = 2
@@ -525,7 +534,8 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/crowbar) && state == 2 )
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove the electronics from the airlock assembly.")
+		user.visible_message("<span class='warning'>[user] removes the electronics from the airlock assembly.</span>", \
+								"You start to remove electronics from the airlock assembly.")
 
 		if(do_after(user, 40))
 			if( src.state != 2 )
@@ -546,7 +556,8 @@ obj/structure/door_assembly/New()
 			if(G.get_amount() >= 1)
 				if(G.type == /obj/item/stack/sheet/rglass)
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-					user.visible_message("[user] adds [G.name] to the airlock assembly.", "You start to install [G.name] into the airlock assembly.")
+					user.visible_message("<span class='warning'>[user] adds [G.name] to the airlock assembly.</span>", \
+										"You start to install [G.name] into the airlock assembly.")
 					if(do_after(user, 40))
 						if(G.get_amount() < 1 || mineral) return
 						user << "<span class='notice'>You've installed reinforced glass windows into the airlock assembly.</span>"
@@ -569,7 +580,8 @@ obj/structure/door_assembly/New()
 					var/M = G.sheettype
 					if(G.get_amount() >= 2)
 						playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-						user.visible_message("[user] adds [G.name] to the airlock assembly.", "You start to install [G.name] into the airlock assembly.")
+						user.visible_message("<span class='warning'>[user] adds [G.name] to the airlock assembly.</span>", \
+										 "You start to install [G.name] into the airlock assembly.")
 						if(do_after(user, 40))
 							if(G.get_amount() < 2 || mineral) return
 							user << "<span class='notice'>You've installed [M] plating into the airlock assembly.</span>"
@@ -583,25 +595,27 @@ obj/structure/door_assembly/New()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && state == 2 )
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] finishes the airlock.", "You start finishing the airlock.")
+		user.visible_message("<span class='warning'>[user] finishes the airlock.</span>", \
+							 "You start finishing the airlock.")
 
 		if(do_after(user, 40))
-			user << "<span class='notice'> You've finished the airlock.</span>"
-			var/obj/machinery/door/airlock/door
-			if(mineral == "glass")
-				door = new src.glass_type( src.loc )
-			else
-				door = new src.airlock_type( src.loc )
-			//door.req_access = src.req_access
-			door.electronics = src.electronics
-			if(src.electronics.use_one_access)
-				door.req_one_access = src.electronics.conf_access
-			else
-				door.req_access = src.electronics.conf_access
-			if(created_name)
-				door.name = created_name
-			src.electronics.loc = door
-			qdel(src)
+			if(state == 2)
+				user << "<span class='notice'> You've finished the airlock.</span>"
+				var/obj/machinery/door/airlock/door
+				if(mineral == "glass")
+					door = new src.glass_type( src.loc )
+				else
+					door = new src.airlock_type( src.loc )
+				//door.req_access = src.req_access
+				door.electronics = src.electronics
+				if(src.electronics.use_one_access)
+					door.req_one_access = src.electronics.conf_access
+				else
+					door.req_access = src.electronics.conf_access
+				if(created_name)
+					door.name = created_name
+				src.electronics.loc = door
+				qdel(src)
 	else
 		..()
 	if(mineral == "glass")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -383,29 +383,30 @@
 	if (istype(W, /obj/item/weapon/crowbar) && opened)
 		if (has_electronics==1)
 			if (terminal)
-				user << "<span class='danger'>Disconnect wires first.</span>"
+				user << "<span class='warning'>Disconnect wires first.</span>"
 				return
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
 			user << "You are trying to remove the power control board..." //lpeters - fixed grammar issues
 			if(do_after(user, 50))
-				has_electronics = 0
-				if ((stat & BROKEN) || malfhack)
-					user.visible_message(\
-						"<span class='danger'>[user.name] has broken the power control board inside [src.name]!</span>",\
-						"You broke the charred power control board and remove the remains.",
-						"You hear a crack!")
-					//ticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
-				else
-					user.visible_message(\
-						"<span class='danger'>[user.name] has removed the power control board from [src.name]!</span>",\
-						"You remove the power control board.")
-					new /obj/item/weapon/module/power_control(loc)
+				if (has_electronics==1)
+					has_electronics = 0
+					if ((stat & BROKEN) || malfhack)
+						user.visible_message(\
+							"<span class='warning'>[user.name] has broken the power control board inside [src.name]!</span>",\
+							"<span class='notice'>You broke the charred power control board and remove the remains.</span>",
+							"You hear a crack!")
+						//ticker.mode:apcs-- //XSI said no and I agreed. -rastaf0
+					else
+						user.visible_message(\
+							"<span class='warning'>[user.name] has removed the power control board from [src.name]!</span>",\
+							"<span class='notice'>You remove the power control board.</span>")
+						new /obj/item/weapon/module/power_control(loc)
 		else if (opened!=2) //cover isn't removed
 			opened = 0
 			update_icon()
 	else if (istype(W, /obj/item/weapon/crowbar) && !((stat & BROKEN) || malfhack) )
 		if(coverlocked && !(stat & MAINT))
-			user << "<span class='danger'>The cover is locked and cannot be opened.</span>"
+			user << "<span class='warning'>The cover is locked and cannot be opened.</span>"
 			return
 		else
 			opened = 1
@@ -416,20 +417,20 @@
 			return
 		else
 			if (stat & MAINT)
-				user << "<span class='danger'>There is no connector for your power cell.</span>"
+				user << "<span class='warning'>There is no connector for your power cell.</span>"
 				return
 			user.drop_item()
 			W.loc = src
 			cell = W
 			user.visible_message(\
-				"<span class='danger'>[user.name] has inserted the power cell to [src.name]!</span>",\
-				"You insert the power cell.")
+				"<span class='warning'>[user.name] has inserted the power cell to [src.name]!</span>",\
+				"<span class='warning'>You insert the power cell.</span>")
 			chargecount = 0
 			update_icon()
 	else if	(istype(W, /obj/item/weapon/screwdriver))	// haxing
 		if(opened)
 			if (cell)
-				user << "<span class='danger'>Close the APC first.</span>" //Less hints more mystery!
+				user << "<span class='warning'>Close the APC first.</span>" //Less hints more mystery!
 				return
 			else
 				if (has_electronics==1 && terminal)
@@ -443,7 +444,7 @@
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 					user << "You unfasten the electronics."
 				else /* has_electronics==0 */
-					user << "<span class='danger'>There is nothing to secure.</span>"
+					user << "<span class='warning'>There is nothing to secure.</span>"
 					return
 				update_icon()
 		else if(emagged)
@@ -468,7 +469,7 @@
 				user << "You [ locked ? "lock" : "unlock"] the APC interface."
 				update_icon()
 			else
-				user << "<span class='danger'>Access denied.</span>"
+				user << "<span class='warning'>Access denied.</span>"
 	else if (istype(W, /obj/item/weapon/card/emag) && !(emagged || malfhack))		// trying to unlock with an emag card
 		if(opened)
 			user << "You must close the cover to swipe an ID card."
@@ -482,10 +483,10 @@
 				if(prob(50))
 					emagged = 1
 					locked = 0
-					user << "You emag the APC interface."
+					user << "<span class='notice'>You emag the APC interface.</span>"
 					update_icon()
 				else
-					user << "You fail to [ locked ? "unlock" : "lock"] the APC interface."
+					user << "<span class='warning'>You fail to [ locked ? "unlock" : "lock"] the APC interface.</span>"
 	else if (istype(W, /obj/item/stack/cable_coil) && !terminal && opened && has_electronics!=2)
 		if (src.loc:intact)
 			user << "<span class='warning'>You must remove the floor plating in front of the APC first.</span>"
@@ -494,7 +495,8 @@
 		if(C.get_amount() < 10)
 			user << "<span class='warning'>You need ten lengths of cable for APC.</span>"
 			return
-		user << "You start adding cables to the APC frame..."
+		user.visible_message("<span class='warning'>[user.name] adds cables to the APC frame.</span>", \
+							"You start adding cables to the APC frame...")
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 20))
 			if (C.amount >= 10 && !terminal && opened && has_electronics != 2)
@@ -506,59 +508,59 @@
 					s.start()
 					return
 				C.use(10)
-				user.visible_message(\
-					"<span class='danger'>[user.name] has added cables to the APC frame!</span>",\
-					"You add cables to the APC frame.")
+				user << "<span class='notice'>You add cables to the APC frame.</span>"
 				make_terminal()
 				terminal.connect_to_network()
 	else if (istype(W, /obj/item/weapon/wirecutters) && terminal && opened && has_electronics!=2)
 		if (src.loc:intact)
-			user << "<span class='danger'>You must remove the floor plating in front of the APC first.</span>"
+			user << "<span class='warning'>You must remove the floor plating in front of the APC first.</span>"
 			return
-		user << "You begin to cut the cables..."
+		user.visible_message("<span class='warning'>[user.name] dismantles the power terminal from [src].</span>", \
+							"You begin to cut the cables...")
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 50))
-			if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
-				return
-			new /obj/item/stack/cable_coil(loc,10)
-			user.visible_message(\
-				"<span class='danger'>[user.name] cut the cables and dismantled the power terminal.</span>",\
-				"You cut the cables and dismantle the power terminal.")
-			qdel(terminal)
+			if(terminal && opened && has_electronics!=2)
+				if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
+					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+					s.set_up(5, 1, src)
+					s.start()
+					return
+				new /obj/item/stack/cable_coil(loc,10)
+				user << "<span class='notice'>You cut the cables and dismantle the power terminal.</span>"
+				qdel(terminal)
 	else if (istype(W, /obj/item/weapon/module/power_control) && opened && has_electronics==0 && !((stat & BROKEN) || malfhack))
-		user << "You trying to insert the power control board into the frame..."
+		user.visible_message("<span class='warning'>[user.name] inserts the power control board into [src].</span>", \
+							"You start to insert the power control board into the frame...")
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		if(do_after(user, 10))
-			has_electronics = 1
-			user << "You place the power control board inside the frame."
-			qdel(W)
+			if(has_electronics==0)
+				has_electronics = 1
+				user << "<span class='notice'>You place the power control board inside the frame.</span>"
+				qdel(W)
 	else if (istype(W, /obj/item/weapon/module/power_control) && opened && has_electronics==0 && ((stat & BROKEN) || malfhack))
-		user << "<span class='danger'>You cannot put the board inside, the frame is damaged.</span>"
+		user << "<span class='warning'>You cannot put the board inside, the frame is damaged.</span>"
 		return
 	else if (istype(W, /obj/item/weapon/weldingtool) && opened && has_electronics==0 && !terminal)
 		var/obj/item/weapon/weldingtool/WT = W
 		if (WT.get_fuel() < 3)
-			user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
+			user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
 			return
-		user << "You start welding the APC frame..."
+		user.visible_message("<span class='warning'>[user.name] welds [src].</span>", \
+							"You start welding the APC frame...", \
+							"You hear welding.")
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 		if(do_after(user, 50))
 			if(!src || !WT.remove_fuel(3, user)) return
 			if (emagged || malfhack || (stat & BROKEN) || opened==2)
 				new /obj/item/stack/sheet/metal(loc)
 				user.visible_message(\
-					"<span class='danger'>[src] has been cut apart by [user.name] with the weldingtool.</span>",\
-					"You disassembled the broken APC frame.",\
-					"<span class='danger'>You hear welding.</span>")
+					"<span class='warning'>[src] has been cut apart by [user.name] with the weldingtool.</span>",\
+					"<span class='notice'>You disassembled the broken APC frame.</span>")
 			else
 				new /obj/item/apc_frame(loc)
 				user.visible_message(\
-					"<span class='danger'>[src] has been cut from the wall by [user.name] with the weldingtool.</span>",\
-					"You cut the APC frame from the wall.",\
-					"<span class='danger'>You hear welding.</span>")
+					"<span class='warning'>[src] has been cut from the wall by [user.name] with the weldingtool.</span>",\
+					"<span class='notice'>You cut the APC frame from the wall.</span>")
 			qdel(src)
 			return
 	else if (istype(W, /obj/item/apc_frame) && opened && emagged)
@@ -566,19 +568,18 @@
 		if (opened==2)
 			opened = 1
 		user.visible_message(\
-			"<span class='danger'>[user.name] has replaced the damaged APC frontal panel with a new one.</span>",\
-			"You replace the damaged APC frontal panel with a new one.")
+			"<span class='warning'>[user.name] has replaced the damaged APC frontal panel with a new one.</span>",\
+			"<span class='notice'>You replace the damaged APC frontal panel with a new one.</span>")
 		qdel(W)
 		update_icon()
 	else if (istype(W, /obj/item/apc_frame) && opened && ((stat & BROKEN) || malfhack))
 		if (has_electronics)
-			user << "You cannot repair this APC until you remove the electronics still inside."
+			user << "<span class='warning'>You cannot repair this APC until you remove the electronics still inside.</span>"
 			return
-		user << "You begin to replace the damaged APC frame..."
+		user.visible_message("<span class='warning'>[user.name] replaces the damaged APC frame with a new one.</span>",\
+							"You begin to replace the damaged APC frame...")
 		if(do_after(user, 50))
-			user.visible_message(\
-				"<span class='danger'>[user.name] has replaced the damaged APC frame with new one.</span>",\
-				"You replace the damaged APC frame with new one.")
+			user << "<span class='notice'>You've replaced the damaged APC frame with a new one.</span>"
 			qdel(W)
 			stat &= ~BROKEN
 			malfai = null
@@ -623,7 +624,8 @@
 			cell.updateicon()
 
 			src.cell = null
-			user.visible_message("<span class='danger'>[user.name] removes the power cell from [src.name]!</span>", "You remove the power cell.")
+			user.visible_message("<span class='warning'>[user.name] removes the power cell from [src.name]!</span>",\
+								 "<span class='notice'>You remove the power cell.</span>")
 			//user << "You remove the power cell."
 			charging = 0
 			src.update_icon()
@@ -768,18 +770,18 @@
 
 /obj/machinery/power/apc/proc/can_use(mob/user as mob, var/loud = 0) //used by attack_hand() and Topic()
 	if (user.stat)
-		user << "<span class='danger'>You must be conscious to use this [src]!</span>"
+		user << "<span class='warning'>You must be conscious to use this [src]!</span>"
 		return 0
 	if(!user.client)
 		return 0
 	if(!user.IsAdvancedToolUser())
-		user << "<span class='danger'>You don't have the dexterity to use this [src]!</span>"
+		user << "<span class='warning'>You don't have the dexterity to use this [src]!</span>"
 		return 0
 	if(user.restrained())
-		user << "<span class='danger'>You must have free hands to use this [src].</span>"
+		user << "<span class='warning'>You must have free hands to use this [src].</span>"
 		return 0
 	if(user.lying)
-		user << "<span class='danger'>You must stand to use this [src]!</span>"
+		user << "<span class='warning'>You must stand to use this [src]!</span>"
 		return 0
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
@@ -802,8 +804,7 @@
 	var/mob/living/carbon/human/H = user
 	if (istype(H))
 		if(H.getBrainLoss() >= 60)
-			for(var/mob/M in viewers(src, null))
-				M << "<span class='danger'>[H] stares cluelessly at [src] and drools.</span>"
+			H.visible_message("<span class='danger'>[H] stares cluelessly at [src] and drools.</span>")
 			return 0
 		else if(prob(H.getBrainLoss()))
 			user << "<span class='danger'>You momentarily forget how to use [src].</span>"
@@ -979,8 +980,8 @@
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 				s.set_up(3, 1, src)
 				s.start()
-				for(var/mob/M in viewers(src))
-					M.show_message("<span class='danger'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", 3, "<span class='danger'>You hear sizzling electronics.</span>", 2)
+				visible_message("<span class='danger'>The [src.name] suddenly lets out a blast of smoke and some sparks!</span>", \
+								"<span class='danger'>You hear sizzling electronics.</span>")
 
 
 /obj/machinery/power/apc/surplus()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -424,7 +424,7 @@
 			cell = W
 			user.visible_message(\
 				"<span class='warning'>[user.name] has inserted the power cell to [src.name]!</span>",\
-				"<span class='warning'>You insert the power cell.</span>")
+				"<span class='notice'>You insert the power cell.</span>")
 			chargecount = 0
 			update_icon()
 	else if	(istype(W, /obj/item/weapon/screwdriver))	// haxing
@@ -770,18 +770,18 @@
 
 /obj/machinery/power/apc/proc/can_use(mob/user as mob, var/loud = 0) //used by attack_hand() and Topic()
 	if (user.stat)
-		user << "<span class='warning'>You must be conscious to use this [src]!</span>"
+		user << "<span class='warning'>You must be conscious to use [src]!</span>"
 		return 0
 	if(!user.client)
 		return 0
 	if(!user.IsAdvancedToolUser())
-		user << "<span class='warning'>You don't have the dexterity to use this [src]!</span>"
+		user << "<span class='warning'>You don't have the dexterity to use [src]!</span>"
 		return 0
 	if(user.restrained())
-		user << "<span class='warning'>You must have free hands to use this [src].</span>"
+		user << "<span class='warning'>You must have free hands to use [src].</span>"
 		return 0
 	if(user.lying)
-		user << "<span class='warning'>You must stand to use this [src]!</span>"
+		user << "<span class='warning'>You must stand to use [src]!</span>"
 		return 0
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user


### PR DESCRIPTION
- Fixes the duplication exploit of APC and air alarm electronics. Fixes #4989 .
- Fixes success message spam: when crowbaring electronics or other procedures in APC/Alarms/airlock/door_assembly, click spamming the src X times will no longer give X 'success' messages. (it also fixes a runtime error due to clickspamming when cutting wires of an APC terminal)
- Trying to install two electronics at the same time in a door assembly no longer deletes one of the two.
- Replaces "sleep()" with "do_after()" for fire alarm electronics removal procedure so you can no longer leave during the waiting period.
- Span class changes: replacing "danger" by "warning" in those procedures when there's no danger involved.
- Procedures consistency fix: all these procedures with a duration now have a visible 'initial' message for third parties w/ "warning" span class (3rd parties need to be alerted before the action is over, not after). For the user, the initial 'trying' msg is standardised to no span class, and success msg uses 'notice'. (although there's a few exceptions)
- Adding a couple 'self_message' to some visible_message() proc.
- replacing "for()+show_message()" by visible_message/audible_message() in a few instances.
- Deaf people can no longer hear bolt toggling clicksound.
- Removes the horrible "switch(doortype)" code by making doortype var the typepath of the door assembly.
- Deconstructing freezer airlock now gives a freezer door assembly (instead of nothing).
