### PR TITLE
Maploader rewriting

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -1,249 +1,322 @@
-dmm_suite{
-	load_map(var/dmm_file as file, var/z_offset as num){
-		if(!z_offset){
-			z_offset = world.maxz+1
-			}
-		var/quote = ascii2text(34)
-		var/tfile = file2text(dmm_file)
-		var/tfile_len = length(tfile)
-		var/list/grid_models[0]
-		var/key_len = length(copytext(tfile,2,findtext(tfile,quote,2,0)))
-		for(var/lpos=1;lpos<tfile_len;lpos=findtext(tfile,"\n",lpos,0)+1){
-			var/tline = copytext(tfile,lpos,findtext(tfile,"\n",lpos,0))
-			if(copytext(tline,1,2)!=quote){break}
-			var/model_key = copytext(tline,2,findtext(tfile,quote,2,0))
-			var/model_contents = copytext(tline,findtext(tfile,"=")+3,length(tline))
-			grid_models[model_key] = model_contents
+///////////////////////////////////////////////////////////////
+//SS13 Optimized Map loader
+//////////////////////////////////////////////////////////////
+
+
+/**
+ * Construct the model map and control the loading process
+ *
+ * WORKING :
+ *
+ * 1) Makes an associative mapping of model_keys with model
+ *		e.g aa = /turf/unsimulated/wall{icon_state = "rock"}
+ * 2) Read the map line by line, parsing the result (using parse_grid)
+ *
+ */
+/dmm_suite/load_map(var/dmm_file as file, var/z_offset as num)
+	if(!z_offset)//what z_level we are creating the map on
+		z_offset = world.maxz+1
+
+	var/quote = ascii2text(34)
+	var/tfile = file2text(dmm_file)//the map file we're creating
+	var/tfile_len = length(tfile)
+	var/lpos = 1 // the models definition index
+
+	///////////////////////////////////////////////////////////////////////////////////////
+	//first let's map model keys (e.g "aa") to their contents (e.g /turf/space{variables})
+	///////////////////////////////////////////////////////////////////////////////////////
+	var/list/grid_models = list()
+	var/key_len = length(copytext(tfile,2,findtext(tfile,quote,2,0)))//the length of the model key (e.g "aa" or "aba")
+
+	//proceed line by line
+	for(lpos=1; lpos<tfile_len; lpos=findtext(tfile,"\n",lpos,0)+1)
+		var/tline = copytext(tfile,lpos,findtext(tfile,"\n",lpos,0))
+		if(copytext(tline,1,2) != quote)//we reached the map "layout"
+			break
+		var/model_key = copytext(tline,2,2+key_len)
+		var/model_contents = copytext(tline,findtext(tfile,"=")+3,length(tline))
+		grid_models[model_key] = model_contents
+		sleep(-1)
+
+	///////////////////////////////////////////////////////////////////////////////////////
+	//now let's fill the map with turf and objects using the constructed model map
+	///////////////////////////////////////////////////////////////////////////////////////
+
+	//position of the currently processed square
+	var/zcrd=-1
+	var/ycrd=0
+	var/xcrd=0
+
+	for(var/zpos=findtext(tfile,"\n(1,1,",lpos,0);zpos!=0;zpos=findtext(tfile,"\n(1,1,",zpos+1,0))	//in case there's several maps to load
+
+		zcrd++
+		world.maxz = max(world.maxz, zcrd+z_offset)//create a new z_level if needed
+
+		var/zgrid = copytext(tfile,findtext(tfile,quote+"\n",zpos,0)+2,findtext(tfile,"\n"+quote,zpos,0)+1) //copy the whole map grid
+		var/z_depth = length(zgrid)
+
+		//if exceeding the world max x or y, increase it
+		var/x_depth = length(copytext(zgrid,1,findtext(zgrid,"\n",2,0)))
+		if(world.maxx<x_depth)
+			world.maxx=x_depth
+
+		var/y_depth = z_depth / (x_depth+1)//x_depth + 1 because we're counting the '\n' characters in z_depth
+		if(world.maxy<y_depth)
+			world.maxy=y_depth
+
+		//then proceed it line by line, starting from top
+		ycrd = y_depth
+
+		for(var/gpos=1;gpos!=0;gpos=findtext(zgrid,"\n",gpos,0)+1)
+			var/grid_line = copytext(zgrid,gpos,findtext(zgrid,"\n",gpos,0))
+
+			//fill the current square using the model map
+			xcrd=0
+			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
+				xcrd++
+				var/model_key = copytext(grid_line,mpos,mpos+key_len)
+				parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset)
+
+			//reached end of current map
+			if(gpos+x_depth+1>z_depth)
+				break
+
+			ycrd--
+
 			sleep(-1)
-			}
-		var/zcrd=-1
-		var/ycrd=0
-		var/xcrd=0
-		for(var/zpos=findtext(tfile,"\n(1,1,");TRUE;zpos=findtext(tfile,"\n(1,1,",zpos+1,0)){
-			zcrd++
-			world.maxz = max(world.maxz, zcrd+z_offset)
-			ycrd=0
-			var/zgrid = copytext(tfile,findtext(tfile,quote+"\n",zpos,0)+2,findtext(tfile,"\n"+quote,zpos,0)+1)
-			for(var/gpos=1;gpos!=0;gpos=findtext(zgrid,"\n",gpos,0)+1){
-				var/grid_line = copytext(zgrid,gpos,findtext(zgrid,"\n",gpos,0)+1)
-				var/y_depth = length(zgrid)/(length(grid_line))
-				if(world.maxy<y_depth){world.maxy=y_depth}
-				grid_line=copytext(grid_line,1,length(grid_line))
-				if(!ycrd){
-					ycrd = y_depth
-					}
-				else{ycrd--}
-				xcrd=0
-				for(var/mpos=1;mpos<=length(grid_line);mpos+=key_len){
-					xcrd++
-					if(world.maxx<xcrd){world.maxx=xcrd}
-					var/model_key = copytext(grid_line,mpos,mpos+key_len)
-					parse_grid(grid_models[model_key],xcrd,ycrd,zcrd+z_offset)
-					}
-				if(gpos+length(grid_line)+1>length(zgrid)){break}
-				sleep(-1)
-				}
-			if(findtext(tfile,quote+"}",zpos,0)+2==tfile_len){break}
-			sleep(-1)
-			}
-		}
-	proc{
-		parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num){
-			/*Method parse_grid()
-				- Accepts a text string containing a comma separated list of type paths of the
-					same construction as those contained in a .dmm file, and instantiates them.
-				*/
-			var/list/text_strings[0]
-			for(var/index=1;findtext(model,quote);index++){
-				/*Loop: Stores quoted portions of text in text_strings, and replaces them with an
-					index to that list.
-					- Each iteration represents one quoted section of text.
-					*/
-				text_strings.len=index
-				text_strings[index] = copytext(model,findtext(model,quote)+1,findtext(model,quote,findtext(model,quote)+1,0))
-				model = copytext(model,1,findtext(model,quote))+"~[index]"+copytext(model,findtext(model,quote,findtext(model,quote)+1,0)+1,0)
-				sleep(-1)
-				}
-			var/list/old_turf_underlays[0]
-			var/old_turf_density
-			var/old_turf_opacity
-			/*The old_turf variables store information about turfs instantiated in this location/iteration.
-				This is done to approximate the layered turf effect of DM's map editor.
-				An image of each turf is stored in old_turf_underlays[], and is later added to the new turf's underlays.
-				*/
-			for(var/dpos=1;dpos!=0;dpos=findtext(model,",",dpos,0)+1){
-				/*Loop: Identifies each object's data, instantiates it, and reconstitues it's fields.
-					- Each iteration represents one object's data, including type path and field values.
-					*/
-				var/full_def = copytext(model,dpos,findtext(model,",",dpos,0))
-				var/atom_def = text2path(copytext(full_def,1,findtext(full_def,"{")))
-				var/list/attributes[0]
-				if(findtext(full_def,"{")){
-					full_def = copytext(full_def,1,length(full_def))
-					for(var/apos=findtext(full_def,"{")+1;apos!=0;apos=findtext(full_def,";",apos,0)+1){
-						//Loop: Identifies each attribute/value pair, and stores it in attributes[].
-						attributes.Add(copytext(full_def,apos,findtext(full_def,";",apos,0)))
-						if(!findtext(copytext(full_def,apos,0),";")){break}
-						sleep(-1)
-						}
-					}
-				//Construct attributes associative list
-				var/list/fields = list()
-				for(var/index=1;index<=attributes.len;index++){
-					var/trim_left = trim_text(copytext(attributes[index],1,findtext(attributes[index],"=")))
-					var/trim_right = trim_text(copytext(attributes[index],findtext(attributes[index],"=")+1,0))
-					//Check for string
-					if(findtext(trim_right,"~")){
-						var/reference_index = copytext(trim_right,findtext(trim_right,"~")+1,0)
-						trim_right=text_strings[text2num(reference_index)]
-						}
-					//Check for number
-					else if(isnum(text2num(trim_right))){
-						trim_right = text2num(trim_right)
-						}
-					//Check for file
-					else if(copytext(trim_right,1,2) == "'"){
-						trim_right = file(copytext(trim_right,2,length(trim_right)))
-						}
-					fields[trim_left] = trim_right
-					}
-					//End construction
+
+		//reached End Of File
+		if(findtext(tfile,quote+"}",zpos,0)+2==tfile_len)
+			break
+		sleep(-1)
+
+/**
+ * Fill a given tile with its area/turf/objects/mobs
+ * Variable model is one full map line (e.g /turf/unsimulated/wall{icon_state = "rock"},/area/mine/explored)
+ *
+ * WORKING :
+ *
+ * 1) Read the model string, member by member (delimiter is ',')
+ *
+ * 2) Get the path of the atom and store it into a list
+ *
+ * 3) a) Check if the member has variables (text within '{' and '}')
+ *
+ * 3) b) Construct an associative list with found variables, if any (the atom index in members is the same as its variables in members_attributes)
+ *
+ * 4) Instanciates the atom with its variables
+ *
+ */
+/dmm_suite/proc/parse_grid(var/model as text,var/xcrd as num,var/ycrd as num,var/zcrd as num)
+	/*Method parse_grid()
+	- Accepts a text string containing a comma separated list of type paths of the
+		same construction as those contained in a .dmm file, and instantiates them.
+	*/
+
+	var/list/members = list()//will contain all members (paths) in model (in our example : /turf/unsimulated/wall and /area/mine/explored)
+	var/list/members_attributes = list()//will contain lists filled with corresponding variables, if any (in our example : list(icon_state = "rock") and list())
 
 
-				//Begin Instanciation
-				var/atom/instance
-				var/dmm_suite/preloader/_preloader = new(fields)
-				if(ispath(atom_def,/area)){
-					instance = locate(atom_def)
-					instance.contents.Add(locate(xcrd,ycrd,zcrd))
-					}
-				else if(ispath(atom_def,/turf)){
-					var/turf/old_turf = locate(xcrd,ycrd,zcrd)
-					if(old_turf.density){old_turf_density = 1}
-					if(old_turf.opacity){old_turf_opacity = 1}
-					if(old_turf.icon){
-						var/image/old_turf_image = image(old_turf.icon,null,old_turf.icon_state,old_turf.layer,old_turf.dir)
-						old_turf_underlays.Add(old_turf_image)
-						}
-					instance = new atom_def(old_turf, _preloader)
-					for(var/inverse_index=old_turf_underlays.len;inverse_index;inverse_index--){
-						var/image/image_underlay = old_turf_underlays[inverse_index]
-						image_underlay.loc = instance
-						instance.underlays.Add(image_underlay)
-						}
-					if(!instance.density){instance.density = old_turf_density}
-					if(!instance.opacity){instance.opacity = old_turf_opacity}
-					}
+	/////////////////////////////////////////////////////////
+	//Constructing members and corresponding variables lists
+	////////////////////////////////////////////////////////
 
-				if(_preloader && instance){
-					_preloader.load(instance)
-					}
-					//End Instanciation
-				if(!findtext(copytext(model,dpos,0),",")){break}
-				sleep(-1)
-				}
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	var/index=1
+	var/old_position = 1
+	var/dpos
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	do
+		//finding next member (e.g /turf/unsimulated/wall{icon_state = "rock"} or /area/mine/explored)
+		dpos= find_next_delimiter_position(model,old_position,",","{","}")//find next delimiter (comma here) that's not within {...}
 
-			for(var/dpos=1;dpos!=0;dpos=findtext(model,",",dpos,0)+1)
-			{
-				/*Loop: Identifies each object's data, instantiates it, and reconstitues it's fields.
-					- Each iteration represents one object's data, including type path and field values.
-					*/
-				var/full_def = copytext(model,dpos,findtext(model,",",dpos,0))
-				var/atom_def = text2path(copytext(full_def,1,findtext(full_def,"{")))
-				var/list/attributes[0]
-				if(findtext(full_def,"{")){
-					full_def = copytext(full_def,1,length(full_def))
-					for(var/apos=findtext(full_def,"{")+1;apos!=0;apos=findtext(full_def,";",apos,0)+1){
-						//Loop: Identifies each attribute/value pair, and stores it in attributes[].
-						attributes.Add(copytext(full_def,apos,findtext(full_def,";",apos,0)))
-						if(!findtext(copytext(full_def,apos,0),";")){break}
-						sleep(-1)
-						}
-					}
-				//Construct attributes associative list
-				var/list/fields = list()
-				for(var/index=1;index<=attributes.len;index++){
-					var/trim_left = trim_text(copytext(attributes[index],1,findtext(attributes[index],"=")))
-					var/trim_right = trim_text(copytext(attributes[index],findtext(attributes[index],"=")+1,0))
-					//Check for string
-					if(findtext(trim_right,"~")){
-						var/reference_index = copytext(trim_right,findtext(trim_right,"~")+1,0)
-						trim_right=text_strings[text2num(reference_index)]
-						}
-					//Check for number
-					else if(isnum(text2num(trim_right))){
-						trim_right = text2num(trim_right)
-						}
-					//Check for file
-					else if(copytext(trim_right,1,2) == "'"){
-						trim_right = file(copytext(trim_right,2,length(trim_right)))
-						}
-					fields[trim_left] = trim_right
-					}
-					//End construction
+		var/full_def = copytext(model,old_position,dpos)//full definition, e.g : /obj/foo/bar{variables=derp}
+		var/atom_def = text2path(copytext(full_def,1,findtext(full_def,"{")))//path definition, e.g /obj/foo/bar
+		members.Add(atom_def)
+		old_position = dpos + 1
+
+		//transform the variables in text format into a list (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))
+		var/list/fields = list()
+
+		var/variables_start = findtext(full_def,"{")
+		if(variables_start)//if there's any variable
+			full_def = copytext(full_def,variables_start+1,length(full_def))//removing the last '}'
+			fields = text2list(full_def,";")
+
+		//then fill the members_attributes list with the corresponding variables
+		members_attributes.len++
+		members_attributes[index++] = fields
+
+		sleep(-1)
+	while(dpos != 0)
 
 
-				//Begin Instanciation
-				var/atom/instance
-				var/dmm_suite/preloader/_preloader = new(fields)
-				if(!ispath(atom_def,/area) && !ispath(atom_def,/turf))
-				{
-					instance = new atom_def(locate(xcrd,ycrd,zcrd), _preloader)
-				}
+	////////////////
+	//Instanciation
+	////////////////
+
+	//The next part of the code assumes there's ALWAYS an /area AND a /turf on a given tile
+
+	//first instance the /area and remove it from the members list
+	var/length = members.len
+	var/atom/instance
+	var/dmm_suite/preloader/_preloader = new(members_attributes[length])//preloader for assigning  set variables on atom creation
+
+	instance = locate(members[length])
+	instance.contents.Add(locate(xcrd,ycrd,zcrd))
+
+	if(_preloader && instance)
+		_preloader.load(instance)
+
+	members.Remove(members[length])
+
+	//then instance the /turf and remove it from the members list
+	length = members.len
+
+	instance_atom(members[length],members_attributes[length],xcrd,ycrd,zcrd)
+	members.Remove(members[length])
+
+	//Replace the previous part of the code with this if it's unsafe to assume tiles have ALWAYS an /area AND a /turf
+	/*while(members.len > 0)
+		var/length = members.len
+		var/member = members[length]
+
+		if(ispath(member,/area))
+			var/atom/instance
+			var/dmm_suite/preloader/_preloader = new(members_attributes[length])
+
+			instance = locate(member)
+			instance.contents.Add(locate(xcrd,ycrd,zcrd))
+
+			if(_preloader && instance)
+				_preloader.load(instance)
+
+			members.Remove(member)
+			continue
+
+		else if(ispath(member,/turf))
+			instance_atom(member,members_attributes[length],xcrd,ycrd,zcrd)
+			members.Remove(member)
+			continue
+
+		else
+			break
+		*/
+
+	//finally instance all remainings objects/mobs
+	for(var/k=1,k<=members.len,k++)
+		instance_atom(members[k],members_attributes[k],xcrd,ycrd,zcrd)
+
+////////////////
+//Helpers procs
+////////////////
+
+//Instance an atom at (x,y,z) and gives it the variables in attributes
+/dmm_suite/proc/instance_atom(var/path,var/list/attributes, var/x, var/y, var/z)
+	var/atom/instance
+	var/dmm_suite/preloader/_preloader = new(attributes)
+
+	instance = new path (locate(x,y,z), _preloader)//first preloader pass
+
+	if(_preloader && instance)//second preloader pass, as some variables may have been reset/changed by New()
+		_preloader.load(instance)
+
+//text trimming (both directions) helper proc
+//optionally removes quotes before and after the text (for variable name)
+/dmm_suite/proc/trim_text(var/what as text,var/trim_quotes=0)
+	while(length(what) && (findtext(what," ",1,2)))// || findtext(what,quote,1,2)))
+		what=copytext(what,2,0)
+	while(length(what) && (findtext(what," ",length(what),0)))// || findtext(what,quote,length(what),0)))
+		what=copytext(what,1,length(what))
+	if(trim_quotes)
+		while(length(what) && (findtext(what,quote,1,2)))
+			what=copytext(what,2,0)
+		while(length(what) && (findtext(what,quote,length(what),0)))
+			what=copytext(what,1,length(what))
+	return what
+
+//find the position of the next delimiter,skipping whatever is comprised between opening_escape and closing_escape
+//returns 0 if reached the last delimiter
+/dmm_suite/proc/find_next_delimiter_position(var/text as text,var/initial_position as num, var/delimiter=",",var/opening_escape=quote,var/closing_escape=quote)
+	var/position = initial_position
+	var/next_delimiter = findtext(text,delimiter,position,0)
+	var/next_opening = findtext(text,opening_escape,position,0)
+
+	while((next_opening != 0) && (next_opening < next_delimiter))
+		position = findtext(text,closing_escape,next_opening + 1,0)+1
+		next_delimiter = findtext(text,delimiter,position,0)
+		next_opening = findtext(text,opening_escape,position,0)
+
+	return next_delimiter
 
 
-				if(_preloader && instance)
-				{
-					_preloader.load(instance)
-				}
-					//End Instanciation
-				if(!findtext(copytext(model,dpos,0),",")){break}
-				sleep(-1)
-				}
+//build a list from variables in text form (e.g {var1="derp"; var2; var3=7} => list(var1="derp", var2, var3=7))
+//return the filled list
+/dmm_suite/proc/text2list(var/text as text,var/delimiter=",")
 
+	var/list/to_return = list()
 
+	var/position
+	var/old_position = 1
 
+	do
+		//find next delimiter that is not within  "..."
+		position = find_next_delimiter_position(text,old_position,delimiter)
 
-			}
-		trim_text(var/what as text){
-			while(length(what) && findtext(what," ",1,2)){
-				what=copytext(what,2,0)
-				}
-			while(length(what) && findtext(what," ",length(what),0)){
-				what=copytext(what,1,length(what))
-				}
-			return what
-			}
-		}
-	}
-atom/New(atom/loc, dmm_suite/preloader/_dmm_preloader){
-	if(istype(_dmm_preloader, /dmm_suite/preloader)){
+		//check if this is a simple variable (as in list(var1, var2)) or an associative one (as in list(var1="foo",var2=7))
+		var/equal_position = findtext(text,"=",old_position, position)
+
+		var/trim_left = trim_text(copytext(text,old_position,equal_position),1)//the name of the variable, must trim quotes to build a BYOND compliant associatives list
+		old_position = position + 1
+
+		if(equal_position)//associative var, so do the association
+			var/trim_right = trim_text(copytext(text,equal_position+1,position))//the content of the variable
+
+			//Check for string
+			if(findtext(trim_right,quote,1,2))
+				trim_right = copytext(trim_right,2,findtext(trim_right,quote,3,0))
+
+			//Check for number
+			else if(isnum(text2num(trim_right)))
+				trim_right = text2num(trim_right)
+
+			//Check for file
+			else if(copytext(trim_right,1,2) == "'")
+				trim_right = file(copytext(trim_right,2,length(trim_right)))
+
+			//Check for list
+			else if(copytext(trim_right,1,5) == "list")
+				trim_right = text2list(copytext(trim_right,6,length(trim_right)))
+
+			to_return[trim_left] = trim_right
+
+		else//simple var
+			to_return[trim_left] = null
+
+	while(position != 0)
+
+	return to_return
+
+//atom creation method that preloads variables before creation
+atom/New(atom/loc, dmm_suite/preloader/_dmm_preloader)
+	if(istype(_dmm_preloader, /dmm_suite/preloader))
 		_dmm_preloader.load(src)
-		}
 	. = ..()
-	}
-dmm_suite{
-	preloader{
-		parent_type = /datum
-		var{
-			list/attributes
-			}
-		New(list/the_attributes){
-			.=..()
-			if(!the_attributes.len){ Del()}
-			attributes = the_attributes
-			}
-		proc{
-			load(atom/what){
-				for(var/attribute in attributes){
-					what.vars[attribute] = attributes[attribute]
-					}
-				Del()
-				}
-			}
-		}
-	}
 
+//////////////////
+//Preloader datum
+//////////////////
+
+/dmm_suite/preloader
+	parent_type = /datum
+	var/list/attributes
+
+/dmm_suite/preloader/New(list/the_attributes)
+	.=..()
+	if(!the_attributes.len)
+		Del()
+	attributes = the_attributes
+
+/dmm_suite/preloader/proc/load(atom/what)
+	for(var/attribute in attributes)
+		what.vars[attribute] = attributes[attribute]
+	Del()


### PR DESCRIPTION
Rewrote maploader to act faster and better handle set variables (a.k.a basically reimplemented BYOND map parser to load DM maps at init or in-game).

**Most notably :**
- better loading times, less processing loops, got ride of the _old_turf_ checking, since we're building the map on area/turf/space

Had to make one assumption, that is there's always an /area AND /turf on a given tiles (if any other project where that assertion fails, wants to use it i've provided a commented code sample that takes that into account)
- full path procs and commented code
- **lists variables are now taken into account (simples and associatives)**

To think it began with simply adding that...
That means it's now possible to use multiple access, cameras (using my other PR), etc
- every character can now be used inside a string without fear of breaking the loading process (before 
  using ; could mess the whole thing up)

I've respected the BYOND logic of instanciating : area => turf => obj/mob.

This has been thoroughly tested and everything found working so far.
Obviously, large parts of BYOND being undocumented (notably the creation process of /area and /turf), there _may_ be some discrepancies left...
