### PR TITLE
Throwing bugfixes

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -220,7 +220,7 @@
 	icon_state = "act_throw_off"
 
 /obj/screen/throw_catch/Click()
-	if(iscarbon(usr) && !usr.stat && isturf(usr.loc) && !usr.restrained())
+	if(iscarbon(usr))
 		var/mob/living/carbon/C = usr
 		C.toggle_throw_mode()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -83,6 +83,11 @@
 	user.s_active = src
 
 
+/obj/item/weapon/storage/throw_at(atom/target, range, speed)
+	close_all()
+	return ..()
+
+
 /obj/item/weapon/storage/proc/hide_from(mob/user)
 	if(!user.client)
 		return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -255,6 +255,8 @@
 
 //Throwing stuff
 /mob/living/carbon/proc/toggle_throw_mode()
+	if(stat)
+		return
 	if(in_throw_mode)
 		throw_mode_off()
 	else
@@ -275,9 +277,9 @@
 
 /mob/living/carbon/throw_item(atom/target)
 	throw_mode_off()
-	if(usr.stat || !target)
+	if(!target || !isturf(loc))
 		return
-	if(target.type == /obj/screen) return
+	if(istype(target, /obj/screen)) return
 
 	var/atom/movable/item = src.get_active_hand()
 
@@ -295,7 +297,7 @@
 				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
 
-				add_logs(usr, M, "thrown", admin=0, addition="from [start_T_descriptor] with the target [end_T_descriptor]")
+				add_logs(src, M, "thrown", admin=0, addition="from [start_T_descriptor] with the target [end_T_descriptor]")
 
 	if(!item) return //Grab processing has a chance of returning null
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -61,16 +61,6 @@
 	return
 
 
-/client/verb/toggle_throw_mode()
-	set hidden = 1
-	if(!istype(mob, /mob/living/carbon))
-		return
-	if (!mob.stat && isturf(mob.loc) && !mob.restrained())
-		mob:toggle_throw_mode()
-	else
-		return
-
-
 /client/verb/drop_item()
 	set hidden = 1
 	if(!isrobot(mob))


### PR DESCRIPTION
Removed an unused client verb, changed a usr to src where they're the same mob, and changed a type == check to istype().

Allowed turning on throw mode when clicking the UI button (hotkeys already allow you to do this).
Disallowed throwing when not on a turf.
Fixes #4823

Made storage items close out the onscreen stuff when they get thrown.
Fixes #5296
