### PR TITLE
Fixes #7880 Engiborg wirecutters bug

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -113,6 +113,14 @@
 	attack_verb = list("pinched", "nipped")
 	hitsound = 'sound/items/Wirecutter.ogg'
 
+
+/obj/item/weapon/wirecutters/standard
+	name = "wirecutters"
+
+
+/obj/item/weapon/wirecutters/cyborg
+	name = "cyborg wirecutters"
+
 /obj/item/weapon/wirecutters/New()
 	if(prob(50))
 		icon_state = "cutters-y"
@@ -130,10 +138,18 @@
 	else
 		..()
 
+
+/obj/item/weapon/wirecutters/proc/attachable()
+	return
+
+
 /obj/item/weapon/wirecutters/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is cutting at \his arteries with the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1, -1)
 	return (BRUTELOSS)
+
+
+
 
 /*
  * Welding Tool

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -139,8 +139,7 @@
 		..()
 
 
-/obj/item/weapon/wirecutters/proc/attachable()
-	return
+
 
 
 /obj/item/weapon/wirecutters/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -120,7 +120,7 @@ obj/item/weapon/wirerod/attackby(var/obj/item/I, mob/user as mob)
 		qdel(I)
 		qdel(src)
 
-	else if(istype(I, /obj/item/weapon/wirecutters))
+	else if(istype(I, /obj/item/weapon/wirecutters/standard))
 		var/obj/item/weapon/melee/baton/cattleprod/P = new /obj/item/weapon/melee/baton/cattleprod
 
 		user.unEquip(I)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -23,7 +23,7 @@
 	result = /obj/item/weapon/melee/baton/cattleprod
 	reqs = list(/obj/item/weapon/restraints/handcuffs/cable = 1,
 				/obj/item/stack/rods = 1,
-				/obj/item/weapon/wirecutters = 1,
+				/obj/item/weapon/wirecutters/standard = 1,
 				/obj/item/weapon/stock_parts/cell = 1)
 	time = 80
 	parts = list(/obj/item/weapon/stock_parts/cell = 1)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -130,7 +130,7 @@
 	modules += new /obj/item/weapon/screwdriver(src)
 	modules += new /obj/item/weapon/wrench(src)
 	modules += new /obj/item/weapon/crowbar(src)
-	modules += new /obj/item/weapon/wirecutters(src)
+	modules += new /obj/item/weapon/wirecutters/cyborg(src)
 	modules += new /obj/item/device/multitool(src)
 	modules += new /obj/item/device/t_scanner(src)
 	modules += new /obj/item/device/analyzer(src)

--- a/html/changelogs/Mandurrrh-engiborgfix.yml
+++ b/html/changelogs/Mandurrrh-engiborgfix.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - bugfix: 'fixed bug causing engineering borgs the ability to attach their wirecutters to wiredrods to create stunprods'


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/issues/7880 Fixed engiborgs being able to attach their module wirecutters to a wirerod to make a stunprod. They also lost their wirecutters in the process. 
