### PR TITLE
Adds feedback gathering for a hell of a lot more things.

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -21,6 +21,7 @@
 	attach(A2,user)
 	name = "[A.name]-[A2.name] assembly"
 	update_icon()
+	feedback_add_details("assembly_made","[name]")
 
 /obj/item/device/assembly_holder/proc/attach(var/obj/item/device/assembly/A, var/mob/user)
 	if(!A.remove_item_from_storage(src))

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -78,6 +78,7 @@
 
 /obj/structure/table/proc/construct_item(mob/user, datum/table_recipe/R)
 	check_table()
+	var/send_feedback = 1
 	if(check_contents(R) && check_tools(user, R))
 		if(do_after(user, R.time))
 			if(!check_contents(R) || !check_tools(user, R))
@@ -86,6 +87,8 @@
 			if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
 				var/obj/item/weapon/reagent_containers/food/snacks/S = I
 				S.create_reagents(S.volume)
+				feedback_add_details("food_made","[S.name]")
+				send_feedback = 0
 			var/list/parts = del_reqs(R, I)
 			for(var/A in parts)
 				if(istype(A, /obj/item))
@@ -98,6 +101,8 @@
 						I.reagents = new /datum/reagents()
 					I.reagents.reagent_list.Add(A)
 			I.CheckParts()
+			if(send_feedback)
+				feedback_add_details("object_crafted","[I.name]")
 			return 1
 	return 0
 

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -28,6 +28,7 @@
 		return PROCESS_KILL
 	var/datum/round_event/E = new typepath()
 	E.control = src
+	feedback_add_details("event_ran","[E]")
 	occurrences++
 
 	testing("[time2text(world.time, "hh:mm:ss")] [E.type]")

--- a/code/modules/food&drinks/kitchen machinery/microwave.dm
+++ b/code/modules/food&drinks/kitchen machinery/microwave.dm
@@ -251,6 +251,7 @@
 			if(F.cooked_type)
 				var/obj/item/weapon/reagent_containers/food/snacks/S = new F.cooked_type (get_turf(src))
 				F.initialize_cooked_food(S, efficiency)
+				feedback_add_details("food_made","[F.name]")
 			else
 				new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(src)
 				if(dirty < 100)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -802,7 +802,7 @@
 	var/t_amount = 0
 	var/list/result = list()
 	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
-
+	var/product_name
 	while(t_amount < getYield())
 		var/obj/item/weapon/reagent_containers/food/snacks/grown/t_prod = new product(output_loc, potency)
 		result.Add(t_prod) // User gets a consumable
@@ -815,7 +815,9 @@
 		t_prod.potency = potency
 		t_prod.plant_type = plant_type
 		t_amount++
-
+		product_name = t_prod.name
+	if(getYield() >= 1)
+		feedback_add_details("food_harvested","[product_name]|[getYield()]")
 	parent.update_tray()
 
 	return result

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -17,7 +17,7 @@ var/global/list/rockTurfEdgeCache
 	density = 1
 	blocks_air = 1
 	temperature = TCMB
-	var/mineralType = null
+	var/obj/mineralType = null
 	var/mineralAmt = 3
 	var/spread = 0 //will the seam spread?
 	var/spreadChance = 0 //the percentual chance of an ore spreading to the neighbouring tiles
@@ -439,6 +439,7 @@ var/global/list/rockTurfEdgeCache
 				user << "<span class='notice'>You finish cutting into the rock.</span>"
 				P.update_icon()
 				gets_drilled(user)
+				feedback_add_details("pick_used_mining","[P.name]")
 	else
 		return attack_hand(user)
 	return
@@ -448,6 +449,7 @@ var/global/list/rockTurfEdgeCache
 		var/i
 		for (i=0;i<mineralAmt;i++)
 			new mineralType(src)
+		feedback_add_details("ore_mined","[mineralType.name]|[mineralAmt]")
 	var/turf/simulated/floor/plating/asteroid/airless/N = ChangeTurf(/turf/simulated/floor/plating/asteroid/airless)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	N.fullUpdateMineralOverlays()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -130,6 +130,8 @@ emp_act
 	var/obj/item/organ/limb/affecting = get_organ(ran_zone(user.zone_sel.selecting))
 	var/hit_area = parse_zone(affecting.name)
 	var/target_area = parse_zone(target_limb.name)
+	feedback_add_details("item_used_for_combat","[I.name]|[I.force]")
+	feedback_add_details("zone_targeted","[def_zone]")
 
 	if(dna)	// allows your species to affect the attacked_by code
 		return dna.species.spec_attacked_by(I,user,def_zone,affecting,hit_area,src.a_intent,target_limb,target_area,src)
@@ -154,7 +156,6 @@ emp_act
 		var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 		apply_damage(I.force, I.damtype, affecting, armor , I)
-
 		var/bloody = 0
 		if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))
 			if(affecting.status == ORGAN_ORGANIC)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -41,6 +41,10 @@
 			return
 	..()
 
+/mob/living/simple_animal/hostile/asteroid/death(gibbed)
+	feedback_add_details("mobs_killed_mining","[src.name]")
+	..(gibbed)
+
 /mob/living/simple_animal/hostile/asteroid/basilisk
 	name = "basilisk"
 	desc = "A territorial beast, covered in a thick shell that absorbs energy. Its stare causes victims to freeze from the inside."
@@ -109,6 +113,7 @@
 		var/obj/item/weapon/ore/diamond/D = new /obj/item/weapon/ore/diamond(src.loc)
 		D.layer = 4.1
 	..(gibbed)
+
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub
 	name = "goldgrub"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -43,6 +43,8 @@
 		return 0
 	if(charge < amount)	return 0
 	charge = (charge - amount)
+	if(!istype(loc, /obj/machinery/power/apc))
+		feedback_add_details("cell_used","[src.name]")
 	return 1
 
 // recharge the cell

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -132,6 +132,7 @@
 	process_fire(target,user,1,params)
 
 
+
 /obj/item/weapon/gun/proc/can_trigger_gun(mob/living/carbon/user)
 	if (!user.IsAdvancedToolUser())
 		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
@@ -218,7 +219,7 @@
 		user.update_inv_l_hand(0)
 	else
 		user.update_inv_r_hand(0)
-
+	feedback_add_details("gun_fired","[src.name]")
 
 /obj/item/weapon/gun/attack(mob/M as mob, mob/user)
 	if(user.a_intent == "harm") //Flogging

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -177,6 +177,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 
 /datum/feedback_variable/proc/add_details(var/text)
 	if (istext(text))
+		text = replacetext(text, " ", "_")
 		if (!details)
 			details = text
 		else

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -276,6 +276,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
 								linked_lathe.m_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.m_amt*(linked_destroy.decon_mod/10)))
 								linked_lathe.g_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.g_amt*(linked_destroy.decon_mod/10)))
+								feedback_add_details("item_deconstructed","[linked_destroy.loaded_item.name]")
 							linked_destroy.loaded_item = null
 						else
 							screen = 1.0
@@ -406,6 +407,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					var/R = being_built.reliability
 					spawn(32*amount/coeff)
 						if(g2g) //And if we only fail the material requirements, we still spend time and power
+							var/already_logged = 0
 							for(var/i = 0, i<amount, i++)
 								var/obj/item/new_item = new P(src)
 								if( new_item.type == /obj/item/weapon/storage/backpack/holding )
@@ -416,6 +418,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								if(linked_lathe.hacked)
 									R = max((new_item.reliability/2), 0)
 								new_item.loc = linked_lathe.loc
+								if(!already_logged)
+									feedback_add_details("item_printed","[new_item.name]|[amount]")
+									already_logged = 1
 						linked_lathe.busy = 0
 						screen = old_screen
 						updateUsrDialog()
@@ -469,6 +474,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							var/obj/item/new_item = new P(src)
 							new_item.reliability = R
 							new_item.loc = linked_imprinter.loc
+							feedback_add_details("circuit_printed","[new_item.name]")
 						linked_imprinter.busy = 0
 						screen = old_screen
 						updateUsrDialog()

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -48,6 +48,7 @@
 						user.visible_message("[user] drapes [I] over [M]'s [parse_zone(procedure.location)] to prepare for \an [procedure.name].", "<span class='notice'>You drape [I] over [M]'s [parse_zone(procedure.location)] to prepare for \an [procedure.name].</span>")
 
 						add_logs(user, M, "operated", addition="Operation type: [procedure.name]")
+						feedback_add_details("surgery_initiated","[procedure.name]")
 						return 1
 					else
 						user << "<span class='warning'>You need to expose [M]'s [procedure.location] first!</span>"

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -73,6 +73,7 @@
 
 /datum/surgery_step/proc/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] succeeds!", "<span class='notice'>You succeed.</span>")
+	feedback_add_details("surgery_step_success","[src.type]")
 	return 1
 
 /datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -80,10 +81,12 @@
 		var/mob/living/carbon/human/H = target
 		H.apply_damage(75,"brute","[target_zone]")
 		user.visible_message("[user] saws [target]'s [parse_zone(target_zone)] open!", "<span class='notice'>You saw [target]'s [parse_zone(target_zone)] open.</span>")
+		feedback_add_details("surgery_step_success","[src.type]")
 	return 1
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='warning'>[user] screws up!</span>", "<span class='warning'>You screw up!</span>")
+	feedback_add_details("surgery_step_failed","[src.type]")
 	return 0
 
 /datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
The following things give feedback now, for us to gather data without relying on word of mouth or being there, and allows for us to have the ~RAW NUMBERS~ accessable.
http://ss13.eu/tgdb/tg/latest_stats.html

Assemblies Made, and their type.
Food made via microwaves and tablecrafting.
Objects made via tablecrafting.
Events triggering.
Crops harvested from hydroponics.
Picks used in mining, and their type.
Ore mined, and their type.
Mining mobs killed, and their type.
Power cells used, and their type. APCs are excluded from this.
Guns fired, and their type.
Items deconstructed in the Decon. Analyzer, and their type.
Items printed in the Protolathe, and their type.
Circuitboards printed in the Circuit Imprinter, and their type.
Surgeries attempted, and their type.
Surgery Step successes, and their type.
Surgery Step failures, and their type.
Items used in attacking, and their damage caused.
Zones targeted while attacking.
@MrStonedOne 
