### PR TITLE
Makes it so not only humans are counted when summoning narsie.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -142,7 +142,7 @@ var/list/sacrificed = list()
 
 
 /obj/effect/rune/proc/tearreality()
-	var/list/mob/living/carbon/human/cultist_count = list()
+	var/list/mob/living/cultist_count = list()
 	var/mob/living/user = usr
 	user.say("Tok-lyr rqa'nap g[pick("'","`")]lt-ulotf!")
 	for(var/mob/M in range(1,src))


### PR DESCRIPTION
This makes it so not only humans are counted when using the SUMMON NAR NAR rune, but instead any living mob(provided they are cultists naturally). Thus it should now count cult monkeys and cult constructs.(Plus any other cultist if admins can somehow do that.)

Fixes #7050
