### PR TITLE
Makes Gang mode functional again

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -99,6 +99,7 @@
 	var/enforce_human_authority = 0		//If non-human species are barred from joining as a head of staff
 	var/allow_latejoin_antagonists = 0 	// If late-joining players can be traitor/changeling
 	var/continuous_round_rev = 0		// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
+	var/continuous_round_gang = 0
 	var/continuous_round_wiz = 0
 	var/continuous_round_malf = 0
 	var/continuous_round_blob = 0
@@ -388,6 +389,8 @@
 					config.gateway_delay			= text2num(value)
 				if("continuous_round_rev")
 					config.continuous_round_rev		= 1
+				if("continuous_round_gang")
+					config.continuous_round_gang	= 1
 				if("continuous_round_wiz")
 					config.continuous_round_wiz		= 1
 				if("continuous_round_malf")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -288,15 +288,15 @@
 		text = "<i><b>[text]</b></i>: "
 		if (src in ticker.mode.A_bosses)
 			text += "loyal|<a href='?src=\ref[src];gang=clear'>none</a>|<B>(A)</B> <a href='?src=\ref[src];gang=agang'>gangster</a> <b>BOSS</b>|(B) <a href='?src=\ref[src];gang=bgang'>gangster</a> <a href='?src=\ref[src];gang=bboss'>boss</a>"
-			text += "<br>Flash & Recaller: <a href='?src=\ref[src];gang=equip'>give</a>"
+			text += "<br>Equipment: <a href='?src=\ref[src];gang=equip'>give</a>"
 
 			var/list/L = current.get_contents()
 			var/obj/item/device/flash/flash = locate() in L
 			if (flash)
 				if(!flash.broken)
-					text += "|<a href='?src=\ref[src];gang=takeequip'>take equipment</a>."
+					text += "|<a href='?src=\ref[src];gang=takeequip'>take</a>."
 				else
-					text += "|<a href='?src=\ref[src];gang=takeequip'>take equipment</a>|<a href='?src=\ref[src];gang=repairflash'>repair flash</a>."
+					text += "|<a href='?src=\ref[src];gang=takeequip'>take</a>|<a href='?src=\ref[src];gang=repairflash'>repair flash</a>."
 			else
 				text += "."
 
@@ -306,15 +306,15 @@
 
 		else if (src in ticker.mode.B_bosses)
 			text += "loyal|<a href='?src=\ref[src];gang=clear'>none</a>|(A) <a href='?src=\ref[src];gang=agang'>gangster</a> <a href='?src=\ref[src];gang=aboss'>boss</a>|<B>(B)</B> <a href='?src=\ref[src];gang=bgang'>gangster</a> <b>BOSS</b>"
-			text += "<br>Flash & Recaller: <a href='?src=\ref[src];gang=equip'>give</a>"
+			text += "<br>Equipment: <a href='?src=\ref[src];gang=equip'>give</a>"
 
 			var/list/L = current.get_contents()
 			var/obj/item/device/flash/flash = locate() in L
 			if (flash)
 				if(!flash.broken)
-					text += "<br><a href='?src=\ref[src];gang=takeequip'>take equipment</a>."
+					text += "<br><a href='?src=\ref[src];gang=takeequip'>take</a>."
 				else
-					text += "<br><a href='?src=\ref[src];gang=takeequip'>take equipment</a>|<a href='?src=\ref[src];gang=repairflash'>repair flash</a>."
+					text += "<br><a href='?src=\ref[src];gang=takeequip'>take</a>|<a href='?src=\ref[src];gang=repairflash'>repair flash</a>."
 			else
 				text += "."
 
@@ -527,6 +527,8 @@
 
 
 	if (((src in ticker.mode.head_revolutionaries) || \
+		(src in ticker.mode.A_bosses)              || \
+		(src in ticker.mode.B_bosses)              || \
 		(src in ticker.mode.traitors)              || \
 		(src in ticker.mode.syndicates))           && \
 		istype(current,/mob/living/carbon/human)      )

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -14,7 +14,7 @@
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
 	required_players = 20
 	required_enemies = 2
-	recommended_enemies = 4
+	recommended_enemies = 2
 	enemy_minimum_age = 14
 
 	var/finished = 0
@@ -24,7 +24,7 @@
 ///////////////////////////
 /datum/game_mode/gang/announce()
 	world << "<B>The current game mode is - Gang War!</B>"
-	world << "<B>A violent turf war has erupted on the station!<BR>Gangsters -  Take over the station by killing the rival gang's bosses! Recruit gangsters by flashing them! <BR>Security - Protect the Crew! Identify and stop the mob bosses!</B>"
+	world << "<B>A violent turf war has erupted on the station!<BR>Gangsters -  Take over the station by recruiting gangsters and killing the rival gang's boss! <BR>Crew - Identify and stop the mob bosses without killing either of them!</B>"
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,8 +44,6 @@
 
 	if(antag_candidates.len >= 2)
 		assign_bosses()
-		if(antag_candidates.len > 20)
-			assign_bosses()
 
 	if(!A_bosses.len || !B_bosses.len)
 		return 0
@@ -120,6 +118,47 @@
 			mob << "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself."
 			mob.dna.remove_mutation(CLOWNMUT)
 
+	// find a radio! toolbox(es), backpack, belt, headset
+	var/loc = ""
+	var/obj/item/R = locate(/obj/item/device/pda) in mob.contents //Hide the uplink in a PDA if available, otherwise radio
+	if(!R)
+		R = locate(/obj/item/device/radio) in mob.contents
+
+	if (!R)
+		mob << "Unfortunately, Your Syndicate benefactors wasn't able to get you an uplink."
+		. = 0
+	else
+		if (istype(R, /obj/item/device/radio))
+			// generate list of radio freqs
+			var/obj/item/device/radio/target_radio = R
+			var/freq = 1441
+			var/list/freqlist = list()
+			while (freq <= 1489)
+				if (freq < 1451 || freq > 1459)
+					freqlist += freq
+				freq += 2
+				if ((freq % 2) == 0)
+					freq += 1
+			freq = freqlist[rand(1, freqlist.len)]
+
+			var/obj/item/device/uplink/hidden/T = new(R)
+			target_radio.hidden_uplink = T
+			T.uplink_owner = "[mob.key]"
+			target_radio.traitor_frequency = freq
+			mob << "Your Syndicate benefactors have cunningly disguised a Syndicate Uplink as your [R.name] [loc]. Simply dial the frequency [format_frequency(freq)] to unlock its hidden features."
+			mob.mind.store_memory("<B>Radio Freq:</B> [format_frequency(freq)] ([R.name] [loc]).")
+		else if (istype(R, /obj/item/device/pda))
+			// generate a passcode if the uplink is hidden in a PDA
+			var/pda_pass = "[rand(100,999)] [pick("Alpha","Bravo","Delta","Omega")]"
+
+			var/obj/item/device/uplink/hidden/T = new(R)
+			R.hidden_uplink = T
+			T.uplink_owner = "[mob.key]"
+			var/obj/item/device/pda/P = R
+			P.lock_code = pda_pass
+
+			mob << "Your Syndicate benefactors have cunningly disguised a Syndicate Uplink as your [R.name] [loc]. Simply enter the code \"[pda_pass]\" into the ringtone select to unlock its hidden features."
+			mob.mind.store_memory("<B>Uplink Passcode:</B> [pda_pass] ([R.name] [loc]).")
 
 	var/obj/item/device/flash/T = new(mob)
 	var/obj/item/device/recaller/recaller = new(mob)
@@ -146,7 +185,6 @@
 		mob << "Your Syndicate benefactors were unfortunately unable to get you a flash."
 	else
 		mob << "The <b>flash</b> in your [where] will help you to persuade the crew to work for you."
-		mob << "<span class='userdanger'>Keep in mind that your underlings can only identify their bosses, but not each other. You must coordinate your gang effectively to beat out the competition.</span>"
 		. += 1
 
 	mob.update_icons()
@@ -173,7 +211,7 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/gang/check_finished()
-	if(finished) //Check for Gang Boss death
+	if(finished && !config.continuous_round_gang) //Check for Gang Boss death
 		return 1
 	return ..() //Check for evacuation/nuke
 
@@ -190,7 +228,7 @@
 	else
 		B_gangsters += gangster_mind
 	gangster_mind.current << "<FONT size=3 color=red><B>You are now a member of the [gang=="A" ? gang_name("A") : gang_name("B")] Gang!</B></FONT>"
-	gangster_mind.current << "<font color='red'>Help your bosses take over the station by defeating their rivals. You can identify your bosses by the brown \"B\" icons, but <B>only they know who the other members of your gang are!</B> Work with your boss to avoid attacking your own gang.</font>"
+	gangster_mind.current << "<font color='red'>Help your Boss take over the station by defeating the rival gang. You can identify your Boss by their brown \"B\" icon.</font>"
 	gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has been converted to the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]!</font>"
 	gangster_mind.special_role = "[gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]"
 	update_gang_icons_added(gangster_mind,gang)
@@ -198,22 +236,23 @@
 //////////////////////////////////////////////////////////////
 //Deals with players going straight (Not a gangster anymore)//
 //////////////////////////////////////////////////////////////
-/datum/game_mode/proc/remove_gangster(datum/mind/gangster_mind, var/beingborged, var/silent)
+/datum/game_mode/proc/remove_gangster(datum/mind/gangster_mind, var/beingborged, var/silent, var/exclude_bosses=0)
 	var/gang
 
-	if(gangster_mind in A_bosses)
-		A_bosses -= gangster_mind
-		gang = "A"
+	if(!exclude_bosses)
+		if(gangster_mind in A_bosses)
+			A_bosses -= gangster_mind
+			gang = "A"
 
-	else if(gangster_mind in A_gangsters)
+		if(gangster_mind in B_bosses)
+			B_bosses -= gangster_mind
+			gang = "B"
+
+	if(gangster_mind in A_gangsters)
 		A_gangsters -= gangster_mind
 		gang = "A"
 
-	else if(gangster_mind in B_bosses)
-		B_bosses -= gangster_mind
-		gang = "B"
-
-	else if(gangster_mind in B_gangsters)
+	if(gangster_mind in B_gangsters)
 		B_gangsters -= gangster_mind
 		gang = "B"
 
@@ -278,7 +317,7 @@
 		return 0
 	for(var/datum/mind/boss_mind in boss_list)
 		if(boss_mind.current)
-			if(boss_mind.current.stat == DEAD || !ishuman(boss_mind.current) || !boss_mind.current.ckey || !boss_mind.current.client)
+			if(boss_mind.current.stat == DEAD || !ishuman(boss_mind.current) || !boss_mind.current.ckey)
 				return 1
 			var/turf/T = get_turf(boss_mind.current)
 			if(T && (T.z != ZLEVEL_STATION))			//If they leave the station they count as dead for this
@@ -303,7 +342,10 @@
 	var/winner
 	var/datum/game_mode/gang/game_mode = ticker.mode
 	if(istype(game_mode))
-		winner = game_mode.finished
+		if(game_mode.finished)
+			winner = game_mode.finished
+		else
+			winner = "Draw"
 
 	var/num_ganga = 0
 	var/list/agang = A_gangsters + A_bosses
@@ -319,26 +361,23 @@
 			if(bgangster.current in living_mob_list)
 				num_gangb++
 
-	var/num_survivors = 0
-	for(var/mob/living/carbon/survivor in living_mob_list)
-		if(survivor.key)
-			num_survivors++
-
 	if(A_bosses.len || A_gangsters.len)
-		if(winner == "A" || winner == "B")
-			world << "<br><b>The [gang_name("A")] Gang was [winner=="A" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [round((num_ganga/num_survivors)*100, 0.1)]% influence.</b>"
-		world << "<br><font size=2><b>The [gang_name("A")] Gang bosses were:</b></font>"
+		if(winner)
+			world << "<br><b>The [gang_name("A")] Gang was [winner=="A" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [num_ganga] members!</b>"
+		world << "<br><font size=2><b>The [gang_name("A")] Gang Boss was:</b></font>"
 		gang_membership_report(A_bosses)
 		world << "<br><font size=2><b>The [gang_name("A")] Gangsters were:</b></font>"
 		gang_membership_report(A_gangsters)
+		world << "<br>"
 
 	if(B_bosses.len || B_gangsters.len)
-		if(winner == "A" || winner == "B")
-			world << "<br><b>The [gang_name("B")] Gang was [winner=="B" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [round((num_gangb/num_survivors)*100, 0.1)]% influence.</b>"
-		world << "<br><font size=2><b>The [gang_name("B")] Gang bosses were:</b></font>"
+		if(winner)
+			world << "<br><b>The [gang_name("B")] Gang was [winner=="B" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [num_gangb] members!</b>"
+		world << "<br><font size=2><b>The [gang_name("B")] Gang Boss was:</b></font>"
 		gang_membership_report(B_bosses)
 		world << "<br><font size=2><b>The [gang_name("B")] Gangsters were:</b></font>"
 		gang_membership_report(B_gangsters)
+		world << "<br>"
 
 /datum/game_mode/proc/gang_membership_report(var/list/membership)
 	var/text = ""
@@ -356,6 +395,5 @@
 		else
 			text += "body destroyed"
 		text += ")"
-	text += "<br><br>"
 
 	world << text

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -227,6 +227,8 @@
 		A_gangsters += gangster_mind
 	else
 		B_gangsters += gangster_mind
+	if(check)
+		gangster_mind.current.Paralyse(5)
 	gangster_mind.current << "<FONT size=3 color=red><B>You are now a member of the [gang=="A" ? gang_name("A") : gang_name("B")] Gang!</B></FONT>"
 	gangster_mind.current << "<font color='red'>Help your Boss take over the station by defeating the rival gang. You can identify your Boss by their brown \"B\" icon.</font>"
 	gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has been converted to the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]!</font>"
@@ -270,6 +272,7 @@
 			message_admins("[key_name_admin(gangster_mind.current)] <A HREF='?_src_=holder;adminmoreinfo=\ref[gangster_mind.current]'>?</A> has been borged while being a member of the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"] Gang. They are no longer a gangster.")
 		else
 			if(!silent)
+				gangster_mind.current.Paralyse(5)
 				gangster_mind.current.visible_message("[gangster_mind.current] looks like they've given up the life of crime!")
 			gangster_mind.current << "<FONT size=3 color=red><B>You have been reformed! You are no longer a gangster!</B></FONT>"
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -168,11 +168,12 @@
 
 /obj/item/weapon/implant/loyalty/implanted(mob/target)
 	..()
-	if(target.mind in ticker.mode.head_revolutionaries)
+	if((target.mind in ticker.mode.head_revolutionaries) || (target.mind in ticker.mode.A_bosses) || (target.mind in ticker.mode.B_bosses))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
-	if(target.mind in ticker.mode.revolutionaries)
+	if((target.mind in ticker.mode.revolutionaries) || (target.mind in ticker.mode.A_gangsters) || (target.mind in ticker.mode.B_gangsters))
 		ticker.mode.remove_revolutionary(target.mind)
+		ticker.mode.remove_gangster(target.mind, exclude_bosses=0)
 	target << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"
 	return 1
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -418,7 +418,7 @@ client/proc/one_click_antag()
 
 	for(var/mob/living/carbon/human/applicant in player_list)
 		if(applicant.client.prefs.be_special & BE_GANG)
-			if(applicant.stat == CONSCIOUS)
+			if(!applicant.stat)
 				if(applicant.mind)
 					if(!applicant.mind.special_role)
 						if(!jobban_isbanned(applicant, "gangster") && !jobban_isbanned(applicant, "Syndicate"))
@@ -432,7 +432,6 @@ client/proc/one_click_antag()
 		candidates.Remove(H)
 		H = pick(candidates)
 		H.mind.make_Gang("B")
-		candidates.Remove(H)
 		return 1
 
 	return 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -179,11 +179,12 @@ emp_act
 
 			switch(hit_area)
 				if("head")	//Harder to score a stun but if you do it lasts a bit longer
-					if(stat == CONSCIOUS && prob(I.force))
-						visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
-										"<span class='userdanger'>[src] has been knocked unconscious!</span>")
-						apply_effect(20, PARALYZE, armor)
-						if(src != user && I.damtype == BRUTE)
+					if(stat == CONSCIOUS)
+						if(prob(I.force))
+							visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
+											"<span class='userdanger'>[src] has been knocked unconscious!</span>")
+							apply_effect(20, PARALYZE, armor)
+						if(prob(I.force + ((100 - src.health)/2)) && src != user && I.damtype == BRUTE)
 							ticker.mode.remove_revolutionary(mind)
 							ticker.mode.remove_gangster(mind, exclude_bosses=1)
 					if(bloody)	//Apply blood

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -185,7 +185,7 @@ emp_act
 						apply_effect(20, PARALYZE, armor)
 						if(src != user && I.damtype == BRUTE)
 							ticker.mode.remove_revolutionary(mind)
-							ticker.mode.remove_gangster(mind)
+							ticker.mode.remove_gangster(mind, exclude_bosses=1)
 					if(bloody)	//Apply blood
 						if(wear_mask)
 							wear_mask.add_blood(src)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -925,11 +925,12 @@
 
 		switch(hit_area)
 			if("head")	//Harder to score a stun but if you do it lasts a bit longer
-				if(H.stat == CONSCIOUS && prob(I.force) && armor < 50)
-					H.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", \
-									"<span class='userdanger'>[H] has been knocked unconscious!</span>")
-					H.apply_effect(20, PARALYZE, armor)
-					if(H != user && I.damtype == BRUTE)
+				if(H.stat == CONSCIOUS && armor < 50)
+					if(prob(I.force))
+						H.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", \
+										"<span class='userdanger'>[H] has been knocked unconscious!</span>")
+						H.apply_effect(20, PARALYZE, armor)
+					if(prob(I.force + ((100 - H.health)/2)) && H != user && I.damtype == BRUTE)
 						ticker.mode.remove_revolutionary(H.mind)
 						ticker.mode.remove_gangster(H.mind, exclude_bosses=1)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -931,7 +931,7 @@
 					H.apply_effect(20, PARALYZE, armor)
 					if(H != user && I.damtype == BRUTE)
 						ticker.mode.remove_revolutionary(H.mind)
-						ticker.mode.remove_gangster(H.mind)
+						ticker.mode.remove_gangster(H.mind, exclude_bosses=1)
 
 				if(bloody)	//Apply blood
 					if(H.wear_mask)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -100,6 +100,7 @@ PROBABILITY SANDBOX 0
 ## the shuttle is called or the station is nuked.
 ## Malf and Rev will let the shuttle be called when the antags/protags are dead.
 #CONTINUOUS_ROUND_REV
+#CONTINUOUS_ROUND_GANG
 #CONTINUOUS_ROUND_WIZ
 #CONTINUOUS_ROUND_MALF
 #CONTINUOUS_ROUND_BLOB


### PR DESCRIPTION
I'm going on vacation soon so I thought I might as well bring this game mode back up to at least a minimally functional state before I go.

A lot of features (Gang membership visibility, conversion pens, weapons, deconversion methods) have been stripped out for now. I gave gang bosses uplinks in the meantime.

It's basically rev vs rev right now, but the victory conditions with the recallers are still there. I'll work on adding more stuff after I return from my vacation.

I also increased the chance of deconversion when applying brute force to someone's head. The more hurt they are, the more likely they'll turn.
