### PR TITLE
Floating animation and life() fixes.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -92,7 +92,7 @@
 		var/mob/O = M
 		if(!O.lastarea)
 			O.lastarea = get_area(O.loc)
-		O.update_gravity(O.mob_has_gravity())
+//		O.update_gravity(O.mob_has_gravity())
 
 	var/loopsanity = 100
 	for(var/atom/A in range(1))

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -60,7 +60,7 @@
 /mob/living/carbon/alien/getToxLoss()
 	return 0
 
-/mob/living/carbon/alien/proc/handle_environment(var/datum/gas_mixture/environment)
+/mob/living/carbon/alien/handle_environment(var/datum/gas_mixture/environment)
 
 	//If there are alien weeds on the ground then heal if needed or give some toxins
 	if(locate(/obj/structure/alien/weeds) in loc)
@@ -111,7 +111,7 @@
 					fire_alert = max(fire_alert, 2)
 	return
 
-/mob/living/carbon/alien/proc/handle_mutations_and_radiation()
+/mob/living/carbon/alien/handle_mutations_and_radiation()
 
 	// Aliens love radiation nom nom nom
 	if (radiation)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -8,61 +8,6 @@
 	var/temperature_alert = 0
 
 
-/mob/living/carbon/alien/humanoid/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-
-	if (notransform)
-		return
-
-	..()
-
-	var/datum/gas_mixture/environment = loc.return_air()
-
-	if (stat != DEAD) //still breathing
-
-		//First, resolve location and get a breath
-
-		if(SSmob.times_fired%4==2)
-			//Only try to take a breath every 4 seconds, unless suffocating
-			spawn(0) breathe()
-
-		else //Still give containing object the chance to interact
-			if(istype(loc, /obj/))
-				var/obj/location_as_object = loc
-				location_as_object.handle_internal_lifeform(src, 0)
-
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(environment)
-
-	//stuff in the stomach
-	handle_stomach()
-
-	//Handle being on fire
-	handle_fire()
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
-	if(client)
-		handle_regular_hud_updates()
-
 /mob/living/carbon/alien/humanoid/proc/adjust_body_temperature(current, loc_temp, boost)
 	var/temperature = current
 	var/difference = abs(current-loc_temp)	//get difference
@@ -80,7 +25,7 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/carbon/alien/humanoid/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/humanoid/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -160,7 +105,7 @@
 	return 1
 
 
-/mob/living/carbon/alien/humanoid/proc/handle_regular_hud_updates()
+/mob/living/carbon/alien/humanoid/handle_regular_hud_updates()
 
 	if (stat == 2)
 		sight |= SEE_TURFS

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -3,63 +3,18 @@
 /mob/living/carbon/alien/larva
 	var/temperature_alert = 0
 
-
 /mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
 
-	if (notransform)
-		return
-
-	..()
-	var/datum/gas_mixture/enviroment = loc.return_air()
-	if (stat != DEAD) //still breathing
-
+	if(..())
 		// GROW!
 		if(amount_grown < max_grown)
 			amount_grown++
 
-		//First, resolve location and get a breath
-		if(SSair.times_fired%4==2)
-			//Only try to take a breath every 4 seconds, unless suffocating
-			spawn(0) breathe()
-		else //Still give containing object the chance to interact
-			if(istype(loc, /obj/))
-				var/obj/location_as_object = loc
-				location_as_object.handle_internal_lifeform(src, 0)
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(enviroment)
-
-	//stuff in the stomach
-	//handle_stomach()
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
 	//some kind of bug in canmove() isn't properly calling update_icons, so this is here as a placeholder
 	update_icons()
 
-	if(client)
-		handle_regular_hud_updates()
 
-/mob/living/carbon/alien/larva/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/larva/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -69,6 +24,7 @@
 		if(health < -25 || !getorgan(/obj/item/organ/brain))
 			death()
 			eye_blind = max(1, eye_blind)
+
 			silent = 0
 			return 1
 
@@ -134,7 +90,7 @@
 	return 1
 
 
-/mob/living/carbon/alien/larva/proc/handle_regular_hud_updates()
+/mob/living/carbon/alien/larva/handle_regular_hud_updates()
 
 	if (stat == 2)
 		sight |= SEE_TURFS
@@ -213,6 +169,4 @@
 
 	return 1
 
-/mob/living/carbon/alien/larva/proc/handle_random_events()
-	return
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,4 +1,19 @@
-/mob/living/carbon/alien/proc/handle_chemicals_in_body()
+
+/mob/living/carbon/alien/Life()
+
+	if(..())
+		//First, resolve location and get a breath
+		if(SSair.times_fired%4==2)
+			//Only try to take a breath every 4 seconds, unless suffocating
+			spawn(0) breathe()
+		else //Still give containing object the chance to interact
+			if(istype(loc, /obj/))
+				var/obj/location_as_object = loc
+				location_as_object.handle_internal_lifeform(src, 0)
+		return 1
+
+
+/mob/living/carbon/alien/handle_chemicals_in_body()
 	if(reagents)
 		reagents.metabolize(src)
 
@@ -113,19 +128,4 @@
 
 	return 1
 
-/mob/living/carbon/alien/proc/handle_stomach()
-	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
-				continue
-			if(istype(M, /mob/living/carbon) && stat != 2)
-				if(M.stat == 2)
-					M.death(1)
-					stomach_contents.Remove(M)
-					qdel(M)
-					continue
-				if(SSmob.times_fired%3==1)
-					if(!(M.status_flags & GODMODE))
-						M.adjustBruteLoss(5)
-					nutrition += 10
+

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -1,37 +1,5 @@
-/mob/living/carbon/brain/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-	..()
 
-	if(stat != DEAD)
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-	var/datum/gas_mixture/environment // Added to prevent null location errors
-	if(loc)
-		environment = loc.return_air()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-
-	//Handle temperature/pressure differences between body and environment
-	if(environment)	// More error checking
-		handle_environment(environment)
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	if(client)
-		handle_regular_hud_updates()
-
-
-/mob/living/carbon/brain/proc/handle_mutations_and_radiation()
+/mob/living/carbon/brain/handle_mutations_and_radiation()
 
 	if (radiation)
 		if (radiation > 100)
@@ -68,7 +36,7 @@
 				updatehealth()
 
 
-/mob/living/carbon/brain/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/brain/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		return
 	var/environment_heat_capacity = environment.heat_capacity()
@@ -104,7 +72,7 @@
 
 
 
-/mob/living/carbon/brain/proc/handle_chemicals_in_body()
+/mob/living/carbon/brain/handle_chemicals_in_body()
 
 	if(reagents) reagents.metabolize(src)
 
@@ -120,7 +88,7 @@
 	return //TODO: DEFERRED
 
 
-/mob/living/carbon/brain/proc/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
+/mob/living/carbon/brain/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -204,7 +172,7 @@
 	return 1
 
 
-/mob/living/carbon/brain/proc/handle_regular_hud_updates()
+/mob/living/carbon/brain/handle_regular_hud_updates()
 
 	if (stat == 2)
 		sight |= SEE_TURFS

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -43,7 +43,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				src << "<span class='warning'>The blood soaks through your bandage.</span>"
 
 // Takes care blood loss and regeneration
-/mob/living/carbon/human/proc/handle_blood()
+/mob/living/carbon/human/handle_blood()
 
 	if(NOBLOOD in dna.species.specflags)
 		return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -36,35 +36,14 @@
 
 
 /mob/living/carbon/human/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
 
-	if (notransform)	return
-	if(!loc)			return	// Fixing a null error that occurs when the mob isn't found in the world -- TLE
-
-	..()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
 	fire_alert = 0 //Reset this here, because both breathe() and handle_environment() have a chance to set it.
 	tinttotal = tintcheck() //here as both hud updates and status updates call it
 
-	//TODO: seperate this out
-	var/datum/gas_mixture/environment = loc.return_air()
-
-	handle_regular_hud_updates()
-
-	//Status updates, death etc.
-		//TODO: optimise ~Carn
-	handle_regular_status_updates()
-
-	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD)
-		for(var/datum/mutation/human/HM in dna.mutations)
-			HM.on_life(src)
-
+	if(..())
+		if(dna)
+			for(var/datum/mutation/human/HM in dna.mutations)
+				HM.on_life(src)
 		if(SSmob.times_fired%4==2 || failed_last_breath) 	//First, resolve location and get a breath
 			breathe() 				//Only try to take a breath every 4 ticks, unless suffocating
 		else //Still give containing object the chance to interact
@@ -72,45 +51,11 @@
 				var/obj/location_as_object = loc
 				location_as_object.handle_internal_lifeform(src, 0)
 
-		//Updates the number of stored chemicals for powers
-		handle_changeling()
-
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-		//Disabilities
-		handle_disabilities()
-
-		//Blud
-		handle_blood()
-
-		//Random events (vomiting etc)
-		handle_random_events()
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(environment)
-
-	//Check if we're on fire
-	handle_fire()
-
-	//stuff in the stomach
-	handle_stomach()
-
-
-	update_canmove()
-
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
 	if(dna)
 		dna.species.spec_life(src) // for mutantraces
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
 
 
 /mob/living/carbon/human/calculate_affecting_pressure(var/pressure)
@@ -130,7 +75,7 @@
 		return ONE_ATMOSPHERE - pressure_difference
 
 
-/mob/living/carbon/human/proc/handle_disabilities()
+/mob/living/carbon/human/handle_disabilities()
 	if (getBrainLoss() >= 60 && stat != 2)
 		if (prob(3))
 			switch(pick(1,2,3))
@@ -142,7 +87,7 @@
 					emote("drool")
 
 
-/mob/living/carbon/human/proc/handle_mutations_and_radiation()
+/mob/living/carbon/human/handle_mutations_and_radiation()
 	if(dna)
 		dna.species.handle_mutations_and_radiation(src)
 
@@ -152,7 +97,7 @@
 
 	return
 
-/mob/living/carbon/human/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/human/handle_environment(datum/gas_mixture/environment)
 	if(dna)
 		dna.species.handle_environment(environment, src)
 
@@ -407,13 +352,13 @@
 			apply_damage(0.4*discomfort, BURN, "r_arm")
 */
 
-/mob/living/carbon/human/proc/handle_chemicals_in_body()
+/mob/living/carbon/human/handle_chemicals_in_body()
 	if(dna)
 		dna.species.handle_chemicals_in_body(src)
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/human/proc/handle_regular_status_updates()
+/mob/living/carbon/human/handle_regular_status_updates()
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
@@ -539,7 +484,7 @@
 
 	return 1
 
-/mob/living/carbon/human/proc/handle_regular_hud_updates()
+/mob/living/carbon/human/handle_regular_hud_updates()
 	if(!client)	return 0
 
 	client.screen.Remove(global_hud.blurry, global_hud.druggy, global_hud.vimpaired, global_hud.darkMask)
@@ -631,7 +576,7 @@
 
 	return 1
 
-/mob/living/carbon/human/proc/handle_random_events()
+/mob/living/carbon/human/handle_random_events()
 	// Puke if toxloss is too high
 	if(!stat)
 		if (getToxLoss() >= 45 && nutrition > 20)
@@ -653,24 +598,8 @@
 				// make it so you can only puke so fast
 				lastpuke = 0
 
-/mob/living/carbon/human/proc/handle_stomach()
-	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
-				continue
-			if(istype(M, /mob/living/carbon) && stat != 2)
-				if(M.stat == 2)
-					M.death(1)
-					stomach_contents.Remove(M)
-					qdel(M)
-					continue
-				if(SSmob.times_fired%3==1)
-					if(!(M.status_flags & GODMODE))
-						M.adjustBruteLoss(5)
-					nutrition += 10
 
-/mob/living/carbon/human/proc/handle_changeling()
+/mob/living/carbon/human/handle_changeling()
 	if(mind && mind.changeling)
 		mind.changeling.regenerate()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -12,3 +12,118 @@
 			if (internals)
 				internals.icon_state = "internal0"
 	return
+
+/mob/living/carbon/Life()
+	set invisibility = 0
+	set background = BACKGROUND_ENABLED
+
+	if (notransform)
+		return
+	if(!loc)
+		return
+	var/datum/gas_mixture/environment = loc.return_air()
+
+	//Handle temperature/pressure differences between body and environment
+	handle_environment(environment)
+
+	handle_regular_status_updates() // Status updates, death etc.
+
+	if(stat != DEAD)
+
+		//Updates the number of stored chemicals for powers
+		handle_changeling()
+
+		//Mutations and radiation
+		handle_mutations_and_radiation()
+
+		//Chemicals in the body
+		handle_chemicals_in_body()
+
+		//Disabilities
+		handle_disabilities()
+
+		//Blud
+		handle_blood()
+
+		//Random events (vomiting etc)
+		handle_random_events()
+
+		. = 1
+
+	handle_fire()
+
+	//stuff in the stomach
+	handle_stomach()
+
+	update_canmove()
+
+	update_gravity(mob_has_gravity())
+
+	for(var/obj/item/weapon/grab/G in src)
+		G.process()
+
+	if(client)
+		handle_regular_hud_updates()
+
+	return .
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//remember to remove the "proc" of the child procs of these.
+
+/mob/living/carbon/proc/handle_changeling()
+	return
+
+/mob/living/carbon/proc/handle_mutations_and_radiation()
+	return
+
+/mob/living/carbon/proc/handle_chemicals_in_body()
+	return
+
+/mob/living/carbon/proc/handle_disabilities()
+	return
+
+/mob/living/carbon/proc/handle_blood()
+	return
+
+/mob/living/carbon/proc/handle_random_events()
+	return
+
+/mob/living/carbon/proc/handle_environment(var/datum/gas_mixture/environment)
+	return
+
+/mob/living/carbon/proc/handle_regular_status_updates()
+	return
+
+/mob/living/carbon/proc/handle_stomach()
+	spawn(0)
+		for(var/mob/living/M in stomach_contents)
+			if(M.loc != src)
+				stomach_contents.Remove(M)
+				continue
+			if(istype(M, /mob/living/carbon) && stat != 2)
+				if(M.stat == 2)
+					M.death(1)
+					stomach_contents.Remove(M)
+					qdel(M)
+					continue
+				if(SSmob.times_fired%3==1)
+					if(!(M.status_flags & GODMODE))
+						M.adjustBruteLoss(5)
+					nutrition += 10
+
+/mob/living/carbon/proc/handle_regular_hud_updates()
+	return
+
+

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -10,16 +10,7 @@
 
 
 /mob/living/carbon/monkey/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-	if (notransform)	return
-	..()
-
-	var/datum/gas_mixture/environment // Added to prevent null location errors-- TLE
-	if(loc)
-		environment = loc.return_air()
-
-	if (stat != DEAD) //still breathing
+	if(..())
 		//First, resolve location and get a breath
 		if(SSmob.times_fired%4==2)
 			//Only try to take a breath every 4 seconds, unless suffocating
@@ -28,42 +19,6 @@
 			if(istype(loc, /obj/))
 				var/obj/location_as_object = loc
 				location_as_object.handle_internal_lifeform(src, 0)
-
-
-		//Updates the number of stored chemicals for powers
-		handle_changeling()
-
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-		//Disabilities
-		handle_disabilities()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-
-	//Handle temperature/pressure differences between body and environment
-	if(environment)	// More error checking -- TLE
-		handle_environment(environment)
-
-	//Check if we're on fire
-	handle_fire()
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	if(client)
-		handle_regular_hud_updates()
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
 
 	if(!client && stat == CONSCIOUS)
 		if(prob(33) && canmove && isturf(loc) && !pulledby && !grabbed_by.len)
@@ -75,9 +30,9 @@
 	..()
 	return pressure
 
-/mob/living/carbon/monkey/proc/handle_disabilities()
+/mob/living/carbon/monkey/handle_disabilities()
 
-/mob/living/carbon/monkey/proc/handle_mutations_and_radiation()
+/mob/living/carbon/monkey/handle_mutations_and_radiation()
 
 	if (radiation)
 		if (radiation > 100)
@@ -272,7 +227,7 @@
 
 	return 1
 
-/mob/living/carbon/monkey/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/monkey/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		return
 	var/environment_heat_capacity = environment.heat_capacity()
@@ -320,7 +275,7 @@
 	else
 		adjustFireLoss(5.0*discomfort)
 
-/mob/living/carbon/monkey/proc/handle_chemicals_in_body()
+/mob/living/carbon/monkey/handle_chemicals_in_body()
 
 	if(reagents) reagents.metabolize(src)
 
@@ -342,7 +297,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/monkey/proc/handle_regular_status_updates()
+/mob/living/carbon/monkey/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -412,7 +367,7 @@
 	return 1
 
 
-/mob/living/carbon/monkey/proc/handle_regular_hud_updates()
+/mob/living/carbon/monkey/handle_regular_hud_updates()
 
 	if (stat == 2)
 		sight |= SEE_TURFS
@@ -513,14 +468,14 @@
 
 	return 1
 
-/mob/living/carbon/monkey/proc/handle_random_events()
+/mob/living/carbon/monkey/handle_random_events()
 	if (prob(1) && prob(2))
 		spawn(0)
 			emote("scratch")
 			return
 
 
-/mob/living/carbon/monkey/proc/handle_changeling()
+/mob/living/carbon/monkey/handle_changeling()
 	if(mind && mind.changeling)
 		mind.changeling.regenerate()
 		hud_used.lingchemdisplay.invisibility = 0

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -6,38 +6,12 @@
 	var/SStun = 0 // stun variable
 
 /mob/living/carbon/slime/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-
-	if (src.notransform)
-		return
-
-	..()
-
-	if(stat != DEAD)
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
+	if(..())
 		handle_nutrition()
-
 		handle_targets()
-
 		if (!ckey)
 			handle_speech_and_mood()
 
-	var/datum/gas_mixture/environment
-	if(src.loc)
-		environment = loc.return_air()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-
-	if(environment)
-		handle_environment(environment) // Handle temperature/pressure differences between body and environment
-
-	handle_regular_status_updates() // Status updates, death etc.
 
 /mob/living/carbon/slime/proc/AIprocess()  // the master AI process
 
@@ -118,7 +92,7 @@
 
 	AIproc = 0
 
-/mob/living/carbon/slime/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/slime/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		adjustToxLoss(rand(10,20))
 		return
@@ -167,7 +141,7 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/carbon/slime/proc/handle_chemicals_in_body()
+/mob/living/carbon/slime/handle_chemicals_in_body()
 
 	if(reagents) reagents.metabolize(src)
 
@@ -181,7 +155,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/slime/proc/handle_regular_status_updates()
+/mob/living/carbon/slime/handle_regular_status_updates()
 
 	if(is_adult)
 		health = 200 - (getOxyLoss() + getToxLoss() + getFireLoss() + getBruteLoss() + getCloneLoss())

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -24,4 +24,4 @@
 
 	if(changed)
 		animate(src, transform = ntransform, time = 2, pixel_y = final_pixel_y, dir = final_dir, easing = EASE_IN|EASE_OUT)
-		floating = 0  // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+		floating = 0  // If we were without gravity, the bouncing animation got stopped, so we make sure we restart it in next life().

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -737,7 +737,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/float(on)
 	if(on && !floating)
-		animate(src, pixel_y = 2, time = 10, loop = -1)
+		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
 		floating = 1
 	else if(!on && floating)
 		animate(src, pixel_y = initial(pixel_y), time = 10)
@@ -820,7 +820,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/do_attack_animation(atom/A)
 	..()
-	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure to restart it in next life().
 
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)
@@ -828,5 +828,5 @@ Sorry Giacom. Please don't be mad :(
 	var/pixel_y_diff = rand(-amplitude/3, amplitude/3)
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff , time = 2, loop = 6)
 	animate(pixel_x = initial(pixel_x) , pixel_y = initial(pixel_y) , time = 2)
-	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure to restart it in next life().
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -12,6 +12,8 @@
 
 		src.updatehealth()
 
+		update_gravity(mob_has_gravity())
+
 		if (src.malfhack)
 			if (src.malfhack.aidisabled)
 				src << "<span class='danger'>ERROR: APC access disabled, hack attempt canceled.</span>"

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -14,7 +14,11 @@
 		update_items()
 	if (src.stat != DEAD) //still using power
 		use_power()
+
 	update_canmove()
+
+	update_gravity(mob_has_gravity())
+
 	handle_fire()
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -85,6 +85,8 @@
 
 /mob/living/simple_animal/Life()
 
+	update_gravity(mob_has_gravity())
+
 	//Health
 	if(stat == DEAD)
 		if(health > 0)


### PR DESCRIPTION
- Fixes floating animation not updating correctly.
  Fixes #6599
  Maybe fix #4567 
  Fixes half of #6123
  Fixes #5969 
  The fix has a flaw though, in no gravity the falling to the ground & getting up animations can sometimes be skipped (and you look like you just instantly go from lying to standing).
- Makes life() procs for mob/living/carbon mobs more object oriented. 
