### PR TITLE
That damn wizard life check again

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -173,9 +173,7 @@
 /datum/game_mode/wizard/check_finished()
 
 	for(var/datum/mind/wizard in wizards)
-		if(!wizard.current)
-			continue
-		if(wizard.current.stat != DEAD)
+		if(isliving(wizard.current) && wizard.current.stat!=DEAD)
 			return ..()
 
 	if(SSevent.wizardmode) //If summon events was active, turn it off


### PR DESCRIPTION
Fixes a bug in wizard mulligans where dead wizards wouldn't trigger mulligans. I've stolen the malf version of the check to be sure it works decently enough (also I tested it, of course I did).

On the plus side proper mulligans are finally working in other modes apparently!
