### PR TITLE
Fixes some bugs and runtimes with fastmos.

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -78,6 +78,7 @@
 		set_frequency(frequency)
 
 /obj/machinery/air_sensor/Destroy()
+	SSair.atmos_machinery -= src
 	if(radio_controller)
 		radio_controller.remove_object(src,frequency)
 	..()

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -18,6 +18,11 @@
 	src.target = locate(/obj/machinery/atmospherics/pipe) in loc
 	return 1
 
+/obj/machinery/meter/Destroy()
+	SSair.atmos_machinery -= src
+	src.target = null
+	..()
+
 /obj/machinery/meter/initialize()
 	if (!target)
 		src.target = locate(/obj/machinery/atmospherics/pipe) in loc

--- a/code/game/machinery/atmoalter/zvent.dm
+++ b/code/game/machinery/atmoalter/zvent.dm
@@ -9,6 +9,14 @@
 	var/on = 0
 	var/volume_rate = 800
 
+/obj/machinery/zvent/New()
+	..()
+	SSair.atmos_machinery += src
+
+/obj/machinery/zvent/Destroy()
+	SSair.atmos_machinery -= src
+	..()
+
 /obj/machinery/zvent/process_atmos()
 
 	//all this object does, is make its turf share air with the ones above and below it, if they have a vent too.


### PR DESCRIPTION
Fixes meters and air sensors processing after getting qdeleted, causing runtimes and preventing their GC'ing
Fixes meters preventing the pipes they were attached to from getting GC'ed if both were deleted in the same action.
Fixes z-vents not processing (we don't even use this, so it didn't matter)
