### PR TITLE
Fireaxecabinet bullet fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -152,23 +152,19 @@
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		health -= Proj.damage
 		if(health <= 0)
-			for(var/atom/movable/A as mob|obj in src)
-				A.loc = src.loc
+			dump_contents()
 			qdel(src)
 	return
 
 /obj/structure/closet/attack_animal(mob/living/simple_animal/user as mob)
 	if(user.environment_smash)
 		visible_message("<span class='danger'>[user] destroys the [src].</span>")
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
+		dump_contents()
 		qdel(src)
 
-// this should probably use dump_contents()
 /obj/structure/closet/blob_act()
 	if(prob(75))
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
+		dump_contents()
 		qdel(src)
 
 

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -36,7 +36,7 @@
 			if(src.smashed || src.localopened)
 				if(localopened)
 					localopened = 0
-					icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+					icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 					spawn(10) update_icon()
 				return
 			else
@@ -68,10 +68,10 @@
 			else
 				localopened = !localopened
 				if(localopened)
-					icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
+					icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]opening"
 					spawn(10) update_icon()
 				else
-					icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+					icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 					spawn(10) update_icon()
 	else
 		if(src.smashed)
@@ -79,7 +79,7 @@
 		if(istype(O, /obj/item/device/multitool))
 			if(localopened)
 				localopened = 0
-				icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+				icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 				spawn(10) update_icon()
 				return
 			else
@@ -92,17 +92,52 @@
 		else
 			localopened = !localopened
 			if(localopened)
-				icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
+				icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]opening"
 				spawn(10) update_icon()
 			else
-				icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+				icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 				spawn(10) update_icon()
 
 
+/obj/structure/closet/fireaxecabinet/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			qdel(src)
+			return
+		if(2.0)
+			if(prob(50))
+				if(fireaxe)
+					fireaxe.loc = src.loc
+				qdel(src)
+				return
+		if(3.0)
+			return
+
+/obj/structure/closet/fireaxecabinet/bullet_act(var/obj/item/projectile/Proj)
+	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
+		health -= Proj.damage
+		if(Proj.damage >= 15 && !smashed && !localopened)
+			hitstaken++
+		if(health <= 0)
+			if(fireaxe)
+				fireaxe.loc = src.loc
+			qdel(src)
+			return
+		if(hitstaken >= 4)
+			playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
+			smashed = 1
+			locked = 0
+			localopened = 1
+			update_icon()
+
+/obj/structure/closet/fireaxecabinet/blob_act()
+	if(prob(75))
+		if(fireaxe)
+			fireaxe.loc = src.loc
+			qdel(src)
 
 
 /obj/structure/closet/fireaxecabinet/attack_hand(mob/user as mob)
-
 	var/hasaxe = 0
 	if(fireaxe)
 		hasaxe = 1
@@ -123,19 +158,19 @@
 			else
 				localopened = !localopened
 				if(localopened)
-					src.icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
+					src.icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]opening"
 					spawn(10) update_icon()
 				else
-					src.icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+					src.icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 					spawn(10) update_icon()
 
 	else
 		localopened = !localopened //I'm pretty sure we don't need an if(src.smashed) in here. In case I'm wrong and it fucks up teh cabinet, **MARKER**. -Agouri
 		if(localopened)
-			src.icon_state = text("fireaxe[][][][]opening",hasaxe,src.localopened,src.hitstaken,src.smashed)
+			src.icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]opening"
 			spawn(10) update_icon()
 		else
-			src.icon_state = text("fireaxe[][][][]closing",hasaxe,src.localopened,src.hitstaken,src.smashed)
+			src.icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]closing"
 			spawn(10) update_icon()
 
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
@@ -199,7 +234,7 @@
 	var/hasaxe = 0
 	if(fireaxe)
 		hasaxe = 1
-	icon_state = text("fireaxe[][][][]",hasaxe,src.localopened,src.hitstaken,src.smashed)
+	icon_state = "fireaxe[hasaxe][src.localopened][src.hitstaken][src.smashed]"
 
 /obj/structure/closet/fireaxecabinet/open()
 	return

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -128,7 +128,7 @@
 			smashed = 1
 			locked = 0
 			localopened = 1
-			update_icon()
+		update_icon()
 
 /obj/structure/closet/fireaxecabinet/blob_act()
 	if(prob(75))

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -9,6 +9,21 @@
 	var/opened = 0
 
 
+/obj/structure/extinguisher_cabinet/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			qdel(src)
+			return
+		if(2.0)
+			if(prob(50))
+				if(has_extinguisher)
+					has_extinguisher.loc = src.loc
+				qdel(src)
+				return
+		if(3.0)
+			return
+
+
 /obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user)
 	if(isrobot(user) || isalien(user))
 		return


### PR DESCRIPTION
Removing some "text(...)" stuff.
Little fixes in closets.dm
Adding bullet_act, blob_act and ex_act to fireaxecabinet so it drops the axe when destroyed. Fixes #2948
You can now break the cabinet's glass with projectiles (with damage >=15).
Adding ex_act to extinguisher cabinet so it sometimes drops the extinguisher when destroyed.
