### PR TITLE
Movable UI Elements!

### DIFF
--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -1,0 +1,42 @@
+
+//////////////////////////
+//Movable Screen Objects//
+//   By RemieRichards	//
+//////////////////////////
+
+
+//Movable Screen Object
+//Not tied to the grid, places it's center where the cursor is
+
+/obj/screen/movable
+	var/snap2grid = FALSE
+
+
+//Snap Screen Object
+//Tied to the grid, snaps to the nearest turf
+
+/obj/screen/movable/snap
+	snap2grid = TRUE
+
+
+/obj/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+	var/list/PM = params2list(params)
+
+	//Split screen-loc up into X+Pixel_X and Y+Pixel_Y
+	var/list/screen_loc_params = text2list(PM["screen-loc"], ",")
+
+	//Split X+Pixel_X up into list(X, Pixel_X)
+	var/list/screen_loc_X = text2list(screen_loc_params[1],":")
+
+	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
+	var/list/screen_loc_Y = text2list(screen_loc_params[2],":")
+
+	if(snap2grid) //Discard Pixel Values
+		screen_loc = "[screen_loc_X[1]],[screen_loc_Y[1]]"
+
+	else //Normalise Pixel Values (So the object drops at the center of the mouse, not 16 pixels off)
+		var/pix_X = text2num(screen_loc_X[2]) - 16
+		var/pix_Y = text2num(screen_loc_Y[2]) - 16
+		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
+
+

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -22,6 +22,10 @@
 /obj/screen/movable/MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
 	var/list/PM = params2list(params)
 
+	//No screen-loc information? abort.
+	if(!PM || !PM["screen-loc"])
+		return
+
 	//Split screen-loc up into X+Pixel_X and Y+Pixel_Y
 	var/list/screen_loc_params = text2list(PM["screen-loc"], ",")
 

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -40,3 +40,41 @@
 		screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
 
+
+//Debug procs
+/client/proc/test_movable_UI()
+	set category = "Debug"
+	set name = "Spawn Movable UI Object"
+
+	var/obj/screen/movable/M = new()
+	M.name = "Movable UI Object"
+	M.icon_state = "block"
+	M.maptext = "Movable"
+	M.maptext_width = 64
+
+	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Movable UI Object") as text
+	if(!screen_l)
+		return
+
+	M.screen_loc = screen_l
+
+	screen += M
+
+
+/client/proc/test_snap_UI()
+	set category = "Debug"
+	set name = "Spawn Snap UI Object"
+
+	var/obj/screen/movable/snap/S = new()
+	S.name = "Snap UI Object"
+	S.icon_state = "block"
+	S.maptext = "Snap"
+	S.maptext_width = 64
+
+	var/screen_l = input(usr,"Where on the screen? (Formatted as 'X,Y' e.g: '1,1' for bottom left)","Spawn Snap UI Object") as text
+	if(!screen_l)
+		return
+
+	S.screen_loc = screen_l
+
+	screen += S

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -114,7 +114,9 @@ var/list/admin_verbs_debug = list(
 	/client/proc/restart_controller,
 	/client/proc/enable_debug_verbs,
 	/client/proc/callproc,
-	/client/proc/SDQL2_query
+	/client/proc/SDQL2_query,
+	/client/proc/test_movable_UI,
+	/client/proc/test_snap_UI
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -82,6 +82,7 @@
 #include "code\_onclick\hud\hud.dm"
 #include "code\_onclick\hud\human.dm"
 #include "code\_onclick\hud\monkey.dm"
+#include "code\_onclick\hud\movable_screen_objects.dm"
 #include "code\_onclick\hud\other_mobs.dm"
 #include "code\_onclick\hud\robot.dm"
 #include "code\_onclick\hud\screen_objects.dm"


### PR DESCRIPTION
Adds 2 types of Movable UI Element (Fancier name for "Screen object")
- <B>Movable:</B> Places it's centre where the cursor is
- <B>Snap:</B> Snaps itself to the nearest turf

Also includes 2 debug verbs (requiring R_DEBUG Admin rank) to spawn a Movable and a Snap UI Element. These debug verbs request a screen_loc from the user. the message recommends the numerical format for screen_loc but will happily accept the keywords instead (CENTER,CENTER)

<B>Example Gif:</B> (Note, Any unresponsiveness in the gif is the result of my mouse and gifcam hating each other)

![movableuielements](https://cloud.githubusercontent.com/assets/4043781/6088631/7441c6c6-ae50-11e4-93b2-8354fff4475e.gif)
