### PR TITLE
Traitors can now buy blood-red hardsuits for 8 TC

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -474,7 +474,7 @@ var/list/uplink_items = list()
 	When the built in helmet is deployed your identity will be protected, even in death, as the suit cannot be removed by outside forces. Toggling the suit into combat mode \
 	will allow you all the mobility of a loose fitting uniform without sacrificing armoring. Additionally the suit is collapsible, small enough to fit within a backpack. \
 	Nanotrasen crewmembers are trained to report red space suit sightings, these suits in particular are known to drive employees into a panic."
-	item = /obj/item/weapon/storage/box/syndie_kit/space
+	item = /obj/item/clothing/suit/space/hardsuit/syndi
 	cost = 8
 
 /datum/uplink_item/device_tools/thermal

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -468,6 +468,15 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/space
 	cost = 5
 
+/datum/uplink_item/device_tools/hardsuit
+	name = "Blood-red Hardsuit"
+	desc = "The feared suit of a syndicate nuclear agent. Features slightly better armoring and a built in jetpack that runs off standard atmospheric tanks. \
+	When the built in helmet is deployed your identity will be protected, even in death, as the suit cannot be removed by outside forces. Toggling the suit into combat mode \
+	will allow you all the mobility of a loose fitting uniform without sacrificing armoring. Additionally the suit is collapsible, small enough to fit within a backpack. \
+	Nanotrasen crewmembers are trained to report red space suit sightings, these suits in particular are known to drive employees into a panic."
+	item = /obj/item/weapon/storage/box/syndie_kit/space
+	cost = 8
+
 /datum/uplink_item/device_tools/thermal
 	name = "Thermal Imaging Glasses"
 	desc = "These glasses are thermals disguised as engineers' optical meson scanners. \

--- a/html/changelogs/Incoming-hardsuitsforall.yml
+++ b/html/changelogs/Incoming-hardsuitsforall.yml
@@ -1,0 +1,7 @@
+author: Incoming
+
+delete-after: True
+
+changes: 
+
+  - rscadd: "The iconic blood-red hardsuits of nuke ops can now be purchased for a moderate sum of 8 TC by traitors."


### PR DESCRIPTION
Normal buyable suit/helmet is currently 5 TC

Differences between the suits:

Hardsuit has internals jetpack
Hardsuit has inbuilt helmet
Hardsuit is slightly more resistant to exotic dangers like bio and radiation
Hardsuit helmet intrinsically hides identity
Hardsuit can't be removed when the helmet's up
Hardsuit has slowdown but can be toggled to not have it at the cost of space-worthiness with combat mode
Hardsuit makes people shit their pants a little harder because of meta, at least until they realize the meta is dead.
