### PR TITLE
Fixes warnings related to add_reagent 

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -125,7 +125,7 @@
 	var/dat
 	dat += "<h3>Injector</h3>"
 	if(occupant)
-		dat += "<A href='?src=\ref[src];inject=epinephrine'>Inject epinephrine</A>"
+		dat += "<A href='?src=\ref[src];inject=epinephrine'>Inject Epinephrine</A>"
 	else
 		dat += "<span class='linkOff'>Inject Epinephrine</span>"
 	if(occupant && occupant.health > min_health)
@@ -168,7 +168,7 @@
 			dat += "<div class='line'><span class='average'>Significant brain damage detected.</span></div>"
 		if(occupant.reagents.reagent_list.len)
 			for(var/datum/reagent/R in occupant.reagents.reagent_list)
-				dat += text("<div class='line'><div class='statusLabel'>[R.name]:</div><div class='statusValue'>[] units</div></div>", round(R.volume, 0.1))
+				dat += "<div class='line'><div style='width: 170px;' class='statusLabel'>[R.name]:</div><div class='statusValue'>[round(R.volume, 0.1)] units</div></div>"
 	dat += "</div>"
 
 	var/datum/browser/popup = new(user, "sleeper", "Sleeper Console", 520, 540)	//Set up the popup browser window
@@ -221,7 +221,7 @@
 			if(occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency)
 				occupant.reagents.add_reagent(chem, 10)
 			var/units = round(occupant.reagents.get_reagent_amount(chem))
-			user << "<span class='notice'>Occupant now has [units] unit\s of [chem] in their bloodstream.</span>"
+			user << "<span class='notice'>Occupant now has [units] unit\s of [chemical_reagents_list[chem]] in their bloodstream.</span>"
 
 /obj/machinery/sleeper/update_icon()
 	if(state_open)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -161,7 +161,7 @@
 		dat +=  "<div class='line'><div class='statusLabel'>\> Toxin Content:</div><div class='progressBar'><div style='width: [occupant.getToxLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getToxLoss()]%</div></div>"
 		dat +=  "<div class='line'><div class='statusLabel'>\> Burn Severity:</div><div class='progressBar'><div style='width: [occupant.getFireLoss()]%;' class='progressFill bad'></div></div><div class='statusValue'>[occupant.getFireLoss()]%</div></div>"
 
-		dat += "<HR><div class='line'><div class='statusLabel'>Paralysis Summary:</div><div class='statusValue'>[round(occupant.paralysis)]% [occupant.paralysis ? "([round(occupant.paralysis / 4)] seconds left)" : ""]</div></div>"
+		dat += "<HR><div class='line'><div style='width: 170px;' class='statusLabel'>Paralysis Summary:</div><div class='statusValue'>[round(occupant.paralysis)]% [occupant.paralysis ? "([round(occupant.paralysis / 4)] seconds left)" : ""]</div></div>"
 		if(occupant.getCloneLoss())
 			dat += "<div class='line'><span class='average'>Subject appears to have cellular damage.</span></div>"
 		if(occupant.getBrainLoss())

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -306,22 +306,27 @@ MASS SPECTROMETER
 			else
 				blood_traces = params2list(R.data["trace_chem"])
 				break
-		var/dat = "Trace Chemicals Found: "
-		for(var/R in blood_traces)
-			if(prob(reliability))
-				if(details)
-					dat += "[R] ([blood_traces[R]] units) "
+		var/dat = "<i><b>Trace Chemicals Found:</b>"
+		if(!blood_traces.len)
+			dat += "<br>None"
+		else
+			for(var/R in blood_traces)
+				if(prob(reliability))
+					dat += "<br>[chemical_reagents_list[R]]"
+
+					if(details)
+						dat += " ([blood_traces[R]] units)"
+
+					recent_fail = 0
 				else
-					dat += "[R] "
-				recent_fail = 0
-			else
-				if(recent_fail)
-					crit_fail = 1
-					reagents.clear_reagents()
-					return
-				else
-					recent_fail = 1
-		user << "[dat]"
+					if(recent_fail)
+						crit_fail = 1
+						reagents.clear_reagents()
+						return
+					else
+						recent_fail = 1
+		dat += "</i>"
+		user << dat
 		reagents.clear_reagents()
 	return
 

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -159,8 +159,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		B.data["resistances"] = src.resistances.Copy()
 	var/list/temp_chem = list()
 	for(var/datum/reagent/R in src.reagents.reagent_list)
-		temp_chem += R.name
-		temp_chem[R.name] = R.volume
+		temp_chem[R.id] = R.volume
 	B.data["trace_chem"] = list2params(temp_chem)
 	if(mind)
 		B.data["mind"] = src.mind
@@ -206,7 +205,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	container.reagents.remove_reagent("blood", amount)
 
-//Transfers blood from container to vessels, respecting blood types compatability.
+//Transfers blood from container to vessels, respecting blood types compatibility.
 /mob/living/carbon/human/inject_blood(obj/item/weapon/reagent_containers/container, var/amount)
 
 	var/datum/reagent/blood/injected = get_blood(container.reagents)


### PR DESCRIPTION
When trying to inject blood containing reagents, it was using the reagent name instead of the reagent id (straight porting ?).

**Edit** : formatted the mass spectrometer output and fixes sleepers displayed reagent id instead of name while i was at it.
Also widened the reagent <div> to account for the massive _"Saline-Glucose Solution"_ reagent name.
