### PR TITLE
You can no longer put transit tube pods in a station that already has one

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -47,6 +47,8 @@
 		return
 	if (!istype(R) || get_dist(user, src) > 1 || get_dist(src,R) > 1)
 		return
+	for(var/obj/structure/transit_tube_pod/pod in loc)
+		return //no fun allowed
 	var/obj/structure/transit_tube_pod/T = new/obj/structure/transit_tube_pod(src)
 	R.transfer_fingerprints_to(T)
 	T.add_fingerprint(user)


### PR DESCRIPTION
Fixes #5486 or at least makes it a lot less relevant
