### PR TITLE
Adds a missing victory condition for noncontinuous nuke ops

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -202,6 +202,15 @@
 			return 0
 	return 1
 
+/datum/game_mode/nuclear/check_finished() //to be called by ticker
+	if(replacementmode && round_converted == 2)
+		return replacementmode.check_finished()
+	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || station_was_nuked)
+		return 1
+	if(are_operatives_dead())
+		if(bomb_set) //snaaaaaaaaaake! It's not over yet!
+			return 0
+	..()
 
 /datum/game_mode/nuclear/declare_completion()
 	var/disk_rescued = 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -238,7 +238,7 @@
 		world << "<FONT size = 3><B>[syndicate_name()] operatives have earned Darwin Award!</B></FONT>"
 		world << "<B>[syndicate_name()] operatives blew up something that wasn't [station_name()] and got caught in the explosion.</B> Next time, don't lose the disk!"
 
-	else if ( disk_rescued && are_operatives_dead())
+	else if ((disk_rescued || SSshuttle.emergency.mode < SHUTTLE_ENDGAME) && are_operatives_dead())
 		feedback_set_details("round_end_result","loss - evacuation - disk secured - syndi team dead")
 		world << "<FONT size = 3><B>Crew Major Victory!</B></FONT>"
 		world << "<B>The Research Staff has saved the disc and killed the [syndicate_name()] Operatives</B>"


### PR DESCRIPTION
where the round ends because all the ops died but was still counting it as a syndicate victory because the disk was still on the station.

---

Adds an edge case situation so if the nuke ops all die but the nuke is live the round doesn't end in noncontinuous
