### PR TITLE
Makes PlaceInPool() call Destroy() on the atom

### DIFF
--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -70,13 +70,13 @@ var/global/list/GlobalPool = list()
 	if(AM in GlobalPool[AM.type])
 		return
 	
-	AM.Destroy()
-	AM.ResetVars()
-
 	if(!GlobalPool[AM.type])
 		GlobalPool[AM.type] = list()
 
-	GlobalPool[AM.type] += AM
+	GlobalPool[AM.type] |= AM
+	
+	AM.Destroy()
+	AM.ResetVars()
 
 
 

--- a/code/game/pooling/atom_pool.dm
+++ b/code/game/pooling/atom_pool.dm
@@ -69,7 +69,8 @@ var/global/list/GlobalPool = list()
 
 	if(AM in GlobalPool[AM.type])
 		return
-
+	
+	AM.Destroy()
 	AM.ResetVars()
 
 	if(!GlobalPool[AM.type])


### PR DESCRIPTION
vg's doing it, it's a smart idea, we're doing it.

For further reasoning: Destroy() is for removing references on objects about to be garbage collected, we can reuse the reference removal here to prevent a recycled object being referred to by something from it's previous use. (However I don't believe we ever actually had any issues with this prior but it makes it safer to expand pooling to atoms that do important work on Destroy() which would previously never be called as they're literally not being destroyed)

Just because your cup is made from recycled CDs does not mean it will play music.
