### PR TITLE
Fixes Round End Sound

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -51,8 +51,6 @@ var/datum/subsystem/ticker/ticker
 	if(SSevent.holidays && SSevent.holidays[APRIL_FOOLS])
 		login_music = 'sound/ambience/clown.ogg'
 
-	round_end_sound = pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg','sound/misc/leavingtg.ogg')
-
 /datum/subsystem/ticker/Initialize()
 	if(!syndicate_code_phrase)		syndicate_code_phrase	= generate_code_phrase()
 	if(!syndicate_code_response)	syndicate_code_response	= generate_code_phrase()

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -42,7 +42,7 @@ var/sound/admin_sound
 	if(!check_rights(R_SOUNDS))	return
 
 	if(ticker)
-		ticker.round_end_sound = S
+		ticker.round_end_sound = fcopy_rsc(S)
 	else
 		return
 


### PR DESCRIPTION
Fixes a pretty significant bug where sounds set with set round end sound would only actually play for the person who set the sound. 

I thought placing the sound file would provide enough impetus for players to download the new sound, but apparently not. 

fcopy_rsc is a nice little way to "force" something into the public consciousness (the rsc file) ahead of them actually experiencing it, which is a luxury people just don't have when the round ends pretty much immediately after the call to download it is made. Note that even without fcopy_rsc, any sound an admin plays ends up there, it's just that when fcopy_rsc isn't called it isn't downloaded to there until it's actually coded to play.
