### PR TITLE
Fixes blob zombie overlays+colouring when it doesn't have an overmind.

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -83,8 +83,7 @@
 	H.hair_style = null
 	H.update_hair()
 	human_overlays = H.overlays
-	if(overmind && overmind.blob_reagent_datum)
-		adjustcolors(overmind.blob_reagent_datum.color)
+	update_icons()
 	H.loc = src
 	loc.visible_message("<span class='warning'> The corpse of [H.name] suddenly rises!</span>")
 
@@ -120,8 +119,18 @@
 	..()
 
 
+/mob/living/simple_animal/hostile/blob/blobspore/update_icons()
+	..()
+
+	if(overmind && overmind.blob_reagent_datum)
+		adjustcolors(overmind.blob_reagent_datum.color)
+	else
+		adjustcolors(color) //to ensure zombie/other overlays update
+
+
 /mob/living/simple_animal/hostile/blob/blobspore/adjustcolors(var/a_color)
 	color = a_color
+
 	if(is_zombie)
 		overlays.Cut()
 		overlays = human_overlays
@@ -129,7 +138,6 @@
 		I.color = color
 		color = initial(color)//looks better.
 		overlays += I
-
 
 /////////////////
 // BLOBBERNAUT //


### PR DESCRIPTION
I broke this when me and goof added reagent blobs.

Before you ask "Won't they all have an overmind?"
1. Badminnery
2. The "Zombie Outbreak!" Event spawns blobspores on all corpses to create zombies, this means they are without overmind and fail to update their appearance.
