### PR TITLE
Fixes visible_messages. 

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -82,24 +82,37 @@ var/next_mob_id = 0
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
 /mob/visible_message(var/message, var/self_message, var/blind_message)
-	var/list/atom_viewers = list()
-	for(var/atom/movable/A in view(src))
-		atom_viewers |= recursive_hear_check(A)
-	atom_viewers |= src
-	for(var/mob/M in atom_viewers)
+	var/list/mob_viewers = list()
+	var/list/possible_viewers = list()
+	mob_viewers |= src
+	mob_viewers |= viewers(src)
+	var/heard = get_hear(7, src)
+	for(var/atom/movable/A in heard)
+		possible_viewers |= recursive_hear_check(A)
+	for(var/mob/B in possible_viewers)
+		if(B in mob_viewers)
+			continue
+		if(isturf(B.loc))
+			continue
+		var/turf/T = get_turf(B)
+		if(src in view(T))
+			mob_viewers |= B
+
+	for(var/mob/M in mob_viewers)
 		if(M.see_invisible < invisibility)
 			continue //can't view the invisible
 		var/msg = message
 		if(self_message && M==src)
 			msg = self_message
-		M.show_message( msg, 1)
+		M.show_message(msg, 1)
+
 	if(blind_message)
-		var/list/atom_hearers = list()
-		for(var/atom/movable/O in get_hearers_in_view(7, src))
-			if(O in atom_viewers)
+		var/list/mob_hearers = list()
+		for(var/mob/C in get_hearers_in_view(7, src))
+			if(C in mob_viewers)
 				continue
-			atom_hearers |= O
-		for(var/mob/MOB in atom_hearers)
+			mob_hearers |= C
+		for(var/mob/MOB in mob_hearers)
 			MOB.show_message(blind_message, 2)
 
 // Show a message to all mobs who sees this atom
@@ -108,18 +121,31 @@ var/next_mob_id = 0
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
 /atom/proc/visible_message(var/message, var/blind_message)
-	var/list/atom_viewers = list()
-	for(var/atom/movable/A in view(src))
-		atom_viewers |= recursive_hear_check(A)
-	for(var/mob/M in atom_viewers)
-		M.show_message( message, 1)
+	var/list/mob_viewers = list()
+	var/list/possible_viewers = list()
+	mob_viewers |= viewers(src)
+	var/heard = get_hear(7, src)
+	for(var/atom/movable/A in heard)
+		possible_viewers |= recursive_hear_check(A)
+	for(var/mob/B in possible_viewers)
+		if(B in mob_viewers)
+			continue
+		if(isturf(B.loc))
+			continue
+		var/turf/T = get_turf(B)
+		if(src in view(T))
+			mob_viewers |= B
+
+	for(var/mob/M in mob_viewers)
+		M.show_message(message, 1)
+
 	if(blind_message)
-		var/list/atom_hearers = list()
-		for(var/atom/movable/O in get_hearers_in_view(7, src))
-			if(O in atom_viewers)
+		var/list/mob_hearers = list()
+		for(var/mob/C in get_hearers_in_view(7, src))
+			if(C in mob_viewers)
 				continue
-			atom_hearers |= O
-		for(var/mob/MOB in atom_hearers)
+			mob_hearers |= C
+		for(var/mob/MOB in mob_hearers)
 			MOB.show_message(blind_message, 2)
 
 // Show a message to all mobs in earshot of this one


### PR DESCRIPTION
Now ghost will properly see visible_messages and will only see the audible part of a visible_message if the src is hidden inside a container.
Fixes #6715 

Fixes people seeing visible_messages from a src that is in the dark or inside a container; and fixes people not seeing the message when they are in the dark but not the src.

Changing a few var names.
