### PR TITLE
Fixes neurotoxin reaction's required temperature.

### DIFF
--- a/code/modules/reagents/Chemistry-Goon-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Goon-Toxins.dm
@@ -117,7 +117,7 @@ datum/reagent/neurotoxin2/on_mob_life(var/mob/living/M as mob)
 	result = "neurotoxin2"
 	required_reagents = list("space_drugs" = 1)
 	result_amount = 1
-	required_temp = 200
+	required_temp = 370
 
 datum/reagent/cyanide
 	name = "Cyanide"


### PR DESCRIPTION
The required temperature was 200K , and the reaction has only one component, space drugs, this meant that space drugs upon creation immediately reacted to become neurotoxin.
I changed the temperature to 370K.
Fixes #7754
