### PR TITLE
Newscaster code big cleanup.

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -569,22 +569,22 @@ Code:
 		if (53) // Newscaster
 			menu = "<h4><img src=pda_notes.png> Newscaster Access</h4>"
 			menu += "<br> Current Newsfeed: <A href='byond://?src=\ref[src];choice=Newscaster Switch Channel'>[current_channel ? current_channel : "None"]</a> <br>"
-			var/datum/feed_channel/current
-			for(var/datum/feed_channel/chan in news_network.network_channels)
+			var/datum/newscaster/feed_channel/current
+			for(var/datum/newscaster/feed_channel/chan in news_network.network_channels)
 				if (chan.channel_name == current_channel)
 					current = chan
 			if(!current)
 				menu += "<h5> ERROR : NO CHANNEL FOUND </h5>"
 				return
 			var/i = 1
-			for(var/datum/feed_message/msg in current.messages)
-				menu +="-[msg.body] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[msg.author]</FONT>\]</FONT><BR>"
+			for(var/datum/newscaster/feed_message/msg in current.messages)
+				menu +="-[msg.returnBody(-1)] <BR><FONT SIZE=1>\[Story by <FONT COLOR='maroon'>[msg.returnAuthor(-1)]</FONT>\]</FONT><BR>"
 				menu +="<b><font size=1>[msg.comments.len] comment[msg.comments.len > 1 ? "s" : ""]</font></b><br>"
 				if(msg.img)
 					user << browse_rsc(msg.img, "tmp_photo[i].png")
 					menu +="<img src='tmp_photo[i].png' width = '180'><BR>"
 				i++
-				for(var/datum/feed_comment/comment in msg.comments)
+				for(var/datum/newscaster/feed_comment/comment in msg.comments)
 					menu +="<font size=1><small>[comment.body]</font><br><font size=1><small><small><small>[comment.author] [comment.time_stamp]</small></small></small></small></font><br>"
 			menu += "<br> <A href='byond://?src=\ref[src];choice=Newscaster Message'>Post Message</a>"
 
@@ -662,8 +662,8 @@ Code:
 		if("Newscaster Message")
 			var/pda_owner_name = pda.id ? "[pda.id.registered_name] ([pda.id.assignment])" : "Unknown"
 			var/message = pda.msg_input()
-			var/datum/feed_channel/current
-			for(var/datum/feed_channel/chan in news_network.network_channels)
+			var/datum/newscaster/feed_channel/current
+			for(var/datum/newscaster/feed_channel/chan in news_network.network_channels)
 				if (chan.channel_name == current_channel)
 					current = chan
 			if(current.locked && current.author != pda_owner_name)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -8,10 +8,11 @@ var/list/admin_datums = list()
 
 	var/datum/marked_datum
 
-	var/admincaster_screen = 0	//See newscaster.dm under machinery for a full description
-	var/datum/feed_message/admincaster_feed_message = new /datum/feed_message   //These two will act as holders.
-	var/datum/feed_channel/admincaster_feed_channel = new /datum/feed_channel
-	var/admincaster_signature	//What you'll sign the newsfeeds as
+	var/admincaster_screen = 0	//TODO: remove all these 5 variables, they are completly unacceptable
+	var/datum/newscaster/feed_message/admincaster_feed_message = new /datum/newscaster/feed_message
+	var/datum/newscaster/wanted_message/admincaster_wanted_message = new /datum/newscaster/wanted_message
+	var/datum/newscaster/feed_channel/admincaster_feed_channel = new /datum/newscaster/feed_channel
+	var/admincaster_signature
 
 /datum/admins/New(datum/admin_rank/R, ckey)
 	if(!ckey)


### PR DESCRIPTION
Removes lots of copypaste.
Admin newscaster barely modified, they still are a gigantic copypaste from the topic.dm() of the newscaster object.
Printed diaries will now only report the information available when they were printed, including wanted status and the different types of censorship.
All datums are now under /datum/newscaster
Wanted is now a different type of datum, /datum/newscaster/wanted_message
Fixed a bug where you couldn't censor normal submissions, made by crewmembers.
Fixes #944
Fixes #8494 

I added a 'TODO' comment on the admin holder datum, where the vars are set. This took me seven hours from start to finish, so I don't really feel like continuing. I kinda hate agouri now, kinda cool.
