### PR TITLE
Adds a new spell, Repulse.

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -267,7 +267,7 @@
 	invocation = "GITTAH WEIGH"
 	invocation_type = "shout"
 	range = 5
-	cooldown_min = 200 //50 deciseconds reduction per rank
+	cooldown_min = 150
 	selection_type = "view"
 	var/maxthrow = 5
 

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -295,10 +295,10 @@
 				var/mob/living/M = AM
 				M.Weaken(5)
 				M.adjustBruteLoss(5)
-				M << "You're slammed into the floor by a mystical force!"
+				M << "<span class='userdanger'>You're slammed into the floor by a mystical force!</span>"
 		else
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
 				M.Weaken(2)
-				M << "You're thrown back by a mystical force!"
+				M << "<span class='userdanger'>You're thrown back by a mystical force!</span>"
 			spawn(0) AM.throw_at(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1)//So stuff gets tossed around at the same time.

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -258,3 +258,50 @@
 	ex_heavy = -1
 	ex_light = 2
 	ex_flash = 5
+
+/obj/effect/proc_holder/spell/aoe_turf/repulse
+	name = "Repulse"
+	desc = "This spell throws everything around the user away.."
+	charge_max = 400
+	clothes_req = 1
+	invocation = "GITTAH WEIGH"
+	invocation_type = "shout"
+	range = 5
+	cooldown_min = 200 //50 deciseconds reduction per rank
+	selection_type = "view"
+	var/maxthrow = 5
+
+/obj/effect/proc_holder/spell/aoe_turf/repulse/cast(list/targets)
+	var/mob/user = usr
+	var/list/thrownatoms = list()
+	var/atom/throwtarget
+	var/distfromcaster
+	for(var/turf/T in targets) //Done this way so things don't get thrown all around hilariously.
+		for(var/atom/movable/AM in T)
+			thrownatoms += AM
+	
+	for(var/atom/movable/AM in thrownatoms)
+		if(AM == user || AM.anchored) continue
+	
+		var/obj/effect/overlay/targeteffect = new /obj/effect/overlay(AM.loc)
+		targeteffect.icon = "icons/effects/effects.dmi"
+		targeteffect.icon_state = "shieldsparkles"
+		targeteffect.anchored = 1
+		targeteffect.density = 0
+
+		throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(AM, user)))
+		distfromcaster = get_dist(user, AM)
+		if(distfromcaster == 0)
+			if(istype(AM, /mob/living))
+				var/mob/living/M = AM
+				M.Weaken(5)
+				M.adjustBruteLoss(5)
+				M << "You're slammed into the floor by an invisible force!"
+				spawn(10) qdel(targeteffect)
+		else
+			if(istype(AM, /mob/living))
+				var/mob/living/M = AM
+				M.Weaken(2)
+				M << "You're thrown back by an invisible force!"
+			spawn(10) qdel(targeteffect)
+			spawn(0) AM.throw_at(throwtarget, (Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow)), 1)//So stuff gets tossed around at the same time.

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -261,7 +261,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/repulse
 	name = "Repulse"
-	desc = "This spell throws everything around the user away.."
+	desc = "This spell throws everything around the user away."
 	charge_max = 400
 	clothes_req = 1
 	invocation = "GITTAH WEIGH"
@@ -283,25 +283,22 @@
 	for(var/atom/movable/AM in thrownatoms)
 		if(AM == user || AM.anchored) continue
 	
-		var/obj/effect/overlay/targeteffect = new /obj/effect/overlay(AM.loc)
-		targeteffect.icon = "icons/effects/effects.dmi"
-		targeteffect.icon_state = "shieldsparkles"
-		targeteffect.anchored = 1
-		targeteffect.density = 0
-
+		var/obj/effect/overlay/targeteffect	= new /obj/effect/overlay{icon='icons/effects/effects.dmi'; icon_state="shieldsparkles"; mouse_opacity=0; density = 0}()
+		AM.overlays += targeteffect
 		throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(AM, user)))
 		distfromcaster = get_dist(user, AM)
+		spawn(10)
+			AM.overlays -= targeteffect
+			qdel(targeteffect)
 		if(distfromcaster == 0)
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
 				M.Weaken(5)
 				M.adjustBruteLoss(5)
-				M << "You're slammed into the floor by an invisible force!"
-				spawn(10) qdel(targeteffect)
+				M << "You're slammed into the floor by a mystical force!"
 		else
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
 				M.Weaken(2)
-				M << "You're thrown back by an invisible force!"
-			spawn(10) qdel(targeteffect)
-			spawn(0) AM.throw_at(throwtarget, (Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow)), 1)//So stuff gets tossed around at the same time.
+				M << "You're thrown back by a mystical force!"
+			spawn(0) AM.throw_at(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1)//So stuff gets tossed around at the same time.

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -261,6 +261,7 @@
 						if("repulse")
 							feedback_add_details("wizard_spell_learned","RP") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							H.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/repulse(null)
+							temp = "You have learned repulse."
 						if("smoke")
 							feedback_add_details("wizard_spell_learned","SM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							H.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/smoke(null)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -62,6 +62,9 @@
 		dat += "<A href='byond://?src=\ref[src];spell_choice=disabletech'>Disable Technology</A> (60)<BR>"
 		dat += "<I>This spell disables all weapons, cameras and most other technology in range.</I><BR>"
 
+		dat += "<A href='byond://?src=\ref[src];spell_choice=repulse'>Repulse</A> (40)<BR>"
+		dat += "<I>This spell throws nearby objects away from you and knocks creatures down.</I><BR>"
+
 		dat += "<A href='byond://?src=\ref[src];spell_choice=smoke'>Smoke</A> (10)<BR>"
 		dat += "<I>This spell spawns a cloud of choking smoke at your location and does not require wizard garb.</I><BR>"
 
@@ -205,7 +208,7 @@
 				uses--
 			/*
 			*/
-				var/list/available_spells = list(magicmissile = "Magic Missile", fireball = "Fireball", disintegrate = "Disintegrate", disabletech = "Disable Tech", smoke = "Smoke", blind = "Blind", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate", etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", fleshtostone = "Flesh to Stone", summonitem = "Instant Summons", summonguns = "Summon Guns", summonmagic = "Summon Magic", summonevents = "Summon Events", staffchange = "Staff of Change", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation", staffchaos = "Staff of Chaos", staffdoor = "Staff of Door Creation", wands = "Wand Assortment")
+				var/list/available_spells = list(magicmissile = "Magic Missile", fireball = "Fireball", disintegrate = "Disintegrate", disabletech = "Disable Tech", repulse = "Repulse", smoke = "Smoke", blind = "Blind", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate", etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", fleshtostone = "Flesh to Stone", summonitem = "Instant Summons", summonguns = "Summon Guns", summonmagic = "Summon Magic", summonevents = "Summon Events", staffchange = "Staff of Change", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation", staffchaos = "Staff of Chaos", staffdoor = "Staff of Door Creation", wands = "Wand Assortment")
 				var/already_knows = 0
 				for(var/obj/effect/proc_holder/spell/aspell in H.mind.spell_list)
 					if(available_spells[href_list["spell_choice"]] == initial(aspell.name))
@@ -255,6 +258,9 @@
 							feedback_add_details("wizard_spell_learned","DT") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							H.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech(null)
 							temp = "You have learned disable technology."
+						if("repulse")
+							feedback_add_details("wizard_spell_learned","RP") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
+							H.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/repulse(null)
 						if("smoke")
 							feedback_add_details("wizard_spell_learned","SM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 							H.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/smoke(null)

--- a/html/changelogs/Boggart-PR-6963.yml
+++ b/html/changelogs/Boggart-PR-6963.yml
@@ -1,0 +1,6 @@
+author: Boggart
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a new spell: Repulse. (Cooldown: 40 seconds, 15 at max upgrade.) Repulse throws objects and creatures within 5 tiles of the caster away and stuns them for a very short time. Distance thrown decreases as the distance from the caster increases. (Max of 5, minimum of 3) Casting it while standing over someone will stun them for longer and cause brute damage but will not throw them."


### PR DESCRIPTION
Repulse has a cooldown of 40 seconds, 15 with max upgrade.

It knocks down (short, weaken(2)) and throws away everything within a 5 tile range (thowforce depends on the distance from the caster, minimum of three, max of 5). If you're standing on someone when you use it they take damage and are stunned for longer. (weaken(5))

It's mostly intended for throwing back pursuers and making them drop their guns, but you can also launch grenades back at the thrower, launch soap at pursuers and shoot hoops with it.
