### PR TITLE
Fixes AI not being able to use maintenance APCs

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -242,7 +242,8 @@ Class Procs:
 		return
 	//stop AIs from leaving windows open and using then after they lose vision
 	//apc_override is needed here because AIs use their own APC when powerless
-	if(cameranet && !cameranet.checkTurfVis(get_turf(M)) && !apc_override)
+	//the snowflake get_wall_mounted_turf() is because APCs in maint aren't actually in view of the inner camera
+	if(cameranet && !cameranet.checkTurfVis(get_wall_mounted_turf(M)) && !apc_override)
 		return
 	return 1
 


### PR DESCRIPTION
This is done by adding a new get_wall_mounted_turf() helper proc.
Fixes #6508
