### PR TITLE
Fixes #9335 - pipe panic runtime.

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -44,12 +44,6 @@ Filter types:
 	if(frequency)
 		radio_connection = radio_controller.add_object(src, frequency, RADIO_ATMOSIA)
 
-/obj/machinery/atmospherics/trinary/filter/New()
-	..()
-	if(radio_controller)
-		atmosinit()
-		initialize()
-
 /obj/machinery/atmospherics/trinary/filter/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src,frequency)


### PR DESCRIPTION
Fixes #9335

These procs are called by the atmos subsystem or during construction when they are needed, so calling them on New() only fucks shit up.

I have a branch with these changes I made and tested like 50 years ago when the issue report first came up. but I don't want to stash my current working branch to push it
