### PR TITLE
Projectiles bump fix, spawn() removal

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -276,8 +276,7 @@
 	LE.current = T
 	LE.yo = U.y - T.y
 	LE.xo = U.x - T.x
-	spawn( 1 )
-		LE.process()
+	LE.fire()
 
 /mob/living/carbon/human/LaserEyes()
 	if(nutrition>0)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -504,10 +504,7 @@ Auto Patrol[]"},
 	A.current = U
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
-	spawn( 0 )
-		A.process()
-		return
-	return
+	A.fire()
 
 /obj/machinery/bot/ed209/attack_alien(var/mob/living/carbon/alien/user as mob)
 	..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -610,8 +610,7 @@
 	A.current = T
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
-	spawn( 1 )
-		A.process()
+	A.fire()
 
 /obj/machinery/porta_turret/proc/setState(var/on, var/emagged)
 	if(controllock)

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -235,8 +235,7 @@
 	A.current = T
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
-	spawn( 0 )
-		A.process()
+	A.fire()
 	return
 
 
@@ -482,8 +481,7 @@
 	A.current = curloc
 	A.yo = targloc.y - curloc.y
 	A.xo = targloc.x - curloc.x
-	spawn(0)
-		A.process()
+	A.fire()
 	return
 
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -27,7 +27,7 @@
 	A.current = curloc
 	A.yo = targloc.y - curloc.y
 	A.xo = targloc.x - curloc.x
-	A.process()
+	A.fire()
 	chassis.log_message("Fired from [src.name], targeting [target].")
 	do_after_cooldown()
 	return 1

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -1122,7 +1122,7 @@ This could be a lot better but I'm too tired atm.*/
 			A.yo = targloc.y - curloc.y
 			A.xo = targloc.x - curloc.x
 			cell.charge-=(C*10)
-			A.process()
+			A.fire()
 		else
 			U << "<span class='danger'>There are no targets in view.</span>"
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -134,7 +134,7 @@ Doesn't work on other aliens/AI.*/
 		A.current = U
 		A.yo = U.y - T.y
 		A.xo = U.x - T.x
-		A.process()
+		A.fire()
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -269,8 +269,7 @@
 	A.firer = src
 	A.yo = target:y - start:y
 	A.xo = target:x - start:x
-	spawn( 0 )
-		A.process()
+	A.fire()
 	return
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -145,7 +145,7 @@
 			else // Any other
 				A.yo = -20
 				A.xo = 0
-		A.process()	//TODO: Carn: check this out
+		A.fire()
 
 
 /obj/machinery/power/emitter/attackby(obj/item/W, mob/user)

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -50,7 +50,7 @@
 			BB.p_y = text2num(mouse_control["icon-y"])
 
 	if(BB)
-		BB.process()
+		BB.fire()
 	BB = null
 	return 1
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1,14 +1,3 @@
-/*
-#define BRUTE "brute"
-#define BURN "burn"
-#define TOX "tox"
-#define OXY "oxy"
-#define CLONE "clone"
-
-#define ADD "add"
-#define SET "set"
-*/
-
 /obj/item/projectile
 	name = "projectile"
 	icon = 'icons/obj/projectiles.dmi'
@@ -37,7 +26,7 @@
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	var/projectile_type = "/obj/item/projectile"
-	var/kill_count = 50 //This will de-increment every process(). When 0, it will delete the projectile.
+	var/kill_count = 50 //This will de-increment every step. When 0, it will delete the projectile.
 		//Effects
 	var/stun = 0
 	var/weaken = 0
@@ -48,15 +37,7 @@
 	var/drowsy = 0
 	var/forcedodge = 0
 
-
-
-/obj/item/projectile/proc/delete()
-	// Garbage collect the projectiles
-	loc = null
-
-
-
-/obj/item/projectile/proc/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
+/obj/item/projectile/proc/on_hit(atom/target, blocked = 0, hit_zone)
 	if(!isliving(target))	return 0
 	if(isanimal(target))	return 0
 	var/mob/living/L = target
@@ -69,22 +50,15 @@
 	else
 		return 50 //if the projectile doesn't do damage, play its hitsound at 50% volume
 
-
-/obj/item/projectile/Bump(atom/A as mob|obj|turf|area)
+/obj/item/projectile/Bump(atom/A)
 	if(A == firer)
 		loc = A.loc
 		return 0 //cannot shoot yourself
-
 	if(bumped)//Stops multihit projectiles
 		return 1
-
 	bumped = 1
-	if(ismob(A))
-		var/mob/M = A
-		if(!istype(A, /mob/living))
-			loc = A.loc
-			return 0// nope.avi
-
+	if(isliving(A))
+		var/mob/living/M = A
 		var/reagent_note
 		if(reagents && reagents.reagent_list)
 			reagent_note = " REAGENTS:"
@@ -104,29 +78,14 @@
 								"<span class='userdanger'>[M] is hit by \a [src] in the [parse_zone(def_zone)]!")	//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
 		add_logs(firer, M, "shot", object="[src]", addition=reagent_note)
 
-
-	spawn(0)
-		if(A)
-			// We get the location before running A.bullet_act, incase the proc deletes A and makes it null
-			var/turf/new_loc = null
-			if(istype(A, /turf))
-				new_loc = A
-			else
-				new_loc = A.loc
-
-			var/permutation = A.bullet_act(src, def_zone) // searches for return value, could be deleted after run so check A isn't null
-
-			if(permutation == -1 || (forcedodge && !istype(A, /turf)))// the bullet passes through a dense object!
-				bumped = 0 // reset bumped variable!
-				loc = new_loc
-				permutated.Add(A)
-				return 0
-
-
-			delete()
-			return 0
-	return 1
-
+	var/turf/new_loc = get_turf(A)
+	var/permutation = A.bullet_act(src, def_zone) // searches for return value, could be deleted after run so check A isn't null
+	if(permutation == -1 || forcedodge)// the bullet passes through a dense object!
+		bumped = 0 // reset bumped variable!
+		loc = new_loc
+		permutated.Add(A)
+		return 0
+	qdel(src)
 
 /obj/item/projectile/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0) return 1
@@ -140,26 +99,22 @@
 	return 1 //Bullets don't drift in space
 
 
-/obj/item/projectile/process()
-	if(kill_count < 1)
-		delete()
-		return
-	kill_count--
-	spawn while(loc)
-		if((!( current ) || loc == current))
-			current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
-		if((x == 1 || x == world.maxx || y == 1 || y == world.maxy))
-			delete()
-			return
-		step_towards(src, current)
-		sleep(1)
-		if(!bumped && ((original && original.layer>=2.75) || ismob(original)))
-			if(loc == get_turf(original))
-				if(!(original in permutated))
-					Bump(original)
-					sleep(1)
-		Range()
-	return
+/obj/item/projectile/proc/fire()
+	spawn()
+		while(loc)
+			if(kill_count < 1)
+				qdel(src)
+				return
+			kill_count--
+			if((!( current ) || loc == current))
+				current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
+			step_towards(src, current)
+			if(!bumped && ((original && original.layer>=2.75) || ismob(original)))
+				if(loc == get_turf(original))
+					if(!(original in permutated))
+						Bump(original)
+			Range()
+			sleep(1)
 
 /obj/item/projectile/proc/Range()
 	return

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -57,8 +57,9 @@
 /obj/item/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-//obj/item/projectile/beam/emitter/Destroy()
-	//PlaceInPool(src)
+obj/item/projectile/beam/emitter/Destroy()
+	PlaceInPool(src)
+	return 1 //cancels the GCing
 
 /obj/item/projectile/lasertag
 	name = "laser tag beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -57,8 +57,8 @@
 /obj/item/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-/obj/item/projectile/beam/emitter/delete() //what projectiles use to set loc = null
-	PlaceInPool(src)
+//obj/item/projectile/beam/emitter/Destroy()
+	//PlaceInPool(src)
 
 /obj/item/projectile/lasertag
 	name = "laser tag beam"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -62,7 +62,7 @@
 /obj/item/projectile/energy/disabler/Range()
 	range--
 	if(range <= 0)
-		delete()
+		qdel(src)
 
 
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -240,7 +240,7 @@ proc/wabbajack(mob/living/M)
 	flag = "magic"
 
 /obj/item/projectile/magic/animate/Bump(var/atom/change)
-	. = ..()
+	..()
 	if(istype(change, /obj/item) || istype(change, /obj/structure) && !is_type_in_list(change, protected_objects))
 		if(istype(change, /obj/structure/closet/statue))
 			for(var/mob/living/carbon/human/H in change.contents)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -7,9 +7,9 @@
 	flag = "energy"
 
 
-	on_hit(var/atom/target, var/blocked = 0)
-		empulse(target, 1, 1)
-		return 1
+/obj/item/projectile/ion/on_hit(atom/target, blocked = 0)
+	empulse(target, 1, 1)
+	return 1
 
 
 /obj/item/projectile/bullet/gyro
@@ -19,9 +19,9 @@
 	flag = "bullet"
 
 
-	on_hit(var/atom/target, var/blocked = 0)
-		explosion(target, -1, 0, 2)
-		return 1
+/obj/item/projectile/bullet/gyro/on_hit(atom/target, blocked = 0)
+	explosion(target, -1, 0, 2)
+	return 1
 
 /obj/item/projectile/temp
 	name = "freeze beam"
@@ -33,11 +33,11 @@
 	var/temperature = 100
 
 
-	on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob
-		if(istype(target, /mob/living))
-			var/mob/M = target
-			M.bodytemperature = temperature
-		return 1
+/obj/item/projectile/temp/on_hit(atom/target, blocked = 0)//These two could likely check temp protection on the mob
+	if(istype(target, /mob/living))
+		var/mob/M = target
+		M.bodytemperature = temperature
+	return 1
 
 /obj/item/projectile/temp/hot
 	name = "heat beam"
@@ -52,26 +52,16 @@
 	nodamage = 1
 	flag = "bullet"
 
-	Bump(atom/A as mob|obj|turf|area)
-		if(A == firer)
-			loc = A.loc
-			return
-
-		sleep(-1) //Might not be important enough for a sleep(-1) but the sleep/spawn itself is necessary thanks to explosions and metoerhits
-
-		if(src)//Do not add to this if() statement, otherwise the meteor won't delete them
-			if(A)
-
-				A.ex_act(2)
-				playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
-
-				for(var/mob/M in range(10, src))
-					if(!M.stat && !istype(M, /mob/living/silicon/ai))\
-						shake_camera(M, 3, 1)
-				delete()
-				return 1
-		else
-			return 0
+/obj/item/projectile/meteor/Bump(atom/A)
+	if(A == firer)
+		loc = A.loc
+		return
+	A.ex_act(2)
+	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, 1)
+	for(var/mob/M in range(10, src))
+		if(!M.stat)
+			shake_camera(M, 3, 1)
+	qdel(src)
 
 /obj/item/projectile/energy/floramut
 	name = "alpha somatoray"
@@ -81,10 +71,6 @@
 	nodamage = 1
 	flag = "energy"
 
-	on_hit(var/atom/target, var/blocked = 0)
-		..()
-		return
-
 /obj/item/projectile/energy/florayield
 	name = "beta somatoray"
 	icon_state = "energy2"
@@ -93,19 +79,14 @@
 	nodamage = 1
 	flag = "energy"
 
-	on_hit(mob/living/carbon/human/target, var/blocked = 0)
-		..()
-		return
-
-
 /obj/item/projectile/beam/mindflayer
 	name = "flayer ray"
 
-	on_hit(var/atom/target, var/blocked = 0)
-		if(ishuman(target))
-			var/mob/living/carbon/human/M = target
-			M.adjustBrainLoss(20)
-			M.hallucination += 20
+/obj/item/projectile/beam/mindflayer/on_hit(atom/target, blocked = 0)
+	if(ishuman(target))
+		var/mob/living/carbon/human/M = target
+		M.adjustBrainLoss(20)
+		M.hallucination += 20
 
 /obj/item/projectile/kinetic
 	name = "kinetic force"
@@ -130,9 +111,9 @@ obj/item/projectile/kinetic/New()
 	range--
 	if(range <= 0)
 		new /obj/item/effect/kinetic_blast(src.loc)
-		delete()
+		qdel(src)
 
-/obj/item/projectile/kinetic/on_hit(var/atom/target)
+/obj/item/projectile/kinetic/on_hit(atom/target)
 	var/turf/target_turf= get_turf(target)
 	if(istype(target_turf, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = target_turf


### PR DESCRIPTION
Removes the spawn() in the Bump() proc of projectiles.
Fixes issue #1291
Cleaned up some files of projectiles/firing.dm
Instead of calling process(), when firing a projectile it will use fire()
Projectiles will now use qdel(), due to this, the emitters beams won't be in the object pool.
Changes the call from process() to fire() in all places where a projectile is created.
Mobs won't walk past projectiles anymore
Fixes issue #1332
Fix #5941
