### PR TITLE
Fix can_speak check in megaphone

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -17,12 +17,11 @@
 		if(user.client.prefs.muted & MUTE_IC)
 			src << "<span class='warning'>You cannot speak in IC (muted).</span>"
 			return
+
 	if(!ishuman(user))
 		user << "<span class='warning'>You don't know how to use this!</span>"
 		return
-	if(user.can_speak())
-		user << "<span class='warning'>You find yourself unable to speak at all.</span>"
-		return
+
 	if(spamcheck > world.time)
 		user << "<span class='warning'>\The [src] needs to recharge!</span>"
 		return
@@ -30,7 +29,12 @@
 	var/message = copytext(sanitize(input(user, "Shout a message?", "Megaphone", null)  as text),1,MAX_MESSAGE_LEN)
 	if(!message)
 		return
+
 	message = capitalize(message)
+	if(!user.can_speak(message))
+		user << "<span class='warning'>You find yourself unable to speak at all.</span>"
+		return
+
 	if ((src.loc == user && user.stat == 0))
 		if(emagged)
 			if(insults)


### PR DESCRIPTION
The original check actually made no sense since it was checking if you could say the message and then returning as if you couldn't, but worked because it returned false every time as there was never a message passed through

Fixes #8748
