### PR TITLE
Fixes increased borg battery drain

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -8,6 +8,9 @@
 	clamp_values()
 	..()
 
+	if(!stat)
+		use_power()
+
 /mob/living/silicon/robot/proc/clamp_values()
 
 	SetStunned(min(stunned, 30))
@@ -70,8 +73,6 @@
 
 		if (paralysis || stunned || weakened) //Stunned etc.
 			stat = UNCONSCIOUS
-
-		use_power()
 
 		return 1
 


### PR DESCRIPTION
Fixes #9363 

The issue was borgs drained power in handle_regular_status_updates, which was recently added to adjust damage procs.
