### PR TITLE
acquiring negative mutations shows in red in chat

### DIFF
--- a/code/datums/goon_mutations_disabilities.dm
+++ b/code/datums/goon_mutations_disabilities.dm
@@ -12,8 +12,8 @@
 /datum/mutation/human/mute
 	name = "Mute"
 	quality = NEGATIVE
-	text_gain_indication = "<span class='notice'>You feel unable to express yourself at all.</span>"
-	text_lose_indication = "<span class='notice'>You feel able to speak freely again.</span>"
+	text_gain_indication = "<span class='danger'>You feel unable to express yourself at all.</span>"
+	text_lose_indication = "<span class='danger'>You feel able to speak freely again.</span>"
 
 /datum/mutation/human/mute/on_acquiring(mob/living/carbon/human/owner)
 	if(..())	return
@@ -81,8 +81,8 @@
 /datum/mutation/human/unintelligable
 	name = "Unintelligable"
 	quality = NEGATIVE
-	text_gain_indication = "<span class='notice'>You can't seem to form any coherent thoughts!</span>"
-	text_lose_indication = "<span class='notice'>Your mind feels more clear.</span>"
+	text_gain_indication = "<span class='danger'>You can't seem to form any coherent thoughts!</span>"
+	text_lose_indication = "<span class='danger'>Your mind feels more clear.</span>"
 
 /datum/mutation/human/unintelligable/say_mod(var/message)
 	if(message)


### PR DESCRIPTION
2 negative goon mutations were shown as "notice" in chat when they should be "danger"
