### PR TITLE
Makes AIs not hear local speech with two spaces.

### DIFF
--- a/code/game/gamemodes/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/abduction/machinery/experiment.dm
@@ -201,6 +201,3 @@
 		icon_state = "experiment-open"
 	else
 		icon_state = "experiment"
-
-/obj/machinery/abductor/experiment/say_quote(text)
-	return "beeps, \"[text]\""

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -17,7 +17,7 @@
 
 /mob/living/silicon/ai/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	//Also includes the </a> for AI hrefs, for convenience.
-	return " [radio_freq ? "(" + speaker.GetJob() + ")" : ""]" + "[speaker.GetSource() ? "</a>" : ""]"
+	return "[radio_freq ? " (" + speaker.GetJob() + ")" : ""]" + "[speaker.GetSource() ? "</a>" : ""]"
 
 /mob/living/silicon/ai/IsVocal()
 	return !config.silent_ai


### PR DESCRIPTION
Also removes an unneeded say_quote() override.

Fixes #6482
