### PR TITLE
Fixes alien nest buckling

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -7,23 +7,32 @@
 	icon_state = "nest"
 	var/health = 100
 
-/*
-/obj/structure/stool/bed/nest/unbuckle_other(mob/user as mob)
-	buckled_mob.visible_message(\
-		"<span class='notice'>[user.name] pulls [buckled_mob.name] free from the sticky nest!</span>",\
-		"[user.name] pulls you free from the gelatinous resin.",\
-		"You hear squelching...")
-	unbuckle()
+/obj/structure/stool/bed/nest/user_unbuckle_mob(mob/user as mob)
+	if(buckled_mob && buckled_mob.buckled == src)
+		var/mob/living/M = buckled_mob
+		if(M != user)
+			M.visible_message(\
+				"<span class='notice'>[user.name] pulls [M.name] free from the sticky nest!</span>",\
+				"<span class='notice'>[user.name] pulls you free from the gelatinous resin.</span>",\
+				"You hear squelching...")
+		else
+			M.visible_message(\
+				"<span class='warning'>[M.name] struggles to break free from the gelatinous resin!</span>",\
+				"<span class='warning'>You struggle to break free from the gelatinous resin. (Stay still for two minutes.)</span>",\
+				"You hear squelching...")
+			if(!do_after(M, 1200))
+				if(M && M.buckled)
+					M << "<span class='warning'>You fail to unbuckle yourself!</span>"
+				return
+			if(!M.buckled)
+				return
+			M.visible_message(\
+				"<span class='warning'>[M.name] breaks free from the gelatinous resin!</span>",\
+				"<span class='warning'>You break free from the gelatinous resin!</span>",\
+				"You hear squelching...")
 
-/obj/structure/stool/bed/nest/unbuckle_myself(mob/user as mob)
-	buckled_mob.visible_message(\
-		"<span class='warning'>[buckled_mob.name] struggles to break free of the gelatinous resin...</span>",\
-		"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",\
-		"You hear squelching...")
-	spawn(600)
-		if(user && buckled_mob && user.buckled == src)
-			unbuckle()
-*/
+		unbuckle_mob()
+		add_fingerprint(user)
 
 /obj/structure/stool/bed/nest/user_buckle_mob(mob/M as mob, mob/user as mob)
 	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.stat || M.buckled || istype(user, /mob/living/silicon/pai) )
@@ -44,12 +53,15 @@
 
 /obj/structure/stool/bed/nest/post_buckle_mob(mob/living/M)
 	if(M == buckled_mob)
-		M.pixel_y += 6
-		M.pixel_x += 2
+		M.pixel_y = 0
+		M.pixel_x = initial(M.pixel_x) + 2
 		overlays += image('icons/mob/alien.dmi', "nestoverlay", layer=6)
 	else
-		M.pixel_x -= 2
+		M.pixel_x = initial(M.pixel_x)
 		M.pixel_y = initial(M.pixel_y)
+		if(M.lying)
+			var/lying_pixel_y_offset = -6
+			M.pixel_y += lying_pixel_y_offset
 		overlays.Cut()
 
 /obj/structure/stool/bed/nest/attackby(obj/item/weapon/W as obj, mob/user as mob, params)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -59,7 +59,6 @@
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "down"
 	anchored = 0
-	var/const/buckled_pixel_y_offset = 6 //Mobs buckled will have their pixel_y offset by this much
 
 
 /obj/structure/stool/bed/roller/post_buckle_mob(mob/M)
@@ -72,7 +71,8 @@
 		icon_state = "down"
 		M.pixel_y = initial(M.pixel_y)
 		if(M.lying)
-			M.pixel_y -= buckled_pixel_y_offset
+			var/lying_pixel_y_offset = -6
+			M.pixel_y += lying_pixel_y_offset
 
 
 /obj/item/roller

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -38,6 +38,8 @@
 	living_mob_list -= src
 	if(!gibbed)
 		dead_mob_list += src
+	else if(buckled)
+		buckled.unbuckle_mob()
 
 
 /mob/living/proc/setup_animation(var/animation, var/prev_lying)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -693,13 +693,12 @@ Sorry Giacom. Please don't be mad :(
 					if(do_after(usr, 600))
 						if(!C.buckled)
 							return
-						C.visible_message("<span class='danger'>[C] manages to unbuckle themself!</span>", \
-											"<span class='notice'>You successfully unbuckle yourself.</span>")
 						C.buckled.user_unbuckle_mob(C,C)
 					else
-						C << "<span class='warning'>You fail to unbuckle yourself!</span>"
+						if(C && C.buckled)
+							C << "<span class='warning'>You fail to unbuckle yourself!</span>"
 			else
-				L.buckled.user_unbuckle_mob(L,L)
+				C.buckled.user_unbuckle_mob(C,C)
 		else
 			L.buckled.user_unbuckle_mob(L,L)
 


### PR DESCRIPTION
Fixes alien nest not blocking the victim from instantly unbuckling. The victim now needs to click the nest or resist, then wait 2 minutes before being free.

Fixes alien nest buckling pixel offset.
Removes resist unbuckling 'success' message so there's not two unbuckling messages.
Fixes objects with buckling not unbuckling its buckled mob when the mob is gibbed (Fixes alien nest overlay not disappearing when larva burst and gib its host). Fixes #8523 
