### PR TITLE
Disposals cleaning/fixing part 2

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -26,12 +26,14 @@ Buildable meters
 #define DISP_PIPE_STRAIGHT		0
 #define DISP_PIPE_BENT			1
 #define DISP_JUNCTION			2
-#define DISP_YJUNCTION			3
-#define DISP_END_TRUNK			4
-#define DISP_END_BIN			5
-#define DISP_END_OUTLET			6
-#define DISP_END_CHUTE			7
-#define DISP_SORTJUNCTION		8
+#define DISP_JUNCTION_FLIP		3
+#define DISP_YJUNCTION			4
+#define DISP_END_TRUNK			5
+#define DISP_END_BIN			6
+#define DISP_END_OUTLET			7
+#define DISP_END_CHUTE			8
+#define DISP_SORTJUNCTION		9
+#define DISP_SORTJUNCTION_FLIP	10
 
 /obj/item/pipe
 	name = "pipe"

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -145,21 +145,19 @@ Nah
 		return 1
 
 	var/dat = {"<b>Disposal Pipes</b><br><br>
-<A href='?src=\ref[src];dmake=0'>Pipe</A><BR>
-<A href='?src=\ref[src];dmake=1'>Bent Pipe</A><BR>
-<A href='?src=\ref[src];dmake=2'>Junction</A><BR>
-<A href='?src=\ref[src];dmake=3'>Y-Junction</A><BR>
-<A href='?src=\ref[src];dmake=4'>Trunk</A><BR>
-<A href='?src=\ref[src];dmake=5'>Bin</A><BR>
-<A href='?src=\ref[src];dmake=6'>Outlet</A><BR>
-<A href='?src=\ref[src];dmake=7'>Chute</A><BR>
-<A href='?src=\ref[src];dmake=8'>Sort Junction</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_PIPE_STRAIGHT]'>Pipe</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_PIPE_BENT]'>Bent Pipe</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_JUNCTION]'>Junction</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_YJUNCTION]'>Y-Junction</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_END_TRUNK]'>Trunk</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_END_BIN]'>Bin</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_END_OUTLET]'>Outlet</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_END_CHUTE]'>Chute</A><BR>
+<A href='?src=\ref[src];dmake=[DISP_SORTJUNCTION]'>Sort Junction</A><BR>
 "}
 
 	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
 	return
-
-// 0=straight, 1=bent, 2=junction-j1, 3=junction-j2, 4=junction-y, 5=trunk
 
 
 /obj/machinery/pipedispenser/disposal/Topic(href, href_list)
@@ -170,7 +168,7 @@ Nah
 	if(href_list["dmake"])
 		if(!wait)
 			var/p_type = text2num(href_list["dmake"])
-			var/obj/structure/disposalconstruct/C = new (src.loc,p_type+1)
+			var/obj/structure/disposalconstruct/C = new (src.loc,p_type)
 
 			if(!C.can_place())
 				usr << "<span class='warning'>There's not enough room to build that here!</span>"

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -86,6 +86,7 @@
 	icon_state = "engine"
 	thermal_conductivity = 0.025
 	heat_capacity = 325000
+	floor_tile = /obj/item/stack/rods
 
 /turf/simulated/floor/engine/break_tile()
 	return //unbreakable
@@ -93,7 +94,9 @@
 /turf/simulated/floor/engine/burn_tile()
 	return //unburnable
 
-/turf/simulated/floor/engine/make_plating()
+/turf/simulated/floor/engine/make_plating(var/force = 0)
+	if(force)
+		..()
 	return //unplateable
 
 /turf/simulated/floor/engine/attackby(obj/item/weapon/C as obj, mob/user as mob)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -237,13 +237,18 @@
 	var/start_flush = 0
 	var/c_mode = 0
 
-/obj/machinery/disposal/deliveryChute/New()
+/obj/machinery/disposal/deliveryChute/New(loc,var/obj/structure/disposalconstruct/make_from)
 	..()
-	stored.ptype = 8 // 8 =  Delivery chute
+	stored.ptype = DISP_END_CHUTE
 	spawn(5)
 		trunk = locate() in loc
 		if(trunk)
 			trunk.linked = src	// link the pipe trunk to self
+
+/obj/machinery/disposal/deliveryChute/Destroy()
+	if(trunk)
+		trunk.linked = null
+	..()
 
 /obj/machinery/disposal/deliveryChute/interact()
 	return


### PR DESCRIPTION
#### Contents
- Cleaned the disposals code (making it uses the defines !). Fixes #7181.
- Disposals constructs are now stored inside disposals instead of having them deleted and a copy created (side effect, the construct direction is not reinitialized when deconstructing a disposal structure)
- Bins, chutes and outlets will now properly clean any connected trunk on qdel() (unreported runtime afaik)
- You can no longer interact with the RPD at distance by keeping its window opened
- You can no longer use the RPD as a non-dextrous mob
- Reinforced floors will now be broken by ejected items/mobs, instead of stucking them in the void indefinitely (fixes #7071 and runtimes 18 and 19 of #6351).
