### PR TITLE
Magic Mania 1.83: Attack of the Flying Invisible Magic Brains!

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -25,6 +25,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 	var/clothes_req = 1 //see if it requires clothes
 	var/human_req = 0 //spell can only be cast by humans
+	var/nonabstract_req = 0 //spell can only be cast by mobs that are physical entities
 	var/stat_allowed = 0 //see if it requires being conscious/alive, need to set to 1 for ghostpells
 	var/invocation = "HURP DURP" //what is uttered when the wizard casts the spell
 	var/invocation_emote_self = null
@@ -94,6 +95,9 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	else
 		if(clothes_req || human_req)
 			user << "<span class='notice'>This spell can only be cast by humans!</span>"
+			return 0
+		if(nonabstract_req && (isbrain(user) || ispAI(user)))
+			user << "<span class='notice'>This spell can only be cast by physical beings!</span>"
 			return 0
 
 	if(!skipcharge)

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -1,6 +1,7 @@
 /obj/effect/proc_holder/spell/targeted/area_teleport
 	name = "Area teleport"
 	desc = "This spell teleports you to a type of area of your selection."
+	nonabstract_req = 1
 
 	var/randomise_selection = 0 //if it lets the usr choose the teleport loc or picks it from the list
 	var/invocation_area = 1 //if the invocation appends the selected area

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -11,6 +11,7 @@
 	cooldown_min = 100 //50 deciseconds reduction per rank
 	include_user = 1
 	centcom_cancast = 0 //Prevent people from getting to centcom
+	nonabstract_req = 1
 	var/jaunt_duration = 50 //in deciseconds
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets) //magnets, so mostly hardcoded

--- a/code/datums/spells/turf_teleport.dm
+++ b/code/datums/spells/turf_teleport.dm
@@ -1,6 +1,7 @@
 /obj/effect/proc_holder/spell/targeted/turf_teleport
 	name = "Turf Teleport"
 	desc = "This spell teleports the target to the turf in range."
+	nonabstract_req = 1
 
 	var/inner_tele_radius = 1
 	var/outer_tele_radius = 2


### PR DESCRIPTION
Locks up teleportation spells behind a var, nonabstract_req, that keeps pAI and brain mobs from leaving their respective jail objects.

The crew is none the less emphatically warned of the hilarious danger of putting magic brains in MMIs.

![7fa](https://cloud.githubusercontent.com/assets/4176358/5698532/d622a52c-99dd-11e4-99dc-5757a5426cc3.jpg)

Fixes #6983
