### PR TITLE
Fix for #5288

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -203,7 +203,7 @@ its easier to just keep the beam vertical.
 /atom/proc/examine(mob/user)
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src]."
-	if(src.blood_DNA)
+	if(src.blood_DNA && !istype(src, /obj/effect/decal))
 		if(gender == PLURAL)
 			f_name = "some "
 		else


### PR DESCRIPTION
Fixing the blood decals being called "blood-stained blood" upon examination by adding a check for decals. Fixes #5288
