### PR TITLE
Nuke Op COMMUNITY FEEDBACK PR

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -637,7 +637,7 @@ var/list/uplink_items = list()
 	name = "Explosive Implant"
 	desc = "An implant injected into the body, and later activated either manually or automatically upon death. Creates a moderately-sized fiery explosion. For those agents who know there is no going back."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	cost = 6
+	cost = 4
 
 // POINTLESS BADASSERY
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -182,7 +182,7 @@
 		name = initial(name)
 		desc = initial(desc)
 		user.AddLuminosity(brightness_on)
-		flags |= HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
+		flags |= HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE
 		flags_inv |= HIDEMASK|HIDEEYES|HIDEFACE
 		cold_protection |= HEAD
 	else
@@ -190,7 +190,7 @@
 		name += " (combat)"
 		desc = alt_desc
 		user.AddLuminosity(-brightness_on)
-		flags &= ~(HEADCOVERSEYES| HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL)
+		flags &= ~(HEADCOVERSEYES| HEADCOVERSMOUTH | STOPSPRESSUREDMAGE)
 		flags_inv &= ~(HIDEMASK|HIDEEYES|HIDEFACE)
 		cold_protection &= ~HEAD
 	update_icon()
@@ -204,13 +204,13 @@
 			linkedsuit.name = initial(linkedsuit.name)
 			linkedsuit.desc = initial(linkedsuit.desc)
 			linkedsuit.slowdown = 1
-			linkedsuit.flags |= STOPSPRESSUREDMAGE | THICKMATERIAL
+			linkedsuit.flags |= STOPSPRESSUREDMAGE
 			linkedsuit.cold_protection |= CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 		else
 			linkedsuit.name += " (combat)"
 			linkedsuit.desc = linkedsuit.alt_desc
 			linkedsuit.slowdown = 0
-			linkedsuit.flags &= ~(STOPSPRESSUREDMAGE | THICKMATERIAL)
+			linkedsuit.flags &= ~(STOPSPRESSUREDMAGE)
 			linkedsuit.cold_protection &= ~(CHEST | GROIN | LEGS | FEET | ARMS | HANDS)
 
 		linkedsuit.icon_state = "hardsuit[on]-[item_color]"
@@ -232,10 +232,6 @@
 	armor = list(melee = 60, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
-
-/obj/item/clothing/suit/space/hardsuit/syndi/ToggleHelmet()
-	..()
-	flags ^= NODROP
 
 /obj/item/clothing/suit/space/hardsuit/syndi/New()
 	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)


### PR DESCRIPTION
-Nuke Hardsuits are no longer unremovable when in combat mode, allowing for better healing/defibbing.
-Combat mode no longer removes THICKMATERIAL flag, which made them very vulnerable to syringe guns.
-Explosive implants reduced to 4 TC.

If you don't want to get looted, get good and don't die or buy an implant.

Fixes #8996
