### PR TITLE
Hulk crit fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -38,6 +38,9 @@
 	tinttotal = tintcheck() //here as both hud updates and status updates call it
 
 	if(..())
+		if(dna)
+			for(var/datum/mutation/human/HM in dna.mutations)
+				HM.on_life(src)
 
 		//Stuff jammed in your limbs hurts
 		handle_embedded_objects()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -343,12 +343,12 @@
 			silent = 0
 			return 1
 
-		if( (getOxyLoss() > 50) || (config.health_threshold_crit >= health) )
+		if(getOxyLoss() > 50 || health <= config.health_threshold_crit)
 			Paralyse(3)
+			stat = UNCONSCIOUS
 
 		if(paralysis)
 			AdjustParalysis(-1)
-			stat = UNCONSCIOUS
 		else if(sleeping)
 			handle_dreams()
 			adjustStaminaLoss(-10)


### PR DESCRIPTION
Fixes carbon mobs resistant to paralysis not going unconscious when below crit level health.
Fixes hulks not losing their mutation when low on health, and mutation effects not being in taken into account in life().
Fixes #8224 
Fixes #8250 
