### PR TITLE
Deathsquad Armour Buff

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -25,7 +25,7 @@
 	desc = "That's not red paint. That's real blood."
 	icon_state = "deathsquad"
 	item_state = "deathsquad"
-	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 50, bio = 30, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/space/deathsquad
 	name = "deathsquad suit"
@@ -33,7 +33,7 @@
 	icon_state = "deathsquad"
 	item_state = "swat_suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen)
-	armor = list(melee = 80, bullet = 80, laser = 50,energy = 50, bomb = 50, bio = 30, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50,energy = 50, bomb = 100, bio = 100, rad = 100)
 	slowdown = 1
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -25,7 +25,7 @@
 	desc = "That's not red paint. That's real blood."
 	icon_state = "deathsquad"
 	item_state = "deathsquad"
-	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 30, bio = 30, rad = 30)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 50, bio = 30, rad = 100)
 
 /obj/item/clothing/suit/space/deathsquad
 	name = "deathsquad suit"
@@ -33,7 +33,7 @@
 	icon_state = "deathsquad"
 	item_state = "swat_suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank/emergency_oxygen)
-	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 0, rad = 0)
+	armor = list(melee = 80, bullet = 80, laser = 50,energy = 50, bomb = 50, bio = 30, rad = 100)
 	slowdown = 1
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret


### PR DESCRIPTION
I found it weird that the Deathsquads armour is inconsistent and not that great, considering the whole point of the Deathsquad is to be extremely overpowered. 

As such, I've buffed their armour values. Both to make the Deathsquad Helmet consistent with the Body armour, but also to make it better.

The stats are identical for both items, and they are...

melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100
