### PR TITLE
More runtimes fixed

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -23,6 +23,8 @@
 	var/trashtype = null //for disposable cuffs
 
 /obj/item/weapon/restraints/handcuffs/attack(mob/living/carbon/C, mob/living/carbon/human/user)
+	if(!istype(C))
+		return
 	if(user.disabilities & CLUMSY && prob(50))
 		user << "<span class='warning'>Uh... how do those things work?!</span>"
 		apply_cuffs(user,user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -128,9 +128,10 @@
 							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
 			return
 	else
-		..()
 		if(status)
 			baton_stun(L, user)
+		..()
+
 
 
 /obj/item/weapon/melee/baton/proc/baton_stun(mob/living/L, mob/user)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -80,7 +80,7 @@
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music)	return
-	if(prefs.toggles & SOUND_LOBBY)
+	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		src << sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS
 
 /proc/get_rand_frequency()

--- a/code/modules/admin/verbs/bluespacearty.dm
+++ b/code/modules/admin/verbs/bluespacearty.dm
@@ -21,6 +21,10 @@
 		if(prob(80))	T.break_tile_to_plating()
 		else			T.break_tile()
 
+	target << "<span class='userdanger'>You're hit by bluespace artillery!</span>"
+	log_admin("[target.name] has been hit by Bluespace Artillery fired by [usr]")
+	message_admins("[target.name] has been hit by Bluespace Artillery fired by [usr]")
+
 	if(target.health <= 1)
 		target.gib()
 	else
@@ -29,6 +33,3 @@
 		target.Weaken(20)
 		target.stuttering = 20
 
-	target << "<span class='userdanger'>You're hit by bluespace artillery!</span>"
-	log_admin("[target.name] has been hit by Bluespace Artillery fired by [usr]")
-	message_admins("[target.name] has been hit by Bluespace Artillery fired by [usr]")

--- a/code/modules/food&drinks/food/customizables.dm
+++ b/code/modules/food&drinks/food/customizables.dm
@@ -328,7 +328,7 @@
 
 /obj/item/weapon/reagent_containers/glass/bowl/update_icon()
 	overlays.Cut()
-	if(reagents.total_volume)
+	if(reagents && reagents.total_volume)
 		var/image/filling = image('icons/obj/food/soupsalad.dmi', "fullbowl")
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		overlays += filling

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -377,11 +377,13 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 
 	if(!istype(H.wear_suit, /obj/item/clothing/suit/space/eva/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/hardsuit/plasmaman))
 		if(environment)
-			if((environment.oxygen /environment.total_moles()) >= 0.01)
-				if(!H.on_fire)
-					H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
-				H.adjust_fire_stacks(0.5)
-				H.IgniteMob()
+			var/total_moles = environment.total_moles()
+			if(total_moles)
+				if((environment.oxygen /total_moles) >= 0.01)
+					if(!H.on_fire)
+						H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
+					H.adjust_fire_stacks(0.5)
+					H.IgniteMob()
 	else
 		if(H.fire_stacks)
 			var/obj/item/clothing/suit/space/eva/plasmaman/P = H.wear_suit

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -211,8 +211,8 @@
 /obj/machinery/particle_accelerator/control_box/proc/toggle_power()
 	src.active = !src.active
 	investigate_log("turned [active?"<font color='red'>ON</font>":"<font color='green'>OFF</font>"] by [usr ? usr.key : "outside forces"]","singulo")
-	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [key_name(usr, usr.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr.ckey]([usr]) in ([x],[y],[z])")
+	message_admins("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? key_name(usr, usr.client) : "outside forces"](<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+	log_game("PA Control Computer turned [active ?"ON":"OFF"] by [usr ? "[usr.ckey]([usr])" : "outside forces"] in ([x],[y],[z])")
 	if(src.active)
 		src.use_power = 2
 		for(var/obj/structure/particle_accelerator/part in connected_parts)


### PR DESCRIPTION
Fixes some runtimes with bluespace artillery, handcuffs on simple animals, playing music, stunbaton attack, kitchen bowl update_icon, particle accelerator admin log message, and plasmaman spec_life().

The runtimes:

runtime error: Cannot read null.name
proc name: Bluespace Artillery (/client/proc/bluespace_artillery)
  source file: bluespacearty.dm,33

runtime error: Division by zero
proc name: spec life (/datum/species/plasmaman/spec_life)
  source file: species_types.dm,378

runtime error: Cannot read null.client
proc name: toggle power (/obj/machinery/particle_accelerator/control_box/proc/toggle_power)
  source file: particle_control.dm,214
  usr: null

runtime error: Cannot read null.toggles
proc name: playtitlemusic (/client/proc/playtitlemusic)
  source file: sound.dm,83
  usr: NoTipPizzaBoy (/mob/new_player)
  src: NoTipPizzaBoy (/client)
  call stack:
NoTipPizzaBoy (/client): playtitlemusic()
NoTipPizzaBoy (/mob/new_player): Login()

runtime error: Cannot read null.total_volume
proc name: update icon (/obj/item/weapon/reagent_containers/glass/bowl/update_icon)
  source file: customizables.dm,331

runtime error: undefined variable /mob/living/simple_animal/hostile/poison/giant_spider/nurse/var/handcuffed
proc name: attack (/obj/item/weapon/restraints/handcuffs/attack)
  source file: handcuffs.dm,31
  usr: the monkey (750) (/mob/living/carbon/monkey)
  src: the handcuffs (/obj/item/weapon/restraints/handcuffs)
  call stack:
the handcuffs (/obj/item/weapon/restraints/handcuffs): attack(the giant spider 

runtime error: Cannot modify null.lastattacker.
proc name: baton stun (/obj/item/weapon/melee/baton/proc/baton_stun)
  source file: stunbaton.dm,138
