### PR TITLE
Adds Destination Tagger and Hand Labeler to Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -522,3 +522,19 @@
 	materials = list("$metal" = 100, "$glass" = 100)
 	build_path = /obj/item/toy/crayon/spraycan
 	category = list("initial", "Tools")
+
+/datum/design/desttagger
+	name = "Destination tagger"
+	id = "desttagger"
+	build_type = AUTOLATHE
+	materials = list("$metal" = 250, "$glass" = 125)
+	build_path = /obj/item/device/destTagger
+	category = list("initial", "Electronics")
+
+/datum/design/handlabeler
+	name = "Hand labeler"
+	id = "handlabel"
+	build_type = AUTOLATHE
+	materials = list("$metal" = 150, "$glass" = 125)
+	build_path = /obj/item/weapon/hand_labeler
+	category = list("initial", "Electronics")

--- a/html/changelogs/Gun-Hog-PR-9667.yml
+++ b/html/changelogs/Gun-Hog-PR-9667.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Gun Hog
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Nanotrasen has approved the designs for destination taggers and hand labelers in the autolathe."


### PR DESCRIPTION
Adds the Destination Tagger and Hand Labeler to the  autolathe. They are both found under "Electronics". 

Please let me know if this violates the terms of the feature freeze.
