### PR TITLE
Fixes chem grenade phasing through windows/windoors

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -186,10 +186,16 @@
 		steam.attach(src)
 		steam.start()
 
-	for(var/atom/A in view(affected_area, loc))
-		if(A == src)
-			continue
-		reagents.reaction(A, 1, 10)
+	var/list/accessible = can_flood_from(loc, affected_area)
+	var/list/reactable = accessible
+	var/mycontents = GetAllContents()
+	for(var/turf/T in accessible)
+		for(var/atom/A in T.GetAllContents())
+			if(A in mycontents) continue
+			reactable |= A
+	var/fraction = (reagents.total_volume/reactable.len) - reagents.total_volume
+	for(var/atom/A in reactable)
+		reagents.reaction(A, TOUCH, fraction)
 
 	invisibility = INVISIBILITY_MAXIMUM		//Why am i doing this?
 	spawn(50)		   //To make sure all reagents can work
@@ -198,6 +204,19 @@
 /obj/item/weapon/grenade/chem_grenade/proc/mix_reagents()
 	for(var/obj/item/weapon/reagent_containers/glass/G in beakers)
 		G.reagents.trans_to(src, G.reagents.total_volume)
+
+/obj/item/weapon/grenade/chem_grenade/proc/can_flood_from(myloc, maxrange)
+	var/list/reachable = list(myloc)
+	for(var/i=1; i<=maxrange; i++)
+		for(var/turf/T in (orange(i, myloc) - orange(i-1, myloc)))
+			if(T in reachable) continue
+			for(var/turf/NT in orange(1, T))
+				if(!(NT in reachable)) continue
+				if(!(get_dir(T,NT) in cardinal)) continue
+				if(!NT.CanAtmosPass(T)) continue
+				reachable |= T
+				break
+	return reachable
 
 //Large chem grenades accept slime cores and use the appropriately.
 /obj/item/weapon/grenade/chem_grenade/large


### PR DESCRIPTION
NO, OLD CODER. VIEW() IS NOT A SAFE PROC TO CHECK FOR DENSITY. YOU RETARD.

Also nerfs chem grenades greatly. Instead of injecting their maximum volume plus 10 in each atom in range (!), they'll divide their total volume equally among all those atoms.

Fixes #3303
