### PR TITLE
Removes tableclimbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -416,24 +416,6 @@ Destroy type values:
 			return
 	..()
 
-/obj/structure/table/MouseDrop_T(mob/target, mob/living/carbon/human/user)
-	if(istype(target) && user == target && istype(user))
-		if(user.canmove)
-			climb_table(user)
-
-/obj/structure/table/proc/climb_table(mob/user)
-	src.add_fingerprint(user)
-	user.visible_message("<span class='warning'>[user] starts climbing onto [src].</span>", \
-								"<span class='notice'>[user] starts climbing onto [src].</span>")
-	if(do_mob(user, user, 20))
-		user.pass_flags += PASSTABLE
-		step(user,get_dir(user,src.loc))
-		user.pass_flags -= PASSTABLE
-		user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
-									"<span class='notice'>[user] climbs onto [src].</span>")
-		add_logs(user, src, "climbed onto")
-		user.Stun(2)
-
 /*
  * Racks
  */


### PR DESCRIPTION
The tableclimbing was a perfect test of the old saying 'this is why we can't have nice things'. While there are some nice moments when this feature can be used properly, in moment of a hurry usually, the chances of that ever happening are really low, mainly tableclimbing is used for stealing, tresspas, antagonize, annoy, greytide, etc. This doesn't only come from my perspective as a player, observer and admin, but from looking at the feedback of other players about the feature itself, in OOC and forums.
There's more loss than gain, I honestly waited to see a few weeks if the behaviour changed instead of instantly removing it, but this is still used for greytiding purposes. I talked with several people about it, including hg, the guy who added the tableclimbing and they agreed on removing it.

Old comments: http://i.imgur.com/sbIb8PC.png
If you comment with a single emoticon or other bullcrap I'll delete your comment, constructive comments allowed only.
