### PR TITLE
Fixes admin healing not giving blood back.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -141,7 +141,7 @@ mob/living/carbon/human/proc/hat_fall_prob()
 	if(update)	update_damage_overlays(0)
 
 /mob/living/carbon/human/proc/restore_blood()
-	if(!NOBLOOD in dna.species.specflags)
+	if(!(NOBLOOD in dna.species.specflags))
 		var/blood_volume = vessel.get_reagent_amount("blood")
 		vessel.add_reagent("blood",560.0-blood_volume)
 


### PR DESCRIPTION
In doubt, use the prefix notation.

Solves one half of #7638 .
