### PR TITLE
Undefining a mode probability means it doesn't run

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -16,7 +16,7 @@
 	var/name = "invalid"
 	var/config_tag = null
 	var/votable = 1
-	var/probability = 1
+	var/probability = 0
 	var/station_was_nuked = 0 //see nuclearbomb.dm and malfunction.dm
 	var/explosion_in_progress = 0 //sit back and relax
 	var/list/datum/mind/modePlayer = new


### PR DESCRIPTION
mode probabilities that aren't defined in game_options will default to 0 (never) Instead of 1 (rarely)
