### PR TITLE
Fixes stamina damage

### DIFF
--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -62,3 +62,6 @@
 	handle_hud_icons_health()
 
 	return 1
+
+/mob/living/carbon/alien/CheckStamina()
+	return

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -274,12 +274,23 @@
 		if(sleeping)
 			stat = UNCONSCIOUS
 
-		CheckStamina()
 		return 1
+
+/mob/living/carbon/proc/CheckStamina()
+	if(staminaloss)
+		var/total_health = (health - staminaloss)
+		if(total_health <= config.health_threshold_crit && !stat)
+			src << "<span class='notice'>You're too exhausted to keep going...</span>"
+			Weaken(5)
+			setStaminaLoss(health - 2)
+			return
+		setStaminaLoss(max((staminaloss - 2), 0))
 
 //this updates all special effects: stunned, sleeping, weakened, druggy, stuttering, etc..
 /mob/living/carbon/handle_status_effects()
 	..()
+
+	CheckStamina()
 
 	if(sleeping)
 		handle_dreams()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -313,12 +313,10 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/adjustStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	staminaloss = min(max(staminaloss + amount, 0),(maxHealth*2))
-	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/setStaminaLoss(var/amount)
 	if(status_flags & GODMODE)	return 0
 	staminaloss = amount
-	handle_regular_status_updates() //we update our health right away.
 
 /mob/living/proc/getMaxHealth()
 	return maxHealth
@@ -659,19 +657,6 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/get_visible_name()
 	return name
-
-/mob/living/proc/CheckStamina()
-	if(staminaloss)
-		var/total_health = (health - staminaloss)
-		if(total_health <= config.health_threshold_crit && !stat)
-			Exhaust()
-			setStaminaLoss(health - 2)
-			return
-		setStaminaLoss(max((staminaloss - 2), 0))
-
-/mob/living/proc/Exhaust()
-	src << "<span class='notice'>You're too exhausted to keep going...</span>"
-	Weaken(5)
 
 /mob/living/update_gravity(has_gravity)
 	if(!ticker)


### PR DESCRIPTION
Fixes nearly infinite loop when calling setStaminaLoss -> CHeckStamina -> SetStaminaLoss -> etc...
CheckStamina is now called in carbon/handle_status_effects instead of carbon/handle_regular_status_updates().
Fixes aliens getting an exhaustion message.

Fixes #9402
