### PR TITLE
Adds optional population caps

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1449,3 +1449,9 @@ var/list/WALLITEMS = list(
 		chance = max(chance - (initial_chance / steps), 0)
 		steps--
 
+/proc/living_player_count()
+	var/living_player_count = 0
+	for(var/mob in player_list)
+		if(mob in living_mob_list)
+			living_player_count += 1
+	return living_player_count

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -67,6 +67,14 @@
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
 	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
+	//Population cap vars
+	var/soft_popcap				= 0
+	var/hard_popcap				= 0
+	var/extreme_popcap			= 0
+	var/soft_popcap_message		= "Be warned that the server is currently serving a high number of users, consider using alternative game servers."
+	var/hard_popcap_message		= "The server is currently serving a high number of users, You cannot currently join. You may wait for the number of living crew to decline, observe, or find alternative servers."
+	var/extreme_popcap_message	= "The server is currently serving a high number of users, find alternative servers."
+
 	//game_options.txt configs
 	var/force_random_names = 0
 	var/list/mode_names = list()
@@ -292,6 +300,18 @@
 						global.comms_allowed = 1
 				if("see_own_notes")
 					config.see_own_notes = 1
+				if("soft_popcap")
+					config.soft_popcap = text2num(value)
+				if("hard_popcap")
+					config.hard_popcap = text2num(value)
+				if("extreme_popcap")
+					config.extreme_popcap = text2num(value)
+				if("soft_popcap_message")
+					config.soft_popcap_message = value
+				if("hard_popcap_message")
+					config.hard_popcap_message = value
+				if("extreme_popcap_message")
+					config.extreme_popcap_message = value
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -47,6 +47,11 @@ world/IsBanned(key,address,computer_id)
 		message_admins("<span class='adminnotice'>Failed Login: [key] - Guests not allowed</span>")
 		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
 
+	//Population Cap Checking
+	if(config.extreme_popcap && living_player_count() >= config.extreme_popcap && !(ckey(key) in admin_datums))
+		log_access("Failed Login: [key] - Population cap reached")
+		return list("reason"="popcap", "desc"= "\nReason: [config.extreme_popcap_message]")
+
 	if(config.ban_legacy_system)
 
 		//Ban Checking

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -6,6 +6,9 @@
 	if(admin_notice)
 		src << "<span class='notice'><b>Admin Notice:</b>\n \t [admin_notice]</span>"
 
+	if(config.soft_popcap && living_player_count() >= config.soft_popcap)
+		src << "<span class='notice'><b>Server Notice:</b>\n \t [config.soft_popcap_message]</span>"
+
 	if(!mind)
 		mind = new /datum/mind(key)
 		mind.active = 1

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -126,6 +126,10 @@
 		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
 			usr << "<span class='danger'>The round is either not ready, or has already finished...</span>"
 			return
+		var/relevent_cap = max(config.hard_popcap, config.extreme_popcap)
+		if(relevent_cap && living_player_count() >= relevent_cap && !(ckey(key) in admin_datums))
+			usr << "<span class='danger'>[config.hard_popcap_message]</span>"
+			return
 		LateChoices()
 
 	if(href_list["manifest"])

--- a/config/config.txt
+++ b/config/config.txt
@@ -156,3 +156,23 @@ TICKCOMP 0
 
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
 #SEE_OWN_NOTES
+
+##Note: all population caps can be used with each other if desired.
+
+## Uncomment for 'soft' population caps, players will be warned while joining if the living crew exceeds the listed number.
+#SOFT_POPCAP 100
+
+## Message for soft cap
+SOFT_MESSAGE Be warned that the server is currently serving a high number of users, consider using alternative game servers.
+
+## Uncomment for 'hard' population caps, players will not be allowed to spawn if the living crew exceeds the listed number, though they may still observe or wait for the living crew to decrease in size.
+#HARD_POPCAP 150
+
+## Message for hard cap
+HARD_MESSAGE The server is currently serving a high number of users, You cannot currently join. You may wait for the number of living crew to decline, observe, or find alternative servers.
+
+## Uncomment for 'extreme' population caps, players will not be allowed to join the server if living crew exceeds the listed number.
+#EXTREME_POPCAP 200
+
+## Message for extreme cap
+EXTREME_MESSAGE The server is currently serving a high number of users, find alternative servers.

--- a/html/changelogs/Incoming5643-population caps.yml
+++ b/html/changelogs/Incoming5643-population caps.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "Optional population cap functionality has been added to the game. By default all caps are disabled. Server owners should refer to config.txt to see their list of options."


### PR DESCRIPTION
For those that want them. These be dark measures, so tread carefully ye who dare enter this place.

There are three "levels" of popcaps, and you can use them in any assortment you like:

-The "soft" cap produces a message on join, and takes no action.
-The "hard" cap disallows joining whilst too many other people are alive and playing in game, but allows observing.
-The "extreme" cap prevents people from joining the server at all while the cap is exceeded. It won't kick out people who failed to qualify during roundstart, but if they leave they won't be able to get back in.

In each case a customizable message option has been given. Admins are also immune to most population caps (they still are hit by the ones in job shuffling, but can late join as normal afterwards). All popcaps default to off, seriously think long and hard about this.

Standard disclaimer: It's really hard to test this on anything else than a legitimate server, so don't be all shocked if a hotfix or two is needed once people see how/if it actually performs.

Fixes #7537
