### PR TITLE
Fixes paper burning causing lag

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -340,10 +340,10 @@
 	burning = 1
 	icon_state = "paper_onfire"
 	info = "[stars(info)]"
-	sleep(burntime) //7 seconds
-	src.visible_message("<span class='warning'>[src] burns away, leaving behind a pile of ashes.</span>")
-	new /obj/effect/decal/cleanable/ash(src.loc)
-	qdel(src)
+	spawn(burntime) //7 seconds
+		src.visible_message("<span class='warning'>[src] burns away, leaving behind a pile of ashes.</span>")
+		new /obj/effect/decal/cleanable/ash(src.loc)
+		qdel(src)
 
 /*
  * Premade paper

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -335,6 +335,8 @@
 	burn(1, 50)
 
 /obj/item/weapon/paper/proc/burn(var/showmsg, var/burntime)
+	if (burning)
+		return
 	if(showmsg)
 		src.visible_message("<span class='warning'>[src] catches on fire.</span>")
 	burning = 1


### PR DESCRIPTION
By sleeping here, it froze the master controller for 7 seconds, at that point every subsystem would rapid fire to make up for the miss ticks.
