### PR TITLE
[DNM]Overhauls death and dying completely.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -22,3 +22,4 @@
 
 	var/co2overloadtime = null
 	var/temperature_resistance = T0C+75
+	var/was_incrit = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -365,7 +365,6 @@
 	else
 		losebreath += 5
 		adjustOxyLoss(5)
-		adjustBruteLoss(1)
+		adjustBrainLoss(0.5)
 	return
-
 #undef HUMAN_MAX_OXYLOSS

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1015,8 +1015,6 @@
 
 	var/datum/gas_mixture/environment = H.loc.return_air()
 	var/datum/gas_mixture/breath
-	if(H.health <= config.health_threshold_crit)
-		H.losebreath++
 	if(H.losebreath>0) //Suffocating so do not take a breath
 		H.losebreath--
 		if (prob(10)) //Gasp per 10 ticks? Sounds about right.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -25,6 +25,9 @@
 		//Random events (vomiting etc)
 		handle_random_events()
 
+		//Critical Health Status handling
+		handle_crit()
+
 		. = 1
 
 	//Handle temperature/pressure differences between body and environment
@@ -177,4 +180,7 @@
 	return
 
 /mob/living/proc/handle_hud_icons_health()
+	return
+
+/mob/living/proc/handle_crit()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -244,14 +244,18 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/adjustBruteLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	bruteloss = min(max(bruteloss + amount, 0),(maxHealth*2))
+	bruteloss += amount
+	if(bruteloss <= 0)
+		bruteloss = 0
 
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
 /mob/living/proc/adjustOxyLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	oxyloss = min(max(oxyloss + amount, 0),(maxHealth*2))
+	oxyloss += amount
+	if(oxyloss <= 0)
+		oxyloss = 0
 
 /mob/living/proc/setOxyLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
@@ -262,7 +266,9 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/adjustToxLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
+	toxloss += amount
+	if(toxloss <= 0)
+		toxloss = 0
 
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
@@ -273,14 +279,18 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/adjustFireLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	fireloss = min(max(fireloss + amount, 0),(maxHealth*2))
+	fireloss += amount
+	if(fireloss <= 0)
+		fireloss = 0
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss
 
 /mob/living/proc/adjustCloneLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	cloneloss = min(max(cloneloss + amount, 0),(maxHealth*2))
+	cloneloss += amount
+	if(cloneloss <= 0)
+		cloneloss = 0
 
 /mob/living/proc/setCloneLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
@@ -291,7 +301,9 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	brainloss = min(max(brainloss + amount, 0),(maxHealth*2))
+	brainloss  += amount
+	if(brainloss <= 0)
+		brainloss = 0
 
 /mob/living/proc/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
@@ -302,7 +314,9 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/adjustStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
-	staminaloss = min(max(staminaloss + amount, 0),(maxHealth*2))
+	staminaloss += amount
+	if(staminaloss <= 0)
+		staminaloss = 0
 
 /mob/living/proc/setStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -136,6 +136,13 @@ proc/isorgan(A)
 			return 1
 	return 0
 
+/proc/is_incrit(A)
+	if(istype(A, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = A
+		if(config.health_threshold_crit >= H.health)
+			return 1
+	return 0
+
 /proc/check_zone(zone)
 	if(!zone)	return "chest"
 	switch(zone)


### PR DESCRIPTION
- Completely overhauls death and dying to be more fun for the person dying.
- When you go into crit, you start taking 2 oxygen damage a tick, start stuttering, and roll for 4 potential things to happen. The severity and chances of these effects go up the longer you're in crit.
  - Knocks you out for X amount of seconds. Maximum is 2. Minimum is 0.
  - Gives you X amount of losebreath and Y amount of brain damage. Max losebreath is 8 and max brain damage is 2. Minimum losebreath is 1 and minimum brain damage is 0.
  - X percent chance to have a heart attack. If you are already having a heart attack, you get Y losebreath instead. Maximum heart attack chance is 45%, maximum losebreath is 8. Minimum heart attack is 0%, minimum losebreath is 1.
  - Another roll for "Knocks you out for X amount of seconds." Maximum is 2. Minimum is 0.
- If you have -100 health, it starts rolling a chance for you to die. Your chance to die goes up the more brain loss you have.
- When you get out of crit, you start healing oxygen loss and losing losebreath. This allows you to recover from critical. When you finish healing those you stop recovering oxygen loss and losebreath.
  The benefit of all this is that when you enter crit, you can attempt to crawl to medbay or attempt to get a few last punches out on your attacker.

Only a masochist would enjoy staring at a black screen for 10 minutes, but considering this is me coding, I'm certain you guys are gonna claim that staring at blank screens for 10 minutes is enjoyable gameplay for everyone. :^)

This is a pretty big change that might be a bit disliked:
- Uncaps the amount of damage you can take in every damage type. You can have 500 brute damage now no problem. Before it was capped at 100.
- Brain Loss is now lethal.
- At 100 brain loss, you get weakened every tick and start taking losebreath and cannot speak.
- At 120 brain loss, you die of brain failure.
- Previously, the only thing brain loss did was "lol gibbering joke eecks dee xD". A lot of things used this as a buffer or gimmick damage type. Please tell me locations of brain damage's use so I can remove it or nerf it into reason now that brain damage is an actually worrying thing like all the other damages except cloneloss
  (remove cloneloss when)
- You still do the gibbering at 60 brain loss or higher. I'm not that mean. Yet.

Minor changes:
- Heart attacks now do 0.5 brain loss instead of 1 brute loss since brain loss is now lethal.

Q&A:
- How is this fun for the medical doctor?

Your patients are now more durable and won't die on you immediately after they hit a dedicated "health death threshold".
Your patients in critical condition can try to pull themselves to the medbay for quicker treatment.
- How is this fun for the dying patient?

You aren't staring at a blank screen for 10 minutes watching white creep up on your screen, or immediately hitting "succumb" when you go into crit, because you can now attempt to crawl to safety or get that last hit out on your attacker.
You are engaged in the game a bit more when dying because you're still actively watching the game because there's interesting things going on, as you can still stumble around and crawl places.
