### PR TITLE
Gang-Wide Messages

### DIFF
--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -40,12 +40,17 @@
 		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B><br>"
 		dat += "Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
-		dat += "<a href='?src=\ref[src];choice=ping'>Rally Your Gang</a><br>"
 		dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 		dat += "<br>"
 		dat += "Influence: <B>[points]</B><br>"
 		dat += "Time until Influence grows: <B>[(points >= 100) ? ("--:--") : (time2text(ticker.mode.gang_points.next_point_time - world.time, "mm:ss"))]</B><br>"
 		dat += "<B>Purchase Items:</B><br>"
+
+		dat += "(5 Influence) "
+		if(points >= 5)
+			dat += "<a href='?src=\ref[src];choice=ping'>Send Gang-wide Message</a><br>"
+		else
+			dat += "Send Gang-wide Message<br>"
 
 		dat += "(10 Influence) "
 		if(points >= 10)
@@ -159,19 +164,26 @@
 /obj/item/device/gangtool/proc/ping_gang(var/mob/user)
 	if(!user)
 		return
-	var/area/location = get_area(user)
-	if(location && location.z != 1)
-		user << "<span class='info'>\icon[src]Error: Signal out of range of station.</span>"
+	var/message = input("Discreetly send a gang-wide message.","Send Message") as null|text
+	if(!message || (message == "") || !can_use(user))
+		return
+	if(user.z > 2)
+		user << "<span class='info'>\icon[src]Error: Station out of range.</span>"
 		return
 	var/list/members = list()
 	if(gang == "A")
-		members += ticker.mode.A_bosses | ticker.mode.A_gang
+		if(ticker.mode.gang_points.A >= 5)
+			members += ticker.mode.A_bosses | ticker.mode.A_gang
+			ticker.mode.gang_points.A -= 5
 	else if(gang == "B")
-		members += ticker.mode.B_bosses | ticker.mode.B_gang
+		if(ticker.mode.gang_points.B >= 5)
+			members += ticker.mode.B_bosses | ticker.mode.B_gang
+			ticker.mode.gang_points.B -= 5
 	if(members.len)
 		for(var/datum/mind/ganger in members)
-			ganger.current << "<span class='danger'>A powerful thought invades your mind... The gang is rallying at <b>[location]</b>!</span>"
-		log_game("[key_name(user)] summoned the [gang_name(gang)] Gang ([gang]) to [location].")
+			if(ganger.current.z <= 2)
+				ganger.current << "<span class='danger'><b>BOSS:</b> [message]</span>"
+		log_game("[key_name(user)] sent a global message to the [gang_name(gang)] Gang ([gang]): [message].")
 
 
 /obj/item/device/gangtool/proc/register_device(var/mob/user)

--- a/code/game/objects/items/devices/recaller.dm
+++ b/code/game/objects/items/devices/recaller.dm
@@ -164,7 +164,7 @@
 /obj/item/device/gangtool/proc/ping_gang(var/mob/user)
 	if(!user)
 		return
-	var/message = input("Discreetly send a gang-wide message.","Send Message") as null|text
+	var/message = stripped_input(user,"Discreetly send a gang-wide message.","Send Message") as null|text
 	if(!message || (message == "") || !can_use(user))
 		return
 	if(user.z > 2)
@@ -183,6 +183,7 @@
 		for(var/datum/mind/ganger in members)
 			if(ganger.current.z <= 2)
 				ganger.current << "<span class='danger'><b>BOSS:</b> [message]</span>"
+		message_admins("[key_name_admin(user)] sent a global message to the [gang_name(gang)] Gang ([gang]): [message].")
 		log_game("[key_name(user)] sent a global message to the [gang_name(gang)] Gang ([gang]): [message].")
 
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -112,9 +112,7 @@
 		return
 	cooldown = 1
 	icon_state = "pen_blink"
-	//The more gang members there are the longer the cooldown will be
-	var/time = 450 + (150 * modifier) //45 seconds + 15 seconds for every member in the gang
-	spawn(time)
+	spawn(600)
 		cooldown = 0
 		icon_state = "pen"
 		var/mob/M = get(src, /mob)

--- a/html/changelogs/Ikarrus-gangmessage.yml
+++ b/html/changelogs/Ikarrus-gangmessage.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Gang Bosses will now be able to discreetly send messages to everyone in their gang for 5 influence a message."

--- a/html/changelogs/Ikarrus-gangmessage.yml
+++ b/html/changelogs/Ikarrus-gangmessage.yml
@@ -34,3 +34,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Gang Bosses will now be able to discreetly send messages to everyone in their gang for 5 influence a message."
+  - tweak: "Conversion pens now use a flat 60sec cooldown rate."


### PR DESCRIPTION
For the measly cost of 5 influence, bosses can send a discreet gang-wide message. Replaces the Rally button.

Also pen cooldowns now use a flat 60 second timer.
