### PR TITLE
Fixes a big old mistake in mulligan antag that made extended mulligans WAY too common

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -6,6 +6,7 @@
 	required_players = 0
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
+	reroll_friendly = 1
 
 	var/list/possible_changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -98,14 +98,20 @@
 ///Allows rounds to basically be "rerolled" should the initial premise fall through
 /datum/game_mode/proc/convert_roundtype()
 	var/list/datum/game_mode/runnable_modes = config.get_runnable_modes()
+	var/list/datum/game_mode/usable_modes = list()
 	for(var/datum/game_mode/G in runnable_modes)
-		if(!G.reroll_friendly)	del(G)
+		if(G.reroll_friendly)
+			usable_modes += G
+		else
+			del(G)
 
 	SSshuttle.emergencyNoEscape = 0 //Time to get the fuck out of here
 
-	if(!runnable_modes)	return 0
+	if(!usable_modes)
+		message_admins("Convert_roundtype failed due to no valid modes to convert to. Please report this error to the Coders.")
+		return 0
 
-	replacementmode = pickweight(runnable_modes)
+	replacementmode = pickweight(usable_modes)
 
 	switch(SSshuttle.emergency.mode) //Rounds on the verge of ending don't get new antags, they just run out
 		if(SHUTTLE_STRANDED, SHUTTLE_ESCAPE)
@@ -115,6 +121,7 @@
 				return 1
 
 	if(world.time >= (config.midround_antag_time_check * 600))
+		message_admins("Convert_roundtype failed due to round length. Limit is [config.midround_antag_time_check] minutes.")
 		return 0
 
 	var/living_crew = 0
@@ -123,6 +130,7 @@
 		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
 			living_crew++
 	if(living_crew / joined_player_list.len <= config.midround_antag_life_check) //If a lot of the player base died, we start fresh
+		message_admins("Convert_roundtype failed due to too many dead people. Limit is [config.midround_antag_life_check * 100]% living crew")
 		return 0
 
 	var/list/antag_canadates = list()
@@ -132,6 +140,7 @@
 			antag_canadates += H
 
 	if(!antag_canadates)
+		message_admins("Convert_roundtype failed due to no antag canadates.")
 		return 0
 
 	antag_canadates = shuffle(antag_canadates)
@@ -143,12 +152,11 @@
 
 	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
-	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
+	spawn(1)//rand(1800,4200)) //somewhere between 3 and 7 minutes from now
 		for(var/mob/living/carbon/human/H in antag_canadates)
 			replacementmode.make_antag_chance(H)
 		round_converted = 2
 		message_admins("The roundtype has been converted, antagonists may have been created")
-
 	return 1
 
 ///process()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -152,7 +152,7 @@
 
 	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
-	spawn(1)//rand(1800,4200)) //somewhere between 3 and 7 minutes from now
+	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
 		for(var/mob/living/carbon/human/H in antag_canadates)
 			replacementmode.make_antag_chance(H)
 		round_converted = 2

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,6 +5,7 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
+	reroll_friendly = 1
 
 	traitor_name = "double agent"
 


### PR DESCRIPTION
Hard defines double agents and traitorchan to be possible since there were some indications that inheriting the var wasn't working right

When mulligan decides to quit the admins will get a blurb as to why it quit
