### PR TITLE
Increases firelock layer when closed

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -83,23 +83,6 @@
 			return loc.Adjacent(neighbor,recurse - 1)
 		return 0
 	return ..()
-/*
-	Special case: This allows you to reach a door when it is visally on top of,
-	but technically behind, a fire door
-
-	You could try to rewrite this to be faster, but I'm not sure anything would be.
-	This can be safely removed if border firedoors are ever moved to be on top of doors
-	so they can be interacted with without opening the door.
-*/
-/obj/machinery/door/Adjacent(var/atom/neighbor)
-	var/obj/machinery/door/firedoor/border_only/BOD = locate() in loc
-	if(BOD)
-		BOD.throwpass = 1 // allow click to pass
-		. = ..()
-		BOD.throwpass = 0
-		return .
-	return ..()
-
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -18,6 +18,7 @@
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/emergency = 0 // Emergency access override
 	var/sub_door = 0 // 1 if it's meant to go under another door.
+	var/closingLayer = 3.1
 
 /obj/machinery/door/New()
 	..()
@@ -236,7 +237,7 @@
 	operating = 1
 
 	do_animate("closing")
-	src.layer = 3.1
+	src.layer = closingLayer
 	sleep(5)
 	src.density = 1
 	sleep(5)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -13,7 +13,7 @@
 	var/blocked = 0
 	var/nextstate = null
 	sub_door = 1
-
+	closingLayer = 3.11
 
 /obj/machinery/door/firedoor/Bumped(atom/AM)
 	if(p_open || operating)	return


### PR DESCRIPTION
Firelocks will now have a higher layer than doors when closed, they won't need any more special checks to reach them because an airlock is on top of them.
New variable for doors, closingLayer, on firedoors its 3.11 and normal doors on their classic 3.1
Fixes #412
