### PR TITLE
Fixes ready spam

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -88,7 +88,7 @@
 
 	if(href_list["ready"])
 		if(!ticker || ticker.current_state <= GAME_STATE_PREGAME) // Make sure we don't ready up after the round has started
-			ready = !ready
+			ready = text2num(href_list["ready"])
 		else
 			ready = 0
 

--- a/html/changelogs/Deantwo-ReadySpam.yml
+++ b/html/changelogs/Deantwo-ReadySpam.yml
@@ -3,4 +3,4 @@ author: Deantwo
 delete-after: True
 
 changes: 
-  - bugfix: "You can now spawn the 'Ready' button as much as you want without it setting you 'Not ready' again."
+  - bugfix: "You can now spam the 'Ready' button as much as you want without it setting you 'Not ready' again."

--- a/html/changelogs/Deantwo-ReadySpam.yml
+++ b/html/changelogs/Deantwo-ReadySpam.yml
@@ -1,0 +1,6 @@
+author: Deantwo
+
+delete-after: True
+
+changes: 
+  - bugfix: "You can now spawn the 'Ready' button as much as you want without it setting you 'Not ready' again."


### PR DESCRIPTION
You can now spam the "Ready" button as much as you want without it making you change between "ready" and "not ready" a million times.

The buttons were setting `ready` to either `1` or `0` in the [href](https://github.com/tgstation/-tg-station/blob/master/code/modules/mob/new_player/new_player.dm#L26), but the Topic() proc didn't check the value of `ready` at all.

Simple one-line fix.
