### PR TITLE
Adds cfg option to let players see their own notes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -64,6 +64,7 @@
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
+	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
 	//game_options.txt configs
 	var/force_random_names = 0
@@ -281,6 +282,8 @@
 					global.comms_key = value
 					if(value != "default_pwd" && length(value) > 6) //It's the default value or less than 6 characters long, warn badmins
 						global.comms_allowed = 1
+				if("see_own_notes")
+					config.see_own_notes = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -109,3 +109,14 @@ var/global/normal_ooc_colour = "#002eb8"
 		src << "<div class=\"motd\">[join_motd]</div>"
 	else
 		src << "<span class='notice'>The Message of the Day has not been set.</span>"
+
+/client/proc/self_notes()
+	set name = "View Admin Notes"
+	set category = "OOC"
+	set desc = "View the notes that admins have written about you"
+
+	if(!config.see_own_notes)
+		usr << "<span class='notice'>Sorry, that function is not enabled on this server.</span>"
+		return
+
+	see_own_notes()

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -4,13 +4,35 @@
 
 #define NOTESFILE "data/player_notes.sav"	//where the player notes are saved
 
+/proc/see_own_notes()
+	if(!config.see_own_notes)
+		return
+	var/ckey = usr.client.ckey
+	if(!ckey)
+		usr << "<span class='warning'>Error: No ckey found.</span>"
+		return
+	var/savefile/notesfile = new(NOTESFILE)
+	if(!notesfile)
+		usr << "<span class='warning'>Error: Cannot access [NOTESFILE]</span>"
+		return
+	notesfile.cd = "/[ckey]"
+	var/dat = "<b>Notes for [ckey]:</b><br>"
+	while(!notesfile.eof)
+		var/note
+		notesfile >> note
+		dat += note
+	var/datum/browser/popup = new(usr, "player_notes", "Player Notes", 700, 400)
+	popup.set_content(dat)
+	popup.open()
+
+
 datum/admins/proc/notes_show(var/ckey)
 	usr << browse("<head><title>Player Notes</title></head><body>[notes_gethtml(ckey)]</body>","window=player_notes;size=700x400")
 
 
 datum/admins/proc/notes_gethtml(var/ckey)
 	var/savefile/notesfile = new(NOTESFILE)
-	if(!notesfile)	return "<font color='red'>Error: Cannot access [NOTESFILE]</font>"
+	if(!notesfile)	return "<span class='warning'>Error: Cannot access [NOTESFILE]</span>"
 	if(ckey)
 		. = "<b>Notes for <a href='?_src_=holder;notes=show'>[ckey]</a>:</b> <a href='?_src_=holder;notes=add;ckey=[ckey]'>\[+\]</a><br>"
 		notesfile.cd = "/[ckey]"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -133,6 +133,7 @@ var/next_external_rsc = 0
 		if((global.comms_key == "default_pwd" || length(global.comms_key) <= 6) && global.comms_allowed) //It's the default value or less than 6 characters long, but it somehow didn't disable comms.
 			src << "<span class='danger'>The server's API key is either too short or is the default value! Consider changing it immediately!</span>"
 
+	add_verbs_from_config()
 	set_client_age_from_db()
 
 	if (!ticker || ticker.current_state == GAME_STATE_PREGAME)
@@ -217,6 +218,10 @@ var/next_external_rsc = 0
 	var/serverip = "[world.internet_address]:[world.port]"
 	var/DBQuery/query_accesslog = dbcon.NewQuery("INSERT INTO `[format_table_name("connection_log")]` (`id`,`datetime`,`serverip`,`ckey`,`ip`,`computerid`) VALUES(null,Now(),'[serverip]','[sql_ckey]','[sql_ip]','[sql_computerid]');")
 	query_accesslog.Execute()
+
+/client/proc/add_verbs_from_config()
+	if(config.see_own_notes)
+		verbs += /client/proc/self_notes
 
 
 #undef TOPIC_SPAM_DELAY

--- a/config/config.txt
+++ b/config/config.txt
@@ -153,3 +153,6 @@ TICKCOMP 0
 
 ## Communication key for receiving data through world/Topic(), you don't want to give this out
 #COMMS_KEY default_pwd
+
+## Uncomment this to let players see their own notes (they can still be set by admins only)
+#SEE_OWN_NOTES


### PR DESCRIPTION
This lets players see the admin notes that have been added to their ckey, by using a verb in the OOC tab.
This is a config option and is off by default. Server hosts of this codebase should carefully consider whether they want to enable it or not.
