### PR TITLE
Adds a Syndicate encryption key to uplinks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -399,14 +399,14 @@ var/list/uplink_items = list()
 	name = "Binary Translator Key"
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. "
 	item = /obj/item/device/encryptionkey/binary
-	cost = 6
+	cost = 5
 	surplus = 75
 
 /datum/uplink_item/device_tools/encryptionkey
 	name = "Syndicate Encryption Key"
 	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
 	item = /obj/item/device/encryptionkey/syndicate
-	cost = 6
+	cost = 5
 	surplus = 75
 
 /datum/uplink_item/device_tools/ai_detector

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -402,6 +402,13 @@ var/list/uplink_items = list()
 	cost = 6
 	surplus = 75
 
+/datum/uplink_item/device_tools/encryptionkey
+	name = "Syndicate Encryption Key"
+	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
+	item = /obj/item/device/encryptionkey/syndicate
+	cost = 6
+	surplus = 75
+
 /datum/uplink_item/device_tools/ai_detector
 	name = "Artificial Intelligence Detector" // changed name in case newfriends thought it detected disguised ai's
 	desc = "A functional multitool that turns red when it detects an artificial intelligence watching it or its holder. Knowing when an artificial intelligence is watching you is useful for knowing when to maintain cover."


### PR DESCRIPTION
Partially inspired both by #1700 and a post in the traitor items idea thread this simple addition allows traitors to eavesdrop on the radio channels of every department on the station as well as talk confidentially with any other traitor that also has the key.

Unlike #1700 there's use to this even if nobody else picks it and it's unlikely that security will be able to realize a traitor has it unless the traitor tells them. Considering how in normal gameplay traitors and nukeops never coexist I don't see any real potential for abuse there and it also shouldn't be bad for double agents either as it could prompt some interesting situations.
