### PR TITLE
Fixes non-cultists making cultist constructs.

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -200,6 +200,9 @@ proc/makeNewConstruct(var/mob/living/simple_animal/construct/ctype, var/mob/targ
 	S.faction |= "\ref[U]" //Add the master as a faction, allowing inter-mob cooperation
 	if(iscultist(U))
 		ticker.mode.add_cultist(S.mind,2)
+	else
+		if(iscultist(S))
+			ticker.mode.remove_cultist(S.mind)
 	S.cancel_camera()
 	C.icon_state = "soulstone2"
 	C.name = "Soul Stone: [S.real_name]"


### PR DESCRIPTION
So, when I fixed non-cultists making cultist constructs before, I forgot to take the shardee's cultist status into account. This fixes that, so that cultists sharded by non-cultists will lose their cult status. No more cult-hunting constructs with the ability to tell who all the cultists are.
