### PR TITLE
more VV logging and mass-modify proper admin-rights

### DIFF
--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -26,8 +26,6 @@
 /client/proc/massmodify_variables(var/atom/O, var/var_name = "", var/method = 0)
 	if(!check_rights(R_VAREDIT))	return
 
-	var/list/locked = list("vars", "key", "ckey", "client", "unlock_content")
-
 	for(var/p in forbidden_varedit_object_types)
 		if( istype(O,p) )
 			usr << "<span class='danger'>It is forbidden to edit this object's variables.</span>"
@@ -51,8 +49,13 @@
 	var/var_value = O.vars[variable]
 	var/dir
 
-	if(variable == "holder" || (variable in locked))
+	if(variable in VVckey_edit)
+		usr << "It's forbidden to mass-modify ckeys. I'll crash everyone's client you dummy."
+		return
+	if(variable in VVlocked)
 		if(!check_rights(R_DEBUG))	return
+	if(variable in VVicon_edit_lock)
+		if(!check_rights(R_FUN|R_DEBUG)) return
 
 	if(isnull(var_value))
 		usr << "Unable to determine variable type."
@@ -371,5 +374,6 @@
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
+	world.log << "### MassVarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]"
 	log_admin("[key_name(src)] mass modified [original_name]'s [variable] to [O.vars[variable]]")
 	message_admins("[key_name_admin(src)] mass modified [original_name]'s [variable] to [O.vars[variable]]")

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -5,6 +5,10 @@ var/list/forbidden_varedit_object_types = list(
 										/datum/admin_rank					//editing my own rank? it's more likely than you think
 									)
 
+var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y")
+var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays")
+var/list/VVckey_edit = list("key", "ckey")
+
 /*
 /client/proc/cmd_modify_object_variables(obj/O as obj|mob|turf|area in world)
 	set category = "Debug"
@@ -73,7 +77,7 @@ var/list/forbidden_varedit_object_types = list(
 	return var_value
 
 
-/client/proc/mod_list_add(var/list/L)
+/client/proc/mod_list_add(var/list/L, atom/O, original_name, objectvar)
 
 	var/class = "text"
 	if(src.holder && src.holder.marked_datum)
@@ -125,21 +129,19 @@ var/list/forbidden_varedit_object_types = list(
 			L[var_value] = mod_list_add_ass() //haha
 		if("No")
 			L += var_value
+	world.log << "### ListVarEdit by [src]: [O.type] [objectvar]: ADDED=[var_value]"
+	log_admin("[key_name(src)] modified [original_name]'s [objectvar]: ADDED=[var_value]")
+	message_admins("[key_name_admin(src)] modified [original_name]'s [objectvar]: ADDED=[var_value]")
 
-/client/proc/mod_list(var/list/L)
+/client/proc/mod_list(var/list/L, atom/O, original_name, objectvar)
 	if(!check_rights(R_VAREDIT))	return
-
 	if(!istype(L,/list)) src << "Not a List."
-
-	var/list/locked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y")
-	var/list/ckey_edit = list("key", "ckey")
-	var/list/icon_edit = list("icon", "icon_state", "overlays", "underlays")
 	var/list/names = sortList(L)
 
 	var/variable = input("Which var?","Var") as null|anything in names + "(ADD VAR)"
 
 	if(variable == "(ADD VAR)")
-		mod_list_add(L)
+		mod_list_add(L, O, original_name, objectvar)
 		return
 
 	if(!variable)
@@ -149,11 +151,11 @@ var/list/forbidden_varedit_object_types = list(
 
 	var/dir
 
-	if(variable in locked)
+	if(variable in VVlocked)
 		if(!check_rights(R_DEBUG))	return
-	if(variable in ckey_edit)
+	if(variable in VVckey_edit)
 		if(!check_rights(R_SPAWN|R_DEBUG)) return
-	if(variable in icon_edit)
+	if(variable in VVicon_edit_lock)
 		if(!check_rights(R_FUN|R_DEBUG)) return
 
 	if(isnull(variable))
@@ -232,52 +234,65 @@ var/list/forbidden_varedit_object_types = list(
 	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
 		class = "marked datum"
 
+	var/original_var = L[L.Find(variable)]
+	var/new_var
 	switch(class) //Spits a runtime error if you try to modify an entry in the contents list. Dunno how to fix it, yet.
 
 		if("list")
-			mod_list(variable)
+			mod_list(variable, O, original_name, objectvar)
 
 		if("restore to default")
-			L[L.Find(variable)]=initial(variable)
+			new_var = initial(variable)
+			L[L.Find(variable)] = new_var
 
 		if("edit referenced object")
 			modify_variables(variable)
 
 		if("DELETE FROM LIST")
+			world.log << "### ListVarEdit by [src]: [O.type] [objectvar]: REMOVED=[html_encode("[variable]")]"
+			log_admin("[key_name(src)] modified [original_name]'s [objectvar]: REMOVED=[variable]")
+			message_admins("[key_name_admin(src)] modified [original_name]'s [objectvar]: REMOVED=[variable]")
 			L -= variable
 			return
 
 		if("text")
-			L[L.Find(variable)] = input("Enter new text:","Text") as text
+			new_var = input("Enter new text:","Text") as text
+			L[L.Find(variable)] = new_var
 
 		if("num")
-			L[L.Find(variable)] = input("Enter new number:","Num") as num
+			new_var = input("Enter new number:","Num") as num
+			L[L.Find(variable)] = new_var
 
 		if("type")
-			L[L.Find(variable)] = input("Enter type:","Type") in typesof(/obj,/mob,/area,/turf)
+			new_var = input("Enter type:","Type") in typesof(/obj,/mob,/area,/turf)
+			L[L.Find(variable)] = new_var
 
 		if("reference")
-			L[L.Find(variable)] = input("Select reference:","Reference") as mob|obj|turf|area in world
+			new_var = input("Select reference:","Reference") as mob|obj|turf|area in world
+			L[L.Find(variable)] = new_var
 
 		if("mob reference")
-			L[L.Find(variable)] = input("Select reference:","Reference") as mob in world
+			new_var = input("Select reference:","Reference") as mob in world
+			L[L.Find(variable)] = new_var
 
 		if("file")
-			L[L.Find(variable)] = input("Pick file:","File") as file
+			new_var = input("Pick file:","File") as file
+			L[L.Find(variable)] = new_var
 
 		if("icon")
-			L[L.Find(variable)] = input("Pick icon:","Icon") as icon
+			new_var = input("Pick icon:","Icon") as icon
+			L[L.Find(variable)] = new_var
 
 		if("marked datum")
-			L[L.Find(variable)] = holder.marked_datum
+			new_var = holder.marked_datum
+			L[L.Find(variable)] = new_var
 
+	world.log << "### ListVarEdit by [src]: [O.type] [objectvar]: [original_var]=[new_var]"
+	log_admin("[key_name(src)] modified [original_name]'s [objectvar]: [original_var]=[new_var]")
+	message_admins("[key_name_admin(src)] modified [original_name]'s varlist [objectvar]: [original_var]=[new_var]")
 
 /client/proc/modify_variables(var/atom/O, var/param_var_name = null, var/autodetect_class = 0)
 	if(!check_rights(R_VAREDIT))	return
-
-	var/list/locked = list("vars", "client", "virus", "cuffed", "last_eaten", "mutantrace")
-	var/list/ckey_edit = list("key", "ckey")
-	var/list/icon_edit = list("icon", "icon_state", "overlays", "underlays")
 
 	for(var/p in forbidden_varedit_object_types)
 		if( istype(O,p) )
@@ -297,11 +312,11 @@ var/list/forbidden_varedit_object_types = list(
 			src << "A variable with this name ([param_var_name]) doesn't exist in this atom ([O])"
 			return
 
-		if(param_var_name == "holder" || (param_var_name in locked))
+		if(param_var_name in VVlocked)
 			if(!check_rights(R_DEBUG))	return
-		if(param_var_name in ckey_edit)
+		if(param_var_name in VVckey_edit)
 			if(!check_rights(R_SPAWN|R_DEBUG)) return
-		if(param_var_name in icon_edit)
+		if(param_var_name in VVicon_edit_lock)
 			if(!check_rights(R_FUN|R_DEBUG)) return
 
 		variable = param_var_name
@@ -359,11 +374,11 @@ var/list/forbidden_varedit_object_types = list(
 		if(!variable)	return
 		var_value = O.vars[variable]
 
-		if(variable == "holder" || (variable in locked))
+		if(variable in VVlocked)
 			if(!check_rights(R_DEBUG)) return
-		if(variable in ckey_edit)
+		if(variable in VVckey_edit)
 			if(!check_rights(R_SPAWN|R_DEBUG)) return
-		if(variable in icon_edit)
+		if(variable in VVicon_edit_lock)
 			if(!check_rights(R_FUN|R_DEBUG)) return
 
 	if(!autodetect_class)
@@ -454,7 +469,7 @@ var/list/forbidden_varedit_object_types = list(
 	switch(class)
 
 		if("list")
-			mod_list(O.vars[variable])
+			mod_list(O.vars[variable], O, original_name, variable)
 			return
 
 		if("restore to default")
@@ -519,4 +534,3 @@ var/list/forbidden_varedit_object_types = list(
 	world.log << "### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]"
 	log_admin("[key_name(src)] modified [original_name]'s [variable] to [O.vars[variable]]")
 	message_admins("[key_name_admin(src)] modified [original_name]'s [variable] to [O.vars[variable]]")
-


### PR DESCRIPTION
Small works with VV:
Fixes issues with skipping admin rights with mass modify when editing icons.
Added a check for mass-edit of ckeys, no admin can mass-modify them now.
Added logs for list values modifications, additions and deletions.
Fixes issue #3840
