### PR TITLE
Acid_Act() fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -403,6 +403,9 @@
 
 /obj/item/acid_act(var/acidpwr, var/toxpwr, var/acid_volume)
 	. = 1
+	if(unacidable)
+		return
+
 	for(var/V in armor)
 		if(armor[V] > 0)
 			.-- //it survives the acid...


### PR DESCRIPTION
- acid_act() now respects the unacidable flag for items exposed to acid,
  but are not worn on a mob.

This was once part of #8380, but that is now dead. This fix stands on its own, however.

(Maybe I should have saved it for the freeze, lol)
