### PR TITLE
Busy book binder cannot start a new print job

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -461,14 +461,20 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 	icon_state = "binder"
 	anchored = 1
 	density = 1
+	var/busy = 0
 
 /obj/machinery/bookbinder/attackby(var/obj/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/weapon/paper))
+		if(busy)
+			user << "<span class='warning'>The book binder is busy. Please wait for completion of previous operation.</span>"
+			return
 		user.drop_item()
 		O.loc = src
 		user.visible_message("[user] loads some paper into [src].", "You load some paper into [src].")
 		src.visible_message("[src] begins to hum as it warms up its printing drums.")
+		busy = 1
 		sleep(rand(200,400))
+		busy = 0
 		src.visible_message("[src] whirs as it prints and binds a new book.")
 		var/obj/item/weapon/book/b = new(src.loc)
 		b.dat = O:info


### PR DESCRIPTION
You can no longer start printing a book with the book binder if it's already busy printing one.
