### PR TITLE
Mulebot lag fix

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -24,7 +24,6 @@ var/global/mulebot_count = 0
 	control_freq = 1447
 	bot_type = MULE_BOT
 	bot_filter = RADIO_MULEBOT
-	var/debug_count = 0
 
 	suffix = ""
 
@@ -78,6 +77,9 @@ var/global/mulebot_count = 0
 			suffix = "#[mulebot_count]"
 		name = "\improper Mulebot ([suffix])"
 
+obj/machinery/bot/mulebot/bot_reset()
+	..()
+	reached_target = 0
 
 
 // attack by item
@@ -516,7 +518,7 @@ var/global/mulebot_count = 0
 			process_bot()
 			num_steps--
 			for(var/i=num_steps,i>0,i--)
-				sleep(4)
+				sleep(2)
 				process_bot()
 
 	if(refresh) updateDialog()
@@ -530,8 +532,8 @@ var/global/mulebot_count = 0
 			return
 		if(BOT_LOADING)		// loading/unloading
 			return
-		if(BOT_DELIVER,BOT_GO_HOME,BOT_BLOCKED)		// navigating to deliver,home, or blocked
 
+		if(BOT_DELIVER,BOT_GO_HOME,BOT_BLOCKED)		// navigating to deliver,home, or blocked
 			if(loc == target)		// reached target
 				at_target()
 				return
@@ -649,7 +651,6 @@ var/global/mulebot_count = 0
 // given an optional turf to avoid
 /obj/machinery/bot/mulebot/calc_path(var/turf/avoid = null)
 	path = get_path_to(loc, target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 250, id=botcard, exclude=avoid)
-	world << "[src]_calc_Distance ([path.len])_to: [target]_[destination]"
 
 
 // sets the current destination
@@ -842,10 +843,7 @@ var/global/mulebot_count = 0
 			else
 				loaddir = 0
 			icon_state = "mulebot[(wires.MobAvoid() != null)]"
-			world << "[src]_RX_[debug_count]"
-			debug_count++
 			if(destination) // No need to calculate a path if you do not have a destination set!
-				world << "\red [src]_RX_CALC"
 				calc_path()
 			updateDialog()
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -24,6 +24,7 @@ var/global/mulebot_count = 0
 	control_freq = 1447
 	bot_type = MULE_BOT
 	bot_filter = RADIO_MULEBOT
+	var/debug_count = 0
 
 	suffix = ""
 
@@ -514,10 +515,9 @@ var/global/mulebot_count = 0
 		if(num_steps)
 			process_bot()
 			num_steps--
-			spawn(0)
-				for(var/i=num_steps,i>0,i--)
-					sleep(2)
-					process_bot()
+			for(var/i=num_steps,i>0,i--)
+				sleep(4)
+				process_bot()
 
 	if(refresh) updateDialog()
 
@@ -649,6 +649,7 @@ var/global/mulebot_count = 0
 // given an optional turf to avoid
 /obj/machinery/bot/mulebot/calc_path(var/turf/avoid = null)
 	path = get_path_to(loc, target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 250, id=botcard, exclude=avoid)
+	world << "[src]_calc_Distance ([path.len])_to: [target]_[destination]"
 
 
 // sets the current destination
@@ -841,7 +842,11 @@ var/global/mulebot_count = 0
 			else
 				loaddir = 0
 			icon_state = "mulebot[(wires.MobAvoid() != null)]"
-			calc_path()
+			world << "[src]_RX_[debug_count]"
+			debug_count++
+			if(destination) // No need to calculate a path if you do not have a destination set!
+				world << "\red [src]_RX_CALC"
+				calc_path()
 			updateDialog()
 
 	//Detects and stores current active delivery beacons.


### PR DESCRIPTION
Fix for the server crippling MULEbot lag.
- Removes a spawn() which is no longer needed since bots have their own place in the master controller which run them independently.
- Fixes an infinite loop that results in extreme server lag.
- MULEs will no longer calculate a path to a destination not matching their own when receiving a signal through the radio controller.

Note: This could potentially make MULEbots less effective at handling pathing failures, but it is a lot better than being able to completely shut down the server.

Infinite loop details:
<i>When a MULEbot is commanded to proceed to a turf in which it is already located, and is not set to automatically return home, it call its at_target() proc infinitely. That proc sends a signal to all the other MULEbots, Cargo PDAs, and beacons. When other MULEs receive this signal, they will pointlessly calculate a path to the sending MULE, regardless of their own status. If the MULE got stuck in such a loop, it would broadcast its status several times a second, causing distant MULEs to calculate a path to the source MULE, creating A-Star lag which exponentially increases as more MULEs are added.</i>

Please comment your methods of replicating any further bugs, and I will work to
patch it.
