### PR TITLE
Some replica pod cloning fixes

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -81,10 +81,11 @@
 	var/blood_gender = null
 	var/blood_type = null
 	var/factions = null
+	var/contains_sample = 0
 
 /obj/item/seeds/replicapod/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/reagent_containers/syringe))
-		if(ckey == null)
+		if(!contains_sample)
 			for(var/datum/reagent/blood/bloodSample in W.reagents.reagent_list)
 				if(bloodSample.data["mind"] && bloodSample.data["cloneable"] == 1)
 					mind = bloodSample.data["mind"]
@@ -95,6 +96,7 @@
 					factions = bloodSample.data["factions"]
 					W.reagents.clear_reagents()
 					user << "You inject the contents of the syringe into the seeds."
+					contains_sample = 1
 				else
 					user << "The seeds reject the sample!"
 		else


### PR DESCRIPTION
Fixing an issue that would prevent pod cloning from working if the mob leaves its body before blood is drawn

Makes the mob cloning check a little bit more smart by checking mind datums and sanitized keys
