### PR TITLE
get_turf_pixel()

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1226,6 +1226,12 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //32 - 16; 16/16 = 1, DX = 1
 //32 - 16; 15/16 = 0.9375 = 0 when round()'d, DX = 0
 
+//NOTE: this proc is held back by the speed of icon() objects
+//They're shit, so this is by extension slightly slower than
+//a specific proc for each use case
+//Now, It's Not slow, far from it, but if you stick it in a loop
+//that calls it many times, this may be the first place to check.
+
 /proc/get_turf_pixel(atom/movable/AM)
 	if(AM)
 		var/rough_x = 0

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1226,11 +1226,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //32 - 16; 16/16 = 1, DX = 1
 //32 - 16; 15/16 = 0.9375 = 0 when round()'d, DX = 0
 
-//NOTE: this proc is held back by the speed of icon() objects
-//They're shit, so this is by extension slightly slower than
-//a specific proc for each use case
-//Now, It's Not slow, far from it, but if you stick it in a loop
-//that calls it many times, this may be the first place to check.
+//NOTE: if your atom has non-standard bounds then this proc
+//will handle it, but it'll be a bit slower.
 
 /proc/get_turf_pixel(atom/movable/AM)
 	if(AM)
@@ -1239,20 +1236,26 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		var/final_x = 0
 		var/final_y = 0
 
-		//Creates an icon so that objects with a different size
-		//to world.icon_size can still be located fine
-		var/icon/AMicon = icon(AM.icon, AM.icon_state)
+		//Assume standards
+		var/i_width = world.icon_size
+		var/i_height = world.icon_size
 
-		var/i_width = AMicon.Width()
-		var/i_height = AMicon.Height()
-		qdel(AMicon)
+		//Handle snowflake objects only if necessary
+		if(AM.bound_height != world.icon_size || AM.bound_width != world.icon_size)
+			var/icon/AMicon = icon(AM.icon, AM.icon_state)
+			i_width = AMicon.Width()
+			i_height = AMicon.Height()
+			qdel(AMicon)
 
+		//Find a value to divide pixel_ by
 		var/n_width = (world.icon_size - (i_width/2))
 		var/n_height = (world.icon_size - (i_height/2))
 
+		//DY and DX
 		rough_x = round(AM.pixel_x/n_width)
 		rough_y = round(AM.pixel_y/n_height)
 
+		//Find coordinates
 		final_x = AM.x + rough_x
 		final_y = AM.y + rough_y
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1230,7 +1230,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //will handle it, but it'll be a bit slower.
 
 /proc/get_turf_pixel(atom/movable/AM)
-	if(AM)
+	if(istype(AM))
 		var/rough_x = 0
 		var/rough_y = 0
 		var/final_x = 0

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -242,8 +242,8 @@ Class Procs:
 		return
 	//stop AIs from leaving windows open and using then after they lose vision
 	//apc_override is needed here because AIs use their own APC when powerless
-	//the snowflake get_wall_mounted_turf() is because APCs in maint aren't actually in view of the inner camera
-	if(cameranet && !cameranet.checkTurfVis(get_wall_mounted_turf(M)) && !apc_override)
+	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
+	if(cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
 		return
 	return 1
 


### PR DESCRIPTION
The documentation speaks for itself

//Gets the turf this atom's _ICON_ appears to inhabit
//Uses half the width/height respectively to work out
//A minimum pixel amt this icon needs to be pixel'd by
//to be considered to be in another turf

//division = world.icon_size - icon-width/2; DX = pixel_x/division
//division = world.icon_size - icon-height/2; DY = pixel_y/division

//Eg: Humans
//32 - 16; 16/16 = 1, DX = 1
//32 - 16; 15/16 = 0.9375 = 0 when round()'d, DX = 0

//NOTE: if your atom has non-standard bounds then this proc
//will handle it, but it'll be a bit slower.
### tl;dr:

find where something LOOKS to be instead of where it actually is (eg APC's and other wall mounts)
replaces get_wall_mounted_turf() as it fulfill's its job more accurately (if a tiny bit more costly)
I made this for something I was testing but scrapped (it didn't work out) and realised it still has it's uses as a general proc.
