### PR TITLE
Fixes bot targeting logic [DNM]

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -375,12 +375,13 @@ obj/machinery/bot/proc/scan(var/scan_type, var/old_target, var/scan_range = DEFA
 	for (var/scan in view (scan_range, src) ) //Search for something in range!
 		if(!istype(scan, scan_type)) //Check that the thing we found is the type we want!
 			continue //If not, keep searching!
-		if( !(scan in ignore_list) && (scan != old_target) ) //Filter for blacklisted elements, usually unreachable or previously processed oness
-			var/scan_result = process_scan(scan) //Some bots may require additional processing when a result is selected.
-			if( scan_result )
-				final_result = scan_result
-			else
-				continue //The current element failed assessment, move on to the next.
+		if( (scan in ignore_list) || (scan == old_target) ) //Filter for blacklisted elements, usually unreachable or previously processed oness
+			continue
+		var/scan_result = process_scan(scan) //Some bots may require additional processing when a result is selected.
+		if( scan_result )
+			final_result = scan_result
+		else
+			continue //The current element failed assessment, move on to the next.
 		return final_result
 
 //When the scan finds a target, run bot specific processing to select it for the next step. Empty by default.

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -405,8 +405,13 @@ obj/machinery/bot/proc/bot_move(var/dest, var/move_speed)
 	if(!dest || !path || path.len == 0) //A-star failed or a path/destination was not set.
 		path = list()
 		return 0
-	if(get_turf(src) == get_turf(dest)) //We have arrived, no need to move again.
+	dest = get_turf(dest) //We must always compare turfs, so get the turf of the dest var if dest was originally something else.
+	var/turf/last_node = get_turf(path[path.len]) //This is the turf at the end of the path, it should be equal to dest.
+	if(get_turf(src) == dest) //We have arrived, no need to move again.
 		return 1
+	else if (dest != last_node) //The path should lead us to our given destination. If this is not true, we must stop.
+		path = list()
+		return 0
 	var/success
 	var/step_count = move_speed ? move_speed : speed //If a value is passed into move_speed, use that instead of the default speed var.
 	if(step_count >= 1 && tries < 4)

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -27,7 +27,6 @@
 	var/blood = 1
 	var/list/target_types = list()
 	var/obj/effect/decal/cleanable/target
-	var/obj/effect/decal/cleanable/oldtarget
 	var/max_targets = 50 //Maximum number of targets a cleanbot can ignore.
 	var/oldloc = null
 	req_one_access = list(access_janitor, access_robotics)
@@ -68,7 +67,6 @@
 	..()
 	ignore_list = list() //Allows the bot to clean targets it previously ignored due to being unreachable.
 	target = null
-	oldtarget = null
 	oldloc = null
 
 /obj/machinery/bot/cleanbot/set_custom_texts()
@@ -163,21 +161,14 @@ text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
 		visible_message("[src] makes an excited beeping booping sound!")
 
 	if(!target) //Search for cleanables it can see.
-		target = scan(/obj/effect/decal/cleanable/, oldtarget)
-		oldtarget = target
+		target = scan(/obj/effect/decal/cleanable/)
 
-	if(!target)
-		if(loc != oldloc)
-			oldtarget = null
+	if(!target && auto_patrol) //Search for cleanables it can see.
+		if(mode == BOT_IDLE || mode == BOT_START_PATROL)
+			start_patrol()
 
-		if(auto_patrol)
-			if(mode == BOT_IDLE || mode == BOT_START_PATROL)
-				start_patrol()
-
-			if(mode == BOT_PATROL)
-				bot_patrol()
-
-		return
+		if(mode == BOT_PATROL)
+			bot_patrol()
 
 	if(target)
 		if(!path || path.len == 0) //No path, need a new one

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -45,7 +45,6 @@
 	var/nagged = 0 //Prevents the Floorbot nagging more than once per refill.
 	var/max_targets = 50
 	var/turf/target
-	var/turf/oldtarget
 	var/oldloc = null
 	req_one_access = list(access_construction, access_robotics)
 	var/targetdirection
@@ -83,7 +82,6 @@
 /obj/machinery/bot/floorbot/bot_reset()
 	..()
 	target = null
-	oldtarget = null
 	oldloc = null
 	ignore_list = list()
 	nagged = 0
@@ -209,11 +207,11 @@
 
 	if(amount <= 0 && !target) //Out of tiles! We must refill!
 		if(eattiles) //Configured to find and consume floortiles!
-			target = scan(/obj/item/stack/tile/plasteel, oldtarget)
+			target = scan(/obj/item/stack/tile/plasteel)
 			process_type = null
 
 		if(!target && maketiles) //We did not manage to find any floor tiles! Scan for metal stacks and make our own!
-			target = scan(/obj/item/stack/sheet/metal, oldtarget)
+			target = scan(/obj/item/stack/sheet/metal)
 			process_type = null
 			return
 		else
@@ -232,24 +230,24 @@
 				target = T
 
 			else //Find a space tile farther way!
-				target = scan(/turf/space, oldtarget)
+				target = scan(/turf/space)
 			process_type = BRIDGE_MODE
 
 		if(!target)
 			process_type = HULL_BREACH //Ensures the floorbot does not try to "fix" space areas or shuttle docking zones.
-			target = scan(/turf/space, oldtarget)
+			target = scan(/turf/space)
 
 		if(!target && replacetiles) //Finds a floor without a tile and gives it one.
 			process_type = REPLACE_TILE //The target must be the floor and not a tile. The floor must not already have a floortile.
-			target = scan(/turf/simulated/floor, oldtarget)
+			target = scan(/turf/simulated/floor)
 
 		if(!target && fixfloors) //Repairs damaged floors and tiles.
 			process_type = FIX_TILE
-			target = scan(/turf/simulated/floor, oldtarget)
+			target = scan(/turf/simulated/floor)
 
 	if(!target && emagged == 2) //We are emagged! Time to rip up the floors!
 		process_type = TILE_EMAG
-		target = scan(/turf/simulated/floor, oldtarget)
+		target = scan(/turf/simulated/floor)
 
 
 	if(!target)
@@ -261,11 +259,6 @@
 			if(mode == BOT_PATROL)
 				bot_patrol()
 
-	if(!target)
-		if(loc != oldloc)
-			oldtarget = null
-		return
-
 	if(target)
 		if(path.len == 0)
 			if(!istype(target, /turf/))
@@ -276,12 +269,10 @@
 
 			if(!bot_move(target))
 				add_to_ignore(target)
-				oldtarget = target
 				target = null
 				mode = BOT_IDLE
 				return
 		else if( !bot_move(target) )
-			oldtarget = target
 			target = null
 			mode = BOT_IDLE
 			return


### PR DESCRIPTION
It was possible for a unreachable target to essentially disable a bot's
(cleanbots mostly) ability to perform its function. This fixes cleanbots
ignoring valid and reachable stains, and ignoring stains while in patrol
mode.

<b>I have not had a chance to test this extensively, only on cleanbots so far. As it affects all bots, I must verify that all functions that use the affected proc are working as intended. Until then, please do not merge this fix.</b>
