### PR TITLE
You can no longer gib mob with c4+signaler

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -95,6 +95,8 @@
 		if (istype(target, /turf/simulated/wall))
 			var/turf/simulated/wall/W = target
 			W.dismantle_wall(1)
+		else if(istype(target, /mob/living))
+			target.ex_act(2) // c4 can't gib mobs anymore.
 		else
 			target.ex_act(1)
 	if(target)


### PR DESCRIPTION
You can no longer gib living mobs by placing a c4 with a signaler on its wire in the hands/pocket/backpack of the mob and sending the signal. 

With this fix, the mob will call ex_act(2) instead of ex_act(1). (which means 120 damage on unarmored human)
