### PR TITLE
Explosion Performance Upgrades

### DIFF
--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -45,11 +45,11 @@
 
 	stat(name, "[round(cost,0.001)]ds\t[dwait][msg]")
 
-//could be used to postpone a costly subsystem for one cycle
+//could be used to postpone a costly subsystem for (default one) var/cycles, cycles
 //for instance, during cpu intensive operations like explosions
-/datum/subsystem/proc/postpone()
+/datum/subsystem/proc/postpone(var/cycles = 1)
 	if(next_fire - world.time < wait)
-		next_fire += wait
+		next_fire += (wait*cycles)
 
 //usually called via datum/subsystem/New() when replacing a subsystem (i.e. due to a recurring crash)
 //should attempt to salvage what it can from the old instance of subsystem

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -74,7 +74,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
 		//postpone processing for a bit
-		var/postponeCycles = max(devastation_range/8,1)
+		var/postponeCycles = max(round(devastation_range/8),1)
 		SSlighting.postpone(postponeCycles)
 		SSpower.postpone(postponeCycles)
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -73,8 +73,10 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 							far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
 							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
-		//postpone light processing for a bit
-		SSlighting.postpone()
+		//postpone processing for a bit
+		var/postponeCycles = max(devastation_range/8,1)
+		SSlighting.postpone(postponeCycles)
+		SSpower.postpone(postponeCycles)
 
 		if(heavy_impact_range > 1)
 			var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
@@ -112,10 +114,11 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			var/throw_dir = get_dir(epicenter,T)
 			for(var/obj/item/I in T)
 				spawn(0) //Simultaneously not one at a time
-					var/throw_range = rand(throw_dist, max_range)
-					var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-					I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
-					I.throw_at(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
+					if(I)
+						var/throw_range = rand(throw_dist, max_range)
+						var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
+						I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
+						I.throw_at(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
 
 
 		var/took = (world.timeofday-start)/10

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -17,6 +17,14 @@
 	SSpower.powernets += src
 
 /datum/powernet/Destroy()
+	//Go away references, you suck!
+	for(var/obj/structure/cable/C in cables)
+		cables -= C
+		C.powernet = null
+	for(var/obj/machinery/power/M in nodes)
+		nodes -= M
+		M.powernet = null
+
 	SSpower.powernets -= src
 
 /datum/powernet/proc/is_empty()


### PR DESCRIPTION
Before:
## DEBUG: Explosion(113,135,1)(d3,h7,l14): Took 3.2 seconds.

After:
## DEBUG: Explosion(113,135,1)(d3,h7,l14): Took 1 seconds.

(Tested on box, at the bridge, where the AI holopad is, both bombs)

Thanks to @clusterfack for discussing the topic of datum references being inefficient.
- subsystem `postpone()` now takes an optional `cycles` argument, to allow for postponing for more than one cycle
- powernet datums now manually throw away references, because byond sucks.
- adds a sanity check to item throwing, because objects were apparently deleting between `spawn(0)`
