### PR TITLE
[DNM] Tweaks Grenade Launcher, adds to Nuclear uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -178,7 +178,16 @@ var/list/uplink_items = list()
 	desc = "The Minibomb is a grenade with a five-second fuse."
 	item = /obj/item/weapon/grenade/syndieminibomb
 	cost = 6
+	
+/datum/uplink_item/dangerous/grenade_launcher
+	name = "Syndicate Grenade Launcher"
+	desc = "A 6-cylinder grenade launcher used for rapid delivery of multiple grenades to a target area. Comes unloaded."
+	item = /obj/item/weapon/gun/grenadelauncher
+	cost = 25
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 2
 
+	
 /datum/uplink_item/dangerous/foamsmg
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade rounds with a 20-round magazine."

--- a/code/modules/projectiles/guns/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/grenade_launcher.dm
@@ -1,15 +1,15 @@
 /obj/item/weapon/gun/grenadelauncher
-	name = "grenade launcher"
-	desc = "a terrible, terrible thing. it's really awful!"
+	name = "syndicate grenade launcher"
+	desc = "A grenade launcher furnished with a 6-slot rotating cylinder that can hold a wide variety of grenades. The stenciled label marks this as a creation of the Gorlex Marauders. "
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "riotgun"
 	item_state = "riotgun"
 	w_class = 4.0
-	throw_speed = 2
-	throw_range = 7
+	throw_speed = 2.5
+	throw_range = 8
 	force = 5.0
 	var/list/grenades = new/list()
-	var/max_grenades = 3
+	var/max_grenades = 6
 	m_amt = 2000
 
 /obj/item/weapon/gun/grenadelauncher/examine(mob/user)
@@ -23,10 +23,10 @@
 			user.drop_item()
 			I.loc = src
 			grenades += I
-			user << "<span class='notice'>You put the grenade in the grenade launcher.</span>"
+			user << "<span class='notice'>You put the grenade in the syndicate grenade launcher.</span>"
 			user << "<span class='notice'>[grenades.len] / [max_grenades] Grenades.</span>"
 		else
-			usr << "<span class='danger'>The grenade launcher cannot hold more grenades.</span>"
+			usr << "<span class='danger'>The syndicate grenade launcher cannot hold more grenades.</span>"
 
 /obj/item/weapon/gun/grenadelauncher/afterattack(obj/target, mob/user , flag)
 
@@ -42,17 +42,17 @@
 	if(grenades.len)
 		spawn(0) fire_grenade(target,user)
 	else
-		usr << "<span class='danger'>The grenade launcher is empty.</span>"
+		usr << "<span class='danger'>The syndicate grenade launcher is empty.</span>"
 
 /obj/item/weapon/gun/grenadelauncher/proc/fire_grenade(atom/target, mob/user)
-	user.visible_message("<span class='danger'>[user] fired a grenade!</span>", \
-						"<span class='danger'>You fire the grenade launcher!</span>")
+	user.visible_message("<span class='danger'>[user] fires the syndicate grenade launcher!</span>", \
+						"<span class='danger'>You fire the syndicate grenade launcher!</span>")
 	var/obj/item/weapon/grenade/chem_grenade/F = grenades[1] //Now with less copypasta!
 	grenades -= F
 	F.loc = user.loc
 	F.throw_at(target, 30, 2)
-	message_admins("[key_name_admin(user)] fired a grenade ([F.name]) from a grenade launcher ([src.name]).")
-	log_game("[key_name(user)] fired a grenade ([F.name]) from a grenade launcher ([src.name]).")
+	message_admins("[key_name_admin(user)] fired a grenade ([F.name]) from a syndicate grenade launcher ([src.name]).")
+	log_game("[key_name(user)] fired a grenade ([F.name]) from a syndicate grenade launcher ([src.name]).")
 	F.active = 1
 	F.icon_state = initial(icon_state) + "_active"
 	playsound(user.loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)


### PR DESCRIPTION
Do you like blowing things up? Are you tired of tedious inventory juggling to constantly have to reach for more explosives? Does the concept of chaining someone with flashbangs, teargas, and finishing with a minibomb appeal to your sadistic needs?

**Then Gorlex Marauders has the thing for you!**

The grenade launcher is now available for purchase from nuclear operative uplinks for 25 TC, with an upped capacity of 6. Use it to rapidly chain horrifying war-crime combinations of grenades, or just fill a room with explosives very quickly. As for the most part it's just a grenade launcher with slightly diff. stats. All of this is subject to change.

AS OF NOWL
- Adds 6-shot grenade launcher for 25 TC to nuke uplinks

THINGS TO DO:
- Get a unique sprite set up
- Have grenades detonate on impact(?Please help)
- Adjust cost/capacity for balance concerns
- **Die**
