### PR TITLE
Lets Silicons and Drones use the Ore Redemption Machine

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -161,8 +161,8 @@
 				I.loc = src
 				inserted_id = I
 			else usr << "<span class='warning'>No valid ID.</span>"
-	if(href_list["release"] && istype(inserted_id))
-		if(check_access(inserted_id))
+	if(href_list["release"])
+		if(check_access(inserted_id) || issilicon(usr))
 			if(!(text2path(href_list["release"]) in stack_list)) return
 			var/obj/item/stack/sheet/inp = stack_list[text2path(href_list["release"])]
 			var/obj/item/stack/sheet/out = new inp.type()
@@ -173,8 +173,8 @@
 				unload_mineral(out)
 		else
 			usr << "<span class='warning'>Required access not found.</span>"
-	if(href_list["plasteel"] && istype(inserted_id))
-		if(check_access(inserted_id))
+	if(href_list["plasteel"])
+		if(check_access(inserted_id) || issilicon(usr))
 			if(!(/obj/item/stack/sheet/metal in stack_list)) return
 			if(!(/obj/item/stack/sheet/mineral/plasma in stack_list)) return
 			var/obj/item/stack/sheet/metalstack = stack_list[/obj/item/stack/sheet/metal]

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -162,7 +162,7 @@
 				inserted_id = I
 			else usr << "<span class='warning'>No valid ID.</span>"
 	if(href_list["release"])
-		if(check_access(inserted_id) || issilicon(usr))
+		if(check_access(inserted_id) || usr.has_unlimited_silicon_privilege)
 			if(!(text2path(href_list["release"]) in stack_list)) return
 			var/obj/item/stack/sheet/inp = stack_list[text2path(href_list["release"])]
 			var/obj/item/stack/sheet/out = new inp.type()
@@ -174,7 +174,7 @@
 		else
 			usr << "<span class='warning'>Required access not found.</span>"
 	if(href_list["plasteel"])
-		if(check_access(inserted_id) || issilicon(usr))
+		if(check_access(inserted_id) || usr.has_unlimited_silicon_privilege)
 			if(!(/obj/item/stack/sheet/metal in stack_list)) return
 			if(!(/obj/item/stack/sheet/mineral/plasma in stack_list)) return
 			var/obj/item/stack/sheet/metalstack = stack_list[/obj/item/stack/sheet/metal]

--- a/html/changelogs/Gun-Hog-PR-7582.yml
+++ b/html/changelogs/Gun-Hog-PR-7582.yml
@@ -1,0 +1,9 @@
+
+author: Gun Hog
+
+
+delete-after: True
+
+
+changes: 
+  - tweak: "Nanotrasen has released a firmware patch for the Ore Redemption Machine, which now allows the station AI, cyborgs, and maintenance drones to smelt raw resources without the need of a valid identification card installed."


### PR DESCRIPTION
Silicons and drones can now use the Ore Redeemer.

The reasoning is simple. Mining cyborgs were unable to access the ore machine, forcing them to ask for a human to help, or smash down the barrier to the old smelter in the mining area. 

This provides a benefit to both borgs and humans: Mining borgs can smelt at the ore machine, and human miners can claim the points from the borg's haul! The AI and non-mining borgs can be ordered to release minerals for those without access, should that be needed.

_Addendum: Drones now have access as well! They can mine on their own and build golden fortresses all they like!_

Codernote: I removed the "istype(inserted_id)" checks for the release
and plasteel functions as they do not do anything to the ID inside
except the check_access() proc. That proc returns 0 if called when no ID
is inserted, so it can safely be removed from those two options.
