### PR TITLE
Adds three new blob chems

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -147,6 +147,44 @@ datum/reagent/blob/explosive/reaction_mob(var/mob/living/M as mob, var/method=TO
 				M << "<span class = 'userdanger'>The blob strikes you, and its tendrils explode!</span>"
 			explosion(M.loc, 0, 0, 1, 0, 0)
 
+datum/reagent/blob/omnizine
+	name = "Omnizine"
+	id = "b_omnizine"
+	description = ""
+	color = "#C8A5DC"
+
+datum/reagent/blob/omnizine/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
+	if(method == TOUCH)
+		if(show_message)
+			M << "<span class = 'userdanger'>The blob squirts something at you, and you feel great!</span>"
+		M.reagents.add_reagent("omnizine", 11)
+
+datum/reagent/blob/morphine
+	name = "Morphine"
+	id = "b_morphine"
+	description = ""
+	color = "#335555"
+
+datum/reagent/blob/morphine/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
+	if(method == TOUCH)
+		if(show_message)
+			M << "<span class = 'userdanger'>The blob squirts something at you, and you feel numb!</span>"
+		M.reagents.add_reagent("morphine", 16)
+
+datum/reagent/blob/spacedrugs
+	name = "Space drugs"
+	id = "b_space_drugs"
+	description = ""
+	color = "#60A584"
+
+datum/reagent/blob/spacedrugs/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
+	if(method == TOUCH)
+		if(show_message)
+			M << "<span class = 'userdanger'>The blob squirts something at you, and you feel funny!</span>"
+		M.reagents.add_reagent("space_drugs", 15)
+		M.apply_damage(10, TOX)
+
+
 /proc/reagent_vortex(var/mob/living/M as mob, var/setting_type)
 	var/turf/pull = get_turf(M)
 	for(var/atom/movable/X in orange(4,pull))


### PR DESCRIPTION
Omnizine blobs inject omnizine on hit, which initially HELPS mobs fighting it, but if they aren't careful in how often the blob hits them, they can rapidly fall into a very painful and hard to treat overdose. Three hits will inflict a heavy damage over time effect, more than that will inevitably cause death without treatment. They're a pleasent light lavender color.

Morphine blobs inject morphine on hit, which will keep mobs from slowing down but eventually will make them fall asleep. One hit will force a very small sleep after a while of fighting, multiple hits will forces longer sleeping after the same delay and overdose mechanics that make people drop held items and do minor tox damage. They're gunmetal grey.

Space Drugs will inject space drugs on hit, which makes mobs stumble around and make backing off from the blob more difficult. It also does minor on hit toxin damage. It's a weedy green.

Adding more blob chems makes any one chem type rarer, so I feel like this is one of the more fun ways the strength of some blob chems can be mitigated.
