### PR TITLE
Ventcrawling Fixes

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -25,12 +25,7 @@ Pipelines + Other Objects -> Pipe network
 	var/global/list/pipeimages = list()
 	var/datum/pipeline/parent = null
 
-
-/obj/machinery/atmospherics/Destroy()
-	for(var/mob/living/L in src)
-		L.remove_ventcrawl()
-		L.forceMove(get_turf(src))
-	..()
+	var/image/pipe_vision_img = null
 
 
 /obj/machinery/atmospherics/New()
@@ -45,6 +40,13 @@ Pipelines + Other Objects -> Pipe network
 	if (stored)
 		qdel(stored)
 	stored = null
+
+	for(var/mob/living/L in src)
+		L.remove_ventcrawl()
+		L.forceMove(get_turf(src))
+	if(pipe_vision_img)
+		qdel(pipe_vision_img)
+
 	..()
 
 //this is called just after the air controller sets up turfs
@@ -128,6 +130,7 @@ Pipelines + Other Objects -> Pipe network
 		var/turf/T = loc
 		stored.loc = T
 		transfer_fingerprints_to(stored)
+		stored = null
 
 	qdel(src)
 
@@ -200,17 +203,6 @@ Pipelines + Other Objects -> Pipe network
 		else if(target_move.can_crawl_through())
 			if(returnPipenet() != target_move.returnPipenet())
 				user.update_pipe_vision(target_move)
-
-			/*
-			var/list/myPipenets = getAllPipenets()
-			var/list/targetAllPipenets = target_move.getAllPipenets()
-			for(var/datum/pipeline/I in targetAllPipenets)
-				for(var/datum/pipeline/J in myPipenets)
-					if(I != J)
-						update_pipe_vision(target_move)
-						break
-			*/
-
 			user.loc = target_move
 			user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -23,6 +23,7 @@ Pipelines + Other Objects -> Pipe network
 	var/welded = 0 //Used on pumps and scrubbers
 	var/global/list/iconsetids = list()
 	var/global/list/pipeimages = list()
+	var/datum/pipeline/parent = null
 
 
 /obj/machinery/atmospherics/Destroy()
@@ -65,7 +66,7 @@ Pipelines + Other Objects -> Pipe network
 	return default_set
 
 /obj/machinery/atmospherics/proc/returnPipenet()
-	return
+	return parent
 
 /obj/machinery/atmospherics/proc/returnPipenetAir()
 	return
@@ -197,6 +198,19 @@ Pipelines + Other Objects -> Pipe network
 			user.forceMove(target_move.loc) //handle entering and so on.
 			user.visible_message("<span class='notice'>You hear something squeezing through the ducts...</span>","<span class='notice'>You climb out the ventilation system.")
 		else if(target_move.can_crawl_through())
+			if(returnPipenet() != target_move.returnPipenet())
+				user.update_pipe_vision(target_move)
+
+			/*
+			var/list/myPipenets = getAllPipenets()
+			var/list/targetAllPipenets = target_move.getAllPipenets()
+			for(var/datum/pipeline/I in targetAllPipenets)
+				for(var/datum/pipeline/J in myPipenets)
+					if(I != J)
+						update_pipe_vision(target_move)
+						break
+			*/
+
 			user.loc = target_move
 			user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
 			if(world.time - user.last_played_vent > VENT_SOUND_DELAY)
@@ -221,3 +235,5 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1
+
+

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -5,7 +5,6 @@
 	layer = TURF_LAYER+0.1
 	var/datum/gas_mixture/air_contents
 	var/obj/machinery/atmospherics/node
-	var/datum/pipeline/parent
 	var/showpipe = 0
 
 /obj/machinery/atmospherics/unary/New()
@@ -113,9 +112,6 @@ Housekeeping and pipe network stuff below
 
 /obj/machinery/atmospherics/unary/setPipenet(datum/pipeline/P)
 	parent = P
-
-/obj/machinery/atmospherics/unary/returnPipenet()
-	return parent
 
 /obj/machinery/atmospherics/unary/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
 	if(Old == parent)

--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -1,6 +1,5 @@
 /obj/machinery/atmospherics/pipe
 	var/datum/gas_mixture/air_temporary //used when reconstructing a pipeline that broke
-	var/datum/pipeline/parent
 	var/volume = 0
 	layer = 2.4 //under wires with their 2.44
 	use_power = 0

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -14,7 +14,7 @@
 	if(ventcrawler)
 		src << "<span class='notice'>You can ventcrawl! Use alt+click on vents to quickly travel about the station.</span>"
 	//Should update regardless of if we can ventcrawl, since we can end up in pipes in other ways.
-	update_pipe_vision()
+	update_pipe_vision(loc)
 
 	update_interface()
 	return .

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -62,10 +62,12 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		src << "<span class='warning'>This ventilation duct is not connected to anything!</span>"
 
 
-/mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/unary/starting_machine)
-	if(!starting_machine)
+/mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
+	if(!istype(starting_machine) || !starting_machine.returnPipenet())
 		return
-	var/list/totalMembers = starting_machine.parent.members + starting_machine.parent.other_atmosmch
+	var/list/totalMembers = list()
+	totalMembers |= starting_machine.parent.members
+	totalMembers |= starting_machine.parent.other_atmosmch
 	for(var/atom/A in totalMembers)
 		var/image/new_image = image(A, A.loc, dir = A.dir)
 		pipes_shown += new_image
@@ -84,13 +86,13 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 
 //OOP
-/atom/proc/update_pipe_vision()
+/atom/proc/update_pipe_vision(var/atom/new_loc = null)
 	return
 
-/mob/living/update_pipe_vision()
-	if(pipes_shown.len)
-		if(!istype(loc, /obj/machinery/atmospherics))
-			remove_ventcrawl()
-	else
-		if(istype(loc, /obj/machinery/atmospherics))
-			add_ventcrawl(loc)
+/mob/living/update_pipe_vision(var/atom/new_loc = null)
+	. = loc
+	if(new_loc)
+		. = new_loc
+	remove_ventcrawl()
+	add_ventcrawl(.)
+

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -68,11 +68,14 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	var/list/totalMembers = list()
 	totalMembers |= starting_machine.parent.members
 	totalMembers |= starting_machine.parent.other_atmosmch
-	for(var/atom/A in totalMembers)
-		var/image/new_image = image(A, A.loc, dir = A.dir)
-		pipes_shown += new_image
+
+	for(var/obj/machinery/atmospherics/A in totalMembers)
+		if(!A.pipe_vision_img)
+			A.pipe_vision_img = image(A, A.loc, layer = 20, dir = A.dir)
+			//20 for being above darkness
+		pipes_shown |= A.pipe_vision_img
 		if(client)
-			client.images += new_image
+			client.images |= A.pipe_vision_img
 
 
 /mob/living/proc/remove_ventcrawl()


### PR DESCRIPTION
tg version of https://github.com/d3athrow/vgstation13/pull/4251
- Fixes moving between pipeline datums not updating pipe vision
- Fixes login() not correctly updating pipe vision.
- Moves `var/datum/pipeline/parent` from pipes and unary, to atmospherics base class (Before you shout at me Aran, it will always be null on the machines that don't use 1 parent (Binaries/Trinaries) changing _nothing_ mechanically, atmos wise)
- Makes pipe vision visible in darkness
- Makes pipes/atmos machines hold their images AND delete the image if it is destroyed, the makes destroyed pipes disappear from the view correctly
- fixes #9311 
