### PR TITLE
Prevents golems and skeletons from dropping due to shards and mousetraps

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -69,6 +69,7 @@
 #define NOBLOOD		1024
 #define NOFIRE		2048
 #define VIRUSIMMUNE	4096
+#define HARDFEET	8192
 
 /*
 	These defines are used specifically with the atom/movable/languages bitmask.

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -332,6 +332,8 @@
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
+			if(HARDFEET in H.dna.species.specflags)
+				return 0
 			if(!H.shoes)
 				H.apply_damage(5,BRUTE,(pick("l_leg", "r_leg")))
 				H.Weaken(3)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -80,6 +80,8 @@
 
 /obj/item/weapon/dice/d4/Crossed(var/mob/living/carbon/human/H)
 	if(istype(H) && !H.shoes)
+		if(HARDFEET in H.dna.species.specflags)
+			return 0
 		H << "<span class='userdanger'>You step on the D4!</span>"
 		H.apply_damage(4,BRUTE,(pick("l_leg", "r_leg")))
 		H.Weaken(3)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -42,6 +42,12 @@
 	var/obj/item/organ/limb/affecting = null
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
+		if(HARDFEET in H.dna.species.specflags)
+			playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+			armed = 0
+			update_icon()
+			pulse(0)
+			return 0
 		switch(type)
 			if("feet")
 				if(!H.shoes)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -232,7 +232,7 @@
 	// Animated beings of stone. They have increased defenses, and do not need to breathe. They're also slow as fuuuck.
 	name = "Golem"
 	id = "golem"
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,HARDFEET)
 	speedmod = 3
 	armor = 55
 	punchmod = 5
@@ -281,7 +281,7 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE,VIRUSIMMUNE)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,HARDFEET)
 /*
  ZOMBIES
 */


### PR DESCRIPTION
This adds a new species flag called HARDFEET. Any species assigned with this flag now doesn't drop due to mousetraps and glass shards. I added this flag to both Skeletons and Golems.

Edit: Added the HARDFEET check to D4 aswell.

Fixes #6477
