### PR TITLE
Fixes Turret Upgrade Malfunction Power

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -48,9 +48,10 @@
 	set category = "Malfunction"
 	set name = "Upgrade Turrets"
 	src.verbs -= /mob/living/silicon/ai/proc/upgrade_turrets
-	for(var/obj/machinery/turret/turret in machines)
-		turret.health += 30
-		turret.shot_delay = 20
+	for(var/obj/machinery/porta_turret/turret in machines)
+		if(turret.ai) //Make sure only the AI's turrets are affected.
+			turret.health += 30
+			turret.shot_delay = 10 //Standard portable turret delay is 15.
 	src << "<span class='notice'>Turrets upgraded.</span>"
 
 /datum/AI_Module/large/lockdown


### PR DESCRIPTION
When the AI's turrets were switched to the portable version, this power was never changed to match. This corrects that issue. At half the AI's CPU, it is one that really does need to work properly.
- Repaths the Turret Upgrade power to work on portable turrets.
- Corrects the shot_delay value to actually be a buff instead of a nerf.
