### PR TITLE
Fixes about half a dozen runtimes related to monkey mode

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -93,8 +93,8 @@
 
 /datum/disease/transformation/jungle_fever/do_disease_transformation(var/mob/living/carbon/affected_mob)
 	if(!ismonkey(affected_mob))
-		affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
 		ticker.mode.add_monkey(affected_mob.mind)
+		affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
 
 /datum/disease/transformation/jungle_fever/stage_act()
 	..()

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -132,12 +132,12 @@
 	return spans
 
 /proc/hardset_dna(mob/living/carbon/owner, ui, se, real_name, blood_type, datum/species/mrace, mcolor)
-	if(!istype(owner, /mob/living/carbon/monkey) && !istype(owner, /mob/living/carbon/human))
+	if(!ismonkey(owner) && !ishuman(owner))
 		return
 	if(!owner.dna)
 		create_dna(owner, mrace)
 
-	if(mrace)
+	if(mrace && !ismonkey(owner))
 		if(owner.dna.species.exotic_blood)
 			var/datum/reagent/exotic_blood = owner.dna.species.exotic_blood
 			owner.reagents.del_reagent(exotic_blood.id)

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -69,15 +69,35 @@
 		carriermind.current.viruses += D
 	..()
 
+/datum/game_mode/monkey/check_finished()
+	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || station_was_nuked)
+		return 1
+
+	if(!round_converted)
+		for(var/datum/mind/monkey_mind in ape_infectees)
+			if(monkey_mind.current && monkey_mind.current.stat != DEAD)
+				return 0
+
+		var/datum/disease/D = new /datum/disease/transformation/jungle_fever() //ugly but unfortunately needed
+		for(var/mob/living/carbon/human/H in living_mob_list)
+			if(H.mind && H.stat != DEAD)
+				if(H.HasDisease(D))
+					return 0
+
+	..()
+
 /datum/game_mode/monkey/proc/check_monkey_victory()
+	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
+		return 0
+	var/datum/disease/D = new /datum/disease/transformation/jungle_fever()
 	for(var/mob/living/carbon/monkey/M in living_mob_list)
-		if (M.HasDisease(/datum/disease/transformation/jungle_fever))
+		if (M.HasDisease(D))
 			if(M.onCentcom())
 				escaped_monkeys++
 	if(escaped_monkeys >= monkeys_to_win)
-		return 0
-	else
 		return 1
+	else
+		return 0
 
 /datum/game_mode/proc/add_monkey(datum/mind/monkey_mind)
 	ape_infectees |= monkey_mind
@@ -89,7 +109,7 @@
 
 
 /datum/game_mode/monkey/declare_completion()
-	if(!check_monkey_victory())
+	if(check_monkey_victory())
 		feedback_set_details("round_end_result","win - monkey win")
 		feedback_set("round_end_result",escaped_monkeys)
 		world << "<span class='userdanger'>The monkeys have overthrown their captors! Eeek eeeek!!</span>"


### PR DESCRIPTION
Fixes monkeys not getting a special role when made with jungle fever because of a runtime. Fixes #4223

Fixes check_monkey_victory runtiming and always defaulting to "the monkeys won!"

Adds a check for monkey modes that end on station because all the monkeys died and continuous is off (it is by default off)

Fixes a runtime relating to trying to change a monkey's mutantrace (don't do this)

Adds a check to not end the round if all the monkeys died but there are still people waiting to become monkeys because they got bit.

Maybe some other tiny monkey fixes I'm not even sure at this point I wasted a sunday night fixing monkey mode problems

By virtue of fixing antag status reporting for infected monkeys noncontinuous monkey rounds will now work (as would mulligans if the config was changed to allow them)
