### PR TITLE
Modifies some win conditions

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -27,21 +27,27 @@
 	if(blobwincount <= blobs.len)
 		feedback_set_details("round_end_result","win - blob took over")
 		world << "<FONT size = 3><B>The blob has taken over the station!</B></FONT>"
-		world << "<B>The entire station was eaten by the Blob</B>"
+		world << "<B>The Blob grew too large and became unstoppable!</B>"
 		log_game("Blob mode completed with a blob victory.")
 
 	else if(station_was_nuked)
-		feedback_set_details("round_end_result","halfwin - nuke")
-		world << "<FONT size = 3><B>Partial Win: The station has been destroyed!</B></FONT>"
-		world << "<B>Directive 7-12 has been successfully carried out preventing the Blob from spreading.</B>"
+		feedback_set_details("round_end_result","draw - nuke")
+		world << "<FONT size = 3><B>Draw: The station has been destroyed!</B></FONT>"
+		world << "<B>The Blob has been destroyed, but so has the station!</B>"
 		log_game("Blob mode completed with a tie (station destroyed).")
 
 	else if(!blob_cores.len)
 		feedback_set_details("round_end_result","loss - blob eliminated")
 		world << "<FONT size = 3><B>The staff has won!</B></FONT>"
-		world << "<B>The alien organism has been eradicated from the station</B>"
+		world << "<B>The Blob has been eradicated from the station</B>"
 		log_game("Blob mode completed with a crew victory.")
 		world << "<span class='notice'>Rebooting in 30s</span>"
+	else
+		feedback_set_details("round_end_result","loss - crew fled")
+		world << "<FONT size = 3><B>The crew fled the blob!</B></FONT>"
+		world << "<B>By abandoning the fight the blob eventually took over the station!</B>"
+		log_game("Blob mode completed with a blob victory.")
+
 	..()
 	return 1
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -257,7 +257,7 @@
 		world << "<B>The self-destruction of [station_name()] killed everyone on board!</B>"
 
 	else if ( station_captured &&  malf_dead && !station_was_nuked)
-		feedback_set_details("round_end_result","halfwin - AI killed, staff lost control")
+		feedback_set_details("round_end_result","draw - AI killed, staff lost control")
 		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
 		world << "<B>The AI has been killed!</B> However, the staff have lost control of [station_name()]."
 
@@ -267,8 +267,8 @@
 		world << "<B>The AI has chosen not to detonate the station!</B>"
 
 	else if (!station_captured &&                station_was_nuked)
-		feedback_set_details("round_end_result","halfwin - everyone killed by nuke")
-		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
+		feedback_set_details("round_end_result","draw - everyone killed by nuke")
+		world << "<FONT size = 3><B>Draw</B></FONT>"
 		world << "<B>Everyone was killed by the nuclear blast!</B>"
 
 	else if (!station_captured &&  malf_dead && !station_was_nuked)
@@ -282,12 +282,12 @@
 		world << "<b>The malfunctioning AI has left the station's z-level and was disconnected from its systems!</b> The crew are victorious."
 
 	else if (!station_captured && !malf_dead && !station_was_nuked && crew_evacuated)
-		feedback_set_details("round_end_result","halfwin - evacuated")
+		feedback_set_details("round_end_result","win - AI win - evacuated")
 		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
 		world << "<B>Nanotrasen has lost control of [station_name()]! All surviving personnel will be fired.</B>"
 
 	else if (!station_captured && !malf_dead && !station_was_nuked && !crew_evacuated)
-		feedback_set_details("round_end_result","halfwin - interrupted")
+		feedback_set_details("round_end_result","draw - interrupted")
 		world << "<FONT size = 3><B>Neutral Victory</B></FONT>"
 		world << "<B>Round was mysteriously interrupted!</B>"
 	..()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -202,28 +202,19 @@ var/bomb_set
 		ticker.mode:syndies_didnt_escape = (Shuttle && Shuttle.z == ZLEVEL_CENTCOM) ? 0 : 1
 		ticker.mode:nuke_off_station = off_station
 	ticker.station_explosion_cinematic(off_station,null)
+
+	ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
+													//kinda shit but I couldn't  get permission to do what I wanted to do.
+
 	if(ticker.mode)
 		ticker.mode.explosion_in_progress = 0
 		if(ticker.mode.name == "nuclear emergency")
 			ticker.mode:nukes_left --
-		else
+		else if(ticker.mode.station_was_nuked)
 			world << "<B>The station was destoyed by the nuclear blast!</B>"
 
-		ticker.mode.station_was_nuked = (off_station<2)	//offstation==1 is a draw. the station becomes irradiated and needs to be evacuated.
-														//kinda shit but I couldn't  get permission to do what I wanted to do.
+		ticker.mode.check_win()
 
-		if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
-			world << "<B>Resetting in 30 seconds!</B>"
-
-			feedback_set_details("end_error","nuke - unhandled ending")
-
-			if(blackbox)
-				blackbox.save_all_data_to_sql()
-			sleep(300)
-			log_game("Rebooting due to nuclear detonation")
-			kick_clients_in_lobby("<span class='danger'>The round came to an end with you in the lobby.</span>", 1) //second parameter ensures only afk clients are kicked
-			world.Reboot()
-			return
 	return
 
 /*

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -204,9 +204,9 @@
 //////////////////////////////////////
 /datum/game_mode/revolution/check_win()
 	if(check_rev_victory())
-		finished = 1
-	else if(check_heads_victory())
-		finished = 2
+		finished += 1
+	if(check_heads_victory())
+		finished += 2
 	return
 
 ///////////////////////////////
@@ -311,6 +311,9 @@
 	else if(finished == 2)
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		world << "<span class='danger'><FONT size = 3>The heads of staff managed to stop the revolution!</FONT></span>"
+	else if(finished == 3)
+		feedback_set_details("round_end_result","draw - heads and rev heads killed")
+		world << "<span class='danger'><FONT size = 3>The revolution was successful but their leaders are dead as well!</FONT></span>"
 	..()
 	return 1
 


### PR DESCRIPTION
Blob
- Nuking the blob now counts as a Draw instead of a partial win for the blob
- If the crew should somehow ride the shuttle out while the blob is still alive that's a blob win
- The flavor text has also been changed since the blob victory condition isn't exactly "the whole station"

Malf
- Nuking the malf now counts as a draw instead of a "neutral victory" (what?)
- Somehow evacuating during a living malf round now counts a victory for the malf
- Killing a malf who has already won but not yet nuked the station counts as a draw

Nuke
- Activates a BUNCH of in code but unintentionally unused win conditions for nuke agents, mostly silly edge cases where the nuke goes off somewhere other than the station. Fixes #8778
- Note that in these cases the round doesn't  end in case the admins want to have pity on the nukes and give them another both to blow up, they'll only report once the shuttle docks.
- In general a nuke that misses the station won't end the round now.

Revolution
- If both sides win/lose at the same time, there's now a draw conclusion to represent this.
