### PR TITLE
Updated MetaStation.v40B.dmm and MetaStation/z2.dmm - Fixes Tequila Compile Error

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v40B.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v40B.dmm
@@ -5059,7 +5059,7 @@
 "bTo" = (/obj/item/device/radio/beacon,/turf/simulated/floor/plasteel{tag = "icon-vault (WEST)"; icon_state = "vault"; dir = 8},/area/teleporter{name = "\improper Teleporter Room"})
 "bTp" = (/obj/machinery/atmospherics/unary/vent_scrubber{dir = 1; on = 1; scrub_N2O = 1; scrub_Toxins = 1},/obj/machinery/door_control{id = "teleshutter"; name = "Teleporter Shutter Control"; pixel_x = 26; pixel_y = -26; req_access_txt = "19"},/turf/simulated/floor/plasteel{tag = "icon-vault (WEST)"; icon_state = "vault"; dir = 8},/area/teleporter{name = "\improper Teleporter Room"})
 "bTq" = (/obj/structure/cable/yellow,/obj/machinery/shieldwallgen,/turf/simulated/floor/plasteel{tag = "icon-vault (EAST)"; icon_state = "vault"; dir = 4},/area/teleporter{name = "\improper Teleporter Room"})
-"bTr" = (/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla,/obj/structure/table/wood,/turf/simulated/floor/wood,/area/maintenance/aft{name = "Aft Maintenance"})
+"bTr" = (/obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,/obj/structure/table/wood,/turf/simulated/floor/wood,/area/maintenance/aft{name = "Aft Maintenance"})
 "bTs" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/assembly/showroom{name = "\improper Corporate Showroom"})
 "bTt" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 2; on = 1},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/wood,/area/assembly/showroom{name = "\improper Corporate Showroom"})
 "bTu" = (/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/assembly/showroom{name = "\improper Corporate Showroom"})

--- a/_maps/map_files/MetaStation/z2.dmm
+++ b/_maps/map_files/MetaStation/z2.dmm
@@ -521,7 +521,7 @@
 "ka" = (/obj/machinery/computer/telecrystals/uplinker,/turf/unsimulated/floor{tag = "icon-podhatch (NORTHWEST)"; icon_state = "podhatch"; dir = 9},/area/syndicate_mothership)
 "kb" = (/obj/structure/dresser,/turf/unsimulated/floor{icon_state = "grimy"},/area/syndicate_mothership)
 "kc" = (/obj/structure/table/wood,/obj/item/weapon/clipboard,/obj/item/weapon/pen,/turf/unsimulated/floor{icon_state = "grimy"},/area/syndicate_mothership)
-"kd" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka{pixel_x = -5},/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{pixel_x = 5},/turf/unsimulated/floor{icon_state = "dark"},/area/centcom/ferry)
+"kd" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,/obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka{pixel_x = -5},/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{pixel_x = 5},/turf/unsimulated/floor{icon_state = "dark"},/area/centcom/ferry)
 "ke" = (/obj/structure/closet/secure_closet/ertMed,/turf/unsimulated/floor{tag = "icon-darkblue"; icon_state = "darkblue"; dir = 2},/area/centcom/ferry)
 "kf" = (/obj/structure/closet/secure_closet/ertEngi,/obj/structure/extinguisher_cabinet{pixel_y = -28},/turf/unsimulated/floor{tag = "icon-darkbrown"; icon_state = "darkbrown"; dir = 2},/area/centcom/ferry)
 "kg" = (/obj/structure/closet/secure_closet/ertSec,/turf/unsimulated/floor{tag = "icon-darkred"; icon_state = "darkred"; dir = 2},/area/centcom/ferry)


### PR DESCRIPTION
-Updated tequila path (formerly "tequilla", fixed in typo fix update https://github.com/tgstation/-tg-station/pull/7568)
-Map compiles again as before in https://github.com/tgstation/-tg-station/pull/7549.
