### PR TITLE
Gives a much needed buff to IV drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -93,7 +93,7 @@
 		return PROCESS_KILL
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
-		attached << "<span class='warning'>The IV drip needle is ripped out of you, doesn't that hurt?</span>"
+		attached << "<span class='userdanger'>The IV drip needle is ripped out of you!</span>"
 		attached.apply_damage(3, BRUTE, pick("r_arm", "l_arm"))
 		attached = null
 		update_icon()
@@ -103,10 +103,10 @@
 		// Give blood
 		if(mode)
 			if(beaker.volume > 0)
-				var/transfer_amount = REAGENTS_METABOLISM
+				var/transfer_amount = 5
 				if(istype(beaker, /obj/item/weapon/reagent_containers/blood))
 					// speed up transfer on blood packs
-					transfer_amount = 4
+					transfer_amount = 10
 				beaker.reagents.reaction(attached, INGEST, 1,0) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
 				update_icon()


### PR DESCRIPTION
It was quite literally faster to syringe out blood from a pack and inject it into myself then it was to sit there using the IV drip. This should be faster and better for use.

Also, I made that weird ass "needle ripped out of you" message consistent with the rest, and gave it userdanger since it's direct harm to you.

PS. whoever decided that reagent containers that aren't blood packs should transfer at 0.4u is a horrible human being
