### PR TITLE
Adds briefcase with cash to uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -571,7 +571,7 @@ var/list/uplink_items = list()
 	desc = "A secure briefcase containing 5000 space credits. Useful for bribing personnel, or purchasing goods and services at lucrative prices. \
 	The briefcase also feels a little heavier to hold; it has been manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/weapon/storage/secure/briefcase/syndie
-	cost = 2
+	cost = 1
 
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -566,6 +566,13 @@ var/list/uplink_items = list()
 	excludefrom = list(/datum/game_mode/nuclear)
 	surplus = 40
 
+/datum/uplink_item/badass/syndiecash
+	name = "Syndicate Briefcase Full of Cash"
+	desc = "A secure briefcase containing 5000 space credits. Useful for bribing personnel, or purchasing goods and services at lucrative prices. \
+	The briefcase also feels a little heavier to hold; it has been manufactured to pack a little bit more of a punch if your client needs some convincing."
+	item = /obj/item/weapon/storage/secure/briefcase/syndie
+	cost = 2
+
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"
 	desc = "A useless red balloon with the syndicate logo on it, which can blow the deepest of covers."

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -189,6 +189,15 @@
 	src.add_fingerprint(user)
 	return
 
+//Syndie variant of Secure Briefcase. Contains space cash, slightly more robust.
+/obj/item/weapon/storage/secure/briefcase/syndie
+	force = 15.0
+
+/obj/item/weapon/storage/secure/briefcase/syndie/New()
+	..()
+	for(var/i = 0, i < 5, i++)
+		new /obj/item/weapon/spacecash/c1000(src)
+
 // -----------------------------
 //        Secure Safe
 // -----------------------------

--- a/html/changelogs/fleure-PR-6871.yml
+++ b/html/changelogs/fleure-PR-6871.yml
@@ -1,0 +1,11 @@
+# Your name.
+author: fleure
+# Optional: Remove this file after generating master changelog. Useful for PR changelogs that won't get used again.
+delete-after: True
+# Any changes you've made. See valid prefix list above.
+# INDENT WITH TWO SPACES. NOT TABS. SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading. Just remove the brackets when you add new shit.
+# Please surround your changes in single (') or double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+- rscadd: "Added briefcase filled with cash to uplink."


### PR DESCRIPTION
Adds a secure briefcase filled with 5000 space credits as a pointless badassery traitor and nuke-ops item. The briefcase is also slightly more robust (8->15 brute damage). Costs 2TC on account of the extra robustness.

Update: Changed to 1 TC
