### PR TITLE
Fixes table having two mousedrop_T() procs.

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -184,12 +184,11 @@
 	..()
 	if(severity == 3)
 		if(prob(25))
-			density = 0
+			table_destroy(1)
 
 /obj/structure/table/blob_act()
 	if(prob(75))
 		table_destroy(1)
-		qdel(src)
 		return
 
 /obj/structure/table/attack_alien(mob/living/user)
@@ -231,8 +230,11 @@
 	else
 		return 0
 
-
-/obj/structure/table/MouseDrop_T(obj/O, mob/user)
+/obj/structure/table/MouseDrop_T(atom/movable/O, mob/user)
+	if(ismob(O) && user == O && ishuman(user))
+		if(user.canmove)
+			climb_table(user)
+			return
 	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))
 		return
 	if(isrobot(user))
@@ -358,10 +360,6 @@
  * TABLE CLIMBING
  */
 
-/obj/structure/table/MouseDrop_T(mob/target, mob/living/carbon/human/user)
-	if(istype(target) && user == target && istype(user))
-		if(user.canmove)
-			climb_table(user)
 
 /obj/structure/table/proc/climb_table(mob/user)
 	src.add_fingerprint(user)
@@ -494,21 +492,20 @@
 		if(1.0)
 			qdel(src)
 		if(2.0)
-			qdel(src)
 			if(prob(50))
-				new /obj/item/weapon/rack_parts(src.loc)
+				rack_destroy()
+			else
+				qdel(src)
 		if(3.0)
 			if(prob(25))
-				qdel(src)
-				new /obj/item/weapon/rack_parts(src.loc)
+				rack_destroy()
 
 /obj/structure/rack/blob_act()
 	if(prob(75))
 		qdel(src)
 		return
 	else if(prob(50))
-		new /obj/item/weapon/rack_parts(src.loc)
-		qdel(src)
+		rack_destroy()
 		return
 
 /obj/structure/rack/CanPass(atom/movable/mover, turf/target, height=0)
@@ -534,9 +531,8 @@
 
 /obj/structure/rack/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/wrench))
-		new /obj/item/weapon/rack_parts( src.loc )
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		qdel(src)
+		rack_destroy()
 		return
 
 	if(isrobot(user))
@@ -559,37 +555,41 @@
 						 "<span class='warning'>You kick [src].</span>")
 
 	if(HULK in user.mutations)
-		health -= 5
+		rack_destroy()
 	else
 		health -= rand(1,2)
-	healthcheck()
+		healthcheck()
 
 
 /obj/structure/rack/attack_alien(mob/living/user)
 	user.do_attack_animation(src)
 	visible_message("<span class='danger'>[user] slices [src] apart!</span>")
-	new /obj/item/weapon/rack_parts(loc)
-	density = 0
-	qdel(src)
+	rack_destroy()
 
 
 /obj/structure/rack/attack_animal(mob/living/simple_animal/user)
 	if(user.environment_smash)
 		user.do_attack_animation(src)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
-		new /obj/item/weapon/rack_parts(loc)
-		density = 0
-		qdel(src)
+		rack_destroy()
 /obj/structure/rack/attack_tk() // no telehulk sorry
 	return
 
 /obj/structure/rack/proc/healthcheck()
 	if(health <= 0)
-		density = 0
-		var/obj/item/weapon/rack_parts/newparts = new(loc)
-		transfer_fingerprints_to(newparts)
-		qdel(src)
+		rack_destroy()
 	return
+
+/*
+ * Rack destruction
+ */
+
+/obj/structure/rack/proc/rack_destroy()
+	density = 0
+	var/obj/item/weapon/rack_parts/newparts = new(loc)
+	transfer_fingerprints_to(newparts)
+	qdel(src)
+
 
 /*
  * Rack Parts


### PR DESCRIPTION
Fixes table having two mousedrop_T() procs. Fixes #5999
Adding a rack_destroy() proc.
Fixes table blob_act and ex_act a bit.
