### PR TITLE
Fixes a few RPD painting bugs

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -50,3 +50,7 @@
 			meter.transfer_fingerprints_to(PM)
 			qdel(meter)
 	..()
+
+/obj/machinery/atmospherics/pipe/proc/update_node_icon()
+	//Used for pipe painting. Overriden in the children.
+	return

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -115,6 +115,15 @@
 /obj/machinery/atmospherics/pipe/manifold/pipeline_expansion()
 	return list(node1, node2, node3)
 
+/obj/machinery/atmospherics/pipe/manifold/update_node_icon()
+	..()
+	if(node1)
+		node1.update_icon()
+	if(node2)
+		node2.update_icon()
+	if(node3)
+		node3.update_icon()
+
 
 //Colored pipes, use these for mapping
 /obj/machinery/atmospherics/pipe/manifold/general

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -122,6 +122,17 @@
 	if(node4)
 		overlays += getpipeimage('icons/obj/atmospherics/pipe_manifold.dmi', "manifold_full[invis]", WEST)
 
+/obj/machinery/atmospherics/pipe/manifold4w/update_node_icon()
+	..()
+	if(node1)
+		node1.update_icon()
+	if(node2)
+		node2.update_icon()
+	if(node3)
+		node3.update_icon()
+	if(node4)
+		node4.update_icon()
+
 //Colored pipes, use these for mapping
 /obj/machinery/atmospherics/pipe/manifold4w/general
 	name="pipe"

--- a/code/ATMOSPHERICS/pipes/simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple.dm
@@ -137,6 +137,13 @@ The regular pipe you see everywhere, including bent ones.
 /obj/machinery/atmospherics/pipe/simple/pipeline_expansion()
 	return list(node1, node2)
 
+/obj/machinery/atmospherics/pipe/simple/update_node_icon()
+	..()
+	if(node1)
+		node1.update_icon()
+	if(node2)
+		node2.update_icon()
+
 /obj/machinery/atmospherics/pipe/simple/insulated
 	icon = 'icons/obj/atmospherics/red_pipe.dmi'
 	icon_state = "intact"

--- a/code/game/objects/items/devices/pipe_painter.dm
+++ b/code/game/objects/items/devices/pipe_painter.dm
@@ -29,37 +29,9 @@
 	var/obj/machinery/atmospherics/pipe/P = A
 	P.color = modes[mode]
 	P.pipe_color = modes[mode]
+	P.stored.color = modes[mode]
 	user.visible_message("<span class='notice'>[user] paints \the [P] [mode].</span>","<span class='notice'>You paint \the [P] [mode].</span>")
-	//P.update_icon()
-
-	if(istype(A,/obj/machinery/atmospherics/pipe/simple))
-		var/obj/machinery/atmospherics/pipe/simple/pipe = A
-
-		if(pipe.node1)
-			pipe.node1.update_icon()
-		if(pipe.node2)
-			pipe.node2.update_icon()
-	else if(istype(A,/obj/machinery/atmospherics/pipe/manifold))
-		var/obj/machinery/atmospherics/pipe/manifold/pipe = A
-
-		if(pipe.node1)
-			pipe.node1.update_icon()
-		if(pipe.node2)
-			pipe.node2.update_icon()
-		if(pipe.node3)
-			pipe.node3.update_icon()
-	else if(istype(A,/obj/machinery/atmospherics/pipe/manifold4w))
-		var/obj/machinery/atmospherics/pipe/manifold4w/pipe = A
-
-		if(pipe.node1)
-			pipe.node1.update_icon()
-		if(pipe.node2)
-			pipe.node2.update_icon()
-		if(pipe.node3)
-			pipe.node3.update_icon()
-		if(pipe.node4)
-			pipe.node4.update_icon()
-
+	P.update_node_icon() //updates the neighbors
 
 /obj/item/device/pipe_painter/attack_self(mob/user as mob)
 	mode = input("Which colour do you want to use?","Pipe painter") in modes

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -140,13 +140,13 @@ var/global/list/RPD_recipes=list(
 	var/p_class = ATMOS_MODE
 	var/p_disposal = 0
 	var/list/paint_colors = list(
-		"grey"   = "#cccccc",
-		"red"    = "#800000",
-		"blue"   = "#000080",
-		"cyan"   = "#1C94C4",
-		"green"  = "#00CC00",
-		"yellow" = "#FFCC00",
-		"purple" = "#822BFF"
+		"grey"		= rgb(255,255,255),
+		"red"		= rgb(255,0,0),
+		"blue"		= rgb(0,0,255),
+		"cyan"		= rgb(0,256,249),
+		"green"		= rgb(30,255,0),
+		"yellow"	= rgb(255,198,0),
+		"purple"	= rgb(130,43,255)
 	)
 	var/paint_color="grey"
 
@@ -478,7 +478,8 @@ var/global/list/RPD_recipes=list(
 			P.pipe_color = paint_colors[paint_color]
 			P.stored.color = paint_colors[paint_color]
 			user.visible_message("<span class='notice'>[user] paints \the [P] [paint_color].</span>","<span class='notice'>You paint \the [P] [paint_color].</span>")
-			P.update_icon()
+			//P.update_icon()
+			P.update_node_icon()
 			return 1
 		if(EATING_MODE) // Eating pipes
 			// Must click on an actual pipe or meter.

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -488,7 +488,7 @@ var/global/list/RPD_recipes=list(
 				playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 				if(do_after(user, 5))
 					activate()
-					del(A)
+					qdel(A)
 					return 1
 				return 0
 


### PR DESCRIPTION
Changes RPD colors to be consistent with pipe painter & default pipes.
Makes the RPD properly update its neighbors on painting.
Offloads the neighbor updating logic from pipe_painter to a pipe proc.
Fixes #6783
