### PR TITLE
Fixes #6654

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -195,7 +195,7 @@
 
 /obj/item/device/radio/headset/ai
 	name = "\proper Integrated Subspace Transceiver "
-	keyslot = new /obj/item/device/encryptionkey/ai
+	keyslot2 = new /obj/item/device/encryptionkey/ai
 
 /obj/item/device/radio/headset/ai/receive_range(freq, level)
 	return ..(freq, level, 1)


### PR DESCRIPTION
- Sets the AI's encryption key to slot 2 so it is not lost upon the AI
  being traitorized.
- Fixes #6654 by reverting the change in #6399 to the AI's key.
