### PR TITLE
[WIP][Needs Testing] Removes colons from all subsytems but shuttles.

### DIFF
--- a/code/controllers/subsystem/bots.dm
+++ b/code/controllers/subsystem/bots.dm
@@ -12,10 +12,10 @@ var/datum/subsystem/bots/SSbot
 /datum/subsystem/bots/fire()
 	var/seconds = wait * 0.1
 	var/i=1
-	for(var/thing in processing)
-		if(thing && !thing:gc_destroyed)
+	for(var/obj/machinery/bot/b in processing)
+		if(b && !b.gc_destroyed)
 			spawn(-1)
-				thing:bot_process(seconds)
+				b.bot_process(seconds)
 			++i
 			continue
 		processing.Cut(i, i+1)

--- a/code/controllers/subsystem/diseases.dm
+++ b/code/controllers/subsystem/diseases.dm
@@ -12,9 +12,9 @@ var/datum/subsystem/diseases/SSdisease
 
 /datum/subsystem/diseases/fire()
 	var/i=1
-	for(var/thing in processing)
-		if(thing)
-			thing:process()
+	for(var/datum/disease/d in processing)
+		if(d)
+			d.process()
 			++i
 			continue
 		processing.Cut(i,i+1)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -35,9 +35,9 @@ var/datum/subsystem/events/SSevent
 /datum/subsystem/events/fire()
 	checkEvent()
 	var/i=1
-	for(var/thing in running)
-		if(thing)
-			thing:process()
+	for(var/datum/round_event/e in running)
+		if(e)
+			e.process()
 			++i
 			continue
 		running.Cut(i,i+1)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -39,16 +39,16 @@ var/datum/subsystem/lighting/SSlighting
 /datum/subsystem/lighting/fire()
 	lights_workload = MC_AVERAGE(lights_workload, lights.len)
 	var/i=1
-	for(var/thing in lights)
-		if(thing && !thing:check())	//yes, cry that I'm using the : operator, it's much faster looping like this. And this gets called a lot. Dealwithit.
+	for(var/datum/light_source/l in lights)
+		if(l && !l.check())	//yes, cry that I'm using the : operator, it's much faster looping like this. And this gets called a lot. Dealwithit.
 			++i
 			continue
 		lights.Cut(i, i+1)
 
 	changed_turfs_workload = MC_AVERAGE(changed_turfs_workload, changed_turfs.len)
-	for(var/thing in changed_turfs)
-		if(thing && thing:lighting_changed)
-			thing:shift_to_subarea()
+	for(var/turf/t in changed_turfs)
+		if(t && t.lighting_changed)
+			t.shift_to_subarea()
 	changed_turfs.Cut()
 
 
@@ -58,8 +58,8 @@ var/datum/subsystem/lighting/SSlighting
 //z-levels with the z_level argument
 /datum/subsystem/lighting/Initialize(timeofday, z_level)
 	var/i=1
-	for(var/thing in lights)
-		if(thing && !thing:check())
+	for(var/datum/light_source/l in lights)
+		if(l && !l.check())
 			++i
 			continue
 		lights.Cut(i, i+1)
@@ -81,8 +81,8 @@ var/datum/subsystem/lighting/SSlighting
 	if(z_level)
 		//we need to loop through to clear only shifted turfs from the list. or we will cause errors
 		i=1
-		for(var/thing in changed_turfs)
-			if(thing && thing:z < z_start && z_finish < thing:z)
+		for(var/turf/t in changed_turfs)
+			if(t && t.z < z_start && z_finish <t.z)
 				++i
 				continue
 			changed_turfs.Cut(i, i+1)

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -22,10 +22,10 @@ var/datum/subsystem/machines/SSmachine
 
 /datum/subsystem/machines/fire()
 	var/seconds = wait * 0.1
-	for(var/thing in processing)
-		if(thing && (thing:process(seconds) != PROCESS_KILL))
-			if(thing:use_power)
-				thing:auto_use_power()
+	for(var/obj/machinery/m in processing)
+		if(m && (m.process(seconds) != PROCESS_KILL))
+			if(m.use_power)
+				m.auto_use_power()
 			continue
-		processing.Remove(thing)
+		processing.Remove(m)
 

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -15,10 +15,8 @@ var/datum/subsystem/mobs/SSmob
 
 /datum/subsystem/mobs/fire()
 	var/seconds = wait * 0.1
-	var/i=1
-	for(var/thing in mob_list)
-		if(thing)
-			thing:Life(seconds)
-			++i
+	for(var/mob/m in mob_list)
+		if(m)
+			m.Life(seconds)
 			continue
-		mob_list.Cut(i, i+1)
+		mob_list.Remove(m)

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -23,9 +23,9 @@ var/datum/subsystem/objects/SSobj
 
 /datum/subsystem/objects/fire()
 	var/i=1
-	for(var/thing in SSobj.processing)
-		if(thing)
-			thing:process(wait)
+	for(var/obj/o in SSobj.processing)
+		if(o)
+			o.process(wait)
 			++i
 			continue
 		SSobj.processing.Cut(i, i+1)

--- a/code/controllers/subsystem/pipenets.dm
+++ b/code/controllers/subsystem/pipenets.dm
@@ -28,9 +28,9 @@ var/datum/subsystem/pipenets/SSpipe
 
 /datum/subsystem/pipenets/fire()
 	var/i=1
-	for(var/thing in networks)
-		if(thing)
-			thing:process()
+	for(var/datum/pipeline/p in networks)
+		if(p)
+			p.process()
 			++i
 			continue
 		networks.Cut(i, i+1)


### PR DESCRIPTION
Removes the colons from all subsytems and replaces var/thing with the appropriate paths.
I'll try to remove them from the shuttle subsystem as well but it's more complicated. 

I'm opening this for review/to make sure I'm not wrong to do this: (If someone wants to jump in and remove the colons from the shuttle controller if possible, I'd be thankful.)
`//yes, cry that I'm using the : operator, it's much faster looping like this. And this gets called a lot. Dealwithit.` (This was in the lighting subsystem file.)

![colon cleaner](https://dl.dropboxusercontent.com/u/83869314/ShareX/2015/01/cc.jpg)
