### PR TITLE
Exofab revamp finishing and fixes

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -14,3 +14,11 @@
 #define BOLTS	4
 #define SHOCK	8
 #define SAFE	16
+
+//used in design to specify which machine can build it
+#define	IMPRINTER	1	//For circuits. Uses glass/chemicals.
+#define PROTOLATHE	2	//New stuff. Uses glass/metal/chemicals
+#define	AUTOLATHE	4	//Uses glass/metal only.
+#define CRAFTLATHE	8	//Uses fuck if I know. For use eventually.
+#define MECHFAB		16 //Remember, objects utilising this flag should have construction_time and construction_cost vars.
+//Note: More then one of these can be added to a design but imprinter and lathe designs are incompatable.

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -8,8 +8,6 @@
 	icon_state = "mecha_equip"
 	force = 5
 	origin_tech = "materials=2"
-	construction_time = 100
-	construction_cost = list("metal"=10000)
 	var/equip_cooldown = 0
 	var/equip_ready = 1
 	var/energy_drain = 0

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -6,7 +6,6 @@
 	origin_tech = "programming=2;biotech=3"
 	energy_drain = 20
 	range = MELEE
-	construction_cost = list("metal"=5000,"glass"=10000)
 	reliability = 1000
 	equip_cooldown = 20
 	var/mob/living/carbon/occupant = null
@@ -256,8 +255,6 @@
 	range = MELEE|RANGED
 	equip_cooldown = 10
 	origin_tech = "materials=3;biotech=4;magnets=4;programming=3"
-	construction_time = 200
-	construction_cost = list("metal"=3000,"glass"=2000)
 
 /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun/New()
 	..()

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -150,7 +150,6 @@
 	desc = "Equipment for engineering and combat exosuits. This is an upgraded version of the drill that'll pierce the heavens!"
 	icon_state = "mecha_diamond_drill"
 	origin_tech = "materials=4;engineering=3"
-	construction_cost = list("metal"=10000,"diamond"=6500)
 	equip_cooldown = 20
 	force = 15
 
@@ -284,8 +283,6 @@
 	equip_cooldown = 10
 	energy_drain = 250
 	range = MELEE|RANGED
-	construction_time = 1200
-	construction_cost = list("metal"=30000,"gold"=20000,"plasma"=25000,"silver"=20000)
 	var/mode = 0 //0 - deconstruct, 1 - wall or floor, 2 - airlock.
 	var/disabled = 0 //malf
 
@@ -676,7 +673,6 @@
 	equip_cooldown = 10
 	energy_drain = 50
 	range = 0
-	construction_cost = list("metal"=20000,"silver"=5000)
 	var/deflect_coeff = 1.15
 	var/damage_coeff = 0.8
 
@@ -727,7 +723,6 @@
 	equip_cooldown = 10
 	energy_drain = 50
 	range = 0
-	construction_cost = list("metal"=20000,"gold"=5000)
 	var/deflect_coeff = 1.15
 	var/damage_coeff = 0.8
 
@@ -799,7 +794,6 @@
 	equip_cooldown = 20
 	energy_drain = 100
 	range = 0
-	construction_cost = list("metal"=10000,"glass"=5000,"gold"=1000,"silver"=2000)
 	var/health_boost = 2
 	var/datum/global_iterator/pr_repair_droid
 	var/icon/droid_overlay
@@ -894,7 +888,6 @@
 	equip_cooldown = 10
 	energy_drain = 0
 	range = 0
-	construction_cost = list("metal"=10000,"glass"=2000,"gold"=2000,"silver"=3000)
 	var/datum/global_iterator/pr_energy_relay
 	var/coeff = 100
 	var/list/use_channels = list(EQUIP,ENVIRON,LIGHT)
@@ -1011,7 +1004,6 @@
 	equip_cooldown = 10
 	energy_drain = 0
 	range = MELEE
-	construction_cost = list("metal"=10000,"glass"=1000,"silver"=500)
 	var/datum/global_iterator/pr_mech_generator
 	var/coeff = 100
 	var/obj/item/stack/sheet/fuel
@@ -1153,7 +1145,6 @@
 	desc = "An exosuit module that generates power using uranium as fuel. Pollutes the environment."
 	icon_state = "tesla"
 	origin_tech = "powerstorage=3;engineering=3"
-	construction_cost = list("metal"=10000,"glass"=1000,"silver"=500)
 	max_fuel = 50000
 	fuel_per_cycle_idle = 10
 	fuel_per_cycle_active = 30

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -67,7 +67,6 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/ion
 	fire_sound = 'sound/weapons/Laser.ogg'
-	construction_cost = list("metal"=20000,"silver"=6000,"uranium"=2000)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	equip_cooldown = 30
@@ -112,8 +111,6 @@
 	energy_drain = 200
 	equip_cooldown = 150
 	range = MELEE|RANGED
-	construction_time = 500
-	construction_cost = list("metal"=20000,"bananium"=10000)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/honker/can_attach(obj/mecha/combat/honker/M as obj)
 	if(..())
@@ -319,7 +316,6 @@
 	equip_cooldown = 60
 	var/missile_speed = 2
 	var/missile_range = 30
-	construction_cost = list("metal"=22000,"gold"=6000,"silver"=8000)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/action(target)
 	if(!action_checks(target)) return
@@ -387,7 +383,6 @@
 	projectile = /obj/item/weapon/grenade/flashbang/clusterbang
 	projectile_energy_cost = 1600 //getting off cheap seeing as this is 3 times the flashbangs held in the grenade launcher.
 	equip_cooldown = 90
-	construction_cost = list("metal"=20000,"gold"=10000,"uranium"=10000) //now as expensive as a Honkblast.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar
 	name = "banana mortar"
@@ -399,8 +394,6 @@
 	missile_speed = 1.5
 	projectile_energy_cost = 100
 	equip_cooldown = 20
-	construction_time = 300
-	construction_cost = list("metal"=20000,"bananium"=5000)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar/can_attach(obj/mecha/combat/honker/M as obj)
 	if(..())
@@ -430,8 +423,6 @@
 	missile_speed = 1.5
 	projectile_energy_cost = 100
 	equip_cooldown = 10
-	construction_time = 300
-	construction_cost = list("metal"=20000,"bananium"=5000)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar/can_attach(obj/mecha/combat/honker/M as obj)
 	if(..())

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -36,6 +36,7 @@
 	var/list/part_sets = list(
 								"Cyborg",
 								"Ripley",
+								"Firefighter",
 								"Odysseus",
 								"Gygax",
 								"Durand",
@@ -60,24 +61,21 @@
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
+
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
 	res_max_amount = (187500+(T * 37500))
-	T = 0
+
+	T = -1
 	for(var/obj/item/weapon/stock_parts/micro_laser/Ma in component_parts)
 		T += Ma.rating
-	T -= 1
-	var/diff
-	diff = round(initial(resource_coeff) - (initial(resource_coeff)*(T))/8,0.01)
-	if(resource_coeff!=diff)
-		resource_coeff = diff
-	T = 0
+	resource_coeff = round(initial(resource_coeff) - (initial(resource_coeff)*(T))/8,0.01)
+
+	T = -1
 	for(var/obj/item/weapon/stock_parts/manipulator/Ml in component_parts)
 		T += Ml.rating
-	T -= 1
-	diff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
-	if(time_coeff!=diff)
-		time_coeff = diff
+	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
+
 
 /obj/machinery/mecha_part_fabricator/check_access(obj/item/weapon/card/id/I)
 	if(istype(I, /obj/item/device/pda))
@@ -108,28 +106,19 @@
 		if(1)
 			visible_message("\icon[src] <b>\The [src]</b> beeps: \"No records in User DB\"")
 	return
-/*
-/obj/machinery/mecha_part_fabricator/proc/add_part_to_set(set_name, part)
-	if(!part)
-		return 0
-	if(!set_name in part_sets)//attempt to create duplicate set
-		part_sets[set_name] = list()
-	part_sets[set_name] += part
-	return 1
-*/
+
 /obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
 	var/output = ""
 	for(var/datum/design/D in files.known_designs)
-		if(D.build_type&16)
-			if(D.category != set_name)
+		if(D.build_type & MECHFAB)
+			if(!(set_name in D.category))
 				continue
 			var/resources_available = check_resources(D)
 			output += "<div class='part'>[output_part_info(D)]<br>\[[resources_available?"<a href='?src=\ref[src];part=[D.id]'>Build</a> | ":null]<a href='?src=\ref[src];add_to_queue=[D.id]'>Add to queue</a>\]\[<a href='?src=\ref[src];part_desc=[D.id]'>?</a>\]</div>"
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/output_part_info(datum/design/D)
-	var/obj/part = D.build_path
-	var/output = "[initial(part.name)] (Cost: [output_part_cost(D)]) [get_construction_time_w_coeff(part)/10]sec"
+	var/output = "[initial(D.name)] (Cost: [output_part_cost(D)]) [get_construction_time_w_coeff(D)/10]sec"
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/output_part_cost(datum/design/D)
@@ -137,7 +126,7 @@
 	var/output
 	for(var/c in D.materials)
 		if(c in resources)
-			output += "[i?" | ":null][get_resource_cost_w_coeff(D,c)] [c]"
+			output += "[i?" | ":null][get_resource_cost_w_coeff(D,c)] [material2name(c)]"
 			i++
 	return output
 
@@ -145,9 +134,9 @@
 	var/output
 	for(var/resource in resources)
 		var/amount = min(res_max_amount, resources[resource])
-		output += "<span class=\"res_name\">[resource]: </span>[amount] cm&sup3;"
+		output += "<span class=\"res_name\">[material2name(resource)]: </span>[amount] cm&sup3;"
 		if(amount>0)
-			output += "<span style='font-size:80%;'> - Remove \[<a href='?src=\ref[src];remove_mat=1;material=[resource]'>1</a>\] | \[<a href='?src=\ref[src];remove_mat=10;material=[resource]'>10</a>\] | \[<a href='?src=\ref[src];remove_mat=[res_max_amount];material=[resource]'>All</a>\]</span>"
+			output += "<span style='font-size:80%;'> - Remove \[<a href='?src=\ref[src];remove_mat=1;material=[resource]'>1</a>\] | \[<a href='?src=\ref[src];remove_mat=10;material=[resource]'>10</a>\] | \[<a href='?src=\ref[src];remove_mat=[resources[resource] / MINERAL_MATERIAL_AMOUNT];material=[resource]'>All</a>\]</span>"
 		output += "<br/>"
 	return output
 
@@ -155,9 +144,6 @@
 	for(var/resource in D.materials)
 		if(resource in resources)
 			resources[resource] -= get_resource_cost_w_coeff(D,resource)
-
-/obj/item/mechavars //until these values are extracted from the design datum (most objects on the mech fabricators don't have these), this is necessary, to make the initial() work.
-	var/construction_time
 
 /obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
 	for(var/R in D.materials)
@@ -169,14 +155,13 @@
 	return 1
 
 /obj/machinery/mecha_part_fabricator/proc/build_part(datum/design/D)
-	var/obj/part = D.build_path
 	being_built = D
-	desc = "It's building \a [initial(part.name)]."
+	desc = "It's building \a [initial(D.name)]."
 	remove_resources(D)
 	overlays += "fab-active"
 	use_power = 2
 	updateUsrDialog()
-	sleep(get_construction_time_w_coeff(part))
+	sleep(get_construction_time_w_coeff(D))
 	use_power = 1
 	overlays -= "fab-active"
 	desc = initial(desc)
@@ -198,8 +183,8 @@
 /obj/machinery/mecha_part_fabricator/proc/add_part_set_to_queue(set_name)
 	if(set_name in part_sets)
 		for(var/datum/design/D in files.known_designs)
-			if(D.build_type&16)
-				if(D.category == set_name)
+			if(D.build_type & MECHFAB)
+				if(set_name in D.category)
 					add_to_queue(D)
 
 /obj/machinery/mecha_part_fabricator/proc/add_to_queue(D)
@@ -252,21 +237,8 @@
 		output += "</ol>"
 		output += "\[<a href='?src=\ref[src];process_queue=1'>Process queue</a> | <a href='?src=\ref[src];clear_queue=1'>Clear queue</a>\]"
 	return output
-/*
-/obj/machinery/mecha_part_fabricator/proc/convert_designs()
-	if(!files) return
-	var/i = 0
-	for(var/datum/design/D in files.known_designs)
-		if(D.build_type&16)
-			if(D.category in part_sets)//Checks if it's a valid category
-				if(add_part_to_set(D.category, D))//Adds it to said category
-					i++
-			else
-				if(add_part_to_set("Misc", D))//If in doubt, chunk it into the Misc
-					i++
-	return i
-*/
-/obj/machinery/mecha_part_fabricator/proc/update_tech()
+
+/*/obj/machinery/mecha_part_fabricator/proc/update_tech()
 	if(!files) return
 	var/output
 	for(var/datum/tech/T in files.known_tech)
@@ -293,7 +265,7 @@
 					if(time_coeff_tech>diff)
 						time_coeff_tech = diff
 						output+="Production routines updated.<br>"
-	return output
+	return output*/
 
 
 /obj/machinery/mecha_part_fabricator/proc/sync()
@@ -301,11 +273,9 @@
 	updateUsrDialog()
 	sleep(30) //only sleep if called by user
 
-	var/found = 0
 	for(var/obj/machinery/computer/rdconsole/RDC in area_contents(get_area(src)))
 		if(!RDC.sync)
 			continue
-		found = 1
 		for(var/datum/tech/T in RDC.files.known_tech)
 			files.AddTech2Known(T)
 		for(var/datum/design/D in RDC.files.known_designs)
@@ -319,17 +289,17 @@
 		updateUsrDialog()
 		//if(i || tech_output)
 		visible_message("\icon[src] <b>\The [src]</b> beeps, \"Successfully synchronized with R&D server.\"")
-	if(!found)
-		temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
-		updateUsrDialog()
+		return
+
+	temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
+	updateUsrDialog()
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(datum/design/D, resource, roundto = 1)
 	return round(D.materials[resource]*resource_coeff*resource_coeff_tech, roundto)
 
-/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(P, roundto = 1) //aran
-	var/obj/item/mechavars/part = P
-	return round(initial(part.construction_time)*time_coeff*time_coeff_tech, roundto)
+/obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(datum/design/D, roundto = 1) //aran
+	return round(initial(D.construction_time)*time_coeff*time_coeff_tech, roundto)
 
 /obj/machinery/mecha_part_fabricator/attack_hand(mob/user)
 	if(!(..()))
@@ -390,7 +360,7 @@
 				</table>
 				</body>
 				</html>"}
-	user << browse(dat, "window=mecha_fabricator;size=1000x400")
+	user << browse(dat, "window=mecha_fabricator;size=1000x430")
 	onclose(user, "mecha_fabricator")
 	return
 
@@ -409,7 +379,7 @@
 	if(href_list["part"])
 		var/T = filter.getStr("part")
 		for(var/datum/design/D in files.known_designs)
-			if(D.build_type&16)
+			if(D.build_type & MECHFAB)
 				if(D.id == T)
 					if(!processing_queue)
 						build_part(D)
@@ -419,7 +389,7 @@
 	if(href_list["add_to_queue"])
 		var/T = filter.getStr("add_to_queue")
 		for(var/datum/design/D in files.known_designs)
-			if(D.build_type&16)
+			if(D.build_type & MECHFAB)
 				if(D.id == T)
 					add_to_queue(D)
 					break
@@ -456,7 +426,7 @@
 	if(href_list["part_desc"])
 		var/T = filter.getStr("part_desc")
 		for(var/datum/design/D in files.known_designs)
-			if(D.build_type&16)
+			if(D.build_type & MECHFAB)
 				if(D.id == T)
 					var/obj/part = D.build_path
 					temp = {"<h1>[initial(part.name)] description:</h1>
@@ -466,11 +436,24 @@
 					break
 
 	if(href_list["remove_mat"] && href_list["material"])
-		temp = "Ejected [remove_material(href_list["material"],text2num(href_list["remove_mat"]))] of [href_list["material"]]<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
+		var/amount = text2num(href_list["remove_mat"])
+		var/material = href_list["material"]
+		if(amount < 0 || amount > resources[material]) //href protection
+			return
+
+		var/removed = remove_material(material,amount)
+		if(removed == -1)
+			temp = "Not enough [material2name(material)] to produce a sheet."
+		else
+			temp = "Ejected [removed] of [material2name(material)]"
+		temp += "<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
+
 	updateUsrDialog()
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/remove_material(var/mat_string, var/amount)
+	if(resources[mat_string] < MINERAL_MATERIAL_AMOUNT) //not enough mineral for a sheet
+		return -1
 	var/type
 	switch(mat_string)
 		if("$metal")
@@ -492,15 +475,19 @@
 		else
 			return 0
 	var/result = 0
-	var/obj/item/stack/sheet/res = new type(src)
-	if(amount>0 && amount<=50)
-		var/total_amount = round(resources[mat_string]/MINERAL_MATERIAL_AMOUNT)
-		res.amount = min(amount,total_amount)
+
+	while(amount > 50)
+		new type(get_turf(src),50)
+		amount -= 50
+		result += 50
+		resources[mat_string] -= 50 * MINERAL_MATERIAL_AMOUNT
+
+	var/total_amount = round(resources[mat_string]/MINERAL_MATERIAL_AMOUNT)
+	if(total_amount)//if there's still enough material for sheets
+		var/obj/item/stack/sheet/res = new type(get_turf(src),min(amount,total_amount))
 		resources[mat_string] -= res.amount*MINERAL_MATERIAL_AMOUNT
-		res.Move(src.loc)
-		result = res.amount
-	else
-		qdel(res)
+		result += res.amount
+
 	return result
 
 
@@ -513,46 +500,8 @@
 
 	if(panel_open)
 		if(istype(W, /obj/item/weapon/crowbar))
-			while(resources["$metal"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/metal/G = new /obj/item/stack/sheet/metal(src.loc)
-				var/sheet_conversion = round(resources["$metal"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$metal"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$glass"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src.loc)
-				var/sheet_conversion = round(resources["$glass"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$glass"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$plasma"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/plasma/G = new /obj/item/stack/sheet/mineral/plasma(src.loc)
-				var/sheet_conversion = round(resources["$plasma"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$plasma"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$silver"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/silver/G = new /obj/item/stack/sheet/mineral/silver(src.loc)
-				var/sheet_conversion = round(resources["$silver"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$silver"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$gold"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold(src.loc)
-				var/sheet_conversion = round(resources["$gold"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$gold"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$uranium"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/uranium/G = new /obj/item/stack/sheet/mineral/uranium(src.loc)
-				var/sheet_conversion = round(resources["$uranium"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$uranium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$diamond"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/diamond/G = new /obj/item/stack/sheet/mineral/diamond(src.loc)
-				var/sheet_conversion = round(resources["$diamond"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$diamond"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
-			while(resources["$bananium"] >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/bananium/G = new /obj/item/stack/sheet/mineral/bananium(src.loc)
-				var/sheet_conversion = round(resources["$bananium"] / MINERAL_MATERIAL_AMOUNT)
-				G.amount = min(sheet_conversion, G.max_amount)
-				resources["$bananium"] -= (G.amount * MINERAL_MATERIAL_AMOUNT)
+			for(var/material in resources)
+				remove_material(material, resources[material]/MINERAL_MATERIAL_AMOUNT)
 			default_deconstruction_crowbar(W)
 			return 1
 		else
@@ -588,19 +537,24 @@
 		if(being_built)
 			user << "\The [src] is currently processing. Please wait until completion."
 			return
+		if(res_max_amount - resources[material] < MINERAL_MATERIAL_AMOUNT) //overstuffing the fabricator
+			user << "\The [src] [material2name(material)] storage is full."
+			return
 		var/obj/item/stack/sheet/stack = W
 		var/sname = "[stack.name]"
 		if(resources[material] < res_max_amount)
-			var/count = 0
-			overlays += "fab-load-[material]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
-			while(resources[material] < res_max_amount && stack && stack.amount > 0)
-				resources[material] += MINERAL_MATERIAL_AMOUNT
-				stack.use(1)
-				count++
+			overlays += "fab-load-[material2name(material)]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
+
+			var/transfer_amount = min(stack.amount, round((res_max_amount - resources[material])/MINERAL_MATERIAL_AMOUNT,1))
+			resources[material] += transfer_amount * MINERAL_MATERIAL_AMOUNT
+			stack.use(transfer_amount)
+			user << "You insert [transfer_amount] [sname] sheet\s into \the [src]."
 			sleep(10)
-			user << "You insert [count] [sname] sheet\s into \the [src]."
 			updateUsrDialog()
-			overlays -= "fab-load-[material]" //No matter what the overlay shall still be deleted
+			overlays -= "fab-load-[material2name(material)]" //No matter what the overlay shall still be deleted
 		else
 			user << "\The [src] cannot hold any more [sname] sheet\s."
 		return
+
+/obj/machinery/mecha_part_fabricator/proc/material2name(var/ID)
+	return copytext(ID,2)

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -66,8 +66,6 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "motion2"
 	origin_tech = "programming=2;magnets=2"
-	construction_time = 50
-	construction_cost = list("metal"=500)
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_info()
 	if(!in_mecha())

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -9,15 +9,11 @@
 	w_class = 6
 	flags = CONDUCT
 	origin_tech = "programming=2;materials=2"
-	var/construction_time = 100
-	var/list/construction_cost = list("metal"=20000,"glass"=5000)
-
 
 /obj/item/mecha_parts/chassis
 	name="Mecha Chassis"
 	icon_state = "backbone"
 	var/datum/construction/construct
-	construction_cost = list("metal"=20000)
 
 /obj/item/mecha_parts/chassis/attackby(obj/item/W as obj, mob/user as mob)
 	if(!construct || !construct.action(W, user))
@@ -41,40 +37,30 @@
 	desc = "A torso part of Ripley APLU. Contains power unit, processing core and life support systems."
 	icon_state = "ripley_harness"
 	origin_tech = "programming=2;materials=2;biotech=2;engineering=2"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"glass"=7500)
 
 /obj/item/mecha_parts/part/ripley_left_arm
 	name = "\improper Ripley left arm"
 	desc = "A Ripley APLU left arm. Data and power sockets are compatible with most exosuit tools."
 	icon_state = "ripley_l_arm"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 150
-	construction_cost = list("metal"=15000)
 
 /obj/item/mecha_parts/part/ripley_right_arm
 	name = "\improper Ripley right arm"
 	desc = "A Ripley APLU right arm. Data and power sockets are compatible with most exosuit tools."
 	icon_state = "ripley_r_arm"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 150
-	construction_cost = list("metal"=15000)
 
 /obj/item/mecha_parts/part/ripley_left_leg
 	name = "\improper Ripley left leg"
 	desc = "A Ripley APLU left leg. Contains somewhat complex servodrives and balance maintaining systems."
 	icon_state = "ripley_l_leg"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 150
-	construction_cost = list("metal"=15000)
 
 /obj/item/mecha_parts/part/ripley_right_leg
 	name = "\improper Ripley right leg"
 	desc = "A Ripley APLU right leg. Contains somewhat complex servodrives and balance maintaining systems."
 	icon_state = "ripley_r_leg"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 150
-	construction_cost = list("metal"=15000)
 
 ///////// Gygax
 
@@ -90,48 +76,36 @@
 	desc = "A torso part of Gygax. Contains power unit, processing core and life support systems."
 	icon_state = "gygax_harness"
 	origin_tech = "programming=2;materials=2;biotech=3;engineering=3"
-	construction_time = 300
-	construction_cost = list("metal"=20000,"glass"=10000,"diamond"=2000)
 
 /obj/item/mecha_parts/part/gygax_head
 	name = "\improper Gygax head"
 	desc = "A Gygax head. Houses advanced surveilance and targeting sensors."
 	icon_state = "gygax_head"
 	origin_tech = "programming=2;materials=2;magnets=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=10000,"glass"=5000, "diamond"=2000)
 
 /obj/item/mecha_parts/part/gygax_left_arm
 	name = "\improper Gygax left arm"
 	desc = "A Gygax left arm. Data and power sockets are compatible with most exosuit tools and weapons."
 	icon_state = "gygax_l_arm"
 	origin_tech = "programming=2;materials=2;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000, "diamond"=1000)
 
 /obj/item/mecha_parts/part/gygax_right_arm
 	name = "\improper Gygax right arm"
 	desc = "A Gygax right arm. Data and power sockets are compatible with most exosuit tools and weapons."
 	icon_state = "gygax_r_arm"
 	origin_tech = "programming=2;materials=2;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000, "diamond"=1000)
 
 /obj/item/mecha_parts/part/gygax_left_leg
 	name = "\improper Gygax left leg"
 	desc = "A Gygax left leg. Constructed with advanced servomechanisms and actuators to enable faster speed."
 	icon_state = "gygax_l_leg"
 	origin_tech = "programming=2;materials=2;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000, "diamond"=2000)
 
 /obj/item/mecha_parts/part/gygax_right_leg
 	name = "\improper Gygax right leg"
 	desc = "A Gygax right leg. Constructed with advanced servomechanisms and actuators to enable faster speed."
 	icon_state = "gygax_r_leg"
 	origin_tech = "programming=2;materials=2;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000, "diamond"=2000)
 
 /obj/item/mecha_parts/part/gygax_armor
 	gender = PLURAL
@@ -139,15 +113,12 @@
 	desc = "A set of armor plates designed for the Gygax. Designed to effectively deflect damage with a lightweight construction."
 	icon_state = "gygax_armor"
 	origin_tech = "materials=6;combat=4;engineering=5"
-	construction_time = 600
-	construction_cost = list("metal"=25000,"diamond"=10000)
 
 
 //////////// Durand
 
 /obj/item/mecha_parts/chassis/durand
 	name = "\improper Durand chassis"
-	construction_cost = list("metal"=25000)
 
 /obj/item/mecha_parts/chassis/durand/New()
 	..()
@@ -158,48 +129,36 @@
 	desc = "A torso part of Durand. Contains power unit, processing core and life support systems within a robust protective frame."
 	icon_state = "durand_harness"
 	origin_tech = "programming=2;materials=3;biotech=3;engineering=3"
-	construction_time = 300
-	construction_cost = list("metal"=25000,"glass"=10000,"silver"=10000)
 
 /obj/item/mecha_parts/part/durand_head
 	name = "\improper Durand head"
 	desc = "A Durand head. Houses advanced surveilance and targeting sensors."
 	icon_state = "durand_head"
 	origin_tech = "programming=2;materials=3;magnets=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=10000,"glass"=15000,"silver"=2000)
 
 /obj/item/mecha_parts/part/durand_left_arm
 	name = "\improper Durand left arm"
 	desc = "A Durand left arm. Data and power sockets are compatible with most exosuit tools and weapons. Packs a really mean punch as well."
 	icon_state = "durand_l_arm"
 	origin_tech = "programming=2;materials=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=10000,"silver"=4000)
 
 /obj/item/mecha_parts/part/durand_right_arm
 	name = "\improper Durand right arm"
 	desc = "A Durand right arm. Data and power sockets are compatible with most exosuit tools and weapons. Packs a really mean punch as well."
 	icon_state = "durand_r_arm"
 	origin_tech = "programming=2;materials=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=10000,"silver"=4000)
 
 /obj/item/mecha_parts/part/durand_left_leg
 	name = "\improper Durand left leg"
 	desc = "A Durand left leg. Built particlarly sturdy to support the Durand's heavy weight and defensive needs."
 	icon_state = "durand_l_leg"
 	origin_tech = "programming=2;materials=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000,"silver"=4000)
 
 /obj/item/mecha_parts/part/durand_right_leg
 	name = "\improper Durand right leg"
 	desc = "A Durand right leg. Built particlarly sturdy to support the Durand's heavy weight and defensive needs."
 	icon_state = "durand_r_leg"
 	origin_tech = "programming=2;materials=3;engineering=3"
-	construction_time = 200
-	construction_cost = list("metal"=15000,"silver"=4000)
 
 /obj/item/mecha_parts/part/durand_armor
 	gender = PLURAL
@@ -207,8 +166,6 @@
 	desc = "A set of armor plates for the Durand. Built heavy to resist an incredible amount of brute force."
 	icon_state = "durand_armor"
 	origin_tech = "materials=5;combat=4;engineering=5"
-	construction_time = 600
-	construction_cost = list("metal"=50000,"uranium"=30000)
 
 ////////// Firefighter
 
@@ -253,43 +210,31 @@
 	name = "\improper H.O.N.K torso"
 	desc = "A torso part of H.O.N.K. Contains chuckle unit, bananium core and honk support systems."
 	icon_state = "honker_harness"
-	construction_time = 300
-	construction_cost = list("metal"=20000,"glass"=10000,"bananium"=10000)
 
 /obj/item/mecha_parts/part/honker_head
 	name = "\improper H.O.N.K head"
 	desc = "A H.O.N.K head. Appears to lack a face plate."
 	icon_state = "honker_head"
-	construction_time = 200
-	construction_cost = list("metal"=10000,"glass"=5000,"bananium"=5000)
 
 /obj/item/mecha_parts/part/honker_left_arm
 	name = "\improper H.O.N.K left arm"
 	desc = "A H.O.N.K left arm. With unique sockets that accept odd weaponry designed by clown scientists."
 	icon_state = "honker_l_arm"
-	construction_time = 200
-	construction_cost = list("metal"=15000,"bananium"=5000)
 
 /obj/item/mecha_parts/part/honker_right_arm
 	name = "\improper H.O.N.K right arm"
 	desc = "A H.O.N.K right arm. With unique sockets that accept odd weaponry designed by clown scientists."
 	icon_state = "honker_r_arm"
-	construction_time = 200
-	construction_cost = list("metal"=15000,"bananium"=5000)
 
 /obj/item/mecha_parts/part/honker_left_leg
 	name = "\improper H.O.N.K left leg"
 	desc = "A H.O.N.K left leg. The foot appears just large enough to fully accomodate a clown shoe."
 	icon_state = "honker_l_leg"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"bananium"=5000)
 
 /obj/item/mecha_parts/part/honker_right_leg
 	name = "\improper H.O.N.K right leg"
 	desc = "A H.O.N.K right leg. The foot appears just large enough to fully accomodate a clown shoe."
 	icon_state = "honker_r_leg"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"bananium"=5000)
 
 
 ////////// Phazon
@@ -306,56 +251,42 @@
 	name="\improper Phazon torso"
 	desc="A Phazon torso part. The socket for the bluespace core that powers the exosuit's unique phase drives is located in the middle."
 	icon_state = "phazon_harness"
-	construction_time = 300
-	construction_cost = list("metal"=35000,"glass"=10000,"plasma"=20000)
 	origin_tech = "programming=5;materials=6;bluespace=5;powerstorage=5"
 
 /obj/item/mecha_parts/part/phazon_head
 	name="\improper Phazon head"
 	desc="A Phazon head. Its sensors are carefully calibrated to provide vision and data even when the exosuit is phasing."
 	icon_state = "phazon_head"
-	construction_time = 200
-	construction_cost = list("metal"=15000,"glass"=5000,"plasma"=10000)
 	origin_tech = "programming=4;materials=5;magnets=5"
 
 /obj/item/mecha_parts/part/phazon_left_arm
 	name="\improper Phazon left arm"
 	desc="A Phazon left arm. Several microtool arrays are located under the armor plating, which can be adjusted to the situation at hand."
 	icon_state = "phazon_l_arm"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"plasma"=10000)
 	origin_tech = "materials=5;bluespace=2;magnets=2"
 
 /obj/item/mecha_parts/part/phazon_right_arm
 	name="\improper Phazon right arm"
 	desc="A Phazon right arm. Several microtool arrays are located under the armor plating, which can be adjusted to the situation at hand."
 	icon_state = "phazon_r_arm"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"plasma"=10000)
 	origin_tech = "materials=5;bluespace=2;magnets=2"
 
 /obj/item/mecha_parts/part/phazon_left_leg
 	name="\improper Phazon left leg"
 	desc="A Phazon left leg. It contains the unique phase drives that allow the exosuit to phase through solid matter when engaged."
 	icon_state = "phazon_l_leg"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"plasma"=10000)
 	origin_tech = "materials=5;bluespace=3;magnets=3"
 
 /obj/item/mecha_parts/part/phazon_right_leg
 	name="\improper Phazon right leg"
 	desc="A Phazon right leg. It contains the unique phase drives that allow the exosuit to phase through solid matter when engaged."
 	icon_state = "phazon_r_leg"
-	construction_time = 200
-	construction_cost = list("metal"=20000,"plasma"=10000)
 	origin_tech = "materials=5;bluespace=3;magnets=3"
 
 /obj/item/mecha_parts/part/phazon_armor
 	name="Phazon armor"
 	desc="Phazon armor plates. They are layered with plasma to protect the pilot from the stress of phasing and have unusual properties."
 	icon_state = "phazon_armor"
-	construction_time = 300
-	construction_cost = list("metal"=45000,"plasma"=30000)
 	origin_tech = "materials=6;bluespace=5;magnets=5"
 ///////// Odysseus
 
@@ -371,8 +302,6 @@
 	name = "\improper Odysseus head"
 	desc = "An Odysseus head. Contains an integrated medical HUD scanner."
 	icon_state = "odysseus_head"
-	construction_time = 100
-	construction_cost = list("metal"=6000,"glass"=10000)
 	origin_tech = "programming=3;materials=2"
 
 /obj/item/mecha_parts/part/odysseus_torso
@@ -380,40 +309,30 @@
 	desc="A torso part of Odysseus. Contains power unit, processing core and life support systems along with an attachment port for a mounted sleeper."
 	icon_state = "odysseus_torso"
 	origin_tech = "programming=2;materials=2;biotech=2;engineering=2"
-	construction_time = 180
-	construction_cost = list("metal"=12000)
 
 /obj/item/mecha_parts/part/odysseus_left_arm
 	name = "\improper Odysseus left arm"
 	desc = "An Odysseus left arm. Data and power sockets are compatible with specialized medical equipment."
 	icon_state = "odysseus_l_arm"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 120
-	construction_cost = list("metal"=6000)
 
 /obj/item/mecha_parts/part/odysseus_right_arm
 	name = "\improper Odysseus right arm"
 	desc = "An Odysseus right arm. Data and power sockets are compatible with specialized medical equipment."
 	icon_state = "odysseus_r_arm"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 120
-	construction_cost = list("metal"=6000)
 
 /obj/item/mecha_parts/part/odysseus_left_leg
 	name = "\improper Odysseus left leg"
 	desc = "An Odysseus left leg. Contains complex servodrives and balance maintaining systems to maintain stability for critical patients."
 	icon_state = "odysseus_l_leg"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 130
-	construction_cost = list("metal"=7000)
 
 /obj/item/mecha_parts/part/odysseus_right_leg
 	name = "\improper Odysseus right leg"
 	desc = "A Odysseus right leg. Contains complex servodrives and balance maintaining systems to maintain stability for critical patients."
 	icon_state = "odysseus_r_leg"
 	origin_tech = "programming=2;materials=2;engineering=2"
-	construction_time = 130
-	construction_cost = list("metal"=7000)
 
 /*/obj/item/mecha_parts/part/odysseus_armor
 	name="Odysseus Carapace"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -5,43 +5,31 @@
 	icon_state = "blank"
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
-	var/construction_time = 100
-	var/list/construction_cost = list("metal"=20000,"glass"=5000)
 
 /obj/item/robot_parts/l_arm
 	name = "cyborg left arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_arm"
-	construction_time = 200
-	construction_cost = list("metal"=10000)
 
 /obj/item/robot_parts/r_arm
 	name = "cyborg right arm"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_arm"
-	construction_time = 200
-	construction_cost = list("metal"=10000)
 
 /obj/item/robot_parts/l_leg
 	name = "cyborg left leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "l_leg"
-	construction_time = 200
-	construction_cost = list("metal"=10000)
 
 /obj/item/robot_parts/r_leg
 	name = "cyborg right leg"
 	desc = "A skeletal limb wrapped in pseudomuscles, with a low-conductivity case."
 	icon_state = "r_leg"
-	construction_time = 200
-	construction_cost = list("metal"=10000)
 
 /obj/item/robot_parts/chest
 	name = "cyborg torso"
 	desc = "A heavily reinforced case containing cyborg logic boards, with space for a standard power cell."
 	icon_state = "chest"
-	construction_time = 350
-	construction_cost = list("metal"=40000)
 	var/wires = 0.0
 	var/obj/item/weapon/stock_parts/cell/cell = null
 
@@ -49,8 +37,6 @@
 	name = "cyborg head"
 	desc = "A standard reinforced braincase, with spine-plugged neural socket and sensor gimbals."
 	icon_state = "head"
-	construction_time = 350
-	construction_cost = list("metal"=5000)
 	var/obj/item/device/flash/handheld/flash1 = null
 	var/obj/item/device/flash/handheld/flash2 = null
 
@@ -58,8 +44,6 @@
 	name = "cyborg endoskeleton"
 	desc = "A complex metal backbone with standard limb sockets and pseudomuscle anchors."
 	icon_state = "robo_suit"
-	construction_time = 500
-	construction_cost = list("metal"=15000)
 	var/obj/item/robot_parts/l_arm/l_arm = null
 	var/obj/item/robot_parts/r_arm/r_arm = null
 	var/obj/item/robot_parts/l_leg/l_leg = null

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -6,8 +6,6 @@
 	desc = "Protected by FRM."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade"
-	var/construction_time = 120
-	var/construction_cost = list("metal"=10000)
 	var/locked = 0
 	var/require_module = 0
 	var/installed = 0
@@ -45,7 +43,6 @@
 	name = "cyborg reclassification board"
 	desc = "Used to rename a cyborg."
 	icon_state = "cyborg_upgrade1"
-	construction_cost = list("metal"=35000)
 	var/heldname = "default name"
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user as mob)
@@ -64,7 +61,6 @@
 /obj/item/borg/upgrade/restart
 	name = "cyborg emergency restart module"
 	desc = "Used to force a restart of a disabled-but-repaired cyborg, bringing it back online."
-	construction_cost = list("metal"=60000 , "glass"=5000)
 	icon_state = "cyborg_upgrade1"
 
 
@@ -89,7 +85,6 @@
 /obj/item/borg/upgrade/vtec
 	name = "cyborg VTEC module"
 	desc = "Used to kick in a cyborg's VTEC systems, increasing their speed."
-	construction_cost = list("metal"=80000 , "glass"=6000 , "gold"= 5000)
 	icon_state = "cyborg_upgrade2"
 	require_module = 1
 
@@ -106,7 +101,6 @@
 /obj/item/borg/upgrade/tasercooler
 	name = "cyborg rapid taser cooling module"
 	desc = "Used to cool a mounted taser, increasing the potential current in it and thus its recharge rate."
-	construction_cost = list("metal"=80000 , "glass"=6000 , "gold"= 2000, "diamond" = 500)
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 
@@ -141,7 +135,6 @@
 /obj/item/borg/upgrade/jetpack
 	name = "mining cyborg jetpack"
 	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
-	construction_cost = list("metal"=10000,"plasma"=15000,"uranium" = 20000)
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 
@@ -164,7 +157,6 @@
 /obj/item/borg/upgrade/syndicate/
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg"
-	construction_cost = list("metal"=10000,"glass"=15000,"diamond" = 10000)
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -16,8 +16,6 @@
 	g_amt = 50
 	var/rigged = 0		// true if rigged to explode
 	var/minor_fault = 0 //If not 100% reliable, it will build up faults.
-	var/construction_cost = list("metal"=750,"glass"=75)
-	var/construction_time=100
 
 /obj/item/weapon/stock_parts/cell/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is licking the electrodes of the [src.name]! It looks like \he's trying to commit suicide.</span>")
@@ -64,7 +62,6 @@
 	icon_state = "scell"
 	maxcharge = 20000
 	g_amt = 70
-	construction_cost = list("metal"=750,"glass"=100)
 	rating = 4
 
 /obj/item/weapon/stock_parts/cell/super/empty/New()
@@ -77,7 +74,6 @@
 	icon_state = "hpcell"
 	maxcharge = 30000
 	g_amt = 80
-	construction_cost = list("metal"=500,"glass"=150,"gold"=200,"silver"=200)
 	rating = 5
 
 /obj/item/weapon/stock_parts/cell/hyper/empty/New()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -8,10 +8,6 @@
 	w_class = 3
 	origin_tech = "biotech=3"
 
-	var/list/construction_cost = list("metal"=1000,"glass"=500)
-	var/construction_time = 75
-	//these vars are so the mecha fabricator doesn't shit itself anymore. --NEO
-
 	req_access = list(access_robotics)
 
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.

--- a/code/modules/mob/living/simple_animal/friendly/drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone.dm
@@ -521,8 +521,6 @@
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_item"
 	origin_tech = "programming=2;biotech=4"
-	var/construction_cost = list("metal"=800, "glass"=350)
-	var/construction_time=150
 	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 
 /obj/item/drone_shell/attack_ghost(mob/user)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -14,7 +14,7 @@ The currently supporting non-reagent materials. All material amounts are set as 
 - $gold (/obj/item/stack/gold).
 - $uranium (/obj/item/stack/uranium).
 - $diamond (/obj/item/stack/diamond).
-- $clown (/obj/item/stack/clown).
+- $bananium (/obj/item/stack/bananium).
 (Insert new ones here)
 
 Don't add new keyword/IDs if they are made from an existing one (such as rods which are made from metal). Only add raw materials.
@@ -27,15 +27,7 @@ reliability_mod (starts at 0, gets improved through experimentation). Example: P
 - A single sheet of anything is 3750 units of material. Materials besides metal/glass require help from other jobs (mining for
 other types of metals and chemistry for reagents).
 - Add the AUTOLATHE tag to
-
-
 */
-#define	IMPRINTER	1	//For circuits. Uses glass/chemicals.
-#define PROTOLATHE	2	//New stuff. Uses glass/metal/chemicals
-#define	AUTOLATHE	4	//Uses glass/metal only.
-#define CRAFTLATHE	8	//Uses fuck if I know. For use eventually.
-#define MECHFAB		16 //Remember, objects utilising this flag should have construction_time and construction_cost vars.
-//Note: More then one of these can be added to a design but imprinter and lathe designs are incompatable.
 
 datum/design						//Datum for object designs, used in construction
 	var/name = "Name"					//Name of the created object.
@@ -45,9 +37,10 @@ datum/design						//Datum for object designs, used in construction
 	var/reliability = 100				//Reliability of the device.
 	var/build_type = null				//Flag as to what kind machine the design is built in. See defines.
 	var/list/materials = list()			//List of materials. Format: "id" = amount.
+	var/construction_time				//Amount of time required for building the object
 	var/build_path = ""					//The file path of the object that gets created
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
-	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
+	var/list/category = null 			//Primarily used for Mech Fabricators, but can be used for anything
 
 
 //A proc to calculate the reliability of a design based on tech levels and innate modifiers.
@@ -168,7 +161,7 @@ datum/design/beacon
 	id = "beacon"
 	req_tech = list("bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list ("$metal" = 20, "$glass" = 10)
+	materials = list("$metal" = 20, "$glass" = 10)
 	build_path = /obj/item/device/radio/beacon
 
 datum/design/bag_holding
@@ -199,7 +192,6 @@ datum/design/telesci_gps
 	build_type = PROTOLATHE
 	materials = list("$metal" = 500, "$glass" = 1000)
 	build_path = /obj/item/device/gps
-
 
 
 /////////////////////////////////////////
@@ -286,7 +278,9 @@ datum/design/borg_syndicate_module
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "syndicate" = 3)
 	build_path = /obj/item/borg/upgrade/syndicate
-	category = "Cyborg Upgrade Modules"
+	materials = list("$metal"=10000,"$glass"=15000,"$diamond" = 10000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 
 /////////////////////////////////////////
@@ -336,8 +330,9 @@ datum/design/drone_shell
 	req_tech = list("programming" = 2, "biotech" = 4)
 	build_type = MECHFAB
 	materials = list("$metal" = 800, "$glass" = 350)
+	construction_time=150
 	build_path = /obj/item/drone_shell
-	category = "Misc"
+	category = list("Misc")
 
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -3,7 +3,7 @@
 ///////////////////////////////////
 
 datum/design/safeguard_module
-	name = "Module Design (Safeguard)"
+	name = "AI Module(Safeguard)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "safeguard_module"
 	req_tech = list("programming" = 3, "materials" = 4)
@@ -12,7 +12,7 @@ datum/design/safeguard_module
 	build_path = /obj/item/weapon/aiModule/supplied/safeguard
 
 datum/design/onehuman_module
-	name = "Module Design (OneHuman)"
+	name = "AI Module (OneHuman)"
 	desc = "Allows for the construction of a OneHuman AI Module."
 	id = "onehuman_module"
 	req_tech = list("programming" = 4, "materials" = 6)
@@ -21,7 +21,7 @@ datum/design/onehuman_module
 	build_path = /obj/item/weapon/aiModule/zeroth/oneHuman
 
 datum/design/protectstation_module
-	name = "Module Design (ProtectStation)"
+	name = "AI Module (ProtectStation)"
 	desc = "Allows for the construction of a ProtectStation AI Module."
 	id = "protectstation_module"
 	req_tech = list("programming" = 3, "materials" = 6)
@@ -30,7 +30,7 @@ datum/design/protectstation_module
 	build_path = /obj/item/weapon/aiModule/supplied/protectStation
 
 datum/design/quarantine_module
-	name = "Module Design (Quarantine)"
+	name = "AI Module (Quarantine)"
 	desc = "Allows for the construction of a Quarantine AI Module."
 	id = "quarantine_module"
 	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
@@ -39,7 +39,7 @@ datum/design/quarantine_module
 	build_path = /obj/item/weapon/aiModule/supplied/quarantine
 
 datum/design/oxygen_module
-	name = "Module Design (OxygenIsToxicToHumans)"
+	name = "AI Module (OxygenIsToxicToHumans)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "oxygen_module"
 	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
@@ -48,7 +48,7 @@ datum/design/oxygen_module
 	build_path = /obj/item/weapon/aiModule/supplied/oxygen
 
 datum/design/freeform_module
-	name = "Module Design (Freeform)"
+	name = "AI Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Module."
 	id = "freeform_module"
 	req_tech = list("programming" = 4, "materials" = 4)
@@ -57,7 +57,7 @@ datum/design/freeform_module
 	build_path = /obj/item/weapon/aiModule/supplied/freeform
 
 datum/design/reset_module
-	name = "Module Design (Reset)"
+	name = "AI Module (Reset)"
 	desc = "Allows for the construction of a Reset AI Module."
 	id = "reset_module"
 	req_tech = list("programming" = 3, "materials" = 6)
@@ -66,7 +66,7 @@ datum/design/reset_module
 	build_path = /obj/item/weapon/aiModule/reset
 
 datum/design/purge_module
-	name = "Module Design (Purge)"
+	name = "AI Module (Purge)"
 	desc = "Allows for the construction of a Purge AI Module."
 	id = "purge_module"
 	req_tech = list("programming" = 4, "materials" = 6)
@@ -75,7 +75,7 @@ datum/design/purge_module
 	build_path = /obj/item/weapon/aiModule/reset/purge
 
 datum/design/freeformcore_module
-	name = "Core Module Design (Freeform)"
+	name = "AI Core Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Core Module."
 	id = "freeformcore_module"
 	req_tech = list("programming" = 4, "materials" = 6)
@@ -84,7 +84,7 @@ datum/design/freeformcore_module
 	build_path = /obj/item/weapon/aiModule/core/freeformcore
 
 datum/design/asimov
-	name = "Core Module Design (Asimov)"
+	name = "AI Core Module (Asimov)"
 	desc = "Allows for the construction of a Asimov AI Core Module."
 	id = "asimov_module"
 	req_tech = list("programming" = 3, "materials" = 6)
@@ -93,7 +93,7 @@ datum/design/asimov
 	build_path = /obj/item/weapon/aiModule/core/full/asimov
 
 datum/design/paladin_module
-	name = "Core Module Design (P.A.L.A.D.I.N.)"
+	name = "AI Core Module (P.A.L.A.D.I.N.)"
 	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Module."
 	id = "paladin_module"
 	req_tech = list("programming" = 4, "materials" = 6)
@@ -102,7 +102,7 @@ datum/design/paladin_module
 	build_path = /obj/item/weapon/aiModule/core/full/paladin
 
 datum/design/tyrant_module
-	name = "Core Module Design (T.Y.R.A.N.T.)"
+	name = "AI Core Module (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
 	req_tech = list("programming" = 4, "syndicate" = 2, "materials" = 6)
@@ -111,7 +111,7 @@ datum/design/tyrant_module
 	build_path = /obj/item/weapon/aiModule/core/full/tyrant
 
 datum/design/corporate_module
-	name = "Core Module Design (Corporate)"
+	name = "AI Core Module (Corporate)"
 	desc = "Allows for the construction of a Corporate AI Core Module."
 	id = "corporate_module"
 	req_tech = list("programming" = 4, "materials" = 6)
@@ -120,7 +120,7 @@ datum/design/corporate_module
 	build_path = /obj/item/weapon/aiModule/core/full/corp
 
 datum/design/custom_module
-	name = "Core Module Design (Custom)"
+	name = "AI Core Module (Custom)"
 	desc = "Allows for the construction of a Custom AI Core Module."
 	id = "custom_module"
 	req_tech = list("programming" = 4, "materials" = 6)

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -3,7 +3,7 @@
 ///////////////////////////////////
 
 datum/design/ripley_main
-	name = "Exosuit Design (APLU \"Ripley\" Central Control module)"
+	name = "Exosuit Module (APLU \"Ripley\" Central Control module)"
 	desc = "Allows for the construction of a \"Ripley\" Central Control module."
 	id = "ripley_main"
 	req_tech = list("programming" = 3)
@@ -12,7 +12,7 @@ datum/design/ripley_main
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
 
 datum/design/ripley_peri
-	name = "Exosuit Design (APLU \"Ripley\" Peripherals Control module)"
+	name = "Exosuit Module (APLU \"Ripley\" Peripherals Control module)"
 	desc = "Allows for the construction of a  \"Ripley\" Peripheral Control module."
 	id = "ripley_peri"
 	req_tech = list("programming" = 3)
@@ -21,7 +21,7 @@ datum/design/ripley_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 
 datum/design/odysseus_main
-	name = "Exosuit Design (\"Odysseus\" Central Control module)"
+	name = "Exosuit Module (\"Odysseus\" Central Control module)"
 	desc = "Allows for the construction of a \"Odysseus\" Central Control module."
 	id = "odysseus_main"
 	req_tech = list("programming" = 3,"biotech" = 2)
@@ -30,7 +30,7 @@ datum/design/odysseus_main
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/main
 
 datum/design/odysseus_peri
-	name = "Exosuit Design (\"Odysseus\" Peripherals Control module)"
+	name = "Exosuit Module (\"Odysseus\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Odysseus\" Peripheral Control module."
 	id = "odysseus_peri"
 	req_tech = list("programming" = 3,"biotech" = 2)
@@ -39,7 +39,7 @@ datum/design/odysseus_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
 
 datum/design/gygax_main
-	name = "Exosuit Design (\"Gygax\" Central Control module)"
+	name = "Exosuit Module (\"Gygax\" Central Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Central Control module."
 	id = "gygax_main"
 	req_tech = list("programming" = 4)
@@ -48,7 +48,7 @@ datum/design/gygax_main
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/main
 
 datum/design/gygax_peri
-	name = "Exosuit Design (\"Gygax\" Peripherals Control module)"
+	name = "Exosuit Module (\"Gygax\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Peripheral Control module."
 	id = "gygax_peri"
 	req_tech = list("programming" = 4)
@@ -57,7 +57,7 @@ datum/design/gygax_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/peripherals
 
 datum/design/gygax_targ
-	name = "Exosuit Design (\"Gygax\" Weapons & Targeting Control module)"
+	name = "Exosuit Module (\"Gygax\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Gygax\" Weapons & Targeting Control module."
 	id = "gygax_targ"
 	req_tech = list("programming" = 4, "combat" = 2)
@@ -66,7 +66,7 @@ datum/design/gygax_targ
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/targeting
 
 datum/design/durand_main
-	name = "Exosuit Design (\"Durand\" Central Control module)"
+	name = "Exosuit Module (\"Durand\" Central Control module)"
 	desc = "Allows for the construction of a \"Durand\" Central Control module."
 	id = "durand_main"
 	req_tech = list("programming" = 4)
@@ -75,7 +75,7 @@ datum/design/durand_main
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
 
 datum/design/durand_peri
-	name = "Exosuit Design (\"Durand\" Peripherals Control module)"
+	name = "Exosuit Module (\"Durand\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Durand\" Peripheral Control module."
 	id = "durand_peri"
 	req_tech = list("programming" = 4)
@@ -84,7 +84,7 @@ datum/design/durand_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
 
 datum/design/durand_targ
-	name = "Exosuit Design (\"Durand\" Weapons & Targeting Control module)"
+	name = "Exosuit Module (\"Durand\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Durand\" Weapons & Targeting Control module."
 	id = "durand_targ"
 	req_tech = list("programming" = 4, "combat" = 2)
@@ -93,7 +93,7 @@ datum/design/durand_targ
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
 
 datum/design/honker_main
-	name = "Exosuit Design (\"H.O.N.K\" Central Control module)"
+	name = "Exosuit Module (\"H.O.N.K\" Central Control module)"
 	desc = "Allows for the construction of a \"H.O.N.K\" Central Control module."
 	id = "honker_main"
 	req_tech = list("programming" = 3)
@@ -102,7 +102,7 @@ datum/design/honker_main
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/main
 
 datum/design/honker_peri
-	name = "Exosuit Design (\"H.O.N.K\" Peripherals Control module)"
+	name = "Exosuit Module (\"H.O.N.K\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"H.O.N.K\" Peripheral Control module."
 	id = "honker_peri"
 	req_tech = list("programming" = 3)
@@ -111,7 +111,7 @@ datum/design/honker_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/peripherals
 
 datum/design/honker_targ
-	name = "Exosuit Design (\"H.O.N.K\" Weapons & Targeting Control module)"
+	name = "Exosuit Module (\"H.O.N.K\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"H.O.N.K\" Weapons & Targeting Control module."
 	id = "honker_targ"
 	req_tech = list("programming" = 3)
@@ -120,7 +120,7 @@ datum/design/honker_targ
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/targeting
 
 datum/design/phazon_main
-	name = "Exosuit Design (\"Phazon\" Central Control module)"
+	name = "Exosuit Module (\"Phazon\" Central Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Central Control module."
 	id = "phazon_main"
 	req_tech = list("programming" = 5, "materials" = 7, "powerstorage" = 6)
@@ -129,7 +129,7 @@ datum/design/phazon_main
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/main
 
 datum/design/phazon_peri
-	name = "Exosuit Design (\"Phazon\" Peripherals Control module)"
+	name = "Exosuit Module (\"Phazon\" Peripherals Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Peripheral Control module."
 	id = "phazon_peri"
 	req_tech = list("programming" = 5, "bluespace" = 6)
@@ -138,7 +138,7 @@ datum/design/phazon_peri
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/peripherals
 
 datum/design/phazon_targ
-	name = "Exosuit Design (\"Phazon\" Weapons & Targeting Control module)"
+	name = "Exosuit Module (\"Phazon\" Weapons & Targeting Control module)"
 	desc = "Allows for the construction of a \"Phazon\" Weapons & Targeting Control module."
 	id = "phazon_targ"
 	req_tech = list("programming" = 5, "magnets" = 6)
@@ -151,163 +151,199 @@ datum/design/phazon_targ
 ////////////////////////////////////////
 
 datum/design/mech_scattershot
-	name = "Exosuit Weapon Design (LBX AC 10 \"Scattershot\")"
+	name = "Exosuit Weapon (LBX AC 10 \"Scattershot\")"
 	desc = "Allows for the construction of LBX AC 10."
 	id = "mech_scattershot"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_carbine
-	name = "Exosuit Weapon Design (FNX-99 \"Hades\" Carbine)"
+	name = "Exosuit Weapon (FNX-99 \"Hades\" Carbine)"
 	desc = "Allows for the construction of FNX-99 \"Hades\" Carbine."
 	id = "mech_carbine"
 	build_type = MECHFAB
 	req_tech = list("combat" = 5, "materials" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_ion
-	name = "Exosuit Weapon Design (MKIV Ion Heavy Cannon)"
+	name = "Exosuit Weapon (MKIV Ion Heavy Cannon)"
 	desc = "Allows for the construction of MKIV Ion Heavy Cannon."
 	id = "mech_ion"
 	build_type = MECHFAB
 	req_tech = list("combat" = 6, "magnets" = 5, "materials" = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
-	category = "Exosuit Equipment"
+	materials = list("$metal"=20000,"$silver"=6000,"$uranium"=2000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_laser
-	name = "Exosuit Weapon Design (CH-PS \"Immolator\" Laser)"
+	name = "Exosuit Weapon (CH-PS \"Immolator\" Laser)"
 	desc = "Allows for the construction of CH-PS Laser."
 	id = "mech_laser"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3, "magnets" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_laser_heavy
-	name = "Exosuit Weapon Design (CH-LC \"Solaris\" Laser Cannon)"
+	name = "Exosuit Weapon (CH-LC \"Solaris\" Laser Cannon)"
 	desc = "Allows for the construction of CH-LC Laser Cannon."
 	id = "mech_laser_heavy"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "magnets" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_grenade_launcher
-	name = "Exosuit Weapon Design (SGL-6 Grenade Launcher)"
+	name = "Exosuit Weapon (SGL-6 Grenade Launcher)"
 	desc = "Allows for the construction of SGL-6 Grenade Launcher."
 	id = "mech_grenade_launcher"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang
-	category = "Exosuit Equipment"
+	materials = list("$metal"=22000,"$gold"=6000,"$silver"=8000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_missile_rack
-	name = "Exosuit Weapon Design (SRM-8 Missile Rack)"
+	name = "Exosuit Weapon (SRM-8 Missile Rack)"
 	desc = "Allows for the construction of SRM-8 Missile Rack."
 	id = "mech_missile_rack"
 	build_type = MECHFAB
 	req_tech = list("combat" = 6, "materials" = 6)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
-	category = "Exosuit Equipment"
+	materials = list("$metal"=22000,"$gold"=6000,"$silver"=8000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/clusterbang_launcher
-	name = "Exosuit Module Design (SOB-3 Clusterbang Launcher)"
+	name = "Exosuit Module (SOB-3 Clusterbang Launcher)"
 	desc = "A weapon that violates the Geneva Convention at 3 rounds per minute"
 	id = "clusterbang_launcher"
 	build_type = MECHFAB
 	req_tech = list("combat"= 5, "materials" = 5, "syndicate" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang/clusterbang
-	category = "Exosuit Equipment"
+	materials = list("$metal"=20000,"$gold"=10000,"$uranium"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_wormhole_gen
-	name = "Exosuit Module Design (Localized Wormhole Generator)"
+	name = "Exosuit Module (Localized Wormhole Generator)"
 	desc = "An exosuit module that allows generating of small quasi-stable wormholes."
 	id = "mech_wormhole_gen"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 3, "magnets" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/wormhole_generator
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_teleporter
-	name = "Exosuit Module Design (Teleporter Module)"
+	name = "Exosuit Module (Teleporter Module)"
 	desc = "An exosuit module that allows exosuits to teleport to any position in view."
 	id = "mech_teleporter"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 10, "magnets" = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_rcd
-	name = "Exosuit Module Design (RCD Module)"
+	name = "Exosuit Module (RCD Module)"
 	desc = "An exosuit-mounted Rapid Construction Device."
 	id = "mech_rcd"
 	build_type = MECHFAB
 	req_tech = list("materials" = 4, "bluespace" = 3, "magnets" = 4, "powerstorage"=4, "engineering" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/rcd
-	category = "Exosuit Equipment"
+	materials = list("$metal"=30000,"$gold"=20000,"$plasma"=25000,"$silver"=20000)
+	construction_time = 1200
+	category = list("Exosuit Equipment")
 
 datum/design/mech_gravcatapult
-	name = "Exosuit Module Design (Gravitational Catapult Module)"
+	name = "Exosuit Module (Gravitational Catapult Module)"
 	desc = "An exosuit mounted Gravitational Catapult."
 	id = "mech_gravcatapult"
 	build_type = MECHFAB
 	req_tech = list("bluespace" = 2, "magnets" = 3, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/gravcatapult
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_repair_droid
-	name = "Exosuit Module Design (Repair Droid Module)"
+	name = "Exosuit Module (Repair Droid Module)"
 	desc = "Automated Repair Droid. BEEP BOOP"
 	id = "mech_repair_droid"
 	build_type = MECHFAB
 	req_tech = list("magnets" = 3, "programming" = 3, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000,"$glass"=5000,"$gold"=1000,"$silver"=2000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_energy_relay
-	name = "Exosuit Module Design (Tesla Energy Relay)"
+	name = "Exosuit Module (Tesla Energy Relay)"
 	desc = "Tesla Energy Relay"
 	id = "mech_energy_relay"
 	build_type = MECHFAB
 	req_tech = list("magnets" = 4, "powerstorage" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000,"$glass"=2000,"$gold"=2000,"$silver"=3000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_ccw_armor
-	name = "Exosuit Module Design(Reactive Armor Booster Module)"
+	name = "Exosuit Module (Reactive Armor Booster Module)"
 	desc = "Exosuit-mounted armor booster."
 	id = "mech_ccw_armor"
 	build_type = MECHFAB
 	req_tech = list("materials" = 5, "combat" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster
-	category = "Exosuit Equipment"
+	materials = list("$metal"=20000,"$silver"=5000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_proj_armor
-	name = "Exosuit Module Design(Reflective Armor Booster Module)"
+	name = "Exosuit Module (Reflective Armor Booster Module)"
 	desc = "Exosuit-mounted armor booster."
 	id = "mech_proj_armor"
 	build_type = MECHFAB
 	req_tech = list("materials" = 5, "combat" = 5, "engineering"=3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
-	category = "Exosuit Equipment"
+	materials = list("$metal"=20000,"$gold"=5000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_diamond_drill
-	name = "Exosuit Module Design (Diamond Mining Drill)"
+	name = "Exosuit Module (Diamond Mining Drill)"
 	desc = "An upgraded version of the standard drill."
 	id = "mech_diamond_drill"
 	build_type = MECHFAB
 	req_tech = list("materials" = 4, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000,"$diamond"=6500)
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 datum/design/mech_generator_nuclear
-	name = "Exosuit Module Design (ExoNuclear Reactor)"
+	name = "Exosuit Module (ExoNuclear Reactor)"
 	desc = "Compact nuclear reactor module."
 	id = "mech_generator_nuclear"
 	build_type = MECHFAB
 	req_tech = list("powerstorage"= 3, "engineering" = 3, "materials" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator/nuclear
-	category = "Exosuit Equipment"
+	materials = list("$metal"=10000,"$glass"=1000,"$silver"=500)
+	construction_time = 100
+	category = list("Exosuit Equipment")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1,515 +1,660 @@
 //Cyborg
 /datum/design/borg_suit
+	name = "Cyborg Endoskeleton"
 	id = "borg_suit"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/robot_suit
 	materials = list("$metal"=15000)
-	category = "Cyborg"
+	construction_time = 500
+	category = list("Cyborg")
 
 /datum/design/borg_chest
+	name = "Cyborg Torso"
 	id = "borg_chest"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/chest
 	materials = list("$metal"=40000)
-	category = "Cyborg"
+	construction_time = 350
+	category = list("Cyborg")
 
 /datum/design/borg_head
+	name = "Cyborg Head"
 	id = "borg_head"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/head
 	materials = list("$metal"=5000)
-	category = "Cyborg"
+	construction_time = 350
+	category = list("Cyborg")
 
 /datum/design/borg_l_arm
+	name = "Cyborg Left Arm"
 	id = "borg_l_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/l_arm
 	materials = list("$metal"=10000)
-	category = "Cyborg"
+	construction_time = 200
+	category = list("Cyborg")
 
 /datum/design/borg_r_arm
+	name = "Cyborg Right Arm"
 	id = "borg_r_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/r_arm
 	materials = list("$metal"=10000)
-	category = "Cyborg"
+	construction_time = 200
+	category = list("Cyborg")
 
 /datum/design/borg_l_leg
+	name = "Cyborg Left Leg"
 	id = "borg_l_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/l_leg
 	materials = list("$metal"=10000)
-	category = "Cyborg"
+	construction_time = 200
+	category = list("Cyborg")
 
 /datum/design/borg_r_leg
+	name = "Cyborg Right Leg"
 	id = "borg_r_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/robot_parts/r_leg
 	materials = list("$metal"=10000)
-	category = "Cyborg"
-
+	construction_time = 200
+	category = list("Cyborg")
 
 //Ripley
 /datum/design/ripley_chassis
+	name = "Exosuit Chassis (APLU \"Ripley\")"
 	id = "ripley_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/ripley
 	materials = list("$metal"=20000)
-	category = "Ripley"
+	construction_time = 100
+	category = list("Ripley")
 
+//firefighter subtype
 /datum/design/firefighter_chassis
+	name = "Exosuit Chassis (APLU \"Firefighter\")"
 	id = "firefighter_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/firefighter
 	materials = list("$metal"=20000)
-	category = "Ripley"
+	construction_time = 100
+	category = list("Firefighter")
 
 /datum/design/ripley_torso
+	name = "Exosuit Torso (APLU \"Ripley\")"
 	id = "ripley_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_torso
 	materials = list("$metal"=20000, "$glass"=7500)
-	category = "Ripley"
+	construction_time = 200
+	category = list("Ripley","Firefighter")
 
 /datum/design/ripley_left_arm
+	name = "Exosuit Left Arm (APLU \"Ripley\")"
 	id = "ripley_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_left_arm
 	materials = list("$metal"=15000)
-	category = "Ripley"
+	construction_time = 150
+	category = list("Ripley","Firefighter")
 
 /datum/design/ripley_right_arm
+	name = "Exosuit Right Arm (APLU \"Ripley\")"
 	id = "ripley_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_right_arm
 	materials = list("$metal"=15000)
-	category = "Ripley"
+	construction_time = 150
+	category = list("Ripley","Firefighter")
 
 /datum/design/ripley_left_leg
+	name = "Exosuit Left Leg (APLU \"Ripley\")"
 	id = "ripley_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_left_leg
 	materials = list("$metal"=15000)
-	category = "Ripley"
+	construction_time = 150
+	category = list("Ripley","Firefighter")
 
 /datum/design/ripley_right_leg
+	name = "Exosuit Right Leg (APLU \"Ripley\")"
 	id = "ripley_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/ripley_right_leg
 	materials = list("$metal"=15000)
-	category = "Ripley"
-
+	construction_time = 150
+	category = list("Ripley","Firefighter")
 
 //Odysseus
 /datum/design/odysseus_chassis
+	name = "Exosuit Chassis (\"Odysseus\")"
 	id = "odysseus_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/odysseus
 	materials = list("$metal"=20000)
-	category = "Odysseus"
+	construction_time = 100
+	category = list("Odysseus")
 
 /datum/design/odysseus_torso
+	name = "Exosuit Torso (\"Odysseus\")"
 	id = "odysseus_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_torso
 	materials = list("$metal"=12000)
-	category = "Odysseus"
+	construction_time = 180
+	category = list("Odysseus")
 
 /datum/design/odysseus_head
+	name = "Exosuit Head (\"Odysseus\")"
 	id = "odysseus_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_head
 	materials = list("$metal"=6000,"$glass"=10000)
-	category = "Odysseus"
+	construction_time = 100
+	category = list("Odysseus")
 
 /datum/design/odysseus_left_arm
+	name = "Exosuit Left Arm (\"Odysseus\")"
 	id = "odysseus_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_left_arm
 	materials = list("$metal"=6000)
-	category = "Odysseus"
+	construction_time = 120
+	category = list("Odysseus")
 
 /datum/design/odysseus_right_arm
+	name = "Exosuit Right Arm (\"Odysseus\")"
 	id = "odysseus_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_right_arm
 	materials = list("$metal"=6000)
-	category = "Odysseus"
+	construction_time = 120
+	category = list("Odysseus")
 
 /datum/design/odysseus_left_leg
+	name = "Exosuit Left Leg (\"Odysseus\")"
 	id = "odysseus_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_left_leg
-	materials = list("$metal"=6000)
-	category = "Odysseus"
+	materials = list("$metal"=7000)
+	construction_time = 130
+	category = list("Odysseus")
 
 /datum/design/odysseus_right_leg
+	name = "Exosuit Right Leg (\"Odysseus\")"
 	id = "odysseus_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/odysseus_right_leg
-	materials = list("$metal"=6000)
-	category = "Odysseus"
+	materials = list("$metal"=7000)
+	construction_time = 130
+	category = list("Odysseus")
 
+/*/datum/design/odysseus_armor
+	name = "Exosuit Armor (\"Odysseus\")"
+	id = "odysseus_armor"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/part/odysseus_armor
+	materials = list("$metal"=15000)
+	construction_time = 200
+	category = list("Odysseus")
+	*/
 
 //Gygax
 /datum/design/gygax_chassis
+	name = "Exosuit Chassis (\"Gygax\")"
 	id = "gygax_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/gygax
 	materials = list("$metal"=20000)
-	category = "Gygax"
+	construction_time = 100
+	category = list("Gygax")
 
 /datum/design/gygax_torso
+	name = "Exosuit Torso (\"Gygax\")"
 	id = "gygax_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_torso
 	materials = list("$metal"=20000,"$glass"=10000,"$diamond"=2000)
-	category = "Gygax"
+	construction_time = 300
+	category = list("Gygax")
 
 /datum/design/gygax_head
+	name = "Exosuit Head (\"Gygax\")"
 	id = "gygax_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_head
 	materials = list("$metal"=10000,"$glass"=5000, "$diamond"=2000)
-	category = "Gygax"
+	construction_time = 200
+	category = list("Gygax")
 
 /datum/design/gygax_left_arm
+	name = "Exosuit Left Arm (\"Gygax\")"
 	id = "gygax_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_left_arm
 	materials = list("$metal"=15000, "$diamond"=1000)
-	category = "Gygax"
+	construction_time = 200
+	category = list("Gygax")
 
 /datum/design/gygax_right_arm
+	name = "Exosuit Right Arm (\"Gygax\")"
 	id = "gygax_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_right_arm
 	materials = list("$metal"=15000, "$diamond"=1000)
-	category = "Gygax"
+	construction_time = 200
+	category = list("Gygax")
 
 /datum/design/gygax_left_leg
+	name = "Exosuit Left Leg (\"Gygax\")"
 	id = "gygax_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_left_leg
-	materials = list("$metal"=15000, "$diamond"=1000)
-	category = "Gygax"
+	materials = list("$metal"=15000, "$diamond"=2000)
+	construction_time = 200
+	category = list("Gygax")
 
 /datum/design/gygax_right_leg
+	name = "Exosuit Right Leg (\"Gygax\")"
 	id = "gygax_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_right_leg
-	materials = list("$metal"=15000, "$diamond"=1000)
-	category = "Gygax"
+	materials = list("$metal"=15000, "$diamond"=2000)
+	construction_time = 200
+	category = list("Gygax")
 
 /datum/design/gygax_armor
+	name = "Exosuit Armor (\"Gygax\")"
 	id = "gygax_armor"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_armor
 	materials = list("$metal"=25000,"$diamond"=10000)
-	category = "Gygax"
-
+	construction_time = 600
+	category = list("Gygax")
 
 //Durand
 /datum/design/durand_chassis
+	name = "Exosuit Chassis (\"Durand\")"
 	id = "durand_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/durand
 	materials = list("$metal"=25000)
-	category = "Durand"
+	construction_time = 100
+	category = list("Durand")
 
 /datum/design/durand_torso
+	name = "Exosuit Torso (\"Durand\")"
 	id = "durand_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_torso
 	materials = list("$metal"=25000,"$glass"=10000,"$silver"=10000)
-	category = "Durand"
+	construction_time = 300
+	category = list("Durand")
 
 /datum/design/durand_head
+	name = "Exosuit Head (\"Durand\")"
 	id = "durand_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_head
 	materials = list("$metal"=10000,"$glass"=15000,"$silver"=2000)
-	category = "Durand"
+	construction_time = 200
+	category = list("Durand")
 
 /datum/design/durand_left_arm
+	name = "Exosuit Left Arm (\"Durand\")"
 	id = "durand_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_left_arm
 	materials = list("$metal"=10000,"$silver"=4000)
-	category = "Durand"
+	construction_time = 200
+	category = list("Durand")
 
 /datum/design/durand_right_arm
+	name = "Exosuit Right Arm (\"Durand\")"
 	id = "durand_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_right_arm
 	materials = list("$metal"=10000,"$silver"=4000)
-	category = "Durand"
+	construction_time = 200
+	category = list("Durand")
 
 /datum/design/durand_left_leg
+	name = "Exosuit Left Leg (\"Durand\")"
 	id = "durand_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_left_leg
 	materials = list("$metal"=15000,"$silver"=4000)
-	category = "Durand"
+	construction_time = 200
+	category = list("Durand")
 
 /datum/design/durand_right_leg
+	name = "Exosuit Right Leg (\"Durand\")"
 	id = "durand_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_right_leg
 	materials = list("$metal"=15000,"$silver"=4000)
-	category = "Durand"
+	construction_time = 200
+	category = list("Durand")
 
 /datum/design/durand_armor
+	name = "Exosuit Armor (\"Durand\")"
 	id = "durand_armor"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_armor
 	materials = list("$metal"=50000,"$uranium"=30000)
-	category = "Durand"
-
+	construction_time = 600
+	category = list("Durand")
 
 //H.O.N.K
 /datum/design/honk_chassis
+	name = "Exosuit Chassis (\"H.O.N.K\")"
 	id = "honk_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/honker
 	materials = list("$metal"=20000)
-	category = "H.O.N.K"
+	construction_time = 100
+	category = list("H.O.N.K")
 
 /datum/design/honk_torso
+	name = "Exosuit Torso (\"H.O.N.K\")"
 	id = "honk_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/honker_torso
 	materials = list("$metal"=20000,"$glass"=10000,"$bananium"=10000)
-	category = "H.O.N.K"
+	construction_time = 300
+	category = list("H.O.N.K")
 
 /datum/design/honk_head
+	name = "Exosuit Head (\"H.O.N.K\")"
 	id = "honk_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/honker_head
 	materials = list("$metal"=10000,"$glass"=5000,"$bananium"=5000)
-	category = "H.O.N.K"
+	construction_time = 200
+	category = list("H.O.N.K")
 
 /datum/design/honk_left_arm
+	name = "Exosuit Left Arm (\"H.O.N.K\")"
 	id = "honk_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/honker_left_arm
 	materials = list("$metal"=15000,"$bananium"=5000)
-	category = "H.O.N.K"
+	construction_time = 200
+	category = list("H.O.N.K")
 
 /datum/design/honk_right_arm
+	name = "Exosuit Right Arm (\"H.O.N.K\")"
 	id = "honk_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/honker_right_arm
 	materials = list("$metal"=15000,"$bananium"=5000)
-	category = "H.O.N.K"
+	construction_time = 200
+	category = list("H.O.N.K")
 
 /datum/design/honk_left_leg
+	name = "Exosuit Left Leg (\"H.O.N.K\")"
 	id = "honk_left_leg"
 	build_type = MECHFAB
 	build_path =/obj/item/mecha_parts/part/honker_left_leg
 	materials = list("$metal"=20000,"$bananium"=5000)
-	category = "H.O.N.K"
+	construction_time = 200
+	category = list("H.O.N.K")
 
 /datum/design/honk_right_leg
+	name = "Exosuit Right Leg (\"H.O.N.K\")"
 	id = "honk_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/honker_right_leg
 	materials = list("$metal"=20000,"$bananium"=5000)
-	category = "H.O.N.K"
+	construction_time = 200
+	category = list("H.O.N.K")
 
 
 //Phazon
 /datum/design/phazon_chassis
+	name = "Exosuit Chassis (\"Phazon\")"
 	id = "phazon_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/phazon
 	materials = list("$metal"=20000)
-	category = "Phazon"
+	construction_time = 100
+	category = list("Phazon")
 
 /datum/design/phazon_torso
+	name = "Exosuit Torso (\"Phazon\")"
 	id = "phazon_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_torso
 	materials = list("$metal"=35000,"$glass"=10000,"$plasma"=20000)
-	category = "Phazon"
+	construction_time = 300
+	category = list("Phazon")
 
 /datum/design/phazon_head
+	name = "Exosuit Head (\"Phazon\")"
 	id = "phazon_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_head
 	materials = list("$metal"=15000,"$glass"=5000,"$plasma"=10000)
-	category = "Phazon"
+	construction_time = 200
+	category = list("Phazon")
 
 /datum/design/phazon_left_arm
+	name = "Exosuit Left Arm (\"Phazon\")"
 	id = "phazon_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_left_arm
 	materials = list("$metal"=20000,"$plasma"=10000)
-	category = "Phazon"
+	construction_time = 200
+	category = list("Phazon")
 
 /datum/design/phazon_right_arm
+	name = "Exosuit Right Arm (\"Phazon\")"
 	id = "phazon_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_right_arm
 	materials = list("$metal"=20000,"$plasma"=10000)
-	category = "Phazon"
+	construction_time = 200
+	category = list("Phazon")
 
 /datum/design/phazon_left_leg
+	name = "Exosuit Left Leg (\"Phazon\")"
 	id = "phazon_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_left_leg
 	materials = list("$metal"=20000,"$plasma"=10000)
-	category = "Phazon"
+	construction_time = 200
+	category = list("Phazon")
 
 /datum/design/phazon_right_leg
+	name = "Exosuit Right Leg (\"Phazon\")"
 	id = "phazon_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_right_leg
 	materials = list("$metal"=20000,"$plasma"=10000)
-	category = "Phazon"
+	construction_time = 200
+	category = list("Phazon")
 
 /datum/design/phazon_armor
+	name = "Exosuit Armor (\"Phazon\")"
 	id = "phazon_armor"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/phazon_armor
 	materials = list("$metal"=45000,"$plasma"=30000)
-	category = "Phazon"
-
+	construction_time = 300
+	category = list("Phazon")
 
 //Exosuit Equipment
 /datum/design/mech_hydraulic_clamp
+	name = "Exosuit Engineering Equipement (Hydraulic Clamp)"
 	id = "mech_hydraulic_clamp"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_drill
+	name = "Exosuit Engineering Equipement (Drill)"
 	id = "mech_drill"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/drill
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_extinguisher
+	name = "Exosuit Engineering Equipement (Extinguisher)"
 	id = "mech_extinguisher"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/extinguisher
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_cable_layer
+	name = "Exosuit Engineering Equipement (Cable Layer)"
 	id = "mech_cable_layer"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/cable_layer
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_sleeper
+	name = "Exosuit Medical Equipement (Mounted Sleeper)"
 	id = "mech_sleeper"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/sleeper
 	materials = list("$metal"=5000,"$glass"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_syringe_gun
+	name = "Exosuit Medical Equipement (Syringe Gun)"
 	id = "mech_syringe_gun"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/tool/syringe_gun
 	materials = list("$metal"=3000,"$glass"=2000)
-	category = "Exosuit Equipment"
+	construction_time = 200
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_generator
+	name = "Exosuit Equipement (Plasma Generator)"
 	id = "mech_generator"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator
 	materials = list("$metal"=10000,"$glass"=1000,"$silver"=500)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_taser
+	name = "Exosuit Weapon (PBT \"Pacifier\" Mounted Taser)"
 	id = "mech_taser"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_lmg
+	name = "Exosuit Weapon (\"Ultra AC 2\" LMG)"
 	id = "mech_lmg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	materials = list("$metal"=10000)
-	category = "Exosuit Equipment"
+	construction_time = 100
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_mousetrap_mortar
+	name = "H.O.N.K Mousetrap Mortar"
 	id = "mech_mousetrap_mortar"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/mousetrap_mortar
 	materials = list("$metal"=20000,"$bananium"=5000)
-	category = "Exosuit Equipment"
+	construction_time = 300
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_banana_mortar
+	name = "H.O.N.K Banana Mortar"
 	id = "mech_banana_mortar"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar
 	materials = list("$metal"=20000,"$bananium"=5000)
-	category = "Exosuit Equipment"
+	construction_time = 300
+	category = list("Exosuit Equipment")
 
 /datum/design/mech_honker
+	name = "HoNkER BlAsT 5000"
 	id = "mech_honker"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/honker
 	materials = list("$metal"=20000,"$bananium"=10000)
-	category = "Exosuit Equipment"
-
+	construction_time = 500
+	category = list("Exosuit Equipment")
 
 //Cyborg Upgrade Modules
 /datum/design/borg_upgrade_reset
+	name = "Cyborg Upgrade Module (Reset Module)"
 	id = "borg_upgrade_reset"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/reset
 	materials = list("$metal"=10000)
-	category = "Cyborg Upgrade Modules"
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_rename
+	name = "Cyborg Upgrade Module (Rename Module)"
 	id = "borg_upgrade_rename"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/rename
 	materials = list("$metal"=35000)
-	category = "Cyborg Upgrade Modules"
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_restart
+	name = "Cyborg Upgrade Module (Restart Module)"
 	id = "borg_upgrade_restart"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/restart
 	materials = list("$metal"=60000 , "$glass"=5000)
-	category = "Cyborg Upgrade Modules"
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_vtec
+	name = "Cyborg Upgrade Module (VTEC Module)"
 	id = "borg_upgrade_vtec"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/vtec
 	materials = list("$metal"=80000 , "$glass"=6000 , "$gold"= 5000)
-	category = "Cyborg Upgrade Modules"
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_tasercooler
+	name = "Cyborg Upgrade Module (Rapid Taser Cooling Module)"
 	id = "borg_upgrade_tasercooler"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/tasercooler
 	materials = list("$metal"=80000 , "$glass"=6000 , "$gold"= 2000, "$diamond" = 500)
-	category = "Cyborg Upgrade Modules"
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_jetpack
+	name = "Cyborg Upgrade Module (Mining Jetpack)"
 	id = "borg_upgrade_jetpack"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/jetpack
 	materials = list("$metal"=10000,"$plasma"=15000,"$uranium" = 20000)
-	category = "Cyborg Upgrade Modules"
-
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 //Misc
 /datum/design/mecha_tracking
+	name = "Exosuit Tracking Beacon"
 	id = "mecha_tracking"
 	build_type = MECHFAB
 	build_path =/obj/item/mecha_parts/mecha_tracking
 	materials = list("$metal"=500)
-	category = "Misc"
+	construction_time = 50
+	category = list("Misc")

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -29,9 +29,10 @@ datum/design/mmi
 	req_tech = list("programming" = 2, "biotech" = 3)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 1000, "$glass" = 500)
+	construction_time = 75
 	reliability = 76
 	build_path = /obj/item/device/mmi
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/mmi_radio
 	name = "Radio-enabled Man-Machine Interface"
@@ -40,9 +41,10 @@ datum/design/mmi_radio
 	req_tech = list("programming" = 2, "biotech" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 1200, "$glass" = 500)
+	construction_time = 75
 	reliability = 74
 	build_path = /obj/item/device/mmi/radio_enabled
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/synthetic_flash
 	name = "Flash"
@@ -51,9 +53,10 @@ datum/design/synthetic_flash
 	req_tech = list("magnets" = 3, "combat" = 2)
 	build_type = MECHFAB
 	materials = list("$metal" = 750, "$glass" = 750)
+	construction_time = 100
 	reliability = 76
 	build_path = /obj/item/device/flash/handheld
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/bluespacebeaker
 	name = "Bluespace Beaker"
@@ -64,7 +67,7 @@ datum/design/bluespacebeaker
 	materials = list("$metal" = 3000, "$plasma" = 3000, "$diamond" = 500)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/noreactbeaker
 	name = "Cryostasis Beaker"
@@ -75,7 +78,7 @@ datum/design/noreactbeaker
 	materials = list("$metal" = 3000)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/bluespacebodybag
 	name = "Bluespace body bag"
@@ -86,7 +89,7 @@ datum/design/bluespacebodybag
 	materials = list("$metal" = 3000, "$plasma" = 2000, "$diamond" = 500)
 	reliability = 76
 	build_path = /obj/item/bodybag/bluespace
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/defib
 	name = "Defibrillator"
@@ -97,4 +100,4 @@ datum/design/defib
 	materials = list("$metal" = 5000, "$glass" = 2000, "$silver" = 1000)
 	reliability = 76
 	build_path = /obj/item/weapon/defibrillator
-	category = "Misc"
+	category = list("Misc")

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -10,7 +10,8 @@ datum/design/basic_cell
 	build_type = PROTOLATHE | AUTOLATHE |MECHFAB
 	materials = list("$metal" = 700, "$glass" = 50)
 	build_path = /obj/item/weapon/stock_parts/cell
-	category = "Misc"
+	construction_time=100
+	category = list("Misc")
 
 datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -19,8 +20,9 @@ datum/design/high_cell
 	req_tech = list("powerstorage" = 2)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB
 	materials = list("$metal" = 700, "$glass" = 60)
+	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/high
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/super_cell
 	name = "Super-Capacity Power Cell"
@@ -30,8 +32,9 @@ datum/design/super_cell
 	reliability = 75
 	build_type = PROTOLATHE | MECHFAB
 	materials = list("$metal" = 700, "$glass" = 70)
+	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/super
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -40,9 +43,10 @@ datum/design/hyper_cell
 	req_tech = list("powerstorage" = 5, "materials" = 4)
 	reliability = 70
 	build_type = PROTOLATHE | MECHFAB
-	materials = list("$metal" = 400, "$gold" = 150, "$silver" = 150, "$glass" = 70)
+	materials = list("$metal" = 400, "$gold" = 150, "$silver" = 150, "$glass" = 80)
+	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/hyper
-	category = "Misc"
+	category = list("Misc")
 
 datum/design/light_replacer
 	name = "Light Replacer"

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -74,7 +74,7 @@ Note: Must be placed west/left of and R&D console to function.
 			A = uranium_amount
 		if("$diamond")
 			A = diamond_amount
-		if("$clown")
+		if("$bananium")
 			A = clown_amount
 		else
 			A = reagents.get_reagent_amount(M)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -385,7 +385,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								linked_lathe.uranium_amount = max(0, (linked_lathe.uranium_amount-(being_built.materials[M]/coeff * amount)))
 							if("$diamond")
 								linked_lathe.diamond_amount = max(0, (linked_lathe.diamond_amount-(being_built.materials[M]/coeff * amount)))
-							if("$clown")
+							if("$bananium")
 								linked_lathe.clown_amount = max(0, (linked_lathe.clown_amount-(being_built.materials[M]/coeff * amount)))
 							else
 								linked_lathe.reagents.remove_reagent(M, being_built.materials[M]/coeff * amount)


### PR DESCRIPTION
#### Contents:
- designs are now using the _construction_time_ var and the hacky _/obj/item/mechavars_ is gone
- designs updated : there shouldn't be "free" designs anymore, names added, etc
- cleaned the objects of their _construction_cost_ and _construction_time_ vars
- fixes the material name being displayed with $ character before
  - this also fixes the overlay animation in inserting sheets
- the category var is now a list, so parts can be build/used with several chassis (fixes the Firefighter Chassis appearing when building Ripley)
- properly fix the href vulnerability when emptying the exofab (you can now remove all sheets of a given material at once)
- the exofab now won't create a material sheet when emptying and there's not enough material (e.g 1000 metal)
- the exofab now won't accept a sheet if it would overstuff it (losing some material in the process)
- cleaned the code a bit (simplified, streamlined, using global vars, etc)
- upgrading the exofab is still working
- _Materials_ and _programming_ techs now reduces building cost and building time respectively.

Finish #5722 and fixes #5954.
Also fixes #6281, at least when the exofab rounding of the ejected material was the culprit (thanks Tkdrg).
