### PR TITLE
Updates Manage Job Slots to work with assistant slots

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -59,12 +59,11 @@ var/datum/subsystem/job/SSjob
 		var/position_limit = job.total_positions
 		if(!latejoin)
 			position_limit = job.spawn_positions
-		if((job.current_positions < position_limit) || position_limit == -1)
-			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
-			player.mind.assigned_role = rank
-			unassigned -= player
-			job.current_positions++
-			return 1
+		Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
+		player.mind.assigned_role = rank
+		unassigned -= player
+		job.current_positions++
+		return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -815,22 +815,29 @@ var/global/floorIsLava = 0
 			var/J_title = html_encode(job.title)
 			var/J_opPos = html_encode(job.total_positions - (job.total_positions - job.current_positions))
 			var/J_totPos = html_encode(job.total_positions)
-			if(job.total_positions <= 0)
-				dat += "[J_title]: [J_opPos]"
+			if(job.total_positions < 0)
+				dat += "[J_title]: [J_opPos]   (unlimited)"
 			else
 				dat += "[J_title]: [J_opPos]/[J_totPos]"
-			if(initial(job.total_positions) > 0)
+
+			if(job.title == "AI" || job.title == "Cyborg")
+				dat += "   (Cannot Late Join)<br>"
+				continue
+			if(job.total_positions >= 0)
 				dat += "   <A href='?src=\ref[src];addjobslot=[job.title]'>Add</A>  |  "
 				if(job.total_positions > job.current_positions)
-					dat += "<A href='?src=\ref[src];removejobslot=[job.title]'>Remove</A>"
+					dat += "<A href='?src=\ref[src];removejobslot=[job.title]'>Remove</A>  |  "
 				else
-					dat += "Remove"
+					dat += "Remove  |  "
+				dat += "<A href='?src=\ref[src];unlimitjobslot=[job.title]'>Unlimit</A>"
+			else
+				dat += "   <A href='?src=\ref[src];limitjobslot=[job.title]'>Limit</A>"
 			dat += "<br>"
 
 	dat += "</body>"
 	var/winheight = 100 + (count * 20)
 	winheight = min(winheight, 690)
-	usr << browse(dat, "window=players;size=316x[winheight]")
+	usr << browse(dat, "window=players;size=375x[winheight]")
 
 //
 //

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1404,6 +1404,31 @@
 
 		src.manage_free_slots()
 
+	else if(href_list["unlimitjobslot"])
+		if(!check_rights(R_ADMIN))	return
+
+		var/Unlimit = href_list["unlimitjobslot"]
+
+		for(var/datum/job/job in SSjob.occupations)
+			if(job.title == Unlimit)
+				job.total_positions = -1
+				break
+
+		src.manage_free_slots()
+
+	else if(href_list["limitjobslot"])
+		if(!check_rights(R_ADMIN))	return
+
+		var/Limit = href_list["limitjobslot"]
+
+		for(var/datum/job/job in SSjob.occupations)
+			if(job.title == Limit)
+				job.total_positions = job.current_positions
+				break
+
+		src.manage_free_slots()
+
+
 	else if(href_list["adminspawncookie"])
 		if(!check_rights(R_ADMIN|R_FUN))	return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -249,7 +249,6 @@
 		if(job.title == "Assistant")
 			for(var/datum/job/J in SSjob.occupations)
 				if(J && J.current_positions < J.total_positions && J.title != job.title)
-					world << "[J.title]"
 					return 0
 		else
 			return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -246,7 +246,13 @@
 	if(!job)
 		return 0
 	if((job.current_positions >= job.total_positions) && job.total_positions != -1)
-		return 0
+		if(job.title == "Assistant")
+			for(var/datum/job/J in SSjob.occupations)
+				if(J && J.current_positions < J.total_positions && J.title != job.title)
+					world << "[J.title]"
+					return 0
+		else
+			return 0
 	if(jobban_isbanned(src,rank))
 		return 0
 	if(!job.player_old_enough(src.client))
@@ -329,6 +335,11 @@
 			if (job.title in command_positions)
 				position_class = "commandPosition"
 			dat += "<a class='[position_class]' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a><br>"
+	if(!job_count) //if there's nowhere to go, assistant opens up.
+		for(var/datum/job/job in SSjob.occupations)
+			if(job.title != "Assistant") continue
+			dat += "<a class='otherPosition' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a><br>"
+			break
 	dat += "</div></div>"
 
 	// Removing the old window method but leaving it here for reference


### PR DESCRIPTION
Any (non-silicon) job can now be set to be an unlimited slot job from Manage Job Slots
People will be allowed to join as assistant if no other jobs are available
Removes a redundant sanity check from AssignRole()

Fixes #7952 Fixes #7965
