### PR TITLE
Adds tentative code for "metamodes"

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,6 +13,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
+	latejoin_friendly = 1
 	reroll_friendly = 1
 
 

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -6,6 +6,7 @@
 	required_players = 0
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
+	latejoin_friendly = 1
 	reroll_friendly = 1
 
 	var/list/possible_changelings = list()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -255,10 +255,12 @@
 /datum/game_mode/cult/proc/get_unconvertables()
 	var/list/ucs = list()
 	for(var/mob/living/carbon/human/player in player_list)
-		if(player.mind && !is_convertable_to_cult(player.mind))
+		if(player.mind && !is_convertable_to_cult(player.mind) && player.stat != DEAD)
 			ucs += player.mind
 	return ucs
 
+/datum/game_mode/cult/late_start_round()
+	makeCult()
 
 /datum/game_mode/cult/proc/check_cult_victory()
 	var/cult_fail = 0

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -113,6 +113,9 @@
 		message_admins("Convert_roundtype failed due to no valid modes to convert to. Please report this error to the Coders.")
 		return 0
 
+	if(istype(ticker.mode, /datum/game_mode/multimode)) //These are already chock fulla antags
+		return 1
+
 	replacementmode = pickweight(usable_modes)
 
 	switch(SSshuttle.emergency.mode) //Rounds on the verge of ending don't get new antags, they just run out

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -32,7 +32,9 @@
 	var/list/datum/game_mode/replacementmode = null
 	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
 	var/reroll_friendly 	//During mode conversion only these are in the running
+	var/latejoin_friendly   //Only modes with this set will attempt to use make_antag_chance() for new arrivals
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
+	var/metamode			//A mode of modes
 
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
@@ -153,11 +155,20 @@
 	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
 	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
-		for(var/mob/living/carbon/human/H in antag_canadates)
-			replacementmode.make_antag_chance(H)
+		if(latejoin_friendly) //make_antag_chance handles each player seperately
+			for(var/mob/living/carbon/human/H in antag_canadates)
+				replacementmode.make_antag_chance(H)
+		else //late_start_round handles the round as a whole
+			late_start_round()
 		round_converted = 2
 		message_admins("The roundtype has been converted, antagonists may have been created")
 	return 1
+
+///late_start_round()
+///Jumpstarts a round added after roundstart
+/datum/game_mode/proc/late_start_round()
+	if(pre_setup())
+		post_setup()
 
 ///process()
 ///Called by the gameticker

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -312,6 +312,9 @@
 	ganghud.leave_hud(defector_mind.current)
 	set_antag_hud(defector_mind.current, null)
 
+/datum/game_mode/gang/late_start_round()
+	makeGangsters()
+
 ///////////////////////////
 //Checks for gang victory//
 ///////////////////////////

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -36,7 +36,8 @@
 		if(player.client && player.ready)
 			if(player.client.prefs.be_special & BE_MALF)
 				if(!jobban_isbanned(player, "Syndicate") && !jobban_isbanned(player, "AI") && DummyAIjob.player_old_enough(player.client))
-					antag_candidates += player.mind
+					if(!player.mind.assigned_role)
+						antag_candidates += player.mind
 	antag_candidates = shuffle(antag_candidates)
 	return antag_candidates
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -98,6 +98,9 @@
 	malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
 	return
 
+/datum/game_mode/malfunction/late_start_round()
+	src.makeMalfAImode()
+
 /datum/game_mode/malfunction/process(seconds)
 	if ((apcs > 0) && malf_mode_declared)
 		AI_win_timeleft -= apcs * seconds	//Victory timer de-increments based on how many APCs are hacked

--- a/code/game/gamemodes/multimode/multimode.dm
+++ b/code/game/gamemodes/multimode/multimode.dm
@@ -1,0 +1,91 @@
+/datum/game_mode/multimode
+	name = "double trouble"
+	config_tag = "doubletrouble"
+	required_players = 40
+	pre_setup_before_jobs = 1
+	metamode = 1
+	var/number_of_modes = 2
+	var/list/modes = list()
+	var/list/post_job_antagonists = list()
+
+/datum/game_mode/multimode/triple //Oh baby
+	name = "triple threat"
+	config_tag = "triplethreat"
+	required_players = 50
+	number_of_modes = 3
+
+/datum/game_mode/multimode/announce()
+	for(var/datum/game_mode/G in modes)
+		G.announce()
+
+/datum/game_mode/multimode/pre_setup()
+	var/list/datum/game_mode/runnable_modes = config.get_runnable_modes()
+	var/list/datum/game_mode/usable_modes = list()
+
+	for(var/datum/game_mode/mode in runnable_modes)
+		if(!mode.metamode)
+			usable_modes += mode
+
+	if(!usable_modes)
+		return 0
+
+	for(var/i = 1, i <= number_of_modes, i++)
+		var/mode_to_add = pickweight(usable_modes)
+		modes += mode_to_add
+		usable_modes -= mode_to_add
+		if(!usable_modes)
+			break
+
+	for(var/datum/game_mode/mode in modes)
+		if(!mode.pre_setup_before_jobs) //Run their pre_setup later after job selection but before post
+			post_job_antagonists += mode
+		else
+			mode.pre_setup()
+
+/datum/game_mode/multimode/post_setup()
+	for(var/datum/game_mode/mode in post_job_antagonists)
+		mode.pre_setup()
+
+	for(var/datum/game_mode/mode in modes)
+		mode.post_setup()
+
+	spawn(150)	handle_edgecases() //Allow other spawn shinanagans in indiviudual modes to resolve before finalizing things
+
+	SSshuttle.emergencyNoEscape = 0
+
+/datum/game_mode/multimode/make_antag_chance()
+	return
+
+/datum/game_mode/multimode/process()
+	for(var/datum/game_mode/mode in modes)
+		mode.process()
+
+/datum/game_mode/multimode/declare_completion() //only one gets top billing if neither ended the round on their own terms
+	var/datum/game_mode/mode = pick(modes)
+	mode.declare_completion()
+
+/datum/game_mode/multimode/proc/handle_edgecases() //AW HERE WE GO
+	if(syndicates && traitors) //These guys are actually on the same side and should help each other if possible
+		var/hijacker_present
+		var/escape_needed
+		for(var/datum/mind/traitor in traitors) //Traitors are informed that nuke ops are here and how to succeed if the station explodes
+			var/message = "<B><font size=3 color=red>Your employers have marked this station for annihilation!</font><br>The team tasked with destroying the station has been made aware of your presence here, do not impede their mission.</B>"
+			if(locate(/datum/objective/hijack) in traitor.objectives)
+				message += "<br>You will need to hijack the shuttle before the nuke is detonated."
+				hijacker_present = 1
+			else if(locate(/datum/objective/escape) in traitor.objectives)
+				message += "<br>Be aware that if the team is successful in deploying the nuke you may still escape alive by extracting with the team."
+				escape_needed = 1
+			else if(locate(/datum/objective/survive) in traitor.objectives)
+				message += "<br>You should seek asylum away from the station if the team successfully arms the nuke."
+			traitor.current << message
+		for(var/datum/mind/nukeop in syndicates) //Syndicates are told how they can help the traitors.
+			var/message = "<B><font size=3 color=red>We have agents on the station already.</font><br>While your mission takes priority, try to avoid friendly fire.</B>"
+			if(hijacker_present)
+				message += "<br>We have tasked one or more agent to hijack the escape shuttle. If practical consider setting the nuke to detonate after the escape shuttle leaves the station so that the shuttle may be salvaged."
+			if(escape_needed)
+				message += "<br>One or more agents will need extraction. If practical allow them to return with your team to the shuttle."
+ 			message += "<br><B>Agents currently operating on station:</B><br>"
+ 			for(var/datum/mind/traitor in traitors)
+ 				message += "[traitor.name], "
+ 			nukeop.current << message

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -35,7 +35,12 @@
 		agent_number = n_players/2
 
 	while(agent_number > 0)
+		if(!antag_candidates)
+			break
 		var/datum/mind/new_syndicate = pick(antag_candidates)
+		if(new_syndicate.assigned_role) //This mind is already taken
+			antag_candidates -= new_syndicate
+			continue
 		syndicates += new_syndicate
 		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
 		agent_number--

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -188,6 +188,8 @@
 	synd_mob.update_icons()
 	return 1
 
+/datum/game_mode/nuclear/late_start_round()
+	makeNukeTeam()
 
 /datum/game_mode/nuclear/check_win()
 	if (nukes_left == 0)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -94,6 +94,8 @@
 	SSshuttle.emergencyNoEscape = 1
 	..()
 
+/datum/game_mode/revolution/late_start_round()
+	makeRevs()
 
 /datum/game_mode/revolution/process()
 	check_counter++

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -15,6 +15,7 @@
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
+	latejoin_friendly = 1
 	reroll_friendly = 1
 
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -122,15 +122,3 @@
 		feedback_set_details("round_end_result","loss - wizard killed")
 		world << "<FONT size=3><B>The crew has managed to hold off the wizard attack! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT>"
 	..(1)
-
-/datum/game_mode/wizard/raginmages/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
-	if(!G_found || !G_found.key)	return
-
-	//First we spawn a dude.
-	var/mob/living/carbon/human/new_character = new(pick(latejoin))//The mob being spawned.
-
-	G_found.client.prefs.copy_to(new_character)
-	ready_dna(new_character)
-	new_character.key = G_found.key
-
-	return new_character

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -19,7 +19,16 @@
 
 /datum/game_mode/wizard/pre_setup()
 
-	var/datum/mind/wizard = pick(antag_candidates)
+	var/datum/mind/wizard
+	while(!wizard)
+		if(!antag_candidates)
+			return 0
+		var/datum/mind/candidate = pick(antag_candidates)
+		if(candidate.assigned_role) //already taken
+			antag_candidates -= candidate
+			continue
+		wizard = candidate
+
 	wizards += wizard
 	modePlayer += wizard
 	wizard.assigned_role = "MODE"

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -168,6 +168,8 @@
 	wizard_mob.update_icons()
 	return 1
 
+/datum/game_mode/wizard/late_start_round()
+	makeWizard()
 
 /datum/game_mode/wizard/check_finished()
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -36,7 +36,7 @@ client/proc/one_click_antag()
 	return
 
 
-/datum/admins/proc/makeMalfAImode()
+/datum/proc/makeMalfAImode()
 
 	var/list/mob/living/silicon/AIs = list()
 	var/mob/living/silicon/malfAI = null
@@ -57,7 +57,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeTraitors()
+/datum/proc/makeTraitors()
 	var/datum/game_mode/traitor/temp = new
 
 	if(config.protect_roles_from_antagonist)
@@ -93,7 +93,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeChanglings()
+/datum/proc/makeChanglings()
 
 	var/datum/game_mode/changeling/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -127,7 +127,7 @@ client/proc/one_click_antag()
 
 	return 0
 
-/datum/admins/proc/makeRevs()
+/datum/proc/makeRevs()
 
 	var/datum/game_mode/revolution/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -160,7 +160,7 @@ client/proc/one_click_antag()
 
 	return 0
 
-/datum/admins/proc/makeWizard()
+/datum/proc/makeWizard()
 	var/datum/game_mode/wizard/temp = new
 	var/list/mob/dead/observer/candidates = list()
 	var/mob/dead/observer/theghost = null
@@ -198,7 +198,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeCult()
+/datum/proc/makeCult()
 
 	var/datum/game_mode/cult/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -235,7 +235,7 @@ client/proc/one_click_antag()
 
 
 
-/datum/admins/proc/makeNukeTeam()
+/datum/proc/makeNukeTeam()
 
 	var/datum/game_mode/nuclear/temp = new
 	var/list/mob/dead/observer/candidates = list()
@@ -317,16 +317,16 @@ client/proc/one_click_antag()
 
 
 
-/datum/admins/proc/makeAliens()
+/datum/proc/makeAliens()
 	new /datum/round_event/alien_infestation{spawncount=3}()
 	return 1
 
-/datum/admins/proc/makeSpaceNinja()
+/datum/proc/makeSpaceNinja()
 	new /datum/round_event/ninja()
 	return 1
 
 // DEATH SQUADS
-/datum/admins/proc/makeDeathsquad()
+/datum/proc/makeDeathsquad()
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
 	var/mission = input("Assign a mission to the deathsquad", "Assign Mission", "Leave no witnesses.")
@@ -404,7 +404,7 @@ client/proc/one_click_antag()
 	return
 
 
-/datum/admins/proc/makeGangsters()
+/datum/proc/makeGangsters()
 
 	var/datum/game_mode/gang/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -437,7 +437,7 @@ client/proc/one_click_antag()
 	return 0
 
 // EMERGENCY RESPONSE TEAM
-/datum/admins/proc/makeEmergencyresponseteam()
+/datum/proc/makeEmergencyresponseteam()
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
 	var/mission = input("Assign a mission to the Emergency Response Team", "Assign Mission", "Assist the station.")
@@ -522,7 +522,7 @@ client/proc/one_click_antag()
 
 	return
 
-/datum/admins/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
+/datum/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
 	if(!G_found || !G_found.key)	return
 
 	//First we spawn a dude.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -288,7 +288,7 @@
 
 	joined_player_list += character.ckey
 
-	if(config.allow_latejoin_antagonists)
+	if(config.allow_latejoin_antagonists && ticker.mode.latejoin_friendly)
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_RECALL, SHUTTLE_IDLE)
 				ticker.mode.make_antag_chance(character)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -329,6 +329,7 @@
 #include "code\game\gamemodes\meteor\meteor.dm"
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\monkey\monkey.dm"
+#include "code\game\gamemodes\multimode\multimode.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"


### PR DESCRIPTION
- Adds Double Trouble and Triple Threat, which as you might have guessed are rounds where two or three modes happen concurently from roundstart. Neither has been given suggested odds to be run and are admin run only at this BETA stage. Please run them really sparingly and let me know what doesn't work right.
- Adds the proc late_start_round() for instruction on how a mode should be "added" to a preexisting mode in progress. This isn't actually use here, but the framework will be needed for the meta tensioner mode currently in dev.
- Generalizes a lot of one click antag from datum/admins/ to just /datum/. AS FAR AS I KNOW this doesn't open the door to any crazy exploits, but if I've missed something here, please let me know!
