### PR TITLE
Fix for #5191

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -82,3 +82,21 @@
 		usr << "<span class='notice'>You empty the box.</span>"
 	src.updateUsrDialog()
 	return
+
+obj/structure/ore_box/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			for(var/obj/item/weapon/ore/O in contents)
+				O.loc = src.loc
+				O.ex_act(severity++)
+			qdel(src)
+			return
+		if(2.0)
+			if(prob(50))
+				for(var/obj/item/weapon/ore/O in contents)
+					O.loc = src.loc
+					O.ex_act(severity++)
+				qdel(src)
+				return
+		if(3.0)
+			return


### PR DESCRIPTION
Adding an ex_act() proc to ore_box so the ores it contains aren't all deleted when the box is deleted by an explosion. Fixes #5191
