### PR TITLE
Possibly fixes taser not being consumed in ED construction.

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -629,7 +629,7 @@ Auto Patrol[]"},
 				if (do_after(user, 40))
 					if (coil.get_amount() >= 1 && build_step == 6)
 						coil.use(1)
-						build_step = 7
+						build_step++
 						user << "<span class='notice'>You wire the ED-209 assembly.</span>"
 						name = "wired ED-209 assembly"
 
@@ -649,12 +649,12 @@ Auto Patrol[]"},
 					name = "taser ED-209 assembly"
 				else
 					return
+			user.drop_item()
+			qdel(W)
 			build_step++
 			user << "<span class='notice'>You add [W] to [src].</span>"
 			item_state = "[lasercolor]ed209_taser"
 			icon_state = "[lasercolor]ed209_taser"
-			user.drop_item()
-			qdel(W)
 
 		if(8)
 			if(istype(W, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -649,12 +649,12 @@ Auto Patrol[]"},
 					name = "taser ED-209 assembly"
 				else
 					return
-			user.drop_item()
-			qdel(W)
-			build_step++
 			user << "<span class='notice'>You add [W] to [src].</span>"
 			item_state = "[lasercolor]ed209_taser"
 			icon_state = "[lasercolor]ed209_taser"
+			user.drop_item()
+			qdel(W)
+			build_step++
 
 		if(8)
 			if(istype(W, /obj/item/weapon/screwdriver))


### PR DESCRIPTION
This possibly fixes the rare issue with a taser not being consumed in the ED209's construction, though I cannot be 100% sure since this is a rare issue, almost unreproducable. I did test this several times and could not reproduce it. It MAY have been due to the buildstep being furthered before the taser was deleted, unlike the other steps in the ED construction where it was deleted before the buildstep was furthered, like with the helmet. I also made stape 6, just before the tasers step, be build_step++ instead of build_step = 7, like the rest of the construction code for the ED209 is.

Possibly Fixes #3156
