### PR TITLE
Fixes object processing list 

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -12,7 +12,7 @@
 
 /obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2)
 	blob_cores += src
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	if(!overmind)
 		create_overmind(new_overmind)
 	if(overmind)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -9,7 +9,7 @@
 
 /obj/effect/blob/node/New(loc, var/h = 100)
 	blob_nodes += src
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	..(loc, h)
 
 /obj/effect/blob/node/adjustcolors(var/a_color)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -225,7 +225,7 @@ var/bomb_set
 
 /obj/item/weapon/disk/nuclear/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/item/weapon/disk/nuclear/process()
 	var/turf/disk_loc = get_turf(src)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -58,7 +58,7 @@
 	var/cowsleft = 20
 
 /obj/effect/rend/cow/New()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	return
 
 /obj/effect/rend/cow/process()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1159,7 +1159,7 @@ FIRE ALARM
 	else if (href_list["time"])
 		src.timing = text2num(href_list["time"])
 		last_process = world.timeofday
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 	else if (href_list["tp"])
 		var/tp = text2num(href_list["tp"])
 		src.time += tp

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -24,7 +24,7 @@
 /obj/effect/forcefield/mime/New()
 	..()
 	last_process = world.time
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/effect/forcefield/mime/process()
 	timeleft -= (world.time - last_process)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -81,7 +81,7 @@
 /obj/effect/spider/eggcluster/New()
 	pixel_x = rand(3,-3)
 	pixel_y = rand(3,-3)
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/effect/spider/eggcluster/process()
 	amount_grown += rand(0,2)
@@ -109,7 +109,7 @@
 /obj/effect/spider/spiderling/New()
 	pixel_x = rand(6,-6)
 	pixel_y = rand(6,-6)
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/effect/spider/spiderling/Bump(atom/user)
 	if(istype(user, /obj/structure/table))

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -54,7 +54,7 @@
 		for(var/mob/O in viewers(usr, null))
 			O.show_message(flavor_text, 1)
 		SetLuminosity(CANDLE_LUMINOSITY)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 
 /obj/item/candle/process()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -283,7 +283,7 @@ obj/item/device/flashlight/lamp/bananalamp
 
 /obj/item/device/flashlight/emp/New()
 		..()
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 /obj/item/device/flashlight/emp/Destroy()
 		SSobj.processing.Remove(src)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -186,7 +186,7 @@
 	if(energy <= max_energy)
 		if(!recharging)
 			recharging = 1
-			SSobj.processing.Add(src)
+			SSobj.processing |= src
 		if(energy <= 0)
 			user << "<span class='warning'>You've overused the battery of [src], now it needs time to recharge!</span>"
 			recharge_locked = 1

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -47,7 +47,7 @@
 		if(OPERATING)
 			if(!attached)
 				return
-			SSobj.processing.Add(src)
+			SSobj.processing |= src
 			anchored = 1
 
 	mode = value

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -25,7 +25,7 @@ MASS SPECTROMETER
 	icon_state = copytext(icon_state, 1, length(icon_state))+"[on]"
 
 	if(on)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 
 /obj/item/device/t_scanner/process()

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -176,7 +176,7 @@
 		update_icon()
 
 		desc = initial(desc) + "<br><span class='info'>It appears to contain [target.name].</span>"
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/effect/chrono_field/Destroy()
 	if(gun && gun.field_check(src))

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -50,7 +50,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		name = "lit match"
 		desc = "A match. This one is lit."
 		attack_verb = list("burnt","singed")
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 		update_icon()
 	return
 
@@ -185,7 +185,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(flavor_text)
 			var/turf/T = get_turf(src)
 			T.visible_message(flavor_text)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 		//can't think of any other way to update the overlays :<
 		if(ismob(loc))
@@ -475,7 +475,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light [src], they however burn their finger in the process.</span>")
 
 			user.AddLuminosity(1)
-			SSobj.processing.Add(src)
+			SSobj.processing |= src
 		else
 			lit = 0
 			icon_state = icon_off

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -140,7 +140,7 @@
 		if(!status)	return
 		lit = !lit
 		if(lit)
-			SSobj.processing.Add(src)
+			SSobj.processing |= src
 	if(href_list["amount"])
 		throw_amount = throw_amount + text2num(href_list["amount"])
 		throw_amount = max(50, min(5000, throw_amount))

--- a/code/game/objects/items/weapons/singularityhammer.dm
+++ b/code/game/objects/items/weapons/singularityhammer.dm
@@ -17,7 +17,7 @@
 
 /obj/item/weapon/twohanded/singularityhammer/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/twohanded/singularityhammer/Destroy()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -24,7 +24,7 @@
 	src.air_contents.volume = volume //liters
 	src.air_contents.temperature = T20C
 
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 	return
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -317,7 +317,7 @@
 			damtype = "fire"
 			hitsound = 'sound/items/welder.ogg'
 			icon_state = "welder1"
-			SSobj.processing.Add(src)
+			SSobj.processing |= src
 		else
 			user << "<span class='notice'>You need more fuel.</span>"
 			welding = 0

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -46,7 +46,7 @@
 		qdel(src)
 		return
 
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	..()
 
 /obj/structure/closet/statue/process()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -23,7 +23,7 @@
 /obj/item/device/assembly/infra/toggle_secure()
 	secured = !secured
 	if(secured)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 	else
 		on = 0
 		if(first)	qdel(first)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -31,7 +31,7 @@
 /obj/item/device/assembly/prox_sensor/toggle_secure()
 	secured = !secured
 	if(secured)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 	else
 		scanning = 0
 		timing = 0

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -27,7 +27,7 @@
 /obj/item/device/assembly/timer/toggle_secure()
 	secured = !secured
 	if(secured)
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 	else
 		timing = 0
 		SSobj.processing.Remove(src)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -74,7 +74,7 @@
 		src.force = 3
 		src.damtype = "fire"
 		src.icon_state = "cake1"
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 	else
 		src.force = null
 		src.damtype = "brute"

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -145,7 +145,7 @@
 					user << "\[ <span style='color: #00ff00;'>ok</span> \] Starting ui display driver"
 					user << "\[ <span style='color: #00ff00;'>ok</span> \] Initializing chronowalk4-view"
 					new_camera(user)
-					SSobj.processing.Add(src)
+					SSobj.processing |= src
 					activated = 1
 				else
 					user << "\[ <span style='color: #ff0000;'>fail</span> \] Mounting /dev/helmet"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -323,7 +323,7 @@
 		qdel(src)
 
 	spawn_spacevine_piece(loc, , muts)
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	init_subtypes(/datum/spacevine_mutation/, mutations_list)
 	if(mttv != null)
 		mutativness = mttv

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -39,7 +39,7 @@
 	if(!(user in color_altered_mobs))
 		color_altered_mobs += user
 	user.color = "#00FF00"
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	..()
 
 /obj/item/weapon/greentext/dropped(mob/living/user as mob)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -576,7 +576,7 @@
 	..()
 	if( istype(src.loc, /mob) )
 		held_mob = src.loc
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili/process()
 	if(held_mob && src.loc == held_mob)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -14,11 +14,10 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 	if(istype(loc, /mob/living))
 		affected_mob = loc
 		affected_mob.status_flags |= XENO_HOST
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 		if(istype(affected_mob,/mob/living/carbon))
 			var/mob/living/carbon/H = affected_mob
 			H.med_hud_set_status()
-		SSobj.processing.Add(src)
 		spawn(0)
 			AddInfectionImages(affected_mob)
 	else
@@ -42,7 +41,6 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 		if(istype(affected_mob,/mob/living/carbon))
 			var/mob/living/carbon/H = affected_mob
 			H.med_hud_set_status()
-		SSobj.processing.Remove(src)
 		spawn(0)
 			RemoveInfectionImages(affected_mob)
 			affected_mob = null

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -815,7 +815,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 	New()
 		..()
-		SSobj.processing.Add(src)
+		SSobj.processing |= src
 
 /obj/effect/golemrune/process()
 	var/mob/dead/observer/ghost

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -251,7 +251,7 @@ var/global/chicken_count = 0
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
 		if(chicken_count < MAX_CHICKENS && prob(25))
-			SSobj.processing.Add(E)
+			SSobj.processing |= E
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/var/amount_grown = 0
 /obj/item/weapon/reagent_containers/food/snacks/egg/process()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -32,7 +32,7 @@
 
 	src.energy = starting_energy
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 	for(var/obj/machinery/power/singularity_beacon/singubeacon in world)
 		if(singubeacon.active)
 			target = singubeacon

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -31,7 +31,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/captain/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/laser/captain/Destroy()
@@ -110,7 +110,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/bluetag/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/item/weapon/gun/energy/laser/bluetag/Destroy()
 	SSobj.processing.Remove(src)
@@ -140,7 +140,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/redtag/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/item/weapon/gun/energy/laser/redtag/Destroy()
 	SSobj.processing.Remove(src)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -26,7 +26,7 @@
 
 /obj/item/weapon/gun/energy/gun/nuclear/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/gun/nuclear/Destroy()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -35,7 +35,7 @@
 
 /obj/item/weapon/gun/energy/floragun/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/floragun/Destroy()
@@ -71,7 +71,7 @@
 
 /obj/item/weapon/gun/energy/meteorgun/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/meteorgun/Destroy()
@@ -174,7 +174,7 @@
 
 /obj/item/weapon/gun/energy/disabler/cyborg/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/disabler/cyborg/Destroy()
@@ -259,7 +259,7 @@
 
 /obj/item/weapon/gun/energy/printer/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/printer/Destroy()

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg/Destroy()

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -50,7 +50,8 @@
 	..()
 	charges = max_charges
 	chambered = new ammo_type(src)
-	if(can_charge)	SSobj.processing.Add(src)
+	if(can_charge)
+		SSobj.processing |= src
 
 
 /obj/item/weapon/gun/magic/Destroy()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -38,7 +38,7 @@ Borg Hypospray
 		modes[R] = iteration
 		iteration++
 
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 
 /obj/item/weapon/reagent_containers/borghypo/Destroy()

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -119,7 +119,7 @@
 
 /obj/item/weapon/rcs/New()
 	..()
-	SSobj.processing.Add(src)
+	SSobj.processing |= src
 
 /obj/item/weapon/rcs/examine(mob/user)
 	..()


### PR DESCRIPTION
by replacing "SSobj.processing.Add" with "SSobj.processing |= " to avoid having duplicated objects in the list, meaning the objects would be processed more than once per iteration.

Also, I fixed Alien embryo processing that was processed twice. Fixes #7508
