### PR TITLE
Combat messages in first person

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -10,9 +10,10 @@
 /atom/movable/attackby(obj/item/W, mob/living/user, params)
 	user.do_attack_animation(src)
 	if(W && !(W.flags&NOBLUDGEON))
-		visible_message("<span class='danger'>[user] has hit [src] with [W].</span>")
-		user << "<span class='danger'>You hit [src] with [W].</span>"
-		src << "<span class='userdanger'>[user] has hit you with [W]!</span>"
+		src.visible_message("<span class='danger'>[user] hits [src] with [W].</span>", \
+							"<span class='userdanger'>[user] hits you with [W]!</span>", \
+							"<span class='italics'>You hear a hit!</span>", \
+							user, "<span class='userdanger'>You hit [src] with [W]!</span>")
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -53,18 +53,23 @@
 				var/damage = rand(1, 9)
 				if (prob(90))
 					playsound(loc, "punch", 25, 1, -1)
-					visible_message("<span class='danger'>[M] has punched [src]!</span>", \
-							"<span class='userdanger'>[M] has punched [src]!</span>")
+					src.visible_message("<span class='danger'>[M] punched [src]!</span>", \
+										"<span class='userdanger'>[M] punched you!</span>", \
+										"<span class='italics'>You hear a slap!</span>", \
+										M, "<span class='userdanger'>You punched [src]!</span>")
 					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of weakening an alien.
 						Paralyse(2)
-						visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
-								"<span class='userdanger'>[M] has weakened [src]!</span>")
+						src.visible_message("<span class='danger'>[M] weakens [src]!</span>", \
+											"<span class='userdanger'>[M] weakens you!</span>", null, \
+											M, "<span class='userdanger'>You weaken [src]!</span>")
 					adjustBruteLoss(damage)
 					add_logs(M, src, "attacked", admin=0)
 					updatehealth()
 				else
 					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-					visible_message("<span class='danger'>[M] has attempted to punch [src]!</span>")
+					src.visible_message("<span class='danger'>[M] attempts to punch [src], but misses!</span>", \
+										"<span class='danger'>[M] attempts to punch you, but missed!</span>", null, \
+										M, "<span class='danger'>Your punch missed [src]!</span>")
 
 			if ("disarm")
 				if (!lying)
@@ -72,17 +77,23 @@
 						Paralyse(2)
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						add_logs(M, src, "pushed", admin=0)
-						visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
-							"<span class='userdanger'>[M] has pushed down [src]!</span>")
+						src.visible_message("<span class='danger'>[M] pushes down [src]!</span>", \
+										"<span class='userdanger'>[M] pushes you down!</span>", \
+										"<span class='italics'>You hear a thud!</span>", \
+										M, "<span class='userdanger'>You push [src] down!</span>")
 					else
 						if (prob(50))
 							drop_item()
 							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-							visible_message("<span class='danger'>[M] has disarmed [src]!</span>", \
-							"<span class='userdanger'>[M] has disarmed [src]!</span>")
+							src.visible_message("<span class='danger'>[M] disarms [src]!</span>", \
+												"<span class='userdanger'>[M] disarms you!</span>", \
+												"<span class='italics'>You hear a slap!</span>", \
+												M, "<span class='userdanger'>You disarm [src]!</span>")
 						else
 							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-							visible_message("<span class='danger'>[M] has attempted to disarm [src]!</span>")
+							src.visible_message("<span class='danger'>[M] fails to disarm [src]!</span>", \
+												"<span class='userdanger'>[M] fails to disarm you!</span>", null, \
+												M, "<span class='userdanger'>You fail to disarm [src]!</span>")
 
 /mob/living/carbon/alien/humanoid/restrained()
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -53,10 +53,10 @@
 				var/damage = rand(1, 9)
 				if (prob(90))
 					playsound(loc, "punch", 25, 1, -1)
-					src.visible_message("<span class='danger'>[M] punched [src]!</span>", \
-										"<span class='userdanger'>[M] punched you!</span>", \
+					src.visible_message("<span class='danger'>[M] punches [src]!</span>", \
+										"<span class='userdanger'>[M] punches you!</span>", \
 										"<span class='italics'>You hear a slap!</span>", \
-										M, "<span class='userdanger'>You punched [src]!</span>")
+										M, "<span class='userdanger'>You punch [src]!</span>")
 					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of weakening an alien.
 						Paralyse(2)
 						src.visible_message("<span class='danger'>[M] weakens [src]!</span>", \
@@ -68,8 +68,8 @@
 				else
 					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 					src.visible_message("<span class='danger'>[M] attempts to punch [src], but misses!</span>", \
-										"<span class='danger'>[M] attempts to punch you, but missed!</span>", null, \
-										M, "<span class='danger'>Your punch missed [src]!</span>")
+										"<span class='danger'>[M] attempts to punch you, but misses!</span>", null, \
+										M, "<span class='danger'>Your punch misses [src]!</span>")
 
 			if ("disarm")
 				if (!lying)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -58,8 +58,10 @@
 		if (prob(90))
 			playsound(loc, "punch", 25, 1, -1)
 			add_logs(M, src, "attacked", admin=0)
-			visible_message("<span class='danger'>[M] has kicked [src]!</span>", \
-					"<span class='userdanger'>[M] has kicked [src]!</span>")
+			src.visible_message("<span class='danger'>[M] kick [src]!</span>", \
+							"<span class='userdanger'>[M] kicks you!</span>", \
+							"<span class='italics'>You hear a slap!</span>", \
+							M, "<span class='userdanger'>You kick [src]!</span>")
 			if ((stat != DEAD) && (damage > 4.9))
 				Paralyse(rand(5,10))
 
@@ -67,8 +69,9 @@
 			updatehealth()
 		else
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] has attempted to kick [src]!</span>", \
-					"<span class='userdanger'>[M] has attempted to kick [src]!</span>")
+			src.visible_message("<span class='danger'>[M] attempts to kick [src], but misses!</span>", \
+							"<span class='userdanger'>[M] attempts to kick you, but misses!</span>", null, \
+							M, "<span class='userdanger'>Your kick misses [src]!</span>")
 
 	return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -138,11 +138,15 @@ emp_act
 				return 0
 
 		if(I.attack_verb && I.attack_verb.len)
-			visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>", \
-							"<span class='userdanger'>[user] has [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>")
+			src.visible_message("<span class='danger'>[user] [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>", \
+								"<span class='userdanger'>[user] [pick(I.attack_verb)] you in the [hit_area] with [I]!</span>", \
+								"<span class='italics'>You hear a hit!</span>", \
+								user, "<span class='userdanger'>You [pick(I.attack_verb)] [src] in the [hit_area] with [I]!</span>")
 		else if(I.force)
-			visible_message("<span class='danger'>[user] has attacked [src] in the [hit_area] with [I]!</span>", \
-							"<span class='userdanger'>[user] has attacked [src] in the [hit_area] with [I]!</span>")
+			src.visible_message("<span class='danger'>[user] attack [src] in the [hit_area] with [I]!</span>", \
+								"<span class='userdanger'>[user] attacks you in the [hit_area] with [I]!</span>", \
+								"<span class='italics'>You hear a hit!</span>", \
+								user, "<span class='userdanger'>You attack [src] in the [hit_area] with [I]!</span>")
 		else
 			return 0
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -89,20 +89,20 @@ emp_act
 	if(l_hand && istype(l_hand, /obj/item/weapon))//Current base is the prob(50-d/3)
 		var/obj/item/weapon/I = l_hand
 		if(I.IsShield() && (prob(50 - round(damage / 3))))
-			visible_message("<span class='danger'>[src] blocks [attack_text] with [l_hand]!</span>", \
-							"<span class='userdanger'>[src] blocks [attack_text] with [l_hand]!</span>")
+			src.visible_message("<span class='danger'>[src] blocks [attack_text] with [l_hand]!</span>", \
+							"<span class='userdanger'>You block [attack_text] with [l_hand]!</span>")
 			return 1
 	if(r_hand && istype(r_hand, /obj/item/weapon))
 		var/obj/item/weapon/I = r_hand
 		if(I.IsShield() && (prob(50 - round(damage / 3))))
-			visible_message("<span class='danger'>[src] blocks [attack_text] with [r_hand]!</span>", \
-							"<span class='userdanger'>[src] blocks [attack_text] with [r_hand]!</span>")
+			src.visible_message("<span class='danger'>[src] blocks [attack_text] with [r_hand]!</span>", \
+							"<span class='userdanger'>You block [attack_text] with [r_hand]!</span>")
 			return 1
 	if(wear_suit && istype(wear_suit, /obj/item/))
 		var/obj/item/I = wear_suit
 		if(I.IsShield() && (prob(50)))
-			visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>", \
-							"<span class='userdanger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
+			src.visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>", \
+							"<span class='userdanger'>The reactive teleport system flings you clear of [attack_text]!</span>")
 			var/list/turfs = new/list()
 			for(var/turf/T in orange(6, src))
 				if(istype(T,/turf/space)) continue
@@ -185,8 +185,8 @@ emp_act
 				if("head")	//Harder to score a stun but if you do it lasts a bit longer
 					if(stat == CONSCIOUS)
 						if(prob(I.force))
-							visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
-											"<span class='userdanger'>[src] has been knocked unconscious!</span>")
+							src.visible_message("<span class='danger'>[src] has been knocked unconscious!</span>", \
+											"<span class='userdanger'>You've been knocked unconscious!</span>")
 							apply_effect(20, PARALYZE, armor)
 						if(prob(I.force + ((100 - src.health)/2)) && src != user && I.damtype == BRUTE)
 							ticker.mode.remove_revolutionary(mind)
@@ -204,8 +204,8 @@ emp_act
 
 				if("chest")	//Easier to score a stun but lasts less time
 					if(stat == CONSCIOUS && I.force && prob(I.force + 10))
-						visible_message("<span class='danger'>[src] has been knocked down!</span>", \
-										"<span class='userdanger'>[src] has been knocked down!</span>")
+						src.visible_message("<span class='danger'>[src] has been knocked down!</span>", \
+										"<span class='userdanger'>You've been knocked down!</span>")
 						apply_effect(5, WEAKEN, armor)
 
 					if(bloody)
@@ -442,8 +442,10 @@ emp_act
 				update_damage_overlays(0)
 			updatehealth()
 
-		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
-								"<span class='userdanger'>[M.name] has hit [src]!</span>")
+		src.visible_message("<span class='danger'>[M.name] hits [src]!</span>", \
+							"<span class='userdanger'>[M.name] hits you!</span>", \
+							"<span class='italics'>You hear a hit!</span>", \
+							M, "<span class='userdanger'>You hit [src]!</span>")
 		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -706,9 +706,9 @@
 		return
 	if((M != H) && H.check_shields(0, M.name))
 		add_logs(M, H, "attempted to touch")
-		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>", \
-						"<span class='danger'>[M] attempted to touch you!</span>", null, \
-						M, "<span class='warning'>You attempted to touch [H]!</span>")
+		H.visible_message("<span class='warning'>[M] attempts to touch [H]!</span>", \
+						"<span class='danger'>[M] attempts to touch you!</span>", null, \
+						M, "<span class='warning'>You attempt to touch [H]!</span>")
 		return 0
 
 	var/datum/martial_art/attacker_style = M.martial_art
@@ -738,8 +738,10 @@
 				M.do_attack_animation(H)
 
 				var/atk_verb = "punch"
+				var/atk_verb1 = "punches"
 				if(H.lying)
 					atk_verb = "kick"
+					atk_verb1 = "kicks"
 				else if(M.dna)
 					atk_verb = M.dna.species.attack_verb
 
@@ -753,9 +755,9 @@
 					else
 						playsound(H.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
-					H.visible_message("<span class='warning'>[M] attempted to [atk_verb] [H]!</span>", \
-									"<span class='danger'>[M] attempted to [atk_verb] you!</span>", null, \
-									M, "<span class='danger'>You attempted to [atk_verb] [H]!</span>")
+					H.visible_message("<span class='warning'>[M] attempts to [atk_verb] [H], but misses!</span>", \
+									"<span class='danger'>[M] attempts to [atk_verb] you, but misses!</span>", null, \
+									M, "<span class='danger'>Your [atk_verb] misses [H]!</span>")
 					return 0
 
 
@@ -768,16 +770,16 @@
 					playsound(H.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
 
 
-				H.visible_message("<span class='danger'>[M] [atk_verb]ed [H]!</span>", \
-								"<span class='userdanger'>[M] [atk_verb]ed you!</span>", \
+				H.visible_message("<span class='danger'>[M] [atk_verb1] [H]!</span>", \
+								"<span class='userdanger'>[M] [atk_verb1] you!</span>", \
 								"<span class='italics'>You hear a slap!</span>", \
-								M, "<span class='userdanger'>You [atk_verb]ed [H]!</span>")
+								M, "<span class='userdanger'>You [atk_verb] [H]!</span>")
 
 				H.apply_damage(damage, BRUTE, affecting, armor_block)
 				if((H.stat != DEAD) && damage >= 9)
-					H.visible_message("<span class='danger'>[M] weakened [H]!</span>", \
-									"<span class='userdanger'>[M] weakened you!</span>", null, \
-									M, "<span class='userdanger'>You weakened [H]!</span>")
+					H.visible_message("<span class='danger'>[M] weakens [H]!</span>", \
+									"<span class='userdanger'>[M] weakens you!</span>", null, \
+									M, "<span class='userdanger'>You weaken [H]!</span>")
 					H.apply_effect(4, WEAKEN, armor_block)
 					H.forcesay(hit_appends)
 				else if(H.lying)
@@ -795,10 +797,10 @@
 				var/randn = rand(1, 100)
 				if(randn <= 25)
 					playsound(H, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					H.visible_message("<span class='danger'>[M] pushed [H]!</span>", \
-									"<span class='userdanger'>[M] pushed you!</span>", \
+					H.visible_message("<span class='danger'>[M] pushes [H]!</span>", \
+									"<span class='userdanger'>[M] pushes you!</span>", \
 									"<span class='italics'>You hear a slap!</span>", \
-									M, "<span class='userdanger'>You pushed [H]!</span>")
+									M, "<span class='userdanger'>You push [H]!</span>")
 					H.apply_effect(2, WEAKEN, H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor prevents your fall!</span>", "<span class='notice'>Your armor softens your fall!</span>"))
 					H.forcesay(hit_appends)
 					return
@@ -808,10 +810,10 @@
 				if(randn <= 60)
 					//BubbleWrap: Disarming breaks a pull
 					if(H.pulling)
-						H.visible_message("<span class='warning'>[M] broke [H]'s grip on [H.pulling]!</span>", \
-										"<span class='danger'>[M] broke your grip on [H.pulling]!</span>", \
+						H.visible_message("<span class='warning'>[M] breaks [H]'s grip on [H.pulling]!</span>", \
+										"<span class='danger'>[M] breaks your grip on [H.pulling]!</span>", \
 										"<span class='italics'>You hear a slap!</span>", \
-										M, "<span class='danger'>You broke [H]'s grip on [H.pulling]!</span>")
+										M, "<span class='danger'>You break [H]'s grip on [H.pulling]!</span>")
 						talked = 1
 						H.stop_pulling()
 
@@ -819,20 +821,20 @@
 					if(istype(H.l_hand, /obj/item/weapon/grab))
 						var/obj/item/weapon/grab/lgrab = H.l_hand
 						if(lgrab.affecting)
-							H.visible_message("<span class='warning'>[M] broke [H]'s grip on [lgrab.affecting]!</span>", \
-											"<span class='danger'>[M] broke your grip on [lgrab.affecting]!</span>", \
+							H.visible_message("<span class='warning'>[M] breaks [H]'s grip on [lgrab.affecting]!</span>", \
+											"<span class='danger'>[M] breaks your grip on [lgrab.affecting]!</span>", \
 											"<span class='italics'>You hear a slap!</span>", \
-											M, "<span class='danger'>You broke [H]'s grip on [lgrab.affecting]!</span>")
+											M, "<span class='danger'>You break [H]'s grip on [lgrab.affecting]!</span>")
 							talked = 1
 						spawn(1)
 							qdel(lgrab)
 					if(istype(H.r_hand, /obj/item/weapon/grab))
 						var/obj/item/weapon/grab/rgrab = H.r_hand
 						if(rgrab.affecting)
-							H.visible_message("<span class='warning'>[M] broke [H]'s grip on [rgrab.affecting]!</span>", \
-											"<span class='danger'>[M] broke your grip on [rgrab.affecting]!</span>", \
+							H.visible_message("<span class='warning'>[M] breaks [H]'s grip on [rgrab.affecting]!</span>", \
+											"<span class='danger'>[M] breaks your grip on [rgrab.affecting]!</span>", \
 											"<span class='italics'>You hear a slap!</span>", \
-											M, "<span class='danger'>You broke [H]'s grip on [rgrab.affecting]!</span>")
+											M, "<span class='danger'>You break [H]'s grip on [rgrab.affecting]!</span>")
 							talked = 1
 						spawn(1)
 							qdel(rgrab)
@@ -840,18 +842,18 @@
 
 					if(!talked)	//BubbleWrap
 						if(H.drop_item())
-							H.visible_message("<span class='danger'>[M] disarmed [H]!</span>", \
-											"<span class='userdanger'>[M] disarmed you!</span>", \
+							H.visible_message("<span class='danger'>[M] disarms [H]!</span>", \
+											"<span class='danger'>[M] disarms you!</span>", \
 											"<span class='italics'>You hear a slap!</span>", \
-											M, "<span class='danger'>You disarmed [H]!</span>")
+											M, "<span class='danger'>You disarm [H]!</span>")
 					playsound(H, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					return
 
 
 				playsound(H, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-				H.visible_message("<span class='danger'>[M] attempted to disarm [H]!</span>", \
-								"<span class='danger'>[M] attempted to disarm you!</span>", null, \
-								M, "<span class='danger'>You attempted to disarm [H]!</span>")
+				H.visible_message("<span class='warning'>[M] attempts to disarm [H], but fails!</span>", \
+								"<span class='danger'>[M] attempts to disarm you, but fails!</span>", null, \
+								M, "<span class='danger'>You fail to disarm [H]!</span>")
 	return
 
 /datum/species/proc/spec_attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/obj/item/organ/limb/affecting, var/hit_area, var/intent, var/obj/item/organ/limb/target_limb, target_area, var/mob/living/carbon/human/H)
@@ -905,8 +907,8 @@
 			if("head")	//Harder to score a stun but if you do it lasts a bit longer
 				if(H.stat == CONSCIOUS && armor < 50)
 					if(prob(I.force))
-						H.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", \
-										"<span class='userdanger'>You've been knocked unconscious!</span>")
+						H.visible_message("<span class='danger'>[H] is knocked unconscious!</span>", \
+										"<span class='userdanger'>You're knocked unconscious!</span>")
 						H.apply_effect(20, PARALYZE, armor)
 					if(prob(I.force + ((100 - H.health)/2)) && H != user && I.damtype == BRUTE)
 						ticker.mode.remove_revolutionary(H.mind)
@@ -925,8 +927,8 @@
 
 			if("chest")	//Easier to score a stun but lasts less time
 				if(H.stat == CONSCIOUS && I.force && prob(I.force + 10))
-					H.visible_message("<span class='danger'>[H] has been knocked down!</span>", \
-									"<span class='userdanger'>You are knocked down!</span>")
+					H.visible_message("<span class='danger'>[H] is knocked down!</span>", \
+									"<span class='userdanger'>You're knocked down!</span>")
 					H.apply_effect(5, WEAKEN, armor)
 
 				if(bloody)
@@ -955,11 +957,11 @@
 	else if(I.force)
 		message_verb = "attacked"
 
-	var/attack_message = "[H] has been [message_verb] with [I]."
+	var/attack_message = "[H] is [message_verb] with [I]."
 	if(user)
 		user.do_attack_animation(src)
 		if(user in viewers(src, null))
-			attack_message = "[user] has [message_verb] [H] with [I]!"
+			attack_message = "[user] [message_verb] [H] with [I]!"
 	if(message_verb)
 		H.visible_message("<span class='danger'>[attack_message]</span>",
 		"<span class='userdanger'>[attack_message]</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -387,11 +387,11 @@
 				return 0
 			if(!H.wear_suit.allowed)
 				if(!disable_warning)
-					H << "You somehow have a suit with no defined allowed items for suit storage, stop that."
+					H << "<span class='warning'>You somehow have a suit with no defined allowed items for suit storage, stop that!</span>"
 				return 0
 			if(I.w_class > 4)
 				if(!disable_warning)
-					H << "The [I.name] is too big to attach."  //should be src?
+					H << "<span class='warning'>The [I.name] is too big to attach!</span>"  //should be src?
 				return 0
 			if( istype(I, /obj/item/device/pda) || istype(I, /obj/item/weapon/pen) || is_type_in_list(I, H.wear_suit.allowed) )
 				return 1
@@ -437,13 +437,13 @@
 	//The fucking FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
 	if(H.disabilities & FAT)
 		if(H.overeatduration < 100)
-			H << "<span class='notice'>You feel fit again!</span>"
+			H << "<span class='notice'>You feel fit again.</span>"
 			H.disabilities &= ~FAT
 			H.update_inv_w_uniform(0)
 			H.update_inv_wear_suit()
 	else
 		if(H.overeatduration > 500)
-			H << "<span class='danger'>You suddenly feel blubbery!</span>"
+			H << "<span class='notice'>You suddenly feel blubbery.</span>"
 			H.disabilities |= FAT
 			H.update_inv_w_uniform(0)
 			H.update_inv_wear_suit()
@@ -623,7 +623,7 @@
 						H.emote("collapse")
 					if(prob(15))
 						if(!( H.hair_style == "Shaved") || !(H.hair_style == "Bald") || HAIR in specflags)
-							H << "<span class='danger'>Your hair starts to fall out in clumps...<span>"
+							H << "<span class='userdanger'>Your hair starts to fall out in clumps...<span>"
 							spawn(50)
 								H.facial_hair_style = "Shaved"
 								H.hair_style = "Bald"
@@ -631,7 +631,7 @@
 
 				if(75 to 100)
 					if(prob(1))
-						H << "<span class='danger'>You mutate!</span>"
+						H << "<span class='userdanger'>You mutate!</span>"
 						randmutb(H)
 						domutcheck(H,null)
 						H.emote("gasp")
@@ -706,7 +706,9 @@
 		return
 	if((M != H) && H.check_shields(0, M.name))
 		add_logs(M, H, "attempted to touch")
-		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>")
+		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>", \
+						"<span class='danger'>[M] attempted to touch you!</span>", null, \
+						M, "<span class='warning'>You attempted to touch [H]!</span>")
 		return 0
 
 	var/datum/martial_art/attacker_style = M.martial_art
@@ -751,7 +753,9 @@
 					else
 						playsound(H.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
-					H.visible_message("<span class='warning'>[M] has attempted to [atk_verb] [H]!</span>")
+					H.visible_message("<span class='warning'>[M] attempted to [atk_verb] [H]!</span>", \
+									"<span class='danger'>[M] attempted to [atk_verb] you!</span>", null, \
+									M, "<span class='danger'>You attempted to [atk_verb] [H]!</span>")
 					return 0
 
 
@@ -764,13 +768,16 @@
 					playsound(H.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
 
 
-				H.visible_message("<span class='danger'>[M] has [atk_verb]ed [H]!</span>", \
-								"<span class='userdanger'>[M] has [atk_verb]ed [H]!</span>")
+				H.visible_message("<span class='danger'>[M] [atk_verb]ed [H]!</span>", \
+								"<span class='userdanger'>[M] [atk_verb]ed you!</span>", \
+								"<span class='italics'>You hear a slap!</span>", \
+								M, "<span class='userdanger'>You [atk_verb]ed [H]!</span>")
 
 				H.apply_damage(damage, BRUTE, affecting, armor_block)
 				if((H.stat != DEAD) && damage >= 9)
-					H.visible_message("<span class='danger'>[M] has weakened [H]!</span>", \
-									"<span class='userdanger'>[M] has weakened [H]!</span>")
+					H.visible_message("<span class='danger'>[M] weakened [H]!</span>", \
+									"<span class='userdanger'>[M] weakened you!</span>", null, \
+									M, "<span class='userdanger'>You weakened [H]!</span>")
 					H.apply_effect(4, WEAKEN, armor_block)
 					H.forcesay(hit_appends)
 				else if(H.lying)
@@ -788,9 +795,11 @@
 				var/randn = rand(1, 100)
 				if(randn <= 25)
 					playsound(H, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					H.visible_message("<span class='danger'>[M] has pushed [H]!</span>",
-									"<span class='userdanger'>[M] has pushed [H]!</span>")
-					H.apply_effect(2, WEAKEN, H.run_armor_check(affecting, "melee", "Your armor prevents your fall!", "Your armor softens your fall!"))
+					H.visible_message("<span class='danger'>[M] pushed [H]!</span>", \
+									"<span class='userdanger'>[M] pushed you!</span>", \
+									"<span class='italics'>You hear a slap!</span>", \
+									M, "<span class='userdanger'>You pushed [H]!</span>")
+					H.apply_effect(2, WEAKEN, H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor prevents your fall!</span>", "<span class='notice'>Your armor softens your fall!</span>"))
 					H.forcesay(hit_appends)
 					return
 
@@ -799,7 +808,10 @@
 				if(randn <= 60)
 					//BubbleWrap: Disarming breaks a pull
 					if(H.pulling)
-						H.visible_message("<span class='warning'>[M] has broken [H]'s grip on [H.pulling]!</span>")
+						H.visible_message("<span class='warning'>[M] broke [H]'s grip on [H.pulling]!</span>", \
+										"<span class='danger'>[M] broke your grip on [H.pulling]!</span>", \
+										"<span class='italics'>You hear a slap!</span>", \
+										M, "<span class='danger'>You broke [H]'s grip on [H.pulling]!</span>")
 						talked = 1
 						H.stop_pulling()
 
@@ -807,14 +819,20 @@
 					if(istype(H.l_hand, /obj/item/weapon/grab))
 						var/obj/item/weapon/grab/lgrab = H.l_hand
 						if(lgrab.affecting)
-							H.visible_message("<span class='warning'>[M] has broken [H]'s grip on [lgrab.affecting]!</span>")
+							H.visible_message("<span class='warning'>[M] broke [H]'s grip on [lgrab.affecting]!</span>", \
+											"<span class='danger'>[M] broke your grip on [lgrab.affecting]!</span>", \
+											"<span class='italics'>You hear a slap!</span>", \
+											M, "<span class='danger'>You broke [H]'s grip on [lgrab.affecting]!</span>")
 							talked = 1
 						spawn(1)
 							qdel(lgrab)
 					if(istype(H.r_hand, /obj/item/weapon/grab))
 						var/obj/item/weapon/grab/rgrab = H.r_hand
 						if(rgrab.affecting)
-							H.visible_message("<span class='warning'>[M] has broken [H]'s grip on [rgrab.affecting]!</span>")
+							H.visible_message("<span class='warning'>[M] broke [H]'s grip on [rgrab.affecting]!</span>", \
+											"<span class='danger'>[M] broke your grip on [rgrab.affecting]!</span>", \
+											"<span class='italics'>You hear a slap!</span>", \
+											M, "<span class='danger'>You broke [H]'s grip on [rgrab.affecting]!</span>")
 							talked = 1
 						spawn(1)
 							qdel(rgrab)
@@ -822,15 +840,18 @@
 
 					if(!talked)	//BubbleWrap
 						if(H.drop_item())
-							H.visible_message("<span class='danger'>[M] has disarmed [H]!</span>", \
-											"<span class='userdanger'>[M] has disarmed [H]!</span>")
+							H.visible_message("<span class='danger'>[M] disarmed [H]!</span>", \
+											"<span class='userdanger'>[M] disarmed you!</span>", \
+											"<span class='italics'>You hear a slap!</span>", \
+											M, "<span class='danger'>You disarmed [H]!</span>")
 					playsound(H, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					return
 
 
 				playsound(H, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				H.visible_message("<span class='danger'>[M] attempted to disarm [H]!</span>", \
-								"<span class='userdanger'>[M] attemped to disarm [H]!</span>")
+								"<span class='danger'>[M] attempted to disarm you!</span>", null, \
+								M, "<span class='danger'>You attempted to disarm [H]!</span>")
 	return
 
 /datum/species/proc/spec_attacked_by(var/obj/item/I, var/mob/living/user, var/def_zone, var/obj/item/organ/limb/affecting, var/hit_area, var/intent, var/obj/item/organ/limb/target_limb, target_area, var/mob/living/carbon/human/H)
@@ -841,15 +862,16 @@
 		return 0
 
 	if(I.attack_verb && I.attack_verb.len)
-		H.visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>", \
-						"<span class='userdanger'>[user] has [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>")
+		H.visible_message("<span class='danger'>[user] [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>", \
+						"<span class='userdanger'>[user] [pick(I.attack_verb)] you in the [hit_area] with [I]!</span>", \
+						"<span class='italics'>You hear a thud!</span>", \
+						user, "<span class='userdanger'>You [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>")
 	else if(I.force)
-		H.visible_message("<span class='danger'>[user] has attacked [H] in the [hit_area] with [I]!</span>", \
-						"<span class='userdanger'>[user] has attacked [H] in the [hit_area] with [I]!</span>")
+		H.visible_message("<span class='danger'>[user] attacked [H] in the [hit_area] with [I]!</span>")
 	else
 		return 0
 
-	var/armor = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>")
+	var/armor = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area]!</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area]!</span>")
 	if(armor >= 100)	return 0
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
@@ -884,7 +906,7 @@
 				if(H.stat == CONSCIOUS && armor < 50)
 					if(prob(I.force))
 						H.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", \
-										"<span class='userdanger'>[H] has been knocked unconscious!</span>")
+										"<span class='userdanger'>You've been knocked unconscious!</span>")
 						H.apply_effect(20, PARALYZE, armor)
 					if(prob(I.force + ((100 - H.health)/2)) && H != user && I.damtype == BRUTE)
 						ticker.mode.remove_revolutionary(H.mind)
@@ -904,7 +926,7 @@
 			if("chest")	//Easier to score a stun but lasts less time
 				if(H.stat == CONSCIOUS && I.force && prob(I.force + 10))
 					H.visible_message("<span class='danger'>[H] has been knocked down!</span>", \
-									"<span class='userdanger'>[H] has been knocked down!</span>")
+									"<span class='userdanger'>You are knocked down!</span>")
 					H.apply_effect(5, WEAKEN, armor)
 
 				if(bloody)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -74,8 +74,10 @@
 		if("harm")
 			M.do_attack_animation(src)
 			if (prob(75))
-				visible_message("<span class='danger'>[M] has punched [name]!</span>", \
-						"<span class='userdanger'>[M] has punched [name]!</span>")
+				src.visible_message("<span class='danger'>[M] punched [name]!</span>", \
+									"<span class='userdanger'>[M] punched you!</span>", \
+									"<span class='italics'>You hear a slap!</span>", \
+									M, "<span class='userdanger'>You punched [name]!</span>")
 
 				playsound(loc, "punch", 25, 1, -1)
 				var/damage = rand(5, 10)
@@ -84,16 +86,19 @@
 					if ( (paralysis < 5)  && (health > 0) )
 						Paralyse(rand(10, 15))
 						spawn( 0 )
-							visible_message("<span class='danger'>[M] has knocked out [name]!</span>", \
-									"<span class='userdanger'>[M] has knocked out [name]!</span>")
+							src.visible_message("<span class='danger'>[M] has knocked out [name]!</span>", \
+											"<span class='userdanger'>You're knocked out by [M]!</span>", \
+											"<span class='italics'>You hear a thud!</span>", \
+											M, "<span class='userdanger'>You knocked out [name]!</span>")
 							return
 				adjustBruteLoss(damage)
 				add_logs(M, src, "attacked", admin=0)
 				updatehealth()
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] has attempted to punch [name]!</span>", \
-						"<span class='userdanger'>[M] has attempted to punch [name]!</span>")
+				src.visible_message("<span class='danger'>[M] attempts to punch [name], but misses!</span>", \
+								"<span class='userdanger'>[M] attempts to punch you, but misses!</span>", null, \
+								M, "<span class='userdanger'>Your punch misses [name]!</span>")
 
 		if("disarm")
 			if (!( paralysis ))
@@ -102,13 +107,16 @@
 					Paralyse(2)
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					add_logs(M, src, "pushed", admin=0)
-					visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
-							"<span class='userdanger'>[M] has pushed down [src]!</span>")
+					src.visible_message("<span class='danger'>[M] pushes down [src]!</span>", \
+									"<span class='userdanger'>[M] pushes you down!</span>", \
+									"<span class='italics'>You hear a thud!</span>", \
+									M, "<span class='userdanger'>You push down [src]!</span>")
 				else
 					if(drop_item())
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						visible_message("<span class='danger'>[M] has disarmed [src]!</span>", \
-								"<span class='userdanger'>[M] has disarmed [src]!</span>")
+						src.visible_message("<span class='danger'>[M] disarms [src]!</span>", \
+										"<span class='userdanger'>[M] disarms you!</span>", null, \
+										M, "<span class='userdanger'>You disarm [src]!</span>")
 	return
 
 /mob/living/carbon/monkey/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
@@ -121,11 +129,13 @@
 					damage = rand(20, 40)
 					if (paralysis < 15)
 						Paralyse(rand(10, 15))
-					visible_message("<span class='danger'>[M] has wounded [name]!</span>", \
-							"<span class='userdanger'>[M] has wounded [name]!</span>")
+					src.visible_message("<span class='danger'>[M] wounded [name]!</span>", \
+										"<span class='userdanger'>[M] wounded you!</span>", null, \
+										M, "<span class='userdanger'>You wounded [name]!</span>")
 				else
-					visible_message("<span class='danger'>[M] has slashed [name]!</span>", \
-							"<span class='userdanger'>[M] has slashed [name]!</span>")
+					src.visible_message("<span class='danger'>[M] slashed [name]!</span>", \
+									"<span class='userdanger'>[M] slashed [name]!</span>", null, \
+									M, "<span class='userdanger'>You slashed [name]!</span>")
 				add_logs(M, src, "attacked", admin=0)
 				if (stat != DEAD)
 					adjustBruteLoss(damage)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -74,10 +74,10 @@
 		if("harm")
 			M.do_attack_animation(src)
 			if (prob(75))
-				src.visible_message("<span class='danger'>[M] punched [name]!</span>", \
-									"<span class='userdanger'>[M] punched you!</span>", \
+				src.visible_message("<span class='danger'>[M] punches [name]!</span>", \
+									"<span class='userdanger'>[M] punches you!</span>", \
 									"<span class='italics'>You hear a slap!</span>", \
-									M, "<span class='userdanger'>You punched [name]!</span>")
+									M, "<span class='userdanger'>You punch [name]!</span>")
 
 				playsound(loc, "punch", 25, 1, -1)
 				var/damage = rand(5, 10)
@@ -86,10 +86,10 @@
 					if ( (paralysis < 5)  && (health > 0) )
 						Paralyse(rand(10, 15))
 						spawn( 0 )
-							src.visible_message("<span class='danger'>[M] has knocked out [name]!</span>", \
-											"<span class='userdanger'>You're knocked out by [M]!</span>", \
+							src.visible_message("<span class='danger'>[M] knocks out [name]!</span>", \
+											"<span class='userdanger'>[M] knocks you out!</span>", \
 											"<span class='italics'>You hear a thud!</span>", \
-											M, "<span class='userdanger'>You knocked out [name]!</span>")
+											M, "<span class='userdanger'>You knock out [name]!</span>")
 							return
 				adjustBruteLoss(damage)
 				add_logs(M, src, "attacked", admin=0)
@@ -129,32 +129,37 @@
 					damage = rand(20, 40)
 					if (paralysis < 15)
 						Paralyse(rand(10, 15))
-					src.visible_message("<span class='danger'>[M] wounded [name]!</span>", \
-										"<span class='userdanger'>[M] wounded you!</span>", null, \
-										M, "<span class='userdanger'>You wounded [name]!</span>")
+					src.visible_message("<span class='danger'>[M] wounds [name]!</span>", \
+										"<span class='userdanger'>[M] wounds you!</span>", null, \
+										M, "<span class='userdanger'>You wound [name]!</span>")
 				else
-					src.visible_message("<span class='danger'>[M] slashed [name]!</span>", \
-									"<span class='userdanger'>[M] slashed [name]!</span>", null, \
-									M, "<span class='userdanger'>You slashed [name]!</span>")
+					src.visible_message("<span class='danger'>[M] slashes [name]!</span>", \
+									"<span class='userdanger'>[M] slashes [name]!</span>", null, \
+									M, "<span class='userdanger'>You slash [name]!</span>")
 				add_logs(M, src, "attacked", admin=0)
 				if (stat != DEAD)
 					adjustBruteLoss(damage)
 					updatehealth()
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
-				visible_message("<span class='danger'>[M] has attempted to lunge at [name]!</span>", \
-						"<span class='userdanger'>[M] has attempted to lunge at [name]!</span>")
+				src.visible_message("<span class='danger'>[M] attempts to lunge at [name], but misses!</span>", \
+								"<span class='danger'>[M] attempts to lunge at [name], but misses!</span>", null, \
+								M, "<span class='danger'>Your slash misses [name]!</span>")
 
 		if (M.a_intent == "disarm")
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			if(prob(95))
 				Weaken(10)
-				visible_message("<span class='danger'>[M] has tackled down [name]!</span>", \
-						"<span class='userdanger'>[M] has tackled down [name]!</span>")
+				src.visible_message("<span class='danger'>[M] tackles down [name]!</span>", \
+									"<span class='userdanger'>[M] tackles you down!</span>", \
+									"<span class='italics'>You hear a thud!</span>", \
+									M, "<span class='userdanger'>You tackle [name] down!</span>")
 			else
 				if(drop_item())
-					visible_message("<span class='danger'>[M] has disarmed [name]!</span>", \
-							"<span class='userdanger'>[M] has disarmed [name]!</span>")
+					src.visible_message("<span class='danger'>[M] disarms [name]!</span>", \
+										"<span class='userdanger'>[M] disarms you!</span>", \
+										"<span class='italics'>You hear a slap!</span>", \
+										M, "<span class='userdanger'>You disarm [name]!</span>")
 			add_logs(M, src, "disarmed", admin=0)
 			updatehealth()
 	return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -183,7 +183,7 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 	if(!supress_message)
 		src.visible_message("<span class='warning'>[user] grabs [src] passively!</span>", \
 							"<span class='danger'>[user] grabs you passively!</span>", null, \
-							user, "<span class='danger'>You grab [src] passively!</span>")
+							user, "<span class='notice'>You grab [src] passively!</span>")
 
 
 /mob/living/attack_slime(mob/living/simple_animal/slime/M as mob)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -177,7 +177,9 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 
 	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	if(!supress_message)
-		visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>")
+		src.visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>", \
+							"<span class='danger'>[user] grabs you passively!</span>", null, \
+							user, "<span class='danger'>You grab [src] passively!</span>")
 
 
 /mob/living/attack_slime(mob/living/simple_animal/slime/M as mob)
@@ -191,20 +193,26 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 	if (stat != DEAD)
 		add_logs(M, src, "attacked", admin=0)
 		M.do_attack_animation(src)
-		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
-				"<span class='userdanger'>The [M.name] glomps [src]!</span>")
+		src.visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
+							"<span class='userdanger'>The [M.name] glomps you!</span>", \
+							"<span class='italics'>You hear a glomp!</span>", \
+							M, "<span class='userdanger'>You glomp [src]!</span>")
 		return 1
 
 /mob/living/attack_animal(mob/living/simple_animal/M as mob)
 	if(M.melee_damage_upper == 0)
-		M.visible_message("<span class='notice'>\The [M] [M.friendly] [src]!</span>")
+		src.visible_message("<span class='notice'>\The [M] [M.friendly] [src]!</span>", \
+						"<span class='notice'>\The [M] [M.friendly] you!</span>", null, \
+						M, "<span class='notice'>You [M.friendly] [src]!</span>")
 		return 0
 	else
 		if(M.attack_sound)
 			playsound(loc, M.attack_sound, 50, 1, 1)
 		M.do_attack_animation(src)
-		visible_message("<span class='danger'>\The [M] [M.attacktext] [src]!</span>", \
-						"<span class='userdanger'>\The [M] [M.attacktext] [src]!</span>")
+		src.visible_message("<span class='danger'>\The [M] [M.attacktext] [src]!</span>", \
+						"<span class='userdanger'>\The [M] [M.attacktext] you!</span>", \
+						"<span class='italics'>You hear a slap!</span>", \
+						M, "<span class='userdanger'>You [M.attacktext] [src]!</span>")
 		add_logs(M, src, "attacked", admin=0)
 		return 1
 
@@ -226,12 +234,15 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		if (prob(75))
 			add_logs(M, src, "attacked", admin=0)
 			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-					"<span class='userdanger'>[M.name] bites [src]!</span>")
+			src.visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
+							"<span class='userdanger'>[M.name] bites you!</span>", \
+							"<span class='italics'>You hear a munch!</span>", \
+							M, "<span class='userdanger'>You bite [src]!</span>")
 			return 1
 		else
-			visible_message("<span class='danger'>[M.name] has attempted to bite [src]!</span>", \
-				"<span class='userdanger'>[M.name] has attempted to bite [src]!</span>")
+			src.visible_message("<span class='danger'>[M.name] attempted to bite [src]!</span>", \
+							"<span class='userdanger'>[M.name] attempted to bite you!</span>", null, \
+							M, "<span class='userdanger'>You attempted to bite [src]!</span>")
 	return 0
 
 /mob/living/attack_larva(mob/living/carbon/alien/larva/L as mob)
@@ -245,13 +256,16 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 			L.do_attack_animation(src)
 			if(prob(90))
 				add_logs(L, src, "attacked", admin=0)
-				visible_message("<span class='danger'>[L.name] bites [src]!</span>", \
-						"<span class='userdanger'>[L.name] bites [src]!</span>")
+				src.visible_message("<span class='danger'>[L.name] bites [src]!</span>", \
+									"<span class='userdanger'>[L.name] bites you!</span>", \
+									"<span class='italics'>You hear a munch!</span>", \
+									L, "<span class='userdanger'>You bite [src]!</span>")
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				return 1
 			else
-				visible_message("<span class='danger'>[L.name] has attempted to bite [src]!</span>", \
-					"<span class='userdanger'>[L.name] has attempted to bite [src]!</span>")
+				src.visible_message("<span class='danger'>[L.name] attempted to bite [src]!</span>", \
+								"<span class='danger'>[L.name] attempted to bite you!</span>", null, \
+								L, "<span class='danger'>You attempted to bite [src]!</span>")
 	return 0
 
 /mob/living/attack_alien(mob/living/carbon/alien/humanoid/M as mob)
@@ -265,7 +279,9 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 
 	switch(M.a_intent)
 		if ("help")
-			visible_message("<span class='notice'>[M] caresses [src] with its scythe like arm.</span>")
+			visible_message("<span class='notice'>[M] caresses [src] with its scythe-like arm.</span>", \
+							"<span class='notice'>[M] caresses you with its scythe-like arm.</span>", null, \
+							M, "<span class='notice'>You caress [src] with your scythe-like arm.</span>")
 			return 0
 
 		if ("grab")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -58,8 +58,8 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 		if(!I.throwforce)// Otherwise, if the item's throwforce is 0...
 			playsound(loc, 'sound/weapons/throwtap.ogg', 1, volume, -1)//...play throwtap.ogg.
 
-		visible_message("<span class='danger'>[src] has been hit by [I].</span>", \
-						"<span class='userdanger'>[src] has been hit by [I].</span>")
+		visible_message("<span class='danger'>[src] is hit by [I]!</span>", \
+						"<span class='userdanger'>You're hit by [I]!</span>")
 		var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].")
 		apply_damage(I.throwforce, dtype, zone, armor, I)
 		if(!I.fingerprintslast)
@@ -86,13 +86,17 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 			else
 				return
 		updatehealth()
-		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
-						"<span class='userdanger'>[M.name] has hit [src]!</span>")
+		src.visible_message("<span class='danger'>[M.name] hits [src]!</span>", \
+							"<span class='userdanger'>[M.name] hits you!</span>", \
+							"<span class='italics'>You hear a slap!</span>", \
+							M, "<span class='userdanger'>You hit [src]!</span>")
 		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	else
 		step_away(src,M)
 		add_logs(M.occupant, src, "pushed", object=M, admin=0)
-		visible_message("<span class='warning'>[M] pushes [src] out of the way.</span>")
+		src.visible_message("[M] pushes [src] out of the way.", \
+							"<span class='notice'>[M] pushes you out of the way.</span>", null, \
+							M, "<span class='notice'>You push [src] out of the way.</span>")
 
 		return
 
@@ -177,7 +181,7 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 
 	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	if(!supress_message)
-		src.visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>", \
+		src.visible_message("<span class='warning'>[user] grabs [src] passively!</span>", \
 							"<span class='danger'>[user] grabs you passively!</span>", null, \
 							user, "<span class='danger'>You grab [src] passively!</span>")
 
@@ -240,16 +244,18 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 							M, "<span class='userdanger'>You bite [src]!</span>")
 			return 1
 		else
-			src.visible_message("<span class='danger'>[M.name] attempted to bite [src]!</span>", \
-							"<span class='userdanger'>[M.name] attempted to bite you!</span>", null, \
-							M, "<span class='userdanger'>You attempted to bite [src]!</span>")
+			src.visible_message("<span class='danger'>[M.name] attempts to bite [src], but misses!</span>", \
+							"<span class='userdanger'>[M.name] attempts to bite you, but misses!</span>", null, \
+							M, "<span class='userdanger'>Your bite misses [src]!</span>")
 	return 0
 
 /mob/living/attack_larva(mob/living/carbon/alien/larva/L as mob)
 
 	switch(L.a_intent)
 		if("help")
-			visible_message("<span class='notice'>[L.name] rubs its head against [src].</span>")
+			src.visible_message("[L.name] rubs its head against [src].", \
+								"<span class='notice'>[L.name] rubs its head against you.</span>", null, \
+								L, "<span class='notice'>You rub your head against [src].</span>")
 			return 0
 
 		else
@@ -263,9 +269,9 @@ proc/vol_by_throwforce_and_or_w_class(var/obj/item/I)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 				return 1
 			else
-				src.visible_message("<span class='danger'>[L.name] attempted to bite [src]!</span>", \
-								"<span class='danger'>[L.name] attempted to bite you!</span>", null, \
-								L, "<span class='danger'>You attempted to bite [src]!</span>")
+				src.visible_message("<span class='danger'>[L.name] attempts to bite [src], but misses!</span>", \
+								"<span class='danger'>[L.name] attempts to bite you, but misses!</span>", null, \
+								L, "<span class='danger'>Your bite misses [src]!</span>")
 	return 0
 
 /mob/living/attack_alien(mob/living/carbon/alien/humanoid/M as mob)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -310,8 +310,8 @@
 			add_logs(M, src, "disarmed", admin=0)
 		else
 			var/damage = rand(15, 30)
-			src.visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
-						"<span class='userdanger'>[M] has slashed at you!</span>", \
+			src.visible_message("<span class='danger'>[M] slashes at [src]!</span>", \
+						"<span class='userdanger'>[M] slashes at you!</span>", \
 						"<span class='italics'>You hear a slap!</span>", \
 						M, "<span class='userdanger'>You slash at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -264,7 +264,9 @@
 
 		if("help")
 			if (health > 0)
-				visible_message("<span class='notice'>[M] [response_help] [src].</span>")
+				src.visible_message("<span class='notice'>[M] [response_help] [src].</span>", \
+									"<span class='notice'>[M] [response_help] you.</span>", null, \
+									M, "<span class='notice'>You [response_help] [src].</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		if("grab")
@@ -273,7 +275,7 @@
 		if("harm", "disarm")
 			M.do_attack_animation(src)
 			src.visible_message("<span class='danger'>[M] [response_harm] [src]!</span>", \
-								"<span class='danger'>[M] [response_harm] [src]!</span>", \
+								"<span class='danger'>[M] [response_harm] you!</span>", \
 								"<span class='italics'>You hear a slap!</span>", \
 								M, "<span class='danger'>You [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
@@ -290,7 +292,9 @@
 			return 1
 	if (M.a_intent == "help")
 		if (health > 0)
-			visible_message("<span class='notice'>[M.name] [response_help] [src].</span>")
+			src.visible_message("<span class='notice'>[M.name] [response_help] [src].</span>", \
+							"<span class='notice'>[M.name] [response_help] you.</span>", null, \
+							M, "<span class='notice'>You [response_help] [src].</span>")
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 	return
@@ -299,13 +303,17 @@
 	if(..()) //if harm or disarm intent.
 		if(M.a_intent == "disarm")
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
-					"<span class='userdanger'>[M] [response_disarm] [name]!</span>")
+			src.visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
+								"<span class='userdanger'>[M] [response_disarm] you!</span>", \
+								"<span class='italics'>You hear a slap!</span>", \
+								M, "<span class='userdanger'>You [response_disarm] [name]!</span>")
 			add_logs(M, src, "disarmed", admin=0)
 		else
 			var/damage = rand(15, 30)
-			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
-					"<span class='userdanger'>[M] has slashed at [src]!</span>")
+			src.visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
+						"<span class='userdanger'>[M] has slashed at you!</span>", \
+						"<span class='italics'>You hear a slap!</span>", \
+						M, "<span class='userdanger'>You slash at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
 			add_logs(M, src, "attacked", admin=0)
 			attack_threshold_check(damage)
@@ -350,16 +358,18 @@
 						MED.amount -= 1
 						if(MED.amount <= 0)
 							qdel(MED)
-						visible_message("<span class='notice'> [user] applies [MED] on [src].</span>")
+						src.visible_message("<span class='notice'>[user] applies [MED] on [src].</span>", \
+										"<span class='notice'>[user] applies [MED] on you.</span>", null, \
+										user, "<span class='notice'>You apply [MED] on [src].</span>")
 						return
 					else
-						user << "<span class='notice'> [MED] won't help at all.</span>"
+						user << "<span class='warning'>[MED] won't help at all!</span>"
 						return
 			else
-				user << "<span class='notice'> [src] is at full health.</span>"
+				user << "<span class='notice'>[src] is at full health.</span>"
 				return
 		else
-			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
+			user << "<span class='warning'>[src] is dead! Medical items won't bring it back to life.</span>"
 			return
 
 	if((meat_type || skin_type) && (stat == DEAD))	//if the animal has a meat, and if it is dead.
@@ -391,7 +401,7 @@
 	stat = DEAD
 	density = 0
 	if(!gibbed)
-		visible_message("<span class='danger'>\the [src] stops moving...</span>")
+		visible_message("<span class='warning'>\the [src] stops moving...</span>")
 	..()
 
 /mob/living/simple_animal/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -272,7 +272,10 @@
 
 		if("harm", "disarm")
 			M.do_attack_animation(src)
-			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
+			src.visible_message("<span class='danger'>[M] [response_harm] [src]!</span>", \
+								"<span class='danger'>[M] [response_harm] [src]!</span>", \
+								"<span class='italics'>You hear a slap!</span>", \
+								M, "<span class='danger'>You [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
 			attack_threshold_check(harm_intent_damage)
 			add_logs(M, src, "attacked", admin=0)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -27,8 +27,11 @@
 
 	//Interaction
 	var/response_help   = "pokes"
+	var/response_help1   = "poke"
 	var/response_disarm = "shoves"
+	var/response_disarm1 = "shove"
 	var/response_harm   = "hits"
+	var/response_harm1   = "hit"
 	var/harm_intent_damage = 3
 	var/force_threshold = 0 //Minimum force required to deal any damage
 
@@ -266,7 +269,7 @@
 			if (health > 0)
 				src.visible_message("<span class='notice'>[M] [response_help] [src].</span>", \
 									"<span class='notice'>[M] [response_help] you.</span>", null, \
-									M, "<span class='notice'>You [response_help] [src].</span>")
+									M, "<span class='notice'>You [response_help1] [src].</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		if("grab")
@@ -277,7 +280,7 @@
 			src.visible_message("<span class='danger'>[M] [response_harm] [src]!</span>", \
 								"<span class='danger'>[M] [response_harm] you!</span>", \
 								"<span class='italics'>You hear a slap!</span>", \
-								M, "<span class='danger'>You [response_harm] [src]!</span>")
+								M, "<span class='danger'>You [response_harm1] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
 			attack_threshold_check(harm_intent_damage)
 			add_logs(M, src, "attacked", admin=0)
@@ -294,7 +297,7 @@
 		if (health > 0)
 			src.visible_message("<span class='notice'>[M.name] [response_help] [src].</span>", \
 							"<span class='notice'>[M.name] [response_help] you.</span>", null, \
-							M, "<span class='notice'>You [response_help] [src].</span>")
+							M, "<span class='notice'>You [response_help1] [src].</span>")
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 	return
@@ -306,7 +309,7 @@
 			src.visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
 								"<span class='userdanger'>[M] [response_disarm] you!</span>", \
 								"<span class='italics'>You hear a slap!</span>", \
-								M, "<span class='userdanger'>You [response_disarm] [name]!</span>")
+								M, "<span class='userdanger'>You [response_disarm1] [name]!</span>")
 			add_logs(M, src, "disarmed", admin=0)
 		else
 			var/damage = rand(15, 30)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -80,8 +80,10 @@ var/next_mob_id = 0
 // message is the message output to anyone who can see e.g. "[src] does something!"
 // self_message (optional) is what the src mob sees e.g. "You do something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
+// othermob (optional) if there's an attacker in this situation who should get a separate message, set him here
+// othermob_message (optional) is what the attacker will see e.g. "You hit [src]!"
 
-/mob/visible_message(var/message, var/self_message, var/blind_message)
+/mob/visible_message(var/message, var/self_message, var/blind_message, var/othermob, var/othermob_message)
 	var/list/mob_viewers = list()
 	var/list/possible_viewers = list()
 	mob_viewers |= src
@@ -104,6 +106,8 @@ var/next_mob_id = 0
 		var/msg = message
 		if(self_message && M==src)
 			msg = self_message
+		if(M==othermob && othermob_message)
+			msg = othermob_message
 		M.show_message(msg, 1)
 
 	if(blind_message)
@@ -119,8 +123,10 @@ var/next_mob_id = 0
 // Use for objects performing visible actions
 // message is output to anyone who can see, e.g. "The [src] does something!"
 // blind_message (optional) is what blind people will hear e.g. "You hear something!"
+// othermob (optional) if there's an attacker in this situation who should get a separate message, set him here
+// othermob_message (optional) is what the attacker will see e.g. "You hit [src]!"
 
-/atom/proc/visible_message(var/message, var/blind_message)
+/atom/proc/visible_message(var/message, var/blind_message, var/othermob, var/othermob_message)
 	var/list/mob_viewers = list()
 	var/list/possible_viewers = list()
 	mob_viewers |= viewers(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -134,16 +134,20 @@
 	if(state < GRAB_AGGRESSIVE)
 		if(!allow_upgrade)
 			return
-		assailant.visible_message("<span class='warning'>[assailant] has grabbed [affecting] aggressively (now hands)!</span>")
+		affecting.visible_message("<span class='warning'>[assailant] reinforces \his grip on [affecting]!</span>", \
+								"<span class='warning'>[assailant] reinforces \his grip on you!</span>", null, \
+								assailant, "<span class='notice'>You reinforce your grip on [affecting]!</span>")
 		state = GRAB_AGGRESSIVE
 		icon_state = "grabbed1"
 	else
 		if(state < GRAB_NECK)
 			if(isslime(affecting))
-				assailant << "<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>"
+				assailant << "<span class='warning'>You squeeze [affecting], but nothing interesting happens!</span>"
 				return
 
-			assailant.visible_message("<span class='warning'>[assailant] has reinforced \his grip on [affecting] (now neck)!</span>")
+			affecting.visible_message("<span class='warning'>[assailant] moves \his grip to [affecting]'s neck!</span>", \
+										"<span class='warning'>[assailant] moves \his grip to your neck!</span>", null, \
+										assailant, "<span class='notice'>You move your grip to [affecting]'s neck!</span>")
 			state = GRAB_NECK
 			icon_state = "grabbed+1"
 			if(!affecting.buckled)
@@ -153,7 +157,9 @@
 			hud.name = "disarm/kill"
 		else
 			if(state < GRAB_UPGRADING)
-				assailant.visible_message("<span class='danger'>[assailant] starts to tighten \his grip on [affecting]'s neck!</span>")
+				affecting.visible_message("<span class='danger'>[assailant] starts to tighten \his grip on [affecting]'s neck!</span>", \
+										"<span class='danger'>[assailant] starts to tighten \his grip on your neck!</span>", null, \
+										assailant, "<span class='danger'>You start to tighten your grip on [affecting]'s neck...</span>")
 				hud.icon_state = "disarm/kill1"
 				state = GRAB_UPGRADING
 				if(do_after(assailant, UPGRADE_KILL_TIMER))
@@ -166,14 +172,18 @@
 						qdel(src)
 						return
 					state = GRAB_KILL
-					assailant.visible_message("<span class='danger'>[assailant] has tightened \his grip on [affecting]'s neck!</span>")
+					affecting.visible_message("<span class='danger'>[assailant] tightens \his grip on [affecting]'s neck!</span>", \
+											"<span class='userdanger'>[assailant] tightens \his grip on your neck!</span>", null, \
+											assailant, "<span class='userdanger'>You tighten your grip on [affecting]'s neck!</span>")
 					add_logs(assailant, affecting, "strangled")
 
 					assailant.changeNext_move(CLICK_CD_TKSTRANGLE)
 					affecting.losebreath += 1
 				else
 					if(assailant)
-						assailant.visible_message("<span class='warning'>[assailant] was unable to tighten \his grip on [affecting]'s neck!</span>")
+						affecting.visible_message("<span class='warning'>[assailant] is unable to tighten \his grip on [affecting]'s neck!</span>", \
+												"<span class='warning'>[assailant] is unable to tighten \his grip on your neck!</span>", null, \
+												assailant, "<span class='warning'>You're unable to tighten your grip on [affecting]'s neck!</span>")
 						hud.icon_state = "disarm/kill"
 						state = GRAB_NECK
 
@@ -203,12 +213,16 @@
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
 		if( (ishuman(user) && (user.disabilities & FAT) && ismonkey(affecting) ) || ( isalien(user) && iscarbon(affecting) ) )
 			var/mob/living/carbon/attacker = user
-			user.visible_message("<span class='danger'>[user] is attempting to devour [affecting]!</span>")
+			affecting.visible_message("<span class='danger'>[user] is attempting to devour [affecting]!</span>", \
+								"<span class='userdanger'>[user] is attempting to devour you!</span>", null, \
+								affecting, "<span class='danger'>You're attempting to devour [affecting]...</span>")
 			if(istype(user, /mob/living/carbon/alien/humanoid/hunter))
 				if(!do_mob(user, affecting)||!do_after(user, 30)) return
 			else
 				if(!do_mob(user, affecting)||!do_after(user, 100)) return
-			user.visible_message("<span class='danger'>[user] devours [affecting]!</span>")
+			affecting.visible_message("<span class='danger'>[user] devours [affecting]!</span>", \
+								"<span class='userdanger'>[user] devours you!</span>", null, \
+								user, "<span class='userdanger'>You devour [affecting]!</span>")
 			affecting.loc = user
 			attacker.stomach_contents.Add(affecting)
 			qdel(src)


### PR DESCRIPTION
So you can have a random name every round, forget your name and still realize if you're being attacked in the escape shuttle. Plus immersions, more polished look on the game and such.

_Before:_
You and everyone saw: **"John Doe punches Anders Andersen!"**

_Now:_
John sees: **"You punch Anders Andersen!"**
Anders sees: **"John Doe punches you!"**
Bystanders see: **"John Doe punches Anders Andersen!"**

_This is still a WIP! To do list:_
- [x] Find all combat messages and add the var/othermob and var/othermob_message to them.
- [x] Change combat messages to use the present tense.
- [ ] Figure out how to make simple_animals have several different time tenses in the attack verbs (so there's no "John Doe punch the goat").
- [ ] Fix the /atom/proc/visible_message to work as well.
