### PR TITLE
More Silicon Emotes!

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -220,7 +220,7 @@
 			m_type = 2
 
 		if ("help")
-			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob, clap, custom, deathgasp, flap, glare-(none)/mob, look-(none)/mob, me, nod, ping-(none)/mob, \nsalute-(none)/mob, twitch, twitch_s,"
+			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob,buzz2,chime, clap, custom, deathgasp, flap, glare-(none)/mob, honk, look-(none)/mob, me, nod, ping-(none)/mob, sad, \nsalute-(none)/mob, twitch, twitch_s, warn,"
 
 		else
 			src << "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -30,7 +30,7 @@
 			else
 				message = "<B>[src]</B> beeps."
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
-			m_type = 1
+			m_type = 2
 
 		if ("bow")
 			if (!src.buckled)
@@ -63,7 +63,17 @@
 			else
 				message = "<B>[src]</B> buzzes."
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
-			m_type = 1
+			m_type = 2
+
+		if ("buzz2")
+			message = "<B>[src]</B> buzzes twice."
+			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+			m_type = 2
+
+		if ("chime") //You have mail!
+			message = "<B>[src]</B> chimes."
+			playsound(loc, 'sound/machines/chime.ogg', 50, 0)
+			m_type = 2
 
 		if ("clap")
 			if (!src.restrained())
@@ -106,6 +116,11 @@
 				message = "<B>[src]</B> glares at [param]."
 			else
 				message = "<B>[src]</B> glares."
+
+		if ("honk") //Honk!
+			message = "<B>[src]</B> honks!"
+			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
+			m_type = 2
 
 		if ("look")
 			var/M = null
@@ -153,7 +168,12 @@
 			else
 				message = "<B>[src]</B> pings."
 			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-			m_type = 1
+			m_type = 2
+
+		if ("sad") //When words cannot express...
+			message = "<B>[src]</B> plays a sad trombone."
+			playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 0)
+			m_type = 2
 
 		if ("salute")
 			if (!src.buckled)
@@ -193,6 +213,11 @@
 		if ("twitch_s")
 			message = "<B>[src]</B> twitches."
 			m_type = 1
+
+		if ("warn") //HUMAN HARM DETECTED. PLEASE DIE IN AN ORDERLY FASHION.
+			message = "<B>[src]</B> blares an alarm!"
+			playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
+			m_type = 2
 
 		if ("help")
 			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob, clap, custom, deathgasp, flap, glare-(none)/mob, look-(none)/mob, me, nod, ping-(none)/mob, \nsalute-(none)/mob, twitch, twitch_s,"


### PR DESCRIPTION
Adds the following emotes, all audible:
- buzz2 (from MULEbots)
- chime (MULEbot delivery chime)
- honk, with the pitch variation of the standard bike horn!
- sad, the sad trombone sound from HONK mechs!
- warn, the warning buzzer from newscasters and disposal shutes

I also set the other audible emotes to audio message type.
