### PR TITLE
Fixes lings getting implanted roles specifically in traitorling

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -39,11 +39,6 @@
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount/2))
 
-	for(var/datum/mind/player in possible_changelings)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				possible_changelings -= player
-
 	if(possible_changelings.len>0)
 		for(var/j = 0, j < num_changelings, j++)
 			if(!possible_changelings.len) break
@@ -51,6 +46,7 @@
 			possible_changelings -= changeling
 			changelings += changeling
 			modePlayer += changelings
+			changeling.restricted_roles = restricted_jobs
 		return ..()
 	else
 		return 0


### PR DESCRIPTION
Fixes a missed change from #9364 in relation to lings in traitorling

I had forgotten that (unlike Double Agents) traitor/ling (which is a child of traitor but exists in the ling folder [BLECH]) calls its own pre_setup. In the future if everything goes right traitor/ling will cease to be its own roundtype in terms of code and will get a refactor just be a traitor and ling datum running at the same time with slightly nerfed antag to player ratios to match what traitor/ling is now.

Fixes #9514 

On the plus side every other aspect of that pull is working perfectly. :tada: 
