### PR TITLE
adjustmask() now uses visor_flags and visor_flags_inv

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -3,8 +3,8 @@
 	var/flash_protect = 0		//Malk: What level of bright light protection item has. 1 = Flashers, Flashes, & Flashbangs | 2 = Welding | -1 = OH GOD WELDING BURNT OUT MY RETINAS
 	var/tint = 0				//Malk: Sets the item's level of visual impairment tint, normally set to the same as flash_protect
 	var/up = 0					//	   but seperated to allow items to protect but not impair vision, like space helmets
-	var/visor_flags = null
-	var/visor_flags_inv = null
+	var/visor_flags = 0			// flags that are added/removed when an item is adjusted up/down
+	var/visor_flags_inv = 0		// same as visor_flags, but for flags_inv
 
 //Ears: currently only used for headsets and earmuffs
 /obj/item/clothing/ears
@@ -102,8 +102,8 @@ BLIND     // can't see anything
 			src.icon_state = initial(icon_state)
 			gas_transfer_coefficient = initial(gas_transfer_coefficient)
 			permeability_coefficient = initial(permeability_coefficient)
-			flags = initial(flags)
-			flags_inv = initial(flags_inv)
+			flags |= visor_flags
+			flags_inv |= visor_flags_inv
 			usr << "You push \the [src] back into place."
 			src.mask_adjusted = 0
 		else
@@ -111,8 +111,8 @@ BLIND     // can't see anything
 			usr << "You push \the [src] out of the way."
 			gas_transfer_coefficient = null
 			permeability_coefficient = null
-			flags = null
-			flags_inv = null
+			flags &= ~visor_flags
+			flags_inv &= ~visor_flags_inv
 			src.mask_adjusted = 1
 		usr.update_inv_wear_mask()
 

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -5,6 +5,7 @@
 	item_state = "balaclava"
 	flags = BLOCKHAIR
 	flags_inv = HIDEFACE
+	visor_flags_inv = HIDEFACE
 	w_class = 2
 	action_button_name = "Adjust Balaclava"
 	ignore_maskadjust = 0

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -5,6 +5,7 @@
 	item_state = "m_mask"
 	body_parts_covered = 0
 	flags = MASKCOVERSMOUTH | MASKINTERNALS
+	visor_flags = MASKCOVERSMOUTH | MASKINTERNALS
 	w_class = 2
 	gas_transfer_coefficient = 0.10
 	permeability_coefficient = 0.50

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -24,6 +24,8 @@
 	w_class = 1
 	flags = MASKCOVERSMOUTH
 	flags_inv = HIDEFACE
+	visor_flags = MASKCOVERSMOUTH
+	visor_flags_inv = HIDEFACE
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 25, rad = 0)


### PR DESCRIPTION
This means that it works similarly to the riot helmet.
visor_flags/visor_flags_inv are removed from flags/flags_inv whilst the mask is adjusted and are re-applied once the mask is returned to its default position.

Fixes #5461
