### PR TITLE
Replaces Plasmaman Gas Mask w/ Breath Mask

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -999,7 +999,7 @@ var/global/list/g_fancy_list_of_types = null
 			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/plasmaman(M), slot_head)
 			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/eva/plasmaman(M),slot_wear_suit)
 			M.equip_to_slot_or_del(new /obj/item/weapon/tank/internals/plasmaman/full(M),slot_back)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(M),slot_wear_mask)
+			M.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(M),slot_wear_mask)
 
 
 	M.regenerate_icons()


### PR DESCRIPTION
Currently the equipment set spawns with gas masks, which makes them unknown - The Plasmaman helmet does not hide your face, and this is intended. Gas masks are an oversight and you are supposed to be able to see their faces.

Really minor fix that makes things slightly more convenient.
