### PR TITLE
Fixes firefighter ripley dropping goliath hides when destroyed

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -62,7 +62,7 @@
 	max_temperature = 65000
 	health = 250
 	lights_power = 7
-	damage_absorption = list("fire"=0.5,"bullet"=0.8,"bomb"=0.5)
+	damage_absorption = list("brute"=1,"fire"=0.5,"bullet"=0.8,"bomb"=0.5)
 	wreckage = /obj/structure/mecha_wreckage/ripley/firefighter
 
 /obj/mecha/working/ripley/deathripley


### PR DESCRIPTION
Note: This is a band-aid fix; the 'real' fix would be to make the generic working ripley a child of /obj/mecha/working/ripley and move all the goliath hide stuff there, so the firefighting version doesn't inherit it.
