### PR TITLE
Assistant jobbans now ban people from using "Be assistant"

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -123,7 +123,7 @@ var/global/datum/controller/occupations/job_master
 	return
 
 
-//This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until�
+//This proc is called before the level loop of DivideOccupations() and will try to select a head, ignoring ALL non-head preferences for every level until
 //it locates a head or runs out of levels to check
 //This is basically to ensure that there's atleast a few heads in the round
 /datum/controller/occupations/proc/FillHeadPosition()
@@ -276,7 +276,7 @@ var/global/datum/controller/occupations/job_master
 	// Hand out random jobs to the people who didn't get any in the last check
 	// Also makes sure that they got their preference correct
 	for(var/mob/new_player/player in unassigned)
-		if(player.client.prefs.userandomjob)
+		if(player.client.prefs.userandomjob || jobban_isbanned(player, "Assistant"))
 			GiveRandomJob(player)
 
 	Debug("DO, Standard Check end")

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -276,7 +276,11 @@ var/global/datum/controller/occupations/job_master
 	// Hand out random jobs to the people who didn't get any in the last check
 	// Also makes sure that they got their preference correct
 	for(var/mob/new_player/player in unassigned)
-		if(player.client.prefs.userandomjob || jobban_isbanned(player, "Assistant"))
+		if(jobban_isbanned(player, "Assistant"))
+			GiveRandomJob(player) //you get to roll for random before everyone else just to be sure you don't get assistant. you're so speshul
+
+	for(var/mob/new_player/player in unassigned)
+		if(player.client.prefs.userandomjob)
 			GiveRandomJob(player)
 
 	Debug("DO, Standard Check end")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -533,7 +533,10 @@ datum/preferences
 					ResetJobs()
 					SetChoices(user)
 				if("random")
-					userandomjob = !userandomjob
+					if(jobban_isbanned(user, "Assistant"))
+						userandomjob = 1
+					else
+						userandomjob = !userandomjob
 					SetChoices(user)
 				if("setJobLevel")
 					UpdateJobPreference(user, href_list["text"], text2num(href_list["level"]))


### PR DESCRIPTION
They'll ban people from using "Be assistant if preferences unavailable".
Fixes #4142

Now the only way people jobbanned from assistant can become one is if they set all their preferences to none AND there are not enough open job slots for random assignment to all jobbanned players. In other words, very much an edge case unless the server has extremely high population.
