### PR TITLE
E.X.P.E.R.I-MENTOR fixes

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -26,7 +26,6 @@
 	var/mob/trackedIan
 	var/mob/trackedRuntime
 	var/obj/item/loaded_item = null
-	///
 	var/badThingCoeff = 0
 	var/resetTime = 15
 	var/cloneMode = FALSE
@@ -225,7 +224,10 @@
 			--cloneCount
 			if(cloneCount == 0)
 				cloneMode = FALSE
-		loaded_item.loc = get_turf(pick(oview(1,src)))
+		var/turf/dropturf = get_turf(pick(oview(1,src)))
+		if(!dropturf) //Failsafe to prevent the object being lost in the void forever.
+			dropturf = get_turf(src)
+		loaded_item.loc = dropturf
 		if(delete)
 			qdel(loaded_item)
 		loaded_item = null
@@ -272,7 +274,8 @@
 			if(target)
 				var/obj/item/throwing = loaded_item
 				ejectItem()
-				throwing.throw_at(target, 10, 1)
+				if(throwing)
+					throwing.throw_at(target, 10, 1)
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	if(exp == SCANTYPE_IRRADIATE)
 		visible_message("<span class='notice'>[src] reflects radioactive rays at [exp_on]!</span>")
@@ -529,7 +532,11 @@
 		if(recentlyExperimented)
 			usr << "<span class='notice'>[src] has been used too recently!</span>"
 			return
-		var/dotype = matchReaction(process,scantype)
+		var/dotype
+		if(text2num(scantype) == SCANTYPE_DISCOVER)
+			dotype = SCANTYPE_DISCOVER
+		else
+			dotype = matchReaction(process,scantype)
 		experiment(dotype,process)
 		use_power(750)
 		if(dotype != FAIL)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -521,6 +521,7 @@
 		if(D)
 			linked_console = D
 	else if(scantype == "eject")
+		busy = 0
 		ejectItem()
 	else if(scantype == "refresh")
 		src.updateUsrDialog()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -167,6 +167,9 @@
 
 	return
 
+/obj/machinery/r_n_d/experimentor/default_deconstruction_crowbar(var/obj/item/O)
+	ejectItem()
+	..(O)
 
 /obj/machinery/r_n_d/experimentor/attack_hand(mob/user as mob)
 	user.set_machine(src)


### PR DESCRIPTION
Fixes an issue in which manually ejecting an item from the
E.X.P.E.R.I-MENTOR caused it to become inoperable.
EDIT: More bugfixes added:
- Relic discovery works again!
- Fixed a runtime when the Experimentor tries to throw items at players.
- Ejected items are no longer sent to the void.
- If the machine is deconstructed, it will also eject the loaded item, if any.
