### PR TITLE
Adds a cyborg upgrade module for the satchel of holding.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -171,7 +171,27 @@
 			qdel(D)
 		for(var/obj/item/weapon/shovel/S in R.module.modules)
 			qdel(S)
-		R.module.modules += new /obj/item/weapon/pickaxe/drill/diamonddrill(src)
+		R.module.modules += new /obj/item/weapon/pickaxe/drill/diamonddrill(R.module)
+		R.module.rebuild()
+		return 1
+
+/obj/item/borg/upgrade/soh
+	name = "mining cyborg satchel of holding"
+	desc = "A satchel of holding replacement for mining cyborg's ore satchel module."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+
+/obj/item/borg/upgrade/soh/action(var/mob/living/silicon/robot/R)
+	if(..()) return 0
+
+	if(!istype(R.module, /obj/item/weapon/robot_module/miner))
+		R << "Upgrade mounting error!  No suitable hardpoint detected!"
+		usr << "There's no mounting point for the module!"
+		return 0
+	else
+		for(var/obj/item/weapon/storage/bag/ore/cyborg/S in R.module.modules)
+			qdel(S)
+		R.module.modules += new /obj/item/weapon/storage/bag/ore/holding(R.module)
 		R.module.rebuild()
 		return 1
 

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -79,6 +79,9 @@
 	max_w_class = 3
 	can_hold = list(/obj/item/weapon/ore)
 
+/obj/item/weapon/storage/bag/ore/cyborg
+	name = "cyborg mining satchel"
+
 /obj/item/weapon/storage/bag/ore/holding //miners, your messiah has arrived
 	name = "mining satchel of holding"
 	desc = "A revolution in convenience, this satchel allows for infinite ore storage. It's been outfitted with anti-malfunction safety measures."
@@ -86,7 +89,6 @@
 	max_combined_w_class = INFINITY
 	origin_tech = "bluespace=3"
 	icon_state = "satchel_bspace"
-
 
 // -----------------------------
 //          Plant bag

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -237,7 +237,7 @@
 	..()
 	modules += new /obj/item/borg/sight/meson(src)
 	emag = new /obj/item/borg/stun(src)
-	modules += new /obj/item/weapon/storage/bag/ore(src)
+	modules += new /obj/item/weapon/storage/bag/ore/cyborg(src)
 	modules += new /obj/item/weapon/pickaxe/drill/cyborg(src)
 	modules += new /obj/item/weapon/shovel(src)
 	modules += new /obj/item/device/flashlight/lantern(src)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -665,6 +665,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_holding
+	name = "Cyborg Upgrade (Ore Satchel of Holding)"
+	id = "borg_upgrade_holding"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/soh
+	req_tech = list("engineering" = 5, "materials" = 5, "bluespace" = 3)
+	materials = list("$metal" = 10000, "$gold" = 250, "$uranium" = 500)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_syndicate_module
 	name = "Cyborg Illegal Upgrades Module"
 	desc = "Allows for the construction of restricted upgrades for cyborgs"

--- a/html/changelogs/Mandurrrh-sohborgupgrade.yml
+++ b/html/changelogs/Mandurrrh-sohborgupgrade.yml
@@ -1,0 +1,10 @@
+#
+# Your name.  
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - rscadd: "Added a cyborg upgrade module for the satchel of holding."


### PR DESCRIPTION
Adds a new cyborg upgrade module for mining borgs that upgrades the borgs standard mining satchel to a satchel of holding. Requires the same materials cost as the satchel in the prolathe(gold=250 uranium=500) plus 10000 metal. Requires engi 5 materials 5 and bluespace 3. 

Also fixed the diamond drill upgrade: before it gave the borg the diamond drill but you could not equip it for use. 
