### PR TITLE
Cargo shuttle href exploit fixed + orderable syndi crates

### DIFF
--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -479,10 +479,11 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 		//Find the correct supply_pack datum
 		var/datum/supply_packs/P = supply_shuttle.supply_packs[href_list["doorder"]]
-		if(!istype(P))	return
+		if(!istype(P) || P.hidden  || P.contraband) //href protection
+			return
 
 		var/timeout = world.time + 600
-		var/reason = copytext(sanitize(input(usr,"Reason:","Why do you require this item?","") as null|text),1,MAX_MESSAGE_LEN)
+		var/reason = stripped_input(usr,"Reason:","Why do you require this item?","")
 		if(world.time > timeout)	return
 		if(!reason)	return
 
@@ -550,7 +551,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 /obj/machinery/computer/supplycomp/attack_hand(var/mob/user as mob)
 	if(!allowed(user))
-		user << "<span class='warning'> Access Denied.</span>"
+		user << "<span class='warning'>Access Denied.</span>"
 		return
 
 	if(..())
@@ -579,7 +580,7 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 /obj/machinery/computer/supplycomp/attackby(I as obj, user as mob)
 	if(istype(I,/obj/item/weapon/card/emag) && !hacked)
-		user << "<span class='notice'> Special supplies unlocked.</span>"
+		user << "<span class='notice'>Special supplies unlocked.</span>"
 		hacked = 1
 		return
 	else
@@ -654,8 +655,9 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 			temp += "<b>Request from: [get_supply_group_name(cat)]</b><BR><BR>"
 			for(var/supply_name in supply_shuttle.supply_packs )
 				var/datum/supply_packs/N = supply_shuttle.supply_packs[supply_name]
-				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != cat) continue		//Have to send the type instead of a reference to
-				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"		//the obj because it would get caught by the garbage
+				if((N.hidden && !hacked) || (N.contraband && !can_order_contraband) || N.group != cat)	//Have to send the type instead of a reference to
+					continue																			//the obj because it would get caught by the garbage
+				temp += "<A href='?src=\ref[src];doorder=[supply_name]'>[supply_name]</A> Cost: [N.cost]<BR>"
 
 		/*temp = "Supply points: [supply_shuttle.points]<BR><HR><BR>Request what?<BR><BR>"
 
@@ -673,10 +675,11 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 		//Find the correct supply_pack datum
 		var/datum/supply_packs/P = supply_shuttle.supply_packs[href_list["doorder"]]
-		if(!istype(P))	return
+		if(!istype(P) || (P.hidden && !hacked) || (P.contraband && !can_order_contraband)) //href exploit protection
+			return
 
 		var/timeout = world.time + 600
-		var/reason = copytext(sanitize(input(usr,"Reason:","Why do you require this item?","") as null|text),1,MAX_MESSAGE_LEN)
+		var/reason = stripped_input(usr,"Reason:","Why do you require this item?","")
 		if(world.time > timeout)	return
 //		if(!reason)	return
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -154,7 +154,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	hidden = 1
 
 /datum/supply_packs/emergency/syndicate
-	name = "#ERROR_NULL_ENTRY"
+	name = "ERROR_NULL_ENTRY"
 	contains = list(/obj/item/weapon/storage/box/syndicate)
 	cost = 140
 	containertype = /obj/structure/closet/crate


### PR DESCRIPTION
**Contents :**
- Fixed supply comp/order comp href exploit (being able to order any supply pack, even if not hacked/contraband enabled) (fixes #5864).
  Order computer (e.g the one from the bridge) still can't order hacked/contraband.
- HTML tags are now properly stripped from inputted text.
- Syndicates crates are now orderable (fixes  #5284).
  Removed the # in the name, if we ever decides to keep it, i'll replace that with a sanitize call.
- Some minor text alignement fixed
