### PR TITLE
Renames Fake Explosion to Fake Nuclear Explosion

### DIFF
--- a/code/modules/events/wizard/fakeexplosion.dm
+++ b/code/modules/events/wizard/fakeexplosion.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/wizard/fake_explosion //Oh no the station is gone!
-	name = "Fake Explosion"
+	name = "Fake Nuclear Explosion"
 	weight = 0 //Badmin exclusive now because once it's expected its not funny
 	typepath = /datum/round_event/wizard/fake_explosion/
 	max_occurrences = 1


### PR DESCRIPTION
Just so it's very explicit to certain admins (myself) that it's a nukeops cinematic and not just a soundbite of a boom.
