### PR TITLE
Cold temperature slowdown in low gravity environments

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -694,8 +694,8 @@
 
 	if((H.disabilities & FAT) && grav)
 		mspeed += 1.5
-	if(H.bodytemperature < 283.222 && grav)
-		mspeed += (283.222 - H.bodytemperature) / 10 * 1.75
+	if(H.bodytemperature < 283.222)
+		mspeed += (283.222 - H.bodytemperature) / 10 * (grav+0.5)
 
 	mspeed += speedmod
 


### PR DESCRIPTION
As discussed in #6159
This mostly affects hull breaches and cryosting. And the deadliness of space in general.

Tested that it's possible to escape a hull breach instead of getting pushed back by atmos, atleast with the input lag of a local game.

Edit, After more testing:
Returning to station through double airlocks is problematic for the worst case scenario where you don't have a spacesuit or even internals. Stacking slowdowns from damage and temperature may cause you to not be able to pass the second airlock. But this is not caused by me, because by that time you already have gravity under your feet. With this temperature slowdown you just were slower in space and took more damage, but you should know better than to go in space without protection.
