### PR TITLE
Airlock controller hotfixes

### DIFF
--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -160,7 +160,7 @@
 /obj/machinery/doorButtons/airlock_controller/proc/cycleClose(obj/machinery/door/airlock/A)
 	if(!A || !exteriorAirlock || !interiorAirlock)
 		return
-	if(exteriorAirlock.density == interiorAirlock.density)
+	if(exteriorAirlock.density == interiorAirlock.density || !A.density)
 		return
 	busy = CYCLE
 	update_icon()
@@ -202,6 +202,7 @@
 	busy = 0
 	if(update)
 		update_icon()
+	updateUsrDialog()
 
 /obj/machinery/doorButtons/airlock_controller/process()
 	if(stat & NOPOWER)


### PR DESCRIPTION
Fixes a bug where the airlock controller sprite would get stuck in the 'working' sprite until getting a new order.
Added an updateUsrDialog() call to the airlock controller, the window information should update now.
