### PR TITLE
Fixes #8035 energy shield reflect var

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -70,7 +70,6 @@
 		w_class = 4
 		playsound(user, 'sound/weapons/saberon.ogg', 35, 1)
 		user << "<span class='notice'>[src] is now active.</span>"
-		reflect_chance = 40
 	else
 		force = 3
 		throwforce = 3
@@ -78,7 +77,6 @@
 		w_class = 1
 		playsound(user, 'sound/weapons/saberoff.ogg', 35, 1)
 		user << "<span class='notice'>[src] can now be concealed.</span>"
-		reflect_chance = 0
 	add_fingerprint(user)
 
 /obj/item/weapon/shield/riot/tele

--- a/html/changelogs/Mandurrh-PR8046.yml
+++ b/html/changelogs/Mandurrh-PR8046.yml
@@ -1,0 +1,9 @@
+
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - bugfix: "Fixes #8035 by removing the reflect var"


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/issues/8035 

Removes the reflect var from energy shields since they didn't do anything in the first place and was decided upon that they were balanced as is.
