### PR TITLE
Table-Item Pixel Placement Improvements

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -324,8 +324,11 @@
 			I.Move(loc)
 			var/list/click_params = params2list(params)
 			//Center the icon where the user clicked.
-			I.pixel_x = (text2num(click_params["icon-x"]) - 16)
-			I.pixel_y = (text2num(click_params["icon-y"]) - 16)
+			if(!click_params || !click_params["icon-x"] || !click_params["icon-y"])
+				return
+			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
+			I.pixel_x = Clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
+			I.pixel_y = Clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
 
 
 /*


### PR DESCRIPTION
Fixes #8020 

I am <i>pissed</i> that byond interprets the NAME of an object as valid values for pixel-x and pixel-y in the AltClick menu. That is stupid, and byond is stupid.

Also adds some sanity because if clicking the name can cause things to happen, I wonder what the hell else can.
