### PR TITLE
Couple more changes to reagent sprayers.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -92,6 +92,10 @@
 
 	emag.reagents.add_reagent("pacid", 250)
 	emag.name = "polyacid spray"
+
+	var/obj/item/weapon/reagent_containers/spray/S = emag
+	S.banned_reagents = list()
+
 	fix_modules()
 
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -153,6 +153,7 @@
 	amount_per_transfer_from_this = 10
 	volume = 600
 	origin_tech = "combat=3;materials=3;engineering=3"
+	banned_reagents = list()//the safeties are off, spray and pay!
 
 
 /obj/item/weapon/reagent_containers/spray/chemsprayer/spray(var/atom/A)


### PR DESCRIPTION
As Incomptinence reminded me on the forums, Emagged med borgs have a spray bottle full of pacid.
While they would be able to fire the acid fine, they would not be able to refil the bottle (if they even can? idk)

Also lets the chemsprayer fire acids again.
