### PR TITLE
Redo cyborg icon updating

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -37,7 +37,7 @@
 	R.status_flags |= CANPUSH
 	R.designation = "Default"
 	R.notify_ai(2)
-	R.updateicon()
+	R.update_icons()
 
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -33,8 +33,7 @@
 	sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_LEVEL_TWO
-	updateicon()
-	update_fire()
+	update_icons()
 	tod = worldtime2text() //weasellos time of death patch
 	if(mind)	mind.store_memory("Time of death: [tod]", 0)
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -295,8 +295,6 @@
 	overlays -= image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing")
 	if(on_fire)
 		overlays += image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing")
-	update_icons()
-	return
 
 /mob/living/silicon/robot/fire_act()
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -74,7 +74,7 @@
 
 	ident = rand(1, 999)
 	updatename()
-	updateicon()
+	update_icons()
 
 	if(!cell)
 		cell = new /obj/item/weapon/stock_parts/cell(src)
@@ -209,11 +209,9 @@
 			modtype = "Jan"
 			feedback_inc("cyborg_janitor",1)
 
-	overlays -= "eyes" //Takes off the eyes that it started with
-
 	transform_animation(animation_length)
 	notify_ai(2)
-	updateicon()
+	update_icons()
 	SetEmagged(emagged) // Update emag status and give/take emag modules.
 
 /mob/living/silicon/robot/proc/transform_animation(animation_length)
@@ -430,14 +428,14 @@
 		if(opened)
 			user << "You close the cover."
 			opened = 0
-			updateicon()
+			update_icons()
 		else
 			if(locked)
 				user << "The cover is locked and cannot be opened."
 			else
 				user << "You open the cover."
 				opened = 1
-				updateicon()
+				update_icons()
 
 	else if (istype(W, /obj/item/weapon/stock_parts/cell) && opened)	// trying to put a cell inside
 		if(wiresexposed)
@@ -450,7 +448,7 @@
 			cell = W
 			user << "You insert the power cell."
 //			chargecount = 0
-		updateicon()
+		update_icons()
 
 	else if (istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/multitool) || istype(W, /obj/item/device/assembly/signaler))
 		if (wiresexposed)
@@ -461,14 +459,14 @@
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
 		user << "The wires have been [wiresexposed ? "exposed" : "unexposed"]"
-		updateicon()
+		update_icons()
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && opened && cell)	// radio
 		if(radio)
 			radio.attackby(W,user)//Push it to the radio to let it handle everything
 		else
 			user << "Unable to locate a radio."
-		updateicon()
+		update_icons()
 
 	else if(istype(W, /obj/item/weapon/wrench) && opened && !cell) //Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
 		if(!lockcharge)
@@ -513,7 +511,7 @@
 			if(allowed(usr))
 				locked = !locked
 				user << "You [ locked ? "lock" : "unlock"] [src]'s cover."
-				updateicon()
+				update_icons()
 			else
 				user << "<span class='danger'>Access denied.</span>"
 
@@ -570,7 +568,7 @@
 						laws.show_laws(src)
 						src << "<span class='danger'>ALERT: [user.real_name] is your new master. Obey your new laws and their commands.</span>"
 						SetLockdown(0)
-						updateicon()
+						update_icons()
 					else
 						user << "You fail to [ locked ? "unlock" : "lock"] [src]'s interface."
 						if(prob(25))
@@ -615,7 +613,7 @@
 		switch(alert("You can not lock your cover again, are you sure?\n      (You can still ask for a human to lock it)", "Unlock Own Cover", "Yes", "No"))
 			if("Yes")
 				locked = 0
-				updateicon()
+				update_icons()
 				usr << "You unlock your cover."
 
 /mob/living/silicon/robot/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
@@ -672,7 +670,7 @@
 			user.put_in_active_hand(cell)
 			user << "You remove \the [cell]."
 			cell = null
-			updateicon()
+			update_icons()
 
 	if(!opened)
 		if(..()) // hulk attack
@@ -717,34 +715,30 @@
 			return 0
 	return 1
 
-/mob/living/silicon/robot/proc/updateicon()
+/mob/living/silicon/robot/regenerate_icons()
+	return update_icons()
+
+/mob/living/silicon/robot/update_icons()
 
 	overlays.Cut()
 	if(stat == 0)
-		overlays += "eyes"
-		if(icon_state == "robot")
-			overlays.Cut()
-			overlays += "eyes-standard"
-		if(icon_state == "toiletbot")
-			overlays.Cut()
-			overlays += "eyes-toiletbot"
-		if(icon_state == "secborg")
-			overlays.Cut()
-			overlays += "eyes-secborg"
-		if(icon_state =="engiborg")
-			overlays.Cut()
-			overlays += "eyes-engiborg"
-		if(icon_state =="janiborg")
-			overlays.Cut()
-			overlays += "eyes-janiborg"
-		if(icon_state =="minerborg" || icon_state =="Miner+j")
-			overlays.Cut()
-			overlays += "eyes-minerborg"
-		if(icon_state =="syndie_bloodhound")
-			overlays.Cut()
-			overlays+= "eyes-syndie_bloodhound"
-	else
-		overlays -= "eyes"
+		switch(icon_state)
+			if("robot")
+				overlays += "eyes-standard"
+			if("toiletbot")
+				overlays += "eyes-toiletbot"
+			if("secborg")
+				overlays += "eyes-secborg"
+			if("engiborg")
+				overlays += "eyes-engiborg"
+			if("janiborg")
+				overlays += "eyes-janiborg"
+			if("minerborg" || "Miner+j")
+				overlays += "eyes-minerborg"
+			if("syndie_bloodhound")
+				overlays += "eyes-syndie_bloodhound"
+			else
+				overlays += "eyes"
 
 	if(opened)
 		if(wiresexposed)
@@ -755,7 +749,6 @@
 			overlays += "ov-opencover -c"
 
 	update_fire()
-	return
 
 
 
@@ -959,7 +952,7 @@
 			uneq_module(module.emag)
 	if(hud_used)
 		hud_used.update_robot_modules_display()	//Shows/hides the emag item if the inventory screen is already open.
-	updateicon()
+	update_icons()
 
 /mob/living/silicon/robot/verb/outputlaws()
 	set category = "Robot Commands"


### PR DESCRIPTION
Removed the stupid "updateicon()" proc and placed the behavior in update_icons() and regenerate_icons()
Removed redundant update_fire() calls
Fixes #6057 since the staff calls regenerate_icons()
