### PR TITLE
Fixes Spraycans bugs

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -113,20 +113,25 @@
 			update_icon()
 
 /obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user as mob, proximity)
+	if(!proximity)
+		return
 	if(capped)
 		return
 	else
 		if(iscarbon(target))
-			var/mob/living/carbon/human/C = target
-			user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
-			if(C.client)
-				C.eye_blurry = max(C.eye_blurry, 3)
-				C.eye_blind = max(C.eye_blind, 1)
-				C.confused = max(C.confused, 3)
-				C.Weaken(3)
-			C.lip_style = "spray_face"
-			C.lip_color = colour
-			C.update_body()
+			if(uses-10 > 0)
+				uses = uses - 10
+				var/mob/living/carbon/human/C = target
+				user.visible_message("<span class='danger'> [user] sprays [src] into the face of [target]!</span>")
+				if(C.client)
+					C.eye_blurry = max(C.eye_blurry, 3)
+					C.eye_blind = max(C.eye_blind, 1)
+					if(C.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
+						C.confused = max(C.confused, 3)
+						C.Weaken(3)
+				C.lip_style = "spray_face"
+				C.lip_color = colour
+				C.update_body()
 		playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
 		..()
 


### PR DESCRIPTION
- Fixes Spraycans being used at a range
- Fixes Spraycans not consuming ammo when used as a stun.
- Changes the stun mechanic, so people with eye protection are only blinded, without it they are stunned fully.

Fixes #8871 
