### PR TITLE
Drone Tweaks, Adjustments, Additions

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone.dm
@@ -25,7 +25,7 @@
 	ventcrawler = 2
 	pass_flags = PASSTABLE | PASSMOB
 	sight = (SEE_TURFS | SEE_OBJS)
-	status_flags = (CANPUSH | CANSTUN)
+	status_flags = (CANPUSH | CANSTUN | CANWEAKEN)
 	gender = NEUTER
 	voice_name = "synthesized chirp"
 	languages = DRONE
@@ -36,6 +36,7 @@
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
 	"3. Your goals are to build, maintain, repair, improve, and power to the best of your abilities, You must never actively work against these goals."
 	var/light_on = 0
+	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())
 	var/obj/item/internal_storage //Drones can store one item, of any size/type in their body
 	var/obj/item/head
@@ -71,8 +72,18 @@
 				if(d_input)
 					switch(d_input)
 						if("Reactivate")
-							if(!client)
-								D << "<span class='notice'>This drone's OS has blue screened, there is no point in repairing them.</span>"
+							var/mob/dead/observer/G = get_ghost()
+							if(!client && !G)
+								var/list/faux_gadgets = list("hypertext inflator","failsafe directory","DRM switch","stack initializer",\
+															 "anti-freeze capacitor","data stream diode","TCP bottleneck","supercharged I/O bolt",\
+															 "tradewind stablizer","radiated XML cable","registry fluid tank","open-source debunker")
+
+								var/list/faux_problems = list("won't be able to tune their bootstrap projector","will constantly remix their binary pool"+\
+															  " even though the BMX calibrator is working","will start leaking their XSS coolant",\
+															  "can't tell if their ethernet detour is moving or not", "won't be able to reseed enough"+\
+															  " kernels to function properly","can't start their neurotube console")
+
+								D << "<span class='notice'>You can't seem to find the [pick(faux_gadgets)]. Without it, [src] [pick(faux_problems)].</span>"
 								return
 							D.visible_message("<span class='notice'>[D] begins to reactivate [src].</span>")
 							if(do_after(user,30,needhand = 1))
@@ -81,6 +92,8 @@
 								icon_state = icon_living
 								D.visible_message("<span class='notice'>[D] reactivates [src]!</span>")
 								alert_drones(DRONE_NET_CONNECT)
+								if(G)
+									G << "<span class='boldnotice'>DRONE NETWORK: </span><span class='ghostalert'>You were reactivated by [D]!</span>"
 							else
 								D << "<span class='notice'>You need to remain still to reactivate [src].</span>"
 
@@ -126,6 +139,11 @@
 
 	..()
 
+/mob/living/simple_animal/drone/examine(mob/user)
+	. = ..()
+	if(!client && stat != DEAD)
+		user << "<span class='notice'>A small blue LED is blinking on and off at a steady rate.</span>"
+
 /mob/living/simple_animal/drone/Move()
 	if(pullin)
 		if(pulling)
@@ -137,7 +155,16 @@
 /mob/living/simple_animal/drone/IsAdvancedToolUser()
 	return 1
 
-/mob/living/simple_animal/drone/radio(message, message_mode)
+/mob/living/simple_animal/drone/say(var/message)
+	return ..(message, "R")
+
+/mob/living/simple_animal/drone/lang_treat(atom/movable/speaker, message_langs, raw_message) //This is so drones can understand humans without being able to speak human
+	. = ..()
+	var/hear_override_langs = HUMAN
+	if(message_langs & hear_override_langs)
+		return ..(speaker, languages, raw_message)
+
+/mob/living/simple_animal/drone/handle_inherent_channels(message, message_mode)
 	if(message_mode == MODE_BINARY)
 		drone_chat(message)
 		return ITALICS | REDUCE_RANGE
@@ -208,7 +235,7 @@
 				if(F in M.faction)
 					send_msg = 1
 					break
-		else if(dead_can_hear && (M.stat == DEAD) && (M.client.prefs.toggles & CHAT_GHOSTEARS) && !istype(M, /mob/new_player))
+		else if(dead_can_hear && (M in dead_mob_list))
 			send_msg = 1
 
 		if(send_msg)
@@ -303,9 +330,12 @@
 			src << "<span class='danger'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>"
 			return
 
-/mob/living/simple_animal/drone/emp_act()
+/mob/living/simple_animal/drone/emp_act(severity)
 	Stun(5)
-	src << "<span class='alert'><b>ER@%R: MME^RY CO#RU9T!</b> R&$b@0tin)...</span>"
+	src << "<span class='danger'><b>ER@%R: MME^RY CO#RU9T!</b> R&$b@0tin)...</span>"
+	if(severity == 1)
+		adjustBruteLoss(heavy_emp_damage)
+		src << "<span class='userdanger'>HeAV% DA%^MMA+G TO I/O CIR!%UUT!</span>"
 
 
 /mob/living/simple_animal/drone/proc/triggerAlarm(var/class, area/A, var/O, var/alarmsource)
@@ -516,6 +546,7 @@
 	health = 30
 	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
 	faction = list("syndicate")
+	heavy_emp_damage = 10
 	laws = \
 	"1. Interfere.\n"+\
 	"2. Kill.\n"+\
@@ -526,7 +557,7 @@
 /mob/living/simple_animal/drone/syndrone/New()
 	..()
 	if(internal_storage && internal_storage.hidden_uplink)
-		internal_storage.hidden_uplink.uses = 5
+		internal_storage.hidden_uplink.uses = (initial(internal_storage.hidden_uplink.uses) / 2)
 		internal_storage.name = "syndicate uplink"
 
 /mob/living/simple_animal/drone/syndrone/Login()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -551,10 +551,16 @@
 	gib()
 	return
 
-/mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who)
-	src << "<span class='warning'>You don't have the dexterity to do this!</span>"
-	return
+/mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who, where, child_override)
+	if(!child_override)
+		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
+		return
+	else
+		..()
 
-/mob/living/simple_animal/stripPanelEquip(obj/item/what, mob/who)
-	src << "<span class='warning'>You don't have the dexterity to do this!</span>"
-	return
+/mob/living/simple_animal/stripPanelEquip(obj/item/what, mob/who, where, child_override)
+	if(!child_override)
+		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
+		return
+	else
+		..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -856,3 +856,11 @@ var/list/slot_equipment_priority = list( \
 
 /mob/proc/assess_threat() //For sec bot threat assessment
 	return
+
+/mob/proc/get_ghost(even_if_they_cant_reenter = 0)
+	if(mind)
+		for(var/mob/dead/observer/G in player_list)
+			if(G.mind == mind)
+				if(G.can_reenter_corpse || even_if_they_cant_reenter)
+					return G
+				break

--- a/html/changelogs/JJRcop-PR-5185.yml
+++ b/html/changelogs/JJRcop-PR-5185.yml
@@ -1,0 +1,11 @@
+author: JJRcop
+delete-after: True
+changes:
+  - rscadd: "We have managed to re-discover drones! We improved the formula, and have discovered some cool stuff."
+  - rscadd: "After some fiddling with audio recognition, drones can now understand human speech!"
+  - rscadd: "One of our engineers found some screws that were loose on some of our tests, screwing them in made the drone work as if it had just come out of robotics."
+  - tweak: "We had to sacrifice some of our NT brand EMP protection for the speech recognition, so drones can get damaged if subjected to heavy EMP radiation."
+  - bugfix: "We figured out why drones couldn't remove objects from people, that has been fixed."
+  - bugfix: "The standby light wasn't wired correctly."
+# ^ These aren't actually code bugs, but I'm writing this all In Character from Nanotrasen, and the icons fit well
+  - rscdel: "Unfortunately one of our assistants tasked with transporting the only copy of the data dropped the flash drive in hot water because he wanted to see what \"drone tea\" tasted like. You'll have to discover them again."


### PR DESCRIPTION
Some tweaks and additions to drones

**Commit log:**
## 1e51b88
- Drones can hear and understand human speech, but still cannot speak it
- Drones recieve 25 brute damage when hit by a heavy EMP blast
- You can tell if drones do not have a player controlling them
- If you attempt to repair a dead drone, but the player is ghosted and can re-enter, you will repair it, and the ghost will be notified
- Added new get_ghost proc to mobs, which will attempt to retrieve the ghost mob of the player if it exists and can re-enter, override arg available if you want it even if it can't re-enter
- Syndrones now start with initial TC/2 instead of a hard coded 5 (which was made before the TC*2 update)
- Drones get a robotic chat bubble
- _Allowed drones to be weakened, as an addition to already being stunned (Forgot to add to commit log)_
- _All ghosts now hear drone chat (Forgot to add to commit log)_
## 8c30ad0
- Drones can now be repaired by a screwdriver after an 8 second delay
- Drones now repair to a health_repair_max instead of maxHealth that defaults to their initial health
- Drones can now use the strip panel
- Added child_override var to simple_animal/stripPanel(Un)Equip that calls the parent if true
