### PR TITLE
Fixes the mining borg diamond drill upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -171,7 +171,7 @@
 			qdel(D)
 		for(var/obj/item/weapon/shovel/S in R.module.modules)
 			qdel(S)
-		R.module.modules += new /obj/item/weapon/pickaxe/drill/diamonddrill(R.module)
+		R.module.modules += new /obj/item/weapon/pickaxe/drill/cyborg/diamond(R.module)
 		R.module.rebuild()
 		return 1
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -144,6 +144,11 @@
 			return 0
 	return 1
 
+/obj/item/weapon/pickaxe/drill/cyborg/diamond
+	name = "diamond-tipped cyborg mining drill"
+	icon_state = "diamonddrill"
+	digspeed = 10
+
 /obj/item/weapon/pickaxe/drill/diamonddrill
 	name = "diamond-tipped mining drill"
 	icon_state = "diamonddrill"


### PR DESCRIPTION
- Made the borg diamond drill upgrade into a child of the standard borg
  mining drill.

There must be very few players to  receive this upgrade, as I doubt it ever worked at all! I am honestly not surprised though, as I found playing as a mining cyborg to be a truly awful experience. But, enough ranting, this PR is not about that. The diamond drill upgrade for mining borgs is now operational!
