### PR TITLE
Prevent some mobs from spawning in nullspace

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -639,21 +639,33 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 	name = "killer-tomato"
 	desc = "I say to-mah-to, you say tom-mae-to... OH GOD IT'S EATING MY LEGS!!"
 	icon_state = "killertomato"
+	var/awakening = 0
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/tomato/killer/attack(mob/M, mob/user, def_zone)
+	if(awakening)
+		user << "<span class='warning'>The tomato is twitching and shaking, preventing you from eating it.</span>"
+		return
+	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/killer/attack_self(mob/user as mob)
-	if(istype(user.loc,/turf/space))
+	if(awakening || istype(user.loc,/turf/space))
 		return
 	user << "<span class='notice'>You begin to awaken the Killer Tomato.</span>"
-	sleep(30)
-	var/mob/living/simple_animal/hostile/killertomato/K = new /mob/living/simple_animal/hostile/killertomato(get_turf(src.loc))
-	K.maxHealth += round(endurance / 3)
-	K.melee_damage_lower += round(potency / 10)
-	K.melee_damage_upper += round(potency / 10)
-	K.move_to_delay -= round(production / 50)
-	K.health = K.maxHealth
-	user.unEquip(src)
-	qdel(src)
-	K.visible_message("<span class='notice'>The Killer Tomato growls as it suddenly awakens.</span>")
+	awakening = 1
+
+	spawn(30)
+		if(!gc_destroyed)
+			var/mob/living/simple_animal/hostile/killertomato/K = new /mob/living/simple_animal/hostile/killertomato(get_turf(src.loc))
+			K.maxHealth += round(endurance / 3)
+			K.melee_damage_lower += round(potency / 10)
+			K.melee_damage_upper += round(potency / 10)
+			K.move_to_delay -= round(production / 50)
+			K.health = K.maxHealth
+			K.visible_message("<span class='notice'>The Killer Tomato growls as it suddenly awakens.</span>")
+			if(user)
+				user.unEquip(src)
+			qdel(src)
+
 
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -82,12 +82,10 @@
 		else
 			M.key = brainmob.key
 
+		qdel(brainmob)
+
 		M.internal_organs += src
 		loc = null
-
-		//Update the body's icon so it doesnt appear debrained anymore
-		if(ishuman(M))
-			H.update_hair(0)
 
 		//Update the body's icon so it doesnt appear debrained anymore
 		if(ishuman(M))

--- a/code/modules/mob/living/simple_animal/friendly/drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone.dm
@@ -113,7 +113,7 @@
 									new /obj/effect/decal/cleanable/oil/streak(get_turf(src))
 									qdel(src)
 								else
-									D << "<span class='notice'>You need to remain still to canibalize [src].</span>"
+									D << "<span class='notice'>You need to remain still to cannibalize [src].</span>"
 							else
 								D << "<span class='notice'>You're already in perfect condition!</span>"
 						if("Nothing")
@@ -530,7 +530,7 @@
 		return
 
 	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(be_drone == "No")
+	if(be_drone == "No" || gc_destroyed)
 		return
 	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
 	D.key = user.key


### PR DESCRIPTION
**Killer tomatoes :**
- Prevent killer tomato from spawning inside nullspace
- It's now impossible to eat an awakening killer tomato
- Fixed been able to spawn lots of killer tomatoes by spam-clicking the tomato object

**Drones :**

Prevent an edge case which would lead to a client spawning as drone in null space (may happen when two ghosts clients clicked on a drone before accepting : the first one was correctly respawn, the second was send to nullspace)

**Brains :**

Makes brainmobs qdel instead of piling up inside the brain object.
I haven't been able to reproduce the mobbrain null location bug, but i'm pretty sure this didn't help.

Fixes #5785 (except _maybe_ mobbrains...)
