### PR TITLE
Makes rainbowtide a config option.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -148,6 +148,7 @@
 	var/assistant_cap = -1
 
 	var/starlight = 0
+	var/gray_assistants = 0
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -448,6 +449,8 @@
 					config.assistant_cap			= text2num(value)
 				if("starlight")
 					config.starlight			= 1
+				if("gray_assistants")
+					config.gray_assistants			= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -148,7 +148,7 @@
 	var/assistant_cap = -1
 
 	var/starlight = 0
-	var/gray_assistants = 0
+	var/grey_assistants = 0
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -449,8 +449,8 @@
 					config.assistant_cap			= text2num(value)
 				if("starlight")
 					config.starlight			= 1
-				if("gray_assistants")
-					config.gray_assistants			= 1
+				if("grey_assistants")
+					config.grey_assistants			= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -15,7 +15,10 @@ Assistant
 
 /datum/job/assistant/equip_items(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/random(H), slot_w_uniform)
+	if (config.gray_assistants)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
+	else
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/color/random(H), slot_w_uniform)
 
 /datum/job/assistant/get_access()
 	if((config.jobs_have_maint_access & ASSISTANTS_HAVE_MAINT_ACCESS) || !config.jobs_have_minimal_access) //Config has assistant maint access set

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -15,7 +15,7 @@ Assistant
 
 /datum/job/assistant/equip_items(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
-	if (config.gray_assistants)
+	if (config.grey_assistants)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/color/random(H), slot_w_uniform)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -223,5 +223,5 @@ ASSISTANT_CAP -1
 ## Starlight for exterior walls and breaches. Uncomment for starlight!
 STARLIGHT
 
-## Uncomment to bring back old gray suit assistants instead of the now default rainbow colored assistants.
-#GRAY_ASSISTANTS
+## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
+#GREY_ASSISTANTS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -222,3 +222,6 @@ ASSISTANT_CAP -1
 
 ## Starlight for exterior walls and breaches. Uncomment for starlight!
 STARLIGHT
+
+## Uncomment to bring back old gray suit assistants instead of the now default rainbow colored assistants.
+#GRAY_ASSISTANTS


### PR DESCRIPTION
Defaults to enabling rainbowtide, even if the config entry is absent from the config file.

I had to name it in a such a way that it it was a enabling a negative to have it make sense for a default of on even if absent from the config.
