### PR TITLE
Camera EMP + qdel runtime fix.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -76,14 +76,15 @@
 			emped = emped+1  //Increase the number of consecutive EMP's
 			var/thisemp = emped //Take note of which EMP this proc is for
 			spawn(900)
-				if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
-					network = previous_network
-					icon_state = initial(icon_state)
-					stat &= ~EMPED
-					cancelCameraAlarm()
-					if(can_use())
-						cameranet.addCamera(src)
-					emped = 0 //Resets the consecutive EMP count
+				if(loc) //qdel limbo
+					if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
+						network = previous_network
+						icon_state = initial(icon_state)
+						stat &= ~EMPED
+						cancelCameraAlarm()
+						if(can_use())
+							cameranet.addCamera(src)
+						emped = 0 //Resets the consecutive EMP count
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()


### PR DESCRIPTION
Fixes a runtime related to cameras being EMPed and finishing a spawn() while being in the qdel limbo
