### PR TITLE
Made the mech recharger computer display a warning when the mech cell is faulty

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -107,7 +107,10 @@
 			data += "<div class='statusDisplay'>No mech detected.</div>"
 		else
 			data += "<div class='statusDisplay'>Integrity: [recharge_port.recharging_mech.health]<BR>"
-			data += "Power: [recharge_port.recharging_mech.cell.charge]/[recharge_port.recharging_mech.cell.maxcharge]</div>"
+			if(recharge_port.recharging_mech.cell.crit_fail)
+				data += "<span class='bad'>WARNING : the mech cell seems faulty!</span></div>"
+			else
+				data += "Power: [recharge_port.recharging_mech.cell.charge]/[recharge_port.recharging_mech.cell.maxcharge]</div>"
 
 	var/datum/browser/popup = new(user, "mech recharger", name, 300, 300)
 	popup.set_content(data)


### PR DESCRIPTION
Players were often wondering why mechs weren't charging anymore after upgrading cell : chances are it was because the cell had critically failed (can't recharge anymore), as the reliability was < 100.

So, made a warning appears on the mech recharger computer to inform the player the mech power source is faulty and needs replacing (reducing confusion).
