### PR TITLE
Fixes href exploit relating to admins without +fun being able to force events

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -81,6 +81,7 @@
 					usr << "<span class='danger'>Unfortunatly there were not enough candidates available.</span>"
 
 	else if(href_list["forceevent"])
+		if(!check_rights(R_FUN))	return
 		var/datum/round_event_control/E = locate(href_list["forceevent"]) in SSevent.control
 		if(E)
 			var/datum/round_event/event = E.runEvent()


### PR DESCRIPTION
Noticed this when I was coding ghost drag, no permission checks on this topic.

@Ikarrus this is your mistake.
