### PR TITLE
Fixes radiation levels getting stuck

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -578,13 +578,13 @@
 
 		else
 			switch(H.radiation)
-				if(1 to 49)
+				if(0 to 50)
 					H.radiation--
 					if(prob(25))
 						H.adjustToxLoss(1)
 						H.updatehealth()
 
-				if(50 to 74)
+				if(50 to 75)
 					H.radiation -= 2
 					H.adjustToxLoss(1)
 					if(prob(5))


### PR DESCRIPTION
The `X to Y` expression is apparently X exclusive but Y inclusive.

Fixes #5304

Also : "rejuvenators" (in reality inaprovaline) has no effect on radiations.
