### PR TITLE
Fixes #693, non-humans pushing restrained mobs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -77,7 +77,7 @@ Sorry Giacom. Please don't be mad :(
 		return 1
 
 	//BubbleWrap: Should stop you pushing a restrained person out of the way
-	if(istype(M, /mob/living/carbon/human))
+	if(istype(M, /mob/living))
 		for(var/mob/MM in range(M, 1))
 			if( ((MM.pulling == M && ( M.restrained() && !( MM.restrained() ) && MM.stat == CONSCIOUS)) || locate(/obj/item/weapon/grab, M.grabbed_by.len)) )
 				if ( !(world.time % 5) )

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -141,13 +141,6 @@
 						spawn(45)
 							Atkcool = 0
 
-/mob/living/simple_animal/slime/MobBump(mob/M)
-	if(istype(M, /mob/living/carbon/human)) //pushing humans
-		if(is_adult && prob(10)) //only if we're adult, and 10% of the time
-			return 0
-		else
-			return 1
-
 /mob/living/simple_animal/slime/Process_Spacemove(var/movement_dir = 0)
 	return 2
 


### PR DESCRIPTION
Fixes #693

This also removes adult slimes pushing humans because messes with the fix, retaining it would need some ugly typecasts, and frankly seems to be more of an annoyance than useful; sentient slimes can just pass humans by moving onto them.
