### PR TITLE
Acid immunity for Biosuits, Ninja, and DeathSquad, and fire protection for DeathSquad

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -27,6 +27,8 @@
 	item_state = "deathsquad"
 	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	strip_delay = 130
+	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
+	unacidable = 1
 
 /obj/item/clothing/suit/space/deathsquad
 	name = "deathsquad suit"
@@ -37,6 +39,8 @@
 	armor = list(melee = 80, bullet = 80, laser = 50,energy = 50, bomb = 100, bio = 100, rad = 100)
 	slowdown = 1
 	strip_delay = 130
+	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
+	unacidable = 1
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"

--- a/code/modules/clothing/spacesuits/ninja.dm
+++ b/code/modules/clothing/spacesuits/ninja.dm
@@ -6,6 +6,7 @@
 	allowed = list(/obj/item/weapon/stock_parts/cell)
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 25)
 	strip_delay = 12
+	unacidable = 1
 
 
 /obj/item/clothing/suit/space/space_ninja
@@ -15,6 +16,7 @@
 	item_state = "s-ninja_suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/stock_parts/cell)
 	slowdown = 0
+	unacidable = 1
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	strip_delay = 12
 

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -7,6 +7,7 @@
 	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|BLOCKHAIR|THICKMATERIAL
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
+	unacidable = 1
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -24,6 +25,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70
 	put_on_delay = 70
+	unacidable = 1
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general


### PR DESCRIPTION
- Biosuits, Ninja armor, and Deathsquad armor are now immune to acid.
- Deathsquad armor is now also fireproof!

Note that acid immunity for your suit and helmet _does not protect your backpack or held items!_ Do not get sprayed, or you might just lose that shiny pulse rifle!
