### PR TITLE
Add the message argument to can_speak in the cult runes speaking check so that cultists are able to be played again. This is a small bugfix I coded on the 19/01 to fix issue #7172 as reported by tkdrg

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -169,8 +169,9 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 	if(!iscultist(user))
 		user << "<span class='notice'>You can't mouth the arcane scratchings without fumbling over them.</span>"
 		return
-	if(!user.can_speak() && (user.mind && !user.mind.miming))
-		user << "<span class='notice'>You are unable to speak the words of the rune.</span>"
+	var/message = "<span class='notice'>You are unable to speak the words of the rune.</span>"
+	if(!user.can_speak(message) && (user.mind && !user.mind.miming))
+		user << message
 		return
 	if(!word1 || !word2 || !word3 || prob(user.getBrainLoss()))
 		return fizzle(user)


### PR DESCRIPTION
It is needed for _raisans_

Fixes #7172 
