### PR TITLE
All assembly items start secured/ready 

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -51,6 +51,15 @@
 /obj/item/device/assembly/proc/describe()									// Called by grenades to describe the state of the trigger (time left, etc)
 	return "The trigger assembly looks broken!"
 
+
+/obj/item/device/assembly/proc/is_secured(mob/user)
+	if(!secured)
+		user << "<span class='warning'>The [name] is unsecured!</span>"
+		return 0
+	return 1
+
+
+
 /obj/item/device/assembly/process_cooldown()
 	cooldown--
 	if(cooldown <= 0)	return 0

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -6,8 +6,6 @@
 	g_amt = 500
 	origin_tech = "magnets=2"
 
-	secured = 0
-
 	var/on = 0
 	var/visible = 0
 	var/obj/effect/beam/i_beam/first = null
@@ -90,21 +88,22 @@
 	if((!secured)||(!on)||(cooldown > 0))
 		return 0
 	pulse(0)
-	visible_message("\icon[src] *beep* *beep*")
+	if(src.loc)
+		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
 	return
 
 /obj/item/device/assembly/infra/interact(mob/user as mob)//TODO: change this this to the wire control panel
-	if(!secured)	return
-	user.set_machine(src)
-	var/dat = text("<TT><B>Infrared Laser</B>\n<B>Status</B>: []<BR>\n<B>Visibility</B>: []<BR>\n</TT>", (on ? text("<A href='?src=\ref[];state=0'>On</A>", src) : text("<A href='?src=\ref[];state=1'>Off</A>", src)), (src.visible ? text("<A href='?src=\ref[];visible=0'>Visible</A>", src) : text("<A href='?src=\ref[];visible=1'>Invisible</A>", src)))
-	dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
-	dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
-	user << browse(dat, "window=infra")
-	onclose(user, "infra")
-	return
+	if(is_secured(user))
+		user.set_machine(src)
+		var/dat = text("<TT><B>Infrared Laser</B>\n<B>Status</B>: []<BR>\n<B>Visibility</B>: []<BR>\n</TT>", (on ? text("<A href='?src=\ref[];state=0'>On</A>", src) : text("<A href='?src=\ref[];state=1'>Off</A>", src)), (src.visible ? text("<A href='?src=\ref[];visible=0'>Visible</A>", src) : text("<A href='?src=\ref[];visible=1'>Invisible</A>", src)))
+		dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
+		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
+		user << browse(dat, "window=infra")
+		onclose(user, "infra")
+		return
 
 /obj/item/device/assembly/infra/Topic(href, href_list)
 	..()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -6,8 +6,6 @@
 	g_amt = 200
 	origin_tech = "magnets=1"
 
-	secured = 0
-
 	var/scanning = 0
 	var/timing = 0
 	var/time = 10
@@ -50,7 +48,8 @@
 /obj/item/device/assembly/prox_sensor/sense()
 	if((!secured)||(!scanning)||(cooldown > 0))	return 0
 	pulse(0)
-	visible_message("\icon[src] *beep* *beep*", "*beep* *beep*")
+	if(src.loc)
+		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
@@ -102,18 +101,16 @@
 
 
 /obj/item/device/assembly/prox_sensor/interact(mob/user as mob)//TODO: Change this to the wires thingy
-	if(!secured)
-		user.show_message("<span class='danger'>The [name] is unsecured!</span>")
-		return 0
-	var/second = time % 60
-	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Arming</A>", src) : text("<A href='?src=\ref[];time=1'>Not Arming</A>", src)), minute, second, src, src, src, src)
-	dat += "<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
-	dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
-	dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
-	user << browse(dat, "window=prox")
-	onclose(user, "prox")
-	return
+	if(is_secured(user))
+		var/second = time % 60
+		var/minute = (time - second) / 60
+		var/dat = "<TT><B>Proximity Sensor</B>\n[(timing ? "<A href='?src=\ref[src];time=0'>Arming</A>" : "<A href='?src=\ref[src];time=1'>Not Arming</A>")] [minute]:[second]\n<A href='?src=\ref[src];tp=-30'>-</A> <A href='?src=\ref[src];tp=-1'>-</A> <A href='?src=\ref[src];tp=1'>+</A> <A href='?src=\ref[src];tp=30'>+</A>\n</TT>"
+		dat += "<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
+		dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
+		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
+		user << browse(dat, "window=prox")
+		onclose(user, "prox")
+		return
 
 
 /obj/item/device/assembly/prox_sensor/Topic(href, href_list)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -8,8 +8,6 @@
 	origin_tech = "magnets=1"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 
-	secured = 1
-
 	var/code = 30
 	var/frequency = 1457
 	var/delay = 0
@@ -42,12 +40,13 @@
 	return
 
 /obj/item/device/assembly/signaler/interact(mob/user as mob, flag1)
-	var/t1 = "-------"
-//	if ((src.b_stat && !( flag1 )))
-//		t1 = text("-------<BR>\nGreen Wire: []<BR>\nRed Wire:   []<BR>\nBlue Wire:  []<BR>\n", (src.wires & 4 ? text("<A href='?src=\ref[];wires=4'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=4'>Mend Wire</A>", src)), (src.wires & 2 ? text("<A href='?src=\ref[];wires=2'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=2'>Mend Wire</A>", src)), (src.wires & 1 ? text("<A href='?src=\ref[];wires=1'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=1'>Mend Wire</A>", src)))
-//	else
-//		t1 = "-------"	Speaker: [src.listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>
-	var/dat = {"
+	if(is_secured(user))
+		var/t1 = "-------"
+	//	if ((src.b_stat && !( flag1 )))
+	//		t1 = text("-------<BR>\nGreen Wire: []<BR>\nRed Wire:   []<BR>\nBlue Wire:  []<BR>\n", (src.wires & 4 ? text("<A href='?src=\ref[];wires=4'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=4'>Mend Wire</A>", src)), (src.wires & 2 ? text("<A href='?src=\ref[];wires=2'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=2'>Mend Wire</A>", src)), (src.wires & 1 ? text("<A href='?src=\ref[];wires=1'>Cut Wire</A>", src) : text("<A href='?src=\ref[];wires=1'>Mend Wire</A>", src)))
+	//	else
+	//		t1 = "-------"	Speaker: [src.listening ? "<A href='byond://?src=\ref[src];listen=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];listen=1'>Disengaged</A>"]<BR>
+		var/dat = {"
 <TT>
 
 <A href='byond://?src=\ref[src];send=1'>Send Signal</A><BR>
@@ -67,9 +66,9 @@ Code:
 <A href='byond://?src=\ref[src];code=5'>+</A><BR>
 [t1]
 </TT>"}
-	user << browse(dat, "window=radio")
-	onclose(user, "radio")
-	return
+		user << browse(dat, "window=radio")
+		onclose(user, "radio")
+		return
 
 
 /obj/item/device/assembly/signaler/Topic(href, href_list)

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -6,8 +6,6 @@
 	g_amt = 50
 	origin_tech = "magnets=1"
 
-	secured = 0
-
 	var/timing = 0
 	var/time = 5
 
@@ -37,9 +35,11 @@
 
 
 /obj/item/device/assembly/timer/proc/timer_end()
-	if((!secured)||(cooldown > 0))	return 0
+	if((!secured)||(cooldown > 0))
+		return 0
 	pulse(0)
-	visible_message("\icon[src] *beep* *beep*", "*beep* *beep*")
+	if(src.loc)
+		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
@@ -68,18 +68,16 @@
 
 
 /obj/item/device/assembly/timer/interact(mob/user as mob)//TODO: Have this use the wires
-	if(!secured)
-		user.show_message("<span class='danger'>The [name] is unsecured!</span>")
-		return 0
-	var/second = time % 60
-	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='?src=\ref[];tp=-30'>-</A> <A href='?src=\ref[];tp=-1'>-</A> <A href='?src=\ref[];tp=1'>+</A> <A href='?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='?src=\ref[];time=0'>Timing</A>", src) : text("<A href='?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
-	dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
-	dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
-	var/datum/browser/popup = new(user, "timer", name)
-	popup.set_content(dat)
-	popup.open()
-	return
+	if(is_secured(user))
+		var/second = time % 60
+		var/minute = (time - second) / 60
+		var/dat = "<TT><B>Timing Unit</B>\n[(timing ? "<A href='?src=\ref[src];time=0'>Timing</A>" : "<A href='?src=\ref[src];time=1'>Not Timing</A>")] [minute]:[second]\n<A href='?src=\ref[src];tp=-30'>-</A> <A href='?src=\ref[src];tp=-1'>-</A> <A href='?src=\ref[src];tp=1'>+</A> <A href='?src=\ref[src];tp=30'>+</A>\n</TT>"
+		dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
+		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
+		var/datum/browser/popup = new(user, "timer", name)
+		popup.set_content(dat)
+		popup.open()
+		return
 
 
 /obj/item/device/assembly/timer/Topic(href, href_list)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -31,7 +31,8 @@
 	return "beeps, \"[text]\""
 
 /obj/item/device/assembly/voice/attack_self(mob/user)
-	if(!user)	return 0
+	if(!user)
+		return 0
 	activate()
 	return 1
 


### PR DESCRIPTION
- All assembly items start secured (ready). Fixes #5928
- Fixes not being able to hear the beeping of infrared beam, timer and proximity sensor in the dark or in your hand, and changing the beep range to 3 for all assembly items except signaler.
- Fixes certain assembly items being usable while unsecured and not getting the unsecured warning message. Fixes #6008 
- Fixing some absolute path.
