### PR TITLE
Automatic Round-start Access Scaling

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -47,7 +47,7 @@
 	var/kick_inactive = 0				//force disconnect for inactive players
 	var/load_jobs_from_txt = 0
 	var/automute_on = 0					//enables automuting/spam prevention
-	var/minimal_access_threshold = 0	//If the number of players is larger than this threshold, minimal access will be turned on and jobs_have_maint_access will be set to 3
+	var/minimal_access_threshold = 0	//If the number of players is larger than this threshold, minimal access will be turned on and assistants and security will get maint access
 	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access. Only used if minimal_access_threshold is 0.
 	var/jobs_have_maint_access = 0 		//Who gets maint access?  See defines above. Only used if minimal_access_threshold is 0.
 	var/sec_start_brig = 0				//makes sec start in brig or dept sec posts

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -47,8 +47,9 @@
 	var/kick_inactive = 0				//force disconnect for inactive players
 	var/load_jobs_from_txt = 0
 	var/automute_on = 0					//enables automuting/spam prevention
-	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access.
-	var/jobs_have_maint_access = 0 		//Who gets maint access?  See defines above
+	var/minimal_access_threshold = 0	//If the number of players is larger than this threshold, minimal access will be turned on and jobs_have_maint_access will be set to 3
+	var/jobs_have_minimal_access = 0	//determines whether jobs use minimal access or expanded access. Only used if minimal_access_threshold is 0.
+	var/jobs_have_maint_access = 0 		//Who gets maint access?  See defines above. Only used if minimal_access_threshold is 0.
 	var/sec_start_brig = 0				//makes sec start in brig or dept sec posts
 
 	var/server
@@ -395,6 +396,8 @@
 					config.allow_latejoin_antagonists	= 1
 				if("allow_random_events")
 					config.allow_random_events		= 1
+				if("minimal_access_threshold")
+					config.minimal_access_threshold	= text2num(value)
 				if("jobs_have_minimal_access")
 					config.jobs_have_minimal_access	= 1
 				if("humans_need_surnames")

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -211,6 +211,15 @@ var/datum/subsystem/job/SSjob
 	//Scale number of open security officer slots to population
 	setup_officer_positions()
 
+	//Jobs will have fewer access permissions if the number of players exceeds the threshold defined in game_options.txt
+	if(config.minimal_access_threshold)
+		if(config.minimal_access_threshold > unassigned.len)
+			config.jobs_have_minimal_access = 0
+			config.jobs_have_maint_access = 3 //Sec and Assistants get maint access
+		else
+			config.jobs_have_minimal_access = 1
+			config.jobs_have_maint_access = 0 //Sec and Assistants don't get maint access
+
 	//Shuffle players and jobs
 	unassigned = shuffle(unassigned)
 
@@ -335,6 +344,7 @@ var/datum/subsystem/job/SSjob
 	H << "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>"
 	if(job.req_admin_notify)
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
+	H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access"] have been added to your ID card.</B></font>"
 
 	H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
 	return 1

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -344,7 +344,8 @@ var/datum/subsystem/job/SSjob
 	H << "<b>To speak on your departments radio, use the :h button. To see others, look closely at your headset.</b>"
 	if(job.req_admin_notify)
 		H << "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>"
-	H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access"] have been added to your ID card.</B></font>"
+	if(config.minimal_access_threshold)
+		H << "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access"] have been added to your ID card.</B></font>"
 
 	H.update_hud() 	// Tmp fix for Github issue 1006. TODO: make all procs in update_icons.dm do client.screen |= equipment no matter what.
 	return 1

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -215,10 +215,10 @@ var/datum/subsystem/job/SSjob
 	if(config.minimal_access_threshold)
 		if(config.minimal_access_threshold > unassigned.len)
 			config.jobs_have_minimal_access = 0
-			config.jobs_have_maint_access = 3 //Sec and Assistants get maint access
+			config.jobs_have_maint_access |= ASSISTANTS_HAVE_MAINT_ACCESS
+			config.jobs_have_maint_access |= SECURITY_HAS_MAINT_ACCESS
 		else
 			config.jobs_have_minimal_access = 1
-			config.jobs_have_maint_access = 0 //Sec and Assistants don't get maint access
 
 	//Shuffle players and jobs
 	unassigned = shuffle(unassigned)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -158,19 +158,28 @@ GATEWAY_DELAY 18000
 
 
 ### ACCESS ###
+
+## If the number of players ready at round starts exceeds this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically toggle on.
+## If the number of players does not reach this threshold, expanded access will be used.
+## Set to 0 to disable this automatic toggle.
+MINIMAL_ACCESS_THRESHOLD 20
+
 ## Comment this out if you wish to use the setup where jobs have more access.
 ## This is intended for servers with low populations - where there are not enough
 ## players to fill all roles, so players need to do more than just one job.
-## Also for servers where they don't want people to hide in their own departments.
+## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #JOBS_HAVE_MINIMAL_ACCESS
 
 ## Uncomment to give assistants maint access.
+## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you comment JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
+## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #SECURITY_HAS_MAINT_ACCESS
 
 ## Uncomment to give everyone maint access.
+## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #EVERYONE_HAS_MAINT_ACCESS
 
 ## Comment this to make security officers spawn in departmental security posts

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -160,8 +160,9 @@ GATEWAY_DELAY 18000
 ### ACCESS ###
 
 ## If the number of players ready at round starts exceeds this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically toggle on.
-## If the number of players does not reach this threshold, expanded access will be used.
-## Set to 0 to disable this automatic toggle.
+## If the number of players does not reach this threshold, JOBS_HAVE_MINIMAL_ACCESS will automatically toggle off, and assistants/security will be given maintenance access.
+## This is useful for accomodating both low and high population rounds on the same server.
+## Comment out or set to 0 to disable this automatic toggle.
 MINIMAL_ACCESS_THRESHOLD 20
 
 ## Comment this out if you wish to use the setup where jobs have more access.
@@ -171,15 +172,12 @@ MINIMAL_ACCESS_THRESHOLD 20
 #JOBS_HAVE_MINIMAL_ACCESS
 
 ## Uncomment to give assistants maint access.
-## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you comment JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
-## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #SECURITY_HAS_MAINT_ACCESS
 
 ## Uncomment to give everyone maint access.
-## This option is ignored if MINIMAL_ACCESS_THRESHOLD is non-zero.
 #EVERYONE_HAS_MAINT_ACCESS
 
 ## Comment this to make security officers spawn in departmental security posts

--- a/html/changelogs/Changelog.yml
+++ b/html/changelogs/Changelog.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in single (') or double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a new config option MINIMAL_ACCESS_THRESHOLD that can be used to automatically give players more access during low-pop rounds. See game_options.txt for more information."
+  - rscadd: "Added a new config option MINIMAL_ACCESS_THRESHOLD that can be used to automatically give players more access during low-population rounds. See game_options.txt for more information."

--- a/html/changelogs/Changelog.yml
+++ b/html/changelogs/Changelog.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscdel (general adding of nice things)
+#   rscadd (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in single (') or double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a new config option MINIMAL_ACCESS_THRESHOLD that can be used to automatically give players more access during low-pop rounds. See game_options.txt for more information."


### PR DESCRIPTION
- Added a new config option MINIMAL_ACCESS_THRESHOLD in game_options.txt that can be used to automatically give players more access during low-pop rounds.
  - If the number of readied players is below this threshold, expanded access will be used and security and assistants will be granted maintenance access if they do not already get it from other server config settings.
  - If the number of readied players exceeds the threshold, minimal access will be used.
  - Default threshold is 20 readied players, which is also when most game modes become available
- Not defining or setting the threshold to 0 will disable this function, if server ops want to manually set the state of round-start access
- If MINIMAL_ACCESS_THRESHOLD is set, players joining the game will be notified whether or not they have expanded access that round.

_This only affects round-start! Access does not automatically change mid-round!_
