### PR TITLE
Search button on game panel spawn menu

### DIFF
--- a/html/create_object.html
+++ b/html/create_object.html
@@ -27,7 +27,7 @@
 	<form name="spawner" action="byond://?src=/* ref src */" method="get">
 		<input type="hidden" name="src" value="/* ref src */">
 		
-		Type <input type="text" name="filter" value="" onkeyup="updateSearch()" onkeypress="submitFirst(event)" style="width:350px"><br>
+		Type <input type="text" name="filter" value="" onkeypress="submitFirst(event)" style="width:280px;height:25"> <input type = "button" value = "Search" onclick = "updateSearch()" /><br>
 		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
 		
 		A <input type="radio" name="offset_type" value="absolute">


### PR DESCRIPTION
Adds Bay's search button to the game panel's spawn menu so it doesn't start sorting through it's list of atoms as soon as any character is entered and rustle the jimmies of anyone who tried to use it.
