### PR TITLE
Welding mask toggling while buckeled fix

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -69,7 +69,7 @@
 
 /obj/item/device/taperecorder/proc/can_use(mob/user)
 	if(user && ismob(user))
-		if(!user.stat && user.canmove && !user.restrained())
+		if(!user.incapacitated())
 			return 1
 	return 0
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -28,7 +28,7 @@
 	if (usr.get_item_by_slot(slot_back) != src)
 		usr << "<span class='notice'>The watertank needs to be on your back to use.</span>"
 		return
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 	on = !on
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -409,7 +409,7 @@ atom/proc/generate_female_clothing(index,t_color,icon,type)
 
 /obj/item/clothing/proc/can_use(mob/user)
 	if(user && ismob(user))
-		if(!user.stat && user.canmove && !user.restrained())
+		if(!user.incapacitated())
 			return 1
 	return 0
 


### PR DESCRIPTION
Welding mask can now be pushed while buckled to a chair.
Also found a similar instance with the tape recorder and fixed it as well.

Fixes #9071
