### PR TITLE
Removes the rare gibbing mechanic from blood boil

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -912,9 +912,6 @@ var/list/sacrificed = list()
 				continue
 			M.take_overall_damage(51,51)
 			M << "<span class='danger'>Your blood boils!</span>"
-			if(prob(5))
-				spawn(5)
-					M.gib()
 		for(var/obj/effect/rune/R in view(src))
 			if(prob(10))
 				explosion(R.loc, -1, 0, 1, 5)


### PR DESCRIPTION
Because it can accidentally fuck over a cult by RNG gibbing a target (which doesn't count as a proper sac).

If cultists WANT to gib people reliably, they already have a rune for that.

Also holy crap I didn't know blood boil was literally a one hit crit (does 102 damage)
