### PR TITLE
Transit tube construction bugfix

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -44,13 +44,13 @@
 
 //pod insertion
 /obj/structure/transit_tube/station/MouseDrop_T(obj/structure/c_transit_tube_pod/R as obj, mob/user as mob)
-	if(!usr.canmove || usr.stat || usr.restrained())
+	if(!user.canmove || user.stat || user.restrained())
 		return
 	if (!istype(R) || get_dist(user, src) > 1 || get_dist(src,R) > 1)
 		return
 	var/obj/structure/transit_tube_pod/T = new/obj/structure/transit_tube_pod(src)
 	R.transfer_fingerprints_to(T)
-	T.add_fingerprint(usr)
+	T.add_fingerprint(user)
 	T.loc = src.loc
 	T.dir = turn(src.dir, -90)
 	user.visible_message("<span class='notice'>[user] inserts the [R].</span>", "<span class='notice'>You insert the [R].</span>")

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -41,21 +41,31 @@
 
 // disposals-style flip and rotate verbs
 /obj/structure/c_transit_tube/verb/rotate()
-	set name = "Rotate Tube"
+	set name = "Rotate Tube CW"
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.canUseTopic())
+	if(!usr.canUseTopic(src))
 		return
 
 	tube_turn(-90)
+
+/obj/structure/c_transit_tube/verb/rotate_ccw()
+	set name = "Rotate Tube CCW"
+	set category = "Object"
+	set src in view(1)
+
+	if(!usr.canUseTopic(src))
+		return
+
+	tube_turn(90)
 
 /obj/structure/c_transit_tube/verb/flip()
 	set name = "Flip"
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.canUseTopic())
+	if(!usr.canUseTopic(src))
 		return
 
 	tube_flip()

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -30,7 +30,7 @@
 		if(!moving)
 			for(var/obj/structure/transit_tube/station/T in loc)
 				return
-			if(src.contents)
+			if(src.contents.len)
 				user.visible_message("<span class='notice'>[user] empties the [src].</span>", "<span class='notice'>You empty the [src].</span>")
 				for(var/atom/movable/M in src.contents)
 					M.loc = src.loc


### PR DESCRIPTION
Fixes tube pod deconstruction if they get stuck and/or leave the tubes.
Gives tubes a counterclockwise rotate verb.
