### PR TITLE
Fixes atmos machinery sometimes getting null pipenet.

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -75,7 +75,6 @@
 	..()
 
 /obj/machinery/atmospherics/binary/initialize()
-	src.disconnect(src)
 
 	var/node2_connect = dir
 	var/node1_connect = turn(dir, 180)

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -44,7 +44,6 @@ var/global/list/datum/pipeline/pipe_networks = list()
 var/pipenetwarnings = 10
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/base)
-	base.setPipenet(src)
 	var/volume = 0
 	if(istype(base, /obj/machinery/atmospherics/pipe))
 		var/obj/machinery/atmospherics/pipe/E = base


### PR DESCRIPTION
For binaries and terniaries with null nodes when constructed (i.e no connecting pipes), the same pipenet was used for all parents, because of a useless _setPipenet_ call.
Unwrenching any pipe connected to them would then delete the whole pipenet, on **both sides**.

Fixes #6632 .

Also removed a left-over call from the revamp, in _binaries initialize()_.
