### PR TITLE
Fix for #4999

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -134,6 +134,7 @@
 		sleep(6)
 		open()
 		emagged = 1
+		desc = "<span class='warning'>Its electronics look damaged.</span>"
 		if(istype(src, /obj/machinery/door/airlock))
 			var/obj/machinery/door/airlock/A = src
 			A.lights = 0

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -134,7 +134,7 @@
 		sleep(6)
 		open()
 		emagged = 1
-		desc = "<span class='warning'>Its electronics look damaged.</span>"
+		desc = "<span class='warning'>Its access panel is smoking slightly.</span>"
 		if(istype(src, /obj/machinery/door/airlock))
 			var/obj/machinery/door/airlock/A = src
 			A.lights = 0

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -238,6 +238,7 @@
 		src.operating = -1
 		flick("[src.base_state]spark", src)
 		sleep(6)
+		desc += "<BR><span class='warning'>Its electronics look damaged.</span>"
 		if(istype(I, /obj/item/weapon/melee/energy/blade))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -238,7 +238,7 @@
 		src.operating = -1
 		flick("[src.base_state]spark", src)
 		sleep(6)
-		desc += "<BR><span class='warning'>Its electronics look damaged.</span>"
+		desc += "<BR><span class='warning'>Its access panel is smoking slightly.</span>"
 		if(istype(I, /obj/item/weapon/melee/energy/blade))
 			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 			spark_system.set_up(5, 0, src.loc)


### PR DESCRIPTION
Adding a line in the airlock/windoor description when it's emagged.
Fixes #4999 
