### PR TITLE
Fix for omnious reagent transfer error in #1673

### DIFF
--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -74,14 +74,13 @@
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			user << "<span class='warning'>[target] is full.</span>"
 			return
-
+		var/refill = reagents.get_master_reagent_id()
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 		user << "<span class='notice'> You transfer [trans] units of the solution to [target].</span>"
 
 		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/mob/living/silicon/robot/bro = user
 			bro.cell.use(30)
-			var/refill = reagents.get_master_reagent_id()
 			spawn(600)
 				reagents.add_reagent(refill, trans)
 


### PR DESCRIPTION
If your glass is empty get_master_reagent_id() will return null and proc will try to add 5 units of null to glass
Took me half a hour of guessing and then one minute of testing after changing WARNING to CRASH
Lesson for future generations - 1 message with chain of calls is better than 1000 of the most elaborate of warnings, use crash for your own good kids
Fixes  #1673
