### PR TITLE
Fixes taser stun duration 

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -12,6 +12,7 @@
 	color = "#FFFF00"
 	nodamage = 1
 	stun = 5
+	weaken = 5
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
@@ -29,9 +30,8 @@
 			if(C.dna && C.dna.check_mutation(HULK))
 				C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 			else if(C.status_flags & CANWEAKEN)
-				C.do_jitter_animation(jitter)
-				spawn(20)
-					C.Weaken(5)
+				spawn(5)
+					C.do_jitter_animation(jitter)
 	..()
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet


### PR DESCRIPTION
Fixes taser stun duration  to be back to normal, also jitter animation now only starts after the mob falls to the ground.

Fixes #7967 
