### PR TITLE
Icecream vat fix

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
+++ b/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
@@ -1,50 +1,9 @@
 #define ICECREAM_VANILLA 1
-#define FLAVOUR_CHOCOLATE 2
-#define FLAVOUR_STRAWBERRY 3
-#define FLAVOUR_BLUE 4
+#define ICECREAM_CHOCOLATE 2
+#define ICECREAM_STRAWBERRY 3
+#define ICECREAM_BLUE 4
 #define CONE_WAFFLE 5
 #define CONE_CHOC 6
-#define INGR_MILK 7
-#define INGR_FLOUR 8
-#define INGR_SUGAR 9
-#define INGR_ICE 10
-#define MUCK 11
-
-var/list/ingredients_source = list(
-"berryjuice" = FLAVOUR_STRAWBERRY,\
-"coco" = FLAVOUR_CHOCOLATE,\
-"singulo" = FLAVOUR_BLUE,\
-"milk" = INGR_MILK,\
-"soymilk" = INGR_MILK,\
-"ice" = INGR_ICE,\
-"flour" = INGR_FLOUR,\
-"sugar" = INGR_SUGAR,\
-)
-
-/proc/get_icecream_flavour_string(var/flavour_type)
-	switch(flavour_type)
-		if(FLAVOUR_CHOCOLATE)
-			return "chocolate"
-		if(FLAVOUR_STRAWBERRY)
-			return "strawberry"
-		if(FLAVOUR_BLUE)
-			return "blue"
-		if(CONE_WAFFLE)
-			return "waffle"
-		if(CONE_CHOC)
-			return "chocolate"
-		if(INGR_MILK)
-			return "milk"
-		if(INGR_FLOUR)
-			return "flour"
-		if(INGR_SUGAR)
-			return "sugar"
-		if(INGR_ICE)
-			return "ice"
-		if(MUCK)
-			return "muck"
-		else
-			return "vanilla"
 
 /obj/machinery/icecream_vat
 	name = "icecream vat"
@@ -53,15 +12,54 @@ var/list/ingredients_source = list(
 	icon_state = "icecream_vat"
 	density = 1
 	anchored = 0
-	var/list/ingredients = list()
+	use_power = 0
+	var/list/product_types = list()
 	var/dispense_flavour = ICECREAM_VANILLA
-	var/obj/item/weapon/reagent_containers/glass/held_container
+	var/flavour_name = "vanilla"
+	flags = OPENCONTAINER | NOREACT
+	reagents = new()
+
+/obj/machinery/icecream_vat/proc/get_ingredient_list(var/type)
+	switch(type)
+		if(ICECREAM_CHOCOLATE)
+			return list("milk", "ice", "coco")
+		if(ICECREAM_STRAWBERRY)
+			return list("milk", "ice", "berryjuice")
+		if(ICECREAM_BLUE)
+			return list("milk", "ice", "singulo")
+		if(CONE_WAFFLE)
+			return list("flour", "sugar")
+		if(CONE_CHOC)
+			return list("flour", "sugar", "coco")
+		else
+			return list("milk", "ice")
+
+
+/obj/machinery/icecream_vat/proc/get_flavour_name(var/flavour_type)
+	switch(flavour_type)
+		if(ICECREAM_CHOCOLATE)
+			return "chocolate"
+		if(ICECREAM_STRAWBERRY)
+			return "strawberry"
+		if(ICECREAM_BLUE)
+			return "blue"
+		if(CONE_WAFFLE)
+			return "waffle"
+		if(CONE_CHOC)
+			return "chocolate"
+		else
+			return "vanilla"
+
 
 /obj/machinery/icecream_vat/New()
 	..()
-
-	while(ingredients.len < 11)
-		ingredients.Add(5)
+	while(product_types.len < 6)
+		product_types.Add(5)
+	reagents.my_atom = src
+	reagents.add_reagent("milk", 5)
+	reagents.add_reagent("flour", 5)
+	reagents.add_reagent("sugar", 5)
+	reagents.add_reagent("ice", 5)
 
 /obj/machinery/icecream_vat/attack_hand(mob/user as mob)
 	user.set_machine(src)
@@ -69,140 +67,97 @@ var/list/ingredients_source = list(
 
 /obj/machinery/icecream_vat/interact(mob/user as mob)
 	var/dat
-	dat += "<a href='?src=\ref[src];dispense=[ICECREAM_VANILLA]'><b>Dispense vanilla icecream</b></a> There is [ingredients[ICECREAM_VANILLA]] scoops of vanilla icecream left (made from milk and ice).<br>"
-	dat += "<a href='?src=\ref[src];dispense=[FLAVOUR_STRAWBERRY]'><b>Dispense strawberry icecream</b></a> There is [ingredients[FLAVOUR_STRAWBERRY]] dollops of strawberry flavouring left (obtained from berry juice.<br>"
-	dat += "<a href='?src=\ref[src];dispense=[FLAVOUR_CHOCOLATE]'><b>Dispense chocolate icecream</b></a> There is [ingredients[FLAVOUR_CHOCOLATE]] dollops of chocolate flavouring left (obtained from cocoa powder).<br>"
-	dat += "<a href='?src=\ref[src];dispense=[FLAVOUR_BLUE]'><b>Dispense blue icecream</b></a> There is [ingredients[FLAVOUR_BLUE]] dollops of blue flavouring left (obtained from bluespace tomato singulo).<br>"
+	dat += "<b>ICECREAM</b><br><div class='statusDisplay'>"
+	dat += "<b>Dispensing: [flavour_name] icecream </b> <br><br>"
+	dat += "<b>Vanilla icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_VANILLA]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=5'><b>x5</b></a> [product_types[ICECREAM_VANILLA]] scoops left. (Ingredients: milk, ice)<br>"
+	dat += "<b>Strawberry icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_STRAWBERRY]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=5'><b>x5</b></a> [product_types[ICECREAM_STRAWBERRY]] dollops left. (Ingredients: milk, ice, berry juice)<br>"
+	dat += "<b>Chocolate icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_CHOCOLATE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=5'><b>x5</b></a> [product_types[ICECREAM_CHOCOLATE]] dollops left. (Ingredients: milk, ice, coco powder)<br>"
+	dat += "<b>Blue icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_BLUE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=5'><b>x5</b></a> [product_types[ICECREAM_BLUE]] dollops left. (Ingredients: milk, ice, singulo)<br></div>"
+	dat += "<br><b>CONES</b><br><div class='statusDisplay'>"
+	dat += "<b>Waffle cones:</b> <a href='?src=\ref[src];cone=[CONE_WAFFLE]'><b>Dispense</b></a> <a href='?src=\ref[src];make=[CONE_WAFFLE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[CONE_WAFFLE];amount=5'><b>x5</b></a> [product_types[CONE_WAFFLE]] cones left. (Ingredients: flour, sugar)<br>"
+	dat += "<b>Chocolate cones:</b> <a href='?src=\ref[src];cone=[CONE_CHOC]'><b>Dispense</b></a> <a href='?src=\ref[src];make=[CONE_CHOC];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[CONE_CHOC];amount=5'><b>x5</b></a> [product_types[CONE_CHOC]] cones left. (Ingredients: flour, sugar, coco powder)<br></div>"
 	dat += "<br>"
-	dat += "<a href='?src=\ref[src];cone=[CONE_WAFFLE]'><b>Dispense waffle cones</b></a> There are [ingredients[CONE_WAFFLE]] waffle cones left. <br>"
-	dat += "<a href='?src=\ref[src];cone=[CONE_CHOC]'><b>Dispense chocolate cones</b></a> There are [ingredients[CONE_CHOC]] chocolate cones left.<br>"
-	dat += "<br>"
-	dat += "<a href='?src=\ref[src];make=[CONE_WAFFLE]'><b>Make waffle cones</b></a> There is [ingredients[INGR_FLOUR]]/[ingredients[INGR_SUGAR]] of flour and sugar left.<br>"
-	dat += "<a href='?src=\ref[src];make=[CONE_CHOC]'><b>Make chocolate cones</b></a> There is [ingredients[FLAVOUR_CHOCOLATE]]/[ingredients[CONE_WAFFLE]] of chocolate flavouring and waffle cones left.<br>"
-	dat += "<a href='?src=\ref[src];make=[ICECREAM_VANILLA]'><b>Make vanilla icecream</b></a> There is [ingredients[INGR_MILK]]/[ingredients[INGR_ICE]] of milk and ice left.<br>"
-	dat += "<br>"
-	if(held_container)
-		dat += "<a href='?src=\ref[src];eject=1'>Eject [held_container]</a> "
-	else
-		dat += "No beaker inserted. "
+	dat += "<b>VAT CONTENT</b><br>"
+	for(var/datum/reagent/R in reagents.reagent_list)
+		dat += "[R.name]: [R.volume]"
+		dat += "<A href='?src=\ref[src];disposeI=[R.id]'>Purge</A><BR>"
 	dat += "<a href='?src=\ref[src];refresh=1'>Refresh</a> <a href='?src=\ref[src];close=1'>Close</a>"
 
-	var/datum/browser/popup = new(user, "icecreamvat","Icecream Vat", 700, 400, src)
+	var/datum/browser/popup = new(user, "icecreamvat","Icecream Vat", 700, 500, src)
 	popup.set_content(dat)
 	popup.open()
 
 /obj/machinery/icecream_vat/attackby(var/obj/item/O as obj, var/mob/user as mob)
-	if(istype(O, /obj/item/weapon/reagent_containers))
-		if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/icecream))
-			var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = O
-			if(!I.ice_creamed)
-				if(ingredients[ICECREAM_VANILLA] > 0)
-					var/flavour_name = get_icecream_flavour_string(dispense_flavour)
-					if(ingredients[dispense_flavour] > 0)
-						src.visible_message("\icon[src] <span class='info'>[user] scoops delicious [flavour_name] flavoured icecream into [I].</span>")
-						ingredients[dispense_flavour] -= 1
-						ingredients[ICECREAM_VANILLA] -= 1
+	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/icecream))
+		var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = O
+		if(!I.ice_creamed)
+			if(product_types[dispense_flavour] > 0)
+				src.visible_message("\icon[src] <span class='info'>[user] scoops delicious [flavour_name] icecream into [I].</span>")
+				product_types[dispense_flavour] -= 1
 
-						I.add_ice_cream(dispense_flavour)
-						if(held_container)
-							held_container.reagents.trans_to(I, 10)
-						if(I.reagents.total_volume < 10)
-							I.reagents.add_reagent("sugar", 10 - I.reagents.total_volume)
-					else
-						user << "<span class='warning'>There is not enough [flavour_name] flavouring left! Insert more of the required ingredients.</span>"
-				else
-					user << "<span class='warning'>There is not enough icecream left! Insert more milk and ice.</span>"
+				I.add_ice_cream(flavour_name)
+			//	if(beaker)
+			//		beaker.reagents.trans_to(I, 10)
+				if(I.reagents.total_volume < 10)
+					I.reagents.add_reagent("sugar", 10 - I.reagents.total_volume)
 			else
-				user << "<span class='notice'>[O] already has icecream in it.</span>"
-		else if(istype(O, /obj/item/weapon/reagent_containers/glass))
-			if(held_container)
-				user << "<span class='notice'>You must remove [held_container] from [src] first.</span>"
-			else
-				user << "<span class='info'>You insert [O] into [src].</span>"
-				user.drop_item()
-				O.loc = src
-				held_container = O
+				user << "<span class='warning'>There is not enough icecream left!</span>"
 		else
-			var/obj/item/weapon/reagent_containers/R = O
-			if(R.reagents)
-				src.visible_message("<span class='info'>[user] has emptied all of [R] into [src].</span>")
-				for (var/datum/reagent/current_reagent in R.reagents.reagent_list)
-					if(ingredients_source[current_reagent.id])
-						add(ingredients_source[current_reagent.id], current_reagent.volume / 2)
-					else
-						add(MUCK, current_reagent.volume / 5)
-				R.reagents.clear_reagents()
+			user << "<span class='notice'>[O] already has icecream in it.</span>"
 		return 1
+	else if(O.is_open_container())
+		return
 	else
 		..()
 
-/obj/machinery/icecream_vat/proc/add(var/add_type, var/amount)
-	if(add_type <= ingredients.len)
-		ingredients[add_type] += amount
-		updateDialog()
-
-/obj/machinery/icecream_vat/proc/make(var/mob/user, var/make_type)
-	switch(make_type)
-		if(CONE_WAFFLE)
-			if(ingredients[INGR_FLOUR] > 0 && ingredients[INGR_SUGAR] > 0)
-				var/amount = max( min(ingredients[INGR_FLOUR], ingredients[INGR_SUGAR]), 5)
-				ingredients[INGR_FLOUR] -= amount
-				ingredients[INGR_SUGAR] -= amount
-				ingredients[CONE_WAFFLE] += amount
-				src.visible_message("<span class='info'>[user] cooks up some waffle cones.</span>")
-			else
-				user << "<span class='notice'>You require sugar and flour to make waffle cones.</span>"
-		if(CONE_CHOC)
-			if(ingredients[FLAVOUR_CHOCOLATE] > 0 && ingredients[CONE_WAFFLE] > 0)
-				var/amount = min(ingredients[CONE_WAFFLE], ingredients[FLAVOUR_CHOCOLATE])
-				ingredients[CONE_WAFFLE] -= amount
-				ingredients[FLAVOUR_CHOCOLATE] -= amount
-				ingredients[CONE_CHOC] += amount
-				src.visible_message("<span class='info'>[user] cooks up some chocolate cones.</span>")
-			else
-				user << "<span class='notice'>You require waffle cones and chocolate flavouring to make chocolate cones.</span>"
-		if(ICECREAM_VANILLA)
-			if(ingredients[INGR_ICE] > 0 && ingredients[INGR_MILK] > 0)
-				var/amount = min(ingredients[INGR_ICE], ingredients[INGR_MILK])
-				ingredients[INGR_ICE] -= amount
-				ingredients[INGR_MILK] -= amount
-				ingredients[ICECREAM_VANILLA] += amount
-				src.visible_message("<span class='info'>[user] whips up some vanilla icecream.</span>")
-			else
-				user << "<span class='notice'>You require milk and ice to make vanilla icecream.</span>"
-	updateDialog()
+/obj/machinery/icecream_vat/proc/make(var/mob/user, var/make_type, var/amount)
+	for(var/R in get_ingredient_list(make_type))
+		if(reagents.has_reagent(R, amount))
+			continue
+		amount = 0
+		break
+	if(amount)
+		for(var/R in get_ingredient_list(make_type))
+			reagents.remove_reagent(R, amount)
+		product_types[make_type] += amount
+		var/flavour = get_flavour_name(make_type)
+		if(make_type > 4)
+			src.visible_message("<span class='info'>[user] cooks up some [flavour] cones.</span>")
+		else
+			src.visible_message("<span class='info'>[user] whips up some [flavour] icecream.</span>")
+	else
+		user << "<span class='warning'>You don't have the ingredients to make this.</span>"
 
 /obj/machinery/icecream_vat/Topic(href, href_list)
 	if(..())
 		return
-	if(href_list["dispense"])
-		dispense_flavour = text2num(href_list["dispense"])
-		src.visible_message("<span class='notice'>[usr] sets [src] to dispense [get_icecream_flavour_string(dispense_flavour)] flavoured icecream.</span>")
+	if(href_list["select"])
+		dispense_flavour = text2num(href_list["select"])
+		flavour_name = get_flavour_name(dispense_flavour)
+		src.visible_message("<span class='notice'>[usr] sets [src] to dispense [flavour_name] flavoured icecream.</span>")
 
 	if(href_list["cone"])
 		var/dispense_cone = text2num(href_list["cone"])
-		if(ingredients[dispense_cone] <= ingredients.len)
-			var/cone_name = get_icecream_flavour_string(dispense_cone)
-			if(ingredients[dispense_cone] >= 1)
-				ingredients[dispense_cone] -= 1
-				var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = new(src.loc)
-				I.cone_type = cone_name
-				I.icon_state = "icecream_cone_[cone_name]"
-				I.desc = "Delicious [cone_name] cone, but no ice cream."
-				src.visible_message("<span class='info'>[usr] dispenses a crunchy [cone_name] cone from [src].</span>")
-			else
-				usr << "<span class='warning'>There are no [cone_name] cones left!</span>"
-		updateDialog()
+		var/cone_name = get_flavour_name(dispense_cone)
+		if(product_types[dispense_cone] >= 1)
+			product_types[dispense_cone] -= 1
+			var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = new(src.loc)
+			I.cone_type = cone_name
+			I.icon_state = "icecream_cone_[cone_name]"
+			I.desc = "Delicious [cone_name] cone, but no ice cream."
+			src.visible_message("<span class='info'>[usr] dispenses a crunchy [cone_name] cone from [src].</span>")
+		else
+			usr << "<span class='warning'>There are no [cone_name] cones left!</span>"
 
 	if(href_list["make"])
-		make( usr, text2num(href_list["make"]) )
-		updateDialog()
+		var/amount = (text2num(href_list["amount"]))
+		var/C = text2num(href_list["make"])
+		make(usr, C, amount)
 
-	if(href_list["eject"])
-		if(held_container)
-			held_container.loc = src.loc
-			held_container = null
-		updateDialog()
+	if(href_list["disposeI"])
+		reagents.del_reagent(href_list["disposeI"])
+
+	updateDialog()
 
 	if(href_list["refresh"])
 		updateDialog()
@@ -226,8 +181,7 @@ var/list/ingredients_source = list(
 	create_reagents(20)
 	reagents.add_reagent("nutriment", 5)
 
-/obj/item/weapon/reagent_containers/food/snacks/icecream/proc/add_ice_cream(var/flavour)
-	var/flavour_name = get_icecream_flavour_string(flavour)
+/obj/item/weapon/reagent_containers/food/snacks/icecream/proc/add_ice_cream(var/flavour_name)
 	name = "[flavour_name] icecream"
 	src.overlays += "icecream_[flavour_name]"
 	desc = "Delicious [cone_type] cone with a dollop of [flavour_name] ice cream."
@@ -239,8 +193,3 @@ var/list/ingredients_source = list(
 #undef FLAVOUR_BLUE
 #undef CONE_WAFFLE
 #undef CONE_CHOC
-#undef INGR_MILK
-#undef INGR_FLOUR
-#undef INGR_SUGAR
-#undef INGR_ICE
-#undef MUCK


### PR DESCRIPTION
- You can now transfer a specific amount of reagent with a beaker to the icecreamvat using only open containers like beakers.
- Vat can no longer contain a beaker.
- You can purge the vat's content.(similar to circuit imprinter)
- You can now make a specific amount of icecream/cones (not just the maximum you can make with all the reagents currently in the vat)
- The icecream vat no longer needs APC power.
- The icecream vat window gets a lifting.
- Simplifying the code.

FIXED BUG LIST:

Beaker can't be used to add reagents to vat, it goes directly inside the vat and the vat doesn't detect what's inside the beaker. Beaker is useless and its reagents (whatever they are) are used when making icecream somehow.

Cannot put just a bit of reagents in the vat, it empties all the item's reagents or nothing.

Click icecream vat with a snack it will take all the reagents, the snack doesn't disappear until you try to eat it. "Vinny Saylor has emptied all of the egg into the icecream vat."

The vat doesn't work w/o power

Cant dispense cones if their total amount is bigger than 11.

Take empty condiment bottle, click on vat, it still says that you empty the content in it.
