### PR TITLE
[Critical Bug] [Merge ASAP] Crashing Closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -238,7 +238,7 @@
 		if(secure && broken)
 			user << "<span class='notice'>The locker appears to be broken.</span>"
 			return
-		if(!place(user, W))
+		if(!place(user, W) && !isnull(W))
 			src.attack_hand(user)
 
 /obj/structure/closet/proc/place(var/mob/user, var/obj/item/I)


### PR DESCRIPTION
Fixes a critical bug where clicking on a closed closet that can't be opened (welded most likely) would lead to an infinite loop of attacking attackby and attack_hand until the mob pulled away from the closet. Eating too many of these errors causes the server to cry for mercy and shut down. Meaning of course that EVERY PLAYER IN THE GAME WHO READS THIS PULL CAN NOW CRASH THE GAME AT THEIR LEISURE (please don't do this players, this shit IS logged, you'll get caught).

So yeah merge quick please.

Fixes the actual cause of #9580
