### PR TITLE
Juggernaut Balance Option 1: Removes the base brute damage from blobbernauts

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -140,8 +140,8 @@
 	icon_dead = "blobbernaut_dead"
 	health = 240
 	maxHealth = 240
-	melee_damage_lower = 10
-	melee_damage_upper = 10
+	melee_damage_lower = 0
+	melee_damage_upper = 0
 	attacktext = "hits"
 	attack_sound = 'sound/effects/blobattack.ogg'
 	minbodytemp = 0


### PR DESCRIPTION
Blobbernauts overall since the changes made to blob in Blob Mania have been recieved as overpowered.

This is the first option to fix it, which makes them rely on their chemical's effect to get kills. They tend to hit faster and more often then a human blob overmind can, therefore they apply the effects more often.
