### PR TITLE
Fixes BlobRev

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -9,6 +9,7 @@
 		return 1
 	if(!blob_cores.len) // blob is dead
 		if(config.continuous["blob"])
+			SSshuttle.emergencyNoEscape = 0
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -114,8 +114,6 @@
 		else
 			del(G)
 
-	SSshuttle.emergencyNoEscape = 0 //Time to get the fuck out of here
-
 	if(!usable_modes)
 		message_admins("Convert_roundtype failed due to no valid modes to convert to. Please report this error to the Coders.")
 		return null


### PR DESCRIPTION
Fixes a goof where if a blob round was continuous but not using midround_antag (in this case from admins disabling the system in round and manually making revs) the shuttle would get caught in a loop of repeatedly stranding and unstranding itself. emergencyNoEscape was being turned off in the mulligan code, and I forgot to generalize it out when it stopped being an assured thing that a continuous round was also a mulligan round. The other two potentially affected modes (Malf and Wizard) already had this check generalized.

I checked.

Trust me.
