### PR TITLE
"Fixes" pAI being deaf. 

### DIFF
--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -19,9 +19,3 @@
 		stat = CONSCIOUS
 		return
 	health = maxHealth - getBruteLoss() - getFireLoss()
-
-/mob/living/silicon/pai/proc/follow_pai()
-	while(card)
-		loc = get_turf(card)
-		sleep(5)
-	qdel(src) //if there's no pAI we shouldn't exist

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -51,7 +51,7 @@
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
 	make_laws()
 	canmove = 0
-	src.loc = get_turf(paicard)
+	src.loc = paicard
 	card = paicard
 	sradio = new(src)
 	if(card)
@@ -66,7 +66,6 @@
 		pda.owner = text("[]", src)
 		pda.name = pda.owner + " (" + pda.ownjob + ")"
 
-		follow_pai()
 	..()
 
 /mob/living/silicon/pai/make_laws()


### PR DESCRIPTION
"Fixes" pAI being deaf. But this also makes pAI unable to see visible_message, audible_message and emotes unfortunately. I think it's better to have pAI able to hear sounds and speech rather than emotes and visible_message() while we wait for a fix for those (basically reopening #99 that was left open anyway). At least it will make pAI playable again.

This PR basically reverts the ugly hack in https://github.com/tgstation/-tg-station/commit/a2b5256121448757b80369586787924dcde06b40

This "should" fix:
#5834
#6045
#5729
#2947
#5759
#810
