### PR TITLE
Mediborg Improvement Drive: The man in gauze

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -101,6 +101,11 @@
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
 	stop_bleeding = 900
 
+/obj/item/stack/medical/gauze/cyborg/
+	m_amt = 0
+	is_cyborg = 1
+	cost = 250
+
 /obj/item/stack/medical/ointment
 	name = "ointment"
 	desc = "Used to treat those nasty burn wounds."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -297,3 +297,8 @@
 	max_energy = 50
 	recharge_rate = 2
 	name = "Wire Synthesizer"
+
+/datum/robot_energy_storage/gauze
+	max_energy = 2500
+	recharge_rate = 250
+	name = "Gauze Synthesizer"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -96,6 +96,14 @@
 	var/obj/item/weapon/reagent_containers/spray/S = emag
 	S.banned_reagents = list()
 
+	var/datum/robot_energy_storage/gauze/gauzestore = new /datum/robot_energy_storage/gauze(src)
+
+	var/obj/item/stack/medical/gauze/cyborg/G = new /obj/item/stack/medical/gauze/cyborg(src)
+	G.source = gauzestore
+	modules += G
+
+	storages += gauzestore
+
 	fix_modules()
 
 


### PR DESCRIPTION
Adds gauze to Mediborgs, it can be regenerated in chargers much the same as the engiborgs materials.

Split from #7694 as no one had any problems with this bit
