### PR TITLE
Changes Gargle Blaster description

### DIFF
--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -153,7 +153,7 @@
 			if("gargleblaster")
 				icon_state = "gargleblasterglass"
 				name = "Pan-Galactic Gargle Blaster"
-				desc = "Does... does this mean that Arthur and Ford are on the station? Oh joy."
+				desc = "Like having your brain smashed out by a slice of lemon wrapped around a large gold brick."
 			if("bravebull")
 				icon_state = "bravebullglass"
 				name = "Brave Bull"


### PR DESCRIPTION
Changes the cringey original description (Seriously, who wrote this?) to the one given to the drink in the original Hitchhiker's book series.

I anticipate this PR is going to kick off an argument about copyright and references.
