### PR TITLE
Lasers can now go through transit tubes

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -19,6 +19,10 @@
 	//  this continues to work.
 	var/global/list/tube_dir_list = list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
 
+/obj/structure/transit_tube/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return 1
+	return !density
 
 // When destroyed by explosions, properly handle contents.
 obj/structure/transit_tube/ex_act(severity)


### PR DESCRIPTION
Fixes #5827
They'll still block ballistic projectiles, and I think that's reasonable, as they are reinforced tubes for vacuum transportation and thus can stand a few shots.
As for blocking movement, I'm ambivalent on this. I feel like it wouldn't make sense if tubes were climbable (I mean, they can fit a lot of people inside), but using them as barricades is pretty shit too. Opinions?
