### PR TITLE
Allows HUDs to be emagged with an emag as well as an EMP

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -20,13 +20,11 @@
 		emagged = 1
 		desc = desc + " The display flickers slightly."
 
-/obj/item/clothing/glasses/hud/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	..()
-	if(istype(W, /obj/item/weapon/card/emag))
-		if(emagged == 0)
-			emagged = 1
-			user << "<span class='warning'>PZZTTPFFFT</span>"
-			desc = desc + " The display flickers slightly."
+/obj/item/clothing/glasses/hud/emag_act(mob/user)
+	if(emagged == 0)
+		emagged = 1
+		user << "<span class='warning'>PZZTTPFFFT</span>"
+		desc = desc + " The display flickers slightly."
 
 
 
@@ -75,13 +73,11 @@
 		emagged = 1
 		desc = desc + " The display flickers slightly."
 
-/obj/item/clothing/glasses/hud/security/sunglasses/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	..()
-	if(istype(W, /obj/item/weapon/card/emag))
-		if(emagged == 0)
-			emagged = 1
-			user << "<span class='warning'>PZZTTPFFFT</span>"
-			desc = desc + " The display flickers slightly."
+/obj/item/clothing/glasses/hud/security/sunglasses/emag_act(mob/user)
+	if(emagged == 0)
+		emagged = 1
+		user << "<span class='warning'>PZZTTPFFFT</span>"
+		desc = desc + " The display flickers slightly."
 
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -15,10 +15,15 @@
 		var/datum/atom_hud/H = huds[hud_type]
 		H.remove_hud_from(user)
 
-/obj/item/clothing/glasses/hud/emp_act(severity)
-	if(emagged == 0)
-		emagged = 1
-		desc = desc + " The display flickers slightly."
+/obj/item/clothing/glasses/hud/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	..()
+	if(istype(W, /obj/item/weapon/card/emag))
+		if(emagged == 0)
+			emagged = 1
+			user << "<span class='warning'>PZZTTPFFFT</span>"
+			desc = desc + " The display flickers slightly."
+		else
+			user << "<span class='warning'>It is already emagged!</span>"
 
 /obj/item/clothing/glasses/hud/health
 	name = "Health Scanner HUD"
@@ -60,10 +65,15 @@
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
 
-/obj/item/clothing/glasses/hud/security/sunglasses/emp_act(severity)
-	if(emagged == 0)
-		emagged = 1
-		desc = desc + " The display flickers slightly."
+/obj/item/clothing/glasses/hud/security/sunglasses/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	..()
+	if(istype(W, /obj/item/weapon/card/emag))
+		if(emagged == 0)
+			emagged = 1
+			user << "<span class='warning'>PZZTTPFFFT</span>"
+			desc = desc + " The display flickers slightly."
+		else
+			user << "<span class='warning'>It is already emagged!</span>"
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars
 	name = "HUD gar glasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -26,8 +26,6 @@
 		user << "<span class='warning'>PZZTTPFFFT</span>"
 		desc = desc + " The display flickers slightly."
 
-
-
 /obj/item/clothing/glasses/hud/health
 	name = "Health Scanner HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status."
@@ -67,18 +65,6 @@
 	icon_state = "securityhudnight"
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
-
-/obj/item/clothing/glasses/hud/security/sunglasses/emp_act(severity)
-	if(emagged == 0)
-		emagged = 1
-		desc = desc + " The display flickers slightly."
-
-/obj/item/clothing/glasses/hud/security/sunglasses/emag_act(mob/user)
-	if(emagged == 0)
-		emagged = 1
-		user << "<span class='warning'>PZZTTPFFFT</span>"
-		desc = desc + " The display flickers slightly."
-
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars
 	name = "HUD gar glasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -15,6 +15,11 @@
 		var/datum/atom_hud/H = huds[hud_type]
 		H.remove_hud_from(user)
 
+/obj/item/clothing/glasses/hud/emp_act(severity)
+	if(emagged == 0)
+		emagged = 1
+		desc = desc + " The display flickers slightly."
+
 /obj/item/clothing/glasses/hud/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	if(istype(W, /obj/item/weapon/card/emag))
@@ -22,8 +27,8 @@
 			emagged = 1
 			user << "<span class='warning'>PZZTTPFFFT</span>"
 			desc = desc + " The display flickers slightly."
-		else
-			user << "<span class='warning'>It is already emagged!</span>"
+
+
 
 /obj/item/clothing/glasses/hud/health
 	name = "Health Scanner HUD"
@@ -65,6 +70,11 @@
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
 
+/obj/item/clothing/glasses/hud/security/sunglasses/emp_act(severity)
+	if(emagged == 0)
+		emagged = 1
+		desc = desc + " The display flickers slightly."
+
 /obj/item/clothing/glasses/hud/security/sunglasses/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
 	if(istype(W, /obj/item/weapon/card/emag))
@@ -72,8 +82,7 @@
 			emagged = 1
 			user << "<span class='warning'>PZZTTPFFFT</span>"
 			desc = desc + " The display flickers slightly."
-		else
-			user << "<span class='warning'>It is already emagged!</span>"
+
 
 /obj/item/clothing/glasses/hud/security/sunglasses/gars
 	name = "HUD gar glasses"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -83,3 +83,4 @@ vekter = Game Master
 Ahammer18 = Game Master
 ACCount12 = Game Master
 fayrik = Game Master
+shadowlight213 = Game Master

--- a/html/changelogs/palpatine213-hudemag.yml
+++ b/html/changelogs/palpatine213-hudemag.yml
@@ -33,5 +33,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Changed Sechud emagging from being triggered by EMPs, to being triggered by an emag."
+  - tweak: "Allows sechuds to have their id locks removed via emag as well as EMP"
 

--- a/html/changelogs/palpatine213-hudemag.yml
+++ b/html/changelogs/palpatine213-hudemag.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Palpatine213
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Changed Sechud emagging from being triggered by EMPs, to being triggered by an emag."
+


### PR DESCRIPTION
Not sure why this was supposed to be a thing, with how rare EMPs are on the station. Emagging a sechud will allow you to remove any id locks on it and modify sec records without needing to get sec access on your id 

I basically made this off of the commented out code in #560, so feedback is appreciated.
