### PR TITLE
Fixes a bug in mulligan antag where it would pick extended too much (yes another one)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -560,3 +560,18 @@
 			runnable_modes[M] = probabilities[M.config_tag]
 			//world << "DEBUG: runnable_mode\[[runnable_modes.len]\] = [M.config_tag]"
 	return runnable_modes
+
+datum/configuration/proc/get_runnable_midround_modes(crew)
+	var/list/datum/game_mode/runnable_modes = new
+	for(var/T in (typesof(/datum/game_mode) - /datum/game_mode))
+		var/datum/game_mode/M = new T()
+		if(!(M.config_tag in modes))
+			world << "DEBUG: fail tag [M.config_tag]"
+			del(M)
+			continue
+		if(probabilities[M.config_tag]<=0)
+			del(M)
+			continue
+		if(M.required_players <= crew)
+			runnable_modes[M] = probabilities[M.config_tag]
+	return runnable_modes

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -566,11 +566,10 @@ datum/configuration/proc/get_runnable_midround_modes(crew)
 	for(var/T in (typesof(/datum/game_mode) - /datum/game_mode))
 		var/datum/game_mode/M = new T()
 		if(!(M.config_tag in modes))
-			world << "DEBUG: fail tag [M.config_tag]"
-			del(M)
+			qdel(M)
 			continue
 		if(probabilities[M.config_tag]<=0)
-			del(M)
+			qdel(M)
 			continue
 		if(M.required_players <= crew)
 			runnable_modes[M] = probabilities[M.config_tag]

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -2,7 +2,7 @@
 	name = "extended"
 	config_tag = "extended"
 	required_players = 0
-	reroll_friendly = 1
+	//reroll_friendly = 1
 
 /datum/game_mode/announce()
 	world << "<B>The current game mode is - Extended Role-Playing!</B>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -97,7 +97,16 @@
 ///convert_roundtype()
 ///Allows rounds to basically be "rerolled" should the initial premise fall through
 /datum/game_mode/proc/convert_roundtype()
-	var/list/datum/game_mode/runnable_modes = config.get_runnable_modes()
+	var/living_crew = 0
+
+	for(var/mob/Player in mob_list)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
+			living_crew++
+	if(living_crew / joined_player_list.len <= config.midround_antag_life_check) //If a lot of the player base died, we start fresh
+		message_admins("Convert_roundtype failed due to too many dead people. Limit is [config.midround_antag_life_check * 100]% living crew")
+		return 0
+
+	var/list/datum/game_mode/runnable_modes = config.get_runnable_midround_modes(living_crew)
 	var/list/datum/game_mode/usable_modes = list()
 	for(var/datum/game_mode/G in runnable_modes)
 		if(G.reroll_friendly)
@@ -122,15 +131,6 @@
 
 	if(world.time >= (config.midround_antag_time_check * 600))
 		message_admins("Convert_roundtype failed due to round length. Limit is [config.midround_antag_time_check] minutes.")
-		return 0
-
-	var/living_crew = 0
-
-	for(var/mob/Player in mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
-			living_crew++
-	if(living_crew / joined_player_list.len <= config.midround_antag_life_check) //If a lot of the player base died, we start fresh
-		message_admins("Convert_roundtype failed due to too many dead people. Limit is [config.midround_antag_life_check * 100]% living crew")
 		return 0
 
 	var/list/antag_canadates = list()


### PR DESCRIPTION
Because it was seeing what modes it could run with new_players and not the crew.

Outright stops extended mulligans for the time because because it keeps interfering with my debugging and also no one seems to want it.

Was a part of #8586 but has been split off because that's gonna take longer and I want this bug quashed soon.
