### PR TITLE
fix poddoors leaking gasses

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -73,13 +73,14 @@
 	flick("closing", src)
 	icon_state = "closed"
 	SetOpacity(1)
+	sleep(5)
+	density = 1
+	sleep(5)
 	air_update_turf(1)
 	update_freelook_sight()
 	sleep(5)
 	crush()
-	density = 1
 	sleep(5)
-
 	operating = 0
 
 


### PR DESCRIPTION
Fixes poddoors letting air and other gasses through after being opened (even if you close them afterwards).

The problem was that the density was set back to 1 after `air_update_turf` and not before in the closing proc.

AFAIK there haven't been any bug reports about this, but this fixes the cargo bay air alarms going off all the time because one of the cargo techs opened the door and it kept leaking out air even after closing. It also fixes the problem with the turbine being really ineffective if you opened the auxiliary vent (again, even after closing because it would be leaking out into space).

I'm talking about these: 
![20150327125238](https://cloud.githubusercontent.com/assets/5191426/6866373/339e56e2-d480-11e4-9b77-c88265bb4208.jpg)
