### PR TITLE
Adds Chem Master board

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -381,6 +381,16 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/cell = 1)
+							
+/obj/item/weapon/circuitboard/chem_master
+	name = "circuit board (Chem Master 2999)"
+	build_path = /obj/machinery/chem_master/constructable
+	board_type = "machine"
+	origin_tech = "materials=2;programming=2;biotech=1"
+	req_components = list(
+							/obj/item/weapon/reagent_containers/glass/beaker = 2,
+							/obj/item/weapon/stock_parts/manipulator = 1,
+							/obj/item/weapon/stock_parts/console_screen = 1)
 
 /obj/item/weapon/circuitboard/chem_heater
 	name = "circuit board (Chemical Heater)"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -592,7 +592,7 @@
 	
 /obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob, params)
 
-	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", I)
+	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", I))
 		if(beaker)
 			beaker.loc = src.loc
 			beaker = null

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -579,7 +579,7 @@
 
 /obj/machinery/chem_master/constructable
 	name = "ChemMaster 2999"
-	desc = "Used to seperate chemicals and distribute them in a variety of forms"
+	desc = "Used to seperate chemicals and distribute them in a variety of forms."
 	
 /obj/machinery/chem_master/constructable/New()
 	..()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -590,9 +590,9 @@
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(null)
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(null)
 	
-/obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob, params)
+/obj/machinery/chem_master/constructable/attackby(var/obj/item/B as obj, var/mob/user as mob, params)
 
-	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", B))
+	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0_", B))
 		if(beaker)
 			beaker.loc = src.loc
 			beaker = null

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -592,7 +592,7 @@
 	
 /obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob, params)
 
-	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", I))
+	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", B))
 		if(beaker)
 			beaker.loc = src.loc
 			beaker = null
@@ -602,12 +602,15 @@
 			loaded_pill_bottle = null
 		return
 		
-	if(exchange_parts(user, I))
+	if(exchange_parts(user, B))
 		return
 		
 	if(panel_open)
-		if(istype(I, /obj/item/weapon/crowbar))
-			default_deconstruction_crowbar(I)
+		if(istype(B, /obj/item/weapon/crowbar))
+			default_deconstruction_crowbar(B)
+			return 1
+		else
+			user << "<span class='warning'>You can't use the [src.name] while it's panel is opened.</span>"
 			return 1
 
 	if(istype(B, /obj/item/weapon/reagent_containers/glass))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -575,6 +575,64 @@
 	desc = "Used to create condiments and other cooking supplies."
 	condi = 1
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/obj/machinery/chem_master/constructable
+	name = "ChemMaster 2999"
+	desc = "Used to seperate chemicals and distribute them in a variety of forms"
+	
+/obj/machinery/chem_master/constructable/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/chem_master(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
+	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(null)
+	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker(null)
+	
+/obj/machinery/chem_master/attackby(var/obj/item/B as obj, var/mob/user as mob, params)
+
+	if(default_deconstruction_screwdriver(user, "mixer0", "mixer0", I)
+		if(beaker)
+			beaker.loc = src.loc
+			beaker = null
+			reagents.clear_reagents()
+		if(loaded_pill_bottle)
+			loaded_pill_bottle.loc = src.loc
+			loaded_pill_bottle = null
+		return
+		
+	if(exchange_parts(user, I))
+		return
+		
+	if(panel_open)
+		if(istype(I, /obj/item/weapon/crowbar))
+			default_deconstruction_crowbar(I)
+			return 1
+
+	if(istype(B, /obj/item/weapon/reagent_containers/glass))
+		if(src.beaker)
+			user << "<span class='alert'>A beaker is already loaded into the machine.</span>"
+			return
+		src.beaker = B
+		user.drop_item()
+		B.loc = src
+		user << "You add the beaker to the machine!"
+		src.updateUsrDialog()
+		icon_state = "mixer1"
+
+	else if(!condi && istype(B, /obj/item/weapon/storage/pill_bottle))
+		if(src.loaded_pill_bottle)
+			user << "<span class='alert'>A pill bottle is already loaded into the machine.</span>"
+			return
+		src.loaded_pill_bottle = B
+		user.drop_item()
+		B.loc = src
+		user << "You add the pill bottle into the dispenser slot!"
+		src.updateUsrDialog()
+
+	return
+
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -111,6 +111,16 @@
 	materials = list("$glass" = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/chem_dispenser
 	category = list ("Medical Machinery")
+	
+/datum/design/chem_master
+	name = "Machine Design (Chem Master Board)"
+	desc = "The circuit board for a Chem Master 2999."
+	id = "chem_master"
+	req_tech = list("biotech" = 1, "materials" = 2, "programming" = 2)
+	build_type = IMPRINTER
+	materials = list("$glass" = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/chem_master
+	category = list ("Medical Machinery")
 
 /datum/design/chem_heater
 	name = "Machine Design (Chemical Heater Board)"

--- a/html/changelogs/Pennwick-AddChemMast.yml
+++ b/html/changelogs/Pennwick-AddChemMast.yml
@@ -1,0 +1,6 @@
+author: Pennwick
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added a buildable Chem Master, board is in Circuit Imprinter."


### PR DESCRIPTION
Adds a buildable chem master.

Requires Materials and Data 2 for the board. 
Takes a manip, console screen, and two beakers.
Upgrading it does nothing.

Sorry about the extra commits. I needed to fix things while testing. Next time I'll set up TortioseGit and figure out how to do it more cleanly.
