### PR TITLE
Moves BoH singulo spawn logic so you can't bypass it with quick-equip

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -35,21 +35,19 @@
 	max_w_class = 5
 	max_combined_w_class = 35
 
-/obj/item/weapon/storage/backpack/holding/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(crit_fail)
-		user << "<span class='danger'>The Bluespace generator isn't working.</span>"
-		return
-	if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
-		investigate_log("has become a singularity. Caused by [user.key]","singulo")
-		user << "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>"
+/obj/item/weapon/storage/backpack/holding/can_be_inserted(obj/item/weapon/W, stop_messages = 0)
+	. = ..()
+	if(. && istype(W, /obj/item/weapon/storage/backpack/holding))
+		investigate_log("has become a singularity. Caused by [usr.key]","singulo")
+		usr << "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>"
+		// This message is important, so we'll disregard the stop_messages arg
 		qdel(W)
 		var/obj/machinery/singularity/singulo = new /obj/machinery/singularity (get_turf(src))
 		singulo.energy = 300 //should make it a bit bigger~
-		message_admins("[key_name_admin(user)] detonated a bag of holding")
-		log_game("[key_name(user)] detonated a bag of holding")
+		message_admins("[key_name_admin(usr)] detonated a bag of holding")
+		log_game("[key_name(usr)] detonated a bag of holding")
 		qdel(src)
-		return
-	..()
+		return 0
 
 /obj/item/weapon/storage/backpack/holding/proc/failcheck(mob/user as mob)
 	if (prob(src.reliability)) return 1 //No failure


### PR DESCRIPTION
Fixes #6076

PS after the freeze, someone please add singulo.Bump(usr) so the asshole who makes these is guaranteed eaten.
