### PR TITLE
slime feeding hotfix

### DIFF
--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -205,9 +205,9 @@
 	return
 
 /mob/living/carbon/slime/MouseDrop(var/atom/movable/A as mob|obj)
-	if(isliving(A) && A != usr)
+	if(isliving(A) && A != src && usr == src)
 		var/mob/living/Food = A
-		if(Food.Adjacent(usr) && !stat && Food.stat != DEAD) //messy
+		if(Food.Adjacent(src) && !stat && Food.stat != DEAD) //messy
 			Feedon(Food)
 	..()
 


### PR DESCRIPTION
turns out checking usr adjacency is a bad idea, great famry shame for not noticing this before.
*fixes any mob being able to teleport slimes, probably even nonlivings could do this oh god

i liked the idea of being able to feed a slime by dropping it onto a monkeys head, but that will require rewriting feedon and probably other slime procs because feedon is a nightmare, still working on getting that done.
