### PR TITLE
Fixes ausbushes icon_state for the subclasses

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -89,7 +89,8 @@
 	anchored = 1
 
 /obj/structure/flora/ausbushes/New()
-	icon_state = "firstbush_[rand(1, 4)]"
+	if(icon_state == "firstbush_1")
+		icon_state = "firstbush_[rand(1, 4)]"
 	..()
 
 /obj/structure/flora/ausbushes/reedbush


### PR DESCRIPTION
Yay for butchered inheritance. OOP is good and all but please learn how to use it properly. The right way to do this would be repathing but I won't do that because I don't want to change the aesthetics of any current maps.

Fixes #6200
