### PR TITLE
Allows you to build on shuttle turf.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -26,7 +26,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \
 	null, \
 	new/datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 25, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1, not_on_shuttle = 1), \
 	new/datum/stack_recipe("airlock assembly", /obj/structure/door_assembly, 4, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = 1, on_floor = 1), \

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -166,6 +166,11 @@
 		usr << "<span class='warning'>There is another [R.title] here!</span>"
 		return 0
 	if (R.on_floor && !istype(usr.loc, /turf/simulated/floor))
+		if(istype(usr.loc, /turf/simulated/shuttle))
+			if(istype(usr.loc, /turf/simulated/shuttle/wall))
+				usr << "<span class='warning'>\The [R.title] must be constructed on the floor!</span>"
+				return 0
+			return 1
 		usr << "<span class='warning'>\The [R.title] must be constructed on the floor!</span>"
 		return 0
 	return 1

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -165,6 +165,9 @@
 	if (R.one_per_turf && (locate(R.result_type) in usr.loc))
 		usr << "<span class='warning'>There is another [R.title] here!</span>"
 		return 0
+	if (R.not_on_shuttle && istype(usr.loc, /turf/simulated/shuttle))
+		usr << "<span class='warning'>\The [R.title] cannot be constructed on a shuttle!</span>"
+		return 0
 	if (R.on_floor && !istype(usr.loc, /turf/simulated/floor))
 		if(istype(usr.loc, /turf/simulated/shuttle))
 			if(istype(usr.loc, /turf/simulated/shuttle/wall))
@@ -284,7 +287,8 @@
 	var/time = 0
 	var/one_per_turf = 0
 	var/on_floor = 0
-	New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0)
+	var/not_on_shuttle = 0
+	New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0, not_on_shuttle = 0)
 		src.title = title
 		src.result_type = result_type
 		src.req_amount = req_amount
@@ -293,3 +297,4 @@
 		src.time = time
 		src.one_per_turf = one_per_turf
 		src.on_floor = on_floor
+		src.not_on_shuttle = not_on_shuttle


### PR DESCRIPTION
This allows you to build things on the shuttle without actually making the shuttle turfs real floors and walls, which would kinda be messy and might cause a lot of problems.

Though this will be great for building chairs on the escape shuttle(cloner anyone?), making the white ship look better and function better with machines and computers, I am just slightly worried that the more asshole of players will use this to spam the escape or arrivals shuttle with machine assemblies/computer consoles, thus blocking everyone.

Also, the thing is, as @Aranclanos said in #1711, this definitely appears to be a bug. Considering building stuff with stacks is limited to being on_floor, which is /turf/simulated/floors. Due to whoever originally made shuttle turfs, they are not actualy /floors or /walls, but instead shuttle/floors and shuttle/walls. I believe the restriction was more to stop building in space or on walls than to stop building on shuttles.

Fixes #1711 

PS: If this does get merged, then #7690 Might become irrelevant.

Edit: Now added an option to prevent certain things from being build on shuttles. For now this is only the girders, since they are the only problem I am mostly seeing.(And by that I mean a seperate problem from one or two assholes spamming shuttles with stuff)
