### PR TITLE
Assembly holder no longer needs to be secured.

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -10,8 +10,6 @@
 	var/valve_open = 0
 	var/toggle = 1
 
-/obj/item/device/transfer_valve/proc/process_activation(var/obj/item/device/D)
-
 /obj/item/device/transfer_valve/IsAssemblyHolder()
 	return 1
 
@@ -44,7 +42,7 @@
 			user << "<span class='notice'>The device is secured.</span>"
 			return
 		if(attached_device)
-			user << "<span class='warning'>There is already an device attached to the valve, remove it first.</span>"
+			user << "<span class='warning'>There is already a device attached to the valve, remove it first.</span>"
 			return
 		user.remove_from_mob(item)
 		attached_device = A
@@ -114,7 +112,7 @@
 		return
 	return
 
-/obj/item/device/transfer_valve/process_activation(var/obj/item/device/D)
+/obj/item/device/transfer_valve/proc/process_activation(var/obj/item/device/D)
 	if(toggle)
 		toggle = 0
 		toggle_valve()

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -76,8 +76,6 @@
 
 	else if(stage == EMPTY && istype(I, /obj/item/device/assembly_holder))
 		var/obj/item/device/assembly_holder/A = I
-		if(!A.secured)
-			return
 		if(isigniter(A.a_left) == isigniter(A.a_right))	//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
 			return
 

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -24,28 +24,7 @@
 	var/const/WIRE_RADIO_RECEIVE = 8		//Allows Pulsed(1) to call Activate()
 	var/const/WIRE_RADIO_PULSE = 16		//Allows Pulse(1) to send a radio message
 
-/obj/item/device/assembly/proc/activate()									//What the device does when turned on
-	return
-
-/obj/item/device/assembly/proc/pulsed(var/radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
-	return
-
-/obj/item/device/assembly/proc/pulse(var/radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
-	return
-
-/obj/item/device/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
-	return
-
-/obj/item/device/assembly/proc/attach_assembly(var/obj/A, var/mob/user)	//Called when an assembly is attacked by another
-	return
-
-/obj/item/device/assembly/proc/process_cooldown()							//Called via spawn(10) to have it count down the cooldown var
-	return
-
 /obj/item/device/assembly/proc/holder_movement()							//Called when the holder is moved
-	return
-
-/obj/item/device/assembly/interact(mob/user as mob)					//Called when attack_self is called
 	return
 
 /obj/item/device/assembly/proc/describe()									// Called by grenades to describe the state of the trigger (time left, etc)
@@ -59,16 +38,18 @@
 	return 1
 
 
-
-/obj/item/device/assembly/process_cooldown()
+//Called via spawn(10) to have it count down the cooldown var
+/obj/item/device/assembly/proc/process_cooldown()
 	cooldown--
-	if(cooldown <= 0)	return 0
+	if(cooldown <= 0)
+		return 0
 	spawn(10)
 		process_cooldown()
 	return 1
 
 
-/obj/item/device/assembly/pulsed(var/radio = 0)
+//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
+/obj/item/device/assembly/proc/pulsed(var/radio = 0)
 	if(holder && (wires & WIRE_RECEIVE))
 		activate()
 	if(radio && (wires & WIRE_RADIO_RECEIVE))
@@ -76,48 +57,41 @@
 	return 1
 
 
-/obj/item/device/assembly/pulse(var/radio = 0)
+//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+/obj/item/device/assembly/proc/pulse(var/radio = 0)
 	if(holder && (wires & WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
 	if(holder && (wires & WIRE_PULSE_SPECIAL))
 		holder.process_activation(src, 0, 1)
-
-	if(istype(loc,/obj/item/weapon/grenade)) // This is a hack.  Todo: Manage this better -Sayu
-		var/obj/item/weapon/grenade/G = loc
-		G.prime() 							 // Adios, muchachos
-//	if(radio && (wires & WIRE_RADIO_PULSE))
-		//Not sure what goes here quite yet send signal?
 	return 1
 
 
-/obj/item/device/assembly/activate()
-	if(!secured || (cooldown > 0))	return 0
+// What the device does when turned on
+/obj/item/device/assembly/proc/activate()
+	if(!secured || (cooldown > 0))
+		return 0
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
 	return 1
 
 
-/obj/item/device/assembly/toggle_secure()
+/obj/item/device/assembly/proc/toggle_secure()
 	secured = !secured
 	update_icon()
 	return secured
-
-
-/obj/item/device/assembly/attach_assembly(var/obj/item/device/assembly/A, var/mob/user)
-	holder = new/obj/item/device/assembly_holder(get_turf(src))
-	if(holder.attach(A,src,user))
-		user << "<span class='notice'>You attach \the [A] to \the [src]!</span>"
-		return 1
-	return 0
 
 
 /obj/item/device/assembly/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isassembly(W))
 		var/obj/item/device/assembly/A = W
 		if((!A.secured) && (!secured))
-			attach_assembly(A,user)
-			return
+			holder = new/obj/item/device/assembly_holder(get_turf(src))
+			holder.assemble(src,A,user)
+			user << "<span class='notice'>You attach and secure \the [A] to \the [src]!</span>"
+		else
+			user << "<span class='warning'>Both devices must be in attachable mode to be attached together.</span>"
+		return
 	if(istype(W, /obj/item/weapon/screwdriver))
 		if(toggle_secure())
 			user << "<span class='notice'>\The [src] is ready!</span>"
@@ -142,7 +116,8 @@
 
 
 /obj/item/device/assembly/attack_self(mob/user as mob)
-	if(!user)	return 0
+	if(!user)
+		return 0
 	user.set_machine(src)
 	interact(user)
 	return 1
@@ -151,40 +126,3 @@
 /obj/item/device/assembly/interact(mob/user as mob)
 	return //HTML MENU FOR WIRES GOES HERE
 
-/*
-	var/small_icon_state = null//If this obj will go inside the assembly use this for icons
-	var/list/small_icon_state_overlays = null//Same here
-	var/obj/holder = null
-	var/cooldown = 0//To prevent spam
-
-	proc
-		Activate()//Called when this assembly is pulsed by another one
-		Process_cooldown()//Call this via spawn(10) to have it count down the cooldown var
-		Attach_Holder(var/obj/H, var/mob/user)//Called when an assembly holder attempts to attach, sets src's loc in here
-
-
-	Activate()
-		if(cooldown > 0)
-			return 0
-		cooldown = 2
-		spawn(10)
-			Process_cooldown()
-		//Rest of code here
-		return 0
-
-
-	Process_cooldown()
-		cooldown--
-		if(cooldown <= 0)	return 0
-		spawn(10)
-			Process_cooldown()
-		return 1
-
-
-	Attach_Holder(var/obj/H, var/mob/user)
-		if(!H)	return 0
-		if(!H.IsAssemblyHolder())	return 0
-		//Remember to have it set its loc somewhere in here
-
-
-*/

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -87,8 +87,6 @@
 /obj/item/weapon/tank/proc/bomb_assemble(W,user)	//Bomb assembly proc. This turns assembly+tank into a bomb
 	var/obj/item/device/assembly_holder/S = W
 	var/mob/M = user
-	if(!S.secured)										//Check if the assembly is secured
-		return
 	if(isigniter(S.a_left) == isigniter(S.a_right))		//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
 		return
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -9,37 +9,29 @@
 	throw_speed = 2
 	throw_range = 7
 
-	var/secured = 0
 	var/obj/item/device/assembly/a_left = null
 	var/obj/item/device/assembly/a_right = null
-
-/obj/item/device/assembly_holder/proc/attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
-	return
-
-/obj/item/device/assembly_holder/proc/process_activation(var/obj/item/device/D)
-	return
 
 /obj/item/device/assembly_holder/IsAssemblyHolder()
 	return 1
 
 
-/obj/item/device/assembly_holder/attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
-	if((!D)||(!D2))	return 0
-	if((!isassembly(D))||(!isassembly(D2)))	return 0
-	if((D:secured)||(D2:secured))	return 0
-	if(user)
-		user.remove_from_mob(D)
-		user.remove_from_mob(D2)
-	D:holder = src
-	D2:holder = src
-	D.loc = src
-	D2.loc = src
-	a_left = D
-	a_right = D2
-	name = "[D.name]-[D2.name] assembly"
+/obj/item/device/assembly_holder/proc/assemble(var/obj/item/device/assembly/A, var/obj/item/device/assembly/A2, var/mob/user)
+	attach(A,user)
+	attach(A2,user)
+	name = "[A.name]-[A2.name] assembly"
 	update_icon()
-	return 1
 
+/obj/item/device/assembly_holder/proc/attach(var/obj/item/device/assembly/A, var/mob/user)
+	if(user)
+		user.remove_from_mob(A)
+	A.holder = src
+	A.loc = src
+	A.toggle_secure()
+	if(!a_left)
+		a_left = A
+	else
+		a_right = A
 
 /obj/item/device/assembly_holder/update_icon()
 	overlays.Cut()
@@ -53,16 +45,6 @@
 			overlays += "[O]_r"
 	if(master)
 		master.update_icon()
-
-
-/obj/item/device/assembly_holder/examine(mob/user)
-	..()
-	if(secured)
-		user << "\The [src] is secured and ready to be used."
-	else
-		user << "\The [src] can be attached to other things."
-
-
 
 /obj/item/device/assembly_holder/HasProximity(atom/movable/AM as mob|obj)
 	if(a_left)
@@ -97,55 +79,39 @@
 	..()
 	return
 
-
 /obj/item/device/assembly_holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/screwdriver))
-		if(!a_left || !a_right)
-			user << "<span class='danger'>BUG:Assembly part missing, please report this!</span>"
-			return
-		a_left.toggle_secure()
-		a_right.toggle_secure()
-		secured = !secured
-		if(secured)
-			user << "<span class='notice'>\The [src] is ready!</span>"
-		else
-			user << "<span class='notice'>\The [src] can now be taken apart!</span>"
-		update_icon()
-		return
+		var/turf/T = get_turf(src)
+		if(!T)
+			return 0
+		if(a_left)
+			a_left.holder = null
+			a_left.loc = T
+		if(a_right)
+			a_right.holder = null
+			a_right.loc = T
+		qdel(src)
 	else
 		..()
-	return
-
 
 /obj/item/device/assembly_holder/attack_self(mob/user as mob)
 	src.add_fingerprint(user)
-	if(src.secured)
-		if(!a_left || !a_right)
-			user << "<span class='danger'>Assembly part missing!</span>"
-			return
-		if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-			switch(alert("Which side would you like to use?",,"Left","Right"))
-				if("Left")	a_left.attack_self(user)
-				if("Right")	a_right.attack_self(user)
-			return
-		else
-			a_left.attack_self(user)
-			a_right.attack_self(user)
+	if(!a_left || !a_right)
+		user << "<span class='danger'>Assembly part missing!</span>"
+		return
+	if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
+		switch(alert("Which side would you like to use?",,"Left","Right"))
+			if("Left")	a_left.attack_self(user)
+			if("Right")	a_right.attack_self(user)
+		return
 	else
-		var/turf/T = get_turf(src)
-		if(!T)	return 0
-		if(a_left)
-			a_left:holder = null
-			a_left.loc = T
-		if(a_right)
-			a_right:holder = null
-			a_right.loc = T
-		qdel(src)
-	return
+		a_left.attack_self(user)
+		a_right.attack_self(user)
 
 
-/obj/item/device/assembly_holder/process_activation(var/obj/D, var/normal = 1, var/special = 1)
-	if(!D)	return 0
+/obj/item/device/assembly_holder/proc/process_activation(var/obj/D, var/normal = 1, var/special = 1)
+	if(!D)
+		return 0
 	if((normal) && (a_right) && (a_left))
 		if(a_right != D)
 			a_right.pulsed(0)


### PR DESCRIPTION
Assembly holder is no longer secured/unsecured to simplify stuff and to avoid confusion about not being able to use the holder in some cases b/c it's unsecured. Screwdrive now disassemble it and attack_self to interact with its parts.
Also, adding feedback message when trying to attach two assemblies that aren't both in attach mode. Fixes #4147 

Fix hacky code to prime grenade by pulsing its assembly.
Removing some commented code and some duplicated proc instances.
Fixing a typo.
