### PR TITLE
Fixes being able to sleep to avoid Hostile Mobs. [WIP]

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -40,6 +40,8 @@
 	maxbodytemp = 1500
 
 	faction = list("russian")
+	robust_searching = 0
+	stat_attack = 0 //you're actually supposed to sleep if a bear attacks you!
 
 //SPACE BEARS! SQUEEEEEEEE~     OW! FUCK! IT BIT MY HAND OFF!!
 /mob/living/simple_animal/hostile/bear/Hudson

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -20,13 +20,13 @@
 
 
 //These vars are related to how mobs locate and target
-	var/robust_searching = 0 //By default, mobs have a simple searching method, set this to 1 for the more scrutinous searching (stat_attack, stat_exclusive, etc), should be disabled on most mobs
+	var/robust_searching = 0 //Set this to 0 for simple targetting, Set this to 1 for the more scrutinous searching (stat_attack, stat_exclusive, etc)
 	var/vision_range = 9 //How big of an area to search for targets in, a vision of 9 attempts to find targets as soon as they walk into screen view
 	var/aggro_vision_range = 9 //If a mob is aggro, we search in this radius. Defaults to 9 to keep in line with original simple mob aggro radius
 	var/idle_vision_range = 9 //If a mob is just idling around, it's vision range is limited to this. Defaults to 9 to keep in line with original simple mob aggro radius
 	var/search_objects = 0 //If we want to consider objects when searching around, set this to 1. If you want to search for objects while also ignoring mobs until hurt, set it to 2. To completely ignore mobs, even when attacked, set it to 3
 	var/list/wanted_objects = list() //A list of objects that will be checked against to attack, should we have search_objects enabled
-	var/stat_attack = 0 //Mobs with stat_attack to 1 will attempt to attack things that are unconscious, Mobs with stat_attack set to 2 will attempt to attack the dead.
+	var/stat_attack = 1 //Mobs with stat_attack to 1 will attempt to attack things that are unconscious, Mobs with stat_attack set to 2 will attempt to attack the dead.
 	var/stat_exclusive = 0 //Mobs with this set to 1 will exclusively attack things defined by stat_attack, stat_attack 2 means they will only attack corpses
 	var/attack_same = 0 //Set us to 1 to allow us to attack our own faction, or 2, to only ever attack our own faction
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -18,8 +18,6 @@
 	response_harm = "strikes"
 	status_flags = 0
 	a_intent = "harm"
-	robust_searching = 1 //Activate more advance targetting AI
-	stat_attack = 1 //Attack people who sleep on the job, because that's not a valid combat technique
 	var/throw_message = "bounces off of"
 	var/icon_aggro = null // for swapping to when we get aggressive
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -18,6 +18,8 @@
 	response_harm = "strikes"
 	status_flags = 0
 	a_intent = "harm"
+	robust_searching = 1 //Activate more advance targetting AI
+	stat_attack = 1 //Attack people who sleep on the job, because that's not a valid combat technique
 	var/throw_message = "bounces off of"
 	var/icon_aggro = null // for swapping to when we get aggressive
 

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -56,8 +56,7 @@ Emergency internals tanks can be used from your hands, your pockets, your belt, 
 When walking through halls, stay on the Help intent to pass through people rather than bumping into them.
 Trying to do surgery but you keep cutting your patient? Remember to be on the help intent and to target the right limb!
 Glass shards can be welded to make glass, and metal rods can be welded to make metal. Ores can be welded, too, but this takes a lot of fuel.
-Many monsters won't attack you if you're unconscious. If you see a space bear, go to sleep, quick!
-Many monsters won't attack you if you're unconscious, but a medibot will still heal you. Keep one around when you're mining and never worry about dying again.
+If you're unconscious a medibot will still heal you. Keep one around when you're mining and never worry about dying again.
 Two people are critical and need your help, but you don't have time for two trips? Pull one and use the grab intent to grab the other. This will make you slower, but you will be able to take them both.
 When using the grab intent, grab someone by clicking on them then upgrade your grab by clicking on your hand slot. Holding them by the hands lets you throw them or table them.
 Can't seem to get a patient into the cryo tube or sleepers? Just drag their sprite to it to put them in it instantly. No more needing to shuffle around pulling them into it awkwardly.


### PR DESCRIPTION
The title says it all.
The tactic is shit, and needs to go.
- Sets robust_searching to 1 for all hostile mobs (Except bears, you're supposed to sleep against bears In real life.)
- Sets stat_attack to 1 for all hostile mobs (causing the sleep combat exploit to no longer work)
- Removes the tip telling you to powergame like this

WIP: Going to split unconsciousness and sleep inside hostile mob AI so that this can be fixed without causing simple mobs to murder the unconscious/already dead.
