### PR TITLE
RCD can no longer delete floor in away missions.

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -200,6 +200,11 @@ RCD
 				return 0
 
 			if(istype(A, /turf/simulated/floor))
+				var/turf/T = get_turf(user)
+				if(T.z > 6)
+					// No floors deconstruction on planet away missions
+					return 0
+
 				if(checkResource(5, user))
 					user << "Deconstructing Floor..."
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)


### PR DESCRIPTION
Ported from NT code. Fixes #5042 
