### PR TITLE
Meteors infinigib/infinisplosion fixes

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -85,7 +85,7 @@
 	pass_flags = PASSTABLE
 	var/heavy = 0
 	var/meteorsound = 'sound/effects/meteorimpact.ogg'
-	var/z_original
+	var/z_original = 1
 
 	var/meteordrop = /obj/item/weapon/ore/iron
 	var/dropamt = 2
@@ -93,6 +93,7 @@
 /obj/effect/meteor/Move()
 	if(z != z_original || loc == dest)
 		qdel(src)
+		return
 	return ..()
 
 /obj/effect/meteor/Destroy()


### PR DESCRIPTION
Since it's probably plaguing Spookoween and my meteor PR is getting conflicts with Pumpkins Meteors, here's the hotfix for the meteors bumping bug.

**Content**
Fixed meteors not properly qdel'ing (fixing infinigibs or infinisplotions) and variables initialization (fixes #5226).
Admin-spawned meteors should not instaqdel anymore.
