### PR TITLE
Contaiment fields will now bounce off structures, machinery and mechs

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -37,9 +37,13 @@
 	return 0
 
 
-/obj/machinery/field/containment/Crossed(atom/movable/mover)
+/obj/machinery/field/containment/Crossed(mob/mover as mob)
 	if(isliving(mover))
 		shock(mover)
+
+/obj/machinery/field/containment/Crossed(obj/mover as obj)
+	if(istype(mover, /obj/machinery) || istype(mover, /obj/structure))
+		bump(mover)
 
 /obj/machinery/field/containment/proc/set_master(var/master1,var/master2)
 	if(!master1 || !master2)
@@ -60,9 +64,15 @@
 /obj/machinery/field
 	var/hasShocked = 0 //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
 
-/obj/machinery/field/CanPass(atom/movable/mover, turf/target, height=0)
+/obj/machinery/field/CanPass(mob/mover as mob, turf/target, height=0)
 	if(isliving(mover)) // Don't let mobs through
 		shock(mover)
+		return 0
+	return ..()
+
+/obj/machinery/field/CanPass(obj/mover as obj, turf/target, height=0)
+	if(istype(mover, /obj/machinery) || istype(mover, /obj/structure))
+		bump(mover)
 		return 0
 	return ..()
 
@@ -70,10 +80,6 @@
 	if(hasShocked)
 		return 0
 	if(isliving(user))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, user.loc)
-		s.start()
-
 		hasShocked = 1
 		var/shock_damage = min(rand(30,40),rand(30,40))
 
@@ -95,9 +101,15 @@
 			"<span class='danger'>You hear an electrical crack.</span>")
 
 		user.updatehealth()
-		var/atom/target = get_edge_target_turf(user, get_dir(src, get_step_away(user, src)))
-		user.throw_at(target, 200, 4)
+		bump(user)
 
 		spawn(5)
 			hasShocked = 0
 	return
+
+/obj/machinery/field/proc/bump(atom/movable/AM as mob|obj)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, AM.loc)
+	s.start()
+	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
+	AM.throw_at(target, 200, 4)


### PR DESCRIPTION
Singularity containment fields will now bump /obj/machinery, /obj/structure and /obj/mecha
Fixes #4388
