### PR TITLE
Reworked a bit the suicide verb

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -2,25 +2,12 @@
 
 /mob/living/carbon/human/verb/suicide()
 	set hidden = 1
-
-	if (stat == DEAD)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (!ticker)
-		src << "You can't commit suicide before the game starts!"
-		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
-		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
-			return
 		suiciding = 1
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
@@ -74,21 +61,11 @@
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1
-
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (!ticker)
-		src << "You can't commit suicide before the game starts!"
-		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
 		suiciding = 1
 		viewers(loc) << "<span class='userdanger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>"
@@ -98,25 +75,12 @@
 
 /mob/living/carbon/monkey/verb/suicide()
 	set hidden = 1
-
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (!ticker)
-		src << "You can't commit suicide before the game starts!"
-		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
-		if(!canmove || restrained())
-			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
-			return
 		suiciding = 1
 		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
 		viewers(src) << "<span class='userdanger'>[src] is attempting to bite \his tongue. It looks like \he's trying to commit suicide.</span>"
@@ -125,17 +89,11 @@
 
 /mob/living/silicon/ai/verb/suicide()
 	set hidden = 1
-
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
 		suiciding = 1
 		viewers(src) << "<span class='userdanger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>"
@@ -145,17 +103,11 @@
 
 /mob/living/silicon/robot/verb/suicide()
 	set hidden = 1
-
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
 		suiciding = 1
 		viewers(src) << "<span class='userdanger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>"
@@ -178,17 +130,11 @@
 
 /mob/living/carbon/alien/humanoid/verb/suicide()
 	set hidden = 1
-
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
 		suiciding = 1
 		viewers(src) << "<span class='userdanger'>[src] is thrashing wildly! It looks like \he's trying to commit suicide.</span>"
@@ -199,16 +145,11 @@
 
 /mob/living/carbon/slime/verb/suicide()
 	set hidden = 1
-	if (stat == 2)
-		src << "You're already dead!"
+	if(!canSuicide())
 		return
-
-	if (suiciding)
-		src << "You're already committing suicide! Be patient!"
-		return
-
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
-
+	if(!canSuicide())
+		return
 	if(confirm == "Yes")
 		suiciding = 1
 		setOxyLoss(100)
@@ -217,3 +158,20 @@
 		setCloneLoss(100)
 
 		updatehealth()
+
+/mob/living/proc/canSuicide()
+	if(stat == CONSCIOUS)
+		return 1
+	else if(stat == DEAD)
+		src << "You're already dead!"
+	else if(stat == UNCONSCIOUS)
+		src << "You need to be conscious to suicide"
+	return
+
+/mob/living/carbon/canSuicide()
+	if(!..())
+		return
+	if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
+		src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
+		return
+	return 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -164,9 +164,6 @@
 		if(100 to 200)
 			msg += "<span class='warning'>[t_He] [t_is] twitching ever so slightly.</span>\n"
 
-	if(suiciding)
-		msg += "<span class='warning'>[t_He] appears to have commited suicide... there is no hope of recovery.</span>\n"
-
 	if(gender_ambiguous) //someone fucked up a gender reassignment surgery
 		if (gender == MALE)
 			msg += "[t_He] has a strange feminine quality to [t_him].\n"
@@ -177,8 +174,9 @@
 	if(stat == DEAD || (status_flags & FAKEDEATH))
 		appears_dead = 1
 		if(getorgan(/obj/item/organ/brain))//Only perform these checks if there is no brain
+			if(suiciding)
+				msg += "<span class='warning'>[t_He] appears to have commited suicide... there is no hope of recovery.</span>\n"
 			msg += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life"
-
 			if(!key)
 				var/foundghost = 0
 				if(mind)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1047,14 +1047,9 @@
 	if((H.status_flags & GODMODE))
 		return
 
-	if(!breath || (breath.total_moles() == 0) || H.suiciding)
+	if(!breath || (breath.total_moles() == 0))
 		if(H.reagents.has_reagent("inaprovaline"))
 			return
-		if(H.suiciding)
-			H.adjustOxyLoss(2)//If you are suiciding, you should die a little bit faster
-			H.failed_last_breath = 1
-			H.oxygen_alert = max(H.oxygen_alert, 1)
-			return 0
 		if(H.health >= config.health_threshold_crit)
 			if(NOBREATH in specflags)	return 1
 			H.adjustOxyLoss(HUMAN_MAX_OXYLOSS)


### PR DESCRIPTION
Breathing won't check anymore if the person if committed suicide.
People will be able to perform several suicides if they survived previous ones.
The examine suicide text will only appear if the person is dead.
