### PR TITLE
Botcall MC Lag Fix + Floorbot tweak

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -210,10 +210,7 @@
 	else
 		return 0
 
-/obj/machinery/bot/process() //Master process which handles code common across most bots.
-
-	set background = BACKGROUND_ENABLED
-
+/obj/machinery/bot/proc/main_process() //Master process which handles code common across most bots.
 	if(!on)
 		return
 
@@ -225,6 +222,13 @@
 			bot_summon()
 			return
 	return 1 //Successful completion. Used to prevent child process() continuing if this one is ended early.
+
+/obj/machinery/bot/proc/bot_process()
+
+/obj/machinery/bot/process()
+	set background = BACKGROUND_ENABLED
+	spawn(0)
+		bot_process()
 
 
 /obj/machinery/bot/attackby(obj/item/weapon/W as obj, mob/user as mob)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -141,8 +141,8 @@ text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
 		if(istype(D, T))
 			return D
 
-/obj/machinery/bot/cleanbot/process()
-	if (!..())
+/obj/machinery/bot/cleanbot/bot_process()
+	if (!main_process())
 		return
 
 	if(mode == BOT_CLEANING)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -206,8 +206,8 @@ Auto Patrol[]"},
 		icon_state = "[lasercolor]ed209[on]"
 		set_weapon()
 
-/obj/machinery/bot/ed209/process()
-	if (!..())
+/obj/machinery/bot/ed209/bot_process()
+	if (!main_process())
 		return
 
 	if(disabled)

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -117,6 +117,7 @@
 		dat += "Make pieces of metal into tiles when empty: <A href='?src=\ref[src];operation=make'>[maketiles ? "Yes" : "No"]</A><BR>"
 		dat += "Transmit notice when empty: <A href='?src=\ref[src];operation=emptynag'>[nag_on_empty ? "Yes" : "No"]</A><BR>"
 		dat += "Repair damaged tiles and platings: <A href='?src=\ref[src];operation=fix'>[fixfloors ? "Yes" : "No"]</A><BR>"
+		dat += "Traction Magnets: <A href='?src=\ref[src];operation=anchor'>[anchored ? "Engaged" : "Disengaged"]</A><BR>"
 		dat += "Patrol Station: <A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A><BR>"
 		var/bmode
 		if (targetdirection)
@@ -181,6 +182,8 @@
 			autotile = !autotile
 		if("emptynag")
 			nag_on_empty = !nag_on_empty
+		if("anchor")
+			anchored = !anchored
 
 		if("bridgemode")
 			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")
@@ -197,8 +200,8 @@
 					targetdirection = null
 	updateUsrDialog()
 
-/obj/machinery/bot/floorbot/process()
-	if (!..())
+/obj/machinery/bot/floorbot/bot_process()
+	if (!main_process())
 		return
 
 	if(mode == BOT_REPAIRING)
@@ -230,30 +233,23 @@
 
 			else //Find a space tile farther way!
 				target = scan(/turf/space, oldtarget)
-				anchored = 1
 			process_type = BRIDGE_MODE
-			return
 
 		if(!target)
 			process_type = HULL_BREACH //Ensures the floorbot does not try to "fix" space areas or shuttle docking zones.
 			target = scan(/turf/space, oldtarget)
-			anchored = 1 //Prevent the floorbot being blown off-course while trying to reach a hull breach.
-			return
 
 		if(!target && replacetiles) //Finds a floor without a tile and gives it one.
 			process_type = REPLACE_TILE //The target must be the floor and not a tile. The floor must not already have a floortile.
-			//target = scan(/turf/simulated/floor, oldtarget)
-			return
+			target = scan(/turf/simulated/floor, oldtarget)
 
 		if(!target && fixfloors) //Repairs damaged floors and tiles.
 			process_type = FIX_TILE
 			target = scan(/turf/simulated/floor, oldtarget)
-			return
 
 	if(!target && emagged == 2) //We are emagged! Time to rip up the floors!
 		process_type = TILE_EMAG
 		target = scan(/turf/simulated/floor, oldtarget)
-		return
 
 
 	if(!target)
@@ -336,9 +332,11 @@ obj/machinery/bot/floorbot/process_scan(var/scan_target)
 		if(HULL_BREACH) //The most common job, patching breaches in the station's hull.
 			if(is_hull_breach(scan_target)) //Ensure that the targeted space turf is actually part of the station, and not random space.
 				result = scan_target
+				anchored = 1 //Prevent the floorbot being blown off-course while trying to reach a hull breach.
 		if(BRIDGE_MODE) //Only space turfs in our chosen direction are considered.
 			if(get_dir(src, scan_target) == targetdirection)
 				result = scan_target
+				anchored = 1
 		if(REPLACE_TILE)
 			F = scan_target
 			if(istype(F, /turf/simulated/floor/plating)) //The floor must not already have a tile.

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -273,8 +273,8 @@
 	else
 		return
 
-/obj/machinery/bot/medbot/process()
-	if (!..())
+/obj/machinery/bot/medbot/bot_process()
+	if (!main_process())
 		return
 
 	if(mode == BOT_HEALING)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -189,8 +189,8 @@ Auto Patrol: []"},
 		declare_arrests = 0
 		icon_state = "secbot[on]"
 
-/obj/machinery/bot/secbot/process()
-	if (!..())
+/obj/machinery/bot/secbot/bot_process()
+	if (!main_process())
 		return
 
 	switch(mode)
@@ -314,14 +314,14 @@ Auto Patrol: []"},
 	last_found = world.time
 	frustration = 0
 	spawn(0)
-		process() //ensure bot quickly responds
+		bot_process() //ensure bot quickly responds
 
 /obj/machinery/bot/secbot/proc/back_to_hunt()
 	anchored = 0
 	frustration = 0
 	mode = BOT_HUNT
 	spawn(0)
-		process() //ensure bot quickly responds
+		bot_process() //ensure bot quickly responds
 // look for a criminal in view of the bot
 
 /obj/machinery/bot/secbot/proc/look_for_perp()
@@ -346,7 +346,7 @@ Auto Patrol: []"},
 			visible_message("<b>[src]</b> points at [C.name]!")
 			mode = BOT_HUNT
 			spawn(0)
-				process()	// ensure bot quickly responds to a perp
+				bot_process()	// ensure bot quickly responds to a perp
 			break
 		else
 			continue


### PR DESCRIPTION
- Attempts to fix a major screwup in bot movement code that created
  artificial lag for the entire Master Controller.
- Fixes floorbots not patrolling or performing certain functions.
- You can now toggle the anchored status on Floorbots manually. They
  will still automatically anchor when fixing hull breaches.

Allow me to apologize for taking so long to come up with a fix for this. I tried several other solutions such as simply removing the sleep(4) that causes this issue (it results in 'teleportation' movement). Other times I used spawn() incorrectly, resulting in several race conditions. And then I tried to give them their own ticker, independent of the MC. The game lagged and runtimed before it even finished setting up.

Excuses aside, this solution seems to be working so far, but I welcome any more elegant solutions to fixing this issue.

fixes #5560
