### PR TITLE
Strangeness text, janicart, alien nest, weak golem fixes

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -76,7 +76,7 @@
 	alerts -= category
 	if(client && hud_used)
 		hud_used.reorganize_alerts()
-	client.screen -= alert
+		client.screen -= alert
 	qdel(alert)
 
 // Make sure any alerts you throw have a path that matches /obj/screen/alert/[id] or /obj/screen/alert/[category]

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -215,6 +215,7 @@
 	text_gain_indication = "<span class='danger'>You feel strange.</span>"
 
 /datum/mutation/human/bad_dna/on_acquiring(var/mob/living/carbon/human/owner)
+	owner << text_gain_indication
 	var/mob/new_mob
 	if(prob(95))
 		if(prob(50))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -82,7 +82,6 @@
 				"<span class='danger'>[M.name] is buckled to [src] by [user.name]!</span>",\
 				"<span class='danger'>You are buckled to [src] by [user.name]!</span>",\
 				"<span class='notice'>You heat metal clanking.</span>")
-		return 1
 
 /obj/proc/user_unbuckle_mob(mob/user)
 	var/mob/living/M = unbuckle_mob()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -82,6 +82,7 @@
 				"<span class='danger'>[M.name] is buckled to [src] by [user.name]!</span>",\
 				"<span class='danger'>You are buckled to [src] by [user.name]!</span>",\
 				"<span class='notice'>You heat metal clanking.</span>")
+		return 1
 
 /obj/proc/user_unbuckle_mob(mob/user)
 	var/mob/living/M = unbuckle_mob()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -258,8 +258,8 @@
 			if(A != src && A != M)
 				return
 	M.loc = loc //we move the mob on the janicart's turf before checking if we can buckle.
-	if(..())
-		update_mob()
+	..()
+	update_mob()
 
 /obj/structure/stool/bed/chair/janicart/unbuckle_mob()
 	if(buckled_mob)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -250,11 +250,16 @@
 	else
 		user << "<span class='notice'>You'll need the keys in one of your hands to drive this [callme].</span>"
 
-
 /obj/structure/stool/bed/chair/janicart/user_buckle_mob(mob/living/M, mob/user)
-	M.loc = loc
-	..()
-	update_mob()
+	if(user.incapacitated()) //user can't move the mob on the janicart's turf if incapacitated
+		return
+	for(var/atom/movable/A in get_turf(src)) //we check for obstacles on the turf.
+		if(A.density)
+			if(A != src && A != M)
+				return
+	M.loc = loc //we move the mob on the janicart's turf before checking if we can buckle.
+	if(..())
+		update_mob()
 
 /obj/structure/stool/bed/chair/janicart/unbuckle_mob()
 	if(buckled_mob)

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -26,7 +26,7 @@
 */
 
 /obj/structure/stool/bed/nest/user_buckle_mob(mob/M as mob, mob/user as mob)
-	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || usr.stat || M.buckled || istype(user, /mob/living/silicon/pai) )
+	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.stat || M.buckled || istype(user, /mob/living/silicon/pai) )
 		return
 
 	if(istype(M,/mob/living/carbon/alien))
@@ -36,26 +36,21 @@
 
 	unbuckle_mob()
 
-	if(M == usr)
-		return
-	else
+	if(buckle_mob(M))
 		M.visible_message(\
 			"<span class='notice'>[user.name] secretes a thick vile goo, securing [M.name] into [src]!</span>",\
 			"<span class='warning'>[user.name] drenches you in a foul-smelling resin, trapping you in [src]!</span>",\
 			"<span class='notice'>You hear squelching...</span>")
-	return
 
 /obj/structure/stool/bed/nest/post_buckle_mob(mob/living/M)
 	if(M == buckled_mob)
-		M.pixel_y += 1
+		M.pixel_y += 6
 		M.pixel_x += 2
 		overlays += image('icons/mob/alien.dmi', "nestoverlay", layer=6)
 	else
-		buckled_mob.pixel_y -= 1
-		buckled_mob.pixel_x -= 2
+		M.pixel_x -= 2
+		M.pixel_y = initial(M.pixel_y)
 		overlays.Cut()
-
-
 
 /obj/structure/stool/bed/nest/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	var/aforce = W.force

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -757,7 +757,8 @@
 				atk_verb = M.dna.species.attack_verb
 
 			var/damage = rand(0, 9)
-			damage += punchmod
+			if(M.dna)
+				damage += M.dna.species.punchmod
 
 			if(!damage)
 				if(M.dna)


### PR DESCRIPTION
- Fixes Strangeness mutation gain text not appearing.
  Fixes #7764 
- Fixes a runtime with the screen alert for buckling
- Fixes being able to buckle to janicart while crit and when there's a dense object on the janicart's turf.
  Fixes #7998
- Fixes alien nest not buckling and being wrongly pixel shifted, and fixed a runtime.
  Fixes #8048
  Fixes #6400
- Fixes golems being super easy to weaken by punch and not doing more damage themselves via punch. Fixes #8067 
- Fixes some typos.
