### PR TITLE
Fixes #9722 - regression in carn shuttle breaking certain admin events.

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -159,7 +159,7 @@
 	var/timer						//used as a timer (if you want time left to complete move, use timeLeft proc)
 	var/mode = SHUTTLE_IDLE			//current shuttle mode (see global defines)
 	var/callTime = 50				//time spent in transit (deciseconds)
-
+	var/turfchecks = 3			//0 = move ALL turfs, 1 = move all non-space turfs, 2 = move only simulated turfs, 3 (or anything else) move only shuttle turfs.
 	var/travelDir = 0			//direction the shuttle would travel in
 
 	var/obj/docking_port/stationary/destination
@@ -297,13 +297,24 @@
 		for(var/turf/T0 in L0)
 			A0.contents += T0
 
-	//move or squish anything in the way ship at destination
+	//move or squish anything in the way of the ship at destination
 	roadkill(L1, S1.dir)
 
 	for(var/i=1, i<=L0.len, ++i)
 		var/turf/T0 = L0[i]
-		if(!istype(T0, /turf/simulated/shuttle))	//only move shuttle turfs!
-			continue
+		if (turfchecks) //if 0, move ALL turfs.
+			switch (turfchecks)
+				if (1) //only move non-space turfs!
+					if(istype(T0, /turf/space))
+						continue
+				if (2) //only move simulated turfs!
+					if(!istype(T0, /turf/simulated))
+						continue
+				else //only move shuttle turfs!
+					if(!istype(T0, /turf/simulated/shuttle))
+						continue
+
+
 
 		var/turf/T1 = L1[i]
 		if(!T1)


### PR DESCRIPTION
The mobile docking port (the one that stays with the shuttle as it moves) now has a var called turfchecks

0 = move ALL turfs

1 = move all non-space turfs

2 = move only simulated turfs

3 = move only shuttle turfs. (default)

All other numbers or values are assumed to be 3.

No shuttles have been changed from old behavior, as map edits scare me, but most shuttles could be moved to 2 (and some, even 1) without issue.

Setting it to 0 will most likely break transit space.

No testing done other than checking that it compiles, I'll get to that now.

Fixes #9722
Technically Fixes #6856
