### PR TITLE
Make DS's IE browser use the most modern available instead of IE7

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -70,6 +70,7 @@
 	return {"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<head>
 		[head_content]
 	</head>


### PR DESCRIPTION
Read this for more info http://www.byond.com/forum/?post=1820325
Assuming the user has a modern version of IE installed, this allows access to supported CSS 3 elements that we currently can't use. Visually everything seems to remain the same.
Tried doing this with nano and it stopped working for me. Since I know jack all about how nano works, it stays as-is for now.
