### PR TITLE
Adds a config option to cap silicon laws. [NEW CONFIG OPTION]

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -134,6 +134,7 @@
 	var/sandbox_autoclose = 0 // close the sandbox panel after spawning an item, potentially reducing griff
 
 	var/default_laws = 0 //Controls what laws the AI spawns with.
+	var/silicon_max_law_amount = 0
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -402,6 +403,8 @@
 					config.sandbox_autoclose		= 1
 				if("default_laws")
 					config.default_laws				= text2num(value)
+				if("silicon_max_law_amount")
+					config.silicon_max_law_amount	= text2num(value)
 				if("join_with_mutant_race")
 					config.mutant_races				= 1
 				if("mutant_colors")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -33,6 +33,7 @@ AI MODULES
 		tot_laws += reciever.laws.inherent.len
 		tot_laws += reciever.laws.supplied.len
 		tot_laws += reciever.laws.ion.len
+		tot_laws += laws.len
 		if(tot_laws > config.silicon_max_law_amount && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
 			user << "<span class='caution'>You cannot upload any more laws to [reciever], they are at the limit: [tot_laws]/[tot_laws] laws."
 			message_admins("[key_name_admin(user)] tried to upload laws to [key_name_admin(reciever)] when they were already at max laws.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -35,8 +35,8 @@ AI MODULES
 		tot_laws += reciever.laws.ion.len
 		tot_laws += laws.len
 		if(tot_laws > config.silicon_max_law_amount && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
-			user << "<span class='caution'>You cannot upload any more laws to [reciever], they are at the limit: [tot_laws]/[tot_laws] laws."
-			message_admins("[key_name_admin(user)] tried to upload laws to [key_name_admin(reciever)] when they were already at max laws.")
+			user << "<span class='caution'>Not enough memory allocated to [reciever]'s law processor to handle this amount of laws."
+			message_admins("[key_name_admin(user)] tried to upload laws to [key_name_admin(reciever)] that would exceed the law cap.")
 			return
 
 	var/law2log = src.transmitInstructions(reciever, user) //Freeforms return something extra we need to log

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -20,12 +20,23 @@ AI MODULES
 	throw_range = 7
 	origin_tech = "programming=3"
 	var/list/laws = list()
+	var/bypass_law_amt_check = 0
 
 //The proc other things should be calling
 /obj/item/weapon/aiModule/proc/install(var/mob/living/silicon/reciever, var/mob/user)
 	if(!laws.len || laws[1] == "") //So we don't loop trough an empty list and end up with runtimes.
 		user << "<span class='warning'>ERROR: No laws found on board.</span>"
 		return
+
+	if(reciever.laws)
+		var/tot_laws = 0
+		tot_laws += reciever.laws.inherent.len
+		tot_laws += reciever.laws.supplied.len
+		tot_laws += reciever.laws.ion.len
+		if(tot_laws > config.silicon_max_law_amount && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
+			user << "<span class='caution'>You cannot upload any more laws to [reciever], they are at the limit: [tot_laws]/[tot_laws] laws."
+			message_admins("[key_name_admin(user)] tried to upload laws to [key_name_admin(reciever)] when they were already at max laws.")
+			return
 
 	var/law2log = src.transmitInstructions(reciever, user) //Freeforms return something extra we need to log
 	user << "Upload complete. [reciever]'s laws have been modified."
@@ -206,6 +217,7 @@ AI MODULES
 	desc = "A 'reset' AI module: Resets back to the original core laws."
 	origin_tech = "programming=3;materials=4"
 	laws = list("This is a bug.")  //This won't give the AI a message reading "these are now your laws: 1. this is a bug" because this list is only read in aiModule's subtypes.
+	bypass_law_amt_check = 1
 
 /obj/item/weapon/aiModule/reset/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -204,6 +204,11 @@ SEC_START_BRIG
 ## Set to 2 for "random", silicons will start with a random lawset picked from (at the time of writing): P.A.L.A.D.I.N., Corporate, Asimov. More can be added by changing the law datum paths in ai_laws.dm.
 DEFAULT_LAWS 1
 
+### SILICON LAW MAX AMOUNT ###
+## The maximum number of laws a silicon can have
+## Attempting to upload laws past this point will fail unless the AI is reset
+SILICON_MAX_LAW_AMOUNT 12
+
 ## Uncoment to give players the choice of their species before they join the game
 #JOIN_WITH_MUTANT_RACE
 


### PR DESCRIPTION
Config option that caps silicon mob laws.
Adds a variable to bypass this cap (only used on Reset boards atm, they need to skip the cap/check)

Defaults to 12 but Sos can change it to whatever he feels is appropriate.

fixes #4687
