### PR TITLE
Change holidays into datums

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -13,6 +13,15 @@
 #define NOVEMBER	11
 #define DECEMBER	12
 
+//Select holiday names -- If you test for a holiday in the code, make the holiday's name a define and test for that instead
+#define NEW_YEAR				"New Year"
+#define VALENTINES				"Valentine's Day"
+#define APRIL_FOOLS				"April Fool's Day"
+#define EASTER					"Easter"
+#define HALLOWEEN				"Halloween"
+#define CHRISTMAS				"Christmas"
+#define FRIDAY_13TH				"Friday the 13th"
+
 //Human Overlays Indexes/////////
 #define SPECIES_LAYER			26		// mutantrace colors... these are on a seperate layer in order to prvent
 #define BODY_BEHIND_LAYER		25

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -1,5 +1,17 @@
 #define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
 
+#define JANUARY		1
+#define FEBRUARY	2
+#define MARCH		3
+#define APRIL		4
+#define MAY			5
+#define JUNE		6
+#define JULY		7
+#define AUGUST		8
+#define SEPTEMBER	9
+#define OCTOBER		10
+#define NOVEMBER	11
+#define DECEMBER	12
 
 //Human Overlays Indexes/////////
 #define SPECIES_LAYER			26		// mutantrace colors... these are on a seperate layer in order to prvent

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -70,23 +70,16 @@ var/religion_name = null
 		new_station_name = name + " "
 
 	// Prefix
-	switch(SSevent.holiday)
-		//get normal name
-		if(null,"",0)
-			name = pick("", "Stanford", "Dorf", "Alium", "Prefix", "Clowning", "Aegis", "Ishimura", "Scaredy", "Death-World", "Mime", "Honk", "Rogue", "MacRagge", "Ultrameens", "Safety", "Paranoia", "Explosive", "Neckbear", "Donk", "Muppet", "North", "West", "East", "South", "Slant-ways", "Widdershins", "Rimward", "Expensive", "Procreatory", "Imperial", "Unidentified", "Immoral", "Carp", "Ork", "Pete", "Control", "Nettle", "Aspie", "Class", "Crab", "Fist","Corrogated","Skeleton","Race", "Fatguy", "Gentleman", "Capitalist", "Communist", "Bear", "Beard", "Derp", "Space", "Spess", "Star", "Moon", "System", "Mining", "Neckbeard", "Research", "Supply", "Military", "Orbital", "Battle", "Science", "Asteroid", "Home", "Production", "Transport", "Delivery", "Extraplanetary", "Orbital", "Correctional", "Robot", "Hats", "Pizza")
-			if(name)
-				new_station_name += name + " "
-
-		//For special days like christmas, easter, new-years etc ~Carn
-		if("Friday the 13th")
-			name = pick("Mike","Friday","Evil","Myers","Murder","Deathly","Stabby")
-			new_station_name += name + " "
+	for(var/holiday_name in SSevent.holidays)
+		if(holiday_name == "Friday the 13th")
 			random = 13
-		else
-			//get the first word of the Holiday and use that
-			var/i = findtext(SSevent.holiday," ",1,0)
-			name = copytext(SSevent.holiday,1,i)
-			new_station_name += name + " "
+		var/datum/holiday/holiday = SSevent.holidays[holiday_name]
+		name = holiday.getStationPrefix()
+		//get normal name
+	if(!name)
+		name = pick("", "Stanford", "Dorf", "Alium", "Prefix", "Clowning", "Aegis", "Ishimura", "Scaredy", "Death-World", "Mime", "Honk", "Rogue", "MacRagge", "Ultrameens", "Safety", "Paranoia", "Explosive", "Neckbear", "Donk", "Muppet", "North", "West", "East", "South", "Slant-ways", "Widdershins", "Rimward", "Expensive", "Procreatory", "Imperial", "Unidentified", "Immoral", "Carp", "Ork", "Pete", "Control", "Nettle", "Aspie", "Class", "Crab", "Fist","Corrogated","Skeleton","Race", "Fatguy", "Gentleman", "Capitalist", "Communist", "Bear", "Beard", "Derp", "Space", "Spess", "Star", "Moon", "System", "Mining", "Neckbeard", "Research", "Supply", "Military", "Orbital", "Battle", "Science", "Asteroid", "Home", "Production", "Transport", "Delivery", "Extraplanetary", "Orbital", "Correctional", "Robot", "Hats", "Pizza")
+	if(name)
+		new_station_name += name + " "
 
 	// Suffix
 	name = pick("Station", "Fortress", "Frontier", "Suffix", "Death-trap", "Space-hulk", "Lab", "Hazard","Spess Junk", "Fishery", "No-Moon", "Tomb", "Crypt", "Hut", "Monkey", "Bomb", "Trade Post", "Fortress", "Village", "Town", "City", "Edition", "Hive", "Complex", "Base", "Facility", "Depot", "Outpost", "Installation", "Drydock", "Observatory", "Array", "Relay", "Monitor", "Platform", "Construct", "Hangar", "Prison", "Center", "Port", "Waystation", "Factory", "Waypoint", "Stopover", "Hub", "HQ", "Office", "Object", "Fortification", "Colony", "Planet-Cracker", "Roost", "Fat Camp")

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -65,7 +65,7 @@ var/datum/subsystem/events/SSevent
 		if(E.occurrences >= E.max_occurrences)	continue
 		if(E.earliest_start >= world.time)		continue
 		if(E.holidayID)
-			if(!holidays[E.holidayID])			continue
+			if(!holidays || !holidays[E.holidayID])			continue
 		if(E.weight < 0)						//for round-start events etc.
 			if(E.runEvent() == PROCESS_KILL)
 				E.max_occurrences = 0
@@ -82,7 +82,7 @@ var/datum/subsystem/events/SSevent
 		if(E.occurrences >= E.max_occurrences)	continue
 		if(E.earliest_start >= world.time)		continue
 		if(E.holidayID)
-			if(!holidays[E.holidayID])			continue
+			if(!holidays || !holidays[E.holidayID])			continue
 		sum_of_weights -= E.weight
 
 		if(sum_of_weights <= 0)				//we've hit our goal

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -11,7 +11,7 @@ var/datum/subsystem/events/SSevent
 	var/frequency_lower = 3000	//5 minutes lower bound.
 	var/frequency_upper = 9000	//15 minutes upper bound. Basically an event will happen every 5 to 15 minutes.
 
-	var/holiday					//This will be a string of the name of any realworld holiday which occurs today (GMT time)
+	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = 0
 
 
@@ -65,7 +65,7 @@ var/datum/subsystem/events/SSevent
 		if(E.occurrences >= E.max_occurrences)	continue
 		if(E.earliest_start >= world.time)		continue
 		if(E.holidayID)
-			if(E.holidayID != holiday)			continue
+			if(!holidays[E.holidayID])			continue
 		if(E.weight < 0)						//for round-start events etc.
 			if(E.runEvent() == PROCESS_KILL)
 				E.max_occurrences = 0
@@ -82,7 +82,7 @@ var/datum/subsystem/events/SSevent
 		if(E.occurrences >= E.max_occurrences)	continue
 		if(E.earliest_start >= world.time)		continue
 		if(E.holidayID)
-			if(E.holidayID != holiday)			continue
+			if(!holidays[E.holidayID])			continue
 		sum_of_weights -= E.weight
 
 		if(sum_of_weights <= 0)				//we've hit our goal
@@ -152,12 +152,12 @@ var/datum/subsystem/events/SSevent
 //////////////
 //Uncommenting ALLOW_HOLIDAYS in config.txt will enable holidays
 
-//It's easy to add stuff. Just modify getHoliday to set holiday to something using the switch for DD(#day) MM(#month) YY(#year).
-//You can then check if it's a special day in any code in the game by doing if(events.holiday == "MyHolidayID")
+//It's easy to add stuff. Just add a holiday datum in code/modules/holiday/holidays.dm
+//You can then check if it's a special day in any code in the game by doing if(SSevent.holidays["Groundhog Day"])
 
 //You can also make holiday random events easily thanks to Pete/Gia's system.
-//simply make a random event normally, then assign it a holidayID string which matches the one you gave it in getHolday.
-//Anything with a holidayID, which does not match the holiday string, will never occur.
+//simply make a random event normally, then assign it a holidayID string which matches the holiday's name.
+//Anything with a holidayID, which isn't in the holidays list, will never occur.
 
 //Please, Don't spam stuff up with stupid stuff (key example being april-fools Pooh/ERP/etc),
 //And don't forget: CHECK YOUR CODE!!!! We don't want any zero-day bugs which happen only on holidays and never get found/fixed!
@@ -165,111 +165,27 @@ var/datum/subsystem/events/SSevent
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 //ALSO, MOST IMPORTANTLY: Don't add stupid stuff! Discuss bonus content with Project-Heads first please!//
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-~Carn */
+*/
 
-//sets up the holiday string in the events manager.
+//sets up the holidays and holidays list
 /datum/subsystem/events/proc/getHoliday()
 	if(!config.allow_holidays)	return		// Holiday stuff was not enabled in the config!
-	holiday = null
 
-	var/YY	=	text2num(time2text(world.timeofday, "YY")) 	// get the current year
-	var/MM	=	text2num(time2text(world.timeofday, "MM")) 	// get the current month
-	var/DD	=	text2num(time2text(world.timeofday, "DD")) 	// get the current day
+	var/YY = text2num(time2text(world.timeofday, "YY")) 	// get the current year
+	var/MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
+	var/DD = text2num(time2text(world.timeofday, "DD")) 	// get the current day
 
-	//Main switch. If any of these are too dumb/inappropriate, or you have better ones, feel free to change whatever
-	switch(MM)
-		if(1)	//Jan
-			switch(DD)
-				if(1)							holiday = "New Year"
+	for(var/H in typesof(/datum/holiday) - /datum/holiday)
+		var/datum/holiday/holiday = new H()
+		if(holiday.shouldCelebrate(DD, MM, YY))
+			holiday.celebrate()
+			if(!holidays)
+				holidays = list()
+			holidays[holiday.name] = holiday
 
-		if(2)	//Feb
-			switch(DD)
-				if(2)							holiday = "Groundhog Day"
-				if(14)							holiday = "Valentine's Day"
-				if(17)							holiday = "Random Acts of Kindness Day"
-
-		if(3)	//Mar
-			switch(DD)
-				if(14)							holiday = "Pi Day"
-				if(17)							holiday = "St. Patrick's Day"
-				if(27)
-					if(YY == 16)
-						holiday = "Easter"
-				if(31)
-					if(YY == 13)
-						holiday = "Easter"
-
-		if(4)	//Apr
-			switch(DD)
-				if(1)
-					holiday = "April Fool's Day"
-					if(YY == 18 && prob(50)) 	holiday = "Easter"
-				if(5)
-					if(YY == 15)				holiday = "Easter"
-				if(16)
-					if(YY == 17)				holiday = "Easter"
-				if(20)
-					holiday = "Four-Twenty"
-					if(YY == 14 && prob(50))	holiday = "Easter"
-				if(22)							holiday = "Earth Day"
-
-		if(5)	//May
-			switch(DD)
-				if(1)							holiday = "Labour Day"
-				if(4)							holiday = "FireFighter's Day"
-				if(12)							holiday = "Owl and Pussycat Day"	//what a dumb day of observence...but we -do- have costumes already :3
-
-		if(6)	//Jun
-
-		if(7)	//Jul
-			switch(DD)
-				if(1)							holiday = "Doctor's Day"
-				if(2)							holiday = "UFO Day"
-				if(8)							holiday = "Writer's Day"
-				if(30)							holiday = "Friendship Day"
-
-		if(8)	//Aug
-			switch(DD)
-				if(5)							holiday = "Beer Day"
-
-		if(9)	//Sep
-			switch(DD)
-				if(19)							holiday = "Talk-Like-a-Pirate Day"
-				if(28)							holiday = "Stupid-Questions Day"
-
-		if(10)	//Oct
-			switch(DD)
-				if(4)							holiday = "Animal's Day"
-				if(7)							holiday = "Smiling Day"
-				if(16)							holiday = "Boss' Day"
-				if(31)							holiday = "Halloween"
-
-		if(11)	//Nov
-			switch(DD)
-				if(1)							holiday = "Vegan Day"
-				if(13)							holiday = "Kindness Day"
-				if(19)							holiday = "Flowers Day"
-				if(21)							holiday = "Saying-'Hello' Day"
-
-		if(12)	//Dec
-			switch(DD)
-				if(10)							holiday = "Human-Rights Day"
-				if(14)							holiday = "Monkey Day"
-				if(21)							holiday = "Mayan Doomsday Anniversary"
-				if(22)							holiday = "Orgasming Day"		//lol. These all actually exist
-				if(24)							holiday = "Xmas"
-				if(25)							holiday = "Xmas"
-				if(26)							holiday = "Boxing Day"
-				if(31)							holiday = "New Year"
-
-	if(!holiday)
-		//Friday the 13th
-		if(DD == 13)
-			if(time2text(world.timeofday, "DDD") == "Fri")
-				holiday = "Friday the 13th"
-
-	world.update_status()
-
+	if(holidays)
+		holidays = shuffle(holidays)
+		world.update_status()
 
 /datum/subsystem/events/proc/toggleWizardmode()
 	wizardmode = !wizardmode

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -47,7 +47,7 @@ var/datum/subsystem/ticker/ticker
 	NEW_SS_GLOBAL(ticker)
 
 	login_music = pickweight(list('sound/ambience/title2.ogg' = 49, 'sound/ambience/title1.ogg' = 49, 'sound/ambience/clown.ogg' = 2)) // choose title music!
-	if(SSevent.holiday == "April Fool's Day")
+	if(SSevent.holidays["April Fool's Day"])
 		login_music = 'sound/ambience/clown.ogg'
 
 /datum/subsystem/ticker/Initialize()
@@ -188,11 +188,13 @@ var/datum/subsystem/ticker/ticker
 
 
 	world << "<FONT color='blue'><B>Welcome to [station_name()], enjoy your stay!</B></FONT>"
-	world << sound('sound/AI/welcome.ogg') // Skie
-	//Holiday Round-start stuff	~Carn
-	if(SSevent.holiday)
+	world << sound('sound/AI/welcome.ogg')
+
+	if(SSevent.holidays)
 		world << "<font color='blue'>and...</font>"
-		world << "<h4>Happy [SSevent.holiday] Everybody!</h4>"
+		for(var/holidayname in SSevent.holidays)
+			var/datum/holiday/holiday = SSevent.holidays[holidayname]
+			world << "<h4>[holiday.greet()]</h4>"
 
 
 	spawn(0)//Forking here so we dont have to wait for this to finish

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -47,7 +47,7 @@ var/datum/subsystem/ticker/ticker
 	NEW_SS_GLOBAL(ticker)
 
 	login_music = pickweight(list('sound/ambience/title2.ogg' = 49, 'sound/ambience/title1.ogg' = 49, 'sound/ambience/clown.ogg' = 2)) // choose title music!
-	if(SSevent.holidays["April Fool's Day"])
+	if(SSevent.holidays && SSevent.holidays[APRIL_FOOLS])
 		login_music = 'sound/ambience/clown.ogg'
 
 /datum/subsystem/ticker/Initialize()

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -13,7 +13,7 @@ var/sound/admin_sound
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]")
 
-	if(SSevent.holiday == "April Fool's Day")
+	if(SSevent.holidays["April Fool's Day"])
 		admin_sound.frequency = pick(0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1.1, 1.2, 1.4, 1.6, 2.0, 2.5)
 		src << "You feel the Honkmother messing with your song..."
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -13,7 +13,7 @@ var/sound/admin_sound
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]")
 
-	if(SSevent.holidays["April Fool's Day"])
+	if(SSevent.holidays && SSevent.holidays[APRIL_FOOLS])
 		admin_sound.frequency = pick(0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1.1, 1.2, 1.4, 1.6, 2.0, 2.5)
 		src << "You feel the Honkmother messing with your song..."
 

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -13,7 +13,7 @@
 	var/max_occurrences = 20		//The maximum number of times this event can occur (naturally), it can still be forced.
 								//By setting this to 0 you can effectively disable an event.
 
-	var/holidayID				//string which should match the events.holiday variable if you wish this event to be holiday-specific
+	var/holidayID = ""			//string which should be in the SSevents.holidays list if you wish this event to be holiday-specific
 								//anything with a (non-null) holidayID which does not match holiday, cannot run.
 	var/wizardevent = 0
 

--- a/code/modules/events/holiday/friday13th.dm
+++ b/code/modules/events/holiday/friday13th.dm
@@ -2,7 +2,7 @@
 
 /datum/round_event_control/fridaythethirteen
 	name = "Friday the 13th"
-	holidayID = "Friday the 13th"
+	holidayID = FRIDAY_13TH
 	typepath = /datum/round_event/fridaythethirteen
 	weight = -1
 	max_occurrences = 1

--- a/code/modules/events/holiday/halloween.dm
+++ b/code/modules/events/holiday/halloween.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/spooky
 	name = "2 SPOOKY! (Halloween)"
-	holidayID = "Halloween"
+	holidayID = HALLOWEEN
 	typepath = /datum/round_event/spooky
 	weight = -1							//forces it to be called, regardless of weight
 	max_occurrences = 1
@@ -27,7 +27,7 @@
 /datum/round_event_control/carp_migration/eyeballs
 	name = "Eyeball Migration"
 	typepath = /datum/round_event/carp_migration/eyeballs
-	holidayID = "Halloween"
+	holidayID = HALLOWEEN
 	weight = 25
 	earliest_start = 0
 
@@ -40,7 +40,7 @@
 /datum/round_event_control/meteor_wave/spooky
 	name = "Pumpkin Wave"
 	typepath = /datum/round_event/meteor_wave/spooky
-	holidayID = "Halloween"
+	holidayID = HALLOWEEN
 	weight = 20
 	max_occurrences = 2
 

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/treevenge
 	name = "Treevenge (Christmas)"
-	holidayID = "Xmas"
+	holidayID = CHRISTMAS
 	typepath = /datum/round_event/treevenge
 	max_occurrences = 1
 	weight = 20
@@ -17,7 +17,7 @@
 //this is an example of a possible round-start event
 /datum/round_event_control/presents
 	name = "Presents under Trees (Christmas)"
-	holidayID = "Xmas"
+	holidayID = CHRISTMAS
 	typepath = /datum/round_event/presents
 	weight = -1							//forces it to be called, regardless of weight
 	max_occurrences = 1
@@ -81,7 +81,7 @@
 
 /datum/round_event_control/santa
 	name = "Santa is coming to town! (Christmas)"
-	holidayID = "Xmas"
+	holidayID = CHRISTMAS
 	typepath = /datum/round_event/santa
 	weight = 150
 	max_occurrences = 1

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -1,0 +1,316 @@
+/datum/holiday
+	var/name = "Bugsgiving"
+	//Right now, only holidays that take place on a certain day or within a time period are supported
+	//It would be nice to support things like "the second monday in march" or "the first sunday after the second sunday in june"
+	var/begin_day = 1
+	var/begin_month = 0
+	var/end_day = 0 // Default of 0 means the holiday lasts a single day
+	var/end_month = 0
+
+// This proc gets run before the game starts when the holiday is activated. Do festive shit here.
+/datum/holiday/proc/celebrate()
+
+// When the round starts, this proc is ran to get a text message to display to everyone to wish them a happy holiday
+/datum/holiday/proc/greet()
+	return "Have a happy [name]!"
+
+// Returns special prefixes for the station name on certain days. You wind up with names like "Christmas Object Epsilon". See new_station_name()
+/datum/holiday/proc/getStationPrefix()
+	//get the first word of the Holiday and use that
+	var/i = findtext(name," ",1,0)
+	return copytext(name,1,i)
+
+// Return 1 if this holidy should be celebrated today
+/datum/holiday/proc/shouldCelebrate(dd, mm, yy)
+	if(!end_day)
+		end_day = begin_day
+	if(!end_month)
+		end_month = begin_month
+
+	if(end_month > begin_month) //holiday spans multiple months in one year
+		if(mm == end_month) //in final month
+			if(dd <= end_day)
+				return 1
+
+		else if(mm == begin_month)//in first month
+			if(dd >= begin_day)
+				return 1
+
+		else if(mm in begin_month to end_month) //holiday spans 3+ months and we're in the middle, day doesn't matter at all
+			return 1
+
+	else if(end_month == begin_month) // starts and stops in same month, simplest case
+		if(mm == begin_month && (dd in begin_day to end_day))
+			return 1
+
+	else // starts in one year, ends in the next
+		if(mm >= begin_month && dd >= begin_day) // Holiday ends next year
+			return 1
+		if(mm <= end_month && dd <= end_day) // Holiday started last year
+			return 1
+
+	return 0
+
+// The actual holidays
+
+/datum/holiday/new_year
+	name = "New Year"
+	begin_day = 30 // 1 day early
+	begin_month = DECEMBER
+	end_day = 5 //4 days extra
+	end_month = JANUARY
+
+/datum/holiday/groundhog
+	name = "Groundhog Day"
+	begin_day = 2
+	begin_month = FEBRUARY
+
+/datum/holiday/velentines
+	name = "Velentine's Day"
+	begin_day = 9 //6 days early
+	begin_month = FEBRUARY
+	end_day = 15 //1 day extra
+
+/datum/holiday/random_kindness
+	name = "Random Acts of Kindness Day"
+	begin_day = 17
+	begin_month = FEBRUARY
+
+/datum/holiday/random_kindness/greet()
+	return "Go do some random acts of kindness for a stranger!" //haha yeah right
+
+/datum/holiday/pi
+	name = "Pi Day"
+	begin_day = 14
+	begin_month = MARCH
+
+/datum/holiday/no_this_is_patrick
+	name = "St. Patrick's Day"
+	begin_day = 17
+	begin_month = MARCH
+
+/datum/holiday/april_fools
+	name = "April Fool's Day"
+	begin_day = 1
+	begin_month = APRIL
+	end_day = 8 //7 days extra so everyone can enjoy the festivities
+
+/datum/holiday/fourtwenty
+	name = "Four-Twenty"
+	begin_day = 20
+	begin_month = APRIL
+
+/datum/holiday/earth
+	name = "Earth Day"
+	begin_day = 22
+	begin_month = APRIL
+
+/datum/holiday/labor
+	name = "Labor Day"
+	begin_day = 1
+	begin_month = MAY
+
+/datum/holiday/firefighter
+	name = "Firefighter's Day"
+	begin_day = 4
+	begin_month = MAY
+
+// No holidays in June :'(
+
+/datum/holiday/doctor
+	name = "Doctor's Day"
+	begin_day = 1
+	begin_month = JULY
+
+/datum/holiday/UFO
+	name = "UFO Day"
+	begin_day = 2
+	begin_month = JULY
+
+/datum/holiday/writer
+	name = "Writer's Day"
+	begin_day = 8
+	begin_month = JULY
+
+/datum/holiday/friendship
+	name = "Friendship Day"
+	begin_day = 30
+	begin_month = JULY
+
+/datum/holiday/friendship/greet()
+	return "Have a magical [name]!"
+
+/datum/holiday/beer
+	name = "Beer Day"
+	begin_day = 5
+	begin_month = AUGUST
+
+/datum/holiday/pirate
+	name = "Talk-Like-a-Pirate Day"
+	begin_day = 19
+	begin_month = SEPTEMBER
+
+/datum/holiday/pirate/greet()
+	return "Ye be talkin' like a pirate today or else ye'r walkin' tha plank, matey!"
+
+/datum/holiday/questions
+	name = "Stupid-Questions Day"
+	begin_day = 28
+	begin_month = SEPTEMBER
+
+/datum/holiday/questions/greet()
+	return "Are you having a happy [name]?"
+
+/datum/holiday/animal
+	name = "Animal's Day"
+	begin_day = 4
+	begin_month = OCTOBER
+
+/datum/holiday/smile
+	name = "Smiling Day"
+	begin_day = 7
+	begin_month = OCTOBER
+
+/datum/holiday/boss
+	name = "Boss' Day"
+	begin_day = 16
+	begin_month = OCTOBER
+
+/datum/holiday/halloween
+	name = "Halloween"
+	begin_day = 24 //7 days early
+	begin_month = OCTOBER
+	end_day = 7 //7 days extra
+	end_month = NOVEMBER
+
+/datum/holiday/halloween/greet()
+	return "Have a spooky Halloween!"
+
+/datum/holiday/vegan
+	name = "Vegan Day"
+	begin_day = 1
+	begin_month = NOVEMBER
+
+/datum/holiday/kindness
+	name = "Kindness Day"
+	begin_day = 13
+	begin_month = NOVEMBER
+
+/datum/holiday/flowers
+	name = "Flowers Day"
+	begin_day = 19
+	begin_month = NOVEMBER
+
+/datum/holiday/hello
+	name = "Saying-'Hello' Day"
+	begin_day = 21
+	begin_month = NOVEMBER
+
+/datum/holiday/hello/greet()
+	return "[pick(list("Aloha", "Bonjour", "Hello", "Hi", "Greetings", "Salutations", "Bienvenidos", "Hola", "Howdy"))]! " + ..()
+
+/datum/holiday/human_rights
+	name = "Human-Rights Day"
+	begin_day = 10
+	begin_month = DECEMBER
+
+/datum/holiday/monkey
+	name = "Monkey Day"
+	begin_day = 14
+	begin_month = DECEMBER
+
+/datum/holiday/xmas
+	name = "Christmas"
+	begin_day = 18 //7 days early
+	begin_month = DECEMBER
+	end_day = 8 //14 days extra, christmas is important
+	end_month = JANUARY
+
+/datum/holiday/xmas/greet()
+	return "Have a merry Christmas!"
+
+/datum/holiday/boxing
+	name = "Boxing Day"
+	begin_day = 26
+	begin_month = DECEMBER
+
+/datum/holiday/friday_thirteenth
+	name = "Friday the 13th"
+
+/datum/holiday/friday_thirteenth/shouldCelebrate(dd, mm, yy)
+	if(dd == 13)
+		if(time2text(world.timeofday, "DDD") == "Fri")
+			return 1
+	return 0
+
+/datum/holiday/friday_thirteenth/getStationPrefix()
+	return pick("Mike","Friday","Evil","Myers","Murder","Deathly","Stabby")
+
+/datum/holiday/easter
+	name = "Easter"
+	var/const/days_early = 1 //to make editing the holiday easier
+	var/const/days_extra = 6
+
+/datum/holiday/easter/shouldCelebrate(dd, mm, yy)
+// Easter's celebration day is as snowflakey as Uhangi's code
+
+	if(!begin_month)
+
+		var/yy_string = "[yy]"
+// year = days after March 22that Easter falls on that year.
+// For 2015 Easter is on April 5th, so 2015 = 14 since the 5th is 14 days past the 22nd
+// If it's 2040 and this is still in use, invent a time machine and teach me a better way to do this. Also tell us about HL3.
+		var/list/easters = list(
+		"15" = 14,\
+		"16" = 6,\
+		"17" = 25,\
+		"18" = 10,\
+		"19" = 30,\
+		"20" = 22,\
+		"21" = 13,\
+		"22" = 26,\
+		"23" = 18,\
+		"24" = 9,\
+		"25" = 29,\
+		"26" = 14,\
+		"27" = 6,\
+		"28" = 25,\
+		"29" = 10,\
+		"30" = 30,\
+		"31" = 23,\
+		"32" = 6,\
+		"33" = 26,\
+		"34" = 18,\
+		"35" = 3,\
+		"36" = 22,\
+		"37" = 14,\
+		"38" = 34,\
+		"39" = 19,\
+		"40" = 9,\
+		)
+
+		begin_day = easters[yy_string]
+		if(begin_day <= 9)
+			begin_day += 22
+			begin_month = MARCH
+		else
+			begin_day -= 9
+			begin_month = APRIL
+
+		end_day = begin_day + days_extra
+		end_month = begin_month
+		if(end_day >= 32 && end_month == MARCH) //begins in march, ends in april
+			end_day -= 31
+			end_month++
+		if(end_day >= 31 && end_month == APRIL) //begins in april, ends in june
+			end_day -= 30
+			end_month++
+
+		begin_day -= days_early
+		if(begin_day <= 0)
+			if(begin_month == APRIL)
+				begin_day += 31
+				begin_month-- //begins in march, ends in april
+
+//	world << "Easter calculates to be on [begin_day] of [begin_month] ([days_early] early) to [end_day] of [end_month] ([days_extra] extra) for 20[yy]"
+	return ..()

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -54,7 +54,7 @@
 // The actual holidays
 
 /datum/holiday/new_year
-	name = "New Year"
+	name = NEW_YEAR
 	begin_day = 30 // 1 day early
 	begin_month = DECEMBER
 	end_day = 5 //4 days extra
@@ -65,8 +65,8 @@
 	begin_day = 2
 	begin_month = FEBRUARY
 
-/datum/holiday/velentines
-	name = "Velentine's Day"
+/datum/holiday/valentines
+	name = VALENTINES
 	begin_day = 9 //6 days early
 	begin_month = FEBRUARY
 	end_day = 15 //1 day extra
@@ -90,7 +90,7 @@
 	begin_month = MARCH
 
 /datum/holiday/april_fools
-	name = "April Fool's Day"
+	name = APRIL_FOOLS
 	begin_day = 1
 	begin_month = APRIL
 	end_day = 8 //7 days extra so everyone can enjoy the festivities
@@ -177,7 +177,7 @@
 	begin_month = OCTOBER
 
 /datum/holiday/halloween
-	name = "Halloween"
+	name = HALLOWEEN
 	begin_day = 24 //7 days early
 	begin_month = OCTOBER
 	end_day = 7 //7 days extra
@@ -220,7 +220,7 @@
 	begin_month = DECEMBER
 
 /datum/holiday/xmas
-	name = "Christmas"
+	name = CHRISTMAS
 	begin_day = 18 //7 days early
 	begin_month = DECEMBER
 	end_day = 8 //14 days extra, christmas is important
@@ -247,7 +247,7 @@
 	return pick("Mike","Friday","Evil","Myers","Murder","Deathly","Stabby")
 
 /datum/holiday/easter
-	name = "Easter"
+	name = EASTER
 	var/const/days_early = 1 //to make editing the holiday easier
 	var/const/days_extra = 6
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -81,7 +81,7 @@
 
 /obj/item/weapon/paper/attack_self(mob/user)
 	user.examinate(src)
-	if(rigged && (SSevent.holiday == "April Fool's Day"))
+	if(rigged && (SSevent.holidays["April Fool's Day"]))
 		if(spam_flag == 0)
 			spam_flag = 1
 			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -81,7 +81,7 @@
 
 /obj/item/weapon/paper/attack_self(mob/user)
 	user.examinate(src)
-	if(rigged && (SSevent.holidays["April Fool's Day"]))
+	if(rigged && (SSevent.holidays && SSevent.holidays[APRIL_FOOLS]))
 		if(spam_flag == 0)
 			spam_flag = 1
 			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -47,7 +47,7 @@
 			papers.Remove(P)
 		else
 			P = new /obj/item/weapon/paper
-			if(SSevent.holidays["April Fool's Day"])
+			if(SSevent.holidays && SSevent.holidays[APRIL_FOOLS])
 				if(prob(30))
 					P.info = "<font face=\"[CRAYON_FONT]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"
 					P.rigged = 1

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -47,7 +47,7 @@
 			papers.Remove(P)
 		else
 			P = new /obj/item/weapon/paper
-			if(SSevent.holiday == "April Fool's Day")
+			if(SSevent.holidays["April Fool's Day"])
 				if(prob(30))
 					P.info = "<font face=\"[CRAYON_FONT]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"
 					P.rigged = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -993,6 +993,7 @@
 #include "code\modules\food&drinks\recipes\tablecraft\recipes_sandwich.dm"
 #include "code\modules\food&drinks\recipes\tablecraft\recipes_soup.dm"
 #include "code\modules\food&drinks\recipes\tablecraft\recipes_spaghetti.dm"
+#include "code\modules\holiday\holidays.dm"
 #include "code\modules\hydroponics\biogenerator.dm"
 #include "code\modules\hydroponics\grown.dm"
 #include "code\modules\hydroponics\growninedible.dm"


### PR DESCRIPTION
- Holiday datums run a proc called celebrate() when it's time to celebrate them. Currently none of them do anything but that should change, :wink: :wink:
- Holidays can now run for more than a day. The important ones, april fools, christmas, halloween, new years, and easter, all last at least a week. The idea is so people can celebrate christmas in game without having to, you know, actually play on fucking christmas. And also to put a time limit on how long stuff like the annoying spookoween closet skeletons will stick around so it doesn't overstay its welcome and become annoying as shit like last year.
- The event SS now allows more than 1 holiday to run at a time. This matters for new years + christmas, easter + april fools, easter + 4/20, and any holiday that can happen on friday the 13th. The events get stored in a list that's only initialized if there's an active holiday so testing for potential holidays is still pretty easy.
- Added more easter dates so we won't have to add more until 2040. The current batch run out in 2018.
