### PR TITLE
Fire spread on mob touch

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -239,6 +239,8 @@
 	if(istype(MB))
 		MB.RunOver(src)
 
+	spreadFire(AM)
+
 //Added a safety check in case you want to shock a human mob directly through electrocute_act.
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/safety = 0)
 	if(!safety)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -71,6 +71,9 @@ Sorry Giacom. Please don't be mad :(
 
 //Called when we bump onto a mob
 /mob/living/proc/MobBump(mob/M)
+	//Even if we don't push/swap places, we "touched" them, so spread fire
+	spreadFire(M)
+
 	if(now_pushing)
 		return 1
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -134,6 +134,24 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 	adjust_fire_stacks(0.5)
 	IgniteMob()
 
+
+//Share fire evenly between the two mobs
+//Called in MobBump() and Crossed()
+/mob/living/proc/spreadFire(var/mob/living/L)
+	if(!istype(L))
+		return
+	var/L_old_on_fire = L.on_fire
+
+	if(on_fire) //Only spread fire stacks if we're on fire
+		fire_stacks /= 2
+		L.fire_stacks += fire_stacks
+		L.IgniteMob()
+
+	if(L_old_on_fire) //Only ignite us and gain their stacks if they were onfire before we bumped them
+		L.fire_stacks /= 2
+		fire_stacks += L.fire_stacks
+		IgniteMob()
+
 //Mobs on Fire end
 
 


### PR DESCRIPTION
- When a burning mob MobBump()s another, they halve their own fire stacks, and give the other half to the mob they Bumped, igniting them as well
- When a burning mob is Crossed(), they halve their own fire stacks, and give the other half to the mob that Crossed them, igniting them as well.
