### PR TITLE
Preferred colours for Podpeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -94,6 +94,7 @@
 	// A mutation caused by a human being ressurected in a revival pod. These regain health in light, and begin to wither in darkness.
 	name = "Podperson"
 	id = "pod"
+	specflags = list(MUTCOLORS,EYECOLOR)
 
 /datum/species/plant/pod/spec_life(mob/living/carbon/human/H)
 	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing


### PR DESCRIPTION
Makes podpeople use colours set in Setup Character(Eye Color and Alien Color) instead of always having grey skin and black eyes.
