### PR TITLE
Roundstart turfs next to space deactivated (LINDA) fix

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -118,7 +118,7 @@ datum/controller/air_system
 						active_turfs |= T
 						break
 				else
-					if(!T.air.check_turf(enemy_tile))
+					if(!T.air.check_turf_total(enemy_tile))
 						T.excited = 1
 						active_turfs |= T
 

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -194,7 +194,7 @@ turf/simulated/proc/share_temperature_mutual_solid(turf/simulated/sharer, conduc
 		/******************* GROUP HANDLING FINISH *********************************************************************/
 
 		else
-			if(!air.check_turf(enemy_tile))
+			if(!air.check_turf(enemy_tile, atmos_adjacent_turfs_amount))
 				var/difference = air.mimic(enemy_tile,,atmos_adjacent_turfs_amount)
 				if(difference)
 					if(difference > 0)

--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -502,11 +502,11 @@ What are the archived variables for?
 
 	return 1
 
-/datum/gas_mixture/check_turf(turf/model)
-	var/delta_oxygen = (oxygen_archived - model.oxygen)/5
-	var/delta_carbon_dioxide = (carbon_dioxide_archived - model.carbon_dioxide)/5
-	var/delta_nitrogen = (nitrogen_archived - model.nitrogen)/5
-	var/delta_toxins = (toxins_archived - model.toxins)/5
+/datum/gas_mixture/check_turf(turf/model, atmos_adjacent_turfs = 4)
+	var/delta_oxygen = (oxygen_archived - model.oxygen)/(atmos_adjacent_turfs+1)
+	var/delta_carbon_dioxide = (carbon_dioxide_archived - model.carbon_dioxide)/(atmos_adjacent_turfs+1)
+	var/delta_nitrogen = (nitrogen_archived - model.nitrogen)/(atmos_adjacent_turfs+1)
+	var/delta_toxins = (toxins_archived - model.toxins)/(atmos_adjacent_turfs+1)
 
 	var/delta_temperature = (temperature_archived - model.temperature)
 
@@ -521,6 +521,29 @@ What are the archived variables for?
 	if(trace_gases.len)
 		for(var/datum/gas/trace_gas in trace_gases)
 			if(trace_gas.moles_archived > MINIMUM_AIR_TO_SUSPEND*4)
+				return 0
+
+	return 1
+
+/datum/gas_mixture/proc/check_turf_total(turf/model)
+	var/delta_oxygen = (oxygen - model.oxygen)
+	var/delta_carbon_dioxide = (carbon_dioxide - model.carbon_dioxide)
+	var/delta_nitrogen = (nitrogen - model.nitrogen)
+	var/delta_toxins = (toxins - model.toxins)
+
+	var/delta_temperature = (temperature - model.temperature)
+
+	if(((abs(delta_oxygen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_oxygen) >= oxygen*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
+		|| ((abs(delta_carbon_dioxide) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_carbon_dioxide) >= carbon_dioxide*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
+		|| ((abs(delta_nitrogen) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_nitrogen) >= nitrogen*MINIMUM_AIR_RATIO_TO_SUSPEND)) \
+		|| ((abs(delta_toxins) > MINIMUM_AIR_TO_SUSPEND) && (abs(delta_toxins) >= toxins*MINIMUM_AIR_RATIO_TO_SUSPEND)))
+		return 0
+	if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
+		return 0
+
+	if(trace_gases.len)
+		for(var/datum/gas/trace_gas in trace_gases)
+			if(trace_gas.moles > MINIMUM_AIR_TO_SUSPEND*4)
 				return 0
 
 	return 1


### PR DESCRIPTION
Fixes LINDA not properly activating turfs who are next to unsimulated turfs with differences (space turfs are unsimulated)
Fixes turfs losing air too slow next to space turfs when the adjacent turfs number is low.
Fixes issue #1447
