### PR TITLE
Improves robotics control console feedback for admins and the AI

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,8 +92,10 @@
 						R << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
 						R.ResetSecurityCodes()
 					else
-						message_admins("<span class='notice'>[key_name_admin(usr)] detonated [R.name]!</span>")
-						log_game("\<span class='notice'>[key_name(usr)] detonated [R.name]!</span>")
+						message_admins("<span class='notice'>[key_name(usr, usr.client)](<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>) detonated [key_name(R, R.client)](<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>)!</span>")
+						log_game("\<span class='notice'>[key_name(usr)] detonated [key_name(R)]!</span>")
+						if(R.connected_ai)
+							R.connected_ai << "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [R.name]</span><br>"
 						R.self_destruct()
 		else
 			usr << "<span class='danger'>Access Denied.</span>"
@@ -104,10 +106,12 @@
 			if(can_control(usr, R))
 				var/choice = input("Are you certain you wish to [R.canmove ? "lock down" : "release"] [R.name]?") in list("Confirm", "Abort")
 				if(choice == "Confirm" && can_control(usr, R) && !..())
-					message_admins("<span class='notice'>[key_name_admin(usr)] [R.canmove ? "locked down" : "released"] [R.name]!</span>")
-					log_game("[key_name(usr)] [R.canmove ? "locked down" : "released"] [R.name]!")
+					message_admins("<span class='notice'>[key_name(usr, usr.client)](<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>) [R.canmove ? "locked down" : "released"] [key_name(R, R.client)](<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>)!</span>")
+					log_game("[key_name(usr)] [R.canmove ? "locked down" : "released"] [key_name(R)]!")
 					R.SetLockdown(!R.lockcharge)
 					R << "[!R.lockcharge ? "<span class='notice'>Your lockdown has been lifted!" : "<span class='alert'>You have been locked down!"]</span>"
+					if(R.connected_ai)
+						R.connected_ai << "[!R.lockcharge ? "<span class='notice'>NOTICE - Cyborg lockdown lifted" : "<span class='alert'>ALERT - Cyborg lockdown detected"]: <a href='byond://?src=\ref[R.connected_ai];track2=\ref[R.connected_ai];track=\ref[R]'>[R.name]</a></span><br>"
 
 		else
 			usr << "<span class='danger'>Access Denied.</span>"


### PR DESCRIPTION
Admins will get the name/ckey and a JMP link for both blower/lockdowner and the blown/lockdowned. AIs will get the blown borg's name, and, in case of lockdown, a Track link as well.

Fixes #4253
