### PR TITLE
Cooking fixes for meat and trash

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -776,7 +776,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		sleep(timefraction)
 		if(!user || !target)
 			return 0
-		if ( user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.stat || ( user.stunned || user.weakened || user.paralysis || user.lying ) )
+		if ( user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying )
 			return 0
 
 	return 1
@@ -798,7 +798,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		sleep(delayfraction)
 
 
-		if(!user || user.stat || user.weakened || user.stunned || !(user.loc == T))
+		if(!user || user.incapacitated() || !(user.loc == T))
 			return 0
 
 		if(needhand)	//Sometimes you don't want the user to have to keep their active hand

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -33,7 +33,7 @@
 	icon_state = "syndi_cakes"
 
 /obj/item/trash/waffles
-	name = "waffles"
+	name = "waffles tray"
 	icon_state = "waffles"
 
 /obj/item/trash/plate

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -380,11 +380,6 @@
 		user << "<span class='notice'>Someone's already washing here.</span>"
 		return
 
-	if(istype(O, /obj/item/trash))
-		user.drop_item()
-		user << "<span class='notice'>You wash up [O].</span>"	//sims!!!
-		qdel(O)
-
 	if(istype(O, /obj/item/weapon/reagent_containers))
 		var/obj/item/weapon/reagent_containers/RG = O
 		RG.reagents.add_reagent("water", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))

--- a/code/modules/food&drinks/food/snacks.dm
+++ b/code/modules/food&drinks/food/snacks.dm
@@ -203,7 +203,7 @@
 
 	overlays += I
 
-// cook() is called when microwaving the food
+// initialize_cooked_food() is called when microwaving the food
 /obj/item/weapon/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
 	if(reagents)
 		reagents.trans_to(S, reagents.total_volume)

--- a/code/modules/food&drinks/food/snacks/meat.dm
+++ b/code/modules/food&drinks/food/snacks/meat.dm
@@ -10,12 +10,17 @@
 	slices_num = 3
 	filling_color = "#FF0000"
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice)
+/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/slice)
 	var/image/I = new(icon, "rawcutlet_coloration")
 	I.color = filling_color
 	slice.overlays += I
 	slice.filling_color = filling_color
+	slice.name = "raw [name] cutlet"
+	slice.meat_type = name
 
+/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+	..()
+	S.name = "[name] steak"
 
 ///////////////////////////////////// HUMAN MEATS //////////////////////////////////////////////////////
 
@@ -24,23 +29,24 @@
 	name = "-meat"
 	var/subjectname = ""
 	var/subjectjob = null
+	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/meatsteak/plain/human
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human/slice)
 	..()
 	if(subjectname)
 		slice.subjectname = subjectname
-		slice.name = "[subjectname] [initial(slice.name)]"
+		slice.name = "raw [subjectname] cutlet"
 	else if(subjectjob)
 		slice.subjectjob = subjectjob
-		slice.name = "[subjectjob] [initial(slice.name)]"
+		slice.name = "raw [subjectjob] cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
 	..()
 	if(subjectname)
-		S.name = "[subjectname] [initial(S.name)]"
+		S.name = "[subjectname] meatsteak"
 	else if(subjectjob)
-		S.name = "[subjectjob] [initial(S.name)]"
+		S.name = "[subjectjob] meatsteak"
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/slime
@@ -117,7 +123,7 @@
 	desc = "Tastes like... well you know..."
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/killertomato
-	name = "tomato slice"
+	name = "killer tomato meat"
 	desc = "A slice from a huge tomato."
 	icon_state = "tomatomeat"
 	list_reagents = list("nutriment" = 2)
@@ -161,7 +167,7 @@
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak
-	name = "meat steak"
+	name = "steak"
 	desc = "A piece of hot spicy meat."
 	icon_state = "meatsteak"
 	list_reagents = list("nutriment" = 2, "vitamin" = 1)
@@ -173,21 +179,18 @@
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak/plain/human
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak/killertomato
-	name = "killer tomato steak"
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak/bear
-	name = "bear steak"
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak/xeno
-	name = "xeno steak"
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak/spider
-	name = "spider steak"
 
 
 
 //////////////////////////////// MEAT CUTLETS ///////////////////////////////////////////////////////
 
+//Raw cutlets
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet
 	name = "raw cutlet"
@@ -196,10 +199,17 @@
 	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/cutlet/plain
 	bitesize = 2
 	filling_color = "#B22222"
+	var/meat_type = "meat"
+
+/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+	..()
+	S.name = "[meat_type] cutlet"
+
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human
+	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/cutlet/plain/human
 	var/subjectname = ""
 	var/subjectjob = null
 
@@ -211,17 +221,15 @@
 		S.name = "[subjectjob] [initial(S.name)]"
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/killertomato
-	name = "raw killer tomato cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/bear
-	name = "raw bear cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/xeno
-	name = "raw xeno cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/spider
-	name = "raw spider cutlet"
 
+
+//Cooked cutlets
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -236,13 +244,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/plain/human
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/killertomato
-	name = "killer tomato cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/bear
-	name = "bear cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/xeno
-	name = "xeno cutlet"
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/spider
-	name = "spider cutlet"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -331,6 +331,8 @@
 	if(O.flags & NOBLUDGEON)
 		return
 
+	user.changeNext_move(CLICK_CD_MELEE)
+
 	if(istype(O, /obj/item/stack/medical))
 		if(stat != DEAD)
 			var/obj/item/stack/medical/MED = O
@@ -352,11 +354,13 @@
 		else
 			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
 			return
-	if((meat_type || skin_type) && (stat == DEAD))	//if the animal has a meat, and if it is dead.
-		if(istype(O, /obj/item/weapon/kitchenknife))
-			harvest()
 
-	user.changeNext_move(CLICK_CD_MELEE)
+	if((meat_type || skin_type) && (stat == DEAD))	//if the animal has a meat, and if it is dead.
+		var/sharpness = is_sharp(O)
+		if(sharpness)
+			harvest(user, sharpness)
+			return
+
 	user.do_attack_animation(src)
 	var/damage = 0
 	if(O.force)
@@ -475,8 +479,12 @@
 		new childtype(loc)
 
 // Harvest an animal's delicious byproducts
-/mob/living/simple_animal/proc/harvest()
-	gib()
+/mob/living/simple_animal/proc/harvest(mob/living/user, sharpness = 1)
+	user << "<span class='notice'>You begin to butcher [src].</span>"
+	playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
+	if(do_mob(user, src, 80/sharpness))
+		visible_message("<span class='notice'>[user] butchers [src].</span>")
+		gib()
 	return
 
 /mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who, where, child_override)

--- a/html/changelogs/phil235-CookTrash.yml
+++ b/html/changelogs/phil235-CookTrash.yml
@@ -1,0 +1,4 @@
+author: phil235
+delete-after: True
+changes:
+  - tweak: "Harvesting meat from dead simple animals now takes time, has a sound, and can be done with any sharp weapon."


### PR DESCRIPTION
- Fixes trash disappearing when washed in a sink.
- Fixes waffle trash being named "waffles". Fixes #7374
- Replacing some stat/weakened/stunned checks with incapacitated()
- Fixes meat cutlets and steak not including the meat type in their name (e.g. raw corgi meat cutlet)
- Harvesting meat from dead simple animals now takes time, has a sound, and can be done with any sharp weapon.
