### PR TITLE
Fixing the megacarp sprite

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -73,6 +73,8 @@ F
 	icon_gib = "megacarp_gib"
 	maxHealth = 65
 	health = 65
+	pixel_x = -16
+	mob_size = 2
 
 	melee_damage_lower = 20
 	melee_damage_upper = 20


### PR DESCRIPTION
 Fixing the megacarp sprite by adding a pixel_x offset like the alien empress. Also giving it a mob_size of 2 (doesn't fit in regular closets).
Fixes #5183
