### PR TITLE
Fixes runtime with moving objects in/out of storage while clientless mobs peeking

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -104,7 +104,7 @@
 /obj/item/weapon/storage/proc/can_see_contents()
 	var/list/cansee = list()
 	for(var/mob/M in is_seeing)
-		if(M.s_active == src)
+		if(M.s_active == src && M.client)
 			cansee |= M
 		else
 			is_seeing -= M


### PR DESCRIPTION
For example a ghost could be peeking on a mob's bag content, then disconnect.
The mob would then runtime every time he moves an object in/out of his/her bag.

Unreported as far as i know.
