### PR TITLE
minor disposal fixes

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -345,7 +345,8 @@
 	src.updateDialog()
 
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE )	// flush can happen even without power
-		flush()
+		spawn(0)
+			flush()
 
 	if(stat & NOPOWER)			// won't charge if no power
 		return
@@ -378,39 +379,32 @@
 		update()
 	return
 
-// perform a flush
 /obj/machinery/disposal/proc/flush()
-
 	flushing = 1
-	flick("[icon_state]-flush", src)
-
-	var/wrapcheck = 0
-	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
-										// travels through the pipes.
-	for(var/obj/item/smallDelivery/O in src)
-		wrapcheck = 1
-
-	if(wrapcheck == 1)
-		H.tomail = 1
-
+	flushAnimation()
+	var/obj/structure/disposalholder/H = new()
+	newHolderDestination(H)
 	sleep(10)
 	if(last_sound < world.time + 1)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
 		last_sound = world.time
-	sleep(5) // wait for animation to finish
-
-	H.init(src)	// copy the contents of disposer to holder
-	air_contents = new()		// new empty gas resv.
-
-	H.start(src) // start the holder processing movement
+	sleep(5)
+	H.init(src)
+	air_contents = new()
+	H.start(src)
 	flushing = 0
-	// now reset disposal state
 	flush = 0
-	if(mode == 2)	// if was ready,
-		mode = 1	// switch to charging
+	if(mode == 2)
+		mode = 1
 	update()
-	return
 
+/obj/machinery/disposal/proc/newHolderDestination(obj/structure/disposalholder/H)
+	for(var/obj/item/smallDelivery/O in src)
+		H.tomail = 1
+		return
+
+/obj/machinery/disposal/proc/flushAnimation()
+	flick("[icon_state]-flush", src)
 
 // called when area power changes
 /obj/machinery/disposal/power_change()
@@ -490,6 +484,8 @@
 	//hasmob effects whether the package goes to cargo or its tagged destination.
 	for(var/mob/living/M in D)
 		if(M && M.stat != DEAD)
+			if(M.client)
+				M.client.eye = src
 			hasmob = 1
 
 	//Checks 1 contents level deep. This means that players can be sent through disposals...
@@ -498,6 +494,8 @@
 		if(O.contents)
 			for(var/mob/living/M in O.contents)
 				if(M && M.stat != DEAD)
+					if(M.client)
+						M.client.eye = src
 					hasmob = 1
 
 	// now everything inside the disposal gets put into the holder
@@ -541,8 +539,6 @@
 		if(!(count--))
 			active = 0
 	return
-
-
 
 // find the turf which should contain the next pipe
 /obj/structure/disposalholder/proc/nextloc()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -234,8 +234,6 @@
 	desc = "A chute for big and small packages alike!"
 	density = 1
 	icon_state = "intake"
-
-	var/start_flush = 0
 	var/c_mode = 0
 
 /obj/machinery/disposal/deliveryChute/New(loc,var/obj/structure/disposalconstruct/make_from)
@@ -287,40 +285,11 @@
 /obj/mecha/disposalEnterTry()
 	return
 
-/obj/machinery/disposal/deliveryChute/flush()
-	flushing = 1
+/obj/machinery/disposal/deliveryChute/flushAnimation()
 	flick("intake-closing", src)
-	var/deliveryCheck = 0
-	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
-												// travels through the pipes.
-/*		for(var/obj/structure/bigDelivery/O in src)
-		deliveryCheck = 1
-		if(O.sortTag == 0)						//This auto-sorts package wrapped objects to disposals
-			O.sortTag = 1						//Cargo techs can do this themselves with their taggers
-	for(var/obj/item/smallDelivery/O in src)	//With this disabled packages will loop back round and come out the mail chute
-		deliveryCheck = 1
-		if(O.sortTag == 0)
-			O.sortTag = 1						*/
-	if(deliveryCheck == 0)
-		H.destinationTag = 1
 
-	sleep(10)
-	if((start_flush + 15) < world.time)
-		start_flush = world.time
-		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
-	sleep(5) // wait for animation to finish
-
-	H.init(src)	// copy the contents of disposer to holder
-	air_contents = new()		// new empty gas resv.
-
-	H.start(src) // start the holder processing movement
-	flushing = 0
-	// now reset disposal state
-	flush = 0
-	if(mode == 2)	// if was ready,
-		mode = 1	// switch to charging
-	update()
-	return
+/obj/machinery/disposal/deliveryChute/newHolderDestination(obj/structure/disposalholder/H)
+	H.destinationTag = 1
 
 /obj/machinery/disposal/deliveryChute/attackby(var/obj/item/I, var/mob/user, params)
 	if(!I || !user)


### PR DESCRIPTION
Merges the two flush() from the disposal bins and disposals deliveryChutes.
Stops the disposal bin from holding back the machinery controller when flushing.
The mobs clients eye will be instantly moved to the disposal object when the mob is moved into them.
Fixes issue #1724
