### PR TITLE
Fixes the grammar error of the Grenade Launcher.

### DIFF
--- a/code/modules/projectiles/guns/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/grenade_launcher.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/gun/grenadelauncher/examine(mob/user)
 	..()
-	user << "[grenades] / [max_grenades] grenades loaded."
+	user << "[grenades.len] / [max_grenades] grenades loaded."
 
 /obj/item/weapon/gun/grenadelauncher/attackby(obj/item/I as obj, mob/user as mob, params)
 


### PR DESCRIPTION
Well, it fixes the description error of the Grenade Launcher.

Fixes #8956 
