### PR TITLE
Fixes syringe bug from #6372

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -331,7 +331,7 @@ datum/reagents/proc/update_total()
 	for(var/datum/reagent/R in reagent_list)
 		if(R.volume < 0.1)
 			del_reagent(R.id)
-		else
+		else if (total_volume + R.volume <= maximum_volume) // only add to the volume if it can hold that much
 			total_volume += R.volume
 
 	return 0

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -331,7 +331,7 @@ datum/reagents/proc/update_total()
 	for(var/datum/reagent/R in reagent_list)
 		if(R.volume < 0.1)
 			del_reagent(R.id)
-		else if (total_volume + R.volume <= maximum_volume) // only add to the volume if it can hold that much
+		else
 			total_volume += R.volume
 
 	return 0

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -88,6 +88,7 @@
 						if(!do_mob(user, target))
 							busy = 0
 							return
+					busy = 0
 					B.holder = src
 					B.volume = amount
 					//set reagent data
@@ -129,7 +130,6 @@
 					on_reagent_change()
 					reagents.handle_reactions()
 					user.visible_message("<span class='notice'>[user] takes a blood sample from [target].</span>")
-					busy = 0
 
 			else //if not mob
 				if(!target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,6 +14,7 @@
 	possible_transfer_amounts = null	//list(5, 10, 15)
 	volume = 15
 	var/mode = SYRINGE_DRAW
+	var/busy = 0		// needed for delayed drawing of blood
 	g_amt = 20
 	m_amt = 10
 
@@ -43,6 +44,8 @@
 	return
 
 /obj/item/weapon/reagent_containers/syringe/afterattack(obj/target, mob/user , proximity)
+	if(busy)
+		return
 	if(!proximity) return
 	if(!target.reagents) return
 
@@ -81,7 +84,9 @@
 					if(target != user)
 						target.visible_message("<span class='danger'>[user] is trying to take a blood sample from [target]!</span>", \
 										"<span class='userdanger'>[user] is trying to take a blood sample from [target]!</span>")
+						busy = 1
 						if(!do_mob(user, target))
+							busy = 0
 							return
 					B.holder = src
 					B.volume = amount
@@ -119,11 +124,12 @@
 					B.data["gender"] = T.gender
 					B.data["real_name"] = T.real_name
 					B.data["factions"] = T.faction
-					reagents.reagent_list += B
+					reagents.reagent_list = list(B) // syringes can only hold one blood reagent
 					reagents.update_total()
 					on_reagent_change()
 					reagents.handle_reactions()
 					user.visible_message("<span class='notice'>[user] takes a blood sample from [target].</span>")
+					busy = 0
 
 			else //if not mob
 				if(!target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -124,7 +124,7 @@
 					B.data["gender"] = T.gender
 					B.data["real_name"] = T.real_name
 					B.data["factions"] = T.faction
-					reagents.reagent_list = list(B) // syringes can only hold one blood reagent
+					reagents.reagent_list += B
 					reagents.update_total()
 					on_reagent_change()
 					reagents.handle_reactions()


### PR DESCRIPTION
Fixes syringe bug from #6372 

Ok so the main problem was that `/obj/item/weapon/reagent_containers/syringe/afterattack` checked if the syringe was full or had blood _before_ sleeping in `do_mob`. So if you clicked it rapidly, the procs would pass through the checks okay and then after sleeping they would continue and overfill the syringe. I fixed that by adding an ugly `busy` var that makes sure you don't "queue up" drawing blood. As far as I can tell there's no smarter way to do this.

I also made drawing blood slightly more robust in the future in the sense that instead of appending the blood to the `reagent_list`, it assigns a new list with the blood reagent to it since syringes are only supposed to hold one kind of blood reagent anyways.
