### PR TITLE
Fixes #9815 - Lizards, rejoice!

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -916,15 +916,6 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 		character.real_name = real_name
 		character.name = character.real_name
 
-		if(character.dna)
-			character.dna.real_name = character.real_name
-			if(pref_species != /datum/species/human && config.mutant_races)
-				hardset_dna(character, null, null, null, null, pref_species.type)
-			else
-				hardset_dna(character, null, null, null, null, /datum/species/human)
-			character.dna.mutant_color = mutant_color
-			character.update_mutcolor()
-
 		character.gender = gender
 		character.age = age
 		character.blood_type = blood_type
@@ -944,5 +935,15 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 			backbag = 1 //Same as above
 		character.backbag = backbag
 
-		character.update_body()
-		character.update_hair()
+		if(character.dna)
+			var/datum/species/chosen_species
+
+			character.dna.real_name = character.real_name
+			if(pref_species != /datum/species/human && config.mutant_races)
+				chosen_species = pref_species.type
+			else
+				chosen_species = /datum/species/human
+			hardset_dna(character, null, null, null, null, chosen_species, mutant_color)
+		else
+			character.update_body()
+			character.update_hair()

--- a/html/changelogs/SvartaSvansen-LizardGeneticist.yml
+++ b/html/changelogs/SvartaSvansen-LizardGeneticist.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: SvartaSvansen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "A panel of lizard geneticists has been hard at work fixing what NanoTrasen had screwed up, and they've finally found the cure! The days of misgendered bodies are finally over!"
+  - tweak: "Shaved a bit of fluff off character spawn in the process."


### PR DESCRIPTION
I found the lizard misgendering issue (#9815) lying inside /datum/preferences, in the chunk of code that initializes a character on spawn. The mutant race icon is updated before the character's gender is set, when the gender is still randomized. So in the case that your lizard has the wrong sprite, for a small fraction of a second it actually was that gender when its icons were regenerated. But its icons weren't regenerated again after its gender was set to your preference.

I moved the if(character.dna) block to the end so everything is set before hardset_dna() calls regenerate_icons(). With those four null arguments, it doesn't touch anything that was set before it, so values that are already set won't be overridden by a default or randomized value.

Lizards, rejoice! The days of joining with a body of the opposite sex are over!

I also cleaned up the code a bit in the process. I found out that update_mutcolor() is called twice when a character is spawned in (my note about the redundant regenerate_icons() call is wrong), and it fails to set a mutant color the first time. I moved things around so update_mutcolor() is only called once and succeeds the first time.
