### PR TITLE
Fixes #5613 null acid loc

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -448,9 +448,9 @@
 	pixel_y = target.pixel_y
 
 	if(isturf(target))	//Turfs take twice as long to take down.
-		target_strength = 8
+		target_strength = 640
 	else
-		target_strength = 4
+		target_strength = 320
 	tick()
 
 
@@ -472,16 +472,20 @@
 		qdel(src)
 		return
 
+	x = target.x
+	y = target.y
+	z = target.z
+
 	switch(target_strength - ticks)
-		if(6)
+		if(480)
 			visible_message("<span class='warning'>[target] is holding up against the acid!</span>")
-		if(4)
+		if(320)
 			visible_message("<span class='warning'>[target] is being melted by the acid!</span>")
-		if(2)
+		if(160)
 			visible_message("<span class='warning'>[target] is struggling to withstand the acid!</span>")
-		if(0 to 1)
+		if(80)
 			visible_message("<span class='warning'>[target] begins to crumble under the acid!</span>")
 
-	spawn(rand(150, 200))
+	spawn(1)
 		if(src)
 			tick()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -472,8 +472,6 @@
 		qdel(src)
 		return
 
-	loc = target.loc
-
 	switch(target_strength - ticks)
 		if(6)
 			visible_message("<span class='warning'>[target] is holding up against the acid!</span>")


### PR DESCRIPTION
Fixes #5613

Loc checking has been replaced with coord-alignments of the target; this fixes acid being incorrectly placed on walls since their loc is an area.

The 150-200 spawn that was stopping the acid's position from updating in time with a target being removed has been replaced with target_strength values being multiplied by 80. The time it takes for acid to melt something is a bit shorter and less random.
