### PR TITLE
Made non-leaping thrown aliens impact like normal mobs

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -95,6 +95,9 @@
 /mob/living/carbon/alien/humanoid/hunter/throw_impact(A)
 	var/msg = ""
 
+	if(!leaping)
+		return ..()
+
 	if(A)
 		if(istype(A, /mob/living))
 			var/mob/living/L = A
@@ -162,7 +165,5 @@
 
 
 	src.throwing = 0
-	if(isobj(src))
-		src.throw_impact(get_turf(src))
 
 	return 1


### PR DESCRIPTION
#### Contents
- Non-leaping thrown aliens are now impacting like other mobs, instead of weakening every mob encountered, even if stunned or dead. Fixes #6032.
- Removed a useless check
