### PR TITLE
Loyalty Implant Firing Pins

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -16,7 +16,7 @@
 	name = "loyalty firing pin"
 	desc = "This is a security firing pin which only authorizes users who are loyalty-implanted."
 	id = "pin_loyalty"
-	req_tech = list("combat" = 10, "materials" = 3, "powerstorage" = 3)
+	req_tech = list("combat" = 5, "materials" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$silver" = 600, "$diamond" = 600, "$uranium" = 200)
 	build_path = /obj/item/device/firing_pin/implant/loyalty

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -16,7 +16,7 @@
 	name = "loyalty firing pin"
 	desc = "This is a security firing pin which only authorizes users who are loyalty-implanted."
 	id = "pin_loyalty"
-	req_tech = list("combat" = 5, "materials" = 3, "powerstorage" = 3)
+	req_tech = list("combat" = 6, "materials" = 6, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list("$silver" = 600, "$diamond" = 600, "$uranium" = 200)
 	build_path = /obj/item/device/firing_pin/implant/loyalty

--- a/html/changelogs/Gun_Hog-LoyaltyPins.yml
+++ b/html/changelogs/Gun_Hog-LoyaltyPins.yml
@@ -1,0 +1,7 @@
+
+author: Gun Hog
+
+delete-after: True
+
+changes: 
+  - rscadd: "Nanotrasen has approved distribution of Loyalty Implant Firing Pin designs. They can be fabricated with sufficient research into weapons technology. If inserted into a firearm, it will only fire upon successful interface with a user's Loyalty Implant."


### PR DESCRIPTION
- Allows the construction of Loyalty Pins at Combat tech 6, instead of
  10.

<b>Sets requirements to Combat 6, Materials 6, and Power 3.<.b>

The original levels intended for the firing pins were Combat 5, Materials 3, and Power 3. This sets them to _somewhat above_ those levels to allow them to be constructed at RnD.

<b>Feedback thread here!</b>
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=3112
