### PR TITLE
Allows drones to use middleclick to swap their hands.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -182,6 +182,9 @@
 	else
 		swap_hand()
 
+/mob/living/simple_animal/drone/MiddleClickOn(var/atom/A)
+	swap_hand()
+
 // In case of use break glass
 /*
 /atom/proc/MiddleClick(var/mob/M as mob)


### PR DESCRIPTION
Well, basically what it says on the tin. This allows you to use the middleclick button to swap your hands just like the carbon races can.

Fixes #5023
