### PR TITLE
Removes slowdown from Reactive Teleport Armor and increases activation chance

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -116,7 +116,6 @@
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
-	slowdown = 1
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	action_button_name = "Toggle Armor"
 	unacidable = 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -104,13 +104,13 @@ emp_act
 			visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>", \
 							"<span class='userdanger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
 			var/list/turfs = new/list()
-			for(var/turf/T in orange(6))
+			for(var/turf/T in orange(6, src))
 				if(istype(T,/turf/space)) continue
 				if(T.density) continue
 				if(T.x>world.maxx-6 || T.x<6)	continue
 				if(T.y>world.maxy-6 || T.y<6)	continue
 				turfs += T
-			if(!turfs.len) turfs += pick(/turf in orange(6))
+			if(!turfs.len) turfs += pick(/turf in orange(6, src))
 			var/turf/picked = pick(turfs)
 			if(!isturf(picked)) return
 			if(buckled)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -100,7 +100,7 @@ emp_act
 			return 1
 	if(wear_suit && istype(wear_suit, /obj/item/))
 		var/obj/item/I = wear_suit
-		if(I.IsShield() && (prob(35)))
+		if(I.IsShield() && (prob(50)))
 			visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>", \
 							"<span class='userdanger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
 			var/list/turfs = new/list()

--- a/html/changelogs/Gun_Hog_RD_Armor_Buff.yml
+++ b/html/changelogs/Gun_Hog_RD_Armor_Buff.yml
@@ -1,0 +1,7 @@
+author: Gun Hog
+
+delete-after: True
+
+changes: 
+
+  - rscadd: "Nanotrasen research has finalized improvements for the experimental Reactive Teleport Armor. The armor is now made of a thinner, lightweight material which will not hinder movement. In addition, the armor shows an increase in responsiveness, activating in at least 50% of tests."


### PR DESCRIPTION
The Reactive Teleport Armor's slowdown has been removed.
The armor's activation chance has been increased to 50%!
It also actually works now!
- The "armor" has zero defensive stats.
- ~~The chance to teleport is only <b>35%</b>.~~
- The whole point of the armor is to take a gamble, it is just as likely to make your situation worse than better!

I believe the armor is a fun item that deserves to be used more. For many RDs the only thing stopping them was the slowdown penalty to wear something that has no defensive values anyway! This should help to encourage more RD players to roll the dice to see if they escape _or get spaced!_ No longer should it be a nigh worthless traitor target item that an RD does not care about losing!
