### PR TITLE
Replaces Xenomicrobes with Sulfuic Acid

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -328,8 +328,8 @@
 			R.delete()
 			ejectItem(TRUE)
 		if(prob(EFFECT_PROB_VERYLOW-badThingCoeff))
-			visible_message("<span class='notice'>[src]'s chemical chamber has sprung a leak!.</span>")
-			chosenchem = pick("mutationtoxin","nanomachines","xenomicrobes")
+			visible_message("<span class='danger'>[src]'s chemical chamber has sprung a leak!</span>")
+			chosenchem = pick("mutationtoxin","nanomachines","sacid")
 			var/datum/reagents/R = new/datum/reagents(50)
 			R.my_atom = src
 			R.add_reagent(chosenchem , 50)

--- a/html/changelogs/Gun-Hog-PR-8004.yml
+++ b/html/changelogs/Gun-Hog-PR-8004.yml
@@ -1,0 +1,9 @@
+################################
+
+
+author: Gun Hog
+
+delete-after: True
+
+changes: 
+  - tweak: "We have perged the xenomicrobes contamination in the E.X.P.E.R.I-MENTOR using sulfuric acid. Take care not to be exposed should it leak!"


### PR DESCRIPTION
- Xenomicrobes replaces with Sulfuric Acid in the Experimentor.

I have received feedback from the admins, and they feel logging has not quelled the abuse. 

_Hornygranny suggested making it turn people into simple animals, I will try to find a way for that to work!_
