### PR TITLE
Fixes the welder's onmob sprite not updating when turning off 

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -210,9 +210,9 @@
 		if(1)
 			force = 15
 			damtype = "fire"
-			update_icon()
 			if(prob(5))
 				remove_fuel(1)
+			update_icon()
 
 	//This is to start fires. process() is only called if the welder is on.
 	var/turf/location = loc
@@ -283,14 +283,12 @@
 /obj/item/weapon/weldingtool/proc/check_fuel(mob/user)
 	if(get_fuel() <= 0 && welding)
 		toggle(user, 1)
-
+		update_icon()
 		//mob icon update
 		if(ismob(loc))
 			var/mob/M = loc
-			if(M.r_hand == src)
-				M.update_inv_r_hand(0)
-			else if(M.l_hand == src)
-				M.update_inv_l_hand(0)
+			M.update_inv_r_hand(0)
+			M.update_inv_l_hand(0)
 
 		return 0
 	return 1
@@ -321,7 +319,7 @@
 		damtype = "brute"
 		hitsound = "swing_hit"
 		icon_state = "welder"
-		welding = 0
+
 
 
 //Decides whether or not to damage a player's eyes based on what they're wearing as protection
@@ -416,7 +414,6 @@
 	m_amt = 70
 	g_amt = 120
 	origin_tech = "engineering=4;plasmatech=3"
-	icon_state = "ewelder"
 	var/last_gen = 0
 
 


### PR DESCRIPTION
due to lack of fuel.  Fixes #6233
Fixing experimental weldingtool having an invisible sprite.
