### PR TITLE
Blob zombie runtime fix + a tweak

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -84,11 +84,12 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	icon = H.icon
-	icon_state = "husk_s"
+	icon_state = "zombie_s"
 	H.hair_style = null
 	H.update_hair()
 	human_overlays = H.overlays
-	adjustcolors(overmind.blob_reagent_datum.color)
+	if(overmind && overmind.blob_reagent_datum)
+		adjustcolors(overmind.blob_reagent_datum.color)
 	H.loc = src
 	loc.visible_message("<span class='warning'> The corpse of [H.name] suddenly rises!</span>")
 


### PR DESCRIPTION
Fixes a runtime when blobs unaffiliated with a overmind zombified someone

Fixes #8406

Zombified corpses will now use the zombie body instead of the husked body. This doesn't mean that people cloned post zombification will be zombies though.
