### PR TITLE
Girder & machine frame disassembly changes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -93,8 +93,9 @@
 				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 				if(do_after(user, 40, target = src))
-					user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
-					anchored = !anchored
+					if(state == 1)
+						user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
+						anchored = !anchored
 
 		if(2)
 			if(istype(P, /obj/item/weapon/wrench))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -85,10 +85,11 @@
 					if(do_after(user, 40, target = src))
 						if( !WT.isOn() )
 							return
-						user << "<span class='notice'>You disassemble the frame.</span>"
-						var/obj/item/stack/sheet/metal/M = new (loc, 5)
-						M.add_fingerprint(user)
-						qdel(src)
+						if(state == 1)
+							user << "<span class='notice'>You disassemble the frame.</span>"
+							var/obj/item/stack/sheet/metal/M = new (loc, 5)
+							M.add_fingerprint(user)
+							qdel(src)
 			if(istype(P, /obj/item/weapon/wrench))
 				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -67,10 +67,7 @@
 				if(C.get_amount() >= 5)
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 					user << "<span class='notice'>You start to add cables to the frame...</span>"
-					var oldloc = src.loc
-					if(do_after(user, 20))
-						if(src.loc!=oldloc)
-							return
+					if(do_after(user, 20, target = src))
 						if(C.get_amount() >= 5 && state == 1)
 							C.use(5)
 							user << "<span class='notice'>You add cables to the frame.</span>"
@@ -85,11 +82,8 @@
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("<span class='warning'>[user] disassembles the frame.</span>", \
 										"<span class='notice'>You start to disassemble the frame...</span>", "You hear welding and clanking.")
-					var oldloc = src.loc
-					if(do_after(user, 40))
+					if(do_after(user, 40, target = src))
 						if( !WT.isOn() )
-							return
-						if(src.loc!=oldloc)
 							return
 						user << "<span class='notice'>You disassemble the frame.</span>"
 						var/obj/item/stack/sheet/metal/M = new (loc, 5)
@@ -98,10 +92,7 @@
 			if(istype(P, /obj/item/weapon/wrench))
 				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				var oldloc = src.loc
-				if(do_after(user, 40))
-					if(src.loc!=oldloc)
-						return
+				if(do_after(user, 40, target = src))
 					user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
 					anchored = !anchored
 
@@ -109,10 +100,7 @@
 			if(istype(P, /obj/item/weapon/wrench))
 				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				var oldloc = src.loc
-				if(do_after(user, 40))
-					if(src.loc!=oldloc)
-						return
+				if(do_after(user, 40, target = src))
 					user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
 					anchored = !anchored
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "box_0"
 	density = 1
-	anchored = 1
+	anchored = 0
 	use_power = 0
 	var/obj/item/weapon/circuitboard/circuit = null
 	var/list/components = null
@@ -59,27 +59,57 @@
 		return
 	switch(state)
 		if(1)
+			if(istype(P, /obj/item/weapon/circuitboard))
+				user << "<span class='warning'>The frame needs wiring first!</span>"
+				return
 			if(istype(P, /obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/C = P
 				if(C.get_amount() >= 5)
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					user << "<span class='notice'>You start to add cables to the frame.</span>"
+					user << "<span class='notice'>You start to add cables to the frame...</span>"
+					var oldloc = src.loc
 					if(do_after(user, 20))
+						if(src.loc!=oldloc)
+							return
 						if(C.get_amount() >= 5 && state == 1)
 							C.use(5)
 							user << "<span class='notice'>You add cables to the frame.</span>"
 							state = 2
 							icon_state = "box_1"
 				else
-					user << "<span class='warning'>You need five length of cable to wire the frame.</span>"
+					user << "<span class='warning'>You need five length of cable to wire the frame!</span>"
 					return
-			if(istype(P, /obj/item/weapon/wrench))
+			if(istype(P, /obj/item/weapon/weldingtool) && !anchored)
+				var/obj/item/weapon/weldingtool/WT = P
+				if(WT.remove_fuel(0,user))
+					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+					user.visible_message("<span class='warning'>[user] disassembles the frame.</span>", \
+										"You start to disassemble the frame...", "You hear welding and clanking.")
+					var oldloc = src.loc
+					if(do_after(user, 40))
+						if( !WT.isOn() )
+							return
+						if(src.loc!=oldloc)
+							return
+						user << "<span class='notice'>You disassemble the frame.</span>"
+						var/obj/item/stack/sheet/metal/M = new (loc, 5)
+						M.add_fingerprint(user)
+						qdel(src)
+			if(istype(P, /obj/item/weapon/wrench) && state == 1 && state == 2)
+				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user << "<span class='notice'>You dismantle the frame.</span>"
-				new /obj/item/stack/sheet/metal(src.loc, 5)
-				qdel(src)
+				var oldloc = src.loc
+				if(do_after(user, 40))
+					if(src.loc!=oldloc)
+						return
+					user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
+					anchored = !anchored
+
 		if(2)
 			if(istype(P, /obj/item/weapon/circuitboard))
+				if(!anchored)
+					user << "<span class='warning'>The frame needs to be secured first!</span>"
+					return
 				var/obj/item/weapon/circuitboard/B = P
 				if(B.board_type == "machine")
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
@@ -94,7 +124,7 @@
 					update_namelist()
 					update_req_desc()
 				else
-					user << "<span class='danger'>This frame does not accept circuit boards of this type!</span>"
+					user << "<span class='warning'>This frame does not accept circuit boards of this type!</span>"
 			if(istype(P, /obj/item/weapon/wirecutters))
 				playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
 				user << "<span class='notice'>You remove the cables.</span>"
@@ -381,7 +411,7 @@ to destroy them and players will be able to make replacements.
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/cell = 1)
-							
+
 /obj/item/weapon/circuitboard/chem_master
 	name = "circuit board (Chem Master 2999)"
 	build_path = /obj/machinery/chem_master/constructable

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "box_0"
 	density = 1
-	anchored = 0
+	anchored = 1
 	use_power = 0
 	var/obj/item/weapon/circuitboard/circuit = null
 	var/list/components = null
@@ -84,7 +84,7 @@
 				if(WT.remove_fuel(0,user))
 					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 					user.visible_message("<span class='warning'>[user] disassembles the frame.</span>", \
-										"You start to disassemble the frame...", "You hear welding and clanking.")
+										"<span class='notice'>You start to disassemble the frame...</span>", "You hear welding and clanking.")
 					var oldloc = src.loc
 					if(do_after(user, 40))
 						if( !WT.isOn() )
@@ -95,7 +95,7 @@
 						var/obj/item/stack/sheet/metal/M = new (loc, 5)
 						M.add_fingerprint(user)
 						qdel(src)
-			if(istype(P, /obj/item/weapon/wrench) && state == 1 && state == 2)
+			if(istype(P, /obj/item/weapon/wrench))
 				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 				var oldloc = src.loc
@@ -106,6 +106,16 @@
 					anchored = !anchored
 
 		if(2)
+			if(istype(P, /obj/item/weapon/wrench))
+				user << "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>"
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+				var oldloc = src.loc
+				if(do_after(user, 40))
+					if(src.loc!=oldloc)
+						return
+					user << "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>"
+					anchored = !anchored
+
 			if(istype(P, /obj/item/weapon/circuitboard))
 				if(!anchored)
 					user << "<span class='warning'>The frame needs to be secured first!</span>"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -20,11 +20,8 @@
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
 								"<span class='notice'>You start to disassemble the girder...</span>", "You hear welding and clanking.")
-			var/oldloc = src.loc
-			if(do_after(user, 40))
+			if(do_after(user, 40, target = src))
 				if( !WT.isOn() )
-					return
-				if(src.loc!=oldloc)
 					return
 				user << "<span class='notice'>You disassemble the girder.</span>"
 				var/obj/item/stack/sheet/metal/M = new (loc, 2)
@@ -37,10 +34,7 @@
 			return
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		user << "<span class='notice'>You start securing the girder...</span>"
-		var/oldloc = src.loc
-		if(do_after(user, 40))
-			if(src.loc!=oldloc)
-				return
+		if(do_after(user, 40, target = src))
 			user << "<span class='notice'>You secure the girder.</span>"
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)
@@ -48,9 +42,7 @@
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
 		user << "<span class='notice'>You start slicing apart the girder...</span>"
-		if(do_after(user,30))
-			if(!src.loc)
-				return
+		if(do_after(user, 30, target = src))
 			user << "<span class='notice'>You slice apart the girder.</span>"
 			var/obj/item/stack/sheet/metal/M = new (loc, 2)
 			M.add_fingerprint(user)
@@ -70,18 +62,14 @@
 	else if(istype(W, /obj/item/weapon/screwdriver) && state == GIRDER_REINF)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		user << "<span class='notice'>You start unsecuring support struts...</span>"
-		if(do_after(user,40))
-			if(!src.loc)
-				return
+		if(do_after(user, 40, target = src))
 			user << "<span class='notice'>You unsecure the support struts.</span>"
 			state = GIRDER_REINF_STRUTS
 
 	else if(istype(W, /obj/item/weapon/wirecutters) && state == GIRDER_REINF_STRUTS)
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		user << "<span class='notice'>You start removing support struts...</span>"
-		if(do_after(user,40))
-			if(!src.loc)
-				return
+		if(do_after(user, 40, target = src))
 			user << "<span class='notice'>You remove the support struts.</span>"
 			new /obj/item/stack/sheet/plasteel(get_turf(src))
 			var/obj/structure/girder/G = new (loc)
@@ -91,9 +79,7 @@
 	else if(istype(W, /obj/item/weapon/wrench) && state == GIRDER_NORMAL && anchored )
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		user << "<span class='notice'>You start unsecuring the girder...</span>"
-		if(do_after(user, 40))
-			if(!src.loc)
-				return
+		if(do_after(user, 40, target = src))
 			user << "<span class='notice'>You unsecure the girder.</span>"
 			var/obj/structure/girder/displaced/D = new (loc)
 			transfer_fingerprints_to(D)
@@ -109,19 +95,18 @@
 
 			if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
 				if(!anchored)
-					if (S.use(2))
-						user << "<span class='notice'>You start building a false wall...</span>"
-						var/oldloc = src.loc
-						if(do_after(user, 20))
-							if(src.loc!=oldloc)
-								return
+					if(S.get_amount() < 2)
+						user << "<span class='warning'>You need two sheets of metal to create a false wall!</span>"
+						return
+					user << "<span class='notice'>You start building a false wall...</span>"
+					if(do_after(user, 20, target = src))
+						if(!src.loc || !S || S.amount < 2)
+							return
+						S.use(2)
 						user << "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>"
 						var/obj/structure/falsewall/F = new (loc)
 						transfer_fingerprints_to(F)
 						qdel(src)
-					else
-						user << "<span class='warning'>You need two sheets of metal to create a false wall!</span>"
-						return
 				else
 					if(S.get_amount() < 2)
 						user << "<span class='warning'>You need two sheets of metal to finish a wall!</span>"
@@ -145,16 +130,15 @@
 					if(S.amount < 2)
 						user << "<span class='warning'>You need at least two sheets to create a false wall!</span>"
 						return
-					S.use(2)
 					user << "<span class='notice'>You start building a reinforced false wall...</span>"
-					var/oldloc = src.loc
-					if(do_after(user, 20))
-						if(src.loc!=oldloc)
+					if(do_after(user, 20, target = src))
+						if(!src.loc || !S || S.amount < 2)
 							return
-					user << "<span class='notice'>You create a reinforced false wall. Push on it to open or close the passage.</span>"
-					var/obj/structure/falsewall/reinforced/FW = new (loc)
-					transfer_fingerprints_to(FW)
-					qdel(src)
+						S.use(2)
+						user << "<span class='notice'>You create a reinforced false wall. Push on it to open or close the passage.</span>"
+						var/obj/structure/falsewall/reinforced/FW = new (loc)
+						transfer_fingerprints_to(FW)
+						qdel(src)
 				else
 					if (src.icon_state == "reinforced") //I cant believe someone would actually write this line of code...
 						if(S.amount < 1) return ..()
@@ -173,7 +157,7 @@
 					else
 						if(S.amount < 1) return ..()
 						user << "<span class='notice'>You start reinforcing the girder...</span>"
-						if (do_after(user,60))
+						if (do_after(user, 60))
 							if(!src.loc || !S || S.amount < 1)
 								return
 							S.use(1)
@@ -187,7 +171,7 @@
 			var/M = S.sheettype
 			if(!anchored)
 				if(S.amount < 2)
-					user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
+					user << "<span class='warning'>You need at least two sheets to create a false wall!</span>"
 					return
 				S.use(2)
 				user << "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>"
@@ -198,7 +182,7 @@
 			else
 				if(S.amount < 2) return ..()
 				user << "<span class='notice'>You start adding plating...</span>"
-				if (do_after(user,40))
+				if (do_after(user, 40))
 					if(!src.loc || !S || S.amount < 2)
 						return
 					S.use(2)
@@ -315,7 +299,7 @@
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
 		user << "<span class='notice'>You start slicing apart the girder...</span>"
-		if(do_after(user,30))
+		if(do_after(user, 30))
 			user << "<span class='notice'>You slice apart the girder.</span>"
 			var/obj/effect/decal/remains/human/R = new (get_turf(src))
 			transfer_fingerprints_to(R)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -23,10 +23,11 @@
 			if(do_after(user, 40, target = src))
 				if( !WT.isOn() )
 					return
-				user << "<span class='notice'>You disassemble the girder.</span>"
-				var/obj/item/stack/sheet/metal/M = new (loc, 2)
-				M.add_fingerprint(user)
-				qdel(src)
+				if(state == 1)
+					user << "<span class='notice'>You disassemble the girder.</span>"
+					var/obj/item/stack/sheet/metal/M = new (loc, 2)
+					M.add_fingerprint(user)
+					qdel(src)
 
 	else if(istype(W, /obj/item/weapon/wrench) && state == GIRDER_DISPLACED)
 		if (!istype(src.loc, /turf/simulated/floor))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -25,7 +25,7 @@
 				M.add_fingerprint(user)
 				qdel(src)
 
-	else if(istype(W, /obj/item/weapon/wrench) && state == 3 && 4)
+	else if(istype(W, /obj/item/weapon/wrench) && state == 3)
 		if (!istype(src.loc, /turf/simulated/floor))
 			usr << "<span class='warning'>A floor must be present to secure the girder!</span>"
 			return
@@ -46,7 +46,8 @@
 			if(!src.loc)
 				return
 			user << "<span class='notice'>You slice apart the girder.</span>"
-			new /obj/item/stack/sheet/metal(get_turf(src))
+			var/obj/item/stack/sheet/metal/M = new (loc, 2)
+			M.add_fingerprint(user)
 			qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -19,8 +19,8 @@
 		if(WT.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
-								"You start to disassemble the girder...", "You hear welding and clanking.")
-			var oldloc = src.loc
+								"<span class='notice'>You start to disassemble the girder...</span>", "You hear welding and clanking.")
+			var/oldloc = src.loc
 			if(do_after(user, 40))
 				if( !WT.isOn() )
 					return
@@ -37,7 +37,7 @@
 			return
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		user << "<span class='notice'>You start securing the girder...</span>"
-		var oldloc = src.loc
+		var/oldloc = src.loc
 		if(do_after(user, 40))
 			if(src.loc!=oldloc)
 				return
@@ -111,7 +111,7 @@
 				if(!anchored)
 					if (S.use(2))
 						user << "<span class='notice'>You start building a false wall...</span>"
-						var oldloc = src.loc
+						var/oldloc = src.loc
 						if(do_after(user, 20))
 							if(src.loc!=oldloc)
 								return
@@ -147,7 +147,7 @@
 						return
 					S.use(2)
 					user << "<span class='notice'>You start building a reinforced false wall...</span>"
-					var oldloc = src.loc
+					var/oldloc = src.loc
 					if(do_after(user, 20))
 						if(src.loc!=oldloc)
 							return
@@ -190,7 +190,7 @@
 					user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
 					return
 				S.use(2)
-				user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
+				user << "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>"
 				var/F = text2path("/obj/structure/falsewall/[M]")
 				var/obj/structure/FW = new F (loc)
 				transfer_fingerprints_to(FW)
@@ -202,7 +202,7 @@
 					if(!src.loc || !S || S.amount < 2)
 						return
 					S.use(2)
-					user << "<span class='notice'>You added the plating!</span>"
+					user << "<span class='notice'>You add the plating.</span>"
 					var/turf/Tsrc = get_turf(src)
 					Tsrc.ChangeTurf(text2path("/turf/simulated/wall/mineral/[M]"))
 					for(var/turf/simulated/wall/mineral/X in Tsrc.loc)
@@ -217,7 +217,7 @@
 		if (P.pipe_type in list(0, 1, 5))	//simple pipes, simple bends, and simple manifolds.
 			user.drop_item()
 			P.loc = src.loc
-			user << "<span class='notice'>You fit the pipe into \the [src]!</span>"
+			user << "<span class='notice'>You fit the pipe into \the [src].</span>"
 	else
 		..()
 
@@ -263,6 +263,7 @@
 	anchored = 0
 	state = GIRDER_DISPLACED
 	girderpasschance = 25
+	layer = 2.45
 
 /obj/structure/girder/reinforced
 	name = "reinforced girder"
@@ -303,7 +304,7 @@
 		if(WT.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
-								"You start to disassemble the girder...", "You hear welding and clanking.")
+								"<span class='notice'>You start to disassemble the girder...</span>", "You hear welding and clanking.")
 			if(do_after(user, 40))
 				if( !WT.isOn() )
 					return

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -4,48 +4,55 @@
 	anchored = 1
 	density = 1
 	layer = 2
-	var/state = 0
+	var/state = 0 //state 0 = normal girder, state 1 = no idea, state 2 = reinforced girder, state 3 = displaced/dislodged girder
 	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 
 /obj/structure/girder/attackby(obj/item/W as obj, mob/user as mob, params)
 	add_fingerprint(user)
-	if(istype(W, /obj/item/weapon/wrench) && state == 0)
-		if(anchored && !istype(src,/obj/structure/girder/displaced))
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'>Now disassembling the girder...</span>"
-			if(do_after(user,40))
-				if(!src.loc)
-					return
-				user << "<span class='notice'>You dissasembled the girder!</span>"
-				new /obj/item/stack/sheet/metal(get_turf(src))
-				qdel(src)
-		else if(!anchored)
-			if (!istype(src.loc, /turf/simulated/floor))
-				usr << "<span class='danger'>A floor must be present to secure the girder!</span>"
-				return
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'>Now securing the girder...</span>"
+	if(istype(W, /obj/item/weapon/weldingtool) && state == 3)
+		var/obj/item/weapon/weldingtool/WT = W
+		if(WT.remove_fuel(0,user))
+			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
+								"You start to disassemble the girder...", "You hear welding and clanking.")
 			if(do_after(user, 40))
+				if( !WT.isOn() )
+					return
 				if(!src.loc)
 					return
-				user << "<span class='notice'>You secured the girder!</span>"
-				var/obj/structure/girder/G = new (loc)
-				transfer_fingerprints_to(G)
+				user << "<span class='notice'>You disassemble the girder.</span>"
+				var/obj/item/stack/sheet/metal/M = new (loc, 2)
+				transfer_fingerprints_to(M)
 				qdel(src)
 
+	else if(istype(W, /obj/item/weapon/wrench) && state == 3 && 4)
+		if (!istype(src.loc, /turf/simulated/floor))
+			usr << "<span class='warning'>A floor must be present to secure the girder!</span>"
+			return
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+		user << "<span class='notice'>You start securing the girder...</span>"
+		var oldloc = src.loc
+		if(do_after(user, 40))
+			if(src.loc!=oldloc)
+				return
+			user << "<span class='notice'>You secure the girder.</span>"
+			var/obj/structure/girder/G = new (loc)
+			transfer_fingerprints_to(G)
+			qdel(src)
+
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
-		user << "<span class='notice'>Now slicing apart the girder...</span>"
+		user << "<span class='notice'>You start slicing apart the girder...</span>"
 		if(do_after(user,30))
 			if(!src.loc)
 				return
-			user << "<span class='notice'>You slice apart the girder!</span>"
+			user << "<span class='notice'>You slice apart the girder.</span>"
 			new /obj/item/stack/sheet/metal(get_turf(src))
 			qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W
 		if(!D.bcell.use(D.drillcost))
-			user << "<span class='notice'>Your [D.name] doesn't have enough power to break through the [name].</span>"
+			user << "<span class='warning'>Your [D.name] doesn't have enough power to break through the [name]!</span>"
 			return
 		D.update_icon()
 		user << "<span class='notice'>You smash through the girder!</span>"
@@ -55,38 +62,38 @@
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && state == 2 && istype(src,/obj/structure/girder/reinforced))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user << "<span class='notice'>Now unsecuring support struts...</span>"
+		user << "<span class='notice'>You start unsecuring support struts...</span>"
 		if(do_after(user,40))
 			if(!src.loc)
 				return
-			user << "<span class='notice'>You unsecured the support struts!</span>"
+			user << "<span class='notice'>You unsecure the support struts.</span>"
 			state = 1
 
 	else if(istype(W, /obj/item/weapon/wirecutters) && istype(src,/obj/structure/girder/reinforced) && state == 1)
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user << "<span class='notice'>Now removing support struts...</span>"
+		user << "<span class='notice'>You start removing support struts...</span>"
 		if(do_after(user,40))
 			if(!src.loc)
 				return
-			user << "<span class='notice'>You removed the support struts!</span>"
+			user << "<span class='notice'>You remove the support struts.</span>"
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)
 			qdel(src)
 
-	else if(istype(W, /obj/item/weapon/crowbar) && state == 0 && anchored )
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user << "<span class='notice'>Now dislodging the girder...</span>"
+	else if(istype(W, /obj/item/weapon/wrench) && state == 0 && anchored )
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+		user << "<span class='notice'>Now unsecuring the girder...</span>"
 		if(do_after(user, 40))
 			if(!src.loc)
 				return
-			user << "<span class='notice'>You dislodged the girder!</span>"
+			user << "<span class='notice'>You unsecure the girder.</span>"
 			var/obj/structure/girder/displaced/D = new (loc)
 			transfer_fingerprints_to(D)
 			qdel(src)
 
 	else if(istype(W, /obj/item/stack/sheet))
 		if (!istype(src.loc, /turf/simulated/floor))
-			usr << "<span class='danger'>The girder is too unstable to build anything!</span>"
+			usr << "<span class='warning'>A floor must be present to build a false wall!</span>"
 			return
 
 		var/obj/item/stack/sheet/S = W
@@ -95,23 +102,23 @@
 			if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
 				if(!anchored)
 					if (S.use(2))
-						user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
+						user << "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>"
 						var/obj/structure/falsewall/F = new (loc)
 						transfer_fingerprints_to(F)
 						qdel(src)
 					else
-						user << "<span class='warning'>You need two sheets of metal to create a false wall.</span>"
+						user << "<span class='warning'>You need two sheets of metal to create a false wall!</span>"
 						return
 				else
 					if(S.get_amount() < 2)
-						user << "<span class='warning'>You need two sheets of metal to finish a wall.</span>"
+						user << "<span class='warning'>You need two sheets of metal to finish a wall!</span>"
 						return
 					user << "<span class='notice'>Now adding plating...</span>"
 					if (do_after(user, 40))
 						if(loc == null || S.get_amount() < 2)
 							return
 						S.use(2)
-						user << "<span class='notice'>You added the plating!</span>"
+						user << "<span class='notice'>You add the plating.</span>"
 						var/turf/Tsrc = get_turf(src)
 						Tsrc.ChangeTurf(/turf/simulated/wall)
 						for(var/turf/simulated/wall/X in Tsrc.loc)
@@ -123,22 +130,22 @@
 			if(/obj/item/stack/sheet/plasteel)
 				if(!anchored)
 					if(S.amount < 2)
-						user << "<span class='warning'>You need at least two sheets to create a false wall.</span>"
+						user << "<span class='warning'>You need at least two sheets to create a false wall!</span>"
 						return
 					S.use(2)
-					user << "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>"
+					user << "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>"
 					var/obj/structure/falsewall/reinforced/FW = new (loc)
 					transfer_fingerprints_to(FW)
 					qdel(src)
 				else
 					if (src.icon_state == "reinforced") //I cant believe someone would actually write this line of code...
 						if(S.amount < 1) return ..()
-						user << "<span class='notice'>Now finalising reinforced wall...</span>"
+						user << "<span class='notice'>You start finalizing the reinforced wall...</span>"
 						if(do_after(user, 50))
 							if(!src.loc || !S || S.amount < 1)
 								return
 							S.use(1)
-							user << "<span class='notice'>Wall fully reinforced!</span>"
+							user << "<span class='notice'>You fully reinforce the wall.</span>"
 							var/turf/Tsrc = get_turf(src)
 							Tsrc.ChangeTurf(/turf/simulated/wall/r_wall)
 							for(var/turf/simulated/wall/r_wall/X in Tsrc.loc)
@@ -147,12 +154,12 @@
 						return
 					else
 						if(S.amount < 1) return ..()
-						user << "<span class='notice'>Now reinforcing girders...</span>"
+						user << "<span class='notice'>You start reinforcing the girder...</span>"
 						if (do_after(user,60))
 							if(!src.loc || !S || S.amount < 1)
 								return
 							S.use(1)
-							user << "<span class='notice'>Girders reinforced!</span>"
+							user << "<span class='notice'>You reinforce the girder.</span>"
 							var/obj/structure/girder/reinforced/R = new (loc)
 							transfer_fingerprints_to(R)
 							qdel(src)
@@ -236,6 +243,7 @@
 	name = "displaced girder"
 	icon_state = "displaced"
 	anchored = 0
+	state = 3
 	girderpasschance = 25
 
 /obj/structure/girder/reinforced
@@ -271,23 +279,28 @@
 	layer = 2
 
 /obj/structure/cultgirder/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/weapon/wrench))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user << "<span class='notice'>Now disassembling the girder...</span>"
-		if(do_after(user,40))
-			user << "<span class='notice'>You dissasembled the girder!</span>"
-			var/obj/effect/decal/remains/human/R = new (get_turf(src))
-			transfer_fingerprints_to(R)
-			qdel(src)
+	add_fingerprint(user)
+	if(istype(W, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/WT = W
+		if(WT.remove_fuel(0,user))
+			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
+								"You start to disassemble the girder...", "You hear welding and clanking.")
+			if(do_after(user, 40))
+				if( !WT.isOn() )
+					return
+				user << "<span class='notice'>You disassemble the girder.</span>"
+				var/obj/effect/decal/remains/human/R = new (get_turf(src))
+				transfer_fingerprints_to(R)
+				qdel(src)
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
-		user << "<span class='notice'>Now slicing apart the girder...</span>"
+		user << "<span class='notice'>You start slicing apart the girder...</span>"
 		if(do_after(user,30))
-			user << "<span class='notice'>You slice apart the girder!</span>"
+			user << "<span class='notice'>You slice apart the girder.</span>"
 			var/obj/effect/decal/remains/human/R = new (get_turf(src))
 			transfer_fingerprints_to(R)
 			qdel(src)
-
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		var/obj/item/weapon/pickaxe/drill/jackhammer/D = W

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -22,7 +22,7 @@
 					return
 				user << "<span class='notice'>You disassemble the girder.</span>"
 				var/obj/item/stack/sheet/metal/M = new (loc, 2)
-				transfer_fingerprints_to(M)
+				M.add_fingerprint(user)
 				qdel(src)
 
 	else if(istype(W, /obj/item/weapon/wrench) && state == 3 && 4)

--- a/html/changelogs/kingofkosmos-girderrakennus.yml
+++ b/html/changelogs/kingofkosmos-girderrakennus.yml
@@ -3,4 +3,4 @@ author: kingofkosmos
 delete-after: True
 
 changes: 
-  - rscadd: "Girder disassembly method changed: only dislodged girders can be disassembled by using a welder."
+  - wip: "Girder and machine frame construction protocols has been changed. They can now be secured/unsecured with a wrench and disassembled with a welder."

--- a/html/changelogs/kingofkosmos-girderrakennus.yml
+++ b/html/changelogs/kingofkosmos-girderrakennus.yml
@@ -1,0 +1,6 @@
+author: kingofkosmos
+
+delete-after: True
+
+changes: 
+  - rscadd: "Girder disassembly method changed: only dislodged girders can be disassembled by using a welder."


### PR DESCRIPTION
Old way:
Wrenching a girder (unsecured) -> secures the girder.
Wrenching a girder (secured) -> disassembles the girder.
Crowbarring a girder (secured) -> unsecures the girder.

**New way:**
Wrenching a girder (unsecured) -> secures the girder (same as before).
Wrenching a girder (secured) -> unsecures the girder.
Welding a girder (unsecured) -> disassembles the girder.

Also:
**Machine frames** can now be secured/unsecured with a wrench and disassembled with a welder. Old way was that they couldn't be unsecured at all, and disassembly was done with a wrench.

This way they're more consistent with nearly every other frame in the game, which have to be first unsecured with a wrench and then disassembled with a welder.
