### PR TITLE
Fixes some roundstart runtimes relating to set_species().

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -13,12 +13,16 @@
 		else			return "000"
 
 /proc/random_underwear(gender)
+	if(!underwear_list.len)
+		init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, underwear_list, underwear_m, underwear_f)
 	switch(gender)
 		if(MALE)	return pick(underwear_m)
 		if(FEMALE)	return pick(underwear_f)
 		else		return pick(underwear_list)
 
 /proc/random_undershirt(gender)
+	if(!undershirt_list.len)
+		init_sprite_accessory_subtypes(/datum/sprite_accessory/undershirt, undershirt_list, undershirt_m, undershirt_f)
 	switch(gender)
 		if(MALE)	return pick(undershirt_m)
 		if(FEMALE)	return pick(undershirt_f)

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -33,8 +33,12 @@
 			var/mob/living/carbon/human/H = character
 			if(!H.dna.species)
 				H.dna.species = new /datum/species/human()
+			if(!hair_styles_list.len)
+				init_sprite_accessory_subtypes(/datum/sprite_accessory/hair, hair_styles_list, hair_styles_male_list, hair_styles_female_list)
 			L[DNA_HAIR_STYLE_BLOCK] = construct_block(hair_styles_list.Find(H.hair_style), hair_styles_list.len)
 			L[DNA_HAIR_COLOR_BLOCK] = sanitize_hexcolor(H.hair_color)
+			if(!facial_hair_styles_list.len)
+				init_sprite_accessory_subtypes(/datum/sprite_accessory/facial_hair, facial_hair_styles_list, facial_hair_styles_male_list, facial_hair_styles_female_list)
 			L[DNA_FACIAL_HAIR_STYLE_BLOCK] = construct_block(facial_hair_styles_list.Find(H.facial_hair_style), facial_hair_styles_list.len)
 			L[DNA_FACIAL_HAIR_COLOR_BLOCK] = sanitize_hexcolor(H.facial_hair_color)
 			L[DNA_SKIN_TONE_BLOCK] = construct_block(skin_tones.Find(H.skin_tone), skin_tones.len)


### PR DESCRIPTION
Corpses on away missions and such were calling set_species() since that is called in human New(), but the hair/underwear lists weren't initialized at that time, so their len was null, so zero division happened.

Big thanks to @wild-billy for telling me about these runtimes and pointing me to his PR that fixes them for vg. (d3athrow/vgstation13#1487)
