### PR TITLE
Fixes supply computers not been able to order contraband

### DIFF
--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -138,6 +138,11 @@
 	var/can_order_contraband = 0
 	var/last_viewed_group = "categories"
 
+/obj/machinery/computer/supplycomp/New()
+	..()
+
+	var/obj/item/weapon/circuitboard/supplycomp/board = circuit
+	can_order_contraband = board.contraband_enabled
 
 /obj/machinery/computer/ordercomp
 	name = "supply ordering console"


### PR DESCRIPTION
The supply computer now correctly inherits the contraband variable from its board (fixes #7391).
