### PR TITLE
Resist out of a gibber fix

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -141,18 +141,20 @@ Class Procs:
 	..()
 
 /obj/machinery/proc/open_machine()
-	var/turf/T = get_turf(src)
-	if(T)
-		state_open = 1
-		density = 0
-		T.contents += contents
-		if(occupant)
-			if(occupant.client)
-				occupant.client.eye = occupant
-				occupant.client.perspective = MOB_PERSPECTIVE
-			occupant = null
+	state_open = 1
+	density = 0
+	dropContents()
 	update_icon()
 	updateUsrDialog()
+
+/obj/machinery/proc/dropContents()
+	var/turf/T = get_turf(src)
+	T.contents += contents
+	if(occupant)
+		if(occupant.client)
+			occupant.client.eye = occupant
+			occupant.client.perspective = MOB_PERSPECTIVE
+		occupant = null
 
 /obj/machinery/proc/close_machine(mob/living/target = null)
 	state_open = 0

--- a/code/modules/food&drinks/kitchen machinery/gibber.dm
+++ b/code/modules/food&drinks/kitchen machinery/gibber.dm
@@ -117,18 +117,8 @@
 	return
 
 /obj/machinery/gibber/proc/go_out()
-	if (!src.occupant)
-		return
-	for(var/obj/O in src)
-		O.loc = src.loc
-	if (src.occupant.client)
-		src.occupant.client.eye = src.occupant.client.mob
-		src.occupant.client.perspective = MOB_PERSPECTIVE
-	src.occupant.loc = src.loc
-	src.occupant = null
+	dropContents()
 	update_icon()
-	return
-
 
 /obj/machinery/gibber/proc/startgibbing(mob/user as mob)
 	if(src.operating)


### PR DESCRIPTION
The gibber will now react properly to a mob trying to escape from it, even if the mob isn't the 'occupant'. It can happen if the mob changes to another one, like a changeling.
New machinery proc, dropContents, it's basically a chunk of open_machine()
