### PR TITLE
Fixes #8148, Improves drill's handling of power

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -124,10 +124,9 @@
 	if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(300))
-			user << "<span class='notice'>Your jackhammer doesn't have enough power to break through that wall.</span>"
-			D.update_charge()
+			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
 			return
-		D.update_charge()
+		D.update_icon()
 		D.playDigSound()
 		dismantle(user)
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -42,9 +42,9 @@
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(D.drillcost))
-			D.update_charge()
+			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
 			return
-		D.update_charge()
+		D.update_icon()
 		user << "<span class='notice'>You smash through the girder!</span>"
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		D.playDigSound()
@@ -283,9 +283,8 @@
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(D.drillcost))
-			D.update_charge()
 			return
-		D.update_charge()
+		D.update_icon()
 		user << "<span class='notice'>Your jackhammer smashes through the girder!</span>"
 		var/obj/effect/decal/remains/human/R = new (get_turf(src))
 		transfer_fingerprints_to(R)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -57,9 +57,9 @@
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(D.drillcost))
-			D.update_charge()
+			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
 			return
-		D.update_charge()
+		D.update_icon()
 		if(!src.loc)
 			return
 		user.visible_message("<span class='notice'>[user] destroys the [name]!</span>", \

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -215,16 +215,15 @@
 	if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(400))
-			D.update_charge()
-			user << "<span class='notice'>Your jackhammer doesn't have enough power to break through that wall.</span>"
+			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
 			return
-		D.update_charge()
+		D.update_icon()
 		if( !istype(src, /turf/simulated/wall) || !user || !W || !T )
 			return 1
 		if( user.loc == T && user.get_active_hand() == W )
 			D.playDigSound()
 			dismantle_wall()
-			visible_message("<span class='warning'>[user] smashes through the wall with [W]!</span>", "<span class='warning'>You hear the grinding of metal.</span>")
+			visible_message("<span class='warning'>[user] smashes through the [name] with the [W.name]!</span>", "<span class='warning'>You hear the grinding of metal.</span>")
 			return 1
 	else if( istype(W, /obj/item/weapon/melee/energy/blade) )
 		var/obj/item/weapon/melee/energy/blade/EB = W

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -34,20 +34,17 @@
 		return 1
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
-		if(!D.powered)
+		if(!D.bcell.use(800))
+			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
 			return 1
-		user << "<span class='notice'>You begin to smash though the reinforced wall.</span>"
+		user << "<span class='notice'>You begin to smash though the [name].</span>"
 		if(do_after(user, 50))
 			if( !istype(src, /turf/simulated/wall/r_wall) || !user || !W || !T )
 				return 1
 			if( user.loc == T && user.get_active_hand() == W )
-				if(!D.bcell.use(800))
-					user << "<span class='notice'>Your jackhammer doesn't have enough power to break through that wall.</span>"
-					D.update_charge()
-					return 1
-				D.update_charge()
+				D.update_icon()
 				D.playDigSound()
-				user << "<span class='notice'>Your jackhammer smashes though the last of the reinforced plating.</span>"
+				visible_message("<span class='warning'>[user] smashes through the [name] with the [D.name]!</span>", "<span class='warning'>You hear the grinding of metal.</span>")
 				dismantle_wall()
 				return 1
 	else if(istype(W, /obj/item/stack/sheet/metal) && d_state)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -63,7 +63,6 @@
 	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
-	var/powered = 1 //used to check for drill charge when mining
 
 /obj/item/weapon/pickaxe/proc/playDigSound()
 	playsound(src, pick(digsound),50,1)
@@ -87,20 +86,11 @@
 	desc = "An electric mining drill for the especially scrawny."
 	var/drillcost = 125 //80 mineral walls by default
 	var/obj/item/weapon/stock_parts/cell/high/bcell = null
-	powered = 0
 
 /obj/item/weapon/pickaxe/drill/New() //this one starts with a cell pre-installed.
 	..()
 	bcell = new(src)
-	update_charge()
 	return
-
-/obj/item/weapon/pickaxe/drill/proc/update_charge()
-	if(bcell && bcell.charge >= drillcost)
-		powered = 1
-	else
-		powered = 0
-	update_icon()
 
 /obj/item/weapon/pickaxe/drill/update_icon()
 	if(!bcell)
@@ -119,14 +109,14 @@
 			W.loc = src
 			bcell = W
 			user << "<span class='notice'>You install a cell in [src].</span>"
-			update_charge()
+			update_icon()
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		if(bcell)
 			bcell.updateicon()
 			bcell.loc = get_turf(src.loc)
 			bcell = null
 			user << "<span class='notice'>You remove the cell from [src].</span>"
-			update_charge()
+			update_icon()
 			return
 		..()
 	return

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -392,39 +392,28 @@
 		if (!( istype(T, /turf) ))
 			return
 
-		if(!P.powered)
-			return
-/*
-	if (istype(W, /obj/item/weapon/pickaxe/radius))
-		var/turf/T = user.loc
-		if (!( istype(T, /turf) ))
-			return
-*/
-//Watch your tabbing, microwave. --NEO
+		if(istype(P, /obj/item/weapon/pickaxe/drill))
+			var/obj/item/weapon/pickaxe/drill/D = P
+			if(isrobot(user))
+				var/mob/living/silicon/robot/R = user
+				if(!R.cell.use(D.drillcost))
+					R << "<span class='notice'>Your [D.name] doesn't have enough charge.</span>"
+					return
+			if(!D.bcell.use(D.drillcost))
+				user << "<span class='notice'>Your [D.name] doesn't have enough charge.</span>"
+				return
+
 		if(last_act+P.digspeed > world.time)//prevents message spam
 			return
 		last_act = world.time
 		user << "<span class='danger'>You start picking.</span>"
-		//playsound(user, 'sound/weapons/Genhit.ogg', 20, 1)
 		P.playDigSound()
 
 		if(do_after(user,P.digspeed))
-			if(istype(P, /obj/item/weapon/pickaxe/drill))
-				var/obj/item/weapon/pickaxe/drill/D = P
-				if(isrobot(user))
-					var/mob/living/silicon/robot/R = user
-					if(R && R.cell)
-						if(!R.cell.use(D.drillcost))
-							D.update_charge()
-							return
-				else
-					if(!D.bcell.use(D.drillcost))
-						user << "<span class='warning'>Your drill ran out of power.</span>"
-						D.update_charge()
-						return
-				D.update_charge()
-			user << "<span class='notice'>You finish cutting into the rock.</span>"
-			gets_drilled(user)
+			if(istype(src, /turf/simulated/mineral)) //sanity check against turf being deleted during digspeed delay
+				user << "<span class='notice'>You finish cutting into the rock.</span>"
+				P.update_icon()
+				gets_drilled(user)
 	else
 		return attack_hand(user)
 	return


### PR DESCRIPTION
Fixes #8148

Improves how mining drills handle power usage and checking

Replaces some hard names with [name].

Added a sanity check to prevent runtimes when a mineral wall is deleted after someone has started mining it.
