### PR TITLE
Fixes #5626 Null coloring runtime, auto-ejection

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -67,9 +67,11 @@
 			return
 		if(!in_range(src, user))
 			return
-
+		if(!storedpda)//is the pda still there?
+			return
 		storedpda.icon_state = P.icon_state
 		storedpda.desc = P.desc
+		ejectpda()
 
 	else
 		user << "<span class='notice'>The [src] is empty.</span>"


### PR DESCRIPTION
Fixes #5626
PDA painter checks if there's still a PDA before trying to color it.
Makes painter auto-eject once it's painted the PDA.

I thought about adding a delay and whirring message to the machine but I'm not sure it needs one.
