### PR TITLE
Air Alarm O2 sensor settings change

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -77,7 +77,7 @@
 
 	// breathable air according to human/Life()
 	var/list/TLV = list(
-		"oxygen"         = new/datum/tlv(  16,   19, 135, 140), // Partial pressure, kpa
+		"oxygen"         = new/datum/tlv(  16,   19, 100, -1.0), // Partial pressure, kpa
 		"carbon dioxide" = new/datum/tlv(-1.0, -1.0,   5,  10), // Partial pressure, kpa
 		"plasma"         = new/datum/tlv(-1.0, -1.0, 0.2, 0.5), // Partial pressure, kpa
 		"other"          = new/datum/tlv(-1.0, -1.0, 0.5, 1.0), // Partial pressure, kpa

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -103,7 +103,7 @@
 
 /obj/machinery/alarm/kitchen_cold_room
 	TLV = list(
-		"oxygen"         = new/datum/tlv(  16,   19, 135, 140), // Partial pressure, kpa
+		"oxygen"         = new/datum/tlv(  16,   19, 100, -1.0), // Partial pressure, kpa
 		"carbon dioxide" = new/datum/tlv(-1.0, -1.0,   5,  10), // Partial pressure, kpa
 		"plasma"         = new/datum/tlv(-1.0, -1.0, 0.2, 0.5), // Partial pressure, kpa
 		"other"          = new/datum/tlv(-1.0, -1.0, 0.5, 1.0), // Partial pressure, kpa


### PR DESCRIPTION
The air alarms used to notify if the air O2 somehow miraculously raised above 135 % and alert at 140 %, while getting it above 100 % was impossible.

Now it notifies mildly if it's 100%, which in practice is never. Which is fine imo since pure O2 isn't poisonous or flammable in itself so its overabundance is not a big danger.

**New air alarm O2 sensor settings:**
![newairalarmo2sensor](https://cloud.githubusercontent.com/assets/5420151/6992373/a0b3d92a-dad2-11e4-9bab-819936dc5f67.png)
