### PR TITLE
Fix for #4565

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1031,7 +1031,7 @@ About the new airlock wires panel:
 		if(locate(/mob/living) in get_turf(src))
 		//	playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)	//THE BUZZING IT NEVER STOPS	-Pete
 			spawn (60)
-				close()
+				autoclose()
 			return
 
 	crush()


### PR DESCRIPTION
Fixes the superimposing of airlock sound by changing one close() to autoclose(). Fixes #4565
