### PR TITLE
Fixes *flip

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -86,9 +86,9 @@
 				m_type = 2
 
 		if ("flip")
-			if (!src.restrained())
-				message = "<B>[src]</B> does a flip!"
-				src.SpinAnimation(5,1)
+			if (!src.restrained() || src.resting || src.sleeping)
+				src << "<span class = 'notice'>You do a flip!</span>"
+				src.SpinAnimation(7,1)
 				m_type = 2
 
 		if ("frown")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -86,8 +86,7 @@
 				m_type = 2
 
 		if ("flip")
-			if (!src.restrained() || src.resting || src.sleeping)
-				src << "<span class = 'notice'>You do a flip!</span>"
+			if (!src.restrained() || !src.resting || !src.sleeping)
 				src.SpinAnimation(7,1)
 				m_type = 2
 


### PR DESCRIPTION
You now can't flip while asleep or resting.

The spin animation is slightly slower to not be damn near instant.

The flip message is now only displayed to you, due to it spamming up the logs of other players and admins.
