### PR TITLE
Statue fixes

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -17,7 +17,6 @@
 	..()
 
 /obj/structure/statue/attackby(obj/item/weapon/W, mob/living/user as mob)
-	user.do_attack_animation(src)
 	add_fingerprint(user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(W, /obj/item/weapon/wrench))
@@ -75,8 +74,8 @@
 
 	else
 		hardness -= W.force/100
-		CheckHardness()
 		..()
+		CheckHardness()
 
 /obj/structure/statue/attack_hand(mob/living/user as mob)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -56,27 +56,28 @@
 			Dismantle(1)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/diamonddrill))
-		user.visible_message("<span class='notice'>[name] begins to drill apart the [name]!</span>", \
+		user.visible_message("<span class='notice'>[user] begins to drill apart the [name]!</span>", \
 							 "<span class='notice'>You begin to drill apart the [name]!</span>")
 		if(do_after(user,5))
 			if(!src) return
-			user.visible_message("<span class='notice'>[name] destroys the [name]!</span>", \
+			user.visible_message("<span class='notice'>[user] destroys the [name]!</span>", \
 								 "<span class='notice'>You destroy the [name]!</span>")
 			qdel(src)
 
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		if(!anchored)
-			user.visible_message("<span class='notice'>[name] is slicing apart the [name]...</span>", \
+			user.visible_message("<span class='notice'>[user] is slicing apart the [name]...</span>", \
 								 "<span class='notice'>You are slicing apart the [name]...</span>")
 			if(do_after(user, 40))
 				if(!src) return
-				user.visible_message("<span class='notice'>[name] slices apart the [name]!</span>", \
+				user.visible_message("<span class='notice'>[user] slices apart the [name]!</span>", \
 									 "<span class='notice'>You slice apart the [name]!</span>")
 				Dismantle(1)
 
 	else
 		hardness -= W.force/100
-		user << "You hit the [name] with your [W.name]!"
+		user.visible_message("[user] hits the [name] with their [W.name]!", \
+							 "You hit the [name] with your [W.name]!")
 		CheckHardness()
 
 /obj/structure/statue/attack_hand(mob/living/user as mob)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -19,47 +19,59 @@
 	density = 0
 	..()
 
-/obj/structure/statue/attackby(obj/item/weapon/W, mob/user)
+/obj/structure/statue/attackby(obj/item/weapon/W, mob/living/user as mob)
+	user.do_attack_animation(src)
 	add_fingerprint(user)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(W, /obj/item/weapon/wrench))
 		if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'>Now loosening the [name]'s bolts...</span>"
+			user.visible_message("<span class='notice'>[user] is loosening the [name]'s bolts...</span>", \
+								 "<span class='notice'>You are loosening the [name]'s bolts...</span>")
 			if(do_after(user,40))
 				if(!src) return
-				user << "<span class='notice'>You loosened the [name]'s bolts!</span>"
+				user.visible_message("<span class='notice'>[user] loosened the [name]'s bolts!</span>", \
+									 "<span class='notice'>You loosened the [name]'s bolts!</span>")
 				anchored = 0
 		else if(!anchored)
 			if (!istype(src.loc, /turf/simulated/floor))
-				usr << "<span class='danger'>A floor must be present to secure the [name]!</span>"
+				user.visible_message("<span class='danger'>A floor must be present to secure the [name]!</span>")
 				return
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'>Now securing the [name]'s bolts...</span>"
+			user.visible_message("<span class='notice'>[user] is securing the [name]'s bolts...</span>", \
+								 "<span class='notice'>You are securing the [name]'s bolts...</span>")
 			if(do_after(user, 40))
 				if(!src) return
-				user << "<span class='notice'>You secured the [name]'s bolts!</span>"
+				user.visible_message("<span class='notice'>[user] has secured the [name]'s bolts!</span>", \
+									 "<span class='notice'>You have secured the [name]'s bolts!</span>")
 				anchored = 1
 
 	else if(istype(W, /obj/item/weapon/pickaxe/plasmacutter))
-		user << "<span class='notice'>Now slicing apart the [name]...</span>"
+		user.visible_message("<span class='notice'>[user] is slicing apart the [name]...</span>", \
+							 "<span class='notice'>You are slicing apart the [name]...</span>")
 		if(do_after(user,30))
 			if(!src) return
-			user << "<span class='notice'>You slice apart the [name]!</span>"
+			user.visible_message("<span class='notice'>[user] slices apart the [name]!</span>", \
+								 "<span class='notice'>You slice apart the [name]!</span>")
 			Dismantle(1)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/diamonddrill))
-		user << "<span class='notice'>You begin to drill apart the [name]!</span>"
+		user.visible_message("<span class='notice'>[name] begins to drill apart the [name]!</span>", \
+							 "<span class='notice'>You begin to drill apart the [name]!</span>")
 		if(do_after(user,5))
 			if(!src) return
-			user << "<span class='notice'>You destroy the [name]!</span>"
+			user.visible_message("<span class='notice'>[name] destroys the [name]!</span>", \
+								 "<span class='notice'>You destroy the [name]!</span>")
 			qdel(src)
 
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		if(!anchored)
-			user << "<span class='notice'>Now slicing apart the [name]...</span>"
+			user.visible_message("<span class='notice'>[name] is slicing apart the [name]...</span>", \
+								 "<span class='notice'>You are slicing apart the [name]...</span>")
 			if(do_after(user, 40))
 				if(!src) return
-				user << "<span class='notice'>You slice apart the [name]!</span>"
+				user.visible_message("<span class='notice'>[name] slices apart the [name]!</span>", \
+									 "<span class='notice'>You slice apart the [name]!</span>")
 				Dismantle(1)
 
 	else
@@ -67,10 +79,12 @@
 		user << "You hit the [name] with your [W.name]!"
 		CheckHardness()
 
-/obj/structure/statue/attack_hand(mob/user)
+/obj/structure/statue/attack_hand(mob/living/user as mob)
+	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
-	visible_message("<span class='notice'>[user] rubs some dust off from the [name]'s surface.</span>")
+	user.visible_message("<span class='notice'>[user] rubs some dust off from the [name]'s surface.</span>", \
+						 "<span class='notice'>You rub some dust off from the [name]'s surface.</span>")
 
 /obj/structure/statue/CanAtmosPass()
 	return !density

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -11,9 +11,6 @@
 	var/hardness = 1
 	var/oreAmount = 7
 	var/mineralType = "metal"
-	var/last_event = 0
-	var/active = null
-	var/spam_flag = 0
 
 /obj/structure/statue/Destroy()
 	density = 0
@@ -143,6 +140,8 @@
 	hardness = 3
 	luminosity = 2
 	mineralType = "uranium"
+	var/last_event = 0
+	var/active = null
 
 /obj/structure/statue/uranium/nuke
 	name = "Statue of a Nuclear Fission Explosive"
@@ -160,6 +159,7 @@
 
 /obj/structure/statue/uranium/Bumped(atom/user)
 	radiate()
+	..()
 
 /obj/structure/statue/uranium/attack_hand(mob/user)
 	radiate()
@@ -167,6 +167,7 @@
 
 /obj/structure/statue/uranium/attack_paw(mob/user)
 	radiate()
+	..()
 
 /obj/structure/statue/uranium/proc/radiate()
 	if(!active)
@@ -298,6 +299,7 @@
 	hardness = 3
 	mineralType = "bananium"
 	desc = "A bananium statue with a small engraving:'HOOOOOOONK'."
+	var/spam_flag = 0
 
 /obj/structure/statue/bananium/clown
 	name = "Statue of a clown"
@@ -305,6 +307,7 @@
 
 /obj/structure/statue/bananium/Bumped(atom/user)
 	honk()
+	..()
 
 /obj/structure/statue/bananium/attackby(obj/item/weapon/W, mob/user)
 	honk()
@@ -316,9 +319,10 @@
 
 /obj/structure/statue/bananium/attack_paw(mob/user)
 	honk()
+	..()
 
 /obj/structure/statue/bananium/proc/honk()
-	if(spam_flag == 0)
+	if(!spam_flag)
 		spam_flag = 1
 		playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 		spawn(20)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -27,6 +27,7 @@
 								 "<span class='notice'>You are loosening the [name]'s bolts...</span>")
 			if(do_after(user,40))
 				if(!src) return
+				if(!anchored) return
 				user.visible_message("<span class='notice'>[user] loosened the [name]'s bolts!</span>", \
 									 "<span class='notice'>You loosened the [name]'s bolts!</span>")
 				anchored = 0
@@ -39,6 +40,7 @@
 								 "<span class='notice'>You are securing the [name]'s bolts...</span>")
 			if(do_after(user, 40))
 				if(!src) return
+				if(anchored) return
 				user.visible_message("<span class='notice'>[user] has secured the [name]'s bolts!</span>", \
 									 "<span class='notice'>You have secured the [name]'s bolts!</span>")
 				anchored = 1
@@ -47,7 +49,7 @@
 		user.visible_message("<span class='notice'>[user] is slicing apart the [name]...</span>", \
 							 "<span class='notice'>You are slicing apart the [name]...</span>")
 		if(do_after(user,30))
-			if(!src) return
+			if(!src.loc) return
 			user.visible_message("<span class='notice'>[user] slices apart the [name]!</span>", \
 								 "<span class='notice'>You slice apart the [name]!</span>")
 			Dismantle(1)
@@ -56,7 +58,7 @@
 		user.visible_message("<span class='notice'>[user] begins to drill apart the [name]!</span>", \
 							 "<span class='notice'>You begin to drill apart the [name]!</span>")
 		if(do_after(user,5))
-			if(!src) return
+			if(!src.loc) return
 			user.visible_message("<span class='notice'>[user] destroys the [name]!</span>", \
 								 "<span class='notice'>You destroy the [name]!</span>")
 			qdel(src)
@@ -66,19 +68,17 @@
 			user.visible_message("<span class='notice'>[user] is slicing apart the [name]...</span>", \
 								 "<span class='notice'>You are slicing apart the [name]...</span>")
 			if(do_after(user, 40))
-				if(!src) return
+				if(!src.loc) return
 				user.visible_message("<span class='notice'>[user] slices apart the [name]!</span>", \
 									 "<span class='notice'>You slice apart the [name]!</span>")
 				Dismantle(1)
 
 	else
 		hardness -= W.force/100
-		user.visible_message("[user] hits the [name] with their [W.name]!", \
-							 "You hit the [name] with your [W.name]!")
 		CheckHardness()
+		..()
 
 /obj/structure/statue/attack_hand(mob/living/user as mob)
-	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
 	user.visible_message("<span class='notice'>[user] rubs some dust off from the [name]'s surface.</span>", \

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -14,7 +14,6 @@
 	var/last_event = 0
 	var/active = null
 	var/spam_flag = 0
-	var/state = 0
 
 /obj/structure/statue/Destroy()
 	density = 0
@@ -22,7 +21,7 @@
 
 /obj/structure/statue/attackby(obj/item/weapon/W, mob/user)
 	add_fingerprint(user)
-	if(istype(W, /obj/item/weapon/wrench) && state == 0)
+	if(istype(W, /obj/item/weapon/wrench))
 		if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			user << "<span class='notice'>Now loosening the [name]'s bolts...</span>"
@@ -70,6 +69,7 @@
 
 /obj/structure/statue/attack_hand(mob/user)
 	user.changeNext_move(CLICK_CD_MELEE)
+	add_fingerprint(user)
 	visible_message("<span class='notice'>[user] rubs some dust off from the [name]'s surface.</span>")
 
 /obj/structure/statue/CanAtmosPass()


### PR DESCRIPTION
This PR adds some fixes to the mineral statues.
1. Adds a cooldown to attacking it with your hand, so it doesn't rapidly spam the rubbing message anymore.
2. Mineral statues starts of unanchored, so you can pull/push them around.
   2.A. It takes 4 seconds to wrench and unwrench.
3. Mineral statues can now be deconstructed.
   3.A. When unanchored, a welding can be used to deconstruct it. It takes 4 seconds.
   3.B. A plasmacutter can deconstruct it, it takes 3 seconds. Regardless if anchored or not.
   3.C. A diamond drill can also deconstruct it. It takes .5 seconds. Regardless of it is anchored or not. Using a diamond drill destroys it though and leaves no minerals behind.
4. Mineral Statues now leaves fingerprints when attacked.

PR Fixes:
1. Attacking the statues barehanded or with tools uses the attack animation now.
2. Added many cases of user.visible_message.
