### PR TITLE
Adds a (follow) link to ghost messages

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -310,3 +310,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	dat += data_core.get_manifest()
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
+
+/mob/dead/observer/Topic(href, href_list)
+	if(href_list["follow"])
+		var/atom/movable/target = locate(href_list["follow"])
+		if((usr == src) && istype(target) && (target != src)) //for safety against href exploits
+			ManualFollow(target)
+

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -17,5 +17,5 @@
 	. = src.say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-	src << "<a href=?src=\ref[src];follow=\ref[speaker]>(Follow)</a> [message]"
+	src << "<a href=?src=\ref[src];follow=\ref[speaker]>(F)</a> [message]"
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -17,4 +17,5 @@
 	. = src.say_dead(message)
 
 /mob/dead/observer/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-	src << message
+	src << "<a href=?src=\ref[src];follow=\ref[speaker]>(Follow)</a> [message]"
+


### PR DESCRIPTION
Clicking on said link is the same as using the "Follow" verb and
selecting the sender's name. Inspired by the feature on baycode.
