### PR TITLE
 Makes photocopiers less exploitable.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -252,13 +252,16 @@
 			user << "<span class='notice'>This cartridge is not yet ready for replacement! Use up the rest of the toner.</span>"
 
 	else if(istype(O, /obj/item/weapon/wrench))
+		if(isinspace())
+			user << "<span class='warning'>There's nothing to fasten [src] to!</span>"
+			return
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		user << "<span class='warning'>You start [anchored ? "wrenching" : "unwrenching"] [src]</span>"
+		user << "<span class='warning'>You start [anchored ? "unwrenching" : "wrenching"] [src]</span>"
 		if(do_after(user, 20))
 			if(gc_destroyed)
 				return
+			user << "<span class='notice'>You [anchored ? "unwrench" : "wrench"] [src].</span>"
 			anchored = !anchored
-			user << "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>"
 
 	else if(istype(O, /obj/item/weapon/grab)) //For ass-copying.
 		var/obj/item/weapon/grab/G = O
@@ -342,6 +345,8 @@
 /obj/machinery/photocopier/proc/copier_blocked()
 	if(gc_destroyed)
 		return
+	if(loc.density)
+		return 1
 	for(var/atom/movable/AM in loc)
 		if(AM == src)
 			continue

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -24,16 +24,14 @@
 	var/toner = 40 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 	var/greytoggle = "Greyscale"
-	var/mob/living/ass = null
+	var/mob/living/ass //i can't believe i didn't write a stupid-ass comment about this var when i first coded asscopy.
 	var/busy = 0
 
 /obj/machinery/photocopier/attack_ai(mob/user)
 	return attack_hand(user)
 
-
 /obj/machinery/photocopier/attack_paw(mob/user)
 	return attack_hand(user)
-
 
 /obj/machinery/photocopier/attack_hand(mob/user)
 	user.set_machine(src)
@@ -122,7 +120,7 @@
 			for(var/i = 0, i < copies, i++)
 				var/icon/temp_img
 				if(ishuman(ass) && (ass.get_item_by_slot(slot_w_uniform) || ass.get_item_by_slot(slot_wear_suit)))
-					usr << "<span class='notice'>You feel kind of silly copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "their"] clothes on.</span>"
+					usr << "<span class='notice'>You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "their"] clothes on.</span>" //'
 					break
 				else if(toner >= 5 && !busy && check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
 					if(isalienadult(ass) || istype(ass,/mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.
@@ -231,6 +229,7 @@
 			updateUsrDialog()
 		else
 			user << "<span class='notice'>There is already something in [src].</span>"
+
 	else if(istype(O, /obj/item/weapon/photo))
 		if(copier_empty())
 			user.drop_item()
@@ -241,6 +240,7 @@
 			updateUsrDialog()
 		else
 			user << "<span class='notice'>There is already something in [src].</span>"
+
 	else if(istype(O, /obj/item/device/toner))
 		if(toner <= 0)
 			user.drop_item()
@@ -250,30 +250,26 @@
 			updateUsrDialog()
 		else
 			user << "<span class='notice'>This cartridge is not yet ready for replacement! Use up the rest of the toner.</span>"
+
 	else if(istype(O, /obj/item/weapon/wrench))
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		anchored = !anchored
-		user << "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>"
+		user << "<span class='warning'>You start [anchored ? "wrenching" : "unwrenching"] [src]</span>"
+		if(do_after(20, user))
+			if(gc_destroyed)
+				return
+			anchored = !anchored
+			user << "<span class='notice'>You [anchored ? "wrench" : "unwrench"] [src].</span>"
+
 	else if(istype(O, /obj/item/weapon/grab)) //For ass-copying.
 		var/obj/item/weapon/grab/G = O
 		if(ismob(G.affecting) && G.affecting != ass)
-			var/mob/GM = G.affecting
-			visible_message("<span class='warning'>[usr] drags [GM.name] onto the photocopier!</span>")
-			GM.loc = get_turf(src)
-			ass = GM
-			if(photocopy)
-				photocopy.loc = src.loc
-				photocopy = null
-			else if(copy)
-				copy.loc = src.loc
-				copy = null
-			updateUsrDialog()
+			MouseDrop_T(G.affecting, user)
 
 /obj/machinery/photocopier/ex_act(severity, target)
 	switch(severity)
-		if(1.0)
+		if(1)
 			qdel(src)
-		if(2.0)
+		if(2)
 			if(prob(50))
 				qdel(src)
 			else
@@ -297,25 +293,35 @@
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
-	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai) || target == ass)
+	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, 1) || target == ass || copier_blocked())
 		return
 	src.add_fingerprint(user)
-	if(target == user && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-		visible_message("<span class='warning'>[usr] jumps onto the photocopier!</span>")
-	else if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
-		if(target.anchored) return
-		if(!ishuman(user) && !ismonkey(user)) return
-		visible_message("<span class='warning'>[usr] drags [target.name] onto the photocopier!</span>")
-	target.loc = get_turf(src)
-	ass = target
-	if(photocopy)
-		photocopy.loc = src.loc
-		visible_message("<span class='notice'>[photocopy] is shoved out of the way by [ass]!</span>")
-		photocopy = null
-	else if(copy)
-		copy.loc = src.loc
-		visible_message("<span class='notice'>[copy] is shoved out of the way by [ass]!</span>")
-		copy = null
+	if(target == user)
+		visible_message("<span class='warning'>[user] starts climbing onto the photocopier!</span>")
+	else
+		visible_message("<span class='warning'>[user] starts putting [target] onto the photocopier!</span>")
+
+	if(do_after(user, 20))
+		if(!target || target.gc_destroyed || gc_destroyed || !Adjacent(target)) //check if the photocopier/target still exists.
+			return
+
+		if(target == user)
+			visible_message("<span class='warning'>[user] climbs onto the photocopier!</span>")
+		else
+			visible_message("<span class='warning'>[user] puts [target] onto the photocopier!</span>")
+
+		target.loc = get_turf(src)
+		ass = target
+
+		if(photocopy)
+			photocopy.loc = src.loc
+			visible_message("<span class='notice'>[photocopy] is shoved out of the way by [ass]!</span>")
+			photocopy = null
+
+		else if(copy)
+			copy.loc = src.loc
+			visible_message("<span class='notice'>[copy] is shoved out of the way by [ass]!</span>")
+			copy = null
 	updateUsrDialog()
 
 /obj/machinery/photocopier/proc/check_ass() //I'm not sure wether I made this proc because it's good form or because of the name.
@@ -332,6 +338,16 @@
 			return 0
 	else
 		return 1
+
+/obj/machinery/photocopier/proc/copier_blocked()
+	if(gc_destroyed)
+		return
+	for(var/atom/movable/AM in loc)
+		if(AM == src)
+			continue
+		if(AM.density || AM.density)
+			return 1
+	return 0
 
 /obj/machinery/photocopier/proc/copier_empty()
 	if(copy || photocopy || check_ass())

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -254,7 +254,7 @@
 	else if(istype(O, /obj/item/weapon/wrench))
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		user << "<span class='warning'>You start [anchored ? "wrenching" : "unwrenching"] [src]</span>"
-		if(do_after(20, user))
+		if(do_after(user, 20))
 			if(gc_destroyed)
 				return
 			anchored = !anchored

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -345,7 +345,7 @@
 	for(var/atom/movable/AM in loc)
 		if(AM == src)
 			continue
-		if(AM.density || AM.density)
+		if(AM.density)
 			return 1
 	return 0
 


### PR DESCRIPTION
- Adds a delay to (un)wrenching and putting people on photocopiers.
- You can no longer put people on photocopiers if there are other dense things on the same tile.

Also makes the proc for putting people on copiers less awful.

Fixes #6544.

Tested.
