### PR TITLE
Severs cryo's connection to the spirit world

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -104,6 +104,9 @@
 		open_machine()
 		add_fingerprint(usr)
 	else
+		if(!istype(usr, /mob/living))
+			usr << "<span class='warning'>You can't do that!</span>"
+			return
 		open_machine()
 
 /obj/machinery/atmospherics/unary/cryo_cell/examine(mob/user)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -104,7 +104,7 @@
 		open_machine()
 		add_fingerprint(usr)
 	else
-		if(!istype(usr, /mob/living))
+		if(!istype(usr, /mob/living) || usr.stat)
 			usr << "<span class='warning'>You can't do that!</span>"
 			return
 		open_machine()

--- a/html/changelogs/thunder12345-PR-9331.yml
+++ b/html/changelogs/thunder12345-PR-9331.yml
@@ -1,0 +1,6 @@
+author: Thunder12345
+
+delete-after: True
+
+changes: 
+  - bugfix: "Severed the cryo tube's connection to the spirit world. Ghosts will no longer be able to eject people from cryo. Please report further instances of poltergeist activity to your local exorcist."


### PR DESCRIPTION
Ghosts can no longer use the eject cryo tube verb to force people out of cryo.
Fixes #9267
