### PR TITLE
Adds windoor deconstruction & bug fixes

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -254,7 +254,7 @@
 
 	if(istype(I, /obj/item/weapon/screwdriver))
 		if(src.density || src.operating)
-			user << "<span class='warning'>You need to open the [src.name] to access the maintenance panel.</span>"
+			user << "<span class='warning'>You need to open the door to access the maintenance panel.</span>"
 			return
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		src.p_open = !( src.p_open )
@@ -271,16 +271,16 @@
 					var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
 					switch(base_state)
 						if("left")
-							WA.icon_state = "l_windoor_assembly02"
+							WA.facing = "l"
 						if("right")
-							WA.icon_state = "r_windoor_assembly02"
+							WA.facing = "r"
 						if("leftsecure")
-							WA.icon_state = "l_secure_windoor_assembly02"
+							WA.facing = "l"
 							WA.secure = 1
 						if("rightsecure")
-							WA.icon_state = "r_secure_windoor_assembly02"
+							WA.facing = "r"
 							WA.secure = 1
-							WA.anchored = 1
+					WA.anchored = 1
 					WA.state= "02"
 					WA.dir = src.dir
 					WA.ini_dir = src.dir

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -4,9 +4,8 @@
 	icon = 'icons/obj/doors/windoor.dmi'
 	icon_state = "left"
 	var/base_state = "left"
-	var/health = 150.0 //If you change this, consiter changing ../door/window/brigdoor/ health at the bottom of this .dm file
+	var/health = 150.0 //If you change this, consider changing ../door/window/brigdoor/ health at the bottom of this .dm file
 	visible = 0.0
-	use_power = 0
 	flags = ON_BORDER
 	opacity = 0
 	var/obj/item/weapon/airlock_electronics/electronics = null
@@ -22,7 +21,8 @@
 
 /obj/machinery/door/window/Destroy()
 	density = 0
-	playsound(src, "shatter", 70, 1)
+	if(health == 0)
+		playsound(src, "shatter", 70, 1)
 	..()
 
 
@@ -104,7 +104,7 @@
 	if (!ticker)
 		return 0
 	if(!forced)
-		if(stat & NOPOWER)
+		if(!hasPower())
 			return 0
 	if(forced < 2)
 		if(emagged)
@@ -130,7 +130,7 @@
 	if (src.operating)
 		return 0
 	if(!forced)
-		if(stat & NOPOWER)
+		if(!hasPower())
 			return 0
 	if(forced < 2)
 		if(emagged)
@@ -252,9 +252,68 @@
 		emagged = 1
 		return 1
 
+	if(istype(I, /obj/item/weapon/screwdriver))
+		if(src.density || src.operating)
+			user << "<span class='warning'>You need to open the [src.name] to access the maintenance panel.</span>"
+			return
+		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		src.p_open = !( src.p_open )
+		user << "<span class='notice'>You [p_open ? "open":"close"] the maintenance panel of the [src.name].</span>"
+		return
+
+	if(istype(I, /obj/item/weapon/crowbar))
+		if(p_open && !src.density && !src.operating)
+			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
+			user.visible_message("<span class='warning'>[user] removes the electronics from the [src.name].</span>", \
+								 "You start to remove electronics from the [src.name].")
+			if(do_after(user,40))
+				if(src.p_open && !src.density && !src.operating && src.loc)
+					var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(src.loc)
+					switch(base_state)
+						if("left")
+							WA.icon_state = "l_windoor_assembly02"
+						if("right")
+							WA.icon_state = "r_windoor_assembly02"
+						if("leftsecure")
+							WA.icon_state = "l_secure_windoor_assembly02"
+							WA.secure = 1
+						if("rightsecure")
+							WA.icon_state = "r_secure_windoor_assembly02"
+							WA.secure = 1
+							WA.anchored = 1
+					WA.state= "02"
+					WA.dir = src.dir
+					WA.ini_dir = src.dir
+					WA.update_icon()
+					WA.created_name = src.name
+
+					if(emagged)
+						user << "<span class='warning'>You discard the damaged electronics.</span>"
+						qdel(src)
+						return
+
+					user << "<span class='notice'>You removed the airlock electronics!</span>"
+
+					var/obj/item/weapon/airlock_electronics/ae
+					if(!electronics)
+						ae = new/obj/item/weapon/airlock_electronics( src.loc )
+						if(req_one_access)
+							ae.use_one_access = 1
+							ae.conf_access = src.req_one_access
+						else
+							ae.conf_access = src.req_access
+					else
+						ae = electronics
+						electronics = null
+						ae.loc = src.loc
+
+					qdel(src)
+			return
+
+
 	//If windoor is unpowered, crowbar, fireaxe and armblade can force it.
 	if(istype(I, /obj/item/weapon/crowbar) || istype(I, /obj/item/weapon/twohanded/fireaxe) || istype(I, /obj/item/weapon/melee/arm_blade) )
-		if(stat & NOPOWER)
+		if(!hasPower())
 			if(src.density)
 				open(2)
 			else
@@ -264,6 +323,8 @@
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
 	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card) )
 		user.changeNext_move(CLICK_CD_MELEE)
+		if( (I.flags&NOBLUDGEON) || !I.force )
+			return
 		var/aforce = I.force
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>\The [src] has been hit by [user] with [I].</span>")

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -219,15 +219,18 @@
 			src.use(2)
 
 		if("Windoor")
-			if(!src || src.loc != user) return 1
-
-			if(isturf(user.loc) && locate(/obj/structure/windoor_assembly/, user.loc))
-				user << "<span class='warning'>There is already a windoor assembly in that location.</span>"
+			if(!src || src.loc != user || !isturf(user.loc))
 				return 1
 
-			if(isturf(user.loc) && locate(/obj/machinery/door/window/, user.loc))
-				user << "<span class='warning'>There is already a windoor in that location.</span>"
-				return 1
+			for(var/obj/structure/windoor_assembly/WA in user.loc)
+				if(WA.dir == user.dir)
+					user << "<span class='warning'>There is already a windoor assembly in that location.</span>"
+					return 1
+
+			for(var/obj/machinery/door/window/W in user.loc)
+				if(W.dir == user.dir)
+					user << "<span class='warning'>There is already a windoor in that location.</span>"
+					return 1
 
 			if(src.get_amount() < 5)
 				user << "<span class='warning'>You need more glass to do that.</span>"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -20,11 +20,12 @@ obj/structure/windoor_assembly
 
 	var/ini_dir
 	var/obj/item/weapon/airlock_electronics/electronics = null
+	var/created_name = null
 
 	//Vars to help with the icon's name
 	var/facing = "l"	//Does the windoor open to the left or right?
-	var/secure = ""		//Whether or not this creates a secure windoor
-	var/state = "01"	//How far the door assembly has progressed in terms of sprites
+	var/secure = 0		//Whether or not this creates a secure windoor
+	var/state = "01"	//How far the door assembly has progressed
 
 obj/structure/windoor_assembly/New(dir=NORTH)
 	..()
@@ -42,7 +43,7 @@ obj/structure/windoor_assembly/Destroy()
 	move_update_air(T)
 
 /obj/structure/windoor_assembly/update_icon()
-	icon_state = "[facing]_[secure]windoor_assembly[state]"
+	icon_state = "[facing]_[secure ? "secure_" : ""]windoor_assembly[state]"
 
 /obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
@@ -97,7 +98,8 @@ obj/structure/windoor_assembly/Destroy()
 				user.visible_message("[user] secures the windoor assembly to the floor.", "You start to secure the windoor assembly to the floor.")
 
 				if(do_after(user, 40))
-					if(!src) return
+					if(!src || src.anchored)
+						return
 					user << "<span class='notice'>You've secured the windoor assembly!</span>"
 					src.anchored = 1
 					if(src.secure)
@@ -111,7 +113,8 @@ obj/structure/windoor_assembly/Destroy()
 				user.visible_message("[user] unsecures the windoor assembly to the floor.", "You start to unsecure the windoor assembly to the floor.")
 
 				if(do_after(user, 40))
-					if(!src) return
+					if(!src || !src.anchored)
+						return
 					user << "<span class='notice'>You've unsecured the windoor assembly!</span>"
 					src.anchored = 0
 					if(src.secure)
@@ -128,11 +131,12 @@ obj/structure/windoor_assembly/Destroy()
 				user << "<span class='notice'>You start to reinforce the windoor with plasteel.</span>"
 
 				if(do_after(user,40))
-					if(!src) return
+					if(!src || !secure)
+						return
 
 					P.use(2)
 					user << "<span class='notice'>You reinforce the windoor.</span>"
-					src.secure = "secure_"
+					src.secure = 1
 					if(src.anchored)
 						src.name = "secure anchored windoor assembly"
 					else
@@ -143,7 +147,8 @@ obj/structure/windoor_assembly/Destroy()
 				user.visible_message("[user] wires the windoor assembly.", "You start to wire the windoor assembly.")
 
 				if(do_after(user, 40))
-					if(!src) return
+					if(!src || !src.anchored || src.state != "01")
+						return
 					var/obj/item/stack/cable_coil/CC = W
 					CC.use(1)
 					user << "<span class='notice'>You wire the windoor!</span>"
@@ -163,7 +168,8 @@ obj/structure/windoor_assembly/Destroy()
 				user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
 
 				if(do_after(user, 40))
-					if(!src) return
+					if(!src || src.state != "02")
+						return
 
 					user << "<span class='notice'>You cut the windoor wires!</span>"
 					new/obj/item/stack/cable_coil(get_turf(user), 1)
@@ -177,12 +183,13 @@ obj/structure/windoor_assembly/Destroy()
 			else if(istype(W, /obj/item/weapon/airlock_electronics))
 				playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 				user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+				user.drop_item()
+				W.loc = src
 
 				if(do_after(user, 40))
-					if(!src) return
-
-					user.drop_item()
-					W.loc = src
+					if(!src || src.electronics)
+						W.loc = src.loc
+						return
 					user << "<span class='notice'>You've installed the airlock electronics!</span>"
 					src.name = "near finished windoor assembly"
 					src.electronics = W
@@ -198,16 +205,24 @@ obj/structure/windoor_assembly/Destroy()
 				user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly.")
 
 				if(do_after(user, 40))
-					if(!src) return
+					if(!src || !electronics)
+						return
 					user << "<span class='notice'>You've removed the airlock electronics!</span>"
 					src.name = "wired windoor assembly"
 					var/obj/item/weapon/airlock_electronics/ae
-					if (!electronics) //This shouldnt happen, but if it does, lets not crash and runtime.
-						ae = new/obj/item/weapon/airlock_electronics( src.loc )
-					else
-						ae = electronics
-						electronics = null
-						ae.loc = src.loc
+					ae = electronics
+					electronics = null
+					ae.loc = src.loc
+
+			else if(istype(W, /obj/item/weapon/pen))
+				var/t = copytext(stripped_input(user, "Enter the name for the door.", src.name, src.created_name),1,MAX_NAME_LEN)
+				if(!t)
+					return
+				if(!in_range(src, usr) && src.loc != usr)
+					return
+				created_name = t
+				return
+
 
 
 			//Crowbar to complete the assembly, Step 7 complete.
@@ -221,7 +236,8 @@ obj/structure/windoor_assembly/Destroy()
 
 				if(do_after(user, 40))
 
-					if(!src) return
+					if(!src.loc || !src.electronics)
+						return
 
 					density = 1 //Shouldn't matter but just incase
 					user << "<span class='notice'>You finish the windoor!</span>"
@@ -243,7 +259,11 @@ obj/structure/windoor_assembly/Destroy()
 							windoor.req_access = src.electronics.conf_access
 						windoor.electronics = src.electronics
 						src.electronics.loc = windoor
+						if(created_name)
+							windoor.name = created_name
 						windoor.close()
+
+
 					else
 						var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(src.loc)
 						if(src.facing == "l")
@@ -258,7 +278,10 @@ obj/structure/windoor_assembly/Destroy()
 						windoor.req_access = src.electronics.conf_access
 						windoor.electronics = src.electronics
 						src.electronics.loc = windoor
+						if(created_name)
+							windoor.name = created_name
 						windoor.close()
+
 
 					qdel(src)
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -183,9 +183,9 @@ obj/structure/windoor_assembly/Destroy()
 					new/obj/item/stack/cable_coil(get_turf(user), 1)
 					src.state = "01"
 					if(src.secure)
-						src.name = "secure wired windoor assembly"
+						src.name = "secure anchored windoor assembly"
 					else
-						src.name = "wired windoor assembly"
+						src.name = "anchored windoor assembly"
 
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/weapon/airlock_electronics))

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -94,12 +94,20 @@ obj/structure/windoor_assembly/Destroy()
 
 			//Wrenching an unsecure assembly anchors it in place. Step 4 complete
 			if(istype(W, /obj/item/weapon/wrench) && !anchored)
+				for(var/obj/machinery/door/window/WD in src.loc)
+					if(WD.dir == src.dir)
+						user << "<span class='warning'>There is already a windoor in that location.</span>"
+						return
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 				user.visible_message("[user] secures the windoor assembly to the floor.", "You start to secure the windoor assembly to the floor.")
 
 				if(do_after(user, 40))
 					if(!src || src.anchored)
 						return
+					for(var/obj/machinery/door/window/WD in src.loc)
+						if(WD.dir == src.dir)
+							user << "<span class='warning'>There is already a windoor in that location.</span>"
+							return
 					user << "<span class='notice'>You've secured the windoor assembly!</span>"
 					src.anchored = 1
 					if(src.secure)
@@ -131,7 +139,7 @@ obj/structure/windoor_assembly/Destroy()
 				user << "<span class='notice'>You start to reinforce the windoor with plasteel.</span>"
 
 				if(do_after(user,40))
-					if(!src || !secure)
+					if(!src || secure)
 						return
 
 					P.use(2)
@@ -236,51 +244,50 @@ obj/structure/windoor_assembly/Destroy()
 
 				if(do_after(user, 40))
 
-					if(!src.loc || !src.electronics)
-						return
+					if(src.loc && src.electronics)
 
-					density = 1 //Shouldn't matter but just incase
-					user << "<span class='notice'>You finish the windoor!</span>"
+						density = 1 //Shouldn't matter but just incase
+						user << "<span class='notice'>You finish the windoor!</span>"
 
-					if(secure)
-						var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(src.loc)
-						if(src.facing == "l")
-							windoor.icon_state = "leftsecureopen"
-							windoor.base_state = "leftsecure"
+						if(secure)
+							var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(src.loc)
+							if(src.facing == "l")
+								windoor.icon_state = "leftsecureopen"
+								windoor.base_state = "leftsecure"
+							else
+								windoor.icon_state = "rightsecureopen"
+								windoor.base_state = "rightsecure"
+							windoor.dir = src.dir
+							windoor.density = 0
+
+							if(src.electronics.use_one_access)
+								windoor.req_one_access = src.electronics.conf_access
+							else
+								windoor.req_access = src.electronics.conf_access
+							windoor.electronics = src.electronics
+							src.electronics.loc = windoor
+							if(created_name)
+								windoor.name = created_name
+							windoor.close()
+
+
 						else
-							windoor.icon_state = "rightsecureopen"
-							windoor.base_state = "rightsecure"
-						windoor.dir = src.dir
-						windoor.density = 0
+							var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(src.loc)
+							if(src.facing == "l")
+								windoor.icon_state = "leftopen"
+								windoor.base_state = "left"
+							else
+								windoor.icon_state = "rightopen"
+								windoor.base_state = "right"
+							windoor.dir = src.dir
+							windoor.density = 0
 
-						if(src.electronics.use_one_access)
-							windoor.req_one_access = src.electronics.conf_access
-						else
 							windoor.req_access = src.electronics.conf_access
-						windoor.electronics = src.electronics
-						src.electronics.loc = windoor
-						if(created_name)
-							windoor.name = created_name
-						windoor.close()
-
-
-					else
-						var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(src.loc)
-						if(src.facing == "l")
-							windoor.icon_state = "leftopen"
-							windoor.base_state = "left"
-						else
-							windoor.icon_state = "rightopen"
-							windoor.base_state = "right"
-						windoor.dir = src.dir
-						windoor.density = 0
-
-						windoor.req_access = src.electronics.conf_access
-						windoor.electronics = src.electronics
-						src.electronics.loc = windoor
-						if(created_name)
-							windoor.name = created_name
-						windoor.close()
+							windoor.electronics = src.electronics
+							src.electronics.loc = windoor
+							if(created_name)
+								windoor.name = created_name
+							windoor.close()
 
 
 					qdel(src)


### PR DESCRIPTION
- Windoors are now deconstructable. It needs to be open to access the maintenance panel, screwdriver the panel open then crowbar to remove the electronics, the windoor then becomes a windoor assembly.
-  You can no longer build two windoors on top of each other. You can now make a windoor_assembly w/ rglass on the same tile as another one as long as they have different directions. Wrenching a windoor assembly checks if there's already an assembly in the same direction as well.
- Fix being able to hit windoor with grab. Fixes #5028
- Fixes being able to open powerless windoors (w/o crowbar).
- Fixes Electronics removal duplication exploits in windoor assembly.
- Fixes other duplication/spam issue in windoor assembly construction procedures.
- Make naming windoor assembly/windoors possible with a pen. (similar to airlock assembly).
