### PR TITLE
Meteors redux

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -1,14 +1,24 @@
 /var/const/meteor_wave_delay = 625 //minimum wait between waves in tenths of seconds
 //set to at least 100 unless you want evarr ruining every round
 
-/var/list/meteorsA = list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
-						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3)
+//Meteors probability of spawning during a given wave
+/var/list/meteors_normal = list(/obj/effect/meteor/dust=3, /obj/effect/meteor/medium=8, /obj/effect/meteor/big=3, \
+						  /obj/effect/meteor/flaming=1, /obj/effect/meteor/irradiated=3) //for normal meteor event
 
-/var/list/meteorsB = list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1)
+/var/list/meteors_threatening = list(/obj/effect/meteor/medium=4, /obj/effect/meteor/big=8, \
+						  /obj/effect/meteor/flaming=3, /obj/effect/meteor/irradiated=3) //for threatening meteor event
+
+/var/list/meteors_catastrophic = list(/obj/effect/meteor/medium=5, /obj/effect/meteor/big=75, \
+						  /obj/effect/meteor/flaming=10, /obj/effect/meteor/irradiated=10, /obj/effect/meteor/tunguska = 1) //for catastrophic meteor event
+
+/var/list/meteorsB = list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1) //for meaty ore event
 
 /var/list/meteorsC = list(/obj/effect/meteor/dust) //for space dust event
 
-/var/list/meteorsSPOOKY = list(/obj/effect/meteor/pumpkin)
+
+///////////////////////////////
+//Meteor spawning global procs
+///////////////////////////////
 
 /proc/spawn_meteors(var/number = 10, var/list/meteortypes)
 	for(var/i = 0; i < number; i++)
@@ -18,7 +28,7 @@
 	var/turf/pickedstart
 	var/turf/pickedgoal
 	var/max_i = 10//number of tries to spawn meteor.
-	while (!istype(pickedstart, /turf/space) || pickedstart.loc.name != "Space" )
+	while (!istype(pickedstart, /turf/space))
 		var/startSide = pick(cardinal)
 		pickedstart = spaceDebrisStartLoc(startSide, 1)
 		pickedgoal = spaceDebrisFinishLoc(startSide, 1)
@@ -71,6 +81,9 @@
 	var/turf/T = locate(endx, endy, Z)
 	return T
 
+///////////////////////
+//The meteor effect
+//////////////////////
 
 /obj/effect/meteor
 	name = "the concept of meteor"
@@ -94,12 +107,81 @@
 	if(z != z_original || loc == dest)
 		qdel(src)
 		return
-	return ..()
+
+	. = ..() //process movement...
+
+	if(.)//.. if did move, ram the turf we get in
+		var/turf/T = get_turf(loc)
+		ram_turf(T)
+
+		if(prob(10) && !istype(T, /turf/space))//randomly takes a 'hit' from ramming
+			get_hit()
+
+	return .
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc
 	..()
 
+/obj/effect/meteor/New()
+	..()
+	SpinAnimation()
+
+/obj/effect/meteor/Bump(atom/A)
+	if(A)
+		ram_turf(get_turf(A))
+		playsound(src.loc, meteorsound, 40, 1)
+		get_hit()
+
+/obj/effect/meteor/proc/ram_turf(var/turf/T)
+	//first bust whatever is in the turf
+	for(var/atom/A in T)
+		if(A != src)
+			A.ex_act(hitpwr)
+
+	//then, ram the turf if it still exists
+	if(T)
+		T.ex_act(hitpwr)
+
+
+//process getting 'hit' by colliding with a dense object
+//or randomly when ramming turfs
+/obj/effect/meteor/proc/get_hit()
+	hits--
+	if(hits <= 0)
+		make_debris()
+		meteor_effect(heavy)
+		qdel(src)
+
+/obj/effect/meteor/ex_act()
+	return
+
+/obj/effect/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/pickaxe))
+		qdel(src)
+		return
+	..()
+
+/obj/effect/meteor/proc/make_debris()
+	for(var/throws = dropamt, throws > 0, throws--)
+		var/obj/item/O = new meteordrop(get_turf(src))
+		O.throw_at(dest, 5, 10)
+
+/obj/effect/meteor/proc/meteor_effect(var/sound=1)
+	if(sound)
+		for(var/mob/M in player_list)
+			var/turf/T = get_turf(M)
+			if(!T || T.z != src.z)
+				continue
+			var/dist = get_dist(M.loc, src.loc)
+			shake_camera(M, dist > 20 ? 3 : 5, dist > 20 ? 1 : 3)
+			M.playsound_local(src.loc, meteorsound, 50, 1, get_rand_frequency(), 10)
+
+///////////////////////
+//Meteor types
+///////////////////////
+
+//Dust
 /obj/effect/meteor/dust
 	name = "space dust"
 	icon_state = "dust"
@@ -109,34 +191,115 @@
 	meteorsound = 'sound/weapons/throwtap.ogg'
 	meteordrop = /obj/item/weapon/ore/glass
 
+//Medium-sized
 /obj/effect/meteor/medium
 	name = "meteor"
 	dropamt = 3
 
+/obj/effect/meteor/medium/meteor_effect()
+	..(heavy)
+	explosion(src.loc, 0, 1, 2, 3, 0)
+
+//Large-sized
 /obj/effect/meteor/big
 	name = "big meteor"
 	icon_state = "large"
-	hits = 7
+	hits = 6
 	heavy = 1
 	dropamt = 4
 
+/obj/effect/meteor/big/meteor_effect()
+	..(heavy)
+	explosion(src.loc, 1, 2, 3, 4, 0)
+
+//Flaming meteor
 /obj/effect/meteor/flaming
 	name = "flaming meteor"
 	icon_state = "flaming"
-	hits = 3
+	hits = 5
 	heavy = 1
 	meteorsound = 'sound/effects/bamf.ogg'
 	meteordrop = /obj/item/weapon/ore/plasma
 
+/obj/effect/meteor/flaming/meteor_effect()
+	..(heavy)
+	explosion(src.loc, 1, 2, 3, 4, 0, 0, 5)
+
+//Radiation meteor
 /obj/effect/meteor/irradiated
 	name = "glowing meteor"
 	icon_state = "glowing"
-	hits = 4
 	heavy = 1
 	meteordrop = /obj/item/weapon/ore/uranium
 
+
+/obj/effect/meteor/irradiated/meteor_effect()
+	..(heavy)
+	explosion(src.loc, 0, 0, 4, 3, 0)
+	new /obj/effect/decal/cleanable/greenglow(get_turf(src))
+	for(var/mob/living/L in view(5, src))
+		L.apply_effect(40, IRRADIATE)
+
+//Meaty Ore
+/obj/effect/meteor/meaty
+	name = "meaty ore"
+	icon_state = "meateor"
+	desc = "Just... don't think too hard about where this thing came from."
+	hits = 2
+	heavy = 1
+	meteorsound = 'sound/effects/blobattack.ogg'
+	meteordrop = /obj/item/weapon/reagent_containers/food/snacks/meat
+	var/meteorgibs = /obj/effect/gibspawner/generic
+
+/obj/effect/meteor/meaty/make_debris()
+	..()
+	new meteorgibs(get_turf(src))
+
+
+/obj/effect/meteor/meaty/ram_turf(var/turf/T)
+	if(!istype(T, /turf/space))
+		new /obj/effect/decal/cleanable/blood (T)
+
+/obj/effect/meteor/meaty/Bump(atom/A)
+	A.ex_act(hitpwr)
+	get_hit()
+
+//Meaty Ore Xeno edition
+/obj/effect/meteor/meaty/xeno
+	color = "#5EFF00"
+	meteordrop = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
+	meteorgibs = /obj/effect/gibspawner/xeno
+
+/obj/effect/meteor/meaty/xeno/ram_turf(var/turf/T)
+	if(!istype(T, /turf/space))
+		new /obj/effect/decal/cleanable/xenoblood (T)
+
+//Station buster Tunguska
+/obj/effect/meteor/tunguska
+	name = "tunguska meteor"
+	icon_state = "flaming"
+	desc = "Your life briefly passes before your eyes the moment you lay them on this monstruosity"
+	hits = 30
+	hitpwr = 1
+	heavy = 1
+	meteorsound = 'sound/effects/bamf.ogg'
+	meteordrop = /obj/item/weapon/ore/plasma
+
+/obj/effect/meteor/tunguska/meteor_effect()
+	..(heavy)
+	explosion(src.loc, 5, 10, 15, 20, 0)
+
+/obj/effect/meteor/tunguska/Bump()
+	..()
+	if(prob(20))
+		explosion(src.loc,2,4,6,8)
+
 //////////////////////////
 //Spookoween meteors
+/////////////////////////
+
+/var/list/meteorsSPOOKY = list(/obj/effect/meteor/pumpkin)
+
 /obj/effect/meteor/pumpkin
 	name = "PUMPKING"
 	desc = "THE PUMPKING'S COMING!"
@@ -151,88 +314,3 @@
 	meteordrop = pick(/obj/item/clothing/head/hardhat/pumpkinhead, /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin)
 	meteorsound = pick('sound/hallucinations/im_here1.ogg','sound/hallucinations/im_here2.ogg')
 //////////////////////////
-
-/obj/effect/meteor/meaty
-	name = "meaty ore"
-	icon_state = "meateor"
-	desc = "Just... don't think too hard about where this thing came from."
-	hits = 2
-	heavy = 1
-	meteorsound = 'sound/effects/blobattack.ogg'
-	meteordrop = /obj/item/weapon/reagent_containers/food/snacks/meat
-	var/meteorgibs = /obj/effect/gibspawner/generic
-
-/obj/effect/meteor/meaty/xeno
-	color = "#5EFF00"
-	meteordrop = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
-	meteorgibs = /obj/effect/gibspawner/xeno
-
-
-/obj/effect/meteor/New()
-	..()
-	SpinAnimation()
-
-/obj/effect/meteor/Bump(atom/A)
-	if(A)
-		A.ex_act(hitpwr)
-		playsound(src.loc, meteorsound, 40, 1)
-	if(--src.hits <= 0)
-		make_debris()
-		meteor_effect(heavy)
-		qdel(src)
-
-
-/obj/effect/meteor/ex_act()
-	return
-
-
-/obj/effect/meteor/proc/meteor_effect(var/sound=1)
-	if(sound)
-		for(var/mob/M in player_list)
-			var/turf/T = get_turf(M)
-			if(!T || T.z != src.z)
-				continue
-			var/dist = get_dist(M.loc, src.loc)
-			shake_camera(M, dist > 20 ? 3 : 5, dist > 20 ? 1 : 3)
-			M.playsound_local(src.loc, meteorsound, 50, 1, get_rand_frequency(), 10)
-
-
-/obj/effect/meteor/medium/meteor_effect()
-	..(heavy)
-	explosion(src.loc, 1, 2, 3, 4, 0)
-
-
-/obj/effect/meteor/big/meteor_effect()
-	..(heavy)
-	explosion(src.loc, 0, 1, 2, 3, 0)
-
-
-/obj/effect/meteor/flaming/meteor_effect()
-	..(heavy)
-	explosion(src.loc, 0, 1, 2, 3, 0, 0, 5)
-
-
-/obj/effect/meteor/irradiated/meteor_effect()
-	..(heavy)
-	explosion(src.loc, 0, 0, 4, 3, 0)
-	new /obj/effect/decal/cleanable/greenglow(get_turf(src))
-	for(var/mob/living/L in view(5, src))
-		L.apply_effect(40, IRRADIATE)
-
-
-
-/obj/effect/meteor/proc/make_debris()
-	for(var/throws = dropamt, throws > 0, throws--)
-		var/obj/item/O = new meteordrop(get_turf(src))
-		O.throw_at(dest, 5, 10)
-
-/obj/effect/meteor/meaty/make_debris()
-	..()
-	new meteorgibs(get_turf(src))
-
-
-/obj/effect/meteor/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weapon/pickaxe))
-		qdel(src)
-		return
-	..()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -204,18 +204,17 @@
 			qdel(src)
 			return
 		if(2.0)
-			if (prob(30))
+			if (prob(70))
 				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
 				new remains(loc)
 				qdel(src)
 			return
 		if(3.0)
-			if (prob(5))
+			if (prob(15))
 				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
 				new remains(loc)
 				qdel(src)
 			return
-		else
 	return
 
 /obj/structure/girder/displaced
@@ -229,6 +228,25 @@
 	icon_state = "reinforced"
 	state = 2
 	girderpasschance = 0
+
+/obj/structure/girder/reinforced/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			qdel(src)
+			return
+		if(2.0)
+			if (prob(30))
+				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
+				new remains(loc)
+				qdel(src)
+			return
+		if(3.0)
+			if (prob(5))
+				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
+				new remains(loc)
+				qdel(src)
+			return
+	return
 
 /obj/structure/cultgirder
 	icon= 'icons/obj/cult.dmi'

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -8,6 +8,21 @@
 	startWhen		= 6
 	endWhen			= 66
 	announceWhen	= 1
+	var/list/wave_type
+
+/datum/round_event/meteor_wave/New()
+	..()
+	random_wave_type()
+
+/datum/round_event/meteor_wave/proc/random_wave_type()
+	var/picked_wave = pickweight(list("normal" = 75, "threatening" = 20, "catastrophic" = 5))
+	switch(picked_wave)
+		if("normal")
+			wave_type = meteors_normal
+		if("threatening")
+			wave_type = meteors_threatening
+		if("catastrophic")
+			wave_type = meteors_catastrophic
 
 /datum/round_event/meteor_wave/announce()
 	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/AI/meteors.ogg')
@@ -15,4 +30,4 @@
 
 /datum/round_event/meteor_wave/tick()
 	if(IsMultiple(activeFor, 3))
-		spawn_meteors(5, meteorsA) //meteor list types defined in gamemode/meteor/meteors.dm
+		spawn_meteors(5, wave_type) //meteor list types defined in gamemode/meteor/meteors.dm

--- a/html/changelogs/Menshin-PR-5425.yml
+++ b/html/changelogs/Menshin-PR-5425.yml
@@ -1,0 +1,7 @@
+author: Menshin
+delete-after: True
+changes: 
+  - tweak: "Made meteors more threatening."
+  - rscadd: "Added three levels of danger for meteors waves, randomly selected at spawn."
+  - rscadd: "Rumors speaks of a very rare meteor of unfathomable destructive power in the station sector..."
+  - bugfix: "Fixed infinigib/infinisplosion with meteors bumping"


### PR DESCRIPTION
**Fixes and changes to meteors waves to make it more threatening.**
- Fixed meteors not properly qdel'ing (fixing infinigibs or infinisplotions) and variables initialization. Admin-spawned meteors should not instaqdel anymore (fixes #5226)
- Meteors are more threatening : they now more oftenly get inside the station and bust any non-dense tile they move into (present objects are hit with the full force of the meteor).
- Three types of waves, chosen at random when the wave is created : normal (mostly medium meteors), threatening (a lot more big, flaming and irradiated) and catastrophic (mostly big meteors, with a very low chance to spawn the station buster Tunguska meteor)
- Medium meteors no longer explodes when it was intended for big ones
- Meaty Ores now splat blood on turfs instead of busting them (Xeno splat xeno blood)
- Reinforced girders now have their own ex_act proc. Regular girders are then less resistant to explosions.

The whole thing is still largely dependant on RNG, with sometimes rwall being torn down by medium meteors, some other times big meteors exploding on reinforced girders without even getting inside the station (ex_act haphazardness being the main cause).
