### PR TITLE
Fixes reusable syndicate bombs

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -188,6 +188,8 @@
 		message_admins(adminlog)
 		log_game(adminlog)
 	explosion(get_turf(src),2,5,11, flame_range = 11)
+	if(src.loc && istype(src.loc,/obj/machinery/syndicatebomb/))
+		qdel(src.loc)
 	qdel(src)
 
 /obj/item/weapon/bombcore/proc/defuse()


### PR DESCRIPTION
Normally when something gets ex_acted 3 you expect that it'll probably delete itself no problem, but I guess every "sure thing" still has its exceptions.

Fixes #9384 
