### PR TITLE
Grants Cargo Technicians access to the Ore Redemption Machine!

### DIFF
--- a/code/game/jobs/job/cargo_service.dm
+++ b/code/game/jobs/job/cargo_service.dm
@@ -42,7 +42,7 @@ Cargo Technician
 	default_headset = /obj/item/device/radio/headset/headset_cargo
 
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station, access_mineral_storeroom)
-	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
+	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_mineral_storeroom)
 
 /datum/job/cargo_tech/equip_items(var/mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)

--- a/html/changelogs/Gun_Hog-Mail-Man-Buff.yml
+++ b/html/changelogs/Gun_Hog-Mail-Man-Buff.yml
@@ -1,0 +1,5 @@
+author: Gun Hog
+delete-after: true
+
+changes: 
+  - tweak: "Nanotrasen has approved an access upgrade for Cargo Technicians! They are now authorized to release minerals from the ore redemption machine, to allow proper inventory management and shipping."


### PR DESCRIPTION
Cargo Technicians may now release ore from the Ore Redemption Machine. This is to encourage the Supply team to mail the minerals out. It should make the job 0.02% more interesting!

_They cannot claim the points! Shaft Miners need not worry about losing them!_

Inspired by: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=3334&p=81365#p80822
