### PR TITLE
Medibot fixes

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -317,12 +317,18 @@
 		return
 
 	//Patient has moved away from us!
-	else if(patient && path && path.len && (get_dist(patient,path[path.len]) > 2))
+	else if(patient && path.len && (get_dist(patient,path[path.len]) > 2))
 		path = list()
 		mode = BOT_IDLE
 		last_found = world.time
 
-	if(!stationary_mode && patient && path.len == 0 && (get_dist(src,patient) > 1))
+	else if(stationary_mode && patient) //Since we cannot move in this mode, ignore the patient and wait for another.
+		patient = null
+		mode = BOT_IDLE
+		last_found = world.time
+		return
+
+	if(patient && path.len == 0 && (get_dist(src,patient) > 1))
 		spawn(0)
 			path = get_path_to(loc, get_turf(patient), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance_cardinal, 0, 30,id=botcard)
 
@@ -478,6 +484,7 @@
 					patient.reagents.add_reagent(reagent_id,injection_amount)
 				C.visible_message("<span class='danger'>[src] injects [patient] with the syringe!</span>", \
 					"<span class='userdanger'>[src] injects [patient] with the syringe!</span>")
+				patient = null
 
 			mode = BOT_IDLE
 			updateicon()
@@ -522,7 +529,7 @@
 	speak("Medical emergency! [crit_patient ? "<b>[crit_patient]</b>" : "A patient"] is in critical condition at [location]!",radio_frequency)
 	declare_cooldown = 1
 	spawn(200) //Twenty seconds
-	declare_cooldown = 0
+		declare_cooldown = 0
 
 /*
  *	Medbot Assembly -- Can be made out of all three medkits.


### PR DESCRIPTION
- Medibots should no longer chase people they have already healed or
  ignore other patients after completing a heal cycle.
- Medibots in stationary mode will now correctly disregard patients that
  have left its proximity.
- The critical patient declaration should now work properly.
