### PR TITLE
Re-admin bugfixes.

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -1,5 +1,6 @@
 var/list/clients = list()							//list of all clients
 var/list/admins = list()							//list of all clients whom are admins
+var/list/deadmins = list()							//list of all clients who have used the de-admin verb.
 var/list/directory = list()							//list of all ckeys with associated client
 
 //Since it didn't really belong in any other category, I'm putting this here

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -506,6 +506,7 @@ var/list/admin_verbs_hideable = list(
 		message_admins("[src] deadmined themself.")
 		deadmin()
 		verbs += /client/proc/readmin
+		deadmins += ckey
 		src << "<span class='interface'>You are now a normal player.</span>"
 	feedback_add_details("admin_verb","DAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -569,9 +570,11 @@ var/list/admin_verbs_hideable = list(
 		D.associate(C)
 		message_admins("[src] re-adminned themselves.")
 		log_admin("[src] re-adminned themselves.")
+		deadmins -= ckey
 		feedback_add_details("admin_verb","RAS")
 		return
 	else
 		src << "You are already an admin."
 		verbs -= /client/proc/readmin
+		deadmins -= ckey
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -570,7 +570,6 @@ var/list/admin_verbs_hideable = list(
 		message_admins("[src] re-adminned themselves.")
 		log_admin("[src] re-adminned themselves.")
 		feedback_add_details("admin_verb","RAS")
-		verbs -= /client/proc/readmin
 		return
 	else
 		src << "You are already an admin."

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -31,6 +31,7 @@ var/list/admin_datums = list()
 		owner = C
 		owner.holder = src
 		owner.add_admin_verbs()	//TODO
+		owner.verbs -= /client/proc/readmin
 		admins |= C
 
 /datum/admins/proc/disassociate()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -51,6 +51,8 @@
 
 	//readd this mob's HUDs (antag, med, etc)
 	reload_huds()
+	if(ckey in deadmins)
+		verbs += /client/proc/readmin
 
 // Calling update_interface() in /mob/Login() causes the Cyborg to immediately be ghosted; because of winget().
 // Calling it in the overriden Login, such as /mob/living/Login() doesn't cause this.

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -30,6 +30,8 @@
 		loc = pick(watch_locations)
 */
 	new_player_panel()
+	if(ckey in deadmins)
+		verbs += /client/proc/readmin
 	spawn(40)
 		if(client)
 			handle_privacy_poll()


### PR DESCRIPTION
Moves the removal of the re-admin verb to the admin holder's associate proc to prevent reload_admins and any other method of re-admining someone from leaving them with the re-admin verb. (If used while you're an admin, it just tells you that you're already an admin and removes itself.)
Fixes #6813: admins being unable to re-admin after disconnecting.
