### PR TITLE
adding CoolDown to welding repair on bot/borg/mecha

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -234,34 +234,36 @@
 			user << "<span class='notice'>Maintenance panel is now [open ? "opened" : "closed"].</span>"
 		else
 			user << "<span class='warning'>Maintenance panel is locked.</span>"
-	else if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm")
-		if(health < maxhealth)
-			if(open)
-				var/obj/item/weapon/weldingtool/WT = W
-				if(!WT.isOn())
-					user << "<span class='warning'>The welder must be on for this task.</span>"
-				health = min(maxhealth, health+10)
-				user.visible_message("<span class='danger'>[user] repairs [src]!</span>","<span class='notice'>You repair [src]!</span>")
-			else
-				user << "<span class='notice'>Unable to repair with the maintenance panel closed.</span>"
-		else
-			user << "<span class='notice'>[src] does not need a repair.</span>"
 	else if (istype(W, /obj/item/weapon/card/emag) && emagged < 2)
 		Emag(user)
 	else
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(W.force) //if force is non-zero
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(5, 1, src)
-			switch(W.damtype)
-				if("fire")
-					health -= W.force * fire_dam_coeff
-					s.start()
-				if("brute")
-					health -= W.force * brute_dam_coeff
-					s.start()
-			..()
-			healthcheck()
+		if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm")
+			if(health >= maxhealth)
+				user << "<span class='warning'>[src] does not need a repair.</span>"
+				return
+			if(!open)
+				user << "<span class='warning'>Unable to repair with the maintenance panel closed.</span>"
+				return
+			var/obj/item/weapon/weldingtool/WT = W
+			if(WT.remove_fuel(0, user))
+				health = min(maxhealth, health+10)
+				user.visible_message("<span class='notice'>[user] repairs [src]!</span>","<span class='notice'>You repair [src]!</span>")
+			else
+				user << "<span class='warning'>The welder must be on for this task.</span>"
+		else
+			if(W.force) //if force is non-zero
+				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+				s.set_up(5, 1, src)
+				switch(W.damtype)
+					if("fire")
+						health -= W.force * fire_dam_coeff
+						s.start()
+					if("brute")
+						health -= W.force * brute_dam_coeff
+						s.start()
+				..()
+				healthcheck()
 
 
 /obj/machinery/bot/bullet_act(var/obj/item/projectile/Proj)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -520,8 +520,8 @@
 		src.visible_message("The [A] fastens firmly to [src].")
 		return
 	if(prob(src.deflect_chance) || istype(A, /mob))
-		src.occupant_message("<span class='notice'>The [A] bounces off the armor.</span>")
-		src.visible_message("The [A] bounces off the [src.name] armor")
+		src.occupant_message("<span class='notice'>[A] bounces off the armor.</span>")
+		src.visible_message("[A] bounces off the [src.name] armor")
 		src.log_append_to_last("Armor saved.")
 		if(istype(A, /mob/living))
 			var/mob/living/M = A
@@ -738,19 +738,22 @@
 		return
 
 	else if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm")
+		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/weapon/weldingtool/WT = W
-		if (WT.remove_fuel(0,user))
-			if (hasInternalDamage(MECHA_INT_TANK_BREACH))
-				clearInternalDamage(MECHA_INT_TANK_BREACH)
-				user << "<span class='notice'>You repair the damaged gas tank.</span>"
-		else
-			return
 		if(src.health<initial(src.health))
-			user << "<span class='notice'>You repair some damage to [src.name].</span>"
-			src.health += min(10, initial(src.health)-src.health)
+			if (WT.remove_fuel(0,user))
+				if (hasInternalDamage(MECHA_INT_TANK_BREACH))
+					clearInternalDamage(MECHA_INT_TANK_BREACH)
+					user << "<span class='notice'>You repair the damaged gas tank.</span>"
+				else
+					user.visible_message("<span class='notice'>[user] repairs some damage to [src.name].</span>")
+					src.health += min(10, initial(src.health)-src.health)
+			else
+				user << "<span class='warning'>The welder must be on for this task.</span>"
+				return 1
 		else
-			user << "The [src.name] is at full integrity"
-		return
+			user << "<span class='warning'>The [src.name] is at full integrity.</span>"
+		return 1
 
 	else if(istype(W, /obj/item/mecha_parts/mecha_tracking))
 		if(!user.unEquip(W))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -397,29 +397,30 @@
 		return
 
 	if (istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm")
+		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/weapon/weldingtool/WT = W
 		if (src == user)
 			user << "<span class='warning'>You lack the reach to be able to repair yourself.</span>"
-			return
+			return 1
 		if (src.health >= src.maxHealth)
 			user << "<span class='warning'>[src] is already in good condition.</span>"
-			return
-		if (WT.remove_fuel(0))
+			return 1
+		if (WT.remove_fuel(0, user))
 			adjustBruteLoss(-30)
 			updatehealth()
 			add_fingerprint(user)
-			for(var/mob/O in viewers(user, null))
-				O.show_message(text("<span class='danger'>[user] has fixed some of the dents on [src]!</span>"), 1)
+			visible_message("<span class='notice'>[user] has fixed some of the dents on [src].</span>")
+			return 0
 		else
-			return
+			user << "<span class='warning'>The welder must be on for this task.</span>"
+			return 1
 
 	else if(istype(W, /obj/item/stack/cable_coil) && wiresexposed)
 		var/obj/item/stack/cable_coil/coil = W
 		if (coil.use(1))
 			adjustFireLoss(-30)
 			updatehealth()
-			for(var/mob/O in viewers(user, null))
-				O.show_message(text("<span class='danger'>[user] has fixed some of the burnt wires on [src]!</span>"), 1)
+			visible_message("<span class='notice'>[user] has fixed some of the burnt wires on [src].</span>")
 		else
 			user << "<span class='warning'>You need one length of cable to repair [src].</span>"
 


### PR DESCRIPTION
Now eye prot needed to repair bot/borg (just like with mecha)
fix bug where you're repairing despite weldingtool being off
Fixes the amount of fuel used per repair to 1 for bot/borg/mecha
Adding message when not enough fuel during borg/mecha repair.
Fuel not used when repair attempt on borg/mecha is canceled (no damage or welder off).
For bot/borg/mecha, now using notice span class for all repair messages and visible message instead of << . All cancel messages uses warning span class.
