### PR TITLE
Fixes Syndiborg Lock/Cover Access

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1018,6 +1018,7 @@
 	modtype = "Synd"
 	faction = list("syndicate")
 	designation = "Syndicate"
+	req_access = list(access_syndicate)
 
 /mob/living/silicon/robot/syndicate/New(loc)
 	..()


### PR DESCRIPTION
Fixes Syndicate borgs requiring Robotics access to open their locks, instead of Syndicate access
Fixes #7264.
