### PR TITLE
Fixes some runtimes linked to signalers.

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -134,7 +134,8 @@ Code:
 	if(signal.encryption != code)	return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
 	pulse(1)
-	src.loc.audible_message("\icon[src] *beep* *beep*", null, 1)
+	if(src.loc)
+		src.loc.audible_message("\icon[src] *beep* *beep*", null, 1)
 	return
 
 


### PR DESCRIPTION
- Fixes the runtime error when sending signal at default frequency and code. 
- Fixes the runtime from receive_signal() proc of the signaler inside a c4 that is exploding via a signal. 
- Fixes the issue of the three beep message when sending signal at default frequency and code. (fixes #3781 )
