### PR TITLE
Fixes two runtimes

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -11,7 +11,7 @@
 		H.add_hud_to(user)
 
 /obj/item/clothing/glasses/hud/dropped(mob/living/carbon/human/user)
-	if(user.glasses == src)
+	if(istype(user) && user.glasses == src)
 		var/datum/atom_hud/H = huds[hud_type]
 		H.remove_hud_from(user)
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -228,7 +228,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	return
 
 /proc/CanHug(var/mob/M)
-	if(!M)
+	if(!istype(M))
 		return 0
 	if(M.stat == DEAD)
 		return 0


### PR DESCRIPTION
Related to issue #6351
These are all just simple sanity checks.

Fixes facehuggers checking oreboxes for stat.
Fixes monkeys dropping HUDs runtime.
