### PR TITLE
Embedded Item Balancing. Also fixes #8029

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -52,6 +52,12 @@
 
 
 //Embedded objects
-#define EMBEDDED_PAIN_CHANCE 		15	//Chance for embedded objects to cause pain (damage user)
-#define EMBEDDED_ITEM_FALLOUT 		5	//Chance for embedded object to fall out (causing pain but removing the object)
-#define EMBED_CHANCE				45	//Chance for an object to embed into somebody when thrown (if it's sharp)
+#define EMBEDDED_PAIN_CHANCE 					15	//Chance for embedded objects to cause pain (damage user)
+#define EMBEDDED_ITEM_FALLOUT 					5	//Chance for embedded object to fall out (causing pain but removing the object)
+#define EMBED_CHANCE							45	//Chance for an object to embed into somebody when thrown (if it's sharp)
+#define EMBEDDED_PAIN_MULTIPLIER				2	//Coefficient of multiplication for the damage the item does while embedded (this*item.w_class)
+#define EMBEDDED_FALL_PAIN_MULTIPLIER			5	//Coefficient of multiplication for the damage the item does when it falls out (this*item.w_class)
+#define EMBEDDED_IMPACT_PAIN_MULTIPLIER			4	//Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
+#define EMBED_THROWSPEED_THRESHOLD				4	//The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
+#define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 8	//Coefficient of multiplication for the damage the item does when removed without a surgery (this*item.w_class)
+#define EMBEDDED_UNSAFE_REMOVAL_TIME			30	//A Time in ticks, total removal time = (this*item.w_class)

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -13,6 +13,8 @@
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.restore_blood()
+			H.remove_all_embedded_objects()
+
 		for(var/i = 0, i<10,i++)
 			user.adjustBruteLoss(-10)
 			user.adjustOxyLoss(-10)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -23,6 +23,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()
+		H.remove_all_embedded_objects()
 	user << "<span class='notice'>We have regenerated.</span>"
 
 	user.status_flags &= ~(FAKEDEATH)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -113,7 +113,9 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 				spawn(0) //Simultaneously not one at a time
 					var/throw_range = rand(throw_dist, max_range)
 					var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-					I.throw_at(throw_at, throw_range,1)
+					I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
+					I.throw_at(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
+
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -48,9 +48,15 @@
 	var/hooded = 0
 
 	//So items can have custom embedd values
+	//Because customisation is king
 	var/embed_chance = EMBED_CHANCE
 	var/embedded_fall_chance = EMBEDDED_ITEM_FALLOUT
 	var/embedded_pain_chance = EMBEDDED_PAIN_CHANCE
+	var/embedded_pain_multiplier = EMBEDDED_PAIN_MULTIPLIER  //The coefficient of multiplication for the damage this item does while embedded (this*w_class)
+	var/embedded_fall_pain_multiplier = EMBEDDED_FALL_PAIN_MULTIPLIER //The coefficient of multiplication for the damage this item does when falling out of a limb (this*w_class)
+	var/embedded_impact_pain_multiplier = EMBEDDED_IMPACT_PAIN_MULTIPLIER //The coefficient of multiplication for the damage this item does when first embedded (this*w_class)
+	var/embedded_unsafe_removal_pain_multiplier = EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER //The coefficient of multiplication for the damage removing this without surgery causes (this*w_class)
+	var/embedded_unsafe_removal_time = EMBEDDED_UNSAFE_REMOVAL_TIME //A time in ticks, multiplied by the w_class.
 
 	var/list/can_be_placed_into = list(
 		/obj/structure/table,
@@ -417,16 +423,19 @@
 
 
 /obj/item/throw_impact(A)
-	if(istype(A, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = A
-		if(can_embed(src))
-			if(prob(embed_chance))
-				var/obj/item/organ/limb/L = pick(H.organs)
-				L.embedded_objects |= src
-				add_blood(H)//it embedded itself in you, of course it's bloody!
-				loc = H
-				L.take_damage(w_class*5)
-				H.visible_message("<span class='danger'>\the [name] embeds itself in [H]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\the [name] embeds itself in your [L.getDisplayName()]!</span>")
-				return
+	if(throw_speed >= EMBED_THROWSPEED_THRESHOLD)
+		if(istype(A, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = A
+			if(can_embed(src))
+				if(prob(embed_chance))
+					var/obj/item/organ/limb/L = pick(H.organs)
+					L.embedded_objects |= src
+					add_blood(H)//it embedded itself in you, of course it's bloody!
+					loc = H
+					L.take_damage(w_class*embedded_impact_pain_multiplier)
+					H.visible_message("<span class='danger'>\the [name] embeds itself in [H]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\the [name] embeds itself in your [L.getDisplayName()]!</span>")
+					return
 
+	//Reset regardless of if we hit a human.
+	throw_speed = initial(throw_speed) //explosions change this.
 	..()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -279,9 +279,10 @@ obj/item/weapon/twohanded/
 	w_class = 4.0
 	slot_flags = SLOT_BACK
 	force_unwielded = 10
-	force_wielded = 18 // Was 13, Buffed - RR
+	force_wielded = 18
 	throwforce = 20
-	throw_speed = 3
+	throw_speed = 4
+	embedded_impact_pain_multiplier = 3
 	flags = NOSHIELD
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -138,11 +138,15 @@ obj/item/weapon/wirerod/attackby(var/obj/item/I, mob/user as mob, params)
 	icon_state = "throwingstar"
 	item_state = "eshield0"
 	force = 2
-	throwforce = 20
+	throwforce = 0 //This is never used since this has a 100% embed chance.
+	throw_speed = 4
+	embedded_pain_multiplier = 4
 	w_class = 2
 	embed_chance = 100
 	embedded_fall_chance = 0 //Hahaha!
 
+//5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
+//Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
 /obj/item/weapon/storage/box/throwing_stars/New()
 	..()
 	contents = list()
@@ -151,3 +155,7 @@ obj/item/weapon/wirerod/attackby(var/obj/item/I, mob/user as mob, params)
 	new /obj/item/weapon/throwing_star(src)
 	new /obj/item/weapon/throwing_star(src)
 	new /obj/item/weapon/throwing_star(src)
+
+
+
+

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -257,11 +257,11 @@
 			var/obj/item/organ/limb/L = locate(href_list["embedded_limb"])
 			if(!I || !L || I.loc != src) //no item, no limb, or item is not in limb (the person atleast) anymore
 				return
-			var/time_taken = 30*I.w_class
+			var/time_taken = I.embedded_unsafe_removal_time*I.w_class
 			usr.visible_message("<span class='notice'>[usr] attempts to remove [I] from their [L.getDisplayName()]!</span>","<span class='notice'>You attempt to remove [I] from your [L.getDisplayName()], it will take [time_taken/10] seconds.</span>")
 			if(do_after(usr, time_taken, needhand = 1))
 				L.embedded_objects -= I
-				L.take_damage(8*I.w_class)//It hurts to rip it out, get surgery you dingus.
+				L.take_damage(I.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
 				I.loc = get_turf(src)
 				usr.put_in_hands(I)
 				usr.emote("scream")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -613,11 +613,11 @@
 	for(var/obj/item/organ/limb/L in organs)
 		for(var/obj/item/I in L.embedded_objects)
 			if(prob(I.embedded_pain_chance))
-				L.take_damage(I.w_class*2)
+				L.take_damage(I.w_class*I.embedded_pain_multiplier)
 				src << "<span class='userdanger'>\the [I] embedded in your [L.getDisplayName()] hurts!</span>"
 
 			if(prob(I.embedded_fall_chance))
-				L.take_damage(I.w_class*5)
+				L.take_damage(I.w_class*I.embedded_fall_pain_multiplier)
 				L.embedded_objects -= I
 				I.loc = get_turf(src)
 				visible_message("<span class='danger'>\the [I] falls out of [name]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\the [I] falls out of your [L.getDisplayName()]!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -413,6 +413,8 @@ Sorry Giacom. Please don't be mad :(
 	if(ishuman(src))
 		var/mob/living/carbon/human/human_mob = src
 		human_mob.restore_blood()
+		human_mob.remove_all_embedded_objects()
+
 	update_fire()
 	regenerate_icons()
 	..()

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -170,7 +170,7 @@
 		return 0
 
 //Returns a display name for the organ
-/obj/item/organ/limb/proc/getDisplayName() //Added "Chest" and "Head" just in case, this may not be needed - RR.
+/obj/item/organ/limb/proc/getDisplayName() //Added "Chest" and "Head" just in case, this may not be needed
 	switch(name)
 		if("l_leg")		return "left leg"
 		if("r_leg")		return "right leg"
@@ -181,3 +181,11 @@
 		else			return name
 
 
+//Remove all embedded objects from all limbs on the human mob
+/mob/living/carbon/human/proc/remove_all_embedded_objects()
+	var/turf/T = get_turf(src)
+
+	for(var/obj/item/organ/limb/L in organs)
+		for(var/obj/item/I in L.embedded_objects)
+			L.embedded_objects -= I
+			I.loc = T


### PR DESCRIPTION
- Exposes all embedding related multipliers as variables and definitions
- The multiplier for Impact damage has been lowered from 5 to 4 (what can I say? I'm nice :) )
- Throwing star pain damage multiplier increased from 2 to 4, meaning it does 8 damage at a 15% pain chance.
- Spear pain damage multiplier increased from 2 to 3.
- Only items of throw_speed 4 and above can embed now (By default, just throwing stars and spears)
- Explosions ALWAYS throw their items around at throw_speed 4, and reset to their normal values after they land to prevent griff, changing nothing gameplay wise.
- The throw_speed threshold is ON TOP of needing to be a can_embed() object, changing nothing gameplay wise.

If you throw all 5 throwing stars from the box into 1 person you will do 45 damage to them (Not counting the damage over time from pain) I believe this is fine since throwing all 5 into one person means you no longer have them anymore. (This is technically a nerf from 50 damage with all 5 stars to 45 with all 5, with the pain damage being increased to compensate)

Fixes #8005 
Fixes #8029 
