### PR TITLE
Hostile Mob AI Optimisation

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -44,11 +44,18 @@
 #define GRAB_UPGRADING	4
 #define GRAB_KILL		5
 
+
+//Hostile Mob Stances
 #define HOSTILE_STANCE_IDLE			1
 //#define HOSTILE_STANCE_ALERT		2 //Was only used by bears
 #define HOSTILE_STANCE_ATTACK		3
 #define HOSTILE_STANCE_ATTACKING	4
 //#define HOSTILE_STANCE_TIRED		5 //Was also only used by bears
+
+//Hostile Mob AI Status
+#define AI_ON		1
+#define AI_SLEEP	2
+#define AI_OFF		3
 
 
 //Embedded objects


### PR DESCRIPTION
If running something less than normal can be called an Optimisation.

Hostile mobs now have an `AIStatus` variable which is one of 3 values.
- `AI_ON`, This is the default, and how everything acts prior to this PR
- `AI_OFF`, It will never process it's hostile AI loop, and will simply wander like a passive animal
- `AI_SLEEP`, it runs it's own checks to decide if it should "Wake up" the main hostile AI loop, by default it just checks if it can find a target (A mob or item, depending on other settings on the mob), and if it can it wakes up. This is different to `AI_OFF` as `AI_OFF` will never become `AI_ON` and vice versa.

They'll still wander about a bit, they won't sit dead still like statues.
This means you won't accidentally walk in on every hostile mob just sat there, doing nothing.
