### PR TITLE
Fix nuke-op shuttle gets infinitely hot issue

### DIFF
--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -37,7 +37,7 @@ What are the archived variables for?
 
 	var/volume = CELL_VOLUME
 
-	var/temperature = 0 //in Kelvin, use calculate_temperature() to modify
+	var/temperature = 0 //in Kelvin
 
 	var/last_share
 
@@ -746,7 +746,7 @@ What are the archived variables for?
 			if(border_multiplier)
 				temperature = (old_self_heat_capacity*temperature - heat_capacity_transferred*border_multiplier*temperature_archived)/new_self_heat_capacity
 			else
-				temperature = (old_self_heat_capacity*temperature - heat_capacity_transferred*border_multiplier*temperature_archived)/new_self_heat_capacity
+				temperature = (old_self_heat_capacity*temperature - heat_capacity_transferred*temperature_archived)/new_self_heat_capacity
 
 		temperature_mimic(model, model.thermal_conductivity, border_multiplier)
 


### PR DESCRIPTION
Cause was faulty logic in datum/gas_mixture/mimic() that was leaking a null value into some multiplication math. It's still wrong, but at least it keeps the air too cold instead of making it literally infinitely hot.
Fixes #7691
Fixes #4740
Fixes #8166
