### PR TITLE
Mediborg Improvement Drive: Reefer Madness

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -23,7 +23,7 @@ Borg Hypospray
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list("omnizine", "epinephrine", "spaceacillin")
+	var/list/reagent_ids = list("salbutamol", "salglu_solution", "charcoal", "epinephrine", "spaceacillin")
 	//var/list/reagent_ids = list("salbutamol", "salglu_solution", "salglu_solution", "charcoal", "ephedrine", "spaceacillin")
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.


### PR DESCRIPTION
Removes omnizine from mediborgs for having a hideously deadly overdose mechanic that was making asimov borgs cry and replaces them with the "big three" injectible healers of goonchem. Between them all four types of vanilla damage are covered.

Split from #7694
