### PR TITLE
Revert "Adds dirt overlays for walking on simulated turfs"

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -21,8 +21,6 @@
 obj/item/weapon/mop/proc/clean(turf/simulated/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1))
 		A.clean_blood()
-		var/turf/simulated/floor/F = A
-		F.dirt = 0
 		for(var/obj/effect/O in A)
 			if(istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				qdel(O)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -37,10 +37,12 @@
 	if (istype(A,/mob/living/carbon))
 		var/mob/living/carbon/M = A
 		if(M.lying)	return
+
 		switch (src.wet)
 			if(1) //wet floor
 				if(!M.slip(4, 2, null, (NO_SLIP_WHEN_WALKING|STEP)))
 					M.inertia_dir = 0
 				return
+
 			if(2) //lube
 				M.slip(0, 7, null, (STEP|SLIDE|GALOSHES_DONT_HELP))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -32,8 +32,6 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/obj/item/stack/tile/builtin_tile = null //needed for performance reasons when the singularity rips off floor tiles
 	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	var/list/burnt_states = list()
-	var/dirt = 0
-	var/ignoredirt = 0
 
 /turf/simulated/floor/New()
 	..()
@@ -164,19 +162,3 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 /turf/simulated/floor/narsie_act()
 	if(prob(20))
 		ChangeTurf(/turf/simulated/floor/engine/cult)
-
-/turf/simulated/floor/Entered(atom/A, atom/OL)
-	..()
-	if(!ignoredirt)
-		if(has_gravity(src))
-			if(istype(A,/mob/living/carbon))
-				var/mob/living/carbon/M = A
-				if(M.lying)	return
-				dirt++
-				var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt, src)
-				if (dirt >= 30)
-					if (!dirtoverlay)
-						dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
-						dirtoverlay.alpha = 15
-					else if (dirt > 30)
-						dirtoverlay.alpha = min(dirtoverlay.alpha+20, 255)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -41,7 +41,6 @@
 	icon_state = "grass1"
 	floor_tile = /obj/item/stack/tile/grass
 	broken_states = list("sand1", "sand2", "sand3")
-	ignoredirt = 1
 
 /turf/simulated/floor/fancy/grass/New()
 	..()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -63,7 +63,6 @@
 /turf/simulated/floor/beach
 	name = "Beach"
 	icon = 'icons/misc/beach.dmi'
-	ignoredirt = 1
 
 /turf/simulated/floor/beach/ex_act(severity, target)
 	contents_explosion(severity, target)
@@ -85,13 +84,11 @@
 	..()
 	name = "Iron Sand"
 	icon_state = "ironsand[rand(1,15)]"
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/snow
 	name = "snow"
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/snow/ex_act(severity, target)
 	contents_explosion(severity, target)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -475,7 +475,6 @@
 	icon_state = "asteroid"
 	icon_plating = "asteroid"
 	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/asteroid/airless
 	oxygen = 0.01

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -846,9 +846,6 @@
 			var/turf/tile = loc
 			if(isturf(tile))
 				tile.clean_blood()
-				if (istype(tile, /turf/simulated/floor))
-					var/turf/simulated/floor/F = tile
-					F.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
 						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents.dm
@@ -650,10 +650,6 @@ datum/reagent/space_cleaner/reaction_turf(var/turf/T, var/volume)
 
 		for(var/mob/living/carbon/slime/M in T)
 			M.adjustToxLoss(rand(5,10))
-	if(istype(T, /turf/simulated/floor))
-		var/turf/simulated/floor/F = T
-		if(volume >= 1)
-			F.dirt = 0
 
 datum/reagent/space_cleaner/reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 	if(iscarbon(M))


### PR DESCRIPTION
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=2440
this change has left the station completely overwhelmingly dirty. regardless of how high the number is increased to, us being the most popular server means that we have the most people to walk over tiles 30 times. also ruins muh immersions, why would shoes just randomly create dirt?
