### PR TITLE
Linda gas bubbles fix

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -82,7 +82,7 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5)
 /atom/movable/proc/air_update_turf(var/command = 0)
 	if(!istype(loc,/turf) && command)
 		return
-	var/turf/T = loc
+	var/turf/T = get_turf(loc)
 	T.air_update_turf(command)
 
 /turf/proc/air_update_turf(var/command = 0)


### PR DESCRIPTION
Fixes air bubbles in Linda if the object who activates the floor is inside of an another object, for example a locker.
Fixes #1265

So much for the contributor friendly tag
