### PR TITLE
Fixes the modified detective revolver blowing up with empty chamber

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -88,12 +88,12 @@
 
 	add_fingerprint(user)
 
-	if(!special_check(user))
-		return
 	if(chambered)
 		if(!chambered.fire(target, user, params, , suppressed))
 			shoot_with_empty_chamber(user)
 		else
+			if(!special_check(user))
+				return
 			if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
 				shoot_live_shot(user, 1, target)
 			else

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -61,6 +61,7 @@
 	if(magazine.caliber == initial(magazine.caliber))
 		return 1
 	if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
+		playsound(M, fire_sound, 50, 1)
 		M << "<span class='danger'>[src] blows up in your face!</span>"
 		M.take_organ_damage(0,20)
 		M.drop_item()


### PR DESCRIPTION
Fixes the modified detective revolver blowing up with an empty chamber, revolver malfunction can only happen with live rounds. Adding a firing sound when the malfunction happens. Fixes #5872 .
