### PR TITLE
Fixes arcade machine runtimes from #6351

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -31,14 +31,14 @@
 							)
 
 /obj/machinery/computer/arcade/New()
-	// If spawning the generic arcade machine, pick a random type
-	// and spawn that instead
-	if (!src.circuit)
-		var/choice = pick(typesof(/obj/machinery/computer/arcade) - /obj/machinery/computer/arcade)
-		new choice(loc)
+	..()
+	// If it's a generic arcade machine, pick a random arcade
+	// circuit board for it and make the new machine
+	if(!circuit)
+		var/choice = pick(typesof(/obj/item/weapon/circuitboard/arcade) - /obj/item/weapon/circuitboard/arcade)
+		var/obj/item/weapon/circuitboard/CB = new choice()
+		new CB.build_path(loc, CB)
 		qdel(src)
-	else
-		..()
 
 /obj/machinery/computer/arcade/proc/prizevend()
 	if(!contents.len)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -31,10 +31,14 @@
 							)
 
 /obj/machinery/computer/arcade/New()
-	..()
-	var/choice = pick(typesof(/obj/machinery/computer/arcade) - /obj/machinery/computer/arcade)
-	new choice(loc)
-	qdel(src)
+	// If spawning the generic arcade machine, pick a random type
+	// and spawn that instead
+	if (!src.circuit)
+		var/choice = pick(typesof(/obj/machinery/computer/arcade) - /obj/machinery/computer/arcade)
+		new choice(loc)
+		qdel(src)
+	else
+		..()
 
 /obj/machinery/computer/arcade/proc/prizevend()
 	if(!contents.len)
@@ -87,6 +91,7 @@
 	var/turtle = 0
 
 /obj/machinery/computer/arcade/battle/New()
+	..()
 	var/name_action
 	var/name_part1
 	var/name_part2
@@ -304,6 +309,7 @@
 	var/list/stopblurbs = list()
 
 /obj/machinery/computer/arcade/orion_trail/New()
+	..()
 	// Sets up the main trail
 	stops = list("Pluto","Asteroid Belt","Proxima Centauri","Dead Space","Rigel Prime","Tau Ceti Beta","Black Hole","Space Outpost Beta-9","Orion Prime")
 	stopblurbs = list(


### PR DESCRIPTION
This fixes runtimes 7 and 14 from #6351. It was actually worse than "just a runtime" as it made the two arcade machines that spawn on the station come with no actual circuit board (just the type) so if you disconnected the display you couldn't get it back together, and if you disassembled the machine you couldn't get the circuit board out at all.

I made an issue at #6663 before realizing it was the same one as 7 in #6351, although mine has more information if you're curious.
