### PR TITLE
Xenomorphs with has_fine_manipulation  can now pick up even big items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -190,7 +190,7 @@
 /obj/item/attack_alien(mob/user as mob)
 	var/mob/living/carbon/alien/A = user
 
-	if(!A.has_fine_manipulation || w_class >= 4)
+	if(!A.has_fine_manipulation)
 		if(src in A.contents) // To stop Aliens having items stuck in their pockets
 			A.unEquip(src)
 		user << "<span class='warning'>Your claws aren't capable of such fine manipulation!</span>"


### PR DESCRIPTION
Xenomorphs with has_fine_manipulation (admin var edit only)  can now pick up even big items of w_class 4 and 5. Fixes #8502 

That w_class >= 4 check was added 3.5 years ago, there's no comments explaining why in its PR... 
