### PR TITLE
Makes aliens process reagents again & Stop, drop 'n roll ignores CANWEAKEN requirement

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -178,3 +178,6 @@
 			if(do_mob(usr, src, POCKET_STRIP_DELAY * 0.5))
 				unEquip(r_store)
 				unEquip(l_store)
+
+/mob/living/carbon/alien/humanoid/reagent_check(var/datum/reagent/R)
+	return 0

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/alien/proc/handle_chemicals_in_body()
-	if(reagents) reagents.metabolize(src)
+	if(reagents)
+		reagents.metabolize(src)
 
 	if (drowsyness)
 		drowsyness--

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -652,7 +652,8 @@
 		var/mob/living/carbon/CM = L
 		if(CM.on_fire && CM.canmove)
 			CM.fire_stacks -= 5
-			CM.Weaken(3)
+			CM.weakened = max(CM.weakened, 3)//We dont check for CANWEAKEN, I don't care how immune to weakening you are, if you're rolling on the ground, you're busy.
+			CM.update_canmove()
 			CM.spin(32,2)
 			CM.visible_message("<span class='danger'>[CM] rolls on the floor, trying to put themselves out!</span>", \
 				"<span class='notice'>You stop, drop, and roll!</span>")


### PR DESCRIPTION
Technically nerfs abriums too

You can once again stun aliens with neurotoxin, and they will now be stunned while rolling on the floor

Fixes #6562 
