### PR TITLE
Makes assembly parts work with wires

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -132,11 +132,13 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 				// Attach
 				else
-					if(istype(I, /obj/item/device/assembly/signaler))
-						L.drop_item()
-						Attach(colour, I)
-					else
-						L << "<span class='error'>You need a remote signaller!</span>"
+					if(istype(I, /obj/item/device/assembly))
+						var/obj/item/device/assembly/A = I;
+						if(A.attachable)
+							L.drop_item()
+							Attach(colour, A)
+						else
+							L << "<span class='error'>You need a attachable assembly!</span>"
 
 
 
@@ -229,8 +231,8 @@ var/const/POWER = 8
 		return signallers[colour]
 	return null
 
-/datum/wires/proc/Attach(var/colour, var/obj/item/device/assembly/signaler/S)
-	if(colour && S)
+/datum/wires/proc/Attach(var/colour, var/obj/item/device/assembly/S)
+	if(colour && S && S.attachable)
 		if(!IsAttached(colour))
 			signallers[colour] = S
 			S.loc = holder
@@ -239,7 +241,7 @@ var/const/POWER = 8
 
 /datum/wires/proc/Detach(var/colour)
 	if(colour)
-		var/obj/item/device/assembly/signaler/S = GetAttached(colour)
+		var/obj/item/device/assembly/S = GetAttached(colour)
 		if(S)
 			signallers -= colour
 			S.connected = null
@@ -247,7 +249,7 @@ var/const/POWER = 8
 			return S
 
 
-/datum/wires/proc/Pulse(var/obj/item/device/assembly/signaler/S)
+/datum/wires/proc/Pulse(var/obj/item/device/assembly/S)
 
 	for(var/colour in signallers)
 		if(S == signallers[colour])

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1198,3 +1198,8 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/CanAStarPass(var/obj/item/weapon/card/id/ID)
 //Airlock is passable if it is open (!density), bot has access, and is not bolted shut)
 	return !density || (check_access(ID) && !locked)
+
+/obj/machinery/door/airlock/HasProximity(atom/movable/AM as mob|obj)
+	for (var/obj/A in contents)
+		A.HasProximity(AM)
+	return

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -17,6 +17,8 @@
 	var/obj/item/device/assembly_holder/holder = null
 	var/cooldown = 0//To prevent spam
 	var/wires = WIRE_RECEIVE | WIRE_PULSE
+	var/attachable = 0 // can this be attached to wires
+	var/datum/wires/connected = null
 
 	var/const/WIRE_RECEIVE = 1			//Allows Pulsed(0) to call Activate()
 	var/const/WIRE_PULSE = 2				//Allows Pulse(0) to act on the holder
@@ -59,6 +61,9 @@
 
 //Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
 /obj/item/device/assembly/proc/pulse(var/radio = 0)
+	if(src.connected && src.wires)
+		connected.Pulse(src)
+		return 1
 	if(holder && (wires & WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
 	if(holder && (wires & WIRE_PULSE_SPECIAL))

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -5,6 +5,7 @@
 	m_amt = 800
 	g_amt = 200
 	origin_tech = "magnets=1"
+	attachable = 1
 
 	var/scanning = 0
 	var/timing = 0

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -7,11 +7,11 @@
 	g_amt = 120
 	origin_tech = "magnets=1"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
+	attachable = 1
 
 	var/code = 30
 	var/frequency = 1457
 	var/delay = 0
-	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
 
 /obj/item/device/assembly/signaler/New()
@@ -125,14 +125,6 @@ Code:
 				spawn(0)
 					if(S)	S.pulse(0)
 		return 0*/
-
-
-/obj/item/device/assembly/signaler/pulse(var/radio = 0)
-	if(src.connected && src.wires)
-		connected.Pulse(src)
-	else
-		return ..(radio)
-
 
 /obj/item/device/assembly/signaler/receive_signal(datum/signal/signal)
 	if(!signal)	return 0

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -5,6 +5,7 @@
 	m_amt = 500
 	g_amt = 50
 	origin_tech = "magnets=1"
+	attachable = 1
 
 	var/timing = 0
 	var/time = 5

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -6,6 +6,7 @@
 	g_amt = 50
 	origin_tech = "magnets=1"
 	flags = HEAR
+	attachable = 1
 	var/listening = 0
 	var/recorded = "" //the activation message
 


### PR DESCRIPTION
Allows for password opened doors/bombs/kill-phrases for borgs etc without the need for secondary assembly.

I didn't modify other wire-using stuff HasProximity because i wasn't sure syndie-bombs that explode when someone runs to disarm them are good thing or not. 
