### PR TITLE
Removes geneticist from sci and pAI from silicon jobbans

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -73,7 +73,7 @@ var/list/engineering_positions = list(
 var/list/medical_positions = list(
 	"Chief Medical Officer",
 	"Medical Doctor",
-	"Geneticist",	//Part of both medical and science
+	"Geneticist",
 	"Virologist",
 	"Chemist"
 )
@@ -82,7 +82,6 @@ var/list/medical_positions = list(
 var/list/science_positions = list(
 	"Research Director",
 	"Scientist",
-	"Geneticist",	//Part of both medical and science
 	"Roboticist"
 )
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -680,7 +680,6 @@
 					if(!temp) continue
 					joblist += temp.title
 			if("nonhumandept")
-				joblist += "pAI"
 				for(var/jobPos in nonhuman_positions)
 					if(!jobPos)	continue
 					var/datum/job/temp = job_master.GetJob(jobPos)


### PR DESCRIPTION
Majority (read: all) of science jobbans are for science related stuff and not related to genetics. Same goes for pAIs and silicon bans.
