### PR TITLE
Grille throwforce is now halved against grilles, instead of -5

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -244,7 +244,7 @@
 		tforce = 5
 	else if(isobj(AM))
 		var/obj/item/I = AM
-		tforce = max(0, I.throwforce - 5)
+		tforce = max(0, I.throwforce * 0.5)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	health = max(0, health - tforce)
 	healthcheck()


### PR DESCRIPTION
As per dicusssion on #6092 which Raz merged before I could add the change.

Max left in as a guard against -forces magically healing the grille.
