### PR TITLE
Fixes the lasergun icon never being empty.

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -68,6 +68,8 @@
 	var/ratio = power_supply.charge / power_supply.maxcharge
 	ratio = Ceiling(ratio*4) * 25
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+	if(power_supply.charge < shot.e_cost)
+		ratio = 0 //so the icon changes to empty if the charge isn't zero but not enough for a shot.
 	switch(modifystate)
 		if (0)
 			icon_state = "[initial(icon_state)][ratio]"


### PR DESCRIPTION
Fixes #5361 
This means energy guns don't need an energy cost per shot to be a multiple of 25. It also means that charging an egun for just a split second (so that it still doesn't have enough charge for a shot) doesn't show up as 25% full.
