### PR TITLE
[ready]Workaround for Out of resources byond bug

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -82,8 +82,8 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5)
 /atom/movable/proc/air_update_turf(var/command = 0)
 	if(!istype(loc,/turf) && command)
 		return
-	for(var/turf/T in locs) // used by double wide doors and other nonexistant multitile structures
-		T.air_update_turf(command)
+	var/turf/T = loc
+	T.air_update_turf(command)
 
 /turf/proc/air_update_turf(var/command = 0)
 	if(command)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1072,18 +1072,30 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 
 //Gets the turf this atom inhabits
-/proc/get_turf(atom/movable/AM)
-	if(istype(AM))
-		var/list/atom/checkedatoms = list() //prevent recursion from badmins being dumbasses
-		var/atom/A = AM
-		while (!isturf(A))
-			if (A in checkedatoms || !A.loc)
-				return
-			checkedatoms += A
-			A = A.loc
+
+/proc/get_turf(atom/A)
+	if (!istype(A))
+		return
+	if (isturf(A))
 		return A
-	else if(isturf(AM))
-		return AM
+
+	var/list/atom/checked_turf_candidates = list() //prevent recursion from badmins being dumbasses
+	var/atom/turf_candidate = A.loc
+
+	while (!isturf(turf_candidate))
+		if (!turf_candidate || turf_candidate in checked_turf_candidates)
+			return
+		checked_turf_candidates += turf_candidate
+
+		//SO I BET YOU MIGHT BE WONDERING WHY I'M CHECKING THIS AGAIN.
+		//I'LL FUCKING TELL YOU WAY, ITS BECAUSE FOR SOME GOD DAMN REASON, WHEN THIS IS CALLED
+		//IN AN OBJECT'S NEW() PROC, THE FIRST CHECK WILL FUCKING PASS, BUT FUCKING RUNTIME HERE
+		//BITCHING ABOUT HOW IT CAN'T READ NULL.LOC, SO FUCK IT, WE CHECK THIS TWICE.
+		if (!turf_candidate)
+			return
+		turf_candidate = turf_candidate.loc
+	return turf_candidate
+
 
 //Gets the turf this atom's *ICON* appears to inhabit
 //Uses half the width/height respectively to work out

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1074,7 +1074,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Gets the turf this atom inhabits
 /proc/get_turf(atom/movable/AM)
 	if(istype(AM))
-		return locate(/turf) in AM.locs
+		var/list/atom/moveable/checkedlocs = list() //prevent recursion from badmins being dumbasses
+		while (!isturf(AM))
+			if (AM in checkedlocs || !AM.loc)
+				return
+			checkedlocs += AM
+			AM = AM.loc
+		return AM
 	else if(isturf(AM))
 		return AM
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1074,13 +1074,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Gets the turf this atom inhabits
 /proc/get_turf(atom/movable/AM)
 	if(istype(AM))
-		var/list/atom/moveable/checkedlocs = list() //prevent recursion from badmins being dumbasses
-		while (!isturf(AM))
-			if (AM in checkedlocs || !AM.loc)
+		var/list/atom/checkedatoms = list() //prevent recursion from badmins being dumbasses
+		var/atom/A = AM
+		while (!isturf(A))
+			if (A in checkedatoms || !A.loc)
 				return
-			checkedlocs += AM
-			AM = AM.loc
-		return AM
+			checkedatoms += A
+			A = A.loc
+		return A
 	else if(isturf(AM))
 		return AM
 

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -62,17 +62,11 @@
 /*
 	Adjacency (to anything else):
 	* Must be on a turf
-	* In the case of a multiple-tile object, all valid locations are checked for adjacency.
-
-	Note: Multiple-tile objects are created when the bound_width and bound_height are creater than the tile size.
-	This is not used in stock /tg/station currently.
 */
 /atom/movable/Adjacent(var/atom/neighbor)
 	if(neighbor == loc) return 1
 	if(!isturf(loc)) return 0
-	for(var/turf/T in locs)
-		if(isnull(T)) continue
-		if(T.Adjacent(neighbor,src)) return 1
+	if(loc.Adjacent(neighbor,src)) return 1
 	return 0
 
 // This is necessary for storage items not on your person.

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -348,9 +348,9 @@
 
 	var/obj/item/weapon/folder/syndicate/folder
 	if(owner == exchange_red)
-		folder = new/obj/item/weapon/folder/syndicate/red(mob.locs)
+		folder = new/obj/item/weapon/folder/syndicate/red(mob.loc)
 	else
-		folder = new/obj/item/weapon/folder/syndicate/blue(mob.locs)
+		folder = new/obj/item/weapon/folder/syndicate/blue(mob.loc)
 
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,


### PR DESCRIPTION
Fixes #9503 - Out of resources runtime (dubbed "the mc crashing" for whatever fucking reason.)
Fixes #7410 (same as above)

~~Simply put, running locate in locs causes the copy of the list byond creates in locate to never get deallocated.~~ actually, it turns out that it's any accessing of atom/movable.locs.

If you later run a "thing in things" style for loop after hitting some limit (2^24) on the total number of lists, an out of resources runtime will spew, everything will break, and attempts to access lists will randomly fail and cause that list to get corrupted.

Test Case: http://pastebin.com/1kiXQb6s

~~I haven't actually tested this, i'm going to bed. test before merging if you decide to quick merge this.~~

~~I tested it, shit is runtiming about something being null when we just checked it the line before. most likely ANOTHER byond bug.~~

~~do not merge quite yet.~~

Ready.
