### PR TITLE
Constructable transit tubes!

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -7,6 +7,7 @@
  *			angle2dir
  *			angle2text
  *			worldtime2text
+ *			text2dir_extended & dir2text_short
  */
 
 //Returns an integer given a hex input, supports negative values "-ff"
@@ -405,3 +406,51 @@ for(var/t in test_times)
 
 /proc/isLeap(y)
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
+
+// A copy of text2dir, extended to accept one and two letter
+//  directions, and to clearly return 0 otherwise.
+/proc/text2dir_extended(direction)
+	switch(uppertext(direction))
+		if("NORTH", "N")
+			return 1
+		if("SOUTH", "S")
+			return 2
+		if("EAST", "E")
+			return 4
+		if("WEST", "W")
+			return 8
+		if("NORTHEAST", "NE")
+			return 5
+		if("NORTHWEST", "NW")
+			return 9
+		if("SOUTHEAST", "SE")
+			return 6
+		if("SOUTHWEST", "SW")
+			return 10
+		else
+	return 0
+
+
+
+// A copy of dir2text, which returns the short one or two letter
+//  directions used in tube icon states.
+/proc/dir2text_short(direction)
+	switch(direction)
+		if(1)
+			return "N"
+		if(2)
+			return "S"
+		if(4)
+			return "E"
+		if(8)
+			return "W"
+		if(5)
+			return "NE"
+		if(6)
+			return "SE"
+		if(9)
+			return "NW"
+		if(10)
+			return "SW"
+		else
+	return

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -128,7 +128,7 @@ Nah
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return
 
-	if (!istype(pipe, /obj/structure/disposalconstruct) && !istype(pipe, /obj/structure/c_transit_tube) && !istype(pipe, /obj/structure/transit_tube_pod))
+	if (!istype(pipe, /obj/structure/disposalconstruct) && !istype(pipe, /obj/structure/c_transit_tube) && !istype(pipe, /obj/structure/c_transit_tube_pod))
 		return
 
 	if (get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -123,12 +123,15 @@
 Nah
 */
 
-//Allow you to drag-drop disposal pipes into it
-/obj/machinery/pipedispenser/disposal/MouseDrop_T(var/obj/structure/disposalconstruct/pipe as obj, mob/usr as mob)
+//Allow you to drag-drop disposal pipes and transit tubes into it
+/obj/machinery/pipedispenser/disposal/MouseDrop_T(var/obj/structure/pipe as obj, mob/usr as mob)
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return
 
-	if (!istype(pipe) || get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )
+	if (!istype(pipe, /obj/structure/disposalconstruct) && !istype(pipe, /obj/structure/c_transit_tube) && !istype(pipe, /obj/structure/transit_tube_pod))
+		return
+
+	if (get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )
 		return
 
 	if (pipe.anchored)
@@ -196,3 +199,79 @@ Nah
 				wait = 0
 	return
 
+//transit tube dispenser
+//inherit disposal for the dragging proc
+/obj/machinery/pipedispenser/disposal/transit_tube
+	name = "transit tube dispenser"
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "pipe_d"
+	density = 1
+	anchored = 1.0
+
+/obj/machinery/pipedispenser/disposal/transit_tube/attack_hand(user as mob)
+	if(..())
+		return
+
+	var/dat = {"<B>Transit Tubes:</B><BR>
+<A href='?src=\ref[src];tube=0'>Straight Tube</A><BR>
+<A href='?src=\ref[src];tube=1'>Straight Tube with Crossing</A><BR>
+<A href='?src=\ref[src];tube=2'>Clockwise Curved Tube</A><BR>
+<A href='?src=\ref[src];tube=3'>Counterclockwise Curved Tube</A><BR>
+<A href='?src=\ref[src];tube=4'>Diagonal Tube</A><BR>
+<A href='?src=\ref[src];tube=5'>Clockwise Junction</A><BR>
+<A href='?src=\ref[src];tube=6'>Counterclockwise Junction</A><BR>
+<b>Station Equipment:</b><BR>
+<A href='?src=\ref[src];tube=7'>Through Tube Station</A><BR>
+<A href='?src=\ref[src];tube=8'>Terminus Tube Station</A><BR>
+<A href='?src=\ref[src];tube=9'>Tube Blocker</A><BR>
+<A href='?src=\ref[src];tube=10'>Transit Tube Pod</A><BR>
+"}
+
+	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
+	return
+
+
+/obj/machinery/pipedispenser/disposal/Topic(href, href_list)
+	if(..())
+		return
+	usr.set_machine(src)
+	src.add_fingerprint(usr)
+	if(!wait)
+		if(href_list["tube"])
+			var/tube_type = text2num(href_list["tube"])
+			if(tube_type <= 6)
+				var/obj/structure/c_transit_tube/C = new/obj/structure/c_transit_tube(src.loc)
+				switch(tube_type)
+					if(0)
+						C.icon_state = "E-W"
+					if(1)
+						C.icon_state = "E-W-Pass"
+					if(2)
+						C.icon_state = "S-NE"
+					if(3)
+						C.icon_state = "S-NW"
+					if(4)
+						C.icon_state = "NE-SW"
+					if(5)
+						C.icon_state = "W-NE-SE"
+					if(6)
+						C.icon_state = "S-NE-NW"
+				C.add_fingerprint(usr)
+			else
+				switch(tube_type)
+					if(7)
+						var/obj/structure/c_transit_tube/station/C = new/obj/structure/c_transit_tube/station(src.loc)
+						C.add_fingerprint(usr)
+					if(8)
+						var/obj/structure/c_transit_tube/station/reverse/C = new/obj/structure/c_transit_tube/station/reverse(src.loc)
+						C.add_fingerprint(usr)
+					if(9)
+						var/obj/structure/c_transit_tube/station/block/C = new/obj/structure/c_transit_tube/station/block(src.loc)
+						C.add_fingerprint(usr)
+					if(10)
+						var/obj/structure/c_transit_tube_pod/C = new/obj/structure/c_transit_tube_pod(src.loc)
+						C.add_fingerprint(usr)
+			wait = 1
+			spawn(15)
+				wait = 0
+	return

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -215,16 +215,14 @@ Nah
 	var/dat = {"<B>Transit Tubes:</B><BR>
 <A href='?src=\ref[src];tube=0'>Straight Tube</A><BR>
 <A href='?src=\ref[src];tube=1'>Straight Tube with Crossing</A><BR>
-<A href='?src=\ref[src];tube=2'>Clockwise Curved Tube</A><BR>
-<A href='?src=\ref[src];tube=3'>Counterclockwise Curved Tube</A><BR>
-<A href='?src=\ref[src];tube=4'>Diagonal Tube</A><BR>
-<A href='?src=\ref[src];tube=5'>Clockwise Junction</A><BR>
-<A href='?src=\ref[src];tube=6'>Counterclockwise Junction</A><BR>
+<A href='?src=\ref[src];tube=2'>Curved Tube</A><BR>
+<A href='?src=\ref[src];tube=3'>Diagonal Tube</A><BR>
+<A href='?src=\ref[src];tube=4'>Junction</A><BR>
 <b>Station Equipment:</b><BR>
-<A href='?src=\ref[src];tube=7'>Through Tube Station</A><BR>
-<A href='?src=\ref[src];tube=8'>Terminus Tube Station</A><BR>
-<A href='?src=\ref[src];tube=9'>Tube Blocker</A><BR>
-<A href='?src=\ref[src];tube=10'>Transit Tube Pod</A><BR>
+<A href='?src=\ref[src];tube=5'>Through Tube Station</A><BR>
+<A href='?src=\ref[src];tube=6'>Terminus Tube Station</A><BR>
+<A href='?src=\ref[src];tube=7'>Tube Blocker</A><BR>
+<A href='?src=\ref[src];tube=8'>Transit Tube Pod</A><BR>
 "}
 
 	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
@@ -239,7 +237,7 @@ Nah
 	if(!wait)
 		if(href_list["tube"])
 			var/tube_type = text2num(href_list["tube"])
-			if(tube_type <= 6)
+			if(tube_type <= 4)
 				var/obj/structure/c_transit_tube/C = new/obj/structure/c_transit_tube(src.loc)
 				switch(tube_type)
 					if(0)
@@ -249,26 +247,22 @@ Nah
 					if(2)
 						C.icon_state = "S-NE"
 					if(3)
-						C.icon_state = "S-NW"
-					if(4)
 						C.icon_state = "NE-SW"
-					if(5)
+					if(4)
 						C.icon_state = "W-NE-SE"
-					if(6)
-						C.icon_state = "S-NE-NW"
 				C.add_fingerprint(usr)
 			else
 				switch(tube_type)
-					if(7)
+					if(5)
 						var/obj/structure/c_transit_tube/station/C = new/obj/structure/c_transit_tube/station(src.loc)
 						C.add_fingerprint(usr)
-					if(8)
+					if(6)
 						var/obj/structure/c_transit_tube/station/reverse/C = new/obj/structure/c_transit_tube/station/reverse(src.loc)
 						C.add_fingerprint(usr)
-					if(9)
+					if(7)
 						var/obj/structure/c_transit_tube/station/block/C = new/obj/structure/c_transit_tube/station/block(src.loc)
 						C.add_fingerprint(usr)
-					if(10)
+					if(8)
 						var/obj/structure/c_transit_tube_pod/C = new/obj/structure/c_transit_tube_pod(src.loc)
 						C.add_fingerprint(usr)
 			wait = 1

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -8,6 +8,7 @@
 	icon_state = "closed"
 	exit_delay = 2
 	enter_delay = 3
+	tube_construction = /obj/structure/c_transit_tube/station
 	var/pod_moving = 0
 	var/automatic_launch_time = 100
 	var/cooldown_delay = 200
@@ -27,6 +28,7 @@
 
 // Stations which will send the tube in the opposite direction after their stop.
 /obj/structure/transit_tube/station/reverse
+	tube_construction = /obj/structure/c_transit_tube/station/reverse
 	reverse_launch = 1
 
 /obj/structure/transit_tube/station/should_stop_pod(pod, from_dir)

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -40,6 +40,20 @@
 				return
 
 
+//pod insertion
+/obj/structure/transit_tube/station/MouseDrop_T(obj/structure/c_transit_tube_pod/R as obj, mob/user as mob)
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return
+	if (!istype(R) || get_dist(user, src) > 1 || get_dist(src,R) > 1)
+		return
+	var/obj/structure/transit_tube_pod/T = new/obj/structure/transit_tube_pod(src)
+	R.transfer_fingerprints_to(T)
+	T.add_fingerprint(usr)
+	T.loc = src.loc
+	T.dir = turn(src.dir, -90)
+	user.visible_message("<span class='notice'>[user] inserts the [R].</span>", "<span class='notice'>You insert the [R].</span>")
+	qdel(R)
+
 
 /obj/structure/transit_tube/station/attack_hand(mob/user as mob)
 	if(!pod_moving)
@@ -76,6 +90,17 @@
 					src.Bumped(GM)
 					qdel(G)
 				break
+	if(istype(W, /obj/item/weapon/crowbar))
+		for(var/obj/structure/transit_tube_pod/pod in loc)
+			if(pod.contents)
+				user << "<span class='notice'>Empty the pod first.</span>"
+				return
+			user.visible_message("<span class='notice'>[user] removes the [pod].</span>", "<span class='notice'>You remove the [pod].</span>")
+			var/obj/structure/c_transit_tube_pod/R = new/obj/structure/c_transit_tube_pod(src.loc)
+			pod.transfer_fingerprints_to(R)
+			R.add_fingerprint(user)
+			qdel(pod)
+	..(W, user)
 
 /obj/structure/transit_tube/station/proc/open_animation()
 	if(icon_state == "closed")

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -1,4 +1,3 @@
-
 // Basic transit tubes. Straight pieces, curved sections,
 //  and basic splits/joins (no routing logic).
 // Mappers: you can use "Generate Instances from Icon-states"
@@ -48,6 +47,30 @@ obj/structure/transit_tube/ex_act(severity)
 	if(tube_dirs == null)
 		init_dirs()
 
+/obj/structure/transit_tube/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/weapon/wrench))
+		for(var/obj/structure/transit_tube_pod/pod in loc)
+			user << "<span class='notice'>Remove the pod first.</span>"
+			return
+		user.visible_message("<span class='warning'>[user] starts to deattach the [src]!</span>", "<span class='notice'>You start deattaching the [name]...</span>")
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		if(do_after(user, 80))
+			user << "<span class='notice'>You deattach the [name]!</span>"
+			if(copytext(icon_state, 1, 3) != "D-")
+				if(istype(src, /obj/structure/transit_tube/station/reverse))
+					var/obj/structure/R = new/obj/structure/c_transit_tube/station/reverse(src.loc)
+					src.transfer_fingerprints_to(R)
+					R.add_fingerprint(user)
+				else if(istype(src, /obj/structure/transit_tube/station))
+					var/obj/structure/R = new/obj/structure/c_transit_tube/station(src.loc)
+					src.transfer_fingerprints_to(R)
+					R.add_fingerprint(user)
+				else
+					var/obj/structure/R = new/obj/structure/c_transit_tube(src.loc)
+					R.icon_state = src.icon_state
+					src.transfer_fingerprints_to(R)
+					R.add_fingerprint(user)
+			qdel(src)
 
 // Called to check if a pod should stop upon entering this tube.
 /obj/structure/transit_tube/proc/should_stop_pod(pod, from_dir)
@@ -258,53 +281,3 @@ obj/structure/transit_tube/ex_act(severity)
 
 	direction_table[text] = directions
 	return directions
-
-
-
-// A copy of text2dir, extended to accept one and two letter
-//  directions, and to clearly return 0 otherwise.
-/obj/structure/transit_tube/proc/text2dir_extended(direction)
-	switch(uppertext(direction))
-		if("NORTH", "N")
-			return 1
-		if("SOUTH", "S")
-			return 2
-		if("EAST", "E")
-			return 4
-		if("WEST", "W")
-			return 8
-		if("NORTHEAST", "NE")
-			return 5
-		if("NORTHWEST", "NW")
-			return 9
-		if("SOUTHEAST", "SE")
-			return 6
-		if("SOUTHWEST", "SW")
-			return 10
-		else
-	return 0
-
-
-
-// A copy of dir2text, which returns the short one or two letter
-//  directions used in tube icon states.
-/obj/structure/transit_tube/proc/dir2text_short(direction)
-	switch(direction)
-		if(1)
-			return "N"
-		if(2)
-			return "S"
-		if(4)
-			return "E"
-		if(8)
-			return "W"
-		if(5)
-			return "NE"
-		if(6)
-			return "SE"
-		if(9)
-			return "NW"
-		if(10)
-			return "SW"
-		else
-	return

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -54,7 +54,7 @@ obj/structure/transit_tube/ex_act(severity)
 			return
 		user.visible_message("<span class='warning'>[user] starts to deattach the [src]!</span>", "<span class='notice'>You start deattaching the [name]...</span>")
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 80))
+		if(do_after(user, 35))
 			user << "<span class='notice'>You deattach the [name]!</span>"
 			if(copytext(icon_state, 1, 3) != "D-")
 				if(istype(src, /obj/structure/transit_tube/station/reverse))

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -23,28 +23,42 @@
 		newdir = list2text(split_text, "-")
 	icon_state = newdir
 
-// disposals-style "flip" and rotate verbs
+/obj/structure/c_transit_tube/proc/tube_flip()
+	var/list/split_text = text2list(icon_state, "-")
+	//skip straight pipes
+	if(length(split_text[2]) < 2)
+		return
+	//for junctions, just swap the diagonals with each other
+	if(split_text.len == 3 && split_text[3] != "Pass")
+		split_text.Swap(2,3)
+	//for curves, swap the diagonal direction that is not in the same axis as the cardinal direction
+	else
+		if(split_text[1] == "N" || split_text[1] == "S")
+			split_text[2] = copytext(split_text[2],1,2) + ((copytext(split_text[2],2,3) == "E") ? "W" : "E")
+		else
+			split_text[2] = ((copytext(split_text[2],1,2) == "N") ? "S" : "N") + copytext(split_text[2],2,3)
+	icon_state = list2text(split_text, "-")
+
+// disposals-style flip and rotate verbs
 /obj/structure/c_transit_tube/verb/rotate()
 	set name = "Rotate Tube"
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.stat)
+	if(usr.canUseTopic())
 		return
 
 	tube_turn(-90)
 
-//not a real flip because it won't mirror junction pipe exits
-//yes i am autistic
 /obj/structure/c_transit_tube/verb/flip()
-	set name = "Rotate Tube Twice"
+	set name = "Flip"
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.stat)
+	if(usr.canUseTopic())
 		return
 
-	tube_turn(180)
+	tube_flip()
 
 /obj/structure/c_transit_tube/proc/buildtube()
 	var/obj/structure/transit_tube/R = new/obj/structure/transit_tube(src.loc)
@@ -71,25 +85,11 @@
 	icon = 'icons/obj/pipes/transit_tube_station.dmi'
 	icon_state = "closed"
 
-/obj/structure/c_transit_tube/station/rotate()
-	set name = "Rotate Tube"
-	set category = "Object"
-	set src in view(1)
+/obj/structure/c_transit_tube/station/tube_turn(var/angle)
+	src.dir = turn(src.dir, angle)
 
-	if(usr.stat)
-		return
-
-	src.dir = turn(src.dir, -90)
-
-/obj/structure/c_transit_tube/station/flip()
-	set name = "Rotate Tube Twice"
-	set category = "Object"
-	set src in view(1)
-
-	if(usr.stat)
-		return
-
-	src.dir = turn(src.dir, 180)
+/obj/structure/c_transit_tube/station/tube_flip()
+	src.tube_turn(180)
 
 /obj/structure/c_transit_tube/station/buildtube()
 	var/obj/structure/transit_tube/station/R = new/obj/structure/transit_tube/station(src.loc)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -1,0 +1,132 @@
+// transit tube construction
+//TODO: dispenser, restrict flip/rotate, testing
+
+// normal transit tubes
+/obj/structure/c_transit_tube
+	name = "unattached transit tube"
+	icon = 'icons/obj/pipes/transit_tube.dmi'
+	icon_state = "E-W" //icon_state decides which tube will be built
+	density = 0
+	layer = 3.1 //same as the built tube
+	anchored = 0.0
+
+//wrapper for turn that changes the transit tube formatted icon_state instead of the dir
+/obj/structure/c_transit_tube/proc/tube_turn(var/angle)
+	var/list/badtubes = list("W-E", "W-E-Pass", "S-N", "S-N-Pass", "SW-NE", "SE-NW")
+	var/list/split_text = text2list(icon_state, "-")
+	for(var/i=1; i<=split_text.len; i++)
+		var/curdir = text2dir_extended(split_text[i]) //0 if not a valid direction (e.g. Pass, Block)
+		if(curdir)
+			split_text[i] = dir2text_short(turn(curdir, angle))
+	var/newdir = list2text(split_text, "-")
+	if(badtubes.Find(newdir))
+		split_text.Swap(1,2)
+		newdir = list2text(split_text, "-")
+	icon_state = newdir
+
+// disposals-style "flip" and rotate verbs
+/obj/structure/c_transit_tube/verb/rotate()
+	set name = "Rotate Tube"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.stat)
+		return
+
+	tube_turn(-90)
+
+//not a real flip because it won't mirror junction pipe exits
+//yes i am autistic
+/obj/structure/c_transit_tube/verb/flip()
+	set name = "Rotate Tube Twice"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.stat)
+		return
+
+	tube_turn(180)
+
+/obj/structure/c_transit_tube/proc/buildtube()
+	var/obj/structure/transit_tube/R = new/obj/structure/transit_tube(src.loc)
+	R.icon_state = src.icon_state
+	R.init_dirs()
+	R.generate_automatic_corners(R.tube_dirs)
+	return R
+
+/obj/structure/c_transit_tube/attackby(var/obj/item/I, var/mob/user)
+	if(istype(I, /obj/item/weapon/wrench))
+		user << "<span class='notice'>You start attaching the [name]...</span>"
+		src.add_fingerprint(user)
+		if(do_after(user, 40))
+			if(!src) return
+			user << "<span class='notice'>You attach the [name]!</span>"
+			var/obj/structure/transit_tube/R = src.buildtube()
+			src.transfer_fingerprints_to(R)
+			qdel(src)
+			return
+
+// transit tube station
+/obj/structure/c_transit_tube/station
+	name = "unattached through station"
+	icon = 'icons/obj/pipes/transit_tube_station.dmi'
+	icon_state = "closed"
+
+/obj/structure/c_transit_tube/station/rotate()
+	set name = "Rotate Tube"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.stat)
+		return
+
+	src.dir = turn(src.dir, -90)
+
+/obj/structure/c_transit_tube/station/flip()
+	set name = "Rotate Tube Twice"
+	set category = "Object"
+	set src in view(1)
+
+	if(usr.stat)
+		return
+
+	src.dir = turn(src.dir, 180)
+
+/obj/structure/c_transit_tube/station/buildtube()
+	var/obj/structure/transit_tube/station/R = new/obj/structure/transit_tube/station(src.loc)
+	R.dir = src.dir
+	R.init_dirs()
+	return R
+
+// reverser station, used for the terminus
+/obj/structure/c_transit_tube/station/reverse
+	name = "unattached terminus station"
+
+/obj/structure/c_transit_tube/station/reverse/buildtube()
+	var/obj/structure/transit_tube/station/reverse/R = new/obj/structure/transit_tube/station/reverse(src.loc)
+	R.dir = src.dir
+	return R
+
+// block, used after the terminus of a transit tube station, decorative only
+// code-wise they're normal tubes but they're ~speshul~ because they care about the dir instead of the icon_state
+// in that sense they're the same as stations and can reuse their flip and rotate verbs
+/obj/structure/c_transit_tube/station/block
+	name = "unattached tube blocker"
+	icon = 'icons/obj/pipes/transit_tube.dmi'
+	icon_state = "Block"
+
+/obj/structure/c_transit_tube/station/block/buildtube()
+	var/obj/structure/transit_tube/R = new/obj/structure/transit_tube(src.loc)
+	R.icon_state = src.icon_state
+	R.dir = src.dir
+	R.init_dirs()
+	return R
+
+//transit tube pod
+//see station.dm for the logic
+/obj/structure/c_transit_tube_pod
+	name = "unattached transit tube pod"
+	icon = 'icons/obj/pipes/transit_tube_pod.dmi'
+	icon_state = "pod"
+	anchored = 0.0
+	density = 0

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -104,6 +104,7 @@
 /obj/structure/c_transit_tube/station/reverse/buildtube()
 	var/obj/structure/transit_tube/station/reverse/R = new/obj/structure/transit_tube/station/reverse(src.loc)
 	R.dir = src.dir
+	R.init_dirs()
 	return R
 
 // block, used after the terminus of a transit tube station, decorative only

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -1,5 +1,4 @@
 // transit tube construction
-//TODO: dispenser, restrict flip/rotate, testing
 
 // normal transit tubes
 /obj/structure/c_transit_tube

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -25,6 +25,23 @@
 
 	..()
 
+/obj/structure/transit_tube_pod/attackby(var/obj/item/I, var/mob/user)
+	if(istype(I, /obj/item/weapon/crowbar))
+		if(!moving)
+			for(var/obj/structure/transit_tube/station/T in loc)
+				return
+			if(src.contents)
+				user.visible_message("<span class='notice'>[user] empties the [src].</span>", "<span class='notice'>You empty the [src].</span>")
+				for(var/atom/movable/M in src.contents)
+					M.loc = src.loc
+				return
+			else
+				user << "<span class='notice'>You free the [src].</span>"
+				var/obj/structure/c_transit_tube_pod/R = new/obj/structure/c_transit_tube_pod(src.loc)
+				src.transfer_fingerprints_to(R)
+				R.add_fingerprint(user)
+				qdel(src)
+
 /obj/structure/transit_tube_pod/proc/follow_tube(var/reverse_launch)
 	if(moving)
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -672,6 +672,7 @@
 #include "code\game\objects\structures\stool_bed_chair_nest\chairs.dm"
 #include "code\game\objects\structures\stool_bed_chair_nest\stools.dm"
 #include "code\game\objects\structures\transit_tubes\station.dm"
+#include "code\game\objects\structures\transit_tubes\transit_tube_construction.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube_pod.dm"
 #include "code\game\pooling\atom_pool.dm"


### PR DESCRIPTION
You can now build lifelike public transport networks, or even a sci-fi themed rollercoaster!

List of changes:
- There is a new transit tube dispenser, similar to the disposal pipes dispenser
- It dispenses construction-stage transit tubes, which take four seconds and a wrench to become solid
- Tubes can now be deconstructed with 3.5 seconds and a wrench
- Construction-stage tube pods can be dragged into a station to be loaded
- Stuck pods can be pried from the tube with a crowbar
- text2dir_extended & dir2text_short are now global procs

This was somewhat tested and should be relatively not completely broken, but any further testing is welcome.
I'm concerned about the possibility that the unwrenched tubes might become barricades, so I'm very open to suggestions about how to avoid that.

This PR does not edit the map. Once it is merged, I'll update the changelog and add the dispenser to atmos.
