### PR TITLE
Lets borgs interact with air alarm wire panels

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -188,7 +188,7 @@
 		popup.open()
 		refresh_all()
 
-	if(panel_open && (!istype(user, /mob/living/silicon)))
+	if(panel_open && (!istype(user, /mob/living/silicon/ai)))
 		wires.Interact(user)
 
 	return


### PR DESCRIPTION
This check looks intentional, but it has been here ever since hackable air alarms were first added (see https://code.google.com/p/tgstation13/source/detail?r=2854) and I have no idea why, so what could possibly go wrong?
Fixes #5339
