### PR TITLE
Preserve Objectives when admins remove antag status

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -110,7 +110,6 @@
 			qdel(changeling)
 			changeling = null
 	special_role = null
-	remove_objectives()
 	remove_antag_equip()
 
 /datum/mind/proc/remove_traitor()
@@ -121,7 +120,6 @@
 			A.set_zeroth_law("")
 			A.show_laws()
 	special_role = null
-	remove_objectives()
 	remove_antag_equip()
 
 /datum/mind/proc/remove_nukeop()
@@ -137,7 +135,6 @@
 		ticker.mode.wizards -= src
 		current.spellremove(current)
 	special_role = null
-	remove_objectives()
 	remove_antag_equip()
 
 /datum/mind/proc/remove_cultist()


### PR DESCRIPTION
Sometimes admins want to change someone's antag type or simply refresh their antag status to fix bugs, while still preserving their objectives.  Being forced to lose them makes these really frustrating to do!

Admins can still easily remove their objectives from the same window (Mind Window/Traitor Panel).

Fixes #7516
