### PR TITLE
Gang Update 5

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -131,11 +131,11 @@ var/syndicate_name = null
 	syndicate_name = name
 	return name
 
+var/gang_name_pool = list("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel")
 var/gang_A_name = null
 var/gang_B_name = null
 /proc/gang_name(var/gang)
 	if(!gang_A_name || !gang_B_name)
-		var/gang_name_pool = list("Clandestine", "Prima", "Blue", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel")
 		gang_A_name = pick(gang_name_pool)
 		gang_name_pool -= gang_A_name
 		gang_B_name = pick(gang_name_pool)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -125,6 +125,7 @@ proc/process_ghost_teleport_locs()
 	luminosity = 1
 	lighting_use_dynamic = 1
 	has_gravity = 1
+	valid_territory = 0
 
 
 /area/start
@@ -658,6 +659,7 @@ proc/process_ghost_teleport_locs()
 	requires_power = 0
 	luminosity = 1
 	lighting_use_dynamic = 0
+	valid_territory = 0
 
 	auxport
 		name = "\improper Fore Port Solar Array"
@@ -966,6 +968,7 @@ proc/process_ghost_teleport_locs()
 	icon_state = "toxmisc"
 
 /area/toxins/test_area
+	valid_territory = 0
 	name = "\improper Toxins Test Area"
 	icon_state = "toxtest"
 

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -26,14 +26,14 @@
 	recommended_enemies = 2
 	enemy_minimum_age = 14
 	var/finished = 0
-	var/goal_coeff = 3 //Goal = Total territories / goal_coeff
+	var/goal_scalar = 0.6 //Goal = Total territories x goal_scalar
 
 ///////////////////////////
 //Announces the game type//
 ///////////////////////////
 /datum/game_mode/gang/announce()
 	world << "<B>The current game mode is - Gang War!</B>"
-	world << "<B>A violent turf war has erupted on the station!<BR>Gangsters -  Take over the station by claiming more than [round(100/goal_coeff,1)]% of the station! <BR>Crew - The gangs will try to keep you on the station. Successfully evacuate the station to win!</B>"
+	world << "<B>A violent turf war has erupted on the station!<BR>Gangsters -  Take over the station by claiming more than [round(100*goal_scalar,1)]% of the station! <BR>Crew - The gangs will try to keep you on the station. Successfully evacuate the station to win!</B>"
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -94,7 +94,7 @@
 /datum/game_mode/proc/forge_gang_objectives(var/datum/mind/boss_mind)
 	var/datum/objective/rival_obj = new
 	rival_obj.owner = boss_mind
-	rival_obj.explanation_text = "Claim more than [round(100/goal_coeff,1)]% the station before the [(boss_mind in A_bosses) ? gang_name("B") : gang_name("A")] Gang does."
+	rival_obj.explanation_text = "Claim more than 60% the station before the [(boss_mind in A_bosses) ? gang_name("B") : gang_name("A")] Gang does."
 	boss_mind.objectives += rival_obj
 
 
@@ -162,9 +162,9 @@
 //Checks if the either gang have won or not//
 /////////////////////////////////////////////
 /datum/game_mode/gang/check_win()
-	if(A_territory.len > (start_state.num_territories / goal_coeff))
+	if(A_territory.len > (start_state.num_territories * goal_scalar))
 		finished = "A" //Gang A wins
-	else if(B_territory.len > (start_state.num_territories / goal_coeff))
+	else if(B_territory.len > (start_state.num_territories * goal_scalar))
 		finished = "B" //Gang B wins
 
 ///////////////////////////////

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -35,38 +35,30 @@
 		qdel(src)
 
 	var/area/territory = get_area(location)
-	var/list/recipients = list()
 	var/color
 
 	if(type == "A")
 		gang = type
 		color = "#00b4ff"
 		icon_state = gang_name("A")
-		recipients = ticker.mode.A_tools
-		ticker.mode.A_territory |= territory.type
+		ticker.mode.A_territory_new |= list(territory.type = territory.name)
+		ticker.mode.A_territory_lost -= territory.type
 	else if(type == "B")
 		gang = type
 		color = "#ff3232"
 		icon_state = gang_name("B")
-		recipients = ticker.mode.B_tools
-		ticker.mode.B_territory |= territory.type
-
-	if(recipients.len)
-		ticker.mode.message_gangtools(recipients,"New territory claimed: [territory]",0)
+		ticker.mode.B_territory_new |= list(territory.type = territory.name)
+		ticker.mode.B_territory_lost -= territory.type
 
 	..(location, color, icon_state, e_name, rotation)
 
 /obj/effect/decal/cleanable/crayon/gang/Destroy()
 	var/area/territory = get_area(src)
-	var/list/recipients = list()
 
 	if(gang == "A")
-		recipients += ticker.mode.A_tools
-		ticker.mode.A_territory -= territory.type
+		ticker.mode.A_territory_new -= territory.type
+		ticker.mode.A_territory_lost |= list(territory.type = territory.name)
 	if(gang == "B")
-		recipients += ticker.mode.B_tools
-		ticker.mode.B_territory -= territory.type
-	if(recipients.len)
-		ticker.mode.message_gangtools(recipients,"Territory lost: [territory]",1)
-
+		ticker.mode.B_territory_new -= territory.type
+		ticker.mode.B_territory_lost |= list(territory.type = territory.name)
 	..()

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -18,6 +18,9 @@
 
 	name = e_name
 	desc = "A [name] drawn in crayon."
+	if(type == "poseur tag")
+		gang_name() //Generate gang names so they get removed from the pool
+		type = pick(gang_name_pool)
 	icon_state = type
 
 	var/matrix/M = matrix()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -133,7 +133,6 @@
 		if(iscarbon(target))
 			if(uses)
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
-				uses = max(0,uses-10)
 				var/mob/living/carbon/human/C = target
 				user.visible_message("<span class='danger'>[user] sprays [src] into the face of [target]!</span>")
 				target << "<span class='userdanger'>[user] sprays [src] into your face!</span>"
@@ -146,6 +145,7 @@
 				C.lip_style = "spray_face"
 				C.lip_color = colour
 				C.update_body()
+				uses = max(0,uses-10)
 		..()
 
 /obj/item/toy/crayon/spraycan/update_icon()

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -12,7 +12,6 @@
 	var/gang //Which gang uses this?
 	var/boss = 1 //If it has the power to promote gang members
 	var/recalling = 0
-	var/ignore_messages = 0
 	var/promotion_cost = 20
 
 /obj/item/device/gangtool/New() //Initialize supply point income if it hasn't already been started
@@ -29,7 +28,7 @@
 	var/dat
 	if(!gang)
 		dat += "This device is not registered.<br>"
-		if((user.mind in ticker.mode.B_bosses) || (user.mind in ticker.mode.A_bosses))
+		if(user.mind in (ticker.mode.A_bosses | ticker.mode.B_bosses))
 			dat += "Give this device to another member of your organization to use.<br>"
 		else
 			dat += "<a href='?src=\ref[src];choice=register'>Register Device</a><br>"
@@ -40,13 +39,7 @@
 
 		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Member"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B><br>"
-		dat += "Territories Controlled: <B>[round((gang_territory/start_state.num_territories)*100, 1)]% of [station_name()]</B><br>"
-		var/alert = "Recieve all alerts"
-		if(ignore_messages == 1)
-			alert = "Ignore territories gained"
-		else if(ignore_messages == 2)
-			alert = "Ignore territories gained and lost"
-		dat += "Message Setting: <a href='?src=\ref[src];choice=ignore'>[alert]</a><br>"
+		dat += "Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
 		dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 		dat += "<br>"
 		dat += "Influence: <B>[points]</B><br>"
@@ -142,10 +135,6 @@
 
 	else if(href_list["choice"])
 		switch(href_list["choice"])
-			if("ignore")
-				ignore_messages++
-				if(ignore_messages>2)
-					ignore_messages = 0
 			if("recall")
 				recall(usr)
 			if("register")
@@ -155,7 +144,7 @@
 
 /obj/item/device/gangtool/proc/register_device(var/mob/user)
 	var/promoted
-	if((user.mind in ticker.mode.A_gang) || (user.mind in ticker.mode.A_bosses))
+	if(user.mind in (ticker.mode.A_gang | ticker.mode.A_bosses))
 		ticker.mode.A_tools += src
 		gang = "A"
 		if(!(user.mind in ticker.mode.A_bosses))
@@ -165,7 +154,7 @@
 			ticker.mode.update_gang_icons_added(user.mind, "A")
 			log_game("[key_name(user)] has been promoted to Lieutenant in the [gang_name("A")] Gang (A)")
 			promoted = 1
-	else if((user.mind in ticker.mode.B_gang) || (user.mind in ticker.mode.B_bosses))
+	else if(user.mind in (ticker.mode.B_gang | ticker.mode.B_bosses))
 		ticker.mode.B_tools += src
 		gang = "B"
 		if(!(user.mind in ticker.mode.B_bosses))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -425,20 +425,20 @@
 				var/area/user_area = get_area(user.loc)
 				territory = get_area(target)
 				if(territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
+					//Check if this area is already tagged by a gang
+					if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
+						if(territory_claimed(territory, user))
+							return
 					//Prevent people spraying from outside of the territory (ie. Maint walls)
 					if(istype(user_area) && (user_area.type == territory.type))
-						//Check if this area is already tagged by a gang
-						if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
-							if(territory_claimed(territory, user))
-								return
-						if((locate(/obj/machinery/power/terminal) in target) || (locate(/obj/machinery/power/terminal) in user.loc))
+						if((locate(/obj/machinery/power/terminal) in target) || (locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents)))
 							user << "<span class='warning'>You cannot tag here.</span>"
 							return
 					else
 						user << "<span class='warning'>You cannot tag [territory] from the outside.</span>"
 						return
 				else
-					user << "<span class='warning'>[territory] is unsuitable for territory tagging.</span>"
+					user << "<span class='warning'>[territory] is unsuitable for tagging.</span>"
 					return
 		/////////////////////////////////////////
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -320,7 +320,7 @@
 	attack_verb = list("attacked", "coloured")
 	var/colour = "#FF0000" //RGB
 	var/drawtype = "rune"
-	var/list/graffiti = list("amyjon","face","matt","revolution","engie","guy","end","dwarf","uboa","body","cyka","arrow")
+	var/list/graffiti = list("amyjon","face","matt","revolution","engie","guy","end","dwarf","uboa","body","cyka","arrow","poseur tag")
 	var/list/letters = list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z")
 	var/list/oriented = list("arrow","body") // These turn to face the same way as the drawer
 	var/uses = 30 //0 for unlimited uses
@@ -399,6 +399,11 @@
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return
+	if(!uses)
+		user << "<span class='warning'>There is no more of [src.name] left!</span>"
+		if(!instant)
+			qdel(src)
+		return
 	if(istype(target, /obj/effect/decal/cleanable))
 		target = target.loc
 	if(is_type_in_list(target,validSurfaces))
@@ -476,10 +481,10 @@
 			user << "<span class='notice'>You finish [instant ? "spraying" : "drawing"] [temp].</span>"
 			if(instant<0)
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
-			if(uses)
-				uses--
-				if(!uses)
-					user << "<span class='warning'>You used up your [src.name]!</span>"
+			uses = max(0,uses-1)
+			if(!uses)
+				user << "<span class='warning'>There is no more of [src.name] left!</span>"
+				if(!instant)
 					qdel(src)
 	return
 
@@ -487,11 +492,10 @@
 	if(edible && (M == user))
 		user << "You take a bite of the [src.name]. Delicious!"
 		user.nutrition += 5
-		if(uses)
-			uses -= 5
-			if(uses <= 0)
-				user << "<span class='warning'>There is no more of [src.name] left!</span>"
-				qdel(src)
+		uses = max(0,uses-5)
+		if(!uses)
+			user << "<span class='warning'>There is no more of [src.name] left!</span>"
+			qdel(src)
 	else
 		..()
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -431,7 +431,7 @@
 							return
 					//Prevent people spraying from outside of the territory (ie. Maint walls)
 					if(istype(user_area) && (user_area.type == territory.type))
-						if((locate(/obj/machinery/power/terminal) in target) || (locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents)))
+						if(locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents))
 							user << "<span class='warning'>You cannot tag here.</span>"
 							return
 					else

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -413,22 +413,33 @@
 		var/gangID
 		if(gang)
 			//Determine gang affiliation
-			if((user.mind in ticker.mode.A_bosses) || (user.mind in ticker.mode.A_gang))
+			if(user.mind in (ticker.mode.A_bosses | ticker.mode.A_gang))
 				temp = "[gang_name("A")] gang tag"
 				gangID = "A"
-			else if((user.mind in ticker.mode.B_bosses) || (user.mind in ticker.mode.B_gang))
+			else if(user.mind in (ticker.mode.B_bosses | ticker.mode.B_gang))
 				temp = "[gang_name("B")] gang tag"
 				gangID = "B"
 
 			//Check area validity. Reject space, player-created areas, and non-station z-levels.
-			territory = get_area(target)
-			if (gangID && territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
-				//Check if this area is already tagged by a gang
-				if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
-					if(territory_claimed(territory, user))
+			if (gangID)
+				var/area/user_area = get_area(user.loc)
+				territory = get_area(target)
+				if(territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
+					//Prevent people spraying from outside of the territory (ie. Maint walls)
+					if(istype(user_area) && (user_area.type == territory.type))
+						//Check if this area is already tagged by a gang
+						if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
+							if(territory_claimed(territory, user))
+								return
+						if((locate(/obj/machinery/power/terminal) in target) || (locate(/obj/machinery/power/terminal) in user.loc))
+							user << "<span class='warning'>You cannot tag here.</span>"
+							return
+					else
+						user << "<span class='warning'>You cannot tag [territory] from the outside.</span>"
 						return
-			else
-				user << "<span class='warning'>This area is unsuitable for territory tagging!</span>"
+				else
+					user << "<span class='warning'>[territory] is unsuitable for territory tagging.</span>"
+					return
 		/////////////////////////////////////////
 
 		var/graf_rot
@@ -486,9 +497,9 @@
 
 /obj/item/toy/crayon/proc/territory_claimed(var/area/territory,mob/user)
 	var/occupying_gang
-	if(territory.type in ticker.mode.A_territory)
+	if(territory.type in (ticker.mode.A_territory | ticker.mode.A_territory_new))
 		occupying_gang = gang_name("A")
-	if(territory.type in ticker.mode.B_territory)
+	if(territory.type in (ticker.mode.B_territory | ticker.mode.B_territory_new))
 		occupying_gang = gang_name("B")
 	if(occupying_gang)
 		user << "<span class='danger'>[territory] has already been tagged by the [occupying_gang] gang! You must get rid of or spray over the old tag first!</span>"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -173,10 +173,10 @@
 
 /obj/item/weapon/implant/loyalty/implanted(mob/target)
 	..()
-	if((target.mind in ticker.mode.head_revolutionaries) || (target.mind in ticker.mode.A_bosses) || (target.mind in ticker.mode.B_bosses) || is_shadow_or_thrall(target))
+	if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(target))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
-	if((target.mind in ticker.mode.revolutionaries) || (target.mind in ticker.mode.A_gang) || (target.mind in ticker.mode.B_gang))
+	if(target.mind in (ticker.mode.revolutionaries | ticker.mode.A_gang | ticker.mode.B_gang))
 		ticker.mode.remove_revolutionary(target.mind)
 		ticker.mode.remove_gangster(target.mind, exclude_bosses=0)
 	target << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"

--- a/html/changelogs/Ikarrus-gang5.yml
+++ b/html/changelogs/Ikarrus-gang5.yml
@@ -1,0 +1,9 @@
+author: Ikarrus
+
+delete-after: True
+
+changes: 
+  - tweak: "Gangs Capture goal reduced to 60%"
+  - tweak: "Influence income changed to provide weaker gangs a bigger boost, while slowing down stronger gangs to promote opportunity for comebacks."
+  - tweak: "Gangs only earn influence on territories they have held on to since the previous Status Report (the income calculation every 5 minutes). This places more significance on defending your existing territory."
+  - bugfix: "You must be in the territory physically to tag it now. So no more tagging everything from maint."

--- a/html/changelogs/Ikarrus-gang5.yml
+++ b/html/changelogs/Ikarrus-gang5.yml
@@ -3,6 +3,7 @@ author: Ikarrus
 delete-after: True
 
 changes: 
+  - rscadd: "Spraycans and crayons can now draw Poseur Tags, aka Fake Gang Tags, as grafiti."
   - tweak: "Gangs Capture goal reduced to 60%"
   - tweak: "Influence income changed to provide weaker gangs a bigger boost, while slowing down stronger gangs to promote opportunity for comebacks."
   - tweak: "Gangs only earn influence on territories they have held on to since the previous Status Report (the income calculation every 5 minutes). This places more significance on defending your existing territory."


### PR DESCRIPTION
#### Major Changes
- Capture goal reduced to 60%
- You must be in the territory physically to tag it now. So no more tagging everything from maint.
- Influence income changed to provide weaker gangs a bigger boost, while slowing down stronger gangs to promote opportunity for comebacks
- Gangs only earn influence on territories they have held on to since the previous Status Report (the income calculation every 5 minutes). This places more significance on defending your existing territory.
- Crayons and spraycans can now draw poseur tags (Fake gang tags) as graffiti.
#### Minor Changes
- Removed solars and shuttles, and the toxins test chamber from valid territory list
- Victory conditions are only checked during Status Reports.
- Bosses no longer receive territory updates real-time. They now get them all as a list of new and lost territories in the Status Update.
- You cannot tag tiles with APCs. No cheating, you maint crawlers.
- Goal is now a scalar var so it can be modified in-game for debugging/playtesting purposes
- Simplified some list checks for gang
- Fixed bug that allowed infinite spraycan use.
- Trying to tag an invalid area will just error out and return, instead of the ganger spraying regular grafiti and confusing them

Fixes #9134 
