### PR TITLE
view_core() AI verb won't reset the client eye

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -59,6 +59,12 @@ var/list/ai_list = list()
 	var/turf/waypoint //Holds the turf of the currently selected waypoint.
 	var/waypoint_mode = 0 //Waypoint mode is for selecting a turf via clicking.
 
+
+	var/mob/camera/aiEye/eyeobj = new()
+	var/sprint = 10
+	var/cooldown = 0
+	var/acceleration = 1
+
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
 	var/list/possibleNames = ai_names
 
@@ -125,6 +131,11 @@ var/list/ai_list = list()
 			job = "AI"
 	ai_list += src
 	shuttle_caller_list += src
+
+	eyeobj.ai = src
+	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
+	eyeobj.loc = src.loc
+
 	..()
 	return
 
@@ -132,6 +143,7 @@ var/list/ai_list = list()
 	ai_list -= src
 	shuttle_caller_list -= src
 	emergency_shuttle.autoshuttlecall()
+	qdel(eyeobj) // No AI, no Eye
 	..()
 
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -31,29 +31,8 @@
 /mob/camera/aiEye/Move()
 	return 0
 
-
-// AI MOVEMENT
-
-// The AI's "eye". Described on the top of the page.
-
-/mob/living/silicon/ai
-	var/mob/camera/aiEye/eyeobj = new()
-	var/sprint = 10
-	var/cooldown = 0
-	var/acceleration = 1
-
-
-// Intiliaze the eye by assigning it's "ai" variable to us. Then set it's loc to us.
-/mob/living/silicon/ai/New()
-	..()
-	eyeobj.ai = src
-	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
-	spawn(5)
-		eyeobj.loc = src.loc
-
-/mob/living/silicon/ai/Destroy()
-	eyeobj.ai = null
-	qdel(eyeobj) // No AI, no Eye
+/mob/camera/aiEye/Destroy()
+	ai = null
 	..()
 
 /atom/proc/move_camera_by_click()
@@ -109,10 +88,7 @@
 		src.eyeobj.ai = src
 		src.eyeobj.name = "[src.name] (AI Eye)" // Give it a name
 
-	if(client && client.eye)
-		client.eye = src
-	for(var/datum/camerachunk/c in eyeobj.visibleCameraChunks)
-		c.remove(eyeobj)
+	eyeobj.setLoc(loc)
 
 /mob/living/silicon/ai/verb/toggle_acceleration()
 	set category = "AI Commands"


### PR DESCRIPTION
Removed the New() and Destroy() double definitions from the aiEYE code.
view_core() now will move the aiEYE instead of setting the client's eye to the AI core
fixes issue #1328
