### PR TITLE
Fixes incorrect icon for exosuit control console.

### DIFF
--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -66,7 +66,7 @@
 	if(stat & BROKEN)
 		icon_state = "mechab"
 		return
-	icon_state = "mecha0"
+	icon_state = "mecha"
 
 /obj/item/mecha_parts/mecha_tracking
 	name = "exosuit tracking beacon"

--- a/html/changelogs/Boggart-PR-6994.yml
+++ b/html/changelogs/Boggart-PR-6994.yml
@@ -1,0 +1,6 @@
+author: Boggart
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the Exosuit Control Console having the unpowered icon state while powered."


### PR DESCRIPTION
Fixes incorrect icon for powered exosuit control console, it was accidentally setting the icon state to the unpowered one.
