### PR TITLE
Fixes mimic spawning in nullspace

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -193,7 +193,7 @@
 				audible_message("<span class='notice'>You hear a loud electrical buzzing sound!</span>")
 				src << "<span class='warning'>Reprogramming machine behaviour...</span>"
 				spawn(50)
-					if(M)
+					if(M && !M.gc_destroyed)
 						new /mob/living/simple_animal/hostile/mimic/copy/machine(get_turf(M), M, src, 1)
 			else src << "<span class='notice'>Out of uses.</span>"
 	else src << "<span class='notice'>That's not a machine.</span>"

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -51,7 +51,7 @@
 
 	if(!vendingMachines.len)	//if every machine is infected
 		for(var/obj/machinery/vending/upriser in infectedMachines)
-			if(prob(70))
+			if(prob(70) && !upriser.gc_destroyed)
 				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()


### PR DESCRIPTION
Happened when a Malf AI overridden a machinery that was qdel'ed.

Also prevents an _extreme edge_ case with the brand intelligence event, that could happen when all the vending machine were infected

Fixes number 1 of #6351.
