### PR TITLE
Fixes HiveLord broodling spawn rate

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -253,8 +253,8 @@
         var/i = 0
         i++
         if(i = 3)
-            OpenFire()
-            i = 0
+         OpenFire()
+         i = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -250,7 +250,11 @@
 	return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
-	OpenFire()
+        var/i = 0
+        i++
+        if(i = 3)
+            OpenFire()
+            i = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -252,8 +252,8 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
         var/i = 0
         if(i = 3)
-        	OpenFire()
-        	i = 0
+          OpenFire()
+          i = 0
         else(i++)
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -244,18 +244,19 @@
 	var/recentlyspawned = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
-        var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
-        A.GiveTarget(target)
-        A.friends = friends
-        A.faction = faction
+	if(!recentlyspawned)
+	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
+	A.GiveTarget(target)
+	A.friends = friends
+	A.faction = faction
+	recentlyspawned = 1
+	spawn(30)
+		recentlyspawned = 0
         return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
-    if(!recentlyspawned)
+    
         OpenFire()
-        recentlyspawned = 1
-        spawn(30)
-            recentlyspawned = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -241,7 +241,7 @@
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
-        var/recentlyspawned = 0
+	var/recentlyspawned = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
         var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -256,6 +256,7 @@
 		i = 0
 	else()
 		i++	
+
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)
 	mouse_opacity = 1

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -252,7 +252,7 @@
 	recentlyspawned = 1
 	spawn(30)
 		recentlyspawned = 0
-        return
+		return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
     

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -251,10 +251,10 @@
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
         var/i = 0
-        i++
         if(i = 3)
-         OpenFire()
-         i = 0
+        	OpenFire()
+        	i = 0
+        else(i++)
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -242,18 +242,18 @@
 	minimum_distance = 3
 	pass_flags = PASSTABLE
 	var/recentlyspawned = 0
-
+// This code denotes how often the hivelord can spawn a brood, modify the below spawn(30) timer to change spawn time. currently set to every 3 seconds. Current spawn rate gives max of 3 broodlings per actively attacking hivelord - EchoFade
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
 	if(!recentlyspawned)
-	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
-	A.GiveTarget(target)
-	A.friends = friends
-	A.faction = faction
-	recentlyspawned = 1
-	spawn(30)
-		recentlyspawned = 0
+		var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
+		A.GiveTarget(target)
+		A.friends = friends
+		A.faction = faction
+		recentlyspawned = 1
+		spawn(30)
+			recentlyspawned = 0
+	
 	return
-
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
     
         OpenFire()
@@ -265,7 +265,7 @@
 
 /obj/item/asteroid/hivelord_core
 	name = "hivelord remains"
-	desc = "All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt... its healing properties will soon become inert if not used quickly. Try not to think about what you're eating."
+	desc = "All that remains of a hivelord, it seems to be what allows it to break pieces of itself off without being hurt... its healing properties will soon become inert if not used quickly. Try not to think about what you're doing."
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "boiledrorocore"
 	var/inert = 0
@@ -286,10 +286,10 @@
 				user << "<span class='notice'>[src] are useless on the dead.</span>"
 				return
 			if(H != user)
-				H.visible_message("[user] forces [H] to eat [src]... they quickly regenerate all injuries!")
+				H.visible_message("[user] forces [H] to apply [src]... they quickly regenerate all injuries!")
 			else
-				user << "<span class='notice'>You chomp into [src], barely managing to hold it down, but feel amazingly refreshed in mere moments.</span>"
-			playsound(src.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+				user << "<span class='notice'>You start to smear [src] on yourself. It feels and smells disgusting as it seeps into your suit, but you feel amazingly refreshed in mere moments.</span>"
+			//playsound(src.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 			H.revive()
 			qdel(src)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -252,7 +252,7 @@
 	recentlyspawned = 1
 	spawn(30)
 		recentlyspawned = 0
-		return
+	return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
     

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -241,21 +241,21 @@
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
+        var/recentlyspawned = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(var/the_target)
-	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
-	A.GiveTarget(target)
-	A.friends = friends
-	A.faction = faction
-	return
+        var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
+        A.GiveTarget(target)
+        A.friends = friends
+        A.faction = faction
+        return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
-	var/i = 0
-	if(i = 3)
-		OpenFire()
-		i = 0
-	else()
-		i++	
+    if(!recentlyspawned)
+        OpenFire()
+        recentlyspawned = 1
+        spawn(30)
+            recentlyspawned = 0
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -250,12 +250,12 @@
 	return
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/AttackingTarget()
-        var/i = 0
-        if(i = 3)
-          OpenFire()
-          i = 0
-        else(i++)
-
+	var/i = 0
+	if(i = 3)
+		OpenFire()
+		i = 0
+	else()
+		i++	
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
 	new /obj/item/asteroid/hivelord_core(src.loc)
 	mouse_opacity = 1


### PR DESCRIPTION
Fixes Undocumented bug:

Hivelords attack the player and spawn a hivelord brood. For whatever reason this happens seemingly once every server tic. This will quickly fill a tunnel with 10+ broodlings while the hivelord sits in the corner and laughs at you.

This code denotes how often the hivelord can spawn a brood, modify the spawn(30) timer to change broodling spawn time. Currently set to spawn one every 3 attacks. Current spawn rate gives max of 3 broodlings per actively attacking hivelord.

This also allows tweaks to the broodling spawn rate if that's your kinda thing.

ALSO,
because EATING THROUGH MASKS is such a huge deal for our dear coderbus; I've changed the wording of using hivelord cores for healing to make it so that it seems like you smear it on your suit instead of eating it. If this angers you still I feel I must remind you of spees magic and for you some chill pills

HG helped me get started on this and LordBistian helped me get this working. We tested on a fresh pull of the /tg/ master repository and it seems to work really well.

Apologies if I tried to merge this incorrectly.

Also credit to Man_Shroom for moral support. OLE!
