### PR TITLE
Fix the lag produced by oversized Pumpkings (spookofix)

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -135,6 +135,8 @@
 	heavy = 1
 	meteordrop = /obj/item/weapon/ore/uranium
 
+//////////////////////////
+//Spookoween meteors
 /obj/effect/meteor/pumpkin
 	name = "PUMPKING"
 	desc = "THE PUMPKING'S COMING!"
@@ -142,17 +144,13 @@
 	icon_state = "pumpkin"
 	hits = 10
 	heavy = 1
-	meteordrop = /obj/item/clothing/head/hardhat/pumpkinhead
-	meteorsound = 'sound/hallucinations/im_here1.ogg'
 	dropamt = 1
-	bound_width = 96
-	bound_height = 96
 
 /obj/effect/meteor/pumpkin/New()
 	..()
-	if(prob(50))
-		meteordrop = /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin
-		meteorsound = 'sound/hallucinations/im_here2.ogg'
+	meteordrop = pick(/obj/item/clothing/head/hardhat/pumpkinhead, /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin)
+	meteorsound = pick('sound/hallucinations/im_here1.ogg','sound/hallucinations/im_here2.ogg')
+//////////////////////////
 
 /obj/effect/meteor/meaty
 	name = "meaty ore"

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -36,6 +36,7 @@
 		if(C.name == "carpspawn")
 			new /mob/living/simple_animal/hostile/carp/eyeball(C.loc)
 
+//Pumpking meteors waves
 /datum/round_event_control/meteor_wave/spooky
 	name = "Pumpkin Wave"
 	typepath = /datum/round_event/meteor_wave/spooky
@@ -44,11 +45,11 @@
 	max_occurrences = 2
 
 /datum/round_event/meteor_wave/spooky
-	endWhen	= 33
+	endWhen	= 40
 
 /datum/round_event/meteor_wave/spooky/tick()
-	if(IsMultiple(activeFor, 3))
-		spawn_meteors(5, meteorsSPOOKY) //meteor list types defined in gamemode/meteor/meteors.dm
+	if(IsMultiple(activeFor, 4))
+		spawn_meteors(3, meteorsSPOOKY) //meteor list types defined in gamemode/meteor/meteors.dm
 
 //spooky foods (you can't actually make these when it's not halloween)
 /obj/item/weapon/reagent_containers/food/snacks/sugarcookie/spookyskull


### PR DESCRIPTION
The oversized bounds were interacting with space transitions (removed them, sorry Remie but i didn't felt like doing a hacky check for one seasonal event).

Reduced the number of meteors to 10 waves of 3 over 40 seconds (since Byond seems to be not-so-good at drawing that many large sprites).

_Note :  those event belongs to the halloween sicrit file, don't they ?_
