### PR TITLE
Juggernaut Balance Option 2: Removes the chemical effects from blobbernauts and buffs their brute damage

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -140,8 +140,8 @@
 	icon_dead = "blobbernaut_dead"
 	health = 240
 	maxHealth = 240
-	melee_damage_lower = 10
-	melee_damage_upper = 10
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 	attacktext = "hits"
 	attack_sound = 'sound/effects/blobattack.ogg'
 	minbodytemp = 0
@@ -149,13 +149,6 @@
 	force_threshold = 10
 	environment_smash = 3
 	mob_size = MOB_SIZE_LARGE
-
-
-/mob/living/simple_animal/hostile/blob/blobbernaut/AttackingTarget()
-	..()
-	if(isliving(target))
-		if(overmind)
-			overmind.blob_reagent_datum.reaction_mob(target, TOUCH)
 
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()


### PR DESCRIPTION
Blobbernauts overall since the changes made to blob in Blob Mania have been received as overpowered.

This is the second option to fix it, which makes them rely on their base brute damage to get kills. Since most people walk up to a blob expecting it's set reagent effects, this will serve to catch blob fighters off guard if they're expecting oxygen loss and get hit with brute.
