### PR TITLE
Payday Guns Bundle (Adds gloves, clown mask, suit to the guns syndicate bundle)

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -40,6 +40,9 @@
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/weapon/card/emag(src)
 			new /obj/item/weapon/c4(src)
+			new /obj/item/clothing/gloves/color/latex/nitrile(src)
+			new /obj/item/clothing/mask/gas/clown_hat(src)
+			new /obj/item/clothing/under/suit_jacket/really_black(src)
 			return
 
 		if("murder")


### PR DESCRIPTION
Adds nitrile gloves, clown mask, and a suit to the Guns bundle.

As suggested by Balut on the fora.
![image](https://cloud.githubusercontent.com/assets/5368127/5831474/64ecd8fc-a101-11e4-92a4-9f948b83d7d1.png)
