### PR TITLE
Fixes emagged windoors

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -249,7 +249,7 @@
 
 /obj/machinery/door/window/emag_act(mob/user as mob)
 	if(density && !emagged)
-		operating = -1
+		operating = 0
 		flick("[src.base_state]spark", src)
 		sleep(6)
 		desc += "<BR><span class='warning'>Its access panel is smoking slightly.</span>"


### PR DESCRIPTION
This fixes emagged windoors so they can be deconstructed. Tested and everything still works. Emagged windoors can't be used normally, and they can be deconstructed.

Fixes #8510 
