### PR TITLE
Makes some full face covering masks/helmets block drinking/eating stuff.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -24,7 +24,8 @@
 #define HEADCOVERSEYES		1024		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		2048		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		2048
-#define CANNOTFACEHUG			2048
+
+#define CANNOTFACEHUG		16384		//Protects you from being facehugged.
 
 #define HEADBANGPROTECT		4096
 #define EARBANGPROTECT		1024

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -24,6 +24,7 @@
 #define HEADCOVERSEYES		1024		// feel free to realloc these numbers for other purposes
 #define MASKCOVERSMOUTH		2048		// on other items, these are just for mask/head
 #define HEADCOVERSMOUTH		2048
+#define CANNOTFACEHUG			2048
 
 #define HEADBANGPROTECT		4096
 #define EARBANGPROTECT		1024

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -271,7 +271,7 @@
 	name = "flesh mass"
 	icon_state = "lingspacehelmet"
 	desc = "A covering of pressure and temperature-resistant organic tissue with a glass-like chitin front."
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | NODROP //Again, no THICKMATERIAL.
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | NODROP | CANNOTFACEHUG //Again, no THICKMATERIAL.
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/head/helmet/space/changeling/dropped()

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -70,7 +70,7 @@
 	item_state = "magus"
 	desc = "A helm worn by the followers of Nar-Sie."
 	flags_inv = HIDEFACE
-	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|BLOCKHAIR
+	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|BLOCKHAIR|CANNOTFACEHUG
 	armor = list(melee = 30, bullet = 30, laser = 30,energy = 20, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/magusred

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -166,7 +166,7 @@ BLIND     // can't see anything
 	name = "space helmet"
 	icon_state = "spaceold"
 	desc = "A special helmet with solar UV shielding to protect your eyes from harmful rays."
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | CANNOTFACEHUG
 	item_state = "spaceold"
 	permeability_coefficient = 0.01
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -19,6 +19,7 @@
 	name = "collectable xenomorph helmet!"
 	desc = "Hiss hiss hiss!"
 	icon_state = "xenom"
+	flags = HEADCOVERSMOUTH | BLOCKHAIR
 
 /obj/item/clothing/head/collectable/chef
 	name = "collectable chef's hat"
@@ -58,6 +59,7 @@
 	desc = "A collectable welding helmet. Now with 80% less lead! Not for actual welding. Any welding done while wearing this helmet is done so at the owner's own risk!"
 	icon_state = "welding"
 	item_state = "welding"
+	flags = HEADCOVERSMOUTH
 
 /obj/item/clothing/head/collectable/slime
 	name = "collectable slime hat"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -142,7 +142,7 @@
 	name = "gladiator helmet"
 	desc = "Ave, Imperator, morituri te salutant."
 	icon_state = "gladiator"
-	flags = HEADCOVERSEYES|BLOCKHAIR|HEADCOVERSMOUTH
+	flags = HEADCOVERSEYES|BLOCKHAIR
 	item_state = "gladiator"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -142,7 +142,7 @@
 	name = "gladiator helmet"
 	desc = "Ave, Imperator, morituri te salutant."
 	icon_state = "gladiator"
-	flags = HEADCOVERSEYES|BLOCKHAIR
+	flags = HEADCOVERSEYES|BLOCKHAIR|HEADCOVERSMOUTH
 	item_state = "gladiator"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -49,7 +49,7 @@
 	toggle_message = "You pull the visor down on"
 	alt_toggle_message = "You push the visor up on"
 	can_toggle = 1
-	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|HEADBANGPROTECT
+	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|HEADBANGPROTECT|CANNOTFACEHUG
 	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	strip_delay = 80

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -41,7 +41,7 @@
 	name = "hastur's hood"
 	desc = "It's <i>unspeakably</i> stylish."
 	icon_state = "hasturhood"
-	flags = HEADCOVERSEYES|BLOCKHAIR
+	flags = HEADCOVERSEYES|BLOCKHAIR|HEADCOVERSMOUTH
 
 /obj/item/clothing/head/nursehat
 	name = "nurse's hat"
@@ -53,7 +53,7 @@
 	icon_state = "syndicate-helm-black-red"
 	item_state = "syndicate-helm-black-red"
 	desc = "A plastic replica of a Syndicate agent's space helmet. You'll look just like a real murderous Syndicate agent in this! This is a toy, it is not made for use in space!"
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/that
@@ -76,7 +76,7 @@
 	desc = "Fight for what's righteous!"
 	icon_state = "justicered"
 	item_state = "justicered"
-	flags = HEADCOVERSEYES|BLOCKHAIR
+	flags = HEADCOVERSEYES|BLOCKHAIR|HEADCOVERSMOUTH
 
 /obj/item/clothing/head/justice/blue
 	icon_state = "justiceblue"
@@ -141,7 +141,7 @@
 	desc = "Bkaw!"
 	icon_state = "chickenhead"
 	item_state = "chickensuit"
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/griffin
@@ -149,7 +149,7 @@
 	desc = "Why not 'eagle head'? Who knows."
 	icon_state = "griffinhat"
 	item_state = "griffinhat"
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/bearpelt
@@ -163,7 +163,7 @@
 	icon_state = "xenos"
 	item_state = "xenos_helm"
 	desc = "A helmet made out of chitinous alien hide."
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/fedora

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -116,7 +116,7 @@
 	icon_state = "hardhat0_pumpkin"
 	item_state = "hardhat0_pumpkin"
 	item_color = "pumpkin"
-	flags = HEADCOVERSEYES | BLOCKHAIR
+	flags = HEADCOVERSEYES | BLOCKHAIR|HEADCOVERSMOUTH
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	action_button_name = "Toggle Pumpkin Light"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -18,7 +18,7 @@
 	desc = "Worn by robust fighters, flying high to defeat their foes!"
 	icon_state = "luchag"
 	item_state = "luchag"
-	flags = BLOCKHAIR | MASKCOVERSMOUTH
+	flags = BLOCKHAIR
 	flags_inv = HIDEFACE
 	w_class = 2
 

--- a/code/modules/clothing/masks/boxing.dm
+++ b/code/modules/clothing/masks/boxing.dm
@@ -18,7 +18,7 @@
 	desc = "Worn by robust fighters, flying high to defeat their foes!"
 	icon_state = "luchag"
 	item_state = "luchag"
-	flags = BLOCKHAIR
+	flags = BLOCKHAIR | MASKCOVERSMOUTH
 	flags_inv = HIDEFACE
 	w_class = 2
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -12,7 +12,7 @@
 	var/on = 0
 	item_color = "engineering" //Determines used sprites: hardsuit[on]-[color] and hardsuit[on]-[color]2 (lying down sprite)
 	action_button_name = "Toggle Helmet Light"
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP | CANNOTFACEHUG
 
 
 /obj/item/clothing/head/helmet/space/hardsuit/attack_self(mob/user)
@@ -162,7 +162,7 @@
 	on = 0
 	var/obj/item/clothing/suit/space/hardsuit/syndi/linkedsuit = null
 	action_button_name = "Toggle Helmet Mode"
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP | CANNOTFACEHUG
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
@@ -182,7 +182,7 @@
 		name = initial(name)
 		desc = initial(desc)
 		user.AddLuminosity(brightness_on)
-		flags |= HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
+		flags |= HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | CANNOTFACEHUG
 		flags_inv |= HIDEMASK|HIDEEYES|HIDEFACE
 		cold_protection |= HEAD
 	else
@@ -190,7 +190,7 @@
 		name += " (combat)"
 		desc = alt_desc
 		user.AddLuminosity(-brightness_on)
-		flags &= ~(HEADCOVERSEYES| HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL)
+		flags &= ~(HEADCOVERSEYES| HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | CANNOTFACEHUG)
 		flags_inv &= ~(HIDEMASK|HIDEEYES|HIDEFACE)
 		cold_protection &= ~HEAD
 	update_icon()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -141,7 +141,7 @@
 	item_color = "ert_commander"
 	armor = list(melee = 65, bullet = 50, laser = 50, energy = 50, bomb = 50, bio = 100, rad = 100)
 	strip_delay = 130
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP | CANNOTFACEHUG
 	brightness_on = 7
 
 /obj/item/clothing/suit/space/hardsuit/ert

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -39,7 +39,7 @@
 	icon_state = "plasmaman_helmet0-plasma"
 	item_color = "plasma" //needed for the helmet lighting
 	item_state = "plasmaman_helmet0"
-	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL
+	flags = HEADCOVERSEYES | BLOCKHAIR | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL | CANNOTFACEHUG
 	//Removed the NODROP from /helmet/space/hardsuit.
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 	//Removed the HIDEFACE from /helmet/space/hardsuit

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -123,7 +123,7 @@ var/const/MAX_ACTIVE_TIME = 400
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(H.is_mouth_covered(head_only = 1))
+		if(H.cannot_facehug(head_only = 1))
 			H.visible_message("<span class='danger'>[src] smashes against [H]'s [H.head]!</span>", \
 								"<span class='userdanger'>[src] smashes against [H]'s [H.head]!</span>")
 			Die()
@@ -239,7 +239,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	var/mob/living/carbon/C = M
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if(H.is_mouth_covered(head_only = 1))
+		if(H.cannot_facehug(head_only = 1))
 			return 0
 		return 1
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -496,6 +496,10 @@ var/const/GALOSHES_DONT_HELP = 8
 	if( (!mask_only && head && (head.flags & HEADCOVERSMOUTH)) || (!head_only && wear_mask && (wear_mask.flags & MASKCOVERSMOUTH)) )
 		return 1
 
+/mob/living/carbon/proc/cannot_facehug(head_only = 0, mask_only = 0)
+	if( (!mask_only && head && (head.flags & CANNOTFACEHUG)) || (!head_only && wear_mask && (wear_mask.flags & CANNOTFACEHUG)) )
+		return 1
+
 /mob/living/carbon/get_standard_pixel_y_offset(lying = 0)
 	if(lying)
 		return -6

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -496,8 +496,8 @@ var/const/GALOSHES_DONT_HELP = 8
 	if( (!mask_only && head && (head.flags & HEADCOVERSMOUTH)) || (!head_only && wear_mask && (wear_mask.flags & MASKCOVERSMOUTH)) )
 		return 1
 
-/mob/living/carbon/proc/cannot_facehug(head_only = 0, mask_only = 0)
-	if( (!mask_only && head && (head.flags & CANNOTFACEHUG)) || (!head_only && wear_mask && (wear_mask.flags & CANNOTFACEHUG)) )
+/mob/living/carbon/proc/cannot_facehug(head_only = 0)
+	if(head && (head.flags & CANNOTFACEHUG))
 		return 1
 
 /mob/living/carbon/get_standard_pixel_y_offset(lying = 0)


### PR DESCRIPTION
This adds the HEADCOVERSMOUTH and MASKCOVERSMOUTH flags to more facecovering masks/headgear, so you can't drink/eat through them. This should thus fix the rest of issue #5919 . If there are any more masks/headgear you believe should have these flags aswell, then inform me of it.

Fixes #5919

Edit: This now adds a special flag CANNOTFACEHUG and applies it to the helmets which currently blocks being facehugged. Tested and everything still seems to work as intended. Thus being able to eat/use lipstick/etc. uses a different flag than something preventing you from being facehugged.
