### PR TITLE
Reworks cyborg drill's power usage handling and fixes recharging

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -157,7 +157,14 @@
 						F.broken = 0
 						F.times_used = 0
 						F.icon_state = "flash"
-				// Engineering
+				// Mining
+				if(istype(O, /obj/item/weapon/pickaxe/drill/cyborg))
+					var/obj/item/weapon/pickaxe/drill/cyborg/D = O
+					if(D.bcell.charge < D.bcell.maxcharge)
+						D.bcell.charge = min(D.bcell.charge + recharge_speed, D.bcell.maxcharge)
+						D.update_icon()
+						if(D.warned)
+							D.warned = 0
 				// Security
 				if(istype(O,/obj/item/weapon/gun/energy/gun/advtaser/cyborg))
 					var/obj/item/weapon/gun/energy/gun/advtaser/cyborg/T = O

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -130,6 +130,22 @@
 
 /obj/item/weapon/pickaxe/drill/cyborg
 	name = "cyborg mining drill"
+	desc = "An integrated electric mining drill."
+	var/warned = 0
+
+/obj/item/weapon/pickaxe/drill/cyborg/update_icon()
+	..() //piggybacking this since it's always called once a turf is dug and doesn't need it's own proc
+	if(bcell.charge < drillcost && !warned)
+		usr << "<span class='danger'>Drill internal battery depleted, power will be drawn from user's power supply.</span>"
+		playsound(src, 'sound/weapons/smg_empty_alarm.ogg',50,1)
+		warned = 1
+
+/obj/item/weapon/pickaxe/drill/cyborg/proc/use_robot_power(var/mob/living/silicon/robot/R)
+	if(!bcell.use(drillcost))
+		if(!R.cell.use(drillcost))
+			R << "<span class='notice'>You don't have enough charge to drill.</span>"
+			return 0
+	return 1
 
 /obj/item/weapon/pickaxe/drill/diamonddrill
 	name = "diamond-tipped mining drill"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -133,10 +133,6 @@
 	desc = "An integrated electric mining drill."
 	var/warned = 0
 
-/obj/item/weapon/pickaxe/drill/cyborg/update_icon()
-	..() //piggybacking this since it's always called once a turf is dug and doesn't need it's own proc
-
-
 /obj/item/weapon/pickaxe/drill/cyborg/proc/use_robot_power(var/mob/living/silicon/robot/R)
 	if(!bcell.use(drillcost))
 		if(!warned)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -135,13 +135,14 @@
 
 /obj/item/weapon/pickaxe/drill/cyborg/update_icon()
 	..() //piggybacking this since it's always called once a turf is dug and doesn't need it's own proc
-	if(bcell.charge < drillcost && !warned)
-		usr << "<span class='danger'>Drill internal battery depleted, power will be drawn from user's power supply.</span>"
-		playsound(src, 'sound/weapons/smg_empty_alarm.ogg',50,1)
-		warned = 1
+
 
 /obj/item/weapon/pickaxe/drill/cyborg/proc/use_robot_power(var/mob/living/silicon/robot/R)
 	if(!bcell.use(drillcost))
+		if(!warned)
+			usr << "<span class='danger'>Drill internal battery depleted, power will be drawn from user's power supply.</span>"
+			playsound(src, 'sound/weapons/smg_empty_alarm.ogg',50,1)
+			warned = 1
 		if(!R.cell.use(drillcost))
 			R << "<span class='notice'>You don't have enough charge to drill.</span>"
 			return 0

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -417,11 +417,10 @@
 		if(istype(P, /obj/item/weapon/pickaxe/drill))
 			var/obj/item/weapon/pickaxe/drill/D = P
 			if(isrobot(user))
-				var/mob/living/silicon/robot/R = user
-				if(!R.cell.use(D.drillcost))
-					R << "<span class='notice'>Your [D.name] doesn't have enough charge.</span>"
+				var/obj/item/weapon/pickaxe/drill/cyborg/RD = D
+				if(!RD.use_robot_power(user))
 					return
-			if(!D.bcell.use(D.drillcost))
+			else if(!D.bcell.use(D.drillcost))
 				user << "<span class='notice'>Your [D.name] doesn't have enough charge.</span>"
 				return
 

--- a/html/changelogs/Jordie0608 drill.yml
+++ b/html/changelogs/Jordie0608 drill.yml
@@ -1,0 +1,7 @@
+author: Jordie0608
+
+delete-after: True
+
+changes: 
+  - tweak: "Cyborg mining drills now use up their internal battery before drawing power from a borg's cell."
+  - bugfix: "Fixes cyborg mining drills not recharging."


### PR DESCRIPTION
Cyborg mining drills will now only use a borg's power once their internal battery is empty. A warning message and sound is given when the drill runs out.

Fixes #8649, cyborg drill not recharging.
