### PR TITLE
Add an optional target var to the do_after helper

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -781,30 +781,32 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return 1
 
-/proc/do_after(mob/user, delay, numticks = 5, needhand = 1)
-	if(!user || isnull(user))
+/proc/do_after(mob/user, delay, numticks = 5, needhand = 1, atom/target = null)
+	if(!user)
 		return 0
+
 	if(numticks == 0)
 		return 0
 
+	var/atom/Tloc = null
+	if(target)
+		Tloc = target.loc
+
 	var/delayfraction = round(delay/numticks)
-	var/turf/T = user.loc
+	var/atom/Uloc = user.loc
 	var/holding = user.get_active_hand()
-	var/holdingnull = 1
-	if(holding)
-		holdingnull = 0
 
 	for(var/i = 0, i<numticks, i++)
 		sleep(delayfraction)
-
-
-		if(!user || user.stat || user.weakened || user.stunned  || !(user.loc == T))
+		if(!user || user.stat || user.weakened || user.stunned  || !(user.loc == Uloc))
 			return 0
 
+		if(Tloc && (!target || Tloc != target.loc)) //Tloc not set when we don't want to track target
+			return 0 // Target no longer exists or has moved
+
 		if(needhand)	//Sometimes you don't want the user to have to keep their active hand
-			if(!holdingnull)
-				if(!holding)
-					return 0
+			if(!holding)
+				return 0
 			if(user.get_active_hand() != holding)
 				return 0
 


### PR DESCRIPTION
The target item's loc must not move for do_after to return true, if left
null behaviour is unchanged from before
