### PR TITLE
Adds admin alert when random events fire

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -89,7 +89,8 @@ var/datum/subsystem/events/SSevent
 			if(E.runEvent() == PROCESS_KILL)//we couldn't run this event for some reason, set its max_occurrences to 0
 				E.max_occurrences = 0
 				continue
-			message_admins("Random Event triggering: [E.name] ([E.typepath])")
+			if (E.alertadmins)
+				message_admins("Random Event triggering: [E.name] ([E.typepath])")
 			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -70,6 +70,8 @@ var/datum/subsystem/events/SSevent
 			if(E.runEvent() == PROCESS_KILL)
 				E.max_occurrences = 0
 				continue
+			message_admins("Random Event triggering: [E.name] ([E.typepath])")
+			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 		sum_of_weights += E.weight
 
@@ -86,6 +88,8 @@ var/datum/subsystem/events/SSevent
 			if(E.runEvent() == PROCESS_KILL)//we couldn't run this event for some reason, set its max_occurrences to 0
 				E.max_occurrences = 0
 				continue
+			message_admins("Random Event triggering: [E.name] ([E.typepath])")
+			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 
 

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -70,7 +70,8 @@ var/datum/subsystem/events/SSevent
 			if(E.runEvent() == PROCESS_KILL)
 				E.max_occurrences = 0
 				continue
-			message_admins("Random Event triggering: [E.name] ([E.typepath])")
+			if (E.alertadmins)
+				message_admins("Random Event triggering: [E.name] ([E.typepath])")
 			log_game("Random Event triggering: [E.name] ([E.typepath])")
 			return
 		sum_of_weights += E.weight

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -4,6 +4,8 @@
 	weight = 300
 	max_occurrences = 1000
 	earliest_start = 0
+	alertadmins = 0
+
 
 /datum/round_event/meteor_wave/dust
 	startWhen		= 1

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/electrical_storm
 	earliest_start = 6000
 	weight = 40
+	alertadmins = 0
 
 /datum/round_event/electrical_storm
 	var/lightsoutAmount	= 1

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -17,6 +17,9 @@
 								//anything with a (non-null) holidayID which does not match holiday, cannot run.
 	var/wizardevent = 0
 
+	var/alertadmins = 1			//should we let the admins know this event is firing
+								//should be disabled on events that fire a lot
+
 /datum/round_event_control/wizard
 	wizardevent = 1
 


### PR DESCRIPTION
Not sure why it took this long for this to happened.
Will only trigger on random event firing, and not when an admin triggers an event to prevent unneeded duplicate messages
Also triggers for events triggered by the wizard summon events
Logs in the game log under the GAME: heading as well

Certain spammy events do not trigger it. Namely Space Dust and Electrical Storm (they still log thou)
