### PR TITLE
Fixes  #7883 Borgs can't pass through holotape

### DIFF
--- a/code/game/objects/items/holotape.dm
+++ b/code/game/objects/items/holotape.dm
@@ -153,13 +153,15 @@
 		spawn(40)
 			charging = 0
 
-/obj/item/holotape/Bumped(var/mob/living/carbon/C)
-	if(C.m_intent == "walk")
-		var/turf/T = get_turf(src)
-		C.loc = T
+/obj/item/holotape/Bumped(var/mob/M)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(C.m_intent == "walk")
+			var/turf/T = get_turf(src)
+			C.loc = T
 
-/obj/item/holotape/Bumped(var/mob/living/silicon/S)
-	if(S.a_intent == "help")
+	if(issilicon(M))
+		var/mob/living/silicon/S = M
 		var/turf/T = get_turf(src)
 		S.loc = T
 

--- a/code/game/objects/items/holotape.dm
+++ b/code/game/objects/items/holotape.dm
@@ -160,10 +160,9 @@
 			var/turf/T = get_turf(src)
 			C.loc = T
 
-	if(issilicon(M))
-		var/mob/living/silicon/S = M
+	if(M.has_unlimited_silicon_privilege)
 		var/turf/T = get_turf(src)
-		S.loc = T
+		M.loc = T
 
 /obj/item/holotape/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(!density) return 1

--- a/code/game/objects/items/holotape.dm
+++ b/code/game/objects/items/holotape.dm
@@ -158,6 +158,11 @@
 		var/turf/T = get_turf(src)
 		C.loc = T
 
+/obj/item/holotape/Bumped(var/mob/living/silicon/S)
+	if(S.a_intent == "help")
+		var/turf/T = get_turf(src)
+		S.loc = T
+
 /obj/item/holotape/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(!density) return 1
 	if(air_group || (height==0)) return 1


### PR DESCRIPTION
Fixes #7883. Fix for this issue. Added the ability for borgs to pass as long as they are set to help intent. 
