### PR TITLE
Exosuit fabricator revamp

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -497,4 +497,4 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "capacitor"
 	desc = "A debug item for research."
-	origin_tech = "materials=8;programming=8;magnets=8;powerstorage=8;bluespace=8;combat=8;biotech=8;syndicate=8"
+	origin_tech = "materials=8;programming=8;magnets=8;powerstorage=8;bluespace=8;combat=8;biotech=8;syndicate=8;engineering=8;plasmatech=8"

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -1,7 +1,3 @@
-/////////////////////////////
-///// Part Fabricator ///////
-/////////////////////////////
-
 /obj/machinery/mecha_part_fabricator
 	icon = 'icons/obj/robotics.dmi'
 	icon_state = "fab-idle"
@@ -18,129 +14,37 @@
 	var/time_coeff_tech = 1
 	var/resource_coeff_tech = 1
 	var/list/resources = list(
-										"metal"=0,
-										"glass"=0,
-										"bananium"=0,
-										"diamond"=0,
-										"gold"=0,
-										"plasma"=0,
-										"silver"=0,
-										"uranium"=0
-										)
+								"$metal"=0,
+								"$glass"=0,
+								"$bananium"=0,
+								"$diamond"=0,
+								"$gold"=0,
+								"$plasma"=0,
+								"$silver"=0,
+								"$uranium"=0
+								)
 	var/res_max_amount = 200000
 	var/datum/research/files
 	var/id
 	var/sync = 0
 	var/part_set
-	var/obj/being_built
+	var/datum/design/being_built
 	var/list/queue = list()
 	var/processing_queue = 0
 	var/screen = "main"
 	var/temp
-	var/list/part_sets = list( //set names must be unique
-	"Cyborg"=list(
-						/obj/item/robot_parts/robot_suit,
-						/obj/item/robot_parts/chest,
-						/obj/item/robot_parts/head,
-						/obj/item/robot_parts/l_arm,
-						/obj/item/robot_parts/r_arm,
-						/obj/item/robot_parts/l_leg,
-						/obj/item/robot_parts/r_leg
-					),
-	"Ripley"=list(
-						/obj/item/mecha_parts/chassis/ripley,
-						/obj/item/mecha_parts/chassis/firefighter,
-						/obj/item/mecha_parts/part/ripley_torso,
-						/obj/item/mecha_parts/part/ripley_left_arm,
-						/obj/item/mecha_parts/part/ripley_right_arm,
-						/obj/item/mecha_parts/part/ripley_left_leg,
-						/obj/item/mecha_parts/part/ripley_right_leg
-					),
-	"Odysseus"=list(
-						/obj/item/mecha_parts/chassis/odysseus,
-						/obj/item/mecha_parts/part/odysseus_torso,
-						/obj/item/mecha_parts/part/odysseus_head,
-						/obj/item/mecha_parts/part/odysseus_left_arm,
-						/obj/item/mecha_parts/part/odysseus_right_arm,
-						/obj/item/mecha_parts/part/odysseus_left_leg,
-						/obj/item/mecha_parts/part/odysseus_right_leg
-					),
-
-	"Gygax"=list(
-						/obj/item/mecha_parts/chassis/gygax,
-						/obj/item/mecha_parts/part/gygax_torso,
-						/obj/item/mecha_parts/part/gygax_head,
-						/obj/item/mecha_parts/part/gygax_left_arm,
-						/obj/item/mecha_parts/part/gygax_right_arm,
-						/obj/item/mecha_parts/part/gygax_left_leg,
-						/obj/item/mecha_parts/part/gygax_right_leg,
-						/obj/item/mecha_parts/part/gygax_armor
-					),
-	"Durand"=list(
-						/obj/item/mecha_parts/chassis/durand,
-						/obj/item/mecha_parts/part/durand_torso,
-						/obj/item/mecha_parts/part/durand_head,
-						/obj/item/mecha_parts/part/durand_left_arm,
-						/obj/item/mecha_parts/part/durand_right_arm,
-						/obj/item/mecha_parts/part/durand_left_leg,
-						/obj/item/mecha_parts/part/durand_right_leg,
-						/obj/item/mecha_parts/part/durand_armor
-					),
-	"H.O.N.K"=list(
-						/obj/item/mecha_parts/chassis/honker,
-						/obj/item/mecha_parts/part/honker_torso,
-						/obj/item/mecha_parts/part/honker_head,
-						/obj/item/mecha_parts/part/honker_left_arm,
-						/obj/item/mecha_parts/part/honker_right_arm,
-						/obj/item/mecha_parts/part/honker_left_leg,
-						/obj/item/mecha_parts/part/honker_right_leg
-					),
-	"Phazon"=list(
-						/obj/item/mecha_parts/chassis/phazon,
-						/obj/item/mecha_parts/part/phazon_torso,
-						/obj/item/mecha_parts/part/phazon_head,
-						/obj/item/mecha_parts/part/phazon_left_arm,
-						/obj/item/mecha_parts/part/phazon_right_arm,
-						/obj/item/mecha_parts/part/phazon_left_leg,
-						/obj/item/mecha_parts/part/phazon_right_leg,
-						/obj/item/mecha_parts/part/phazon_armor
-					),
-	"Exosuit Equipment"=list(
-						/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
-						/obj/item/mecha_parts/mecha_equipment/tool/drill,
-						/obj/item/mecha_parts/mecha_equipment/tool/extinguisher,
-						/obj/item/mecha_parts/mecha_equipment/tool/cable_layer,
-						/obj/item/mecha_parts/mecha_equipment/tool/sleeper,
-						/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun,
-						/obj/item/mecha_parts/mecha_equipment/repair_droid,
-						/obj/item/mecha_parts/mecha_equipment/generator,
-						///obj/item/mecha_parts/mecha_equipment/jetpack, //TODO MECHA JETPACK SPRITE MISSING
-						/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
-						/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
-						/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar,
-						/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar,
-						/obj/item/mecha_parts/mecha_equipment/weapon/honker
-						),
-
-	"Cyborg Upgrade Modules" = list(
-						/obj/item/borg/upgrade/reset,
-						/obj/item/borg/upgrade/rename,
-						/obj/item/borg/upgrade/restart,
-						/obj/item/borg/upgrade/vtec,
-						/obj/item/borg/upgrade/tasercooler,
-						/obj/item/borg/upgrade/jetpack
-						),
-
-
-
-
-
-
-	"Misc"=list(/obj/item/mecha_parts/mecha_tracking)
-	)
-
-
-
+	var/list/part_sets = list(
+								"Cyborg",
+								"Ripley",
+								"Odysseus",
+								"Gygax",
+								"Durand",
+								"H.O.N.K",
+								"Phazon",
+								"Exosuit Equipment",
+								"Cyborg Upgrade Modules",
+								"Misc"
+								)
 
 /obj/machinery/mecha_part_fabricator/New()
 	..()
@@ -152,19 +56,7 @@
 	component_parts += new /obj/item/weapon/stock_parts/micro_laser(null)
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	RefreshParts()
-
-	//	part_sets["Cyborg Upgrade Modules"] = typesof(/obj/item/borg/upgrade/) - /obj/item/borg/upgrade/  // Eh.  This does it dymaically, but to support having the items referenced otherwhere in the code but not being constructable, going to do it manaully.
-
-	for(var/part_set in part_sets)
-		convert_part_set(part_set)
 	files = new /datum/research(src) //Setup the research data holder.
-	/*
-	if(!id)
-		for(var/obj/machinery/r_n_d/server/centcom/S in world)
-			S.initialize()
-			break
-	*/
-	return
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
@@ -187,25 +79,6 @@
 	if(time_coeff!=diff)
 		time_coeff = diff
 
-/obj/machinery/mecha_part_fabricator/Destroy()
-	for(var/atom/A in src)
-		qdel(A)
-	..()
-	return
-
-/obj/machinery/mecha_part_fabricator/proc/operation_allowed(mob/M)
-	if(isrobot(M) || isAI(M))
-		return 1
-	if(!istype(req_access) || !req_access.len)
-		return 1
-	else if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		for(var/ID in list(H.get_active_hand(), H.wear_id, H.belt))
-			if(src.check_access(ID))
-				return 1
-	M << "<span class='alert'>You don't have the required permissions to use \the [src]!</span>"
-	return 0
-
 /obj/machinery/mecha_part_fabricator/check_access(obj/item/weapon/card/id/I)
 	if(istype(I, /obj/item/device/pda))
 		var/obj/item/device/pda/pda = I
@@ -218,119 +91,55 @@
 	return 1
 
 /obj/machinery/mecha_part_fabricator/proc/emag()
-	sleep()
 	switch(emagged)
 		if(0)
 			emagged = 0.5
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB error \[Code 0x00F1\]\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB error \[Code 0x00F1\]\"")
 			sleep(10)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"Attempting auto-repair\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"Attempting auto-repair\"")
 			sleep(15)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
 			sleep(30)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
 			req_access = null
 			emagged = 1
 		if(0.5)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")
 		if(1)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps: \"No records in User DB\"")
+			visible_message("\icon[src] <b>\The [src]</b> beeps: \"No records in User DB\"")
 	return
-
-/obj/machinery/mecha_part_fabricator/proc/convert_part_set(set_name as text)
-	var/list/parts = part_sets[set_name]
-	if(istype(parts, /list))
-		for(var/i=1;i<=parts.len;i++)
-			var/path = parts[i]
-			var/part = new path(src)
-			if(part)
-				parts[i] = part
-			//debug below
-			if(!istype(parts[i],/obj/item)) return 0
-	return
-
-
-/obj/machinery/mecha_part_fabricator/proc/add_part_set(set_name as text,parts=null)
-	if(set_name in part_sets)//attempt to create duplicate set
+/*
+/obj/machinery/mecha_part_fabricator/proc/add_part_to_set(set_name, part)
+	if(!part)
 		return 0
-	if(isnull(parts))
+	if(!set_name in part_sets)//attempt to create duplicate set
 		part_sets[set_name] = list()
-	else
-		part_sets[set_name] = parts
-	convert_part_set(set_name)
+	part_sets[set_name] += part
 	return 1
-
-/obj/machinery/mecha_part_fabricator/proc/add_part_to_set(set_name as text,part)
-	if(!part) return 0
-	src.add_part_set(set_name)//if no "set_name" set exists, create
-	var/list/part_set = part_sets[set_name]
-	var/atom/apart
-	if(ispath(part))
-		apart = new part(src)
-	else
-		apart = part
-	if(!istype(apart)) return 0
-	for(var/obj/O in part_set)
-		if(O.type == apart.type)
-			qdel(apart)
-			return 0
-	part_set[++part_set.len] = apart
-	return 1
-
-/obj/machinery/mecha_part_fabricator/proc/remove_part_set(set_name as text)
-	for(var/i=1,i<=part_sets.len,i++)
-		if(part_sets[i]==set_name)
-			part_sets.Cut(i,++i)
-	return
-/*
-	proc/sanity_check()
-		for(var/p in resources)
-			var/index = resources.Find(p)
-			index = resources.Find(p, ++index)
-			if(index) //duplicate resource
-				world << "Duplicate resource definition for [src](\ref[src])"
-				return 0
-		for(var/set_name in part_sets)
-			var/index = part_sets.Find(set_name)
-			index = part_sets.Find(set_name, ++index)
-			if(index) //duplicate part set
-				world << "Duplicate part set definition for [src](\ref[src])"
-				return 0
-		return 1
 */
-/*
-	New()
-		..()
-		src.add_part_to_set("Test",list("result"="/obj/item/mecha_parts/part/gygax_armor","time"=600,"metal"=75000,"diamond"=10000))
-		src.add_part_to_set("Test",list("result"="/obj/item/mecha_parts/part/ripley_left_arm","time"=200,"metal"=25000))
-		src.remove_part_set("Gygax")
-		return
-*/
-
 /obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
 	var/output = ""
-	var/list/part_set = listgetindex(part_sets, set_name)
-	if(istype(part_set))
-		for(var/obj/item/part in part_set)
-			var/resources_available = check_resources(part)
-			output += "<div class='part'>[output_part_info(part)]<br>\[[resources_available?"<a href='?src=\ref[src];part=\ref[part]'>Build</a> | ":null]<a href='?src=\ref[src];add_to_queue=\ref[part]'>Add to queue</a>\]\[<a href='?src=\ref[src];part_desc=\ref[part]'>?</a>\]</div>"
+	for(var/datum/design/D in files.known_designs)
+		if(D.build_type&16)
+			if(D.category != set_name)
+				continue
+			var/resources_available = check_resources(D)
+			output += "<div class='part'>[output_part_info(D)]<br>\[[resources_available?"<a href='?src=\ref[src];part=[D.id]'>Build</a> | ":null]<a href='?src=\ref[src];add_to_queue=[D.id]'>Add to queue</a>\]\[<a href='?src=\ref[src];part_desc=[D.id]'>?</a>\]</div>"
 	return output
 
-/obj/machinery/mecha_part_fabricator/proc/output_part_info(var/obj/item/part)
-	var/output = "[part.name] (Cost: [output_part_cost(part)]) [get_construction_time_w_coeff(part)/10]sec"
+/obj/machinery/mecha_part_fabricator/proc/output_part_info(datum/design/D)
+	var/obj/part = D.build_path
+	var/output = "[initial(part.name)] (Cost: [output_part_cost(D)]) [get_construction_time_w_coeff(part)/10]sec"
 	return output
 
-/obj/machinery/mecha_part_fabricator/proc/output_part_cost(var/obj/item/part)
+/obj/machinery/mecha_part_fabricator/proc/output_part_cost(datum/design/D)
 	var/i = 0
 	var/output
-	if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))//The most efficient way to go about this. Not all objects have these vars, but if they don't then they CANNOT be made by the mech fab. Doing it this way reduces a major amount of typecasting and switches, while cutting down maintenece for them as well -Sieve
-		for(var/c in part:construction_cost)//The check should ensure that anything without the var doesn't make it to this point
-			if(c in resources)
-				output += "[i?" | ":null][get_resource_cost_w_coeff(part,c)] [c]"
-				i++
-		return output
-	else
-		return 0
+	for(var/c in D.materials)
+		if(c in resources)
+			output += "[i?" | ":null][get_resource_cost_w_coeff(D,c)] [c]"
+			i++
+	return output
 
 /obj/machinery/mecha_part_fabricator/proc/output_available_resources()
 	var/output
@@ -342,70 +151,62 @@
 		output += "<br/>"
 	return output
 
-/obj/machinery/mecha_part_fabricator/proc/remove_resources(var/obj/item/part)
-//Be SURE to add any new equipment to this switch, but don't be suprised if it spits out children objects
-	if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))
-		for(var/resource in part:construction_cost)
-			if(resource in src.resources)
-				src.resources[resource] -= get_resource_cost_w_coeff(part,resource)
-	else
-		return
+/obj/machinery/mecha_part_fabricator/proc/remove_resources(datum/design/D)
+	for(var/resource in D.materials)
+		if(resource in resources)
+			resources[resource] -= get_resource_cost_w_coeff(D,resource)
 
-/obj/machinery/mecha_part_fabricator/proc/check_resources(var/obj/item/part)
-//		if(istype(part, /obj/item/robot_parts) || istype(part, /obj/item/mecha_parts) || istype(part,/obj/item/borg/upgrade))
-//Be SURE to add any new equipment to this switch, but don't be suprised if it spits out children objects
-	if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))
-		for(var/resource in part:construction_cost)
-			if(resource in src.resources)
-				if(src.resources[resource] < get_resource_cost_w_coeff(part,resource))
-					return 0
-		return 1
-	else
-		return 0
+/obj/item/mechavars //until these values are extracted from the design datum (most objects on the mech fabricators don't have these), this is necessary, to make the initial() work.
+	var/construction_time
 
-/obj/machinery/mecha_part_fabricator/proc/build_part(var/obj/item/part)
-	if(!part) return
+/obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
+	for(var/R in D.materials)
+		if(R in resources)
+			if(resources[R] < get_resource_cost_w_coeff(D, R))
+				return 0
+		else
+			return 0
+	return 1
 
-	 // critical exploit prevention, do not remove unless you replace it
-	if( (part.loc != src) || !(hasvar(part, "construction_time")) || !(hasvar(part, "construction_cost")) ) // these 3 are the current requirements for an object being buildable by the mech_fabricator
-		return
-
-	src.being_built = new part.type(src)
-	src.desc = "It's building \a [src.being_built]."
-	src.remove_resources(part)
-	part.m_amt = get_resource_cost_w_coeff(part,"metal")
-	part.g_amt = get_resource_cost_w_coeff(part,"glass")
-	src.overlays += "fab-active"
-	src.use_power = 2
-	src.updateUsrDialog()
+/obj/machinery/mecha_part_fabricator/proc/build_part(datum/design/D)
+	var/obj/part = D.build_path
+	being_built = D
+	desc = "It's building \a [initial(part.name)]."
+	remove_resources(D)
+	overlays += "fab-active"
+	use_power = 2
+	updateUsrDialog()
 	sleep(get_construction_time_w_coeff(part))
-	src.use_power = 1
-	src.overlays -= "fab-active"
-	src.desc = initial(src.desc)
-	if(being_built)
-		src.being_built.loc = get_step(src,SOUTH)
-		src.visible_message("\icon[src] <b>\The [src]</b> beeps, \"\The [src.being_built] is complete.\"")
-		src.being_built = null
-	src.updateUsrDialog()
+	use_power = 1
+	overlays -= "fab-active"
+	desc = initial(desc)
+
+	var/obj/item/I = new D.build_path
+	I.loc = get_step(src,SOUTH)
+	I.m_amt = get_resource_cost_w_coeff(D,"$metal")
+	I.g_amt = get_resource_cost_w_coeff(D,"$glass")
+	visible_message("\icon[src] <b>\The [src]</b> beeps, \"\The [I] is complete.\"")
+	being_built = null
+
+	updateUsrDialog()
 	return 1
 
 /obj/machinery/mecha_part_fabricator/proc/update_queue_on_page()
-	send_byjax(usr,"mecha_fabricator.browser","queue",src.list_queue())
+	send_byjax(usr,"mecha_fabricator.browser","queue",list_queue())
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/add_part_set_to_queue(set_name)
 	if(set_name in part_sets)
-		var/list/part_set = part_sets[set_name]
-		if(islist(part_set))
-			for(var/obj/item/part in part_set)
-				add_to_queue(part)
-	return
+		for(var/datum/design/D in files.known_designs)
+			if(D.build_type&16)
+				if(D.category == set_name)
+					add_to_queue(D)
 
-/obj/machinery/mecha_part_fabricator/proc/add_to_queue(part)
+/obj/machinery/mecha_part_fabricator/proc/add_to_queue(D)
 	if(!istype(queue))
 		queue = list()
-	if(part)
-		queue[++queue.len] = part
+	if(D)
+		queue[++queue.len] = D
 	return queue.len
 
 /obj/machinery/mecha_part_fabricator/proc/remove_from_queue(index)
@@ -415,30 +216,26 @@
 	return 1
 
 /obj/machinery/mecha_part_fabricator/proc/process_queue()
-	var/obj/item/part = listgetindex(src.queue, 1)
-	if(!part)
+	var/datum/design/D = queue[1]
+	if(!D)
 		remove_from_queue(1)
-		if(src.queue.len)
+		if(queue.len)
 			return process_queue()
 		else
 			return
-	if(!(hasvar(part, "construction_time")) || !(hasvar(part, "construction_cost")))//If it shouldn't be printed
-		remove_from_queue(1)//Take it out of the quene
-		return process_queue()//Then reprocess it
 	temp = null
-	while(part)
+	while(D)
 		if(stat&(NOPOWER|BROKEN))
 			return 0
-		if(!check_resources(part))
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps, \"Not enough resources. Queue processing stopped.\"")
+		if(!check_resources(D))
+			visible_message("\icon[src] <b>\The [src]</b> beeps, \"Not enough resources. Queue processing stopped.\"")
 			temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
 						<a href='?src=\ref[src];process_queue=1'>Try again</a> | <a href='?src=\ref[src];clear_temp=1'>Return</a><a>"}
 			return 0
 		remove_from_queue(1)
-		build_part(part)
-		part = listgetindex(src.queue, 1)
-	src.visible_message("\icon[src] <b>\The [src]</b> beeps, \"Queue processing finished successfully.\"")
-	return 1
+		build_part(D)
+		D = listgetindex(queue, 1)
+	visible_message("\icon[src] <b>\The [src]</b> beeps, \"Queue processing finished successfully.\"")
 
 /obj/machinery/mecha_part_fabricator/proc/list_queue()
 	var/output = "<b>Queue contains:</b>"
@@ -446,31 +243,29 @@
 		output += "<br>Nothing"
 	else
 		output += "<ol>"
-		for(var/i=1;i<=queue.len;i++)
-			var/obj/item/part = listgetindex(src.queue, i)
-			if(istype(part))
-				if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))
-					output += "<li[!check_resources(part)?" style='color: #f00;'":null]>[part.name] - [i>1?"<a href='?src=\ref[src];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] [i<queue.len?"<a href='?src=\ref[src];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] <a href='?src=\ref[src];remove_from_queue=[i]'>Remove</a></li>"
-				else//Prevents junk items from even appearing in the list, and they will be silently removed when the fab processes
-					remove_from_queue(i)//Trash it
-					return list_queue()//Rebuild it
+		var/i = 0
+		for(var/datum/design/D in queue)
+			i++
+			var/obj/part = D.build_path
+			output += "<li[!check_resources(D)?" style='color: #f00;'":null]>[initial(part.name)] - [i>1?"<a href='?src=\ref[src];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] [i<queue.len?"<a href='?src=\ref[src];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] <a href='?src=\ref[src];remove_from_queue=[i]'>Remove</a></li>"
+
 		output += "</ol>"
 		output += "\[<a href='?src=\ref[src];process_queue=1'>Process queue</a> | <a href='?src=\ref[src];clear_queue=1'>Clear queue</a>\]"
 	return output
-
+/*
 /obj/machinery/mecha_part_fabricator/proc/convert_designs()
 	if(!files) return
 	var/i = 0
 	for(var/datum/design/D in files.known_designs)
 		if(D.build_type&16)
 			if(D.category in part_sets)//Checks if it's a valid category
-				if(add_part_to_set(D.category, D.build_path))//Adds it to said category
+				if(add_part_to_set(D.category, D))//Adds it to said category
 					i++
 			else
-				if(add_part_to_set("Misc", D.build_path))//If in doubt, chunk it into the Misc
+				if(add_part_to_set("Misc", D))//If in doubt, chunk it into the Misc
 					i++
 	return i
-
+*/
 /obj/machinery/mecha_part_fabricator/proc/update_tech()
 	if(!files) return
 	var/output
@@ -501,17 +296,10 @@
 	return output
 
 
-/obj/machinery/mecha_part_fabricator/proc/sync(silent=null)
-/*		if(queue.len)
-			if(!silent)
-				temp = "Error.  Please clear processing queue before updating!"
-				src.updateUsrDialog()
-			return
-*/
-	if(!silent)
-		temp = "Updating local R&D database..."
-		src.updateUsrDialog()
-		sleep(30) //only sleep if called by user
+/obj/machinery/mecha_part_fabricator/proc/sync()
+	temp = "Updating local R&D database..."
+	updateUsrDialog()
+	sleep(30) //only sleep if called by user
 
 	var/found = 0
 	for(var/obj/machinery/computer/rdconsole/RDC in area_contents(get_area(src)))
@@ -523,36 +311,25 @@
 		for(var/datum/design/D in RDC.files.known_designs)
 			files.AddDesign2Known(D)
 		files.RefreshResearch()
-		var/i = src.convert_designs()
-		var/tech_output = update_tech()
-		if(!silent)
-			temp = "Processed [i] equipment designs.<br>"
-			temp += tech_output
-			temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
-			src.updateUsrDialog()
-		if(i || tech_output)
-			src.visible_message("\icon[src] <b>\The [src]</b> beeps, \"Successfully synchronized with R&D server. New data processed.\"")
-	if(!silent && !found)
+		//var/i = convert_designs() aran
+		//var/tech_output = update_tech()
+		temp = "Processed equipment designs.<br>"
+		//temp += tech_output
+		temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
+		updateUsrDialog()
+		//if(i || tech_output)
+		visible_message("\icon[src] <b>\The [src]</b> beeps, \"Successfully synchronized with R&D server.\"")
+	if(!found)
 		temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
-		src.updateUsrDialog()
+		updateUsrDialog()
 	return
 
-/obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(var/obj/item/part as obj,var/resource as text, var/roundto=1)
-//Be SURE to add any new equipment to this switch, but don't be suprised if it spits out children objects
-	if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))
-		var/list/L = part_sets["Misc"]
-		if(L.Find(part.type))
-			return round(part:construction_cost[resource]*(resource_coeff/2)*resource_coeff_tech, roundto)             //hacky scary skeletons send shivers down your spine
-		return round(part:construction_cost[resource]*resource_coeff*resource_coeff_tech, roundto)
-	else
-		return 0
+/obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(datum/design/D, resource, roundto = 1)
+	return round(D.materials[resource]*resource_coeff*resource_coeff_tech, roundto)
 
-/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(var/obj/item/part as obj, var/roundto=1)
-//Be SURE to add any new equipment to this switch, but don't be suprised if it spits out children objects
-	if(hasvar(part, "construction_time") && hasvar(part, "construction_cost"))
-		return round(part:construction_time*time_coeff*time_coeff_tech, roundto)
-	else
-		return 0
+/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(P, roundto = 1) //aran
+	var/obj/item/mechavars/part = P
+	return round(initial(part.construction_time)*time_coeff*time_coeff_tech, roundto)
 
 /obj/machinery/mecha_part_fabricator/attack_hand(mob/user)
 	if(!(..()))
@@ -562,17 +339,16 @@
 	var/dat, left_part
 	if (..())
 		return
-	if(!operation_allowed(user))
-		return
 	user.set_machine(src)
 	var/turf/exit = get_step(src,SOUTH)
 	if(exit.density)
-		src.visible_message("\icon[src] <b>\The [src]</b> beeps, \"Error! Part outlet is obstructed.\"")
+		visible_message("\icon[src] <b>\The [src]</b> beeps, \"Error! Part outlet is obstructed.\"")
 		return
 	if(temp)
 		left_part = temp
-	else if(src.being_built)
-		left_part = {"<TT>Building [src.being_built.name].<BR>
+	else if(being_built)
+		var/obj/I = being_built.build_path
+		left_part = {"<TT>Building [initial(I.name)].<BR>
 							Please wait until completion...</TT>"}
 	else
 		switch(screen)
@@ -586,7 +362,7 @@
 				left_part += "<hr><a href='?src=\ref[src];screen=main'>Return</a>"
 	dat = {"<html>
 			  <head>
-			  <title>[src.name]</title>
+			  <title>[name]</title>
 				<style>
 				.res_name {font-weight: bold; text-transform: capitalize;}
 				.red {color: #f00;}
@@ -618,21 +394,6 @@
 	onclose(user, "mecha_fabricator")
 	return
 
-/obj/machinery/mecha_part_fabricator/proc/exploit_prevention(var/obj/Part, mob/user as mob, var/desc_exploit)
-// critical exploit prevention, feel free to improve or replace this, but do not remove it
-
-	if(!istype(Part) || !istype(user)) // sanity
-		return 1
-
-	if( (Part.loc != src) || !(hasvar(Part, "construction_time")) || !(hasvar(Part, "construction_cost")) ) // these 3 are the current requirements for an object being buildable by the mech_fabricator
-
-		var/turf/LOC = get_turf(user)
-		message_admins("[key_name_admin(user)] tried to exploit an Exosuit Fabricator to [desc_exploit ? "get the desc of" : "duplicate"] <a href='?_src_=vars;Vars=\ref[Part]'>[Part]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
-		log_admin("EXPLOIT : [key_name(user)] tried to exploit an Exosuit Fabricator to [desc_exploit ? "get the desc of" : "duplicate"] [Part] !")
-		return 1
-
-	return null
-
 /obj/machinery/mecha_part_fabricator/Topic(href, href_list)
 	if(..())
 		return
@@ -641,30 +402,27 @@
 		var/tpart_set = filter.getStr("part_set")
 		if(tpart_set)
 			if(tpart_set=="clear")
-				src.part_set = null
+				part_set = null
 			else
-				src.part_set = tpart_set
+				part_set = tpart_set
 				screen = "parts"
 	if(href_list["part"])
-		var/obj/part = filter.getObj("part")
-
-		// critical exploit prevention, do not remove unless you replace it
-		if(src.exploit_prevention(part, usr))
-			return
-
-		if(!processing_queue)
-			build_part(part)
-		else
-			add_to_queue(part)
+		var/T = filter.getStr("part")
+		for(var/datum/design/D in files.known_designs)
+			if(D.build_type&16)
+				if(D.id == T)
+					if(!processing_queue)
+						build_part(D)
+					else
+						add_to_queue(D)
+					break
 	if(href_list["add_to_queue"])
-		var/obj/part = filter.getObj("add_to_queue")
-
-		// critical exploit prevention, do not remove unless you replace it
-		if(src.exploit_prevention(part, usr))
-			return
-
-		add_to_queue(part)
-
+		var/T = filter.getStr("add_to_queue")
+		for(var/datum/design/D in files.known_designs)
+			if(D.build_type&16)
+				if(D.id == T)
+					add_to_queue(D)
+					break
 		return update_queue_on_page()
 	if(href_list["remove_from_queue"])
 		remove_from_queue(filter.getNum("remove_from_queue"))
@@ -679,14 +437,10 @@
 			processing_queue = 1
 			process_queue()
 			processing_queue = 0
-/*
-		if(href_list["list_queue"])
-			list_queue()
-*/
 	if(href_list["clear_temp"])
 		temp = null
 	if(href_list["screen"])
-		src.screen = href_list["screen"]
+		screen = href_list["screen"]
 	if(href_list["queue_move"] && href_list["index"])
 		var/index = filter.getNum("index")
 		var/new_index = index + filter.getNum("queue_move")
@@ -698,42 +452,42 @@
 		queue = list()
 		return update_queue_on_page()
 	if(href_list["sync"])
-		src.sync()
+		sync()
 	if(href_list["part_desc"])
-		var/obj/part = filter.getObj("part_desc")
+		var/T = filter.getStr("part_desc")
+		for(var/datum/design/D in files.known_designs)
+			if(D.build_type&16)
+				if(D.id == T)
+					var/obj/part = D.build_path
+					temp = {"<h1>[initial(part.name)] description:</h1>
+								[initial(part.desc)]<br>
+								<a href='?src=\ref[src];clear_temp=1'>Return</a>
+								"}
+					break
 
-		// critical exploit prevention, do not remove unless you replace it
-		if(src.exploit_prevention(part, usr, 1))
-			return
-
-		if(part)
-			temp = {"<h1>[part] description:</h1>
-						[part.desc]<br>
-						<a href='?src=\ref[src];clear_temp=1'>Return</a>
-						"}
 	if(href_list["remove_mat"] && href_list["material"])
 		temp = "Ejected [remove_material(href_list["material"],text2num(href_list["remove_mat"]))] of [href_list["material"]]<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
-	src.updateUsrDialog()
+	updateUsrDialog()
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/remove_material(var/mat_string, var/amount)
 	var/type
 	switch(mat_string)
-		if("metal")
+		if("$metal")
 			type = /obj/item/stack/sheet/metal
-		if("glass")
+		if("$glass")
 			type = /obj/item/stack/sheet/glass
-		if("gold")
+		if("$gold")
 			type = /obj/item/stack/sheet/mineral/gold
-		if("silver")
+		if("$silver")
 			type = /obj/item/stack/sheet/mineral/silver
-		if("diamond")
+		if("$diamond")
 			type = /obj/item/stack/sheet/mineral/diamond
-		if("plasma")
+		if("$plasma")
 			type = /obj/item/stack/sheet/mineral/plasma
-		if("uranium")
+		if("$uranium")
 			type = /obj/item/stack/sheet/mineral/uranium
-		if("bananium")
+		if("$bananium")
 			type = /obj/item/stack/sheet/mineral/bananium
 		else
 			return 0
@@ -746,10 +500,8 @@
 		res.Move(src.loc)
 		result = res.amount
 	else
-		result = 0
 		qdel(res)
 	return result
-
 
 
 /obj/machinery/mecha_part_fabricator/attackby(obj/W as obj, mob/user as mob)
@@ -761,92 +513,94 @@
 
 	if(panel_open)
 		if(istype(W, /obj/item/weapon/crowbar))
-			while(src.resources["metal"] >= MINERAL_MATERIAL_AMOUNT)
+			while(resources["$metal"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/metal/G = new /obj/item/stack/sheet/metal(src.loc)
-				var/sheet_conversion = round(src.resources["metal"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$metal"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["metal"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["glass"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$metal"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$glass"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src.loc)
-				var/sheet_conversion = round(src.resources["glass"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$glass"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["glass"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["plasma"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$glass"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$plasma"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/plasma/G = new /obj/item/stack/sheet/mineral/plasma(src.loc)
-				var/sheet_conversion = round(src.resources["plasma"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$plasma"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["plasma"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["silver"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$plasma"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$silver"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/silver/G = new /obj/item/stack/sheet/mineral/silver(src.loc)
-				var/sheet_conversion = round(src.resources["silver"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$silver"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["silver"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["gold"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$silver"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$gold"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold(src.loc)
-				var/sheet_conversion = round(src.resources["gold"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$gold"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["gold"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["uranium"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$gold"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$uranium"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/uranium/G = new /obj/item/stack/sheet/mineral/uranium(src.loc)
-				var/sheet_conversion = round(src.resources["uranium"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$uranium"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["uranium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["diamond"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$uranium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$diamond"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/diamond/G = new /obj/item/stack/sheet/mineral/diamond(src.loc)
-				var/sheet_conversion = round(src.resources["diamond"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$diamond"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["diamond"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(src.resources["bananium"] >= MINERAL_MATERIAL_AMOUNT)
+				resources["$diamond"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			while(resources["$bananium"] >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/bananium/G = new /obj/item/stack/sheet/mineral/bananium(src.loc)
-				var/sheet_conversion = round(src.resources["bananium"] / MINERAL_MATERIAL_AMOUNT)
+				var/sheet_conversion = round(resources["$bananium"] / MINERAL_MATERIAL_AMOUNT)
 				G.amount = min(sheet_conversion, G.max_amount)
-				src.resources["bananium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+				resources["$bananium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
 			default_deconstruction_crowbar(W)
 			return 1
 		else
-			user << "<span class='danger'>You can't load \the [src.name] while it's opened.</span>"
+			user << "<span class='danger'>You can't load \the [name] while it's opened.</span>"
 			return 1
 
 	if(istype(W, /obj/item/weapon/card/emag))
 		emag()
 		return
-	var/material
-	switch(W.type)
-		if(/obj/item/stack/sheet/mineral/gold)
-			material = "gold"
-		if(/obj/item/stack/sheet/mineral/silver)
-			material = "silver"
-		if(/obj/item/stack/sheet/mineral/diamond)
-			material = "diamond"
-		if(/obj/item/stack/sheet/mineral/plasma)
-			material = "plasma"
-		if(/obj/item/stack/sheet/metal)
-			material = "metal"
-		if(/obj/item/stack/sheet/glass)
-			material = "glass"
-		if(/obj/item/stack/sheet/mineral/bananium)
-			material = "bananium"
-		if(/obj/item/stack/sheet/mineral/uranium)
-			material = "uranium"
-		else
-			return ..()
 
-	if(src.being_built)
-		user << "\The [src] is currently processing. Please wait until completion."
+	if(istype(W, /obj/item/stack))
+		var/material
+		switch(W.type)
+			if(/obj/item/stack/sheet/mineral/gold)
+				material = "$gold"
+			if(/obj/item/stack/sheet/mineral/silver)
+				material = "$silver"
+			if(/obj/item/stack/sheet/mineral/diamond)
+				material = "$diamond"
+			if(/obj/item/stack/sheet/mineral/plasma)
+				material = "$plasma"
+			if(/obj/item/stack/sheet/metal)
+				material = "$metal"
+			if(/obj/item/stack/sheet/glass)
+				material = "$glass"
+			if(/obj/item/stack/sheet/mineral/bananium)
+				material = "$bananium"
+			if(/obj/item/stack/sheet/mineral/uranium)
+				material = "$uranium"
+			else
+				return ..()
+
+		if(being_built)
+			user << "\The [src] is currently processing. Please wait until completion."
+			return
+		var/obj/item/stack/sheet/stack = W
+		var/sname = "[stack.name]"
+		if(resources[material] < res_max_amount)
+			var/count = 0
+			overlays += "fab-load-[material]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
+			while(resources[material] < res_max_amount && stack && stack.amount > 0)
+				resources[material] += MINERAL_MATERIAL_AMOUNT
+				stack.use(1)
+				count++
+			sleep(10)
+			user << "You insert [count] [sname] sheet\s into \the [src]."
+			updateUsrDialog()
+			overlays -= "fab-load-[material]" //No matter what the overlay shall still be deleted
+		else
+			user << "\The [src] cannot hold any more [sname] sheet\s."
 		return
-	var/obj/item/stack/sheet/stack = W
-	var/sname = "[stack.name]"
-	if(src.resources[material] < res_max_amount)
-		var/count = 0
-		src.overlays += "fab-load-[material]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
-		while(src.resources[material] < res_max_amount && stack && stack.amount > 0)
-			src.resources[material] += MINERAL_MATERIAL_AMOUNT
-			stack.use(1)
-			count++
-		sleep(10)
-		user << "You insert [count] [sname] sheet\s into \the [src]."
-		src.updateUsrDialog()
-		src.overlays -= "fab-load-[material]" //No matter what the overlay shall still be deleted
-	else
-		user << "\The [src] cannot hold any more [sname] sheet\s."
-	return

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -294,15 +294,6 @@ datum/design/mech_proj_armor
 	build_path = /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
 	category = "Exosuit Equipment"
 
-datum/design/mech_syringe_gun
-	name = "Exosuit Module Design(Syringe Gun)"
-	desc = "Exosuit-mounted syringe gun and chemical synthesizer."
-	id = "mech_syringe_gun"
-	build_type = MECHFAB
-	req_tech = list("materials" = 3, "biotech"=4, "magnets"=4, "programming"=3)
-	build_path = /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
-	category = "Exosuit Equipment"
-
 datum/design/mech_diamond_drill
 	name = "Exosuit Module Design (Diamond Mining Drill)"
 	desc = "An upgraded version of the standard drill."

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -175,10 +175,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	usr.set_machine(src)
 	if(href_list["menu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
 		var/temp_screen = text2num(href_list["menu"])
-		if(temp_screen <= 1.1 || (3 <= temp_screen && 4.9 >= temp_screen) || src.allowed(usr) || emagged) //Unless you are making something, you need access.
-			screen = temp_screen
-		else
-			usr << "Unauthorized Access."
+		screen = temp_screen
 
 	else if(href_list["updt_tech"]) //Update the research holder with information from the technology disk.
 		screen = 0.0


### PR DESCRIPTION
Exosuits will now use the designs from RnD to create objects instead of having the object already created on their contents.
Each one of the default items to build are now designs.
Removed access required to use the exosuit fabricators.
Removed an unused mech syringe gun design and replaced with a new one, with no cost.
Added a temporal object, /obj/item/mechavars, to be able to use initalize() for the construction time. This will be later on removed and the construction time will be ported to the design datums.
Some minors issues are still present, due to the amount of files needed to fix these, it won't be part of this commit, but a future one.
Fixes #3893
Removed required access to access the setting controls of the RnD console.

edit (forgot to mention):
updates the research debug object, it will now cover all research branches
added a new file for all the default exosuit designs

known issues:
minerals show up with a '$' at the start (for example, '$metal')
overlay at applying minerals to the machine doesn't appear (related to $metal)
firefighter appears when adding all ripley to queue (not my issue but still)
still using the hacky machinery object for the construction_time var
    -/obj/item/mechavars
all objects still have the construction_cost var, must be deleted
emags useless on the exo fabs
