### PR TITLE
Ported the variable payload clusterbangs from sayustation

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -380,7 +380,7 @@
 	name = "\improper SOB-3 grenade launcher"
 	desc = "A weapon for combat exosuits. Launches primed clusterbangs. You monster."
 	projectiles = 3
-	projectile = /obj/item/weapon/grenade/flashbang/clusterbang
+	projectile = /obj/item/weapon/grenade/clusterbuster
 	projectile_energy_cost = 1600 //getting off cheap seeing as this is 3 times the flashbangs held in the grenade launcher.
 	equip_cooldown = 90
 

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -1,0 +1,126 @@
+////////////////////
+//Clusterbang
+////////////////////
+/obj/item/weapon/grenade/clusterbuster
+	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."
+	name = "clusterbang"
+	icon = 'icons/obj/grenade.dmi'
+	icon_state = "clusterbang"
+	var/payload = /obj/item/weapon/grenade/flashbang/cluster
+
+/obj/item/weapon/grenade/clusterbuster/prime()
+	update_mob()
+	var/numspawned = rand(4,8)
+	var/again = 0
+
+	for(var/more = numspawned,more > 0,more--)
+		if(prob(35))
+			again++
+			numspawned--
+
+	for(var/loop = again ,loop > 0, loop--)
+		new /obj/item/weapon/grenade/clusterbuster/segment(loc, payload)//Creates 'segments' that launches a few more payloads
+
+	new /obj/effect/payload_spawner(loc, payload, numspawned)//Launches payload
+
+	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+
+	qdel(src)
+
+
+//////////////////////
+//Clusterbang segment
+//////////////////////
+/obj/item/weapon/grenade/clusterbuster/segment
+	desc = "A smaller segment of a clusterbang. Better run."
+	name = "clusterbang segment"
+	icon = 'icons/obj/grenade.dmi'
+	icon_state = "clusterbang_segment"
+
+/obj/item/weapon/grenade/clusterbuster/segment/New(var/loc, var/payload_type = /obj/item/weapon/grenade/flashbang/cluster)
+	..()
+	icon_state = "clusterbang_segment_active"
+	payload = payload_type
+	active = 1
+	walk_away(src,loc,rand(1,4))
+	spawn(rand(15,60))
+		prime()
+
+
+/obj/item/weapon/grenade/clusterbuster/segment/prime()
+
+	new /obj/effect/payload_spawner(loc, payload, rand(4,8))
+
+	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
+
+	qdel(src)
+
+//////////////////////////////////
+//The payload spawner effect
+/////////////////////////////////
+/obj/effect/payload_spawner/New(var/turf/newloc,var/type, var/numspawned as num)
+
+	for(var/loop = numspawned ,loop > 0, loop--)
+		var/obj/item/weapon/grenade/P = new type(loc)
+		P.active = 1
+		walk_away(P,loc,rand(1,4))
+
+		spawn(rand(15,60))
+			P.prime()
+			qdel(src)
+
+
+//////////////////////////////////
+//Custom payload clusterbusters
+/////////////////////////////////
+/obj/item/weapon/grenade/flashbang/cluster/New()
+	..()
+	icon_state = "flashbang_active"
+	banglet = 1
+	walk_away(loc,rand(1,3))
+	spawn(rand(15,60))
+		prime()
+
+/obj/item/weapon/grenade/clusterbuster/emp
+	name = "Electromagnetic Storm"
+	payload = /obj/item/weapon/grenade/empgrenade
+
+/obj/item/weapon/grenade/clusterbuster/smoke
+	name = "Ninja Vanish"
+	payload = /obj/item/weapon/grenade/smokebomb
+
+/obj/item/weapon/grenade/clusterbuster/metalfoam
+	name = "Instant Concrete"
+	payload = /obj/item/weapon/grenade/chem_grenade/metalfoam
+
+/obj/item/weapon/grenade/clusterbuster/inferno
+	name = "Inferno"
+	payload = /obj/item/weapon/grenade/chem_grenade/incendiary
+
+/obj/item/weapon/grenade/clusterbuster/antiweed
+	name = "RoundDown"
+	payload = /obj/item/weapon/grenade/chem_grenade/antiweed
+
+/obj/item/weapon/grenade/clusterbuster/cleaner
+	name = "Mr. Proper"
+	payload = /obj/item/weapon/grenade/chem_grenade/cleaner
+
+/obj/item/weapon/grenade/clusterbuster/teargas
+	name = "Oignon Grenade"
+	payload = /obj/item/weapon/grenade/chem_grenade/teargas
+
+/obj/item/weapon/grenade/clusterbuster/facid
+	name = "Aciding Rain"
+	payload = /obj/item/weapon/grenade/chem_grenade/facid
+
+/obj/item/weapon/grenade/clusterbuster/syndieminibomb
+	name = "SyndiWrath"
+	payload = /obj/item/weapon/grenade/syndieminibomb
+
+/obj/item/weapon/grenade/clusterbuster/spawner_manhacks
+	name = "iViscerator"
+	payload = /obj/item/weapon/grenade/spawnergrenade/manhacks
+
+/obj/item/weapon/grenade/clusterbuster/spawner_spesscarp
+	name = "Invasion of the Space Carps"
+	payload = /obj/item/weapon/grenade/spawnergrenade/spesscarp

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -66,20 +66,17 @@
 		walk_away(P,loc,rand(1,4))
 
 		spawn(rand(15,60))
-			P.prime()
+			if(P && !P.gc_destroyed)
+				P.prime()
 			qdel(src)
 
 
 //////////////////////////////////
 //Custom payload clusterbusters
 /////////////////////////////////
-/obj/item/weapon/grenade/flashbang/cluster/New()
-	..()
+/obj/item/weapon/grenade/flashbang/cluster
 	icon_state = "flashbang_active"
 	banglet = 1
-	walk_away(loc,rand(1,3))
-	spawn(rand(15,60))
-		prime()
 
 /obj/item/weapon/grenade/clusterbuster/emp
 	name = "Electromagnetic Storm"

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -21,7 +21,7 @@
 
 /obj/item/weapon/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/M)
 	M.show_message("<span class='warning'>BANG</span>", 2)
-	playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
+	playsound(loc, 'sound/effects/bang.ogg', 25, 1)
 
 //Checking for protections
 	var/eye_safety = 0
@@ -46,13 +46,13 @@
 		if (M.eye_stat >= 20 && takes_eye_damage)
 			M << "<span class='warning'>Your eyes start to burn badly!</span>"
 			M.disabilities |= NEARSIGHT
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+			if(!banglet)
 				if (prob(M.eye_stat - 20 + 1))
 					M << "<span class='warning'>You can't see anything!</span>"
 					M.disabilities |= BLIND
 
 //Bang
-	if((src.loc == M) || src.loc == M.loc)//Holding on person or being exactly where lies is significantly more dangerous and voids protection
+	if((loc == M) || loc == M.loc)//Holding on person or being exactly where lies is significantly more dangerous and voids protection
 		M.Stun(10)
 		M.Weaken(10)
 	if(!ear_safety)
@@ -61,81 +61,10 @@
 		M.setEarDamage(M.ear_damage + rand(0, 5), max(M.ear_deaf,15))
 		if (M.ear_damage >= 15)
 			M << "<span class='warning'>Your ears start to ring badly!</span>"
-			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
+			if(!banglet)
 				if(prob(M.ear_damage - 10 + 5))
 					M << "<span class='warning'>You can't hear anything!</span>"
 					M.disabilities |= DEAF
 		else
 			if (M.ear_damage >= 5)
 				M << "<span class='warning'>Your ears start to ring!</span>"
-
-////////////////////
-//Clusterbang
-////////////////////
-/obj/item/weapon/grenade/flashbang/clusterbang
-	desc = "Use of this weapon may constiute a war crime in your area, consult your local captain."
-	name = "clusterbang"
-	icon = 'icons/obj/grenade.dmi'
-	icon_state = "clusterbang"
-
-/obj/item/weapon/grenade/flashbang/clusterbang/prime()
-	update_mob()
-	var/numspawned = rand(4,8)
-	var/again = 0
-
-	for(var/more = numspawned,more > 0,more--)
-		if(prob(35))
-			again++
-			numspawned--
-
-	for(var/loop = numspawned, loop > 0, loop--)
-		new /obj/item/weapon/grenade/flashbang/cluster(loc)//Launches flashbangs
-
-	for(var/loop = again ,loop > 0, loop--)
-		new /obj/item/weapon/grenade/flashbang/clusterbang/segment(loc)//Creates a 'segment' that launches a few more flashbangs
-
-	playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-
-	qdel(src)
-
-
-//////////////////////
-//Clusterbang segment
-//////////////////////
-/obj/item/weapon/grenade/flashbang/clusterbang/segment
-	desc = "A smaller segment of a clusterbang. Better run."
-	name = "clusterbang segment"
-	icon = 'icons/obj/grenade.dmi'
-	icon_state = "clusterbang_segment"
-
-/obj/item/weapon/grenade/flashbang/clusterbang/segment/New()
-	..()
-	icon_state = "clusterbang_segment_active"
-	active = 1
-	walk_away(src,loc,rand(1,4))
-	spawn(rand(15,60))
-		prime()
-
-
-/obj/item/weapon/grenade/flashbang/clusterbang/segment/prime()
-	update_mob()
-	var/numspawned = rand(4,8)
-
-	for(var/loop = numspawned ,loop > 0, loop--)
-		new /obj/item/weapon/grenade/flashbang/cluster(loc)
-
-	playsound(src.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-
-	qdel(src)
-
-////////////////////////////////
-//Clusterbang spwaned flashbang
-////////////////////////////////
-/obj/item/weapon/grenade/flashbang/cluster/New()
-	..()
-	icon_state = "flashbang_active"
-	active = 1
-	banglet = 1
-	walk_away(src,loc,rand(1,3))
-	spawn(rand(15,60))
-		prime()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -93,7 +93,7 @@
 
 /obj/item/weapon/storage/lockbox/clusterbang/New()
 	..()
-	new /obj/item/weapon/grenade/flashbang/clusterbang(src)
+	new /obj/item/weapon/grenade/clusterbuster(src)
 
 /obj/item/weapon/storage/lockbox/medal
 	name = "medal box"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -616,6 +616,7 @@
 #include "code\game\objects\items\weapons\vending_items.dm"
 #include "code\game\objects\items\weapons\weaponry.dm"
 #include "code\game\objects\items\weapons\grenades\chem_grenade.dm"
+#include "code\game\objects\items\weapons\grenades\clusterbuster.dm"
 #include "code\game\objects\items\weapons\grenades\emgrenade.dm"
 #include "code\game\objects\items\weapons\grenades\flashbang.dm"
 #include "code\game\objects\items\weapons\grenades\ghettobomb.dm"


### PR DESCRIPTION
As suggested in #7120, i've ported (an adapted version of) the variable payload clusterbang from **_sayustation**_.

It's basically a clusterbang, which can spawn any grenade type.
Actually coded in :
- traditional (flashbangs)
- emp
- incendiary
- metal foam
- smoke
- antiweed
- cleaner
- tear gas
- facid
- syndie mini bomb
- Viscerator spawner
- Spesscarp spawner

The only clusterbuster legally accessible in-game is the traditionnal flashbang one, every others are only spawnable by (b)admins.

Needless to say, this has a _huge_ potential for grieving, but we trust the (b)admins to found an event/RP use for these.
