### PR TITLE
Fix #4332. Also fixes mutant race respawn-char.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -259,6 +259,8 @@ var/record_id_num = 1001
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["enzymes"]		= H.dna.struc_enzymes
 		L.fields["identity"]	= H.dna.uni_identity
+		L.fields["species"]		= H.dna.species.type
+		L.fields["mcolor"]		= H.dna.mutant_color
 		L.fields["image"]		= image
 		locked += L
 	return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -298,7 +298,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	//DNA
 	if(record_found)//Pull up their name from database records if they did have a mind.
-		hardset_dna(new_character, record_found.fields["identity"], record_found.fields["enzymes"], record_found.fields["name"], null, record_found.fields["blood_type"])
+		hardset_dna(new_character, record_found.fields["identity"], record_found.fields["enzymes"], record_found.fields["name"], record_found.fields["blood_type"], record_found.fields["species"], record_found.fields["mcolor"])
 	else//If they have no records, we just do a random DNA for them, based on their random appearance/savefile.
 		ready_dna(new_character)
 


### PR DESCRIPTION
For this, added species type and mutant color records in locked records. Tested.
Fixes #4332 
![1](https://cloud.githubusercontent.com/assets/9455174/7723614/fa13a24a-ff24-11e4-99a3-25463979d17e.png)
![2](https://cloud.githubusercontent.com/assets/9455174/7723617/fbfc4cf6-ff24-11e4-9ceb-8a66d1318881.png)
![2 5](https://cloud.githubusercontent.com/assets/9455174/7723620/0508e106-ff25-11e4-9f96-18d7c106e757.png)
![3](https://cloud.githubusercontent.com/assets/9455174/7723621/0850e188-ff25-11e4-8b9e-970cf1833c74.png)
