### PR TITLE
Fixes radiation levels processing for aliens, brains and monkeys

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -131,12 +131,12 @@
 			radiation = 0
 
 		switch(radiation)
-			if(1 to 49)
+			if(0 to 50)
 				radiation--
 				if(prob(25))
 					adjustToxLoss(1)
 
-			if(50 to 74)
+			if(50 to 75)
 				radiation -= 2
 				adjustToxLoss(1)
 				if(prob(5))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -43,13 +43,13 @@
 				src << "<span class='danger'>STATUS: CRITICAL AMOUNTS OF RADIATION DETECTED.</span>"
 
 		switch(radiation)
-			if(1 to 49)
+			if(0 to 50)
 				radiation--
 				if(prob(25))
 					adjustToxLoss(1)
 					updatehealth()
 
-			if(50 to 74)
+			if(50 to 75)
 				radiation -= 2
 				adjustToxLoss(1)
 				if(prob(5))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -42,6 +42,9 @@
 			else//Fluff-wise, since the brain can't detect anything itself, the MMI handles thing like that
 				src << "<span class='danger'>STATUS: CRITICAL AMOUNTS OF RADIATION DETECTED.</span>"
 
+		if (radiation < 0)
+			radiation = 0
+
 		switch(radiation)
 			if(0 to 50)
 				radiation--

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -122,13 +122,13 @@
 			emote("collapse")
 
 		switch(radiation)
-			if(1 to 49)
+			if(0 to 50)
 				radiation--
 				if(prob(25))
 					adjustToxLoss(1)
 					updatehealth()
 
-			if(50 to 74)
+			if(50 to 75)
 				radiation -= 2
 				adjustToxLoss(1)
 				if(prob(5))

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -121,6 +121,9 @@
 			src << "<span class='danger'>You feel weak.</span>"
 			emote("collapse")
 
+		if (radiation < 0)
+			radiation = 0
+
 		switch(radiation)
 			if(0 to 50)
 				radiation--

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -63,6 +63,7 @@
 		O.adjustBruteLoss(getBruteLoss())
 		O.setOxyLoss(getOxyLoss())
 		O.adjustFireLoss(getFireLoss())
+		O.radiation = radiation
 
 	//re-add implants to new mob
 	for(var/obj/item/weapon/implant/I in implants)
@@ -170,6 +171,7 @@
 		O.adjustBruteLoss(getBruteLoss())
 		O.setOxyLoss(getOxyLoss())
 		O.adjustFireLoss(getFireLoss())
+		O.radiation = radiation
 
 	//re-add implants to new mob
 	for(var/obj/item/weapon/implant/I in implants)


### PR DESCRIPTION
Related to #5304.

Also :
- prevent brains and monkeys from having negative radiation levels
- makes humanize and monkeyize transfer radiation levels when using the TR_KEEPDAMAGE flag (e.g genetics monkey <=> humans or ling human/monkey stings)
