### PR TITLE
Ear damage/deafness tidying

### DIFF
--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -35,8 +35,8 @@ Bonus
 			if(5)
 				if(!(M.ear_deaf))
 					M << "<span class='danger'>Your ears pop and begin ringing loudly!</span>"
-					M.ear_deaf = INFINITY //Shall be enough
+					M.setEarDamage(-1,INFINITY) //Shall be enough
 					spawn(200)
 						if(M)
-							M.ear_deaf = 0
+							M.setEarDamage(-1,0)
 	return

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -11,7 +11,7 @@
 	for(var/mob/living/M in get_hearers_in_view(4, user))
 		if(iscarbon(M))
 			if(!M.mind || !M.mind.changeling)
-				M.ear_deaf += 30
+				M.adjustEarDamage(0,30)
 				M.confused += 20
 				M.Jitter(50)
 			else

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -883,7 +883,7 @@ var/list/sacrificed = list()
 			var/obj/item/weapon/nullrod/N = locate() in C
 			if(N)
 				continue
-			C.ear_deaf += 50
+			C.adjustEarDamage(0, 50)
 			C.show_message("<span class='danger'>The world around you suddenly becomes quiet.</span>", 3)
 			affected++
 			if(prob(1) && ishuman(C))
@@ -902,7 +902,7 @@ var/list/sacrificed = list()
 			var/obj/item/weapon/nullrod/N = locate() in C
 			if(N)
 				continue
-			C.ear_deaf += 30
+			C.adjustEarDamage(0, 30)
 			//talismans is weaker.
 			C.show_message("<span class='danger'>The world around you suddenly becomes quiet.</span>", 3)
 			affected++

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -131,7 +131,7 @@
 		M << "<font color='red' size='7'>HONK</font>"
 		M.sleeping = 0
 		M.stuttering += 20
-		M.ear_deaf += 30
+		M.adjustEarDamage(0, 30)
 		M.Weaken(3)
 		if(prob(30))
 			M.Stun(10)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -58,8 +58,7 @@
 	if(!ear_safety)
 		M.Stun(max(10/distance, 3))
 		M.Weaken(max(10/distance, 3))
-		M.ear_damage += rand(0, 5)
-		M.ear_deaf = max(M.ear_deaf,15)
+		M.setEarDamage(M.ear_damage + rand(0, 5), max(M.ear_deaf,15))
 		if (M.ear_damage >= 15)
 			M << "<span class='warning'>Your ears start to ring badly!</span>"
 			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -46,15 +46,13 @@
 
 			f_loss += 60
 
-			ear_damage += 30
-			ear_deaf += 120
+			adjustEarDamage(30, 120)
 
 		if(3.0)
 			b_loss += 30
 			if (prob(50) && !shielded)
 				Paralyse(1)
-			ear_damage += 15
-			ear_deaf += 60
+			adjustEarDamage(15 , 60)
 
 	adjustBruteLoss(b_loss)
 	adjustFireLoss(f_loss)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -132,11 +132,11 @@
 
 		//Ears
 		if(disabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
+			setEarDamage(-1, max(ear_deaf, 1))
+		else
+			adjustEarDamage(-1, (ear_damage < 25 ? -0.05 : 0))
+			//deafness, heals slowly over time
+			//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
 
 		//Other
 		if(stunned)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -50,15 +50,13 @@
 
 			f_loss += 60
 
-			ear_damage += 30
-			ear_deaf += 120
+			adjustEarDamage(30,120)
 
 		if(3.0)
 			b_loss += 30
 			if (prob(50))
 				Paralyse(1)
-			ear_damage += 15
-			ear_deaf += 60
+			adjustEarDamage(15,60)
 
 	adjustBruteLoss(b_loss)
 	adjustFireLoss(f_loss)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -109,12 +109,12 @@
 			eye_blurry = max(eye_blurry-1, 0)
 
 		//Ears
-		if(disabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
-		else if(ear_damage < 25)	//ear damage heals slowly under this threshold.
-			ear_damage = max(ear_damage-0.05, 0)
+		if(disabilities & DEAF)		//disabled-deaf, doesn't get better on its own
+			setEarDamage(-1, max(ear_deaf, 1))
+		else
+			adjustEarDamage(-1, (ear_damage < 25 ? -0.05 : 0))
+			//deafness, heals slowly over time
+			//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
 
 		//Other
 		if(stunned)

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -144,7 +144,7 @@
 					emp_damage = 30//Let's not overdo it
 				if(21 to 30)//High level of EMP damage, unable to see, hear, or speak
 					eye_blind = max(eye_blind, 1)
-					ear_deaf = 1
+					setEarDamage(-1,1)
 					silent = 1
 					if(!alert)//Sounds an alarm, but only once per 'level'
 						emote("alarm")
@@ -155,12 +155,12 @@
 				if(20)
 					alert = 0
 					eye_blind = 0
-					ear_deaf = 0
+					setEarDamage(-1,0)
 					silent = 0
 					emp_damage -= 1
 				if(11 to 19)//Moderate level of EMP damage, resulting in nearsightedness and ear damage
 					eye_blurry = 1
-					ear_damage = 1
+					setEarDamage(1,-1)
 					if(!alert)
 						emote("alert")
 						src << "<span class='danger'>Primary systems are now online.</span>"
@@ -170,7 +170,7 @@
 				if(10)
 					alert = 0
 					eye_blurry = 0
-					ear_damage = 0
+					setEarDamage(0,-1)
 					emp_damage -= 1
 				if(2 to 9)//Low level of EMP damage, has few effects(handled elsewhere)
 					if(!alert)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -104,8 +104,7 @@
 				f_loss = f_loss/1.5
 
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
-				ear_damage += 30
-				ear_deaf += 120
+				adjustEarDamage(30, 120)
 			if (prob(70) && !shielded)
 				Paralyse(10)
 
@@ -114,8 +113,7 @@
 			if (prob(getarmor(null, "bomb")))
 				b_loss = b_loss/2
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
-				ear_damage += 15
-				ear_deaf += 60
+				adjustEarDamage(15,60)
 			if (prob(50) && !shielded)
 				Paralyse(10)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -473,18 +473,12 @@
 
 		//Ears
 		if(disabilities & DEAF)	//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
-		else
-			/* might be better to create a variable here, and instead of doing this nested for. */
-			// deafness heals slowly over time, unless ear_damage is over 100
-			if (ear_damage < 100)
-				// Heal the first 1/3 here
-				ear_deaf = max(ear_deaf - 1, 0)
-				ear_damage = max(ear_damage-0.05, 0)
-				if(istype(ears, /obj/item/clothing/ears/earmuffs)) // earmuffs rest your ears, healing 3x faster, but keeping you deaf.
-					// Heal the 2/3 here
-					ear_deaf = max(ear_deaf, 1)
-					ear_damage = max(ear_damage-0.10, 0)
+			setEarDamage(-1, max(ear_deaf, 1))
+		else if (ear_damage < 100) // deafness heals slowly over time, unless ear_damage is over 100
+			if(istype(ears, /obj/item/clothing/ears/earmuffs)) // earmuffs rest your ears, healing 3x faster, but keeping you deaf.
+				setEarDamage(max(ear_damage-0.15, 0), max(ear_deaf - 1, 1))
+			else
+				adjustEarDamage(-0.05, -1)
 
 		//Dizziness
 		if(dizziness)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -391,14 +391,11 @@
 
 		//Ears
 		if(disabilities & DEAF)		//disabled-deaf, doesn't get better on its own
-			ear_deaf = max(ear_deaf, 1)
+			setEarDamage(-1, max(ear_deaf, 1))
 		else
-			/* might be better to create a variable here, and instead of doing this nested for. */
 			// deafness heals slowly over time, unless ear_damage is over 100
 			if (ear_damage < 100)
-				// Heal the first 1/3 here
-				ear_deaf = max(ear_deaf - 1, 0)
-				ear_damage = max(ear_damage-0.05, 0)
+				adjustEarDamage(-0.05,-1)
 
 		//Other
 		if(stunned)

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -235,16 +235,12 @@
 		src.eye_blind = 0
 		src.eye_blind = max(eye_blind, 1)
 
-	if (src.ear_deaf > 0) src.ear_deaf = 0
-	if (src.ear_damage < 25)
-		src.ear_damage = 0
+	setEarDamage((ear_damage < 25 ? 0 : ear_damage),(disabilities & DEAF ? 1 :0))
 
 	src.density = !( src.lying )
 
 	if (src.disabilities & BLIND)
 		src.eye_blind = max(eye_blind, 1)
-	if (src.disabilities & DEAF)
-		src.ear_deaf = 1
 
 	if (src.eye_blurry > 0)
 		src.eye_blurry = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -277,9 +277,6 @@ Sorry Giacom. Please don't be mad :(
 
 // MOB PROCS //END
 
-
-/mob/proc/get_contents()
-
 /mob/living/proc/mob_sleep()
 	set name = "Sleep"
 	set category = "IC"
@@ -291,6 +288,7 @@ Sorry Giacom. Please don't be mad :(
 		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
 			usr.sleeping = 20 //Short nap
 
+/mob/proc/get_contents()
 
 /mob/living/proc/lay_down()
 	set name = "Rest"
@@ -343,6 +341,17 @@ Sorry Giacom. Please don't be mad :(
 	var/obj/item/organ/limb/def_zone = ran_zone(t)
 	return def_zone
 
+//damage/heal the mob ears and adjust the deaf amount
+/mob/living/adjustEarDamage(var/damage, var/deaf)
+	ear_damage = max(0, ear_damage + damage)
+	ear_deaf = max(0, ear_deaf + deaf)
+
+//pass a negative argument to skip one of the variable
+/mob/living/setEarDamage(var/damage, var/deaf)
+	if(damage >= 0)
+		ear_damage = damage
+	if(deaf >= 0)
+		ear_deaf = deaf
 
 // heal ONE external organ, organ gets randomly selected from damaged ones.
 /mob/living/proc/heal_organ_damage(var/brute, var/burn)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -170,7 +170,7 @@ var/const/VOX_DELAY = 600
 		if(!only_listener)
 			// Play voice for all mobs in the z level
 			for(var/mob/M in player_list)
-				if(M.client)
+				if(M.client && !M.ear_deaf)
 					var/turf/T = get_turf(M)
 					if(T.z == z_level)
 						M << voice

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -110,17 +110,10 @@
 	if (src.eye_blind)
 		src.eye_blind--
 
-	if (src.ear_deaf > 0) src.ear_deaf--
-	if (src.ear_damage < 25)
-		src.ear_damage -= 0.05
-		src.ear_damage = max(src.ear_damage, 0)
-
 	src.density = !( src.lying )
 
 	if (src.disabilities & BLIND)
 		src.eye_blind = max(1, eye_blind)
-	if (src.disabilities & DEAF)
-		src.ear_deaf = 1
 
 	if (src.eye_blurry > 0)
 		src.eye_blurry--

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -408,3 +408,9 @@
 			visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent.</span>", \
 						"<span class='userdanger'>[M] punches [src], but doesn't leave a dent.!</span>")
 	return 0
+
+/mob/living/silicon/adjustEarDamage()
+	return
+
+/mob/living/silicon/setEarDamage()
+	return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -109,6 +109,8 @@
 	if(paralysis)
 		AdjustParalysis(-1)
 
+	adjustEarDamage((ear_damage < 25 ? -0.05 : 0), -1)
+
 	//Movement
 	if(!client && !stop_automated_movement && wander)
 		if(isturf(src.loc) && !resting && !buckled && canmove)		//This is so it only moves if it's not inside a closet, gentics machine, etc.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -941,3 +941,9 @@ var/list/slot_equipment_priority = list( \
 				if(G.can_reenter_corpse || even_if_they_cant_reenter)
 					return G
 				break
+
+/mob/proc/adjustEarDamage()
+	return
+
+/mob/proc/setEarDamage()
+	return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -47,10 +47,10 @@
 	var/next_move = null
 	var/notransform = null	//Carbon
 	var/hand = null
-	var/eye_blind = null	//Carbon
-	var/eye_blurry = null	//Carbon
-	var/ear_deaf = null		//Carbon
-	var/ear_damage = null	//Carbon
+	var/eye_blind = 0		//Carbon
+	var/eye_blurry = 0		//Carbon
+	var/ear_deaf = 0		//Carbon
+	var/ear_damage = 0		//Carbon
 	var/stuttering = null	//Carbon
 	var/real_name = null
 	var/bhunger = 0			//Carbon
@@ -110,10 +110,6 @@
 	var/music_lastplayed = "null"
 
 	var/job = null//Living
-
-	var/const/blindness = 1//Carbon
-	var/const/deafness = 2//Carbon
-	var/const/muteness = 4//Carbon
 
 	var/radiation = 0//Carbon
 

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -304,8 +304,7 @@ datum/reagent/medicine/inacusiate
 	color = "#6600FF" // rgb: 100, 165, 255
 
 datum/reagent/medicine/inacusiate/on_mob_life(var/mob/living/M as mob)
-	M.ear_damage = 0
-	M.ear_deaf = 0
+	M.setEarDamage(0,0)
 	..()
 	return
 


### PR DESCRIPTION
#### Ear damage/deafness tidying
- OOP'ed ear damages/deafness status updating
- **Silicons** are now immuned to ear damages/deafness (fixes #6614)
- Only living mobs can now take ear damages/be deafened (fixes #4968)
- Simple animals are now healing ear damages/deafness at the same rate as other living mobs (fixes #6442, fixes #6390)
- Deaf people can't hear AI announcements anymore (fixes #5177)
