### PR TITLE
Fixed the changelog example

### DIFF
--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -1,7 +1,7 @@
 ################################
 # Example Changelog File
 #
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read.  If you change this file, you will look really dumb.
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
 #
 # Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
 # When it is, any changes listed below will disappear.
@@ -12,8 +12,8 @@
 #   tweak
 #   soundadd
 #   sounddel
-#   rscdel (general adding of nice things)
-#   rscadd (general deleting of nice things)
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
 #   imageadd
 #   imagedel
 #   spellcheck (typo fixes)
@@ -25,7 +25,7 @@
 author: N3X15
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
-#delete-after: True
+delete-after: True
 
 # Any changes you've made.  See valid prefix list above.
 # INDENT WITH TWO SPACES.  NOT TABS.  SPACES.


### PR DESCRIPTION
- Swapped the notes for `rscadd` and `rscdel`, so that they are now correct.
- Uncommented `delete-after: True`, that way people (including me) don't forget uncomment it every time.

Wiki also got a little update with some examples.
https://tgstation13.org/wiki/Guide_to_Changelogs

This should be safe to merge right away, unless there is something I don't know about the changelog system.
