### PR TITLE
Fixes invincible unstoppable death statues

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -30,8 +30,10 @@
 		intialBrute = L.getBruteLoss()
 		intialOxy = L.getOxyLoss()
 		if(ishuman(L))
-			name = "statue of [L.name]"
-			if(L.gender == "female")
+			var/mob/living/carbon/human/H = L
+			name = "statue of [H.name]"
+			H.bleedsuppress = 1
+			if(H.gender == "female")
 				icon_state = "human_female"
 		else if(ismonkey(L))
 			name = "statue of a monkey"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -649,6 +649,7 @@
 		C = pick(candidates)
 		M.key = C.key
 		M.languages |= HUMAN
+		M.faction = list()
 		M << "<span class='warning'>All at once it makes sense, you know what you are and who you are! Self awareness is yours!</span>"
 		M << "You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost."
 		user << "<span class='warning'>[M] is suddenly attentive and aware. It worked!</span>"

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -649,7 +649,7 @@
 		C = pick(candidates)
 		M.key = C.key
 		M.languages |= HUMAN
-		M.faction = list()
+		M.faction -= "neutral"
 		M << "<span class='warning'>All at once it makes sense, you know what you are and who you are! Self awareness is yours!</span>"
 		M << "You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost."
 		user << "<span class='warning'>[M] is suddenly attentive and aware. It worked!</span>"


### PR DESCRIPTION
Removes the neutral faction from sentient mobs, as they don't need them being player controlled. Losing that faction the sentient will be attacked by gold core mobs of different factions but not other factions that the sentient still holds (i.e. a sentient carp would be attacked by a bear, but not by a magicarp)

Take a look at https://github.com/tgstation/-tg-station/issues/8389#issuecomment-82483199 for an explanation of why this was happening. Fixes #8389

Fixes an unreported bug where statues could bleed out.
