### PR TITLE
Clean slime fix

### DIFF
--- a/code/modules/mob/living/carbon/slime/say.dm
+++ b/code/modules/mob/living/carbon/slime/say.dm
@@ -15,6 +15,6 @@
 	if(speaker != src && !radio_freq)
 		if (speaker in Friends)
 			speech_buffer = list()
-			speech_buffer += speaker.name
+			speech_buffer += speaker
 			speech_buffer += lowertext(html_decode(message))
 	..()


### PR DESCRIPTION
Slimes command references were checking for a name, they needed to check the mob ref.
