### PR TITLE
Xeno blood rewrite + Xeno blood burns people

### DIFF
--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -98,7 +98,7 @@ proc/make_mining_asteroid_secret()
 			walltypes = list(/turf/simulated/mineral/random/high_chance=1)
 			floortypes = list(/turf/simulated/floor/plating/asteroid/airless, /turf/simulated/floor/beach/sand)
 			treasureitems = list(/obj/item/clothing/mask/facehugger=1)
-			fluffitems = list(/obj/effect/decal/remains/human=1,/obj/effect/decal/cleanable/xenoblood/xsplatter=5)
+			fluffitems = list(/obj/effect/decal/remains/human=1,/obj/effect/decal/cleanable/blood/splatter/xeno=5)
 
 		if("hitech")
 			theme = "hitech"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -337,7 +337,7 @@ var/list/blood_splatter_icons = list()
 			if(!B)	B = new(src)
 			B.blood_DNA[M.dna.unique_enzymes] = M.dna.blood_type
 		else if(istype(M, /mob/living/carbon/alien))
-			var/obj/effect/decal/cleanable/xenoblood/B = locate() in contents
+			var/obj/effect/decal/cleanable/blood/xeno/B = locate() in contents
 			if(!B)	B = new(src)
 			B.blood_DNA["UNKNOWN BLOOD"] = "X*"
 		else if(istype(M, /mob/living/silicon/robot))

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -307,10 +307,10 @@ text("<A href='?src=\ref[src];operation=oddbutton'>[src.oddbutton ? "Yes" : "No"
 	target_types += /obj/effect/decal/cleanable/dirt
 
 	if(src.blood)
-		target_types += /obj/effect/decal/cleanable/xenoblood/
-		target_types += /obj/effect/decal/cleanable/xenoblood/xgibs
-		target_types += /obj/effect/decal/cleanable/blood/
-		target_types += /obj/effect/decal/cleanable/blood/gibs/
+		target_types += /obj/effect/decal/cleanable/blood/xeno
+		target_types += /obj/effect/decal/cleanable/blood/gibs/xeno
+		target_types += /obj/effect/decal/cleanable/blood
+		target_types += /obj/effect/decal/cleanable/blood/gibs
 		target_types += /obj/effect/decal/cleanable/trail_holder
 
 /obj/machinery/bot/cleanbot/proc/clean(var/obj/effect/decal/cleanable/target)

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -1,66 +1,55 @@
-// Note: BYOND is object oriented. There is no reason for this to be copy/pasted blood code.
 
-/obj/effect/decal/cleanable/xenoblood
+/obj/effect/decal/cleanable/blood/xeno
 	name = "xeno blood"
 	desc = "It's green and acidic. It looks like... <i>blood?</i>"
-	gender = PLURAL
-	density = 0
-	anchored = 1
-	layer = 2
-	icon = 'icons/effects/blood.dmi'
 	icon_state = "xfloor1"
 	random_icon_states = list("xfloor1", "xfloor2", "xfloor3", "xfloor4", "xfloor5", "xfloor6", "xfloor7")
-	var/list/viruses = list()
-	blood_DNA = list()
+	splatter_type = /obj/effect/decal/cleanable/blood/splatter/xeno
 
-/obj/effect/decal/cleanable/xenoblood/Destroy()
-	for(var/datum/disease/D in viruses)
-		D.cure(0)
-	..()
-
-/obj/effect/decal/cleanable/xenoblood/xgibs/proc/streak(var/list/directions)
-	spawn (0)
-		var/direction = pick(directions)
-		for (var/i = 0, i < pick(1, 200; 2, 150; 3, 50; 4), i++)
-			sleep(3)
-			if (i > 0)
-				var/obj/effect/decal/cleanable/xenoblood/b = new /obj/effect/decal/cleanable/xenoblood/xsplatter(src.loc)
-				for(var/datum/disease/D in src.viruses)
-					var/datum/disease/ND = D.Copy(1)
-					b.viruses += ND
-					ND.holder = b
-			if (step_to(src, get_step(src, direction), 0))
-				break
-
-/obj/effect/decal/cleanable/xenoblood/xsplatter
+/obj/effect/decal/cleanable/blood/splatter/xeno
 	random_icon_states = list("xgibbl1", "xgibbl2", "xgibbl3", "xgibbl4", "xgibbl5")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs
+/obj/effect/decal/cleanable/blood/gibs/xeno
 	name = "xeno gibs"
 	desc = "Gnarly..."
-	gender = PLURAL
-	icon = 'icons/effects/blood.dmi'
 	icon_state = "xgib1"
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/ex_act()
-	return
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/up
+/obj/effect/decal/cleanable/blood/gibs/up/xeno
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibup1","xgibup1","xgibup1")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/down
+/obj/effect/decal/cleanable/blood/gibs/down/xeno
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibdown1","xgibdown1","xgibdown1")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/body
+/obj/effect/decal/cleanable/blood/gibs/body/xeno
 	random_icon_states = list("xgibhead", "xgibtorso")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/limb
+/obj/effect/decal/cleanable/blood/gibs/limb/xeno
 	random_icon_states = list("xgibleg", "xgibarm")
 
-/obj/effect/decal/cleanable/xenoblood/xgibs/core
+/obj/effect/decal/cleanable/blood/gibs/core/xeno
 	random_icon_states = list("xgibmid1", "xgibmid2", "xgibmid3")
 
 /obj/effect/decal/cleanable/blood/xtracks
 	icon_state = "xtracks"
 	random_icon_states = null
+
+//Xeno blood burns\\
+
+/atom/proc/xeno_acid_blood() //Muh OOP
+	return
+
+/obj/effect/decal/cleanable/trail_holder/Crossed(atom/movable/O)
+	if(trail_type && trail_type == "xltrails") //This is messy but I'm not doing it with icon_states and trail_holders are snowflake magic shits
+		O.xeno_acid_blood()
+
+/obj/effect/decal/cleanable/blood/xeno/Crossed(atom/movable/O)
+	O.xeno_acid_blood()
+
+/obj/effect/decal/cleanable/blood/xtracks/Crossed(atom/movable/O)
+	O.xeno_acid_blood()
+
+/mob/living/xeno_acid_blood()
+	apply_damage(10,BURN)
+	src << "<span class='noticealien'>Stepping in the acid burns you!</span>"

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -37,25 +37,27 @@
 
 //Xeno blood burns\\
 
-/atom/proc/xeno_acid_blood() //Muh OOP
+/atom/proc/xeno_acid_blood(var/dmg) //Muh OOP
 	return
 
 /obj/effect/decal/cleanable/blood/gibs/xeno/Crossed(atom/movable/O)
-	O.xeno_acid_blood()
+	O.xeno_acid_blood(15)
 
 /obj/effect/decal/cleanable/trail_holder/Crossed(atom/movable/O)
 	if(trail_type && trail_type == "xltrails") //This is messy but I'm not doing it with icon_states and trail_holders are snowflake magic shits
-		O.xeno_acid_blood()
+		O.xeno_acid_blood(5)
 
 /obj/effect/decal/cleanable/blood/xeno/Crossed(atom/movable/O)
-	O.xeno_acid_blood()
+	O.xeno_acid_blood(10)
 
 /obj/effect/decal/cleanable/blood/xtracks/Crossed(atom/movable/O)
-	O.xeno_acid_blood()
+	O.xeno_acid_blood(10)
 
-/mob/living/xeno_acid_blood()
-	apply_damage(10,BURN)
+/mob/living/xeno_acid_blood(var/dmg)
+	if(!dmg)
+		return
+	apply_damage(dmg,BURN)
 	src << "<span class='noticealien'>Stepping in the acid burns you!</span>"
 
-/mob/living/carbon/alien/xeno_acid_blood()
+/mob/living/carbon/alien/xeno_acid_blood(var/dmg)
 	return //Alien blood doesn't harm aliens

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -16,19 +16,19 @@
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6")
 
 
-/obj/effect/decal/cleanable/blood/gibs/up/xeno
+/obj/effect/decal/cleanable/blood/gibs/xeno/up
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibup1","xgibup1","xgibup1")
 
-/obj/effect/decal/cleanable/blood/gibs/down/xeno
+/obj/effect/decal/cleanable/blood/gibs/xeno/down
 	random_icon_states = list("xgib1", "xgib2", "xgib3", "xgib4", "xgib5", "xgib6","xgibdown1","xgibdown1","xgibdown1")
 
-/obj/effect/decal/cleanable/blood/gibs/body/xeno
+/obj/effect/decal/cleanable/blood/gibs/xeno/body
 	random_icon_states = list("xgibhead", "xgibtorso")
 
-/obj/effect/decal/cleanable/blood/gibs/limb/xeno
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb
 	random_icon_states = list("xgibleg", "xgibarm")
 
-/obj/effect/decal/cleanable/blood/gibs/core/xeno
+/obj/effect/decal/cleanable/blood/gibs/xeno/core
 	random_icon_states = list("xgibmid1", "xgibmid2", "xgibmid3")
 
 /obj/effect/decal/cleanable/blood/xtracks
@@ -39,6 +39,9 @@
 
 /atom/proc/xeno_acid_blood() //Muh OOP
 	return
+
+/obj/effect/decal/cleanable/blood/gibs/xeno/Crossed(atom/movable/O)
+	O.xeno_acid_blood()
 
 /obj/effect/decal/cleanable/trail_holder/Crossed(atom/movable/O)
 	if(trail_type && trail_type == "xltrails") //This is messy but I'm not doing it with icon_states and trail_holders are snowflake magic shits
@@ -53,3 +56,6 @@
 /mob/living/xeno_acid_blood()
 	apply_damage(10,BURN)
 	src << "<span class='noticealien'>Stepping in the acid burns you!</span>"
+
+/mob/living/carbon/alien/xeno_acid_blood()
+	return //Alien blood doesn't harm aliens

--- a/code/game/objects/effects/decals/Cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/Cleanable/aliens.dm
@@ -61,3 +61,12 @@
 
 /mob/living/carbon/alien/xeno_acid_blood(var/dmg)
 	return //Alien blood doesn't harm aliens
+
+/mob/living/carbon/human/xeno_acid_blood(var/dmg)
+	if(shoes && shoes.unacidable)
+		return
+	..()
+
+
+
+

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -10,6 +10,7 @@
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	var/list/viruses = list()
 	blood_DNA = list()
+	var/splatter_type = /obj/effect/decal/cleanable/blood/splatter
 
 /obj/effect/decal/cleanable/blood/Destroy()
 	for(var/datum/disease/D in viruses)
@@ -32,7 +33,6 @@
 /obj/effect/decal/cleanable/blood/tracks
 	icon_state = "tracks"
 	desc = "They look like tracks left by wheels."
-	gender = PLURAL
 	random_icon_states = null
 
 /obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
@@ -40,21 +40,14 @@
 	icon_state = "blank"
 	desc = "Your instincts say you shouldn't be following these."
 	gender = PLURAL
-	density = 0
-	anchored = 1
-	layer = 2
 	random_icon_states = null
 	var/list/existing_dirs = list()
 	blood_DNA = list()
+	var/trail_type = "" //Used to identify what a trail is (blood, xeno blood etc.)
 
 /obj/effect/decal/cleanable/blood/gibs
 	name = "gibs"
 	desc = "They look bloody and gruesome."
-	gender = PLURAL
-	density = 0
-	anchored = 1
-	layer = 2
-	icon = 'icons/effects/blood.dmi'
 	icon_state = "gibbl5"
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 
@@ -86,7 +79,7 @@
 		for (var/i = 0, i < pick(1, 200; 2, 150; 3, 50; 4), i++)
 			sleep(3)
 			if (i > 0)
-				var/obj/effect/decal/cleanable/blood/b = new /obj/effect/decal/cleanable/blood/splatter(src.loc)
+				var/obj/effect/decal/cleanable/blood/b = new splatter_type(src.loc)
 				for(var/datum/disease/D in src.viruses)
 					var/datum/disease/ND = D.Copy(1)
 					b.viruses += ND

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -20,7 +20,7 @@
 	..()
 
 /obj/effect/gibspawner/xeno
-	gibtypes = list(/obj/effect/decal/cleanable/blood/gibs/up/xeno,/obj/effect/decal/cleanable/blood/gibs/down/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/body/xeno,/obj/effect/decal/cleanable/blood/gibs/limb/xeno,/obj/effect/decal/cleanable/blood/gibs/core/xeno)
+	gibtypes = list(/obj/effect/decal/cleanable/blood/gibs/xeno/up,/obj/effect/decal/cleanable/blood/gibs/xeno/down,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno/body,/obj/effect/decal/cleanable/blood/gibs/xeno/limb,/obj/effect/decal/cleanable/blood/gibs/xeno/core)
 	gibamounts = list(1,1,1,1,1,1,1)
 
 /obj/effect/gibspawner/xeno/New()

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -20,7 +20,7 @@
 	..()
 
 /obj/effect/gibspawner/xeno
-	gibtypes = list(/obj/effect/decal/cleanable/xenoblood/xgibs/up,/obj/effect/decal/cleanable/xenoblood/xgibs/down,/obj/effect/decal/cleanable/xenoblood/xgibs,/obj/effect/decal/cleanable/xenoblood/xgibs,/obj/effect/decal/cleanable/xenoblood/xgibs/body,/obj/effect/decal/cleanable/xenoblood/xgibs/limb,/obj/effect/decal/cleanable/xenoblood/xgibs/core)
+	gibtypes = list(/obj/effect/decal/cleanable/blood/gibs/up/xeno,/obj/effect/decal/cleanable/blood/gibs/down/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/xeno,/obj/effect/decal/cleanable/blood/gibs/body/xeno,/obj/effect/decal/cleanable/blood/gibs/limb/xeno,/obj/effect/decal/cleanable/blood/gibs/core/xeno)
 	gibamounts = list(1,1,1,1,1,1,1)
 
 /obj/effect/gibspawner/xeno/New()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -8,7 +8,7 @@
 	action_button_name = "Toggle Magboots"
 	strip_delay = 70
 	put_on_delay = 70
-
+	unacidable = 1
 
 /obj/item/clothing/shoes/magboots/verb/toggle()
 	set name = "Toggle Magboots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -6,6 +6,7 @@
 	permeability_coefficient = 0.05
 	flags = NOSLIP
 	origin_tech = "syndicate=3"
+	unacidable = 1
 
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"
@@ -20,6 +21,7 @@
 	armor = list(melee = 80, bullet = 60, laser = 50,energy = 25, bomb = 50, bio = 10, rad = 0)
 	flags = NOSLIP
 	strip_delay = 70
+	unacidable = 1
 
 /obj/item/clothing/shoes/swat/combat
 	name = "combat boots"
@@ -43,6 +45,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	unacidable = 1
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."
@@ -65,6 +68,7 @@
 	slowdown = SHOES_SLOWDOWN+1
 	strip_delay = 50
 	put_on_delay = 50
+	unacidable = 1
 
 /obj/item/clothing/shoes/clown_shoes
 	desc = "The prankster's standard-issue clowning shoes. Damn, they're huge!"
@@ -83,6 +87,7 @@
 	item_color = "hosred"
 	strip_delay = 50
 	put_on_delay = 50
+	unacidable = 1
 
 /obj/item/clothing/shoes/cult
 	name = "boots"
@@ -95,6 +100,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	unacidable = 1
 
 /obj/item/clothing/shoes/cyborg
 	name = "cyborg boots"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -392,6 +392,7 @@
 									if((!(newdir in H.existing_dirs) || trail_type == "trails_1" || trail_type == "trails_2") && H.existing_dirs.len <= 16) //maximum amount of overlays is 16 (all light & heavy directions filled)
 										H.existing_dirs += newdir
 										H.overlays.Add(image('icons/effects/blood.dmi',trail_type,dir = newdir))
+										H.trail_type = trail_type
 										if(check_dna_integrity(M)) //blood DNA
 											var/mob/living/carbon/DNA_helper = pulling
 											H.blood_DNA[DNA_helper.dna.unique_enzymes] = DNA_helper.dna.blood_type

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -162,7 +162,7 @@ datum/reagent/blood/reaction_turf(var/turf/simulated/T, var/volume)//splash the 
 			newVirus.holder = blood_prop
 
 	else if(istype(self.data["donor"], /mob/living/carbon/alien))
-		var/obj/effect/decal/cleanable/xenoblood/blood_prop = locate() in T
+		var/obj/effect/decal/cleanable/blood/xeno/blood_prop = locate() in T
 		if(!blood_prop)
 			blood_prop = new(T)
 			blood_prop.blood_DNA["UNKNOWN DNA STRUCTURE"] = "X*"


### PR DESCRIPTION
I am angry at:
- the coder who copy pasted blood code and used it again for xenoblood
- the coder who saw this mess and placed a snarky comment instead of fixing it.

I'm not 100% happy with how I handled adding xeno blood burning to trail_holder objects, but they're dodgy as fuck so I added another variable that will allow people to check what type the trail is, since all trail_holder objects are the same typepath regardless of being blood or xeno blood, etc.
## Changes:
- Xeno blood has changed path from /xenoblood to /blood/xeno, all subtypes of xenoblood are updated including gibs.
- Xeno blood and xeno gibs now deal 10 burn damage to whoever walks over them.
