### PR TITLE
Acid protection update

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -393,11 +393,12 @@
 			break
 	if(.)
 		var/turf/T = get_turf(src)
-		T.visible_message("<span class='danger'>[src] melts away!</span>")
-		var/obj/effect/decal/cleanable/molten_item/I = new (get_turf(src))
-		I.pixel_x = rand(1,16)
-		I.pixel_y = rand(1,16)
-		I.desc = "Looks like this was \an [src] some time ago."
+		if(T)
+			T.visible_message("<span class='danger'>[src] melts away!</span>")
+			var/obj/effect/decal/cleanable/molten_item/I = new (T)
+			I.pixel_x = rand(-16,16)
+			I.pixel_y = rand(-16,16)
+			I.desc = "Looks like this was \an [src] some time ago."
 		qdel(src)
 	else
 		for(var/armour_value in armor) //but is weakened

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -232,6 +232,7 @@ emp_act
 
 /mob/living/carbon/human/acid_act(var/acidpwr, var/toxpwr, var/acid_volume)
 	var/list/damaged = list()
+	var/list/inventory_items_to_kill = list()
 
 	//HEAD//
 	var/obj/item/clothing/head_clothes = null
@@ -253,7 +254,8 @@ emp_act
 		. = get_organ("head")
 		if(.)
 			damaged += .
-
+		if(ears)
+			inventory_items_to_kill += ears
 
 	//CHEST//
 	var/obj/item/clothing/chest_clothes = null
@@ -272,6 +274,14 @@ emp_act
 		. = get_organ("chest")
 		if(.)
 			damaged += .
+		if(wear_id)
+			inventory_items_to_kill += wear_id
+		if(r_store)
+			inventory_items_to_kill += r_store
+		if(l_store)
+			inventory_items_to_kill += l_store
+		if(s_store)
+			inventory_items_to_kill += s_store
 
 
 	//ARMS & HANDS//
@@ -338,6 +348,20 @@ emp_act
 				status_flags |= DISFIGURED
 
 		update_damage_overlays()
+
+	//MELTING INVENTORY ITEMS//
+	//these items are all outside of armour visually, so melt regardless.
+	if(back)
+		inventory_items_to_kill += back
+	if(belt)
+		inventory_items_to_kill += belt
+	if(r_hand)
+		inventory_items_to_kill += r_hand
+	if(l_hand)
+		inventory_items_to_kill += l_hand
+
+	for(var/obj/item/I in inventory_items_to_kill)
+		I.acid_act(acidpwr)
 
 /mob/living/carbon/human/grabbedby(mob/living/user)
 	if(w_uniform)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -233,55 +233,63 @@ emp_act
 /mob/living/carbon/human/acid_act(var/acidpwr, var/toxpwr, var/acid_volume)
 	var/list/damaged = list()
 
+	//HEAD//
+	var/obj/item/clothing/head_clothes = null
+	if(glasses)
+		head_clothes = glasses
+	if(wear_mask)
+		head_clothes = wear_mask
 	if(head)
-		if(!head.unacidable)
-			head.acid_act(acidpwr)
+		head_clothes = head
+	if(head_clothes)
+		if(!head_clothes.unacidable)
+			head_clothes.acid_act(acidpwr)
+			update_inv_glasses()
+			update_inv_wear_mask()
 			update_inv_head()
 		else
-			src << "<span class='warning'>Your [head.name] protects your head from the acid!</span>"
+			src << "<span class='warning'>Your [head_clothes.name] protects your head and face from the acid!</span>"
 	else
-		if(wear_mask)
-			if(!wear_mask.unacidable)
-				wear_mask.acid_act(acidpwr)
-				update_inv_wear_mask()
-			else
-				src << "<span class='warning'>Your [wear_mask.name] protects your head from the acid!</span>"
-		else
-			if(glasses)
-				if(!glasses.unacidable)
-					glasses.acid_act(acidpwr)
-					update_inv_glasses()
-				else
-					src << "<span class='warning'>Your [glasses.name] protects your head from the acid!</span>"
-			else
-				. = get_organ("head")
-				if(.)
-					damaged += .
+		. = get_organ("head")
+		if(.)
+			damaged += .
 
+
+	//CHEST//
+	var/obj/item/clothing/chest_clothes = null
+	if(w_uniform)
+		chest_clothes = w_uniform
 	if(wear_suit)
-		if(!wear_suit.unacidable)
-			wear_suit.acid_act(acidpwr)
+		chest_clothes = wear_suit
+	if(chest_clothes)
+		if(!chest_clothes.unacidable)
+			chest_clothes.acid_act(acidpwr)
+			update_inv_w_uniform()
 			update_inv_wear_suit()
 		else
-			src << "<span class='warning'>Your [wear_suit.name] protects your body from the acid!</span>"
+			src << "<span class='warning'>Your [chest_clothes.name] protects your body from the acid!</span>"
 	else
-		if(w_uniform)
-			if(!w_uniform.unacidable)
-				w_uniform.acid_act(acidpwr)
-				update_inv_w_uniform()
-			else
-				src << "<span class='warning'>Your [w_uniform.name] protects your body from the acid!</span>"
-		else
-			. = get_organ("chest")
-			if(.)
-				damaged += .
+		. = get_organ("chest")
+		if(.)
+			damaged += .
 
+
+	//ARMS & HANDS//
+	var/obj/item/clothing/arm_clothes = null
 	if(gloves)
-		if(!gloves.unacidable)
-			gloves.acid_act(acidpwr)
+		arm_clothes = gloves
+	if(w_uniform && (w_uniform.body_parts_covered & HANDS) || w_uniform && (w_uniform.body_parts_covered & ARMS))
+		arm_clothes = w_uniform
+	if(wear_suit && (wear_suit.body_parts_covered & HANDS) || wear_suit && (wear_suit.body_parts_covered & ARMS))
+		arm_clothes = wear_suit
+	if(arm_clothes)
+		if(!arm_clothes.unacidable)
+			arm_clothes.acid_act(acidpwr)
 			update_inv_gloves()
+			update_inv_w_uniform()
+			update_inv_wear_suit()
 		else
-			src << "<span class='warning'>Your [gloves.name] protects your arms from the acid!</span>"
+			src << "<span class='warning'>Your [arm_clothes.name] protects your arms and hands from the acid!</span>"
 	else
 		. = get_organ("r_arm")
 		if(.)
@@ -291,12 +299,22 @@ emp_act
 			damaged += .
 
 
+	//LEGS & FEET//
+	var/obj/item/clothing/leg_clothes = null
 	if(shoes)
-		if(!shoes.unacidable)
-			shoes.acid_act(acidpwr)
+		leg_clothes = shoes
+	if(w_uniform && (w_uniform.body_parts_covered & FEET) || w_uniform && (w_uniform.body_parts_covered & LEGS))
+		leg_clothes = w_uniform
+	if(wear_suit && (wear_suit.body_parts_covered & FEET) || wear_suit && (wear_suit.body_parts_covered & LEGS))
+		leg_clothes = wear_suit
+	if(leg_clothes)
+		if(!leg_clothes.unacidable)
+			leg_clothes.acid_act(acidpwr)
 			update_inv_shoes()
+			update_inv_w_uniform()
+			update_inv_wear_suit()
 		else
-			src << "<span class='warning'>Your [shoes.name] protects your legs from the acid!</span>"
+			src << "<span class='warning'>Your [leg_clothes.name] protects your legs and feet from the acid!</span>"
 	else
 		. = get_organ("r_leg")
 		if(.)
@@ -306,6 +324,7 @@ emp_act
 			damaged += .
 
 
+	//DAMAGE//
 	for(var/obj/item/organ/limb/affecting in damaged)
 		affecting.take_damage(2*toxpwr, toxpwr)
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1656,6 +1656,8 @@ datum/reagent/toxin/acid/reaction_mob(var/mob/living/carbon/C, var/method=TOUCH,
 	C.acid_act(acidpwr, toxpwr, volume)
 
 datum/reagent/toxin/acid/reaction_obj(var/obj/O, var/volume)
+	if(istype(O.loc, /mob)) //handled in human acid_act()
+		return
 	O.acid_act(acidpwr, toxpwr, volume)
 
 datum/reagent/toxin/acid/polyacid


### PR DESCRIPTION
- Adds support for body_parts_covered flags protecting body parts from acid, This means if your only source of protection is your suit (for example) then it will degrade much quicker due to having to protect more than just the chest slot now. this is both a positive and a negative, the positive being that if it looks like it protects your arms, it does.
- Rewrites the code blocks to be neater.
- Item acid_act() grey good pixel_x and _y changed
- Inventory items worn internally (inside armour) only melt when the armour covering them is melted, exclusions are Back items, Belt items, and items held in the hands, since those are visibly external
- Makes item acid_act() check that the Turf exists first.

if you can't understand it from Git's diff:
It's the same hierarchical structure as before, armour closer to the body is checked after armour further away, eg: Suit --> uniform --> painful acidy death. but with body_parts_covered flags counting.
