### PR TITLE
Readded Stungloves (balanced)

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -10,7 +10,7 @@
 	// Special glove functions:
 	// If the gloves do anything, have them return 1 to stop
 	// normal attack_hand() here.
-	if(proximity && istype(G) && G.Touch(A,1))
+	if(proximity && istype(G) && G.Touch(A, 1, src))
 		return
 
 	var/override = 0
@@ -36,7 +36,7 @@
 /mob/living/carbon/human/RangedAttack(var/atom/A)
 	if(gloves)
 		var/obj/item/clothing/gloves/G = gloves
-		if(istype(G) && G.Touch(A,0)) // for magic gloves
+		if(istype(G) && G.Touch(A, 0, src)) // for magic gloves
 			return
 
 	for(var/datum/mutation/human/HM in dna.mutations)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -74,7 +74,7 @@ BLIND     // can't see anything
 	put_on_delay = 40
 
 // Called just before an attack_hand(), in mob/UnarmedAttack()
-/obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity)
+/obj/item/clothing/gloves/proc/Touch(var/atom/A, var/proximity, var/mob/living/carbon/user)
 	return 0 // return 1 to cancel attack_hand()
 
 //Head

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -17,6 +17,7 @@
 				user << "<span class='notice'>You wrap some wires around [src].</span>"
 				update_icon()
 				strip_delay -= 10
+				name = "wired " + name
 			else
 				user << "<span class='notice'>There is not enough wire to cover [src].</span>"
 		else
@@ -49,6 +50,7 @@
 			user << "<span class='notice'>You cut the wires away from [src].</span>"
 			new /obj/item/stack/cable_coil(get_turf(src), 2)
 			strip_delay += 10
+			name = initial(name)
 			update_icon()
 	..()
 	return

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -1,0 +1,98 @@
+/obj/item/clothing/gloves
+	var/wired = 0
+	var/obj/item/weapon/stock_parts/cell/cell = null
+
+/obj/item/clothing/gloves/attackby(var/obj/item/W as obj, mob/user as mob, params)
+	if(istype(src, /obj/item/clothing/gloves/boxing))
+		user << "<span class='notice'>That won't work.</span>"
+		..()
+		return
+
+	if(istype(W, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/C = W
+		if(!wired)
+			if(C.amount >= 2)
+				C.use(2)
+				wired = 1
+				user << "<span class='notice'>You wrap some wires around [src].</span>"
+				update_icon()
+				strip_delay -= 10
+			else
+				user << "<span class='notice'>There is not enough wire to cover [src].</span>"
+		else
+			user << "<span class='notice'>[src] are already wired.</span>"
+
+	else if(istype(W, /obj/item/weapon/stock_parts/cell))
+		if(!wired)
+			user << "<span class='notice'>[src] need to be wired first.</span>"
+		else if(!cell)
+			user.drop_item()
+			W.loc = src
+			cell = W
+			user << "<span class='notice'>You attach a cell to [src].</span>"
+			strip_delay -= 5
+			update_icon()
+		else
+			user << "<span class='notice'>[src] already have a cell.</span>"
+
+	else if(istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/weapon/scalpel))
+		if(cell)
+			cell.updateicon()
+			cell.loc = get_turf(src.loc)
+			cell = null
+			user << "<span class='notice'>You cut the cell away from [src].</span>"
+			strip_delay += 5
+			update_icon()
+			return
+		if(wired)
+			wired = 0
+			user << "<span class='notice'>You cut the wires away from [src].</span>"
+			new /obj/item/stack/cable_coil(get_turf(src), 2)
+			strip_delay += 10
+			update_icon()
+	..()
+	return
+
+/obj/item/clothing/gloves/Touch(A, proximity, var/mob/living/carbon/user)
+	if(!user)		return 0
+	if(!proximity)	return 0
+	if(!cell)		return 0
+	if(ishuman(A) && user.a_intent == "harm")
+		var/mob/living/carbon/human/M = A
+		var/stun = 4
+
+		var/use_charge = min(cell.charge, 5000)
+
+		if(cell.use(use_charge))
+			stun *= round(use_charge / 5000)
+		else
+			stun = 0
+
+		if(stun)
+			if((M != user) && M.check_shields(0, user.name))
+				add_logs(M, user, "attempted to stunglove")
+				user.visible_message("<span class='warning'>[user] attempted to touch [M]!</span>")
+				return 1
+			M.visible_message("<span class='warning'>[A] has been touched with the stun gloves by [user]!</span>",
+				"<span class='userdanger'>[A] has been touched with the stun gloves by [user]!</span>")
+			add_logs(M, user, "stungloved")
+			M.apply_effects(stun,stun,0,0,0,0,0,M.run_armor_check(user.zone_sel.selecting, "energy"))
+			if(siemens_coefficient)
+				user.Stun(stun*siemens_coefficient)
+				user.Weaken(stun*siemens_coefficient)
+				user << "<span class='userdanger'>You are stunned by your own stun gloves!</span>"
+		else
+			user << "<span class='warning'>Not enough charge!</span>"
+
+		return 1
+	return 0
+
+
+
+/obj/item/clothing/gloves/update_icon()
+	..()
+	overlays.Cut()
+	if(wired)
+		overlays += "gloves_wire"
+	if(cell)
+		overlays += "gloves_cell"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -858,6 +858,7 @@
 #include "code\modules\clothing\gloves\boxing.dm"
 #include "code\modules\clothing\gloves\color.dm"
 #include "code\modules\clothing\gloves\miscellaneous.dm"
+#include "code\modules\clothing\gloves\stungloves.dm"
 #include "code\modules\clothing\head\collectable.dm"
 #include "code\modules\clothing\head\hardhat.dm"
 #include "code\modules\clothing\head\helmet.dm"


### PR DESCRIPTION
Yes, stun gloves!
- 4 stun, can be reduced by energy armor.
- 5000 cell charge per stun (3 stuns with cell from assistant storage).
- Gloves can be blocked by shields.
- You can make stun gloves from non-insulated gloves, but then they would stun you too.
- Stun gloves made from insulated gloves are insulated too.
- You can spot "wired insulated gloves" on examine.
- Removing stun gloves with strip menu is really fast.
- Code isn't shitty anymore. 

So stun gloves are balanced now. How about adding them back?

Remember: STUNGLOVES ARE SHIT BECAUSE THEY ARE STUNGLOVES is not a valid argument. Yes @Cheridan, this is about you.
