### PR TITLE
Made datums handle stealth adminery

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -559,7 +559,10 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	if(key)
 		if(include_link)
-			. += "<a href='?priv_msg=[ckey]'>"
+			if(C && C.holder && C.holder.fakekey)
+				. += "<a href='?proxy_msg=\ref[C.holder.fakekey]'>"
+			else
+				. += "<a href='?priv_msg=[ckey]'>"
 
 		if(C && C.holder && C.holder.fakekey && !include_name)
 			. += "Administrator"

--- a/code/datums/href_proxy.dm
+++ b/code/datums/href_proxy.dm
@@ -13,4 +13,8 @@ var/global/list/saved_href_proxies = list()   //they will stay forever so links 
 	saved_href_proxies.Add(src)
 
 /datum/href_proxy/Topic(href, href_list)
-	saved_client.cmd_admin_pm(href_list["priv_msg"])
+	if(!saved_client)
+		var/client/C = directory[href_list["priv_msg"]]
+		C.adminhelp()
+	else
+		saved_client.cmd_admin_pm(href_list["priv_msg"])

--- a/code/datums/href_proxy.dm
+++ b/code/datums/href_proxy.dm
@@ -1,0 +1,16 @@
+var/global/list/saved_href_proxies = list()   //they will stay forever so links in the chat will not runtime after someone turn stealthmode off
+
+/datum/href_proxy
+	var/name
+	var/client/saved_client
+
+/datum/href_proxy/New(client, new_name)
+	saved_client = client
+	if(new_name)
+		name = new_name
+	else
+		name = "Administrator"
+	saved_href_proxies.Add(src)
+
+/datum/href_proxy/Topic(href, href_list)
+	saved_client.cmd_admin_pm(href_list["priv_msg"])

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -48,11 +48,11 @@
 			if(holder)
 				if(!holder.fakekey || C.holder)
 					if(check_rights_for(src, R_ADMIN))
-						C << "<font color=[config.allow_admin_ooccolor ? prefs.ooccolor :"#b82e00" ]><b><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></b></font>"
+						C << "<font color=[config.allow_admin_ooccolor ? prefs.ooccolor :"#b82e00" ]><b><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey.name])" : ""]:</EM> <span class='message'>[msg]</span></b></font>"
 					else
-						C << "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
+						C << "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey.name])" : ""]:</EM> <span class='message'>[msg]</span></span>"
 				else
-					C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
+					C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey.name : key]:</EM> <span class='message'>[msg]</span></span></font>"
 			else
 				C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
 

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -12,7 +12,7 @@
 			for(var/client/C in clients)
 				var/entry = "\t[C.key]"
 				if(C.holder && C.holder.fakekey)
-					entry += " <i>(as [C.holder.fakekey])</i>"
+					entry += " <i>(as [C.holder.fakekey.name])</i>"
 				entry += " - Playing as [C.mob.real_name]"
 				switch(C.mob.stat)
 					if(UNCONSCIOUS)
@@ -34,12 +34,12 @@
 			for(var/client/C in clients)
 				var/entry = "\t[C.key]"
 				if(C.holder && C.holder.fakekey)
-					entry += " <i>(as [C.holder.fakekey])</i>"
+					entry += " <i>(as [C.holder.fakekey.name])</i>"
 				Lines += entry
 	else
 		for(var/client/C in clients)
 			if(C.holder && C.holder.fakekey)
-				Lines += C.holder.fakekey
+				Lines += C.holder.fakekey.name
 			else
 				Lines += C.key
 
@@ -59,7 +59,7 @@
 			msg += "\t[C] is a [C.holder.rank]"
 
 			if(C.holder.fakekey)
-				msg += " <i>(as [C.holder.fakekey])</i>"
+				msg += " <i>(as [C.holder.fakekey.name])</i>"
 
 			if(isobserver(C.mob))
 				msg += " - Observing"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -389,10 +389,9 @@ var/list/admin_verbs_hideable = list(
 		if(holder.fakekey)
 			holder.fakekey = null
 		else
-			var/new_key = ckeyEx(input("Enter your desired display name.", "Fake Key", key) as text|null)
+			var/new_name = input("Enter your desired display name.", "Fake Key", key)
+			var/new_key = new /datum/href_proxy(src, new_name)
 			if(!new_key)	return
-			if(length(new_key) >= 26)
-				new_key = copytext(new_key, 1, 26)
 			holder.fakekey = new_key
 		log_admin("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
 		message_admins("[key_name_admin(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -4,7 +4,7 @@ var/list/admin_datums = list()
 	var/datum/admin_rank/rank
 
 	var/client/owner	= null
-	var/fakekey			= null
+	var/datum/href_proxy/fakekey			= null
 
 	var/datum/marked_datum
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -74,7 +74,7 @@
 			src << "<font color='blue'>Admin PM to-<b>[key_name(C, src, 1)]</b>: [msg]</font>"
 
 		else		//recipient is an admin but sender is not
-			C << "<font color='red'>Reply PM from-<b>[key_name(src, C, 1)]</b>: [msg]</font>"
+			C << "<font color='red'>Reply PM from-<b>[key_name(src, C, 0)]</b>: [msg]</font>"
 			src << "<font color='blue'>PM to-<b>Admins</b>: [msg]</font>"
 
 		//play the recieving admin the adminhelp sound (if they have them enabled)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -34,6 +34,11 @@
 		cmd_admin_pm(href_list["priv_msg"],null)
 		return
 
+	//Hidden adminPM
+	if(href_list["proxy_msg"])
+		var/datum/href_proxy/HP = locate(href_list["proxy_msg"])
+		HP.Topic("?priv_msg=[ckey]",list("priv_msg" = ckey))
+
 	//Logs all hrefs
 	if(config && config.log_hrefs && href_logfile)
 		href_logfile << "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -132,6 +132,7 @@
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"
 #include "code\datums\gas_mixture.dm"
+#include "code\datums\href_proxy.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\mind.dm"
 #include "code\datums\mixed.dm"


### PR DESCRIPTION
Now var/fakekey is not just text but datum with name and client vars
If there is fakekey its datum's ref is being incorporated into chat link
instead of admin's ckey
Then in the client proc this datum is retrieved by the ref, its topic
called with all the shit needed, it calls adminpm that handles everything else afterwards
Fixes #1121
