### PR TITLE
Fixes all possible exploits with the AI tracking href link

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -196,8 +196,10 @@
 		for(var/mob/O in player_list)
 			if(istype(O, /mob/living/silicon/ai))
 				var/mob/living/silicon/ai/AI = O
-				if(U.name == "Unknown") AI << "<b>[U]</b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
-				else AI << "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[U]'>[U]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
+				if(U.name == "Unknown")
+					AI << "<b>[U]</b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
+				else
+					AI << "<b><a href='?src=\ref[AI];track=[U.name]'>[U]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ..."
 				AI.last_paper_seen = "<HTML><HEAD><TITLE>[itemname]</TITLE></HEAD><BODY><TT>[info]</TT></BODY></HTML>"
 			else if (O.client && O.client.eye == src)
 				O << "[U] holds \a [itemname] up to one of the cameras ..."

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -98,7 +98,7 @@
 
 	return targets
 
-/mob/living/silicon/ai/verb/ai_camera_track(var/target_name as null|anything in trackable_mobs())
+/mob/living/silicon/ai/verb/ai_camera_track(var/target_name in trackable_mobs())
 	set name = "track"
 	set hidden = 1 //Don't display it on the verb lists. This verb exists purely so you can type "track Oldman Robustin" and follow his ass
 
@@ -112,7 +112,6 @@
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target as mob)
 	if(!istype(target))	return
 	var/mob/living/silicon/ai/U = usr
-
 	U.cameraFollow = target
 	//U << text("Now tracking [] on camera.", target.name)
 	//if (U.machine == null)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -111,7 +111,7 @@
 					R.SetLockdown(!R.lockcharge)
 					R << "[!R.lockcharge ? "<span class='notice'>Your lockdown has been lifted!" : "<span class='alert'>You have been locked down!"]</span>"
 					if(R.connected_ai)
-						R.connected_ai << "[!R.lockcharge ? "<span class='notice'>NOTICE - Cyborg lockdown lifted" : "<span class='alert'>ALERT - Cyborg lockdown detected"]: <a href='byond://?src=\ref[R.connected_ai];track2=\ref[R.connected_ai];track=\ref[R]'>[R.name]</a></span><br>"
+						R.connected_ai << "[!R.lockcharge ? "<span class='notice'>NOTICE - Cyborg lockdown lifted" : "<span class='alert'>ALERT - Cyborg lockdown detected"]: <a href='?src=\ref[R.connected_ai];track=[R.name]'>[R.name]</a></span><br>"
 
 		else
 			usr << "<span class='danger'>Access Denied.</span>"

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -72,7 +72,6 @@
 	virt.job = job
 	virt.languages = AM.languages
 	virt.source = AM
-	virt.faketrack = data == 4 ? 1 : 0
 	virt.radio = radio
 	virt.verb_say = verb_say
 	virt.verb_ask = verb_ask

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -182,31 +182,7 @@
 		usr << browse(null, "window=radio")
 		return
 	usr.set_machine(src)
-	if (href_list["track"])
-		var/mob/target = locate(href_list["track"])
-		var/mob/living/silicon/ai/A = locate(href_list["track2"])
-		if(A && target)
-			A.ai_actual_track(target)
-		return
-
-	else if (href_list["faketrack"])
-		var/mob/target = locate(href_list["track"])
-		var/mob/living/silicon/ai/A = locate(href_list["track2"])
-		if(A && target)
-
-			A:cameraFollow = target
-			A << text("Now tracking [] on camera.", target.name)
-			if (usr.machine == null)
-				usr.machine = usr
-
-			while (usr:cameraFollow == target)
-				usr << "Target is not on or near any active cameras on the station. We'll check again in 5 seconds (unless you use the cancel-camera verb)."
-				sleep(40)
-				continue
-
-		return
-
-	else if (href_list["freq"])
+	if (href_list["freq"])
 		if (!freqlock)
 			var/new_frequency = (frequency + text2num(href_list["freq"]))
 			if (!freerange || (frequency < 1200 || frequency > 1600))

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -54,7 +54,7 @@ var/list/freqtospan = list(
 	//Message
 	var/messagepart = " <span class='message'>[lang_treat(speaker, message_langs, raw_message, spans)]</span></span>"
 
-	return "[spanpart1][spanpart2][freqpart][compose_track_href(speaker, message_langs, raw_message, radio_freq)][namepart][compose_job(speaker, message_langs, raw_message, radio_freq)][endspanpart][messagepart]"
+	return "[spanpart1][spanpart2][freqpart][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_langs, raw_message, radio_freq)][endspanpart][messagepart]"
 
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
@@ -146,8 +146,6 @@ var/list/freqtospan = list(
 
 /atom/movable/proc/GetJob() //Get a job, you lazy butte
 
-/atom/movable/proc/GetTrack()
-
 /atom/movable/proc/GetSource()
 
 /atom/movable/proc/GetRadio()
@@ -155,15 +153,11 @@ var/list/freqtospan = list(
 //VIRTUALSPEAKERS
 /atom/movable/virtualspeaker
 	var/job
-	var/faketrack
 	var/atom/movable/source
 	var/obj/item/device/radio/radio
 
 /atom/movable/virtualspeaker/GetJob()
 	return job
-
-/atom/movable/virtualspeaker/GetTrack()
-	return faketrack
 
 /atom/movable/virtualspeaker/GetSource()
 	return source

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -432,13 +432,6 @@ var/list/ai_list = list()
 	if(href_list["botrefresh"]) //Refreshes the bot control panel.
 		botcall()
 		return
-	if(href_list["track"])
-		var/mob/target = locate(href_list["track"])
-		var/mob/living/silicon/ai/A = locate(href_list["track2"])
-		world << "radio"
-		if(A && target)
-			A.ai_actual_track(target)
-		return
 
 /mob/living/silicon/ai/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -370,7 +370,6 @@ var/list/ai_list = list()
 
 	return
 
-
 /mob/living/silicon/ai/Topic(href, href_list)
 	if(usr != src)
 		return
@@ -394,55 +393,52 @@ var/list/ai_list = list()
 		if(last_paper_seen)
 			src << browse(last_paper_seen, "window=show_paper")
 	//Carn: holopad requests
-	if (href_list["jumptoholopad"])
+	if(href_list["jumptoholopad"])
 		var/obj/machinery/hologram/holopad/H = locate(href_list["jumptoholopad"])
 		if(stat == CONSCIOUS)
 			if(H)
 				H.attack_ai(src) //may as well recycle
 			else
 				src << "<span class='notice'>Unable to locate the holopad.</span>"
-	if (href_list["track"])
-		var/mob/target = locate(href_list["track"]) in mob_list
-		var/mob/living/silicon/ai/A = locate(href_list["track2"]) in mob_list
-		if(A && target)
-			A.ai_actual_track(target)
+	if(href_list["track"])
+		var/string = href_list["track"]
+		trackable_mobs()
+		var/list/trackeable = list()
+		trackeable += track.humans + track.others
+		var/list/target = list()
+		for(var/I in trackeable)
+			var/mob/M = trackeable[I]
+			if(M.name == string)
+				target += M
+		if(name == string)
+			target += src
+		if(target.len)
+			ai_actual_track(pick(target))
+		else
+			src << "Target is not on or near any active cameras on the station."
 		return
-
-	if (href_list["callbot"]) //Command a bot to move to a selected location.
+	if(href_list["callbot"]) //Command a bot to move to a selected location.
 		Bot = locate(href_list["callbot"]) in SSbot.processing
 		if(!Bot || Bot.remote_disabled || src.control_disabled)
 			return //True if there is no bot found, the bot is manually emagged, or the AI is carded with wireless off.
 		waypoint_mode = 1
 		src << "<span class='notice'>Set your waypoint by clicking on a valid location free of obstructions.</span>"
 		return
-
-	if (href_list["interface"]) //Remotely connect to a bot!
+	if(href_list["interface"]) //Remotely connect to a bot!
 		Bot = locate(href_list["interface"]) in SSbot.processing
 		if(!Bot || Bot.remote_disabled || src.control_disabled)
 			return
 		Bot.attack_ai(src)
-
-	if (href_list["botrefresh"]) //Refreshes the bot control panel.
+	if(href_list["botrefresh"]) //Refreshes the bot control panel.
 		botcall()
 		return
-
-	else if (href_list["faketrack"])
-		var/mob/target = locate(href_list["track"]) in mob_list
-		var/mob/living/silicon/ai/A = locate(href_list["track2"]) in mob_list
+	if(href_list["track"])
+		var/mob/target = locate(href_list["track"])
+		var/mob/living/silicon/ai/A = locate(href_list["track2"])
+		world << "radio"
 		if(A && target)
-
-			A.cameraFollow = target
-			A << "Now tracking [target.name] on camera."
-			if (usr.machine == null)
-				usr.machine = usr
-
-			while (src.cameraFollow == target)
-				usr << "Target is not on or near any active cameras on the station. We'll check again in 5 seconds (unless you use the cancel-camera verb)."
-				sleep(40)
-				continue
+			A.ai_actual_track(target)
 		return
-	return
-
 
 /mob/living/silicon/ai/bullet_act(var/obj/item/projectile/Proj)
 	..(Proj)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -4,15 +4,10 @@
 		return
 	..(message)
 
-/mob/living/silicon/ai/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	//this proc assumes that the message originated from a radio. if the speaker is not a virtual speaker this will probably fuck up hard.
+/mob/living/silicon/ai/compose_track_href(atom/movable/speaker, namepart)
 	var/mob/M = speaker.GetSource()
-	var/obj/item/device/radio = speaker.GetRadio()
 	if(M)
-		var/faketrack = "byond://?src=\ref[radio];track2=\ref[src];track=\ref[M]"
-		if(speaker.GetTrack())
-			faketrack = "byond://?src=\ref[radio];track2=\ref[src];faketrack=\ref[M]"
-		return "<a href='[faketrack]'>"
+		return "<a href='?src=\ref[src];track=[namepart]'>"
 	return ""
 
 /mob/living/silicon/ai/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1041,7 +1041,7 @@
 		return
 	switch(notifytype)
 		if(1) //New Cyborg
-			connected_ai << "<br><br><span class='notice'>NOTICE - New cyborg connection detected: <a href='byond://?src=\ref[connected_ai];track2=\ref[connected_ai];track=\ref[src]'>[name]</a></span><br>"
+			connected_ai << "<br><br><span class='notice'>NOTICE - New cyborg connection detected: <a href='?src=\ref[connected_ai];track=[name]'>[name]</a></span><br>"
 		if(2) //New Module
 			connected_ai << "<br><br><span class='notice'>NOTICE - Cyborg module change detected: [name] has loaded the [designation] module.</span><br>"
 		if(3) //New Name

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -15,7 +15,7 @@
 	for(var/mob/M in player_list)
 		if(M.binarycheck() || (M in dead_mob_list))
 			if(istype(M, /mob/living/silicon/ai))
-				var/renderedAI = "<i><span class='game say'>Robotic Talk, <a href='byond://?src=\ref[M];track2=\ref[M];track=\ref[src]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span></i>"
+				var/renderedAI = "<i><span class='game say'>Robotic Talk, <a href='?src=\ref[M];track=[name]'><span class='name'>[name] ([desig])</span></a> <span class='message'>[message_a]</span></span></i>"
 				M << renderedAI
 			else
 				M << rendered

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -331,7 +331,6 @@ datum/signal
 		var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker,null)
 		virt.name = source
 		virt.job = job
-		virt.faketrack = 1
 		virt.languages = HUMAN
 		//END SAY REWRITE RELATED CODE.
 


### PR DESCRIPTION
Fixes issue #1128
Changes the href link of the AI tracking to be just the name displayed in-game instead of the reference of the mob.
Removes faketrack from atom/movable/virtualspeaker as it becomes useless.

4 hours from start to finish, telecomms code reading is a pain in the ass
