### PR TITLE
Removes spraycan equipping message and moves their priority down

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -174,14 +174,6 @@
 
 	. = 0
 
-	var/spray = mob.equip_in_one_of_slots(SC,slots)
-
-	if (!spray)
-		mob << "Your Syndicate benefactors were unfortunately unable to get you some spraypaint."
-	else
-		mob << "The Spraypaint in your [spray] will help you spread your message of unrest."
-		mob.update_icons()
-
 	var/where2 = mob.equip_in_one_of_slots(recaller, slots)
 	if (!where2)
 		mob << "Your Syndicate benefactors were unfortunately unable to get you a Recaller."
@@ -196,6 +188,7 @@
 		mob << "The <b>flash</b> in your [where] will help you to persuade the crew to work for you."
 		. += 1
 
+	mob.equip_in_one_of_slots(SC,slots)
 	mob.update_icons()
 
 	return .

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -146,18 +146,15 @@
 		"left hand" = slot_l_hand,
 		"right hand" = slot_r_hand,
 	)
-	var/spray = mob.equip_in_one_of_slots(R,slots)
 	var/where = mob.equip_in_one_of_slots(T, slots)
-	if (!spray)
-		mob << "The Syndicate were unfortunately unable to get you some spraypaint."
-	else
-		mob << "The Spraypaint in your [spray] will help you spread your message of unrest and revolution."
-		mob.update_icons()
+	mob.equip_in_one_of_slots(R,slots)
+
+	mob.update_icons()
+
 	if (!where)
 		mob << "The Syndicate were unfortunately unable to get you a flash."
 	else
 		mob << "The flash in your [where] will help you to persuade the crew to join your cause."
-		mob.update_icons()
 		return 1
 
 /////////////////////////////////


### PR DESCRIPTION
Spraycans are nice but non-essential in rev and gang. I'd like to remove the message they send to the user when equipped to keep the round-start instructional text concise.

I also moved their priority down so they are spawned and equipped last, just in case the mob doesn't have the room for all of the stuff.
