### PR TITLE
Stop items having a negative throw force against grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -245,7 +245,7 @@
 		tforce = 5
 	else if(isobj(AM))
 		var/obj/item/I = AM
-		tforce = I.throwforce - 5
+		tforce = max(0, I.throwforce - 5)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	health = max(0, health - tforce)
 	healthcheck()


### PR DESCRIPTION
This prevents the grille from gaining health if you hit it with something less than 5 tforce

Fixes #6090
