### PR TITLE
Fixes infinite rods from reinforced floors

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -98,6 +98,8 @@
 		user << "<span class='notice'>You begin removing rods...</span>"
 		playsound(src, 'sound/items/Ratchet.ogg', 80, 1)
 		if(do_after(user, 30))
+			if(!istype(src, /turf/simulated/floor/engine))
+				return
 			new /obj/item/stack/rods(src, 2)
 			ChangeTurf(/turf/simulated/floor/plating)
 			return


### PR DESCRIPTION
As it says on the tin. This fixes the issue of getting infinite amount of metal rods when deconstructing a reinforced floor.

Fixes #9143 
