### PR TITLE
This fixes the issue of colored jumpsuits not being dyeable into rainbow jumpsuits.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -809,7 +809,7 @@
 "apC" = (/obj/machinery/mineral/labor_claim_console{machinedir = 2; pixel_x = 30; pixel_y = 30},/turf/simulated/shuttle/floor{icon_state = "floor4"},/area/space)
 "apD" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/glass_security{name = "Labor Camp Shuttle Airlock"; req_access_txt = "2"},/obj/machinery/door_control{id = "prison release"; name = "Labor Camp Shuttle Lockdown"; pixel_x = 0; pixel_y = -25; req_access_txt = "2"},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/security/brig)
 "apE" = (/obj/machinery/door/airlock/glass_command{name = "Gravity Generator Area"; req_access_txt = "19; 61"},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/engine/gravity_generator)
-"apF" = (/obj/item/clothing/gloves/color/rainbow,/obj/item/clothing/shoes/sneakers/rainbow,/obj/item/clothing/under/rainbow,/obj/item/clothing/head/soft/rainbow,/turf/simulated/floor/plating,/area/maintenance/fpmaint2{name = "Port Maintenance"})
+"apF" = (/obj/item/clothing/gloves/color/rainbow,/obj/item/clothing/shoes/sneakers/rainbow,/obj/item/clothing/under/color/rainbow,/obj/item/clothing/head/soft/rainbow,/turf/simulated/floor/plating,/area/maintenance/fpmaint2{name = "Port Maintenance"})
 "apG" = (/turf/simulated/shuttle/wall,/area/space)
 "apH" = (/turf/simulated/wall/r_wall,/area/maintenance/auxsolarstarboard)
 "apI" = (/obj/machinery/power/solar_control{id = "forestarboard"; name = "Fore Starboard Solar Control"; track = 0},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor/plating,/area/maintenance/auxsolarstarboard)

--- a/_maps/map_files/MetaStation/z2.dmm
+++ b/_maps/map_files/MetaStation/z2.dmm
@@ -56,7 +56,7 @@
 "bd" = (/turf/simulated/floor/holofloor{dir = 10; icon_state = "red"},/area/holodeck/source_basketball)
 "be" = (/turf/simulated/floor/holofloor{dir = 2; icon_state = "red"},/area/holodeck/source_basketball)
 "bf" = (/turf/simulated/floor/holofloor{dir = 6; icon_state = "red"},/area/holodeck/source_basketball)
-"bg" = (/obj/item/clothing/under/rainbow,/obj/item/clothing/glasses/sunglasses,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
+"bg" = (/obj/item/clothing/under/color/rainbow,/obj/item/clothing/glasses/sunglasses,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
 "bh" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/source_thunderdomecourt)
 "bi" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor,/area/holodeck/source_thunderdomecourt)
 "bj" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/source_thunderdomecourt)

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2449,7 +2449,7 @@
 "aVe" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating,/area/maintenance/port)
 "aVf" = (/obj/machinery/power/apc{dir = 1; name = "Port Emergency Storage APC"; pixel_y = 24},/obj/structure/cable{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating,/area/storage/emergency2)
 "aVg" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/maintenance/port)
-"aVh" = (/obj/item/clothing/gloves/color/rainbow,/obj/item/clothing/shoes/sneakers/rainbow,/obj/item/clothing/under/rainbow,/obj/item/clothing/head/soft/rainbow,/turf/simulated/floor/plating,/area/maintenance/port)
+"aVh" = (/obj/item/clothing/gloves/color/rainbow,/obj/item/clothing/shoes/sneakers/rainbow,/obj/item/clothing/under/color/rainbow,/obj/item/clothing/head/soft/rainbow,/turf/simulated/floor/plating,/area/maintenance/port)
 "aVi" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/plasteel,/area/storage/tools)
 "aVj" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plasteel,/area/storage/tools)
 "aVk" = (/obj/structure/rack{dir = 8; layer = 2.9},/obj/machinery/light,/obj/item/device/multitool,/turf/simulated/floor/plasteel,/area/storage/tools)

--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -56,7 +56,7 @@
 "bd" = (/turf/simulated/floor/holofloor{dir = 10; icon_state = "red"},/area/holodeck/source_basketball)
 "be" = (/turf/simulated/floor/holofloor{dir = 2; icon_state = "red"},/area/holodeck/source_basketball)
 "bf" = (/turf/simulated/floor/holofloor{dir = 6; icon_state = "red"},/area/holodeck/source_basketball)
-"bg" = (/obj/item/clothing/under/rainbow,/obj/item/clothing/glasses/sunglasses,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
+"bg" = (/obj/item/clothing/under/color/rainbow,/obj/item/clothing/glasses/sunglasses,/turf/simulated/floor/beach/sand,/area/holodeck/source_beach)
 "bh" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/source_thunderdomecourt)
 "bi" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor,/area/holodeck/source_thunderdomecourt)
 "bj" = (/obj/structure/holowindow,/turf/simulated/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/source_thunderdomecourt)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -64,6 +64,7 @@
 			var/new_jumpsuit_icon_state = ""
 			var/new_jumpsuit_item_state = ""
 			var/new_jumpsuit_name = ""
+			var/new_can_adjust
 			var/new_glove_icon_state = ""
 			var/new_glove_item_state = ""
 			var/new_glove_name = ""
@@ -81,6 +82,7 @@
 					new_jumpsuit_icon_state = J.icon_state
 					new_jumpsuit_item_state = J.item_state
 					new_jumpsuit_name = J.name
+					new_can_adjust = J.can_adjust
 					qdel(J)
 					break
 				qdel(J)
@@ -125,6 +127,7 @@
 					J.name = new_jumpsuit_name
 					J.desc = new_desc
 					J.suit_color = wash_color
+					J.can_adjust = new_can_adjust
 			if(new_glove_icon_state && new_glove_item_state && new_glove_name)
 				for(var/obj/item/clothing/gloves/color/G in contents)
 					G.item_state = new_glove_item_state

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -139,3 +139,11 @@
 	icon_state = "maroon"
 	item_state = "r_suit"
 	item_color = "maroon"
+
+/obj/item/clothing/under/color/rainbow
+	name = "rainbow jumpsuit"
+	desc = "A multi-colored jumpsuit!"
+	icon_state = "rainbow"
+	item_state = "rainbow"
+	item_color = "rainbow"
+	can_adjust = 0

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -146,14 +146,6 @@
 	item_color = "griffin"
 	can_adjust = 0
 
-/obj/item/clothing/under/rainbow
-	name = "rainbow"
-	desc = "rainbow"
-	icon_state = "rainbow"
-	item_state = "rainbow"
-	item_color = "rainbow"
-	can_adjust = 0
-
 /obj/item/clothing/under/cloud
 	name = "cloud"
 	desc = "cloud"


### PR DESCRIPTION
This fixes the issue of colored jumpsuits not being dyeable into rainbow jumpsuits, since you were unable to. It also fixes the rainbow jumpsuit's name so it isn't just 'rainbow' anymore, and gives it a real description instead of just 'rainbow'. Due to me being unable to sprite a casually worn rainbow jumpsuit, I have made it so that the can_adjust var is also carried over when dye'ing a jumpsuit using the washing machine. Tested and everything works correctly. Also updates the maps correctly.

Fixes #3754 
