### PR TITLE
Fixes amount of materials gotten from deconstructing tables

### DIFF
--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -17,6 +17,8 @@
 	density = 0
 	anchored = 0
 	layer = 2.8
+	var/framestack = /obj/item/stack/rods
+	var/framestackamount = 2
 
 /obj/structure/table_frame/attackby(var/obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/wrench))
@@ -24,7 +26,8 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 30))
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			new /obj/item/stack/rods(src.loc)
+			for(var/i = 1, i <= framestackamount, i++)
+				new framestack(get_turf(src))
 			qdel(src)
 			return
 	if(istype(I, /obj/item/stack/sheet/plasteel))
@@ -60,16 +63,12 @@
 	name = "wooden table frame"
 	desc = "Four wooden legs with four framing wooden rods for a wooden table. You could easily pass through this."
 	icon_state = "wood_frame"
+	framestack = /obj/item/stack/sheet/mineral/wood
+	framestackamount = 2
 
 /obj/structure/table_frame/wood/attackby(var/obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/wrench))
-		user << "<span class='notice'>Now disassembling [src].</span>"
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 30))
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			new /obj/item/stack/sheet/mineral/wood(src.loc)
-			qdel(src)
-			return
+	 ..()
 	if(istype(I, /obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/sheet/mineral/wood/W = I
 		user << "<span class='notice'>Now adding [W] to [src].</span>"

--- a/code/game/objects/structures/table_frames.dm
+++ b/code/game/objects/structures/table_frames.dm
@@ -68,7 +68,7 @@
 
 /obj/structure/table_frame/wood/attackby(var/obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/wrench))
-	 ..()
+		..()
 	if(istype(I, /obj/item/stack/sheet/mineral/wood))
 		var/obj/item/stack/sheet/mineral/wood/W = I
 		user << "<span class='notice'>Now adding [W] to [src].</span>"

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -25,6 +25,8 @@
 	var/framestack = /obj/item/stack/rods
 	var/buildstack = /obj/item/stack/sheet/metal
 	var/busy = 0
+	var/buildstackamount = 1
+	var/framestackamount = 2
 
 /obj/structure/table/New()
 	..()
@@ -333,8 +335,12 @@
 /obj/structure/table/proc/table_destroy(var/destroy_type, var/mob/user)
 
 	if(destroy_type == TBL_DESTROY)
-		new framestack(src.loc)
-		new buildstack(src.loc)
+		var/frameamount = framestack
+		for(var/i = 1, i <= framestackamount, i++)
+			new frameamount(get_turf(src))
+		var/buildamount = buildstack
+		for(var/i = 1, i <= buildstackamount, i++)
+			new buildamount(get_turf(src))
 		qdel(src)
 		return
 
@@ -343,7 +349,9 @@
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, 20))
 			new frame(src.loc)
-			new buildstack(src.loc)
+			var/buildamount = buildstack
+			for(var/i = 1, i <= buildstackamount, i++)
+				new buildamount(get_turf(src))
 			qdel(src)
 			return
 
@@ -351,8 +359,12 @@
 		user << "<span class='notice'>Now deconstructing [src].</span>"
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 40))
-			new framestack(src.loc)
-			new buildstack(src.loc)
+			var/frameamount = framestack
+			for(var/i = 1, i <= framestackamount, i++)
+				new frameamount(get_turf(src))
+			var/buildamount = buildstack
+			for(var/i = 1, i <= buildstackamount, i++)
+				new buildamount(get_turf(src))
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			qdel(src)
 			return

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -335,12 +335,10 @@
 /obj/structure/table/proc/table_destroy(var/destroy_type, var/mob/user)
 
 	if(destroy_type == TBL_DESTROY)
-		var/frameamount = framestack
 		for(var/i = 1, i <= framestackamount, i++)
-			new frameamount(get_turf(src))
-		var/buildamount = buildstack
+			new framestack(get_turf(src))
 		for(var/i = 1, i <= buildstackamount, i++)
-			new buildamount(get_turf(src))
+			new buildstack(get_turf(src))
 		qdel(src)
 		return
 
@@ -349,9 +347,8 @@
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, 20))
 			new frame(src.loc)
-			var/buildamount = buildstack
 			for(var/i = 1, i <= buildstackamount, i++)
-				new buildamount(get_turf(src))
+				new buildstack(get_turf(src))
 			qdel(src)
 			return
 
@@ -359,12 +356,10 @@
 		user << "<span class='notice'>Now deconstructing [src].</span>"
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 40))
-			var/frameamount = framestack
 			for(var/i = 1, i <= framestackamount, i++)
-				new frameamount(get_turf(src))
-			var/buildamount = buildstack
+				new framestack(get_turf(src))
 			for(var/i = 1, i <= buildstackamount, i++)
-				new buildamount(get_turf(src))
+				new buildstack(get_turf(src))
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			qdel(src)
 			return


### PR DESCRIPTION
This PR fixes the amount of materials you get from deconstructing a table. For example you would get 2 wood from deconstructing a wooden table instead of 3(2 for frame, 1 for top). Tested it and it appears to work. Please tell me if there are more problems which I overlooked.

This also makes that it is slightly easier if someone wishes to add spesshul tables which uses more than 1 materials for the top, or more or less materials for the frame and still get the correct amount from deconstructing.

Fixes #6031 

The new commit also adds the same functionality to table_frames, since deconstructing the table frames also only gave 1 of the material instead of 2 like it was supposed to. Everything still works like intended.
