### PR TITLE
Fixes admin-PM on stealth

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -558,12 +558,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		include_link = 0
 
 	if(key)
-		if(include_link)
-			. += "<a href='?priv_msg=[ckey]'>"
-
 		if(C && C.holder && C.holder.fakekey && !include_name)
+			if(include_link)
+				. += "<a href='?priv_msg=[C.findStealthKey()]'>"
 			. += "Administrator"
 		else
+			if(include_link)
+				. += "<a href='?priv_msg=[ckey]'>"
 			. += key
 		if(!C)
 			. += "\[DC\]"

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -1,13 +1,14 @@
-var/list/clients = list()							//list of all clients
-var/list/admins = list()							//list of all clients whom are admins
-var/list/deadmins = list()							//list of all clients who have used the de-admin verb.
-var/list/directory = list()							//list of all ckeys with associated client
+var/list/clients = list()							//all clients
+var/list/admins = list()							//all clients whom are admins
+var/list/deadmins = list()							//all clients who have used the de-admin verb.
+var/list/directory = list()							//all ckeys with associated client
+var/list/stealthminID = list()					//reference list with IDs that store ckeys, for stealthmins
 
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 
-var/global/list/player_list = list()				//List of all mobs **with clients attached**. Excludes /mob/new_player
-var/global/list/mob_list = list()					//List of all mobs, including clientless
-var/global/list/living_mob_list = list()			//List of all alive mobs, including clientless. Excludes /mob/new_player
-var/global/list/dead_mob_list = list()				//List of all dead mobs, including clientless. Excludes /mob/new_player
-var/global/list/joined_player_list = list()			//List of all clients that have joined the game at round-start or as a latejoin.
+var/global/list/player_list = list()				//all mobs **with clients attached**. Excludes /mob/new_player
+var/global/list/mob_list = list()					//all mobs, including clientless
+var/global/list/living_mob_list = list()			//all alive mobs, including clientless. Excludes /mob/new_player
+var/global/list/dead_mob_list = list()				//all dead mobs, including clientless. Excludes /mob/new_player
+var/global/list/joined_player_list = list()			//all clients that have joined the game at round-start or as a latejoin.

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -381,6 +381,26 @@ var/list/admin_verbs_hideable = list(
 	feedback_add_details("admin_verb","S") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
+
+/client/proc/findStealthKey(txt)
+	if(txt)
+		for(var/P in stealthminID)
+			if(stealthminID[P] == txt)
+				return P
+	txt = stealthminID[ckey]
+	return txt
+
+/client/proc/createStealthKey()
+	var/num = (rand(0,1000))
+	var/i = 0
+	while(i == 0)
+		i = 1
+		for(var/P in stealthminID)
+			if(num == stealthminID[P])
+				num++
+				i = 0
+	stealthminID["[ckey]"] = "@[num2text(num)]"
+
 /client/proc/stealth()
 	set category = "Admin"
 	set name = "Stealth Mode"
@@ -393,6 +413,7 @@ var/list/admin_verbs_hideable = list(
 			if(length(new_key) >= 26)
 				new_key = copytext(new_key, 1, 26)
 			holder.fakekey = new_key
+			createStealthKey()
 		log_admin("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
 		message_admins("[key_name_admin(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
 	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -42,6 +42,8 @@
 
 	var/client/C
 	if(istext(whom))
+		if(cmptext(copytext(whom,1,2),"@"))
+			whom = findStealthKey(whom)
 		C = directory[whom]
 	else if(istype(whom,/client))
 		C = whom


### PR DESCRIPTION
Fixes admin stealth failing to be actual stealth due to href reading or and the pop-out window.
Fixes #1121
Adds a new associative list, stealthminID, they will be associated with raw ckey text and their contents will be a random ID. The random ID is generated when an admin goes to stealth, without repeating itself.
New client procs that will handle the list, findStealthKey() and createStealthKey()
Admin-pms will use this special ID for admins who are stealthing, hiding their real ckey.

2 hours from start to finish.
