### PR TITLE
Escape alone joint greentext + escaping on the nuke op shuttle

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -353,7 +353,7 @@ var/datum/subsystem/ticker/ticker
 			if(Player.stat != DEAD && !isbrain(Player))
 				num_survivors++
 				if(station_evacuated) //If the shuttle has already left the station
-					if(!Player.onCentcom())
+					if(!Player.onCentcom() && !Player.onSyndieBase())
 						Player << "<font color='blue'><b>You managed to survive, but were marooned on [station_name()]...</b></FONT>"
 					else
 						num_escapees++

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -38,6 +38,19 @@
 	//finally check for centcom itself
 	return istype(T.loc,/area/centcom)
 
+/atom/proc/onSyndieBase()
+	var/turf/T = get_turf(src)
+	if(!T)
+		return 0
+
+	if(T.z != ZLEVEL_CENTCOM)//if not, don't bother
+		return 0
+
+	if(istype(T.loc,/area/shuttle/syndicate) || istype(T.loc,/area/syndicate_mothership))
+		return 1
+
+	return 0
+
 /atom/proc/throw_impact(atom/hit_atom)
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -300,7 +300,7 @@
 	acolytes_survived = 0
 	for(var/datum/mind/cult_mind in cult)
 		if (cult_mind.current && cult_mind.current.stat != DEAD)
-			if(cult_mind.current.onCentcom())
+			if(cult_mind.current.onCentcom() || cult_mind.current.onSyndieBase())
 				acolytes_survived++
 	if(acolytes_survived>=acolytes_needed)
 		return 0

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -34,6 +34,8 @@
 
 			if(player.onCentcom())
 				text += "<br><b><font size=2>[player.real_name] escaped to the safety of Centcom.</font></b>"
+			else if(player.onSyndieBase())
+				text += "<br><b><font size=2>[player.real_name] escaped to the (relative) safety of Syndicate Space.</font></b>"
 			else
 				text += "<br><font size=1>[player.real_name] survived but is stranded without any hope of rescue.</font>"
 

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -89,7 +89,7 @@
 	var/datum/disease/D = new /datum/disease/transformation/jungle_fever()
 	for(var/mob/living/carbon/monkey/M in living_mob_list)
 		if (M.HasDisease(D))
-			if(M.onCentcom())
+			if(M.onCentcom() || M.onSyndieBase())
 				escaped_monkeys++
 	if(escaped_monkeys >= monkeys_to_win)
 		return 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -113,7 +113,7 @@ datum/objective/maroon/check_completion()
 	if(target && target.current)
 		if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > 6 || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 			return 1
-		if(target.current.onCentcom())
+		if(target.current.onCentcom() || target.current.onSyndieBase())
 			return 0
 	return 1
 
@@ -209,7 +209,8 @@ datum/objective/hijack/check_completion()
 					if(/mob/living/silicon/ai, /mob/living/silicon/pai)
 						continue
 				if(get_area(player) == A)
-					return 0
+					if(!player.mind.special_role && !istype(get_turf(player.mind.current), /turf/simulated/shuttle/floor4))
+						return 0
 	return 1
 
 
@@ -257,7 +258,7 @@ datum/objective/escape/check_completion()
 	if(istype(location, /turf/simulated/shuttle/floor4)) // Fails traitors if they are in the shuttle brig -- Polymorph
 		return 0
 
-	if(location.onCentcom())
+	if(location.onCentcom() || location.onSyndieBase())
 		return 1
 
 	return 0

--- a/html/changelogs/Incoming5643 - whycantwebefriend.yml
+++ b/html/changelogs/Incoming5643 - whycantwebefriend.yml
@@ -1,0 +1,8 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "Antagonists with escape alone can now escape with others on the shuttle, so long as they are also antagonists."
+  - rscadd: "Antagonists with escape alone can also win if non-antagonists are on the shuttle provided they are locked in the brig."
+  - rscadd: "Escaping to syndicate space on board the nuke op shuttle is now a valid way to escape the station."


### PR DESCRIPTION
Antags with escape alone can win jointly with other antagonists, it only matters that normies are kept off.

Non-antagonists can be brought on a shuttle without endangering an escape alone victory provided they're kept locked in the brig.

Escaping to syndicate space aboard the nuke op shuttle is now a valid way to escape in terms of objectives.
