### PR TITLE
Fixes 2 runtimes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -77,9 +77,9 @@
 	if(new_character.mind)								//disassociate any mind currently in our new body's mind variable
 		new_character.mind.current = null
 
-	transfer_antag_huds(new_character)					//inherit the antag HUDs from this mind (TODO: move this to the antag datum)
 	current = new_character								//associate ourself with our new body
 	new_character.mind = src							//and associate our new body with ourself
+	transfer_antag_huds(new_character)					//inherit the antag HUDs from this mind (TODO: move this to a possible antag datum)
 
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -343,7 +343,7 @@ obj/machinery/bot/floorbot/process_scan(var/scan_target)
 				result = F
 		if(FIX_TILE)	//Selects only damaged floors.
 			F = scan_target
-			if(F.broken || F.burnt)
+			if(istype(F) && (F.broken || F.burnt))
 				result = F
 		if(TILE_EMAG) //Emag mode! Rip up the floor and cause breaches to space!
 			F = scan_target


### PR DESCRIPTION
Related to #6351

Fixes antag hud runtime due to checking the mind before transferring it.
Fixes floorbot runtime due to typecasting with no sanity checks.

I still have no idea what's up with the wall/plating try_destroy() runtime. Can't reproduce it, at all.
