### PR TITLE
Fixes pacid chem grenade runtime

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -186,12 +186,14 @@
 		steam.attach(src)
 		steam.start()
 
+	var/list/viewable = view(affected_area, loc)
 	var/list/accessible = can_flood_from(loc, affected_area)
 	var/list/reactable = accessible
 	var/mycontents = GetAllContents()
 	for(var/turf/T in accessible)
 		for(var/atom/A in T.GetAllContents())
 			if(A in mycontents) continue
+			if(!(A in viewable)) continue
 			reactable |= A
 	var/fraction = (reagents.total_volume/reactable.len) - reagents.total_volume
 	for(var/atom/A in reactable)


### PR DESCRIPTION
Making chem grenades affect the contents of stuff meant acid grenades made the contents of deleted containers send a visible_message from nullspace, thus runtiming.
