### PR TITLE
Guns related bugfixes

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -1,4 +1,9 @@
 ////////////////INTERNAL MAGAZINES//////////////////////
+
+//internals magazines are accessible, so replace spent ammo if full when trying to put a live one in
+/obj/item/ammo_box/magazine/internal/give_round(var/obj/item/ammo_casing/R)
+	return ..(R,1)
+
 /obj/item/ammo_box/magazine/internal/cylinder
 	name = "revolver cylinder"
 	desc = "Oh god, this shouldn't be here"

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -34,7 +34,7 @@
 		return 0
 	if(targloc == curloc)			//Fire the projectile
 		user.bullet_act(BB)
-		qdel(BB)
+		del(BB)
 		return 1
 	BB.loc = get_turf(user)
 	BB.starting = get_turf(user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -23,6 +23,7 @@
 	var/obj/item/ammo_casing/chambered = null
 	var/trigger_guard = 1
 	var/sawn_desc = null
+	var/sawn_state = 0 //0 - intact, 1 - sawned off, -1 - currently sawing
 
 /obj/item/weapon/gun/proc/process_chamber()
 	return 0
@@ -30,12 +31,17 @@
 /obj/item/weapon/gun/proc/special_check(var/mob/M) //Placeholder for any special checks, like detective's revolver.
 	return 1
 
+//check if there's enough ammo/energy/whatever to shoot one time
+//i.e if clicking would make it shoot
+/obj/item/weapon/gun/proc/can_shoot()
+	return 1
+
 /obj/item/weapon/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
 	user << "<span class='danger'>*click*</span>"
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	return
 
-/obj/item/weapon/gun/proc/shoot_live_shot(mob/living/user as mob|obj, var/pointblank = 0, var/mob/pbtarget = null)
+/obj/item/weapon/gun/proc/shoot_live_shot(mob/living/user as mob|obj, var/pointblank = 0, var/mob/pbtarget = null, var/message = 1)
 	if(recoil)
 		spawn()
 			shake_camera(user, recoil + 1, recoil)
@@ -44,6 +50,8 @@
 		playsound(user, fire_sound, 10, 1)
 	else
 		playsound(user, fire_sound, 50, 1)
+		if(!message)
+			return
 		if(pointblank)
 			user.visible_message("<span class='danger'>[user] fires [src] point blank at [pbtarget]!</span>", "<span class='danger'>You fire [src] point blank at [pbtarget]!</span>", "You hear a [istype(src, /obj/item/weapon/gun/energy) ? "laser blast" : "gunshot"]!")
 		else
@@ -62,12 +70,12 @@
 			return
 
 	//Exclude lasertag guns from the CLUMSY check.
-	if(clumsy_check)
+	if(clumsy_check && can_shoot())
 		if(istype(user, /mob/living))
 			var/mob/living/M = user
 			if ((CLUMSY in M.mutations) && prob(40))
-				M << "<span class='danger'>You shoot yourself in the foot with \the [src]!</span>"
-				afterattack(user, user)
+				user << "<span class='danger'>You shoot yourself in the foot with \the [src]!</span>"
+				process_fire(user,user,0,params)
 				M.drop_item()
 				return
 
@@ -87,18 +95,23 @@
 				user << "<span class='notice'>Your fingers don't fit in the trigger guard!</span>"
 				return
 
+	process_fire(target,user,flag,params)
+
+/obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, var/message = 1, params)
+
 	add_fingerprint(user)
+
+	if(!special_check(user))
+		return
 
 	if(chambered)
 		if(!chambered.fire(target, user, params, , suppressed))
 			shoot_with_empty_chamber(user)
 		else
-			if(!special_check(user))
-				return
 			if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
-				shoot_live_shot(user, 1, target)
+				shoot_live_shot(user, 1, target,message)
 			else
-				shoot_live_shot(user)
+				shoot_live_shot(user,message)
 	else
 		shoot_with_empty_chamber(user)
 	process_chamber()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1,3 +1,7 @@
+ #define SAWN_INTACT  0
+ #define SAWN_OFF     1
+ #define SAWN_SAWING -1
+
 /obj/item/weapon/gun
 	name = "gun"
 	desc = "It's a gun. It's pretty terrible, though."
@@ -23,7 +27,7 @@
 	var/obj/item/ammo_casing/chambered = null
 	var/trigger_guard = 1
 	var/sawn_desc = null
-	var/sawn_state = 0 //0 - intact, 1 - sawned off, -1 - currently sawing
+	var/sawn_state = SAWN_INTACT
 
 /obj/item/weapon/gun/proc/process_chamber()
 	return 0

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -35,7 +35,9 @@
 /obj/item/weapon/gun/energy/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, params)
 	newshot() //prepare a new shot
 	..()
-
+/obj/item/weapon/gun/energy/can_shoot()
+	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
+	return power_supply.charge >= shot.e_cost
 
 /obj/item/weapon/gun/energy/proc/newshot()
 	if (!ammo_type || !power_supply)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -125,9 +125,11 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/bluetag/process()
 	charge_tick++
-	if(charge_tick < 4) return 0
+	if(charge_tick < 4)
+		return 0
 	charge_tick = 0
-	if(!power_supply) return 0
+	if(!power_supply)
+		return 0
 	power_supply.give(100)
 	update_icon()
 	return 1
@@ -162,9 +164,11 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/redtag/process()
 	charge_tick++
-	if(charge_tick < 4) return 0
+	if(charge_tick < 4)
+		return 0
 	charge_tick = 0
-	if(!power_supply) return 0
+	if(!power_supply)
+		return 0
 	power_supply.give(100)
 	update_icon()
 	return 1

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -29,6 +29,9 @@
 			no_den_usage = 0
 	..()
 
+/obj/item/weapon/gun/magic/can_shoot()
+	return charges
+
 /obj/item/weapon/gun/magic/proc/newshot()
 	if (charges && chambered)
 		chambered.newshot()

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -40,6 +40,11 @@
 		chambered.loc = src
 	return
 
+/obj/item/weapon/gun/projectile/can_shoot()
+	if(!magazine || !magazine.ammo_count(0))
+		return 0
+	return 1
+
 /obj/item/weapon/gun/projectile/attackby(var/obj/item/A as obj, mob/user as mob)
 	..()
 	if (istype(A, /obj/item/ammo_box/magazine))

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -17,6 +17,9 @@
 	if(..() && chambered)
 		alarmed = 0
 
+/obj/item/weapon/gun/projectile/automatic/can_shoot()
+	return get_ammo()
+
 /obj/item/weapon/gun/projectile/automatic/proc/empty_alarm()
 	if(!chambered && !get_ammo() && !alarmed)
 		playsound(src.loc, 'sound/weapons/smg_empty_alarm.ogg', 40, 1)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -5,7 +5,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
 
 /obj/item/weapon/gun/projectile/revolver/chamber_round()
-	if (chambered || !magazine)
+	if ((chambered && chambered.BB)|| !magazine) //if there's a live ammo in the chamber or no magazine
 		return
 	else if (magazine.ammo_count())
 		chambered = magazine.get_round(1)
@@ -36,6 +36,9 @@
 		user << "<span class = 'notice'>You unload [num_unloaded] shell\s from [src].</span>"
 	else
 		user << "<span class='notice'>[src] is empty.</span>"
+
+/obj/item/weapon/gun/projectile/revolver/can_shoot()
+	return get_ammo(0,0)
 
 /obj/item/weapon/gun/projectile/revolver/get_ammo(var/countchambered = 0, var/countempties = 1)
 	var/boolets = 0 //mature var names for mature people

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -167,11 +167,11 @@
 			. = 1
 
 /obj/item/weapon/gun/projectile/proc/sawoff(mob/user as mob)
-	if(sawn_state > 0)
+	if(sawn_state == SAWN_OFF)
 		user << "<span class='notice'>\The [src] is already shorten.</span>"
 		return
 
-	if(sawn_state < 0)//sawing the gun
+	if(sawn_state == SAWN_SAWING)
 		return
 
 	user.visible_message("<span class='notice'>[user] begin to shorten \the [src].</span>", "<span class='notice'>You begin to shorten \the [src].</span>")
@@ -181,7 +181,7 @@
 		user.visible_message("<span class='danger'>\The [src] goes off!</span>", "<span class='danger'>\The [src] goes off in your face!</span>")
 		return
 
-	sawn_state = -1//now sawing
+	sawn_state = SAWN_SAWING
 
 	if(do_after(user, 30))
 		name = "sawn-off [src.name]"
@@ -191,9 +191,9 @@
 		item_state = "gun"
 		slot_flags &= ~SLOT_BACK	//you can't sling it on your back
 		slot_flags |= SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-		sawn_state = 1
+		sawn_state = SAWN_OFF
 		user.visible_message("<span class='warning'>[user] shorten \the [src]!</span>", "<span class='warning'>You shorten \the [src]!</span>")
 		update_icon()
 		return
 	else
-		sawn_state = 0
+		sawn_state = SAWN_INTACT

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -25,6 +25,11 @@
 /obj/item/weapon/gun/projectile/shotgun/chamber_round()
 	return
 
+/obj/item/weapon/gun/projectile/shotgun/can_shoot()
+	if(!chambered)
+		return 0
+	return (chambered.BB ? 1 : 0)
+
 /obj/item/weapon/gun/projectile/shotgun/attack_self(mob/living/user)
 	if(recentpump)	return
 	pump(user)
@@ -69,8 +74,12 @@
 
 /obj/item/weapon/gun/projectile/shotgun/riot/attackby(var/obj/item/A as obj, mob/user as mob)
 	..()
-	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
+	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
 		sawoff(user)
+	if(istype(A, /obj/item/weapon/melee/energy))
+		var/obj/item/weapon/melee/energy/W = A
+		if(W.active)
+			sawoff(user)
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel
 	name = "double-barreled shotgun"
@@ -89,26 +98,12 @@
 	..()
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
 		chamber_round()
-	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/melee/energy) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
+	if(istype(A, /obj/item/weapon/melee/energy))
+		var/obj/item/weapon/melee/energy/W = A
+		if(W.active)
+			sawoff(user)
+	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/pickaxe/plasmacutter))
 		sawoff(user)
-
-/obj/item/weapon/gun/projectile/proc/sawoff(mob/user as mob)
-	user << "<span class='notice'>You begin to shorten \the [src].</span>"
-	if(get_ammo())
-		afterattack(user, user)
-		user.visible_message("<span class='danger'>The [src] goes off!</span>", "<span class='danger'>The [src] goes off in your face!</span>")
-		return
-	if(do_after(user, 30))
-		name = "sawn-off [src.name]"
-		desc = sawn_desc
-		icon_state = initial(icon_state) + "-sawn"
-		w_class = 3.0
-		item_state = "gun"
-		slot_flags &= ~SLOT_BACK	//you can't sling it on your back
-		slot_flags |= SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
-		user << "<span class='warning'>You shorten \the [src]!</span>"
-		update_icon()
-		return
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/attack_self(mob/living/user as mob)
 	var/num_unloaded = 0
@@ -140,7 +135,7 @@
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/attackby(var/obj/item/A as obj, mob/user as mob)
 	..()
-	if(istype(A, /obj/item/stack/cable_coil))
+	if(istype(A, /obj/item/stack/cable_coil) && !sawn_state)
 		var/obj/item/stack/cable_coil/C = A
 		if(C.use(10))
 			flags =  CONDUCT
@@ -151,3 +146,54 @@
 		else
 			user << "<span class='warning'>You need at least ten lengths of cable if you want to make a sling.</span>"
 			return
+
+//Sawing guns related procs
+/obj/item/weapon/gun/projectile/proc/blow_up(mob/user as mob)
+	. = 0
+	for(var/obj/item/ammo_casing/AC in magazine.stored_ammo)
+		if(AC.BB)
+			process_fire(user, user)
+			. = 1
+
+/obj/item/weapon/gun/projectile/shotgun/blow_up(mob/user as mob)
+	. = 0
+	if(chambered && chambered.BB)
+		process_fire(user, user,0)
+		. = 1
+	for(var/obj/item/ammo_casing/AC in magazine.stored_ammo)
+		if(AC.BB)
+			chambered = AC
+			process_fire(user, user,0)
+			. = 1
+
+/obj/item/weapon/gun/projectile/proc/sawoff(mob/user as mob)
+	if(sawn_state > 0)
+		user << "<span class='notice'>\The [src] is already shorten.</span>"
+		return
+
+	if(sawn_state < 0)//sawing the gun
+		return
+
+	user.visible_message("<span class='notice'>[user] begin to shorten \the [src].</span>", "<span class='notice'>You begin to shorten \the [src].</span>")
+
+	//if there's any live ammo inside the gun, makes it go off
+	if(blow_up(user))
+		user.visible_message("<span class='danger'>\The [src] goes off!</span>", "<span class='danger'>\The [src] goes off in your face!</span>")
+		return
+
+	sawn_state = -1//now sawing
+
+	if(do_after(user, 30))
+		name = "sawn-off [src.name]"
+		desc = sawn_desc
+		icon_state = initial(icon_state) + "-sawn"
+		w_class = 3.0
+		item_state = "gun"
+		slot_flags &= ~SLOT_BACK	//you can't sling it on your back
+		slot_flags |= SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
+		sawn_state = 1
+		user.visible_message("<span class='warning'>[user] shorten \the [src]!</span>", "<span class='warning'>You shorten \the [src]!</span>")
+		update_icon()
+		return
+	else
+		sawn_state = 0


### PR DESCRIPTION
### Guns related bugfixes
- fixes #3765 (shotguns sawing off)
  - you can't saw off a shotgun with unactives energy weapons (e.g esword)
  - added a _can_shoot_ proc that check if clicking next would trigger a shot
  - fixed being able to infinitely saw off a gun
  - fixed being able to start multiple sawing at a time
  - tidied the blowing off process : now, if trying to saw off a gun, **any_live_ammo** in the gun will go off on the use
  - bullets were not qdel'ing correctly on gun blowing up, so i made them del() instead (i didn't found an obvious reason for the qdel() to fail).
  - some notifications tweaks (no firing message displayed on clumsy and blowing up)
  - sawing off starting/finishing are now broadcast to visibles players.
- fixes #994 (clumsy guns firing)
  - removed the need for recursive calling (no more bad luck 6 bullets foot shooting)
  - clumsy won't trigger if the gun can't fire (\* click *)
- fixes #6443 (laser tags firing without vest on)
- fixes #6262 (optimizing revolver reloading)
  For any gun with **_internals**_ magazines (revolvers, shotguns, grenade launchers, ...) reloading will replace spent ammo if there's more ammo than magazine size (supposedly these magazines are easily accessed for direct spent ammo replacing).
