### PR TITLE
Fixes the holosign projector making signs when put into storage. (can_be_placed_into refactor)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -44,6 +44,19 @@
 
 	var/suittoggled = 0
 	var/hooded = 0
+	var/list/can_be_placed_into = list(
+		/obj/structure/table,
+		/obj/structure/rack,
+		/obj/structure/closet,
+		/obj/item/weapon/storage,
+		/obj/structure/safe,
+		/obj/machinery/disposal
+	)
+/obj/item/proc/check_allowed_items(atom/target, not_inside)
+	if((src in target) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
+		return 0
+	else
+		return 1
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'

--- a/code/game/objects/items/weapons/janisigns.dm
+++ b/code/game/objects/items/weapons/janisigns.dm
@@ -12,9 +12,19 @@
 	origin_tech = "programming=3"
 	var/list/signs = list()
 	var/max_signs = 10
+	can_be_placed_into = list(
+		/obj/machinery/r_n_d/destructive_analyzer,
+		/obj/structure/table,
+		/obj/structure/rack,
+		/obj/structure/closet,
+		/obj/item/weapon/storage,
+		/obj/structure/safe,
+		/obj/machinery/disposal
+	)
 
 /obj/item/weapon/holosign_creator/afterattack(atom/target, mob/user, flag)
 	if(flag)
+		if(!check_allowed_items(target, 1)) return
 		var/turf/T = get_turf(target)
 		var/obj/effect/overlay/holograph/H = locate() in T
 		if(H)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -471,13 +471,6 @@
 	force = 10
 	throwforce = 10
 	var/cooldown = 0
-	var/list/can_be_placed_into = list(
-		/obj/structure/table,
-		/obj/structure/closet,
-		/obj/item/weapon/storage,
-		/obj/structure/safe,
-		/obj/machinery/disposal
-		)
 
 /obj/item/weapon/resonator/proc/CreateResonance(var/target, var/creator)
 	if(cooldown <= 0)
@@ -493,12 +486,8 @@
 	..()
 
 /obj/item/weapon/resonator/afterattack(atom/target, mob/user, proximity_flag)
-	if(target in user.contents)
-		return
 	if(proximity_flag)
-		for(var/type in can_be_placed_into)
-			if(istype(target, type))
-				return
+		if(!check_allowed_items(target, 1)) return
 		CreateResonance(target, user)
 
 /obj/effect/resonance

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -12,11 +12,13 @@
 	volume = 50
 	flags = OPENCONTAINER
 
-	var/list/can_be_placed_into = list(
+	can_be_placed_into = list(
 		/obj/machinery/chem_master/,
 		/obj/machinery/chem_dispenser/,
 		/obj/machinery/reagentgrinder,
+		/obj/machinery/biogenerator,
 		/obj/structure/table,
+		/obj/structure/rack,
 		/obj/structure/closet,
 		/obj/structure/sink,
 		/obj/item/weapon/storage,
@@ -35,10 +37,7 @@
 
 
 /obj/item/weapon/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
-	if(!proximity) return // not adjacent
-	for(var/type in can_be_placed_into)
-		if(istype(target, type))
-			return
+	if((!proximity) || !check_allowed_items(target)) return
 
 	if(ismob(target) && target.reagents && reagents.total_volume)
 		var/mob/M = target


### PR DESCRIPTION
Creates an item proc that check's the object's can_be_placed_into list as well as if the item is currently inside the target and optionally checks if the target's loc is something other than a turf.

Fixes #6831 (the holosign projector making signs when put into storage), as well as the resonator and holosign projector firing when used on something inside a container or the user.
