### PR TITLE
Magic Mania 1.85: RPG loot event

### DIFF
--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -22,6 +22,6 @@
 			I.name = "[I.name] of [pick(suffixes)]"
 
 		I.force 		+= quality
-		I.force			= max(0,quality)
+		I.force			= max(0,I.force)
 		I.throwforce 	+= quality
-		I.throwforce	= max(0,quality)
+		I.throwforce	= max(0,I.throwforce)

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -1,0 +1,27 @@
+/datum/round_event_control/wizard/rpgloot //its time to minmax your shit
+	name = "RPG Loot"
+	weight = 3
+	typepath = /datum/round_event/wizard/rpgloot/
+	max_occurrences = 1
+	earliest_start = 0
+
+/datum/round_event/wizard/rpgloot/start()
+	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious")
+	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic")
+	var/list/suffixes			= list("orc-slaying", "elf-slaying", "corgi-slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
+
+	for(var/obj/item/I in world)
+		if(istype(I,/obj/item/organ/))
+			continue
+		var/quality = rand(-5,5)
+		if(quality > 0)
+			I.name = "[pick(prefixespositive)] [I.name] of [pick(suffixes)] +[quality]"
+		else if(quality < 0)
+			I.name = "[pick(prefixesnegative)] [I.name] of [pick(suffixes)] [quality]"
+		else
+			I.name = "[I.name] of [pick(suffixes)]"
+
+		I.force 		+= quality
+		I.force			= max(0,quality)
+		I.throwforce 	+= quality
+		I.throwforce	= max(0,quality)

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -6,8 +6,8 @@
 	earliest_start = 0
 
 /datum/round_event/wizard/rpgloot/start()
-	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious")
-	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic")
+	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
+	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
 	var/list/suffixes			= list("orc-slaying", "elf-slaying", "corgi-slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
 
 	for(var/obj/item/I in world)

--- a/html/changelogs/Incoming5643 - Fell_Pull_Commit_of_Orc_Slaying_+2.yml
+++ b/html/changelogs/Incoming5643 - Fell_Pull_Commit_of_Orc_Slaying_+2.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+delete-after: True
+
+
+changes:
+  - rscadd: "A new event has been added to the wizards summon events spell that gives the game a distictively more roleplaying flair."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -928,6 +928,7 @@
 #include "code\modules\events\wizard\magicarp.dm"
 #include "code\modules\events\wizard\petsplosion.dm"
 #include "code\modules\events\wizard\race.dm"
+#include "code\modules\events\wizard\rpgloot.dm"
 #include "code\modules\events\wizard\shuffle.dm"
 #include "code\modules\events\wizard\summons.dm"
 #include "code\modules\flufftext\Dreaming.dm"


### PR DESCRIPTION
Adds the RPG loot wizard event (summon events only) at an uncommon (3) weight. One time only run event.

All items in the world at the time of event gain a small bonus/penalty to force and throwforce, and a corresponding silly name. Less lag inducing then you probably think.

Taking all suggestions for prefixes and suffixes. Prefixes should imply a positive or negative quality, but suffixes shouldn't. Feel free to get a little wacky.
