### PR TITLE
Adds a new martial arts style- Drunk Brawling DNM

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -134,6 +134,66 @@
 			D.forcesay(hit_appends)
 	return 1
 
+/datum/martial_art/drunk_brawling
+	name = "Drunken Brawling"
+
+/datum/martial_art/drunk_brawling/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	if(prob(70))
+		A.visible_message("<span class='warning'>[A] tries to grab ahold of [D], but fails!</span>", \
+							"<span class='warning'>You fail to grab ahold of [D]!</span>")
+		return 1
+	D.grabbedby(A,1)
+	var/obj/item/weapon/grab/G = A.get_active_hand()
+	if(G)
+		D.visible_message("<span class='danger'>[A] grabs ahold of [D] drunkenly!</span>", \
+								"<span class='userdanger'>[A] grabs ahold of [D] drunkenly!</span>")
+	return 1
+
+/datum/martial_art/drunk_brawling/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	add_logs(A, D, "punched")
+	A.do_attack_animation(D)
+
+	var/atk_verb = pick("jab","uppercut","overhand punch","drunken right hook","drunken left hook")
+
+	var/damage = rand(0,6)
+
+	if(atk_verb == "uppercut")
+		if(prob(90))
+			damage = 0
+		else //10% chance to do a massive amount of damage
+			damage = 14
+
+	if(prob(50)) //they are drunk, they aren't going to land half of their hits
+		damage = 0
+
+	if(!damage)
+		playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")
+		return 1 //returns 1 so that they actually miss and don't switch to attackhand damage
+
+	var/obj/item/organ/external/affecting = D.get_organ(ran_zone(A.zone_sel.selecting))
+	var/armor_block = D.run_armor_check(affecting, "melee")
+
+	playsound(D.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
+
+
+	D.visible_message("<span class='danger'>[A] has hit [D] with a [atk_verb]!</span>", \
+								"<span class='userdanger'>[A] has hit [D] with a [atk_verb]!</span>")
+
+	D.apply_damage(damage, BRUTE, null, armor_block)
+	D.apply_effect(damage, STAMINA, armor_block)
+	if(D.getStaminaLoss() > 50)
+		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
+		if((D.stat != DEAD) && prob(knockout_prob))
+			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
+								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
+			D.apply_effect(10,WEAKEN,armor_block)
+			D.SetSleeping(5)
+			D.forcesay(hit_appends)
+		else if(D.lying)
+			D.forcesay(hit_appends)
+	return 1
+
 /datum/martial_art/wrestling
 	name = "Wrestling"
 


### PR DESCRIPTION
Partial port of https://github.com/ParadiseSS13/Paradise/pull/823, waiting on Phils chem refactor to go through before adding this.

This adds a new martial arts datum, labeled as Drunken Brawling. This
style is automatically added and removed to people via ethanol,
specifically, 10 life ticks after they start slurring their words.

The style is mostly debuffs, as there is a flat 50% chance to miss any
harm-intent hit, a 70% chance to fail to grab, and disarm is unaffected.

The actual 'features' of this style can be summarized as such:
- Custom attack verbs
  - "jab","uppercut","overhand punch",
    "drunken right hook","drunken left hook"
  - Uppercut has a 5% chance to do 14 damage
- Limit's combat abilities
  - 70% chance to fail to passively grab
  - 50% chance to miss any harm intent
  - Disarm intent is untouched.
- Added by ethanol when someone has had it into their system
  for a while
  - Removed as soon as the ethanol becomes lower than 3 units

Conflicts:
    code/modules/reagents/Chemistry-Reagents.dm
