### PR TITLE
allows facid and sacid to be put into spray bottles again

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -15,7 +15,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = null
-	banned_reagents = list("facid","sacid")
+	banned_reagents = list()
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob)


### PR DESCRIPTION
considering I can spray things ten times worse than these two from a spray bottle right now i don't see why these should be blacklisted

it's also retardedly easy to bypass with like 20 different methods

acid is tame compared to some of the other shit i can pull so blacklisting it is stupid

and no i'm not blacklisting the rest of the pyrotechnics instead fuck off with that before you even start commenting
