### PR TITLE
Revert #7592 for breaking ai objection interaction. fixes #7671 - ai can not interact with most topic based interfaces

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -23,8 +23,10 @@ var/datum/cameranet/cameranet = new()
 // Returns the chunk in the x, y, z.
 // If there is no chunk, it creates a new chunk and returns that.
 /datum/cameranet/proc/getCameraChunk(x, y, z)
+	x &= ~(CHUNK_SIZE - 1)
+	y &= ~(CHUNK_SIZE - 1)
 	var/key = "[x],[y],[z]"
-	if(!chunkGenerated(x, y, z))
+	if(!chunks[key])
 		chunks[key] = new /datum/camerachunk(null, x, y, z)
 
 	return chunks[key]


### PR DESCRIPTION
This broke all ai object interactions by causing returned camera chunks to not be the right camera chunk, so tests for rather or not the ai can see an interface/object was almost always returning false when the ai could see the object.

Camera chunk code is too scary for me to attempt to fix the core issue, and its a small pr so revert seemed better.

Fixes #7671 

Merge post haste
