### PR TITLE
Balancing out tableclimbing.

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -221,8 +221,8 @@
 /obj/structure/table/attack_hand(mob/living/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(tableclimber)
-		tableclimber.Stun(2)
-		visible_message("You've been knocked off the table!")
+		tableclimber.Weaken(2)
+		tableclimber.visible_message("<span class='warning'>[tableclimber.name] has been knocked off the table", "You've been knocked off the table", "You see [tableclimber.name] get knocked off the table</span>")
 
 
 /obj/structure/table/attack_tk() // no telehulk sorry
@@ -399,7 +399,7 @@
 			add_logs(user, src, "climbed onto")
 			user.Stun(2)
 			return 1
-			tableclimber = null
+	tableclimber = null
 	return 0
 
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -27,6 +27,7 @@
 	var/busy = 0
 	var/buildstackamount = 1
 	var/framestackamount = 2
+	var/mob/tableclimber
 
 /obj/structure/table/New()
 	..()
@@ -219,6 +220,10 @@
 
 /obj/structure/table/attack_hand(mob/living/user)
 	user.changeNext_move(CLICK_CD_MELEE)
+	if(tableclimber)
+		tableclimber.Stun(2)
+		visible_message("You've been knocked off the table!")
+
 
 /obj/structure/table/attack_tk() // no telehulk sorry
 	return
@@ -383,6 +388,7 @@
 	var/climb_time = 20
 	if(user.restrained()) //Table climbing takes twice as long when restrained.
 		climb_time *= 2
+	tableclimber = user
 	if(do_mob(user, user, climb_time))
 		if(src.loc) //Checking if table has been destroyed
 			user.pass_flags += PASSTABLE
@@ -393,6 +399,7 @@
 			add_logs(user, src, "climbed onto")
 			user.Stun(2)
 			return 1
+			tableclimber = null
 	return 0
 
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -398,6 +398,7 @@
 									"<span class='notice'>You climb onto [src].</span>")
 			add_logs(user, src, "climbed onto")
 			user.Stun(2)
+			tableclimber = null
 			return 1
 	tableclimber = null
 	return 0

--- a/html/changelogs/Mandurrrh-tableclimbing.yml
+++ b/html/changelogs/Mandurrrh-tableclimbing.yml
@@ -1,0 +1,9 @@
+
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - rscadd: "Added the ability to stop table climbers by clicking the table if present."


### PR DESCRIPTION
Okay so I added in an attack_hand var to be able to click the table someone has started climbing on to 'You've been knocked off the table!' and prevent them from climbing up. It is kind of a middle ground with removing this feature completely. If no one is around you can climb table no problem. But if some jerk is griefing the chef or bartender he can just click the table to stop the action before they actually get on top of the table. This just allows some balance so you can still break in and table climb to areas but if its just to piss off an area with someone on the other side of the table they can easily stop the action. 

EDIT: It now actually knocks the person over using weaken instead of stun. Ive made the visible warning not global and colored. Thanks oranges, alpha, and mso. 
