### PR TITLE
HTML sanitization tweaking

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -147,32 +147,63 @@
 
 	return t_out
 
-//this proc strips html properly, but it's not lazy like the other procs.
-//this means that it doesn't just remove < and > and call it a day. seriously, who the fuck thought that would be useful.
+//this proc strips html properly, this means that it removes everything between < and >, and between "http" and "://"
 //also limit the size of the input, if specified to
 /proc/strip_html_properly(var/input,var/max_length=MAX_MESSAGE_LEN)
 	if(!input)
 		return
-	var/opentag = 1 //These store the position of < and > respectively.
-	var/closetag = 1
-	while(1)
-		opentag = findtext(input, "<")
-		closetag = findtext(input, ">")
-		if(closetag && opentag)
-			if(closetag < opentag)
-				input = copytext(input, (closetag + 1))
-			else
-				input = copytext(input, 1, opentag) + copytext(input, (closetag + 1))
-		else if(closetag || opentag)
-			if(opentag)
-				input = copytext(input, 1, opentag)
-			else
-				input = copytext(input, (closetag + 1))
+
+	var/sanitized_output
+	var/next_html_tag = findtext(input, "<")
+	var/next_http = findtext(input, "http", 1, next_html_tag)
+
+	//the opening and closing of the expression to skip, e.g '<' and '>'
+	var/opening = non_zero_min(next_html_tag, next_http)
+	var/closing
+
+	sanitized_output = copytext(input, 1, opening)
+
+	while(next_html_tag || next_http)
+
+		//we treat < ... >
+		if(opening == next_html_tag)
+			closing = findtext(input, ">", opening + 1)
+			if(closing)
+				next_html_tag = findtext(input, "<", closing)
+				next_http = findtext(input, "http", closing, next_html_tag)
+			else //no matching ">"
+				next_html_tag = 0
+
+		//we treat "http(s)://"
 		else
-			break
+			closing = findtext(input, "://", opening + 1)
+			if(closing)
+				closing += 2 //skip these extra //
+				next_http = findtext(input, "http", closing)
+				next_html_tag = findtext(input, "<", closing, next_http)
+			else //no matching "://"
+				next_http = 0
+
+		//check if we've something to skip
+		if(closing)
+			opening = non_zero_min(next_html_tag, next_http)
+			sanitized_output += copytext(input, closing + 1, opening)
+
+	sanitized_output += copytext(input, opening) //don't forget the remaining text
+
 	if(max_length)
-		input = copytext(input,1,max_length)
-	return input
+		sanitized_output = copytext(sanitized_output,1,max_length)
+
+	return sanitized_output
+
+//strip_html_properly helper proc that returns the smallest non null of two numbers
+//or 0 if they're both null (needed because of findtext returning 0 when a value is not present)
+/proc/non_zero_min(var/a, var/b)
+	if(!a)
+		return b
+	if(!b)
+		return a
+	return (a < b ? a : b)
 
 /*
  * Text searches

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -37,12 +37,12 @@
 	return t
 
 //Removes a few problematic characters
-/proc/sanitize_simple(var/t,var/list/repl_chars = list("\n"="#","\t"="#","�"="�"))
+/proc/sanitize_simple(var/t,var/list/repl_chars = list("\n"="#","\t"="#"))
 	for(var/char in repl_chars)
 		var/index = findtext(t, char)
 		while(index)
 			t = copytext(t, 1, index) + repl_chars[char] + copytext(t, index+1)
-			index = findtext(t, char)
+			index = findtext(t, char, index+1)
 	return t
 
 //Runs byond's sanitization proc along-side sanitize_simple

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -153,6 +153,9 @@
 	if(!input)
 		return
 
+	if(max_length)
+		input = copytext(input,1,max_length)
+
 	var/sanitized_output
 	var/next_html_tag = findtext(input, "<")
 	var/next_http = findtext(input, "http", 1, next_html_tag)
@@ -190,9 +193,6 @@
 			sanitized_output += copytext(input, closing + 1, opening)
 
 	sanitized_output += copytext(input, opening) //don't forget the remaining text
-
-	if(max_length)
-		sanitized_output = copytext(sanitized_output,1,max_length)
 
 	return sanitized_output
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -396,7 +396,7 @@ var/list/advance_cures = 	list(
 
 	if(D.symptoms.len > 0)
 
-		var/new_name = input(user, "Name your new disease.", "New Name")
+		var/new_name = stripped_input(user, "Name your new disease.", "New Name")
 		if(!new_name)
 			return
 		D.AssignName(new_name)


### PR DESCRIPTION
#### Contents
- Made _strip_html_properly()_ proceed the text in one pass
- Added stripping everything between **http** and **://**, to prevent links from being passed to Byond text window, which automatically parse whatever is "http(s)://XXX" (fixes #7464)
- Stripped an unsafe input for advanced diseases
- Made the message shortening to _max_length_ happen before sanitizing, to avoid unnecessary processing
- Fixed a potential infinite loop in _sanitize_simple_ regarding non-standard character stripping (mentioned/fixed by **volas** in #7503)
