### PR TITLE
Sign synthesizer

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1302,18 +1302,18 @@ var/global/list/common_tools = list(
 Checks if that loc and dir has a item on the wall
 */
 var/list/WALLITEMS = list(
-	"/obj/machinery/power/apc", "/obj/machinery/alarm", "/obj/item/device/radio/intercom",
-	"/obj/structure/extinguisher_cabinet", "/obj/structure/reagent_dispensers/peppertank",
-	"/obj/machinery/status_display", "/obj/machinery/requests_console", "/obj/machinery/light_switch", "/obj/effect/sign",
-	"/obj/machinery/newscaster", "/obj/machinery/firealarm", "/obj/structure/noticeboard", "/obj/machinery/door_control",
-	"/obj/machinery/computer/security/telescreen", "/obj/machinery/embedded_controller/radio/simple_vent_controller",
-	"/obj/item/weapon/storage/secure/safe", "/obj/machinery/door_timer", "/obj/machinery/flasher", "/obj/machinery/keycard_auth",
-	"/obj/structure/mirror", "/obj/structure/closet/fireaxecabinet", "/obj/machinery/computer/security/telescreen/entertainment"
+	/obj/machinery/power/apc, /obj/machinery/alarm, /obj/item/device/radio/intercom,
+	/obj/structure/extinguisher_cabinet, /obj/structure/reagent_dispensers/peppertank,
+	/obj/machinery/status_display, /obj/machinery/requests_console, /obj/machinery/light_switch, /obj/structure/sign,
+	/obj/machinery/newscaster, /obj/machinery/firealarm, /obj/structure/noticeboard, /obj/machinery/door_control,
+	/obj/machinery/computer/security/telescreen, /obj/machinery/embedded_controller/radio/simple_vent_controller,
+	/obj/item/weapon/storage/secure/safe, /obj/machinery/door_timer, /obj/machinery/flasher, /obj/machinery/keycard_auth,
+	/obj/structure/mirror, /obj/structure/closet/fireaxecabinet, /obj/machinery/computer/security/telescreen/entertainment
 	)
 /proc/gotwallitem(loc, dir)
 	for(var/obj/O in loc)
 		for(var/item in WALLITEMS)
-			if(istype(O, text2path(item)))
+			if(istype(O, item))
 				//Direction works sometimes
 				if(O.dir == dir)
 					return 1
@@ -1337,7 +1337,7 @@ var/list/WALLITEMS = list(
 	//Some stuff is placed directly on the wallturf (signs)
 	for(var/obj/O in get_step(loc, dir))
 		for(var/item in WALLITEMS)
-			if(istype(O, text2path(item)))
+			if(istype(O, item))
 				if(O.pixel_x == 0 && O.pixel_y == 0)
 					return 1
 	return 0

--- a/code/game/objects/items/devices/signsyntheziser.dm
+++ b/code/game/objects/items/devices/signsyntheziser.dm
@@ -1,0 +1,128 @@
+
+/obj/item/device/signsyntheziser
+	name = "Sign Syntheziser"
+	icon = 'icons/obj/machines/research.dmi'
+	icon_state = "structural _analyzer"
+	item_state = "flight"
+
+	m_amt = 5000
+	g_amt = 2000
+
+	var/global/beensetup = 0
+	var/global/list/signtypes = list()
+	var/global/list/signs = list()
+
+	var/curiconi = -1
+
+/obj/item/device/signsyntheziser/New()
+	if(!beensetup)
+		beensetup = 1
+
+		signtypes = typesof(/obj/structure/sign)
+		//If you want more decals/signs, add them to this list
+		//signtypes += /obj/some/sign
+
+		var/i = 1
+		for(var/sign in signtypes)
+			var/obj/objsign = new sign()
+			if(length(objsign.icon_state) > 0)
+				var/icon/I = icon(objsign.icon, objsign.icon_state)
+
+				var/list/newsign = list()
+				newsign["name"] = format_text(objsign.name)
+				newsign["icon"] = I
+				newsign["type"] = sign
+
+				//TODO: figure out how to properly add lists within lists.
+				signs.len = i
+				signs[i++] = newsign
+
+			qdel(objsign)
+
+//Will shift the pixel_x and _y depending on set dir
+/obj/proc/pixelshift()
+	if(dir & NORTH)
+		pixel_y += 32
+	if(dir & SOUTH)
+		pixel_y -= 32
+	if(dir & WEST)
+		pixel_x -= 32
+	if(dir & EAST)
+		pixel_x += 32
+
+/obj/item/device/signsyntheziser/proc/newsign(turf/simulated/wall/w, mob/user)
+	if(curiconi == -1)
+		return
+
+	if(!istype(w)) //Make sure it's a wall
+		return
+
+	var/ndir = get_dir(user,w)
+	if(!(ndir in cardinal)) //Make sure we're not diagonally trying to access it
+		return
+
+	var/turf/loc = get_turf(user)
+	if(gotwallitem(loc, ndir))
+		user << "<span class='warning'>There's already an item on this wall!</span>"
+		return
+
+	var/list/signlist = signs[curiconi]
+	var/typ = signlist["type"]
+
+	var/obj/newsign = new typ(loc)
+	newsign.dir = ndir
+	newsign.pixelshift()
+
+	playsound(src.loc, 'sound/items/poster_being_created.ogg', 100, 1)
+
+/obj/item/device/signsyntheziser/proc/issign(obj/o)
+	return signtypes.Find(o.type) > 0
+
+/obj/item/device/signsyntheziser/proc/eatsign(obj/o, mob/user)
+	if(!istype(o))
+		return
+
+	if(!issign(o))
+		return
+
+	playsound(src.loc, 'sound/items/polaroid1.ogg', 100, 1)
+
+	qdel(o)
+
+/obj/item/device/signsyntheziser/afterattack(atom/A, mob/user, proximity_flag)
+//obj/item/device/signsyntheziser/proc/makesign(turf/simulated/wall/w, mob/user)
+	if(proximity_flag!= 1)
+		return
+
+	newsign(A, user)
+	eatsign(A, user)
+
+	return 0
+
+/obj/item/device/signsyntheziser/Topic(href, href_list)
+	if(href_list["seticon"])
+		var/i = text2num(href_list["seticon"])
+
+		curiconi = i
+
+		usr << browse(null, "window=editicon")
+
+/obj/item/device/signsyntheziser/attack_self(mob/user)
+	if(!beensetup)
+		return
+
+	var dat = "<html><body><table>"
+	for(var/i=1,i<=signs.len,i++)
+		var/list/signlist = signs[i]
+		var/nicename = signlist["name"]
+		var/icon/I = signlist["icon"]
+
+		user << browse_rsc(I, "sign[i]")
+		if(i == curiconi)
+			dat += {"<tr><td><img src="sign[i]"></td><td><b>[nicename]</b></td></tr>"}
+		else
+			dat += {"<tr><td><img src="sign[i]"></td><td><a href="?src=\ref[src];seticon=[i]">[nicename]</a></td></tr>"}
+
+	dat += "</table></body></html>"
+
+	user << browse(dat, "window=editicon;can_close=1;can_minimize=0;size=250x650")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -526,6 +526,7 @@
 #include "code\game\objects\items\devices\powersink.dm"
 #include "code\game\objects\items\devices\recaller.dm"
 #include "code\game\objects\items\devices\scanners.dm"
+#include "code\game\objects\items\devices\signsyntheziser.dm"
 #include "code\game\objects\items\devices\taperecorder.dm"
 #include "code\game\objects\items\devices\traitordevices.dm"
 #include "code\game\objects\items\devices\transfer_valve.dm"


### PR DESCRIPTION
This little nifty device is one step ahead of a complete station construction/deconstruction ability.

It lets you select a sign from a (programmically) generated list of signs available, and then slap it onto your wall of choice.

It also lets you remove existing signs from the walls.

Note that this is not done yet, I'm throwing it out here for commenting on ideas and my code.
Things to be done:
- [ ] Add a delay to pasting/removing
- [ ] Fix afterattack/use some other method
- [ ] Make the menu use NanoUI
- [ ] Mergeconflicts
- [ ] Any TODO's left in code
- [ ] Should I implement a fuel/charge/ink level thing?

Current issues I need help with:
- [ ] Implement NanoUI
- [ ] Workaround for afterattack. I want to use it because I don't want to spread my code in everyplace to make sign-removing able, but I don't want it cause it creates these messages "you push the wall", etc.
- [ ] How do I insert a list in a list without this hacky method? See my TODO

![2014-12-25_21-22-14](https://cloud.githubusercontent.com/assets/2332094/5554891/e0e7726e-8c7f-11e4-8130-70197d765733.png)
