### PR TITLE
Makes Syndicate and Deathsquad hardsuits fireproof

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -115,6 +115,8 @@
 	item_state = "syndie_helm"
 	item_color = "syndi"
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
+	heat_protection = HEAD												//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 
 /obj/item/clothing/suit/space/hardsuit/syndi
 	icon_state = "hardsuit-syndi"
@@ -125,6 +127,8 @@
 	w_class = 3
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/emergency_oxygen)
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 
 
 	//Wizard hardsuit

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -27,6 +27,8 @@
 	item_state = "deathsquad"
 	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	strip_delay = 130
+	heat_protection = HEAD												//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 
 /obj/item/clothing/suit/space/deathsquad
 	name = "deathsquad suit"
@@ -37,6 +39,8 @@
 	armor = list(melee = 80, bullet = 80, laser = 50,energy = 50, bomb = 100, bio = 100, rad = 100)
 	slowdown = 1
 	strip_delay = 130
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"


### PR DESCRIPTION
Considering the large arsenal of incendiary weapons nukeops have at their disposal it seems pretty stupid to me that they don't come with any sort of protection against fire, they don't even have a fire extinguisher anywhere at their base or shuttle. Seeing as how many nukeops ditch the hardsuit for the speed boost this provides another option to be a bit slower but not get fucked over by a stray Dark Gygax or bulldog shot in the middle of a fight. Also they're red and red obviously means fireproof.

Deathsquad hardsuit too because deathsquad OP, not the brown space coat or space beret though (Why are those even spaceworthy please).
