### PR TITLE
Standardizing attack messages to always show the attacker first

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -9,7 +9,7 @@
 /atom/movable/attackby(obj/item/W, mob/living/user)
 	user.do_attack_animation(src)
 	if(W && !(W.flags&NOBLUDGEON))
-		visible_message("<span class='danger'>[src] has been hit by [user] with [W].</span>")
+		visible_message("<span class='danger'>[user] has hit [src] with [W].</span>")
 
 /mob/living/attackby(obj/item/I, mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -23,18 +23,21 @@
 			if(istype(location, /turf/simulated))
 				location.add_blood_floor(src)
 
-	var/showname = "."
-	if(user)
-		showname = " by [user]!"
-		user.do_attack_animation(src)
-	if(!(user in viewers(src, null)))
-		showname = "."
+	var/message_verb = ""
 	if(I.attack_verb && I.attack_verb.len)
-		src.visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] with [I][showname]</span>",
-		"<span class='userdanger'>[src] has been [pick(I.attack_verb)] with [I][showname]</span>")
+		message_verb = "[pick(I.attack_verb)]"
 	else if(I.force)
-		src.visible_message("<span class='danger'>[src] has been attacked with [I][showname]</span>",
-		"<span class='userdanger'>[src] has been attacked with [I][showname]</span>")
+		message_verb = "attacked"
+
+	var/attack_message = "[src] has been [message_verb] with [I]."
+	if(user)
+		user.do_attack_animation(src)
+		if(user in viewers(src, null))
+			attack_message = "[user] has [message_verb] [src] with [I]!"
+	if(message_verb)
+		visible_message("<span class='danger'>[attack_message]</span>",
+		"<span class='userdanger'>[attack_message]</span>")
+
 
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -153,7 +153,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1)
-	src.visible_message("<span class='danger'>The [src.name] has been attacked with \the [W][(user ? " by [user]" : "")]!</span>")
+	visible_message("<span class='danger'>[user] has attacked the [src.name] with \the [W]!</span>")
 	var/damage = 0
 	switch(W.damtype)
 		if("fire")
@@ -171,7 +171,7 @@
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
 	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1)
-	src.visible_message("<span class='danger'>The [src.name] has been attacked by \the [M]!</span>")
+	visible_message("<span class='danger'>\The [M] has attacked the [src.name]!</span>")
 	var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 	if(!damage) // Avoid divide by zero errors
 		return

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -267,8 +267,8 @@ Auto Patrol[]"},
 					if(declare_arrests)
 						var/area/location = get_area(src)
 						speak("[arrest_type ? "Detaining" : "Arresting"] level [threatlevel] scumbag <b>[target]</b> in [location].", radio_frequency)
-					target.visible_message("<span class='danger'>[target] has been stunned by [src]!</span>",\
-											"<span class='userdanger'>[target] has been stunned by [src]!</span></span>")
+					target.visible_message("<span class='danger'>[src] has stunned [target]!</span>",\
+											"<span class='userdanger'>[src] has stunned [target]!</span></span>")
 
 					mode = BOT_PREP_ARREST
 					anchored = 1

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -230,8 +230,8 @@ Auto Patrol: []"},
 					if(declare_arrests)
 						var/area/location = get_area(src)
 						speak("[arrest_type ? "Detaining" : "Arresting"] level [threatlevel] scumbag <b>[target]</b> in [location].", radio_frequency)
-					target.visible_message("<span class='danger'>[target] has been stunned by [src]!</span>",\
-											"<span class='userdanger'>[target] has been stunned by [src]!</span>")
+					target.visible_message("<span class='danger'>[src] has stunned [target]!</span>",\
+											"<span class='userdanger'>[src] has stunned [target]!</span>")
 
 					mode = BOT_PREP_ARREST
 					anchored = 1

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -221,7 +221,7 @@
 		spark_system.start()
 		playsound(loc, 'sound/weapons/blade1.ogg', 50, 1)
 		playsound(loc, "sparks", 50, 1)
-		visible_message("<span class='notice'>The camera has been sliced apart by [] with an energy blade!</span>")
+		visible_message("<span class='notice'>[user] has sliced the camera apart with an energy blade!</span>")
 		qdel(src)
 	else if(istype(W, /obj/item/device/laser_pointer))
 		var/obj/item/device/laser_pointer/L = W

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -898,7 +898,7 @@ About the new airlock wires panel:
 					if( !istype(src, /obj/machinery/door/airlock) || !user || !W || !W.isOn() || !user.loc )
 						return					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					welded = !welded
-					user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>", \
+					user.visible_message("<span class='warning'>[user.name] has [welded? "welded shut":"unwelded"] [src].</span>", \
 										"<span class='notice'>You've [welded ? "welded the airlock shut":"unwelded the airlock"].</span>")
 					update_icon()
 		return

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -204,7 +204,7 @@
 	if(M.damtype == "brute")
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
-		visible_message("<span class='danger'>[src] has been hit by [M.name].</span>")
+		visible_message("<span class='danger'>[M.name] has hit [src].</span>")
 		take_damage(M.force)
 	return
 
@@ -353,7 +353,7 @@
 			return
 		var/aforce = I.force
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		visible_message("<span class='danger'>\The [src] has been hit by [user] with [I].</span>")
+		visible_message("<span class='danger'>[user] has hit \the [src] with [I].</span>")
 		if(I.damtype == BURN || I.damtype == BRUTE)
 			take_damage(aforce)
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -321,7 +321,7 @@ obj/mecha/proc/can_use(mob/user)
 	else
 		return
 	M.occupant_message("<span class='danger'>You hit [src].</span>")
-	visible_message("<span class='danger'>[src] has been hit by [M.name].</span>")
+	visible_message("<span class='danger'>[M.name] has hit [src].</span>")
 	take_damage(M.force, damtype)
 	add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	return

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -218,9 +218,9 @@
 /obj/structure/alien/weeds/attackby(obj/item/I, mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(I.attack_verb.len)
-		visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] with [I] by [user].</span>")
+		visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [src] with [I]!</span>")
 	else
-		visible_message("<span class='danger'>[src] has been attacked with [I] by [user]!</span>")
+		visible_message("<span class='danger'>[user] has attacked [src] with [I]!</span>")
 
 	var/damage = I.force / 4.0
 	if(istype(I, /obj/item/weapon/weldingtool))
@@ -373,9 +373,9 @@
 
 /obj/structure/alien/egg/attackby(obj/item/I, mob/user)
 	if(I.attack_verb.len)
-		visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] with [I] by [user].</span>")
+		visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [src] with [I]!</span>")
 	else
-		visible_message("<span class='danger'>[src] has been attacked with [I] by [user]!</span>")
+		visible_message("<span class='danger'>[user] has attacked [src] with [I]!</span>")
 
 	var/damage = I.force / 4
 	if(istype(I, /obj/item/weapon/weldingtool))

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -22,9 +22,9 @@
 
 /obj/effect/spider/attackby(var/obj/item/weapon/W, var/mob/user)
 	if(W.attack_verb.len)
-		visible_message("<span class='danger'>\The [src] has been [pick(W.attack_verb)] with \the [W][(user ? " by [user]" : "")]!</span>")
+		visible_message("<span class='danger'>[user] has [pick(W.attack_verb)] \the [src] with \the [W]!</span>")
 	else
-		visible_message("<span class='danger'>\The [src] has been attacked with \the [W][(user ? " by [user]" : "")]!</span>")
+		visible_message("<span class='danger'>[user] has attacked \the [src] with \the [W]!</span>")
 
 	var/damage = W.force / 4.0
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -332,7 +332,7 @@
 		M.adjustBruteLoss(10)
 		*/
 	if(M != user)
-		M.visible_message("<span class='danger'>[M] has been stabbed in the eye with [src] by [user]!</span>", \
+		M.visible_message("<span class='danger'>[user] has stabbed [M] in the eye with [src]!</span>", \
 							"<span class='userdanger'>[user] stabs you in the eye with [src]!</span>")
 	else
 		user.visible_message( \

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -32,7 +32,7 @@
 	if (user)
 		if (M != user)
 			user.visible_message( \
-				"<span class='notice'>[M] has been applied with [src] by [user].</span>", \
+				"<span class='notice'>[user] has applied [src] on [M].</span>", \
 				"<span class='notice'>You apply \the [src] to [M].</span>" \
 			)
 		else

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -272,7 +272,8 @@
 	else
 		if(user.a_intent == "harm" && !defib.safety)
 			busy = 1
-			H.visible_message("<span class='danger'>[M.name] has been touched with [src] by [user]!</span>")
+			H.visible_message("<span class='danger'>[user] has touched [H.name] with [src]!</span>", \
+					"<span class='userdanger'>[user] has touched [H.name] with [src]!</span>")
 			H.adjustStaminaLoss(50)
 			H.Weaken(5)
 			H.updatehealth() //forces health update before next life tick

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -130,7 +130,7 @@
 	for(var/obj/item/weapon/implant/loyalty/imp in implant_list)
 		if(!imp)	continue
 		if(istype(imp, /obj/item/weapon/implant/loyalty))
-			M.visible_message("<span class='danger'>[M] has been implanted by the [src.name].</span>")
+			M.visible_message("<span class='warning'>[M] has been implanted by the [src.name].</span>")
 
 			if(imp.implanted(M))
 				imp.loc = M

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -25,7 +25,7 @@
 		var/turf/T = get_turf(M)
 		if(T && (M == user || do_after(user, 50)))
 			if(user && M && (get_turf(M) == T) && src && imp)
-				M.visible_message("<span class='warning'>[M] has been implanted by [user].</span>")
+				M.visible_message("<span class='warning'>[user] has implanted [M].</span>")
 				add_logs(user, M, "implanted", object="[name]")
 				user << "<span class='notice'>You implanted the implant into [M].</span>"
 				if(imp.implanted(M))

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -53,14 +53,14 @@
 			M.stuttering = 7
 		M.Stun(7)
 		M.Weaken(7)
-		M.visible_message("<span class='danger'>[M] has been beaten with [src] by [user]!</span>", \
-							"<span class='userdanger'>[M] has been beaten with [src] by [user]!</span>")
+		M.visible_message("<span class='danger'>[user] has beaten [M] with [src]!</span>", \
+							"<span class='userdanger'>[user] has beaten [M] with [src]!</span>")
 	else
 		playsound(loc, 'sound/effects/woodhit.ogg', 50, 1, -1)
 		M.Stun(7)
 		M.Weaken(7)
-		M.visible_message("<span class='danger'>[M] has been stunned with [src] by [user]!</span>", \
-							"<span class='userdanger'>[M] has been stunned with [src] by [user]!</span>")
+		M.visible_message("<span class='danger'>[user] has stunned [M] with [src]!</span>", \
+							"<span class='userdanger'>[user] has stunned [M] with [src]!</span>")
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -127,7 +127,8 @@
 				target.Weaken(3)
 				add_logs(user, target, "stunned", object="telescopic baton")
 				src.add_fingerprint(user)
-				target.visible_message("<span class ='danger'>[target] has been knocked down with \the [src] by [user]!</span>")
+				target.visible_message("<span class ='danger'>[user] has knocked down [target] with \the [src]!</span>", \
+					"<span class ='userdanger'>[user] has knocked down [target] with \the [src]!</span>")
 				if(!iscarbon(user))
 					target.LAssailant = null
 				else

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -46,12 +46,11 @@
 			spark_system.start()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
-			for(var/mob/O in viewers(user, 3))
-				O.show_message(text("<span class='notice'>\The [src] has been sliced open by [] with an energy blade!</span>", user), 1, text("<span class='danger'>You hear metal being sliced and sparks flying.</span>"), 2)
+			visible_message("<span class='notice'>[user] has sliced open \the [src] with an energy blade!</span>", "<span class='danger'>You hear metal being sliced and sparks flying.</span>")
 			return
 		else
 			for(var/mob/O in viewers(user, 3))
-				O.show_message(text("<span class='notice'>\The [src] has been broken by [] with an electromagnetic card!</span>", user), 1, text("You hear a faint electrical spark."), 2)
+				O.show_message("<span class='notice'>[user] has broken \the [src] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
 			return
 	if(!locked)
 		..()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -121,8 +121,8 @@
 			user.do_attack_animation(L)
 			baton_stun(L, user)
 		else
-			L.visible_message("<span class='warning'>[L] has been prodded with [src] by [user]. Luckily it was off.</span>", \
-							"<span class='warning'>You've been prodded with [src] by [user]. Luckily it was off</span>")
+			L.visible_message("<span class='warning'>[user] has prodded [L] with [src]. Luckily it was off.</span>", \
+							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
 			return
 	else
 		..()
@@ -138,8 +138,8 @@
 	L.Weaken(stunforce)
 	L.apply_effect(STUTTER, stunforce)
 
-	L.visible_message("<span class='danger'>[L] has been stunned with [src] by [user]!</span>", \
-							"<span class='userdanger'>You've been stunned with [src] by [user]!</span>")
+	L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
+							"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 	if(isrobot(loc))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -25,6 +25,6 @@
 /obj/structure/mech_melee_attack(obj/mecha/M)
 	if(M.damtype == "brute")
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
-		visible_message("<span class='danger'>[src] has been hit by [M.name].</span>")
+		visible_message("<span class='danger'>[M.name] has hit [src].</span>")
 		return 1
 	return 0

--- a/code/game/objects/structures/OpTable.dm
+++ b/code/game/objects/structures/OpTable.dm
@@ -37,7 +37,7 @@
 			var/mob/M = G.affecting
 			M.resting = 1
 			M.loc = loc
-			visible_message("<span class='notice'>[M] has been laid on [src] by [user].</span>")
+			visible_message("<span class='notice'>[user] has laid [M] on [src].</span>")
 			patient = M
 			check_patient()
 			qdel(W)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -192,7 +192,7 @@
 						return
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					new /obj/item/stack/sheet/metal(src.loc)
-					visible_message("<span class='notice'>\The [src] has been cut apart by [user] with \the [WT].</span>", "You hear welding.")
+					visible_message("<span class='notice'>[user] has cut \the [src] apart with \the [WT].</span>", "You hear welding.")
 					qdel(src)
 			return
 
@@ -214,9 +214,9 @@
 					return
 				playsound(loc, 'sound/items/welder.ogg', 50, 1)
 				welded = !welded
-				user << "<span class='notice'>You [welded ? "welded the [src] shut":"unwelded the [src]"]</span>"
+				user << "<span class='notice'>You [welded ? "welded [src] shut":"unwelded [src]"].</span>"
 				update_icon()
-				user.visible_message("<span class='warning'>[src] has been [welded? "welded shut":"unwelded"] by [user.name].</span>")
+				user.visible_message("<span class='warning'>[user.name] has [welded ? "welded [src] shut":"unwelded [src]"].</span>")
 		return
 	else if(!place(user, W))
 		src.attack_hand(user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -46,7 +46,7 @@
 		add_fingerprint(user)
 		for(var/mob/O in viewers(user, 3))
 			if((O.client && !( O.blinded )))
-				O << "<span class='notice'>The locker has been [locked ? null : "un"]locked by [user].</span>"
+				O << "<span class='notice'>[user] has [locked ? null : "un"]locked the locker.</span>"
 		if(src.locked)
 			src.icon_state = src.icon_locked
 		else
@@ -77,11 +77,10 @@
 			spark_system.start()
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			playsound(src.loc, "sparks", 50, 1)
-			for(var/mob/O in viewers(user, 3))
-				O.show_message("<span class='warning'>The locker has been sliced open by [user] with an energy blade!</span>", 1, "You hear metal being sliced and sparks flying.", 2)
+			visible_message("<span class='warning'>[user] has sliced the locker open with an energy blade!</span>", "You hear metal being sliced and sparks flying.")
 		else
 			for(var/mob/O in viewers(user, 3))
-				O.show_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
+				O.show_message("<span class='warning'>[user] has broken the locker with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
 	else
 		..(W, user)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -74,7 +74,7 @@
 	if(M.damtype == "brute")
 		playsound(src, 'sound/weapons/punch4.ogg', 50, 1)
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
-		visible_message("<span class='danger'>[src] has been hit by [M.name].</span>")
+		visible_message("<span class='danger'>[M.name] has hit [src]!</span>")
 		if(prob(5) && M.force > 20)
 			dismantle_wall(1)
 			M.occupant_message("<span class='warning'>You smash through the wall.</span>")

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -41,7 +41,7 @@
 
 /obj/item/weapon/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
 	if(ismob(target) && target.reagents && reagents.total_volume)
-		user.visible_message("<span class='danger'>\The [target] has been smothered with \the [src] by \the [user]!</span>", "<span class='danger'>You smother \the [target] with \the [src]!</span>", "You hear some struggling and muffled cries of surprise")
+		user.visible_message("<span class='danger'>[user] has smothered \the [target] with \the [src]!</span>", "<span class='danger'>You smother \the [target] with \the [src]!</span>", "You hear some struggling and muffled cries of surprise")
 		src.reagents.reaction(target, TOUCH)
 		src.reagents.clear_reagents()
 		return

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -248,7 +248,7 @@ proc/check_panel(mob/M)
 /obj/effect/fake_attacker/attackby(var/obj/item/weapon/P as obj, mob/user as mob)
 	step_away(src,my_target,2)
 	my_target.visible_message("<span class='danger'>[my_target] flails around wildly.</span>", \
-							"<span class='userdanger'>[src] has been attacked by [my_target] </span>")
+							"<span class='danger'>[my_target] has attacked [src]!</span>")
 
 	src.health -= P.force
 
@@ -305,7 +305,7 @@ proc/check_panel(mob/M)
 			if(prob(15))
 				if(weapon_name)
 					my_target << sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'))
-					my_target.show_message("<span class='danger'>[my_target] has been attacked with [weapon_name] by [src.name]!</span>", 1)
+					my_target.show_message("<span class='danger'>[src.name] has attacked [my_target] with [weapon_name]!</span>", 1)
 					my_target.staminaloss += 30
 					if(prob(20)) my_target.eye_blurry += 3
 					if(prob(33))

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -80,21 +80,20 @@
 	target.apply_damage(force, BRUTE, affecting, armor_block)
 
 	// You are going to knock someone out for longer if they are not wearing a helmet.
+	var/head_attack_message = ""
 	if(affecting == "head" && istype(target, /mob/living/carbon/))
-
-		//Display an attack message.
-		for(var/mob/O in viewers(user, null))
-			if(target != user) O.show_message(text("<span class='danger'>[target] has been hit over the head with a bottle of [src.name], by [user]!</span>"), 1)
-			else O.show_message(text("<span class='danger'>[target] hits himself with a bottle of [src.name] on the head!</span>"), 1)
+		head_attack_message = " on the head"
 		//Weaken the target for the duration that we calculated and divide it by 5.
 		if(armor_duration)
 			target.apply_effect(min(armor_duration, 10) , WEAKEN) // Never weaken more than a flash!
 
+	//Display an attack message.
+	if(target != user)
+		target.visible_message("<span class='danger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>", \
+				"<span class='userdanger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>")
 	else
-		//Default attack message and don't weaken the target.
-		for(var/mob/O in viewers(user, null))
-			if(target != user) O.show_message(text("<span class='danger'>[target] has been attacked with a bottle of [src.name], by [user]!</span>"), 1)
-			else O.show_message(text("<span class='danger'>[target] has attacked himself with a bottle of [src.name]!</span>"), 1)
+		user.visible_message("<span class='danger'>[target] hits himself with a bottle of [src.name][head_attack_message]!</span>", \
+				"<span class='userdanger'>[target] hits himself with a bottle of [src.name][head_attack_message]!</span>")
 
 	//Attack logs
 	add_logs(user, target, "attacked", object="bottle")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -138,11 +138,11 @@ emp_act
 				return 0
 
 		if(I.attack_verb && I.attack_verb.len)
-			visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I] by [user]!</span>", \
-							"<span class='userdanger'>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I] by [user]!</span>")
+			visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>", \
+							"<span class='userdanger'>[user] has [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>")
 		else if(I.force)
-			visible_message("<span class='danger'>[src] has been attacked in the [hit_area] with [I] by [user]!</span>", \
-							"<span class='userdanger'>[src] has been attacked in the [hit_area] with [I] by [user]!</span>")
+			visible_message("<span class='danger'>[user] has attacked [src] in the [hit_area] with [I]!</span>", \
+							"<span class='userdanger'>[user] has attacked [src] in the [hit_area] with [I]!</span>")
 		else
 			return 0
 
@@ -399,8 +399,8 @@ emp_act
 			updatehealth()
 
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
-		visible_message("<span class='danger'>[src] has been hit by [M.name].</span>", \
-								"<span class='userdanger'>[src] has been hit by [M.name].</span>")
+		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
+								"<span class='userdanger'>[M.name] has hit [src]!</span>")
 		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -814,11 +814,11 @@
 		return 0
 
 	if(I.attack_verb && I.attack_verb.len)
-		H.visible_message("<span class='danger'>[H] has been [pick(I.attack_verb)] in the [hit_area] with [I] by [user]!</span>", \
-						"<span class='userdanger'>[H] has been [pick(I.attack_verb)] in the [hit_area] with [I] by [user]!</span>")
+		H.visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>", \
+						"<span class='userdanger'>[user] has [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>")
 	else if(I.force)
-		H.visible_message("<span class='danger'>[H] has been attacked in the [hit_area] with [I] by [user]!</span>", \
-						"<span class='userdanger'>[H] has been attacked in the [hit_area] with [I] by [user]!</span>")
+		H.visible_message("<span class='danger'>[user] has attacked [H] in the [hit_area] with [I]!</span>", \
+						"<span class='userdanger'>[user] has attacked [H] in the [hit_area] with [I]!</span>")
 	else
 		return 0
 
@@ -899,23 +899,20 @@
 			if(istype(location, /turf/simulated))
 				location.add_blood_floor(H)
 
-	var/showname = "."
-	if(user)
-		showname = " by [user]!"
-		if(user != src)
-			user.do_attack_animation(H)
-	if(!(user in viewers(I, null)))
-		showname = "."
-
+	var/message_verb = ""
 	if(I.attack_verb && I.attack_verb.len)
-		H.visible_message("<span class='danger'>[H] has been [pick(I.attack_verb)] with [I][showname]</span>",
-		"<span class='userdanger'>[H] has been [pick(I.attack_verb)] with [I][showname]</span>")
+		message_verb = "[pick(I.attack_verb)]"
 	else if(I.force)
-		H.visible_message("<span class='danger'>[H] has been attacked with [I][showname]</span>",
-		"<span class='userdanger'>[H] has been attacked with [I][showname]</span>")
-	if(!showname && user)
-		if(user.client)
-			user << "<span class='danger'><B>You attack [H] with [I]. </B></span>"
+		message_verb = "attacked"
+
+	var/attack_message = "[H] has been [message_verb] with [I]."
+	if(user)
+		user.do_attack_animation(src)
+		if(user in viewers(src, null))
+			attack_message = "[user] has [message_verb] [H] with [I]!"
+	if(message_verb)
+		H.visible_message("<span class='danger'>[attack_message]</span>",
+		"<span class='userdanger'>[attack_message]</span>")
 
 	return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -380,8 +380,7 @@
 						if (prob(75))
 							var/obj/item/weapon/grab/G = pick(M.grabbed_by)
 							if (istype(G, /obj/item/weapon/grab))
-								for(var/mob/O in viewers(M, null))
-									O.show_message(text("<span class='danger'>[] has been pulled from []'s grip by []</span>", G.affecting, G.assailant, src), 1)
+								visible_message("<span class='danger'>[src] has pulled [G.affecting] from [G.assailant]'s grip.</span>")
 								qdel(G)
 						else
 							ok = 0

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -87,8 +87,8 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 				return
 		updatehealth()
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
-		visible_message("<span class='danger'>[src] has been hit by [M.name].</span>", \
-						"<span class='userdanger'>[src] has been hit by [M.name].</span>")
+		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
+						"<span class='userdanger'>[M.name] has hit [src]!</span>")
 		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	else
 		step_away(src,M)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -64,7 +64,7 @@
 			if (O.damtype == STAMINA)
 				damage = 0
 			health -= damage
-			visible_message("<span class='danger'>[src] has been attacked with [O] by [user]!</span>")
+			visible_message("<span class='danger'>[user] has attacked [src] with [O]!</span>")
 		else
 			visible_message("<span class='danger'>[src] blocks [O] with its shield!</span>")
 		playsound(loc, O.hitsound, 25, 1, -1)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -371,8 +371,8 @@
 			damage = O.force
 			if (O.damtype == STAMINA)
 				damage = 0
-			visible_message("<span class='danger'>[src] has been [O.attack_verb.len ? "[pick(O.attack_verb)]": "attacked"] with [O] by [user]!</span>",\
-							"<span class='userdanger'>[src] has been attacked with [O] by [user]!</span>")
+			visible_message("<span class='danger'>[user] has [O.attack_verb.len ? "[pick(O.attack_verb)]": "attacked"] [src] with [O]!</span>",\
+							"<span class='userdanger'>[user] has [O.attack_verb.len ? "[pick(O.attack_verb)]": "attacked"] you with [O]!</span>")
 		else
 			visible_message("<span class='danger'>[O] bounces harmlessly off of [src].</span>",\
 							"<span class='userdanger'>[O] bounces harmlessly off of [src].</span>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -548,12 +548,12 @@
 			if (emagged || malfhack || (stat & BROKEN) || opened==2)
 				new /obj/item/stack/sheet/metal(loc)
 				user.visible_message(\
-					"<span class='warning'>[src] has been cut apart by [user.name] with the weldingtool.</span>",\
+					"<span class='warning'>[user.name] has cut [src] apart with [W].</span>",\
 					"<span class='notice'>You disassembled the broken APC frame.</span>")
 			else
 				new /obj/item/apc_frame(loc)
 				user.visible_message(\
-					"<span class='warning'>[src] has been cut from the wall by [user.name] with the weldingtool.</span>",\
+					"<span class='warning'>[user.name] has cut [src] from the wall with [W].</span>",\
 					"<span class='notice'>You cut the APC frame from the wall.</span>")
 			qdel(src)
 			return
@@ -588,7 +588,7 @@
 				&& W.w_class >= 3.0 \
 				&& prob(20) )
 			opened = 2
-			user.visible_message("<span class='danger'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
+			user.visible_message("<span class='danger'>[user.name] has knocked down the APC cover  with the [W.name]!</span>", \
 				"<span class='danger'>You knock down the APC cover with your [W.name]!</span>", \
 				"You hear bang")
 			update_icon()
@@ -600,7 +600,7 @@
 				istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/assembly/signaler)))
 				return src.attack_hand(user)
 			user.do_attack_animation(src)
-			user.visible_message("<span class='danger'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
+			user.visible_message("<span class='danger'>[user.name] has hit the [src.name] with the [W.name]!</span>", \
 				"<span class='danger'>You hit the [src.name] with your [W.name]!</span>", \
 				"You hear bang")
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -43,8 +43,8 @@
 	if(ismob(target) && target.reagents && reagents.total_volume)
 		var/mob/M = target
 		var/R
-		target.visible_message("<span class='danger'>[target] has been splashed with something by [user]!</span>", \
-						"<span class='userdanger'>[target] has been splashed with something by [user]!</span>")
+		target.visible_message("<span class='danger'>[user] has splashed [target] with something!</span>", \
+						"<span class='userdanger'>[user] has splashed [target] with something!</span>")
 		if(reagents)
 			for(var/datum/reagent/A in reagents.reagent_list)
 				R += A.id + " ("

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -156,8 +156,8 @@
 			user.visible_message("<span class='warning'>[user] climbs into [src].</span>", \
 									"<span class='notice'>[user] climbs into [src].</span>")
 		else
-			target.visible_message("<span class='danger'>[target] has been placed in [src] by [user].</span>", \
-									"<span class='userdanger'>[target] has been placed in [src] by [user].</span>")
+			target.visible_message("<span class='danger'>[user] has placed [target] in [src].</span>", \
+									"<span class='userdanger'>[user] has placed [target] in [src].</span>")
 			add_logs(user, target, "stuffed", addition="into [src]")
 		update()
 


### PR DESCRIPTION
Standardizes attack messages to always show the attacker first(when there is an attacker). (see poll at https://tgstation13.org/phpBB/viewtopic.php?f=9&t=1903)

Replacing some "for mob in viewers() show_message()" with "visible message()".
Simplifying some message code in a couple places, fixing typos and span classes.

Not sure if this counts as a feature.
