### PR TITLE
Reorder error check for manifest length

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -254,7 +254,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	slip.ordernumber = ordernum
 
 	var/stationName = (errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
-	var/packagesAmt = SSshuttle.shoppinglist.len + ((errors & MANIFEST_ERROR_COUNT) ? 0 : rand(1,2))
+	var/packagesAmt = SSshuttle.shoppinglist.len + ((errors & MANIFEST_ERROR_COUNT) ? rand(1,2) : 0)
 
 	slip.info = "<h3>[command_name()] Shipping Manifest</h3><hr><br>"
 	slip.info +="Order #[ordernum]<br>"


### PR DESCRIPTION
Manifests were reporting an incorrect size when there were no errors in the manifest.

Fixes #6995 
