### PR TITLE
Fixes a blob edge case

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -141,6 +141,7 @@ var/list/blob_nodes = list()
 					core.overmind.mind.name = blob.name
 					infected_crew -= blob
 					infected_crew += core.overmind.mind
+					core.overmind.mind.special_role = "Blob Overmind"
 
 /datum/game_mode/blob/post_setup()
 

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -13,9 +13,7 @@
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 			return ..()
 		return 1
-	if(station_was_nuked)//Nuke went off
-		return 1
-	return 0
+	return ..()
 
 
 /datum/game_mode/blob/declare_completion()

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -106,6 +106,8 @@
 		B.blob_core = src
 		src.overmind = B
 		color = overmind.blob_reagent_datum.color
+		if(B.mind && !B.mind.special_role)
+			B.mind.special_role = "Blob Overmind"
 		spawn(0)
 			if(is_offspring)
 				B.verbs -= /mob/camera/blob/verb/split_consciousness

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -176,7 +176,7 @@
 		return 1
 	if(!round_converted && (!config.continuous[config_tag] || (config.continuous[config_tag] && config.midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
-			for(var/mob/living/Player in mob_list)
+			for(var/mob/Player in mob_list)
 				if(Player.mind)
 					if(Player.mind.special_role)
 						continuous_sanity_checked = 1
@@ -191,7 +191,7 @@
 		if(living_antag_player && living_antag_player.mind && living_antag_player.stat != DEAD && !isnewplayer(living_antag_player) &&!isbrain(living_antag_player))
 			return 0 //A resource saver: once we find someone who has to die for all antags to be dead, we can just keep checking them, cycling over everyone only when we lose our mark.
 
-		for(var/mob/living/Player in living_mob_list)
+		for(var/mob/Player in living_mob_list)
 			if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
 				if(Player.mind.special_role) //Someone's still antaging!
 					living_antag_player = Player


### PR DESCRIPTION
Where combining admin blobs and roundstart blobs lead to weirdness and mulligan malfunction.

Also simplifies blob check_finished to bring it a bit more in line with other modes so it hopefully stops being an unpredictable pile of crap :hankey: 

Genernalized generic antag checking to just /mob/ because blob overminds (mob/camera) are now supported.
