### PR TITLE
Fix: SecBelts can hold Tear Gas Grenades

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -111,6 +111,7 @@
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/melee/classic_baton,
 		/obj/item/weapon/grenade/flashbang,
+		/obj/item/weapon/grenade/chem_grenade/teargas,
 		/obj/item/weapon/reagent_containers/spray/pepper,
 		/obj/item/weapon/restraints/handcuffs,
 		/obj/item/device/flash/handheld,


### PR DESCRIPTION
Read title

For reference: https://github.com/tgstation/-tg-station/issues/5772
