### PR TITLE
Fixes stock grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -1,10 +1,10 @@
-#define EMPTY 0
-#define WIRED 1
-#define READY 2
+#define EMPTY 1
+#define WIRED 2
+#define READY 3
 
 /obj/item/weapon/grenade/chem_grenade
 	name = "grenade"
-	desc = "A do it yourself grenade casing!"
+	desc = "A custom made grenade."
 	icon_state = "chemg"
 	item_state = "flashbang"
 	w_class = 2
@@ -18,7 +18,7 @@
 
 /obj/item/weapon/grenade/chem_grenade/New()
 	create_reagents(1000)
-	name = "[initial(name)] casing" // By adding the " casing" part here we can use initial(name) to get the final name, making it nice to say "large grenade" when it is a large grenade.
+	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
 
 
 /obj/item/weapon/grenade/chem_grenade/examine(mob/user)
@@ -121,18 +121,19 @@
 
 
 /obj/item/weapon/grenade/chem_grenade/proc/stage_change(var/N)
-	stage = N
-	if (stage == EMPTY)
+	if(N)
+		stage = N
+	if(stage == EMPTY)
 		name = "[initial(name)] casing"
-		desc = initial(desc)
+		desc = "A do it yourself [initial(name)] casing!"
 		icon_state = initial(icon_state)
-	else if (stage == WIRED)
+	else if(stage == WIRED)
 		name = "unsecured [initial(name)]"
 		desc = "An unsecured [initial(name)] assembly."
 		icon_state = "[initial(icon_state)]_ass"
-	else if (stage == READY)
+	else if(stage == READY)
 		name = initial(name)
-		desc = "A custom made [initial(name)]."
+		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
 
 
@@ -225,7 +226,7 @@
 //Large chem grenades accept slime cores and use the appropriately.
 /obj/item/weapon/grenade/chem_grenade/large
 	name = "large grenade"
-	desc = "An oversized grenade casing."
+	desc = "A custom made large grenade."
 	icon_state = "large_grenade"
 	allowed_containers = list(/obj/item/weapon/reagent_containers/glass,/obj/item/weapon/reagent_containers/food/condiment,
 								/obj/item/weapon/reagent_containers/food/drinks)
@@ -275,7 +276,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 
 /obj/item/weapon/grenade/chem_grenade/incendiary
@@ -294,7 +294,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 
 /obj/item/weapon/grenade/chem_grenade/antiweed
@@ -314,7 +313,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 
 /obj/item/weapon/grenade/chem_grenade/cleaner
@@ -333,7 +331,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 
 /obj/item/weapon/grenade/chem_grenade/teargas
@@ -353,7 +350,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 
 /obj/item/weapon/grenade/chem_grenade/facid
@@ -373,7 +369,6 @@
 
 	beakers += B1
 	beakers += B2
-	icon_state = "grenade"
 
 #undef EMPTY
 #undef WIRED

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -362,7 +362,7 @@
 	var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
 	var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
 
-	B1.reagents.add_reagent("facid", 100)
+	B1.reagents.add_reagent("facid", 25)
 	B1.reagents.add_reagent("potassium", 25)
 	B2.reagents.add_reagent("phosphorus", 25)
 	B2.reagents.add_reagent("sugar", 25)


### PR DESCRIPTION
This was an unreported bug that I caused last year when I did https://github.com/tgstation/-tg-station/pull/3698. I just noticed it when playing a few days ago.
- The stock grenades no longer have `casing` in their name.
- Fixes dissembling and reassembling a stock grenade changing its description.
- Fixed the stock _acid grenade_'s payload so that it actually works now.

As a side note, _acid grenade_ kills anyone standing close to it in less than a second. So it may need some re-balancing.
