### PR TITLE
Slimes can no longer pull

### DIFF
--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -236,6 +236,9 @@
 /mob/living/carbon/slime/unEquip(obj/item/W as obj)
 	return
 
+/mob/living/carbon/slime/start_pulling(var/atom/movable/AM)
+	return
+
 /mob/living/carbon/slime/attack_ui(slot)
 	return
 


### PR DESCRIPTION
Slimes pulling didn't even make sense.

Fixes #5453 sort of
I know the tagged issue also talks about slimes being too fast, but there is already a config option for SLIME_DELAY. Perhaps it would be wise to contact the relevant server host and request a configuration change.
