### PR TITLE
Fixes Pipes/Wires getting blown up when the wall doesn't

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -126,18 +126,19 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 			//------- THINGS IN TURFS FIRES -------
 
-				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
-					var/atom/movable/AM = atom_movable
+				if(!(istype(T, /turf/simulated/wall)))
+					for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
+						var/atom/movable/AM = atom_movable
 
-					if(AM) //Something is inside T (We have already checked T exists above) - RR
-						if(flame_dist) //if it has flame distance, run this - RR
-							if(isliving(AM) && !hotspot_exists && !istype(T, /turf/space))
-								if(AM && AM.loc!=null)
-									new /obj/effect/hotspot(AM.loc)
-								//Just in case we missed a mob while they were in flame_range, but a hotspot didn't spawn on them, otherwise it looks weird when you just burst into flame out of nowhere
-						if(dist) //if no flame_dist, run this - RR
-							if(AM)
-								AM.ex_act(dist)
+						if(AM) //Something is inside T (We have already checked T exists above) - RR
+							if(flame_dist) //if it has flame distance, run this - RR
+								if(isliving(AM) && !hotspot_exists && !istype(T, /turf/space))
+									if(AM && AM.loc!=null)
+										new /obj/effect/hotspot(AM.loc)
+									//Just in case we missed a mob while they were in flame_range, but a hotspot didn't spawn on them, otherwise it looks weird when you just burst into flame out of nowhere
+							if(dist) //if no flame_dist, run this - RR
+								if(AM)
+									AM.ex_act(dist)
 
 
 

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -59,8 +59,9 @@ proc/explosion_rec(turf/epicenter, power)
 		T.ex_act(severity)
 		if(!T)
 			T = locate(x,y,z)
-		for(var/atom/A in T)
-			A.ex_act(severity)
+		if(!(istype(T, /turf/simulated/wall)))
+			for(var/atom/A in T)
+				A.ex_act(severity)
 
 	explosion_in_progress = 0
 


### PR DESCRIPTION
Added a check between ex_act on the turf and ex_act on the turf's contents.
If the wall isn't blown out the contents are not blown up.
This is to prevent the annoying behaviour of having pipes and wires getting blown up when the wall on top remains intact (doubling the amount of engineering repair work required.)

Note: If the wall gets blown down to girders ex_act is still applied to the turf's contents.
I could fix this for girders/computers/machines/other solid anchored objects, but that would be getting into feature territory.
