### PR TITLE
AI's built in malfunction get the malfunction law

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -184,6 +184,11 @@
 				user << "<span class='notice'>You connect the monitor.</span>"
 				if(!laws.inherent.len) //If laws isn't set to null but nobody supplied a board, the AI would normally be created lawless. We don't want that.
 					laws = null
+				if(ticker.mode.malf_ai) //if there's malfs about, any new AIs get malf laws, but aren't malfs themselves or have malf powers
+					for(var/datum/mind/AI_mind in ticker.mode.malf_ai)
+						if(isAI(AI_mind.current) && AI_mind.current.stat != DEAD)
+							laws.set_zeroth_law("<span class='danger'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*´&110010</span>")
+							break
 				new /mob/living/silicon/ai (loc, laws, brain)
 				feedback_inc("cyborg_ais_created",1)
 				qdel(src)


### PR DESCRIPTION
AI's built in malfunction (while there's still at least one malfunctoning AI still alive), will get the assume control law to keep them from immediately shitting on the primary malf AI

Note that AI's made this way are NOT malfunctioning in terms of antag status, they've just got an unclearable 0th law to bring their will in line with the malfunctioning AI.

A lot of admins will already do this for new AI's built in malf to the point that some people thought we already had this feature.

Fixes what led up to #9566 occurring, but I'll still need to see why it tried to run Double Agents
