### PR TITLE
Gang Update

### DIFF
--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -43,7 +43,10 @@
 		else
 			return
 
-	SSshuttle.emergencyLastCallLoc = signalOrigin
+	if(prob(70))
+		SSshuttle.emergencyLastCallLoc = signalOrigin
+	else
+		SSshuttle.emergencyLastCallLoc = null
 
 	priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlecalled.ogg', "Priority")
 
@@ -56,6 +59,8 @@
 
 	if(prob(70))
 		SSshuttle.emergencyLastCallLoc = signalOrigin
+	else
+		SSshuttle.emergencyLastCallLoc = null
 	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlerecalled.ogg', "Priority")
 
 /*

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -111,7 +111,7 @@
 		user << "It is empty."
 
 /obj/item/toy/crayon/spraycan/attack_self(mob/living/user as mob)
-	var/choice = input(user,"Spraycan options") in list("Toggle Cap","Change Drawing","Change Color","Cancel")
+	var/choice = input(user,"Spraycan options") as null|anything in list("Toggle Cap","Change Drawing","Change Color")
 	switch(choice)
 		if("Toggle Cap")
 			user << "<span class='notice'>You [capped ? "Remove" : "Replace"] the cap of the [src]</span>"

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -31,15 +31,16 @@
 		if(user.mind in (ticker.mode.A_bosses | ticker.mode.B_bosses))
 			dat += "Give this device to another member of your organization to use.<br>"
 		else
-			dat += "<a href='?src=\ref[src];choice=register'>Register Device</a><br>"
+			dat += "<a href='?src=\ref[src];register=1'>Register Device</a><br>"
 	else
 		var/gang_size = ((gang == "A")? (ticker.mode.A_gang.len + ticker.mode.A_bosses.len) : (ticker.mode.B_gang.len + ticker.mode.B_bosses.len))
 		var/gang_territory = ((gang == "A")? ticker.mode.A_territory.len : ticker.mode.B_territory.len)
 		var/points = ((gang == "A") ? ticker.mode.gang_points.A : ticker.mode.gang_points.B)
 
-		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Member"]</B><br>"
+		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B><br>"
 		dat += "Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
+		dat += "<a href='?src=\ref[src];choice=ping'>Summon Gang to Your Location</a><br>"
 		dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 		dat += "<br>"
 		dat += "Influence: <B>[points]</B><br>"
@@ -99,6 +100,12 @@
 
 	add_fingerprint(usr)
 
+	if(href_list["register"])
+		register_device(usr)
+
+	else if(!gang) //Gangtool must be registered before you can use the functions below
+		return
+
 	if(href_list["purchase"])
 		var/points = ((gang == "A") ? ticker.mode.gang_points.A : ticker.mode.gang_points.B)
 		var/item_type
@@ -144,12 +151,34 @@
 		switch(href_list["choice"])
 			if("recall")
 				recall(usr)
-			if("register")
-				register_device(usr)
-
+			if("ping")
+				ping_gang(usr)
 	attack_self(usr)
 
+
+/obj/item/device/gangtool/proc/ping_gang(var/mob/user)
+	if(!user)
+		return
+	var/area/location = get_area(user)
+	if(location && location.z != 1)
+		user << "<span class='info'>\icon[src]Error: Signal out of range of station.</span>"
+		return
+	var/list/members = list()
+	if(gang == "A")
+		members += ticker.mode.A_bosses | ticker.mode.A_gang
+	else if(gang == "B")
+		members += ticker.mode.B_bosses | ticker.mode.B_gang
+	if(members.len)
+		for(var/datum/mind/ganger in members)
+			ganger.current << "<span class='danger'><b>[user] summons the gang to [location]!</b></span>"
+		log_game("[key_name(user)] summoned the [gang_name(gang)] Gang ([gang]) to [location].")
+
+
 /obj/item/device/gangtool/proc/register_device(var/mob/user)
+	if(jobban_isbanned(user, "gangster") || jobban_isbanned(user, "Syndicate"))
+		user << "<span class='warning'>\icon[src] ACCESS DENIED: Blacklisted user.</span>"
+		return 0
+
 	var/promoted
 	if(user.mind in (ticker.mode.A_gang | ticker.mode.A_bosses))
 		ticker.mode.A_tools += src
@@ -185,26 +214,39 @@
 	if(recalling || !can_use(user))
 		return
 
-	var/turf/userturf = get_turf(user)
-	if(userturf.z != 1)
-		user << "<span class='info'>\icon[src]Error: Device out of range of station communication arrays.</span>"
-		return
+	recalling = 1
+	loc << "<span class='info'>\icon[src]Generating shuttle recall order with codes retrieved from last call signal...</span>"
 
-	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
-		recalling = 1
-		loc << "<span class='info'>\icon[src]Generating shuttle recall order with codes retrieved from last call signal...</span>"
-		sleep(rand(10,30))
-		loc << "<span class='info'>\icon[src]Shuttle recall order generated. Accessing station long-range communication arrays...</span>"
-		sleep(rand(10,30))
-		loc << "<span class='info'>\icon[src]Comm arrays accessed. Broadcasting recall signal...</span>"
-		sleep(rand(10,30))
+	sleep(rand(10,30))
+
+	if(SSshuttle.emergency.mode != SHUTTLE_CALL) //Shuttle can only be recalled when it's moving to the station
+		user << "<span class='info'>\icon[src]Emergency shuttle cannot be recalled at this time.</span>"
 		recalling = 0
-		log_game("[key_name(user)] has recalled the shuttle with a gangtool.")
-		message_admins("[key_name_admin(user)] has recalled the shuttle with a gangtool.", 1)
-		if(!SSshuttle.cancelEvac(user))
-			loc << "<span class='info'>\icon[src]No response recieved. Emergency shuttle cannot be recalled at this time.</span>"
 		return
-	user << "<span class='info'>\icon[src]Emergency shuttle cannot be recalled at this time.</span>"
+	loc << "<span class='info'>\icon[src]Shuttle recall order generated. Accessing station long-range communication arrays...</span>"
+
+	sleep(rand(10,30))
+
+	var/turf/userturf = get_turf(user)
+	if(userturf.z != 1) //Shuttle can only be recalled while on station
+		user << "<span class='info'>\icon[src]Error: Device out of range of station communication arrays.</span>"
+		recalling = 0
+		return
+	var/datum/station_state/end_state = new /datum/station_state()
+	end_state.count()
+	if((100 *  start_state.score(end_state)) < 70) //Shuttle cannot be recalled if the station is too damaged
+		user << "<span class='info'>\icon[src]Error: Station communication systems compromised. Unable to establish connection.</span>"
+		recalling = 0
+		return
+	loc << "<span class='info'>\icon[src]Comm arrays accessed. Broadcasting recall signal...</span>"
+
+	sleep(rand(10,30))
+
+	recalling = 0
+	log_game("[key_name(user)] has tried to recall the shuttle with a gangtool.")
+	message_admins("[key_name_admin(user)] has tried to recall the shuttle with a gangtool.", 1)
+	if(!SSshuttle.cancelEvac(user))
+		loc << "<span class='info'>\icon[src]No response recieved. Emergency shuttle cannot be recalled at this time.</span>"
 
 /obj/item/device/gangtool/proc/can_use(mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -170,7 +170,7 @@
 		members += ticker.mode.B_bosses | ticker.mode.B_gang
 	if(members.len)
 		for(var/datum/mind/ganger in members)
-			ganger.current << "<span class='danger'>A powerful thought invades your mind... <b>The gang is rallying at [location]!</b></span>"
+			ganger.current << "<span class='danger'>A powerful thought invades your mind... The gang is rallying at <b>[location]</b>!</span>"
 		log_game("[key_name(user)] summoned the [gang_name(gang)] Gang ([gang]) to [location].")
 
 

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -71,8 +71,8 @@
 		else
 			dat += "10mm Ammo<br>"
 
-		dat += "(50 Influence) "
-		if(points >= 50)
+		dat += "(40 Influence) "
+		if(points >= 40)
 			dat += "<a href='?src=\ref[src];purchase=pen'>Recruitment Pen</a><br>"
 		else
 			dat += "Recruitment Pen<br>"
@@ -127,9 +127,9 @@
 					item_type = /obj/item/ammo_box/magazine/m10mm
 					points = 10
 			if("pen")
-				if(points >= 50)
+				if(points >= 40)
 					item_type = /obj/item/weapon/pen/gang
-					points = 50
+					points = 40
 			if("gangtool")
 				if((promotions < 3) && (points >= (promotions*20)+10))
 					item_type = /obj/item/device/gangtool/lt

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -40,7 +40,7 @@
 		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B><br>"
 		dat += "Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
-		dat += "<a href='?src=\ref[src];choice=ping'>Summon Gang to Your Location</a><br>"
+		dat += "<a href='?src=\ref[src];choice=ping'>Rally Your Gang</a><br>"
 		dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 		dat += "<br>"
 		dat += "Influence: <B>[points]</B><br>"
@@ -170,7 +170,7 @@
 		members += ticker.mode.B_bosses | ticker.mode.B_gang
 	if(members.len)
 		for(var/datum/mind/ganger in members)
-			ganger.current << "<span class='danger'><b>[user] summons the gang to [location]!</b></span>"
+			ganger.current << "<span class='danger'>A powerful thought invades your mind... <b>The gang is rallying at [location]!</b></span>"
 		log_game("[key_name(user)] summoned the [gang_name(gang)] Gang ([gang]) to [location].")
 
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -427,20 +427,21 @@
 
 			//Check area validity. Reject space, player-created areas, and non-station z-levels.
 			if (gangID)
-				var/area/user_area = get_area(user.loc)
 				territory = get_area(target)
 				if(territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
 					//Check if this area is already tagged by a gang
 					if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
 						if(territory_claimed(territory, user))
 							return
+					/*
 					//Prevent people spraying from outside of the territory (ie. Maint walls)
-					if(istype(user_area) && (user_area.type == territory.type))
-						if(locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents))
-							user << "<span class='warning'>You cannot tag here.</span>"
-							return
-					else
+					var/area/user_area = get_area(user.loc)
+					if(istype(user_area) && (user_area.type != territory.type))
 						user << "<span class='warning'>You cannot tag [territory] from the outside.</span>"
+						return
+					*/
+					if(locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents))
+						user << "<span class='warning'>You cannot tag here.</span>"
 						return
 				else
 					user << "<span class='warning'>[territory] is unsuitable for tagging.</span>"

--- a/html/changelogs/Ikarrus-Gang5_2.yml
+++ b/html/changelogs/Ikarrus-Gang5_2.yml
@@ -35,4 +35,6 @@ delete-after: True
 changes: 
   - rscadd: "Gang bosses can now rally their gang to their location with their gangtool."
   - rscadd: "Gangtools can no longer recall the shuttle if station integrity is lower than 70%"
+  - rscdel: "Removed requirement to be in the territory to tag it."
+  - tweak: "Recruitment Pen cost reduced to 40."
   - bugfix: "Communications console should now accurately print the (lack of a) location of the last shuttle call."

--- a/html/changelogs/Ikarrus-Gang5_2.yml
+++ b/html/changelogs/Ikarrus-Gang5_2.yml
@@ -33,6 +33,6 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Gang bosses can now summon their gang to their location with their gangtool."
+  - rscadd: "Gang bosses can now rally their gang to their location with their gangtool."
   - rscadd: "Gangtools can no longer recall the shuttle if station integrity is lower than 70%"
   - bugfix: "Communications console should now accurately print the (lack of a) location of the last shuttle call."

--- a/html/changelogs/Ikarrus-Gang5_2.yml
+++ b/html/changelogs/Ikarrus-Gang5_2.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Gang bosses can now summon their gang to their location with their gangtool."
+  - rscadd: "Gangtools can no longer recall the shuttle if station integrity is lower than 70%"
+  - bugfix: "Communications console should now accurately print the (lack of a) location of the last shuttle call."


### PR DESCRIPTION
- Bosses can now summon their gangsters to a location with the gangtool
- Removed restriction on territory tagging that forced you to be in the territory to tag it
- Reduced pen cost to 40
- Gangtools cannot recall the shuttle if the station is too damaged (<70% Integrity)
- Fixed SSshuttle.emergencyLastCallLoc not being handled or stored properly. Fukken Carn breaking my shuttle features.
- Fixed a potential html injection exploit in gangtool's can_use()
- Jobbanned players cannot be promoted
