### PR TITLE
Adds the ability to remove monkey/xeno skins and make costumes with them

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -26,6 +26,15 @@
 	icon_state = "sheet-monkey"
 	origin_tech = null
 
+var/global/list/datum/stack_recipe/monkey_recipes = list ( \
+	new/datum/stack_recipe("monkey mask", /obj/item/clothing/mask/gas/monkeymask, 1, on_floor = 1), \
+	new/datum/stack_recipe("monkey suit", /obj/item/clothing/suit/monkeysuit, 2, on_floor = 1), \
+	)
+
+/obj/item/stack/sheet/animalhide/monkey/New(var/loc, var/amount=null)
+	recipes = monkey_recipes
+	return ..()
+
 /obj/item/stack/sheet/animalhide/lizard
 	name = "lizard skin"
 	desc = "Sssssss..."
@@ -39,6 +48,15 @@
 	singular_name = "alien hide piece"
 	icon_state = "sheet-xeno"
 	origin_tech = null
+
+var/global/list/datum/stack_recipe/xeno_recipes = list ( \
+	new/datum/stack_recipe("alien helmet", /obj/item/clothing/head/xenos, 1, on_floor = 1), \
+	new/datum/stack_recipe("alien suit", /obj/item/clothing/suit/xenos, 2, on_floor = 1), \
+	)
+
+/obj/item/stack/sheet/animalhide/xeno/New(var/loc, var/amount=null)
+	recipes = xeno_recipes
+	return ..()
 
 //don't see anywhere else to put these, maybe together they could be used to make the xenos suit?
 /obj/item/stack/sheet/xenochitin

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -10,6 +10,8 @@
 	var/meat = 0
 	var/occupied = 0
 	var/meattype = 0 // 0 - Nothing, 1 - Monkey, 2 - Xeno
+	var/skintype = 0
+	var/skin = 0
 
 /obj/structure/kitchenspike/attack_paw(mob/user as mob)
 	return src.attack_hand(usr)
@@ -23,6 +25,8 @@
 			src.occupied = 1
 			src.meat = 5
 			src.meattype = 1
+			src.skin = 1
+			src.skintype = 1
 			for(var/mob/O in viewers(src, null))
 				O.show_message(text("<span class='danger'>[user] has forced [G.affecting] onto the spike, killing them instantly!</span>"))
 			qdel(G.affecting)
@@ -36,6 +40,8 @@
 			src.occupied = 1
 			src.meat = 5
 			src.meattype = 2
+			src.skin = 1
+			src.skintype = 2
 			for(var/mob/O in viewers(src, null))
 				O.show_message(text("<span class='danger'>[user] has forced [G.affecting] onto the spike, killing them instantly!</span>"))
 			qdel(G.affecting)
@@ -55,10 +61,14 @@
 	if(..())
 		return
 	if(src.occupied)
-		if(src.meattype == 1)
-			if(src.meat > 1)
+		if(src.meattype == 1 && src.skintype == 1)
+			if(src.skin == 1)
+				src.skin--
+				new /obj/item/stack/sheet/animalhide/monkey(src.loc)
+				user << "You remove the hide from the monkey!"
+			else if(src.meat > 1)
 				src.meat--
-				new /obj/item/weapon/reagent_containers/food/snacks/meat/monkey( src.loc )
+				new /obj/item/weapon/reagent_containers/food/snacks/meat/monkey(src.loc )
 				usr << "You remove some meat from the monkey."
 			else if(src.meat == 1)
 				src.meat--
@@ -66,10 +76,14 @@
 				usr << "You remove the last piece of meat from the monkey!"
 				src.icon_state = "spike"
 				src.occupied = 0
-		else if(src.meattype == 2)
-			if(src.meat > 1)
+		else if(src.meattype == 2 && src.skintype == 2)
+			if(src.skin == 1)
+				src.skin--
+				new /obj/item/stack/sheet/animalhide/xeno(src.loc)
+				user << "You remove the hide from the alien!"
+			else if(src.meat > 1)
 				src.meat--
-				new /obj/item/weapon/reagent_containers/food/snacks/xenomeat( src.loc )
+				new /obj/item/weapon/reagent_containers/food/snacks/xenomeat(src.loc )
 				usr << "You remove some meat from the alien."
 			else if(src.meat == 1)
 				src.meat--

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -69,7 +69,7 @@
 		return
 	if(src.occupied)
 		if(src.meattype == MEATTYPE_MONKEY && src.skintype == SKINTYPE_MONKEY)
-			if(src.skin == 1)
+			if(src.skin >= 1)
 				src.skin--
 				new /obj/item/stack/sheet/animalhide/monkey(src.loc)
 				user << "You remove the hide from the monkey!"
@@ -84,7 +84,7 @@
 				src.icon_state = "spike"
 				src.occupied = 0
 		else if(src.meattype == MEATTYPE_ALIEN && src.skintype == SKINTYPE_ALIEN)
-			if(src.skin == 1)
+			if(src.skin >= 1)
 				src.skin--
 				new /obj/item/stack/sheet/animalhide/xeno(src.loc)
 				user << "You remove the hide from the alien!"

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -1,3 +1,10 @@
+
+#define SKINTYPE_MONKEY 1
+#define SKINTYPE_ALIEN 2
+
+#define MEATTYPE_MONKEY 1
+#define MEATTYPE_ALIEN 2
+
 //////Kitchen Spike
 
 /obj/structure/kitchenspike
@@ -9,9 +16,9 @@
 	anchored = 1
 	var/meat = 0
 	var/occupied = 0
-	var/meattype = 0 // 0 - Nothing, 1 - Monkey, 2 - Xeno
-	var/skintype = 0
+	var/meattype = null
 	var/skin = 0
+	var/skintype = null
 
 /obj/structure/kitchenspike/attack_paw(mob/user as mob)
 	return src.attack_hand(usr)
@@ -24,9 +31,9 @@
 			src.icon_state = "spikebloody"
 			src.occupied = 1
 			src.meat = 5
-			src.meattype = 1
+			src.meattype = MEATTYPE_MONKEY
 			src.skin = 1
-			src.skintype = 1
+			src.skintype = SKINTYPE_MONKEY
 			for(var/mob/O in viewers(src, null))
 				O.show_message(text("<span class='danger'>[user] has forced [G.affecting] onto the spike, killing them instantly!</span>"))
 			qdel(G.affecting)
@@ -39,9 +46,9 @@
 			src.icon_state = "spikebloodygreen"
 			src.occupied = 1
 			src.meat = 5
-			src.meattype = 2
+			src.meattype = MEATTYPE_ALIEN
 			src.skin = 1
-			src.skintype = 2
+			src.skintype = SKINTYPE_ALIEN
 			for(var/mob/O in viewers(src, null))
 				O.show_message(text("<span class='danger'>[user] has forced [G.affecting] onto the spike, killing them instantly!</span>"))
 			qdel(G.affecting)
@@ -61,7 +68,7 @@
 	if(..())
 		return
 	if(src.occupied)
-		if(src.meattype == 1 && src.skintype == 1)
+		if(src.meattype == MEATTYPE_MONKEY && src.skintype == SKINTYPE_MONKEY)
 			if(src.skin == 1)
 				src.skin--
 				new /obj/item/stack/sheet/animalhide/monkey(src.loc)
@@ -76,7 +83,7 @@
 				usr << "You remove the last piece of meat from the monkey!"
 				src.icon_state = "spike"
 				src.occupied = 0
-		else if(src.meattype == 2 && src.skintype == 2)
+		else if(src.meattype == MEATTYPE_ALIEN && src.skintype == SKINTYPE_ALIEN)
 			if(src.skin == 1)
 				src.skin--
 				new /obj/item/stack/sheet/animalhide/xeno(src.loc)
@@ -91,3 +98,9 @@
 				usr << "You remove the last piece of meat from the alien!"
 				src.icon_state = "spike"
 				src.occupied = 0
+
+#undef SKINTYPE_MONKEY
+#undef SKINTYPE_ALIEN
+
+#undef MEATTYPE_MONKEY
+#undef MEATTYPE_ALIEN

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -11,6 +11,7 @@
 	response_harm = "hits"
 	speed = 0
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
+	skin_type = /obj/item/stack/sheet/animalhide/xeno
 	meat_amount = 3
 	maxHealth = 100
 	health = 100

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -20,6 +20,7 @@
 	var/turns_since_move = 0
 	var/meat_amount = 0
 	var/meat_type
+	var/skin_type
 	var/stop_automated_movement = 0 //Use this to temporarely stop random movement or to if you write special movement code for animals.
 	var/wander = 1	// Does the mob wander around when idle?
 	var/stop_automated_movement_when_pulled = 1 //When set to 1 this stops the animal from moving when someone is pulling it.
@@ -219,6 +220,8 @@
 	if(meat_amount && meat_type)
 		for(var/i = 0; i < meat_amount; i++)
 			new meat_type(src.loc)
+	if(skin_type)
+		new skin_type(src.loc)
 	..()
 
 
@@ -347,7 +350,7 @@
 		else
 			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
 			return
-	if(meat_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+	if(meat_type && (stat == DEAD) || skin_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
 		if(istype(O, /obj/item/weapon/kitchenknife))
 			harvest()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -350,7 +350,7 @@
 		else
 			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
 			return
-	if(meat_type && (stat == DEAD) || skin_type && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+	if((meat_type || skin_type) && (stat == DEAD))	//if the animal has a meat, and if it is dead.
 		if(istype(O, /obj/item/weapon/kitchenknife))
 			harvest()
 

--- a/html/changelogs/FIRECAGE-PR-7282.yml
+++ b/html/changelogs/FIRECAGE-PR-7282.yml
@@ -1,0 +1,7 @@
+author: Firecage
+
+delete-after: True
+
+changes: 
+  - rscadd: "We, at NanoTrasen, have recently upgraded the Kitchen Spikes to include the skin of both Monkeys and Aliens when you harvest their flesh!"
+  - rscadd: "In other news, a station in a nearby Sector has been making monkey and xeno costumes. We are not sure why."


### PR DESCRIPTION
This PR adds the ability to skin monkeys and xenos using the kitchen spike. You simply put them on the spike like you always do, but instead of immediately harvesting meat, you will first harvest the skin/hide and then the meat.

Using the hides, you can make monkey/xeno masks(monkey)/helmets(Xeno) and suits. For the former it takes 1 hide, for the latter 2, so in total 3. Not that much for the monkeys, but it would take work to get 3 xeno hides for a full xeno costume.

Note, you can also harvest xeno hides from simple animal xenos by butchering them.

All sprites used was already in the code. Basically the hides and the costumes.

Tested everything and everything still works properly.
