### PR TITLE
Anomaly Event Changes

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -85,7 +85,7 @@
 
 /obj/effect/anomaly/flux/New()
 	..()
-	aSignal.origin_tech = "powerstorage=5;programming=3;plasmatech=2"
+	aSignal.origin_tech = "powerstorage=6;programming=4;plasmatech=4"
 
 /////////////////////
 
@@ -97,7 +97,7 @@
 
 /obj/effect/anomaly/bluespace/New()
 	..()
-	aSignal.origin_tech = "bluespace=5;magnets=3;powerstorage=2"
+	aSignal.origin_tech = "bluespace=5;magnets=5;powerstorage=3"
 
 /obj/effect/anomaly/bluespace/Bumped(atom/A)
 	if(isliving(A))
@@ -112,7 +112,7 @@
 
 /obj/effect/anomaly/pyro/New()
 	..()
-	aSignal.origin_tech = "plasmatech=5;powerstorage=3;biotech=3"
+	aSignal.origin_tech = "plasmatech=5;powerstorage=4;biotech=6"
 
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
@@ -129,7 +129,7 @@
 
 /obj/effect/anomaly/bhole/New()
 	..()
-	aSignal.origin_tech = "materials=5;combat=4;engineering=3"
+	aSignal.origin_tech = "materials=5;combat=4;engineering=4"
 
 /obj/effect/anomaly/bhole/anomalyEffect()
 	..()

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/anomaly
-	name = "Energetic Flux"
+	name = "Anomaly: Energetic Flux"
 	typepath = /datum/round_event/anomaly
 	max_occurrences = 0 //This one probably shouldn't occur! It'd work, but it wouldn't be very fun.
 	weight = 15
@@ -23,7 +23,7 @@
 		setup(safety_loop)
 
 /datum/round_event/anomaly/announce()
-	priority_announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Localized energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/anomaly/anomaly_bluespace
-	name = "Bluespace Anomaly"
+	name = "Anomaly: Bluespace"
 	typepath = /datum/round_event/anomaly/anomaly_bluespace
 	max_occurrences = 1
 	weight = 5
@@ -7,7 +7,7 @@
 /datum/round_event/anomaly/anomaly_bluespace
 	startWhen = 3
 	announceWhen = 10
-	endWhen = 55
+	endWhen = 95
 
 
 /datum/round_event/anomaly/anomaly_bluespace/announce()
@@ -52,9 +52,7 @@
 				var/x_distance = TO.x - FROM.x
 				for (var/atom/movable/A in range(12, FROM )) // iterate thru list of mobs in the area
 					if(istype(A, /obj/item/device/radio/beacon)) continue // don't teleport beacons because that's just insanely stupid
-					if(A.anchored && istype(A, /obj/machinery)) continue
-					if(istype(A, /obj/structure/disposalpipe )) continue
-					if(istype(A, /obj/structure/cable )) continue
+					if(A.anchored) continue
 
 					var/turf/newloc = locate(A.x + x_distance, A.y + y_distance, TO.z) // calculate the new place
 					if(!A.Move(newloc)) // if the atom, for some reason, can't move, FORCE them to move! :) We try Move() first to invoke any movement-related checks the atom needs to perform after moving

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -1,13 +1,13 @@
 /datum/round_event_control/anomaly/anomaly_flux
-	name = "Energetic Flux"
+	name = "Anomaly: Hyper-Energetic Flux"
 	typepath = /datum/round_event/anomaly/anomaly_flux
-	max_occurrences = 2
-	weight = 15
+	max_occurrences = 5
+	weight = 20
 
 /datum/round_event/anomaly/anomaly_flux
 	startWhen = 3
 	announceWhen = 20
-	endWhen = 60
+	endWhen = 80
 
 
 /datum/round_event/anomaly/anomaly_flux/announce()

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -1,13 +1,13 @@
 /datum/round_event_control/anomaly/anomaly_grav
-	name = "Gravitational Anomaly"
+	name = "Anomaly: Gravitational"
 	typepath = /datum/round_event/anomaly/anomaly_grav
-	max_occurrences = 2
-	weight = 15
+	max_occurrences = 5
+	weight = 20
 
 /datum/round_event/anomaly/anomaly_grav
 	startWhen = 3
 	announceWhen = 20
-	endWhen = 50
+	endWhen = 120
 
 
 /datum/round_event/anomaly/anomaly_grav/announce()

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -1,17 +1,17 @@
 /datum/round_event_control/anomaly/anomaly_pyro
-	name = "Pyroclastic Anomaly"
+	name = "Anomaly: Pyroclastic"
 	typepath = /datum/round_event/anomaly/anomaly_pyro
-	max_occurrences = 2
-	weight = 15
+	max_occurrences = 5
+	weight = 20
 
 /datum/round_event/anomaly/anomaly_pyro
 	startWhen = 10
 	announceWhen = 3
-	endWhen = 70
+	endWhen = 85
 
 
 /datum/round_event/anomaly/anomaly_pyro/announce()
-	priority_announce("Atmospheric anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/anomaly_pyro/start()
 	var/turf/T = pick(get_area_turfs(impact_area))
@@ -24,3 +24,13 @@
 		return
 	if(IsMultiple(activeFor, 5))
 		newAnomaly.anomalyEffect()
+
+
+/datum/round_event/anomaly/anomaly_pyro/end()
+	if(newAnomaly)
+		explosion(get_turf(newAnomaly), -1,0,3, flame_range = 4)
+
+		var/mob/living/carbon/slime/S = new/mob/living/carbon/slime(get_turf(newAnomaly))
+		S.colour = pick("red", "orange")
+
+		qdel(newAnomaly)

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -1,13 +1,13 @@
 /datum/round_event_control/anomaly/anomaly_vortex
-	name = "Vortex Anomaly"
+	name = "Anomaly: Vortex"
 	typepath = /datum/round_event/anomaly/anomaly_vortex
-	max_occurrences = 5
-	weight = 2
+	max_occurrences = 2
+	weight = 5
 
 /datum/round_event/anomaly/anomaly_vortex
 	startWhen = 10
 	announceWhen = 3
-	endWhen = 80
+	endWhen = 95
 
 
 /datum/round_event/anomaly/anomaly_vortex/announce()


### PR DESCRIPTION
Based on feedback:

Increases the duration and occurrence rate of Anomaly events.
Anomaly cores now give much better research values.
Renames Anomaly event datums, so they will appear more organized in the Trigger Event menu.
Bluespace anomalies no longer teleport anchored objects because it looks godawful.

If not defused, Pyroclastic Anomalies will create a red or orange slime.
