### PR TITLE
Fixes player panel only allowing one window to be open at a time.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -150,7 +150,7 @@ var/global/floorIsLava = 0
 	body += "<br>"
 	body += "</body></html>"
 
-	usr << browse(body, "window=adminplayeropts;size=550x515")
+	usr << browse(body, "window=adminplayeropts-\ref[M];size=550x515")
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 


### PR DESCRIPTION
Every other admin window that deals with singular things (vv, traitorpanel, etc) lets you have more then one open (as long as its not about the same thing), But not pp, the central point of all of them.

This fixes that and allows you have a window open for each mob.
