### PR TITLE
Adds Cyborg data to AI's status screen

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -231,7 +231,7 @@ var/list/ai_list = list()
 				borg_area = get_area(R)
 				//Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
 				stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "Empty"] | \
- Module: [R.designation] | Loc: [borg_area.name] | Status: [R.stat ? "Offline" : R.lockcharge ? "Locked Down" : "Normal"]"))
+ Module: [R.designation] | Loc: [borg_area.name] | Status: [R.stat ? "Offline" : "Normal"]"))
 		else
 			stat(null, text("Systems nonfunctional"))
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -224,6 +224,13 @@ var/list/ai_list = list()
 
 		if(!stat)
 			stat(null, text("System integrity: [(health+100)/2]%"))
+			stat(null, text("Connected cyborgs: [connected_robots.len]"))
+			var/area/borg_area
+			for(var/mob/living/silicon/robot/R in connected_robots)
+				borg_area = get_area(R)
+				//Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
+				stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "Empty"] | \
+ Module: [R.designation] | Loc: [borg_area.name] | Status: [R.stat ? "Offline" : R.lockcharge ? "Locked Down" : "Normal"]"))
 		else
 			stat(null, text("Systems nonfunctional"))
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -224,6 +224,7 @@ var/list/ai_list = list()
 
 		if(!stat)
 			stat(null, text("System integrity: [(health+100)/2]%"))
+			stat(null, "Station Time: [worldtime2text()]")
 			stat(null, text("Connected cyborgs: [connected_robots.len]"))
 			var/area/borg_area
 			for(var/mob/living/silicon/robot/R in connected_robots)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -309,6 +309,7 @@
 		else
 			stat(null, text("No Cell Inserted!"))
 
+		stat(null, "Station Time: [worldtime2text()]")
 		if(module)
 			internal = locate(/obj/item/weapon/tank/jetpack) in module.modules
 			if(internal)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -316,6 +316,8 @@
 				stat("Tank Pressure", internal.air_contents.return_pressure())
 			for (var/datum/robot_energy_storage/st in module.storages)
 				stat("[st.name]: [st.energy]/[st.max_energy]")
+		if(connected_ai)
+			stat(null, text("Master AI: [connected_ai.name]"))
 
 /mob/living/silicon/robot/restrained()
 	return 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -129,6 +129,8 @@
 			ghostize()
 			ERROR("A borg has been destroyed, but its MMI lacked a brainmob, so the mind could not be transferred. Player: [ckey].")
 		mmi = null
+	if(connected_ai)
+		connected_ai.connected_robots -= src
 	..()
 
 


### PR DESCRIPTION
Adds all useful data about a Cyborg's health to the AI's status screen.
- Includes Cyborg name, health, cell charge, module, area name, and stat data.
- Strictly read-only, the AI must use the RD console to lock, release, or detonate its cyborgs.
- Cyborgs slaved to an AI will have that AI's name displayed in its status screen.

EDIT: Station Time added as well, for both the AI and Cyborgs!
EDIT2: "Locked Down" status tracking removed.

I am open to suggestions on how much data to provide to or hold from the AI. I am also open to any suggestions on how much data to provide a cyborg about its master AI.

Note: <b>Emagged cyborgs do not disappear from the AI's status screen if they were synced before.</b> The RD computer uses a different var (can_control) to show or hide cyborgs from the AI. An AI watching only its status screen would not know, but a robust and alert AI could cross-reference the two systems and know there is a problem.  I am unsure on if I should also remove a borg from the AI's status screen or not. Suggestions?
- Cyborg status screen: 
  ![screenshot 2015-01-17 00 15 17](https://cloud.githubusercontent.com/assets/4955510/5787928/f2ca6a76-9ddd-11e4-81ee-0f9c4327923c.png)
- AI status screen: _(Outdated, Cyborgs will no longer appear as locked down.)_
  ![screenshot 2015-01-17 00 10 06](https://cloud.githubusercontent.com/assets/4955510/5787915/38bb18c4-9ddd-11e4-8662-301611535dc4.png)
