### PR TITLE
Panic bunker + new player notification configs

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -85,6 +85,9 @@
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
 	var/allow_ai = 0					// allow ai job
+	var/panic_bunker = 0				// prevents new people it hasn't seen before from connecting
+	var/notify_new_player_age = 0		// how long do we notify admins of a new player
+	var/irc_first_connection_alert = 0	// do we notify the irc channel when somebody is connecting for the first time?
 
 	var/traitor_scaling_coeff = 6		//how much does the amount of players get divided by to determine traitors
 	var/changeling_scaling_coeff = 6	//how much does the amount of players get divided by to determine changelings
@@ -316,6 +319,12 @@
 					config.hard_popcap_message = value
 				if("extreme_popcap_message")
 					config.extreme_popcap_message = value
+				if("panic_bunker")
+					config.panic_bunker = 1
+				if("notify_new_player_age")
+					config.notify_new_player_age = text2num(value)
+				if("irc_first_connection_alert")
+					config.irc_first_connection_alert = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -42,10 +42,15 @@ world/IsBanned(key,address,computer_id)
 		return ..()
 
 	//Guest Checking
-	if(!guests_allowed && IsGuestKey(key))
-		log_access("Failed Login: [key] - Guests not allowed")
-		message_admins("<span class='adminnotice'>Failed Login: [key] - Guests not allowed</span>")
-		return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
+	if(IsGuestKey(key))
+		if (!guests_allowed)
+			log_access("Failed Login: [key] - Guests not allowed")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - Guests not allowed</span>")
+			return list("reason"="guest", "desc"="\nReason: Guests not allowed. Please sign in with a byond account.")
+		if (config.panic_bunker && dbcon && dbcon.IsConnected())
+			log_access("Failed Login: [key] - Guests not allowed during panic bunker")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - Guests not allowed during panic bunker</span>")
+			return list("reason"="guest", "desc"="\nReason: Sorry but the server is currently not accepting connections from never before seen players or guests. If you have played on this server with a byond account before, please log in to the byond account you have played from.")
 
 	//Population Cap Checking
 	if(config.extreme_popcap && living_player_count() >= config.extreme_popcap && !(ckey(key) in admin_datums))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -100,7 +100,8 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/toggleAI,
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
-	/client/proc/toggle_random_events
+	/client/proc/toggle_random_events,
+	/client/proc/panicbunker
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/restart_controller,
@@ -190,7 +191,8 @@ var/list/admin_verbs_hideable = list(
 	/proc/possess,
 	/proc/release,
 	/client/proc/reload_admins,
-	/client/proc/reset_all_tcs
+	/client/proc/reset_all_tcs,
+	/client/proc/panicbunker
 	)
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -88,6 +88,23 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	msg = "<span class='adminnotice'><b><font color=red>HELP: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]</span>"
 
 	//send this msg to all admins
+
+	for(var/client/X in admins)
+		if(X.prefs.toggles & SOUND_ADMINHELP)
+			X << 'sound/effects/adminhelp.ogg'
+		X << msg
+
+
+	//show it to the person adminhelping too
+	src << "<span class='adminnotice'>PM to-<b>Admins</b>: [original_msg]</span>"
+
+	//send it to irc if nobody is on and tell us how many were on
+	var/admin_number_present = send2irc_adminless_only(original_msg)
+	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
+	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	return
+
+proc/send2irc_adminless_only(source, msg, requiredflags = R_BAN)
 	var/admin_number_total = 0		//Total number of admins
 	var/admin_number_afk = 0		//Holds the number of admins who are afk
 	var/admin_number_ignored = 0	//Holds the number of admins without +BAN (so admins who are not really admins)
@@ -95,30 +112,24 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	for(var/client/X in admins)
 		admin_number_total++;
 		var/invalid = 0
-		if(!check_rights_for(X, R_BAN))
+		if(requiredflags != 0 && !check_rights_for(X, requiredflags))
 			admin_number_ignored++
 			invalid = 1
 		if(X.is_afk())
 			admin_number_afk++
 			invalid = 1
+		if(X.holder.fakekey)
+			admin_number_ignored++
+			invalid = 1
 		if(invalid)
 			admin_number_decrease++
-		if(X.prefs.toggles & SOUND_ADMINHELP)
-			X << 'sound/effects/adminhelp.ogg'
-		X << msg
-
-	//show it to the person adminhelping too
-	src << "<span class='adminnotice'>PM to-<b>Admins</b>: [original_msg]</span>"
-
 	var/admin_number_present = admin_number_total - admin_number_decrease	//Number of admins who are neither afk nor invalid
-	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
 	if(admin_number_present <= 0)
 		if(!admin_number_afk && !admin_number_ignored)
-			send2irc(ckey, "[original_msg] - No admins online")
+			send2irc(source, "[msg] - No admins online")
 		else
-			send2irc(ckey, "[original_msg] - All admins AFK ([admin_number_afk]/[admin_number_total]) or skipped ([admin_number_ignored]/[admin_number_total])")
-	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	return
+			send2irc(source, "[msg] - All admins AFK ([admin_number_afk]/[admin_number_total]) or skipped ([admin_number_ignored]/[admin_number_total])")
+	return admin_number_present
 
 proc/send2irc(msg,msg2)
 	if(config.useircbot)

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -5,12 +5,11 @@
 		usr << "<span class='adminnotice'>The Database is not enabled!</span>"
 		return
 
-	if (!dbcon || !dbcon.IsConnected())
-		usr << "<span class='adminnotice'>The Database is not connected!</span>"
-		return
-
 	config.panic_bunker = (!config.panic_bunker)
+
 	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
-	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
+	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"enabled":"disabled")].")
+	if (config.panic_bunker && (!dbcon || !dbcon.IsConnected()))
+		message_admins("The Database is not connected! Panic bunker will not work until the connection is reestablished.")
 	feedback_add_details("admin_verb","PANIC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,0 +1,16 @@
+/client/proc/panicbunker()
+	set category = "Server"
+	set name = "Toggle Panic Bunker"
+	if (!config.sql_enabled)
+		usr << "<span class='adminnotice'>The Database is not enabled!</span>"
+		return
+
+	if (!dbcon || !dbcon.IsConnected())
+		usr << "<span class='adminnotice'>The Database is not connected!</span>"
+		return
+
+	config.panic_bunker = (!config.panic_bunker)
+	log_admin("[key_name(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
+	message_admins("[key_name_admin(usr)] has toggled the Panic Bunker, it is now [(config.panic_bunker?"on":"off")]")
+	feedback_add_details("admin_verb","PANIC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -90,7 +90,9 @@ var/list/external_rsc_urls
 var/next_external_rsc = 0
 #endif
 
+
 /client/New(TopicData)
+
 	TopicData = null							//Prevent calls to client.Topic from connect
 
 	if(connection != "seeker")					//Invalid connection type.
@@ -144,9 +146,8 @@ var/next_external_rsc = 0
 
 		if (config.notify_new_player_age >= 0)
 			message_admins("New user: [key_name_admin(src)] is connecting here for the first time.")
-
-		if (config.irc_first_connection_alert)
-			send2irc("New user", "[key_name(src)] is connecting for the first time!")
+			if (config.irc_first_connection_alert)
+				send2irc_adminless_only("New user", "[key_name(src)] is connecting for the first time!")
 
 		player_age = 0 // set it from -1 to 0 so the job selection code doesn't have a panic attack
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -140,6 +140,8 @@ var/next_external_rsc = 0
 
 	if (isnum(player_age) && player_age == -1) //first connection
 		if (config.panic_bunker && !holder && !(ckey in deadmins))
+			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
+			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			src << "Sorry but the server is currently not accepting connections from never before seen players."
 			del(src)
 			return 0

--- a/config/config.txt
+++ b/config/config.txt
@@ -176,3 +176,15 @@ HARD_MESSAGE The server is currently serving a high number of users, You cannot 
 
 ## Message for extreme cap
 EXTREME_MESSAGE The server is currently serving a high number of users, find alternative servers.
+
+## Notify admins when a new player connects for the first x days a player's been around. (0 for first connection only, -1 for never)
+##	Requres database
+NOTIFY_NEW_PLAYER_AGE 0 
+
+## Notify the irc channel when a new player makes their first connection
+##	Requres database
+#IRC_FIRST_CONNECTION_ALERT
+
+## Deny all new connections by ckeys we haven't seen before (exempts admins and only denies the connection if the database is enabled and connected)
+##	Requires database
+#PANIC_BUNKER

--- a/html/changelogs/MrStonedOne-panicBunker-PR-8006.yml
+++ b/html/changelogs/MrStonedOne-panicBunker-PR-8006.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MrStonedOne
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK. Fuck you N3X15, should have made this work with tabs
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in single (') or double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: 'Adds a Panic Bunker!'
+  - tweak: 'This will prevent any player who has never connected before from connecting. (Admins are exempt)'
+  - tweak: 'Can be enabled per-round by any admin with +SERVER or for longer periods via the config.'
+  - recadd: 'Also adds some other config options relating to new joins, server operators should consult their configuration file for more details.'
+  

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -798,6 +798,7 @@
 #include "code\modules\admin\verbs\modifyvariables.dm"
 #include "code\modules\admin\verbs\one_click_antag.dm"
 #include "code\modules\admin\verbs\onlyone.dm"
+#include "code\modules\admin\verbs\panicbunker.dm"
 #include "code\modules\admin\verbs\playsound.dm"
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"


### PR DESCRIPTION
Panic bunker! Uses the power of the database to reject new ckeys that have never connected to the server(s) before.
Admins are exempt, even while deadmin'ed, but they are also unlikely to be new ckeys except in rare cases that involve vv fuckary.

Its both a round only +server verb, and a config option for more long term panic attacks.

New player notification is now configurable. You can change how long they happen for.

Ie: First connection only, first x number of days on the server or never

Adds an optional default disabled irc notification of a players first time connecting.
This will only fire if first connection admin alerts above are turned on AND there are no valid admins on and not afk.
