### PR TITLE
Cleaning reviving of simple animals.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -443,10 +443,10 @@ Sorry Giacom. Please don't be mad :(
 				C.reagents.clear_reagents()
 	for(var/datum/disease/D in viruses)
 		D.cure(0)
-	if(stat == 2)
+	if(stat == DEAD)
 		dead_mob_list -= src
 		living_mob_list += src
-	if(!isanimal(src))	stat = CONSCIOUS
+	stat = CONSCIOUS
 	if(ishuman(src))
 		var/mob/living/carbon/human/human_mob = src
 		human_mob.restore_blood()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -89,15 +89,7 @@
 
 	//Health
 	if(stat == DEAD)
-		if(health > 0)
-			icon_state = icon_living
-			dead_mob_list -= src
-			living_mob_list += src
-			stat = CONSCIOUS
-			density = 1
-			update_canmove()
 		return 0
-
 
 	if(health < 1 && stat != DEAD)
 		Die()
@@ -394,7 +386,6 @@
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
 /mob/living/simple_animal/proc/Die()
-	health = 0 // so /mob/living/simple_animal/Life() doesn't magically revive them
 	dead_mob_list += src
 	icon_state = icon_dead
 	stat = DEAD
@@ -452,6 +443,9 @@
 
 /mob/living/simple_animal/revive()
 	health = maxHealth
+	icon_state = icon_living
+	density = 1
+	update_canmove()
 	..()
 
 /mob/living/simple_animal/proc/make_babies() // <3 <3 <3


### PR DESCRIPTION
Currently reviving is handled in Life() checking for health above 0.
It is different for carbons, they can be revived only with revive().

It is also unintuitive in an overloaded revive that the mob is still not in an alive state after calling super.

So I think reviving should happen in revive(), not in LIfe(). And like half of the rows is in living/revive() already, so it also removes duplication.
