### PR TITLE
You can no longer splash more than one turf/obj with a beaker/bucket by clicking quickly.

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -51,7 +51,7 @@
 				R += num2text(A.volume) + "),"
 		add_logs(user, M, "splashed", object="[R]")
 		reagents.reaction(target, TOUCH)
-		spawn(5) reagents.clear_reagents()
+		reagents.clear_reagents()
 		return
 
 	else if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
@@ -86,8 +86,7 @@
 	else if(reagents.total_volume)
 		user << "<span class='notice'>You splash the solution onto [target].</span>"
 		reagents.reaction(target, TOUCH)
-		spawn(5)
-			reagents.clear_reagents()
+		reagents.clear_reagents()
 
 
 /obj/item/weapon/reagent_containers/glass/beaker


### PR DESCRIPTION
The beaker will now be emptied without a delay after you've splashed its content onto something.
