### PR TITLE
Server time for status panel

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -698,6 +698,7 @@ var/list/slot_equipment_priority = list( \
 	..()
 
 	if(statpanel("Status"))
+		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
 		var/ETA
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_RECALL)

--- a/html/changelogs/Jordie0608 servertime.yml
+++ b/html/changelogs/Jordie0608 servertime.yml
@@ -1,0 +1,6 @@
+author: Jordie0608
+
+delete-after: True
+
+changes:
+  - rscadd: "The server's current local time is now displayed in status panel in ISO date format (YYYY-MM-DD hh:mm)"


### PR DESCRIPTION
Probably most useful for jobban appeals or log checks. This is visible to players no matter what mob they are.
