### PR TITLE
Fixes #772 Toggling darkness off prevents ghosts from seeing one another

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -17,6 +17,7 @@
 	var/last_attack = 0
 	var/datum/reagent/blob_reagent_datum = new/datum/reagent()
 	var/list/blob_mobs = list()
+	var/ghostimage = null
 
 /mob/camera/blob/New()
 	var/new_name = "[initial(name)] ([rand(1, 999)])"
@@ -27,7 +28,18 @@
 	for(var/type in (typesof(/datum/reagent/blob) - /datum/reagent/blob))
 		possible_reagents.Add(new type)
 	blob_reagent_datum = pick(possible_reagents)
+
+	ghostimage = image(src.icon,src,src.icon_state)
+	ghost_darkness_images |= ghostimage //so ghosts can see the blob cursor when they disable darkness
+	updateallghostimages()
 	..()
+
+/mob/camera/blob/Destroy()
+	if (ghostimage)
+		ghost_darkness_images -= ghostimage
+		qdel(ghostimage)
+		ghostimage = null;
+		updateallghostimages()
 
 /mob/camera/blob/Login()
 	..()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -2,4 +2,10 @@
 	..()
 	if(client.prefs.unlock_content)
 		icon_state = client.prefs.ghost_form
+		if (ghostimage)
+			ghostimage.icon_state = src.icon_state
+
+	updateghostimages()
+
+
 	update_interface()

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -1,6 +1,6 @@
 /mob/dead/observer/Logout()
 	if (client)
-		client.images -= ghostimages
+		client.images -= ghost_darkness_images
 	..()
 	spawn(0)
 		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -1,5 +1,6 @@
 /mob/dead/observer/Logout()
-	client.images -= ghostimages
+	if (client)
+		client.images -= ghostimages
 	..()
 	spawn(0)
 		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -1,4 +1,5 @@
 /mob/dead/observer/Logout()
+	client.images -= ghostimages
 	..()
 	spawn(0)
 		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -19,8 +19,10 @@
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
 	var/atom/movable/following = null
 	var/fun_verbs = 0
-	var/image/ghostimage = null
-	var/static/list/image/ghostimages = list() //this is a list of images of other ghosts that ghosts see when they toggle darkness
+	var/static/list/image/ghostimages = list() //this is a list of images of other ghosts that ghosts will use to see ghosts when they toggle darkness
+	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
+	var/seeghosts = 1 //so ghosts can hide other ghosts, requested
+	var/seedarkness = 1
 
 /mob/dead/observer/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
@@ -266,14 +268,26 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set hidden = 1
 	src << "<span class='danger'>You are dead! You have no mind to store memory!</span>"
 
+/mob/dead/observer/verb/toggle_ghostsee()
+	set name = "Toggle Other Ghosts"
+	set desc = "Toggle your ability to see other ghosts"
+	set category = "Ghost"
+	seeghosts = !(seeghosts)
+	updateghostsight()
+
 /mob/dead/observer/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"
+	seedarkness = !(seedarkness)
+	updateghostsight()
 
-	if (see_invisible == SEE_INVISIBLE_OBSERVER_NOLIGHTING)
-		see_invisible = SEE_INVISIBLE_OBSERVER
-	else
+/mob/dead/observer/proc/updateghostsight()
+	if (!seedarkness)
 		see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+	else
+		see_invisible = SEE_INVISIBLE_OBSERVER
+		if (!seeghosts)
+			see_invisible = INVISIBILITY_OBSERVER - 1;
 	updateghostimages()
 
 /mob/dead/observer/proc/updateallghostimages()
@@ -283,7 +297,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/proc/updateghostimages()
 	if (!client)
 		return
-	if (see_invisible >= SEE_INVISIBLE_OBSERVER)
+	if (seedarkness || !seeghosts)
 		client.images -= ghostimages
 	else
 		client.images |= ghostimages //add images for all the ghosts so we can see them

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,4 +1,4 @@
-var/list/image/ghostimages = list() //this is a list of images of other ghosts that ghosts see when they toggle darkness
+
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
@@ -20,6 +20,7 @@ var/list/image/ghostimages = list() //this is a list of images of other ghosts t
 	var/atom/movable/following = null
 	var/fun_verbs = 0
 	var/image/ghostimage = null
+	var/static/list/image/ghostimages = list() //this is a list of images of other ghosts that ghosts see when they toggle darkness
 
 /mob/dead/observer/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF


### PR DESCRIPTION
Fixes #772 

Abuses client.images to get around the issue with flat see_invisible scaling not allowing for both being able to see ghosts while not seeing darkness layers.

Also adds a new toggle ghost visibility verb for users who want the old functionality.
