### PR TITLE
Exercise bikes!

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -945,6 +945,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/largecrate/mule
 	containername = "\improper MULEbot Crate"
 
+/datum/supply_packs/misc/exercise_bike
+	name = "Exercise bike Crate"
+	contains = list(/obj/machinery/power/exercise_bike/orderable)
+	cost = 25
+	containertype = /obj/structure/largecrate
+	containername = "exercise bike crate"
+
 /datum/supply_packs/misc/conveyor
 	name = "Conveyor Assembly Crate"
 	contains = list(/obj/item/conveyor_construct,

--- a/code/modules/power/exercise_bikes/exerciseBike.dm
+++ b/code/modules/power/exercise_bikes/exerciseBike.dm
@@ -1,0 +1,87 @@
+
+/obj/machinery/power/exercise_bike
+	name = "exercise bike"
+	desc = "A Nanotrasen brand exercise bike, it produces power too!"
+	icon = 'icons/obj/power.dmi'
+	icon_state = "portgen0"
+	density = 0
+	anchored = 1
+	use_power = 0
+	can_buckle = 1
+	buckle_lying = 0
+	var/produced_power = 1250
+	var/required_dir = EAST //which button to press to pedal, Alternates WEST/EAST, A/D or arrow keys
+
+/obj/machinery/power/exercise_bike/orderable
+	anchored = 0
+
+/obj/machinery/power/exercise_bike/New()
+	..()
+
+	if(dir == SOUTH)
+		layer = FLY_LAYER
+	else
+		layer = OBJ_LAYER
+
+
+//Fixes dodgy inherited attack_hand()
+/obj/machinery/power/exercise_bike/attack_hand(mob/living/user)
+	. = ..()
+	if(can_buckle && buckled_mob)
+		user_unbuckle_mob(user)
+
+
+/obj/machinery/power/exercise_bike/attackby(var/obj/item/I, var/mob/user)
+	if(istype(I, /obj/item/weapon/wrench))
+		if(!isinspace())
+			anchored = !anchored
+			user << "<span class='notice'>You [anchored ? "secure":"unsecure"] the exercise bike [anchored ? "to":"from"] the floor.</span>"
+
+			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+
+
+/obj/machinery/power/exercise_bike/relaymove(mob/living/user, direction)
+	if(user != buckled_mob || !istype(user))
+		return
+
+	if(user.stat || user.stunned || user.weakened || user.paralysis)
+		unbuckle_mob()
+
+	if(!anchored)
+		user << "<span class='notice'>Secure the exercise bike to the floor before pedalling.</span>"
+		return
+
+	if(direction == required_dir)
+		user.nutrition = max(user.nutrition - 2, 0)
+		add_avail(produced_power)
+		switch(required_dir)
+			if(EAST)
+				required_dir = WEST
+				world << "PRESS WEST"
+			else
+				required_dir = EAST
+				world << "PRESS EAST"
+
+	update_visuals()
+
+
+/obj/machinery/power/exercise_bike/post_buckle_mob(mob/living/M)
+	update_visuals()
+
+
+/obj/machinery/power/exercise_bike/unbuckle_mob()
+	var/mob/living/M = ..()
+	if(M)
+		M.pixel_x = initial(M.pixel_x)
+		M.pixel_y = initial(M.pixel_y)
+	return M
+
+
+/obj/machinery/power/exercise_bike/proc/update_visuals()
+	if(buckled_mob)
+		buckled_mob.dir = dir
+		switch(dir)
+			if(NORTH)
+				buckled_mob.pixel_y = 4
+			else
+				buckled_mob.pixel_y = 7

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1228,6 +1228,7 @@
 #include "code\modules\power\antimatter\containment_jar.dm"
 #include "code\modules\power\antimatter\control.dm"
 #include "code\modules\power\antimatter\shielding.dm"
+#include "code\modules\power\exercise_bikes\exerciseBike.dm"
 #include "code\modules\power\singularity\collector.dm"
 #include "code\modules\power\singularity\containment_field.dm"
 #include "code\modules\power\singularity\emitter.dm"


### PR DESCRIPTION
<B>Details:</B>
- Adds exercise bikes, a new object that produces power (1/4 of a basic portagen at the moment, 1250) 
- Riding on an exercise bike lowers your nutrition (exercise! it causes weight loss!) which is both fluff and to help you realise you're actually pedalling.
- Can be wrenched/unwrenched so they can be moved, need to be wrenched down to pedal+power
- Can be ordered from cargo for 25 points

<B>Mappers:</B>
I suggest they be placed in perma, so that the prisoners can do something useful for the station, pedal!
Although feel free to map them wherever you please (Public Gym anyone?)

<B>How to ride like a pro:</B>
Alternate between the EAST/WEST movement keys (A/D, Arrow keys etc.)
You can tell which one to press based on which pedal is up (Coming soon with sprites)

<B>TODO:</B>
- [ ] Sprite
- [ ] Adjust update_visuals() to work with new sprite
- [ ] Replace debug messages with a visual update
