### PR TITLE
Fixes potato cell construction and eggplant parmigiana recipe

### DIFF
--- a/code/modules/food&drinks/recipes/microwave/recipes_bread.dm
+++ b/code/modules/food&drinks/recipes/microwave/recipes_bread.dm
@@ -3,7 +3,7 @@
 
 ////////////////////////////////////////////////BREAD////////////////////////////////////////////////
 
-/datum/recipe/bread
+/datum/recipe/bread/plain
 	reagents = list("flour" = 15)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/store/bread
 

--- a/code/modules/food&drinks/recipes/microwave/recipes_pie.dm
+++ b/code/modules/food&drinks/recipes/microwave/recipes_pie.dm
@@ -3,7 +3,7 @@
 
 ////////////////////////////////////////////////PIES////////////////////////////////////////////////
 
-/datum/recipe/pie
+/datum/recipe/pie/banana
 	reagents = list("flour" = 10)
 	items = list(
 		 /obj/item/weapon/reagent_containers/food/snacks/grown/banana,

--- a/code/modules/food&drinks/recipes/microwave/recipes_sandwichtoast.dm
+++ b/code/modules/food&drinks/recipes/microwave/recipes_sandwichtoast.dm
@@ -3,7 +3,7 @@
 
 ////////////////////////////////////////////////SANDWICHES////////////////////////////////////////////////
 
-/datum/recipe/sandwich
+/datum/recipe/sandwich/plain
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,

--- a/code/modules/food&drinks/recipes/microwave/recipes_spaghetti.dm
+++ b/code/modules/food&drinks/recipes/microwave/recipes_spaghetti.dm
@@ -3,7 +3,7 @@
 
 ////////////////////////////////////////////////SPAGHETTI////////////////////////////////////////////////
 
-/datum/recipe/spaghetti
+/datum/recipe/spaghetti/plain
 	reagents = list("flour" = 5)
 	result= /obj/item/weapon/reagent_containers/food/snacks/spaghetti
 
@@ -54,6 +54,6 @@
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
-		/obj/item/weapon/reagent_containers/food/snacks/grown/eggplant
+		/obj/item/weapon/reagent_containers/food/snacks/grown/eggplant,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/eggplantparm

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -163,7 +163,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	if(istype(W, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/C
+		var/obj/item/stack/cable_coil/C = W
 		if (C.use(5))
 			user << "<span class='notice'>You add some cable to the potato and slide it inside the battery encasing.</span>"
 			var/obj/item/weapon/stock_parts/cell/potato/pocell = new /obj/item/weapon/stock_parts/cell/potato(user.loc)


### PR DESCRIPTION
Fixes potato cell construction being broken
Fixes eggplant parmigiana recipe (it was inheriting reagent requirements from spaghetti). I changed recipes so that they never inherit items or reagents requirements from a parent recipe to make adding new recipes in each categories less prone to mistakes.
Fixes #6740 
Fixes #6766
