### PR TITLE
Speeds up shuffle()

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -188,7 +188,7 @@
 	for(var/i=1, i<L.len, ++i)
 		L.Swap(i,rand(i,L.len))
 
-	return L
+	. = L
 
 //Return a list with no duplicate entries
 /proc/uniqueList(var/list/L)


### PR DESCRIPTION
It's kind of hilarious how much overhead a return statement actually has.

Profile junk:

100,000 Integers (1-100,000)
![shuffle](https://cloud.githubusercontent.com/assets/4043781/7982113/33d37ea0-0aac-11e5-863f-4607d81f99dd.PNG)
1 Million Integers (1-1,000,000)
![shuffle2](https://cloud.githubusercontent.com/assets/4043781/7982118/3891fe12-0aac-11e5-80c7-6a0f68e51c30.PNG)

Open to ports/theft because I already handed this advice to Bay (they recently ported out shuffle() since it handles assoc lists and that's how I noticed the horrors of a return statement in a helper)
