### PR TITLE
Speeds up space movement a little bit

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -621,12 +621,12 @@
 		mspeed -= 1
 
 	if(!has_gravity(H))
-		mspeed += 2 //Carefully propelling yourself along the walls is actually quite slow
+		mspeed += 1.5 //Carefully propelling yourself along the walls is actually quite slow
 
 		if(istype(H.back, /obj/item/weapon/tank/jetpack))
 			var/obj/item/weapon/tank/jetpack/J = H.back
 			if(J.allow_thrust(0.01, H))
-				mspeed -= 3
+				mspeed -= 2.5
 
 		if(H.l_hand) //Having your hands full makes movement harder when you're weightless. You try climbing around while holding a gun!
 			mspeed += 0.5


### PR DESCRIPTION
Space slowdown is now 1.5 (same speed as a fat person in the station).
Jetpacks will speed you up by 2.5 (which, assuming you aren't slowed down by anything, gives you -1, which is the old space speed) and everything else is unchanged (including the slowdown for having stuff in your hands).
@MrPerson 
