### PR TITLE
Singularity tweaks

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -53,6 +53,8 @@
 	consume(user)
 	return 1
 
+/obj/machinery/singularity/Process_Spacemove() //The singularity stops drifting for no man!
+	return 0
 
 /obj/machinery/singularity/blob_act(severity)
 	return
@@ -88,15 +90,15 @@
 
 
 /obj/machinery/singularity/process()
-	eat()
-	dissipate()
-	check_energy()
-
 	if(current_size >= STAGE_TWO)
 		move()
 		pulse()
 		if(prob(event_chance))//Chance for it to run a special event TODO:Come up with one or two more that fit
 			event()
+	eat()
+	dissipate()
+	check_energy()
+
 	return
 
 
@@ -278,12 +280,12 @@
 			dir2 = 1
 			dir3 = 2
 	var/turf/T2 = T
-	for(var/j = 1 to steps)
+	for(var/j = 1 to steps-1)
 		T2 = get_step(T2,dir2)
 		if(!isturf(T2))
 			return 0
 		turfs.Add(T2)
-	for(var/k = 1 to steps)
+	for(var/k = 1 to steps-1)
 		T = get_step(T,dir3)
 		if(!isturf(T))
 			return 0


### PR DESCRIPTION
- Fix an off-by-one error that caused the singulo to get stuck along contaiment fields. For a 5x5 singulo, it would check 6 squares ahead (correct for a step forward) and then 6 squares to the sides (incorrect). Now it tests 6 squares ahead, 5 to the sides. This is technically wrong for the growth checks but they check every direction anyways, so it's ok.
- Made the singularity drift in all cases and not stop next to lattices.
- In process(), moved the growth checks after the movement attempt so it will take a step and then grow rather than take a step, drift into the walls, and then attempt and fail to grow as part of the next process().
