### PR TITLE
Tablecraft Fix and recipe detection

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -195,9 +195,15 @@
 
 /obj/item/weapon/flamethrower/full/New(var/loc)
 	..()
-	weldtool = new /obj/item/weapon/weldingtool(src)
+	for(var/obj/item/weapon/weldingtool/W in src)
+		weldtool = W
+	for(var/obj/item/device/assembly/igniter/I in src)
+		igniter = I
+	if(!weldtool)
+		weldtool = new /obj/item/weapon/weldingtool(src)
 	weldtool.status = 0
-	igniter = new /obj/item/device/assembly/igniter(src)
+	if(!igniter)
+		igniter = new /obj/item/device/assembly/igniter(src)
 	igniter.secured = 0
 	status = 1
 	update_icon()

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -157,6 +157,10 @@
 	update_icon()
 	return
 
+/obj/item/weapon/flamethrower/CheckParts()
+	weldtool = locate(/obj/item/weapon/weldingtool) in contents
+	igniter = locate(/obj/item/device/assembly/igniter) in contents
+	update_icon()
 
 //Called from turf.dm turf/dblclick
 /obj/item/weapon/flamethrower/proc/flame_turf(turflist)
@@ -195,10 +199,6 @@
 
 /obj/item/weapon/flamethrower/full/New(var/loc)
 	..()
-	for(var/obj/item/weapon/weldingtool/W in src)
-		weldtool = W
-	for(var/obj/item/device/assembly/igniter/I in src)
-		igniter = I
 	if(!weldtool)
 		weldtool = new /obj/item/weapon/weldingtool(src)
 	weldtool.status = 0

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -96,6 +96,7 @@
 		F.ptank = src
 		user.unEquip(src)
 		src.loc = F
+		F.update_icon()
 	return
 
 /obj/item/weapon/tank/internals/plasma/full/New()

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -308,6 +308,7 @@
 //Toggles the welder off and on
 /obj/item/weapon/weldingtool/proc/toggle(mob/user, message = 0)
 	if(!status)
+		user << "<span class='notice'>[src] can't be turned on while unsecured.</span>"
 		return
 	welding = !welding
 	if(welding)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -84,10 +84,12 @@
 
 /datum/table_recipe/flamethrower
 	name = "Flamethrower"
-	result = /obj/item/weapon/flamethrower
+	result = /obj/item/weapon/flamethrower/full
 	reqs = list(/obj/item/weapon/weldingtool = 1,
 				/obj/item/device/assembly/igniter = 1,
 				/obj/item/stack/rods = 2)
+	parts = list(/obj/item/device/assembly/igniter = 1,
+				/obj/item/weapon/weldingtool = 1)
 	tools = list(/obj/item/weapon/screwdriver)
 	time = 20
 

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -5,7 +5,7 @@
 	var/tools[] = list() //type paths of items needed but not consumed
 	var/time = 30 //time in deciseconds
 	var/parts[] = list() //type paths of items that will be placed in the result
-	var/chem_catalists[] = list() //like tools but for reagents
+	var/chem_catalysts[] = list() //like tools but for reagents
 
 
 /datum/table_recipe/IED
@@ -84,10 +84,10 @@
 
 /datum/table_recipe/flamethrower
 	name = "Flamethrower"
-	result = /obj/item/weapon/flamethrower/full
+	result = /obj/item/weapon/flamethrower
 	reqs = list(/obj/item/weapon/weldingtool = 1,
 				/obj/item/device/assembly/igniter = 1,
-				/obj/item/stack/rods = 2)
+				/obj/item/stack/rods = 1)
 	parts = list(/obj/item/device/assembly/igniter = 1,
 				/obj/item/weapon/weldingtool = 1)
 	tools = list(/obj/item/weapon/screwdriver)

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -17,8 +17,8 @@
 					if(table_contents[B] >= R.reqs[A])
 						continue main_loop
 			return 0
-	for(var/A in R.chem_catalists)
-		if(table_contents[A] < R.chem_catalists[A])
+	for(var/A in R.chem_catalysts)
+		if(table_contents[A] < R.chem_catalysts[A])
 			return 0
 	return 1
 
@@ -196,12 +196,12 @@
 						req_text += " [R.reqs[A]] [RE.name]"
 						qdel(RE)
 
-				if(R.chem_catalists.len)
-					catalist_text += ", Catalists:"
-					for(var/C in R.chem_catalists)
+				if(R.chem_catalysts.len)
+					catalist_text += ", Catalysts:"
+					for(var/C in R.chem_catalysts)
 						if(ispath(C, /datum/reagent))
 							var/datum/reagent/RE = new C
-							catalist_text += " [R.chem_catalists[C]] [RE.name]"
+							catalist_text += " [R.chem_catalysts[C]] [RE.name]"
 							qdel(RE)
 				if(R.tools.len)
 					tool_text += ", Tools:"

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -22,6 +22,17 @@
 			return 0
 	return 1
 
+/obj/structure/table/proc/partial_check_contents(datum/table_recipe/R)
+	check_table()
+	var/required_amount = max(round(R.reqs.len/2), 1)
+	var/amount = 0
+	for(var/A in R.reqs)
+		for(var/B in table_contents)
+			if(ispath(B, A))
+				amount += 1
+	if(amount >= required_amount)
+		return 1
+
 /obj/structure/table/proc/check_table()
 	table_contents = list()
 	for(var/obj/item/I in loc)
@@ -164,11 +175,46 @@
 		dat += "Crafting in progress...</div>"
 	else
 		for(var/datum/table_recipe/R in table_recipes)
+			var/name_text = ""
+			var/req_text = ""
+			var/tool_text = ""
+			var/catalist_text = ""
 			if(check_contents(R))
-				dat += "<A href='?src=\ref[src];make=\ref[R]'>[R.name]</A><BR>"
+				name_text ="<A href='?src=\ref[src];make=\ref[R]'>[R.name]</A>"
+
+			else if(partial_check_contents(R))
+				name_text = "<span class='linkOff'>[R.name]</span>"
+
+			if(name_text)
+				for(var/A in R.reqs)
+					if(ispath(A, /obj))
+						var/obj/O = new A
+						req_text += " [R.reqs[A]] [O.name]"
+						qdel(O)
+					if(ispath(A, /datum/reagent))
+						var/datum/reagent/RE = new A
+						req_text += " [R.reqs[A]] [RE.name]"
+						qdel(RE)
+
+				if(R.chem_catalists.len)
+					catalist_text += ", Catalists:"
+					for(var/C in R.chem_catalists)
+						if(ispath(C, /datum/reagent))
+							var/datum/reagent/RE = new C
+							catalist_text += " [R.chem_catalists[C]] [RE.name]"
+							qdel(RE)
+				if(R.tools.len)
+					tool_text += ", Tools:"
+					for(var/O in R.tools)
+						if(ispath(O, /obj))
+							var/obj/T = new O
+							tool_text += " [R.tools[O]] [T.name]"
+							qdel(T)
+
+				dat += "[name_text][req_text][tool_text][catalist_text]<BR>"
 		dat += "</div>"
 
-	var/datum/browser/popup = new(user, "table", "Table", 300, 300)
+	var/datum/browser/popup = new(user, "table", "Table", 500, 500)
 	popup.set_content(dat)
 	popup.open()
 	return

--- a/code/modules/food&drinks/recipes/tablecraft/recipes_sandwich.dm
+++ b/code/modules/food&drinks/recipes/tablecraft/recipes_sandwich.dm
@@ -52,7 +52,7 @@
 	name = "Not a sandwich"
 	reqs = list(
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice/plain = 2,
-		/obj/item/clothing/mask/fakemoustache
+		/obj/item/clothing/mask/fakemoustache = 1
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 

--- a/html/changelogs/phil235-TablecraftFix.yml
+++ b/html/changelogs/phil235-TablecraftFix.yml
@@ -1,0 +1,6 @@
+author: phil235
+
+delete-after: True
+
+changes: 
+  - rscadd: "The tablecrafting window now also shows partial recipes in grey, if there's some of the things required for the recipe on the table. Recipe requirements are now also shown next to the names of recipes listed in the window."


### PR DESCRIPTION
- Fixes notasandwich and flamethrower tablecraft recipes. Fixes #8292. Fixes #8293.
- Add a recipe detection to tablecrafting, if you have some of the things required for the recipe (50% of the amount of different things needed, i.e if less than 3 different things in the recipe then you need 1, otherwise 2+), it will now appear in grey in the tablecrafting window. 
  The tablecrafting window will also lists the requirements for each recipes it shows.
-  Also fixing the flamethrower recipe using 2 rods and the constructed flamethrower not having its weldtool and igniter var set up.
- Also added a fix for the lack of message when trying to turn on an unsecured welding tool, and another fix for the lack of icon update when clicking plasma tank with empty flamethrower (to load it in the flamethrower.
