### PR TITLE
Skipping mulligan antag based on Time/Subjectivity from admins + tweaks

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -102,6 +102,8 @@
 	var/continuous_round_wiz = 0
 	var/continuous_round_malf = 0
 	var/continuous_round_blob = 0
+	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
+	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
@@ -394,6 +396,10 @@
 					config.continuous_round_malf	= 1
 				if("continuous_round_blob")
 					config.continuous_round_blob	= 1
+				if("midround_antag_time_check")
+					config.midround_antag_time_check = text2num(value)
+				if("midround_antag_life_check")
+					config.midround_antag_life_check = text2num(value)
 				if("shuttle_refuel_delay")
 					config.shuttle_refuel_delay     = text2num(value)
 				if("show_game_type_odds")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -9,6 +9,7 @@ var/datum/subsystem/ticker/ticker
 
 	var/restart_timeout = 250				//delay when restarting server
 	var/current_state = GAME_STATE_STARTUP	//state of current round (used by process()) Use the defines GAME_STATE_* !
+	var/force_ending = 0					//Round was ended by admin intervention
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
@@ -91,7 +92,7 @@ var/datum/subsystem/ticker/ticker
 		if(GAME_STATE_PLAYING)
 			mode.process(wait * 0.1)
 
-			if(!mode.explosion_in_progress && mode.check_finished())
+			if(!mode.explosion_in_progress && mode.check_finished() || force_ending)
 				current_state = GAME_STATE_FINISHED
 				auto_toggle_ooc(1) // Turn it on
 				declare_completion()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -112,7 +112,7 @@
 			if(SSshuttle.emergency.timeLeft(1) < initial(SSshuttle.emergencyCallTime)*0.5)
 				return 1
 
-	if(world.time >= 36000) //If it's been over an hour, just end it
+	if(world.time >= (config.midround_antag_time_check * 600))
 		return 0
 
 	var/living_crew = 0
@@ -120,7 +120,7 @@
 	for(var/mob/Player in mob_list)
 		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
 			living_crew++
-	if(living_crew / joined_player_list.len <= 0.7) //If a lot of the player base died, we start fresh
+	if(living_crew / joined_player_list.len <= config.midround_antag_life_check) //If a lot of the player base died, we start fresh
 		return 0
 
 	var/list/antag_canadates = list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -29,6 +29,7 @@
 	var/pre_setup_before_jobs = 0
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
 	var/datum/mind/sacrifice_target = null
+	var/list/datum/game_mode/replacementmode = null
 	var/round_converted = 0
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
@@ -102,7 +103,7 @@
 
 	if(!runnable_modes)	return 0
 
-	var/list/datum/game_mode/replacementmode = pickweight(runnable_modes)
+	replacementmode = pickweight(runnable_modes)
 
 	switch(SSshuttle.emergency.mode) //Rounds on the verge of ending don't get new antags, they just run out
 		if(SHUTTLE_STRANDED, SHUTTLE_ESCAPE)
@@ -110,6 +111,9 @@
 		if(SHUTTLE_CALL)
 			if(SSshuttle.emergency.timeLeft(1) < initial(SSshuttle.emergencyCallTime)*0.5)
 				return 1
+
+	if(world.time >= 36000) //If it's been over an hour, just end it
+		return 0
 
 	var/living_crew = 0
 
@@ -126,8 +130,7 @@
 			antag_canadates += H
 
 	if(!antag_canadates)
-		message_admins("The roundtype has been converted, antagonists may have been created")
-		return 1
+		return 0
 
 	antag_canadates = shuffle(antag_canadates)
 
@@ -135,6 +138,8 @@
 		replacementmode.restricted_jobs += replacementmode.protected_jobs
 	if(config.protect_assistant_from_antagonist)
 		replacementmode.restricted_jobs += "Assistant"
+
+	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
 	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
 		for(var/mob/living/carbon/human/H in antag_canadates)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -30,7 +30,7 @@
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
 	var/datum/mind/sacrifice_target = null
 	var/list/datum/game_mode/replacementmode = null
-	var/round_converted = 0
+	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
 
@@ -90,6 +90,8 @@
 ///make_antag_chance()
 ///Handles late-join antag assignments
 /datum/game_mode/proc/make_antag_chance(var/mob/living/carbon/human/character)
+	if(replacementmode && round_converted == 2)
+		replacementmode.make_antag_chance(character)
 	return
 
 ///convert_roundtype()
@@ -144,7 +146,7 @@
 	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
 		for(var/mob/living/carbon/human/H in antag_canadates)
 			replacementmode.make_antag_chance(H)
-
+		round_converted = 2
 		message_admins("The roundtype has been converted, antagonists may have been created")
 
 	return 1

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -368,6 +368,8 @@
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
+		if(ticker.mode.replacementmode)
+			dat += "Replacement Game Mode: <B>[ticker.mode.replacementmode.name]</B><BR>"
 		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero("[world.time / 600 % 60]", 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if(SSshuttle.emergency.mode < SHUTTLE_CALL)
@@ -379,6 +381,7 @@
 				dat += "<a href='?_src_=holder;call_shuttle=2'>Send Back</a><br>"
 			else
 				dat += "ETA: <a href='?_src_=holder;edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+		dat += "<a href='?_src_=holder;end_round=\ref[usr]'>End Round Now</a><br>"
 		dat += "<a href='?_src_=holder;delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
 		if(ticker.mode.syndicates.len)
 			dat += "<br><table cellspacing=5><tr><td><B>Syndicates</B></td><td></td></tr>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -226,6 +226,21 @@
 		message_admins("<span class='adminnotice'>[key_name(usr)] [ticker.delay_end ? "delayed the round end" : "has made the round end normally"].</span>")
 		href_list["secretsadmin"] = "check_antagonist"
 
+	else if(href_list["end_round"])
+		if(!check_rights(R_ADMIN))	return
+
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] is considering ending the round.</span>")
+		if(alert(usr, "This will end the round, are you SURE you want to do this?", "Confirmation", "Yes", "No") == "Yes")
+			spawn(200) //I wish you would step back from that ledge my friend
+			if(alert(usr, "Final Confirmation: End the round NOW?", "Confirmation", "Yes", "No") == "Yes")
+				message_admins("<span class='adminnotice'>[key_name_admin(usr)] has ended the round.</span>")
+				ticker.force_ending = 1 //Yeah there we go APC destroyed mission accomplished
+				return
+			else
+				message_admins("<span class='adminnotice'>[key_name_admin(usr)] decided against ending the round.</span>")
+		else
+			message_admins("<span class='adminnotice'>[key_name_admin(usr)] decided against ending the round.</span>")
+
 	else if(href_list["simplemake"])
 		if(!check_rights(R_SPAWN))	return
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -5,7 +5,7 @@ var/list/forbidden_varedit_object_types = list(
 										/datum/admin_rank					//editing my own rank? it's more likely than you think
 									)
 
-var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y")
+var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y", "force_ending")
 var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays")
 var/list/VVckey_edit = list("key", "ckey")
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -226,3 +226,11 @@ STARLIGHT
 
 ## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
 #GREY_ASSISTANTS
+
+### Midround Antag (aka Mulligan antag) config options ###
+
+## A time, in minutes, after which the midround antag system stops attempting to run and continuous rounds end immediately upon completion.
+MIDROUND_ANTAG_TIME_CHECK 60
+
+## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped
+MIDROUND_ANTAG_LIFE_CHECK 0.7


### PR DESCRIPTION
When mulligan antag is set to kick in, the suggestion for admins to end the round if they feel enough has happened is given. The option can also be found on the check antagonist panel.

Adds the ability for admins to "take the shot" and end rounds at their discretion. This is behind a two confirmation gate with a 20 second reflection period between them. All this is logged.

The check antagonist panel will show what the mulligan roundtype is if it exists.

Late join antags will appear for the mulligan roundtype as well now.

If absolutely no one wants/can be the midround antags, the round ends there.

The round will end no matter what if the primary antagonist survived over a certain length of time (configurable, default an hour) before biting it (unless the shuttle is already past the point of no return, in which case a peaceful ending takes priority)

The living crew ratio check is now a configurable var

Adds force_ending to VV editing protection, to avoid admins trying to shenanigans it on.
