### PR TITLE
Removes the Trophy Rack from the Armor rune

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -983,7 +983,6 @@ var/list/sacrificed = list()
 	user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
 	user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
 	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
-	user.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
 	//the above update their overlay icons cache but do not call update_icons()
 	//the below calls update_icons() at the end, which will update overlay icons by using the (now updated) cache
 	user.put_in_hands(new /obj/item/weapon/melee/cultblade(user))	//put in hands or on floor


### PR DESCRIPTION
It's a silly cosmetic, but I have seen countless backpacks full of important stuff deleted by unaware cultists trying to armor up. This isn't even an "i lose gun bag plz remove", it's just something that's bothered me for quite some time.

I could make it appear in hands, if people really want it, but currently it will delete your back slot. Honestly it's kind of annoying how it just deletes the other things you wear.

Reminds me - Maybe we should make a rune at some point that allows you to produce the cult space armor.
