### PR TITLE
Fixes nozzle deleting and adds some safety to nozzle toggling

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -41,7 +41,7 @@
 	
 	var/mob/living/carbon/human/user = usr
 	if(on)
-		if(noz == null)
+		if(noz == null || noz.gc_destroyed)
 			noz = make_noz()
 			
 		//Detach the nozzle into the user's hands

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -41,9 +41,12 @@
 	
 	var/mob/living/carbon/human/user = usr
 	if(on)
+		if(noz == null)
+			noz = make_noz()
+			
 		//Detach the nozzle into the user's hands
 		var/list/L = list("left hand" = slot_l_hand,"right hand" = slot_r_hand)
-		if(!user.equip_in_one_of_slots(noz, L))
+		if(!user.equip_in_one_of_slots(noz, L, 0))
 			on = 0
 			user << "<span class='notice'>You need a free hand to hold the mister!</span>"
 			return

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -41,7 +41,7 @@
 	
 	var/mob/living/carbon/human/user = usr
 	if(on)
-		if(noz == null || noz.gc_destroyed)
+		if(noz == null)
 			noz = make_noz()
 			
 		//Detach the nozzle into the user's hands
@@ -73,6 +73,8 @@
 	if (on)
 		var/M = get(noz, /mob)
 		remove_noz(M)
+		qdel(noz)
+		noz = null
 	..()
 	return
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -45,8 +45,7 @@
 			noz = make_noz()
 			
 		//Detach the nozzle into the user's hands
-		var/list/L = list("left hand" = slot_l_hand,"right hand" = slot_r_hand)
-		if(!user.equip_in_one_of_slots(noz, L, 0))
+		if(!user.put_in_hands(noz))
 			on = 0
 			user << "<span class='notice'>You need a free hand to hold the mister!</span>"
 			return


### PR DESCRIPTION
Fixes #4175 

~~The "noz == null" check takes some time to work if the nozzle has been qdel'd. If there is some method to call that handles checking if an object has been qdel'd I'll add that into the conditional.~~

For clarification, I tested by right clicking the object and Deleting it with admin verb.
