### PR TITLE
Fixes player controlled hostile simple animal not calling AttackingTarget() for their melee attack.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -42,11 +42,15 @@
 */
 /mob/living/UnarmedAttack(var/atom/A)
 	A.attack_animal(src)
+
+/mob/living/simple_animal/hostile/UnarmedAttack(var/atom/A)
+	target = A
+	AttackingTarget()
+
 /atom/proc/attack_animal(mob/user as mob)
 	return
 /mob/living/RestrainedClickOn(var/atom/A)
 	return
-
 
 /*
 	Monkeys

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -47,9 +47,9 @@ F
 		emote("me", 1, "nashes at [.]!")
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
-	. =..()
-	var/mob/living/carbon/L = .
-	if(istype(L))
+	..()
+	if(isliving(target))
+		var/mob/living/L = target
 		if(prob(15))
 			L.Weaken(3)
 			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -40,9 +40,9 @@
 		emote("me", 1, "wails at [.]!")
 
 /mob/living/simple_animal/hostile/faithless/AttackingTarget()
-	. =..()
-	var/mob/living/L = .
-	if(istype(L))
+	..()
+	if(isliving(target))
+		var/mob/living/L = target
 		if(prob(12))
 			L.Weaken(3)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -311,5 +311,6 @@
 
 /mob/living/simple_animal/hostile/RangedAttack(var/atom/A, var/params) //Player firing
 	if(ranged && ranged_cooldown <= 0)
+		target = A
 		OpenFire(A)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -206,13 +206,13 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		..()
 
 /mob/living/simple_animal/hostile/mimic/copy/AttackingTarget()
-	. =..()
+	..()
 	if(knockdown_people)
-		var/mob/living/L = .
-		if(istype(L))
+		if(isliving(target))
+			var/mob/living/L = target
 			if(prob(15))
 				L.Weaken(1)
-				L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+				L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
 
 //
 // Machine Mimics (Made by Malf AI)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -88,7 +88,11 @@
 				GiveTarget(watching)
 
 /mob/living/simple_animal/hostile/statue/AttackingTarget()
-	if(!can_be_seen())
+	if(can_be_seen())
+		if(client)
+			src << "<span class='warning'>You cannot attack, there are eyes on you!</span>"
+			return
+	else
 		..()
 
 /mob/living/simple_animal/hostile/statue/DestroySurroundings()
@@ -98,13 +102,6 @@
 /mob/living/simple_animal/hostile/statue/face_atom()
 	if(!can_be_seen())
 		..()
-
-/mob/living/simple_animal/hostile/statue/UnarmedAttack()
-	if(can_be_seen())
-		if(client)
-			src << "<span class='warning'>You cannot attack, there are eyes on you!</span>"
-		return
-	..()
 
 /mob/living/simple_animal/hostile/statue/proc/can_be_seen(var/turf/destination)
 	if(!cannot_be_seen)

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -43,12 +43,12 @@
 		emote("me", 1, "growls at [.].")
 
 /mob/living/simple_animal/hostile/tree/AttackingTarget()
-	. =..()
-	var/mob/living/L = .
-	if(istype(L))
+	..()
+	if(isliving(target))
+		var/mob/living/L = target
 		if(prob(15))
 			L.Weaken(3)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
 
 /mob/living/simple_animal/hostile/tree/Die()
 	..()


### PR DESCRIPTION
- Fixes carp, mimic and tree not being able to knockdown their target.
- Fixes player controlled hostile simple animal not calling AttackingTarget() for their melee attack. Fixes #6665
- Fixes player controlled hostile simple animal's ranged attack targeting the target from their previous melee attack instead of the target clicked.
