### PR TITLE
Simple sound effect map object

### DIFF
--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -16,7 +16,7 @@
 		return
 	if(istype(H, /mob/dead/observer) && !affect_ghosts)
 		return
-	if(istype(H, /mob) && !mobs_only)
+	if(!istype(H, /mob) && mobs_only)
 		return
 	Trigger(H)
 

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -3,6 +3,7 @@
 /obj/effect/step_trigger
 	var/affect_ghosts = 0
 	var/stopper = 1 // stops throwers
+	var/mobs_only = 0
 	invisibility = 101 // nope cant see this shit
 	anchored = 1
 
@@ -15,8 +16,9 @@
 		return
 	if(istype(H, /mob/dead/observer) && !affect_ghosts)
 		return
+	if(istype(H, /mob) && !mobs_only)
+		return
 	Trigger(H)
-
 
 
 /* Tosses things in a certain direction */
@@ -114,3 +116,30 @@
 			A.x = rand(teleport_x, teleport_x_offset)
 			A.y = rand(teleport_y, teleport_y_offset)
 			A.z = rand(teleport_z, teleport_z_offset)
+
+
+/* Simple sound player, Mapper friendly! */
+
+/obj/effect/step_trigger/sound_effect
+	var/sound //eg. path to the sound, inside '' eg: 'growl.ogg'
+	var/volume = 100
+	var/freq_vary = 1 //Should the frequency of the sound vary?
+	var/extra_range = 0 // eg World.view = 7, extra_range = 1, 7+1 = 8, 8 turfs radius
+	var/happens_once = 0
+	var/triggerer_only = 0 //Whether the triggerer is the only person who hears this
+
+
+/obj/effect/step_trigger/sound_effect/Trigger(var/atom/movable/A)
+	var/turf/T = get_turf(A)
+
+	if(!T)
+		return
+
+	if(triggerer_only)
+		A.playsound_local(T, sound, volume, freq_vary)
+	else
+		playsound(T, sound, volume, freq_vary, extra_range)
+
+	if(happens_once)
+		qdel(src)
+

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -20,8 +20,7 @@
 				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, surround)
 
 
-/mob/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
-	if(!src.client || ear_deaf > 0)	return
+/atom/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
 	soundin = get_sfx(soundin)
 
 	var/sound/S = sound(soundin)
@@ -73,6 +72,11 @@
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
 	src << S
+
+/mob/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
+	if(!client || ear_deaf > 0)
+		return
+	..()
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music)	return

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -21,6 +21,8 @@
 
 
 /atom/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
+	if(!client)
+		return
 	soundin = get_sfx(soundin)
 
 	var/sound/S = sound(soundin)
@@ -74,7 +76,7 @@
 	src << S
 
 /mob/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
-	if(!client || ear_deaf > 0)
+	if(ear_deaf > 0)
 		return
 	..()
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -21,8 +21,6 @@
 
 
 /atom/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
-	if(!client)
-		return
 	soundin = get_sfx(soundin)
 
 	var/sound/S = sound(soundin)
@@ -76,7 +74,7 @@
 	src << S
 
 /mob/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
-	if(ear_deaf > 0)
+	if(!client || ear_deaf > 0)
 		return
 	..()
 


### PR DESCRIPTION
- Adds a new step_trigger, "sound_effect", acts as a mapper friendly wrapper for playing sound effects
- Adds a new step_trigger variable, "mobs_only", like affects_ghosts this is a boolean for allowing/denying atom/movables from triggering step_triggers
- playsound_local() is now a /atom proc, all mob specific requirements have been moved to an override, by default playsound never calls playsound_local on non mobs, this is the usual behaviour, I did not make it call on all atoms in range as that would up the cost of playsound()

At request of WJ:
![wj wants sound](https://cloud.githubusercontent.com/assets/4043781/5415190/2bbb142a-821d-11e4-973e-6a0445a85230.PNG)
