### PR TITLE
The Nanoing (Episode 2: The Fix Wars)

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -89,24 +89,18 @@ Passive gate is similar to the regular pump except:
 
 	return 1
 
-/obj/machinery/atmospherics/binary/passive_gate/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/binary/passive_gate/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "atmos_gas_pump.tmpl", name, 400, 120, 0)
 
+/obj/machinery/atmospherics/binary/passive_gate/get_ui_data()
+	var/data = list()
 	data["on"] = on
 	data["pressure_set"] = round(target_pressure*100) //Nano UI can't handle rounded non-integers, apparently.
 	data["max_pressure"] = MAX_OUTPUT_PRESSURE
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "atmos_gas_pump.tmpl", name, 400, 120)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/atmospherics/binary/passive_gate/atmosinit()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -97,24 +97,18 @@ Thus, the two variables affect pump operation are set in New():
 
 	return 1
 
-/obj/machinery/atmospherics/binary/pump/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/binary/pump/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "atmos_gas_pump.tmpl", name, 400, 120, 0)
 
+/obj/machinery/atmospherics/binary/pump/get_ui_data()
+	var/data = list()
 	data["on"] = on
 	data["pressure_set"] = round(target_pressure*100) //Nano UI can't handle rounded non-integers, apparently.
 	data["max_pressure"] = MAX_OUTPUT_PRESSURE
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "atmos_gas_pump.tmpl", name, 400, 120)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/atmospherics/binary/pump/atmosinit()
 	..()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -93,24 +93,18 @@ Thus, the two variables affect pump operation are set in New():
 
 	return 1
 
-/obj/machinery/atmospherics/binary/volume_pump/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/binary/volume_pump/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "atmos_gas_pump.tmpl", name, 400, 120, 0)
 
+/obj/machinery/atmospherics/binary/volume_pump/get_ui_data()
+	var/data = list()
 	data["on"] = on
 	data["transfer_rate"] = round(transfer_rate*100) //Nano UI can't handle rounded non-integers, apparently.
 	data["max_rate"] = MAX_TRANSFER_RATE
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "atmos_gas_pump.tmpl", name, 400, 120)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/atmospherics/binary/volume_pump/atmosinit()
 	..()

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -158,25 +158,19 @@ Filter types:
 
 	ui_interact(user)
 
-/obj/machinery/atmospherics/trinary/filter/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/trinary/filter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "atmos_filter.tmpl", name, 400, 320, 0)
 
+/obj/machinery/atmospherics/trinary/filter/get_ui_data()
+	var/data = list()
 	data["on"] = on
 	data["pressure_set"] = round(target_pressure*100) //Nano UI can't handle rounded non-integers, apparently.
 	data["max_pressure"] = MAX_OUTPUT_PRESSURE
 	data["filter_type"] = filter_type
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "atmos_filter.tmpl", name, 400, 320)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/atmospherics/trinary/filter/Topic(href, href_list)
 	if(..())

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -108,26 +108,20 @@
 
 	ui_interact(user)
 
-/obj/machinery/atmospherics/trinary/mixer/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/trinary/mixer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "atmos_mixer.tmpl", name, 400, 320, 0)
 
+/obj/machinery/atmospherics/trinary/mixer/get_ui_data()
+	var/data = list()
 	data["on"] = on
 	data["pressure_set"] = round(target_pressure*100) //Nano UI can't handle rounded non-integers, apparently.
 	data["max_pressure"] = MAX_OUTPUT_PRESSURE
 	data["node1_concentration"] = round(node1_concentration*100)
 	data["node2_concentration"] = round(node2_concentration*100)
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "atmos_mixer.tmpl", name, 400, 320)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/atmospherics/trinary/mixer/Topic(href,href_list)
 	if(..()) return

--- a/code/controllers/subsystem/nanoUI.dm
+++ b/code/controllers/subsystem/nanoUI.dm
@@ -3,7 +3,7 @@ var/datum/subsystem/nano/SSnano
 /datum/subsystem/nano
 	name = "NanoUI"
 	can_fire = 1
-	wait = 5
+	wait = 10
 	priority = 16
 
 	var/list/open_uis = list()			//a list of current open /nanoui UIs, grouped by src_object and ui_key

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -408,7 +408,7 @@
 				return 1
 
 			if("reset_external_pressure")
-				send_signal(device_id, list(href_list["command"] = ONE_ATMOSPHERE))
+				send_signal(device_id, list("set_external_pressure" = ONE_ATMOSPHERE))
 				return 1
 			if(
 				"power",

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -185,13 +185,6 @@
 			return
 
 	if(!shorted)
-		//user << browse(return_text(),"window=air_alarm")
-		//onclose(user, "air_alarm")
-		/*var/datum/browser/popup = new(user, "air_alarm", "[alarm_area.name] Air Alarm", 500, 400)
-		popup.set_content(return_text())
-		popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
-		popup.open()
-		refresh_all()*/
 		ui_interact(user)
 
 	if(panel_open && (!istype(user, /mob/living/silicon/ai)))
@@ -199,29 +192,22 @@
 
 	return
 
-/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(stat & (BROKEN|NOPOWER))
 		return
 
-	var/data = list()
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "air_alarm.tmpl", "Air Alarm", 350, 500, 1)
 
+/obj/machinery/alarm/get_ui_data(mob/user)
+	var/data = list()
 	data["locked"] = locked
 	data["siliconUser"] = user.has_unlimited_silicon_privilege
 	data["screen"] = screen
 	data["dangerous"] = emagged
-
 	populate_status(data)
 	if (!locked || user.has_unlimited_silicon_privilege)
 		populate_controls(data)
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "air_alarm.tmpl", "Air Alarm", 350, 500)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/alarm/proc/shock(mob/user, prb)
 	if((stat & (NOPOWER)))		// unpowered, no shock

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -259,6 +259,9 @@ update_flag
 /obj/machinery/portable_atmospherics/canister/attack_paw(var/mob/user as mob)
 	return src.attack_hand(user)
 
+/obj/machinery/portable_atmospherics/canister/attack_tk(var/mob/user as mob)
+	return src.attack_hand(user)
+
 /obj/machinery/portable_atmospherics/canister/attack_hand(var/mob/user as mob)
 	return src.ui_interact(user)
 
@@ -327,8 +330,7 @@ update_flag
 		if (href_list["remove_tank"])
 			if(holding)
 				if (valve_open)
-					investigate_log("Valve was <b>closed</b> automatically by [key_name(usr)] removing the [holding]<br>", "atmos")
-					valve_open = !valve_open
+					investigate_log("[key_name(usr)] removed the [holding], leaving the valve open and transfering into the <span class='boldannounce'>air</span><br>", "atmos")
 				holding.loc = loc
 				holding = null
 

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -176,6 +176,7 @@ update_flag
 		can_label = 1
 	else
 		can_label = 0
+
 /obj/machinery/portable_atmospherics/canister/process()
 	src.updateDialog()
 	return ..()
@@ -261,10 +262,19 @@ update_flag
 /obj/machinery/portable_atmospherics/canister/attack_hand(var/mob/user as mob)
 	return src.ui_interact(user)
 
-/obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/portable_atmospherics/canister/interact(mob/user, ui_key = "main")
+	if (src.destroyed || !user)
+		return
+
+	SSnano.try_update_ui(user, src, ui_key, null, src.get_ui_data())
+
+/obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if (src.destroyed)
 		return
 
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "canister.tmpl", "Canister", 480, 400, 0)
+
+/obj/machinery/portable_atmospherics/canister/get_ui_data()
 	var/data = list()
 	data["name"] = src.name
 	data["canLabel"] = src.can_label ? 1 : 0
@@ -278,15 +288,7 @@ update_flag
 	data["hasHoldingTank"] = src.holding ? 1 : 0
 	if (holding)
 		data["holdingTank"] = list("name" = src.holding.name, "tankPressure" = round(src.holding.air_contents.return_pressure()))
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new /datum/nanoui(user, src, ui_key, "canister.tmpl", "Canister", 480, 400)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
+	return data
 
 /obj/machinery/portable_atmospherics/canister/Topic(href, href_list)
 
@@ -324,6 +326,9 @@ update_flag
 
 		if (href_list["remove_tank"])
 			if(holding)
+				if (valve_open)
+					investigate_log("Valve was <b>closed</b> automatically by [key_name(usr)] removing the [holding]<br>", "atmos")
+					valve_open = !valve_open
 				holding.loc = loc
 				holding = null
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -137,10 +137,14 @@
   *
   * @return nothing
   */
-/obj/machinery/atmospherics/unary/cryo_cell/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/atmospherics/unary/cryo_cell/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(user == occupant || user.stat || panel_open)
 		return
 
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "cryo.tmpl", "Cryo Cell Control System", 520, 410, 1)
+	//user.set_machine(src)
+
+/obj/machinery/atmospherics/unary/cryo_cell/get_ui_data()
 	// this is the data which will be sent to the ui
 	var/data[0]
 	data["isOperating"] = on
@@ -185,21 +189,7 @@
 		for(var/datum/reagent/R in beaker:reagents.reagent_list)
 			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // list in a list because Byond merges the first list...
 	data["beakerContents"] = beakerContents
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		// the ui does not exist, so we'll create a new one
-		ui = new(user, src, ui_key, "cryo.tmpl", "Cryo Cell Control System", 520, 410)
-		// When the UI is first opened this is the data it will use
-		ui.set_initial_data(data)
-		ui.open()
-		// Auto update every Master Controller tick
-		ui.set_auto_update(1)
-	else
-		// The UI is already open so push the new data to it
-		ui.push_data(data)
-		return
-	//user.set_machine(src)
+	return data
 
 /obj/machinery/atmospherics/unary/cryo_cell/Topic(href, href_list)
 	if(usr == occupant || panel_open)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -146,11 +146,11 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/get_ui_data()
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? 1 : 0
 
-	var/occupantData[0]
+	var/occupantData = list()
 	if (!occupant)
 		occupantData["name"] = null
 		occupantData["stat"] = null
@@ -173,7 +173,7 @@
 		occupantData["toxLoss"] = occupant.getToxLoss()
 		occupantData["fireLoss"] = occupant.getFireLoss()
 		occupantData["bodyTemperature"] = occupant.bodytemperature
-	data["occupant"] = occupantData;
+	data["occupant"] = occupantData
 
 	data["isOpen"] = state_open
 	data["cellTemperature"] = round(air_contents.temperature)

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -39,5 +39,8 @@
 /atom/movable/proc/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	return
 
+/atom/movable/proc/get_ui_data()
+	return list()
+
 // Used by the Nano UI SubSystem (/datum/subsystem/nano) to track UIs opened by this mob
 /mob/var/list/open_uis = list()

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -39,7 +39,7 @@
 /atom/movable/proc/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	return
 
-/atom/movable/proc/get_ui_data()
+/atom/movable/proc/get_ui_data(mob/user)
 	return list()
 
 // Used by the Nano UI SubSystem (/datum/subsystem/nano) to track UIs opened by this mob

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -1,3 +1,27 @@
+  /**
+  * Get an open /nanoui ui for the current user, or create a new one.
+  *
+  * @param user /mob The mob who opened/owns the ui
+  * @param src_object /obj|/mob The obj or mob which the ui belongs to
+  * @param ui_key string A string key used for the ui
+  * @param ui /datum/nanoui An existing instance of the ui (can be null)
+  * @param data list The data to be passed to the ui, if it exists
+  *
+  * @return /nanoui Returns the new or found ui
+  */
+/datum/subsystem/nano/proc/push_open_or_new_ui(var/mob/user, var/atom/movable/src_object, ui_key, var/datum/nanoui/ui, template, title, width, height, auto_update)
+	var/list/data = src_object.get_ui_data()
+	if (!data)
+		data = list()
+
+	ui = try_update_ui(user, src_object, ui_key, ui, data)
+
+	if (isnull(ui))
+		ui = new /datum/nanoui(user, src_object, ui_key, template, title, width, height)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(auto_update)
+
  /**
   * Get an open /nanoui ui for the current user, src_object and ui_key and try to update it with data
   *
@@ -11,9 +35,8 @@
   */
 /datum/subsystem/nano/proc/try_update_ui(var/mob/user, src_object, ui_key, var/datum/nanoui/ui, data)
 	if (isnull(ui)) // no ui has been passed, so we'll search for one
-	{
 		ui = get_open_ui(user, src_object, ui_key)
-	}
+
 	if (!isnull(ui))
 		// The UI is already open so push the data to it
 		ui.push_data(data)

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -10,7 +10,7 @@
   * @return /nanoui Returns the new or found ui
   */
 /datum/subsystem/nano/proc/push_open_or_new_ui(var/mob/user, var/atom/movable/src_object, ui_key, var/datum/nanoui/ui, template, title, width, height, auto_update)
-	var/list/data = src_object.get_ui_data()
+	var/list/data = src_object.get_ui_data(user)
 	if (!data)
 		data = list()
 

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -131,8 +131,13 @@ nanoui is used to open and update nano browser uis
 			set_status(STATUS_DISABLED, push_update) // no updates, completely disabled (red visibility)
 	else
 		var/dist = get_dist(src_object, user)
+		var/isTK = 0
 
-		if (dist > 4)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			isTK = H.dna.check_mutation(TK)
+
+		if (dist > 4 && !isTK)
 			close()
 			return
 
@@ -141,10 +146,10 @@ nanoui is used to open and update nano browser uis
 		else if (user.restrained() || user.lying)
 			set_status(STATUS_UPDATE, push_update) // update only (orange visibility)
 		else if (!(src_object in view(4, user))) // If the src object is not in visable, set status to 0
-			set_status(STATUS_DISABLED, push_update) // interactive (green visibility)
+			set_status(STATUS_DISABLED, push_update) // no updates, completely disabled (red visibility)
 		else if (dist <= 1)
 			set_status(STATUS_INTERACTIVE, push_update) // interactive (green visibility)
-		else if (dist <= 2)
+		else if (dist <= 2 || isTK)
 			set_status(STATUS_UPDATE, push_update) // update only (orange visibility)
 		else if (dist <= 4)
 			set_status(STATUS_DISABLED, push_update) // no updates, completely disabled (red visibility)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -667,6 +667,9 @@
 	if(!user)
 		return
 
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "apc.tmpl", "[area.name] - APC", 520, user.has_unlimited_silicon_privilege ? 465 : 420, 1)
+
+/obj/machinery/power/apc/get_ui_data(mob/user)
 	var/list/data = list(
 		"locked" = locked,
 		"isOperating" = operating,
@@ -712,19 +715,7 @@
 			)
 		)
 	)
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data)
-	if (!ui)
-		// the ui does not exist, so we'll create a new() one
-        // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "apc.tmpl", "[area.name] - APC", 520, data["siliconUser"] ? 465 : 420)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
-		// auto update every Master Controller tick
-		ui.set_auto_update(1)
+	return data
 
 /obj/machinery/power/apc/proc/report()
 	return "[area.name] : [equipment]/[lighting]/[environ] ([lastused_equip+lastused_light+lastused_environ]) : [cell? cell.percent() : "N/C"] ([charging])"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -296,6 +296,10 @@
 	if(!user)
 		return
 
+	// update the ui if it exists, create a new one if it doesn't
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "smes.tmpl", "SMES - [name]", 350, 560, 1)
+
+/obj/machinery/power/smes/get_ui_data()
 	var/list/data = list(
 		"capacityPercent" = round(100.0*charge/capacity, 0.1),
 		"capacity" = capacity,
@@ -313,19 +317,7 @@
 		"outputLevelMax" = output_level_max,
 		"outputUsed" = output_used
 	)
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data)
-	if (!ui)
-		// the ui does not exist, so we'll create a new() one
-		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "smes.tmpl", "SMES - [name]", 350, 560)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
-		// auto update every Master Controller tick
-		ui.set_auto_update(1)
+	return data
 
 /obj/machinery/power/smes/Topic(href, href_list)
 //	world << "[href] ; [href_list[href]]"

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -369,8 +369,10 @@
 	if(!..())
 		ui_interact(user)
 
-/obj/machinery/power/solar_control/ui_interact(mob/user, ui_key = "main")
+/obj/machinery/power/solar_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "solar_control.tmpl", name, 490, 420, 1)
 
+/obj/machinery/power/solar_control/get_ui_data()
 	var/data = list()
 
 	data["generated"] = round(lastgen)
@@ -383,16 +385,7 @@
 
 	data["connected_panels"] = connected_panels.len
 	data["connected_tracker"] = (connected_tracker ? 1 : 0)
-
-	var/datum/nanoui/ui = SSnano.get_open_ui(user, src, ui_key)
-	if (!ui)
-		ui = new(user, src, ui_key, "solar_control.tmpl", name, 490, 420)
-		ui.set_initial_data(data)
-		ui.open()
-		ui.set_auto_update(1)
-	else
-		ui.push_data(data)
-		return
+	return data
 
 /obj/machinery/power/solar_control/attackby(I as obj, user as mob, params)
 	if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -75,8 +75,10 @@
 	if(stat & (BROKEN)) return
 	if(user.stat || user.restrained()) return
 
-	// this is the data which will be sent to the ui
-	var/data[0]
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "chem_dispenser.tmpl", "[uiname]", 490, 710, 0)
+
+/obj/machinery/chem_dispenser/get_ui_data()
+	var/data = list()
 	data["amount"] = amount
 	data["energy"] = energy
 	data["maxEnergy"] = max_energy
@@ -103,17 +105,7 @@
 		if(temp)
 			chemicals.Add(list(list("title" = temp.name, "id" = temp.id, "commands" = list("dispense" = temp.id)))) // list in a list because Byond merges the first list...
 	data["chemicals"] = chemicals
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data)
-	if (!ui)
-		// the ui does not exist, so we'll create a new() one
-        // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "chem_dispenser.tmpl", "[uiname]", 490, 710)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
+	return data
 
 /obj/machinery/chem_dispenser/Topic(href, href_list)
 	if(stat & (BROKEN))
@@ -1491,7 +1483,10 @@ obj/machinery/computer/pandemic/proc/replicator_cooldown(var/waittime)
 /obj/machinery/chem_heater/ui_interact(var/mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	if(user.stat || user.restrained()) return
 
-	var/data[0]
+	ui = SSnano.push_open_or_new_ui(user, src, ui_key, ui, "chem_heater.tmpl", "ChemHeater", 350, 270, 0)
+
+/obj/machinery/chem_heater/get_ui_data()
+	var/data = list()
 	data["targetTemp"] = desired_temp
 	data["isActive"] = on
 	data["isBeakerLoaded"] = beaker ? 1 : 0
@@ -1506,13 +1501,7 @@ obj/machinery/computer/pandemic/proc/replicator_cooldown(var/waittime)
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
 			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // list in a list because Byond merges the first list...
 	data["beakerContents"] = beakerContents
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data)
-	if (!ui)
-		ui = new(user, src, ui_key, "chem_heater.tmpl", "ChemHeater", 350, 270)
-		ui.set_initial_data(data)
-		ui.open()
+	return data
 
 ///////////////////////////////////////////////////////////////////////////
 

--- a/html/changelogs/Fayrik-TheNanoingFixes.yml
+++ b/html/changelogs/Fayrik-TheNanoingFixes.yml
@@ -1,0 +1,7 @@
+author: Fayrik
+
+delete-after: True
+
+changes:
+- tweak: "Refactored all NanoUI interfaces to use a more universal proc."
+- bugfix: "Removed automatic updates on atmospheric pumps, canisters and tanks, making them respond to button clicks much faster."

--- a/html/changelogs/Fayrik-TheNanoingFixes.yml
+++ b/html/changelogs/Fayrik-TheNanoingFixes.yml
@@ -3,6 +3,8 @@ author: Fayrik
 delete-after: True
 
 changes:
-- tweak: "Canisters now automatically close their valve when air tanks are removed from them."
+- rscadd: "NanoUI is now Telekenesis aware, but due to other constraints, NanoUI interfaces are read only at a distance."
 - tweak: "Refactored all NanoUI interfaces to use a more universal proc."
+- tweak: "Adjusted the refresh time of the NanoUI SubSystem. All interfaces will update less, but register mouse clicks faster."
 - bugfix: "Removed automatic updates on atmospheric pumps, canisters and tanks, making them respond to button clicks much faster."
+- bugfix: "Atmos alarm reset buttons work now. Probably."

--- a/html/changelogs/Fayrik-TheNanoingFixes.yml
+++ b/html/changelogs/Fayrik-TheNanoingFixes.yml
@@ -3,5 +3,6 @@ author: Fayrik
 delete-after: True
 
 changes:
+- tweak: "Canisters now automatically close their valve when air tanks are removed from them."
 - tweak: "Refactored all NanoUI interfaces to use a more universal proc."
 - bugfix: "Removed automatic updates on atmospheric pumps, canisters and tanks, making them respond to button clicks much faster."

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -91,7 +91,7 @@ Used In File(s): \code\game\machinery\alarm.dm
         <hr>
             {{if mode==3}}
                 {{:~link('PANIC SIPHON ACTIVE - Turn siphoning off', null, { 'mode' : 1}, null, 'redButton')}}
-			{{else}}
+            {{else}}
                 {{:~link('ACTIVATE PANIC SIPHON IN AREA', null, { 'mode' : 3}, null, 'yellowButton')}}
             {{/if}}
     {{else screen == 2}}


### PR DESCRIPTION
Everyone hates their button presses getting ignored. This should make that happen a little less on a few items.
~~(Unfortunately, Air Alarms and APCs aren't going to see the benefit here, but sucks to be them.)~~

I've also taken on board the comments from the first pull request, and fixed an indentation error on one of the HTML templates and made the massive block of code that was called in ui_interact into two procs, so now adding new NanoUI interfaces will be a lot less copy and paste and a lot more actual function.

~~...And I've also made it so that canisters no longer spew out (probably) toxic gasses when you tug an air tank out of them. Flooding areas with canisters is still as easy as ever, you're just not going to do it by accident any more.
(Unless you're REALLY fukken stupid.)~~

Edit:
Caved in to maintainer pressure and removed the amazing feature that stopped the canisters from being the single most annoying thing to use.
Added some fundamental TK compatibility to NanoUI. Sorta. Needs more work but it's in a halfway decent state now.
Fixes #9856 
