### PR TITLE
Removes the minimum damage requirement for defibs

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -323,8 +323,7 @@
 		return 1
 
 /obj/item/weapon/twohanded/shockpaddles/attack(mob/M, mob/user)
-	var/tobehealed
-	var/threshold = -config.health_threshold_dead
+	var/halfwaycritdeath = (config.health_threshold_crit + config.health_threshold_dead) / 2
 	var/mob/living/carbon/human/H = M
 
 	if(busy)
@@ -385,20 +384,23 @@
 						H.heart_attack = 0
 						user.visible_message("<span class='notice'>[defib] pings: Patient's heart is now beating again.</span>")
 					if(H.stat == 2)
-						var/health = H.health
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 						for(var/obj/item/organ/limb/O in H.organs)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
-						if(H.health <= config.health_threshold_dead && total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
-							tobehealed = health + threshold
-							tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
-							H.adjustOxyLoss(tobehealed)
-							H.adjustToxLoss(tobehealed)
-							H.adjustFireLoss(tobehealed)
-							H.adjustBruteLoss(tobehealed)
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
+							//If the body has been fixed so that they would not be in crit when defibbed, give them oxyloss to put them back into crit
+							if (H.health > halfwaycritdeath)
+								H.adjustOxyLoss(H.health - halfwaycritdeath)
+							else
+								var/overall_damage = total_brute + total_burn + H.getToxLoss() + H.getOxyLoss()
+								var/mobhealth = H.health
+								H.adjustOxyLoss((mobhealth - halfwaycritdeath) * (H.getOxyLoss() / overall_damage))
+								H.adjustToxLoss((mobhealth - halfwaycritdeath) * (H.getToxLoss() / overall_damage))
+								H.adjustFireLoss((mobhealth - halfwaycritdeath) * (total_burn / overall_damage))
+								H.adjustBruteLoss((mobhealth - halfwaycritdeath) * (total_brute / overall_damage))
 							user.visible_message("<span class='notice'>[defib] pings: Resuscitation successful.</span>")
 							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
 							H.stat = 1
@@ -410,12 +412,14 @@
 							defib.deductcharge(revivecost)
 							add_logs(user, M, "revived", object="defibrillator")
 						else
-							if(tplus > tlimit)
-								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
+							if (H.suiciding || (NOCLONE in H.mutations))
+								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>")
+							else if (tplus > tlimit)
+								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation. Further attempts futile.</span>")
 							else if(total_burn >= 180 || total_brute >= 180)
 								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - Severe tissue damage detected.</span>")
 							else
-								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed.</span>")
+								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - No soul in patient body. Further attempts may be successful.</span>")
 								if(ghost)
 									ghost << "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)"
 									ghost << sound('sound/effects/genetics.ogg')

--- a/html/changelogs/defibChange-Zel.yml
+++ b/html/changelogs/defibChange-Zel.yml
@@ -1,0 +1,7 @@
+author: Zelacks
+
+delete-after: True
+
+changes: 
+  - tweak: "Defibs no longer have a minimum damage requirement for a successful revive. Patients will have 150 total damage on a successful revive."
+  - tweak: "Additional feedback is given for several failure states of the defib."


### PR DESCRIPTION
-Defibs no longer have a minimum damage requirement. Previously the body required to be damaged in order to be defibbed (Required to be damaged, atleast 200 units). I can only assume that this was the case because the author had math that needed the body to have atleast 200 units of damage for it to work correctly, but I assume that the author naively thought it was impossible to heal corpses.
--Defibs now restore the health of the user to halfway between crit and death (-50 health or 150 sustained damage). If the user has little damage sustained, they will receive oxyloss to place them to the halfway point. If the corpse has more damage than the halfway point, they will be healed to the halfway point, in a ratio based on how much they sustained in each type of damage they took.
--Defibs will not heal cloneloss, and will still damage/heal the patient to the halfway point including the cloneless (eg a patient who is 0/0/0/0 with 30 cloneless receives 120 oxyloss). If the patient has too much cloneloss, they will heal fully, except they will still have the cloneloss (eg, they will be 0/0/0/0 with 180 cloneloss on revival)
--Additonal feedback given for some failure states for the defib.
