### PR TITLE
A bundle of fixes

### DIFF
--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -24,6 +24,7 @@ var/global/mulebot_count = 0
 	control_freq = 1447
 	bot_type = MULE_BOT
 	bot_filter = RADIO_MULEBOT
+	blood_DNA = list()
 
 	suffix = ""
 
@@ -240,7 +241,7 @@ obj/machinery/bot/mulebot/bot_reset()
 
 	//user << browse("<HEAD><TITLE>M.U.L.E. Mk. III [suffix ? "([suffix])" : ""]</TITLE></HEAD>[dat]", "window=mulebot;size=350x500")
 	//onclose(user, "mulebot")
-	var/datum/browser/popup = new(user, "mulebot", "M.U.L.E. Mk. V [suffix ? "([suffix])" : ""]", 350, 500)
+	var/datum/browser/popup = new(user, "mulebot", "M.U.L.E. Mk. V [suffix ? "([suffix])" : ""]", 350, 550)
 	popup.set_content(dat)
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
 	popup.open()
@@ -554,6 +555,7 @@ obj/machinery/bot/mulebot/bot_reset()
 
 					if(bloodiness)
 						var/obj/effect/decal/cleanable/blood/tracks/B = new(loc)
+						B.blood_DNA |= blood_DNA.Copy()
 						var/newdir = get_dir(next, loc)
 						if(newdir == dir)
 							B.dir = newdir
@@ -747,7 +749,8 @@ obj/machinery/bot/mulebot/bot_reset()
 // called from mob/living/carbon/human/Crossed()
 // when mulebot is in the same loc
 /obj/machinery/bot/mulebot/proc/RunOver(var/mob/living/carbon/human/H)
-	visible_message("<span class='danger'>[src] drives over [H]!</span>")
+	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
+					"<span class='userdanger'>[src] drives over you!<span>")
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
 	var/damage = rand(5,15)
@@ -759,9 +762,8 @@ obj/machinery/bot/mulebot/bot_reset()
 	H.apply_damage(0.5*damage, BRUTE, "r_arm")
 
 	var/obj/effect/decal/cleanable/blood/B = new(loc)
-	B.blood_DNA = list()
 	B.blood_DNA[H.dna.unique_enzymes] = H.dna.blood_type
-
+	blood_DNA[H.dna.unique_enzymes] = H.dna.blood_type
 	bloodiness += 4
 
 // player on mulebot attempted to move

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -246,17 +246,20 @@ Crematorium Switch
 		user << "That's not connected to anything."
 
 /obj/structure/tray/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
-	if ((!( istype(O, /atom/movable) ) || O.anchored || get_dist(user, src) > 1 || get_dist(user, O) > 1 || user.contents.Find(src) || user.contents.Find(O)))
+	if(!istype(O, /atom/movable) || O.anchored || !Adjacent(user) || !user.Adjacent(O) || O.loc == user)
 		return
-	if (!ismob(O) && !istype(O, /obj/structure/closet/body_bag))
-		return
-	if (!ismob(user) || user.stat || user.lying || user.stunned)
+	if(!ismob(O))
+		if(!istype(O, /obj/structure/closet/body_bag))
+			return
+	else
+		var/mob/M = O
+		if(M.buckled)
+			return
+	if(!ismob(user) || user.lying || user.incapacitated())
 		return
 	O.loc = src.loc
 	if (user != O)
-		for(var/mob/B in viewers(user, 3))
-			B.show_message("<span class='danger'>[user] stuffs [O] into [src]!</span>", 1)
-			//Foreach goto(99)
+		visible_message("<span class='warning'>[user] stuffs [O] into [src]!</span>")
 	return
 
 /*

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -70,10 +70,9 @@
 	else
 		density = 0
 		icon_state = "down"
-		if(buckled_mob)
-			buckled_mob.pixel_y = initial(buckled_mob.pixel_y)
-			if(buckled_mob.lying)
-				buckled_mob.pixel_y -= buckled_pixel_y_offset
+		M.pixel_y = initial(M.pixel_y)
+		if(M.lying)
+			M.pixel_y -= buckled_pixel_y_offset
 
 
 /obj/item/roller

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -495,7 +495,7 @@ Sorry Giacom. Please don't be mad :(
 						M.stop_pulling()
 
 						//this is the gay blood on floor shit -- Added back -- Skie
-						if(M.lying && (prob(M.getBruteLoss() / 2)))
+						if(M.lying && !M.buckled && (prob(M.getBruteLoss() / 2)))
 							makeTrail(T, M)
 						pulling.Move(T, get_dir(pulling, T))
 						if(M)


### PR DESCRIPTION
- Fixes no blood dna info (for detective scanner) on Mulebot and its blood tracks after running over a human. Fixes #7373
- Fixes putting buckled mobs onto morgue trays. You can no longer put buckled mobs on morgue trays. Fixes #6354
- Fixes mob pixel offset when unbuckled from roller bed. (that broke in #7049 )
- Fixes blood trail appearing when pulling a patient on a roller bed. Fixes #6353
- Fixes other minor stuff.
