### PR TITLE
Fixes #8393, backup shuttle coming when already called

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -162,7 +162,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			break
 
 	if(callShuttle)
-		if(emergency.mode < SHUTTLE_DOCKED)
+		if(emergency.mode < SHUTTLE_CALL)
 			emergency.request(null, 2.5)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")


### PR DESCRIPTION
Backup shuttle won't come if the emergency shuttle is already coming; if the shuttle could get recalled during this time then it'd invalidate the backup anyway.
