### PR TITLE
[new config options][the eternal playtest] Mulligans/Continuous for any roundtype

### DIFF
--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -236,19 +236,11 @@
 
 
 /datum/game_mode/abduction/check_finished()
-	var/all_dead = 1
 	for(var/team_number=1,team_number<=teams,team_number++)
-		var/datum/mind/smind = scientists[team_number]
-		if(smind.current)
-			var/mob/living/M = smind.current
-			if(M.stat != DEAD)
-				all_dead = 0
 		var/obj/machinery/abductor/console/con = get_team_console(team_number)
 		var/datum/objective/objective = team_objectives[team_number]
 		if (con.experiment.points > objective.target_amount)
 			return 1
-	if(all_dead)
-		return 1
 	return ..()
 
 /datum/game_mode/abduction/declare_completion()

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -15,6 +15,7 @@ var/list/blob_nodes = list()
 	required_enemies = 1
 	recommended_enemies = 1
 
+	round_ends_with_antag_death = 1
 	restricted_jobs = list("Cyborg", "AI")
 
 	var/declared = 0

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -1,8 +1,4 @@
 /datum/game_mode/blob/check_finished()
-	if(replacementmode && round_converted == 2)
-		return replacementmode.check_finished()
-	if(round_converted)
-		return ..()
 	if(infected_crew.len > burst)//Some blobs have yet to burst
 		return 0
 	if(blobwincount <= blobs.len)//Blob took over
@@ -14,11 +10,6 @@
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED
 				SSshuttle.emergency.timer = world.time
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
-
-			if(config.midround_antag["blob"])
-				round_converted = convert_roundtype()
-				if(!round_converted)
-					return 1
 			return ..()
 		return 1
 	if(station_was_nuked)//Nuke went off

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -10,7 +10,7 @@
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
 	enemy_minimum_age = 30 //Same as AI minimum age
-
+	round_ends_with_antag_death = 1
 
 	var/AI_win_timeleft = 5400 //started at 5400, in case I change this for testing round end.
 	var/malf_mode_declared = 0
@@ -170,10 +170,6 @@
 
 
 /datum/game_mode/malfunction/check_finished()
-	if(replacementmode && round_converted == 2)
-		return replacementmode.check_finished()
-	if(round_converted == 1) //No reason to waste resources
-		return ..() //Check for evacuation/nuke
 	if (station_captured && !to_nuke_or_not_to_nuke)
 		return 1
 	if (is_malf_ai_dead() || !check_ai_loc())
@@ -186,10 +182,6 @@
 			malf_mode_declared = 0
 			if(get_security_level() == "delta")
 				set_security_level("red")
-			if(config.midround_antag["malfunction"])
-				round_converted = convert_roundtype()
-				if(!round_converted)
-					return 1
 			return ..()
 		else
 			return 1

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -213,11 +213,15 @@
 	if(config.continuous["revolution"])
 		if(finished != 0)
 			SSshuttle.emergencyNoEscape = 0
+			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
+				SSshuttle.emergency.mode = SHUTTLE_DOCKED
+				SSshuttle.emergency.timer = world.time
+				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 		return ..()
 	if(finished != 0)
 		return 1
 	else
-		return 0
+		return ..()
 
 ///////////////////////////////////////////////////
 //Deals with converting players to the revolution//

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -157,28 +157,6 @@ Made by Xhuis
 		new_thrall_mind.spell_list += new /obj/effect/proc_holder/spell/targeted/shadowling_hivemind
 		return 1
 
-
-
-/*
-	GAME FINISH CHECKS
-*/
-
-
-/datum/game_mode/shadowling/check_finished()
-	var/shadows_alive = 0 //and then shadowling was kill
-	for(var/datum/mind/shadow in shadows) //but what if shadowling was not kill?
-		if(!istype(shadow.current,/mob/living/carbon/human) && !istype(shadow.current,/mob/living/simple_animal/ascendant_shadowling))
-			continue
-		if(shadow.current.stat == DEAD)
-			continue
-		shadows_alive++
-	if(shadows_alive)
-		return ..()
-	else
-		shadowling_dead = 1 //but shadowling was kill :(
-		return 1
-
-
 /datum/game_mode/shadowling/proc/check_shadow_victory()
 	var/success = 0 //Did they win?
 	if(shadow_objectives.Find("enthrall"))

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -60,7 +60,7 @@
 	else
 		if(mages_made >= max_mages)
 			finished = 1
-			return 1
+			return ..()
 		else
 			make_more_mages()
 	return ..()

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -10,6 +10,7 @@
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
 	enemy_minimum_age = 14
+	round_ends_with_antag_death = 1
 	var/use_huds = 0
 	var/finished = 0
 
@@ -171,36 +172,15 @@
 
 /datum/game_mode/wizard/check_finished()
 
-	if(replacementmode && round_converted == 2)
-		return replacementmode.check_finished()
-
-	if(round_converted == 1 || !wizards) //No reason to waste resources
-		return ..() //Check for evacuation/nuke
-
 	for(var/datum/mind/wizard in wizards)
 		if(!wizard.current)
 			continue
 		if(wizard.current.stat != DEAD)
 			return ..()
 
-	for(var/datum/mind/traitor in traitors)
-		if(!traitor.current)
-			continue
-		if(traitor.current.stat != DEAD)
-			return ..()
-
-	if(!config.continuous["wizard"])
-		return 1
-
 	if(SSevent.wizardmode) //If summon events was active, turn it off
 		SSevent.toggleWizardmode()
 		SSevent.resetFrequency()
-
-	if(config.midround_antag["wizard"])
-		round_converted = convert_roundtype()
-		if(!round_converted)
-			finished = 1
-			return 1
 
 	return ..()
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -305,8 +305,6 @@
 	usr << browse(dat, "window=players;size=600x480")
 
 /datum/admins/proc/check_antagonists()
-	var/list/supported_continuous_modes = list("revolution", "gang", "wizard", "malfunction", "blob")
-	var/list/supported_midround_antag_modes = list("wizard", "malfunction", "blob")
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
@@ -324,11 +322,8 @@
 			else
 				dat += "ETA: <a href='?_src_=holder;edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
 		dat += "<B>Continuous Round Status</B><BR>"
-		if(!ticker.mode.config_tag in supported_continuous_modes)
-			dat += "Continue if antagonists die"
-		else
-			dat += "<a href='?_src_=holder;toggle_continuous=1'>[config.continuous[ticker.mode.config_tag] ? "Continue if antagonists die" : "End on antagonist death"]</a>"
-		if(config.continuous[ticker.mode.config_tag] && ticker.mode.config_tag in supported_midround_antag_modes)
+		dat += "<a href='?_src_=holder;toggle_continuous=1'>[config.continuous[ticker.mode.config_tag] ? "Continue if antagonists die" : "End on antagonist death"]</a>"
+		if(config.continuous[ticker.mode.config_tag])
 			dat += ", <a href='?_src_=holder;toggle_midround_antag=1'>[config.midround_antag[ticker.mode.config_tag] ? "creating replacement antagonists" : "not creating new antagonists"]</a><BR>"
 		else
 			dat += "<BR>"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -100,20 +100,46 @@ PROBABILITY SANDBOX 0
 
 ## Toggles for continuous modes.
 ## Modes that aren't continuous will end the instant all antagonists are dead.
-## Unlisted modes are not currently supported for noncontinous play
 
+CONTINUOUS TRAITOR
+CONTINUOUS TRAITORCHAN
+CONTINUOUS DOUBLE_AGENTS
+#CONTINUOUS NUCLEAR
 #CONTINUOUS REVOLUTION
+#CONTINUOUS SHADOWLING
+#CONTINUOUS GANG
+CONTINUOUS CULT
+CONTINUOUS CHANGELING
 CONTINUOUS WIZARD
 CONTINUOUS MALFUNCTION
 CONTINUOUS BLOB
+#CONTINUOUS RAGINMAGES
+#CONTINUOUS MONKEY
+
+##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
+
+CONTINUOUS METEOR
+CONTINUOUS EXTENDED
+
 
 ## Toggles for allowing midround antagonists (aka mulligan antagonists).
 ## In modes that are continuous, if all antagonists should die then a new set of antagonists will be created.
-## Only the listed modes are currently supported for this system
 
+MIDROUND_ANTAG TRAITOR
+MIDROUND_ANTAG TRAITORCHAN
+MIDROUND_ANTAG DOUBLE_AGENTS
+#MIDROUND_ANTAG  NUCLEAR
+#MIDROUND_ANTAG  REVOLUTION
+#MIDROUND_ANTAG  SHADOWLING
+#MIDROUND_ANTAG  GANG
+MIDROUND_ANTAG CULT
+MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 MIDROUND_ANTAG MALFUNCTION
 MIDROUND_ANTAG BLOB
+#MIDROUND_ANTAG  RAGINMAGES
+#MIDROUND_ANTAG  MONKEY
+
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
 SHUTTLE_REFUEL_DELAY 12000


### PR DESCRIPTION
Any roundtype can now take advantage of continuous/non-continuous settings as well as the mulligan antag system. (as a reminder at this point the mulligan system only creates lings and/or traitors)

A generic check for antags now exists in check_finished, and overrides a lot of checks in specific modes. Specific checks are still needed if you have special means of determining antag viability (blob cores), or things to do when specific antags die (summon events).

---

In situations where mulligans are on but fail, the round will usually lurch on as "extended" but in wizard/malf/blob/ragin mages the round will end then and there. This mirrors current behavior.

Config settings are fully customizable and for the most part defaults mirror existing behaviors:

Noncontinuous, will end with the death of all antagonists:

Revolution
Shadowling
Gang
Ragin Mages
Monkey .
- There is a change here in shadowling in that rounds with living thralls but no living shadowlings will continue until the thralls are dealt with, as they can still raise their dead master.
- Abductors not ending with the death of all ayyliens if there are still probe victims around is likewise a change. If the dev of abduction would rather have it default the other way, we can do that.
- Monkey being noncontinuous is a change, but given how monkey mode works, it really only makes sense.

---

All modes that are continuous use the mulligan system by default, remember that this will only come into effect if EVERY antagonist dies, so modes with many antagonists are apt to only mulligan very rarely. If even one isn't slaughtered and is instead brigged or otherwise neutralized non-fatally the mulligan will never come. A nice little bonus for security not to kill everyone!

Fixes a bug where shuttle stranding could occur in continuous rev modes (not something on by default)

Probably buggy as hell in initial commit. Please no quick merge
