### PR TITLE
Stops clown shoes from squeaking in zero grav, and thus space. Fixes #6568

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -38,6 +38,8 @@
 	if(shoes)
 		if(!lying)
 			if(loc == NewLoc)
+				if(!has_gravity(loc))
+					return
 				var/obj/item/clothing/shoes/S = shoes
 				S.step_action()
 


### PR DESCRIPTION
This PR stops clown shoes from squeaking in zero gravity areas, thus also in space due to it lacking gravity. Everything worked as expected during testing.

Fixes #6568 
