### PR TITLE
Better admin/config control of mulligans + tweaks

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -98,11 +98,8 @@
 	var/protect_assistant_from_antagonist = 0 //If assistants can be traitor/cult/other
 	var/enforce_human_authority = 0		//If non-human species are barred from joining as a head of staff
 	var/allow_latejoin_antagonists = 0 	// If late-joining players can be traitor/changeling
-	var/continuous_round_rev = 0		// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
-	var/continuous_round_gang = 0
-	var/continuous_round_wiz = 0
-	var/continuous_round_malf = 0
-	var/continuous_round_blob = 0
+	var/list/continuous = list()		// which roundtypes continue if all antagonists die
+	var/list/midround_antag = list() 	// which roundtypes use the midround antagonist system
 	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
 	var/shuttle_refuel_delay = 12000
@@ -397,16 +394,18 @@
 					config.sec_start_brig			= 1
 				if("gateway_delay")
 					config.gateway_delay			= text2num(value)
-				if("continuous_round_rev")
-					config.continuous_round_rev		= 1
-				if("continuous_round_gang")
-					config.continuous_round_gang	= 1
-				if("continuous_round_wiz")
-					config.continuous_round_wiz		= 1
-				if("continuous_round_malf")
-					config.continuous_round_malf	= 1
-				if("continuous_round_blob")
-					config.continuous_round_blob	= 1
+				if("continuous")
+					var/mode_name = lowertext(value)
+					if(mode_name in config.modes)
+						config.continuous[mode_name] = 1
+					else
+						diary << "Unknown continuous configuration definition: [mode_name]."
+				if("midround_antag")
+					var/mode_name = lowertext(value)
+					if(mode_name in config.modes)
+						config.midround_antag[mode_name] = 1
+					else
+						diary << "Unknown midround antagonist configuration definition: [mode_name]."
 				if("midround_antag_time_check")
 					config.midround_antag_time_check = text2num(value)
 				if("midround_antag_life_check")

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -1,4 +1,6 @@
 /datum/game_mode/blob/check_finished()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
 	if(round_converted)
 		return ..()
 	if(infected_crew.len > burst)//Some blobs have yet to burst
@@ -6,15 +8,16 @@
 	if(blobwincount <= blobs.len)//Blob took over
 		return 1
 	if(!blob_cores.len) // blob is dead
-		if(config.continuous_round_blob)
-			round_converted = convert_roundtype()
-			if(!round_converted)
-				return 1
+		if(config.continuous["blob"])
+			if(config.midround_antag["blob"])
+				round_converted = convert_roundtype()
+				if(!round_converted)
+					return 1
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
-			return 0
+			return ..()
 		return 1
 	if(station_was_nuked)//Nuke went off
 		return 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -150,9 +150,12 @@
 	if(config.protect_assistant_from_antagonist)
 		replacementmode.restricted_jobs += "Assistant"
 
-	message_admins("The roundtype will be converted. If you feel that the round should not continue, <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
+	message_admins("The roundtype will be converted. If you have other plans for the station or think the round should end <A HREF='?_src_=holder;toggle_midround_antag=\ref[usr]'>stop the creation of antags</A> or <A HREF='?_src_=holder;end_round=\ref[usr]'>end the round now</A>.")
 
-	spawn(rand(1800,4200)) //somewhere between 3 and 7 minutes from now
+	spawn(rand(1200,3000)) //somewhere between 2 and 5 minutes from now
+		if(!config.midround_antag[ticker.mode.config_tag])
+			round_converted = 0
+			return 1
 		for(var/mob/living/carbon/human/H in antag_canadates)
 			replacementmode.make_antag_chance(H)
 		round_converted = 2

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -220,7 +220,7 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/gang/check_finished()
-	if(finished && !config.continuous_round_gang) //Check for Gang Boss death
+	if(finished && !config.continuous["gang"]) //Check for Gang Boss death
 		return 1
 	return ..() //Check for evacuation/nuke
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -170,12 +170,14 @@
 
 
 /datum/game_mode/malfunction/check_finished()
-	if(round_converted)
-		return ..()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if((config.continuous["malfunction"] && !config.midround_antag["malfunction"]) || round_converted == 1) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
 	if (station_captured && !to_nuke_or_not_to_nuke)
 		return 1
 	if (is_malf_ai_dead() || !check_ai_loc())
-		if(config.continuous_round_malf)
+		if(config.continuous["malfunction"])
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -213,7 +213,7 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
-	if(config.continuous_round_rev)
+	if(config.continuous["revolution"])
 		if(finished != 0)
 			SSshuttle.emergencyNoEscape = 0
 		return ..()

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -171,30 +171,24 @@
 
 /datum/game_mode/wizard/check_finished()
 
-	if(round_converted)
-		return ..()
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
 
-	var/wizards_alive = 0
-	var/traitors_alive = 0
+	if((config.continuous["wizard"] && !config.midround_antag["wizard"]) || round_converted == 1 || !wizards) //No reason to waste resources
+		return ..() //Check for evacuation/nuke
+
 	for(var/datum/mind/wizard in wizards)
-		if(!istype(wizard.current,/mob/living/carbon))
-			continue
-		if(wizard.current.stat==2)
-			continue
-		wizards_alive++
+		if(wizard.current.stat != DEAD)
+			return ..()
 
-	if(!wizards_alive)
-		for(var/datum/mind/traitor in traitors)
-			if(!istype(traitor.current,/mob/living/carbon))
-				continue
-			if(traitor.current.stat==2)
-				continue
-			traitors_alive++
+	for(var/datum/mind/traitor in traitors)
+		if(traitor.current.stat != DEAD)
+			return ..()
 
-	if (wizards_alive || traitors_alive)
-		return ..()
+	if(!config.continuous["wizard"] || !config.midround_antag["wizard"])
+		return 1
 
-	if(config.continuous_round_wiz)
+	else
 		round_converted = convert_roundtype()
 		if(!round_converted)
 			finished = 1
@@ -203,10 +197,7 @@
 			if(SSevent.wizardmode) //If summon events was active, turn it off
 				SSevent.toggleWizardmode()
 				SSevent.resetFrequency()
-			return ..()
-
-	finished = 1
-	return 1
+	return ..()
 
 /datum/game_mode/wizard/declare_completion()
 	if(finished)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -305,6 +305,8 @@
 	usr << browse(dat, "window=players;size=600x480")
 
 /datum/admins/proc/check_antagonists()
+	var/list/supported_continuous_modes = list("revolution", "gang", "wizard", "malfunction", "blob")
+	var/list/supported_midround_antag_modes = list("wizard", "malfunction", "blob")
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
@@ -321,6 +323,16 @@
 				dat += "<a href='?_src_=holder;call_shuttle=2'>Send Back</a><br>"
 			else
 				dat += "ETA: <a href='?_src_=holder;edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+		dat += "<B>Continuous Round Status</B><BR>"
+		if(!ticker.mode.config_tag in supported_continuous_modes)
+			dat += "Continue if antagonists die"
+		else
+			dat += "<a href='?_src_=holder;toggle_continuous=1'>[config.continuous[ticker.mode.config_tag] ? "Continue if antagonists die" : "End on antagonist death"]</a>"
+		if(config.continuous[ticker.mode.config_tag] && ticker.mode.config_tag in supported_midround_antag_modes)
+			dat += ", <a href='?_src_=holder;toggle_midround_antag=1'>[config.midround_antag[ticker.mode.config_tag] ? "creating replacement antagonists" : "not creating new antagonists"]</a><BR>"
+		else
+			dat += "<BR>"
+		dat += "<BR>"
 		dat += "<a href='?_src_=holder;end_round=\ref[usr]'>End Round Now</a><br>"
 		dat += "<a href='?_src_=holder;delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
 		if(ticker.mode.syndicates.len)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -221,6 +221,28 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [timer] seconds</span>")
 		href_list["secretsadmin"] = "check_antagonist"
 
+	else if(href_list["toggle_continuous"])
+		if(!check_rights(R_ADMIN))	return
+
+		if(!config.continuous[ticker.mode.config_tag])
+			config.continuous[ticker.mode.config_tag] = 1
+		else
+			config.continuous[ticker.mode.config_tag] = 0
+
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled the round to [config.continuous[ticker.mode.config_tag] ? "continue if all antagonists die" : "end with the antagonists"].</span>")
+		check_antagonists()
+
+	else if(href_list["toggle_midround_antag"])
+		if(!check_rights(R_ADMIN))	return
+
+		if(!config.midround_antag[ticker.mode.config_tag])
+			config.midround_antag[ticker.mode.config_tag] = 1
+		else
+			config.midround_antag[ticker.mode.config_tag] = 0
+
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] toggled the round to [config.midround_antag[ticker.mode.config_tag] ? "use" : "skip"] the midround antag system.</span>")
+		check_antagonists()
+
 	else if(href_list["delay_round_end"])
 		if(!check_rights(R_SERVER))	return
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -96,14 +96,24 @@ PROBABILITY EXTENDED 0
 ## You probably want to keep sandbox off by default for secret and random.
 PROBABILITY SANDBOX 0
 
-## Uncomment to make rounds which end instantly (Rev, Wizard, Malf) continue until
-## the shuttle is called or the station is nuked.
-## Malf and Rev will let the shuttle be called when the antags/protags are dead.
-#CONTINUOUS_ROUND_REV
-#CONTINUOUS_ROUND_GANG
-#CONTINUOUS_ROUND_WIZ
-#CONTINUOUS_ROUND_MALF
-#CONTINUOUS_ROUND_BLOB
+
+## Toggles for continuous modes.
+## Modes that aren't continuous will end the instant all antagonists are dead.
+## Unlisted modes are not currently supported for noncontinous play
+
+#CONTINUOUS REVOLUTION
+#CONTINUOUS GANG
+CONTINUOUS WIZARD
+CONTINUOUS MALFUNCTION
+CONTINUOUS BLOB
+
+## Toggles for allowing midround antagonists (aka mulligan antagonists).
+## In modes that are continuous, if all antagonists should die then a new set of antagonists will be created.
+## Only the listed modes are currently supported for this system
+
+MIDROUND_ANTAG WIZARD
+MIDROUND_ANTAG MALFUNCTION
+MIDROUND_ANTAG BLOB
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
 SHUTTLE_REFUEL_DELAY 12000


### PR DESCRIPTION
Organizes the various continuous_round_x config options into one set of config options: "continuous". Functionality is only there for the same mode that already had it, everything else is always continuous .

Makes another set of config options for which rounds types, if any, use the midround antagonist (mulligan) system. Keep in mind this is by definition a subset of round with continuous set. Again this feature is only present for the roundtypes where I KNOW it works properly, other modes can't use midround antags.

The check antagonist screen will show how the game will behave when all the antagonists die, and it can be changed on the fly by admins, the four possible states are:

End on antagonist death (noncontinuous rounds)
Continue if antagonists die (unsupported continuous by default round)
Continue if antagonists die, creating replacement antagonists (continuous, using midround antags)
Continue if antagonists die, not creating new antagonists (continuous, not using midround antags)

When rounds prepare to mulligan admins will additionally get the option to just keep the round going without any automatically created antags in case they want to run their own shenanigans instead. They can also as before choose to end the round.

Reduces the time between primary antag death and midround antag creation from between 3 to 7 minutes to between 2 to 5 minutes.

Basically the diet coke version of #8586 without all the crazy stuff I haven't tested yet.
