### PR TITLE
Pipenet hotfix!

### DIFF
--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -110,9 +110,9 @@ var/pipenetwarnings = 10
 				continue
 			var/datum/pipeline/E = I.parent
 			merge(E)
-			if(!members.Find(P))
-				members += P
-				air.volume += P.volume
+		if(!members.Find(P))
+			members += P
+			air.volume += P.volume
 	else
 		A.setPipenet(src, N)
 		addMachineryMember(A)


### PR DESCRIPTION
Fixes addMember() not adding the pipe brought in the argument if it had no other connections.
Big thanks to menshin for giving me steps to reproduce
