### PR TITLE
Airlock easy closing v2

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -22,6 +22,7 @@
 	name = "airlock"
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door_closed"
+	mouse_opacity = 2 //Clicking anywhere on the turf is good enough
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI


### PR DESCRIPTION
Made another version of the [Airlock closing made easy](https://github.com/tgstation/-tg-station/pull/8763) PR, so people can test the both easily and determine which one feels better for the game. It's simpler, and more easily maintained.

In this one, airlocks can be closed by clicking anywhere on the tile! If there's an item on the same turf, it can still be picked up normally.

The only setback now is that crowbarring the floortile and e.g. checking a power wire going under the airlock with a multitool requires using the alt+click-turflist. In my experience, though, a scenario like this is very rare.
