### PR TITLE
Alt-click-toggles now do proper checks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -351,8 +351,8 @@
 
 /obj/structure/closet/AltClick(var/mob/user)
 	..()
-	if(user.stat || !user.canmove || user.restrained() || broken)
-		user << "<span class='notice'>You can't do that right now.</span>"
+	if(!user.canUseTopic(user) || broken)
+		user << "<span class='warning'>You can't do that right now!</span>"
 		return
 	if(src.opened || !secure || !in_range(src, user))
 		return

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -315,9 +315,15 @@ atom/proc/generate_female_clothing(index,t_color,icon,type)
 
 	..()
 
-/obj/item/clothing/under/AltClick()
+/obj/item/clothing/under/AltClick(var/mob/user)
 	..()
-	rolldown()
+	if(!user.canUseTopic(user))
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(!in_range(src, user))
+		return
+	else
+		rolldown()
 
 /obj/item/clothing/under/verb/jumpsuit_adjust()
 	set name = "Adjust Jumpsuit Style"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -19,7 +19,14 @@
 
 
 /obj/item/clothing/head/soft/AltClick(var/mob/user)
-	flip(user)
+	..()
+	if(!user.canUseTopic(user))
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(!in_range(src, user))
+		return
+	else
+		flip(user)
 
 
 /obj/item/clothing/head/soft/proc/flip(var/mob/user)

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -16,7 +16,14 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/breath/AltClick(var/mob/user)
-	adjustmask(user)
+	..()
+	if(!user.canUseTopic(user))
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(!in_range(src, user))
+		return
+	else
+		adjustmask(user)
 
 /obj/item/clothing/mask/breath/examine(mob/user)
 	..()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -53,9 +53,15 @@
 
 //Toggle exosuits for different aesthetic styles (hoodies, suit jacket buttons, etc)
 
-/obj/item/clothing/suit/toggle/AltClick()
+/obj/item/clothing/suit/toggle/AltClick(var/mob/user)
 	..()
-	suit_toggle()
+	if(!user.canUseTopic(user))
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(!in_range(src, user))
+		return
+	else
+		suit_toggle(user)
 
 /obj/item/clothing/suit/toggle/ui_action_click()
 	suit_toggle()


### PR DESCRIPTION
Labcoat button toggles, breath mask adjusting, cap flipping and jumpsuit rolling check for such stuff as if you're near the thing, conscious, alive etc. Also simplified the checks for lockers.
Thanks to Miauw for helping out!

Fixes #9238
