### PR TITLE
Adds a "character description" configuration

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -226,7 +226,7 @@ datum/preferences
 				dat += "<b>Pull requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(toggles & CHAT_PULLR) ? "Yes" : "No"]</a><br>"
 
 				if(config.allow_Metadata)
-					dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'> Edit </a><br>"
+					dat += "<b>Character info:</b> <a href='?_src_=prefs;preference=metadata;task=input'>Edit</a><br>"
 
 				if(user.client)
 					if(user.client.holder)
@@ -594,9 +594,7 @@ datum/preferences
 							age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 					if("metadata")
-						var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null
-						if(new_metadata)
-							metadata = sanitize(copytext(new_metadata,1,MAX_MESSAGE_LEN))
+						metadata = strip_html_properly(input(user, "Describe your character's appearance in up to [MAX_MESSAGE_LEN] characters:", "Game Preference" , metadata) as message, MAX_MESSAGE_LEN)
 
 					if("hair")
 						var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference") as null|color

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -266,6 +266,14 @@
 					msg += "<a href='?src=\ref[src];criminal=1;view_comment=1'>\[View comment log\]</a> "
 					msg += "<a href='?src=\ref[src];criminal=1;add_comment=1'>\[Add comment\]</a>\n"
 
+	//Character RP info (config option)
+	if(config.allow_Metadata && client && client.prefs && client.prefs.metadata)
+		var/metainfo = client.prefs.metadata
+		if(length(metainfo) > 128)
+			metainfo = "[copytext(metainfo,1,127)]<a href='?src=\ref[src];show_metadata=1'>(more)</a>"
+		msg += "*---------*\n"
+		msg += "[metainfo]\n"
+
 	msg += "*---------*</span>"
 
 	user << msg

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -410,6 +410,11 @@
 									return
 					usr << "<span class='warning'>Unable to locate a data core entry for this person.</span>"
 
+
+	if(href_list["show_metadata"])
+		if(client && client.prefs && client.prefs.metadata)
+			usr << "<span class='notice'>[client.prefs.metadata]</span>"
+
 /mob/living/carbon/human/proc/play_xylophone()
 	if(!src.xylophone)
 		visible_message("<span class='notice'>[src] begins playing \his ribcage like a xylophone. It's quite spooky.</span>","<span class='notice'>You begin to play a spooky refrain on your ribcage.</span>","You hear a spooky xylophone melody.")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -405,22 +405,6 @@
 /mob/living/proc/update_damage_overlays()
 	return
 
-
-/mob/living/proc/Examine_OOC()
-	set name = "Examine Meta-Info (OOC)"
-	set category = "OOC"
-	set src in view()
-
-	if(config.allow_Metadata)
-		if(client)
-			usr << "[src]'s Metainfo:<br>[client.prefs.metadata]"
-		else
-			usr << "[src] does not have any stored infomation!"
-	else
-		usr << "OOC Metadata is not supported by this server!"
-
-	return
-
 /mob/living/Move(atom/newloc, direct)
 	if (buckled && buckled.loc != newloc)
 		if (!buckled.anchored)


### PR DESCRIPTION
This repurposes the old and (AFAIK) unused config option allow_Metadata.
Now it will show IC character descriptions, similar to baystation12.
They're set in the "Setup Preferences" tab, and are saved per-character.

EDIT: Apparently this lets people meta lings. Don't merge until I figure out a way to solve this.

Pics:
![2015-01-02-233056_661x438_scrot](https://cloud.githubusercontent.com/assets/6563111/5601357/9fd582d4-92d8-11e4-8f65-28688103e2f7.png)
![2015-01-02-233506_681x443_scrot](https://cloud.githubusercontent.com/assets/6563111/5601358/9ff03e94-92d8-11e4-9bfd-d180cd6c6bf9.png)
