### PR TITLE
Bugfix: Witticism depleted editon

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -346,9 +346,9 @@ var/datum/subsystem/job/SSjob
 			if(locate(/mob/living) in sloc.loc)	continue
 			S = sloc
 			break
-		if(!S)
-			S = locate("start*[rank]") // use old stype
-		if(istype(S, /obj/effect/landmark/start) && istype(S.loc, /turf))
+		if(!S) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
+			S = pick(latejoin)
+		if(istype(S, /obj/effect/landmark) && istype(S.loc, /turf))
 			H.loc = S.loc
 
 	if(H.mind)

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -27,7 +27,8 @@ var/const/AUTOLATHE_DISABLE_WIRE = 4
 	var/obj/machinery/autolathe/A = holder
 	switch(index)
 		if(AUTOLATHE_HACK_WIRE)
-			A.adjust_hacked(!mended)
+			if(!A.hacked)
+				A.adjust_hacked(1)
 		if(AUTOLATHE_SHOCK_WIRE)
 			A.shocked = !mended
 		if(AUTOLATHE_DISABLE_WIRE)

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -16,9 +16,13 @@
 		user.weakeyes = 1
 		user.sight |= SEE_MOBS
 		user.permanent_sight_flags |= SEE_MOBS
+		user.see_in_dark = 8
+		user.see_invisible = SEE_INVISIBLE_MINIMUM
 	else
 		user << "<span class='notice'>Our vision dulls. Shadows gather.</span>"
 		user.weakeyes = 0
 		user.sight -= SEE_MOBS
 		user.permanent_sight_flags -= SEE_MOBS
+		user.see_in_dark = 0
+		user.see_invisible = SEE_INVISIBLE_LIVING
 	return 1

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -246,6 +246,12 @@ Class Procs:
 		return
 	if(!isturf(M.loc) && M.loc != src)
 		return
+	if(getBrainLoss() >= 60)
+		visible_message("<span class='danger'>[src] stares cluelessly at [M] and drools.</span>")
+		return
+	if(prob(getBrainLoss()))
+		src << "<span class='warning'>You momentarily forget how to use [M]!</span>"
+		return
 	return 1
 
 /mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
@@ -281,22 +287,11 @@ Class Procs:
 
 //set_machine must be 0 if clicking the machinery doesn't bring up a dialog
 /obj/machinery/attack_hand(mob/user as mob, var/check_power = 1, var/set_machine = 1)
-	if(check_power && stat & NOPOWER)
-		user << "<span class='danger'>\The [src] seems unpowered.</span>"
-		return 1
-	if(!interact_offline && stat & (BROKEN|MAINT))
-		user << "<span class='danger'>\The [src] seems broken.</span>"
-		return 1
 	if(user.lying || user.stat)
 		return 1
 	if(!user.IsAdvancedToolUser())
 		usr << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 1
-/*
-	//distance checks are made by atom/proc/DblClick
-	if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !istype(user, /mob/living/silicon))
-		return 1
-*/
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.getBrainLoss() >= 60)
@@ -305,7 +300,15 @@ Class Procs:
 		else if(prob(H.getBrainLoss()))
 			user << "<span class='warning'>You momentarily forget how to use [src]!</span>"
 			return 1
-
+	if(panel_open)
+		src.add_fingerprint(user)
+		return 0
+	if(check_power && stat & NOPOWER)
+		user << "<span class='danger'>\The [src] seems unpowered.</span>"
+		return 1
+	if(!interact_offline && stat & (BROKEN|MAINT))
+		user << "<span class='danger'>\The [src] seems broken.</span>"
+		return 1
 	src.add_fingerprint(user)
 	if(set_machine)
 		user.set_machine(src)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -246,12 +246,6 @@ Class Procs:
 		return
 	if(!isturf(M.loc) && M.loc != src)
 		return
-	if(getBrainLoss() >= 60)
-		visible_message("<span class='danger'>[src] stares cluelessly at [M] and drools.</span>")
-		return
-	if(prob(getBrainLoss()))
-		src << "<span class='warning'>You momentarily forget how to use [M]!</span>"
-		return
 	return 1
 
 /mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)

--- a/code/modules/food&drinks/food/snacks_pastry.dm
+++ b/code/modules/food&drinks/food/snacks_pastry.dm
@@ -144,6 +144,7 @@
 	icon_state = "COOKIE!!!"
 	bitesize = 1
 	bonus_reagents = list("nutriment" = 1)
+	list_reagents = list("nutriment" = 1)
 	filling_color = "#F0E68C"
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -276,7 +276,21 @@
 
 	var/mob/living/carbon/human/character = create_character()	//creates the human and transfers vars and mind
 	SSjob.EquipRank(character, rank, 1)					//equips the human
-	character.loc = pick(latejoin)
+
+	var/D = pick(latejoin)
+	if(!D)
+		for(var/turf/T in get_area_turfs(/area/shuttle/arrival))
+			if(!T.density)
+				var/clear = 1
+				for(var/obj/O in T)
+					if(O.density)
+						clear = 0
+						break
+				if(clear)
+					D = T
+					continue
+
+	character.loc = D
 	character.lastarea = get_area(loc)
 
 	if(character.mind.assigned_role != "Cyborg")

--- a/code/modules/projectiles/guns/projectile/toy.dm
+++ b/code/modules/projectiles/guns/projectile/toy.dm
@@ -32,6 +32,9 @@
 	..()
 	icon_state = "[initial(icon_state)][chambered ? "" : "-e"]"
 
+/obj/item/weapon/gun/projectile/automatic/toy/pistol/riot
+	mag_type = /obj/item/ammo_box/magazine/toy/pistol/riot
+
 /obj/item/weapon/gun/projectile/automatic/toy/pistol/riot/New()
 	magazine = new /obj/item/ammo_box/magazine/toy/pistol/riot(src)
 	..()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,5 +1,5 @@
 /datum/surgery
-	var/name = "surgery"
+	var/name = null
 	var/status = 1
 	var/list/steps = list()										//Steps in a surgery
 	var/step_in_progress = 0									//Actively performing a Surgery


### PR DESCRIPTION
Fixes #9049, hacked designs twice in autolathe
Fixes #9717, augmented eyesight not giving night vision
Fixes #9632, generic surgery able to be chosen
Fixes #9685, animated riot dart pistols shooting normal darts
Fixes #5323, unable to access open panel in unpowered air alarm (issue also present for all machinery)
Fixes cookies spawned by admins having no nutriments.
Fixes #7590, jobs being sent to start screen if spawnpoint is missing

More to come
