### PR TITLE
Gives Roboticists a full toolbelt

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -89,4 +89,4 @@ Roboticist
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/roboticist(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/toggle/labcoat(H), slot_wear_suit)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/toolbox/mechanical(H), slot_l_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)

--- a/html/changelogs/TheVekter-PR-Toolbelt.yml
+++ b/html/changelogs/TheVekter-PR-Toolbelt.yml
@@ -1,0 +1,5 @@
+author: Vekter
+
+delete-after: True
+
+  - tweak: "Roboticists will now start with a full toolbelt instead of a toolbox."

--- a/html/changelogs/TheVekter-PR-Toolbelt.yml
+++ b/html/changelogs/TheVekter-PR-Toolbelt.yml
@@ -2,4 +2,4 @@ author: Vekter
 
 delete-after: True
 
-  - tweak: "Roboticists will now start with a full toolbelt instead of a toolbox."
+  - tweak: "Roboticists will now start with a full toolbelt in lieu of a toolbox."

--- a/html/changelogs/TheVekter-PR-Toolbelt.yml
+++ b/html/changelogs/TheVekter-PR-Toolbelt.yml
@@ -2,4 +2,4 @@ author: Vekter
 
 delete-after: True
 
-  - tweak: "Roboticists will now start with a full toolbelt in lieu of a toolbox."
+  - tweak: "Roboticists will now start with a full toolbelt instead of a toolbox."


### PR DESCRIPTION
Replaces the Roboticist's toolboxes with a toolbelt. No more fighting over the only one in Robo! The one on map stays for anyone who gets a jobchange.
