### PR TITLE
Fixes players getting no age on first connection (and adds a new player admin notice)

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -176,7 +176,10 @@ var/next_external_rsc = 0
 
 	while (query.NextRow())
 		player_age = text2num(query.item[2])
-		break
+		return
+	//player not found.
+	player_age = 0
+	message_admins("[key_name_admin(src)] is connecting here for the first time.")
 
 
 /client/proc/sync_client_with_db()


### PR DESCRIPTION
This was allowing them to choose any job on servers that use the job age system.
This also adds an admin message on a player's first connection. (requested)

fixes #6256 as this seems to have been caused by the above bug.
