### PR TITLE
Makes mechs unable to drill space

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -87,6 +87,8 @@
 /obj/item/mecha_parts/mecha_equipment/tool/drill/action(atom/target)
 	if(!action_checks(target))
 		return
+	if(istype(target, /turf) && !istype(target, /turf/simulated))
+		return
 	if(isobj(target))
 		var/obj/target_obj = target
 		if(target_obj.unacidable)


### PR DESCRIPTION
Added a check so mechs aren't able to drill space. Thanks to Miauw for showing me how to do this!

Fixes #9114
