### PR TITLE
a group of fixes.

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -160,6 +160,9 @@
 /obj/item/weapon/flamethrower/CheckParts()
 	weldtool = locate(/obj/item/weapon/weldingtool) in contents
 	igniter = locate(/obj/item/device/assembly/igniter) in contents
+	weldtool.status = 0
+	igniter.secured = 0
+	status = 1
 	update_icon()
 
 //Called from turf.dm turf/dblclick

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -795,14 +795,14 @@ datum/preferences
 							user << "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, 0-9, -, ' and .</font>"
 
 					if("religion_name")
-						var/new_religion_name = reject_bad_name( input(user, "Choose your character's mime name:", "Character Preference")  as text|null )
+						var/new_religion_name = reject_bad_name( input(user, "Choose your character's religion:", "Character Preference")  as text|null )
 						if(new_religion_name)
 							custom_names["religion"] = new_religion_name
 						else
 							user << "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>"
 
 					if("deity_name")
-						var/new_deity_name = reject_bad_name( input(user, "Choose your character's mime name:", "Character Preference")  as text|null )
+						var/new_deity_name = reject_bad_name( input(user, "Choose your character's deity:", "Character Preference")  as text|null )
 						if(new_deity_name)
 							custom_names["deity"] = new_deity_name
 						else

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -702,7 +702,7 @@
 		if( (held_mob.l_hand == src) || (held_mob.r_hand == src))
 			if(hasvar(held_mob,"gloves") && held_mob:gloves)
 				return
-			held_mob.bodytemperature += 20 * TEMPERATURE_DAMAGE_COEFFICIENT
+			held_mob.bodytemperature += 15 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(prob(10))
 				held_mob << "<span class='warning'>Your hand holding [src] burns!</span>"
 	else

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -37,3 +37,12 @@
 			healths.icon_state = "health7"
 
 
+/mob/living/carbon/alien/larva/handle_regular_status_updates()
+
+	if(..()) //alive
+
+		if(health <= -maxHealth)
+			death()
+			return
+
+		return 1

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -2,6 +2,9 @@
 	var/prev_lying = lying
 	death(1)
 
+	if(buckled)
+		buckled.unbuckle_mob() //to update alien nest overlay.
+
 	var/atom/movable/overlay/animate = setup_animation(animation, prev_lying)
 	if(animate)
 		gib_animation(animate)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -245,6 +245,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustBruteLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	bruteloss = min(max(bruteloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/getOxyLoss()
 	return oxyloss
@@ -252,10 +253,12 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustOxyLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	oxyloss = min(max(oxyloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates()
 
 /mob/living/proc/setOxyLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	oxyloss = amount
+	handle_regular_status_updates()
 
 /mob/living/proc/getToxLoss()
 	return toxloss
@@ -263,10 +266,12 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustToxLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates()
 
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	toxloss = amount
+	handle_regular_status_updates()
 
 /mob/living/proc/getFireLoss()
 	return fireloss
@@ -274,6 +279,7 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustFireLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	fireloss = min(max(fireloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss
@@ -281,10 +287,12 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustCloneLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	cloneloss = min(max(cloneloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates()
 
 /mob/living/proc/setCloneLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	cloneloss = amount
+	handle_regular_status_updates()
 
 /mob/living/proc/getBrainLoss()
 	return brainloss
@@ -292,10 +300,12 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	brainloss = min(max(brainloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates()
 
 /mob/living/proc/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	brainloss = amount
+	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/getStaminaLoss()
 	return staminaloss
@@ -303,10 +313,12 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	staminaloss = min(max(staminaloss + amount, 0),(maxHealth*2))
+	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/setStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	staminaloss = amount
+	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/getMaxHealth()
 	return maxHealth
@@ -445,6 +457,7 @@ Sorry Giacom. Please don't be mad :(
 		if(C.reagents)
 			for(var/datum/reagent/R in C.reagents.reagent_list)
 				C.reagents.clear_reagents()
+			C.reagents.addiction_list = list()
 	for(var/datum/disease/D in viruses)
 		D.cure(0)
 	if(stat == DEAD)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -89,8 +89,8 @@
 		stance = HOSTILE_STANCE_ATTACK
 		if(isliving(target))
 			var/mob/living/L = target
-			if(L.bodytemperature > 261)
-				L.bodytemperature = 261
+			if(L.bodytemperature > 200)
+				L.bodytemperature = 200
 				visible_message("<span class='danger'>The [src.name]'s stare chills [L.name] to the bone!</span>")
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
@@ -106,10 +106,14 @@ datum/reagent/consumable/capsaicin/on_mob_life(var/mob/living/M as mob)
 			M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(isslime(M))
 				M.bodytemperature += rand(10,20)
-		if(25 to INFINITY)
+		if(25 to 35)
 			M.bodytemperature += 15 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(isslime(M))
 				M.bodytemperature += rand(15,20)
+		if(35 to INFINITY)
+			M.bodytemperature += 20 * TEMPERATURE_DAMAGE_COEFFICIENT
+			if(isslime(M))
+				M.bodytemperature += rand(20,25)
 	..()
 	return
 
@@ -128,15 +132,21 @@ datum/reagent/consumable/frostoil/on_mob_life(var/mob/living/M as mob)
 			if(isslime(M))
 				M.bodytemperature -= rand(5,20)
 		if(15 to 25)
-			M.bodytemperature -= 15 * TEMPERATURE_DAMAGE_COEFFICIENT
+			M.bodytemperature -= 20 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(isslime(M))
 				M.bodytemperature -= rand(10,20)
-		if(25 to INFINITY)
-			M.bodytemperature -= 20 * TEMPERATURE_DAMAGE_COEFFICIENT
+		if(25 to 35)
+			M.bodytemperature -= 30 * TEMPERATURE_DAMAGE_COEFFICIENT
 			if(prob(1))
 				M.emote("shiver")
 			if(isslime(M))
 				M.bodytemperature -= rand(15,20)
+		if(35 to INFINITY)
+			M.bodytemperature -= 40 * TEMPERATURE_DAMAGE_COEFFICIENT
+			if(prob(5))
+				M.emote("shiver")
+			if(isslime(M))
+				M.bodytemperature -= rand(20,25)
 	..()
 	return
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -21,7 +21,7 @@ REVIVAL_BRAIN_LIFE -1
 ### RENAMING ###
 
 #Uncomment to allow cyborgs to rename themselves at roundstart.  Has no effect on roboticists renaming cyborgs the normal way.
-RENAME_CYBORG
+#RENAME_CYBORG
 
 ### OOC DURING ROUND ###
 #Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -21,7 +21,7 @@ REVIVAL_BRAIN_LIFE -1
 ### RENAMING ###
 
 #Uncomment to allow cyborgs to rename themselves at roundstart.  Has no effect on roboticists renaming cyborgs the normal way.
-#RENAME_CYBORG
+RENAME_CYBORG
 
 ### OOC DURING ROUND ###
 #Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.

--- a/html/changelogs/phil235-BundleFix6.yml
+++ b/html/changelogs/phil235-BundleFix6.yml
@@ -1,0 +1,6 @@
+author: phil235
+
+delete-after: True
+
+changes:
+- tweak: "Temperature effects  from frost oil and capsaicin reagents and basilisk have been buffed to be significant again."


### PR DESCRIPTION
- admin revive clears addiction list. Fixes #8894
- buffed capsaicin/frost oil temperature effects as well as basilisk temperature effect (to counterbalance the recent change in natural bodytemp stabilization). And slight nerf to ghost chili temp boost when held in hand (for consistency). Fixes #8501
- fixes religion name choice window labeled as mime name
- fixes nearly invincible larva Fixes #9223
- your health/status now updates immediately after taking damage, we don't wait for the next life(). Fixes #7031
- Fixes alien nest overlay not updating when dead mob is gibbed by larva exit. Fixes #8523
- fixes flamethrower tablecrafting. Fixes #9261
