### PR TITLE
Fixes disposal climbing.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -809,8 +809,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					t = Gibberish(t, signal.data["compression"] + 50)
 
 	if(useMS && useTC) // only send the message if it's stable
-		if(useTC != 2) // Does our recepient have a broadcaster on their level?
-			U << "ERROR: Cannot reach recepient."
+		if(useTC != 2) // Does our recipient have a broadcaster on their level?
+			U << "ERROR: Cannot reach recipient."
 			return
 		useMS.send_pda_message("[P.owner]","[owner]","[t]")
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -242,19 +242,22 @@ obj/machinery/hydroponics/update_icon()
 	UpdateDescription()
 
 	if(planted)
+		var/image/I
 		if(dead)
-			overlays += image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-dead")
+			I = image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-dead")
 		else if(harvest)
 			if(myseed.plant_type == 2) // Shrooms don't have a -harvest graphic
-				overlays += image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[myseed.growthstages]")
+				I = image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[myseed.growthstages]")
 			else
-				overlays += image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-harvest")
+				I = image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-harvest")
 		else if(age < myseed.maturation)
 			var/t_growthstate = ((age / myseed.maturation) * myseed.growthstages ) // Make sure it won't crap out due to HERPDERP 6 stages only
-			overlays += image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[round(t_growthstate)]")
+			I = image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[round(t_growthstate)]")
 			lastproduce = age //Cheating by putting this here, it means that it isn't instantly ready to harvest
 		else
-			overlays += image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[myseed.growthstages]") // Same
+			I = image('icons/obj/hydroponics/growing.dmi', icon_state = "[myseed.species]-grow[myseed.growthstages]") // Same
+		I.layer = MOB_LAYER + 0.1
+		overlays += I
 
 		if(waterlevel <= 10)
 			overlays += image('icons/obj/hydroponics/equipment.dmi', icon_state = "over_lowwater3")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -131,15 +131,13 @@
 	var/obj/item/weapon/grab/G = I
 	if(istype(G))	// handle grabbed mob
 		if(ismob(G.affecting))
-			stuff_mob_in(G.affecting, usr)
+			stuff_mob_in(G.affecting, user)
 		return
 
 	if(!I)	return
 
 	user.drop_item()
-	if(I)
-		I.loc = src
-
+	I.loc = src
 	user.visible_message("<span class='notice'>[user.name] places \the [I] into \the [src].</span>", \
 						"<span class='notice'>You place \the [I] into \the [src].</span>")
 
@@ -147,12 +145,15 @@
 
 // mouse drop another mob or self
 //
-/obj/machinery/disposal/MouseDrop_T(mob/target, mob/user)
-	if(istype(target))
+/obj/machinery/disposal/MouseDrop_T(mob/living/target, mob/living/user)
+	if(istype(target) && user == target)
 		stuff_mob_in(target, user)
 
-/obj/machinery/disposal/proc/stuff_mob_in(mob/target, mob/user)
-	if (!user.canUseTopic(target) || istype(user, /mob/living/silicon/ai))
+/obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)
+	if(!iscarbon(user))
+		return
+	if(target.mob_size > 1)
+		user << "<span class='warning'>[target] doesn't fit inside [src].</span>"
 		return
 	src.add_fingerprint(user)
 	if(user == target)
@@ -161,7 +162,7 @@
 	else
 		target.visible_message("<span class='danger'>[user] starts putting [target] into [src].</span>", \
 								"<span class='userdanger'>[user] starts putting [target] into [src]!</span>")
-	if(do_mob(usr, target, 20))
+	if(do_mob(user, target, 20))
 		if (target.client)
 			target.client.perspective = EYE_PERSPECTIVE
 			target.client.eye = src
@@ -205,12 +206,8 @@
 
 // monkeys can only pull the flush lever
 /obj/machinery/disposal/attack_paw(mob/user as mob)
-	if(stat & BROKEN)
+	if(!user.canUseTopic(src))
 		return
-
-	flush = !flush
-	update()
-	return
 
 // ai as human but can't flush
 /obj/machinery/disposal/attack_ai(mob/user as mob)
@@ -485,7 +482,6 @@
 	var/active = 0	// true if the holder is moving, otherwise inactive
 	dir = 0
 	var/count = 1000	//*** can travel 1000 steps before going inactive (in case of loops)
-	var/has_fat_guy = 0	// true if contains a fat person
 	var/destinationTag = 0 // changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
 	var/hasmob = 0 //If it contains a mob
@@ -502,7 +498,7 @@
 	//Check for any living mobs trigger hasmob.
 	//hasmob effects whether the package goes to cargo or its tagged destination.
 	for(var/mob/living/M in D)
-		if(M && M.stat != 2)
+		if(M && M.stat != DEAD)
 			hasmob = 1
 
 	//Checks 1 contents level deep. This means that players can be sent through disposals...
@@ -510,17 +506,13 @@
 	for(var/obj/O in D)
 		if(O.contents)
 			for(var/mob/living/M in O.contents)
-				if(M && M.stat != 2)
+				if(M && M.stat != DEAD)
 					hasmob = 1
 
 	// now everything inside the disposal gets put into the holder
 	// note AM since can contain mobs or objs
 	for(var/atom/movable/AM in D)
 		AM.loc = src
-		if(istype(AM, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = AM
-			if(H.disabilities & FAT)		// is a human and fat?
-				has_fat_guy = 1			// set flag on holder
 		if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
 			var/obj/structure/bigDelivery/T = AM
 			src.destinationTag = T.sortTag
@@ -587,9 +579,6 @@
 			var/mob/M = AM
 			if(M.client)	// if a client mob, update eye to follow this holder
 				M.client.eye = src
-
-	if(other.has_fat_guy)
-		has_fat_guy = 1
 	qdel(other)
 
 
@@ -869,14 +858,15 @@
 
 // called when pipe is cut with welder
 /obj/structure/disposalpipe/Deconstruct()
-	var/turf/T = loc
-	stored.loc = T
-	transfer_fingerprints_to(stored)
-	stored.dir = dir
-	stored.density = 0
-	stored.anchored = 1
-	stored.update()
-	..()
+	if(stored)
+		var/turf/T = loc
+		stored.loc = T
+		transfer_fingerprints_to(stored)
+		stored.dir = dir
+		stored.density = 0
+		stored.anchored = 1
+		stored.update()
+		..()
 
 /obj/structure/disposalpipe/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
@@ -1212,13 +1202,10 @@
 	update()
 	return
 
-// called when welded
-// for broken pipe, remove and turn into scrap
+// the disposal outlet machine
 
 /obj/structure/disposalpipe/broken/Deconstruct()
-	..()
-
-// the disposal outlet machine
+	qdel(src)
 
 /obj/structure/disposaloutlet
 	name = "disposal outlet"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -204,10 +204,12 @@
 	return
 
 
-// monkeys can only pull the flush lever
+// monkeys and xenos can only pull the flush lever
 /obj/machinery/disposal/attack_paw(mob/user as mob)
-	if(!user.canUseTopic(src))
+	if(stat & BROKEN)
 		return
+	flush = !flush
+	update()
 
 // ai as human but can't flush
 /obj/machinery/disposal/attack_ai(mob/user as mob)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -150,7 +150,7 @@
 		stuff_mob_in(target, user)
 
 /obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)
-	if(!iscarbon(user))
+	if(!iscarbon(user) && !user.ventcrawler) //only carbon and ventcrawlers can climb into disposal by themselves.
 		return
 	if(target.mob_size > 1)
 		user << "<span class='warning'>[target] doesn't fit inside [src].</span>"

--- a/html/changelogs/phil235-AlienDisposalFix.yml
+++ b/html/changelogs/phil235-AlienDisposalFix.yml
@@ -1,6 +1,6 @@
 author: phil235
 delete-after: True
 changes:
-  - tweak: "Aliens, slimes, monkeys and ventcrawler mobs can now climb into disposal but cannot flush it. Cyborgs and very large mobs can no longer climb into it."
+  - tweak: "Aliens, slimes, monkeys and ventcrawler mobs can now climb into disposal. Cyborgs and very large mobs can no longer climb into it."
   - tweak: "Stuffing another mob in a disposal unit is now only done via grabbing."
 

--- a/html/changelogs/phil235-AlienDisposalFix.yml
+++ b/html/changelogs/phil235-AlienDisposalFix.yml
@@ -1,0 +1,6 @@
+author: phil235
+delete-after: True
+changes:
+  - tweak: "Aliens, slimes and monkeys can now climb into disposal but cannot flush it. Cyborgs and very large mobs can no longer climb into it."
+  - tweak: "Stuffing another mob in a disposal unit is now only done via grabbing."
+

--- a/html/changelogs/phil235-AlienDisposalFix.yml
+++ b/html/changelogs/phil235-AlienDisposalFix.yml
@@ -1,6 +1,6 @@
 author: phil235
 delete-after: True
 changes:
-  - tweak: "Aliens, slimes and monkeys can now climb into disposal but cannot flush it. Cyborgs and very large mobs can no longer climb into it."
+  - tweak: "Aliens, slimes, monkeys and ventcrawler mobs can now climb into disposal but cannot flush it. Cyborgs and very large mobs can no longer climb into it."
   - tweak: "Stuffing another mob in a disposal unit is now only done via grabbing."
 


### PR DESCRIPTION
Aliens, slimes and monkeys can climb into disposal. Fixes #8182
Aliens can now stuff other mobs in disposal.
Non carbon mobs cannot climb into disposal by themselves unless they can ventcrawl.
Stuffing another mob in a disposal unit is now only done via grabbing.(fixes bugs like stuffing someone while being inside the disposal yourself)
Very large mobs no longer fit inside disposal.
Fixes hydrotray growing overlay layer. Fixes #8184 
Fixes slicing broken pipes dropping a straight pipe. Fixes #6157 
Fixes typos. Fixes #8187 
Removing unused var from disposal. 
