### PR TITLE
AI status screen now properly reports AFK cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -230,7 +230,7 @@ var/list/ai_list = list()
 				borg_area = get_area(R)
 				//Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
 				stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "Empty"] | \
- Module: [R.designation] | Loc: [borg_area.name] | Status: [R.stat ? "Offline" : "Normal"]"))
+ Module: [R.designation] | Loc: [borg_area.name] | Status: [R.stat || !R.client ? "OFFLINE" : "Normal"]"))
 		else
 			stat(null, text("Systems nonfunctional"))
 


### PR DESCRIPTION
When I made the original update, I had believed that the stat var would be active for clientless mobs. As this is incorrect, I am adding the check so that it works as intended.

I also changed "Offline" to "OFFLINE" to make it slightly more noticeable.
