### PR TITLE
A fix so mineral floor tiles can be reshaped into mineral sheets.

### DIFF
--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -1,3 +1,5 @@
+/obj/item/stack/tile
+
 /obj/item/stack/tile/plasteel
 	name = "floor tile"
 	singular_name = "floor tile"
@@ -12,6 +14,7 @@
 	flags = CONDUCT
 	max_amount = 60
 	turf_type = /turf/simulated/floor/plasteel
+	mineralType = "metal"
 
 /obj/item/stack/tile/plasteel/cyborg
 	desc = "The ground you walk on" //Not the usual floor tile desc as that refers to throwing, Cyborgs can't do that - RR
@@ -25,27 +28,4 @@
 	src.pixel_y = rand(1, 14)
 	return
 
-/obj/item/stack/tile/plasteel/attackby(obj/item/W as obj, mob/user as mob)
 
-	if (istype(W, /obj/item/weapon/weldingtool))
-		var/obj/item/weapon/weldingtool/WT = W
-
-		if(get_amount() < 4)
-			user << "<span class='warning'>You need at least four tiles to do this.</span>"
-			return
-
-		if(WT.remove_fuel(0,user))
-			var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
-			new_item.add_to_stacks(usr)
-			user.visible_message("<span class='warning'>[user.name] shaped [src] into metal with the weldingtool.</span>", \
-						 "<span class='notice'>You shaped [src] into metal with the weldingtool.</span>", \
-						 "<span class='warning'>You hear welding.</span>")
-			var/obj/item/stack/rods/R = src
-			src = null
-			var/replace = (user.get_inactive_hand()==R)
-			R.use(4)
-			if (!R && replace)
-				user.put_in_hands(new_item)
-		return
-	else
-		..()

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -11,6 +11,7 @@
 	max_amount = 60
 	origin_tech = "plasma=1"
 	turf_type = /turf/simulated/floor/mineral/plasma
+	mineralType = "plasma"
 
 /obj/item/stack/tile/mineral/uranium
 	name = "uranium tile"
@@ -25,6 +26,7 @@
 	max_amount = 60
 	origin_tech = "material=1"
 	turf_type = /turf/simulated/floor/mineral/uranium
+	mineralType = "uranium"
 
 /obj/item/stack/tile/mineral/gold
 	name = "gold tile"
@@ -39,6 +41,7 @@
 	max_amount = 60
 	origin_tech = "material=1"
 	turf_type = /turf/simulated/floor/mineral/gold
+	mineralType = "gold"
 
 /obj/item/stack/tile/mineral/silver
 	name = "silver tile"
@@ -53,6 +56,7 @@
 	max_amount = 60
 	origin_tech = "material=1"
 	turf_type = /turf/simulated/floor/mineral/silver
+	mineralType = "silver"
 
 /obj/item/stack/tile/mineral/diamond
 	name = "diamond tile"
@@ -67,6 +71,7 @@
 	max_amount = 60
 	origin_tech = "material=2"
 	turf_type = /turf/simulated/floor/mineral/diamond
+	mineralType = "diamond"
 
 /obj/item/stack/tile/mineral/bananium
 	name = "bananium tile"
@@ -81,4 +86,5 @@
 	max_amount = 60
 	origin_tech = "material=1"
 	turf_type = /turf/simulated/floor/mineral/bananium
+	mineralType = "bananium"
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -25,7 +25,7 @@
 			user << "<span class='warning'>You need at least four tiles to do this.</span>"
 			return
 
-		if(!mineralType)
+		if(is_hot(WT) && !mineralType)
 			user << "<span class='warning'>You can not reform this.</span>"
 			return
 
@@ -39,8 +39,8 @@
 				return
 
 			if (mineralType == "metal")
-				var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
-				new_item.add_to_stacks(usr)
+				var/obj/item/stack/sheet/metal/new_item = new(user.loc)
+				new_item.add_to_stacks(user)
 				user.visible_message("<span class='warning'>[user.name] shaped [src] into metal with the weldingtool.</span>", \
 							 "<span class='notice'>You shaped [src] into metal with the weldingtool.</span>", \
 							 "<span class='warning'>You hear welding.</span>")
@@ -53,8 +53,8 @@
 
 			else
 				var/sheet_type = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
-				var/obj/item/stack/sheet/mineral/new_item = new sheet_type(usr.loc)
-				new_item.add_to_stacks(usr)
+				var/obj/item/stack/sheet/mineral/new_item = new sheet_type(user.loc)
+				new_item.add_to_stacks(user)
 				user.visible_message("<span class='warning'>[user.name] shaped [src] into a sheet with the weldingtool.</span>", \
 							 "<span class='notice'>You shaped [src] into a sheet with the weldingtool.</span>", \
 							 "<span class='warning'>You hear welding.</span>")

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -14,6 +14,59 @@
 	singular_name = "broken tile"
 	desc = "A broken tile. This should not exist."
 	var/turf_type = null
+	var/mineralType = null
+
+/obj/item/stack/tile/attackby(obj/item/W as obj, mob/user as mob)
+
+	if (istype(W, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/WT = W
+
+		if(get_amount() < 4)
+			user << "<span class='warning'>You need at least four tiles to do this.</span>"
+			return
+
+		if(!mineralType)
+			user << "<span class='warning'>You can not reform this.</span>"
+			return
+
+		if(WT.remove_fuel(0,user))
+
+			if(mineralType == "plasma")
+				atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 5)
+				user.visible_message("<span class='warning'>[user.name] set the plasma tiles on fire!</span>", \
+									"<span class='warning'>You set the plasma tiles on fire!</span>")
+				qdel(src)
+				return
+
+			if (mineralType == "metal")
+				var/obj/item/stack/sheet/metal/new_item = new(usr.loc)
+				new_item.add_to_stacks(usr)
+				user.visible_message("<span class='warning'>[user.name] shaped [src] into metal with the weldingtool.</span>", \
+							 "<span class='notice'>You shaped [src] into metal with the weldingtool.</span>", \
+							 "<span class='warning'>You hear welding.</span>")
+				var/obj/item/stack/rods/R = src
+				src = null
+				var/replace = (user.get_inactive_hand()==R)
+				R.use(4)
+				if (!R && replace)
+					user.put_in_hands(new_item)
+
+			else
+				var/sheet_type = text2path("/obj/item/stack/sheet/mineral/[mineralType]")
+				var/obj/item/stack/sheet/mineral/new_item = new sheet_type(usr.loc)
+				new_item.add_to_stacks(usr)
+				user.visible_message("<span class='warning'>[user.name] shaped [src] into a sheet with the weldingtool.</span>", \
+							 "<span class='notice'>You shaped [src] into a sheet with the weldingtool.</span>", \
+							 "<span class='warning'>You hear welding.</span>")
+				var/obj/item/stack/rods/R = src
+				src = null
+				var/replace = (user.get_inactive_hand()==R)
+				R.use(4)
+				if (!R && replace)
+					user.put_in_hands(new_item)
+		return
+	else
+		..()
 
 /*
  * Grass

--- a/html/changelogs/FIRECAGE-PR-7141.yml
+++ b/html/changelogs/FIRECAGE-PR-7141.yml
@@ -1,0 +1,6 @@
+author: Firecage
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added the ability to reform mineral floortiles back into sheets/bars"


### PR DESCRIPTION
Basically what it says. This is a fix so mineral floortiles can be reshaped back into mineral sheets to be used again.

Just don't try doing this with plasma floortiles.

Fixes #5823 

Note, the second part of that issue isn't actually valid. You can't even do that with normal floor tiles. I checked the code and tried it myself, so honestly no idea where he got that.
