### PR TITLE
Fixes #7910 and #7909 clown related bugs.

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -22,6 +22,7 @@
 	if(user.disabilities & CLUMSY && prob(50))
 		user << "<span class='warning'>Uh... how do those things work?!</span>"
 		apply_cuffs(user,user)
+		return
 
 	if(!C.handcuffed)
 		C.visible_message("<span class='danger'>[user] is trying to put [src.name] on [C]!</span>", \

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -287,11 +287,6 @@
 		if(!in_range(src, usr) && loc != user && !istype(loc, /obj/item/weapon/clipboard) && loc.loc != user && user.get_active_hand() != P)
 			return
 
-		if(istype(P, /obj/item/weapon/stamp/clown))
-			if(!clown)
-				user << "<span class='notice'>You are totally unable to use the stamp. HONK!</span>"
-				return
-
 		stamps += "<img src=large_[P.icon_state].png>"
 
 		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')

--- a/html/changelogs/Mandurrrh-Clownbugfixes.yml
+++ b/html/changelogs/Mandurrrh-Clownbugfixes.yml
@@ -1,0 +1,10 @@
+
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - bugfix- 'Fixes clown cuffing both mobs and two pairs of cuffs appearing.'
+  - bugfix- 'Fixes clown not being able to use his stamp as antag so no meta.'


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/issues/7909
https://github.com/tgstation/-tg-station/issues/7910

One fixes the clown not being able to use his stamp if antag. Clown can now still use his stamp even if traitor. To prevent meta cheats.

Second fixed when the clown handcuffs another mob and his clownclumsy comes about he was cuffing himself and the other mob spawning multiple cable cuffs. Now it only cable cuffs one mob. Happened to be clown in testing so still clumsyclown cuffs themselves but their victim escapes.
