### PR TITLE
Various atmos fixes

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -97,11 +97,7 @@ Pipelines + Other Objects -> Pipe network
 		var/turf/T = loc
 		stored.loc = T
 		transfer_fingerprints_to(stored)
-		if(istype(src, /obj/machinery/atmospherics/pipe))
-			for(var/obj/machinery/meter/meter in T)
-				if(meter.target == src)
-					new /obj/item/pipe_meter(T)
-					qdel(meter)
+
 	qdel(src)
 
 /obj/machinery/atmospherics/proc/nullifyPipenet(datum/pipeline/P)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -124,7 +124,7 @@ Pipelines + Other Objects -> Pipe network
 
 	return img
 
-/obj/machinery/atmospherics/proc/construction(D, P)
+/obj/machinery/atmospherics/construction(D, P)
 	dir = D
 	initialize_directions = P
 	var/turf/T = loc

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -41,3 +41,12 @@
 
 /obj/machinery/atmospherics/pipe/setPipenet(datum/pipeline/P)
 	parent = P
+
+/obj/machinery/atmospherics/pipe/Destroy()
+	var/turf/T = loc
+	for(var/obj/machinery/meter/meter in T)
+		if(meter.target == src)
+			var/obj/item/pipe_meter/PM = new (T)
+			meter.transfer_fingerprints_to(PM)
+			qdel(meter)
+	..()

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -25,6 +25,8 @@
 /obj/machinery/atmospherics/pipe/manifold/New()
 	color = pipe_color
 
+	..()
+
 	switch(dir)
 		if(NORTH)
 			initialize_directions = EAST|SOUTH|WEST
@@ -34,7 +36,6 @@
 			initialize_directions = SOUTH|WEST|NORTH
 		if(WEST)
 			initialize_directions = NORTH|EAST|SOUTH
-	..()
 
 /obj/machinery/atmospherics/pipe/manifold/initialize()
 	for(var/D in cardinal)

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -10,7 +10,7 @@
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/New()
 	..()
-	initialize_directions = dir
+	construction(dir,dir)
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/thermomachine(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
@@ -127,7 +127,7 @@
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/New()
 	..()
-	initialize_directions = dir
+	construction(dir,dir)
 	var/obj/item/weapon/circuitboard/thermomachine/H = new /obj/item/weapon/circuitboard/thermomachine(null)
 	H.build_path = /obj/machinery/atmospherics/unary/heat_reservoir/heater
 	H.name = "circuit board (Heater)"
@@ -204,7 +204,7 @@
 
 	//user << browse(dat, "window=freezer;size=400x500")
 	//onclose(user, "freezer")
-	var/datum/browser/popup = new(user, "freezer", "Cryo Gas Cooling System", 400, 240) // Set up the popup browser window
+	var/datum/browser/popup = new(user, "freezer", "Cryo Gas Heating System", 400, 240) // Set up the popup browser window
 	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
 	popup.set_content(dat)
 	popup.open()

--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -10,7 +10,7 @@
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/New()
 	..()
-	construction(dir,dir)
+	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/thermomachine(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
@@ -20,6 +20,9 @@
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
+
+/obj/machinery/atmospherics/unary/cold_sink/freezer/construction()
+	..(dir,dir)
 
 /obj/machinery/atmospherics/unary/cold_sink/freezer/RefreshParts()
 	var/H
@@ -127,7 +130,7 @@
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/New()
 	..()
-	construction(dir,dir)
+	initialize_directions = dir
 	var/obj/item/weapon/circuitboard/thermomachine/H = new /obj/item/weapon/circuitboard/thermomachine(null)
 	H.build_path = /obj/machinery/atmospherics/unary/heat_reservoir/heater
 	H.name = "circuit board (Heater)"
@@ -140,6 +143,9 @@
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
+
+/obj/machinery/atmospherics/unary/heat_reservoir/heater/construction()
+	..(dir,dir)
 
 /obj/machinery/atmospherics/unary/heat_reservoir/heater/RefreshParts()
 	var/H

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -130,6 +130,7 @@
 				if(component_check)
 					playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 					var/obj/machinery/new_machine = new src.circuit.build_path(src.loc)
+					new_machine.construction()
 					for(var/obj/O in new_machine.component_parts)
 						qdel(O)
 					new_machine.component_parts = list()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -17,8 +17,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/New()
 	..()
-	initialize_directions = dir
-	initialize()
+	construction(dir,dir)
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/cryo_tube(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -17,7 +17,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/New()
 	..()
-	construction(dir,dir)
+	initialize_directions = dir
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/cryo_tube(null)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
@@ -27,6 +27,9 @@
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
+
+/obj/machinery/atmospherics/unary/cryo_cell/construction()
+	..(dir,dir)
 
 /obj/machinery/atmospherics/unary/cryo_cell/RefreshParts()
 	var/C

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -335,8 +335,8 @@ Class Procs:
 /obj/machinery/proc/default_change_direction_wrench(var/mob/user, var/obj/item/weapon/wrench/W)
 	if(panel_open && istype(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		dir = pick(WEST,EAST,SOUTH,NORTH)
-		user << "<span class='notice'>You clumsily rotate [src].</span>"
+		dir = turn(dir,-90)
+		user << "<span class='notice'>You rotate [src].</span>"
 		return 1
 	return 0
 
@@ -382,3 +382,7 @@ Class Procs:
 			W.play_rped_sound()
 		return 1
 	return 0
+
+//called on machinery construction (i.e from frame to machinery) but not on initialization
+/obj/machinery/proc/construction()
+	return


### PR DESCRIPTION
#### Various atmos fixes
- Made manifolds instancing compatible with the maploader.

The _initialize_dir_ setting was done before the preloader could kick in.
- Fixed the runtime which happenend when a pipe was destroyed but not the meter connected to it.

The meter is now properly removed in pipe/Destroy() and fingerprints transferred.
- Freezers, heaters and cryo cells now properly initialize on construction.

Had to add a _/obj/machinery construction() proc_ that is called on machinery construction (i.e screwing a completed machine frame), but not on machinery _New()_.

This fixes  #5118 and, 21 and 22 of #6351.
- Made engineers less clumsy : wrench rotating is always clockwise 90° instead of a random dir now.

If i missed some unfixed atmos bugs, don't hesitate to comment here.
