### PR TITLE
Rolling for antag at roundstart grants popcap immunity

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -463,6 +463,8 @@ var/datum/subsystem/job/SSjob
 	return 0
 
 /datum/subsystem/job/proc/RejectPlayer(var/mob/new_player/player)
+	if(player.mind && player.mind.special_role)
+		return
 	Debug("Popcap overflow Check observer located, Player: [player]")
 	player << "<b>You have failed to qualify for any job you desired.</b>"
 	unassigned -= player


### PR DESCRIPTION
Fixes a very edgy case where if a server was running up against a hard or extreme population cap it could theoretically reject someone already selected to be an antagonist, which could lead to all sorts of oddities.

Not a pressing issue on tgstation servers, as the hard and extreme pop caps exist at higher levels than either server pull on even the highest of traffic days (or they're just off)

Note that this check isn't relevant for late join antagonists, they roll for antag after spawning on the station, you couldn't just mash the join button until you managed to roll for antag.
