### PR TITLE
Adding checks for stun, restrained to many object verbs.

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -77,7 +77,7 @@
 			point_at(location)
 		if(mode == 2)
 			point_at(target)
-		usr << "<span class='notice'>You activate the pinpointer.,/span>"
+		usr << "<span class='notice'>You activate the pinpointer.</span>"
 	else
 		active = 0
 		icon_state = "pinoff"
@@ -88,6 +88,9 @@
 	set category = "Object"
 	set name = "Toggle Pinpointer Mode"
 	set src in view(1)
+
+	if(usr.stat || usr.restrained() || !usr.canmove)
+		return
 
 	active = 0
 	icon_state = "pinoff"

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -80,6 +80,9 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.stat || usr.restrained() || !usr.canmove)
+		return
+
 	if(storedpda)
 		storedpda.loc = get_turf(src.loc)
 		storedpda = null

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -302,7 +302,7 @@
 
 	if(!usr)
 		return
-	if (usr.stat != 0)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	src.go_out()
 	add_fingerprint(usr)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -38,7 +38,7 @@ var/list/doppler_arrays = list()
 
 	if(!usr || !isturf(usr.loc))
 		return
-	if(usr.stat || usr.restrained())
+	if(usr.stat || usr.restrained() || !usr.canmove)
 		return
 	src.dir = turn(src.dir, 90)
 	return

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -155,7 +155,7 @@ Buildable meters
 	set name = "Rotate Pipe"
 	set src in view(1)
 
-	if ( usr.stat || usr.restrained() )
+	if ( usr.stat || usr.restrained() || !usr.canmove )
 		return
 
 	src.dir = turn(src.dir, -90)
@@ -169,7 +169,7 @@ Buildable meters
 	set name = "Flip Pipe"
 	set src in view(1)
 
-	if ( usr.stat || usr.restrained() )
+	if ( usr.stat || usr.restrained() || !usr.canmove )
 		return
 
 	if (pipe_type in list(PIPE_GAS_FILTER, PIPE_GAS_MIXER))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -28,6 +28,9 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.stat || usr.restrained() || !usr.canmove)
+		return
+
 	if( state != 4 )
 		usr << "The washing machine cannot run in this state."
 		return

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -38,7 +38,7 @@
 	set name = "Toggle defence mode"
 	set src = usr.loc
 	set popup_menu = 0
-	if(usr!=src.occupant)
+	if(!can_use(usr))
 		return
 	defence = !defence
 	if(defence)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -56,7 +56,7 @@
 	set name = "Toggle leg actuators overload"
 	set src = usr.loc
 	set popup_menu = 0
-	if(usr!=src.occupant)
+	if(!can_use(usr))
 		return
 	if(overload)
 		overload = 0

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -201,6 +201,13 @@
 
 	return 1
 
+obj/mecha/proc/can_use(mob/user)
+	if(user != src.occupant)
+		return 0
+	if(user && ismob(user))
+		if(!usr.stat && !usr.restrained() && usr.canmove)
+			return 1
+	return 0
 
 /obj/mecha/examine(mob/user)
 	..()
@@ -866,8 +873,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(usr.stat)			return
-	if(usr != src.occupant)	return
+	if(!can_use(usr))
+		return
 
 	var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector/) in loc
 	if(possible_port)
@@ -889,8 +896,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(usr.stat)			return
-	if(usr != src.occupant)	return
+	if(!can_use(usr))
+		return
 
 	if(disconnect())
 		src.occupant_message("<span class='notice'>[name] disconnects from the port.</span>")
@@ -905,8 +912,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(usr.stat)		return
-	if(usr != occupant)	return
+	if(!can_use(usr))
+		return
 
 	lights = !lights
 	if(lights)	AddLuminosity(lights_power)
@@ -922,8 +929,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(usr.stat)			return
-	if(usr != src.occupant)	return
+	if(!can_use(usr))
+		return
 
 	use_internal_tank = !use_internal_tank
 	src.occupant_message("Now taking air from [use_internal_tank?"internal airtank":"environment"].")
@@ -1059,7 +1066,8 @@
 	set category = "Exosuit Interface"
 	set src = usr.loc
 	set popup_menu = 0
-	if(usr!=src.occupant)
+
+	if(!can_use(usr))
 		return
 	//pr_update_stats.start()
 	src.occupant << browse(src.get_stats_html(), "window=exosuit")
@@ -1080,7 +1088,8 @@
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(usr != src.occupant)	return
+	if(!can_use(usr))
+		return
 
 	src.go_out()
 	add_fingerprint(usr)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -80,7 +80,7 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!istype(src.loc, /turf) || usr.stat || usr.restrained() )
+	if(!istype(src.loc, /turf) || usr.stat || usr.restrained() || !usr.canmove)
 		return
 
 	var/turf/T = src.loc

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -164,6 +164,9 @@ MASS SPECTROMETER
 	set name = "Switch Verbosity"
 	set category = "Object"
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	mode = !mode
 	switch (mode)
 		if(1)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -67,11 +67,18 @@
 	..()
 
 
+/obj/item/device/taperecorder/proc/can_use(mob/user)
+	if(user && ismob(user))
+		if(user.stat && user.canmove && !user.restrained())
+			return 1
+	return 0
+
+
 /obj/item/device/taperecorder/verb/ejectverb()
 	set name = "Eject Tape"
 	set category = "Object"
 
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 	if(!mytape)
 		return
@@ -99,7 +106,7 @@
 	set name = "Start Recording"
 	set category = "Object"
 
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 	if(!mytape || mytape.ruined)
 		return
@@ -136,7 +143,7 @@
 	set name = "Stop"
 	set category = "Object"
 
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 
 	if(recording)
@@ -156,7 +163,7 @@
 	set name = "Play Tape"
 	set category = "Object"
 
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 	if(!mytape || mytape.ruined)
 		return
@@ -211,7 +218,7 @@
 	set name = "Print Transcript"
 	set category = "Object"
 
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 	if(!mytape)
 		return

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -33,8 +33,11 @@
 	set category = "Object"
 	set src in usr
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	if (t)
-		src.name = text("data disk- '[]'", t)
+		src.name = "data disk- '[t]'"
 	else
 		src.name = "data disk"
 	src.add_fingerprint(usr)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -96,13 +96,15 @@
 	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."
 	icon_state = "portaseeder"
 
-	verb/dissolve_contents()
-		set name = "Activate Seed Extraction"
-		set category = "Object"
-		set desc = "Activate to convert your plants into plantable seeds."
-		for(var/obj/item/O in contents)
-			seedify(O, 1)
-		close_all()
+/obj/item/weapon/storage/bag/plants/portaseeder/verb/dissolve_contents()
+	set name = "Activate Seed Extraction"
+	set category = "Object"
+	set desc = "Activate to convert your plants into plantable seeds."
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	for(var/obj/item/O in contents)
+		seedify(O, 1)
+	close_all()
 
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -362,6 +362,9 @@
 	set name = "Switch Gathering Method"
 	set category = "Object"
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	collection_mode = (collection_mode+1)%3
 	switch (collection_mode)
 		if(2)
@@ -376,7 +379,7 @@
 	set name = "Empty Contents"
 	set category = "Object"
 
-	if((!ishuman(usr) && (loc != usr)) || usr.stat || usr.restrained())
+	if((!ishuman(usr) && (loc != usr)) || usr.stat || usr.restrained() ||!usr.canmove)
 		return
 
 	do_quick_empty()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -20,6 +20,8 @@
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()
 	set name = "Toggle Jetpack Stabilization"
 	set category = "Object"
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	src.stabilization_on = !( src.stabilization_on )
 	usr << "You toggle the stabilization [stabilization_on? "on":"off"]."
 	return
@@ -28,6 +30,8 @@
 /obj/item/weapon/tank/jetpack/verb/toggle()
 	set name = "Toggle Jetpack"
 	set category = "Object"
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	on = !on
 	if(on)
 		icon_state = "[icon_state]-on"

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -29,6 +29,8 @@
 /obj/item/weapon/watertank/verb/toggle_mister()
 	set name = "Toggle Mister"
 	set category = "Object"
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	on = !on
 
 	var/mob/living/carbon/human/user = usr

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -66,7 +66,7 @@
 	else
 		if(!usr || !isturf(usr.loc))
 			return
-		if(usr.stat || usr.restrained())
+		if(usr.stat || usr.restrained() || !usr.canmove)
 			return
 		spin()
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -304,7 +304,8 @@ obj/structure/windoor_assembly/Destroy()
 	set name = "Rotate Windoor Assembly"
 	set category = "Object"
 	set src in oview(1)
-
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	if (src.anchored)
 		usr << "It is fastened to the floor; therefore, you can't rotate it!"
 		return 0
@@ -325,6 +326,8 @@ obj/structure/windoor_assembly/Destroy()
 	set name = "Flip Windoor Assembly"
 	set category = "Object"
 	set src in oview(1)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 
 	if(src.facing == "l")
 		usr << "The windoor will now slide to the right."

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -239,6 +239,9 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	if(anchored)
 		usr << "It is fastened to the floor therefore you can't rotate it!"
 		return 0
@@ -255,6 +258,9 @@
 	set name = "Rotate Window Clockwise"
 	set category = "Object"
 	set src in oview(1)
+
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 
 	if(anchored)
 		usr << "It is fastened to the floor therefore you can't rotate it!"

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -130,6 +130,9 @@
 	set category = "Object"
 	set src in usr
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	dir = turn(dir, 90)
 	return
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -266,8 +266,10 @@ atom/proc/generate_female_clothing(index,t_color,icon)
 	set category = "Object"
 	set src in usr
 	var/mob/M = usr
-	if (istype(M, /mob/dead/)) return
-	if (usr.stat) return
+	if (istype(M, /mob/dead/))
+		return
+	if (!can_use(usr))
+		return
 	if(src.has_sensor >= 2)
 		usr << "The controls are locked."
 		return 0
@@ -292,7 +294,7 @@ atom/proc/generate_female_clothing(index,t_color,icon)
 	set name = "Adjust Jumpsuit Style"
 	set category = "Object"
 	set src in usr
-	if(usr.stat)
+	if(!can_use(usr))
 		return
 	if(!can_adjust)
 		usr << "You cannot wear this suit any differently."
@@ -313,8 +315,10 @@ atom/proc/generate_female_clothing(index,t_color,icon)
 	set name = "Remove Accessory"
 	set category = "Object"
 	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
+	if(!istype(usr, /mob/living))
+		return
+	if(!can_use(usr))
+		return
 
 	if(hastie)
 		hastie.transform *= 2
@@ -336,7 +340,7 @@ atom/proc/generate_female_clothing(index,t_color,icon)
 	..()
 
 /obj/item/clothing/proc/weldingvisortoggle()			//Malk: proc to toggle welding visors on helmets, masks, goggles, etc.
-	if(usr.canmove && !usr.stat && !usr.restrained())
+	if(can_use(usr))
 		if(up)
 			up = !up
 			flags |= (visor_flags)
@@ -360,3 +364,9 @@ atom/proc/generate_female_clothing(index,t_color,icon)
 		usr.update_inv_glasses(0)
 	if(istype(src, /obj/item/clothing/mask))
 		usr.update_inv_wear_mask(0)
+
+/obj/item/clothing/proc/can_use(mob/user)
+	if(user && ismob(user))
+		if(!user.stat && user.canmove && !user.restrained())
+			return 1
+	return 0

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -87,8 +87,10 @@
 	set category = "Object"
 	set name = "HALT"
 	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
+	if(!istype(usr, /mob/living))
+		return
+	if(!can_use(usr))
+		return
 
 	var/phrase = 0	//selects which phrase to use
 	var/phrase_text = null

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -14,6 +14,8 @@
 	set name = "Toggle Magboots"
 	set category = "Object"
 	set src in usr
+	if(!can_use(usr))
+		return
 	attack_self(usr)
 
 

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -14,7 +14,7 @@
 	set category = "Object"
 	set src in usr
 
-	if(!usr.canmove || usr.stat || usr.restrained())
+	if(!can_use(usr))
 		return 0
 
 	open = !open

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -228,7 +228,7 @@
 	set category = "Object"
 	set src in usr
 
-	if(!usr.canmove || usr.stat || usr.restrained())
+	if(!can_use(usr))
 		return 0
 
 	if(src.icon_state == "suitjacket_blue_open")	//no god no

--- a/code/modules/food&drinks/kitchen machinery/gibber.dm
+++ b/code/modules/food&drinks/kitchen machinery/gibber.dm
@@ -110,7 +110,7 @@
 	set name = "empty gibber"
 	set src in oview(1)
 
-	if (usr.stat != 0)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	src.go_out()
 	add_fingerprint(usr)

--- a/code/modules/food&drinks/kitchen machinery/juicer.dm
+++ b/code/modules/food&drinks/kitchen machinery/juicer.dm
@@ -126,7 +126,7 @@
 	set category = "Object"
 	set name = "Detach Beaker from the juicer"
 	set src in oview(1)
-	if (usr.stat != 0)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	if (!beaker)
 		return

--- a/code/modules/food&drinks/kitchen machinery/processor.dm
+++ b/code/modules/food&drinks/kitchen machinery/processor.dm
@@ -157,7 +157,7 @@
 	set name = "Eject Contents"
 	set src in oview(1)
 
-	if (usr.stat != 0)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	src.empty()
 	add_fingerprint(usr)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -305,7 +305,7 @@ var/list/slot_equipment_priority = list( \
 
 	if(!src || !isturf(src.loc))
 		return
-	if(src.stat || src.restrained())
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	if(src.status_flags & FAKEDEATH)
 		return

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -7,7 +7,7 @@
 
 /obj/item/weapon/paper
 	name = "paper"
-	gender = PLURAL
+	gender = NEUTER
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
 	throwforce = 0
@@ -66,6 +66,8 @@
 	set category = "Object"
 	set src in usr
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	if((CLUMSY in usr.mutations) && prob(25))
 		usr << "<span class='warning'>You cut yourself on the paper! Ahhhh! Ahhhhh!</span>"
 		usr.damageoverlaytemp = 9001

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -73,7 +73,7 @@
 
 	var/n_name = copytext(sanitize(input(usr, "What would you like to label the photo?", "Photo Labelling", null)  as text), 1, MAX_NAME_LEN)
 	//loc.loc check is for making possible renaming photos in clipboards
-	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
+	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0 && usr.canmove && !usr.restrained())
 		name = "photo[(n_name ? text("- '[n_name]'") : null)]"
 	add_fingerprint(usr)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -539,8 +539,9 @@ obj/structure/cable/proc/avail()
 	set category = "Object"
 	var/mob/M = usr
 
-	if(ishuman(M) && !M.restrained() && !M.stat && !M.paralysis && ! M.stunned)
-		if(!istype(usr.loc,/turf)) return
+	if(ishuman(M) && !M.restrained() && !M.stat && M.canmove)
+		if(!istype(usr.loc,/turf))
+			return
 		if(src.amount <= 14)
 			usr << "<span class='danger'>You need at least 15 lengths to make restraints!</span>"
 			return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -27,7 +27,9 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	if (src.anchored)
 		usr << "It is fastened to the floor!"
 		return 0
 	src.dir = turn(src.dir, 90)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -93,7 +93,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	if (src.anchored)
 		usr << "It is fastened to the floor!"
 		return 0
 	src.dir = turn(src.dir, 270)
@@ -104,7 +106,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	if (src.anchored)
 		usr << "It is fastened to the floor!"
 		return 0
 	src.dir = turn(src.dir, 90)
@@ -282,7 +286,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	if (src.anchored)
 		usr << "It is fastened to the floor!"
 		return 0
 	src.dir = turn(src.dir, 270)
@@ -293,7 +299,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	if (src.anchored)
 		usr << "It is fastened to the floor!"
 		return 0
 	src.dir = turn(src.dir, 90)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -76,7 +76,7 @@
 	var/mob/M = usr
 	var/input = stripped_input(M,"What do you want to name the gun?", ,"", MAX_NAME_LEN)
 
-	if(src && input && !M.stat && in_range(M,src))
+	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
 		name = input
 		M << "You name the gun [input]. Say hello to your new friend."
 		return 1
@@ -95,7 +95,7 @@
 	options["The Peacemaker"] = "detective_peacemaker"
 	var/choice = input(M,"What do you want to skin the gun to?","Reskin Gun") in options
 
-	if(src && choice && !M.stat && in_range(M,src))
+	if(src && choice && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
 		icon_state = options[choice]
 		M << "Your gun is now skinned as [choice]. Say hello to your new friend."
 		return 1

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -12,6 +12,8 @@
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in range(0)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -82,7 +82,8 @@
 	set name = "Empty Spray Bottle"
 	set category = "Object"
 	set src in usr
-
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	if (alert(usr, "Are you sure you want to empty that?", "Empty Bottle:", "Yes", "No") != "Yes")
 		return
 	if(isturf(usr.loc) && src.loc == usr)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -43,6 +43,8 @@
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in view(1)
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -88,7 +88,7 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 
 	if(anchored)
@@ -102,7 +102,7 @@
 	set name = "Flip Pipe"
 	set category = "Object"
 	set src in view(1)
-	if(usr.stat)
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 
 	if(anchored)


### PR DESCRIPTION
Adding checks for stun&restrained to many object verbs so you can no longer rotate windows while cuffed or stunned for example.
Fixing paper and supply manifest description upon examination("this is A paper" not SOME paper). Fixes #5523
Fixing being able to adjust jumpsuit while restrained. Fixes #5510
Fixing one typo in advpinpointer message.
