### PR TITLE
Revert the pAI invisibility to make them hear speech and visible_message again.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -4,7 +4,6 @@
 	mouse_opacity = 0
 	density = 0
 	mob_size = 0
-	invisibility = 101
 
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null


### PR DESCRIPTION
This reverts the pAI part of https://github.com/tgstation/-tg-station/pull/5704
This would reopen #2034 and #5394 but would make pAI able to hear speech and visible_message making them playable again.
The only other quick way to fix it that I could think of was https://github.com/tgstation/-tg-station/pull/6128 but it wasn't accepted.
