### PR TITLE
Make cyro only use gas and generate heat when in use [DNM]

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -49,8 +49,10 @@
 	..()
 	if(air_contents)
 		temperature_archived = air_contents.temperature
-		heat_gas_contents()
-		expel_gas()
+		if(state_open || occupant)
+			heat_gas_contents()
+			expel_gas()
+
 	if(abs(temperature_archived-air_contents.temperature) > 1)
 		parent.update = 1
 


### PR DESCRIPTION
In use is defined as having an occupant or having an open door
