### PR TITLE
Ports the kinetic accelerator changes from NT

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -39,6 +39,7 @@
 	var/obj/item/device/flashlight/F = null
 	var/can_flashlight = 0
 
+	var/list/upgrades = list()
 
 /obj/item/weapon/gun/New()
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -115,10 +115,45 @@
 	cell_type = "/obj/item/weapon/stock_parts/cell/emproof"
 	var/overheat = 0
 	var/recent_reload = 1
+	var/range_add = 0
+	var/overheat_time = 20
+	upgrades = list("diamond" = 0, "screwdriver" = 0, "plasma" = 0)
+
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/newshot()
+	..()
+	if(chambered && chambered.BB)
+		var/obj/item/projectile/kinetic/charge = chambered.BB
+		charge.range += range_add
+
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/screwdriver) && upgrades["screwdriver"] < 3)
+		upgrades["screwdriver"]++
+		overheat_time -= 1
+		user << "<span class='info'>You tweak [src]'s thermal exchanger.</span>"
+
+
+	else if(istype(W, /obj/item/stack))
+		var/obj/item/stack/S = W
+
+		if(istype(S, /obj/item/stack/sheet/mineral/diamond) && upgrades["diamond"] < 3)
+			upgrades["diamond"]++
+			overheat_time -= 3
+			user << "<span class='info'>You upgrade [src]'s thermal exchanger with diamonds.</span>"
+			S.use(1)
+
+		if(istype(S, /obj/item/stack/sheet/mineral/plasma) && upgrades["plasma"] < 2)
+			upgrades["plasma"]++
+			range_add++
+			user << "<span class='info'>You upgrade [src]'s accelerating chamber with plasma.</span>"
+			if(prob(5 * (range_add + 1) * (range_add + 1)) && power_supply)
+				power_supply.rigged = 1 // This is dangerous!
+			S.use(1)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
 	overheat = 1
-	spawn(20)
+	spawn(overheat_time)
 		overheat = 0
 		recent_reload = 0
 	..()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -114,13 +114,19 @@ obj/item/projectile/kinetic/New()
 	var/pressure = environment.return_pressure()
 	if(pressure < 50)
 		name = "full strength kinetic force"
-		damage = 30
+		damage *= 2
 	..()
 
 /obj/item/projectile/kinetic/Range()
 	range--
 	if(range <= 0)
 		new /obj/item/effect/kinetic_blast(src.loc)
+		for(var/turf/T in range(1, src.loc))
+			if(!istype(T, /turf/simulated/wall))
+				T.ex_act(3)
+
+		for(var/obj/structure/S in range(1, src.loc))
+			S.ex_act(3)
 		qdel(src)
 
 /obj/item/projectile/kinetic/on_hit(atom/target)
@@ -129,6 +135,13 @@ obj/item/projectile/kinetic/New()
 		var/turf/simulated/mineral/M = target_turf
 		M.gets_drilled(firer)
 	new /obj/item/effect/kinetic_blast(target_turf)
+	if(isturf(target) || istype(target, /obj/structure))
+		for(var/turf/T in range(1, target_turf))
+			if(!istype(T, /turf/simulated/wall))
+				T.ex_act(3)
+
+		for(var/obj/structure/S in range(1, target_turf))
+			S.ex_act(3)
 	..()
 
 /obj/item/effect/kinetic_blast


### PR DESCRIPTION
You can reduce kinetic gun's cooldown by tweaking or upgrading it's thermal exchanger. 
Maximally upgraded gun's cooldown is 8, standard is 20.

You can increase kinetic gun's range with plasma sheets (up to 5, current is 3), but this can make your gun unsafe.

Kinetic charge is buffed a bit and can damage structures and turfs around the kinetic blast (but not station walls or mobs). This makes kinetic guns a bit better in mining.

credit goes to @ACCount12 for the code
