### PR TITLE
requires power = 0 now actually provides real power.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -34,9 +34,9 @@
 	if(requires_power)
 		luminosity = 0
 	else
-		power_light = 0			//rastaf0
-		power_equip = 0			//rastaf0
-		power_environ = 0		//rastaf0
+		power_light = 1			//rastaf0
+		power_equip = 1			//rastaf0
+		power_environ = 1		//rastaf0
 		luminosity = 1
 		lighting_use_dynamic = 0
 


### PR DESCRIPTION
This basically means that if an area has requires power = 0, then you will be able to use things like rechargers there. Since /area also defaults to requires power = 1, this does not cause issues with things having power that shouldnt have it, as far as I tested.

Fixes #9260 
