### PR TITLE
Mulligan Round Fixes/Feature Requests

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -7,15 +7,14 @@
 		return 1
 	if(!blob_cores.len) // blob is dead
 		if(config.continuous_round_blob)
-			if(!convert_roundtype())
-				return ..()
-			else
-				if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
-					SSshuttle.emergency.mode = SHUTTLE_DOCKED
-					SSshuttle.emergency.timer = world.time
-					priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
-				round_converted = 1
-				return 0
+			round_converted = convert_roundtype()
+			if(!round_converted)
+				return 1
+			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
+				SSshuttle.emergency.mode = SHUTTLE_DOCKED
+				SSshuttle.emergency.timer = world.time
+				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+			return 0
 		return 1
 	if(station_was_nuked)//Nuke went off
 		return 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -108,12 +108,12 @@
 			if(SSshuttle.emergency.timeLeft(1) < initial(SSshuttle.emergencyCallTime)*0.5)
 				return 1
 
-	var/list/living_crew = list()
+	var/living_crew = 0
 
 	for(var/mob/Player in mob_list)
 		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
 			living_crew++
-	if(living_crew.len / joined_player_list.len <= 0.7) //If a lot of the player base died, we start fresh
+	if(living_crew / joined_player_list.len <= 0.7) //If a lot of the player base died, we start fresh
 		return 0
 
 	var/list/antag_canadates = list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -122,7 +122,9 @@
 		if(H.client && H.client.prefs.allow_midround_antag)
 			antag_canadates += H
 
-	if(!antag_canadates)	return 1
+	if(!antag_canadates)
+		message_admins("The roundtype has been converted, antagonists may have been created")
+		return 1
 
 	antag_canadates = shuffle(antag_canadates)
 
@@ -132,6 +134,8 @@
 		replacementmode.restricted_jobs += "Assistant"
 	for(var/mob/living/carbon/human/H in antag_canadates)
 		replacementmode.make_antag_chance(H)
+
+	message_admins("The roundtype has been converted, antagonists may have been created")
 
 	return 1
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -110,9 +110,9 @@
 
 	var/list/living_crew = list()
 
-	for(var/mob/mob in player_list)
-		if(mob in living_mob_list && mob.ckey in joined_player_list)
-			living_crew += mob
+	for(var/mob/Player in mob_list)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
+			living_crew++
 	if(living_crew.len / joined_player_list.len <= 0.7) //If a lot of the player base died, we start fresh
 		return 0
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -132,10 +132,12 @@
 		replacementmode.restricted_jobs += replacementmode.protected_jobs
 	if(config.protect_assistant_from_antagonist)
 		replacementmode.restricted_jobs += "Assistant"
-	for(var/mob/living/carbon/human/H in antag_canadates)
-		replacementmode.make_antag_chance(H)
 
-	message_admins("The roundtype has been converted, antagonists may have been created")
+	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
+		for(var/mob/living/carbon/human/H in antag_canadates)
+			replacementmode.make_antag_chance(H)
+
+		message_admins("The roundtype has been converted, antagonists may have been created")
 
 	return 1
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -153,8 +153,7 @@
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 			SSshuttle.emergencyNoEscape = 0
 			malf_mode_declared = 0
-			convert_roundtype()
-			round_converted = 1
+			round_converted = convert_roundtype()
 		else
 			return 1
 	return ..() //check for shuttle and nuke

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -194,11 +194,11 @@
 		return ..()
 
 	if(config.continuous_round_wiz)
-		if(!convert_roundtype())
+		round_converted = convert_roundtype()
+		if(!round_converted)
 			finished = 1
 			return 1
 		else
-			round_converted = 1
 			return ..()
 
 	finished = 1


### PR DESCRIPTION
Replaces the custom "how many people are dead?" check with the one used for survival rates on round end statistics because, lets be honest here, we know that one works.

Shuffles some flags around that should hopefully prevent round_converted() from running more than once. It's not a huge crisis if it does because late join antag is self capping, but still, not intended behavior!

Fixes #8089 (probably)

---

Adds an admin message on round conversion provided it gets far enough to matter. It also reports the same if no antags are made, to stop the exotic threat of unintentional admin meta.

fixes #8082

---

 Adds a lull between when the antagonist eats it and when the new antagonists are created: 3 ~ 7 minutes (5 average)

fixes #8105
