### PR TITLE
Removes the Spooky

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -281,7 +281,7 @@
 	id = "skeleton"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/skeleton
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE)
+	specflags = list(NOBREATH,NOBLOOD)
 /*
  ZOMBIES
 */
@@ -293,7 +293,7 @@
 	say_mod = "moans"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/zombie
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE)
+	specflags = list(NOBREATH,NOBLOOD)
 
 /datum/species/zombie/handle_speech(message)
 	var/list/message_list = text2list(message, " ")

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -281,7 +281,7 @@
 	id = "skeleton"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/skeleton
-	specflags = list(NOBREATH,NOBLOOD)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE)
 /*
  ZOMBIES
 */
@@ -293,7 +293,7 @@
 	say_mod = "moans"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/human/mutant/zombie
-	specflags = list(NOBREATH,NOBLOOD)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE)
 
 /datum/species/zombie/handle_speech(message)
 	var/list/message_list = text2list(message, " ")

--- a/code/modules/reagents/Chemistry-Goon-420BlazeIt.dm
+++ b/code/modules/reagents/Chemistry-Goon-420BlazeIt.dm
@@ -127,12 +127,8 @@ datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
 	..()
 	return
 /datum/reagent/krokodil/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	if(!istype(M.dna.species, /datum/species/skeleton))
-		M << "<span class='userdanger'>Your skin falls off! Holy shit!</span>"
-		M.adjustBruteLoss(rand(50,80)*REM) // holy shit your skin just FELL THE FUCK OFF
-		hardset_dna(M, null, null, null, null, /datum/species/skeleton)
-	else
-		M.adjustBruteLoss(5*REM)
+	M << "<span class='userdanger'>Your skin sloughs off!</span>"
+	M.adjustBruteLoss(rand(50,80)*REM) // holy shit your skin just FELL THE FUCK OFF
 	..()
 	return
 

--- a/code/modules/reagents/Chemistry-Goon-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Goon-Medicine.dm
@@ -618,7 +618,6 @@ datum/reagent/strange_reagent/reaction_mob(var/mob/living/carbon/human/M as mob,
 			living_mob_list |= list(M)
 			M.emote("gasp")
 			add_logs(M, M, "revived", object="strange reagent")
-			hardset_dna(M, null, null, null, null, /datum/species/zombie)
 	..()
 	return
 datum/reagent/strange_reagent/on_mob_life(var/mob/living/M as mob)

--- a/html/changelogs/Incoming5643-skeletonnerf.yml
+++ b/html/changelogs/Incoming5643-skeletonnerf.yml
@@ -6,4 +6,4 @@ author: Incoming5643
 delete-after: True
 
 changes: 
-  - tweak: "Due to the deleterious effects of low gravity environments on bones, skeletons and zombies have become noticeably less resilient to temperature and radiation. Remember to drink lots of milk."
+  - rscdel: "The skeleton and zombie hordes have been quelled, at least for the time being."

--- a/html/changelogs/Incoming5643-skeletonnerf.yml
+++ b/html/changelogs/Incoming5643-skeletonnerf.yml
@@ -1,0 +1,9 @@
+################################
+
+
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - tweak: "Due to the deleterious effects of low gravity environments on bones, skeletons and zombies have become noticeably less resilient to temperature and radiation. Remember to drink lots of milk."


### PR DESCRIPTION
Skeletons and zombies can no longer be achieved with krokodil and strange reagent.

<img src="http://media.tumblr.com/a8776f65c9a2fe31ed5cc140f9b41dde/tumblr_inline_n8xjnzkJst1sod0lp.jpg">

But they can still show up in rare mutations (I think) and wizard business 

<img src="http://img4.wikia.nocookie.net/__cb20140205012818/trollpasta/images/5/59/Dancing_skeleton.gif">

Fixes #8136
