### PR TITLE
Fixes the new AI lawcap config option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -132,7 +132,7 @@
 	var/sandbox_autoclose = 0 // close the sandbox panel after spawning an item, potentially reducing griff
 
 	var/default_laws = 0 //Controls what laws the AI spawns with.
-	var/silicon_max_law_amount = 0
+	var/silicon_max_law_amount = 12
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -28,12 +28,13 @@ AI MODULES
 		user << "<span class='warning'>ERROR: No laws found on board.</span>"
 		return
 
+	//Handle the lawcap
 	if(reciever.laws)
 		var/tot_laws = 0
-		tot_laws += reciever.laws.inherent.len
-		tot_laws += reciever.laws.supplied.len
-		tot_laws += reciever.laws.ion.len
-		tot_laws += laws.len
+		for(var/lawlist in list(reciever.laws.inherent,reciever.laws.supplied,reciever.laws.ion,laws))
+			for(var/mylaw in lawlist)
+				if(mylaw != "")
+					tot_laws++
 		if(tot_laws > config.silicon_max_law_amount && !bypass_law_amt_check)//allows certain boards to avoid this check, eg: reset
 			user << "<span class='caution'>Not enough memory allocated to [reciever]'s law processor to handle this amount of laws."
 			message_admins("[key_name_admin(user)] tried to upload laws to [key_name_admin(reciever)] that would exceed the law cap.")


### PR DESCRIPTION
Previously, it would include null entries in some of the lists, which meant that the total law amount would be grossly exaggerated.

Fixes #5846 properly.
