### PR TITLE
Blank PDA Messages Fix

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -771,6 +771,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	var/t = msg_input(U)
 
+	if (!t)
+		return
+
 	if (last_text && world.time < last_text + 5)
 		return
 


### PR DESCRIPTION
- Added "if (!t) return" after msg_input is called. So no blank
  messages.
- Fixes https://github.com/tgstation/-tg-station/issues/7187.

Edit:
- Cancelling the sending of a PDA message will no longer result in a blank message being send.
