### PR TITLE
Loyalty Implants and Gangsters

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -176,9 +176,11 @@
 	if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(target))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
-	if(target.mind in (ticker.mode.revolutionaries | ticker.mode.A_gang | ticker.mode.B_gang))
-		ticker.mode.remove_revolutionary(target.mind)
+	if(target.mind in (ticker.mode.A_gang | ticker.mode.B_gang))
 		ticker.mode.remove_gangster(target.mind, exclude_bosses=0)
+		return 0
+	if(target.mind in ticker.mode.revolutionaries)
+		ticker.mode.remove_revolutionary(target.mind)
 	target << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"
 	return 1
 

--- a/html/changelogs/Ikarrus-gangimplant.yml
+++ b/html/changelogs/Ikarrus-gangimplant.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Loyalty implants will no longer survive deconverting a gangster. Security now needs to use two of them if they want the permanent effects: The first to deconvert them, and the second to make them loyal."


### PR DESCRIPTION
- Experiment: Loyalty implants will no longer survive deconverting a gangster. Security now needs to use two of them if they want the permanent effects: The first to deconvert them, and the second to make them loyal.
