### PR TITLE
Warning check before sorting long lists in vv

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -136,6 +136,12 @@ var/list/VVckey_edit = list("key", "ckey")
 /client/proc/mod_list(var/list/L, atom/O, original_name, objectvar)
 	if(!check_rights(R_VAREDIT))	return
 	if(!istype(L,/list)) src << "Not a List."
+
+	if(L.len > 1000)
+		var/confirm = alert(src, "The list you're trying to edit is very long, continuing may crash the server.", "Warning", "Continue", "Abort")
+		if(confirm != "Continue")
+			return
+
 	var/list/names = sortList(L)
 
 	var/variable = input("Which var?","Var") as null|anything in names + "(ADD VAR)"


### PR DESCRIPTION
Having BYOND try to sort a lengthy list tends to cause freezing. This adds a confirmation check before sorting if the list is more than 1000 long.

During my testing, 2000 stacks of 1 caused no problems and neither did 5 stacks of 100. 28 stacks of 100 caused BYOND to hang for a few seconds. Finally the roundstart 411k long contents list of /area/space caused server to lock up for a few minutes before I terminated it.

I haven't a clue how the length and compositions of these lists affects Timsort's operation but 1000 seemed like a good margin of safety. If someone is able to determine a more accurate figure of what would cause a crash that'd be great.
