### PR TITLE
HoS/Captain/Riot Armour Change

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -18,7 +18,7 @@
 	icon_state = "riot"
 	item_state = "helmet"
 	flags = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
+	armor = list(melee = 80, bullet = 10, laser = 10,energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	strip_delay = 80
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -16,7 +16,7 @@
 	icon_state = "captain"
 	item_state = "that"
 	flags_inv = 0
-	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 15, laser = 50, energy = 30, bomb = 25, bio = 0, rad = 0)
 	strip_delay = 60
 
 //Captain: This is no longer space-worthy
@@ -66,7 +66,7 @@
 	name = "head of security hat"
 	desc = "The robust hat of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 75, bullet = 60, laser = 60, energy = 50, bomb = 25, bio = 10, rad = 0)
 	flags = 0
 	flags_inv = HIDEEARS
 	strip_delay = 80

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -22,7 +22,7 @@
 	icon_state = "hos"
 	item_state = "hos"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 65, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 65, bullet = 60, laser = 60, energy = 50, bomb = 25, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
@@ -44,7 +44,7 @@
 	icon_state = "capcarapace"
 	item_state = "armor"
 	body_parts_covered = CHEST|GROIN
-	armor = list(melee = 50, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 30, laser = 50, energy = 30, bomb = 25, bio = 0, rad = 0)
 
 
 /obj/item/clothing/suit/armor/riot
@@ -54,7 +54,7 @@
 	item_state = "swat_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 1
-	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 10, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS


### PR DESCRIPTION
Hopefully the final incarnation of this line of PR's from this PR:https://github.com/tgstation/-tg-station/pull/5099. Turns out when I ask git to only merge my changes, it decides to merge every single change made by other people.

Historical text below.

---

Bolded values that have been changed for better identification.

HoS Hat
melee = <b>75</b>, bullet = 60, laser = <b>60</b>, energy = <b>50</b>, bomb = 25, bio = 10, rad = 0
from
melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0

HoS Armour
melee = 65 (+10), bullet = 60, laser = <b>60</b>, energy = <b>50</b>, bomb = 25, bio = 10, rad = 0
from
melee = 65, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0

---

Captain Armour+Hat (Energy changed only)
melee = 50, bullet = 30, laser = 50, energy = <b>30</b>, bomb = 25, bio = 0, rad = 0
from
melee = 50, bullet = 30, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0

---

Riot Armour+Helm
melee = <b>80</b>, bullet = <b>10</b>, laser = <b>10</b>, energy = <b>10</b>, bomb = <b>10</b>, bio = <b>0</b>, rad = 0
from 
melee = 82, bullet = 15, laser = 5, energy = 5, bomb = 5, bio = 2, rad = 0
