### PR TITLE
Fixes subsystems firing way too fast at round start.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -108,6 +108,7 @@ Note: you can set the datum's defined processing_interval to some integer to set
 /datum/controller/game_controller/proc/roundHasStarted()
 	for(var/datum/subsystem/SS in subsystems)
 		SS.can_fire = 1
+		SS.next_fire = world.time
 
 /datum/controller/game_controller/proc/Recover()
 	var/msg = "## DEBUG: [time2text(world.timeofday)] MC restarted. Reports:\n"


### PR DESCRIPTION
next_fire was being left to the world start world time, and only getting incremented every fire. since it doesn't fire before the round starts, it would try to make up those missed fires by repeatedly firing with no delay.

Fixes #7936
Fixes #7598
Fixes #7916
On that note, looks like i'll be attempting to maintain the carn mc. it didn't seem to be too hard to understand. but maybe thats the 35 hours of no sleep talking.
