### PR TITLE
Fix for #5224

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -11,6 +11,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	icon = 'icons/effects/effects.dmi'
 	mouse_opacity = 0
 	unacidable = 1//So effect are not targeted by alien acid.
+	pass_flags = PASSTABLE | PASSGRILLE
 
 /obj/effect/effect/water
 	name = "water"


### PR DESCRIPTION
Adding passtable and passgrille to obj/effect/effect and its children so these effects aren't blocked by tables and grilles. Fixes #5224 
