### PR TITLE
Re-adds changelog popup as a config option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -154,6 +154,8 @@
 	var/starlight = 0
 	var/grey_assistants = 0
 
+	var/aggressive_changelog = 0
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for(var/T in L)
@@ -327,6 +329,8 @@
 					config.notify_new_player_age = text2num(value)
 				if("irc_first_connection_alert")
 					config.irc_first_connection_alert = 1
+				if("aggressive_changelog")
+					config.aggressive_changelog = 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -168,8 +168,10 @@ var/next_external_rsc = 0
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates.
 		src << "<span class='info'>You have unread updates in the changelog.</span>"
-		winset(src, "rpane.changelogb", "background-color=#eaeaea;font-style=bold")
-
+		if(config.aggressive_changelog)
+			src.changes()
+		else
+			winset(src, "rpane.changelogb", "background-color=#eaeaea;font-style=bold")
 
 	//////////////
 	//DISCONNECT//

--- a/config/config.txt
+++ b/config/config.txt
@@ -188,3 +188,6 @@ NOTIFY_NEW_PLAYER_AGE 0
 ## Deny all new connections by ckeys we haven't seen before (exempts admins and only denies the connection if the database is enabled and connected)
 ##	Requires database
 #PANIC_BUNKER
+
+## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
+#AGGRESSIVE_CHANGELOG

--- a/html/changelogs/Jordie0608 changelogpop.yml
+++ b/html/changelogs/Jordie0608 changelogpop.yml
@@ -1,0 +1,6 @@
+author: Jordie0608
+
+delete-after: True
+
+changes:
+  - rscadd: "Server hosts can set a config option to make an unseen changelog pop up on connection."


### PR DESCRIPTION
When uncommented the changelog will pop up upon connecting if a player hasn't seen the latest one, otherwise it will bold the button.

Defaulted to off so this doesn't happen when you're locally testing stuff.
