### PR TITLE
Adds getPixelDistance()

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1267,7 +1267,38 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			var/turf/T = locate(final_x, final_y, AM.z)
 			if(T)
 				return T
+				
+//Finds the distance between two atoms, in pixels
+/proc/getPixelDistance(var/atom/A, var/atom/B)
+	if(!istype(A)||!istype(B))
+		return 0
+	
+	var/_x1 = A.x
+	var/_x2 = B.x
+	var/_y1 = A.y
+	var/_y2 = B.y
+	
+	//Ensure _x1 is bigger, simplicity
+	if(_x2 > _x1)
+		var/tx = _x1
+		_x1 = _x2
+		_x2 = tx
+	
+	//Ensure _y1 is bigger, simplicity
+	if(_y2 > _y1)
+		var/ty = _y1
+		_y1 = _y2
+		_y2 = ty
+	
+	//DY/DX
+	var/dx = _x1 - _x2 + A.pixel_x + B.pixel_x
+	var/dy = _y1 - _y2 + A.pixel_y + B.pixel_y
+	
+	//Distance check
+	if(dx == 0 && dy == 0) //No distance, don't bother calculating
+		return 0
 
+	. = sqrt(((dx**2) + (dy**2)))
 
 /proc/get(atom/loc, type)
 	while(loc)


### PR DESCRIPTION
Adds a proc for finding the distance between two atoms, in pixels

It seems that when I'm bored I make random functions relating to pixels. Whatever.
Maybe one day I'll have added enough pixel functions that we can move to pixel movement :P

(If you want to be pedantic, this calculates the distance in pixels from the edge of each atom's turf, I _could_ offset this by half the width of world.icon_size but the actual distance value remains the same, that's how distance works kids)
