### PR TITLE
Fixes admin_forcemove() leaving the destination turf at 0 density

### DIFF
--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -151,17 +151,14 @@
 /proc/admin_forcemove(var/mob/mover, var/atom/newloc)
 	var/startdensity = mover.density
 	var/startflags = mover.pass_flags
-	var/startincorporeal = 0
-	if(istype(mover, /mob/living))
-		var/mob/living/L = mover
-		startincorporeal = L.incorporeal_move
-		L.incorporeal_move = 1
+	var/startdestinationdensity = newloc.density
+
 	mover.density = 0
 	mover.pass_flags = ALL
 	newloc.density = 0
+
 	. = mover.Move(newloc)
+
 	mover.density = startdensity
 	mover.pass_flags = startflags
-	if(istype(mover, /mob/living))
-		var/mob/living/L = mover
-		L.incorporeal_move = startincorporeal
+	newloc.density = startdestinationdensity


### PR DESCRIPTION
There was reports of non-solid walls because of this.
Also removed the _incorporeal_move_ part, because it was only checked in Client/Move().

_No idea why git insist on seen untouched code as new... The only function changed is admin_forcemove()._

Fixes #7594.
