### PR TITLE
Un-snowflakes heat-proofing glass airlocks, fixes #9437

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -928,7 +928,8 @@ About the new airlock wires panel:
 			if(do_after(user,40))
 				if(src.loc)
 					if(src.doortype)
-						new src.doortype(src.loc)
+						var/obj/structure/door_assembly/A = new src.doortype(src.loc)
+						A.heat_proof_finished = src.heat_proof //tracks whether there's rglass in
 
 					if(emagged)
 						user << "<span class='warning'>You discard the damaged electronics.</span>"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -164,7 +164,6 @@
 	opacity = 0
 	doortype = /obj/structure/door_assembly/door_assembly_research/glass
 	glass = 1
-	heat_proof = 1
 
 /obj/machinery/door/airlock/glass_mining
 	name = "maintenance hatch"
@@ -1114,35 +1113,27 @@ About the new airlock wires panel:
 			if("Default")
 				icon = 'icons/obj/doors/Doorglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_glass
-				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Doorengglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_eng/glass
-				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmoglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_atmo/glass
-				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsecglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_sec/glass
-				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcomglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_com/glass
-				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormedglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_med/glass
-				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearchglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_research/glass
-				heat_proof = 1
 			if("Mining")
 				icon = 'icons/obj/doors/Doorminingglass.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_min/glass
-				heat_proof = 0
 	else
 		//These airlocks have a regular version.
 		var optionlist = list("Default", "Engineering", "Atmospherics", "Security", "Command", "Medical", "Research", "Mining", "Maintenance", "External", "High Security")
@@ -1152,47 +1143,36 @@ About the new airlock wires panel:
 			if("Default")
 				icon = 'icons/obj/doors/Doorint.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_0
-				heat_proof = 0
 			if("Engineering")
 				icon = 'icons/obj/doors/Dooreng.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_eng
-				heat_proof = 0
 			if("Atmospherics")
 				icon = 'icons/obj/doors/Dooratmo.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_atmo
-				heat_proof = 0
 			if("Security")
 				icon = 'icons/obj/doors/Doorsec.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_sec
-				heat_proof = 0
 			if("Command")
 				icon = 'icons/obj/doors/Doorcom.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_com
-				heat_proof = 0
 			if("Medical")
 				icon = 'icons/obj/doors/Doormed.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_med
-				heat_proof = 0
 			if("Research")
 				icon = 'icons/obj/doors/Doorresearch.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_research
-				heat_proof = 0
 			if("Mining")
 				icon = 'icons/obj/doors/Doormining.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_min
-				heat_proof = 0
 			if("Maintenance")
 				icon = 'icons/obj/doors/Doormaint.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_mai
-				heat_proof = 0
 			if("External")
 				icon = 'icons/obj/doors/Doorext.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_ext
-				heat_proof = 0
 			if("High Security")
 				icon = 'icons/obj/doors/hightechsecurity.dmi'
 				doortype = /obj/structure/door_assembly/door_assembly_highsecurity
-				heat_proof = 0
 	update_icon()
 
 /obj/machinery/door/airlock/CanAStarPass(var/obj/item/weapon/card/id/ID)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -274,8 +274,10 @@
 /obj/machinery/door/proc/hasPower()
 	return !(stat & NOPOWER)
 
-/obj/machinery/door/BlockSuperconductivity()
-	return heat_proof
+/obj/machinery/door/BlockSuperconductivity() // All non-glass airlocks block heat, this is intended.
+	if(opacity || heat_proof)
+		return 1
+	return 0
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -15,7 +15,7 @@
 	var/operating = 0
 	var/glass = 0
 	var/normalspeed = 1
-	var/heat_proof = 0 // For plasteel-plated airlocks and firedoors
+	var/heat_proof = 0 // For rglass-windowed airlocks and firedoors
 	var/emergency = 0 // Emergency access override
 	var/sub_door = 0 // 1 if it's meant to go under another door.
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -15,7 +15,7 @@
 	var/operating = 0
 	var/glass = 0
 	var/normalspeed = 1
-	var/heat_proof = 0 // For glass airlocks/opacity firedoors
+	var/heat_proof = 0 // For plasteel-plated airlocks and firedoors
 	var/emergency = 0 // Emergency access override
 	var/sub_door = 0 // 1 if it's meant to go under another door.
 
@@ -275,9 +275,7 @@
 	return !(stat & NOPOWER)
 
 /obj/machinery/door/BlockSuperconductivity()
-	if(opacity || heat_proof)
-		return 1
-	return 0
+	return heat_proof
 
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -6,6 +6,7 @@
 	var/id = 1
 	var/auto_close = 0 // Time in seconds to automatically close when opened, 0 if it doesn't.
 	sub_door = 1
+	var/heat_proof = 1
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -6,7 +6,7 @@
 	var/id = 1
 	var/auto_close = 0 // Time in seconds to automatically close when opened, 0 if it doesn't.
 	sub_door = 1
-	var/heat_proof = 1
+	heat_proof = 1
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -15,7 +15,7 @@ obj/structure/door_assembly
 	var/airlock_type = /obj/machinery/door/airlock //the type path of the airlock once completed
 	var/glass_type = /obj/machinery/door/airlock/glass
 	var/created_name = null
-	var/heat_proof_finished = 0 //will the airlock be heat proof when finished
+	var/heat_proof_finished = 0 //whether to heat-proof the finished airlock
 
 obj/structure/door_assembly/New()
 	base_icon_state = copytext(icon_state,1,lentext(icon_state))
@@ -450,6 +450,8 @@ obj/structure/door_assembly/New()
 					return
 				user << "<span class='notice'> You disassemble the airlock assembly.</span>"
 				new /obj/item/stack/sheet/metal(get_turf(src), 4)
+				if(heat_proof_finished)
+					new /obj/item/stack/sheet/plasteel(get_turf(src))
 				if (mineral)
 					if (mineral == "glass")
 						new /obj/item/stack/sheet/rglass(get_turf(src))

--- a/html/changelogs/spasticVerbalizer-heatproofAirlocks.yml
+++ b/html/changelogs/spasticVerbalizer-heatproofAirlocks.yml
@@ -1,0 +1,6 @@
+author: spasticVerbalizer
+       
+delete-after: True
+              
+changes: 
+  - tweak: "Glass airlocks can now be made heat-proof by using a sheet of reinforced glass to create the window, regular glass creates a normal glass airlock."


### PR DESCRIPTION
Glass airlocks as they are now magically block all heat (only) if they're research airlocks (see #9437), this pull changes that so that any glass airlock can be made heat proof by using a sheet of reinforced glass to create a windowed airlock (regular glass for a non-heat proof airlock).

Feedback needed:
- How should the heat-proofness of airlocks be shown? In the description, name, or sprite, or not at all?
