### PR TITLE
Nuke href exploit fix

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -104,7 +104,7 @@ var/bomb_set
 						var/turf/LOC = get_turf(usr)
 						message_admins("[key_name_admin(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
 						log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered] !")
-					else:
+					else
 						src.code += lastentered
 						if (length(src.code) > 5)
 							src.code = "ERROR"

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -16,6 +16,7 @@ var/bomb_set
 	var/obj/item/weapon/disk/nuclear/auth = null
 	use_power = 0
 	var/previous_level = ""
+	var/lastentered = ""
 
 /obj/machinery/nuclearbomb/process()
 	if (src.timing)
@@ -98,9 +99,15 @@ var/bomb_set
 					src.yes_code = 0
 					src.code = null
 				else
-					src.code += text("[]", href_list["type"])
-					if (length(src.code) > 5)
-						src.code = "ERROR"
+					lastentered = text("[]", href_list["type"])
+					if (text2num(lastentered) == null)
+						var/turf/LOC = get_turf(usr)
+						message_admins("[key_name_admin(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
+						log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered] !")
+					else:
+						src.code += lastentered
+						if (length(src.code) > 5)
+							src.code = "ERROR"
 		if (src.yes_code)
 			if (href_list["time"])
 				var/time = text2num(href_list["time"])


### PR DESCRIPTION
Nuke href exploit fix, disallows non-numerical characters, sends a warning to admins and logs the attempt.
