### PR TITLE
[Merge ASAP Oh God] Makes Mulliganed rounds able to actually end

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -97,6 +97,8 @@
 	for(var/datum/game_mode/G in runnable_modes)
 		if(!G.reroll_friendly)	del(G)
 
+	SSshuttle.emergencyNoEscape = 0 //Time to get the fuck out of here
+
 	if(!runnable_modes)	return 0
 
 	var/list/datum/game_mode/replacementmode = pickweight(runnable_modes)


### PR DESCRIPTION
Fixes mulligan'd rounds from never ending because the shuttle was set to strand still.

Note rounds where the shuttle stranded BEFORE the primary antagonist died are fine.

WHOOPS, AT LEAST IT'S WORKING NOW RIGHT?!
