### PR TITLE
Fixed being able to spam slam someone onto a toilet during a swirlie.

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -18,8 +18,10 @@
 
 /obj/structure/toilet/attack_hand(mob/living/user)
 	if(swirlie)
-		user.visible_message("<span class='danger'>[user] slams the toilet seat onto [swirlie]'s head!</span>", "<span class='notice'>You slam the toilet seat onto [swirlie]'s head!</span>", "You hear reverberating porcelain.")
-		swirlie.adjustBruteLoss(8)
+		user.changeNext_move(CLICK_CD_MELEE)
+		playsound(src.loc, "swing_hit", 25, 1)
+		swirlie.visible_message("<span class='danger'>[user] slams the toilet seat onto [swirlie]'s head!</span>", "<span class='userdanger'>[user] slams the toilet seat onto [swirlie]'s head!</span>", "You hear reverberating porcelain.")
+		swirlie.adjustBruteLoss(5)
 		return
 
 	if(cistern && !open)
@@ -55,6 +57,7 @@
 			return
 
 	if(istype(I, /obj/item/weapon/grab))
+		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/weapon/grab/G = I
 		if(!G.confirm())
 			return
@@ -64,21 +67,23 @@
 				if(GM.loc != get_turf(src))
 					user << "<span class='notice'>[GM] needs to be on [src].</span>"
 					return
-				if(open && !swirlie)
-					user.visible_message("<span class='danger'>[user] starts to give [GM] a swirlie!</span>", "<span class='notice'>You start to give [GM] a swirlie!</span>")
-					swirlie = GM
-					if(do_after(user, 30, 5, 0))
-						user.visible_message("<span class='danger'>[user] gives [GM] a swirlie!</span>", "<span class='notice'>You give [GM] a swirlie!</span>", "You hear a toilet flushing.")
-						if(iscarbon(GM))
-							var/mob/living/carbon/C = GM
-							if(!C.internal)
-								C.adjustOxyLoss(5)
-						else
-							GM.adjustOxyLoss(5)
-					swirlie = null
-				else
-					user.visible_message("<span class='danger'>[user] slams [GM.name] into [src]!</span>", "<span class='notice'>You slam [GM] into [src]!</span>")
-					GM.adjustBruteLoss(8)
+				if(!swirlie)
+					if(open)
+						GM.visible_message("<span class='danger'>[user] starts to give [GM] a swirlie!</span>", "<span class='userdanger'>[user] starts to give [GM] a swirlie!</span>")
+						swirlie = GM
+						if(do_after(user, 30, 5, 0))
+							GM.visible_message("<span class='danger'>[user] gives [GM] a swirlie!</span>", "<span class='userdanger'>[user] gives [GM] a swirlie!</span>", "You hear a toilet flushing.")
+							if(iscarbon(GM))
+								var/mob/living/carbon/C = GM
+								if(!C.internal)
+									C.adjustOxyLoss(5)
+							else
+								GM.adjustOxyLoss(5)
+						swirlie = null
+					else
+						playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
+						GM.visible_message("<span class='danger'>[user] slams [GM.name] into [src]!</span>", "<span class='userdanger'>[user] slams [GM.name] into [src]!</span>")
+						GM.adjustBruteLoss(5)
 			else
 				user << "<span class='notice'>You need a tighter grip.</span>"
 


### PR DESCRIPTION
Added sound when slamming someone onto the toilet and when slamming the toilet lid onto someone's head.
Nerfed the damage for these two actions a bit.
Fixes the victim's message for these actions not being bold red.

Fixes #6464
