### PR TITLE
Items with slowdown will now give slowdown when carried in your hand.

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -699,6 +699,10 @@
 				mspeed += H.shoes.slowdown
 			if(H.back)
 				mspeed += H.back.slowdown
+			if(H.l_hand)
+				mspeed += H.l_hand.slowdown / 2
+			if(H.r_hand)
+				mspeed += H.r_hand.slowdown / 2
 
 			if((H.disabilities & FAT))
 				mspeed += 1.5


### PR DESCRIPTION
Basically, any item which gives a slowdown when worn, will now give a slowdown when carried in your hands. Albeit only half of the slowdown. Tested and everything works.

Fixes #7687 

I will probably make a poll for this tomorrow when I wake up, maybe. I have a bad memory.
