### PR TITLE
Raises action button count from 5 to 30

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -18,11 +18,36 @@
 */
 
 //Upper left action buttons, displayed when you pick up an item that has this enabled.
-#define ui_action_slot1 "WEST  :6, NORTH-1:26"
-#define ui_action_slot2 "WEST+1:8, NORTH-1:26"
-#define ui_action_slot3 "WEST+2:10,NORTH-1:26"
-#define ui_action_slot4 "WEST+3:12,NORTH-1:26"
-#define ui_action_slot5 "WEST+4:14,NORTH-1:26"
+#define ui_action_slot1  "WEST  	:0,	NORTH:0"
+#define ui_action_slot2  "WEST+1	:0,	NORTH:0"
+#define ui_action_slot3  "WEST+2	:0,	NORTH:0"
+#define ui_action_slot4  "WEST+3	:0,	NORTH:0"
+#define ui_action_slot5  "WEST+4	:0,	NORTH:0"
+#define ui_action_slot6  "WEST+5	:0,	NORTH:0"
+#define ui_action_slot7  "WEST+6	:0,	NORTH:0"
+#define ui_action_slot8  "WEST+7	:0,	NORTH:0"
+#define ui_action_slot9  "WEST+8	:0,	NORTH:0"
+#define ui_action_slot10 "WEST+9	:0,	NORTH:0"
+#define ui_action_slot11 "WEST+10	:0,	NORTH:0"
+#define ui_action_slot12 "WEST+11	:0,	NORTH:0"
+#define ui_action_slot13 "WEST+12	:0,	NORTH:0"
+#define ui_action_slot14 "WEST+13	:0,	NORTH:0"
+#define ui_action_slot15 "WEST+14	:0,	NORTH:0"
+#define ui_action_slot16 "WEST  	:0,	NORTH-1:0"
+#define ui_action_slot17 "WEST+1	:0,	NORTH-1:0"
+#define ui_action_slot18 "WEST+2	:0,	NORTH-1:0"
+#define ui_action_slot19 "WEST+3	:0,	NORTH-1:0"
+#define ui_action_slot20 "WEST+4	:0,	NORTH-1:0"
+#define ui_action_slot21 "WEST+5	:0,	NORTH-1:0"
+#define ui_action_slot22 "WEST+6	:0,	NORTH-1:0"
+#define ui_action_slot23 "WEST+7	:0,	NORTH-1:0"
+#define ui_action_slot24 "WEST+8	:0,	NORTH-1:0"
+#define ui_action_slot25 "WEST+9	:0,	NORTH-1:0"
+#define ui_action_slot26 "WEST+10	:0,	NORTH-1:0"
+#define ui_action_slot27 "WEST+11	:0,	NORTH-1:0"
+#define ui_action_slot28 "WEST+12	:0,	NORTH-1:0"
+#define ui_action_slot29 "WEST+13	:0,	NORTH-1:0"
+#define ui_action_slot30 "WEST+14	:0,	NORTH-1:0"
 
 //Lower left, persistant menu
 #define ui_inventory "WEST:6,SOUTH:5"
@@ -128,5 +153,6 @@
 #define ui_ears "WEST+2:10,SOUTH+2:9"
 
 #define ui_head "WEST+1:8,SOUTH+3:11"
+
 
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -368,5 +368,55 @@
 					A.screen_loc = ui_action_slot4
 				if(5)
 					A.screen_loc = ui_action_slot5
-					break //5 slots available, so no more can be added.
+				if(6)
+					A.screen_loc = ui_action_slot6
+				if(7)
+					A.screen_loc = ui_action_slot7
+				if(8)
+					A.screen_loc = ui_action_slot8
+				if(9)
+					A.screen_loc = ui_action_slot9
+				if(10)
+					A.screen_loc = ui_action_slot10
+				if(11)
+					A.screen_loc = ui_action_slot11
+				if(12)
+					A.screen_loc = ui_action_slot12
+				if(13)
+					A.screen_loc = ui_action_slot13
+				if(14)
+					A.screen_loc = ui_action_slot14
+				if(15)
+					A.screen_loc = ui_action_slot15
+				if(16)
+					A.screen_loc = ui_action_slot16
+				if(17)
+					A.screen_loc = ui_action_slot17
+				if(18)
+					A.screen_loc = ui_action_slot18
+				if(19)
+					A.screen_loc = ui_action_slot19
+				if(20)
+					A.screen_loc = ui_action_slot20
+				if(21)
+					A.screen_loc = ui_action_slot21
+				if(22)
+					A.screen_loc = ui_action_slot22
+				if(23)
+					A.screen_loc = ui_action_slot23
+				if(24)
+					A.screen_loc = ui_action_slot24
+				if(25)
+					A.screen_loc = ui_action_slot25
+				if(26)
+					A.screen_loc = ui_action_slot26
+				if(27)
+					A.screen_loc = ui_action_slot27
+				if(28)
+					A.screen_loc = ui_action_slot28
+				if(29)
+					A.screen_loc = ui_action_slot29
+				if(30)
+					A.screen_loc = ui_action_slot30
+					break //30 slots available, so no more can be added.
 			num++


### PR DESCRIPTION
Just a note, as long as we are gonna senselessly move everything to action buttons, lets not forget that only humans have them, and atm monkeys and the like can not use action buttons for things where object verbs have been removed.

Something to think about before it gets to the point where simple mobs/monkeys/borgs/etc can't use anything.

fixes #8087

![image](https://cloud.githubusercontent.com/assets/7069733/6963284/1c254e78-d8f2-11e4-9abc-d896ecc85618.png)
