### PR TITLE
Magic Mania 1.87: Summon Events Settles Down And Starts A Family

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -155,10 +155,9 @@
 		SSevent.reschedule()
 
 	else 																//Speed it up
-		SSevent.frequency_lower = round(SSevent.frequency_lower * 0.8)	//1 minute | 48 seconds | 34.8 seconds | 30.7 seconds | 24.6 seconds
-		SSevent.frequency_upper = round(SSevent.frequency_upper * 0.6)	//5 minutes | 3 minutes | 1 minute 48 seconds | 1 minute 4.8 seconds | 38.9 seconds
-		if(SSevent.frequency_upper < SSevent.frequency_lower)
-			SSevent.frequency_upper = SSevent.frequency_lower				//this can't happen unless somehow multiple spellbooks are used, but just in case
+		SSevent.frequency_upper -= 600	//The upper bound falls a minute each time, making the AVERAGE time between events lessen
+		if(SSevent.frequency_upper < SSevent.frequency_lower) //Sanity
+			SSevent.frequency_upper = SSevent.frequency_lower
 
 		SSevent.reschedule()
 		message_admins("Summon Events intensifies, events will now occur every [SSevent.frequency_lower / 600] to [SSevent.frequency_upper / 600] minutes.")

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -200,6 +200,9 @@
 			finished = 1
 			return 1
 		else
+			if(SSevent.wizardmode) //If summon events was active, turn it off
+				SSevent.toggleWizardmode()
+				SSevent.resetFrequency()
 			return ..()
 
 	finished = 1

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/wizard/deprevolt //stationwide!
 	name = "Departmental Uprising"
-	weight = 2
+	weight = 0 //An order that requires order in a round of chaos was maybe not the best idea. Requiescat in pace departmental uprising August 2014 - March 2015
 	typepath = /datum/round_event/wizard/deprevolt/
 	max_occurrences = 1
 	earliest_start = 0

--- a/html/changelogs/Incoming5643-Summon-Events.yml
+++ b/html/changelogs/Incoming5643-Summon-Events.yml
@@ -1,0 +1,9 @@
+   author: Incoming5643
+   
+   delete-after: True
+   
+   changes: 
+     - bugfix: "Summon Events has been reworked to be a bit less manic."
+     - rscadd: "Summon Events will turn off if the wizard and all apprentices die. Any lingering effects are not reversed however."
+     - rscadd: "Improving Summon Events will reduce the average time between events, but not the minimum time between events."
+     - rscdel: "Departmental Uprising has been made admin only for being an RP heavy event that creates antags in an enviroment that doesn't really support that."


### PR DESCRIPTION
*Retires Departmental Uprising to the land of admin only access like its brother fake explosion before it 

*Changes the mechanics of recasting summon events to only reduce the upper limit of the time between event casts (-1 minute each additional cast) as opposed to touching the lower limit as well. Events every 15/30 seconds which, while certainly a scene, I admit was a bit much. Casting summon events 5, 6, or 7 times will now at worst result in an event every minute.

*If a wizard round mulligans, summon events will turn off if it was used. Remember that in wizard mulligans any apprentices will need to be dead too.
