### PR TITLE
drag-drop items to turf to sort by type & move them

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -183,3 +183,12 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 						dirtoverlay.alpha = 10
 					else if(dirt > 100)
 						dirtoverlay.alpha = min(dirtoverlay.alpha+10, 200)
+
+/turf/simulated/floor/MouseDrop_T(atom/dropping, mob/user)
+	if(istype(dropping, /obj/item) && istype(dropping.loc, /turf))
+		var/obj/item/I = dropping
+		if(isliving(user) && !user.stat)
+			for(I in I.loc)
+				if(!istype(I, dropping.type))
+					continue
+				I.loc = src

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -191,4 +191,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 			for(I in I.loc)
 				if(!istype(I, dropping.type))
 					continue
+				if(I.anchored)
+					continue
 				I.loc = src
+				sleep(1)

--- a/html/changelogs/delimusca-7847.yml
+++ b/html/changelogs/delimusca-7847.yml
@@ -1,0 +1,5 @@
+﻿author: Delimusca
+
+delete-after: True
+
+  - rscadd: "Drag-drop an item to the floor to mass-move any items of that type."


### PR DESCRIPTION
this lets you dragdrop items to turfs, which will move them to that turf along with any items of the same type.
good for sorting mineral bars, moving lots of paper, etc.
