### PR TITLE
SDQL2 admin notice

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -8,6 +8,11 @@
 /proc/warning(msg)
 	world.log << "## WARNING: [msg]"
 
+//not an error or a warning, but worth to mention on the world log, just in case.
+#define NOTICE(MSG) notice(MSG)
+/proc/notice(msg)
+	world.log << "## NOTICE: [msg]"
+
 //print a testing-mode debug message to world.log
 /proc/testing(msg)
 #ifdef TESTING

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -21,8 +21,8 @@
 /client/proc/SDQL2_query(query_text as message)
 	set category = "Debug"
 	if(!check_rights(R_DEBUG))  //Shouldn't happen... but just to be safe.
-		message_admins("<span class='danger'>ERROR: Non-admin [usr.key] attempted to execute a SDQL query!</span>")
-		log_admin("Non-admin [usr.key] attempted to execute a SDQL query!")
+		message_admins("<span class='danger'>ERROR: Non-admin [key_name(usr, usr.client)] attempted to execute a SDQL query!</span>")
+		log_admin("Non-admin [usr.ckey]([usr]) attempted to execute a SDQL query!")
 
 	if(!query_text || length(query_text) < 1)
 		return
@@ -40,10 +40,12 @@
 		return
 
 
-	var/query_log = "[usr] executed SDQL query: \"[query_text]\"."
-	world.log << query_log
-	message_admins(query_log)
+	var/query_log = "executed SDQL query: \"[query_text]\"."
+	message_admins("[key_name_admin(usr)] [query_log]")
+	query_log = "[usr.ckey]([usr]) [query_log]"
 	log_game(query_log)
+	NOTICE(query_log)
+
 
 	for(var/list/query_tree in querys)
 		var/list/from_objs = list()


### PR DESCRIPTION
Added NOTICE() for world.log messages that aren't errors or warnings.
The message that SDQL2 query outputs will now properly state the ckey of the user.
