### PR TITLE
Make the master controller always process at the maximum rate

### DIFF
--- a/code/controllers/failsafe.dm
+++ b/code/controllers/failsafe.dm
@@ -21,7 +21,7 @@ var/datum/controller/failsafe/Failsafe
 			if(!master_controller)		new /datum/controller/game_controller()	//replace the missing master_controller! This should never happen.
 
 			if(processing_interval > 0)
-				if(master_controller.processing_interval > 0)	//only poke if these overrides aren't in effect
+				if(master_controller.processing)	//only poke if these overrides aren't in effect
 					if(MC_iteration == master_controller.iteration)	//master_controller hasn't finished processing in the defined interval
 						switch(MC_defcon)
 							if(0 to 3)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -675,7 +675,7 @@ var/list/slot_equipment_priority = list( \
 			stat("Instances:","[world.contents.len]")
 
 			if(master_controller)
-				stat("MasterController:","[round(master_controller.cost,0.001)]ds (Interval:[master_controller.processing_interval] | Iteration:[master_controller.iteration])")
+				stat("MasterController:","[round(master_controller.cost,0.001)]ds (Processing:[master_controller.processing] | Iteration:[master_controller.iteration])")
 				for(var/datum/subsystem/SS in master_controller.subsystems)
 					if(SS.can_fire)
 						SS.stat_entry()


### PR DESCRIPTION
I need a subsystem (keyboard input reading) that fires every tick so that higher fps rates don't drop keyboard input. This will cause the MC's reported cpu usage to be lower than the truth due to averaging in many non-processing ticks.

If desired I could include this change in with the pull request I need it for, but I think this is better to test separately.
