### PR TITLE
Singularity beacon fix and clean-up

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -100,6 +100,9 @@
 	selfdestructing = 1
 	spawn() explosion(src.loc, rand(3,8), rand(1,3), 1, 10)
 
+////////////////////////////////////////
+//Singularity beacon
+////////////////////////////////////////
 /obj/machinery/power/singularity_beacon
 	name = "ominous beacon"
 	desc = "This looks suspicious..."
@@ -111,7 +114,7 @@
 	layer = MOB_LAYER - 0.1 //so people can't hide it and it's REALLY OBVIOUS
 	stat = 0
 
-	var/active = 0 //It doesn't use up power, so use_power wouldn't really suit it
+	var/active = 0
 	var/icontype = "beacon"
 
 
@@ -124,7 +127,9 @@
 			singulo.target = src
 	icon_state = "[icontype]1"
 	active = 1
-	if(user) user << "<span class='notice'>You activate the beacon.</span>"
+	machines |= src
+	if(user)
+		user << "<span class='notice'>You activate the beacon.</span>"
 
 
 /obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
@@ -133,7 +138,8 @@
 			singulo.target = null
 	icon_state = "[icontype]0"
 	active = 0
-	if(user) user << "<span class='notice'>You deactivate the beacon.</span>"
+	if(user)
+		user << "<span class='notice'>You deactivate the beacon.</span>"
 
 
 /obj/machinery/power/singularity_beacon/attack_ai(mob/user as mob)
@@ -175,13 +181,15 @@
 		Deactivate()
 	..()
 
+//stealth direct power usage
 /obj/machinery/power/singularity_beacon/process()
 	if(!active)
-		return
+		return PROCESS_KILL
 	else
-		if(surplus() < 1500)
+		if(surplus() > 1500)
+			add_load(1500)
+		else
 			Deactivate()
-	return
 
 
 /obj/machinery/power/singularity_beacon/syndicate

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -100,7 +100,93 @@
 	selfdestructing = 1
 	spawn() explosion(src.loc, rand(3,8), rand(1,3), 1, 10)
 
+/obj/machinery/power/singularity_beacon
+	name = "ominous beacon"
+	desc = "This looks suspicious..."
+	icon = 'icons/obj/singularity.dmi'
+	icon_state = "beacon"
 
+	anchored = 0
+	density = 1
+	layer = MOB_LAYER - 0.1 //so people can't hide it and it's REALLY OBVIOUS
+	stat = 0
+
+	var/active = 0 //It doesn't use up power, so use_power wouldn't really suit it
+	var/icontype = "beacon"
+
+
+/obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
+	if(surplus() < 1500)
+		if(user) user << "<span class='notice'>The connected wire doesn't have enough current.</span>"
+		return
+	for(var/obj/machinery/singularity/singulo in world)
+		if(singulo.z == z)
+			singulo.target = src
+	icon_state = "[icontype]1"
+	active = 1
+	if(user) user << "<span class='notice'>You activate the beacon.</span>"
+
+
+/obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
+	for(var/obj/machinery/singularity/singulo in world)
+		if(singulo.target == src)
+			singulo.target = null
+	icon_state = "[icontype]0"
+	active = 0
+	if(user) user << "<span class='notice'>You deactivate the beacon.</span>"
+
+
+/obj/machinery/power/singularity_beacon/attack_ai(mob/user as mob)
+	return
+
+
+/obj/machinery/power/singularity_beacon/attack_hand(var/mob/user as mob)
+	if(anchored)
+		return active ? Deactivate(user) : Activate(user)
+	else
+		user << "<span class='danger'>You need to screw the beacon to the floor first!</span>"
+		return
+
+
+/obj/machinery/power/singularity_beacon/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W,/obj/item/weapon/screwdriver))
+		if(active)
+			user << "<span class='danger'>You need to deactivate the beacon first!</span>"
+			return
+
+		if(anchored)
+			anchored = 0
+			user << "<span class='notice'>You unscrew the beacon from the floor.</span>"
+			disconnect_from_network()
+			return
+		else
+			if(!connect_to_network())
+				user << "This device must be placed over an exposed cable."
+				return
+			anchored = 1
+			user << "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>"
+			return
+	..()
+	return
+
+
+/obj/machinery/power/singularity_beacon/Destroy()
+	if(active)
+		Deactivate()
+	..()
+
+/obj/machinery/power/singularity_beacon/process()
+	if(!active)
+		return
+	else
+		if(surplus() < 1500)
+			Deactivate()
+	return
+
+
+/obj/machinery/power/singularity_beacon/syndicate
+	icontype = "beaconsynd"
+	icon_state = "beaconsynd0"
 
 // SINGULO BEACON SPAWNER
 /obj/item/device/sbeacondrop
@@ -110,7 +196,7 @@
 	desc = "A label on it reads: <i>Warning: Activating this device will send a special beacon to your location</i>."
 	origin_tech = "bluespace=1;syndicate=7"
 	w_class = 2
-	var/droptype = /obj/machinery/singularity_beacon/syndicate
+	var/droptype = /obj/machinery/power/singularity_beacon/syndicate
 
 
 /obj/item/device/sbeacondrop/attack_self(mob/user as mob)
@@ -124,119 +210,3 @@
 /obj/item/device/sbeacondrop/bomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb
-
-#define SCREWED 32
-
-/obj/machinery/singularity_beacon //not the best place for it but it's a hack job anyway -- Urist
-	name = "ominous beacon"
-	desc = "This looks suspicious..."
-	icon = 'icons/obj/singularity.dmi'
-	icon_state = "beacon"
-
-	anchored = 0
-	density = 1
-	layer = MOB_LAYER - 0.1 //so people can't hide it and it's REALLY OBVIOUS
-	stat = 0
-
-	var/active = 0 //It doesn't use up power, so use_power wouldn't really suit it
-	var/icontype = "beacon"
-	var/obj/structure/cable/attached = null
-
-
-/obj/machinery/singularity_beacon/proc/Activate(mob/user = null)
-	if(!checkWirePower())
-		if(user) user << "<span class='notice'>The connected wire doesn't have enough current.</span>"
-		return
-	for(var/obj/machinery/singularity/singulo in world)
-		if(singulo.z == z)
-			singulo.target = src
-	icon_state = "[icontype]1"
-	active = 1
-	if(user) user << "<span class='notice'>You activate the beacon.</span>"
-
-
-/obj/machinery/singularity_beacon/proc/Deactivate(mob/user = null)
-	for(var/obj/machinery/singularity/singulo in world)
-		if(singulo.target == src)
-			singulo.target = null
-	icon_state = "[icontype]0"
-	active = 0
-	if(user) user << "<span class='notice'>You deactivate the beacon.</span>"
-
-
-/obj/machinery/singularity_beacon/attack_ai(mob/user as mob)
-	return
-
-
-/obj/machinery/singularity_beacon/attack_hand(var/mob/user as mob)
-	if(stat & SCREWED)
-		return active ? Deactivate(user) : Activate(user)
-	else
-		user << "<span class='danger'>You need to screw the beacon to the floor first!</span>"
-		return
-
-
-/obj/machinery/singularity_beacon/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/screwdriver))
-		if(active)
-			user << "<span class='danger'>You need to deactivate the beacon first!</span>"
-			return
-
-		if(stat & SCREWED)
-			stat &= ~SCREWED
-			anchored = 0
-			user << "<span class='notice'>You unscrew the beacon from the floor.</span>"
-			attached = null
-			return
-		else
-			var/turf/T = loc
-			if(isturf(T) && !T.intact)
-				attached = locate() in T
-			if(!attached)
-				user << "This device must be placed over an exposed cable."
-				return
-			stat |= SCREWED
-			anchored = 1
-			user << "<span class='notice'>You screw the beacon to the floor and attach the cable.</span>"
-			return
-	..()
-	return
-
-
-/obj/machinery/singularity_beacon/Destroy()
-	if(active) Deactivate()
-	..()
-
-	/*
-	* Added for a simple way to check power. Verifies that the beacon
-	* is connected to a wire, the wire is part of a powernet (that part's
-	* sort of redundant, since all wires either join or create one when placed)
-	* and that the powernet has at least 1500 power units available for use.
-	* Doesn't use them, though, just makes sure they're there.
-	* - QualityVan, Aug 11 2012
-	*/
-/obj/machinery/singularity_beacon/proc/checkWirePower()
-	if(!attached)
-		return 0
-	var/datum/powernet/PN = attached.get_powernet()
-	if(!PN)
-		return 0
-	if(PN.avail < 1500)
-		return 0
-	return 1
-
-/obj/machinery/singularity_beacon/process()
-	if(!active)
-		return
-	else
-		if(!checkWirePower())
-			Deactivate()
-	return
-
-
-/obj/machinery/singularity_beacon/syndicate
-	icontype = "beaconsynd"
-	icon_state = "beaconsynd0"
-
-#undef SCREWED
-

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -33,7 +33,7 @@
 
 	src.energy = starting_energy
 	..()
-	for(var/obj/machinery/singularity_beacon/singubeacon in world)
+	for(var/obj/machinery/power/singularity_beacon/singubeacon in world)
 		if(singubeacon.active)
 			target = singubeacon
 			break


### PR DESCRIPTION
**Content :**
- Fixes singularity beacon deactivating when splitting powernets (a.k.a cutting a cable somewhere on the powernet).
  Thanks MrStonedOne for reporting.
- Made the beacon a power machinery, instead of having its own set of proc (exception is power usage, as we want stealth comsumption).
- The beacon now consumes 1500W instead of just checking if the powernet has this much.
- Removed/added to processing list when inactive/active, instead of constantly processing it.
