### PR TITLE
Reserve PascalCase inits

### DIFF
--- a/code/controllers/lighting_controller.dm
+++ b/code/controllers/lighting_controller.dm
@@ -65,7 +65,7 @@ var/datum/controller/lighting/lighting_controller = new ()
 //Does not loop. Should be run prior to process() being called for the first time.
 //Note: if we get additional z-levels at runtime (e.g. if the gateway thin ever gets finished) we can initialize specific
 //z-levels with the z_level argument
-/datum/controller/lighting/proc/Initialize(var/z_level)
+/datum/controller/lighting/proc/initializeLighting(var/z_level)
 	processing = 0
 	spawn(-1)
 		set background = BACKGROUND_ENABLED

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -17,11 +17,11 @@
 
 
 /datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null)
-	if(!Init(arglist(args)))
+	if(!initTeleport(arglist(args)))
 		return 0
 	return 1
 
-/datum/teleport/proc/Init(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
+/datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout)
 	if(!setTeleatom(ateleatom))
 		return 0
 	if(!setDestination(adestination))

--- a/code/world.dm
+++ b/code/world.dm
@@ -89,7 +89,7 @@
 	master_controller = new /datum/controller/game_controller()
 	spawn(-1)
 		master_controller.setup()
-		lighting_controller.Initialize()
+		lighting_controller.initializeLighting()
 
 	src.update_status()
 


### PR DESCRIPTION
camelCased the couple of occurences of `Init()` and `Initialize()` to reserve the PascalCase versions for standardization (via LDM soon (tm))
