### PR TITLE
Fixes simple animals not being able to unbuckle themselves.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -55,6 +55,8 @@
 	if(M.environment_smash)
 		new /obj/item/stack/sheet/metal(src.loc)
 		qdel(src)
+		return
+	manual_unbuckle(M)
 
 /obj/structure/stool/bed/MouseDrop_T(mob/M as mob, mob/user as mob)
 	if(!istype(M)) return
@@ -112,8 +114,8 @@
 	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.lying || user.stat || M.buckled || istype(user, /mob/living/silicon/pai) || M.anchored)
 		return
 
-	if (istype(M, /mob/living/carbon/slime))
-		user << "The [M] is too squishy to buckle in."
+	if (istype(M, /mob/living/carbon/slime) || istype(M, /mob/living/simple_animal/slime))
+		user << "\The [M] is too squishy to buckle in."
 		return
 
 	unbuckle()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -664,30 +664,30 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime/))//If target is not a slime.
-			user << "<span class='warning'> The potion only works on slimes!</span>"
-			return ..()
-		if(M.stat)
-			user << "<span class='warning'> The slime is dead!</span>"
-			return..()
-		if(M.mind)
-			user << "<span class='warning'> The slime resists!</span>"
-			return ..()
-		var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
-		pet.icon_state = "[M.colour] adult slime"
-		pet.icon_living = "[M.colour] adult slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		user <<"You feed the slime the potion, removing it's powers and calming it."
-		qdel(M)
-		var/newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
+/obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!istype(M, /mob/living/carbon/slime/))//If target is not a slime.
+		user << "<span class='warning'> The potion only works on slimes!</span>"
+		return ..()
+	if(M.stat)
+		user << "<span class='warning'> The slime is dead!</span>"
+		return..()
+	if(M.mind)
+		user << "<span class='warning'> The slime resists!</span>"
+		return ..()
+	var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
+	pet.icon_state = "[M.colour] adult slime"
+	pet.icon_living = "[M.colour] adult slime"
+	pet.icon_dead = "[M.colour] baby slime dead"
+	pet.colour = "[M.colour]"
+	user <<"You feed the slime the potion, removing it's powers and calming it."
+	qdel(M)
+	var/newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
 
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel(src)
+	if (!newname)
+		newname = "pet slime"
+	pet.name = newname
+	pet.real_name = newname
+	qdel(src)
 
 
 /obj/item/weapon/slimesteroid

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -15,34 +15,21 @@
 	ventcrawler = 2
 	var/colour = "grey"
 
-/mob/living/simple_animal/adultslime
-	name = "pet slime"
-	desc = "A lovable, domesticated slime."
-	icon = 'icons/mob/slimes.dmi'
+/mob/living/simple_animal/slime/adult
 	health = 200
 	maxHealth = 200
 	icon_state = "grey adult slime"
 	icon_living = "grey adult slime"
-	icon_dead = "grey baby slime dead"
-	response_help  = "pets"
-	response_disarm = "shoos"
-	response_harm   = "stomps on"
-	emote_see = list("jiggles", "bounces in place")
-	var/colour = "grey"
 
-/mob/living/simple_animal/adultslime/New()
+/mob/living/simple_animal/slime/adult/New()
 	..()
 	overlays += "aslime-:33"
 
 /mob/living/simple_animal/slime/adult/Die()
-	var/mob/living/simple_animal/slime/S1 = new /mob/living/simple_animal/slime (src.loc)
-	S1.icon_state = "[src.colour] baby slime"
-	S1.icon_living = "[src.colour] baby slime"
-	S1.icon_dead = "[src.colour] baby slime dead"
-	S1.colour = "[src.colour]"
-	var/mob/living/simple_animal/slime/S2 = new /mob/living/simple_animal/slime (src.loc)
-	S2.icon_state = "[src.colour] baby slime"
-	S2.icon_living = "[src.colour] baby slime"
-	S2.icon_dead = "[src.colour] baby slime dead"
-	S2.colour = "[src.colour]"
+	for(var/i = 0, i<=1, i++)
+		var/mob/living/simple_animal/slime/S1 = new /mob/living/simple_animal/slime (src.loc)
+		S1.icon_state = "[colour] baby slime"
+		S1.icon_living = "[colour] baby slime"
+		S1.icon_dead = "[colour] baby slime dead"
+		S1.colour = "[colour]"
 	qdel(src)


### PR DESCRIPTION
Some pet slime fixes: There's no longer two types of adult pet slimes, simplifying adult pet slime's Die() proc, pet slimes can no longer be buckled.
Fixing some absolute path in slime/slime.dm.
Fixes one typo.
Fixes #6742 
