### PR TITLE
Chemical implant action button fix

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -141,7 +141,12 @@
 /obj/item/weapon/implant/chem/activate(var/cause)
 	if(!cause || !imp_in)	return 0
 	var/mob/living/carbon/R = imp_in
-	reagents.trans_to(R, cause)
+	var/injectamount = null
+	if (cause == "action_button")
+		injectamount = reagents.total_volume
+	else
+		injectamount = cause
+	reagents.trans_to(R, injectamount)
 	R << "You hear a faint *beep*."
 	if(!reagents.total_volume)
 		R << "You hear a faint click from your chest."

--- a/html/changelogs/Zelacks-ChemImplantGuiFix.yml
+++ b/html/changelogs/Zelacks-ChemImplantGuiFix.yml
@@ -1,0 +1,6 @@
+author: Zelacks
+
+delete-after: True
+
+changes: 
+  - bugfix: "The chemical implant action button should now correctly inject all chemicals when pressed."


### PR DESCRIPTION
Previously, the chemical implant, when the player pressed the action button to activate the implant, the server would run time. This PR corrects the behavior by detecting when the action button is pressed and then correctly injecting all chemicals in the implant into the mob
