### PR TITLE
Fix for #5281

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone.dm
@@ -444,6 +444,10 @@
 	else
 		mode()
 
+/mob/living/simple_animal/drone/assess_threat() //Secbots won't hunt maintenance drones.
+	return -10
+
+
 #undef HANDS_LAYER
 #undef HEAD_LAYER
 #undef TOTAL_LAYERS


### PR DESCRIPTION
Fixes secbots hunting, stunning and arresting maintenance drones that attack them. Secbot won't hunt them anymore, just like with silicons. Fix is done by adding an assess_threat() proc in simple_animal/drone that returns -10 (similar to silicons)

Fixes #5281
