### PR TITLE
Fixes runtime related to handle_vision for clientless mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -498,14 +498,16 @@
 		if(H.tinttotal >= TINT_IMPAIR)
 			if(tinted_weldhelh)
 				if(H.tinttotal >= TINT_BLIND)
-					H.eye_blind = max(H.eye_blind, 1)								// You get the sudden urge to learn to play keyboard
-					H.client.screen += global_hud.darkMask
-				else
+					H.eye_blind = max(H.eye_blind, 1)
+				if(H.client)
 					H.client.screen += global_hud.darkMask
 
 		if(H.blind)
 			if(H.eye_blind)		H.blind.layer = 18
 			else			H.blind.layer = 0
+
+		if(!H.client)//no client, no screen to update
+			return 1
 
 		if( H.disabilities & NEARSIGHT && !istype(H.glasses, /obj/item/clothing/glasses/regular) )
 			H.client.screen += global_hud.vimpaired


### PR DESCRIPTION
If needing to apply vision related overlays, the game was trying to update the client screen without checking if said client existed.

Note that this runtime was **_clogging**_ the runtimes log pretty quickly, given how _handle_vision()_ was triggered once per tick...
