### PR TITLE
Prevents singularities from being send to centcom via cargo shuttle

### DIFF
--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -182,31 +182,24 @@
 
 /proc/forbidden_atoms_check(atom/A)
 	if(A)
-		if(istype(A,/mob/living))
+		if(is_type_in_list(A, blacklist))
 			return 1
-		if(istype(A,/obj))
-			if(istype(A,/obj/effect/blob))
-				return 1
-			if(istype(A,/obj/effect/spider/spiderling))
-				return 1
-			if(istype(A,/obj/item/weapon/disk/nuclear))
-				return 1
-			if(istype(A,/obj/machinery/nuclearbomb))
-				return 1
-			if(istype(A,/obj/item/device/radio/beacon))
-				return 1
-			if(istype(A,/obj/machinery/the_singularitygen/))
-				return 1
-			if(istype(A,/obj/singularity))
-				return 1
-
 		for(var/thing in A)
 			if(.(thing))
 				return 1
 
 	return 0
 
-
+/var/list/blacklist = list(
+	/mob/living,
+	/obj/effect/blob,
+	/obj/effect/spider/spiderling,
+	/obj/item/weapon/disk/nuclear,
+	/obj/machinery/nuclearbomb,
+	/obj/item/device/radio/beacon,
+	/obj/machinery/the_singularitygen,
+	/obj/singularity,
+)
 
 
 /obj/machinery/computer/ordercomp/attack_hand(var/mob/user as mob)

--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -195,6 +195,10 @@
 				return 1
 			if(istype(A,/obj/item/device/radio/beacon))
 				return 1
+			if(istype(A,/obj/machinery/the_singularitygen/))
+				return 1
+			if(istype(A,/obj/singularity))
+				return 1
 
 		for(var/thing in A)
 			if(.(thing))

--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -181,6 +181,16 @@
 
 
 /proc/forbidden_atoms_check(atom/A)
+	var/list/blacklist = list(
+		/mob/living,
+		/obj/effect/blob,
+		/obj/effect/spider/spiderling,
+		/obj/item/weapon/disk/nuclear,
+		/obj/machinery/nuclearbomb,
+		/obj/item/device/radio/beacon,
+		/obj/machinery/the_singularitygen,
+		/obj/singularity,
+	)
 	if(A)
 		if(is_type_in_list(A, blacklist))
 			return 1
@@ -189,17 +199,6 @@
 				return 1
 
 	return 0
-
-/var/list/blacklist = list(
-	/mob/living,
-	/obj/effect/blob,
-	/obj/effect/spider/spiderling,
-	/obj/item/weapon/disk/nuclear,
-	/obj/machinery/nuclearbomb,
-	/obj/item/device/radio/beacon,
-	/obj/machinery/the_singularitygen,
-	/obj/singularity,
-)
 
 
 /obj/machinery/computer/ordercomp/attack_hand(var/mob/user as mob)


### PR DESCRIPTION
Adds the singularity and the singularity generator to cargo blacklist, so you can no longer send a live singularity to it and Mess everything up.

Also, makes the blacklist into a...well...list. Everything still works fine.

Fixes #6177
