### PR TITLE
Fixes spawned food not having any nutriment.

### DIFF
--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -76,6 +76,9 @@
 			if(!check_contents(R) || !check_tools(user, R))
 				return 0
 			var/atom/movable/I = new R.result (loc)
+			if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
+				var/obj/item/weapon/reagent_containers/food/snacks/S = I
+				S.create_reagents(S.volume)
 			var/list/parts = del_reqs(R, I)
 			for(var/A in parts)
 				if(istype(A, /obj/item))

--- a/code/modules/food&drinks/food/customizables.dm
+++ b/code/modules/food&drinks/food/customizables.dm
@@ -129,7 +129,8 @@
 	overlays += I
 
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice)
+/obj/item/weapon/reagent_containers/food/snacks/customizable/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice, reagents_per_slice)
+	..()
 	slice.name = "[customname] [initial(slice.name)]"
 	slice.filling_color = filling_color
 	slice.update_overlays(src)

--- a/code/modules/food&drinks/food/snacks.dm
+++ b/code/modules/food&drinks/food/snacks.dm
@@ -17,6 +17,7 @@
 	var/filling_color = "#FFFFFF" //color to use when added to custom food.
 	var/custom_food_type = null  //for food customizing. path of the custom food to create
 	var/junkiness = 0  //for junk food. used to lower human satiety.
+	var/list/bonus_reagents = list() //the amount of reagents (usually nutriment and vitamin) added to crafted/cooked snacks, on top of the ingredients reagents.
 
 
 	//Placeholder for effect that trigger on eating that aren't tied to reagents.
@@ -154,6 +155,12 @@
 		if(slice(sharpness, W, user))
 			return 1
 
+//Called when you finish tablecrafting a snack.
+/obj/item/weapon/reagent_containers/food/snacks/CheckParts()
+	if(bonus_reagents.len)
+		for(var/r_id in bonus_reagents)
+			var/amount = bonus_reagents[r_id]
+			reagents.add_reagent(r_id, amount)
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/slice(var/accuracy, obj/item/weapon/W, mob/user)
 	if((slices_num <= 0 || !slices_num) || !slice_path) //is the food sliceable?
@@ -186,11 +193,12 @@
 	var/reagents_per_slice = reagents.total_volume/slices_num
 	for(var/i=1 to (slices_num-slices_lost))
 		var/obj/item/weapon/reagent_containers/food/snacks/slice = new slice_path (loc)
-		initialize_slice(slice)
-		reagents.trans_to(slice,reagents_per_slice)
+		initialize_slice(slice, reagents_per_slice)
 	qdel(src)
 
-/obj/item/weapon/reagent_containers/food/snacks/proc/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice)
+/obj/item/weapon/reagent_containers/food/snacks/proc/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/slice, reagents_per_slice)
+	slice.create_reagents(slice.volume)
+	reagents.trans_to(slice,reagents_per_slice)
 	return
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/update_overlays(obj/item/weapon/reagent_containers/food/snacks/S)
@@ -204,9 +212,14 @@
 	overlays += I
 
 // initialize_cooked_food() is called when microwaving the food
-/obj/item/weapon/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+/obj/item/weapon/reagent_containers/food/snacks/proc/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency = 1)
+	S.create_reagents(S.volume)
 	if(reagents)
 		reagents.trans_to(S, reagents.total_volume)
+	if(S.bonus_reagents.len)
+		for(var/r_id in S.bonus_reagents)
+			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
+			S.reagents.add_reagent(r_id, amount)
 
 /obj/item/weapon/reagent_containers/food/snacks/Destroy()
 	if(contents)

--- a/code/modules/food&drinks/food/snacks/meat.dm
+++ b/code/modules/food&drinks/food/snacks/meat.dm
@@ -10,7 +10,8 @@
 	slices_num = 3
 	filling_color = "#FF0000"
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/slice)
+/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/slice, reagents_per_slice)
+	..()
 	var/image/I = new(icon, "rawcutlet_coloration")
 	I.color = filling_color
 	slice.overlays += I
@@ -18,7 +19,7 @@
 	slice.name = "raw [name] cutlet"
 	slice.meat_type = name
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+/obj/item/weapon/reagent_containers/food/snacks/meat/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency)
 	..()
 	S.name = "[name] steak"
 
@@ -32,7 +33,7 @@
 	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/meatsteak/plain/human
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human/slice)
+/obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human/slice, reagents_per_slice)
 	..()
 	if(subjectname)
 		slice.subjectname = subjectname
@@ -41,7 +42,7 @@
 		slice.subjectjob = subjectjob
 		slice.name = "raw [subjectjob] cutlet"
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+/obj/item/weapon/reagent_containers/food/snacks/meat/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency)
 	..()
 	if(subjectname)
 		S.name = "[subjectname] meatsteak"
@@ -170,7 +171,8 @@
 	name = "steak"
 	desc = "A piece of hot spicy meat."
 	icon_state = "meatsteak"
-	list_reagents = list("nutriment" = 2, "vitamin" = 1)
+	list_reagents = list("nutriment" = 5)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 1)
 	trash = /obj/item/trash/plate
 	filling_color = "#B22222"
 
@@ -198,10 +200,11 @@
 	icon_state = "rawcutlet"
 	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/cutlet/plain
 	bitesize = 2
+	list_reagents = list("nutriment" = 1)
 	filling_color = "#B22222"
 	var/meat_type = "meat"
 
-/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency)
 	..()
 	S.name = "[meat_type] cutlet"
 
@@ -213,7 +216,7 @@
 	var/subjectname = ""
 	var/subjectjob = null
 
-/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S)
+/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/plain/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency)
 	..()
 	if(subjectname)
 		S.name = "[subjectname] [initial(S.name)]"
@@ -236,7 +239,8 @@
 	desc = "A cooked meat cutlet."
 	icon_state = "cutlet"
 	bitesize = 2
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
 	filling_color = "#B22222"
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet/plain

--- a/code/modules/food&drinks/food/snacks_bread.dm
+++ b/code/modules/food&drinks/food/snacks_bread.dm
@@ -13,7 +13,8 @@
 	name = "bread"
 	desc = "Some plain old Earthen bread."
 	icon_state = "bread"
-	list_reagents = list("nutriment" = 7)
+	bonus_reagents = list("nutriment" = 7)
+	list_reagents = list("nutriment" = 10)
 	custom_food_type = /obj/item/weapon/reagent_containers/food/snacks/customizable/bread
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/plain
 
@@ -27,7 +28,8 @@
 	desc = "The culinary base of every self-respecting eloquen/tg/entleman."
 	icon_state = "meatbread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/meat
-	list_reagents = list("nutriment" = 5, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 10)
+	list_reagents = list("nutriment" = 30, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/meat
 	name = "meatbread slice"
@@ -39,33 +41,38 @@
 	desc = "The culinary base of every self-respecting eloquen/tg/entleman. Extra Heretical."
 	icon_state = "xenomeatbread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/xenomeat
-	list_reagents = list("nutriment" = 5, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 10)
+	list_reagents = list("nutriment" = 30, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/xenomeat
 	name = "xenomeatbread slice"
 	desc = "A slice of delicious meatbread. Extra Heretical."
 	icon_state = "xenobreadslice"
 	filling_color = "#32CD32"
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/bread/spidermeat
 	name = "spider meat loaf"
 	desc = "Reassuringly green meatloaf made from spider meat."
 	icon_state = "spidermeatbread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/spidermeat
-	list_reagents = list("nutriment" = 5, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 10)
+	list_reagents = list("nutriment" = 30, "toxin" = 15, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/spidermeat
 	name = "spider meat bread slice"
 	desc = "A slice of meatloaf made from an animal that most likely still wants you dead."
 	icon_state = "xenobreadslice"
 	filling_color = "#7CFC00"
+	list_reagents = list("nutriment" = 6, "toxin" = 3, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/bread/banana
 	name = "banana-nut bread"
 	desc = "A heavenly and filling treat."
 	icon_state = "bananabread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/banana
-	list_reagents = list("nutriment" = 5, "banana" = 20)
+	bonus_reagents = list("nutriment" = 5, "banana" = 20)
+	list_reagents = list("nutriment" = 20, "banana" = 20)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/banana
@@ -73,32 +80,37 @@
 	desc = "A slice of delicious banana bread."
 	icon_state = "bananabreadslice"
 	filling_color = "#FFD700"
+	list_reagents = list("nutriment" = 4, "banana" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/bread/tofu
 	name = "Tofubread"
 	desc = "Like meatbread but for vegetarians. Not guaranteed to give superpowers."
 	icon_state = "tofubread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/tofu
-	list_reagents = list("nutriment" = 5, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 10)
+	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/tofu
 	name = "tofubread slice"
 	desc = "A slice of delicious tofubread."
 	icon_state = "tofubreadslice"
 	filling_color = "#FF8C00"
+	list_reagents = list("nutriment" = 4, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/bread/creamcheese
 	name = "cream cheese bread"
 	desc = "Yum yum yum!"
 	icon_state = "creamcheesebread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice/creamcheese
-	list_reagents = list("nutriment" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/creamcheese
 	name = "cream cheese bread slice"
 	desc = "A slice of yum!"
 	icon_state = "creamcheesebreadslice"
 	filling_color = "#FF8C00"
+	list_reagents = list("nutriment" = 4, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice/custom
 	name = "bread slice"
@@ -109,6 +121,7 @@
 	name = "baguette"
 	desc = "Bon appetit!"
 	icon_state = "baguette"
-	list_reagents = list("nutriment" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	bitesize = 3
 	w_class = 3

--- a/code/modules/food&drinks/food/snacks_burgers.dm
+++ b/code/modules/food&drinks/food/snacks_burgers.dm
@@ -2,134 +2,139 @@
 /obj/item/weapon/reagent_containers/food/snacks/burger
 	filling_color = "#CD853F"
 	icon_state = "hburger"
+	bitesize = 3
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/plain
 	name = "burger"
 	desc = "The cornerstone of every nutritious breakfast."
-	list_reagents = list("vitamin" = 1)
-	bitesize = 3
+	bonus_reagents = list("vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/human
 	var/hname = ""
 	var/job = null
 	name = "-burger"
 	desc = "A bloody burger."
-	list_reagents = list("vitamin" = 4)
+	bonus_reagents = list("vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/appendix
 	name = "appendix burger"
 	desc = "Tastes like appendicitis."
-	list_reagents = list("nutriment" = 6, "vitamin" = 6)
+	bonus_reagents = list("nutriment" = 6, "vitamin" = 6)
 	icon_state = "appendixburger"
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/fish
 	name = "fillet -o- carp sandwich"
 	desc = "Almost like a carp is yelling somewhere... Give me back that fillet -o- carp, give me that carp."
 	icon_state = "fishburger"
-	list_reagents = list("nutriment" = 2, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/tofu
 	name = "tofu burger"
 	desc = "What.. is that meat?"
 	icon_state = "tofuburger"
-	list_reagents = list("nutriment" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/roburger
 	name = "roburger"
 	desc = "The lettuce is the only organic component. Beep."
 	icon_state = "roburger"
-	list_reagents = list("nutriment" = 2, "nanomachines" = 2, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 2, "nanomachines" = 2, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "nanomachines" = 5, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/roburgerbig
 	name = "roburger"
 	desc = "This massive patty looks like poison. Beep."
 	icon_state = "roburger"
 	volume = 120
-	list_reagents = list("nutriment" = 5, "nanomachines" = 70, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "nanomachines" = 70, "vitamin" = 10)
+	list_reagents = list("nutriment" = 6, "nanomachines" = 70, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/xeno
 	name = "xenoburger"
 	desc = "Smells caustic. Tastes like heresy."
 	icon_state = "xburger"
-	list_reagents = list("nutriment" = 2, "vitamin" = 6)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/clown
 	name = "clown burger"
 	desc = "This tastes funny..."
 	icon_state = "clownburger"
-	list_reagents = list("nutriment" = 4, "vitamin" = 6, "banana" = 6)
+	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "banana" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/mime
 	name = "mime burger"
 	desc = "Its taste defies language."
 	icon_state = "mimeburger"
-	list_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6)
+	bonus_reagents = list("nutriment" = 4, "vitamin" = 6, "nothing" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/brain
 	name = "brainburger"
 	desc = "A strange looking burger. It looks almost sentient."
 	icon_state = "brainburger"
-	list_reagents = list("nutriment" = 6, "mannitol" = 6, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 6, "mannitol" = 6, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "mannitol" = 5, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/ghost
 	name = "ghost burger"
 	desc = "Too Spooky!"
 	alpha = 125
-	list_reagents = list("nutriment" = 5, "vitamin" = 12)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/red
 	name = "red burger"
 	desc = "Perfect for hiding the fact it's burnt to a crisp."
 	icon_state = "cburger"
 	color = "#DA0000FF"
-	list_reagents = list("redcrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("redcrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/orange
 	name = "orange burger"
 	desc = "Contains 0% juice."
 	icon_state = "cburger"
 	color = "#FF9300FF"
-	list_reagents = list("orangecrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("orangecrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/yellow
 	name = "yellow burger"
 	desc = "Bright to the last bite."
 	icon_state = "cburger"
 	color = "#FFF200FF"
-	list_reagents = list("yellowcrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("yellowcrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/green
 	name = "green burger"
 	desc = "It's not tainted meat, it's painted meat!"
 	icon_state = "cburger"
 	color = "#A8E61DFF"
-	list_reagents = list("greencrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("greencrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/blue
 	name = "blue burger"
 	desc = "Is this blue rare?"
 	icon_state = "cburger"
 	color = "#00B7EFFF"
-	list_reagents = list("bluecrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("bluecrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/purple
 	name = "purple burger"
 	desc = "Regal and low class at the same time."
 	icon_state = "cburger"
 	color = "#DA00FFFF"
-	list_reagents = list("purplecrayonpowder" = 10, "vitamin" = 5)
+	bonus_reagents = list("purplecrayonpowder" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/spell
 	name = "spell burger"
 	desc = "This is absolutely Ei Nath."
 	icon_state = "spellburger"
-	list_reagents = list("nutriment" = 6, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 6, "vitamin" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/bigbite
 	name = "big bite burger"
 	desc = "Forget the Big Mac. THIS is the future!"
 	icon_state = "bigbiteburger"
-	list_reagents = list("vitamin" = 6)
+	bonus_reagents = list("vitamin" = 6)
+	list_reagents = list("nutriment" = 10, "vitamin" = 2)
 	w_class = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/jelly
@@ -138,15 +143,18 @@
 	icon_state = "jellyburger"
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/jelly/slime
-	list_reagents = list("slimejelly" = 5, "vitamin" = 5)
+	bonus_reagents = list("slimejelly" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "slimejelly" = 5, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/jelly/cherry
-	list_reagents = list("cherryjelly" = 5, "vitamin" = 5)
+	bonus_reagents = list("cherryjelly" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "cherryjelly" = 5, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/superbite
 	name = "super bite burger"
 	desc = "This is a mountain of a burger. FOOD!"
 	icon_state = "superbiteburger"
-	list_reagents = list("vitamin" = 10)
+	bonus_reagents = list("vitamin" = 10)
+	list_reagents = list("nutriment" = 40, "vitamin" = 5)
 	w_class = 3
 	volume = 80

--- a/code/modules/food&drinks/food/snacks_cake.dm
+++ b/code/modules/food&drinks/food/snacks_cake.dm
@@ -3,17 +3,18 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain
 	slices_num = 5
 	bitesize = 3
+	list_reagents = list("nutriment" = 20, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice
 	trash = /obj/item/trash/plate
-	bitesize = 3
+	list_reagents = list("nutriment" = 4, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/cake/plain
 	name = "vanilla cake"
 	desc = "A plain cake, not a lie."
 	icon_state = "plaincake"
 	custom_food_type = /obj/item/weapon/reagent_containers/food/snacks/customizable/cake
-	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 10, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/plain
 	name = "vanilla cake slice"
@@ -27,13 +28,15 @@
 	icon_state = "carrotcake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/carrot
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "oculine" = 5, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "oculine" = 5, "vitamin" = 10)
+	list_reagents = list("nutriment" = 20, "oculine" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/carrot
 	name = "carrot cake slice"
 	desc = "Carrotty slice of Carrot Cake, carrots are good for your eyes! Also not a lie."
 	icon_state = "carrotcake_slice"
 	filling_color = "#FFA500"
+	list_reagents = list("nutriment" = 4, "oculine" = 2, "vitamin" = 1)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/store/cake/brain
@@ -42,7 +45,8 @@
 	icon_state = "braincake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/brain
 	slices_num = 5
-	list_reagents = list("nutriment" = 5, "mannitol" = 10, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 5, "mannitol" = 10, "vitamin" = 10)
+	list_reagents = list("nutriment" = 20, "mannitol" = 10, "vitamin" = 5)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/brain
@@ -50,6 +54,7 @@
 	desc = "Lemme tell you something about prions. THEY'RE DELICIOUS."
 	icon_state = "braincakeslice"
 	filling_color = "#FF69B4"
+	list_reagents = list("nutriment" = 4, "mannitol" = 2, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/store/cake/cheese
 	name = "cheese cake"
@@ -57,7 +62,7 @@
 	icon_state = "cheesecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/cheese
 	slices_num = 5
-	list_reagents = list("vitamin" = 10)
+	bonus_reagents = list("vitamin" = 10)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/cheese
@@ -73,7 +78,7 @@
 	icon_state = "orangecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/orange
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "vitamin" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/orange
 	name = "orange cake slice"
@@ -87,7 +92,7 @@
 	icon_state = "limecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/lime
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "vitamin" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/lime
 	name = "lime cake slice"
@@ -102,7 +107,7 @@
 	icon_state = "lemoncake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/lemon
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "vitamin" = 10)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/lemon
@@ -118,7 +123,7 @@
 	icon_state = "chocolatecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/chocolate
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "vitamin" = 10)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/chocolate
@@ -134,13 +139,15 @@
 	icon_state = "birthdaycake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/birthday
 	slices_num = 5
-	list_reagents = list("nutriment" = 7, "sprinkles" = 10, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 7, "sprinkles" = 10, "vitamin" = 5)
+	list_reagents = list("nutriment" = 20, "sprinkles" = 10, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/birthday
 	name = "birthday cake slice"
 	desc = "A slice of your birthday."
 	icon_state = "birthdaycakeslice"
 	filling_color = "#DC143C"
+	list_reagents = list("nutriment" = 4, "sprinkles" = 2, "vitamin" = 1)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/store/cake/apple
@@ -149,7 +156,7 @@
 	icon_state = "applecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/apple
 	slices_num = 5
-	list_reagents = list("nutriment" = 3, "vitamin" = 10)
+	bonus_reagents = list("nutriment" = 3, "vitamin" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/apple
 	name = "apple cake slice"
@@ -168,7 +175,7 @@
 	icon_state = "slimecake"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cakeslice/slimecake
 	slices_num = 5
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/cakeslice/slimecake
 	name = "Slime cake slice"

--- a/code/modules/food&drinks/food/snacks_egg.dm
+++ b/code/modules/food&drinks/food/snacks_egg.dm
@@ -5,7 +5,8 @@
 	name = "chocolate egg"
 	desc = "Such, sweet, fattening food."
 	icon_state = "chocolateegg"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 4, "sugar" = 2, "cocoa" = 2)
 	filling_color = "#A0522D"
 
 /obj/item/weapon/reagent_containers/food/snacks/egg
@@ -73,23 +74,26 @@
 	name = "fried egg"
 	desc = "A fried egg, with a touch of salt and pepper."
 	icon_state = "friedegg"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
 	bitesize = 1
 	filling_color = "#FFFFF0"
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledegg
 	name = "boiled egg"
 	desc = "A hard boiled egg."
 	icon_state = "egg"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
 	filling_color = "#FFFFF0"
+	list_reagents = list("nutriment" = 2, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/omelette	//FUCK THIS
 	name = "omelette du fromage"
 	desc = "That's all you can say!"
 	icon_state = "omelette"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 8, "vitamin" = 1)
 	bitesize = 1
 	w_class = 3
 
@@ -113,6 +117,7 @@
 	name = "eggs benedict"
 	desc = "There is only one egg on this, how rude."
 	icon_state = "benedict"
-	list_reagents = list("vitamin" = 4)
+	bonus_reagents = list("vitamin" = 4)
 	trash = /obj/item/trash/plate
 	w_class = 3
+	list_reagents = list("nutriment" = 6, "vitamin" = 4)

--- a/code/modules/food&drinks/food/snacks_meat.dm
+++ b/code/modules/food&drinks/food/snacks_meat.dm
@@ -8,15 +8,16 @@
 	desc = "A grifftastic sandwich that burns your tongue and then leaves it numb!"
 	icon_state = "cubancarp"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
 	bitesize = 3
 	filling_color = "#CD853F"
+	list_reagents = list("nutriment" = 6, "capsaicin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/carpmeat
 	name = "carp fillet"
 	desc = "A fillet of spess carp meat."
 	icon_state = "fishfillet"
-	list_reagents = list("nutriment" = 2, "carpotoxin" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "carpotoxin" = 2, "vitamin" = 2)
 	bitesize = 6
 	filling_color = "#FA8072"
 
@@ -32,7 +33,8 @@
 	name = "fish fingers"
 	desc = "A finger of fish."
 	icon_state = "fishfingers"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 4)
 	bitesize = 1
 	filling_color = "#CD853F"
 
@@ -40,7 +42,8 @@
 	name = "fish and chips"
 	desc = "I do say so myself chap."
 	icon_state = "fishandchips"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6)
 	filling_color = "#FA8072"
 
 ////////////////////////////////////////////MEATS AND ALIKE////////////////////////////////////////////
@@ -65,7 +68,8 @@
 	desc = "Now you can feel like a real tourist vacationing in Ireland."
 	icon_state = "cornedbeef"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/faggot
 	name = "faggot"
@@ -79,6 +83,8 @@
 	desc = "A piece of mixed, long meat."
 	icon_state = "sausage"
 	filling_color = "#CD5C5C"
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sausage/New()
 	..()
@@ -89,27 +95,29 @@
 	desc = "A savory dish of alien wing wang in soy."
 	icon_state = "wingfangchu"
 	trash = /obj/item/weapon/reagent_containers/glass/bowl
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/kebab
 	trash = /obj/item/stack/rods
 	icon_state = "kebab"
 	w_class = 3
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/kebab/human
 	name = "human-kebab"
 	desc = "A human meat, on a stick."
-	list_reagents = list("nutriment" = 1, "vitamin" = 6)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/kebab/monkey
 	name = "meat-kebab"
 	desc = "Delicious meat, on a stick."
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/kebab/tofu
 	name = "tofu-kebab"
 	desc = "Vegan meat, on a stick."
-	list_reagents = list("nutriment" = 1)
+	bonus_reagents = list("nutriment" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 	name = "monkey cube"
@@ -153,16 +161,18 @@
 	name = "enchiladas"
 	desc = "Viva La Mexico!"
 	icon_state = "enchiladas"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
 	bitesize = 4
 	filling_color = "#FFA07A"
+	list_reagents = list("nutriment" = 8, "capsaicin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat
 	name = "stewed soy meat"
 	desc = "Even non-vegetarians will LOVE this!"
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1)
+	bonus_reagents = list("nutriment" = 1)
+	list_reagents = list("nutriment" = 8)
 	filling_color = "#D2691E"
 
 /obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat/New()
@@ -174,7 +184,8 @@
 	desc = "A giant spider's leg that's still twitching after being cooked. Gross!"
 	icon_state = "spiderlegcooked"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "capsaicin" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "capsaicin" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 3, "capsaicin" = 2)
 	filling_color = "#000000"
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggsham
@@ -182,7 +193,8 @@
 	desc = "Would you eat them on a train? Would you eat them on a plane? Would you eat them on a state of the art corporate deathtrap floating through space?"
 	icon_state = "spidereggsham"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
+	list_reagents = list("nutriment" = 6)
 	bitesize = 4
 	filling_color = "#7FFF00"
 
@@ -190,5 +202,6 @@
 	name = "carp sashimi"
 	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself."
 	icon_state = "sashimi"
-	list_reagents = list("nutriment" = 1, "capsaicin" = 4, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "capsaicin" = 4, "vitamin" = 4)
+	list_reagents = list("nutriment" = 6, "capsaicin" = 5)
 	filling_color = "#FA8072"

--- a/code/modules/food&drinks/food/snacks_other.dm
+++ b/code/modules/food&drinks/food/snacks_other.dm
@@ -15,6 +15,7 @@
 	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
 	icon_state = "cheesewedge"
 	filling_color = "#FFD700"
+	list_reagents = list("nutriment" = 3, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/watermelonslice
 	name = "watermelon slice"
@@ -78,7 +79,8 @@
 	name = "loaded baked potato"
 	desc = "Totally baked."
 	icon_state = "loadedbakedpotato"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6)
 	filling_color = "#D2B48C"
 
 /obj/item/weapon/reagent_containers/food/snacks/fries
@@ -102,7 +104,8 @@
 	desc = "Fries. Covered in cheese. Duh."
 	icon_state = "cheesyfries"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6)
 	filling_color = "#FFD700"
 
 /obj/item/weapon/reagent_containers/food/snacks/badrecipe
@@ -125,7 +128,8 @@
 	desc = "An apple coated in sugary sweetness."
 	icon_state = "candiedapple"
 	bitesize = 3
-	list_reagents = list("nutriment" = 2, "sugar" = 3)
+	bonus_reagents = list("nutriment" = 2, "sugar" = 3)
+	list_reagents = list("nutriment" = 3, "sugar" = 2)
 	filling_color = "#FF4500"
 
 /obj/item/weapon/reagent_containers/food/snacks/mint
@@ -141,14 +145,16 @@
 	name = "egg wrap"
 	desc = "The precursor to Pigs in a Blanket."
 	icon_state = "wrap"
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
+	list_reagents = list("nutriment" = 5)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/beans
 	name = "tin of beans"
 	desc = "Musical fruit in a slightly less musical container."
 	icon_state = "beans"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 10)
 	filling_color = "#B22222"
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggs
@@ -162,14 +168,16 @@
 	name = "chocolate coin"
 	desc = "A completely edible but nonflippable festive coin."
 	icon_state = "chococoin"
-	list_reagents = list("nutriment" = 1, "sugar" = 1)
+	bonus_reagents = list("nutriment" = 1, "sugar" = 1)
+	list_reagents = list("nutriment" = 3, "cocoa" = 1)
 	filling_color = "#A0522D"
 
 /obj/item/weapon/reagent_containers/food/snacks/chocoorange
 	name = "chocolate orange"
 	desc = "A festive chocolate orange"
 	icon_state = "chocoorange"
-	list_reagents = list("nutriment" = 1, "sugar" = 1)
+	bonus_reagents = list("nutriment" = 1, "sugar" = 1)
+	list_reagents = list("nutriment" = 3, "sugar" = 1)
 	filling_color = "#A0522D"
 
 /obj/item/weapon/reagent_containers/food/snacks/eggplantparm
@@ -177,5 +185,6 @@
 	desc = "The only good recipe for eggplant."
 	icon_state = "eggplantparm"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
+	list_reagents = list("nutriment" = 6, "vitamin" = 2)
 	filling_color = "#BA55D3"

--- a/code/modules/food&drinks/food/snacks_pastry.dm
+++ b/code/modules/food&drinks/food/snacks_pastry.dm
@@ -7,7 +7,8 @@
 	desc = "Goes great with Robust Coffee."
 	icon_state = "donut1"
 	bitesize = 5
-	list_reagents = list("sugar" = 1)
+	bonus_reagents = list("sugar" = 1)
+	list_reagents = list("nutriment" = 3, "sugar" = 2)
 	var/extra_reagent = null
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/New()
@@ -16,6 +17,7 @@
 		icon_state = "donut2"
 		name = "frosted donut"
 		reagents.add_reagent("sprinkles", 2)
+		bonus_reagents = list("sprinkles" = 2, "sugar" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/chaos
 	name = "chaos donut"
@@ -26,25 +28,29 @@
 	..()
 	extra_reagent = pick("nutriment", "capsaicin", "frostoil", "krokodil", "plasma", "cocoa", "slimejelly", "banana", "berryjuice", "omnizine")
 	reagents.add_reagent("[extra_reagent]", 3)
+	bonus_reagents = list("[extra_reagent]" = 3, "sugar" = 1)
 	if(prob(30))
 		icon_state = "donut2"
 		name = "frosted chaos donut"
 		reagents.add_reagent("sprinkles", 2)
+		bonus_reagents = list("sprinkles" = 2, "[extra_reagent]" = 3, "sugar" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly
 	name = "jelly donut"
 	desc = "You jelly?"
 	icon_state = "jdonut1"
-	list_reagents = list("sugar" = 1, "vitamin" = 1)
+	bonus_reagents = list("sugar" = 1, "vitamin" = 1)
 	extra_reagent = "berryjuice"
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly/New()
 	..()
-	reagents.add_reagent("[extra_reagent]", 5)
+	if(extra_reagent)
+		reagents.add_reagent("[extra_reagent]", 3)
 	if(prob(30))
 		icon_state = "jdonut2"
 		name = "frosted jelly Donut"
 		reagents.add_reagent("sprinkles", 2)
+		bonus_reagents = list("sprinkles" = 2, "sugar" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly/slimejelly
 	name = "jelly donut"
@@ -64,7 +70,8 @@
 	name = "muffin"
 	desc = "A delicious and spongy little cake."
 	icon_state = "muffin"
-	list_reagents = list("vitamin" = 1)
+	bonus_reagents = list("vitamin" = 1)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/muffin/berry
 	name = "berry muffin"
@@ -82,7 +89,8 @@
 	desc = "A legendary egg custard that makes friends out of enemies. Probably too hot for a cat to eat."
 	icon_state = "chawanmushi"
 	trash = /obj/item/weapon/reagent_containers/glass/bowl
-	list_reagents = list("vitamin" = 1)
+	bonus_reagents = list("vitamin" = 1)
+	list_reagents = list("nutriment" = 5)
 
 ////////////////////////////////////////////WAFFLES////////////////////////////////////////////
 
@@ -91,7 +99,8 @@
 	desc = "Mmm, waffles."
 	icon_state = "waffles"
 	trash = /obj/item/trash/waffles
-	list_reagents = list("vitamin" = 1)
+	bonus_reagents = list("vitamin" = 1)
+	list_reagents = list("nutriment" = 8, "vitamin" = 1)
 	filling_color = "#D2691E"
 
 /obj/item/weapon/reagent_containers/food/snacks/soylentgreen
@@ -99,7 +108,8 @@
 	desc = "Not made of people. Honest." //Totally people.
 	icon_state = "soylent_green"
 	trash = /obj/item/trash/waffles
-	list_reagents = list("vitamin" = 1)
+	bonus_reagents = list("vitamin" = 1)
+	list_reagents = list("nutriment" = 10, "vitamin" = 1)
 	filling_color = "#9ACD32"
 
 /obj/item/weapon/reagent_containers/food/snacks/soylenviridians
@@ -107,7 +117,8 @@
 	desc = "Not made of people. Honest." //Actually honest for once.
 	icon_state = "soylent_yellow"
 	trash = /obj/item/trash/waffles
-	list_reagents = list("vitamin" = 1)
+	bonus_reagents = list("vitamin" = 1)
+	list_reagents = list("nutriment" = 10, "vitamin" = 1)
 	filling_color = "#9ACD32"
 
 /obj/item/weapon/reagent_containers/food/snacks/rofflewaffles
@@ -116,7 +127,8 @@
 	icon_state = "rofflewaffles"
 	trash = /obj/item/trash/waffles
 	bitesize = 4
-	list_reagents = list("vitamin" = 2)
+	bonus_reagents = list("vitamin" = 2)
+	list_reagents = list("nutriment" = 8, "mushroomhallucinogen" = 2, "vitamin" = 2)
 	filling_color = "#00BFFF"
 
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
@@ -126,7 +138,7 @@
 	desc = "COOKIE!!!"
 	icon_state = "COOKIE!!!"
 	bitesize = 1
-	list_reagents = list("nutriment" = 1)
+	bonus_reagents = list("nutriment" = 1)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket
@@ -140,27 +152,31 @@
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm
 	name = "\improper Warm Donk-pocket"
 	desc = "The heated food of choice for the seasoned traitor."
-	list_reagents = list("omnizine" = 4)
+	bonus_reagents = list("omnizine" = 3)
+	list_reagents = list("nutriment" = 4, "omnizine" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/fortunecookie
 	name = "fortune cookie"
 	desc = "A true prophecy in each cookie!"
 	icon_state = "fortune_cookie"
-	list_reagents = list("nutriment" = 2)
+	bonus_reagents = list("nutriment" = 2)
+	list_reagents = list("nutriment" = 3)
 	filling_color = "#F4A460"
 
 /obj/item/weapon/reagent_containers/food/snacks/poppypretzel
 	name = "poppy pretzel"
 	desc = "It's all twisted up!"
 	icon_state = "poppypretzel"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 5)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit
 	name = "plump helmet biscuit"
 	desc = "This is a finely-prepared plump helmet biscuit. The ingredients are exceptionally minced plump helmet, and well-minced dwarven wheat flour."
 	icon_state = "phelmbiscuit"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 5)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit/New()
@@ -169,12 +185,14 @@
 		name = "exceptional plump helmet biscuit"
 		desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump helmet biscuit!"
 		reagents.add_reagent("omnizine", 5)
+		bonus_reagents = list("omnizine" = 5, "nutriment" = 1, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/cracker
 	name = "cracker"
 	desc = "It's a salted cracker."
 	icon_state = "cracker"
 	bitesize = 1
+	bonus_reagents = list("nutriment" = 1)
 	list_reagents = list("nutriment" = 1)
 	filling_color = "#F0E68C"
 
@@ -183,26 +201,30 @@
 	desc = "Fresh footlong ready to go down on."
 	icon_state = "hotdog"
 	bitesize = 3
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
+	list_reagents = list("nutriment" = 6, "ketchup" = 3, "vitamin" = 3)
 	filling_color = "#8B0000"
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbun
 	name = "meat bun"
 	desc = "Has the potential to not be Dog."
 	icon_state = "meatbun"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6, "vitamin" = 2)
 	filling_color = "#8B0000"
 
 /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
 	name = "sugar cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "sugarcookie"
-	list_reagents = list("nutriment" = 1, "sugar" = 3)
+	bonus_reagents = list("nutriment" = 1, "sugar" = 3)
+	list_reagents = list("nutriment" = 3, "sugar" = 3)
 	filling_color = "#CD853F"
 
 /obj/item/weapon/reagent_containers/food/snacks/chococornet
 	name = "chocolate cornet"
 	desc = "Which side's the head, the fat end or the thin end?"
 	icon_state = "chococornet"
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 5, "vitamin" = 1)
 	filling_color = "#FFE4C4"

--- a/code/modules/food&drinks/food/snacks_pastry.dm
+++ b/code/modules/food&drinks/food/snacks_pastry.dm
@@ -10,6 +10,7 @@
 	bonus_reagents = list("sugar" = 1)
 	list_reagents = list("nutriment" = 3, "sugar" = 2)
 	var/extra_reagent = null
+	filling_color = "#D2691E"
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/New()
 	..()
@@ -18,6 +19,7 @@
 		name = "frosted donut"
 		reagents.add_reagent("sprinkles", 2)
 		bonus_reagents = list("sprinkles" = 2, "sugar" = 1)
+		filling_color = "#FF69B4"
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/chaos
 	name = "chaos donut"
@@ -34,6 +36,7 @@
 		name = "frosted chaos donut"
 		reagents.add_reagent("sprinkles", 2)
 		bonus_reagents = list("sprinkles" = 2, "[extra_reagent]" = 3, "sugar" = 1)
+		filling_color = "#FF69B4"
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly
 	name = "jelly donut"
@@ -51,6 +54,7 @@
 		name = "frosted jelly Donut"
 		reagents.add_reagent("sprinkles", 2)
 		bonus_reagents = list("sprinkles" = 2, "sugar" = 1)
+		filling_color = "#FF69B4"
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly/slimejelly
 	name = "jelly donut"
@@ -72,6 +76,7 @@
 	icon_state = "muffin"
 	bonus_reagents = list("vitamin" = 1)
 	list_reagents = list("nutriment" = 6)
+	filling_color = "#F4A460"
 
 /obj/item/weapon/reagent_containers/food/snacks/muffin/berry
 	name = "berry muffin"
@@ -91,6 +96,7 @@
 	trash = /obj/item/weapon/reagent_containers/glass/bowl
 	bonus_reagents = list("vitamin" = 1)
 	list_reagents = list("nutriment" = 5)
+	filling_color = "#FFE4E1"
 
 ////////////////////////////////////////////WAFFLES////////////////////////////////////////////
 

--- a/code/modules/food&drinks/food/snacks_pie.dm
+++ b/code/modules/food&drinks/food/snacks_pie.dm
@@ -3,20 +3,22 @@
 	trash = /obj/item/trash/plate
 	bitesize = 3
 	w_class = 3
+	list_reagents = list("nutriment" = 10, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/plain
 	name = "plain pie"
 	desc = "A simple pie, still delicious."
 	icon_state = "pie"
 	custom_food_type = /obj/item/weapon/reagent_containers/food/snacks/customizable/pie
-	list_reagents = list("nutriment" = 8, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 8, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/cream
 	name = "banana cream pie"
 	desc = "Just like back home, on clown planet! HONK!"
 	icon_state = "pie"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 6, "banana" = 5, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/cream/throw_impact(atom/hit_atom)
 	..()
@@ -29,22 +31,22 @@
 	name = "berry clafoutis"
 	desc = "No black birds, this is a good sign."
 	icon_state = "berryclafoutis"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 10, "berryjuice" = 5, "vitamin" = 2)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/meatpie
 	name = "meat-pie"
 	icon_state = "meatpie"
 	desc = "An old barber recipe, very delicious!"
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/tofupie
 	name = "tofu-pie"
 	icon_state = "meatpie"
 	desc = "A delicious tofu pie."
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
-
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/amanita_pie
@@ -52,14 +54,15 @@
 	desc = "Sweet and tasty poison pie."
 	icon_state = "amanita_pie"
 	bitesize = 4
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
+	list_reagents = list("nutriment" = 6, "amatoxin" = 3, "mushroomhallucinogen" = 1, "vitamin" = 4)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/plump_pie
 	name = "plump pie"
 	desc = "I bet you love stuff made out of plump helmets!"
 	icon_state = "plump_pie"
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/plump_pie/New()
 	..()
@@ -67,6 +70,7 @@
 		name = "exceptional plump pie"
 		desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump pie!"
 		reagents.add_reagent("omnizine", 5)
+		bonus_reagents = list("nutriment" = 1, "omnizine" = 5, "vitamin" = 4)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/xemeatpie
@@ -74,15 +78,14 @@
 	icon_state = "xenomeatpie"
 	desc = "A delicious meatpie. Probably heretical."
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
-
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/applepie
 	name = "apple pie"
 	desc = "A pie containing sweet sweet love...or apple."
 	icon_state = "applepie"
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
 
 
 
@@ -90,7 +93,7 @@
 	name = "cherry pie"
 	desc = "Taste so good, make a grown man cry."
 	icon_state = "cherrypie"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/pumpkinpie
@@ -99,16 +102,18 @@
 	icon_state = "pumpkinpie"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pumpkinpieslice
 	slices_num = 5
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pumpkinpieslice
 	name = "pumpkin pie slice"
 	desc = "A slice of pumpkin pie, with whipped cream on top. Perfection."
 	icon_state = "pumpkinpieslice"
 	trash = /obj/item/trash/plate
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/appletart
 	name = "golden apple streusel tart"
 	desc = "A tasty dessert that won't make it through a metal detector."
 	icon_state = "gappletart"
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
+	list_reagents = list("nutriment" = 8, "gold" = 5, "vitamin" = 4)

--- a/code/modules/food&drinks/food/snacks_pizza.dm
+++ b/code/modules/food&drinks/food/snacks_pizza.dm
@@ -5,15 +5,17 @@
 	w_class = 3
 	slices_num = 6
 
+/obj/item/weapon/reagent_containers/food/snacks/pizzaslice
+	list_reagents = list("nutriment" = 5)
+
 /obj/item/weapon/reagent_containers/food/snacks/pizza/margherita
 	name = "margherita"
 	desc = "The most cheezy pizza in galaxy."
 	icon_state = "pizzamargherita"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/margherita
 	slices_num = 6
-	list_reagents = list("nutriment" = 5, "vitamin" = 5)
-
-
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/margherita
 	name = "margherita slice"
@@ -27,7 +29,8 @@
 	icon_state = "meatpizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/meatpizza
 	slices_num = 6
-	list_reagents = list("nutriment" = 5, "vitamin" = 8)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 8)
+	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/meatpizza
 	name = "meatpizza slice"
@@ -41,7 +44,8 @@
 	icon_state = "mushroompizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/mushroompizza
 	slices_num = 6
-	list_reagents = list("nutriment" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 30, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/mushroompizza
 	name = "mushroom pizza slice"
@@ -55,7 +59,8 @@
 	icon_state = "vegetablepizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/vegetablepizza
 	slices_num = 6
-	list_reagents = list("nutriment" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 25, "tomatojuice" = 6, "oculine" = 12, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/vegetablepizza
 	name = "vegetable pizza slice"
@@ -226,28 +231,20 @@
 
 /obj/item/pizzabox/margherita/New()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/pizza/margherita(src)
-	pizza.reagents.add_reagent("nutriment", 25)
-	pizza.reagents.add_reagent("tomatojuice", 6)
 	boxtag = "Margherita Deluxe"
 	update_icon()
 
 /obj/item/pizzabox/vegetable/New()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/pizza/vegetablepizza(src)
-	pizza.reagents.add_reagent("nutriment", 20)
-	pizza.reagents.add_reagent("tomatojuice", 6)
-	pizza.reagents.add_reagent("oculine", 12)
 	boxtag = "Gourmet Vegatable"
 	update_icon()
 
 /obj/item/pizzabox/mushroom/New()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/pizza/mushroompizza(src)
-	pizza.reagents.add_reagent("nutriment", 25)
 	boxtag = "Mushroom Special"
 	update_icon()
 
 /obj/item/pizzabox/meat/New()
 	pizza = new /obj/item/weapon/reagent_containers/food/snacks/pizza/meatpizza(src)
-	pizza.reagents.add_reagent("nutriment", 25)
-	pizza.reagents.add_reagent("tomatojuice", 6)
 	boxtag = "Meatlover's Supreme"
 	update_icon()

--- a/code/modules/food&drinks/food/snacks_salad.dm
+++ b/code/modules/food&drinks/food/snacks_salad.dm
@@ -13,16 +13,19 @@
 	name = "\improper Aesir salad"
 	desc = "Probably too incredible for mortal men to fully enjoy."
 	icon_state = "aesirsalad"
-	list_reagents = list("omnizine" = 8, "vitamin" = 6)
+	bonus_reagents = list("omnizine" = 2, "vitamin" = 6)
+	list_reagents = list("nutriment" = 8, "omnizine" = 8, "vitamin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/salad/herbsalad
 	name = "herb salad"
 	desc = "A tasty salad with apples on top."
 	icon_state = "herbsalad"
-	list_reagents = list("vitamin" = 4)
+	bonus_reagents = list("vitamin" = 4)
+	list_reagents = list("nutriment" = 8, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/salad/validsalad
 	name = "valid salad"
 	desc = "It's just an herb salad with meatballs and fried potato slices. Nothing suspicious about it."
 	icon_state = "validsalad"
-	list_reagents = list("doctorsdelight" = 5, "vitamin" = 4)
+	bonus_reagents = list("doctorsdelight" = 5, "vitamin" = 4)
+	list_reagents = list("nutriment" = 8, "doctorsdelight" = 5, "vitamin" = 2)

--- a/code/modules/food&drinks/food/snacks_sandwichtoast.dm
+++ b/code/modules/food&drinks/food/snacks_sandwichtoast.dm
@@ -4,7 +4,8 @@
 	desc = "A grand creation of meat, cheese, bread, and several leaves of lettuce! Arthur Dent would be proud."
 	icon_state = "sandwich"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 	cooked_type = /obj/item/weapon/reagent_containers/food/snacks/toastedsandwich
 
 /obj/item/weapon/reagent_containers/food/snacks/toastedsandwich
@@ -12,14 +13,16 @@
 	desc = "Now if you only had a pepper bar."
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "carbon" = 2)
+	bonus_reagents = list("nutriment" = 1, "carbon" = 2)
+	list_reagents = list("nutriment" = 6, "carbon" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese
 	name = "grilled cheese sandwich"
 	desc = "Goes great with Tomato soup!"
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 1)
+	list_reagents = list("nutriment" = 7, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich
 	name = "jelly sandwich"
@@ -29,23 +32,27 @@
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
-	list_reagents = list("slimejelly" = 5, "vitamin" = 2)
+	bonus_reagents = list("slimejelly" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 2, "slimejelly" = 5, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/cherry
-	list_reagents = list("cherryjelly" = 5, "vitamin" = 2)
+	bonus_reagents = list("cherryjelly" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 2, "cherryjelly" = 5, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich
 	name = "icecream sandwich"
 	desc = "Portable Ice-cream in it's own packaging."
 	icon_state = "icecreamsandwich"
-	list_reagents = list("nutriment" = 1, "ice" = 2)
+	bonus_reagents = list("nutriment" = 1, "ice" = 2)
+	list_reagents = list("nutriment" = 2, "ice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 	name = "not-a-sandwich"
 	desc = "Something seems to be wrong with this, you can't quite figure what. Maybe it's his moustache."
 	icon_state = "notasandwich"
 	trash = /obj/item/trash/plate
-	list_reagents = list("vitamin" = 6)
+	bonus_reagents = list("vitamin" = 6)
+	list_reagents = list("nutriment" = 6, "vitamin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast
 	name = "jellied toast"
@@ -55,13 +62,16 @@
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast/cherry
-	list_reagents = list("cherryjelly" = 5, "vitamin" = 2)
+	bonus_reagents = list("cherryjelly" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 1, "cherryjelly" = 5, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast/slime
-	list_reagents = list("slimejelly" = 5, "vitamin" = 2)
+	bonus_reagents = list("slimejelly" = 5, "vitamin" = 2)
+	list_reagents = list("nutriment" = 1, "slimejelly" = 5, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/twobread
 	name = "two bread"
 	desc = "This seems awfully bitter."
 	icon_state = "twobread"
-	list_reagents = list("nutriment" = 1, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 2)
+	list_reagents = list("nutriment" = 2, "vitamin" = 2)

--- a/code/modules/food&drinks/food/snacks_soup.dm
+++ b/code/modules/food&drinks/food/snacks_soup.dm
@@ -2,6 +2,7 @@
 	w_class = 3
 	trash = /obj/item/weapon/reagent_containers/glass/bowl
 	bitesize = 5
+	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/New()
 	..()
@@ -11,7 +12,7 @@
 	name = "wish soup"
 	desc = "I wish this was soup."
 	icon_state = "wishsoup"
-	list_reagents = list("water" = 1)
+	list_reagents = list("water" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/wish/New()
 	..()
@@ -19,98 +20,107 @@
 		desc = "A wish come true!"
 		reagents.add_reagent("nutriment", 9)
 		reagents.add_reagent("vitamin", 1)
-	else
-		reagents.add_reagent("water", 10)
+		bonus_reagents = list("nutriment" = 9, "vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/meatball
 	name = "meatball soup"
 	desc = "You've got balls kid, BALLS!"
 	icon_state = "meatballsoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/slime
 	name = "slime soup"
 	desc = "If no water is available, you may substitute tears."
 	icon_state = "slimesoup"
-	list_reagents = list("nutriment" = 1, "slimejelly" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "slimejelly" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 5, "slimejelly" = 5, "water" = 5, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/blood
 	name = "tomato soup"
 	desc = "Smells like copper."
 	icon_state = "tomatosoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 6)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 6)
+	list_reagents = list("nutriment" = 2, "blood" = 10, "water" = 5, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/clownstears
 	name = "clown's tears"
 	desc = "Not very funny."
 	icon_state = "clownstears"
-	list_reagents = list("nutriment" = 1, "banana" = 5, "vitamin" = 8)
+	bonus_reagents = list("nutriment" = 1, "banana" = 5, "vitamin" = 8)
+	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 5, "vitamin" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/vegetable
 	name = "vegetable soup"
 	desc = "A true vegan meal."
 	icon_state = "vegetablesoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/nettle
 	name = "nettle soup"
 	desc = "To think, the botanist would've beat you to death with one of these."
 	icon_state = "nettlesoup"
-	list_reagents = list("nutriment" = 1, "omnizine" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "omnizine" = 5, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/mystery
 	name = "mystery soup"
 	desc = "The mystery is, why aren't you eating it?"
 	icon_state = "mysterysoup"
-	list_reagents = list("nutriment" = 1, "tomatojuice" = 2)
 	var/extra_reagent = null
+	list_reagents = list("nutriment" = 6)
+
 /obj/item/weapon/reagent_containers/food/snacks/soup/mystery/New()
 	..()
-
 	extra_reagent = pick("capsaicin", "frostoil", "omnizine", "banana", "blood", "slimejelly", "toxin", "banana", "carbon", "oculine")
 	reagents.add_reagent("[extra_reagent]", 5)
+	bonus_reagents = list("[extra_reagent]" = 5, "nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/hotchili
 	name = "hot chili"
 	desc = "A five alarm Texan Chili!"
 	icon_state = "hotchili"
-	list_reagents = list("nutriment" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 5, "capsaicin" = 1, "tomatojuice" = 2, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/coldchili
 	name = "cold chili"
 	desc = "This slush is barely a liquid!"
 	icon_state = "coldchili"
-	list_reagents = list("nutriment" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	bonus_reagents = list("nutriment" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	list_reagents = list("nutriment" = 5, "frostoil" = 1, "tomatojuice" = 2, "vitamin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/monkeysdelight
 	name = "monkey's delight"
 	desc = "A delicious soup with dumplings and hunks of monkey meat simmered to perfection, in a broth that tastes faintly of bananas."
 	icon_state = "monkeysdelight"
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
+	list_reagents = list("nutriment" = 10, "banana" = 5, "vitamin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/tomato
 	name = "tomato soup"
 	desc = "Drinking this feels like being a vampire! A tomato vampire..."
 	icon_state = "tomatosoup"
-	list_reagents = list("nutriment" = 1, "tomatojuice" = 10, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "tomatojuice" = 10, "vitamin" = 3)
+	list_reagents = list("nutriment" = 5, "tomatojuice" = 10, "vitamin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/milo
 	name = "milosoup"
 	desc = "The universes best soup! Yum!!!"
 	icon_state = "milosoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 3)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/mushroom
 	name = "chantrelle soup"
 	desc = "A delicious and hearty mushroom soup."
 	icon_state = "mushroomsoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
+	list_reagents = list("nutriment" = 8, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/beet
 	name = "beet soup"
 	desc = "Wait, how do you spell it again..?"
 	icon_state = "beetsoup"
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
+	list_reagents = list("nutriment" = 8, "vitamin" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/beet/New()
 	..()
@@ -122,18 +132,21 @@
 	desc = "Jello gelatin, from Alfred Hubbard's cookbook."
 	icon_state = "spacylibertyduff"
 	bitesize = 3
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "mushroomhallucinogen" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/amanitajelly
 	name = "amanita jelly"
 	desc = "Looks curiously toxic."
 	icon_state = "amanitajelly"
 	bitesize = 3
-	list_reagents = list("nutriment" = 1, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 5)
+	list_reagents = list("nutriment" = 6, "mushroomhallucinogen" = 3, "amatoxin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/soup/stew
 	name = "stew"
 	desc = "A nice and warm stew. Healthy and strong."
 	icon_state = "stew"
-	list_reagents = list("nutriment" = 1, "tomatojuice" = 5, "vitamin" = 5)
+	bonus_reagents = list("nutriment" = 1, "tomatojuice" = 5, "vitamin" = 5)
+	list_reagents = list("nutriment" = 10, "oculine" = 5, "tomatojuice" = 5, "vitamin" = 5)
 	bitesize = 7

--- a/code/modules/food&drinks/food/snacks_spaghetti.dm
+++ b/code/modules/food&drinks/food/snacks_spaghetti.dm
@@ -12,7 +12,8 @@
 	desc = "A plain dish of noodles, this needs more ingredients."
 	icon_state = "spaghettiboiled"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 2)
+	bonus_reagents = list("nutriment" = 2)
+	list_reagents = list("nutriment" = 2, "vitamin" = 1)
 	custom_food_type = /obj/item/weapon/reagent_containers/food/snacks/customizable/pasta
 	filling_color = "#F0E68C"
 
@@ -22,7 +23,8 @@
 	icon_state = "pastatomato"
 	trash = /obj/item/trash/plate
 	bitesize = 4
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "tomatojuice" = 10, "vitamin" = 4)
+	list_reagents = list("nutriment" = 6, "tomatojuice" = 10, "vitamin" = 4)
 	filling_color = "#DC143C"
 
 /obj/item/weapon/reagent_containers/food/snacks/copypasta
@@ -31,7 +33,8 @@
 	icon_state = "copypasta"
 	trash = /obj/item/trash/plate
 	bitesize = 4
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
+	list_reagents = list("nutriment" = 12, "tomatojuice" = 20, "vitamin" = 8)
 	filling_color = "#DC143C"
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballspaghetti
@@ -39,7 +42,8 @@
 	desc = "Now that's a nic'e meatball!"
 	icon_state = "meatballspaghetti"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 4)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 4)
+	list_reagents = list("nutriment" = 8, "vitamin" = 4)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/spesslaw
@@ -47,5 +51,6 @@
 	desc = "A lawyers favourite."
 	icon_state = "spesslaw"
 	trash = /obj/item/trash/plate
-	list_reagents = list("nutriment" = 1, "vitamin" = 6)
+	bonus_reagents = list("nutriment" = 1, "vitamin" = 6)
+	list_reagents = list("nutriment" = 8, "vitamin" = 6)
 	filling_color = "#F0E68C"

--- a/code/modules/food&drinks/kitchen machinery/microwave.dm
+++ b/code/modules/food&drinks/kitchen machinery/microwave.dm
@@ -245,7 +245,7 @@
 		for(var/obj/item/weapon/reagent_containers/food/snacks/F in contents)
 			if(F.cooked_type)
 				var/obj/item/weapon/reagent_containers/food/snacks/S = new F.cooked_type (get_turf(src))
-				F.initialize_cooked_food(S)
+				F.initialize_cooked_food(S, efficiency)
 			else
 				new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(src)
 				if(dirty < 100)


### PR DESCRIPTION
- Fixes spawned food not having normal amounts of nutriment and other reagents. Fixes #8308 
  All food items have two lists of reagents. One is the standard load for spawned food, the other is the list of bonus reagents added to the food after being crafted or cooked in addition to the reagents of the ingredients used.
- Upgraded microwave now adds more nutriment, vitamin and other reagents to the food it cooks.
- Fixes donuts not having their own filling color.
