### PR TITLE
Mulligan edge case, who woulda thunk it

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -179,6 +179,7 @@
 				priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 			SSshuttle.emergencyNoEscape = 0
 			malf_mode_declared = 0
+			continuous_sanity_checked = 1
 			if(get_security_level() == "delta")
 				set_security_level("red")
 			return ..()

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -71,6 +71,7 @@
 
 	if(!round_converted)
 		for(var/datum/mind/monkey_mind in ape_infectees)
+			continuous_sanity_checked = 1
 			if(monkey_mind.current && monkey_mind.current.stat != DEAD)
 				return 0
 


### PR DESCRIPTION
Fixes an edge case in malf where mulligan could incorrectly determine that there were never any antags because the malf AI died by gibbing

Resolves a similar sort of deal in monkey

Note to self: if a mode has a hard return in the child before ..() you NEED to be sure continuous_sanity_checked is handled in the child.

Note to future self: remove all hard returns in child modes, they are shit and cause all the mulligan bugs
