### PR TITLE
Drone Shell Cargo Crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -650,6 +650,18 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "HEADER"
 	group = supply_science
 
+/datum/supply_packs/science/robotics/droneshells
+	name = "Drone Shell Crate"
+	contains = list(/obj/item/drone_shell,
+		/obj/item/drone_shell,
+		/obj/item/drone_shell,
+		/obj/item/drone_shell,
+		/obj/item/drone_shell,
+		/obj/item/drone_shell)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Drone Shell Crate"
+	access = access_robotics
 
 /datum/supply_packs/science/robotics
 	name = "Robotics Assembly Crate"

--- a/html/changelogs/bananacreampie.yml
+++ b/html/changelogs/bananacreampie.yml
@@ -1,0 +1,16 @@
+
+#################################
+
+# Your name.  
+author: bananacreampie
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a Drone Shell Crate to cargo's supply console."


### PR DESCRIPTION
![droneshellcrate](https://cloud.githubusercontent.com/assets/12781203/8023576/3bb2fdaa-0cdf-11e5-94aa-536d30cd748f.png)

Added a Drone Shell Crate to the cargo supply request console. Its a secure robotics crate with 6 drone shells. Reasonably cost and fast way to get drone shells if research is behind or no roboticist. 
