### PR TITLE
Fixes runtime when clientless mobs change areas

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -332,11 +332,11 @@
 	L.lastarea = newarea
 
 	// Ambience goes down here -- make sure to list each area seperately for ease of adding things in later, thanks! Note: areas adjacent to each other should have the same sounds to prevent cutoff when possible.- LastyScratch
-	if(!L.client.ambience_playing && L.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
+	if(L.client && !L.client.ambience_playing && L.client.prefs.toggles & SOUND_SHIP_AMBIENCE)
 		L.client.ambience_playing = 1
 		L << sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 35, channel = 2)
 
-	if(!(L && L.client && (L.client.prefs.toggles & SOUND_AMBIENCE)))	return //General ambience check is below the ship ambience so one can play without the other
+	if(!(L.client && (L.client.prefs.toggles & SOUND_AMBIENCE)))	return //General ambience check is below the ship ambience so one can play without the other
 
 	if(prob(35))
 		var/sound = pick(ambientsounds)


### PR DESCRIPTION
runtime error: Cannot read null.ambience_playing
proc name: Entered (/area/Entered)
  source file: areas.dm,335
  usr: Locks-The-Doors (/mob/living/carbon/human)
  src: Medbay Central (/area/medical/medbay)
