### PR TITLE
Fixes not being able to tablecraft recipes using differen kinds of an item

### DIFF
--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -12,10 +12,17 @@
 	check_table()
 	main_loop:
 		for(var/A in R.reqs)
+			var/needed_amount = R.reqs[A]
 			for(var/B in table_contents)
 				if(ispath(B, A))
 					if(table_contents[B] >= R.reqs[A])
 						continue main_loop
+					else
+						needed_amount -= table_contents[B]
+						if(needed_amount <= 0)
+							continue main_loop
+						else
+							continue
 			return 0
 	for(var/A in R.chem_catalysts)
 		if(table_contents[A] < R.chem_catalysts[A])
@@ -115,15 +122,18 @@
 			item_loop:
 				for(var/B in table_contents)
 					if(ispath(B, A))
-						while(amt > 0)
+						var/item_amount = table_contents[B]
+						while(item_amount > 0)
 							I = locate(B) in loc
 							Deletion.Add(I)
 							I.loc = null //remove it from the table loc so that we don't locate the same item every time (will be relocated inside the crafted item in construct_item())
 							amt--
+							item_amount--
 							if(reagenttransfer && istype(I,/obj/item/weapon/reagent_containers))
 								var/obj/item/weapon/reagent_containers/RC = I
 								RC.reagents.trans_to(resultobject, RC.reagents.total_volume)
-						break item_loop
+							if(amt <= 0)
+								break item_loop
 		else
 			var/datum/reagent/RG = new A
 			reagent_loop:

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1030,6 +1030,8 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 		reagents.add_reagent("oculine", 3+round(potency / 5, 1))
 		bitesize = 1 + round(reagents.total_volume / 2, 1)
 
+/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom
+	name = "mushroom"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi
 	seed = /obj/item/seeds/reishimycelium

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -68,7 +68,8 @@
 	reagents.trans_to(D, amount_per_transfer_from_this, 1/range)
 	D.color = mix_color_from_reagents(D.reagents.reagent_list)
 	var/puff_reagent_left = range //how many turf, mob or dense objet we can react with before we consider the chem puff consumed
-	var/wait_step = max(round(9/range),2)
+	var/wait_step = max(round(2+3/range), 2)
+
 	spawn(0)
 		for(var/i=0, i<range, i++)
 			step_towards(D,A)


### PR DESCRIPTION
Fixes not being able to tablecraft recipes using differen kinds of an item for a requirements (e.g. two types of cutlets to make a meat pizza). Fixes #8408

Fixes mushroom requirements in tablecraft recipes appearing as "snacks" in the requirement lists.

Reduces the chem puff waiting time when spraying at short range, so it takes less time before it reacts with a turf/mob/object.
