### PR TITLE
Xeno nest wars Random Event

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -305,7 +305,8 @@
 
 
 /obj/structure/alien/egg/New()
-	new /obj/item/clothing/mask/facehugger(src)
+	var/obj/item/clothing/mask/facehugger/F = new /obj/item/clothing/mask/facehugger(src)
+	F.color = color
 	..()
 	spawn(rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME))
 		Grow()

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -43,3 +43,133 @@
 
 		spawncount--
 		successSpawn = 1
+
+
+
+//XENO NEST WARS VARIANT
+//Variant on alien_infestation, summons 2 seperate strains of xenos to have a nest war.
+//Crew become a resource in a battle between two xeno strains.
+
+/datum/round_event_control/alien_infestation/xeno_nest_wars //Subtype so only one of the two occurs (naturally)
+	name = "Xeno Nest Wars"
+	typepath = /datum/round_event/alien_infestation/xeno_nest_wars
+
+
+//The only different proc between the two event types.
+/datum/round_event/alien_infestation/xeno_nest_wars/start()
+
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+		if(temp_vent.loc.z == ZLEVEL_STATION && !temp_vent.welded)
+			if(temp_vent.parent.other_atmosmch.len > 20)	//Stops Aliens getting stuck in small networks. See: Security, Virology
+				vents += temp_vent
+
+	var/total_spawn_count = spawncount*2
+	var/strain1_count = spawncount
+	var/strain2_count = spawncount
+
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+	if(candidates.len < total_spawn_count) //not enough for a fair amount on each strain
+		kill()
+		return
+
+	//Black, Red, Yellow xenos are all canon, so we'll stick with those for now.
+	var/list/possible_strains = list("black","red","yellow")
+	var/list/actual_strains = list()
+
+	actual_strains = possible_strains - pick(possible_strains)
+
+	while(total_spawn_count > 0 && vents.len && candidates.len)
+		var/obj/vent = pick_n_take(vents)
+		var/obj/vent_2 = pick_n_take(vents)
+		var/client/C = pick_n_take(candidates)
+		var/client/CC = pick_n_take(candidates)
+
+		//Makes 2 xenos at once as that's the cleanest way I could code it that worked.
+		//One of each team.
+		var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
+		var/mob/living/carbon/alien/larva/new_xeno_2 = new(vent_2.loc)
+		new_xeno.key = C.key
+		new_xeno_2.key = CC.key
+
+		var/which_strain = 0 //"First" Strain, uses as keys for strain list
+		var/enemy_strain = 0 //"Second" Strain, used as keys for strain list
+
+		//Both same amount? random strain
+		if(strain1_count && strain2_count && strain1_count == strain2_count)
+			which_strain = rand(1,2)
+			if(which_strain == 1)
+				enemy_strain = 2
+			else
+				enemy_strain = 1
+
+		//Ensure one of each strain is made
+		if(strain1_count > strain2_count)
+			which_strain = 2
+			enemy_strain = 1
+		else
+			which_strain = 1
+			enemy_strain = 2
+
+		//Setup the "Strain" of each xeno
+		new_xeno.color = setup_color(actual_strains[which_strain])
+		total_spawn_count--
+		strain1_count--
+
+		new_xeno_2.color = setup_color(actual_strains[enemy_strain])
+		total_spawn_count--
+		strain2_count--
+
+		//Objective to kill the other strain off
+		if(new_xeno.mind)
+			var/datum/objective/xeno_nest_kill/XNK = new /datum/objective/xeno_nest_kill()
+			XNK.enemy_strain = actual_strains[enemy_strain]
+			XNK.update_explanation_text()
+			new_xeno.mind.objectives += XNK
+
+		if(new_xeno_2.mind)
+			var/datum/objective/xeno_nest_kill/XNK2 = new /datum/objective/xeno_nest_kill()
+			XNK2.enemy_strain = actual_strains[which_strain]
+			XNK2.update_explanation_text()
+			new_xeno_2.mind.objectives += XNK2
+
+		successSpawn = 1
+
+
+/datum/round_event/alien_infestation/xeno_nest_wars/proc/setup_color(var/strain)
+	. = ""
+	if(strain && strain != "black")//black uses the default icons, greyscale xenos when?
+		. = strain
+
+
+
+//Xeno nest wars objectives:
+
+/datum/objective/xeno_nest_kill
+	dangerrating = 10
+	var/enemy_strain = ""
+
+//Byond accepts the text variants of colours (red, yellow etc.) but we need to make sure black is ""
+/datum/objective/xeno_nest_kill/proc/get_enemy_colour_value(var/strain = "")
+	. = strain
+	if(strain && strain == "black")
+		. = ""
+
+/datum/objective/xeno_nest_kill/find_target_by_role()
+	return
+
+/datum/objective/xeno_nest_kill/check_completion()
+	var/enemy_count = 0
+	for(var/mob/living/carbon/alien/A in world)
+		if(A.color == get_enemy_colour_value(enemy_strain))
+			enemy_count++
+			break
+	if(enemy_count)
+		return 0
+	return 1
+
+/datum/objective/xeno_nest_kill/update_explanation_text()
+	..()
+	explanation_text = "Destroy the [enemy_strain] xenomorphs!"
+
+

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -42,6 +42,7 @@
 				O.show_message(text("<span class='alertalien'>[src] begins to twist and contort!</span>"), 1)
 			var/mob/living/carbon/alien/humanoid/queen/new_xeno = new (loc)
 			mind.transfer_to(new_xeno)
+			new_xeno.color = color
 			qdel(src)
 		else
 			src << "<span class='notice'>We already have an alive queen.</span>"

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -66,7 +66,9 @@
 		adjustToxLoss(-75)
 		for(var/mob/O in viewers(src, null))
 			O.show_message(text("<span class='alertalien'>[src] has laid an egg!</span>"), 1)
-		new /obj/structure/alien/egg(loc)
+
+		var/obj/structure/alien/egg/E = new /obj/structure/alien/egg(get_turf(src))
+		E.color = color
 	return
 
 

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -44,6 +44,7 @@
 			if("Drone")
 				new_xeno = new /mob/living/carbon/alien/humanoid/drone(loc)
 		if(mind)	mind.transfer_to(new_xeno)
+		new_xeno.color = color
 		qdel(src)
 		return
 	else

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -112,6 +112,7 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 		var/mob/living/carbon/alien/larva/new_xeno = new(affected_mob.loc)
 		new_xeno.key = C.key
 		new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)	//To get the player's attention
+		new_xeno.color = color
 		if(gib_on_success)
 			affected_mob.gib()
 		if(istype(new_xeno.loc,/mob/living/carbon))

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -174,8 +174,8 @@ var/const/MAX_ACTIVE_TIME = 400
 		icon_state = "[initial(icon_state)]_impregnated"
 
 		if(!target.getlimb(/obj/item/organ/limb/robot/chest) && !(target.status_flags & XENO_HOST))
-			new /obj/item/alien_embryo(target)
-
+			var/obj/item/alien_embryo/AE = new /obj/item/alien_embryo(target)
+			AE.color = color
 
 		if(iscorgi(target))
 			var/mob/living/simple_animal/corgi/C = target


### PR DESCRIPTION
New event! Xeno nest wars, 2 opposing colours/strains of xenos are spawned with objectives to kill off the other's nest.

Only one of the two alien infestation events can ever happen naturally, The Current one or the Xeno nest war.

Possibilities:
Black vs. Red
Black vs. Yellow
Red vs Yellow
(These are the only canon colours so yeah)

When a queen lays an egg the egg take's the queen's colour, the facehugger take's the eggs, the embryo the hugger's the larva the embryo, etc. etc. to maintain the "strain"

Muh xeno fluff/canon:
Black xenos are xenos
Red xenos are from the books
Yellow xenos are from AvP Extinction
