### PR TITLE
animal knockdown, nettle soup, defib, extinguisher fixes

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -757,6 +757,8 @@ obj/item/toy/cards/deck/New()
 
 
 obj/item/toy/cards/deck/attack_hand(mob/user as mob)
+	if(user.lying)
+		return
 	var/choice = null
 	if(cards.len == 0)
 		src.icon_state = "deck_[deckstyle]_empty"
@@ -827,7 +829,7 @@ obj/item/toy/cards/deck/attackby(obj/item/toy/cards/cardhand/C, mob/living/user,
 
 /obj/item/toy/cards/deck/MouseDrop(atom/over_object)
 	var/mob/M = usr
-	if(usr.stat || !ishuman(usr) || !usr.canmove || usr.restrained())
+	if(!ishuman(usr) || usr.incapacitated() || usr.lying)
 		return
 	if(Adjacent(usr))
 		if(over_object == M && loc != M)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -312,7 +312,7 @@
 		defib.on = 0
 		loc = defib
 		defib.update_icon()
-	return	unwield()
+	return	unwield(user)
 
 /obj/item/weapon/twohanded/shockpaddles/proc/check_defib_exists(mainunit, var/mob/living/carbon/human/M, var/obj/O)
 	if (!mainunit || !istype(mainunit, /obj/item/weapon/defibrillator))	//To avoid weird issues from admin spawns

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -46,6 +46,13 @@
 	user << "The safety is [safety ? "on" : "off"]."
 	return
 
+/obj/item/weapon/extinguisher/examine(mob/user as mob)
+	..()
+	if(reagents.total_volume)
+		user << "It contains [round(reagents.total_volume)] units."
+	else
+		user << "It is empty."
+
 /obj/item/weapon/extinguisher/proc/AttemptRefill(atom/target, mob/user)
 	if(istype(target, /obj/structure/reagent_dispensers/watertank) && target.Adjacent(user))
 		var/safety_save = safety

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -215,6 +215,8 @@ LINEN BINS
 
 
 /obj/structure/bedsheetbin/attack_hand(mob/user as mob)
+	if(user.lying)
+		return
 	if(amount >= 1)
 		amount--
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -285,6 +285,8 @@
 
 /obj/structure/closet/attack_hand(mob/user as mob)
 	src.add_fingerprint(user)
+	if(user.lying && get_dist(src, user) > 0)
+		return
 
 	if(!src.toggle())
 		return src.attackby(null, user)

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -163,7 +163,7 @@
 
 
 /obj/item/weapon/grown/nettle //abstract type
-	name = "abstract nettle"
+	name = "nettle"
 	desc = "It's probably <B>not</B> wise to touch it with bare hands..."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "nettle"
@@ -211,7 +211,6 @@
 
 /obj/item/weapon/grown/nettle/basic
 	seed = /obj/item/seeds/nettleseed
-	name = "nettle"
 
 /obj/item/weapon/grown/nettle/basic/add_juice()
 	..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -82,7 +82,7 @@
 	else
 		W.loc = get_turf(src)
 		W.layer = initial(W.layer)
-		W.dropped()
+		W.dropped(src)
 		return 0
 
 

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -35,8 +35,9 @@
 
 /mob/living/simple_animal/hostile/faithless/AttackingTarget()
 	..()
-	if(isliving(target))
-		var/mob/living/L = target
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
 		if(prob(12))
-			L.Weaken(3)
-			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
+			C.Weaken(3)
+			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+					"<span class='userdanger'>\The [src] knocks you down!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -114,10 +114,12 @@
 /mob/living/simple_animal/hostile/mimic/crate/AttackingTarget()
 	. =..()
 	var/mob/living/L = .
-	if(istype(L))
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
 		if(prob(15))
-			L.Weaken(2)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+			C.Weaken(2)
+			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+					"<span class='userdanger'>\The [src] knocks you down!</span>")
 
 //
 // Copy Mimic
@@ -206,11 +208,12 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/copy/AttackingTarget()
 	..()
 	if(knockdown_people)
-		if(isliving(target))
-			var/mob/living/L = target
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
 			if(prob(15))
-				L.Weaken(1)
-				L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
+				C.Weaken(2)
+				C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+						"<span class='userdanger'>\The [src] knocks you down!</span>")
 
 //
 // Machine Mimics (Made by Malf AI)

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -39,11 +39,12 @@
 
 /mob/living/simple_animal/hostile/tree/AttackingTarget()
 	..()
-	if(isliving(target))
-		var/mob/living/L = target
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
 		if(prob(15))
-			L.Weaken(3)
-			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
+			C.Weaken(3)
+			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
+					"<span class='userdanger'>\The [src] knocks you down!</span>")
 
 /mob/living/simple_animal/hostile/tree/death(gibbed)
 	..(1)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -37,6 +37,8 @@
 
 
 /obj/item/weapon/paper_bin/attack_hand(mob/user)
+	if(user.lying)
+		return
 	if(amount >= 1)
 		amount--
 		update_icon()


### PR DESCRIPTION
- Fixed nettle soup recipe says abstract nettle.
- Fixes hostile animals weakening non carbons, and adjusted weakening values. Fixes #1958
- Fixes being able to drop defib paddle by toggling the paddles while resting, fix a runtime linked to this.
-  You can no longer pick cards from deck while resting, same for paper bin and bedsheet bin. Takes care of the third point of #2189.
- You can no longer toggle closets while lying if it's not directly on you. Fixes #2468
- Examining extinguisher and atmos watertank nozzle gives you the amount of water remaining.
