### PR TITLE
Fixes #8052 Cyborg recharger density

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -11,6 +11,7 @@
 	req_access = list(access_robotics)
 	var/recharge_speed
 	var/repairs
+	state_open = 1
 
 /obj/machinery/recharge_station/New()
 	..()


### PR DESCRIPTION
Cyborg rechargers now start open, to comply with their density.
