### PR TITLE
Adds APC boards to Autolathe!

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -106,6 +106,14 @@
 	build_path = /obj/item/weapon/stock_parts/console_screen
 	category = list("initial", "Electronics")
 
+/datum/design/apc_board
+	name = "APC Power Control Module"
+	id = "power control"
+	build_type = AUTOLATHE
+	materials = list("$metal" = 100, "$glass" = 100)
+	build_path = /obj/item/weapon/module/power_control
+	category = list("initial", "Electronics")
+
 /datum/design/airlock_board
 	name = "Airlock electronics"
 	id = "airlock_board"

--- a/html/changelogs/Gun_Hog-Autolatheyml.yml
+++ b/html/changelogs/Gun_Hog-Autolatheyml.yml
@@ -1,0 +1,7 @@
+ 
+author: Gun Hog
+
+delete-after: True
+
+changes: 
+  - rscadd: "Nanotrasen has provided designs for fabrication of APC power control modules. You may print them at any autolathe."


### PR DESCRIPTION
You may now print Power Control Modules at the autolathe. They are used to build APCs.
