### PR TITLE
Botcall Runtime fixes

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -409,7 +409,7 @@ obj/machinery/bot/proc/bot_move(var/dest, var/move_speed)
 
 
 obj/machinery/bot/proc/bot_step(var/dest)
-	if(path.len > 1)
+	if(path && path.len > 1)
 		step_to(src, path[1])
 		if(get_turf(src) == path[1]) //Successful move
 			path -= path[1]
@@ -449,6 +449,7 @@ obj/machinery/bot/proc/bot_step(var/dest)
 	else
 		calling_ai << "<span class='danger'>Failed to calculate a valid route. Ensure destination is clear of obstructions and within range.</span>"
 		calling_ai = null
+		path = list()
 
 /obj/machinery/bot/proc/call_mode() //Handles preparing a bot for a call, as well as calling the move proc.
 //Handles the bot's movement during a call.

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -186,17 +186,18 @@ text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
 			if (!bot_move(target))
 				add_to_ignore(target)
 				target = null
+				path = list()
 				return
 			mode = BOT_MOVING
 		else if (!bot_move(target))
 			target = null
 			mode = BOT_IDLE
-
-		if(loc == target.loc)
-			clean(target)
-			path = list()
-			target = null
 			return
+
+	if(target && loc == target.loc)
+		clean(target)
+		path = list()
+		target = null
 
 	oldloc = loc
 

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -200,7 +200,7 @@
 
 	else if (href_list["stationary"])
 		stationary_mode = !stationary_mode
-		path = new()
+		path = list()
 		updateicon()
 
 	else if (href_list["virus"])
@@ -298,7 +298,7 @@
 		patient = null
 		mode = BOT_IDLE
 		last_found = world.time
-		path = new()
+		path = list()
 
 	if(!patient)
 		if(!shut_up && prob(1))
@@ -317,14 +317,16 @@
 		return
 
 	//Patient has moved away from us!
-	else if(patient && (path.len) && (get_dist(patient,path[path.len]) > 2))
-		path = new()
+	else if(patient && path && path.len && (get_dist(patient,path[path.len]) > 2))
+		path = list()
 		mode = BOT_IDLE
 		last_found = world.time
 
 	if(!stationary_mode && patient && path.len == 0 && (get_dist(src,patient) > 1))
 		spawn(0)
 			path = AStar(loc, get_turf(patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 30,id=botcard)
+			if(!path)
+				path = list()
 
 	if(path.len > 0 && patient)
 		if(!bot_move(patient))


### PR DESCRIPTION
It was possible for the "path" list to be null, resulting in runtimes
when checking its lengths.

The cleanbot's "target" var could be null when attempting to compare the
target's location with its own.

Added some missing checks to prevent runtimes.
