### PR TITLE
Fixes show_game_type_odds

### DIFF
--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -38,7 +38,6 @@ var/global/datum/getrev/revdata = new()
 	src << "Protect Assistant Role From Traitor: [config.protect_assistant_from_antagonist]"
 	src << "Enforce Human Authority: [config.enforce_human_authority]"
 	src << "Allow Latejoin Antagonists: [config.allow_latejoin_antagonists]"
-	src << "Protect Assistant From Antagonist: [config.protect_assistant_from_antagonist]"
 	src << "Enforce Continuous Rounds: [config.continuous.len] of [config.modes.len] roundtypes"
 	src << "Allow Midround Antagonists: [config.midround_antag.len] of [config.modes.len] roundtypes"
 	if(config.show_game_type_odds)

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -41,4 +41,13 @@ var/global/datum/getrev/revdata = new()
 	src << "Protect Assistant From Antagonist: [config.protect_assistant_from_antagonist]"
 	src << "Enforce Continuous Rounds: [config.continuous.len] of [config.modes.len] roundtypes"
 	src << "Allow Midround Antagonists: [config.midround_antag.len] of [config.modes.len] roundtypes"
+	if(config.show_game_type_odds)
+		src <<"<b>Game Mode Odds:</b>"
+		var/sum = 0
+		for(var/i=1,i<=config.probabilities.len,i++)
+			sum += config.probabilities[config.probabilities[i]]
+		for(var/i=1,i<=config.probabilities.len,i++)
+			if(config.probabilities[config.probabilities[i]] > 0)
+				var/percentage = round(config.probabilities[config.probabilities[i]] / sum * 100, 0.1)
+				src << "[config.probabilities[i]] [percentage]%"
 	return


### PR DESCRIPTION
It had been accidentally gutted way back in #4215 so I've brought it back properly and better than ever.

![untitled-1 copy](https://cloud.githubusercontent.com/assets/4176358/8022484/fc23d132-0ca2-11e5-9580-7222cd59c24f.png)

Note: Shown odds are what come standard from the github right now, and don't reflect sybil/phybil
