### PR TITLE
Bloody Surgery

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -37,6 +37,10 @@
 			if(H.bleedsuppress)
 				user << "[H]'s bleeding is already bandaged."
 				return
+			if(H.surgeries.len)
+				for(var/datum/surgery/S in H.surgeries)
+					user << "[H]'s surgical incision is bleeding, finish \his [S.name] first!"
+				return
 			else if(!H.blood_max)
 				user << "[H] isn't bleeding."
 				return

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -15,7 +15,7 @@
 /mob/living/carbon/attackby(obj/item/I, mob/user, params)
 	if(lying)
 		if(surgeries.len)
-			if(user != src && user.a_intent == "help")
+			if(user.a_intent == "help")
 				for(var/datum/surgery/S in surgeries)
 					if(S.next_step(user, src))
 						return 1

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -119,6 +119,10 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				blood_max += 1
 			if(brutedamage > 70)
 				blood_max += 2
+			if(surgeries.len)
+				for(var/datum/surgery/S in surgeries)
+					if(S.status != 1)//the initial state is before any incision is made
+						blood_max += 0.5
 		if(bleedsuppress)
 			blood_max = 0
 		drip(blood_max)

--- a/code/modules/surgery/generic_steps.dm
+++ b/code/modules/surgery/generic_steps.dm
@@ -17,6 +17,12 @@
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='notice'>[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].</span>")
 
+/datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(added_blood_loss && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.blood_max -= added_blood_loss
+	added_blood_loss = 0
+	..()
 
 //retract skin
 /datum/surgery_step/retract_skin
@@ -36,6 +42,13 @@
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='notice'>[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].</span>")
 
+/datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(added_blood_loss && ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.blood_max -= added_blood_loss
+	added_blood_loss = 0
+	surgery.complete(target)
+	..()
 
 /datum/surgery_step/close/tool_check(mob/user, obj/item/tool)
 	if(istype(tool, /obj/item/weapon/cautery))

--- a/html/changelogs/Incoming-bloodyhell.yml
+++ b/html/changelogs/Incoming-bloodyhell.yml
@@ -1,0 +1,9 @@
+author: Incoming
+
+delete-after: True
+
+changes: 
+
+  - rscadd: "People now bleed while they are being operated on. Bleeding worsens the more steps are failed and is healed by finishing the surgery."
+  - rscadd: "Operating on a conscious patient increases failure chance on surgery steps, use the anesthetic!"
+  - rscadd: "Self surgery is again possible, but likewise increases your failure chances, weigh your options carefully."


### PR DESCRIPTION
Patients now lose blood during surgeries, the blood loss is very mild, but its rate increases every time a mistake is made and can quickly get out of hand. The step clamp bleeders can remove the extra bloodloss, but the base bleeding won't stop entirely until the surgery is completed.

There is now a success penalty for not sedating patients before surgery.

There's also a success penalty for cases where it's self surgery (they obviously also get the sedation penalty).
