### PR TITLE
Terminal Deconstruction

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -489,22 +489,8 @@
 				make_terminal()
 				terminal.connect_to_network()
 	else if (istype(W, /obj/item/weapon/wirecutters) && terminal && opened && has_electronics!=2)
-		if (src.loc:intact)
-			user << "<span class='warning'>You must remove the floor plating in front of the APC first.</span>"
-			return
-		user.visible_message("<span class='warning'>[user.name] dismantles the power terminal from [src].</span>", \
-							"You begin to cut the cables...")
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		if(do_after(user, 50))
-			if(terminal && opened && has_electronics!=2)
-				if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal))
-					var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-					s.set_up(5, 1, src)
-					s.start()
-					return
-				new /obj/item/stack/cable_coil(loc,10)
-				user << "<span class='notice'>You cut the cables and dismantle the power terminal.</span>"
-				qdel(terminal)
+		terminal.dismantle(user)
+
 	else if (istype(W, /obj/item/weapon/module/power_control) && opened && has_electronics==0 && !((stat & BROKEN) || malfhack))
 		user.visible_message("<span class='warning'>[user.name] inserts the power control board into [src].</span>", \
 							"You start to insert the power control board into the frame...")

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -142,29 +142,7 @@
 
 	//disassembling the terminal
 	if(istype(I, /obj/item/weapon/wirecutters) && terminal && panel_open)
-		var/turf/T = get_turf(terminal)
-		if (T.intact) //is the floor plating removed ?
-			user << "<span class='alert'>You must first expose the power terminal!</span>"
-			return
-
-		user << "You begin to dismantle the power terminal..."
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-
-		if(do_after(user, 50))
-			if (prob(50) && electrocute_mob(usr, terminal.powernet, terminal)) //animate the electrocution if uncautious and unlucky
-				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-				s.set_up(5, 1, src)
-				s.start()
-				return
-
-			//give the wires back and delete the terminal
-			new /obj/item/stack/cable_coil(T,10)
-			user.visible_message(\
-				"<span class='alert'>[user.name] cuts the cables and dismantles the power terminal.</span>",\
-				"You cut the cables and dismantle the power terminal.")
-			inputting = 0 //stop inputting, since we have don't have a terminal anymore
-			qdel(terminal)
-			return
+		terminal.dismantle(user)
 
 	//crowbarring it !
 	default_deconstruction_crowbar(I)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -33,3 +33,48 @@
 		invisibility = 0
 		icon_state = "term"
 
+
+/obj/machinery/power/proc/can_terminal_dismantle()
+	. = 0
+
+/obj/machinery/power/apc/can_terminal_dismantle()
+	. = 0
+	if(opened && has_electronics != 2)
+		. = 1
+
+/obj/machinery/power/smes/can_terminal_dismantle()
+	. = 0
+	if(panel_open)
+		. = 1
+
+
+/obj/machinery/power/terminal/proc/dismantle(var/mob/living/user)
+	if(istype(loc, /turf/simulated))
+		var/turf/simulated/T = loc
+		if(T.intact)
+			user << "<span class='alert'>You must first expose the power terminal!</span>"
+			return
+
+		if(master && master.can_terminal_dismantle())
+			user.visible_message("<span class='warning'>[user.name] dismantles the power terminal from [master].</span>", \
+								"You begin to cut the cables...")
+
+			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+			if(do_after(user, 50))
+				if(master && master.can_terminal_dismantle())
+					if(prob(50) && electrocute_mob(user, powernet, src))
+						var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+						s.set_up(5, 1, master)
+						s.start()
+						return
+					new /obj/item/stack/cable_coil(loc, 10)
+					user << "<span class='notice'>You cut the cables and dismantle the power terminal.</span>"
+					qdel(src)
+
+
+/obj/machinery/power/terminal/attackby(obj/item/W, mob/living/user)
+	if(istype(W, /obj/item/weapon/wirecutters))
+		dismantle(user)
+		return
+
+	..()


### PR DESCRIPTION
fixes #6645 - not really a fix, it's a feature request. requested by @AssassinT90
- Terminal deconstruction is now handled by dismantle() and can_dismantle()
- dismantle() calls can_dismantle() and eventually removes the terminal
- can_dismantle() handles the different requirements of SMES and APCs
- You can call dismantle() on a terminal by clicking it with wirecutters
