### PR TITLE
Reworks the pink/light pink slime line to not be nearly worthless to breed

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -226,6 +226,10 @@
 
 /mob/living/carbon/slime/proc/handle_nutrition()
 
+	if(docile) //God as my witness, I will never go hungry again
+		nutrition = 700
+		return
+
 	if(prob(15))
 		nutrition -= 1 + is_adult
 
@@ -283,7 +287,7 @@
 
 		if(Target)
 			--target_patience
-			if (target_patience <= 0 || SStun || Discipline || attacked) // Tired of chasing or something draws out attention
+			if (target_patience <= 0 || SStun || Discipline || attacked || docile) // Tired of chasing or something draws out attention
 				target_patience = 0
 				Target = null
 
@@ -547,6 +551,7 @@
 	else return 200
 
 /mob/living/carbon/slime/proc/will_hunt(var/hunger = -1) // Check for being stopped from feeding and chasing
+	if (docile)	return 0
 	if (hunger == 2 || rabid || attacked) return 1
 	if (Leader) return 0
 	if (holding_still) return 0

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -381,6 +381,7 @@
 	//Mood starts here
 	var/newmood = ""
 	if (rabid || attacked) newmood = "angry"
+	else if (docile) newmood = ":3"
 	else if (Target) newmood = "mischevous"
 
 	if (!newmood)

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -5,6 +5,10 @@
 		Feedstop()
 		return 0
 
+	if(docile)
+		src << "<i>I'm not hungry anymore...</i>"
+		return 0
+
 	if(stat)
 		src << "<i>I must be conscious to do this...</i>"
 		return 0

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -669,7 +669,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 /obj/item/slimepotion2/afterattack(mob/living/M as mob, mob/user as mob)
 	if(!(isslime(M) || isanimal(M) || ismonkey(M) || !M.ckey)) //I'm sorry for this line
-		user << "<span class='warning'>[M] is already too inteligent for this to work!</span>"
+		user << "<span class='warning'>[M] is already too intelligent for this to work!</span>"
 		return ..()
 	if(M.stat)
 		user << "<span class='warning'>[M] is dead!</span>"
@@ -683,6 +683,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		M.key = C.key
 		M.languages |= HUMAN
 		M << "<span class='warning'>All at once it makes sense, you know what you are and who you are! Self awareness is yours!</span>"
+		M << "You are greatful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost."
 		user << "<span class='warning'>[M] is suddenly attentive and aware. It worked!</span>"
 		qdel(src)
 	else

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -683,7 +683,7 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		M.key = C.key
 		M.languages |= HUMAN
 		M << "<span class='warning'>All at once it makes sense, you know what you are and who you are! Self awareness is yours!</span>"
-		M << "You are greatful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost."
+		M << "You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost."
 		user << "<span class='warning'>[M] is suddenly attentive and aware. It worked!</span>"
 		qdel(src)
 	else

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -6,6 +6,7 @@
 	say_message = "hums"
 	ventcrawler = 2
 	var/is_adult = 0
+	var/docile = 0
 	languages = SLIME | HUMAN
 	faction = list("slime")
 
@@ -135,8 +136,8 @@
 			stat(null, "Health: [round((health / 200) * 100)]%")
 		else
 			stat(null, "Health: [round((health / 150) * 100)]%")
-
-		stat(null, "Nutrition: [nutrition]/[get_max_nutrition()]")
+		if(!docile)
+			stat(null, "Nutrition: [nutrition]/[get_max_nutrition()]")
 		if(amount_grown >= 10)
 			if(is_adult)
 				stat(null, "You can reproduce!")
@@ -634,71 +635,59 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 
 ////Pet Slime Creation///
 
-/obj/item/weapon/slimepotion
+/obj/item/slimepotion
 	name = "docility potion"
-	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
+	desc = "A potent chemical mix that nullifies a slime's hunger, causing it to become docile and tame."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			user << "<span class='warning'> The potion only works on baby slimes!</span>"
-			return ..()
-		if(M.is_adult) //Can't tame adults
-			user << "<span class='warning'> Only baby slimes can be tamed!</span>"
-			return..()
-		if(M.stat)
-			user << "<span class='warning'> The slime is dead!</span>"
-			return..()
-		if(M.mind)
-			user << "<span class='warning'> The slime resists!</span>"
-			return ..()
-		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
-		pet.icon_state = "[M.colour] baby slime"
-		pet.icon_living = "[M.colour] baby slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		user <<"You feed the slime the potion, removing it's powers and calming it."
-		qdel(M)
-		var/newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
-
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel(src)
-
-/obj/item/weapon/slimepotion2
-	name = "advanced docility potion"
-	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame. This one is meant for adult slimes"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle19"
-
-/obj/item/weapon/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime/))//If target is not a slime.
-		user << "<span class='warning'> The potion only works on slimes!</span>"
+/obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	if(!isslime(M))
+		user << "<span class='warning'>The potion only works on slimes!</span>"
 		return ..()
 	if(M.stat)
-		user << "<span class='warning'> The slime is dead!</span>"
+		user << "<span class='warning'>The slime is dead!</span>"
 		return..()
-	if(M.mind)
-		user << "<span class='warning'> The slime resists!</span>"
-		return ..()
-	var/mob/living/simple_animal/slime/adult/pet = new /mob/living/simple_animal/slime/adult(M.loc)
-	pet.icon_state = "[M.colour] adult slime"
-	pet.icon_living = "[M.colour] adult slime"
-	pet.icon_dead = "[M.colour] baby slime dead"
-	pet.colour = "[M.colour]"
-	user <<"You feed the slime the potion, removing it's powers and calming it."
-	qdel(M)
+
+	M.docile = 1
+	M.nutrition = 700
+	M <<"<span class='warning'> You absorb the potion and feel your intense desire to feed melt away.</span>"
+	user <<"<span class='notice'> You feed the slime the potion, removing it's hunger and calming it.</span>"
 	var/newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
 
 	if (!newname)
 		newname = "pet slime"
-	pet.name = newname
-	pet.real_name = newname
+	M.name = newname
+	M.real_name = newname
 	qdel(src)
 
+/obj/item/slimepotion2
+	name = "sentience potion"
+	desc = "A miraculous chemical mix that can raise the intelligence of creatures to human levels."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle19"
+
+/obj/item/slimepotion2/afterattack(mob/living/M as mob, mob/user as mob)
+	if(!(isslime(M) || isanimal(M) || ismonkey(M) || !M.ckey)) //I'm sorry for this line
+		user << "<span class='warning'>[M] is already too inteligent for this to work!</span>"
+		return ..()
+	if(M.stat)
+		user << "<span class='warning'>[M] is dead!</span>"
+		return..()
+
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+	var/client/C = null
+
+	if(candidates.len)
+		C = pick(candidates)
+		M.key = C.key
+		M.languages |= HUMAN
+		M << "<span class='warning'>All at once it makes sense, you know what you are and who you are! Self awareness is yours!</span>"
+		user << "<span class='warning'>[M] is suddenly attentive and aware. It worked!</span>"
+		qdel(src)
+	else
+		user << "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later...</span>"
+		..()
 
 /obj/item/weapon/slimesteroid
 	name = "slime steroid"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -870,7 +870,7 @@ datum/chemical_reaction/pestkiller
 	required_other = 1
 /datum/chemical_reaction/slimeppotion/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-	var/obj/item/weapon/slimepotion/P = new /obj/item/weapon/slimepotion
+	var/obj/item/slimepotion/P = new /obj/item/slimepotion
 	P.loc = get_turf(holder.my_atom)
 
 
@@ -913,7 +913,7 @@ datum/chemical_reaction/pestkiller
 	required_other = 1
 /datum/chemical_reaction/slimepotion2/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-	var/obj/item/weapon/slimepotion2/P = new /obj/item/weapon/slimepotion2
+	var/obj/item/slimepotion2/P = new /obj/item/slimepotion2
 	P.loc = get_turf(holder.my_atom)
 //Adamantine
 /datum/chemical_reaction/slimegolem

--- a/html/changelogs/Incoming5643-slimechanges.yml
+++ b/html/changelogs/Incoming5643-slimechanges.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: Nanotrasen scientists have recently reported mutations within the pink family line of slimes. Station scientists are encoraged to investigate."

--- a/html/changelogs/Incoming5643-slimechanges.yml
+++ b/html/changelogs/Incoming5643-slimechanges.yml
@@ -3,4 +3,4 @@ author: Incoming5643
 delete-after: True
 
 changes: 
-  - rscadd: Nanotrasen scientists have recently reported mutations within the pink family line of slimes. Station scientists are encoraged to investigate."
+  - rscadd: Nanotrasen scientists have recently reported mutations within the pink family line of slimes. Station scientists are encouraged to investigate."


### PR DESCRIPTION
Pink:

Before:
Replaced the slime mob with a peaceful simple animal version. This used to be ok, but then a friend system was added to slimes that meant you could have all the fun of not geting attacked by slimes without having to cripple their ability to defend themselves

Now:
Puts checks in to keep the slime from eating or targeting people, but keeping their friendships intact so the scientist can still make use of the system.

Light Pink:

Then:
Same as pink, except you can use it on adult slimes to make equally pointless adult simple animals

Now:
Can be used on any mindless simple animal/monkey/slime to give them "sentience" aka player control drawn from ghosts with BE_ALIEN. Sample uses include: Weaponizing gold core mobs into working for you, using player mice to spy on people, providing an admittedly convoluted way to get player spiders in the round.

Sepia:

Then: It produces Cameras and film, readily accessible low demand items. Everyone laughs at this slime.

Now: It still does that. Someone please figure out something for the sepia slime to do, its life is a joke.
