### PR TITLE
NTSL Expansion!

### DIFF
--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -4,6 +4,9 @@
 /* --- Traffic Control Scripting Language --- */
 	// Nanotrasen TCS Language - Made by Doohl
 
+//Span classes that players are allowed to set in a radio transmission.
+var/list/allowed_custom_spans = list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS)
+
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler
 
@@ -96,6 +99,17 @@
 		interpreter.SetVar("$job"    , 	signal.data["job"])
 		interpreter.SetVar("$sign"   ,	signal)
 		interpreter.SetVar("$pass"	 ,  !(signal.data["reject"])) // if the signal isn't rejected, pass = 1; if the signal IS rejected, pass = 0
+		interpreter.SetVar("$filters"  ,	signal.data["spans"]) //Important, this is given as a vector! (a list)
+		interpreter.SetVar("$say"    , 	signal.data["verb_say"])
+		interpreter.SetVar("$ask"    , 	signal.data["verb_ask"])
+		interpreter.SetVar("$yell"    , 	signal.data["verb_yell"])
+		interpreter.SetVar("$exclaim"    , 	signal.data["verb_exclaim"])
+
+		//Current allowed span classes
+		interpreter.SetVar("$robot",	SPAN_ROBOT) //The font used by silicons!
+		interpreter.SetVar("$loud",		SPAN_YELL)	//Bolding, applied when ending a message with several exclamation marks.
+		interpreter.SetVar("$emphasis",	SPAN_ITALICS) //Italics
+		interpreter.SetVar("$wacky",		SPAN_SANS) //Comic sans font, normally seen from the genetics power.
 
 		//Language bitflags
 		interpreter.SetVar("HUMAN"   ,	HUMAN)
@@ -124,9 +138,15 @@
 					@param content:		Message to broadcast
 					@param frequency:	Frequency to broadcast to
 					@param source:		The name of the source you wish to imitate. Must be stored in stored_names list.
-					@param job:				The name of the job.
+					@param job:			The name of the job.
+					@param spans		What span classes you want to apply to your message. Must be in the "allowed_custom_spans" list.
+					@param say			Say verb used in messages ending in ".".
+					@param ask			Say verb used in messages ending in "?".
+					@param yell			Say verb used in messages ending in "!!" (or more).
+					@param exclaim		Say verb used in messages ending in "!".
+
 		*/
-		interpreter.SetProc("broadcast", "tcombroadcast", signal, list("message", "freq", "source", "job"))
+		interpreter.SetProc("broadcast", "tcombroadcast", signal, list("message", "freq", "source", "job","spans","say","ask","yell","exclaim"))
 
 		/*
 			-> Send a code signal.
@@ -214,9 +234,16 @@
 
 		if(signal.data["name"] != setname)
 			signal.data["realname"] = setname
-		signal.data["name"]		= setname
-		signal.data["job"]		= interpreter.GetCleanVar("$job", signal.data["job"])
-		signal.data["reject"]	= !(interpreter.GetCleanVar("$pass")) // set reject to the opposite of $pass
+		signal.data["name"]			= setname
+		signal.data["job"]			= interpreter.GetCleanVar("$job", signal.data["job"])
+		signal.data["reject"]		= !(interpreter.GetCleanVar("$pass")) // set reject to the opposite of $pass
+		signal.data["verb_say"]		= interpreter.GetCleanVar("$say")
+		signal.data["verb_ask"]		= interpreter.GetCleanVar("$ask")
+		signal.data["verb_yell"]	= interpreter.GetCleanVar("$yell")
+		signal.data["verb_exclaim"]	= interpreter.GetCleanVar("$exclaim")
+		var/list/setspans 			= interpreter.GetCleanVar("$filters") //Save the span vector/list to a holder list
+		setspans &= allowed_custom_spans //Prune out any illegal ones. Go ahead, comment this line out. See the horror you can unleash!
+		signal.data["spans"]		= setspans //Apply it to the signal
 
 		// If the message is invalid, just don't broadcast it!
 		if(signal.data["message"] == "" || !signal.data["message"])
@@ -271,7 +298,7 @@ datum/signal
 			lastsignalers.Add("[time] <B>:</B> [S.id] sent a signal command, which was triggered by NTSL.<B>:</B> [format_frequency(freq)]/[code]")
 
 
-	proc/tcombroadcast(var/message, var/freq, var/source, var/job)
+	proc/tcombroadcast(var/message, var/freq, var/source, var/job, var/spans, var/say = "says", var/ask = "asks", var/yell = "yells", var/exclaim = "exclaims")
 
 		var/datum/signal/newsign = new
 		var/obj/machinery/telecomms/server/S = data["server"]
@@ -294,6 +321,11 @@ datum/signal
 		if(!job)
 			job = "Unknown"
 
+		if(!islist(spans))
+			spans = list()
+		else
+			spans &= allowed_custom_spans //Removes any spans not on the allowed list. Comment this out if want to let players use ANY span in stylesheet.dm!
+
 		//SAY REWRITE RELATED CODE.
 		//This code is a little hacky, but it *should* work. Even though it'll result in a virtual speaker referencing another virtual speaker. vOv
 		var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker,null)
@@ -311,6 +343,11 @@ datum/signal
 		newsign.data["compression"] = 0
 		newsign.data["message"] = message
 		newsign.data["type"] = 2 // artificial broadcast
+		newsign.data["spans"] = spans
+		newsign.data["verb_say"] = say
+		newsign.data["verb_ask"] = ask
+		newsign.data["verb_yell"]= yell
+		newsign.data["verb_exclaim"] = exclaim
 		if(!isnum(freq))
 			freq = text2num(freq)
 		newsign.frequency = freq

--- a/html/changelogs/Gun_Hog_NTSL_Expansion.yml
+++ b/html/changelogs/Gun_Hog_NTSL_Expansion.yml
@@ -1,0 +1,8 @@
+author: Gun Hog
+
+delete-after: True
+
+changes: 
+
+  - rscadd: "NTSL has been updated! It can now read and modify verbs (says, yells, asks)! You can set your own using $say, $yell, $ask, and $exclaim variables in your scripts."
+  - rscadd: "NTSL can now also modify the font, italics, and bolding of radio messages in four ways! In a script, place $loud, $wacky, $emphasis, and/or $robot in a vector to $filters.


### PR DESCRIPTION
Enables NTSL to read and set four radio span classes to messages. 
<b> They are given as a vector, and must be set as a vector named "$filters".</b>
- The variables are $wacky (comic sans), $emphasis (italics), $loud (bold), and $robot (Courier New)

Also enables NTSL to set each of the say modification verbs to custom
values. There are four, depending on how the message ends.
- $say for ".", $ask for "?", $exclaim for "!", and $yell for "!!".

broadcast() proc of NTSL now accepts 5 additional parameters - spans
and each of the Say verbs.
- broadcast (message, frequency, source, job, spans (as a vector), say, ask, exclaim, yell)

Example below:
![screenshot 2015-03-25 16 17 58](https://cloud.githubusercontent.com/assets/4955510/6835936/2bd9b1a6-d30c-11e4-957f-a146f09f94b4.png)
