### PR TITLE
Buffs the RCD

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -102,12 +102,12 @@ RCD
 /obj/item/weapon/rcd/attackby(obj/item/weapon/W, mob/user)
 	..()
 	if(istype(W, /obj/item/weapon/rcd_ammo))
-		if((matter + 10) > 30)
+		if((matter + 20) > 100)
 			user << "<span class='notice'>The RCD cant hold any more matter-units.</span>"
 			return
 		user.drop_item()
 		qdel(W)
-		matter += 10
+		matter += 20
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user << "<span class='notice'>The RCD now holds [matter]/30 matter-units.</span>"
 		desc = "A RCD. It currently holds [matter]/30 matter-units."

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -219,11 +219,11 @@ RCD
 				return 0
 
 			if(istype(A, /obj/machinery/door/airlock))
-				if(checkResource(10, user))
+				if(checkResource(20, user))
 					user << "Deconstructing Airlock..."
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50))
-						if(!useResource(10, user)) return 0
+						if(!useResource(20, user)) return 0
 						activate()
 						qdel(A)
 						return 1

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -92,7 +92,7 @@ RCD
 
 
 /obj/item/weapon/rcd/New()
-	desc = "A RCD. It currently holds [matter]/30 matter-units."
+	desc = "A RCD. It currently holds [matter]/100 matter-units."
 	src.spark_system = new /datum/effect/effect/system/spark_spread
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -6,7 +6,7 @@ RCD
 */
 /obj/item/weapon/rcd
 	name = "rapid-construction-device (RCD)"
-	desc = "A device used to rapidly build walls/floor."
+	desc = "A device used to rapidly build and deconstruct walls and floors."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "rcd"
 	opacity = 0
@@ -18,7 +18,7 @@ RCD
 	throw_speed = 3
 	throw_range = 5
 	w_class = 3.0
-	m_amt = 30000
+	m_amt = 100000
 	origin_tech = "engineering=4;materials=2"
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/matter = 0

--- a/html/changelogs/Dorsidwarf-RCDbuff-6242.yml.txt
+++ b/html/changelogs/Dorsidwarf-RCDbuff-6242.yml.txt
@@ -1,0 +1,33 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+# bugfix
+# wip (For works in progress)
+# tweak
+# soundadd
+# sounddel
+# rscdel (general adding of nice things)
+# rscadd (general deleting of nice things)
+# imageadd
+# imagedel
+# spellcheck (typo fixes)
+# experiment
+# tgs (TG-ported fixes?)
+#################################
+# Your name.
+author: N3X15
+# Optional: Remove this file after generating master changelog. Useful for PR changelogs that won't get used again.
+#delete-after: True
+# Any changes you've made. See valid prefix list above.
+# INDENT WITH TWO SPACES. NOT TABS. SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading. Just remove the brackets when you add new shit.
+# Please surround your changes in single (') or double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+- tweak: "Buffs the RCD from 30 matter units to max capacity 100, and increases the value of matter charges.

--- a/html/changelogs/Dorsidwarf-RCDbuff-6242.yml.txt
+++ b/html/changelogs/Dorsidwarf-RCDbuff-6242.yml.txt
@@ -21,9 +21,9 @@
 # tgs (TG-ported fixes?)
 #################################
 # Your name.
-author: N3X15
+author: Dorsidwarf
 # Optional: Remove this file after generating master changelog. Useful for PR changelogs that won't get used again.
-#delete-after: True
+delete-after: True
 # Any changes you've made. See valid prefix list above.
 # INDENT WITH TWO SPACES. NOT TABS. SPACES.
 # SCREW THIS UP AND IT WON'T WORK.


### PR DESCRIPTION
The main problem with the RCD is that, well, it's pretty naff for rapid construction. Thirty floor tiles, or a couple of airlocks, then you have to go feed all the station's resources into cargo to recharge it. 

This PR increases it's maximum capacity to a great big 100 matter units (Up from 30) and increases the amount of charge that Compressed Matter gives it from 10 to 20. This effectively doubles the amount of building you can do with the RCD and charges from EVA, and triples it if you're willing to work with cargo to print extras. 
Hopefully this change will encourage not only cargo and engineering to work together more (Hardly ever happens, even though they have more synergy than any other pair - except for mining->R&D - ), but also actual use of the RCD as an engineering tool, rather than a sacredly useless object left locked into EVA all the time because antags want it.
