### PR TITLE
Fixes "Sensor Augmentation" showing in silicon verbs

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -338,7 +338,7 @@
 	var/datum/atom_hud/medsensor = huds[med_hud]
 	medsensor.add_hud_to(src)
 
-/mob/living/silicon/verb/sensor_mode()
+/mob/living/silicon/proc/sensor_mode()
 	set name = "Set Sensor Augmentation"
 	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Disable")
 	remove_med_sec_hud()


### PR DESCRIPTION
- Fixes #8167

Simple fix to prevent this uncategorized verb showing up for all silicons, as its intended users both have HUD buttons to control this, and pAIs access their HUDs by buying the modules.

Testing shows no loss of function for the AI or borgs, and pAI can no longer access HUDs via the verb.
