### PR TITLE
Boosts powerdrain and max power of the powersink

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -12,9 +12,9 @@
 	throw_range = 2
 	m_amt = 750
 	origin_tech = "powerstorage=3;syndicate=5"
-	var/drain_rate = 600000		// amount of power to drain per tick
+	var/drain_rate = 1500000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1e8		// maximum power that can be drained before exploding
+	var/max_power = 2.5e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = 0 // stop spam, only warn the admins once that we are about to boom
 

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -83,3 +83,4 @@ vekter = Game Master
 Ahammer18 = Game Master
 ACCount12 = Game Master
 fayrik = Game Master
+dorsidwarf = Game Master


### PR DESCRIPTION
Fixes #9677 

This doubles the power drain of a powersink. In testing, this means that it drains power from the station like it's supposed to, causing a blackout everywhere bu the engine room as intended, and still overloads when you wire a properly-setup singulo into the grid
