### PR TITLE
Fixes an instance where bleb wouldn't mulligan properly

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -5,6 +5,7 @@
 		return 1
 	if(!blob_cores.len) // blob is dead
 		if(config.continuous["blob"])
+			continuous_sanity_checked = 1 //Nonstandard definition of "alive" gets past the check otherwise
 			SSshuttle.emergencyNoEscape = 0
 			if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
 				SSshuttle.emergency.mode = SHUTTLE_DOCKED


### PR DESCRIPTION
A sanity check was being mistakenly failed because blobs have a different sort of standard for being "alive" or "dead" than other antags. This will fix a problem where blob rounds weren't properly mulliganing.

Always has to be at least one mulligan fix pull live, it's the law guys.
