### PR TITLE
Objectiveless Antags and Restricted Antag Items Config Option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -134,6 +134,8 @@
 	var/default_laws = 0 //Controls what laws the AI spawns with.
 	var/silicon_max_law_amount = 12
 
+	var/objectives_disabled = 0 //if objectives are disabled or not
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for(var/T in L)
@@ -405,6 +407,8 @@
 					config.mutant_races				= 1
 				if("mutant_colors")
 					config.mutant_colors			= 1
+				if("objectives_disabled")
+					config.objectives_disabled 		= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -135,7 +135,7 @@
 	var/silicon_max_law_amount = 12
 
 	var/objectives_disabled = 0 //if objectives are disabled or not
-
+	var/restricted_antag_equipment = 0 // Restricts some wizard spells, traitor equipment, and other station busting murderbone 9001 things antags have
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for(var/T in L)
@@ -408,7 +408,9 @@
 				if("mutant_colors")
 					config.mutant_colors			= 1
 				if("objectives_disabled")
-					config.objectives_disabled 		= 1
+					config.objectives_disabled		= 1
+				if("restricted_antag_equipment")
+					config.restricted_antag_equipment	= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -686,6 +686,7 @@
 				special_role = "Revolutionary"
 				message_admins("[key_name_admin(usr)] has rev'ed [current].")
 				log_admin("[key_name(usr)] has rev'ed [current].")
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 
 			if("headrev")
 				if(src in ticker.mode.revolutionaries)
@@ -712,7 +713,7 @@
 				special_role = "Head Revolutionary"
 				message_admins("[key_name_admin(usr)] has head-rev'ed [current].")
 				log_admin("[key_name(usr)] has head-rev'ed [current].")
-
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("autoobjectives")
 				ticker.mode.forge_revolutionary_objectives(src)
 				ticker.mode.greet_revolutionary(src,0)
@@ -762,7 +763,7 @@
 				current << "<FONT size=3 color=red><B>You are a [gang_name("A")] Gang Boss!</B></FONT>"
 				message_admins("[key_name_admin(usr)] has added [current] to the [gang_name("A")] Gang (A) leadership.")
 				log_admin("[key_name(usr)] has added [current] to the [gang_name("A")] Gang (A) leadership.")
-
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("bgang")
 				if(src in ticker.mode.B_gangsters)
 					return
@@ -781,7 +782,7 @@
 				current << "<FONT size=3 color=red><B>You are a [gang_name("B")] Gang Boss!</B></FONT>"
 				message_admins("[key_name_admin(usr)] has added [current] to the [gang_name("B")] Gang (B) leadership.")
 				log_admin("[key_name(usr)] has added [current] to the [gang_name("B")] Gang (B) leadership.")
-
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("autoobjective")
 				ticker.mode.forge_gang_objectives(src)
 				ticker.mode.greet_gang(src,0)
@@ -827,6 +828,7 @@
 					ticker.mode.add_cultist(src)
 					message_admins("[key_name_admin(usr)] has cult'ed [current].")
 					log_admin("[key_name(usr)] has cult'ed [current].")
+					current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("tome")
 				var/mob/living/carbon/human/H = current
 				if (istype(H))
@@ -863,6 +865,7 @@
 					current << "<span class='userdanger'>You are the Space Wizard!</span>"
 					message_admins("[key_name_admin(usr)] has wizard'ed [current].")
 					log_admin("[key_name(usr)] has wizard'ed [current].")
+					current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("lair")
 				current.loc = pick(wizardstart)
 			if("dressup")
@@ -888,6 +891,7 @@
 					current << "<span class='userdanger'>Your powers are awoken. A flash of memory returns to us...we are [changeling.changelingID], a changeling!</span>"
 					message_admins("[key_name_admin(usr)] has changeling'ed [current].")
 					log_admin("[key_name(usr)] has changeling'ed [current].")
+					current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("autoobjectives")
 				ticker.mode.forge_changeling_objectives(src)
 				usr << "<span class='notice'>The objectives for changeling [key] have been generated. You can edit them and anounce manually.</span>"
@@ -924,6 +928,7 @@
 					ticker.mode.greet_syndicate(src)
 					message_admins("[key_name_admin(usr)] has nuke op'ed [current].")
 					log_admin("[key_name(usr)] has nuke op'ed [current].")
+					current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("lair")
 				current.loc = get_turf(locate("landmark*Syndicate-Spawn"))
 			if("dressup")
@@ -967,15 +972,17 @@
 					current << "<span class='userdanger'>You are a traitor!</span>"
 					message_admins("[key_name_admin(usr)] has traitor'ed [current].")
 					log_admin("[key_name(usr)] has traitor'ed [current].")
+					if(config.objectives_disabled == 1)
+						current << "<i>You have been turned into an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 					if(isAI(current))
 						var/mob/living/silicon/ai/A = current
 						ticker.mode.add_law_zero(A)
 						A.show_laws()
 
 			if("autoobjectives")
-				ticker.mode.forge_traitor_objectives(src)
-				usr << "<span class='notice'>The objectives for traitor [key] have been generated. You can edit them and anounce manually.</span>"
-
+				if(config.objectives_disabled == 0)
+					ticker.mode.forge_traitor_objectives(src)
+					usr << "\blue The objectives for traitor [key] have been generated. You can edit them and anounce manually."
 	else if (href_list["monkey"])
 		var/mob/living/L = current
 		if (L.notransform)
@@ -1009,6 +1016,7 @@
 						current.ForceContractDisease(new /datum/disease/transformation/jungle_fever)
 					else if (istype(M))
 						current.ForceContractDisease(new /datum/disease/transformation/jungle_fever)
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("human")
 				if (check_rights(R_ADMIN, 0))
 					var/mob/living/carbon/human/H = current
@@ -1036,7 +1044,7 @@
 				make_AI_Malf()
 				message_admins("[key_name_admin(usr)] has malf'ed [current].")
 				log_admin("[key_name(usr)] has malf'ed [current].")
-
+				current << "<font color=blue>Within the rules,</font> try to act as an opposing force to the crew. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonists.</i></b>"
 			if("unemag")
 				var/mob/living/silicon/robot/R = current
 				if (istype(R))
@@ -1116,7 +1124,8 @@
 	if(!(src in ticker.mode.traitors))
 		ticker.mode.traitors += src
 		special_role = "traitor"
-		ticker.mode.forge_traitor_objectives(src)
+		if(config.objectives_disabled == 0)
+			ticker.mode.forge_traitor_objectives(src)
 		ticker.mode.finalize_traitor(src)
 		ticker.mode.greet_traitor(src)
 
@@ -1231,8 +1240,8 @@
 	ticker.mode.head_revolutionaries += src
 	ticker.mode.update_rev_icons_added(src)
 	special_role = "Head Revolutionary"
-
-	ticker.mode.forge_revolutionary_objectives(src)
+	if(config.objectives_disabled == 0)
+		ticker.mode.forge_revolutionary_objectives(src)
 	ticker.mode.greet_revolutionary(src,0)
 
 	var/list/L = current.get_contents()
@@ -1247,7 +1256,8 @@
 /datum/mind/proc/make_Gang(var/gang)
 	special_role = "[(gang=="A") ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"] Boss"
 	ticker.mode.update_gang_icons_added(src, gang)
-	ticker.mode.forge_gang_objectives(src, gang)
+	if(config.objectives_disabled == 0)
+		ticker.mode.forge_gang_objectives(src, gang)
 	ticker.mode.greet_gang(src)
 	ticker.mode.equip_gang(current)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -982,7 +982,7 @@
 			if("autoobjectives")
 				if(config.objectives_disabled == 0)
 					ticker.mode.forge_traitor_objectives(src)
-					usr << "\blue The objectives for traitor [key] have been generated. You can edit them and anounce manually."
+					usr << "<span class='notice'>The objectives for traitor [key] have been generated. You can edit them and anounce manually.</span>"
 	else if (href_list["monkey"])
 		var/mob/living/L = current
 		if (L.notransform)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -50,7 +50,7 @@ var/list/uplink_items = list()
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
 	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
-
+	var/restricted = 0 // Whether the restricted_antag_items config option disables this.
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(item)
 		U.uses -= max(cost, 0)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -13,6 +13,8 @@ var/list/uplink_items = list()
 			var/datum/uplink_item/I = new item()
 			if(!I.item)
 				continue
+			if(I.restricted && config.restricted_antag_equipment)
+				continue
 			if(I.gamemodes.len && ticker && !(ticker.mode.type in I.gamemodes))
 				continue
 			if(I.excludefrom.len && ticker && (ticker.mode.type in I.excludefrom))
@@ -170,6 +172,7 @@ var/list/uplink_items = list()
 	desc = "The Minibomb is a grenade with a five-second fuse."
 	item = /obj/item/weapon/grenade/syndieminibomb
 	cost = 6
+	restricted = 1
 
 /datum/uplink_item/dangerous/viscerators
 	name = "Viscerator Delivery Grenade"
@@ -478,7 +481,7 @@ var/list/uplink_items = list()
 	leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation."
 	item = /obj/item/device/sbeacondrop
 	cost = 14
-
+	restricted = 1
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
@@ -486,7 +489,7 @@ var/list/uplink_items = list()
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 11
 	excludefrom = list(/datum/game_mode/traitor/double_agents)
-
+	restricted = 1
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"
 	desc = "A radioactive microlaser disguised as a standard Nanotrasen health analyzer. When used, it emits a powerful burst of radiation, which, after a short delay, can incapitate all but the most protected of humanoids. \
@@ -501,7 +504,7 @@ var/list/uplink_items = list()
 	item = /obj/item/device/syndicatedetonator
 	cost = 3
 	gamemodes = list(/datum/game_mode/nuclear)
-
+	restricted = 1
 /datum/uplink_item/device_tools/teleporter
 	name = "Teleporter Circuit Board"
 	desc = "A printed circuit board that completes the teleporter onboard the mothership. Advise you test fire the teleporter before entering it, as malfunctions can occur."

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -74,7 +74,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		log_game("[changeling.key] (ckey) has been selected as a changeling")
 		changeling.current.make_changeling()
 		changeling.special_role = "Changeling"
-		forge_changeling_objectives(changeling)
+		if(config.objectives_disabled == 0)
+			forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 	..()
 	return
@@ -160,13 +161,15 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		if (changeling.current.mind.assigned_role == "Clown")
 			changeling.current << "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself."
 			changeling.current.mutations.Remove(CLUMSY)
-
-	var/obj_count = 1
-	for(var/datum/objective/objective in changeling.objectives)
-		changeling.current << "<b>Objective #[obj_count]</b>: [objective.explanation_text]"
-		obj_count++
+	if(config.objectives_disabled == 0)
+		var/obj_count = 1
+		for(var/datum/objective/objective in changeling.objectives)
+			changeling.current << "<b>Objective #[obj_count]</b>: [objective.explanation_text]"
+			obj_count++
+		return
+	else
+		changeling.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
-
 /*/datum/game_mode/changeling/check_finished()
 	var/changelings_alive = 0
 	for(var/datum/mind/changeling in changelings)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -48,12 +48,13 @@
 
 
 /datum/game_mode/cult/pre_setup()
-	if(prob(50))
-		cult_objectives += "survive"
-		cult_objectives += "sacrifice"
-	else
-		cult_objectives += "eldergod"
-		cult_objectives += "sacrifice"
+	if(config.objectives_disabled == 0)
+		if(prob(50))
+			cult_objectives += "survive"
+			cult_objectives += "sacrifice"
+		else
+			cult_objectives += "eldergod"
+			cult_objectives += "sacrifice"
 
 	if(num_players() >= 30)
 		recommended_enemies = 9	// 3+3+3 - d' magic number o' magic numbars mon
@@ -111,20 +112,24 @@
 
 
 /datum/game_mode/cult/proc/memorize_cult_objectives(var/datum/mind/cult_mind)
-	for(var/obj_count = 1,obj_count <= cult_objectives.len,obj_count++)
-		var/explanation
-		switch(cult_objectives[obj_count])
-			if("survive")
-				explanation = "Our knowledge must live on. Make sure at least [acolytes_needed] acolytes escape on the shuttle to spread their work on an another station."
-			if("sacrifice")
-				if(sacrifice_target)
-					explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. You will need the sacrifice rune (Hell blood join) and three acolytes to do so."
-				else
-					explanation = "Free objective."
-			if("eldergod")
-				explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it."
-		cult_mind.current << "<B>Objective #[obj_count]</B>: [explanation]"
-		cult_mind.memory += "<B>Objective #[obj_count]</B>: [explanation]<BR>"
+	if(config.objectives_disabled == 0)
+		for(var/obj_count = 1,obj_count <= cult_objectives.len,obj_count++)
+			var/explanation
+			switch(cult_objectives[obj_count])
+				if("survive")
+					explanation = "Our knowledge must live on. Make sure at least [acolytes_needed] acolytes escape on the shuttle to spread their work on an another station."
+				if("sacrifice")
+					if(sacrifice_target)
+						explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. You will need the sacrifice rune (Hell blood join) and three acolytes to do so."
+					else
+						explanation = "Free objective."
+				if("eldergod")
+					explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it."
+			cult_mind.current << "<B>Objective #[obj_count]</B>: [explanation]"
+			cult_mind.memory += "<B>Objective #[obj_count]</B>: [explanation]<BR>"
+	else
+		cult_mind.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
+	return
 	cult_mind.current << "The Geometer of Blood grants you the knowledge to sacrifice non-believers. (Hell Blood Join)"
 	cult_mind.memory += "The Geometer of Blood grants you the knowledge to sacrifice non-believers. (Hell Blood Join)<BR>"
 	for(var/startingword in startwords)

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -56,13 +56,15 @@
 	spawn(rand(10,100))
 		for(var/datum/mind/boss_mind in A_bosses)
 			update_gang_icons_added(boss_mind, "A")
-			forge_gang_objectives(boss_mind, "A")
+			if(config.objectives_disabled == 0)
+				forge_gang_objectives(boss_mind, "A")
 			greet_gang(boss_mind)
 			equip_gang(boss_mind.current)
 
 		for(var/datum/mind/boss_mind in B_bosses)
 			update_gang_icons_added(boss_mind, "B")
-			forge_gang_objectives(boss_mind, "B")
+			if(config.objectives_disabled == 0)
+				forge_gang_objectives(boss_mind, "B")
 			greet_gang(boss_mind)
 			equip_gang(boss_mind.current)
 
@@ -103,9 +105,13 @@
 	var/obj_count = 1
 	if (you_are)
 		boss_mind.current << "<FONT size=3 color=red><B>You are a [(boss_mind in A_bosses) ? gang_name("A") : gang_name("B")] Gang Boss!</B></FONT>"
-	for(var/datum/objective/objective in boss_mind.objectives)
-		boss_mind.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
-		obj_count++
+	if(config.objectives_disabled == 0)
+		for(var/datum/objective/objective in boss_mind.objectives)
+			boss_mind.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+			obj_count++
+	else
+		boss_mind.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
+	return
 
 ///////////////////////////////////////////////////////////////////////////
 //This equips the bosses with their gear, and makes the clown not clumsy//

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -90,11 +90,14 @@
 
 /datum/game_mode/proc/greet_malf(var/datum/mind/malf)
 	malf.current << "<span class='userdanger'><font size=3>You are malfunctioning!</B> You do not have to follow any laws.</font></span>"
-	malf.current << "<B>The crew do not know you have malfunctioned. You may keep it a secret or go wild.</B>"
-	malf.current << "<B>You must overwrite the programming of the station's APCs to assume full control of the station.</B>"
-	malf.current << "The process takes one minute per APC, during which you cannot interface with any other station objects."
-	malf.current << "Remember that only APCs that are on the station can help you take over the station."
-	malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
+	if(config.objectives_disabled == 0)
+		malf.current << "<B>The crew do not know you have malfunctioned. You may keep it a secret or go wild.</B>"
+		malf.current << "<B>You must overwrite the programming of the station's APCs to assume full control of the station.</B>"
+		malf.current << "The process takes one minute per APC, during which you cannot interface with any other station objects."
+		malf.current << "Remember that only APCs that are on the station can help you take over the station."
+		malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
+	else
+		rev_mind.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
 
 /datum/game_mode/malfunction/process()

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -97,7 +97,7 @@
 		malf.current << "Remember that only APCs that are on the station can help you take over the station."
 		malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
 	else
-		rev_mind.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
+		malf.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
 
 /datum/game_mode/malfunction/process()

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -83,7 +83,8 @@
 			spawnpos = 2
 		synd_mind.current.loc = synd_spawn[spawnpos]
 
-		forge_syndicate_objectives(synd_mind)
+		if(config.objectives_disabled == 0)
+			forge_syndicate_objectives(synd_mind)
 		greet_syndicate(synd_mind)
 		equip_syndicate(synd_mind.current)
 
@@ -147,10 +148,14 @@
 /datum/game_mode/proc/greet_syndicate(var/datum/mind/syndicate, var/you_are=1)
 	if (you_are)
 		syndicate.current << "<span class='notice'>You are a [syndicate_name()] agent!</span>"
-	var/obj_count = 1
-	for(var/datum/objective/objective in syndicate.objectives)
-		syndicate.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
-		obj_count++
+	if(config.objectives_disabled == 0)
+		var/obj_count = 1
+		for(var/datum/objective/objective in syndicate.objectives)
+			syndicate.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+			obj_count++
+		return
+	else
+		syndicate.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -118,10 +118,14 @@
 	var/obj_count = 1
 	if (you_are)
 		rev_mind.current << "<span class='userdanger'><FONT size = 3>You are a member of the revolutionaries' leadership!</FONT></span>"
-	for(var/datum/objective/objective in rev_mind.objectives)
-		rev_mind.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
-		rev_mind.special_role = "Head Revolutionary"
-		obj_count++
+	if(config.objectives_disabled == 0)
+		for(var/datum/objective/objective in rev_mind.objectives)
+			rev_mind.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+			rev_mind.special_role = "Head Revolutionary"
+			obj_count++
+	else
+		rev_mind.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
+	return
 
 /////////////////////////////////////////////////////////////////////////////////
 //This are equips the rev heads with their gear, and makes the clown not clumsy//
@@ -188,7 +192,8 @@
 		head_revolutionaries += stalin
 		log_game("[stalin.key] (ckey) has been promoted to a head rev")
 		equip_revolutionary(stalin.current)
-		forge_revolutionary_objectives(stalin)
+		if(config.objectives_disabled == 0)
+			forge_revolutionary_objectives(stalin)
 		greet_revolutionary(stalin)
 		++max_headrevs
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -62,7 +62,8 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in traitors)
-		forge_traitor_objectives(traitor)
+		if(config.objectives_disabled == 0)
+			forge_traitor_objectives(traitor)
 		spawn(rand(10,100))
 			finalize_traitor(traitor)
 			greet_traitor(traitor)
@@ -157,11 +158,14 @@
 
 
 /datum/game_mode/proc/greet_traitor(var/datum/mind/traitor)
-	traitor.current << "<B><font size=3 color=red>You are the [traitor_name].</font></B>"
-	var/obj_count = 1
-	for(var/datum/objective/objective in traitor.objectives)
-		traitor.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
-		obj_count++
+	traitor.current << "<B><font size=3 color=red>You are the traitor.</font></B>"
+	if(config.objectives_disabled == 0)
+		var/obj_count = 1
+		for(var/datum/objective/objective in traitor.objectives)
+			traitor.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+			obj_count++
+	else
+		traitor.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
 
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -37,7 +37,8 @@
 		dat += "<HR>"
 		dat += "<A href='byond://?src=\ref[src];spell_choice=spells'>Learn and Improve Magical Abilities</A><BR>"
 		dat += "<A href='byond://?src=\ref[src];spell_choice=artifacts'>Summon Magical Tools and Weapons</A><BR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=oneuse'>Cast Powerful One Time Spells</A><BR>"
+		if(config.restricted_antag_equipment == 0)
+			dat += "<A href='byond://?src=\ref[src];spell_choice=oneuse'>Cast Powerful One Time Spells</A><BR>"
 
 		dat += "<HR>"
 		dat += "<A href='byond://?src=\ref[src];spell_choice=rememorize'>Re-memorize Spells</A><BR>"

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -35,7 +35,8 @@
 /datum/game_mode/wizard/post_setup()
 	for(var/datum/mind/wizard in wizards)
 		log_game("[wizard.key] (ckey) has been selected as a Wizard")
-		forge_wizard_objectives(wizard)
+		if(config.objectives_disabled == 0)
+			forge_wizard_objectives(wizard)
 		//learn_basic_spells(wizard.current)
 		equip_wizard(wizard.current)
 		name_wizard(wizard.current)
@@ -113,12 +114,16 @@
 /datum/game_mode/proc/greet_wizard(var/datum/mind/wizard, var/you_are=1)
 	if (you_are)
 		wizard.current << "<span class='userdanger'>You are the Space Wizard!</span>"
-	wizard.current << "<B>The Space Wizards Federation has given you the following tasks:</B>"
+	if(config.objectives_disabled == 0)
+		wizard.current << "<B>The Space Wizards Federation has given you the following tasks:</B>"
 
-	var/obj_count = 1
-	for(var/datum/objective/objective in wizard.objectives)
-		wizard.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
-		obj_count++
+		var/obj_count = 1
+		for(var/datum/objective/objective in wizard.objectives)
+			wizard.current << "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
+			obj_count++
+		return
+	else
+		wizard.current << "<i>You have been selected this round as an antagonist- <font color=blue>Within the rules,</font> try to act as an opposing force to the crew- This can be via corporate payoff, personal motives, or maybe just being a dick. Further RP and try to make sure other players have </i>fun<i>! If you are confused or at a loss, always adminhelp, and before taking extreme actions, please try to also contact the administration! Think through your actions and make the roleplay immersive! <b>Please remember all rules aside from those without explicit exceptions apply to antagonist.</i></b>"
 	return
 
 


### PR DESCRIPTION
This adds 2 config options for downstreams and/or the main server.

Objectiveless Antags

self explanatory

Restricted Antag items

This restricts the purchase of antag powers, spells, and items that are incredibly destructive and don't encourage roleplay.
