### PR TITLE
Tweaks MC's dynamic rate system a bit. Lowers lag from singulo getting released.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -9,6 +9,7 @@ var/global/datum/controller/game_controller/master_controller = new()
 	var/processing_interval = 1	//The minimum length of time between MC ticks (in deciseconds). The highest this can be without affecting schedules, is the GCD of all subsystem var/wait. Set to 0 to disable all processing.
 	var/iteration = 0
 	var/cost = 0
+	var/SSCostPerSecond = 0
 	var/last_thing_processed
 
 	var/list/subsystems = list()
@@ -89,10 +90,11 @@ calculate the longest number of ticks the MC can wait between each cycle without
 				++iteration
 
 				start_time = world.timeofday
-
+				var/SubSystemRan = 0
 				for(var/datum/subsystem/SS in subsystems)
 					if(SS.can_fire > 0)
 						if(SS.next_fire <= world.time)
+							SubSystemRan = 1
 							timer = world.timeofday
 							last_thing_processed = SS.type
 							SS.last_fire = world.time
@@ -100,7 +102,9 @@ calculate the longest number of ticks the MC can wait between each cycle without
 							SS.cost = MC_AVERAGE(SS.cost, world.timeofday - timer)
 							if (SS.dynamic_wait)
 								var/oldwait = SS.wait
-								SS.wait = min(max(round(SS.cost*SS.dwait_delta, 0.1),SS.dwait_lower),SS.dwait_upper)
+								var/GlobalCostDelta = (SSCostPerSecond-(SS.cost/SS.wait))/(SS.wait/10)-1
+								var/NewWait = MC_AVERAGE(oldwait,(SS.cost-1.5+GlobalCostDelta)*SS.dwait_delta)
+								SS.wait = Clamp(round(NewWait,0.1),SS.dwait_lower,SS.dwait_upper)
 								if (oldwait != SS.wait)
 									calculateGCD()
 							SS.next_fire += SS.wait
@@ -109,10 +113,19 @@ calculate the longest number of ticks the MC can wait between each cycle without
 							sleep(-1)
 
 				cost = MC_AVERAGE(cost, world.timeofday - start_time)
-
+				if (SubSystemRan)
+					calculateSScost()
 				sleep(processing_interval)
 			else
 				sleep(50)
+
+/datum/controller/game_controller/proc/calculateSScost()
+	var/newcost = 0
+	for(var/datum/subsystem/SS in subsystems)
+		if (!SS.can_fire)
+			continue
+		newcost += SS.cost/(SS.wait/10)
+	SSCostPerSecond = MC_AVERAGE(SSCostPerSecond,newcost)
 
 #undef MC_AVERAGE
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -3,7 +3,6 @@ var/datum/subsystem/air/SSair
 /datum/subsystem/air
 	name = "Air"
 	priority = 20
-	cost = 5
 	wait = 5
 	dynamic_wait = 1
 	dwait_lower = 5

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -5,9 +5,11 @@ var/datum/subsystem/garbage_collector/SSgarbage
 	can_fire = 1
 	wait = 5
 	priority = -1
+	dynamic_wait = 1
+	dwait_delta = 5
 
 	var/collection_timeout = 300// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object
-	var/max_run_time = 2		// how long, in deciseconds, can we run before waiting for the next tick
+	var/max_run_time = 1		// how long, in deciseconds, can we run before waiting for the next tick
 	var/delslasttick = 0		// number of del()'s we've done this tick
 	var/gcedlasttick = 0		// number of things that gc'ed last tick
 	var/totaldels = 0

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -7,6 +7,7 @@ var/datum/subsystem/lighting/SSlighting
 	wait = 5
 	priority = 1
 	dynamic_wait = 1
+	dwait_delta = 1
 
 	var/list/changed_lights = list()		//list of all datum/light_source that need updating
 	var/changed_lights_workload = 0			//stats on the largest number of lights (max changed_lights.len)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -719,6 +719,7 @@ var/list/slot_equipment_priority = list( \
 
 			if(master_controller)
 				stat("MasterController:","[round(master_controller.cost,0.001)]ds (Interval:[master_controller.processing_interval] | Iteration:[master_controller.iteration])")
+				stat("Subsystem cost per second:","[round(master_controller.SSCostPerSecond,0.001)]ds")
 				for(var/datum/subsystem/SS in master_controller.subsystems)
 					if(SS.can_fire)
 						SS.stat_entry()


### PR DESCRIPTION
The MC will now track the total cost of all subsytems (normalized out to a per second cost number so that subsystems that only run every 10 minutes but are costly (looking at you server tasks) aren't accounting for 90% of the number when they shouldn't.)

This new number is now used in dynamic wait subsystems to ensure they slow down when other things are being laggy.

This mainly means that air won't lag things if the singulo gets free.

I also tweaked the scaling curve used by the dynamic wait system so that it scales less during slight lagginess, but much more during higher lag times.

I added qdel to the dynamic wait subsystem with a really high scale. This didn't make sense before, because it limits its run time, but now it can scale back how often it runs when the other subsystems are being laggy. I also lowered qdel's max runtime from 2ds to 1ds, because deletes take 0.9 ds on avg, so it would end up running for 2.9ds often.

This should prevent air+singulo+qdel causing excessive amounts of lag.

Testing this on my local server showed noticeable improvements over lag when every vent had its pressure checks removed, every door/windowdoor/airlock/firedoor deleted, distro varedited to contain 9999999 moles of plasma and o2, and a stage 5 singulo dropped right in the middle of bridge.

Side question: Should I maybe move the singulo to a subsystem with a dynamic fire rate? It tends to use up 6 to 8ds a process() tick.
