### PR TITLE
Adds a delay to anchoring/unanchoring a hydroponics tray. Fixes #6466 

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -712,6 +712,8 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 								"<span class='notice'>You begin to wrench [src] in place.</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 			if (do_after(user, 20))
+				if(anchored)
+					return
 				anchored = 1
 				user.visible_message("<span class='notice'>[user] wrenches [src] into place.</span>", \
 									"<span class='notice'>You wrench [src] in place.</span>")
@@ -720,6 +722,8 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 								"<span class='notice'>You begin to unwrench [src].</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 			if (do_after(user, 20))
+				if(!anchored)
+					return
 				anchored = 0
 				user.visible_message("<span class='notice'>[user] unwrenches [src].</span>", \
 									"<span class='notice'>You unwrench [src].</span>")

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -708,13 +708,21 @@ obj/machinery/hydroponics/attackby(var/obj/item/O as obj, var/mob/user as mob)
 			return
 
 		if(!anchored && !isinspace())
+			user.visible_message("<span class='notice'>[user] begins to wrench [src] into place.</span>", \
+								"<span class='notice'>You begin to wrench [src] in place.</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			anchored = 1
-			user << "You wrench [src] in place."
+			if (do_after(user, 20))
+				anchored = 1
+				user.visible_message("<span class='notice'>[user] wrenches [src] into place.</span>", \
+									"<span class='notice'>You wrench [src] in place.</span>")
 		else if(anchored)
+			user.visible_message("<span class='notice'>[user] begins to unwrench [src].</span>", \
+								"<span class='notice'>You begin to unwrench [src].</span>")
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			anchored = 0
-			user << "You unwrench [src]."
+			if (do_after(user, 20))
+				anchored = 0
+				user.visible_message("<span class='notice'>[user] unwrenches [src].</span>", \
+									"<span class='notice'>You unwrench [src].</span>")
 
 	else if(istype(O, /obj/item/weapon/screwdriver) && unwrenchable) //THIS NEED TO BE DONE DIFFERENTLY, SOMEONE REFACTOR THE TRAY CODE ALREADY
 		if(anchored)


### PR DESCRIPTION
This PR adds a delay of 2 seconds to anchoring and unanchoring a hydroponics tray with the wrench to stop them being used as easy barricades as some people has complained.

Fixes #6466 
