### PR TITLE
Lets people alt-click windows to alt-click the tile the window is on.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -415,6 +415,10 @@
 		hit(round(exposed_volume / 100), 0)
 	..()
 
+/obj/structure/window/AltClick(var/mob/living/L)
+	var/turf/T = get_turf(src)
+	T.AltClick(L)
+
 
 /obj/structure/window/reinforced
 	name = "reinforced window"


### PR DESCRIPTION
This is mainly for atmos techs so they can lay pipes on the turfs under the windows in atmos without having to remove every window first.

You can lay pipes on walls, and windows are basically just transparent walls anyway.
