### PR TITLE
Head of Security/Riot Armour Buff

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -11,35 +11,13 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 
-/obj/item/clothing/head/helmet/HoS
-	name = "head of security hat"
-	desc = "The robust hat of the Head of Security. For showing the officers who's in charge."
-	icon_state = "hoscap"
-	armor = list(melee = 75, bullet = 60, laser = 60,energy = 50, bomb = 25, bio = 10, rad = 0)
-	flags = 0
-	flags_inv = HIDEEARS
-
-/obj/item/clothing/head/helmet/HoS/dermal
-	name = "Dermal Armor Patch"
-	desc = "An armored implant that automatically integrates just below the scalp for robust protection without sacrificing style."
-	icon_state = "dermal"
-	item_state = "dermal"
-	flags_inv = 0
-
-/obj/item/clothing/head/helmet/warden
-	name = "warden's hat"
-	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."
-	icon_state = "policehelm"
-	flags = 0
-	flags_inv = HIDEEARS
-
 /obj/item/clothing/head/helmet/riot
 	name = "riot helmet"
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "riot"
 	item_state = "helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 80, bullet = 10, laser = 10,energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/helmet/swat

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -17,7 +17,7 @@
 	icon_state = "riot"
 	item_state = "helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
+	armor = list(melee = 80, bullet = 10, laser = 10,energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/helmet/swat

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -39,7 +39,7 @@
 	icon_state = "riot"
 	item_state = "helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
+	armor = list(melee = 80, bullet = 10, laser = 10,energy = 10, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/helmet/swat

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -15,7 +15,7 @@
 	name = "head of security hat"
 	desc = "The robust hat of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list(melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 75, bullet = 60, laser = 60,energy = 50, bomb = 25, bio = 10, rad = 0)
 	flags = 0
 	flags_inv = HIDEEARS
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -10,26 +10,25 @@
 //Captain
 /obj/item/clothing/head/caphat
 	name = "captain's hat"
-	icon_state = "captain"
 	desc = "It's good being the king."
+	icon_state = "captain"
 	item_state = "that"
-
-//Captain: This probably shouldn't be space-worthy
-/obj/item/clothing/head/helmet/cap
-	name = "captain's cap"
-	desc = "You fear to wear it for the negligence it brings."
-	icon_state = "capcap"
 	flags_inv = 0
-	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-	heat_protection = HEAD
-	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+
+//Captain: This is no longer space-worthy
+/obj/item/clothing/head/caphat/parade
+	name = "captain's parade cap"
+	desc = "Worn only by Captains with an abundance of class."
+	icon_state = "capcap"
+
 
 //Head of Personnel
 /obj/item/clothing/head/hopcap
 	name = "head of personnel's cap"
 	icon_state = "hopcap"
-	desc = "Glory to Nanotrasen."
+	desc = "The symbol of true bureaucratic micromanagement."
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 //Chaplain
 /obj/item/clothing/head/chaplain_hood
@@ -46,8 +45,8 @@
 	flags = HEADCOVERSEYES|BLOCKHAIR
 
 /obj/item/clothing/head/det_hat
-	name = "hat"
-	desc = "Someone who wears this will look very smart."
+	name = "detective's fedora"
+	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat."
 	icon_state = "detective"
 	allowed = list(/obj/item/weapon/reagent_containers/food/snacks/candy_corn, /obj/item/weapon/pen)
 	armor = list(melee = 50, bullet = 5, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
@@ -59,10 +58,35 @@
 	icon_state = "beret"
 
 //Security
+
+/obj/item/clothing/head/HoS
+	name = "head of security hat"
+	desc = "The robust hat of the Head of Security. For showing the officers who's in charge."
+	icon_state = "hoscap"
+	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	flags = 0
+	flags_inv = HIDEEARS
+
+/obj/item/clothing/head/HoS/dermal
+	name = "Dermal Armor Patch"
+	desc = "An armored implant that automatically integrates just below the scalp for robust protection without sacrificing style."
+	icon_state = "dermal"
+	item_state = "dermal"
+	flags_inv = 0
+
+/obj/item/clothing/head/warden
+	name = "warden's hat"
+	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."
+	icon_state = "policehelm"
+	armor = list(melee = 60, bullet = 5, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
+	flags = 0
+	flags_inv = HIDEEARS
+
 /obj/item/clothing/head/beret/sec
 	name = "security beret"
-	desc = "A beret with the security insignia emblazoned on it. For officers that are more inclined towards style than safety."
+	desc = "A robust beret with the security insignia emblazoned on it. For officers that are more inclined towards style than safety."
 	icon_state = "beret_badge"
+	armor = list(melee = 30, bullet = 5, laser = 15, energy = 10, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/head/beret/sec/navyhos
 	name = "head of security's beret"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -14,7 +14,7 @@
 	icon_state = "captain"
 	item_state = "that"
 	flags_inv = 0
-	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 30, bomb = 25, bio = 0, rad = 0)
 
 //Captain: This is no longer space-worthy
 /obj/item/clothing/head/caphat/parade
@@ -63,7 +63,7 @@
 	name = "head of security hat"
 	desc = "The robust hat of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 75, bullet = 60, laser = 60, energy = 50, bomb = 25, bio = 10, rad = 0)
 	flags = 0
 	flags_inv = HIDEEARS
 

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -5,6 +5,8 @@
 	icon_state = "centcom"
 	desc = "It's good to be emperor."
 	item_state = "that"
+	flags_inv = 0
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/head/powdered_wig
 	name = "powdered wig"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -90,3 +90,4 @@
 	desc = "It's a robust baseball hat in tasteful red colour."
 	icon_state = "secsoft"
 	item_color = "sec"
+	armor = list(melee = 30, bullet = 5, laser = 5, energy = 15, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -20,7 +20,7 @@
 	icon_state = "hos"
 	item_state = "hos"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 70, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 65, bullet = 60, laser = 60, energy = 50, bomb = 25, bio = 10, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -40,7 +40,7 @@
 	icon_state = "capcarapace"
 	item_state = "armor"
 	body_parts_covered = CHEST|GROIN
-	armor = list(melee = 50, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 30, laser = 50, energy = 30, bomb = 25, bio = 0, rad = 0)
 
 
 /obj/item/clothing/suit/armor/riot
@@ -50,7 +50,7 @@
 	item_state = "swat_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 1
-	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -20,7 +20,7 @@
 	icon_state = "hos"
 	item_state = "hos"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 70, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -20,7 +20,7 @@
 	icon_state = "hos"
 	item_state = "hos"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 65, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION
Well, more so making it consistent.

Since I dislike inconsistent protection values, I've modified the HoS's and Riot armour to match the protection offered by their respective helmet/hat values.

I'm also going to visit other armours that I find, however most armour/rig's are consistent. 

---

The new values are...

_EDIT1_ Updated

---

HoS Hat
melee = 75, bullet = 60, laser = 60,energy = 50, bomb = 25, bio = 10, rad = 0
from
melee = 80, bullet = 60, laser = 50,energy = 10, bomb = 25, bio = 10, rad = 0

HoS Armour
melee = 65 (+10), bullet = 60, laser = 60, energy = 50, bomb = 25, bio = 10, rad = 0
from
melee = 70, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0

---

Captain Armour+Hat (Energy changed only)
melee = 50, bullet = 30, laser = 50, energy = 30, bomb = 25, bio = 0, rad = 0
from
melee = 50, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0

---

Riot Armour+Helm
melee = 80, bullet = 10, laser = 10,energy = 10, bomb = 10, bio = 0, rad = 0
from 
melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0
