### PR TITLE
Fixes the hulk slip bug creating huge amounts of lag 

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -352,7 +352,7 @@
 		var/mob/living/carbon/M = slipper
 		if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
 			return 0
-		if(!M.lying)
+		if(!M.lying && (M.status_flags & CANWEAKEN)) // we slip those who are standing and can fall.
 			var/olddir = M.dir
 			M.Stun(s_amount)
 			M.Weaken(w_amount)


### PR DESCRIPTION
Hulks are now unable to slide or slip on space lub. Same bug happened to alien humanoids and all carbons that cannot be weakened and thus could move during the slide. So now, only carbons with CANWEAKEN can slip and/or slide. (this also fixes the message spam when these mobs slide and get one slip message for each lubed tile they cross)
Fixes #5441 
