### PR TITLE
Tweaks and fixes for the appearance window

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -176,44 +176,63 @@ datum/preferences
 					dat += "<b>Species:</b> Human<BR>"
 
 				dat += "<b>Blood Type:</b> [blood_type]<BR>"
-				dat += "<b>Skin Tone:</b><BR><a href='?_src_=prefs;preference=s_tone;task=input'>[skin_tone]</a><BR>"
 				dat += "<b>Underwear:</b><BR><a href ='?_src_=prefs;preference=underwear;task=input'>[underwear]</a><BR>"
 				dat += "<b>Undershirt:</b><BR><a href ='?_src_=prefs;preference=undershirt;task=input'>[undershirt]</a><BR>"
 				dat += "<b>Socks:</b><BR><a href ='?_src_=prefs;preference=socks;task=input'>[socks]</a><BR>"
 				dat += "<b>Backpack:</b><BR><a href ='?_src_=prefs;preference=bag;task=input'>[backbaglist[backbag]]</a><BR>"
 
+				if(pref_species.use_skintones)
 
-				dat += "</td><td valign='top' width='21%'>"
+					dat += "</td><td valign='top' width='21%'>"
 
-				dat += "<h3>Hair Style</h3>"
+					dat += "<h3>Skin Tone</h3>"
 
-				dat += "<a href='?_src_=prefs;preference=hair_style;task=input'>[hair_style]</a><BR>"
-				dat += "<a href='?_src_=prefs;preference=previous_hair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_hair_style;task=input'>&gt;</a><BR>"
-				dat += "<span style='border:1px solid #161616; background-color: #[hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=hair;task=input'>Change</a><BR>"
+					dat += "<a href='?_src_=prefs;preference=s_tone;task=input'>[skin_tone]</a><BR>"
+
+					dat += "</td>"
+
+				if(HAIR in pref_species.specflags)
+
+					dat += "<td valign='top' width='21%'>"
+
+					dat += "<h3>Hair Style</h3>"
+
+					dat += "<a href='?_src_=prefs;preference=hair_style;task=input'>[hair_style]</a><BR>"
+					dat += "<a href='?_src_=prefs;preference=previous_hair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_hair_style;task=input'>&gt;</a><BR>"
+					dat += "<span style='border:1px solid #161616; background-color: #[hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=hair;task=input'>Change</a><BR>"
 
 
-				dat += "</td><td valign='top' width='21%'>"
+					dat += "</td><td valign='top' width='21%'>"
 
-				dat += "<h3>Facial Hair Style</h3>"
+					dat += "<h3>Facial Hair Style</h3>"
 
-				dat += "<a href='?_src_=prefs;preference=facial_hair_style;task=input'>[facial_hair_style]</a><BR>"
-				dat += "<a href='?_src_=prefs;preference=previous_facehair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_facehair_style;task=input'>&gt;</a><BR>"
-				dat += "<span style='border: 1px solid #161616; background-color: #[facial_hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=facial;task=input'>Change</a><BR>"
+					dat += "<a href='?_src_=prefs;preference=facial_hair_style;task=input'>[facial_hair_style]</a><BR>"
+					dat += "<a href='?_src_=prefs;preference=previous_facehair_style;task=input'>&lt;</a> <a href='?_src_=prefs;preference=next_facehair_style;task=input'>&gt;</a><BR>"
+					dat += "<span style='border: 1px solid #161616; background-color: #[facial_hair_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=facial;task=input'>Change</a><BR>"
 
+					dat += "</td>"
 
-				dat += "</td><td valign='top' width='21%'>"
+				if(EYECOLOR in pref_species.specflags)
 
-				dat += "<h3>Eye Color</h3>"
+					dat += "<td valign='top' width='21%'>"
 
-				dat += "<span style='border: 1px solid #161616; background-color: #[eye_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=eyes;task=input'>Change</a><BR>"
+					dat += "<h3>Eye Color</h3>"
 
-				dat += "</td><td valign='top' width='21%'>"
+					dat += "<span style='border: 1px solid #161616; background-color: #[eye_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=eyes;task=input'>Change</a><BR>"
 
-				dat += "<h3>Alien Color</h3>"  // even if choosing your mutantrace is off, this is here in case you gain one during a round
+					dat += "</td>"
 
-				dat += "<span style='border: 1px solid #161616; background-color: #[mutant_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=mutant_color;task=input'>Change</a><BR>"
+				if(MUTCOLORS in pref_species.specflags)
 
-				dat += "</td></tr></table>"
+					dat += "<td valign='top' width='21%'>"
+
+					dat += "<h3>Alien Color</h3>"
+
+					dat += "<span style='border: 1px solid #161616; background-color: #[mutant_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=mutant_color;task=input'>Change</a><BR>"
+
+					dat += "</td>"
+
+				dat += "</tr></table>"
 
 
 			if (1) // Game Preferences

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -65,6 +65,20 @@
 		facial_s.Blend("#[facial_hair_color]", ICON_MULTIPLY)
 		eyes_s.Blend(facial_s, ICON_OVERLAY)
 
+	var/list/relevent_layers = list(BODY_BEHIND_LAYER, BODY_ADJ_LAYER, BODY_FRONT_LAYER)
+	var/icon_state_string = "[pref_species.id]_"
+
+	if(pref_species.sexes)
+		icon_state_string += "[g]_s"
+	else
+		icon_state_string += "_s"
+
+	for(var/layer in relevent_layers)
+		for(var/bodypart in pref_species.mutant_bodyparts)
+			var/icon/part = new/icon("icon" = 'icons/mob/mutant_bodyparts.dmi', "icon_state" = "[icon_state_string]_[bodypart]_[layer]")
+			part.Blend("#[mutant_color]", ICON_MULTIPLY)
+			preview_icon.Blend(part, ICON_OVERLAY)
+
 	var/icon/clothes_s = null
 	if(job_civilian_low & ASSISTANT)//This gives the preview icon clothes depending on which job(if any) is set to 'high'
 		clothes_s = new /icon('icons/mob/uniform.dmi', "grey_s")

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -23,6 +23,21 @@
 	del(preview_icon_side)
 	var/icon/preview_icon = null
 
+	if(job_engsec_high) //cyborg/AI check, put first to avoid so much unneeded blending
+		switch(job_engsec_high)
+			if(AI)
+				preview_icon = new /icon('icons/mob/AI.dmi', "AI")
+
+			if(CYBORG)
+				preview_icon = new /icon('icons/mob/robots.dmi', "robot")
+
+		if(preview_icon) //We're busting out!
+			preview_icon_front = new(preview_icon, dir = SOUTH)
+			preview_icon_side = new(preview_icon, dir = WEST)
+
+			del(preview_icon)
+			return
+
 	var/g = "m"
 	if(gender == FEMALE)	g = "f"
 


### PR DESCRIPTION
Fixes an unreported bug where all the lizardpeople were horrifying on the character preview because it wasn't rendering their tails and noses. Incidentally the proc for character previews is horrifying.

Only relevant appearance settings will appear on the appearance screen for each race.

Moves the skin tones selector to the relevant appearance settings area for humans.

---

If your high setting is a silicon, you'll see that silicon in the preview window
