### PR TITLE
Fixes emergent maploader runtimes on new()

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -324,8 +324,8 @@
 	placed.underlays += turfs_underlays
 
 //atom creation method that preloads variables before creation
-/atom/New(atom/loc, dmm_suite/preloader/_dmm_preloader = null)
-	if(_dmm_preloader)
+/atom/New(atom/loc, dmm_suite/preloader/_dmm_preloader)
+	if(istype(_dmm_preloader, /dmm_suite/preloader))
 		_dmm_preloader.load(src)
 	. = ..()
 


### PR DESCRIPTION
No idea why _if(_dmm_preloader)_ isn't catching nulls...
Going back to the old istype()

Also this wasn't happening before...

**For downstream :** _This is specific to /tg_
