### PR TITLE
Fix powernets not working for away missions

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -54,8 +54,6 @@
 
 	timezoneOffset = text2num(time2text(0,"hh")) * 36000
 
-	makepowernets()
-
 	sun = new /datum/sun()
 	radio_controller = new /datum/controller/radio()
 	data_core = new /obj/effect/datacore()
@@ -83,6 +81,8 @@
 		make_mining_asteroid_secret()
 
 	createRandomZlevel()
+
+	makepowernets()
 
 	master_controller = new /datum/controller/game_controller()
 	spawn(-1)


### PR DESCRIPTION
Powernets are now created after secret rooms and away missions have been created.

Co-fixed by @Cheridan (not stealing credits here !)
