### PR TITLE
Removes the mutant_colors config option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -108,7 +108,6 @@
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
-	var/mutant_colors = 0
 
 	var/no_summon_guns		//No
 	var/no_summon_magic		//Fun
@@ -472,8 +471,6 @@
 					config.silicon_max_law_amount	= text2num(value)
 				if("join_with_mutant_race")
 					config.mutant_races				= 1
-				if("mutant_colors")
-					config.mutant_colors			= 1
 				if("assistant_cap")
 					config.assistant_cap			= text2num(value)
 				if("starlight")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -722,13 +722,10 @@ datum/preferences
 						if(result)
 							var/newtype = roundstart_species[result]
 							pref_species = new newtype()
-							if(!config.mutant_colors || mutant_color == "#000")
+							if(mutant_color == "#000")
 								mutant_color = pref_species.default_color
 
 					if("mutant_color")
-						if(!config.mutant_colors)
-							user << "<span class='danger'>Alien colors are disabled.</span>"
-							return
 						var/new_mutantcolor = input(user, "Choose your character's alien skin color:", "Character Preference") as color|null
 						if(new_mutantcolor)
 							var/temp_hsv = RGBtoHSV(new_mutantcolor)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -92,9 +92,6 @@
 
 	var/g = (H.gender == FEMALE) ? "f" : "m"
 
-	if(!config.mutant_colors)
-		H.dna.mutant_color = default_color
-
 	if(MUTCOLORS in specflags)
 		var/image/spec_base
 		var/icon_state_string = "[id]_"
@@ -128,10 +125,7 @@
 
 			if(hair_color)
 				if(hair_color == "mutcolor")
-					if(!config.mutant_colors)
-						img_facial_s.color = "#" + default_color
-					else
-						img_facial_s.color = "#" + H.dna.mutant_color
+					img_facial_s.color = "#" + H.dna.mutant_color
 				else
 					img_facial_s.color = "#" + hair_color
 			else
@@ -159,10 +153,7 @@
 
 			if(hair_color)
 				if(hair_color == "mutcolor")
-					if(!config.mutant_colors)
-						img_hair_s.color = "#" + default_color
-					else
-						img_hair_s.color = "#" + H.dna.mutant_color
+					img_hair_s.color = "#" + H.dna.mutant_color
 				else
 					img_hair_s.color = "#" + hair_color
 			else
@@ -251,9 +242,6 @@
 		icon_state_string += "[g]_s"
 	else
 		icon_state_string += "_s"
-
-	if(!config.mutant_colors)
-		H.dna.mutant_color = default_color
 
 	for(var/layer in relevent_layers)
 		for(var/bodypart in bodyparts_to_add)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -216,9 +216,6 @@ SILICON_MAX_LAW_AMOUNT 12
 ## Uncoment to give players the choice of their species before they join the game
 #JOIN_WITH_MUTANT_RACE
 
-## Uncomment to allow certain species to have custom colors
-#MUTANT_COLORS
-
 ## Assistant slot cap. Set to -1 for unlimited.
 ASSISTANT_CAP -1
 


### PR DESCRIPTION
Because anyone who's apt to turn on mutant races for joining doesn't want them to all look EXACTLY THE SAME (That's racist guys).

mutant_colors is basically = 1 forever now, you won't be forced into the default color unless you've somehow thrown an invalid value for your preferences

Not everything needs to be a config option. In a silly way this fixes #8819
