### PR TITLE
Fix for #4754

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -37,9 +37,9 @@
 	if((src.loc) && isturf(src.loc))
 		if(!stat && !resting && !buckled)
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
-				if(!M.stat)
-					M.splat()
+				if(!M.stat && Adjacent(M))
 					emote("me", 1, "splats \the [M]!")
+					M.splat()
 					movement_target = null
 					stop_automated_movement = 0
 					break

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -384,6 +384,9 @@
 					else
 						dir = SOUTH
 
+					if(!Adjacent(movement_target)) //can't reach food through windows.
+						return
+
 					if(isturf(movement_target.loc) )
 						movement_target.attack_animal(src)
 					else if(ishuman(movement_target.loc) )


### PR DESCRIPTION
Prevent corgis from eating food through windows, and cats from splatting mice through windows. Also fixing cat emote for splatting mouse. Fixes #4754
