### PR TITLE
[Do Not Merge] Obscuring Reagents

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -31,14 +31,15 @@
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
 
 #define OPENCONTAINER	4096	// is an open container for chemistry purposes
+#define TRANSPARENT	8192	// is used for OPENCONTAINERs that allow seeing amount of content from afar
 
 // BLOCK_GAS_SMOKE_EFFECT only used in masks at the moment.
-#define BLOCK_GAS_SMOKE_EFFECT 8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
-#define THICKMATERIAL 8192		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
+#define BLOCK_GAS_SMOKE_EFFECT 16384	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
+#define THICKMATERIAL 16384		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
 
-#define	NOREACT		16384 		//Reagents dont' react inside this container.
+#define	NOREACT		32768 		//Reagents dont' react inside this container.
 
-#define BLOCKHAIR	32768		// temporarily removes the user's hair icon
+#define BLOCKHAIR	65536		// temporarily removes the user's hair icon
 
 //turf-only flags
 #define NOJAUNT		1

--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -25,3 +25,6 @@
 #define ANTAG_HUD_GANG_A	8
 #define ANTAG_HUD_GANG_B	9
 #define ANTAG_HUD_WIZ		10
+
+// Scan_Vision for chemical/reagent scanning.
+#define SCAN_CHEMICAL 1

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -257,11 +257,11 @@ its easier to just keep the beam vertical.
 					for(var/datum/reagent/R in reagents.reagent_list)
 						user << "[R.volume] units of [R.name]"
 				else
-					user << "[reagents.total_volume] units of chemical" // Water is a chemical, right?
+					user << "[reagents.total_volume] units of something" // Would like to add RGBcode of the content some day.
 			else
 				user << "Nothing."
 		else
-			user << "You cannot see what it contain from here."
+			user << "<span class='notice'>It is too far away.</span>"
 
 /atom/proc/relaymove()
 	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -98,6 +98,9 @@
 /atom/proc/is_open_container()
 	return flags & OPENCONTAINER
 
+/atom/proc/is_transparent_container()
+	return flags & TRANSPARENT
+
 /*//Convenience proc to see whether a container can be accessed in a certain way.
 
 	proc/can_subract_container()
@@ -246,12 +249,19 @@ its easier to just keep the beam vertical.
 	//user << "[name]: Dn:[density] dir:[dir] cont:[contents] icon:[icon] is:[icon_state] loc:[loc]"
 
 	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
-		user << "It contains:"
-		if(reagents.reagent_list.len)
-			for(var/datum/reagent/R in reagents.reagent_list)
-				user << "[R.volume] units of [R.name]"
+		if(get_dist(user, src) <= 1 || is_transparent_container())
+			user << "It contains:"
+			if(reagents.reagent_list.len)
+				var/obj/item/clothing/glasses/G = user.get_item_by_slot(slot_glasses)
+				if(G && (G.scan_vision & SCAN_CHEMICAL) && get_dist(user, src) <= 1)
+					for(var/datum/reagent/R in reagents.reagent_list)
+						user << "[R.volume] units of [R.name]"
+				else
+					user << "[reagents.total_volume] units of chemical" // Water is a chemical, right?
+			else
+				user << "Nothing."
 		else
-			user << "Nothing."
+			user << "You cannot see what it contain from here."
 
 /atom/proc/relaymove()
 	return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -36,6 +36,7 @@
 	var/vision_flags = 0
 	var/darkness_view = 2//Base human is 2
 	var/invis_view = SEE_INVISIBLE_LIVING
+	var/scan_vision = 0
 	var/emagged = 0
 	var/list/icon/current = list() //the current hud icons
 	strip_delay = 20

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -10,9 +10,10 @@
 
 /obj/item/clothing/glasses/science
 	name = "Science Goggles"
-	desc = "A pair of snazzy goggles used to protect against chemical spills."
+	desc = "A pair of advanced chemistry goggles used to scan chemicals and protect against chemical spills."
 	icon_state = "purple"
 	item_state = "glasses"
+	scan_vision = SCAN_CHEMICAL
 
 /obj/item/clothing/glasses/night
 	name = "Night Vision Goggles"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -25,6 +25,7 @@
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status."
 	icon_state = "healthhud"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
+	scan_vision = SCAN_CHEMICAL
 
 /obj/item/clothing/glasses/hud/health/night
 	name = "Night Vision Health Scanner HUD"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -3,7 +3,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 25, 30, 50)
 	volume = 50
-	flags = OPENCONTAINER
+	flags = OPENCONTAINER | TRANSPARENT
 
 	can_be_placed_into = list(
 		/obj/machinery/chem_master/,
@@ -144,7 +144,6 @@
 	volume = 100
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,50,100)
-	flags = OPENCONTAINER
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	name = "cryostasis beaker"


### PR DESCRIPTION
I was reading around some of the older issues and found this: https://github.com/tgstation/-tg-station/issues/5547#issuecomment-61203224. That along with having a game where I could easily tell from afar that a traitor chemist was making _bad_ stuff made me want to try this.
I though up this little idea about making you only able to see the individual chemicals while wearing either **Science Goggles** or a **Health Scanner HUD**. Because making it so that a Chemist has to use his PDA to scan all the beakers he works with would be a total nightmare.

**Changes:**
- If you are not wearing either Science Goggles or a Health Scanner HUD, you can no longer see what types of reagents are in a beaker/bottle/etc. This only works up close though.
- Added a new variable to glasses with a hud.dm define flag, so it is easy to allow other types of glasses to use this feature.
- You can no longer see how much is in a non-transperent container from afar. (Buckets, etc.)
- Added a new define flag, TRANSPARENT, to all items so it is easy to allow OPENCONTAINER items to disable this feature.

**Picture examples:** (a little outdated, but the idea still stand)
![reagentscanner without glasses](https://cloud.githubusercontent.com/assets/2676134/5934897/5bcb8410-a6d5-11e4-99dd-f484f95313da.png) ![reagentscanner with glasses](https://cloud.githubusercontent.com/assets/2676134/5934899/6296ab1c-a6d5-11e4-9525-3831e4f12009.png)

![reagentscanner bucket](https://cloud.githubusercontent.com/assets/2676134/5934905/700f952e-a6d5-11e4-96f9-6a6fd75b186e.png)

**Needed feedback:**
- I don't have a that good knowledge of what else actually could use this or what I may have forgotten.
- Should **Science Goggles** be renamed with this?
- ~~Should it be described as "liquid" instead of "chemicals"?~~
- ~~Is the "You cannot see what it contains from here" message too long?~~
- Should other types of items be able to do this then just glasses? Maybe helmets? Gloves?
- Further ideas

**Things to do:**
- [ ] Handheld Reagent Scanner (report all reagents in target, highlight bad reagents? highlight if over overdose threshold? upgrade PDA reagent scanner to the same?)
- [ ] Make beakers be the only reagent container that give exact unit amounts
- [ ] Ask community more about what they want/think (make a feedback forum thread)
