### PR TITLE
Gives the nuke disk-style respawning

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -61,14 +61,17 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////
 
+var/list/turf/global_synd_spawn = list()
+
+/proc/get_synd_spawn()
+	if(!global_synd_spawn.len)
+		for(var/obj/effect/landmark/A in landmarks_list)
+			if(A.name == "Syndicate-Spawn")
+				global_synd_spawn += get_turf(A)
+	return global_synd_spawn
+
 /datum/game_mode/nuclear/post_setup()
-
-	var/list/turf/synd_spawn = list()
-
-	for(var/obj/effect/landmark/A in landmarks_list)
-		if(A.name == "Syndicate-Spawn")
-			synd_spawn += get_turf(A)
-			continue
+	var/list/synd_spawn = get_synd_spawn()
 
 	var/obj/effect/landmark/uplinklocker = locate("landmark*Syndicate-Uplink")	//i will be rewriting this shortly
 	var/obj/effect/landmark/nuke_spawn = locate("landmark*Nuclear-Bomb")

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -216,6 +216,9 @@ var/bomb_set
 				return
 	return
 
+/obj/machinery/nuclearbomb/Destroy()
+	. = respawn_obj(get_synd_spawn())
+
 
 //==========DAT FUKKEN DISK===============
 /obj/item/weapon/disk/nuclear
@@ -236,13 +239,17 @@ var/bomb_set
 		Destroy()
 
 /obj/item/weapon/disk/nuclear/Destroy()
-	if(blobstart.len > 0)
-		var/obj/item/weapon/disk/nuclear/NEWDISK = new(pick(blobstart))
+	. = respawn_obj(blobstart)
+
+//generic 'RESPAWN THIS SHIT' proc
+/obj/proc/respawn_obj(var/list/respawnlist)
+	if(respawnlist.len > 0)
+		var/obj/NEWDISK = new type(pick(respawnlist))
 		transfer_fingerprints_to(NEWDISK)
 		var/turf/diskturf = get_turf(src)
 		message_admins("[src] has been destroyed in ([diskturf.x], [diskturf.y] ,[diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[NEWDISK.x];Y=[NEWDISK.y];Z=[NEWDISK.z]'>JMP</a>).")
 		log_game("[src] has been destroyed in ([diskturf.x], [diskturf.y] ,[diskturf.z]). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z]).")
 		del(src) //Needed to clear all references to it
 	else
-		ERROR("[src] was supposed to be destroyed, but we were unable to locate a blobstart landmark to spawn a new one.")
-	return 1 // Cancel destruction.
+		ERROR("[src] was supposed to be destroyed, but we were unable to locate an adequate landmark to spawn a new one.")
+		return 1 // Cancel destruction.


### PR DESCRIPTION
Currently, if the sing eats the nuke, the syndies are boned. I'm aware that respawning is a terrible solution but it's better than just making the round unwinnable.
