### PR TITLE
Makes the giant spider verbs not work if dead.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -155,6 +155,8 @@
 
 	var/T = src.loc
 
+	if(health <= 0)
+		return 0
 	if(busy != SPINNING_WEB)
 		busy = SPINNING_WEB
 		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance.</span>")
@@ -171,6 +173,8 @@
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
 
+	if(health <= 0)
+		return 0
 	if(!cocoon_target)
 		var/list/choices = list()
 		for(var/mob/living/L in view(1,src))
@@ -228,6 +232,8 @@
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
 
 	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
+	if(health <= 0)
+		return 0
 	if(E)
 		src << "<span class='warning'>There is already a cluster of eggs here!</span>"
 	else if(!fed)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -155,7 +155,7 @@
 
 	var/T = src.loc
 
-	if(health <= 0)
+	if(!stat)
 		return 0
 	if(busy != SPINNING_WEB)
 		busy = SPINNING_WEB
@@ -173,7 +173,7 @@
 	set category = "Spider"
 	set desc = "Wrap up prey to feast upon and objects for safe keeping."
 
-	if(health <= 0)
+	if(!stat)
 		return 0
 	if(!cocoon_target)
 		var/list/choices = list()
@@ -232,7 +232,7 @@
 	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
 
 	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
-	if(health <= 0)
+	if(!stat)
 		return 0
 	if(E)
 		src << "<span class='warning'>There is already a cluster of eggs here!</span>"


### PR DESCRIPTION
This disables the giant spider verbs(lay eggs, make webs, and wrap stuff) not work when dead. Tested and everything works.

Fixes #9674 
