### PR TITLE
Gang Update

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -262,7 +262,7 @@
 	intercepttext += "<B> Centcom has recently been contacted by the following syndicate affiliated organisations in your area, please investigate any information you may have:</B>"
 
 	var/list/possible_modes = list()
-	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "malf", "changeling", "cult")
+	possible_modes.Add("revolution", "wizard", "nuke", "traitor", "malf", "changeling", "cult", "gang")
 	possible_modes -= "[ticker.mode]" //remove current gamemode to prevent it from being randomly deleted, it will be readded later
 
 	var/number = pick(1, 2)

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -238,7 +238,7 @@
 		else
 			if(!silent)
 				gangster_mind.current.Paralyse(5)
-				gangster_mind.current.visible_message("[gangster_mind.current] looks like they've given up the life of crime!")
+				gangster_mind.current.visible_message("<FONT size=3><B>[gangster_mind.current] looks like they've given up the life of crime!<B></font>")
 			gangster_mind.current << "<FONT size=3 color=red><B>You have been reformed! You are no longer a gangster!</B><BR>You try as hard as you can, but you can't seem to recall any of the identities of your former gangsters...</FONT>"
 
 	update_gang_icons_removed(gangster_mind, gang)

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -239,7 +239,7 @@
 			if(!silent)
 				gangster_mind.current.Paralyse(5)
 				gangster_mind.current.visible_message("[gangster_mind.current] looks like they've given up the life of crime!")
-			gangster_mind.current << "<FONT size=3 color=red><B>You have been reformed! You are no longer a gangster!</B></FONT>"
+			gangster_mind.current << "<FONT size=3 color=red><B>You have been reformed! You are no longer a gangster!</B><BR>You try as hard as you can, but you can't seem to recall any of the identities of your former gangsters...</FONT>"
 
 	update_gang_icons_removed(gangster_mind, gang)
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -176,9 +176,11 @@
 	if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(target))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
-	if(target.mind in (ticker.mode.revolutionaries | ticker.mode.A_gang | ticker.mode.B_gang))
-		ticker.mode.remove_revolutionary(target.mind)
+	if(target.mind in (ticker.mode.A_gang | ticker.mode.B_gang))
 		ticker.mode.remove_gangster(target.mind, exclude_bosses=0)
+		return 0
+	if(target.mind in ticker.mode.revolutionaries)
+		ticker.mode.remove_revolutionary(target.mind)
 	target << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"
 	return 1
 

--- a/html/changelogs/Ikarrus-gangimplant.yml
+++ b/html/changelogs/Ikarrus-gangimplant.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Loyalty implants will no longer survive deconverting a gangster. Security now needs to use two of them if they want the permanent effects: The first to deconvert them, and the second to make them loyal."


### PR DESCRIPTION
- Added a line on deconversion instructing the player that his character does not remember the identities of his former gang.
- the Gang intercept report should show up properly now.
- Made the deconversion notice more noticable to others.
- Experiment: Loyalty implants will no longer survive deconverting a gangster. Security now needs to use two of them if they want the permanent effects: The first to deconvert them, and the second to make them loyal.
