### PR TITLE
Fixes restarted borgs hearing cult chat

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -79,6 +79,8 @@
 				R.key = ghost.key
 
 	R.stat = CONSCIOUS
+	dead_mob_list -= R //please never forget this ever kthx
+	living_mob_list += R
 	R.notify_ai(1)
 
 	return 1


### PR DESCRIPTION
This should fix the issue with borgs hearing cult chat and such after being restarted. Not tested at all, though.
