### PR TITLE
Latejoin Rev Head: Fix n' Tweak

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -187,14 +187,19 @@
 ///////////////////////////////
 /datum/game_mode/revolution/proc/latejoin_headrev()
 	if(revolutionaries) //Head Revs are not in this list
-		var/datum/mind/stalin = pick(revolutionaries)
-		revolutionaries -= stalin
-		head_revolutionaries += stalin
-		log_game("[stalin.key] (ckey) has been promoted to a head rev")
-		equip_revolutionary(stalin.current)
-		forge_revolutionary_objectives(stalin)
-		greet_revolutionary(stalin)
-		++max_headrevs
+		var/list/promotable_revs = list()
+		for(var/datum/mind/khrushchev in revolutionaries)
+			if(khrushchev.current && khrushchev.current.client && khrushchev.current.stat != DEAD)
+				if(khrushchev.current.client.prefs.be_special & BE_REV)
+					promotable_revs += khrushchev
+		if(promotable_revs)
+			var/datum/mind/stalin = pick(promotable_revs)
+			revolutionaries -= stalin
+			head_revolutionaries += stalin
+			log_game("[stalin.key] (ckey) has been promoted to a head rev")
+			equip_revolutionary(stalin.current)
+			forge_revolutionary_objectives(stalin)
+			greet_revolutionary(stalin)
 
 //////////////////////////////////////
 //Checks if the revs have won or not//


### PR DESCRIPTION
Tweaks the midround rev head promotion to only pick revs that have the flag for roundstart rev head on

Fixes a unreported bug that could have led to there being four or five head revs in certain rare(ish) circumstances
