### PR TITLE
Buffs whispers

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -66,13 +66,17 @@
 	var/spans = list(SPAN_ITALICS)
 	rendered = "<span class='game say'><span class='name'>[GetVoice()]</span>[alt_name] [whispers], <span class='message'>\"[attach_spans(message, spans)]\"</span></span>"
 
-	for(var/mob/M in listening)
-		M.Hear(rendered, src, languages, message, , spans)
+	for(var/atom/movable/AM in listening)
+		if(istype(AM,/obj/item/device/radio))
+			continue
+		AM.Hear(rendered, src, languages, message, , spans)
 
 	message = stars(message)
 	rendered = "<span class='game say'><span class='name'>[GetVoice()]</span>[alt_name] [whispers], <span class='message'>\"[attach_spans(message, spans)]\"</span></span>"
-	for(var/mob/M in eavesdropping)
-		M.Hear(rendered, src, languages, message, , spans)
+	for(var/atom/movable/AM in eavesdropping)
+		if(istype(AM,/obj/item/device/radio))
+			continue
+		AM.Hear(rendered, src, languages, message, , spans)
 
 	if(critical) //Dying words.
 		succumb(1)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -153,8 +153,6 @@
 					return
 				if (src.client.handle_spam_prevention(message,MUTE_IC))
 					return
-			if (stat)
-				return
 			if(!(message))
 				return
 			else

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -3,6 +3,9 @@
 //Intended to be called by a higher up emote proc if the requested emote isn't in the custom emotes.
 
 /mob/living/emote(var/act, var/m_type=1, var/message = null)
+	if(stat)
+		return
+
 	var/param = null
 
 	if (findtext(act, "-", 1, null))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -56,14 +56,13 @@ var/list/department_radio_keys = list(
 	  ":ï" = "changeling",	"#ï" = "changeling",	".ï" = "changeling"
 )
 
+var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
+
 /mob/living/say(message, bubble_type,)
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 
 	if(stat == DEAD)
 		say_dead(message)
-		return
-
-	if(stat)
 		return
 
 	if(check_emote(message))
@@ -74,6 +73,9 @@ var/list/department_radio_keys = list(
 		return
 
 	var/message_mode = get_message_mode(message)
+
+	if(stat && !(message_mode in crit_allowed_modes))
+		return
 
 	if(message_mode == MODE_HEADSET || message_mode == MODE_ROBOT)
 		message = copytext(message, 2)


### PR DESCRIPTION
Whispers now activate non-radio voice stuff.
Hivemind/Alientalk can now be used in crit
Fixes whisper succumbing in hotkey mode/through say (aka ":w stuff")

Can't think of any obvious side-effect of this so here it is.

Fixes #8839
Fixes #6658
