### PR TITLE
Flashes runtime fix

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -23,15 +23,15 @@
 	return 1
 
 
-/obj/item/device/flash/proc/burn_out(var/mob/user) //Made so you can override it if you want to have an invincible flash from R&D or something.
+/obj/item/device/flash/proc/burn_out() //Made so you can override it if you want to have an invincible flash from R&D or something.
 	broken = 1
 	icon_state = "[initial(icon_state)]burnt"
-	user.visible_message("<span class='notice'>The [src.name] burns out!</span>")
+	visible_message("<span class='notice'>The [src.name] burns out!</span>")
 
 
 /obj/item/device/flash/proc/flash_recharge(var/mob/user)
 	if(prob(times_used * 2))	//if you use it 5 times in a minute it has a 10% chance to break!
-		burn_out(user)
+		burn_out()
 		return 0
 
 	var/deciseconds_passed = world.time - last_used


### PR DESCRIPTION
Fixes a runtime with flashes when they burn out without user, now they'll display the burn out message from the src instead.
