### PR TITLE
Photography repairs

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -625,7 +625,7 @@ The _flatIcons list is a cache for generated icon files.
 */
 
 // Creates a single icon from a given /atom or /image.  Only the first argument is required.
-/proc/getFlatIcon(image/A, defdir=A.dir, deficon=A.icon, defstate=A.icon_state, defblend=A.blend_mode)
+/proc/getFlatIcon(image/A, defdir=A.dir, deficon=A.icon, defstate=A.icon_state, defblend=A.blend_mode, direction)
 	// We start with a blank canvas, otherwise some icon procs crash silently
 	var/icon/flat = icon('icons/effects/effects.dmi', "nothing") // Final flattened icon
 	if(!A)
@@ -656,10 +656,13 @@ The _flatIcons list is a cache for generated icon files.
 			noIcon = TRUE // Do not render this object.
 
 	var/curdir
-	if(A.dir != 2)
-		curdir = A.dir
+	if(direction == 1)
+		if(defdir != 2)
+			curdir = A.dir
+		else
+			curdir = defdir
 	else
-		curdir = defdir
+		curdir = 2
 
 	var/curblend
 	if(A.blend_mode == BLEND_DEFAULT)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -8,6 +8,7 @@
 	var/list/blood_DNA
 	var/last_bumped = 0
 	var/throwpass = 0
+	var/directional = 1 //This var is used to help proc/getFlatIcon deal with common situations whereas an object will have a dir other than 2, but not have a sprite for that dir.
 
 	///Chemistry.
 	var/datum/reagents/reagents = null

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -16,6 +16,7 @@
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
 	req_access = list(access_security)
 	power_channel = EQUIP	//drains power from the EQUIPMENT channel
+	directional = 1
 
 	var/lasercolor = ""		//Something to do with lasertag turrets, blame Sieve for not adding a comment.
 	var/raised = 0			//if the turret cover is "open" and the turret is raised

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -70,6 +70,7 @@
 	var/atom/movable/cur_target
 	var/targeting_active = 0
 	var/area/turret_protected/protected_area
+	directional = 1
 
 
 /obj/machinery/turret/New()
@@ -359,6 +360,7 @@
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	icon = 'icons/obj/turrets.dmi'
 	icon_state = "syndieturret0"
+	directional = 1
 
 /obj/machinery/gun_turret/New()
 	..()

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -1,5 +1,6 @@
 /obj/mecha/working
 	internal_damage_threshold = 60
+	directional = 1
 
 /obj/mecha/working/New()
 	..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -9,6 +9,7 @@
 
 	var/damtype = "brute"
 	var/force = 0
+	directional = 0
 
 /obj/proc/process()
 	SSobj.processing.Remove(src)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -11,6 +11,7 @@
 	var/intialBrute = 0
 	var/intialOxy = 0
 	var/timer = 240 //eventually the person will be freed
+	directional = 1
 
 /obj/structure/closet/statue/New(loc, var/mob/living/L)
 

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -6,6 +6,7 @@
 	density = 0
 	anchored = 1
 	var/notices = 0
+	directional = 1
 
 /obj/structure/noticeboard/initialize()
 	for(var/obj/item/I in loc)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -3,6 +3,7 @@
 	desc = "You sit in this. Either by will or force."
 	icon_state = "chair"
 	buckle_lying = 0 //you sit in a chair, not lay
+	directional = 1
 
 /obj/structure/stool/bed/chair/New()
 	..()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -27,6 +27,7 @@
 	var/busy = 0
 	var/buildstackamount = 1
 	var/framestackamount = 2
+	directional = 1
 
 /obj/structure/table/New()
 	..()

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -13,6 +13,7 @@
 	var/cooldown_delay = 50
 	var/launch_cooldown = 0
 	var/reverse_launch = 0
+	directional = 1
 
 	var/const/OPEN_DURATION = 6
 	var/const/CLOSE_DURATION = 6

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -6,6 +6,7 @@
 	density = 1
 	var/moving = 0
 	var/datum/gas_mixture/air_contents = new()
+	directional = 1
 
 
 /obj/structure/transit_tube_pod/New(loc)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -9,6 +9,7 @@
 	var/cistern = 0			//if the cistern bit is open
 	var/w_items = 0			//the combined w_class of all the items in the cistern
 	var/mob/living/swirlie = null	//the mob being given a swirlie
+	directional = 1
 
 
 /obj/structure/toilet/New()
@@ -111,6 +112,7 @@
 	icon_state = "urinal"
 	density = 0
 	anchored = 1
+	directional = 1
 
 
 /obj/structure/urinal/attackby(obj/item/I, mob/user)
@@ -143,6 +145,7 @@
 	var/ismist = 0				//needs a var so we can make it linger~
 	var/watertemp = "normal"	//freezing, normal, or boiling
 	var/mobpresent = 0		//true if there is a mob on the shower's loc, this is to ease process()
+	directional = 1
 
 
 /obj/effect/mist
@@ -351,6 +354,7 @@
 	desc = "A sink used for washing one's hands and face."
 	anchored = 1
 	var/busy = 0 	//Something's being washed at the moment
+	directional = 1
 
 
 /obj/structure/sink/attack_hand(mob/user)
@@ -439,6 +443,7 @@
 /obj/structure/sink/puddle	//splishy splashy ^_^
 	name = "puddle"
 	icon_state = "puddle"
+	directional = 0
 
 /obj/structure/sink/puddle/attack_hand(mob/M as mob)
 	icon_state = "puddle-splash"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -17,6 +17,7 @@ obj/structure/windoor_assembly
 	anchored = 0
 	density = 0
 	dir = NORTH
+	directional = 1
 
 	var/ini_dir
 	var/obj/item/weapon/airlock_electronics/electronics = null

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -18,6 +18,7 @@
 	var/fulltile = 0
 	var/obj/item/stack/rods/storedrods
 	var/obj/item/weapon/shard/storedshard
+	directional = 1
 //	var/silicate = 0 // number of units of silicate
 //	var/icon/silicateIcon = null // the silicated icon
 
@@ -441,11 +442,13 @@
 	dir = 5
 	maxhealth = 50
 	fulltile = 1
+	directional = 0
 
 /obj/structure/window/reinforced/fulltile
 	dir = 5
 	maxhealth = 100
 	fulltile = 1
+	directional = 0
 
 /obj/structure/window/reinforced/tinted/fulltile
 	dir = 5

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -34,6 +34,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	anchored = 1
 	var/z_original = 0
 	var/destination
+	directional = 1
 
 /obj/effect/immovablerod/New(atom/start, atom/end)
 	loc = start

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -18,6 +18,7 @@
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
 	var/atom/movable/following = null
 	var/fun_verbs = 0
+	directional = 0
 
 /mob/dead/observer/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -8,6 +8,7 @@
 	var/is_adult = 0
 	languages = SLIME | HUMAN
 	faction = list("slime")
+	directional = 0
 
 	layer = 5
 

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -20,6 +20,7 @@
 	ventcrawler = 2
 	var/obj/item/inventory_head
 	var/obj/item/inventory_mask
+	directional = 0
 
 /mob/living/simple_animal/crab/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -21,6 +21,7 @@
 	environment_smash = 0
 	mouse_opacity = 2
 	pass_flags = PASSTABLE
+	directional = 0
 
 	//Spaceborn beings don't get hurt by space
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -26,6 +26,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+	directional = 0
 
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "hivebot"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -242,6 +242,7 @@
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
+	directional = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
 	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
@@ -312,6 +313,7 @@
 	throw_message = "falls right through the strange body of the"
 	environment_smash = 0
 	pass_flags = PASSTABLE
+	directional = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -15,6 +15,7 @@
 	maxHealth = 250
 	health = 250
 	mob_size = 2
+	directional = 0
 
 	pixel_x = -16
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -26,6 +26,7 @@
 	status_flags = 0
 	faction = list("cult")
 	status_flags = CANPUSH
+	directional = 0
 
 
 /mob/living/simple_animal/shade/Life()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -174,7 +174,7 @@
 	var/icon/res = icon('icons/effects/96x96.dmi', "")
 
 	for(var/atom/A in sorted)
-		var/icon/img = getFlatIcon(A)
+		var/icon/img = getFlatIcon(A, direction=A.directional)
 		if(istype(A, /mob/living) && A:lying)
 			img.Turn(A:lying)
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -174,7 +174,8 @@
 	var/icon/res = icon('icons/effects/96x96.dmi', "")
 
 	for(var/atom/A in sorted)
-		var/icon/img = getFlatIcon(A)
+		world << "[A]"
+		var/icon/img = getFlatIcon(A, direction=A.directional)
 		if(istype(A, /mob/living) && A:lying)
 			img.Turn(A:lying)
 

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -12,6 +12,7 @@
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	level = 2
 	var/ptype = 0
+	directional = 1
 
 	var/dpdir = 0	// directions as disposalpipe
 	var/base_state = "pipe-s"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -625,6 +625,7 @@
 	layer = 2.3			// slightly lower than wires and other pipes
 	var/base_icon_state	// initial icon state on map
 	var/obj/structure/disposalconstruct/stored
+	directional = 1
 
 	// new pipe, set the icon_state as on map
 /obj/structure/disposalpipe/New(loc,var/obj/structure/disposalconstruct/make_from)
@@ -1234,6 +1235,7 @@
 	var/mode = 0
 	var/start_eject = 0
 	var/eject_range = 2
+	directional = 1
 
 /obj/structure/disposaloutlet/New(loc, var/obj/structure/disposalconstruct/make_from)
 	..()


### PR DESCRIPTION
'Refactor' of photography to give all atoms a var 'directional'. This var is used to define if the object has sprites for at least the 4 cardinal directions (1), or if it only has one sprite for SOUTH (0). Proc/getFlatIcon has been modified to take this var into consideration.

Completes #7473
Fixes #7450 
Fixes #4315
Fixes #7092 
Fixes #4019
Fixes untold many other issues.

What I need from you: Review to find if I have missed any objects that need to be specificly designated one way or the other for it's sprites.

Items I need to check:
OVERLAYS (Clothing and such)
