### PR TITLE
Cloning pod malfunctioning update.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -196,9 +196,14 @@
 /obj/machinery/clonepod/process()
 
 	if(!is_operational()) //Autoeject if power is lost
+		var/hasOccupant = FALSE
+		if(occupant)
+			hasOccupant = TRUE
 		malfunction() //always gib when we lose power
-		go_out()
 		src.locked = 0
+		go_out()
+		if(hasOccupant && !occupant)
+			log_admin("A cloning pod has failed due to low power, potentially gibbing somebody")
 		return
 
 	if((src.occupant) && (src.occupant.loc == src))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -252,20 +252,7 @@
 
 	default_deconstruction_crowbar(W)
 
-	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if (!src.check_access(W))
-			user << "<span class='danger'>Access Denied.</span>"
-			return
-		if ((!src.locked) || (isnull(src.occupant)))
-			return
-		if ((src.occupant.health < -20) && (src.occupant.stat != 2))
-			user << "<span class='danger'>Access Refused.</span>"
-			return
-		else
-			src.locked = 0
-			user << "System unlocked."
-	else
-		..()
+	..()
 
 /obj/machinery/clonepod/emag_act(user as mob)
 	if (isnull(src.occupant))
@@ -285,24 +272,15 @@
 	src.connected.updateUsrDialog()
 	return 1
 
-/obj/machinery/clonepod/verb/eject()
-	set name = "Eject Cloner"
-	set category = "Object"
-	set src in oview(1)
-
-	if(!usr)
-		return
-	if(usr.stat || !usr.canmove || usr.restrained())
-		return
-	src.go_out()
-	add_fingerprint(usr)
-	return
-
 /obj/machinery/clonepod/proc/go_out()
 	if (src.locked)
 		return
 
 	var/turf/src_turf = get_turf(src)
+
+	if(occupant)
+		if(round((100 * ((src.occupant.health + 100) / (src.heal_level + 100)))) < 50) //not finished!
+			malfunction()
 
 	if (src.mess) //Clean that mess!
 		src.mess = 0

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -155,7 +155,13 @@
 			if (src.diskette)
 				dat += "<a href='byond://?src=\ref[src];disk=eject'>Eject Disk</a><br>"
 
-
+			//Pod
+			if(pod1)
+				dat += "<h3>Cloning Pod:</h3>"
+				if(pod1.occupant)
+					dat += "<a href='byond://?src=\ref[src];eject_pod=1'>Eject Clone</a><br>"
+				else
+					dat += "<span class='linkOff'>Eject Clone</span><br>"
 
 		if(2)
 			dat += "<h3>Current records</h3>"
@@ -315,6 +321,25 @@
 
 	else if (href_list["refresh"])
 		src.updateUsrDialog()
+
+	else if (href_list["eject_clone"])
+		if(pod1)
+			//badmin info collection
+			var/hasOccupant = FALSE
+			if(pod1.occupant)
+				hasOccupant = TRUE
+
+			//kick them out
+			pod1.locked = 0
+			pod1.go_out()
+			temp = "Cloning pod contents: Ejected"
+
+			//badmin info dump
+			if(hasOccupant && !(pod1.occupant))
+				log_admin("[key_name(usr)] early-ejected a cloning pod, possibly GIBBING the occupant!")
+
+		else
+			temp = "<font class='bad'>No Clonepod detected.</font>"
 
 	else if (href_list["clone"])
 		var/datum/data/record/C = find_record("id", href_list["clone"], records)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -159,7 +159,7 @@
 			if(pod1)
 				dat += "<h3>Cloning Pod:</h3>"
 				if(pod1.occupant)
-					dat += "<a href='byond://?src=\ref[src];eject_pod=1'>Eject Clone</a><br>"
+					dat += "<a href='byond://?src=\ref[src];eject_clone=1'>Eject Clone</a><br>"
 				else
 					dat += "<span class='linkOff'>Eject Clone</span><br>"
 

--- a/html/changelogs/RemieRichards-PR-9405.yml
+++ b/html/changelogs/RemieRichards-PR-9405.yml
@@ -1,0 +1,7 @@
+author: RemieRichards
+delete-after: True
+
+changes: 
+  - tweak: "Cloning pod malfunctions now drop the clone's brain"
+  - add: "Cloning pods now malfunction when they lose power, gibbing any clones inside"
+  - add: "Eject button added to the console instead of a shitty verb, gibs if the clone is not 50% or more complete"


### PR DESCRIPTION
- Ejecting a clone before it is 50% completed gibs it
- A cloning pod that loses power gibs it's clone occupant
- Cloning pod malfunction now leaves a brain and dumps the clone's organs
- Eject object verb removed, Eject function moved to computer console
- ID no longer needed to unlock cloning pod, the Eject button on the console automatically does it (hence the next point below)
- Admins are alerted of early ejections that gib somebody
- Admins are alerted of power loss ejections that gib somebody
