### PR TITLE
Tweaks the 20TC Bundles to be more worthwhile

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -24,6 +24,7 @@
 			new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow(src)
 			new /obj/item/weapon/pen/sleepy(src)
 			new /obj/item/device/chameleon(src)
+			new /obj/item/clothing/glasses/thermal/syndi(src)
 			return
 
 		if("bond")
@@ -33,6 +34,7 @@
 			new /obj/item/ammo_box/magazine/m10mm(src)
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/device/encryptionkey/syndicate(src)
 			return
 
 		if("sabotage")
@@ -58,6 +60,7 @@
 			new /obj/item/clothing/glasses/thermal/syndi(src)
 			new /obj/item/weapon/card/emag(src)
 			new /obj/item/clothing/shoes/sneakers/syndigaloshes(src)
+			new /obj/item/weapon/c4(src)
 			return
 
 		if("implant")
@@ -102,8 +105,11 @@
 			new /obj/item/weapon/card/id/syndicate(src)
 			new /obj/item/weapon/grenade/syndieminibomb(src)
 			new /obj/item/weapon/c4(src)
+			new /obj/item/device/encryptionkey/syndicate(src)
 			var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
 			S.imp = new /obj/item/weapon/implant/explosive(S)
+			return
+		
 
 /obj/item/weapon/storage/box/syndie_kit
 	name = "box"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,7 +2,7 @@
 
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
-	switch (pickweight(list("bloodyspai" = 0, "stealth" = 1, "bond" = 1, "sabotage" = 1, "heist" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "singularity" = 1, "darklord" = 1)))
+	switch (pickweight(list("bloodyspai" = 0, "stealth" = 1, "bond" = 1, "sabotage" = 1, "heist" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "singularity" = 1, "darklord" = 1, "infiltrator" = 1)))
 		if("bloodyspai")
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/clothing/mask/gas/voice(src)
@@ -12,6 +12,14 @@
 			new /obj/item/device/camera_bug(src)
 			return
 
+		if("infiltrator")
+			new /obj/item/device/chameleon(src)
+			new /obj/item/clothing/under/chameleon(src)
+			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/weapon/card/emag(src)
+			new /obj/item/clothing/mask/gas/voice(src)
+		
 		if("stealth")
 			new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow(src)
 			new /obj/item/weapon/pen/sleepy(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -110,7 +110,14 @@
 			var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
 			S.imp = new /obj/item/weapon/implant/explosive(S)
 			return
-		
+			
+		if("takbir")
+			new /obj/item/weapon/grenade/syndieminibomb(src)
+			new /obj/item/weapon/grenade/syndieminibomb(src)
+			new /obj/item/device/sbeacondrop/bomb(src)
+			var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
+			S.imp = new /obj/item/weapon/implant/explosive(S)
+			return
 
 /obj/item/weapon/storage/box/syndie_kit
 	name = "box"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,7 +2,7 @@
 
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
-	switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "bond" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "lordsingulo" = 1, "darklord" = 1)))
+	switch (pickweight(list("bloodyspai" = 0, "stealth" = 1, "bond" = 1, "sabotage" = 1, "heist" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "singularity" = 1, "darklord" = 1)))
 		if("bloodyspai")
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/clothing/mask/gas/voice(src)
@@ -27,7 +27,7 @@
 			new /obj/item/weapon/card/id/syndicate(src)
 			return
 
-		if("screwed")
+		if("sabotage")
 			new /obj/item/device/sbeacondrop/bomb(src)
 			new /obj/item/weapon/grenade/syndieminibomb(src)
 			new /obj/item/device/powersink(src)
@@ -35,7 +35,7 @@
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			return
 
-		if("guns")
+		if("heist")
 			new /obj/item/weapon/gun/projectile/revolver(src)
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/weapon/card/emag(src)
@@ -73,7 +73,7 @@
 			new /obj/item/weapon/aiModule/toyAI(src)
 			return
 
-		if("lordsingulo")
+		if("singularity")
 			new /obj/item/device/sbeacondrop(src)
 			new /obj/item/clothing/suit/space/syndicate/black/red(src)
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
@@ -113,7 +113,7 @@
 */
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	name = "Explosive Implant (with injector)"
+	name = "boxed explosive implant (with injector)"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive/New()
 	var/obj/item/weapon/implanter/O = new(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -106,6 +106,7 @@
 			new /obj/item/weapon/grenade/syndieminibomb(src)
 			new /obj/item/weapon/c4(src)
 			new /obj/item/device/encryptionkey/syndicate(src)
+			new /obj/item/weapon/storage/belt/military(src)
 			var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
 			S.imp = new /obj/item/weapon/implant/explosive(S)
 			return

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,7 +2,7 @@
 
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
-	switch (pickweight(list("bloodyspai" = 0, "stealth" = 1, "bond" = 1, "sabotage" = 1, "heist" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "singularity" = 1, "darklord" = 1, "infiltrator" = 1)))
+	switch (pickweight(list("bloodyspai" = 0, "stealth" = 1, "bond" = 1, "sabotage" = 1, "heist" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "singularity" = 1, "darklord" = 1, "infiltrator" = 1, "falsealarm" = 1)))
 		if("bloodyspai")
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/clothing/mask/gas/voice(src)
@@ -95,6 +95,15 @@
 			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 			new /obj/item/weapon/card/id/syndicate(src)
 			return
+			
+		if("falsealarm")
+			new /obj/item/clothing/suit/space/hardsuit/syndi(src)
+			new /obj/item/weapon/tank/jetpack/oxygen/harness(src)
+			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/weapon/grenade/syndieminibomb(src)
+			new /obj/item/weapon/c4(src)
+			var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
+			S.imp = new /obj/item/weapon/implant/explosive(S)
 
 /obj/item/weapon/storage/box/syndie_kit
 	name = "box"


### PR DESCRIPTION
Nobody ever buys these because they're sort of useless/underwhelming. I personally like being like "Time to invest my 20 TC for 20TC+ of thematic equipment for fun!"

This PR:
- Removes the pathetic ID+voicechanger set, replaces it with the superior Infiltrator bundle
- Adds the False Alarm bundle for making people think it's Nuke (Now with jetpacks!)
- Adds the Takbir bundle, for blowing stuff up and going out with a bang
- Adds several pieces of equipment to bundles, making them a solid investment
- Renames the bundles to make more sense and be less like dumb memes
- Fixes some conventions inconsistency with boxed implants

And yes, I'm aware 'bloodyspai' isn't really removed, just set to prob 0.
