### PR TITLE
Magic Mania NaN: The Fun Ends Here

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -110,6 +110,10 @@
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
 	var/mutant_colors = 0
 
+	var/no_summon_guns		//No
+	var/no_summon_magic		//Fun
+	var/no_summon_events	//Allowed
+
 	var/alert_desc_green = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 	var/alert_desc_blue_upto = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
 	var/alert_desc_blue_downto = "The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed."
@@ -476,6 +480,12 @@
 					config.starlight			= 1
 				if("grey_assistants")
 					config.grey_assistants			= 1
+				if("no_summon_guns")
+					config.no_summon_guns			= 1
+				if("no_summon_magic")
+					config.no_summon_magic			= 1
+				if("no_summon_events")
+					config.no_summon_events			= 1
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -108,7 +108,7 @@
 
 		dat += "<A href='byond://?src=\ref[src];spell_choice=summonitem'>Instant Summons</A> (10)<BR>"
 		dat += "<I>This spell can be used to bind a valuable item to you, bringing it to your hand at will. Using this spell while holding the bound item will allow you to unbind it. It does not require wizard garb.</I><BR>"
-		if(ticker.mode.name != "ragin' mages") // we totally need summon greentext x100
+		if(ticker.mode.name != "ragin' mages" && !config.no_summon_events) // we totally need summon greentext x100
 			dat += "<A href='byond://?src=\ref[src];spell_choice=summonevents'>Summon Events</A> (One time use, persistent global spell)<BR>"
 			dat += "<I>Give Murphy's law a little push and replace all events with special wizard ones that will confound and confuse everyone. Multiple castings increase the rate of these events.</I><BR>"
 
@@ -124,11 +124,11 @@
 
 		dat += "<HR>"
 
-		if(!("summon guns" in active_challenges))
+		if(!("summon guns" in active_challenges) && !config.no_summon_guns)
 			dat += "<A href='byond://?src=\ref[src];spell_choice=summonguns'>Summon Guns</A> (Single use only, global spell)<BR>"
 			dat += "<I>Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. Just be careful not to stand still too long!</I><BR>"
 
-		if(!("summon magic" in active_challenges))
+		if(!("summon magic" in active_challenges) && !config.no_summon_magic)
 			dat += "<A href='byond://?src=\ref[src];spell_choice=summonmagic'>Summon Magic</A> (Single use only, global spell)<BR>"
 			dat += "<I>Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time.</I><BR>"
 

--- a/code/modules/events/wizard/summons.dm
+++ b/code/modules/events/wizard/summons.dm
@@ -5,6 +5,11 @@
 	max_occurrences = 1
 	earliest_start = 0
 
+/datum/round_event_control/wizard/summonguns/New()
+	if(config.no_summon_guns)
+		weight = 0
+	..()
+
 /datum/round_event/wizard/summonguns/start()
 	rightandwrong(0,,10)
 
@@ -14,6 +19,11 @@
 	typepath = /datum/round_event/wizard/summonmagic/
 	max_occurrences = 1
 	earliest_start = 0
+
+/datum/round_event_control/wizard/summonmagic/New()
+	if(config.no_summon_magic)
+		weight = 0
+	..()
 
 /datum/round_event/wizard/summonmagic/start()
 	rightandwrong(1,,10)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -235,3 +235,11 @@ MIDROUND_ANTAG_TIME_CHECK 60
 
 ## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped
 MIDROUND_ANTAG_LIFE_CHECK 0.7
+
+###Limit Spell Choices##
+## Uncomment to disallow wizards from using certain spells that may be too chaotic/fun for your playerbase
+
+#NO_SUMMON_GUNS
+#NO_SUMMON_MAGIC
+#NO_SUMMON_EVENTS
+


### PR DESCRIPTION
Makes the ability for wizards to use summon guns, summon magic, and summon events config options. Admins can still badmin castings themselves regardless.

If you really don't want to see these things in your server for whatever reason, please just use these instead of editing the spellbook.dm file on your side since it's a file that's apt to be touched fairly often (and currently is in #8524) and github will NOT respect local changes by default when you're updating your version of the code from the codebase. In general modifying the local copy beyond keeping it up to date with the codebase is really just asking for heartache down the line.

I still really recommend just giving wizards the option though after all I did nerf the shit people were complaining about back in #8452 

https://www.youtube.com/watch?v=c0n9PzpMtsU
