### PR TITLE
Fixes the ghost message from posibrain 

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -169,8 +169,8 @@
 	overlays -= "fab-active"
 	desc = initial(desc)
 
-	var/obj/item/I = new D.build_path
-	I.loc = get_step(src,SOUTH)
+	var/location = get_step(src,SOUTH)
+	var/obj/item/I = new D.build_path(location)
 	I.m_amt = get_resource_cost_w_coeff(D,"$metal")
 	I.g_amt = get_resource_cost_w_coeff(D,"$glass")
 	visible_message("\icon[src] <b>\The [src]</b> beeps, \"\The [I] is complete.\"")


### PR DESCRIPTION
Fixes the ghost message from posibrain built with the exosuit fabricator. It will now correctly mention the area where the posibrain was created.

Fixes #9546 
