### PR TITLE
Fixes being unable to build doors over firelocks, blast doors and shutters.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -17,6 +17,7 @@
 	var/normalspeed = 1
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/emergency = 0 // Emergency access override
+	var/sub_door = 0 // 1 if it's meant to go under another door.
 
 /obj/machinery/door/New()
 	..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -12,6 +12,7 @@
 	glass = 1
 	var/blocked = 0
 	var/nextstate = null
+	sub_door = 1
 
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -23,12 +23,12 @@
 /obj/machinery/door/poddoor/attackby(obj/item/I, mob/user)
 	add_fingerprint(user)
 
-	if(!istype(I, /obj/item/weapon/crowbar) && !istype(I, /obj/item/weapon/twohanded/fireaxe))
-		return
 	if(istype(I, /obj/item/weapon/twohanded/fireaxe))
 		var/obj/item/weapon/twohanded/fireaxe/F = I
 		if(!F.wielded)
 			return
+	else if(!istype(I, /obj/item/weapon/crowbar))
+		return
 
 	if(stat & NOPOWER)
 		open(1)	//ignore the usual power requirement.

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -5,6 +5,7 @@
 	icon_state = "closed"
 	var/id = 1
 	var/auto_close = 0 // Time in seconds to automatically close when opened, 0 if it doesn't.
+	sub_door = 1
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
@@ -22,7 +23,7 @@
 /obj/machinery/door/poddoor/attackby(obj/item/I, mob/user)
 	add_fingerprint(user)
 
-	if(!istype(I, /obj/item/weapon/crowbar))
+	if(!istype(I, /obj/item/weapon/crowbar) && !istype(I, /obj/item/weapon/twohanded/fireaxe))
 		return
 	if(istype(I, /obj/item/weapon/twohanded/fireaxe))
 		var/obj/item/weapon/twohanded/fireaxe/F = I

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -174,7 +174,13 @@ RCD
 		if(2)
 			if(istype(A, /turf/simulated/floor))
 				if(checkResource(10, user))
-					if(!locate(/obj/machinery/door) in A)
+					var/door_check = 1
+					for(var/obj/machinery/door/D in A)
+						if(!D.sub_door)
+							door_check = 0
+							break
+		
+					if(door_check)
 						user << "Building Airlock..."
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						if(do_after(user, 50))

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -461,7 +461,13 @@ obj/structure/door_assembly/New()
 			return
 
 	else if(istype(W, /obj/item/weapon/wrench) && !anchored )
-		if(!locate(/obj/machinery/door) in loc)
+		var/door_check = 1
+		for(var/obj/machinery/door/D in loc)
+			if(!D.sub_door)
+				door_check = 0
+				break
+		
+		if(door_check)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			user.visible_message("<span class='warning'>[user] secures the airlock assembly to the floor.</span>", \
 								 "You start to secure the airlock assembly to the floor.", \

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -73,3 +73,4 @@ Cuboos = Game Master
 thunder12345 = Game Master
 wjohnston = Game Master
 mandurrh = Game Master
+xerux = Game Master


### PR DESCRIPTION
Fixes #6327 as well as being unable to build doors over blast doors and shutters.

As a result, any door with the sub_door variable set to 1 can have an airlock built over it.  Also fixes using a fireaxe to open unpowered poddoors and adds myself to the admins.txt.
