### PR TITLE
Fixes being unable to construct disposal pipes on walls, an RPD bug and moves it over to the datum/browser ui.

### DIFF
--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -17,8 +17,12 @@ RPD
 #define METER_MODE 1
 #define DISPOSALS_MODE 2
 
+#define CATEGORY_ATMOS 0
+#define CATEGORY_DISPOSALS 1
+
 /datum/pipe_info
 	var/id=-1
+	var/categoryId = CATEGORY_ATMOS
 	var/dir=SOUTH
 	var/dirtype=PIPE_BINARY
 	var/icon = 'icons/obj/pipe-item.dmi'
@@ -59,6 +63,7 @@ var/global/list/disposalpipeID2State=list(
 )
 
 /datum/pipe_info/disposal
+	categoryId = CATEGORY_DISPOSALS
 	icon = 'icons/obj/pipes/disposal.dmi'
 	icon_state = "meterX"
 
@@ -152,6 +157,7 @@ var/global/list/RPD_recipes=list(
 		"purple"	= rgb(130,43,255)
 	)
 	var/paint_color="grey"
+	var/screen = CATEGORY_ATMOS //Starts on the atmos tab.
 
 /obj/item/weapon/pipe_dispenser/New()
 	. = ..()
@@ -163,34 +169,57 @@ var/global/list/RPD_recipes=list(
 	show_menu(user)
 
 /obj/item/weapon/pipe_dispenser/proc/render_dir_img(var/_dir,var/pic,var/title,var/flipped=0)
-	var/selected=""
+	var/selected=" class=\"imglink\""
 	if(_dir == p_dir)
-		selected=" class=\"selected\""
-	return "<a href=\"?src=\ref[src];setdir=[_dir];flipped=[flipped]\" title=\"[title]\"[selected]><img src=\"[pic]\" /></a>"
+		selected=" class=\"imglink selected\""
+	return "<a href=\"?src=\ref[src];setdir=[_dir];flipped=[flipped]\" title=\"[title]\"[selected]\"><img src=\"[pic]\" /></a>"
 
 /obj/item/weapon/pipe_dispenser/proc/show_menu(mob/user as mob)
 	if(!user || !src)	return 0
 	var/dat = {"<h2>Type</h2>
 <b>Utilities:</b>
-<ul>
-	<li><a href='?src=\ref[src];eatpipes=1;type=-1'>Eat Pipes</a></li>
-	<li><a href='?src=\ref[src];paintpipes=1;type=-1'>Paint Pipes</a></li>
-</ul>"}
+<ul>"}
+	if(p_class != EATING_MODE)
+		dat += "<li><a href='?src=\ref[src];eatpipes=1;type=-1'>Eat Pipes</a></li>"
+	else
+		dat += "<li><span class='linkOn'>Eat Pipes</span></li>"
+	if(p_class != PAINT_MODE)
+		dat += "<li><a href='?src=\ref[src];paintpipes=1;type=-1'>Paint Pipes</a></li>"
+	else
+		dat += "<li><span class='linkOn'>Paint Pipes</span></li>"
+	dat += "</ul>"
+
+	dat += "<b>Category:</b><ul>"
+	if(screen == CATEGORY_ATMOS)
+		dat += "<span class='linkOn'>Atmospherics</span> <A href='?src=\ref[src];screen=[CATEGORY_DISPOSALS];dmake=0;type=0'>Disposals</A><BR>"
+	else if(screen == CATEGORY_DISPOSALS)
+		dat += "<A href='?src=\ref[src];screen=[CATEGORY_ATMOS];makepipe=0;dir=1;type=0'>Atmospherics</A> <span class='linkOn'>Disposals</span><BR>"
+	dat += "</ul>"
+	
 	var/icon/preview=null
+	var/datbuild = ""
 	for(var/category in RPD_recipes)
-		dat += "<b>[category]:</b><ul>"
 		var/list/cat=RPD_recipes[category]
 		for(var/label in cat)
 			var/datum/pipe_info/I = cat[label]
 			var/found=0
 			if(I.id == p_type)
-				if(p_class==ATMOS_MODE && I.type==/datum/pipe_info)
+				if((p_class == ATMOS_MODE || p_class == METER_MODE) && (I.type == /datum/pipe_info || I.type == /datum/pipe_info/meter))
 					found=1
-				else if(p_class==DISPOSALS_MODE && I.type==/datum/pipe_info/disposal)
+				else if(p_class == DISPOSALS_MODE && I.type==/datum/pipe_info/disposal)
 					found=1
 			if(found)
 				preview=new /icon(I.icon,I.icon_state)
-			dat += I.Render(src,label)
+			if(screen == I.categoryId)
+				if(I.id == p_type)
+					datbuild += "<span class='linkOn'>[label]</span>"
+				else
+					datbuild += I.Render(src,label)
+		
+		if(length(datbuild) > 0)
+			dat += "<b>[category]:</b><ul>"
+			dat += datbuild
+			datbuild = ""
 		dat += "</ul>"
 
 	var/color_css=""
@@ -217,7 +246,9 @@ var/global/list/RPD_recipes=list(
 	switch(p_conntype)
 		if(-1)
 			if(p_class==PAINT_MODE)
-				dirsel = "<h2>Direction</h2>[color_picker]"
+				dirsel = "<h2>Color</h2>[color_picker]"
+			else
+				dirsel = ""
 
 		if(PIPE_BINARY) // Straight, N-S, W-E
 			if(preview)
@@ -359,47 +390,52 @@ var/global/list/RPD_recipes=list(
 		</p>
 				"}
 
-	dat = {"
-<html>
-	<head>
-		<title>[name]</title>
-		<style type="text/css">
-			html {
-				font-family:sans-serif;
-				font-size:small;
-			}
-			a{
-				color:#0066cc;
-				text-decoration:none;
-			}
 
-			a img {
-				border:1px solid #0066cc;
-				background:#dfdfdf;
-			}
+	var/datsytle = {"
+<style type="text/css">
+	a.imglink {
+		padding: none;
+		text-decoration:none;
+		border-style:none;
+		background:none;
+		margin: 1px;
+	}
+	
+	a.imglink:hover {
+		background:none;
+		color:none;
+	}
+	
+	a.imglink.selected img {
+		border: 1px solid #24722e;
+		background: #2f943c;
+	}
+	
+	a img {
+		border: 1px solid #161616;
+		background: #40628a;
+	}
 
-			a.color {
-				padding: 5px 10px;
-				font-size: large;
-				font-weight: bold;
-				border:1px solid white;
-			}
+	a.color {
+		padding: 5px 10px;
+		font-size: large;
+		font-weight: bold;
+		border: 1px solid #161616;
+	}
 
-			a.selected img,
-			a:hover {
-				background: #0066cc;
-				color: #ffffff;
-			}
-			[color_css]
-		</style>
-	</head>
-	<body>
-[dirsel][dat]
-	</body>
-</html>
-"}
-	user << browse(dat, "window=pipedispenser")
-	onclose(user, "pipedispenser")
+	a.selected img,
+		a:hover {
+			background: #0066cc;
+			color: #ffffff;
+		}
+		[color_css]
+</style>"}
+
+	dat = datsytle + dirsel + dat
+
+	var/datum/browser/popup = new(user, "pipedispenser", name, 300, 550)
+	popup.set_content(dat)
+	popup.open()
 	return
 
 /obj/item/weapon/pipe_dispenser/Topic(href, href_list)
@@ -408,6 +444,10 @@ var/global/list/RPD_recipes=list(
 		return
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
+	if(href_list["screen"])
+		screen = text2num(href_list["screen"])
+		show_menu(usr)
+	
 	if(href_list["setdir"])
 		p_dir= text2num(href_list["setdir"])
 		p_flipped = text2num(href_list["flipped"])
@@ -423,14 +463,14 @@ var/global/list/RPD_recipes=list(
 
 	if(href_list["paintpipes"])
 		p_class = PAINT_MODE
-		p_conntype=-1
-		p_dir=1
+		p_conntype = -1
+		p_dir = 1
 		src.spark_system.start()
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0)
 		show_menu(usr)
 
 	if(href_list["set_color"])
-		paint_color=href_list["set_color"]
+		paint_color = href_list["set_color"]
 		src.spark_system.start()
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0)
 		show_menu(usr)
@@ -446,8 +486,8 @@ var/global/list/RPD_recipes=list(
 
 	if(href_list["makemeter"])
 		p_class = METER_MODE
-		p_conntype=-1
-		p_dir=1
+		p_conntype = -1
+		p_dir = 1
 		src.spark_system.start()
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0)
 		show_menu(usr)
@@ -472,7 +512,12 @@ var/global/list/RPD_recipes=list(
 
 	if(istype(A,/area/shuttle)||istype(A,/turf/space/transit))
 		return 0
-
+	
+	//So that changing the menu settings doesn't affect the pipes already being built.
+	var/queued_p_type = p_type
+	var/queued_p_dir = p_dir
+	var/queued_p_flipped = p_flipped
+	
 	switch(p_class)
 		if(PAINT_MODE) // Paint pipes
 			if(!istype(A,/obj/machinery/atmospherics/pipe))
@@ -510,8 +555,8 @@ var/global/list/RPD_recipes=list(
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 			if(do_after(user, 20))
 				activate()
-				var/obj/item/pipe/P = new (A, pipe_type=p_type, dir=p_dir)
-				P.flipped = p_flipped
+				var/obj/item/pipe/P = new (A, pipe_type=queued_p_type, dir=queued_p_dir)
+				P.flipped = queued_p_flipped
 				P.update()
 				P.add_fingerprint(usr)
 				return 1
@@ -536,7 +581,7 @@ var/global/list/RPD_recipes=list(
 			user << "<span class='notice'>Building Pipes...</span>"
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 			if(do_after(user, 20))
-				var/obj/structure/disposalconstruct/C = new (A,p_type,p_dir)
+				var/obj/structure/disposalconstruct/C = new (A, queued_p_type ,queued_p_dir)
 
 				if(!C.can_place())
 					user << "<span class='warning'>There's not enough room to build that here!</span>"
@@ -557,3 +602,16 @@ var/global/list/RPD_recipes=list(
 /obj/item/weapon/pipe_dispenser/proc/activate()
 	playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 
+#undef PIPE_BINARY
+#undef PIPE_BENT
+#undef PIPE_TRINARY
+#undef PIPE_TRIN_M
+#undef PIPE_UNARY
+#undef PIPE_QUAD
+#undef PAINT_MODE
+#undef EATING_MODE
+#undef ATMOS_MODE
+#undef METER_MODE
+#undef DISPOSALS_MODE
+#undef CATEGORY_ATMOS
+#undef CATEGORY_DISPOSALS

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -170,10 +170,14 @@
 			nicetype = "pipe"
 
 	var/turf/T = loc
-	if(T.intact)
+	if(T.intact && istype(T, /turf/simulated/floor))
 		user << "You can only attach the [nicetype] if the floor plating is removed."
 		return
-
+	
+	if(!ispipe && istype(T, /turf/simulated/wall))
+		user << "You can't build [nicetype]s on walls, only disposal pipes."
+		return
+	
 	var/obj/structure/disposalpipe/CP = locate() in T
 
 	if(istype(I, /obj/item/weapon/wrench))

--- a/html/changelogs/Boggart-PR-9069.yml
+++ b/html/changelogs/Boggart-PR-9069.yml
@@ -1,0 +1,6 @@
+author: Boggart
+
+delete-after: True
+
+changes:
+  - rscadd: "Fixes being unable to build disposal pipes on walls, makes changing the RPD's settings not affect pipes that are currently building, makes the RPD use the datum/browser ui, makes it use categories and makes it show the selected mode."


### PR DESCRIPTION
Fixes #9037 (being unable to construct disposal pipes on walls) and changing the RPD settings while already building affecting the currently building pipes. Also prevents the building of disposal outlets, bins and chutes on walls. (Not possible before the above mentioned change anyway.)
