### PR TITLE
Fixes some RPD bugs

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -31,6 +31,7 @@ Buildable meters
 #define DISP_END_BIN			5
 #define DISP_END_OUTLET			6
 #define DISP_END_CHUTE			7
+#define DISP_SORTJUNCTION		8
 
 /obj/item/pipe
 	name = "pipe"


### PR DESCRIPTION
Fixes pipe painting not working.
Fixes 4-way manifolds and disposals chutes displaying broken icons.
Fixes the lack of Sort Junctions from the RPD.
Fixes drones being unable to use the RPD.
Fixes #6627 
Fixes #6637
