### PR TITLE
Removes the ability to clean Overlays

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -26,7 +26,7 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 		if(istype(F))
 			F.dirt = 0
 		for(var/obj/effect/O in A)
-			if(istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+			if(istype(O,/obj/effect/decal/cleanable))
 				qdel(O)
 	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
@@ -40,7 +40,7 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 		return
 
 	var/turf/simulated/turf = A
-	if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+	if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
 		turf = A.loc
 	A = null
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -1,3 +1,5 @@
+#define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune))
+
 /obj/item/weapon/mop
 	desc = "The world of janitalia wouldn't be complete without a mop."
 	name = "mop"
@@ -26,7 +28,7 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 		if(istype(F))
 			F.dirt = 0
 		for(var/obj/effect/O in A)
-			if(istype(O,/obj/effect/decal/cleanable))
+			if(is_cleanable(O))
 				qdel(O)
 	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
@@ -40,7 +42,7 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 		return
 
 	var/turf/simulated/turf = A
-	if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
+	if(is_cleanable(A))
 		turf = A.loc
 	A = null
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -185,7 +185,7 @@
 				F.dirt = 0
 			for(var/A in tile)
 				if(istype(A, /obj/effect))
-					if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
+					if(is_cleanable(A))
 						qdel(A)
 
 /obj/structure/stool/bed/chair/janicart/examine(mob/user)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -185,7 +185,7 @@
 				F.dirt = 0
 			for(var/A in tile)
 				if(istype(A, /obj/effect))
-					if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+					if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
 						qdel(A)
 
 /obj/structure/stool/bed/chair/janicart/examine(mob/user)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -307,7 +307,7 @@
 		var/turf/tile = loc
 		loc.clean_blood()
 		for(var/obj/effect/E in tile)
-			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable))
+			if(is_cleanable(E))
 				qdel(E)
 
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -307,7 +307,7 @@
 		var/turf/tile = loc
 		loc.clean_blood()
 		for(var/obj/effect/E in tile)
-			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable) || istype(E,/obj/effect/overlay))
+			if(istype(E,/obj/effect/rune) || istype(E,/obj/effect/decal/cleanable))
 				qdel(E)
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -862,7 +862,7 @@
 					F.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
+						if(is_cleanable(A))
 							qdel(A)
 					else if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -862,7 +862,7 @@
 					F.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
+						if(istype(A, /obj/effect/rune) || istype(A, /obj/effect/decal/cleanable))
 							qdel(A)
 					else if(istype(A, /obj/item))
 						var/obj/item/cleaned_item = A


### PR DESCRIPTION
This removes the ability to clean overlays, thus deleting them. As far as I could see in the code, theres no overlay which actually needs to be cleanable, none at all. There aren't even many to begin with. This thus prevents mops, janicarts, janiborgs and waterclosets from being able to delete holosigns and AI holograms(Plus those coconut trees on the beach if their density was made 0, and the coconuts on the beach, both are /effects/overlays)

Fixes #9036 
Fixes #7636

Edit: This now also changes it to be a define instead. Thanks @ComicIronic 
