### PR TITLE
FUZZY_CHANCE_LOW was in a range() call.

### DIFF
--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -566,7 +566,7 @@
 	if((TARGET && (doing & FIGHTING)) || graytide) // this is a redundancy check
 		var/mob/living/M = TARGET
 		if(istype(M,/mob/living))
-			if(M in range(FUZZY_CHANCE_LOW,src))
+			if(M in range(MIN_RANGE_FIND,src))
 				if(M.health > 1)
 					if(main_hand)
 						if(main_hand.force != 0)


### PR DESCRIPTION
I don't really understand this code, but a constant named FUZZY_CHANCE_LOW looks really bad there. FUZZY_CHANCE_LOW  and FUZZY_CHANCE_HIGH is not needed (see #8464), but to remove them I need this to be fixed.
