### PR TITLE
Windows, CPR, lipstick fixes

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -112,8 +112,6 @@
 				return 1
 			var/obj/structure/window/W
 			W = new /obj/structure/window/fulltile( user.loc, 0 )
-			W.dir = SOUTHWEST
-			W.ini_dir = SOUTHWEST
 			W.anchored = 0
 			W.air_update_turf(1)
 			W.add_fingerprint(user)
@@ -213,8 +211,6 @@
 			var/obj/structure/window/W
 			W = new /obj/structure/window/reinforced/fulltile(user.loc, 1)
 			W.state = 0
-			W.dir = SOUTHWEST
-			W.ini_dir = SOUTHWEST
 			W.anchored = 0
 			W.add_fingerprint(user)
 			src.use(2)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -50,6 +50,9 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		if(H.is_mouth_covered())
+			user << "<span class='notice'>Remove [ H == user ? "your" : "their" ] mask!</span>"
+			return
 		if(H.lip_style)	//if they already have lipstick on
 			user << "<span class='notice'>You need to wipe off the old lipstick first!</span>"
 			return

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -3,7 +3,7 @@
 	var/force_on = 30 //force when active
 	var/throwforce_on = 20
 	var/icon_state_on = "axe1"
-	var/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = 2
 	var/w_class_on = 4
 
@@ -31,7 +31,7 @@
 	flags = CONDUCT | NOSHIELD
 	origin_tech = "combat=3"
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
-	attack_verb_on = null
+	attack_verb_on = list()
 
 /obj/item/weapon/melee/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings the [src.name] towards /his head! It looks like \he's trying to commit suicide.</span>")
@@ -47,7 +47,6 @@
 	throw_speed = 3
 	throw_range = 5
 	flags = NOSHIELD
-	attack_verb = null
 	origin_tech = "magnets=3;syndicate=4"
 	var/hacked = 0
 
@@ -69,7 +68,7 @@
 		force = force_on
 		throwforce = throwforce_on
 		hitsound = 'sound/weapons/blade1.ogg'
-		if(attack_verb_on)
+		if(attack_verb_on.len)
 			attack_verb = attack_verb_on
 		if(!item_color)
 			icon_state = icon_state_on
@@ -82,7 +81,8 @@
 		force = initial(force)
 		throwforce = initial(throwforce)
 		hitsound = initial(hitsound)
-		attack_verb = initial(attack_verb)
+		if(attack_verb_on.len)
+			attack_verb = list()
 		icon_state = initial(icon_state)
 		w_class = initial(w_class)
 		playsound(user, 'sound/weapons/saberoff.ogg', 35, 1)  //changed it from 50% volume to 35% because deafness

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -118,6 +118,8 @@
 	return
 
 /obj/structure/grille/Deconstruct()
+	if(!loc) //if already qdel'd somehow, we do nothing
+		return
 	transfer_fingerprints_to(stored)
 	var/turf/T = loc
 	stored.loc = T

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -16,20 +16,25 @@
 	var/disassembled = 0
 	var/wtype = "glass"
 	var/fulltile = 0
-	var/obj/item/stack/rods/storedrods
-	var/obj/item/weapon/shard/storedshard
+	var/list/storeditems = list()
 //	var/silicate = 0 // number of units of silicate
 //	var/icon/silicateIcon = null // the silicated icon
 
 /obj/structure/window/New(Loc,re=0)
 	..()
 	health = maxhealth
-	if(re)	reinf = re
-	storedshard = new/obj/item/weapon/shard(src)
+	if(re)
+		reinf = re
+	storeditems.Add(new/obj/item/weapon/shard(src))
+	if(fulltile)
+		storeditems.Add(new/obj/item/weapon/shard(src))
 	ini_dir = dir
 	if(reinf)
 		state = 2*anchored
-		storedrods = new/obj/item/stack/rods(src)
+		var/obj/item/stack/rods/R = new/obj/item/stack/rods(src)
+		storeditems.Add(R)
+		if(fulltile)
+			R.add(1)
 
 	air_update_turf(1)
 	update_nearby_icons()
@@ -123,9 +128,7 @@
 	..(user, 1)
 	user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
 	user.visible_message("<span class='danger'>[user] smashes through [src]!</span>")
-	storedshard.add_fingerprint(user)
-	if(storedrods)
-		storedrods.add_fingerprint(user)
+	add_fingerprint(user)
 	hit(50)
 	return 1
 
@@ -279,29 +282,23 @@
 	return 1
 
 /obj/structure/window/proc/hit(var/damage, var/sound_effect = 1)
-	if(reinf) damage *= 0.5
+	if(reinf)
+		damage *= 0.5
 	health = max(0, health - damage)
 	update_nearby_icons()
 	if(sound_effect)
 		playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
 	if(health <= 0)
-		if(dir == SOUTHWEST)
-			var/index = null
-			index = 0
-			while(index < 2)
-				spawnfragments()
-				index++
-		else
-			spawnfragments()
+		spawnfragments()
 		return
 
 /obj/structure/window/proc/spawnfragments()
+	if(!loc) //if already qdel'd somehow, we do nothing
+		return
 	var/turf/T = loc
-	storedshard.loc = T
-	transfer_fingerprints_to(storedshard)
-	if(storedrods)
-		storedrods.loc = T
-		transfer_fingerprints_to(storedrods)
+	for(var/obj/item/I in storeditems)
+		I.loc = T
+		transfer_fingerprints_to(I)
 	qdel(src)
 	update_nearby_icons()
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -92,7 +92,6 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/masks.dmi'
 	body_parts_covered = HEAD
 	slot_flags = SLOT_MASK
-	var/alloweat = 0
 	strip_delay = 40
 	put_on_delay = 40
 	var/mask_adjusted = 0

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -222,7 +222,7 @@
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"
 	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "clown"
 	item_state = "clown_hat"
 
@@ -245,28 +245,28 @@ obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
 /obj/item/clothing/mask/gas/sexyclown
 	name = "sexy-clown wig and mask"
 	desc = "A feminine clown mask for the dabbling crossdressers or female entertainers."
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "sexyclown"
 	item_state = "sexyclown"
 
 /obj/item/clothing/mask/gas/mime
 	name = "mime mask"
 	desc = "The traditional mime's mask. It has an eerie facial posture."
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "mime"
 	item_state = "mime"
 
 /obj/item/clothing/mask/gas/monkeymask
 	name = "monkey mask"
 	desc = "A mask used when acting as a monkey."
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "monkeymask"
 	item_state = "monkeymask"
 
 /obj/item/clothing/mask/gas/sexymime
 	name = "sexy mime mask"
 	desc = "A traditional female mime's mask."
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "sexymime"
 	item_state = "sexymime"
 
@@ -283,5 +283,5 @@ obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
 /obj/item/clothing/mask/gas/owl_mask
 	name = "owl mask"
 	desc = "Twoooo!"
-	alloweat = 1
+	flags = MASKCOVERSEYES | BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	icon_state = "owl"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -138,9 +138,6 @@
 /mob/living/carbon/alien/IsAdvancedToolUser()
 	return has_fine_manipulation
 
-/mob/living/carbon/alien/SpeciesCanConsume()
-	return 1 // Aliens can eat, and they can be fed food/drink
-
 /mob/living/carbon/alien/Stat()
 	..()
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -123,7 +123,7 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.head && H.head.flags & HEADCOVERSMOUTH)
+		if(H.is_mouth_covered(head_only = 1))
 			H.visible_message("<span class='danger'>[src] smashes against [H]'s [H.head]!</span>", \
 								"<span class='userdanger'>[src] smashes against [H]'s [H.head]!</span>")
 			Die()
@@ -239,7 +239,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	var/mob/living/carbon/C = M
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if(H.head && H.head.flags & HEADCOVERSMOUTH)
+		if(H.is_mouth_covered(head_only = 1))
 			return 0
 		return 1
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -490,3 +490,7 @@ var/const/GALOSHES_DONT_HELP = 8
 				update_inv_legcuffed(0)
 		else
 			src << "<span class='warning'>You fail to break [I]!</span>"
+
+/mob/living/carbon/proc/is_mouth_covered(head_only = 0, mask_only = 0)
+	if( (!mask_only && head && (head.flags & HEADCOVERSMOUTH)) || (!head_only && wear_mask && (wear_mask.flags & MASKCOVERSMOUTH)) )
+		return 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -671,7 +671,6 @@
 	..()
 
 
-
 /mob/living/carbon/human/help_shake_act(mob/living/carbon/M)
 	if(!istype(M))
 		return
@@ -728,6 +727,34 @@
 				w_uniform.add_fingerprint(M)
 
 			..()
+
+
+/mob/living/carbon/human/proc/do_cpr(mob/living/carbon/C)
+	if(C.stat == DEAD)
+		src << "<span class='warning'>[C.name] is dead!</span>"
+		return
+	if(is_mouth_covered())
+		src << "<span class='notice'>Remove your mask!</span>"
+		return 0
+	if(C.is_mouth_covered())
+		src << "<span class='notice'>Remove their mask!</span>"
+		return 0
+
+	if(C.cpr_time < world.time + 30)
+		add_logs(src, C, "CPRed")
+		visible_message("<span class='notice'>[src] is trying to perform CPR on [C.name]!</span>", \
+						"<span class='notice'>You try to perform CPR on [C.name]. Hold still!</span>")
+		if(!do_mob(src, C))
+			src << "<span class='warning'>You fail to perform CPR on [C]!</span>"
+			return 0
+
+		if(C.health <= config.health_threshold_crit)
+			C.cpr_time = world.time
+			var/suff = min(C.getOxyLoss(), 7)
+			C.adjustOxyLoss(-suff)
+			C.updatehealth()
+			visible_message("<span class='notice'>[src] performs CPR on [C.name]!</span>")
+			C << "<span class='unconscious'>You feel a breath of fresh air enter your lungs. It feels good.</span>"
 
 
 /mob/living/carbon/human/generateStaticOverlay()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -125,9 +125,6 @@
 /mob/living/carbon/human/IsAdvancedToolUser()
 	return 1//Humans can use guns and such
 
-/mob/living/carbon/human/SpeciesCanConsume()
-	return 1 // Humans can eat, drink, and be forced to do so
-
 /mob/living/carbon/human/InCritical()
 	return (health <= config.health_threshold_crit && stat == UNCONSCIOUS)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -703,6 +703,8 @@
 //////////////////
 
 /datum/species/proc/spec_attack_hand(var/mob/living/carbon/human/M, var/mob/living/carbon/human/H)
+	if(!istype(M)) //sanity check for drones.
+		return
 	if((M != H) && H.check_shields(0, M.name))
 		add_logs(M, H, "attempted to touch")
 		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>")
@@ -715,29 +717,8 @@
 				if(H != M)
 					add_logs(M, H, "shaked")
 				return 1
-
-			//CPR
-			if((M.head && (M.head.flags & HEADCOVERSMOUTH)) || (M.wear_mask && (M.wear_mask.flags & MASKCOVERSMOUTH)))
-				M << "<span class='notice'>Remove your mask!</span>"
-				return 0
-			if((H.head && (H.head.flags & HEADCOVERSMOUTH)) || (H.wear_mask && (H.wear_mask.flags & MASKCOVERSMOUTH)))
-				M << "<span class='notice'>Remove their mask!</span>"
-				return 0
-
-			if(H.cpr_time < world.time + 30)
-				add_logs(M, H, "CPRed")
-				M.visible_message("<span class='notice'>[M] is trying to perform CPR on [H]!</span>", \
-								"<span class='notice'>You try to perform CPR on [H]. Hold still!</span>")
-				if(!do_mob(M, H))
-					M << "<span class='warning'>You fail to perform CPR on [H]!</span>"
-					return 0
-				if((H.health >= -99 && H.health <= 0))
-					H.cpr_time = world.time
-					var/suff = min(H.getOxyLoss(), 7)
-					H.adjustOxyLoss(-suff)
-					H.updatehealth()
-					M.visible_message("[M] performs CPR on [H]!")
-					H << "<span class='unconscious'>You feel a breath of fresh air enter your lungs. It feels good.</span>"
+			else
+				M.do_cpr(H)
 
 		if("grab")
 			H.grabbedby(M)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -241,10 +241,6 @@
 
 	return threatcount
 
-/mob/living/carbon/monkey/SpeciesCanConsume()
-	return 1 // Monkeys can eat, drink, and be forced to do so
-
-
 /mob/living/carbon/monkey/acid_act(var/acidpwr, var/toxpwr, var/acid_volume)
 	if(wear_mask)
 		if(!wear_mask.unacidable)
@@ -255,3 +251,10 @@
 		return
 
 	take_organ_damage(min(6*toxpwr, acid_volume * toxpwr))
+
+/mob/living/carbon/monkey/help_shake_act(mob/living/carbon/M)
+	if(health < 0 && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.do_cpr(src)
+	else
+		..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -838,9 +838,6 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/activate_hand(var/selhand)
 	return
 
-/mob/proc/SpeciesCanConsume()
-	return 0
-
 /mob/proc/Jitter(amount)
 	jitteriness = max(jitteriness,amount,0)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -54,28 +54,18 @@
 	else return "No reagents"
 
 /obj/item/weapon/reagent_containers/proc/canconsume(mob/eater, mob/user)
-	if(!eater.SpeciesCanConsume())
+	if(!iscarbon(eater))
 		return 0
-	//Check for covering mask
-	var/obj/item/clothing/cover = eater.get_item_by_slot(slot_wear_mask)
-
-	if(isnull(cover)) // No mask, do we have any helmet?
-		cover = eater.get_item_by_slot(slot_head)
-	else
-		var/obj/item/clothing/mask/covermask = cover
-		if(covermask.alloweat) // Specific cases, clownmask for example.
-			return 1
-
-	if(!isnull(cover))
-		if((cover.flags & HEADCOVERSMOUTH) || (cover.flags & MASKCOVERSMOUTH))
-			var/who = (isnull(user) || eater == user) ? "your" : "their"
-
-			if(istype(cover, /obj/item/clothing/mask/))
-				user << "<span class='warning'>You have to remove [who] mask first!</span>"
-			else
-				user << "<span class='warning'>You have to remove [who] helmet first!</span>"
-
-			return 0
+	var/mob/living/carbon/C = eater
+	var/covered = ""
+	if(C.is_mouth_covered(head_only = 1))
+		covered = "headgear"
+	else if(C.is_mouth_covered(mask_only = 1))
+		covered = "mask"
+	if(covered)
+		var/who = (isnull(user) || eater == user) ? "your" : "their"
+		user << "<span class='warning'>You have to remove [who] [covered] first!</span>"
+		return 0
 	return 1
 
 /obj/item/weapon/reagent_containers/ex_act()

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -17,7 +17,7 @@
 	return // thanks inheritance again
 
 /obj/item/weapon/reagent_containers/pill/patch/canconsume(mob/eater, mob/user)
-	if(!eater.SpeciesCanConsume())
+	if(!iscarbon(eater))
 		return 0
 	return 1 // Masks were stopping people from "eating" patches. Thanks, inheritance.
 

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -70,13 +70,13 @@ proc/get_location_modifier(mob/M)
 	var/eyesmouth_covered	= 0	//based on flags
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		for(var/obj/item/clothing/I in list(C.back, C.wear_mask))
+		for(var/obj/item/clothing/I in list(C.back, C.wear_mask, C.head))
 			covered_locations |= I.body_parts_covered
 			face_covered |= I.flags_inv
 			eyesmouth_covered |= I.flags
 		if(ishuman(C))
 			var/mob/living/carbon/human/H = C
-			for(var/obj/item/I in list(H.wear_suit, H.w_uniform, H.shoes, H.belt, H.gloves, H.glasses, H.head, H.ears))
+			for(var/obj/item/I in list(H.wear_suit, H.w_uniform, H.shoes, H.belt, H.gloves, H.glasses, H.ears))
 				covered_locations |= I.body_parts_covered
 				face_covered |= I.flags_inv
 				eyesmouth_covered |= I.flags
@@ -89,7 +89,7 @@ proc/get_location_modifier(mob/M)
 			if(covered_locations & HEAD || face_covered & HIDEEYES || eyesmouth_covered & GLASSESCOVERSEYES)
 				return 0
 		if("mouth")
-			if(covered_locations & HEAD || face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH)
+			if(covered_locations & HEAD || face_covered & HIDEFACE || eyesmouth_covered & MASKCOVERSMOUTH || eyesmouth_covered & HEADCOVERSMOUTH)
 				return 0
 		if("chest")
 			if(covered_locations & CHEST)


### PR DESCRIPTION
- Fixes fulltile windows not spawning the correct amounts of shards and rods. Fixes #8139
- Fixes broken grille not dropping a rod when shot with buckshots.
- Fixes applying lipstick through masks. Fixes #8874
- Remove mob/proc/SpeciesCanConsume() , replaced by iscarbon checks.
- Remove alloweat var from masks, remove MASKCOVERSMOUTH flag from mime and clown masks so you can still eat through them.
- Some adjustments in surgery checks for bodyparts covered.
- Fixes a runtime in weapon/energy attack_verb.
- Humans can now CPR monkeys. Fixes #7310 
- Add feedback when doing CPR on a corpse. Fixes #8707
- Slight changes to CPR code.
- Fixes runtime with drones trying to do CPR. Fixes #5553 (it's the last runtime remaining)
- Rewrites /obj/item/weapon/reagent_containers/proc/canconsume to be less shitty.
- Adds an is_mouth_covered() proc to carbons to check for mask and headgear with MASKCOVERSMOUTH or HEADCOVERSMOUTH, with argument to restrict the check to only mask or only head if needed.
