### PR TITLE
Removes Cyborg Per-Active Module Powerdrain

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -12,7 +12,6 @@
 		use_power()
 
 /mob/living/silicon/robot/proc/clamp_values()
-
 	SetStunned(min(stunned, 30))
 	SetParalysis(min(paralysis, 30))
 	SetWeakened(min(weakened, 20))
@@ -23,29 +22,16 @@
 	adjustFireLoss(0)
 
 /mob/living/silicon/robot/proc/use_power()
-
-	if(cell)
-		if(cell.charge <= 0)
+	if(cell && cell.charge)
+		if(cell.charge <= 100)
 			uneq_all()
-			stat = UNCONSCIOUS
-		else if (cell.charge <= 100)
-			uneq_all()
-			cell.use(1)
-		else
-			if(module_state_1)
-				cell.use(5)
-			if(module_state_2)
-				cell.use(5)
-			if(module_state_3)
-				cell.use(5)
-			cell.use(1)
+		cell.use(1)
 	else
 		uneq_all()
 		stat = UNCONSCIOUS
 
 
 /mob/living/silicon/robot/handle_regular_status_updates()
-
 	if(camera && !scrambledcodes)
 		if(stat == DEAD || wires.IsCameraCut())
 			camera.status = 0

--- a/html/changelogs/CHERIDAN-PR-9820.yml
+++ b/html/changelogs/CHERIDAN-PR-9820.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Cheridan
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes the powerdrain for individiual active modules on cyborgs."


### PR DESCRIPTION
I could have _sworn_ that someone had already removed this, at some point.

Removes the 5 energy per active module drain from cyborgs.

All this did is add inconvenience. You could store your modules save on drain, but all it takes is 2 clicks to pull something out. It just encourages annoying inventory-fiddling and punishes you if you don't do so.

Even if you don't like borgs (i don't like borgs) this isn't a useful technique to balance them.
