### PR TITLE
Add a fail message to unbuckling, breaking out of cuffs and closets and CPR.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -337,3 +337,5 @@
 		visible_message("<span class='danger'>[user] successfully broke out of [src]!</span>")
 		user << "<span class='notice'>You successfully break out of [src]!</span>"
 		open()
+	else
+		user << "<span class='warning'>You fail to break out of [src]!</span>"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -687,10 +687,10 @@
 
 			if(H.cpr_time < world.time + 30)
 				add_logs(H, M, "CPRed")
-				H.visible_message("<span class='notice'>[M] is trying to perform CPR on [H]!</span>", \
+				M.visible_message("<span class='notice'>[M] is trying to perform CPR on [H]!</span>", \
 								"<span class='notice'>You try to perform CPR on [H]. Hold still!</span>")
 				if(!do_mob(M, H))
-					H << "<span class='warning'>You fail to perform CPR on [H]!</span>"
+					M << "<span class='warning'>You fail to perform CPR on [H]!</span>"
 					return 0
 				if((H.health >= -99 && H.health <= 0))
 					H.cpr_time = world.time

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -687,8 +687,10 @@
 
 			if(H.cpr_time < world.time + 30)
 				add_logs(H, M, "CPRed")
-				H.visible_message("<span class='notice'>[M] is trying to perform CPR on [H]!</span>")
+				H.visible_message("<span class='notice'>[M] is trying to perform CPR on [H]!</span>", \
+								"<span class='notice'>You try to perform CPR on [H]. Hold still!</span>")
 				if(!do_mob(M, H))
+					H << "<span class='warning'>You fail to perform CPR on [H]!</span>"
 					return 0
 				if((H.health >= -99 && H.health <= 0))
 					H.cpr_time = world.time

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -471,9 +471,11 @@
 				if(!I || C.buckled)
 					return
 				cuff_break(I, C)
+			else
+				C << "<span class='warning'>You fail to break [I]!</span>"
 	else
 
-		C.visible_message("<span class='warning'>[usr] attempts to remove [I]!</span>", \
+		C.visible_message("<span class='warning'>[C] attempts to remove [I]!</span>", \
 				"<span class='notice'>You attempt to remove [I]. (This will take around [displaytime] minutes and you need to stand still.)</span>")
 		spawn(0)
 			if(do_after(C, breakouttime))
@@ -490,6 +492,8 @@
 					C.legcuffed.loc = usr.loc
 					C.legcuffed = null
 					C.update_inv_legcuffed(0)
+			else
+				C << "<span class='warning'>You fail to remove [I]!</span>"
 
 /mob/living/verb/resist()
 	set name = "Resist"
@@ -532,15 +536,17 @@
 			if(C.handcuffed)
 				C.changeNext_move(CLICK_CD_BREAKOUT)
 				C.last_special = world.time + CLICK_CD_BREAKOUT
-				C.visible_message("<span class='warning'>[usr] attempts to unbuckle themself!</span>", \
+				C.visible_message("<span class='warning'>[C] attempts to unbuckle themself!</span>", \
 							"<span class='notice'>You attempt to unbuckle yourself. (This will take around one minute and you need to stay still.)</span>")
 				spawn(0)
 					if(do_after(usr, 600))
 						if(!C.buckled)
 							return
-						C.visible_message("<span class='danger'>[usr] manages to unbuckle themself!</span>", \
+						C.visible_message("<span class='danger'>[C] manages to unbuckle themself!</span>", \
 											"<span class='notice'>You successfully unbuckle yourself.</span>")
 						C.buckled.manual_unbuckle(C)
+					else
+						C << "<span class='warning'>You fail to unbuckle yourself!</span>"
 			else
 				L.buckled.manual_unbuckle(L)
 		else


### PR DESCRIPTION
Fixes #4236
Also adds  "hold still!" to the initial CPR message.
Fixed some typos.
