### PR TITLE
Pipe Pressure Panic

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -103,27 +103,55 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob, params)
 	if(can_unwrench && istype(W, /obj/item/weapon/wrench))
-		var/turf/T = src.loc
+		var/turf/T = get_turf(src)
 		if (level==1 && isturf(T) && T.intact)
 			user << "<span class='warning'>You must remove the plating first!</span>"
 			return 1
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()
 		add_fingerprint(user)
-		if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
-			user << "<span class='warning'>You cannot unwrench this [src], it is too exerted due to internal pressure!</span>"
-			return 1
+
+		var/unsafe_wrenching = FALSE
+		var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
+
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		user << "<span class='notice'>You begin to unfasten \the [src]...</span>"
+		if (internal_pressure > 2*ONE_ATMOSPHERE)
+			user << "<span class='warning'>As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?</span>"
+			unsafe_wrenching = TRUE //Oh dear oh dear
+
 		if (do_after(user, 40) && !gc_destroyed)
 			user.visible_message( \
 				"[user] unfastens \the [src].", \
 				"<span class='notice'>You unfasten \the [src].</span>", \
 				"<span class='italics'>You hear ratchet.</span>")
 			investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", "atmos")
+
+			//You unwrenched a pipe full of pressure? let's splat you into the wall silly.
+			if(unsafe_wrenching)
+				unsafe_pressure_release(user,internal_pressure)
 			Deconstruct()
+
 	else
 		return ..()
+
+
+//Called when an atmospherics object is unwrenched while having a large pressure difference
+//with it's locs air contents.
+/obj/machinery/atmospherics/proc/unsafe_pressure_release(var/mob/user,var/pressures)
+	if(!user)
+		return
+
+	if(!pressures)
+		var/datum/gas_mixture/int_air = return_air()
+		var/datum/gas_mixture/env_air = loc.return_air()
+		pressures = int_air.return_pressure()-env_air.return_pressure()
+
+	var/fuck_you_dir = get_dir(src,user)
+	var/turf/general_direction = get_edge_target_turf(user,fuck_you_dir)
+	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
+	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed
+	user.throw_at(general_direction,pressures/10,pressures/50)
 
 /obj/machinery/atmospherics/Deconstruct()
 	if(can_unwrench)

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -161,3 +161,20 @@
 		parent1 = New
 	else if(Old == parent2)
 		parent2 = New
+
+
+/obj/machinery/atmospherics/binary/unsafe_pressure_release(var/mob/user,var/pressures)
+	..()
+
+	var/turf/T = get_turf(src)
+	if(T)
+		//Remove the gas from air1+air2 and assume it
+		var/datum/gas_mixture/environment = T.return_air()
+		var/lost = pressures*environment.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
+		lost += pressures*environment.volume/(air2.temperature * R_IDEAL_GAS_EQUATION)
+		var/shared_loss = lost/2
+
+		var/datum/gas_mixture/to_release = air1.remove(shared_loss)
+		to_release.merge(air2.remove(shared_loss))
+		T.assume_air(to_release)
+		air_update_turf(1)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -220,3 +220,22 @@ Housekeeping and pipe network stuff below
 		parent2 = New
 	else if(Old == parent3)
 		parent3 = New
+
+
+/obj/machinery/atmospherics/trinary/unsafe_pressure_release(var/mob/user,var/pressures)
+	..()
+
+	var/turf/T = get_turf(src)
+	if(T)
+		//Remove the gas from air1+air2+air3 and assume it
+		var/datum/gas_mixture/environment = T.return_air()
+		var/lost = pressures*environment.volume/(air1.temperature * R_IDEAL_GAS_EQUATION)
+		lost += pressures*environment.volume/(air2.temperature * R_IDEAL_GAS_EQUATION)
+		lost += pressures*environment.volume/(air3.temperature * R_IDEAL_GAS_EQUATION)
+		var/shared_loss = lost/3
+
+		var/datum/gas_mixture/to_release = air1.remove(shared_loss)
+		to_release.merge(air2.remove(shared_loss))
+		to_release.merge(air3.remove(shared_loss))
+		T.assume_air(to_release)
+		air_update_turf(1)

--- a/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
@@ -118,3 +118,19 @@ Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/unary/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
 	if(Old == parent)
 		parent = New
+
+
+/obj/machinery/atmospherics/unary/unsafe_pressure_release(var/mob/user,var/pressures)
+	..()
+
+	var/turf/T = get_turf(src)
+	if(T)
+		//Remove the gas from air_contents and assume it
+		var/datum/gas_mixture/environment = T.return_air()
+		var/lost = pressures*environment.volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)
+
+		var/datum/gas_mixture/to_release = air_contents.remove(lost)
+		T.assume_air(to_release)
+		air_update_turf(1)
+
+

--- a/html/changelogs/RemieRichards-PipePressureLethality.yml
+++ b/html/changelogs/RemieRichards-PipePressureLethality.yml
@@ -1,0 +1,8 @@
+
+author: RemieRichards
+
+delete-after: True
+
+changes: 
+  - tweak: "You can now unwrench pipes who's internal pressures are greater than that of their environment..."
+  - rscadd: "However it will throw you away from the pipe at extreme speed! (You are warned beforehand if the pipe will do this, allowing you to cancel)"


### PR DESCRIPTION
- You can now unwrench atmos machinery who's internal pressure is greater than it's environment...
- However this will violently throw you away from the machine, with painful results!
- During the do_after() (the delay of the action) you are warned of the machines danger, allowing you to cancel by walking away

The speed and range of the throw relate to the pressures of the machine, the higher the pressure, the further you go quicker!

The unwrenched machine will also leak it's juicy gas contents all over the floor when unwrenched in this fashion (let's assume when a pipe is unwrenched below the dangerous pressures the Atmos tech caps both ends of each pipe, k?) it does so in the same fashion (code/mechanically) as a portable atmos canister (the big ones, not the hand held ones) except it takes an amount from each of the machine's air mixtures equally (binaries have 2 mixtures, trinaries 3, etc)
