### PR TITLE
Fixes cryosting detection exploit 

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -174,6 +174,5 @@ obj/effect/proc_holder/changeling/sting/cryo
 	add_logs(user, target, "stung", object="cryo sting")
 	if(target.reagents)
 		target.reagents.add_reagent("frostoil", 30)
-		target.reagents.add_reagent("ice", 30)
 	feedback_add_details("changeling_powers","CS")
 	return 1

--- a/code/modules/food&drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food&drinks/recipes/drinks_recipes.dm
@@ -371,13 +371,6 @@
 	name = "Iced Beer"
 	id = "iced_beer"
 	result = "iced_beer"
-	required_reagents = list("beer" = 10, "frostoil" = 1)
-	result_amount = 10
-
-/datum/chemical_reaction/iced_beer2
-	name = "Iced Beer"
-	id = "iced_beer"
-	result = "iced_beer"
 	required_reagents = list("beer" = 5, "ice" = 1)
 	result_amount = 6
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -323,6 +323,7 @@ datum/reagents/proc/handle_reactions()
 					var/list/seen = viewers(4, get_turf(my_atom))
 
 					if(!istype(my_atom, /mob)) // No bubbling mobs
+						playsound(get_turf(my_atom), 'sound/effects/bubbles.ogg', 80, 1)
 						for(var/mob/M in seen)
 							M << "<span class='notice'>\icon[my_atom] [C.mix_message]</span>"
 
@@ -334,8 +335,6 @@ datum/reagents/proc/handle_reactions()
 								M << "<span class='notice'>\icon[my_atom] \The [my_atom]'s power is consumed in the reaction.</span>"
 								ME2.name = "used slime extract"
 								ME2.desc = "This extract has been used up."
-
-					playsound(get_turf(my_atom), 'sound/effects/bubbles.ogg', 80, 1)
 
 					C.on_reaction(src, created_volume)
 					reaction_occured = 1

--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
@@ -187,17 +187,17 @@ datum/reagent/consumable/frostoil/on_mob_life(var/mob/living/M as mob)
 	if(!data) data = 1
 	switch(data)
 		if(1 to 15)
-			M.bodytemperature -= 5 * TEMPERATURE_DAMAGE_COEFFICIENT
+			M.bodytemperature -= 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(holder.has_reagent("capsaicin"))
 				holder.remove_reagent("capsaicin", 5)
 			if(istype(M, /mob/living/carbon/slime))
 				M.bodytemperature -= rand(5,20)
 		if(15 to 25)
-			M.bodytemperature -= 10 * TEMPERATURE_DAMAGE_COEFFICIENT
+			M.bodytemperature -= 15 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(istype(M, /mob/living/carbon/slime))
 				M.bodytemperature -= rand(10,20)
 		if(25 to INFINITY)
-			M.bodytemperature -= 15 * TEMPERATURE_DAMAGE_COEFFICIENT
+			M.bodytemperature -= 20 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(prob(1))
 				M.emote("shiver")
 			if(istype(M, /mob/living/carbon/slime))


### PR DESCRIPTION
Removing ice reagent from cryosting, to prevent exploit and powergaming.
Removing the beer+frostoil= icedbeer (ice+beer=iced beer already exists, plus there was no equivalent for tea and coffee, only ice+coffee/tea)
Buffing frostoil effect to compensate.
Reaction bubbling sound doesn't occur if reaction happens inside a mob.

Fixes #6784 
