### PR TITLE
Adds sanity checking for continuous configuration settings

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -39,4 +39,6 @@ client/verb/showrevinfo()
 	src << "Enforce Human Authority: [config.enforce_human_authority]"
 	src << "Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]"
 	src << "Protect Assistant From Antagonist: [config.protect_assistant_from_antagonist]"
+	src << "Enforce Continuous Rounds: [config.continuous.len] of [config.modes.len] roundtypes"
+	src << "Allow Midround Antagonists: [config.midround_antag.len] of [config.modes.len] roundtypes"
 	return

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -34,6 +34,7 @@
 	var/list/datum/game_mode/replacementmode = null
 	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
 	var/reroll_friendly 	//During mode conversion only these are in the running
+	var/continuous_sanity_checked	//Catches some cases where config options could be used to suggest that modes without antagonists should end when all antagonists die
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
 
 	var/const/waittime_l = 600
@@ -174,6 +175,20 @@
 	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || station_was_nuked)
 		return 1
 	if(!round_converted && (!config.continuous[config_tag] || (config.continuous[config_tag] && config.midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
+		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
+			for(var/mob/living/Player in mob_list)
+				if(Player.mind)
+					if(Player.mind.special_role)
+						continuous_sanity_checked = 1
+			if(!continuous_sanity_checked)
+				message_admins("The roundtype ([config_tag]) is reporting that it should end because no antagonists exist. This is PROBABLY a configuration error.")
+				message_admins("Please alert a server owner to check the game_options.txt to be sure that it is up to date with all toggles relating to CONTINUOUS and MIDROUND_ANTAG.")
+				message_admins("If after checking the settings it doesn't appear to be a configuration problem, create an issue report that [config_tag] isn't reporting its antagonists correctly.")
+				config.continuous[config_tag] = 1
+				config.midround_antag[config_tag] = 0
+				return 0
+
+
 		if(living_antag_player && living_antag_player.mind && living_antag_player.stat != DEAD && !isnewplayer(living_antag_player) &&!isbrain(living_antag_player))
 			return 0 //A resource saver: once we find someone who has to die for all antags to be dead, we can just keep checking them, cycling over everyone only when we lose our mark.
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -180,10 +180,9 @@
 				if(Player.mind)
 					if(Player.mind.special_role)
 						continuous_sanity_checked = 1
+						return 0
 			if(!continuous_sanity_checked)
-				message_admins("The roundtype ([config_tag]) is reporting that it should end because no antagonists exist. This is PROBABLY a configuration error.")
-				message_admins("Please alert a server owner to check the game_options.txt to be sure that it is up to date with all toggles relating to CONTINUOUS and MIDROUND_ANTAG.")
-				message_admins("If after checking the settings it doesn't appear to be a configuration problem, create an issue report that [config_tag] isn't reporting its antagonists correctly.")
+				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				config.continuous[config_tag] = 1
 				config.midround_antag[config_tag] = 0
 				return 0

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,6 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
-	reroll_friendly = 1
 
 	traitor_name = "double agent"
 


### PR DESCRIPTION
Adds sanity checking for situations where round start with no antagonists to be sure they don't immediately end. Any mode that starts like this will have continuous set to yes and midround_antag set to no, essentially turning it into a de facto extended. Note that if a round supports late join antag and it's enabled, these antags will still join if possible.

Fixes #9232  

---

Disables Double Agents from mulligans, as it doesn't actually work

Fixes #9188 (well not really, but it won't be a problem on live because DA mulligans won't come back until I'm sure they're working.)

---

Adds enforce continuous rounds and allow midround antagonist reporting to get revision. It won't tell you which modes have them on from there (because it's player accessible) but will show how many roundtypes are currently set to use the features.

Standard config options would currently read:
Enforce Continuous Rounds: 10 of 18 roundtypes
Allow Midround Antagonists: 8 of 18 roundtypes

Fixes #mybugtestingsanity
