### PR TITLE
Fixes the 3k active turfs at roundstart

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -60,7 +60,8 @@ calculate the longest number of ticks the MC can wait between each cycle without
 	for(var/datum/subsystem/S in subsystems)
 		S.Initialize(world.timeofday, zlevel)
 		sleep(-1)
-
+	for(var/datum/subsystem/S in subsystems)
+		S.AfterInitialize(zlevel)
 	world << "<span class='boldannounce'>Initializations complete</span>"
 	world.log << "Initializations complete"
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -56,9 +56,11 @@ var/datum/subsystem/air/SSair
 
 
 /datum/subsystem/air/Initialize(timeofday, zlevel)
-	setup_allturfs(zlevel)
 	setup_atmos_machinery(zlevel)
 	..()
+
+/datum/subsystem/air/AfterInitialize(zlevel)
+	setup_allturfs(zlevel)
 
 #define MC_AVERAGE(average, current) (0.8*(average) + 0.2*(current))
 /datum/subsystem/air/fire()
@@ -167,15 +169,14 @@ var/datum/subsystem/air/SSair
 			EG.dismantle()
 
 /datum/subsystem/air/proc/setup_allturfs(z_level)
+	active_turfs.Cut()
 	var/z_start = 1
 	var/z_finish = world.maxz
 	if(1 <= z_level && z_level <= world.maxz)
 		z_level = round(z_level)
 		z_start = z_level
 		z_finish = z_level
-
 	var/list/turfs_to_init = block(locate(1, 1, z_start), locate(world.maxx, world.maxy, z_finish))
-
 	for(var/turf/simulated/T in turfs_to_init)
 		T.CalculateAdjacentTurfs()
 		if(!T.blocks_air)

--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -37,6 +37,9 @@
 	world << "<span class='boldannounce'>[msg]</span>"
 	world.log << msg
 
+/datum/subsystem/proc/AfterInitialize()
+	return
+
 //hook for printing stats to the "MC" statuspanel for admins to see performance and related stats etc.
 /datum/subsystem/proc/stat_entry(msg)
 	var/dwait = ""


### PR DESCRIPTION
Adds AfterInitialize() to the subsystem datums, it will be called once all Initialize() calls finish. Currently only atmos uses it to set up the turfs.
Before I had the luxury to initialize atmos last, by just ordering the calls, but now that they are on a list it's not viable

There are some active turfs left at roundstart but those are legit map mistakes
