### PR TITLE
Manage Free Slots

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -797,22 +797,35 @@ var/global/floorIsLava = 0
 /datum/admins/proc/list_free_slots()
 	if(!check_rights())
 		return
-	var/dat = "<html><head><title>List Free Slots</title></head><body>"
+	var/dat = "<html><head><title>Manage Free Slots</title></head><body>"
 	var/count = 0
+
+	if(ticker && !ticker.mode)
+		alert(usr, "You cannot manage jobs before the round starts!")
+		return
 
 	if(job_master)
 		for(var/datum/job/job in job_master.occupations)
 			count++
 			var/J_title = html_encode(job.title)
+			var/J_opPos = html_encode(job.total_positions - (job.total_positions - job.current_positions))
 			var/J_totPos = html_encode(job.total_positions)
-			dat += "[J_title]: [J_totPos]<br>"
+			if(job.total_positions <= 0)
+				dat += "[J_title]: [J_opPos]"
+			else
+				dat += "[J_title]: [J_opPos]/[J_totPos]"
+			if(initial(job.total_positions) > 0)
+				dat += "   <A href='?src=\ref[src];addjobslot=[job.title]'>Add</A>  |  "
+				if(job.total_positions > job.current_positions)
+					dat += "<A href='?src=\ref[src];removejobslot=[job.title]'>Remove</A>"
+				else
+					dat += "Remove"
+			dat += "<br>"
 
 	dat += "</body>"
 	var/winheight = 100 + (count * 20)
 	winheight = min(winheight, 690)
 	usr << browse(dat, "window=players;size=316x[winheight]")
-
-
 
 //
 //

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -794,7 +794,7 @@ var/global/floorIsLava = 0
 	if(!ai_number)
 		usr << "<b>No AIs located</b>" //Just so you know the thing is actually working and not just ignoring you.
 
-/datum/admins/proc/list_free_slots()
+/datum/admins/proc/manage_free_slots()
 	if(!check_rights())
 		return
 	var/dat = "<html><head><title>Manage Free Slots</title></head><body>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1334,7 +1334,7 @@
 				job.total_positions += 1
 				break
 
-		src.list_free_slots()
+		src.manage_free_slots()
 
 	else if(href_list["removejobslot"])
 		if(!check_rights(R_ADMIN))	return
@@ -1346,7 +1346,7 @@
 				job.total_positions -= 1
 				break
 
-		src.list_free_slots()
+		src.manage_free_slots()
 
 	else if(href_list["adminspawncookie"])
 		if(!check_rights(R_ADMIN|R_FUN))	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1324,6 +1324,30 @@
 		src.owner << "[special_role_description]"
 		src.owner << "(<a href='?priv_msg=[M.ckey]'>PM</a>) (<A HREF='?src=\ref[src];adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[M]'>VV</A>) (<A HREF='?src=\ref[src];subtlemessage=\ref[M]'>SM</A>) (<A HREF='?src=\ref[src];adminplayerobservejump=\ref[M]'>JMP</A>) (<A HREF='?src=\ref[src];secretsadmin=check_antagonist'>CA</A>)"
 
+	else if(href_list["addjobslot"])
+		if(!check_rights(R_ADMIN))	return
+
+		var/Add = href_list["addjobslot"]
+
+		for(var/datum/job/job in job_master.occupations)
+			if(job.title == Add)
+				job.total_positions += 1
+				break
+
+		src.list_free_slots()
+
+	else if(href_list["removejobslot"])
+		if(!check_rights(R_ADMIN))	return
+
+		var/Remove = href_list["removejobslot"]
+
+		for(var/datum/job/job in job_master.occupations)
+			if(job.title == Remove && job.total_positions - job.current_positions > 0)
+				job.total_positions -= 1
+				break
+
+		src.list_free_slots()
+
 	else if(href_list["adminspawncookie"])
 		if(!check_rights(R_ADMIN|R_FUN))	return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -449,7 +449,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"
-	set name = "List free slots"
+	set name = "Manage Job Slots"
 
 	if (!holder)
 		src << "Only administrators may use this command."

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -454,8 +454,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if (!holder)
 		src << "Only administrators may use this command."
 		return
-	holder.list_free_slots()
-	feedback_add_details("admin_verb","LFS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	holder.manage_free_slots()
+	feedback_add_details("admin_verb","MFS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_explosion(atom/O as obj|mob|turf in world)
 	set category = "Special Verbs"


### PR DESCRIPTION
Converts the nearly useless List Free Slots command to Manage Free Slots

From here you can painlessly add and remove job slots to your hearts content because the HoP is Dead/Shit/AFK/In Hiding and everyone is rolling assistant because there's nothing else left.

It can't be used before round start to make rounds with only clowns because of jobs.txt being applied at round start. Alas.
