### PR TITLE
You can no longer make stacks of grasstile/sandstone bigger than max amount 

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -736,14 +736,19 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grass/attack_self(mob/user as mob)
 	user << "<span class='notice'>You prepare the astroturf.</span>"
-	var/location = get_turf(user)
 	var/grassAmt = 1 + round(potency / 50) // The grass we're holding
-	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/grass/grassToConvert in location) // The grass on the floor
-		grassAmt += 1
-		qdel(grassToConvert)
-	var/obj/item/stack/tile/newAstroturf = new /obj/item/stack/tile/grass(location)
-	newAstroturf.amount = grassAmt
+	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/grass/G in user.loc) // The grass on the floor
+		grassAmt += 1 + round(G.potency / 50)
+		qdel(G)
+	while(grassAmt > 0)
+		var/obj/item/stack/tile/GT = new /obj/item/stack/tile/grass(user.loc)
+		if(grassAmt >= GT.max_amount)
+			GT.amount = GT.max_amount
+		else
+			GT.amount = grassAmt
+		grassAmt -= GT.max_amount
 	qdel(src)
+	return
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/kudzupod
 	seed = /obj/item/seeds/kudzuseed

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -1,7 +1,7 @@
 /**********************Mineral deposits**************************/
 
 /turf/simulated/mineral //wall piece
-	name = "Rock"
+	name = "rock"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rock_nochance"
 	oxygen = 0
@@ -70,7 +70,7 @@
 	new src.type(T)
 
 /turf/simulated/mineral/random
-	name = "Mineral deposit"
+	name = "mineral deposit"
 	icon_state = "rock"
 	var/mineralSpawnChanceList = list("Uranium" = 5, "Diamond" = 1, "Gold" = 10, "Silver" = 12, "Plasma" = 20, "Iron" = 40, "Gibtonite" = 4/*, "Adamantine" =5*/, "Cave" = 2)//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
@@ -127,7 +127,7 @@
 	..()
 
 /turf/simulated/mineral/uranium
-	name = "Uranium deposit"
+	name = "uranium deposit"
 	mineralName = "Uranium"
 	spreadChance = 5
 	spread = 1
@@ -135,7 +135,7 @@
 	scan_state = "rock_Uranium"
 
 /turf/simulated/mineral/iron
-	name = "Iron deposit"
+	name = "iron deposit"
 	icon_state = "rock_Iron"
 	mineralName = "Iron"
 	spreadChance = 20
@@ -143,7 +143,7 @@
 	hidden = 0
 
 /turf/simulated/mineral/diamond
-	name = "Diamond deposit"
+	name = "diamond deposit"
 	mineralName = "Diamond"
 	spreadChance = 0
 	spread = 1
@@ -151,7 +151,7 @@
 	scan_state = "rock_Diamond"
 
 /turf/simulated/mineral/gold
-	name = "Gold deposit"
+	name = "gold deposit"
 	mineralName = "Gold"
 	spreadChance = 5
 	spread = 1
@@ -159,7 +159,7 @@
 	scan_state = "rock_Gold"
 
 /turf/simulated/mineral/silver
-	name = "Silver deposit"
+	name = "silver deposit"
 	mineralName = "Silver"
 	spreadChance = 5
 	spread = 1
@@ -167,7 +167,7 @@
 	scan_state = "rock_Silver"
 
 /turf/simulated/mineral/plasma
-	name = "Plasma deposit"
+	name = "plasma deposit"
 	icon_state = "rock_Plasma"
 	mineralName = "Plasma"
 	spreadChance = 8
@@ -176,7 +176,7 @@
 	scan_state = "rock_Plasma"
 
 /turf/simulated/mineral/clown
-	name = "Bananium deposit"
+	name = "bananium deposit"
 	icon_state = "rock_Clown"
 	mineralName = "Clown"
 	mineralAmt = 3
@@ -186,7 +186,7 @@
 
 ////////////////////////////////Gibtonite
 /turf/simulated/mineral/gibtonite
-	name = "Gibtonite deposit"
+	name = "gibtonite deposit"
 	icon_state = "rock_Gibtonite"
 	mineralName = "Gibtonite"
 	mineralAmt = 1
@@ -215,7 +215,7 @@
 /turf/simulated/mineral/gibtonite/proc/explosive_reaction()
 	if(stage == 0)
 		icon_state = "rock_Gibtonite_active"
-		name = "Gibtonite deposit"
+		name = "gibtonite deposit"
 		desc = "An active gibtonite reserve. Run!"
 		stage = 1
 		visible_message("<span class='warning'>There was gibtonite inside! It's going to explode!</span>")

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -40,14 +40,15 @@
 
 /obj/item/weapon/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
 	user << "<span class='notice'>You use the sand to make sandstone.</span>"
-	for(var/i = 0,i < 2,i++)
+	for(var/i = 0,i < 1,i++)
 		var/obj/item/stack/sheet/mineral/sandstone/S = new (user.loc)
 		for (var/obj/item/weapon/ore/glass/G in user.loc)
 			if(S.amount < S.max_amount)
 				S.amount++
 				qdel(G)
 			else
-				continue
+				i--
+				break
 	qdel(src)
 	return
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -1,7 +1,7 @@
 /**********************Mineral ores**************************/
 
 /obj/item/weapon/ore
-	name = "Rock"
+	name = "rock"
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "ore"
 	var/points = 0 //How many points this ore gets you from the ore redemption machine
@@ -18,38 +18,41 @@
 	..()
 
 /obj/item/weapon/ore/uranium
-	name = "Uranium ore"
+	name = "uranium ore"
 	icon_state = "Uranium ore"
 	origin_tech = "materials=5"
 	points = 18
 	refined_type = /obj/item/stack/sheet/mineral/uranium
 
 /obj/item/weapon/ore/iron
-	name = "Iron ore"
+	name = "iron ore"
 	icon_state = "Iron ore"
 	origin_tech = "materials=1"
 	points = 1
 	refined_type = /obj/item/stack/sheet/metal
 
 /obj/item/weapon/ore/glass
-	name = "Sand"
+	name = "sand pile"
 	icon_state = "Glass ore"
 	origin_tech = "materials=1"
 	points = 1
 	refined_type = /obj/item/stack/sheet/glass
 
-	attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
-		var/location = get_turf(user)
-		var/sandAmt = 1 // The sand we're holding
-		for(var/obj/item/weapon/ore/glass/sandToConvert in location) // The sand on the floor
-			sandAmt += 1
-			qdel(sandToConvert)
-		var/obj/item/stack/sheet/mineral/newSandstone = new /obj/item/stack/sheet/mineral/sandstone(location)
-		newSandstone.amount = sandAmt
-		qdel(src)
+/obj/item/weapon/ore/glass/attack_self(mob/living/user as mob) //It's magic I ain't gonna explain how instant conversion with no tool works. -- Urist
+	user << "<span class='notice'>You use the sand to make sandstone.</span>"
+	for(var/i = 0,i < 2,i++)
+		var/obj/item/stack/sheet/mineral/sandstone/S = new (user.loc)
+		for (var/obj/item/weapon/ore/glass/G in user.loc)
+			if(S.amount < S.max_amount)
+				S.amount++
+				qdel(G)
+			else
+				continue
+	qdel(src)
+	return
 
 /obj/item/weapon/ore/plasma
-	name = "Plasma ore"
+	name = "plasma ore"
 	icon_state = "Plasma ore"
 	origin_tech = "materials=2"
 	points = 36
@@ -65,40 +68,40 @@
 
 
 /obj/item/weapon/ore/silver
-	name = "Silver ore"
+	name = "silver ore"
 	icon_state = "Silver ore"
 	origin_tech = "materials=3"
 	points = 18
 	refined_type = /obj/item/stack/sheet/mineral/silver
 
 /obj/item/weapon/ore/gold
-	name = "Gold ore"
+	name = "gold ore"
 	icon_state = "Gold ore"
 	origin_tech = "materials=4"
 	points = 18
 	refined_type = /obj/item/stack/sheet/mineral/gold
 
 /obj/item/weapon/ore/diamond
-	name = "Diamond ore"
+	name = "diamond ore"
 	icon_state = "Diamond ore"
 	origin_tech = "materials=6"
 	points = 36
 	refined_type = /obj/item/stack/sheet/mineral/diamond
 
 /obj/item/weapon/ore/bananium
-	name = "Bananium ore"
+	name = "bananium ore"
 	icon_state = "Clown ore"
 	origin_tech = "materials=4"
 	points = 27
 	refined_type = /obj/item/stack/sheet/mineral/bananium
 
 /obj/item/weapon/ore/slag
-	name = "Slag"
+	name = "slag"
 	desc = "Completely useless"
 	icon_state = "slag"
 
 /obj/item/weapon/twohanded/required/gibtonite
-	name = "Gibtonite ore"
+	name = "gibtonite ore"
 	desc = "Extremely explosive if struck with mining equipment, Gibtonite is often used by miners to speed up their work by using it as a mining charge. This material is illegal to possess by unauthorized personnel under space law."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Gibtonite ore"


### PR DESCRIPTION
- You can no longer make stacks of grasstile/sandstone bigger than max amount authorized(Fixes #5002) 
- Fixes an error in the amount of grasstiles produced.
- Fixes some unnecessary capitalisation in mineral names.
