### PR TITLE
Adds notice of license change to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# **Licensing has recently changed from GPLv3 to AGPLv3. See [#6689](https://github.com/tgstation/-tg-station/pull/6689) for more info.**
+
 ##/tg/station v1.0.1
 
 [![Build Status](https://travis-ci.org/tgstation/-tg-station.png)](https://travis-ci.org/tgstation/-tg-station)


### PR DESCRIPTION
Added a prominent notice to the top of README.md to alert server hosts using our codebase of the change.
This is intended as being temporary and will be removed after a month.
