### PR TITLE
Allows cameras networks on away missions

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -33,7 +33,7 @@
 
 		var/list/L = list()
 		for (var/obj/machinery/camera/C in cameranet.cameras)
-			if((z > 6 || C.z > 6) && (C.z != z))//if on away mission, can only recieve feed from same z_level cameras
+			if((z > 7 || C.z > 7) && (C.z != z))//if on away mission, can only recieve feed from same z_level cameras
 				continue
 			L.Add(C)
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -20,9 +20,6 @@
 
 /obj/machinery/computer/security/attack_hand(var/mob/user as mob)
 	if(!stat)
-		if (src.z > 6)
-			user << "<span class='userdanger'>Unable to establish a connection</span>: \black You're too far away from the station!"
-			return
 
 		if (!network)
 			ERROR("A computer lacks a network at [x],[y],[z].")
@@ -36,6 +33,8 @@
 
 		var/list/L = list()
 		for (var/obj/machinery/camera/C in cameranet.cameras)
+			if((z > 6 || C.z > 6) && (C.z != z))//if on away mission, can only recieve feed from same z_level cameras
+				continue
 			L.Add(C)
 
 		camera_sort(L)


### PR DESCRIPTION
The logic is now :
- z_level 1-7 can recieve cameras feed of each others.
- z_level > 7 can only recieve camera feed from same z_level

Needs #5482 to work (you can't set list() variables on away missions without it).

The camera networks handling code is yet another candidate for a rewrite though.
