### PR TITLE
Regenerative statis tweaks

### DIFF
--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -61,7 +61,7 @@
 	if(req_stat < user.stat)
 		user << "<span class='warning'>We are incapacitated.</span>"
 		return 0
-	if((user.status_flags & FAKEDEATH) && name!="Regenerate")
+	if((user.status_flags & FAKEDEATH) && name!="Revive")
 		user << "<span class='warning'>We are incapacitated.</span>"
 		return 0
 	if(c.geneticdamage > max_genetic_damage)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -451,6 +451,8 @@
 			if( prob(10) && health && !hal_crit )
 				spawn(0)
 					emote("snore")
+		else if (status_flags & FAKEDEATH)
+			stat = UNCONSCIOUS
 		//CONSCIOUS
 		else
 			stat = CONSCIOUS

--- a/html/changelogs/Menshin-PR-7792.yml
+++ b/html/changelogs/Menshin-PR-7792.yml
@@ -1,0 +1,7 @@
+author: Menshin
+
+delete-after: True
+
+changes: 
+  - tweak : "Getting into regenerative statis now puts the changeling into unconscious state."
+  - bugfix: "Fixed changeling 'Revive' not working."


### PR DESCRIPTION
#### Contents
- Getting into regenerative statis now puts the changeling into unconscious state
- Fixed reviving not working

Fixes #7784.
Fixes #7641.
