### PR TITLE
Mediborg Improvement Drive: Roller Robo Da

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -100,3 +100,43 @@
 		new/obj/item/roller(get_turf(src))
 		qdel(src)
 		return
+
+/obj/item/roller/robo //ROLLER ROBO DA!
+	name = "roller bed dock"
+	var/loaded = null
+
+/obj/item/roller/robo/New()
+	loaded = new /obj/structure/stool/bed/roller(src)
+	desc = "A collapsed roller bed that can be ejected for emergency use. Must be collected or replaced after use."
+	..()
+
+/obj/item/roller/robo/examine(mob/user)
+	..()
+	user << "The dock is [loaded ? "loaded" : "empty"]"
+
+/obj/item/roller/robo/attack_self(mob/user)
+	if(loaded)
+		var/obj/structure/stool/bed/roller/R = loaded
+		R.loc = user.loc
+		user.visible_message("<span class='notice'>[user] deploys [loaded].</span>")
+		loaded = null
+	else
+		user << "<span class='warning'>The dock is empty!</span>"
+
+/obj/item/roller/robo/afterattack(obj/target, mob/user , proximity)
+	if(istype(target,/obj/structure/stool/bed/roller))
+		if(!proximity)
+			return
+		if(loaded)
+			user << "<span class='notice'>You already have a roller bed docked!</span>"
+			return
+
+		var/obj/structure/stool/bed/roller/R = target
+		if(R.buckled_mob)
+			R.user_unbuckle_mob(user)
+
+		loaded = target
+		target.loc = src
+		user.visible_message("<span class='notice'>[user] collects [loaded].</span>")
+	..()
+

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -88,6 +88,7 @@
 	modules += new /obj/item/weapon/reagent_containers/dropper(src)
 	modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	modules += new /obj/item/weapon/extinguisher/mini(src)
+	modules += new /obj/item/roller/robo(src)
 	emag = new /obj/item/weapon/reagent_containers/spray(src)
 
 	emag.reagents.add_reagent("facid", 250)

--- a/html/changelogs/Incoming5643-rollingbedforborgs.yml
+++ b/html/changelogs/Incoming5643-rollingbedforborgs.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "Medical borgs now have access to a deployable onboard roller bed. Should the bed become lost, any roller bed may be used in its place."


### PR DESCRIPTION
Adds an onboard roller bed dock that the mediborg can deploy wherever they need for on the spot triage/transportation/surgery/kidnapping. It can only hold one roller bed, but starts with one. This isn't regeneratable, so you can be a dick and steal the borg's bed and they'll have to go back to medbay for a replacement.

Related to #7694
