### PR TITLE
Fixes a bug with reactivated drones not being removed from the dead_mob_list

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone.dm
@@ -94,6 +94,8 @@
 								health = health_repair_max
 								stat = CONSCIOUS
 								icon_state = icon_living
+								dead_mob_list -= src
+								living_mob_list += src
 								D.visible_message("<span class='notice'>[D] reactivates [src]!</span>")
 								alert_drones(DRONE_NET_CONNECT)
 								if(G)


### PR DESCRIPTION
Seriously why aren't dead_mob_list and living_mob_list auto-generated by the MC or something?

Fixes #5362
