### PR TITLE
Prevent grabbing paper bins from the other side of the station.

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/paper_bin/MouseDrop(atom/over_object)
 	var/mob/M = usr
-	if(M.restrained() || M.stat)
+	if(M.restrained() || M.stat || !Adjacent(M))
 		return
 
 	if(over_object == M)


### PR DESCRIPTION
Force pull is not even in the game lore !

Fixes #5158
