### PR TITLE
Fixes some runtimes from audible_message proc. 

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -460,7 +460,7 @@
 							customrecepient.tnote += "<i><b>&larr; From <a href='byond://?src=\ref[customrecepient];choice=Message;target=\ref[src]'>[customsender]</a> ([customjob]):</b></i><br>[custommessage]<br>"
 							if (!customrecepient.silent)
 								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								customrecepient.loc.audible_message("\icon[customrecepient] *[customrecepient.ttone]*", null, 3)
+								customrecepient.audible_message("\icon[customrecepient] *[customrecepient.ttone]*", null, 3)
 								if( customrecepient.loc && ishuman(customrecepient.loc) )
 									var/mob/living/carbon/human/H = customrecepient.loc
 									H << "\icon[customrecepient] <b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
@@ -473,7 +473,7 @@
 							customrecepient.tnote += "<i><b>&larr; From <a href='byond://?src=\ref[customrecepient];choice=Message;target=\ref[PDARec]'>[PDARec.owner]</a> ([customjob]):</b></i><br>[custommessage]<br>"
 							if (!customrecepient.silent)
 								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								customrecepient.loc.audible_message("\icon[customrecepient] *[customrecepient.ttone]*", null, 3)
+								customrecepient.audible_message("\icon[customrecepient] *[customrecepient.ttone]*", null, 3)
 								if( customrecepient.loc && ishuman(customrecepient.loc) )
 									var/mob/living/carbon/human/H = customrecepient.loc
 									H << "\icon[customrecepient] <b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[customrecepient];choice=Message;skiprefresh=1;target=\ref[PDARec]'>Reply</a>)"

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -795,9 +795,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			qdel(src)
 		return
 
-	if (src.isbroken)
+	if (isbroken)
 		playsound(src.loc, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
-		src.loc.audible_message("<span class='danger'>[user.name] further abuses the shattered [src.name].</span>", null, 5 )
+		audible_message("<span class='danger'>[user.name] further abuses the shattered [src.name].</span>", null, 5 )
 	else
 		if(istype(I, /obj/item/weapon) )
 			user.do_attack_animation(src)
@@ -805,16 +805,16 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(W.damtype == STAMINA)
 				return
 			if(W.force <15)
-				src.loc.audible_message("<span class='danger'>[user.name] hits the [src.name] with the [W.name] with no visible effect.</span>", null , 5 )
+				audible_message("<span class='danger'>[user.name] hits the [src.name] with the [W.name] with no visible effect.</span>", null , 5 )
 				playsound(src.loc, 'sound/effects/Glasshit.ogg', 100, 1)
 			else
-				src.hitstaken++
-				if(src.hitstaken==3)
-					src.loc.audible_message("<span class='danger'>[user.name] smashes the [src.name]!</span>", null, 5 )
-					src.isbroken=1
+				hitstaken++
+				if(hitstaken==3)
+					audible_message("<span class='danger'>[user.name] smashes the [src.name]!</span>", null, 5 )
+					isbroken=1
 					playsound(src.loc, 'sound/effects/Glassbr3.ogg', 100, 1)
 				else
-					src.loc.audible_message("<span class='danger'>[user.name] forcefully slams the [src.name] with the [I.name]!</span>", null, 5 )
+					audible_message("<span class='danger'>[user.name] forcefully slams the [src.name] with the [I.name]!</span>", null, 5 )
 					playsound(src.loc, 'sound/effects/Glasshit.ogg', 100, 1)
 		else
 			user << "<FONT COLOR='blue'>This does nothing.</FONT>"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -809,7 +809,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 		if (!P.silent)
 			playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-		P.loc.audible_message("\icon[P] *[P.ttone]*", null, 3)
+			P.audible_message("\icon[P] *[P.ttone]*", null, 3)
 		//Search for holder of the PDA.
 		var/mob/living/L = null
 		if(P.loc && isliving(P.loc))
@@ -1150,7 +1150,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		ntrclog[channel] = msg + ntrclog[channel]
 	if (findtext(message, nick) && !silent)
-		loc.audible_message("\icon[src] *[ttone]*", null, 3)
+		audible_message("\icon[src] *[ttone]*", null, 3)
 	new_ntrc_msg++
 
 /obj/item/device/pda/proc/setup_chatrooms() //this can't be done on New() because the messaging server needs to be instanced first

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -88,8 +88,7 @@
 	if((!secured)||(!on)||(cooldown > 0))
 		return 0
 	pulse(0)
-	if(src.loc)
-		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
+	audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -48,8 +48,7 @@
 /obj/item/device/assembly/prox_sensor/sense()
 	if((!secured)||(!scanning)||(cooldown > 0))	return 0
 	pulse(0)
-	if(src.loc)
-		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
+	audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -139,8 +139,7 @@ Code:
 	if(signal.encryption != code)	return 0
 	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
 	pulse(1)
-	if(src.loc)
-		src.loc.audible_message("\icon[src] *beep* *beep*", null, 1)
+	audible_message("\icon[src] *beep* *beep*", null, 1)
 	return
 
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -38,8 +38,7 @@
 	if((!secured)||(cooldown > 0))
 		return 0
 	pulse(0)
-	if(src.loc)
-		src.loc.audible_message("\icon[src] *beep* *beep*", null, 3)
+	audible_message("\icon[src] *beep* *beep*", null, 3)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()

--- a/code/modules/events/ninja.dm
+++ b/code/modules/events/ninja.dm
@@ -1555,7 +1555,7 @@ ________________________________________________________________________________
 			P.tnote += "<i><b>&larr; From [!s_control?(A):"an unknown source"]:</b></i><br>[t]<br>"
 			if (!P.silent)
 				playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-				P.loc.audible_message("\icon[P] *[P.ttone]*", null, 3)
+				P.audible_message("\icon[P] *[P.ttone]*", null, 3)
 			P.overlays.Cut()
 			P.overlays += image('icons/obj/pda.dmi', "pda-r")
 

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -81,5 +81,5 @@
 		if (m_type & 1)
 			visible_message(message)
 		else
-			src.loc.audible_message(message)
+			audible_message(message)
 	return

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -107,5 +107,5 @@
 		if (m_type & 1)
 			visible_message(message)
 		else
-			src.loc.audible_message(message)
+			audible_message(message)
 	return

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -69,4 +69,4 @@
 		if (m_type & 1)
 			visible_message(message)
 		else if (m_type & 2)
-			src.loc.audible_message(message)
+			audible_message(message)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -195,4 +195,4 @@
 		if (m_type & 1)
 			visible_message(message)
 		else if (m_type & 2)
-			src.loc.audible_message(message)
+			audible_message(message)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -342,5 +342,5 @@
 		if (m_type & 1)
 			visible_message(message)
 		else if (m_type & 2)
-			src.loc.audible_message(message)
+			audible_message(message)
 

--- a/code/modules/mob/living/carbon/monkey/emote.dm
+++ b/code/modules/mob/living/carbon/monkey/emote.dm
@@ -77,5 +77,5 @@
 		if (m_type & 1)
 			visible_message(message)
 		else
-			src.loc.audible_message(message)
+			audible_message(message)
 	return

--- a/code/modules/mob/living/carbon/slime/emote.dm
+++ b/code/modules/mob/living/carbon/slime/emote.dm
@@ -82,7 +82,7 @@
 		if (m_type & 1)
 			visible_message(message)
 		else
-			src.loc.audible_message(message)
+			audible_message(message)
 
 	if (regenerate_icons)
 		regenerate_icons()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -275,4 +275,4 @@
 		if (m_type & 1)
 			visible_message(message)
 		else if (m_type & 2)
-			src.loc.audible_message(message)
+			audible_message(message)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -205,5 +205,5 @@
 		if (m_type & 1)
 			visible_message(message)
 		else
-			src.loc.audible_message(message)
+			audible_message(message)
 	return


### PR DESCRIPTION
When obj is qdel'd its loc becomes null and audible_messages were using src.loc.audible_message() (which was unnecessary since the proc end up using get_turf() ).

Also fixes silent PDAs calling audible message when receiving a message.
