### PR TITLE
Removes telesci comp's update_icon override

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -49,17 +49,6 @@
 	for(var/i = 1; i <= starting_crystals; i++)
 		crystals += new /obj/item/bluespace_crystal/artificial(null) // starting crystals
 
-/obj/machinery/computer/telescience/update_icon()
-	if(stat & BROKEN)
-		icon_state = "telescib"
-	else
-		if(stat & NOPOWER)
-			src.icon_state = "teleport0"
-			stat |= NOPOWER
-		else
-			icon_state = initial(icon_state)
-			stat &= ~NOPOWER
-
 /obj/machinery/computer/telescience/attack_paw(mob/user)
 	user << "You are too primitive to use this computer."
 	return


### PR DESCRIPTION
I'm not sure why /computer's proc was being overridden with an almost identical proc but it caused a null icon when the comp broke and everything seemed to work fine when this proc was removed.
