### PR TITLE
Cyborg law additions

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -487,7 +487,7 @@
 			user << "You need to close the wire panel to do that."
 			return
 		if(!cell)
-			user << "You need to install a power cell to do that,"
+			user << "You need to install a power cell to do that."
 			return
 		if(emagged || (connected_ai && lawupdate)) //Can't be sure which, metagamers
 			emote("buzz-[user.name]")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -478,6 +478,23 @@
 				user.visible_message("<span class='danger'>[user] deconstructs [src]!</span>", "<span class='notice'>You unfasten the securing bolts, and [src] falls to pieces!</span>")
 				deconstruct()
 
+	else if(istype(W, /obj/item/weapon/aiModule))
+		var/obj/item/weapon/aiModule/MOD = W
+		if(!opened)
+			user << "You need access to the robot's insides to do that."
+			return
+		if(wiresexposed)
+			user << "You need to close the wire panel to do that."
+			return
+		if(!cell)
+			user << "You need to install a power cell to do that,"
+			return
+		if(emagged || (connected_ai && lawupdate)) //Can't be sure which, metagamers
+			emote("buzz-[user.name]")
+			return
+		MOD.install(src, user) //Proc includes a success mesage so we don't need another one
+		return
+
 	else if(istype(W, /obj/item/device/encryptionkey/) && opened)
 		if(radio)//sanityyyyyy
 			radio.attackby(W,user)//GTFO, you have your own procs
@@ -521,6 +538,7 @@
 					sleep(6)
 					if(prob(50))
 						SetEmagged(1)
+						SetLockdown(1) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 						lawupdate = 0
 						connected_ai = null
 						user << "You emag [src]'s interface."
@@ -548,6 +566,7 @@
 						src << "<b>Obey these laws:</b>"
 						laws.show_laws(src)
 						src << "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and their commands.</span>"
+						SetLockdown(0)
 						updateicon()
 					else
 						user << "You fail to [ locked ? "unlock" : "lock"] [src]'s interface."

--- a/html/changelogs/MrPerson-PR5619.yml
+++ b/html/changelogs/MrPerson-PR5619.yml
@@ -1,0 +1,5 @@
+author: MrPerson
+delete-after: True
+changes: 
+  - rscadd: "You can use AI Upload modules directly on unslaved cyborgs to change their laws. The panel has to be open to do this."
+  - bugfix: "Newly emagged cyborgs get locked down for a little bit until their new laws get shown. Thank you to whoever bitched about it on singulo and filed an issue report."


### PR DESCRIPTION
Allow direct usage of law modules onto unslaved borgs
Lock newly emagged borgs down until their new laws are shown. Fixes #5587
