### PR TITLE
Fixes the orion trail arcade exploit 

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -232,7 +232,7 @@ Class Procs:
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
 	if(incapacitated() || lying )
 		return
-	if(!in_range(M, src))
+	if(!Adjacent(M))
 		if((be_close == 0) && (dna.check_mutation(TK)))
 			if(tkMaxRangeCheck(src, M))
 				return 1


### PR DESCRIPTION
You can no longer use machines window buttons while inside a closet next to it. 
Fixes #7457 
No fun allowed! :japanese_ogre: 
