### PR TITLE
Unbricks Revolutions

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -184,6 +184,7 @@
 				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				config.continuous[config_tag] = 1
 				config.midround_antag[config_tag] = 0
+				SSshuttle.emergencyNoEscape = 0
 				return 0
 
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -44,12 +44,6 @@
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	var/head_check = 0
-	for(var/mob/new_player/player in player_list)
-		if(player.mind.assigned_role in command_positions)
-			head_check = 1
-			break
-
 	for (var/i=1 to max_headrevs)
 		if (antag_candidates.len==0)
 			break
@@ -58,7 +52,7 @@
 		head_revolutionaries += lenin
 		lenin.restricted_roles = restricted_jobs
 
-	if((head_revolutionaries.len < required_enemies)||(!head_check))
+	if(head_revolutionaries.len < required_enemies)
 		return 0
 
 	return 1


### PR DESCRIPTION
Removes a check for living heads I missed in pre setup for revolution (because heads hadn't been picked yet it was automatically failing).

In the extremely unlikely event where a round that qualifies for revolution produces no heads (there' a lot of checks to prevent this) mulligan will warn the admins that there's no antags.

---

Fixes a slight oversight in a sanity check where shuttles could get stranded in a rare few situations where "accidental extended" occurred due to shenanigans.
