### PR TITLE
Removes the modified Detective's revolver explosion chance

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -73,17 +73,6 @@
 	options["The Peacemaker"] = "detective_peacemaker"
 	options["Cancel"] = null
 
-/obj/item/weapon/gun/projectile/revolver/detective/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, var/message = 1, params)
-	if(magazine.caliber != initial(magazine.caliber))
-		if(prob(70 - (magazine.ammo_count() * 10)))	//minimum probability of 10, maximum of 60
-			playsound(user, fire_sound, 50, 1)
-			user << "<span class='userdanger'>[src] blows up in your face!</span>"
-			user.take_organ_damage(0,20)
-			user.drop_item()
-			qdel(src)
-			return 0
-	..()
-
 /obj/item/weapon/gun/projectile/revolver/detective/attackby(var/obj/item/A as obj, mob/user as mob, params)
 	..()
 	if(istype(A, /obj/item/weapon/screwdriver))


### PR DESCRIPTION
I actually don't know if this will work, I assume just cutting that block of garbage out should be fine as it's not tied to anything I could see.

For those of you unaware of how the mechanic works currently: Once modified, the gun has an explosion chance _based on the number of bullets loaded the cylinder_ which makes absolutely no sense from a logical and gameplay standpoint, as it encourages you to only load 1-2 bullets and even then you risk LOSING your unique gun.

If the Detective can get .357, he should be in the clear to use it without fear of instant RNG gun removal. Serves to further separate the Detective, mechanically, from a Security Officer. 
