### PR TITLE
Universal Mulligans [DNM {yet}]

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -84,6 +84,7 @@
 	var/list/midround_probabilities = list()// relative probability of each mode in midround antagonist
 	var/list/continuous = list()			// which roundtypes continue if all antagonists die
 	var/list/midround_antag = list()		// which roundtypes use the midround antagonist system
+	var/list/midround_failure = list()		// which roundtypes just quit if midround fails
 
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
@@ -103,7 +104,8 @@
 	var/allow_latejoin_antagonists = 0 	// If late-joining players can be traitor/changeling
 	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
-	var/midround_antag_depth_check = 3  // A max number of mulligans that can occur in a round (a depth of rounds).
+	var/midround_antag_integrity_check = 70  // A percentage of station intactness below which the check will fail, see blob_report.dm on how integrity is calculated
+
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
@@ -470,8 +472,8 @@
 					config.midround_antag_time_check = text2num(value)
 				if("midround_antag_life_check")
 					config.midround_antag_life_check = text2num(value)
-				if("midround_antag_depth_check")
-					config.midround_antag_depth_check = text2num(value)
+				if("midround_antag_integrity_check")
+					config.midround_antag_integrity_check = text2num(value)
 				if("probability")
 					var/prob_pos = findtext(value, " ")
 					var/prob_name = null
@@ -512,6 +514,12 @@
 						config.midround_antag[mode_name] = 1
 					else
 						diary << "Unknown midround antagonist configuration definition: [mode_name]."
+				if("midround_failure")
+					var/mode_name = lowertext(value)
+					if(mode_name in config.modes)
+						config.midround_failure[mode_name] = 1
+					else
+						diary << "Unknown midround failure condition configuration definition: [mode_name]."
 
 
 	fps = round(fps)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -78,9 +78,12 @@
 	//game_options.txt configs
 	var/force_random_names = 0
 	var/list/mode_names = list()
-	var/list/modes = list()				// allowed modes
-	var/list/votable_modes = list()		// votable modes
-	var/list/probabilities = list()		// relative probability of each mode
+	var/list/modes = list()					// allowed modes
+	var/list/votable_modes = list()			// votable modes
+	var/list/probabilities = list()			// relative probability of each mode
+	var/list/midround_probabilities = list()// relative probability of each mode in midround antagonist
+	var/list/continuous = list()			// which roundtypes continue if all antagonists die
+	var/list/midround_antag = list()		// which roundtypes use the midround antagonist system
 
 	var/humans_need_surnames = 0
 	var/allow_random_events = 0			// enables random events mid-round when set to 1
@@ -98,13 +101,9 @@
 	var/protect_assistant_from_antagonist = 0 //If assistants can be traitor/cult/other
 	var/enforce_human_authority = 0		//If non-human species are barred from joining as a head of staff
 	var/allow_latejoin_antagonists = 0 	// If late-joining players can be traitor/changeling
-	var/continuous_round_rev = 0		// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
-	var/continuous_round_gang = 0
-	var/continuous_round_wiz = 0
-	var/continuous_round_malf = 0
-	var/continuous_round_blob = 0
 	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
+	var/midround_antag_depth_check = 3  // A max number of mulligans that can occur in a round (a depth of rounds).
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
@@ -177,7 +176,7 @@
 		del(M)
 	votable_modes += "secret"
 
-/datum/configuration/proc/load(filename, type = "config") //the type can also be game_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
+/datum/configuration/proc/load(filename, type = "config") //the type can also be game_options or mode_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
 	var/list/Lines = file2list(filename)
 
 	for(var/t in Lines)
@@ -393,20 +392,6 @@
 					config.sec_start_brig			= 1
 				if("gateway_delay")
 					config.gateway_delay			= text2num(value)
-				if("continuous_round_rev")
-					config.continuous_round_rev		= 1
-				if("continuous_round_gang")
-					config.continuous_round_gang	= 1
-				if("continuous_round_wiz")
-					config.continuous_round_wiz		= 1
-				if("continuous_round_malf")
-					config.continuous_round_malf	= 1
-				if("continuous_round_blob")
-					config.continuous_round_blob	= 1
-				if("midround_antag_time_check")
-					config.midround_antag_time_check = text2num(value)
-				if("midround_antag_life_check")
-					config.midround_antag_life_check = text2num(value)
 				if("shuttle_refuel_delay")
 					config.shuttle_refuel_delay     = text2num(value)
 				if("show_game_type_odds")
@@ -479,6 +464,56 @@
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 
+		else if(type == "mode_options")
+			switch(name)
+				if("midround_antag_time_check")
+					config.midround_antag_time_check = text2num(value)
+				if("midround_antag_life_check")
+					config.midround_antag_life_check = text2num(value)
+				if("midround_antag_depth_check")
+					config.midround_antag_depth_check = text2num(value)
+				if("probability")
+					var/prob_pos = findtext(value, " ")
+					var/prob_name = null
+					var/prob_value = null
+
+					if(prob_pos)
+						prob_name = lowertext(copytext(value, 1, prob_pos))
+						prob_value = copytext(value, prob_pos + 1)
+						if(prob_name in config.modes)
+							config.probabilities[prob_name] = text2num(prob_value)
+						else
+							diary << "Unknown game mode probability configuration definition: [prob_name]."
+					else
+						diary << "Incorrect probability configuration definition: [prob_name]  [prob_value]."
+				if("midround_probability")
+					var/prob_pos = findtext(value, " ")
+					var/prob_name = null
+					var/prob_value = null
+
+					if(prob_pos)
+						prob_name = lowertext(copytext(value, 1, prob_pos))
+						prob_value = copytext(value, prob_pos + 1)
+						if(prob_name in config.modes)
+							config.midround_probabilities[prob_name] = text2num(prob_value)
+						else
+							diary << "Unknown midround probability configuration definition: [prob_name]."
+					else
+						diary << "Incorrect midround probability configuration definition: [prob_name]  [prob_value]."
+				if("continuous")
+					var/mode_name = lowertext(value)
+					if(mode_name in config.modes)
+						config.continuous[mode_name] = 1
+					else
+						diary << "Unknown continuous configuration definition: [mode_name]."
+				if("midround_antag")
+					var/mode_name = lowertext(value)
+					if(mode_name in config.modes)
+						config.midround_antag[mode_name] = 1
+					else
+						diary << "Unknown midround antagonist configuration definition: [mode_name]."
+
+
 	fps = round(fps)
 	if(fps <= 0)
 		fps = initial(fps)
@@ -549,4 +584,18 @@
 		if(M.can_start())
 			runnable_modes[M] = probabilities[M.config_tag]
 			//world << "DEBUG: runnable_mode\[[runnable_modes.len]\] = [M.config_tag]"
+	return runnable_modes
+
+datum/configuration/proc/get_runnable_midround_modes()
+	var/list/datum/game_mode/runnable_modes = new
+	for(var/T in (typesof(/datum/game_mode) - /datum/game_mode))
+		var/datum/game_mode/M = new T()
+		if(!(M.config_tag in modes))
+			del(M)
+			continue
+		if(midround_probabilities[M.config_tag]<=0)
+			del(M)
+			continue
+		if(M.can_start())
+			runnable_modes[M] = midround_probabilities[M.config_tag]
 	return runnable_modes

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -1,20 +1,27 @@
 /datum/game_mode/blob/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+
 	if(round_converted)
-		return ..()
+		..()
+
 	if(infected_crew.len > burst)//Some blobs have yet to burst
 		return 0
+
 	if(blobwincount <= blobs.len)//Blob took over
 		return 1
+
 	if(!blob_cores.len) // blob is dead
-		if(config.continuous_round_blob)
-			round_converted = convert_roundtype()
-			if(!round_converted)
-				return 1
+		if(config.continuous["blob"])
+			if(config.midround_antag["blob"])
+				round_converted = convert_roundtype()
+				if(!round_converted)
+					return 1
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
-			return 0
+			return ..()
 		return 1
 	if(station_was_nuked)//Nuke went off
 		return 1

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -16,7 +16,11 @@
 			if(config.midround_antag["blob"])
 				round_converted = convert_roundtype()
 				if(!round_converted)
-					return 1
+					if(config.midround_failure["blob"])
+						return 1
+					else
+						config.midround_antag["blob"] = 0
+						return ..()
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -188,7 +188,10 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["changeling"])
+				return 1
+			else
+				config.midround_antag["changeling"] = 0
 	..()
 
 /datum/game_mode/proc/auto_declare_completion_changeling()

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,7 +13,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
-	reroll_friendly = 1
+	latejoin_friendly = 1
 
 
 	var/const/prob_int_murder_target = 50 // intercept names the assassination target half the time
@@ -170,27 +170,26 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		obj_count++
 	return
 
-/*/datum/game_mode/changeling/check_finished()
-	var/changelings_alive = 0
-	for(var/datum/mind/changeling in changelings)
-		if(!istype(changeling.current,/mob/living/carbon))
-			continue
-		if(changeling.current.stat==2)
-			continue
-		changelings_alive++
+/datum/game_mode/changeling/check_finished()
 
-	if (changelings_alive)
-		changelingdeath = 0
-		return ..()
-	else
-		if (!changelingdeath)
-			changelingdeathtime = world.time
-			changelingdeath = 1
-		if(world.time-changelingdeathtime > TIME_TO_GET_REVIVED)
-			return 1
-		else
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+
+	if((config.continuous["changeling"] && !config.midround_antag["changeling"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	for(var/datum/mind/changeling in changelings)
+		if(isliving(changeling.current)) //mob/living body. Not the same as "stat != DEAD"
 			return ..()
-	return 0*/
+
+	if(!config.continuous["changeling"] || !config.midround_antag["changeling"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
 
 /datum/game_mode/proc/auto_declare_completion_changeling()
 	if(changelings.len)

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -6,7 +6,7 @@
 	required_players = 0
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
-	reroll_friendly = 1
+	latejoin_friendly = 1
 
 	var/list/possible_changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off
@@ -75,4 +75,25 @@
 				if(age_check(character.client))
 					if(!(character.job in ticker.mode.restricted_jobs))
 						character.mind.make_Changling()
+	..()
+
+/datum/game_mode/traitor/changeling/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["traitorchan"] && !config.midround_antag["traitorchan"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+	for(var/datum/mind/changeling in changelings)
+		if(isliving(changeling.current))
+			return ..()
+	for(var/datum/mind/traitor in traitors)
+		if(traitor.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["traitorchan"] || !config.midround_antag["traitorchan"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
 	..()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -260,6 +260,9 @@
 	return ucs
 
 
+/datum/game_mode/cult/late_start_round()
+	makeCult()
+
 /datum/game_mode/cult/proc/check_cult_victory()
 	var/cult_fail = 0
 	if(cult_objectives.Find("survive"))
@@ -284,6 +287,24 @@
 	else
 		return 1
 
+/datum/game_mode/cult/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["cult"] && !config.midround_antag["cult"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	for(var/datum/mind/cultist in cult)
+		if(cultist.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["cult"] || !config.midround_antag["cult"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
 
 /datum/game_mode/cult/declare_completion()
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -303,7 +303,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["cult"])
+				return 1
+			else
+				config.midround_antag["cult"] = 0
 	..()
 
 /datum/game_mode/cult/declare_completion()

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -2,7 +2,6 @@
 	name = "extended"
 	config_tag = "extended"
 	required_players = 0
-	reroll_friendly = 1
 
 /datum/game_mode/announce()
 	world << "<B>The current game mode is - Extended Role-Playing!</B>"
@@ -12,4 +11,9 @@
 	return 1
 
 /datum/game_mode/extended/post_setup()
+	..()
+
+/datum/game_mode/extended/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
 	..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -31,7 +31,7 @@
 	var/datum/mind/sacrifice_target = null
 	var/list/datum/game_mode/replacementmode = null
 	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
-	var/reroll_friendly 	//During mode conversion only these are in the running
+	var/latejoin_friendly   //Only modes with this set will attempt to use make_antag_chance() for new arrivals
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
 
 	var/const/waittime_l = 600
@@ -97,13 +97,17 @@
 ///convert_roundtype()
 ///Allows rounds to basically be "rerolled" should the initial premise fall through
 /datum/game_mode/proc/convert_roundtype()
-	var/list/datum/game_mode/runnable_modes = config.get_runnable_modes()
+	var/list/datum/game_mode/runnable_modes = config.get_runnable_midround_modes()
 	var/list/datum/game_mode/usable_modes = list()
+	var/living_crew = 0
+
+	for(var/mob/Player in mob_list)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
+			living_crew++
+
 	for(var/datum/game_mode/G in runnable_modes)
-		if(G.reroll_friendly)
+		if(G.required_players <= living_crew)
 			usable_modes += G
-		else
-			del(G)
 
 	SSshuttle.emergencyNoEscape = 0 //Time to get the fuck out of here
 
@@ -124,11 +128,6 @@
 		message_admins("Convert_roundtype failed due to round length. Limit is [config.midround_antag_time_check] minutes.")
 		return 0
 
-	var/living_crew = 0
-
-	for(var/mob/Player in mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
-			living_crew++
 	if(living_crew / joined_player_list.len <= config.midround_antag_life_check) //If a lot of the player base died, we start fresh
 		message_admins("Convert_roundtype failed due to too many dead people. Limit is [config.midround_antag_life_check * 100]% living crew")
 		return 0
@@ -153,11 +152,21 @@
 	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
 	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
-		for(var/mob/living/carbon/human/H in antag_canadates)
-			replacementmode.make_antag_chance(H)
+		if(latejoin_friendly) //make_antag_chance handles each player seperately
+			for(var/mob/living/carbon/human/H in antag_canadates)
+				replacementmode.make_antag_chance(H)
+		else //late_start_round handles the round as a whole
+			late_start_round()
+
 		round_converted = 2
 		message_admins("The roundtype has been converted, antagonists may have been created")
 	return 1
+
+///late_start_round()
+///Jumpstarts a round added after roundstart
+/datum/game_mode/proc/late_start_round()
+	if(pre_setup())
+		post_setup()
 
 ///process()
 ///Called by the gameticker

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -235,7 +235,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["gang"])
+				return 1
+			else
+				config.midround_antag["gang"] = 0
 	..()
 
 ///////////////////////////////////////////

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -73,8 +73,7 @@
 /datum/game_mode/gang/process()
 	checkwin_counter++
 	if(checkwin_counter >= 5)
-		if(!finished)
-			ticker.mode.check_win()
+		ticker.mode.check_win()
 		checkwin_counter = 0
 	return 0
 
@@ -211,9 +210,33 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/gang/check_finished()
-	if(finished && !config.continuous_round_gang) //Check for Gang Boss death
+
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["gang"] && !config.midround_antag["gang"]) || round_converted == 1 || !finished) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	var/list/gangster_pool = list()
+	switch(finished)
+		if("A")
+			gangster_pool = B_bosses + B_gangsters
+		if("B")
+			gangster_pool = A_bosses + A_gangsters
+		else
+			gangster_pool = A_bosses + A_gangsters + B_bosses + B_gangsters
+
+	for(var/datum/mind/gangster in gangster_pool) //All remnants of the losers snuffed out
+		if(gangster.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["gang"] || !config.midround_antag["gang"])
 		return 1
-	return ..() //Check for evacuation/nuke
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
 
 ///////////////////////////////////////////
 //Deals with converting players to a gang//
@@ -311,6 +334,9 @@
 
 	ganghud.leave_hud(defector_mind.current)
 	set_antag_hud(defector_mind.current, null)
+
+/datum/game_mode/gang/late_start_round()
+	makeGangsters()
 
 ///////////////////////////
 //Checks for gang victory//

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -98,6 +98,9 @@
 	malf.current << "When you feel you have enough APCs under your control, you may begin the takeover attempt."
 	return
 
+/datum/game_mode/malfunction/late_start_round()
+	src.makeMalfAImode()
+
 /datum/game_mode/malfunction/process(seconds)
 	if ((apcs > 0) && malf_mode_declared)
 		AI_win_timeleft -= apcs * seconds	//Victory timer de-increments based on how many APCs are hacked
@@ -144,12 +147,16 @@
 
 
 /datum/game_mode/malfunction/check_finished()
-	if(round_converted)
-		return ..()
-	if (station_captured && !to_nuke_or_not_to_nuke)
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["malfunction"] && !config.midround_antag["malfunction"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	if (station_captured && !to_nuke_or_not_to_nuke && !config.continuous["malfunction"])
 		return 1
+
 	if (is_malf_ai_dead())
-		if(config.continuous_round_malf)
+		if(config.continuous["malfunction"])
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time
@@ -159,10 +166,12 @@
 			if(get_security_level() == "delta")
 				set_security_level("red")
 			round_converted = convert_roundtype()
+			if(!round_converted)
+				return 1
 		else
 			return 1
-	return ..() //check for shuttle and nuke
 
+	..()
 
 /datum/game_mode/malfunction/proc/takeover()
 	set category = "Malfunction"

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -167,7 +167,10 @@
 				set_security_level("red")
 			round_converted = convert_roundtype()
 			if(!round_converted)
-				return 1
+				if(config.midround_failure["malfunction"])
+					return 1
+				else
+					config.midround_antag["malfunction"] = 0
 		else
 			return 1
 

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -84,7 +84,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["monkey"])
+				return 1
+			else
+				config.midround_antag["monkey"] = 0
 	..()
 
 /datum/game_mode/monkey/proc/check_monkey_victory()

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -69,6 +69,24 @@
 		carriermind.current.viruses += D
 	..()
 
+/datum/game_mode/monkey/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["monkey"] && !config.midround_antag["monkey"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+	for(var/datum/mind/monkey in ape_infectees)
+		if(monkey.current.stat != DEAD || !ismonkey(monkey.current)) //SUFFER NOT AN APE TO LIVE
+			return ..()
+
+	if(!config.continuous["monkey"] || !config.midround_antag["monkey"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
+
 /datum/game_mode/monkey/proc/check_monkey_victory()
 	for(var/mob/living/carbon/monkey/M in living_mob_list)
 		if (M.HasDisease(/datum/disease/transformation/jungle_fever))

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -188,6 +188,27 @@
 	synd_mob.update_icons()
 	return 1
 
+/datum/game_mode/nuclear/late_start_round()
+	makeNukeTeam()
+
+/datum/game_mode/nuclear/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["nuclear"] && !config.midround_antag["nuclear"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	for(var/datum/mind/traitor in syndicates)
+		if(traitor.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["nuclear"] || !config.midround_antag["nuclear"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
 
 /datum/game_mode/nuclear/check_win()
 	if (nukes_left == 0)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -194,11 +194,11 @@
 /datum/game_mode/nuclear/check_finished()
 	if(replacementmode && round_converted == 2)
 		return replacementmode.check_finished()
-	if((config.continuous["nuclear"] && !config.midround_antag["nuclear"]) || round_converted == 1) //No reason to waste resources
+	if((config.continuous["nuclear"] && !config.midround_antag["nuclear"]) || round_converted == 1 || !syndicates) //No reason to waste resources
 		return ..() //Check for evacuation/nuke
 
-	for(var/datum/mind/traitor in syndicates)
-		if(traitor.current.stat != DEAD)
+	for(var/datum/mind/nukeop in syndicates)
+		if(nukeop.current.stat != DEAD)
 			return ..()
 
 	if(!config.continuous["nuclear"] || !config.midround_antag["nuclear"])
@@ -207,7 +207,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["nuclear"])
+				return 1
+			else
+				config.midround_antag["nuclear"] = 0
 	..()
 
 /datum/game_mode/nuclear/check_win()

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -244,7 +244,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["revolution"])
+				return 1
+			else
+				config.midround_antag["revolution"] = 0
 	..()
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -20,7 +20,7 @@
 	recommended_enemies = 3
 	enemy_minimum_age = 14
 
-	var/finished = 0
+	var/finished
 	var/check_counter = 0
 	var/max_headrevs = 3
 	var/list/datum/mind/heads_to_kill = list()
@@ -94,13 +94,15 @@
 	SSshuttle.emergencyNoEscape = 1
 	..()
 
+/datum/game_mode/revolution/late_start_round()
+	makeRevs()
 
 /datum/game_mode/revolution/process()
 	check_counter++
 	if(check_counter >= 5)
 		if(!finished)
 			check_heads()
-			ticker.mode.check_win()
+		ticker.mode.check_win()
 		check_counter = 0
 	return 0
 
@@ -197,23 +199,54 @@
 //////////////////////////////////////
 /datum/game_mode/revolution/check_win()
 	if(check_rev_victory())
-		finished = 1
+		finished = "revs"
 	else if(check_heads_victory())
-		finished = 2
+		finished = "heads"
+
+	if(finished)
+		if(check_rev_victory() && check_heads_victory())
+			finished = "draw"
 	return
 
 ///////////////////////////////
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
-	if(config.continuous_round_rev)
-		if(finished != 0)
+
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["revolution"] && !config.midround_antag["revolution"]) || round_converted == 1 || !finished) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	if(config.continuous["revolution"])
+		if(finished)
 			SSshuttle.emergencyNoEscape = 0
-		return ..()
-	if(finished != 0)
-		return 1
 	else
-		return 0
+		return 1
+
+	if(finished == "revs" || finished == "draw") //The implanted people will still need to be taken care of
+		var/list/loyalists = list()
+		for(var/mob/M in living_mob_list)
+			if(M.mind && isloyal(M))
+				loyalists += M.mind
+		for(var/datum/mind/loyalist in loyalists)
+			if(loyalist.current.stat != DEAD)
+				return ..()
+
+	if(finished == "heads" || finished == "draw") //The remaining revs are still a threat
+		for(var/datum/mind/revolutionaries in (revolutionaries + head_revolutionaries))
+			if(revolutionaries.current.stat != DEAD)
+				return ..()
+
+	if(!config.midround_antag["revolution"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
+	..()
+
 
 ///////////////////////////////////////////////////
 //Deals with converting players to the revolution//
@@ -298,12 +331,15 @@
 //Announces the end of the game with all relavent information stated//
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/declare_completion()
-	if(finished == 1)
+	if(finished == "revs")
 		feedback_set_details("round_end_result","win - heads killed")
 		world << "<span class='danger'><FONT size = 3>The heads of staff were killed or exiled! The revolutionaries win!</FONT></span>"
-	else if(finished == 2)
+	else if(finished == "heads")
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		world << "<span class='danger'><FONT size = 3>The heads of staff managed to stop the revolution!</FONT></span>"
+	else if(finished == "draw")
+		feedback_set_details("round_end_result","draw - heads and rev heads both killed")
+		world << "<span class='danger'><FONT size = 3>The revolution succeeded, but the leaders of the revolution also were killed or exiled!</FONT></span>"
 	..()
 	return 1
 

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -46,7 +46,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["double_agents"])
+				return 1
+			else
+				config.midround_antag["double_agents"] = 0
 	..()
 
 /datum/game_mode/traitor/double_agents/forge_traitor_objectives(var/datum/mind/traitor)

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
-	reroll_friendly = 1
+	latejoin_friendly = 1
 
 	traitor_name = "double agent"
 
@@ -26,6 +26,27 @@
 		if(i + 1 > traitors.len)
 			i = 0
 		target_list[traitor] = traitors[i + 1]
+	..()
+
+/datum/game_mode/traitor/double_agents/check_finished()
+
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+
+	if((config.continuous["double_agents"] && !config.midround_antag["double_agents"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	for(var/datum/mind/traitor in traitors)
+		if(traitor.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["double_agents"] || !config.midround_antag["double_agents"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
 	..()
 
 /datum/game_mode/traitor/double_agents/forge_traitor_objectives(var/datum/mind/traitor)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -15,7 +15,7 @@
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
-	reroll_friendly = 1
+	latejoin_friendly = 1
 
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.
@@ -83,6 +83,27 @@
 				if(age_check(character.client))
 					if(!(character.job in ticker.mode.restricted_jobs))
 						add_latejoin_traitor(character.mind)
+	..()
+
+/datum/game_mode/traitor/check_finished()
+
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+
+	if((config.continuous["traitor"] && !config.midround_antag["traitor"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
+	for(var/datum/mind/traitor in traitors)
+		if(traitor.current.stat != DEAD)
+			return ..()
+
+	if(!config.continuous["traitor"] || !config.midround_antag["traitor"])
+		return 1
+
+	else
+		round_converted = convert_roundtype()
+		if(!round_converted)
+			return 1
 	..()
 
 /datum/game_mode/traitor/proc/add_latejoin_traitor(var/datum/mind/character)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -103,7 +103,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["traitor"])
+				return 1
+			else
+				config.midround_antag["traitor"] = 0
 	..()
 
 /datum/game_mode/traitor/proc/add_latejoin_traitor(var/datum/mind/character)

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -37,6 +37,12 @@
 	return
 
 /datum/game_mode/wizard/raginmages/check_finished()
+
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if(round_converted == 1)
+		..()
+
 	var/wizards_alive = 0
 	for(var/datum/mind/wizard in wizards)
 		if(!istype(wizard.current,/mob/living/carbon))
@@ -59,8 +65,16 @@
 			make_more_mages()
 	else
 		if(mages_made >= max_mages)
-			finished = 1
-			return 1
+			if(!config.continuous["raginmages"])
+				return 1
+			if(config.continuous["raginmages"] && !config.midround_antag["raginmages"])
+				return ..()
+
+			round_converted = convert_roundtype()
+			if(!round_converted)
+				return 1
+			..()
+
 		else
 			make_more_mages()
 	return ..()
@@ -118,19 +132,6 @@
 			return 1
 
 /datum/game_mode/wizard/raginmages/declare_completion()
-	if(finished)
-		feedback_set_details("round_end_result","loss - wizard killed")
-		world << "<FONT size=3><B>The crew has managed to hold off the wizard attack! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT>"
-	..(1)
-
-/datum/game_mode/wizard/raginmages/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
-	if(!G_found || !G_found.key)	return
-
-	//First we spawn a dude.
-	var/mob/living/carbon/human/new_character = new(pick(latejoin))//The mob being spawned.
-
-	G_found.client.prefs.copy_to(new_character)
-	ready_dna(new_character)
-	new_character.key = G_found.key
-
-	return new_character
+	feedback_set_details("round_end_result","loss - wizard killed")
+	world << "<FONT size=3><B>The crew has managed to hold off the wizard attack! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT>"
+	..()

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -175,7 +175,7 @@
 	if(replacementmode && round_converted == 2)
 		return replacementmode.check_finished()
 
-	if((config.continuous["wizard"] && !config.midround_antag["wizard"]) || round_converted == 1) //No reason to waste resources
+	if((config.continuous["wizard"] && !config.midround_antag["wizard"]) || round_converted == 1 || !wizards) //No reason to waste resources
 		return ..() //Check for evacuation/nuke
 
 	for(var/datum/mind/wizard in wizards)
@@ -192,7 +192,10 @@
 	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			return 1
+			if(config.midround_failure["wizard"])
+				return 1
+			else
+				config.midround_antag["wizard"] = 0
 		else
 			if(SSevent.wizardmode) //If summon events was active, turn it off
 				SSevent.toggleWizardmode()

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -11,7 +11,6 @@
 	pre_setup_before_jobs = 1
 	enemy_minimum_age = 14
 	var/use_huds = 0
-	var/finished = 0
 
 /datum/game_mode/wizard/announce()
 	world << "<B>The current game mode is - Wizard!</B>"
@@ -168,50 +167,41 @@
 	wizard_mob.update_icons()
 	return 1
 
+/datum/game_mode/wizard/late_start_round()
+	makeWizard()
 
 /datum/game_mode/wizard/check_finished()
 
-	if(round_converted)
-		return ..()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
 
-	var/wizards_alive = 0
-	var/traitors_alive = 0
+	if((config.continuous["wizard"] && !config.midround_antag["wizard"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
 	for(var/datum/mind/wizard in wizards)
-		if(!istype(wizard.current,/mob/living/carbon))
-			continue
-		if(wizard.current.stat==2)
-			continue
-		wizards_alive++
+		if(wizard.current.stat != DEAD)
+			return ..()
 
-	if(!wizards_alive)
-		for(var/datum/mind/traitor in traitors)
-			if(!istype(traitor.current,/mob/living/carbon))
-				continue
-			if(traitor.current.stat==2)
-				continue
-			traitors_alive++
+	for(var/datum/mind/traitor in traitors)
+		if(traitor.current.stat != DEAD)
+			return ..()
 
-	if (wizards_alive || traitors_alive)
-		return ..()
+	if(!config.continuous["wizard"] || !config.midround_antag["wizard"])
+		return 1
 
-	if(config.continuous_round_wiz)
+	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
-			finished = 1
 			return 1
 		else
 			if(SSevent.wizardmode) //If summon events was active, turn it off
 				SSevent.toggleWizardmode()
 				SSevent.resetFrequency()
-			return ..()
-
-	finished = 1
-	return 1
+	..()
 
 /datum/game_mode/wizard/declare_completion()
-	if(finished)
-		feedback_set_details("round_end_result","loss - wizard killed")
-		world << "<span class='userdanger'>The wizard[(wizards.len>1)?"s":""] has been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</span>"
+	feedback_set_details("round_end_result","loss - wizard killed")
+	world << "<span class='userdanger'>The wizard[(wizards.len>1)?"s":""] has been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</span>"
 	..()
 	return 1
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -367,9 +367,14 @@
 /datum/admins/proc/check_antagonists()
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
-		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
+		dat += "Current Game Mode: <B>[ticker.mode.name]"
 		if(ticker.mode.replacementmode)
-			dat += "Replacement Game Mode: <B>[ticker.mode.replacementmode.name]</B><BR>"
+			dat += "/[ticker.mode.replacementmode.name]"
+			if(ticker.mode.replacementmode.replacementmode)
+				dat += "/[ticker.mode.replacementmode.replacementmode.name]"
+				if(ticker.mode.replacementmode.replacementmode.replacementmode)
+					dat += " (but wait, there's more!)" //This is getting silly
+		dat += "</B><BR>"
 		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero("[world.time / 600 % 60]", 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if(SSshuttle.emergency.mode < SHUTTLE_CALL)
@@ -381,6 +386,13 @@
 				dat += "<a href='?_src_=holder;call_shuttle=2'>Send Back</a><br>"
 			else
 				dat += "ETA: <a href='?_src_=holder;edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+		dat += "<B>Continuous Round Status</B><BR>"
+		dat += "<a href='?_src_=holder;toggle_continuous=1'>[config.continuous[ticker.mode.config_tag] ? "Continue if antagonists die" : "End on antagonist death"]</a>"
+		if(config.continuous[ticker.mode.config_tag])
+			dat += ", <a href='?_src_=holder;toggle_midround_antag=1'>[config.midround_antag[ticker.mode.config_tag] ? "creating replacement antagonists" : "not creating new antagonists"]</a><BR>"
+		else
+			dat += "<BR>"
+		dat += "<BR>"
 		dat += "<a href='?_src_=holder;end_round=\ref[usr]'>End Round Now</a><br>"
 		dat += "<a href='?_src_=holder;delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
 		if(ticker.mode.syndicates.len)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -218,6 +218,28 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [timer] seconds</span>")
 		href_list["secretsadmin"] = "check_antagonist"
 
+	else if(href_list["toggle_continuous"])
+		if(!check_rights(R_ADMIN))	return
+
+		if(!config.continuous[ticker.mode.config_tag])
+			config.continuous[ticker.mode.config_tag] = 1
+		else
+			config.continuous[ticker.mode.config_tag] = 0
+
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled the round to [config.continuous[ticker.mode.config_tag] ? "continue if all antagonists die" : "end with the antagonists"].</span>")
+		check_antagonists()
+
+	else if(href_list["toggle_midround_antag"])
+		if(!check_rights(R_ADMIN))	return
+
+		if(!config.midround_antag[ticker.mode.config_tag])
+			config.midround_antag[ticker.mode.config_tag] = 1
+		else
+			config.midround_antag[ticker.mode.config_tag] = 0
+
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled the round to [config.midround_antag[ticker.mode.config_tag] ? "use" : "skip"] the midround antag system.</span>")
+		check_antagonists()
+
 	else if(href_list["delay_round_end"])
 		if(!check_rights(R_SERVER))	return
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -36,7 +36,7 @@ client/proc/one_click_antag()
 	return
 
 
-/datum/admins/proc/makeMalfAImode()
+/datum/proc/makeMalfAImode()
 
 	var/list/mob/living/silicon/AIs = list()
 	var/mob/living/silicon/malfAI = null
@@ -57,7 +57,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeTraitors()
+/datum/proc/makeTraitors()
 	var/datum/game_mode/traitor/temp = new
 
 	if(config.protect_roles_from_antagonist)
@@ -93,7 +93,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeChanglings()
+/datum/proc/makeChanglings()
 
 	var/datum/game_mode/changeling/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -127,7 +127,7 @@ client/proc/one_click_antag()
 
 	return 0
 
-/datum/admins/proc/makeRevs()
+/datum/proc/makeRevs()
 
 	var/datum/game_mode/revolution/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -160,7 +160,7 @@ client/proc/one_click_antag()
 
 	return 0
 
-/datum/admins/proc/makeWizard()
+/datum/proc/makeWizard()
 	var/datum/game_mode/wizard/temp = new
 	var/list/mob/dead/observer/candidates = list()
 	var/mob/dead/observer/theghost = null
@@ -198,7 +198,7 @@ client/proc/one_click_antag()
 	return 0
 
 
-/datum/admins/proc/makeCult()
+/datum/proc/makeCult()
 
 	var/datum/game_mode/cult/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -235,7 +235,7 @@ client/proc/one_click_antag()
 
 
 
-/datum/admins/proc/makeNukeTeam()
+/datum/proc/makeNukeTeam()
 
 	var/datum/game_mode/nuclear/temp = new
 	var/list/mob/dead/observer/candidates = list()
@@ -317,16 +317,16 @@ client/proc/one_click_antag()
 
 
 
-/datum/admins/proc/makeAliens()
+/datum/proc/makeAliens()
 	new /datum/round_event/alien_infestation{spawncount=3}()
 	return 1
 
-/datum/admins/proc/makeSpaceNinja()
+/datum/proc/makeSpaceNinja()
 	new /datum/round_event/ninja()
 	return 1
 
 // DEATH SQUADS
-/datum/admins/proc/makeDeathsquad()
+/datum/proc/makeDeathsquad()
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
 	var/mission = input("Assign a mission to the deathsquad", "Assign Mission", "Leave no witnesses.")
@@ -404,7 +404,7 @@ client/proc/one_click_antag()
 	return
 
 
-/datum/admins/proc/makeGangsters()
+/datum/proc/makeGangsters()
 
 	var/datum/game_mode/gang/temp = new
 	if(config.protect_roles_from_antagonist)
@@ -437,7 +437,7 @@ client/proc/one_click_antag()
 	return 0
 
 // EMERGENCY RESPONSE TEAM
-/datum/admins/proc/makeEmergencyresponseteam()
+/datum/proc/makeEmergencyresponseteam()
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
 	var/mission = input("Assign a mission to the Emergency Response Team", "Assign Mission", "Assist the station.")
@@ -522,7 +522,7 @@ client/proc/one_click_antag()
 
 	return
 
-/datum/admins/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
+/datum/proc/makeBody(var/mob/dead/observer/G_found) // Uses stripped down and bastardized code from respawn character
 	if(!G_found || !G_found.key)	return
 
 	//First we spawn a dude.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -288,7 +288,7 @@
 
 	joined_player_list += character.ckey
 
-	if(config.allow_latejoin_antagonists)
+	if(config.allow_latejoin_antagonists && ticker.mode.latejoin_friendly)
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_RECALL, SHUTTLE_IDLE)
 				ticker.mode.make_antag_chance(character)

--- a/code/world.dm
+++ b/code/world.dm
@@ -176,6 +176,7 @@
 	config = new /datum/configuration()
 	config.load("config/config.txt")
 	config.load("config/game_options.txt","game_options")
+	config.load("config/mode_options.txt","mode_options")
 	config.loadsql("config/dbconfig.txt")
 	// apply some settings from config..
 	abandon_allowed = config.respawn

--- a/config/mode_options.txt
+++ b/config/mode_options.txt
@@ -1,0 +1,107 @@
+## Probablities for game modes chosen in 'secret' and 'random' modes.
+## Default probablity is 1, increase to make that mode more likely to be picked.
+## Set to 0 to disable that mode.
+
+PROBABILITY TRAITOR 5
+PROBABILITY TRAITORCHAN 4
+PROBABILITY DOUBLE_AGENTS 3
+PROBABILITY NUCLEAR 2
+PROBABILITY REVOLUTION 2
+PROBABILITY GANG 0
+PROBABILITY CULT 2
+PROBABILITY CHANGELING 2
+PROBABILITY WIZARD 4
+PROBABILITY MALFUNCTION 1
+PROBABILITY BLOB 2
+PROBABILITY RAGINMAGES 2
+PROBABILITY MONKEY 1
+PROBABILITY METEOR 0
+PROBABILITY EXTENDED 0
+
+## You probably want to keep sandbox off by default for secret and random.
+PROBABILITY SANDBOX 0
+
+
+
+## Toggles for continuous modes.
+## Modes that aren't continuous will end the instant all antagonists are dead.
+## Keep in mind that this is quite unlikely for round types where antagonists are numerous and/or less obvious.
+
+CONTINUOUS TRAITOR
+CONTINUOUS TRAITORCHAN
+CONTINUOUS DOUBLE_AGENTS
+CONTINUOUS NUCLEAR
+CONTINUOUS REVOLUTION
+CONTINUOUS GANG
+CONTINUOUS CULT
+CONTINUOUS CHANGELING
+CONTINUOUS WIZARD
+CONTINUOUS MALFUNCTION
+CONTINUOUS BLOB
+CONTINUOUS RAGINMAGES
+CONTINUOUS MONKEY
+
+## These modes don't have antagonists and are included only for completion
+#CONTINUOUS METEOR
+#CONTINUOUS EXTENDED
+#CONTINUOUS SANDBOX
+
+
+
+## Toggles for allowing midround antagonists (aka mulligan antagonists).
+## In modes that are continuous, if all antagonists should die then a new set of antagonists will be created.
+## Which rounds can use this feature depend on these toggles. Keep in mind that toggling this for a non continous round is pointless.
+
+MIDROUND_ANTAG TRAITOR
+MIDROUND_ANTAG TRAITORCHAN
+MIDROUND_ANTAG DOUBLE_AGENTS
+MIDROUND_ANTAG NUCLEAR
+MIDROUND_ANTAG REVOLUTION
+MIDROUND_ANTAG GANG
+MIDROUND_ANTAG CULT
+MIDROUND_ANTAG CHANGELING
+MIDROUND_ANTAG WIZARD
+MIDROUND_ANTAG MALFUNCTION
+MIDROUND_ANTAG BLOB
+MIDROUND_ANTAG RAGINMAGES
+MIDROUND_ANTAG MONKEY
+
+## These modes don't have antagonists and are included only for completion
+#MIDROUND_ANTAG METEOR
+#MIDROUND_ANTAG EXTENDED
+#MIDROUND_ANTAG SANDBOX
+
+
+
+## Probablities for midround antagonists (aka mulligan antagonists).
+## When midround antagonoist is activated in one of the modes set in the last section, it will choose a new roundtype from these probablities.
+## Set to 0 to disable that mode.
+
+MIDROUND_PROBABILITY TRAITOR 5
+MIDROUND_PROBABILITY TRAITORCHAN 4
+MIDROUND_PROBABILITY DOUBLE_AGENTS 3
+MIDROUND_PROBABILITY NUCLEAR 2
+MIDROUND_PROBABILITY REVOLUTION 2
+MIDROUND_PROBABILITY GANG 0
+MIDROUND_PROBABILITY CULT 2
+MIDROUND_PROBABILITY CHANGELING 2
+MIDROUND_PROBABILITY WIZARD 4
+MIDROUND_PROBABILITY MALFUNCTION 1
+MIDROUND_PROBABILITY BLOB 2
+MIDROUND_PROBABILITY RAGINMAGES 2
+MIDROUND_PROBABILITY MONKEY 1
+MIDROUND_PROBABILITY METEOR 0
+MIDROUND_PROBABILITY EXTENDED 0
+
+## You probably don't want to segue into sandbox.
+MIDROUND_PROBABILITY SANDBOX 0
+
+
+
+###Other midround antag settings###
+
+## A time, in minutes, after which the midround antag system stops attempting to run and continuous rounds end immediately upon completion.
+MIDROUND_ANTAG_TIME_CHECK 60
+
+## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped.
+MIDROUND_ANTAG_LIFE_CHECK 0.7

--- a/config/mode_options.txt
+++ b/config/mode_options.txt
@@ -74,27 +74,52 @@ MIDROUND_ANTAG MONKEY
 
 
 ## Probablities for midround antagonists (aka mulligan antagonists).
-## When midround antagonoist is activated in one of the modes set in the last section, it will choose a new roundtype from these probablities.
+## When midround antagonist is activated in one of the modes set in the last section, it will choose a new roundtype from these probablities.
 ## Set to 0 to disable that mode.
 
 MIDROUND_PROBABILITY TRAITOR 5
-MIDROUND_PROBABILITY TRAITORCHAN 4
-MIDROUND_PROBABILITY DOUBLE_AGENTS 3
-MIDROUND_PROBABILITY NUCLEAR 2
-MIDROUND_PROBABILITY REVOLUTION 2
+MIDROUND_PROBABILITY TRAITORCHAN 2
+MIDROUND_PROBABILITY DOUBLE_AGENTS 1
+MIDROUND_PROBABILITY NUCLEAR 1
+MIDROUND_PROBABILITY REVOLUTION 1
 MIDROUND_PROBABILITY GANG 0
-MIDROUND_PROBABILITY CULT 2
-MIDROUND_PROBABILITY CHANGELING 2
-MIDROUND_PROBABILITY WIZARD 4
+MIDROUND_PROBABILITY CULT 1
+MIDROUND_PROBABILITY CHANGELING 3
+MIDROUND_PROBABILITY WIZARD 1
 MIDROUND_PROBABILITY MALFUNCTION 1
-MIDROUND_PROBABILITY BLOB 2
-MIDROUND_PROBABILITY RAGINMAGES 2
-MIDROUND_PROBABILITY MONKEY 1
+MIDROUND_PROBABILITY BLOB 1
+MIDROUND_PROBABILITY RAGINMAGES 0
+MIDROUND_PROBABILITY MONKEY 0
 MIDROUND_PROBABILITY METEOR 0
 MIDROUND_PROBABILITY EXTENDED 0
 
 ## You probably don't want to segue into sandbox.
 MIDROUND_PROBABILITY SANDBOX 0
+
+
+
+## Failure behavior for midround antagonists (aka mulligan antagonists).
+## If midround antagonist fails for whatever reason these toggles dictate what happens next.
+## If the toggle is uncommented, the round ends immediately. Otherwise the round will continue seperate of the mulligan system.
+
+#MIDROUND_FAILURE TRAITOR
+#MIDROUND_FAILURE TRAITORCHAN
+#MIDROUND_FAILURE DOUBLE_AGENTS
+#MIDROUND_FAILURE NUCLEAR
+#MIDROUND_FAILURE REVOLUTION
+#MIDROUND_FAILURE GANG
+#MIDROUND_FAILURE CULT
+#MIDROUND_FAILURE CHANGELING
+MIDROUND_FAILURE WIZARD
+MIDROUND_FAILURE MALFUNCTION
+MIDROUND_FAILURE BLOB
+MIDROUND_FAILURE RAGINMAGES
+#MIDROUND_FAILURE MONKEY
+
+## These modes don't have antagonists and are included only for completion
+#MIDROUND_FAILURE METEOR
+#MIDROUND_FAILURE EXTENDED
+#MIDROUND_FAILURE SANDBOX
 
 
 
@@ -105,3 +130,6 @@ MIDROUND_ANTAG_TIME_CHECK 60
 
 ## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped.
 MIDROUND_ANTAG_LIFE_CHECK 0.7
+
+## A percentage for station intactness. Destroyed walls, floors, grills, windows, and machinery will count against this rating.
+MIDROUND_ANTAG_INTEGRITY_CHECK 50


### PR DESCRIPTION
*All modes can now use the midround antag (mulligan) system to switch into each other

*All modes can now be individually set to either end on antag death or continue on until the shuttle is called

*All modes can now choose to use or not use the midround antag system

*The midround antag system now has its own list of configurable probabilities, separate from the traditional probabilities

*The midround antagonist system is now capable of firing multiple times in one round if all the replacement antagonists are ALSO neutralized (note: because of how the system works, this will almost never happen without badmining)

*These round options have been moved into their own config file, mode_options.txt

 *Adds an integrity check to mulligan antag, it has lower priority than the life and time check. Due to how integrity works, this should prevent mulligans in instances of widespread fires, loose singularities, and excessive bombing

*The check antagonist panel has been updated to show what the current settings for continuous rounds and midround antag are, and toggle them from their default config state for the round if desired.

Still to do:
- [ ] Testing Testing Testing
- [ ] code beautification
- [ ] requests
