### PR TITLE
Fixes #9222 Dead monkies still scream when patches applied 

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -195,11 +195,12 @@ datum/reagent/medicine/styptic_powder/reaction_mob(var/mob/living/M as mob, var/
 			M.adjustBruteLoss(-volume)
 			if(show_message)
 				M << "<span class='notice'>You feel your wounds knitting back together!</span>"
-			M.emote("scream")
+			if(M.stat)
+				M.emote("scream")
 		if(method == INGEST)
 			M.adjustToxLoss(0.5*volume)
 			if(show_message)
-				M << "<span class='notice'>You probably shouldn't have eaten that. Maybe you should of splashed it on, or applied a patch?</span>"
+				M << "<span class='notice'>You feel kind of ill. Maybe you ate a medicine you shouldn't have?</span>"
 	..()
 	return
 


### PR DESCRIPTION
I'm not sure what the "fix" goofball used to stop this working on human corpses was but I'm fairly sure not trying to make people who are asleep/unconscious/dead scream is a better solution.

See: #9222 Dead monkies still scream when patches applied 
Fixes #9222 

Oh also it changes the text of the message you get when you eat styptic powder
