### PR TITLE
Admins can now drag ghosts to mobs to put that ghost in control of that mob

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -883,7 +883,7 @@ proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
 	if (ask != "Yes")
 		return 1
 
-	ghostize(tomob,0)
+	tomob.ghostize(0)
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -876,16 +876,14 @@ proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
 
 	var/question = ""
 	if (tomob.ckey)
-		question = "This mob already has a user ([tomob.ckey]) in control of it! "
+		question = "This mob already has a user ([tomob.key]) in control of it! "
 	question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
 
 	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
 	if (ask != "Yes")
 		return 1
 
-	if (tomob.ckey)
-		var/mob/dead/observer/ghost = new/mob/dead/observer(tomob,1)
-		ghost.ckey = tomob.ckey
+	ghostize(tomob,0)
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -864,7 +864,8 @@ proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
 			del(C)
 	return kicked_client_names
 
-
+//returns 1 to let the dragdrop code know we are trapping this event
+//returns 0 if we don't plan to trap the event
 /datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
 
 	//this is the exact two check rights checks required to edit a ckey with vv.
@@ -881,6 +882,9 @@ proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
 
 	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
 	if (ask != "Yes")
+		return 1
+
+	if (!frommob || !tomob) //make sure the mobs don't go away while we waited for a response
 		return 1
 
 	tomob.ghostize(0)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -863,3 +863,35 @@ proc/kick_clients_in_lobby(var/message, var/kick_only_afk = 0)
 			kicked_client_names.Add("[C.ckey]")
 			del(C)
 	return kicked_client_names
+
+
+/datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
+
+	//this is the exact two check rights checks required to edit a ckey with vv.
+	if (!check_rights(R_VAREDIT,0) || !check_rights(R_SPAWN|R_DEBUG,0))
+		return 0
+
+	if (!frommob.ckey)
+		return 0
+
+	var/question = ""
+	if (tomob.ckey)
+		question = "This mob already has a user ([tomob.ckey]) in control of it! "
+	question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
+
+	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
+	if (ask != "Yes")
+		return 1
+
+	if (tomob.ckey)
+		var/mob/dead/observer/ghost = new/mob/dead/observer(tomob,1)
+		ghost.ckey = tomob.ckey
+
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
+	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
+	feedback_add_details("admin_verb","CGD")
+
+	tomob.ckey = frommob.ckey
+	qdel(frommob)
+
+	return 1

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -352,6 +352,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 //this is called when a ghost is drag clicked to something.
 /mob/dead/observer/MouseDrop(atom/over)
+	if(!usr || !over) return
 	if (isobserver(usr) && usr.client.holder && isliving(over))
 		if (usr.client.holder.cmd_ghost_drag(src,over))
 			return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -61,9 +61,8 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 		verbs -= /mob/dead/observer/verb/possess
 
 	animate(src, pixel_y = 2, time = 10, loop = -1)
-
-
 	..()
+
 /mob/dead/observer/Destroy()
 	if (ghostimage)
 		ghost_darkness_images -= ghostimage
@@ -350,6 +349,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	dat += data_core.get_manifest()
 
 	src << browse(dat, "window=manifest;size=387x420;can_close=1")
+
+//this is called when a ghost is drag clicked to something.
+/mob/dead/observer/MouseDrop(atom/over)
+	if (isobserver(usr) && usr.client.holder && isliving(over))
+		if (usr.client.holder.cmd_ghost_drag(src,over))
+			return
+
+	return ..()
 
 /mob/dead/observer/Topic(href, href_list)
 	if(href_list["follow"])

--- a/html/changelogs/MrStonedOne-PR-8957-Admin-ghost-drag.yml
+++ b/html/changelogs/MrStonedOne-PR-8957-Admin-ghost-drag.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MrStonedOne
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+#  FUCK YOU, MAKE THIS SHIT WORK WITH TABS -MrStonedOne
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Admin ghosts can now drag ghosts to mobs to put that ghost in control of that mob."
+


### PR DESCRIPTION
This functions the same way as editing the ckey in vv, and has the same permission checks
It requires the admin also be a ghost to avoid conflicts with other drag drop code.
