### PR TITLE
Fixes being unable to switch back to the previous pipe type without switching off it and back after using the delete or paint modes.

### DIFF
--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -211,7 +211,7 @@ var/global/list/RPD_recipes=list(
 			if(found)
 				preview=new /icon(I.icon,I.icon_state)
 			if(screen == I.categoryId)
-				if(I.id == p_type)
+				if(I.id == p_type && p_class >= 0)
 					datbuild += "<span class='linkOn'>[label]</span>"
 				else
 					datbuild += I.Render(src,label)


### PR DESCRIPTION
Fixes #9187, being unable to switch back to the previous pipe type without switching off it and back after using the delete or paint modes.
