### PR TITLE
Exotic Blood

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -37,6 +37,7 @@
 	var/hair_color = null	// this allows races to have specific hair colors... if null, it uses the H's hair/facial hair colors. if "mutcolor", it uses the H's mutant_color
 	var/hair_alpha = 255	// the alpha used by the hair. 255 is completely solid, 0 is transparent.
 	var/use_skintones = 0	// does it use skintones or not? (spoiler alert this is only used by humans)
+	var/exotic_blood = null	// If your race wants to bleed something other than bog standard blood, change this.
 	var/meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human //What the species drops on gibbing
 	var/list/no_equip = list()	// slots the race can't equip stuff to
 	var/nojumpsuit = 0	// this is sorta... weird. it basically lets you equip stuff that usually needs jumpsuits without one, like belts and pockets and ids

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -158,7 +158,33 @@
 	hair_alpha = 150
 	ignored_by = list(/mob/living/carbon/slime)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/slime
+	exotic_blood = /datum/reagent/toxin/slimejelly
+	var/recently_changed = 1
 
+/datum/species/slime/spec_life(mob/living/carbon/human/H)
+	if(!H.reagents.get_reagent_amount("slimejelly"))
+		if(recently_changed)
+			H.reagents.add_reagent("slimejelly", 80)
+			recently_changed = 0
+		else
+			H.reagents.add_reagent("slimejelly", 5)
+			H.adjustBruteLoss(5)
+			H << "<span class='danger'>You feel empty!</span>"
+
+	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
+		if(S.volume < 100)
+			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
+				H.reagents.add_reagent("slimejelly", 0.5)
+				H.nutrition -= 5
+		if(S.volume < 50)
+			if(prob(5))
+				H << "<span class='danger'>You feel drained!</span>"
+		if(S.volume < 10)
+			H.losebreath++
+
+/datum/species/slime/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	if(chem.id == "slimejelly")
+		return 1
 /*
  JELLYPEOPLE
 */
@@ -172,7 +198,32 @@
 	eyes = "jelleyes"
 	specflags = list(MUTCOLORS,EYECOLOR,NOBLOOD)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/slime
+	exotic_blood = /datum/reagent/toxin/slimejelly
+	var/recently_changed = 1
 
+/datum/species/jelly/spec_life(mob/living/carbon/human/H)
+	if(!H.reagents.get_reagent_amount("slimejelly"))
+		if(recently_changed)
+			H.reagents.add_reagent("slimejelly", 80)
+			recently_changed = 0
+		else
+			H.reagents.add_reagent("slimejelly", 5)
+			H.adjustBruteLoss(5)
+			H << "<span class='danger'>You feel empty!</span>"
+
+	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
+		if(S.volume < 100)
+			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
+				H.reagents.add_reagent("slimejelly", 0.5)
+				H.nutrition -= 5
+			else if(prob(5))
+				H << "<span class='danger'>You feel drained!</span>"
+		if(S.volume < 10)
+			H.losebreath++
+
+/datum/species/jelly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	if(chem.id == "slimejelly")
+		return 1
 /*
  GOLEMS
 */

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -68,7 +68,7 @@
 				if(ishuman(target))
 					var/mob/living/carbon/human/H = target
 					if(H.dna)
-						if(NOBLOOD in H.dna.species.specflags)
+						if(NOBLOOD in H.dna.species.specflags && !H.dna.species.exotic_blood)
 							user << "<span class='notice'>You are unable to locate any blood.</span>"
 							return
 				if(reagents.has_reagent("blood"))
@@ -94,6 +94,13 @@
 					var/datum/reagent/B
 					B = T.take_blood(src,amount)
 
+					if(!B && ishuman(target))
+						var/mob/living/carbon/human/H = target
+						if(H.dna && H.dna.species.exotic_blood && H.reagents.total_volume)
+							target.reagents.trans_to(src, amount)
+						else
+							user << "<span class='notice'>You are unable to locate any blood.</span>"
+							return
 					if (B)
 						src.reagents.reagent_list += B
 						src.reagents.update_total()

--- a/html/changelogs/Incoming5643-youjelly.yml
+++ b/html/changelogs/Incoming5643-youjelly.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "Slime and Jelly mutant races now actually contain slime jelly. While playing as these races you will naturally produce it internally from your nutrition, so be sure to stay well fed as losing too much is dangerous to your health! Beware of chems that clear toxins, as they can be rapidly fatal to you!"


### PR DESCRIPTION
Adds a new species var, exotic_blood, that can be used with species that don't have traditional blood so you can still draw something from them with syringes if such a thing logically makes sense.

It's used here to allow slime jelly to be drawn from slimepeople (and the far less seen jellypeople)

In both cases slime jelly is produced from nutrition, and will always do so unless you've got either extremely low nutrition or extremely high slime jelly.

Practical effects of this:

*You can kill slimepeople in a few special ways, you can syringe all the jelly out and once they run out of nutrition to replace it they'll stop breathing, chems that help clear toxins also screw them over BADLY in this way.

*slimepeople get free access to a semi-potent toxin whenever they want provided they have a syringe on hand, but have to manage their nutrition if they rely on it. Also it's immediately obvious they're at fault as slime jelly can't be produced anywhere beside xenobiology and produces unique messages.

*Other chems can be syringed wholesale out of slimepeople as well provided they haven't been metabolized yet.
