### PR TITLE
More messages fixed

### DIFF
--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -43,7 +43,8 @@ Bonus
 
 /datum/symptom/vomit/proc/Vomit(var/mob/living/M)
 
-	M.visible_message("<B>[M]</B> vomits on the floor!")
+	M.visible_message("<span class='danger'>[M] vomits on the floor!</span>", \
+					"<span class='userdanger'>You throw up on the floor!</span>")
 
 	M.nutrition -= 20
 	M.adjustToxLoss(-3)
@@ -84,7 +85,8 @@ Bonus
 /datum/symptom/vomit/blood/Vomit(var/mob/living/M)
 
 	M.Stun(1)
-	M.visible_message("<B>[M]</B> vomits on the floor!")
+	M.visible_message("<span class='danger'>[M] vomits on the floor!</span>", \
+						"<span class='userdanger'>You throw up on the floor!</span>")
 
 	// They lose blood and health.
 	var/brute_dam = M.getBruteLoss()

--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -44,7 +44,7 @@
 					affected_mob.nutrition -= 95
 					affected_mob.adjustToxLoss(-1)
 				else
-					affected_mob << "<span class='warning'>You gag as you want to throw up, but there's nothing in your stomach!</span>"
+					affected_mob << "<span class='userdanger'>You gag as you want to throw up, but there's nothing in your stomach!</span>"
 					affected_mob.Weaken(10)
 					affected_mob.adjustToxLoss(3)
 

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -316,7 +316,7 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 /obj/machinery/bot/cleanbot/proc/clean(var/obj/effect/decal/cleanable/target)
 	src.anchored = 1
 	src.icon_state = "cleanbot-c"
-	visible_message("<span class='danger'>[src] begins to clean up [target]</span>")
+	visible_message("<span class='notice'>[src] begins to clean up [target]</span>")
 	src.cleaning = 1
 	spawn(50)
 		src.cleaning = 0

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -468,9 +468,10 @@
 	if ((HULK in user.mutations) && !prob(src.deflect_chance))
 		src.take_damage(15)
 		src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
-		user.visible_message("<span class='userdanger'>[user] hits [src.name], doing some damage.</span>", "<span class='userdanger'>You hit [src.name] with all your might. The metal creaks and bends.</span>")
+		user.visible_message("<span class='danger'>[user] hits [src.name], doing some damage.</span>", "<span class='danger'>You hit [src.name] with all your might. The metal creaks and bends.</span>")
+		src.occupant_message("<span class='userdanger'>[user] hits [src.name], doing some damage.</span>")
 	else
-		user.visible_message("<span class='userdanger'>[user] hits [src.name]. Nothing happens</span>","<span class='userdanger'>You hit [src.name] with no visible effect.</span>")
+		user.visible_message("<span class='danger'>[user] hits [src.name]. Nothing happens</span>","<span class='danger'>You hit [src.name] with no visible effect.</span>")
 		src.log_append_to_last("Armor saved.")
 	return
 
@@ -486,6 +487,7 @@
 		playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
 		user << "<span class='danger'>You slash at the armored suit!</span>"
 		visible_message("<span class='danger'>The [user] slashes at [src.name]'s armor!</span>")
+		src.occupant_message("<span class='userdanger'>The [user] slashes at [src.name]'s armor!</span>")
 	else
 		src.log_append_to_last("Armor saved.")
 		playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
@@ -504,12 +506,13 @@
 			var/damage = rand(user.melee_damage_lower, user.melee_damage_upper)
 			src.take_damage(damage)
 			src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
-			visible_message("<span class='danger'><B>[user]</B> [user.attacktext] [src]!</span>")
+			visible_message("<span class='danger'>[user] [user.attacktext] [src]!</span>")
+			src.occupant_message("<span class='userdanger'>[user] [user.attacktext] [src]!</span>")
 			add_logs(user, src, "attacked", admin=0)
 		else
 			src.log_append_to_last("Armor saved.")
 			playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
-			src.occupant_message("<span class='notice'>The [user]'s attack is stopped by the armor.</span>")
+			src.occupant_message("<span class='notice'>[user]'s attack is stopped by the armor.</span>")
 			visible_message("<span class='notice'>The [user] rebounds off [src.name]'s armor!</span>")
 			add_logs(user, src, "attacked", admin=0)
 	return
@@ -537,6 +540,8 @@
 	else if(istype(A, /obj))
 		var/obj/O = A
 		if(O.throwforce)
+			src.occupant_message("<span class='userdanger'>[src.name] is hit by [A].</span>")
+			src.visible_message("<span class='danger'>[src.name] is hit by [A].</span>")
 			src.take_damage(O.throwforce)
 			src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 	return
@@ -562,6 +567,8 @@
 		ignore_threshold = 1
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		src.take_damage(Proj.damage,Proj.flag)
+		src.occupant_message("<span class='userdanger'>[src.name] is hit by [Proj]!</span>")
+		src.visible_message("<span class='danger'>[src.name] is hit by [Proj].</span>")
 		src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),ignore_threshold)
 	Proj.on_hit(src)
 	return
@@ -644,7 +651,7 @@
 		return 0
 	else
 		src.occupant_message("<span class='userdanger'>[user] hits [src] with [W].</span>")
-		user.visible_message("<span class='userdanger'>[user] hits [src] with [W].</span>", "<span class='userdanger'>You hit [src] with [W].</span>")
+		user.visible_message("<span class='danger'>[user] hits [src] with [W].</span>", "<span class='danger'>You hit [src] with [W].</span>")
 		src.take_damage(W.force,W.damtype)
 		src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 		return 1

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -95,9 +95,7 @@
 
 		hp -= Proj.damage
 		if(hp <= 0)
-			for(var/mob/O in oviewers())
-				if ((O.client && !( O.blinded )))
-					O << "<span class='danger'>[src] breaks into tiny pieces and collapses!</span>"
+			visible_message("<span class='warning'>[src] breaks into tiny pieces and collapses!</span>")
 			qdel(src)
 
 		// Create a temporary object to represent the damage

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -85,16 +85,14 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if (src.destroyed && src.occupied)
 		new /obj/item/weapon/gun/energy/laser/captain( src.loc )
-		user << "\b You deactivate the hover field built into the case."
+		user << "<span class='notice'>You deactivate the hover field built into the case.</span>"
 		src.occupied = 0
 		src.add_fingerprint(user)
 		update_icon()
 		return
 	else
-		usr << text("<span class='notice'>You kick the display case.</span>")
-		for(var/mob/O in oviewers())
-			if ((O.client && !( O.blinded )))
-				O << text("<span class='danger'>[] kicks the display case.</span>", usr)
+		user.visible_message("<span class='danger'>[user] kicks the display case.</span>", \
+						 "<span class='notice'>You kick the display case.</span>")
 		src.health -= 2
 		healthcheck()
 		return

--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -75,10 +75,8 @@
 	if (src.destroyed)
 		return
 	else
-		usr << text("<span class='notice'>You kick the lab cage.</span>")
-		for(var/mob/O in oviewers())
-			if ((O.client && !( O.blinded )))
-				O << text("<span class='danger'>[] kicks the lab cage.</span>", usr)
+		user.visible_message("<span class='danger'>[user] kicks the lab cage.</span>", \
+					 		"<span class='notice'>You kick the lab cage.</span>")
 		src.health -= 2
 		healthcheck()
 		return

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -25,7 +25,7 @@
 	CheckHardness()
 
 /obj/structure/statue/attack_hand(mob/user)
-	visible_message("<span class='danger'>[user] rubs some dust off from the [name]'s surface.</span>")
+	visible_message("<span class='notice'>[user] rubs some dust off from the [name]'s surface.</span>")
 
 /obj/structure/statue/CanAtmosPass()
 	return !density

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -2210,9 +2210,8 @@ ________________________________________________________________________________
 			anim(U.loc,U,'icons/mob/mob.dmi',,"cloak",,U.dir)
 		s_active=!s_active
 		U.alpha = 0
-		U << "<span class='notice'>You are now invisible to normal detection.</span>"
-		for(var/mob/O in oviewers(U))
-			O.show_message("[U.name] vanishes into thin air!",1)
+		U.visible_message("<span class='warning'>[U.name] vanishes into thin air!</span>", \
+						"<span class='notice'>You are now invisible to normal detection.</span>")
 	return
 
 /obj/item/clothing/suit/space/space_ninja/proc/cancel_stealth()
@@ -2222,9 +2221,8 @@ ________________________________________________________________________________
 			anim(U.loc,U,'icons/mob/mob.dmi',,"uncloak",,U.dir)
 		s_active=!s_active
 		U.alpha = 255
-		U << "<span class='notice'>You are now visible.</span>"
-		for(var/mob/O in oviewers(U))
-			O.show_message("[U.name] appears from thin air!",1)
+		U.visible_message("<span class='warning'>[U.name] appears from thin air!</span>", \
+						"<span class='notice'>You are now visible.</span>")
 		return 1
 	return 0
 
@@ -2613,143 +2611,139 @@ It is possible to destroy the net by the occupant or someone else.
 	var/mob/living/affecting = null//Who it is currently affecting, if anyone.
 	var/mob/living/master = null//Who shot web. Will let this person know if the net was successful or failed.
 
-	proc
-		healthcheck()
-			if(health <=0)
-				density = 0
-				if(affecting)
-					var/mob/living/carbon/M = affecting
-					M.anchored = 0
-					for(var/mob/O in viewers(src, 3))
-						O.show_message(text("[] was recovered from the energy net!", M.name), 1, text("You hear a grunt."), 2)
-					if(!isnull(master))//As long as they still exist.
-						master << "<span class='userdanger'>ERROR</span>: \black unable to initiate transport protocol. Procedure terminated."
-				qdel(src)
-			return
-
-	process(var/mob/living/carbon/M as mob)
-		var/check = 30//30 seconds before teleportation. Could be extended I guess.
-		var/mob_name = affecting.name//Since they will report as null if terminated before teleport.
-		//The person can still try and attack the net when inside.
-		while(!isnull(M)&&!isnull(src)&&check>0)//While M and net exist, and 30 seconds have not passed.
-			check--
-			sleep(10)
-
-		if(isnull(M)||M.loc!=loc)//If mob is gone or not at the location.
-			if(!isnull(master))//As long as they still exist.
-				master << "<span class='userdanger'>ERROR</span>: \black unable to locate \the [mob_name]. Procedure terminated."
-			qdel(src)//Get rid of the net.
-			return
-
-		if(!isnull(src))//As long as both net and person exist.
-			//No need to check for countdown here since while() broke, it's implicit that it finished.
-
-			density = 0//Make the net pass-through.
-			invisibility = 101//Make the net invisible so all the animations can play out.
-			health = INFINITY//Make the net invincible so that an explosion/something else won't kill it while, spawn() is running.
-			for(var/obj/item/W in M)
-				if(istype(M,/mob/living/carbon/human))
-					if(W==M:w_uniform)	continue//So all they're left with are shoes and uniform.
-					if(W==M:shoes)	continue
-				M.unEquip(W)
-
-			spawn(0)
-				playsound(M.loc, 'sound/effects/sparks4.ogg', 50, 1)
-				anim(M.loc,M,'icons/mob/mob.dmi',,"phaseout",,M.dir)
-
-			M.loc = pick(holdingfacility)//Throw mob in to the holding facility.
-			M << "<span class='danger'>You appear in a strange place!</span>"
-
-			spawn(0)
-				var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-				spark_system.set_up(5, 0, M.loc)
-				spark_system.start()
-				playsound(M.loc, 'sound/effects/phasein.ogg', 25, 1)
-				playsound(M.loc, 'sound/effects/sparks2.ogg', 50, 1)
-				anim(M.loc,M,'icons/mob/mob.dmi',,"phasein",,M.dir)
-				qdel(src)//Wait for everything to finish, delete the net. Else it will stop everything once net is deleted, including the spawn(0).
-
+/obj/effect/energy_net/proc/healthcheck()
+	if(health <=0)
+		density = 0
+		if(affecting)
+			var/mob/living/carbon/M = affecting
+			M.anchored = 0
 			for(var/mob/O in viewers(src, 3))
-				O.show_message(text("[] vanished!", M), 1, text("You hear sparks flying!"), 2)
-
+				O.show_message("[M.name] was recovered from the energy net!", 1, "You hear a grunt.", 2)
 			if(!isnull(master))//As long as they still exist.
-				master << "<span class='notice'><b>SUCCESS</b>: \black transport procedure of \the [affecting] complete.</span>"
+				master << "<span class='userdanger'>ERROR</span>: \black unable to initiate transport protocol. Procedure terminated."
+		qdel(src)
+	return
 
-			M.anchored = 0//Important.
+/obj/effect/energy_net/process(var/mob/living/carbon/M as mob)
+	var/check = 30//30 seconds before teleportation. Could be extended I guess.
+	var/mob_name = affecting.name//Since they will report as null if terminated before teleport.
+	//The person can still try and attack the net when inside.
+	while(!isnull(M)&&!isnull(src)&&check>0)//While M and net exist, and 30 seconds have not passed.
+		check--
+		sleep(10)
 
-		else//And they are free.
-			M << "<span class='notice'>You are free of the net!</span>"
+	if(isnull(M)||M.loc!=loc)//If mob is gone or not at the location.
+		if(!isnull(master))//As long as they still exist.
+			master << "<span class='userdanger'>ERROR</span>: \black unable to locate \the [mob_name]. Procedure terminated."
+		qdel(src)//Get rid of the net.
 		return
 
-	bullet_act(var/obj/item/projectile/Proj)
-		health -= Proj.damage
-		healthcheck()
-		..()
+	if(!isnull(src))//As long as both net and person exist.
+		//No need to check for countdown here since while() broke, it's implicit that it finished.
 
-	ex_act(severity)
-		switch(severity)
-			if(1.0)
-				health-=50
-			if(2.0)
-				health-=50
-			if(3.0)
-				health-=prob(50)?50:25
-		healthcheck()
-		return
+		density = 0//Make the net pass-through.
+		invisibility = 101//Make the net invisible so all the animations can play out.
+		health = INFINITY//Make the net invincible so that an explosion/something else won't kill it while, spawn() is running.
+		for(var/obj/item/W in M)
+			if(istype(M,/mob/living/carbon/human))
+				if(W==M:w_uniform)	continue//So all they're left with are shoes and uniform.
+				if(W==M:shoes)	continue
+			M.unEquip(W)
 
-	blob_act()
-		health-=50
-		healthcheck()
-		return
+		spawn(0)
+			playsound(M.loc, 'sound/effects/sparks4.ogg', 50, 1)
+			anim(M.loc,M,'icons/mob/mob.dmi',,"phaseout",,M.dir)
 
-	hitby(AM as mob|obj)
-		..()
-		for(var/mob/O in viewers(src, null))
-			O.show_message(text("<span class='danger'>[src] was hit by [AM].</span>"), 1)
-		var/tforce = 0
-		if(ismob(AM))
-			tforce = 10
-		else
-			tforce = AM:throwforce
-		playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
-		health = max(0, health - tforce)
-		healthcheck()
-		..()
-		return
+		M.loc = pick(holdingfacility)//Throw mob in to the holding facility.
+		M << "<span class='danger'>You appear in a strange place!</span>"
 
-	attack_hand()
-		if (HULK in usr.mutations)
-			usr << text("<span class='notice'>You easily destroy the energy net.</span>")
-			for(var/mob/O in oviewers(src))
-				O.show_message(text("<span class='danger'>[] rips the energy net apart!</span>", usr), 1)
+		spawn(0)
+			var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
+			spark_system.set_up(5, 0, M.loc)
+			spark_system.start()
+			playsound(M.loc, 'sound/effects/phasein.ogg', 25, 1)
+			playsound(M.loc, 'sound/effects/sparks2.ogg', 50, 1)
+			anim(M.loc,M,'icons/mob/mob.dmi',,"phasein",,M.dir)
+			qdel(src)//Wait for everything to finish, delete the net. Else it will stop everything once net is deleted, including the spawn(0).
+
+		for(var/mob/O in viewers(src, 3))
+			O.show_message("[M] vanished!", 1, "You hear sparks flying!", 2)
+
+		if(!isnull(master))//As long as they still exist.
+			master << "<span class='notice'><b>SUCCESS</b>: \black transport procedure of \the [affecting] complete.</span>"
+
+		M.anchored = 0//Important.
+
+	else//And they are free.
+		M << "<span class='notice'>You are free of the net!</span>"
+	return
+
+/obj/effect/energy_net/bullet_act(var/obj/item/projectile/Proj)
+	health -= Proj.damage
+	healthcheck()
+	..()
+
+/obj/effect/energy_net/ex_act(severity)
+	switch(severity)
+		if(1.0)
 			health-=50
-		healthcheck()
-		return
+		if(2.0)
+			health-=50
+		if(3.0)
+			health-=prob(50)?50:25
+	healthcheck()
+	return
 
-	attack_paw()
-		return attack_hand()
+/obj/effect/energy_net/blob_act()
+	health-=50
+	healthcheck()
+	return
 
-	attack_alien()
-		if (islarva(usr))
-			return
-		usr << text("\green You claw at the net.")
-		for(var/mob/O in oviewers(src))
-			O.show_message(text("<span class='danger'>[] claws at the energy net!</span>", usr), 1)
-		playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
-		health -= rand(10, 20)
-		if(health <= 0)
-			usr << text("\green You slice the energy net to pieces.")
-			for(var/mob/O in oviewers(src))
-				O.show_message(text("<span class='danger'>[] slices the energy net apart!</span>", usr), 1)
-		healthcheck()
-		return
+/obj/effect/energy_net/hitby(AM as mob|obj)
+	..()
+	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
+	var/tforce = 0
+	if(ismob(AM))
+		tforce = 10
+	else
+		tforce = AM:throwforce
+	playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
+	health = max(0, health - tforce)
+	healthcheck()
+	..()
+	return
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob)
-		var/aforce = W.force
-		health = max(0, health - aforce)
-		healthcheck()
-		..()
+/obj/effect/energy_net/attack_hand(mob/user)
+	if (HULK in user.mutations)
+		user.visible_message("<span class='danger'>[user] rips the energy net apart!</span>", \
+								"<span class='notice'>You easily destroy the energy net.</span>")
+		health-=50
+	healthcheck()
+	return
+
+/obj/effect/energy_net/attack_paw(mob/user)
+	return attack_hand()
+
+/obj/effect/energy_net/attack_alien(mob/user as mob)
+	if (islarva(user))
 		return
+	playsound(src.loc, 'sound/weapons/slash.ogg', 80, 1)
+	health -= rand(10, 20)
+	if(health > 0)
+		user.visible_message("<span class='danger'>[user] claws at the energy net!</span>", \
+					 "\green You claw at the net.")
+	else
+		user.visible_message("<span class='danger'>[user] slices the energy net apart!</span>", \
+						 "\green You slice the energy net to pieces.")
+	healthcheck()
+	return
+
+/obj/effect/energy_net/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	var/aforce = W.force
+	health = max(0, health - aforce)
+	healthcheck()
+	..()
+	return
 
 proc/create_ninja_mind(key)
 	var/datum/mind/Mind = new /datum/mind(key)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -247,9 +247,8 @@ proc/check_panel(mob/M)
 
 /obj/effect/fake_attacker/attackby(var/obj/item/weapon/P as obj, mob/user as mob)
 	step_away(src,my_target,2)
-	for(var/mob/M in oviewers(world.view,my_target))
-		M << "<span class='userdanger'>[my_target] flails around wildly.</span>"
-	my_target.show_message("<span class='userdanger'>[src] has been attacked by [my_target] </span>", 1) //Lazy.
+	my_target.visible_message("<span class='danger'>[my_target] flails around wildly.</span>", \
+							"<span class='userdanger'>[src] has been attacked by [my_target] </span>")
 
 	src.health -= P.force
 
@@ -261,7 +260,7 @@ proc/check_panel(mob/M)
 		step_away(src,my_target,2)
 		if(prob(30))
 			for(var/mob/O in oviewers(world.view , my_target))
-				O << "<span class='userdanger'>[my_target] stumbles around.</span>"
+				O << "<span class='danger'>[my_target] stumbles around.</span>"
 
 /obj/effect/fake_attacker/New()
 	..()

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -453,7 +453,8 @@
 					shake_camera(L, 20, 1)
 					spawn(20)
 						if(L)
-							L.visible_message("<span class='danger'>[L.name] vomits from travelling through the [src.name]!</span>")
+							L.visible_message("<span class='danger'>[L.name] vomits from travelling through the [src.name]!</span>", \
+												"<span class='userdanger'>You throw up from travelling through the [src.name]!</span>")
 							L.nutrition -= 20
 							L.adjustToxLoss(-3)
 							var/turf/T = get_turf(L)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -150,8 +150,7 @@ Doesn't work on other aliens/AI.*/
 		if(!choice || !powerc(55))	return
 		adjustToxLoss(-55)
 		src << "<span class='notice'>You shape a [choice].</span>"
-		for(var/mob/O in viewers(src, null))
-			O.show_message(text("<span class='notice'>[src] vomits up a thick purple substance and begins to shape it.</span>"), 1)
+		visible_message("<span class='notice'>[src] vomits up a thick purple substance and begins to shape it.</span>")
 		switch(choice)
 			if("resin wall")
 				new /obj/structure/alien/resin/wall(loc)

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -9,16 +9,12 @@
 
 	if (layer != TURF_LAYER+0.2)
 		layer = TURF_LAYER+0.2
-		src << text("<span class='noticealien'>You are now hiding.</span>")
-		for(var/mob/O in oviewers(src, null))
-			if ((O.client && !( O.blinded )))
-				O << text("<span class='name'>[] scurries to the ground!</span>", src)
+		visible_message("<span class='name'>[src] scurries to the ground!</span>", \
+						"<span class='noticealien'>You are now hiding.</span>")
 	else
 		layer = MOB_LAYER
-		src << text("<span class='noticealien'>You have stopped hiding.</span>")
-		for(var/mob/O in oviewers(src, null))
-			if ((O.client && !( O.blinded )))
-				O << text("[] slowly peaks up from the ground...", src)
+		visible_message("[src] slowly peaks up from the ground...", \
+					"<span class='noticealien'>You have stopped hiding.</span>")
 
 /mob/living/carbon/alien/larva/verb/evolve()
 	set name = "Evolve"

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -137,7 +137,8 @@ var/const/MAX_ACTIVE_TIME = 400
 			if(W.flags & NODROP)	return 0
 			target.unEquip(W)
 
-			target.visible_message("<span class='userdanger'>[src] tears [W] off of [target]'s face!</span>")
+			target.visible_message("<span class='danger'>[src] tears [W] off of [target]'s face!</span>", \
+									"<span class='userdanger'>[src] tears [W] off of [target]'s face!</span>")
 
 		src.loc = target
 		target.equip_to_slot(src, slot_wear_mask,,0)
@@ -166,7 +167,8 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	if(!sterile)
 		//target.contract_disease(new /datum/disease/alien_embryo(0)) //so infection chance is same as virus infection chance
-		target.visible_message("<span class='userdanger'>[src] falls limp after violating [target]'s face!</span>")
+		target.visible_message("<span class='danger'>[src] falls limp after violating [target]'s face!</span>", \
+								"<span class='userdanger'>[src] falls limp after violating [target]'s face!</span>")
 
 		Die()
 		icon_state = "[initial(icon_state)]_impregnated"
@@ -180,7 +182,8 @@ var/const/MAX_ACTIVE_TIME = 400
 			src.loc = get_turf(C)
 			C.facehugger = null
 	else
-		target.visible_message("<span class='userdanger'>[src] violates [target]'s face!</span>")
+		target.visible_message("<span class='danger'>[src] violates [target]'s face!</span>", \
+								"<span class='userdanger'>[src] violates [target]'s face!</span>")
 	return
 
 /obj/item/clothing/mask/facehugger/proc/GoActive()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -438,12 +438,11 @@
 			if (istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
 				if(istype(H.glasses,/obj/item/clothing/glasses/meson))
-					H << "<span class='notice'>You look directly into The [src.name], good thing you had your protective eyewear on!</span>"
+					H << "<span class='notice'>You look directly into the [src.name], good thing you had your protective eyewear on!</span>"
 					return
-		M << "<span class='danger'>You look directly into The [src.name] and feel weak.</span>"
 		M.apply_effect(3, STUN)
-		for(var/mob/O in viewers(M, null))
-			O.show_message(text("<span class='userdanger'>[] stares blankly at The []!</span>", M, src), 1)
+		M.visible_message("<span class='danger'>[M] stares blankly at the [src.name]!</span>", \
+						"<span class='userdanger'>You look directly into the [src.name] and feel weak.</span>")
 	return
 
 


### PR DESCRIPTION
- Replaces "for(mob in oviewers) show_message()"  with "visible_message()" when possible.
- Changes many span classes.
- Fixes the absolute pathing in Ninja code.
- Fixes facehugger attack messages being bold red for third party (only the first leap message will stay bold red for third party, to keep its visibility)
- Standardizes vomiting message. All vomiting will use the same span classes.
- Fixes mech occupant not receiving any attack messages when the mech is attacked.
