### PR TITLE
cleans up mines

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -30,7 +30,7 @@
 		if("explosive")
 			explosion(loc, 0, 1, 2, 3)
 		if("triggerkick")
-			if(victim.client)
+			if(isliving(victim) && victim.client)
 				victim << "<font color='red'><b>You have been kicked FOR NO REISIN!<b></font>"
 				del(victim.client)
 		if("triggerplasma")

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -6,7 +6,7 @@
 	layer = 3
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"
-	var/minepayload = "explode"
+	var/minepayload = "explosive"
 	var/triggered = 0
 
 /obj/effect/mine/New()
@@ -27,8 +27,12 @@
 	s.start()
 
 	switch(triggertype)
-		if("explode")
+		if("explosive")
 			explosion(loc, 0, 1, 2, 3)
+		if("triggerkick")
+			if(victim.client)
+				victim << "<font color='red'><b>You have been kicked FOR NO REISIN!<b></font>"
+				del(victim.client)
 		if("triggerplasma")
 			atmos_spawn_air(SPAWN_TOXINS, 360)
 		if("triggern2o")
@@ -55,3 +59,8 @@
 	name = "stun mine"
 	icon_state = "uglymine"
 	minepayload = "triggerstun"
+
+/obj/effect/mine/kickmine
+	name = "kick mine"
+	icon_state = "uglymine"
+	minepayload = "triggerkick"

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -1,12 +1,12 @@
 /obj/effect/mine
-	name = "mine"
-	desc = "I Better stay away from that thing."
-	density = 1
+	name = "proximity mine"
+	desc = "Better stay away from that thing."
+	density = 0
 	anchored = 1
 	layer = 3
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"
-	var/triggerproc = "explode" //name of the proc thats called when the mine is triggered
+	var/minepayload = "explode"
 	var/triggered = 0
 
 /obj/effect/mine/New()
@@ -15,74 +15,43 @@
 /obj/effect/mine/Crossed(AM as mob|obj)
 	Bumped(AM)
 
-/obj/effect/mine/Bumped(mob/M as mob|obj)
+/obj/effect/mine/Bumped(AM as mob|obj)
 
 	if(triggered) return
+	visible_message("<span class='danger'>[AM] sets off \icon[src] [src]!</span>")
+	triggermine(AM, minepayload)
 
-	if(istype(M, /mob/living/carbon/human) || istype(M, /mob/living/carbon/monkey))
-		for(var/mob/O in viewers(world.view, src.loc))
-			O << "<font color='red'>[M] triggered the \icon[src] [src]</font>"
-		triggered = 1
-		call(src,triggerproc)(M)
-
-/obj/effect/mine/proc/triggerrad(obj)
+/obj/effect/mine/proc/triggermine(mob/victim, var/triggertype)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	obj:radiation += 50
-	randmutb(obj)
-	domutcheck(obj)
-	qdel(src)
 
-/obj/effect/mine/proc/triggerstun(obj)
-	if(ismob(obj))
-		var/mob/M = obj
-		M.Stun(30)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
-	qdel(src)
+	switch(triggertype)
+		if("explode")
+			explosion(loc, 0, 1, 2, 3)
+		if("triggerplasma")
+			atmos_spawn_air(SPAWN_TOXINS, 360)
+		if("triggern2o")
+			atmos_spawn_air(SPAWN_N2O, 360)
+		if("triggerstun")
+			if(isliving(victim))
+				victim.Weaken(8)
 
-/obj/effect/mine/proc/triggern2o(obj)
-	atmos_spawn_air("n2o", 360)
-	qdel(src)
 
-/obj/effect/mine/proc/triggerplasma(obj)
-	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 360)
+	triggered = 1
 	qdel(src)
-
-/obj/effect/mine/proc/triggerkick(obj)
-	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-	s.set_up(3, 1, src)
-	s.start()
-	del(obj:client)
-	qdel(src)
-
-/obj/effect/mine/proc/explode(obj)
-	explosion(loc, 0, 1, 2, 3)
-	qdel(src)
-
-/obj/effect/mine/dnascramble
-	name = "radiation mine"
-	icon_state = "uglymine"
-	triggerproc = "triggerrad"
 
 /obj/effect/mine/plasma
 	name = "plasma mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerplasma"
-
-/obj/effect/mine/kick
-	name = "kick mine"
-	icon_state = "uglymine"
-	triggerproc = "triggerkick"
+	minepayload = "triggerplasma"
 
 /obj/effect/mine/n2o
 	name = "\improper N2O mine"
 	icon_state = "uglymine"
-	triggerproc = "triggern2o"
+	minepayload = "triggern2o"
 
 /obj/effect/mine/stun
 	name = "stun mine"
 	icon_state = "uglymine"
-	triggerproc = "triggerstun"
+	minepayload = "triggerstun"


### PR DESCRIPTION
nominating mines.dm for worst file in the codebase.
only 80 lines and yet 6 pointless procs and two colon operators. and they were dense. completely baffling.
removed radmine and kickmine, i doubt anyone will miss them.
eventually i'd like to make these things disarmable and perhaps craftable like chemnades.
