### PR TITLE
Removes the alt-click panel from the AI

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -151,7 +151,6 @@
 
 
 /atom/proc/AIAltClick(var/mob/living/silicon/ai/user)
-	AltClick(user)
 	return
 
 /obj/machinery/door/airlock/AIAltClick() // Eletrifies doors.
@@ -170,9 +169,3 @@
 		toggle_lethal()
 	add_fingerprint(usr)
 
-//
-// Override TurfAdjacent for AltClicking
-//
-
-/mob/living/silicon/ai/TurfAdjacent(var/turf/T)
-	return (cameranet && cameranet.checkTurfVis(T))


### PR DESCRIPTION
This panel is often exploitable, and for the AI it's seldom useful, since they can't pick up items.
Fixes #1951 (which is what prompted this PR in the first place).
