### PR TITLE
Adds two new events - Major and Minor camera failure 

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -28,6 +28,7 @@
 	var/alarm_on = 0
 	var/busy = 0
 	var/emped = 0  //Number of consecutive EMP's on this camera
+	var/inborg = 0 //Is the camera inside a borg and therefore not eligble for random failure?
 
 /obj/machinery/camera/New()
 	wires = new(src)

--- a/code/modules/events/camerafail.dm
+++ b/code/modules/events/camerafail.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/camerafail
 	name = "Major Camera Failure"
 	typepath = /datum/round_event/camfail
-	weight = 50
-	max_occurrences = 100
+	weight = 40 //same as light failure
+	max_occurrences = 10
 	earliest_start = 20
 	alertadmins = 1
 
@@ -18,8 +18,8 @@
 
 /datum/round_event/camfail/start()
 	var/disabledcount = 0
-	for( var/obj/machinery/camera/C in world)
-		if((C.z == 1) && !(C.inborg == 1))
+	for( var/obj/machinery/camera/C in cameranet.cameras)
+		if((C.z == 1) && !C.inborg)
 			if( !(disabledcount > maxfailures))
 				if(prob(10) && (C.status))
 					C.status = !(C.status)
@@ -40,7 +40,7 @@
 	name = "Minor Camera Failure"
 	typepath = /datum/round_event/camfail/mini
 	weight = 100
-	max_occurrences = 1000
+	max_occurrences = 100
 	earliest_start = 0
 	alertadmins = 0
 

--- a/code/modules/events/camerafail.dm
+++ b/code/modules/events/camerafail.dm
@@ -1,0 +1,51 @@
+/datum/round_event_control/camerafail
+	name = "Major Camera Failure"
+	typepath = /datum/round_event/camfail
+	weight = 50
+	max_occurrences = 100
+	earliest_start = 20
+	alertadmins = 1
+
+/datum/round_event/camfail
+	startWhen		= 0
+	endWhen			= 2
+	announceWhen	= 1
+	var/maxfailures = 50
+
+/datum/round_event/camfail/announce()
+	priority_announce("Unwarranted recording software detected in [station_name()]'s camera network, remotely disabling affected cameras","Camera Shutdown Alert")
+
+
+/datum/round_event/camfail/start()
+	var/disabledcount = 0
+	for( var/obj/machinery/camera/C in world)
+		if((C.z == 1) && !(C.inborg == 1))
+			if( !(disabledcount > maxfailures))
+				if(prob(10) && (C.status))
+					C.status = !(C.status)
+					C.icon_state = "[initial(C.icon_state)]1"
+					C.visible_message("<span class='danger'> \The [C] deactivates! </span>")
+					disabledcount++
+				else if(prob(10))
+					C.emp_act(1)
+					disabledcount++
+
+
+/datum/round_event/camfail/tick()
+	return
+
+//camera event small version
+
+/datum/round_event_control/camerafail/mini
+	name = "Minor Camera Failure"
+	typepath = /datum/round_event/camfail/mini
+	weight = 100
+	max_occurrences = 1000
+	earliest_start = 0
+	alertadmins = 0
+
+/datum/round_event/camfail/mini/announce()
+	return
+
+/datum/round_event/camfail/mini
+	maxfailures = 5

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -97,6 +97,7 @@
 		camera.network = list("SS13")
 		if(wires.IsCameraCut()) // 5 = BORG CAMERA
 			camera.status = 0
+		camera.inborg = 1
 	..()
 
 	//MMI stuff. Held togheter by magic. ~Miauw

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -83,3 +83,4 @@ vekter = Game Master
 Ahammer18 = Game Master
 ACCount12 = Game Master
 fayrik = Game Master
+dorsidwarf = Game Master

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -929,6 +929,7 @@
 #include "code\modules\events\anomaly_vortex.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brand_intelligence.dm"
+#include "code\modules\events\camerafail.dm"
 #include "code\modules\events\carp_migration.dm"
 #include "code\modules\events\communications_blackout.dm"
 #include "code\modules\events\disease_outbreak.dm"


### PR DESCRIPTION
This PR adds two camera failure events, in which a random selection of cameras across the station are either EMPed or deactivated.

Major camera failures deactivate or EMP many cameras, whilst Minor camera failures only deactivate a few.

Also adds myself to the admins.TXT. This is the tenth time I've tried to do so, I think.
