### PR TITLE
Hiding the jumpsuit with HIDEJUMPSUIT exosuits

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -247,6 +247,8 @@
 		if(s_store)
 			unEquip(s_store, 1) //It makes no sense for your suit storage to stay on you if you drop your suit.
 		wear_suit = null
+		if(I.flags_inv & HIDEJUMPSUIT)
+			update_inv_w_uniform()
 		update_inv_wear_suit(0)
 	else if(I == w_uniform)
 		if(r_store)
@@ -366,6 +368,8 @@
 			update_inv_shoes(redraw_mob)
 		if(slot_wear_suit)
 			wear_suit = I
+			if(I.flags_inv & HIDEJUMPSUIT)
+				update_inv_w_uniform()
 			update_inv_wear_suit(redraw_mob)
 		if(slot_w_uniform)
 			w_uniform = I

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -272,6 +272,9 @@ Please contact me on #coderbus IRC. ~Carnie x
 				w_uniform.screen_loc = ui_iclothing //...draw the item in the inventory screen
 			client.screen += w_uniform				//Either way, add the item to the HUD
 
+		if(wear_suit && (wear_suit.flags_inv & HIDEJUMPSUIT))
+			return
+
 		var/t_color = w_uniform.item_color
 		if(!t_color)		t_color = icon_state
 		var/image/standing	= image("icon"='icons/mob/uniform.dmi', "icon_state"="[t_color]_s", "layer"=-UNIFORM_LAYER)


### PR DESCRIPTION
Uniform overlays will now be blocked from showing if the exosuit has the flag HIDEJUMPSUIT, preventing the own and clown suit from sticking out of spacesuit and others.

Fixes issue #3881
