### PR TITLE
Removes resting from ghost verb

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -102,7 +102,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")	return	//didn't want to ghost after-all
-		resting = 1
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 	return
 


### PR DESCRIPTION
This caused issues with mobs like borgs and simple mobs where they would be unable to move if admins put another ckey in the mob after they ghosted but there would be no clear indication as to why they couldn't move and in some cases, no way to un-rest without further admin intervention.
