### PR TITLE
Adds admin verb to reestablish connection to the database

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -14,6 +14,7 @@ var/list/admin_verbs_default = list(
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/client/proc/secrets,
 	/client/proc/reload_admins,
+	/client/proc/reestablish_db_connection,/*reattempt a connection to the database*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel		/*admin-pm list*/
 	)
@@ -184,7 +185,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_debug_del_all,
 	/client/proc/enable_debug_verbs,
 	/proc/possess,
-	/proc/release
+	/proc/release,
+	/client/proc/reload_admins
 	)
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/verbs/reestablish_db_connection.dm
+++ b/code/modules/admin/verbs/reestablish_db_connection.dm
@@ -1,0 +1,27 @@
+/client/proc/reestablish_db_connection()
+	set category = "Special Verbs"
+	set name = "Reestablish DB Connection"
+
+	if (dbcon && dbcon.IsConnected())
+		if (!check_rights(R_DEBUG,0))
+			alert("The database is already connected! (Only those with +debug can force a reconnection)", "The database is already connected!")
+			return
+
+		var/reconnect = alert("The database is already connected! If you *KNOW* that this is incorrect, you can force a reconnection", "The database is already connected!", "Force Reconnect", "Cancel")
+		if (reconnect != "Force Reconnect")
+			return
+
+		dbcon.Disconnect()
+		failed_db_connections = 0
+		log_admin("[key_name(usr)] Has forced the database to reconnect")
+		message_admins("[key_name_admin(usr)] Has <b>forced</b> the database to reconnect")
+		feedback_add_details("admin_verb","FRDB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
+	failed_db_connections = 0
+	spawn(0)
+		establish_db_connection()
+
+	log_admin("[key_name(usr)] Has re-established the DB Connection")
+	message_admins("[key_name_admin(usr)] Has re-established the DB Connection")
+	feedback_add_details("admin_verb","RDB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/reestablish_db_connection.dm
+++ b/code/modules/admin/verbs/reestablish_db_connection.dm
@@ -1,6 +1,9 @@
 /client/proc/reestablish_db_connection()
 	set category = "Special Verbs"
 	set name = "Reestablish DB Connection"
+	if (!config.sql_enabled)
+		usr << "<span class='adminnotice'>The Database is not enabled!</span>"
+		return
 
 	if (dbcon && dbcon.IsConnected())
 		if (!check_rights(R_DEBUG,0))
@@ -13,15 +16,16 @@
 
 		dbcon.Disconnect()
 		failed_db_connections = 0
-		log_admin("[key_name(usr)] Has forced the database to reconnect")
-		message_admins("[key_name_admin(usr)] Has <b>forced</b> the database to reconnect")
+		log_admin("[key_name(usr)] has forced the database to disconnect")
+		message_admins("[key_name_admin(usr)] has <b>forced</b> the database to disconnect!")
 		feedback_add_details("admin_verb","FRDB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+	log_admin("[key_name(usr)] is attempting to re-established the DB Connection")
+	message_admins("[key_name_admin(usr)] is attempting to re-established the DB Connection")
+	feedback_add_details("admin_verb","RDB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	failed_db_connections = 0
-	spawn(0)
-		establish_db_connection()
-
-	log_admin("[key_name(usr)] Has re-established the DB Connection")
-	message_admins("[key_name_admin(usr)] Has re-established the DB Connection")
-	feedback_add_details("admin_verb","RDB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if (!establish_db_connection())
+		message_admins("Database connection failed: " + dbcon.ErrorMsg())
+	else
+		message_admins("Database connection re-established")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -741,6 +741,7 @@
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
+#include "code\modules\admin\verbs\reestablish_db_connection.dm"
 #include "code\modules\admin\verbs\ticklag.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"


### PR DESCRIPTION
Used mainly when the database goes down, is brought back up, but you don't want to wait for the next round for the failed connections counter goes below 5.

Any holder holding admin can use it (like reload), (per consultation with tgstation admins and sos on what they thought made the most sense) but only +DEBUG admins can make it attempt to reconnect when the database appears connected (per request of sos).
