### PR TITLE
World message removal, admin panel override.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2,7 +2,7 @@
 	..()
 
 	if(usr.client != src.owner || !check_rights(0))
-		world << "<span class='adminnotice'>[usr.key] has attempted to override the admin panel!</span>"
+		message_admins("[usr.key] has attempted to override the admin panel!")
 		log_admin("[key_name(usr)] tried to use the admin panel without authorization.")
 		return
 


### PR DESCRIPTION
Swapped the admin panel override alert message from all players to only asay.
'fixes' issue #3869
