### PR TITLE
Prevents "AI Holopad Request" Spam

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -45,6 +45,9 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	if(!istype(user))
 		return
 	if(alert(user,"Would you like to request an AI's presence?",,"Yes","No") == "Yes")
+		if(get_dist(src, user) > 1) //also prevents request spam!
+			user << "<span class='notice'>You are too far from the holopad.</span>"
+			return
 		if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!
 			last_request = world.time
 			user << "<span class='notice'>You request an AI's presence.</span>"

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -45,7 +45,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	if(!istype(user))
 		return
 	if(alert(user,"Would you like to request an AI's presence?",,"Yes","No") == "Yes")
-		if(get_dist(src, user) > 1) //also prevents request spam!
+		if(!Adjacent(user)) //also prevents request spam!
 			user << "<span class='notice'>You are too far from the holopad.</span>"
 			return
 		if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!


### PR DESCRIPTION
Fixes an easy way to spam holopad requests from multiple holopads all at
once. TODO: walk up to a holopad and open the prompt but select no option. Walk up to a dozen more, repeating the same process. Finally, hit "Yes" on all the prompts and watch as the AI goes insane. This adds in a check to make sure the player is within range of the holopad (1 tile adjacent) for the request to be accepted.
