### PR TITLE
PDA Notekeeper 2.2

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -635,12 +635,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 //CHATROOM FUNCTIONS====================================
 
 			if("Set Nick")
-				var/n = stripped_input(U, "Please enter nickname", name, nick, 8)
+				var/n = trim(stripped_input(U, "Please enter nickname", name, nick, 9))
 				if(n)
 					nick = n
 
 			if("Set Channel")
-				var/t = stripped_input(U, "Please enter channel", name, chat_channel, 15)
+				var/t = replacetext(trim(stripped_input(U, "Please enter channel", name, chat_channel, 15)), " ", "_")
 				if(t)
 					var/datum/chatroom/C = chatchannels[chat_channel]
 					var/ret = C.parse_msg(src, nick, "/join [t]")
@@ -661,7 +661,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if("NTRC Help")
 				var/helptext = "<b>NTRC Commands:</b><br><br>"
-				helptext += "/join #channel<br>/register<br>/log amountoflines<br><br>"
+				helptext += "/join \[#\](channel name)<br>/register<br>/log (amount of lines)<br><br>"
 				usr << browse(helptext, "window=ntrchelp;size=200x200;border=1;can_resize=1;can_close=1;can_minimize=1")
 
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -34,6 +34,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
 	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!" //Current note in the notepad function
 	var/notehtml = ""
+	var/notescanned = 0 // True if what is in the notekeeper was from a paper.
 	var/const/notefont = "Verdana"
 	var/const/signfont = "Times New Roman"
 	var/cart = "" //A place to stick cartridge menu information
@@ -371,8 +372,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if (1)
 				dat += "<h4><img src=pda_notes.png> Notekeeper V2.2</h4>"
-				dat += "<a href='byond://?src=\ref[src];choice=Edit'>Edit</a><br><HR>"
-				dat += "<font face=\"[notefont]\">[(!notehtml ? note : notehtml)]</font>"
+				dat += "<a href='byond://?src=\ref[src];choice=Edit'>Edit</a><br>"
+				if(notescanned)
+					dat += "(This is a scanned image, editing it may cause some text formatting to change.)<br>"
+				dat += "<HR><font face=\"[notefont]\">[(!notehtml ? note : notehtml)]</font>"
 
 			if (2)
 				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.5</h4>"
@@ -573,6 +576,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if (mode == 1 && n)
 						note = n
 						notehtml = parsepencode(n, U)
+						notescanned = 0
 				else
 					U << browse(null, "window=pda")
 					return
@@ -1005,7 +1009,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		note = replacetext(note, "<ul>", "\[list\]")
 		note = replacetext(note, "</ul>", "\[/list\]")
 		note = strip_html_properly(note)
-		user << "<span class='notice'>Paper scanned. Saved to notekeeper.</span>" //concept of scanning paper copyright brainoblivion 2009
+		notescanned = 1
+		user << "<span class='notice'>Paper scanned. Saved to PDA's notekeeper.</span>" //concept of scanning paper copyright brainoblivion 2009
 
 
 /obj/item/device/pda/proc/explode() //This needs tuning.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -453,7 +453,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 			if (5)
 				new_ntrc_msg = 0
-				dat += "<h4><img src=pda_chatroom.png> SS13 Nanotrasen Relay Chat Network</h4>"
+				dat += "<h4><img src=pda_chatroom.png> Nanotrasen Relay Chat Network V1.2</h4>"
 
 				dat += "<a href='byond://?src=\ref[src];choice=Set Nick'>[nick]</a> | "
 				dat += "<a href='byond://?src=\ref[src];choice=Set Channel'>[chat_channel]</a> | "

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -378,7 +378,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				dat += "<HR><font face=\"[notefont]\">[(!notehtml ? note : notehtml)]</font>"
 
 			if (2)
-				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.5</h4>"
+				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.6</h4>"
 				dat += "<a href='byond://?src=\ref[src];choice=Toggle Ringer'><img src=pda_bell.png> Ringer: [silent == 1 ? "Off" : "On"]</a> | "
 				dat += "<a href='byond://?src=\ref[src];choice=Toggle Messenger'><img src=pda_mail.png> Send / Receive: [toff == 1 ? "Off" : "On"]</a> | "
 				dat += "<a href='byond://?src=\ref[src];choice=Ringtone'><img src=pda_bell.png> Set Ringtone</a> | "
@@ -414,7 +414,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					dat += "None detected.<br>"
 
 			if(21)
-				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.5</h4>"
+				dat += "<h4><img src=pda_mail.png> SpaceMessenger V3.9.6</h4>"
 				dat += "<a href='byond://?src=\ref[src];choice=Clear'><img src=pda_blank.png> Clear Messages</a>"
 
 				dat += "<h4><img src=pda_mail.png> Messages</h4>"

--- a/code/game/objects/items/devices/PDA/chatroom.dm
+++ b/code/game/objects/items/devices/PDA/chatroom.dm
@@ -25,14 +25,29 @@ var/list/chatchannels = list(default_ntrc_chatroom.name = default_ntrc_chatroom)
 
 	MS.send_chat_message(nick,name,message)
 
-	var/list/cmd=text2list(message, " ")
-	switch(cmd[1])
-		if("/register")
-			return register_auth(client,nick)
-		if("/join")
-			if(cmd[2])	return channel_join(client,nick,cmd[2])
-		if("/log")
-			if(cmd[2])	return get_log(client,nick,cmd[2])
+	if(findtext(message,"/",1,2))
+		var/list/cmd=text2list(message, " ")
+		switch(cmd[1])
+			if("/register")
+				if(cmd.len == 1)
+					return register_auth(client,nick)
+				else
+					return "BAD_COMMAND_ARGUMENTS"
+			if("/join")
+				if(cmd.len == 2 && cmd[2])
+					if((findtext(cmd[2],"#",1,2) && length(cmd[2]) > 1) || (!findtext(cmd[2],"#",1,2) && length(cmd[2]) > 0))
+						return channel_join(client,nick,copytext(cmd[2], 1, 15))
+					else // Happens only if "" or "#" is entered as a channel name.
+						return "BAD_CHANNEL"
+				else
+					return "BAD_COMMAND_ARGUMENTS"
+			if("/log")
+				if(cmd.len == 2 && cmd[2])
+					return get_log(client,nick,cmd[2])
+				else
+					return "BAD_COMMAND_ARGUMENTS"
+			else
+				return "BAD_COMMAND"
 
 	return send_message(client,nick,message)
 


### PR DESCRIPTION
Notekeeper:
- Now uses [PenCode](https://tgstation13.org/wiki/Paper_BBCode) rather
  than HTML.
- Now uses the same font as paper. Meaning that signature has a
  different font, same as paper.
- Editing the notes now uses **stripped_multiline_input** proc.
- Cancelling the input box no longer deletes all the notes.
- Added a horizontal rule between the Edit button and notes section.
- Incremented the Notekeepers version number by 0.1 because of this new
  notekeeper update.
- Scanning paper with your PDA now saves most of the content to the var
  that is shown as default text in the edit input box.
- Scanning paper now states that it is saved to the notekeeper.
- Can no longer scan blank paper. User is notificed of this.

NTRC Chatroom:
- Set Nick now does not allow "" as a name, and cancelling the input box
  doesn't delete the nick.
- Set Channel now has a length limit of 15 rather than 255.
- Message now does not send "" messages, and cancelling the input box
  doesn't send a message.
- Added a horizontal rule between the buttons and chat section.

Other:
- Changed the **msg_input** proc to use **stripped_input**.
