### PR TITLE
upgrades the HARDFEET species flag to PIERCEIMMUNE

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -56,20 +56,20 @@
 
 //flags for species
 
-#define MUTCOLORS	1
-#define HAIR		2
-#define FACEHAIR	4
-#define EYECOLOR	8
-#define LIPS		16
-#define COLDRES		32
-#define HEATRES		64
-#define RADIMMUNE	128
-#define NOBREATH	256
-#define NOGUNS		512
-#define NOBLOOD		1024
-#define NOFIRE		2048
-#define VIRUSIMMUNE	4096
-#define HARDFEET	8192
+#define MUTCOLORS		1
+#define HAIR			2
+#define FACEHAIR		4
+#define EYECOLOR		8
+#define LIPS			16
+#define COLDRES			32
+#define HEATRES			64
+#define RADIMMUNE		128
+#define NOBREATH		256
+#define NOGUNS			512
+#define NOBLOOD			1024
+#define NOFIRE			2048
+#define VIRUSIMMUNE		4096
+#define PIERCEIMMUNE	8192
 
 /*
 	These defines are used specifically with the atom/movable/languages bitmask.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -442,7 +442,7 @@
 		if(istype(A, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = A
 			if(can_embed(src))
-				if(prob(embed_chance))
+				if(prob(embed_chance) && !(PIERCEIMMUNE in H.dna.species.specflags))
 					var/obj/item/organ/limb/L = pick(H.organs)
 					L.embedded_objects |= src
 					add_blood(H)//it embedded itself in you, of course it's bloody!

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -332,7 +332,7 @@
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
-			if(HARDFEET in H.dna.species.specflags)
+			if(PIERCEIMMUNE in H.dna.species.specflags)
 				return 0
 			if(!H.shoes)
 				H.apply_damage(5,BRUTE,(pick("l_leg", "r_leg")))

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -80,7 +80,7 @@
 
 /obj/item/weapon/dice/d4/Crossed(var/mob/living/carbon/human/H)
 	if(istype(H) && !H.shoes)
-		if(HARDFEET in H.dna.species.specflags)
+		if(PIERCEIMMUNE in H.dna.species.specflags)
 			return 0
 		H << "<span class='userdanger'>You step on the D4!</span>"
 		H.apply_damage(4,BRUTE,(pick("l_leg", "r_leg")))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -42,7 +42,7 @@
 	var/obj/item/organ/limb/affecting = null
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(HARDFEET in H.dna.species.specflags)
+		if(PIERCEIMMUNE in H.dna.species.specflags)
 			playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 			armed = 0
 			update_icon()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -529,6 +529,8 @@
 	. = 1 // Default to returning true.
 	if(user && !target_zone)
 		target_zone = user.zone_sel.selecting
+	if(dna && PIERCEIMMUNE in dna.species.specflags)
+		. = 0
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.
 	if(above_neck(target_zone))

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -233,7 +233,7 @@
 	// Animated beings of stone. They have increased defenses, and do not need to breathe. They're also slow as fuuuck.
 	name = "Golem"
 	id = "golem"
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,HARDFEET)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOGUNS,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE)
 	speedmod = 3
 	armor = 55
 	punchmod = 5
@@ -282,7 +282,7 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
-	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,HARDFEET)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOBLOOD,RADIMMUNE,VIRUSIMMUNE,PIERCEIMMUNE)
 /*
  ZOMBIES
 */


### PR DESCRIPTION
In addition to keeping golem feet safe as always golems are now immune to object embeding. As a logical extension, golems can no longer be injected with chems either.

Fixes  #9726
