### PR TITLE
Quashes Double Agents from appearing in mulligans (again)

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,6 +5,7 @@
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
+	reroll_friendly = 0
 
 	traitor_name = "double agent"
 


### PR DESCRIPTION
Yes I already did this once, I'm not sure how it got reverted but oh well. Lots of modes will hopefully be made mulligan safe post freeze.

Fixes #9566 in conjugation with #9567 
