### PR TITLE
Windoors now work on environmental power instead of equipment power

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -22,7 +22,6 @@
 	name = "airlock"
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door_closed"
-	power_channel = ENVIRON
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -7,6 +7,7 @@
 	opacity = 1
 	density = 1
 	layer = 2.7
+	power_channel = ENVIRON
 
 	var/secondsElectrified = 0
 	var/visible = 1

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -8,7 +8,6 @@
 	icon_state = "door_open"
 	opacity = 0
 	density = 0
-	power_channel = ENVIRON
 	var/blocked = 0
 	var/nextstate = null
 


### PR DESCRIPTION
Windoors now work on environmental power instead of equipment power

This was annoying in AI upload, as I turned off equipment power so no law uploads could be made, and then the RD asked me to open the windoor to get boards for research and they wouldn't open.
