### PR TITLE
Fixes russian revolver being abusable. 

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -83,23 +83,28 @@
 				M.drop_item()
 				return
 
+	if(isliving(user))
+		var/mob/living/L = user
+		if(!can_trigger_gun(L))
+			return
+
+	process_fire(target,user,flag,params)
+
+/obj/item/weapon/gun/proc/can_trigger_gun(mob/living/user)
 	if (!user.IsAdvancedToolUser())
 		user << "<span class='notice'>You don't have the dexterity to do this!</span>"
-		return
+		return 0
 
 	if(trigger_guard)
-		if(istype(user, /mob/living))
-			var/mob/living/M = user
-			if (HULK in M.mutations)
-				M << "<span class='notice'>Your meaty finger is much too large for the trigger guard!</span>"
-				return
+		if (HULK in user.mutations)
+			user << "<span class='notice'>Your meaty finger is much too large for the trigger guard!</span>"
+			return 0
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.dna && NOGUNS in H.dna.species.specflags)
 				user << "<span class='notice'>Your fingers don't fit in the trigger guard!</span>"
-				return
-
-	process_fire(target,user,flag,params)
+				return 0
+	return 1
 
 /obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, var/message = 1, params)
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -175,7 +175,7 @@
 	return
 
 /obj/item/weapon/gun/projectile/revolver/russian/attack_self(mob/user as mob)
-	if(!spun && get_ammo(0,0))
+	if(!spun && can_shoot())
 		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
 		Spin()
 	else
@@ -193,34 +193,35 @@
 			user << "<span class='notice'>[src] is empty.</span>"
 
 /obj/item/weapon/gun/projectile/revolver/russian/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, flag, params)
-	if(!spun && get_ammo(0,0))
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-		Spin()
-	..()
-	spun = 0
-
-/obj/item/weapon/gun/projectile/revolver/russian/attack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj)
-	if(!spun && get_ammo(0,0))
-		user.visible_message("<span class='warning'>[user] spins the chamber of the revolver.</span>", "<span class='warning'>You spin the revolver's chamber.</span>")
-		Spin()
+	if(user.a_intent == "harm") // Flogging action
+		return
+	if(isliving(user))
+		if(!can_trigger_gun(user))
+			return
+	if(target != user)
+		user << "<span class='warning'>A mechanism prevents you from shooting anyone but yourself.</span>"
 		return
 
-
-	if(target == user)
-		if(!chambered)
-			user.visible_message("<span class='danger'>*click*</span>", "<span class='danger'>*click*</span>")
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(!spun)
+			user << "<span class='warning'>You need to spin the revolver's chamber first.</span>"
 			return
 
-		if(isliving(target) && isliving(user))
-			var/obj/item/organ/limb/affecting = user.zone_sel.selecting
-			if(affecting == "head")
-				var/obj/item/ammo_casing/AC = chambered
-				if(AC.fire(user, user))
+		spun = 0
+
+		if(chambered)
+			var/obj/item/ammo_casing/AC = chambered
+			if(AC.fire(user, user))
+				playsound(user, fire_sound, 50, 1)
+				var/obj/item/organ/limb/affecting = H.get_organ(check_zone(user.zone_sel.selecting))
+				var/limb_name = affecting.getDisplayName()
+				if(affecting == "head" || affecting == "eyes" || affecting == "mouth")
 					user.apply_damage(300, BRUTE, affecting)
-					playsound(user, fire_sound, 50, 1)
-					user.visible_message("<span class='danger'>[user.name] fires [src] at \his head!</span>", "<span class='danger'>You fire [src] at your head!</span>", "You hear a [istype(AC.BB, /obj/item/projectile/beam) ? "laser blast" : "gunshot"]!")
-					return
+					user.visible_message("<span class='danger'>[user.name] fires [src] at \his head!</span>", "<span class='userdanger'>You fire [src] at your head!</span>", "You hear a gunshot!")
 				else
-					user.visible_message("<span class='danger'>*click*</span>", "<span class='danger'>*click*</span>")
-					return
-	..()
+					user.visible_message("<span class='danger'>[user.name] cowardly fires [src] at \his [limb_name]!</span>", "<span class='userdanger'>You cowardly fire [src] at your [limb_name]!</span>", "You hear a gunshot!")
+				return
+
+		user.visible_message("<span class='danger'>*click*</span>")
+		playsound(user, 'sound/weapons/empty.ogg', 100, 1)


### PR DESCRIPTION
You can no longer use it on someone other than yourself. Fixes #4707 . Aiming somewhere other than head/eyes/mouth doesn't instakill but does deal damage (and the shooting message show that you weren't aiming at your head like you should). You need to spin the chamber after each shooting attempt. Only humans can use the gun.

Making a can_trigger_gun() proc that tests if the mob can trigger the gun.

This doesn't fix the fact that the damage  from the actual bullet are dealt to a random limb instead of the one selected.
