### PR TITLE
[BALANCE] Disallow AI To View Sec Helm Cameras

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -5,7 +5,7 @@
 	circuit = /obj/item/weapon/circuitboard/security
 	var/obj/machinery/camera/current = null
 	var/last_pic = 1.0
-	var/list/network = list("SS13")
+	var/list/network = list("SS13","Helm")
 	var/mapping = 0//For the overview file, interesting bit of code.
 
 /obj/machinery/computer/security/check_eye(var/mob/user as mob)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -21,7 +21,7 @@
 	if(spawnWithHelmetCam)
 		helmetCam = new /obj/machinery/camera/portable(src)
 		helmetCam.c_tag = "Helmet-Mounted Camera (No User)([rand(1,999)])"
-		helmetCam.network = list("SS13")
+		helmetCam.network = list("Helm")
 		update_icon()
 
 /obj/item/clothing/head/helmet/emp_act(severity)
@@ -204,7 +204,7 @@ obj/item/clothing/head/helmet/bluetaghelm
 		helmetCam.assembly = A
 		A.loc = helmetCam
 		helmetCam.c_tag = "Helmet-Mounted Camera (No User)([rand(1,999)])"
-		helmetCam.network = list("SS13")
+		helmetCam.network = list("Helm")
 		update_icon()
 		user.visible_message("<span class='notice'>[user] attaches [A] to [src]</span>","<span class='notice'>You attach [A] to [src]</span>")
 		return

--- a/html/changelogs/Steelpoint-PR-8591.yml
+++ b/html/changelogs/Steelpoint-PR-8591.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Steelpoint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak "AI's can no longer see anything a Helmet Camera can see. The only way to view the Helmet Camera's is now from a Security Camera Console."


### PR DESCRIPTION
This PR disallows the AI to be able to view anything that a Security Helmet Camera can see, it's now located on a separate network that only the Security Camera Consoles can view.
## 

Opinion wise I believe that this should have been the case to begin with, and I think this is one of the main points of contention people have with the feature (barring the whole thing).
