### PR TITLE
Randomizes Order of Job Spawn Points

### DIFF
--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -26,6 +26,7 @@ var/global/list/global_map = null
 	//5 - empty space
 
 var/list/landmarks_list = list()				//list of all landmarks created
+var/list/start_landmarks_list = list()			//list of all spawn points created
 
 var/list/monkeystart = list()
 var/list/wizardstart = list()

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -328,7 +328,7 @@ var/datum/subsystem/job/SSjob
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late)
 		var/obj/S = null
-		for(var/obj/effect/landmark/start/sloc in landmarks_list)
+		for(var/obj/effect/landmark/start/sloc in start_landmarks_list)
 			if(sloc.name != rank)	continue
 			if(locate(/mob/living) in sloc.loc)	continue
 			S = sloc

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -177,6 +177,7 @@ var/datum/subsystem/ticker/ticker
 	auto_toggle_ooc(0) // Turn it off
 	round_start_time = world.time
 
+	start_landmarks_list = shuffle(start_landmarks_list) //Shuffle the order of spawn points so they dont always predictably spawn bottom-up and right-to-left
 	create_characters() //Create player characters and transfer them
 	collect_minds()
 	equip_characters()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -84,6 +84,7 @@
 	..()
 	tag = "start*[name]"
 	invisibility = 101
+	start_landmarks_list += src
 
 	return 1
 


### PR DESCRIPTION
The ticker's setup() will shuffle the list of spawn points, so jobs won't always predictably spawn bottom-up and left-to-right
