### PR TITLE
Players who enjoy loyalty implanted jobs now get fair antagonist rolls in all modes

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -83,11 +83,12 @@ var/datum/subsystem/job/SSjob
 		if(flag && (!player.client.prefs.be_special & flag))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
-
+		if(player.mind && job.title in player.mind.restricted_roles)
+			Debug("FOC incompatible with antagonist role, Player: [player]")
+			continue
 		if(config.enforce_human_authority && (job.title in command_positions) && player.client.prefs.pref_species.id != "human")
 			Debug("FOC non-human failed, Player: [player]")
 			continue
-
 		if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
 			Debug("FOC pass, Player: [player], Level:[level]")
 			candidates += player
@@ -111,6 +112,10 @@ var/datum/subsystem/job/SSjob
 
 		if(!job.player_old_enough(player.client))
 			Debug("GRJ player not old enough, Player: [player]")
+			continue
+
+		if(player.mind && job.title in player.mind.restricted_roles)
+			Debug("GRJ incompatible with antagonist role, Player: [player], Job: [job.title]")
 			continue
 
 		if(config.enforce_human_authority && (job.title in command_positions) && player.client.prefs.pref_species.id != "human")
@@ -280,6 +285,10 @@ var/datum/subsystem/job/SSjob
 
 				if(!job.player_old_enough(player.client))
 					Debug("DO player not old enough, Player: [player], Job:[job.title]")
+					continue
+
+				if(player.mind && job.title in player.mind.restricted_roles)
+					Debug("DO incompatible with antagonist role, Player: [player], Job:[job.title]")
 					continue
 
 				if(config.enforce_human_authority && (job.title in command_positions) && player.client.prefs.pref_species.id != "human")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -154,11 +154,8 @@ var/datum/subsystem/ticker/ticker
 
 	//Configure mode and assign player to special mode stuff
 	var/can_continue = 0
-	if(mode.pre_setup_before_jobs)
-		can_continue = src.mode.pre_setup()
+	can_continue = src.mode.pre_setup()		//Choose antagonists
 	SSjob.DivideOccupations() 				//Distribute jobs
-	if(!mode.pre_setup_before_jobs)
-		can_continue = src.mode.pre_setup()
 
 	if(!Debug2)
 		if(!can_continue)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -39,6 +39,7 @@
 
 	var/assigned_role
 	var/special_role
+	var/list/restricted_roles = list()
 
 	var/datum/job/assigned_job
 

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -5,7 +5,6 @@
 	name = "Abduction"
 	config_tag = "abduction"
 	antag_flag = BE_ABDUCTOR
-	pre_setup_before_jobs = 1
 	recommended_enemies = 2
 	required_players = 15
 	var/max_teams = 4

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -34,17 +34,13 @@ var/list/blob_nodes = list()
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	for(var/j = 0, j < cores_to_spawn, j++)
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/blob = pick(antag_candidates)
 		infected_crew += blob
 		blob.special_role = "Blob"
+		blob.restricted_roles = restricted_jobs
 		log_game("[blob.key] (ckey) has been selected as a Blob")
 		antag_candidates -= blob
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -54,17 +54,13 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount))
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	if(antag_candidates.len>0)
 		for(var/i = 0, i < num_changelings, i++)
 			if(!antag_candidates.len) break
 			var/datum/mind/changeling = pick(antag_candidates)
 			antag_candidates -= changeling
 			changelings += changeling
+			changeling.restricted_roles = restricted_jobs
 			modePlayer += changelings
 		return 1
 	else

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -86,10 +86,6 @@
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
 
 	for(var/cultists_number = 1 to recommended_enemies)
 		if(!antag_candidates.len)
@@ -98,6 +94,7 @@
 		antag_candidates -= cultist
 		cult += cultist
 		cultist.special_role = "Cultist"
+		cultist.restricted_roles = restricted_jobs
 		log_game("[cultist.key] (ckey) has been selected as a cultist")
 
 	return (cult.len>=required_enemies)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -27,7 +27,6 @@
 	var/required_players = 0
 	var/required_enemies = 0
 	var/recommended_enemies = 0
-	var/pre_setup_before_jobs = 0
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag
 	var/datum/mind/sacrifice_target = null
 	var/mob/living/living_antag_player = null

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -46,11 +46,6 @@
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	if(antag_candidates.len >= 2)
 		assign_bosses()
 
@@ -83,12 +78,14 @@
 	A_bosses += boss
 	antag_candidates -= boss
 	boss.special_role = "[gang_name("A")] Gang (A) Boss"
+	boss.restricted_roles = restricted_jobs
 	log_game("[boss.key] has been selected as the boss for the [gang_name("A")] Gang (A)")
 
 	boss = pick(antag_candidates)
 	B_bosses += boss
 	antag_candidates -= boss
 	boss.special_role = "[gang_name("B")] Gang (B) Boss"
+	boss.restricted_roles = restricted_jobs
 	log_game("[boss.key] has been selected as the boss for the [gang_name("B")] Gang (B)")
 
 /datum/game_mode/proc/forge_gang_objectives(var/datum/mind/boss_mind)

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -8,7 +8,6 @@
 	required_players = 25
 	required_enemies = 1
 	recommended_enemies = 1
-	pre_setup_before_jobs = 1
 	enemy_minimum_age = 30 //Same as AI minimum age
 	round_ends_with_antag_death = 1
 

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -24,17 +24,13 @@
 /datum/game_mode/monkey/pre_setup()
 	carriers_to_make = max(round(num_players()/players_per_carrier, 1), 1)
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	for(var/j = 0, j < carriers_to_make, j++)
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/carrier = pick(antag_candidates)
 		carriers += carrier
 		carrier.special_role = "monkey"
+		carrier.restricted_roles = restricted_jobs
 		log_game("[carrier.key] (ckey) has been selected as a Jungle Fever carrier")
 		antag_candidates -= carrier
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -8,7 +8,6 @@
 	required_players = 20 // 20 players - 5 players to be the nuke ops = 15 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
-	pre_setup_before_jobs = 1
 	antag_flag = BE_OPERATIVE
 	enemy_minimum_age = 14
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -50,17 +50,13 @@
 			head_check = 1
 			break
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	for (var/i=1 to max_headrevs)
 		if (antag_candidates.len==0)
 			break
 		var/datum/mind/lenin = pick(antag_candidates)
 		antag_candidates -= lenin
 		head_revolutionaries += lenin
+		lenin.restricted_roles = restricted_jobs
 
 	if((head_revolutionaries.len < required_enemies)||(!head_check))
 		return 0

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -85,11 +85,6 @@ Made by Xhuis
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	var/shadowlings = 2 //How many shadowlings there are; hardcoded to 2
 
 	while(shadowlings)
@@ -98,6 +93,7 @@ Made by Xhuis
 		antag_candidates -= shadow
 		modePlayer += shadow
 		shadow.special_role = "Shadowling"
+		shadow.restricted_roles = restricted_jobs
 		shadowlings--
 	return 1
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -41,17 +41,13 @@
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
 
-	for(var/datum/mind/player in antag_candidates)
-		for(var/job in restricted_jobs)
-			if(player.assigned_role == job)
-				antag_candidates -= player
-
 	for(var/j = 0, j < num_traitors, j++)
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/traitor = pick(antag_candidates)
 		traitors += traitor
 		traitor.special_role = traitor_name
+		traitor.restricted_roles = restricted_jobs
 		log_game("[traitor.key] (ckey) has been selected as a [traitor_name]")
 		antag_candidates.Remove(traitor)
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -8,7 +8,6 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
-	pre_setup_before_jobs = 1
 	enemy_minimum_age = 14
 	round_ends_with_antag_death = 1
 	var/use_huds = 0

--- a/html/changelogs/incoming5643-pleaseplaysecurity.yml
+++ b/html/changelogs/incoming5643-pleaseplaysecurity.yml
@@ -1,0 +1,8 @@
+author: incoming5643
+
+delete-after: True
+
+changes:
+- bugfix: "All modes now select their antagonists before job selection, this means that a player who prefers roles normally immune to being certain antagonists (implanted roles/silicons) can still have a fair shot at every antagonist roll they opt into. If they're selected they simply will not end up with an incompatible job."
+- bugfix: "As an example if someone loved to play Head of Security (humor me here) and had it set to high, and the only other jobs he had set were security officer at medium and botanist at low but he was selected to be a traitor, he would spawn as a botanist even if there ended up being no Head of Security."
+- experiment: "Please give playing security another chance if you'd written it off because it affected your antag chances."


### PR DESCRIPTION
All modes now choose their antagonists before they choose jobs. A new mind attached list, restricted_roles, will keep incompatible jobs out of rotation.

Players who would otherwise qualify to play as an implanted job will spawn as the most wanted not implanted job they qualify for if they are an onstation antagonist. If they don't qualify for any job in this way depending on preferences they will either spawn as an assistant or a random job (which also makes sure they don't end up in an incompatible job).

Note this doesn't impact late join antagonists or mulligan antagonists. Roundstart only.
