### PR TITLE
Changes rgb values for comfy chairs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -111,19 +111,28 @@
 
 
 /obj/structure/stool/bed/chair/comfy/brown
-	color = rgb(255,113,0)
+	color = rgb(141,70,0)
+
+/obj/structure/stool/bed/chair/comfy/red
+	color = rgb(218,2,10)
+
+/obj/structure/stool/bed/chair/comfy/teal
+	color = rgb(0,234,250)
+
+/obj/structure/stool/bed/chair/comfy/black
+	color = rgb(60,60,60)
+
+/obj/structure/stool/bed/chair/comfy/green
+	color = rgb(1,196,8)
+
+/obj/structure/stool/bed/chair/comfy/purp
+	color = rgb(112,2,176)
+
+/obj/structure/stool/bed/chair/comfy/blue
+	color = rgb(2,9,210)
 
 /obj/structure/stool/bed/chair/comfy/beige
 	color = rgb(255,253,195)
-
-/obj/structure/stool/bed/chair/comfy/teal
-	color = rgb(0,255,255)
-
-/obj/structure/stool/bed/chair/comfy/black
-	color = rgb(167,164,153)
-
-/obj/structure/stool/bed/chair/comfy/lime
-	color = rgb(255,251,0)
 
 /obj/structure/stool/bed/chair/office
 	anchored = 0

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -134,6 +134,9 @@
 /obj/structure/stool/bed/chair/comfy/beige
 	color = rgb(255,253,195)
 
+/obj/structure/stool/bed/chair/comfy/lime
+	color = rgb(109,254,0)
+
 /obj/structure/stool/bed/chair/office
 	anchored = 0
 

--- a/html/changelogs/MandurrrhComfyColor.yml
+++ b/html/changelogs/MandurrrhComfyColor.yml
@@ -1,0 +1,10 @@
+
+# Your name.  
+author: Mandurrrh
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+
+changes: 
+  - tweak: "Changed the rgb values for comfy chairs for better colors and more options"


### PR DESCRIPTION
Updates rgb values for comfy chairs
-adds blue chairs
-adds red chairs
-adds purple chairs
-adds green chairs
-changes black chairs
-changes brown chairs
-changes teal chairs 
-removes lime chair color choice

*was originally done for a pr that lets you choose which chair to construct from the metal stack but with the urist chair painter being ported two ways to get colored comfy chairs seems excessive. So this just does color fixes. Uses rgb for the overlays/buckling but leaves a path still so mappers or admins can spawn by color name!

Old colors:
![oldcomfy](https://cloud.githubusercontent.com/assets/7591707/6715417/b9d94e64-cd74-11e4-8284-486d3b141fa6.png)

New Chair colors:
![newcomfychairs](https://cloud.githubusercontent.com/assets/7591707/6715426/c91f0bb6-cd74-11e4-9ba7-bfec5ae85dd9.png)

Revised Lime green(ministation uses it):
![limegreen](https://cloud.githubusercontent.com/assets/7591707/6716091/57a0702e-cd79-11e4-83a1-88bc8f23544a.png)
