### PR TITLE
fixes issue with admin preferences applying to non-admins

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -258,7 +258,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	var/list/receive = get_mobs_in_radio_ranges(radios) //this includes all hearers.
 
 	for(var/mob/R in receive) //Filter receiver list.
-		if (R.client && !(R.client.prefs.chat_toggles & CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
+		if (R.client && R.client.holder && !(R.client.prefs.chat_toggles & CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
 			receive -= R
 
 	for(var/mob/M in player_list)


### PR DESCRIPTION
fixes issue with admin preferences applying to non-admins.

This is a preference that only admins can change, but if a users save file gets fucked, or a admin who turned it off gets de-admined. it still applies to them.

I don't know why this even exists, it seems to have been around since google code, maybe even since goonleak, but it should be checking for admin before applying to peoples nonetheless.
