### PR TITLE
Mild Necromantic Stone Rework/Fix

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -152,7 +152,7 @@
 			spooky_scaries.Remove(X)
 			continue
 		var/mob/living/carbon/human/H = X
-		if(H.stat)
+		if(H.stat == DEAD)
 			spooky_scaries.Remove(X)
 			continue
 	listclearnulls(spooky_scaries)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -136,21 +136,10 @@
 	hardset_dna(M, null, null, null, null, /datum/species/skeleton)
 	M.revive()
 	spooky_scaries |= M
-	M << "<span class='notice'>You have been revived by </span><B>[user.real_name]!</B>"
-	M << "<span class='notice'>They are your master now, assist them even if it costs you your new life!</span>"
+	M << "<span class='userdanger'>You have been revived by </span><B>[user.real_name]!</B>"
+	M << "<span class='userdanger'>They are your master now, assist them even if it costs you your new life!</span>"
 
-	if(prob(33))
-		equip_roman_skeleton(M)
-
-	var/mob/living/carbon/human/master = user
-
-	var/datum/objective/protect/protect_master = new /datum/objective/protect
-	protect_master.owner = M.mind
-	protect_master.target = master.mind
-	protect_master.explanation_text = "Protect [master.real_name], your master."
-	M.mind.objectives += protect_master
-	ticker.mode.traitors += M.mind
-	M.mind.special_role = "skeleton-thrall"
+	equip_roman_skeleton(M)
 
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -2,8 +2,8 @@
 
 /proc/rightandwrong(var/summon_type, var/mob/user, var/survivor_probability) //0 = Summon Guns, 1 = Summon Magic
 	var/list/gunslist 			= list("taser","egun","laser","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","suppressed","cannon","doublebarrel","shotgun","combatshotgun","bulldog","mateba","sabr","crossbow","saw","car","boltaction","speargun","arg")
-	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying", "necromantic","staffdoor", "special")
-	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos")
+	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor", "special")
+	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos", "necromantic")
 
 	if(user) //in this case either someone holding a spellbook or a badmin
 		user << "<B>You summoned [summon_type ? "magic" : "guns"]!</B>"
@@ -133,8 +133,6 @@
 					if (!(H.dna.check_mutation(XRAY)))
 						H.dna.add_mutation(XRAY)
 						H << "<span class='notice'>The walls suddenly disappear.</span>"
-				if("necromantic")
-					new /obj/item/device/necromantic_stone(get_turf(H))
 				if("special")
 					magiclist -= "special" //only one super OP item per summoning max
 					switch (randomizemagicspecial)
@@ -148,6 +146,8 @@
 							new /obj/item/weapon/antag_spawner/contract(get_turf(H))
 						if("staffchaos")
 							new /obj/item/weapon/gun/magic/staff/chaos(get_turf(H))
+						if("necromantic")
+							new /obj/item/device/necromantic_stone(get_turf(H))
 					H << "<span class='notice'>You suddenly feel lucky.</span>"
 
 /proc/summonevents()


### PR DESCRIPTION
Skeleton Thralls lose explicit antag status in favor of implicit "you can wreck shit if the guy who made you can" status, same as adamantine golems. Two reasons:
1. Resurrecting antags played fresh hell with mulligan chances on wizards
2. Every time the skeleton was reraised it'd get a new protection objective, meaning they could theoretically have dozens of the same objective

The roman armor gimmick is now a surefire thing as skeletons would let themselves be killed over and over until they had it proc.

The necromantic stone is moved from the normal summon magic pool to the special "only one of these spawned" pool due to what I believe are buffs.

Buffs the "serve the guy who raised you!" messages from notice all the way to userdanger, because people were just offering to skeleton people for free antag status and cool swords and ignoring what they were actually supposed to be doing.
