### PR TITLE
fixes shadowling veil not resetting luminosity

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -72,7 +72,7 @@
 				P.SetLuminosity(0) //failsafe
 			if(H != usr)
 				H << "<span class='boldannounce'>You feel a chill and are plunged into darkness.</span>"
-			H.luminosity = 0 //This is required with the object-based lighting
+			H.SetLuminosity(0) //This is required with the object-based lighting
 
 
 


### PR DESCRIPTION
I found a bug where the Shadowling Veil ability did not properly reset the human mob's luminosity. In testing, I discovered that the lights carried by a mob would turn off, but the mob itself retained the luminosity of the lights. Thus, turning on the flashlight again results in a luminosity representative of 2 flashlights instead of one, and so on.

To reproduce:
1) Spawn yourself in as a shadowling, hatch in a dark place in maint
2) Spawn a normal mob/living/carbon/human, give them a flashlight
3) Turn on the flashlight
4) Controlling the shadowling, approach and use Veil. Notice that you continue to take damage and the light does not go out
5) Controlling the "victim" mob again, turn your flashlight back on. Notice that the lighting is equivalent to that of 2 flashlights.
6) If you turn off the light again and VV the luminosity of the mob, you will see that is has not been set to 0 as it should be

I fixed this by changing H.luminosity = 0 to H.SetLuminosity(0) in the veil/cast proc. It worked in my testing following the process outlined above. After step 4, the flashlight goes out, the victim's luminosity is set to 0, and the shadowling no longer takes damage (as it should be).
