### PR TITLE
IED fixes

### DIFF
--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -32,7 +32,10 @@
 /obj/item/weapon/grenade/iedcasing/CheckParts()
 	var/obj/item/weapon/reagent_containers/food/drinks/soda_cans/can = locate() in contents
 	if(can)
+		var/muh_layer = can.layer
+		can.layer = FLOAT_LAYER
 		underlays += can
+		can.layer = muh_layer
 
 
 /obj/item/weapon/grenade/iedcasing/attack_self(mob/user as mob) //

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -91,6 +91,8 @@
 				if(istype(A, /obj/item))
 					var/atom/movable/B = A
 					B.loc = I
+					B.pixel_x = initial(B.pixel_x)
+					B.pixel_y = initial(B.pixel_y)
 				else
 					if(!I.reagents)
 						I.reagents = new /datum/reagents()


### PR DESCRIPTION
Fixes #8919 - can pixel_x/pixel_y is inherited by the IED after construction
Fixes an unreported issue where the can underlay of IED's would be rendered underneath your HUD when it was in your hands.
