### PR TITLE
Removes strip_html_properly(), replaces it with html_encode().

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -76,12 +76,12 @@
 // Used to get a properly sanitized input, of max_length
 /proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as text|null
-	return strip_html_properly(name, max_length)
+	return html_encode(name, max_length)
 
 // Used to get a properly sanitized multiline input, of max_length
 /proc/stripped_multiline_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as message|null
-	return strip_html_properly(name, max_length)
+	return html_encode(name, max_length)
 
 //Filters out undesirable characters from names
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)
@@ -147,56 +147,7 @@
 
 	return t_out
 
-//this proc strips html properly, this means that it removes everything between < and >, and between "http" and "://"
-//also limit the size of the input, if specified to
-/proc/strip_html_properly(var/input,var/max_length=MAX_MESSAGE_LEN)
-	if(!input)
-		return
-
-	if(max_length)
-		input = copytext(input,1,max_length)
-
-	var/sanitized_output
-	var/next_html_tag = findtext(input, "<")
-	var/next_http = findtext(input, "http", 1, next_html_tag)
-
-	//the opening and closing of the expression to skip, e.g '<' and '>'
-	var/opening = non_zero_min(next_html_tag, next_http)
-	var/closing
-
-	sanitized_output = copytext(input, 1, opening)
-
-	while(next_html_tag || next_http)
-
-		//we treat < ... >
-		if(opening == next_html_tag)
-			closing = findtext(input, ">", opening + 1)
-			if(closing)
-				next_html_tag = findtext(input, "<", closing)
-				next_http = findtext(input, "http", closing, next_html_tag)
-			else //no matching ">"
-				next_html_tag = 0
-
-		//we treat "http(s)://"
-		else
-			closing = findtext(input, "://", opening + 1)
-			if(closing)
-				closing += 2 //skip these extra //
-				next_http = findtext(input, "http", closing)
-				next_html_tag = findtext(input, "<", closing, next_http)
-			else //no matching "://"
-				next_http = 0
-
-		//check if we've something to skip
-		if(closing)
-			opening = non_zero_min(next_html_tag, next_http)
-			sanitized_output += copytext(input, closing + 1, opening)
-
-	sanitized_output += copytext(input, opening) //don't forget the remaining text
-
-	return sanitized_output
-
-//strip_html_properly helper proc that returns the smallest non null of two numbers
+//html_encode helper proc that returns the smallest non null of two numbers
 //or 0 if they're both null (needed because of findtext returning 0 when a value is not present)
 /proc/non_zero_min(var/a, var/b)
 	if(!a)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -76,12 +76,12 @@
 // Used to get a properly sanitized input, of max_length
 /proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as text|null
-	return html_encode(name, max_length)
+	return html_encode(trim(name, max_length)) //trim is "inside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
 // Used to get a properly sanitized multiline input, of max_length
 /proc/stripped_multiline_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as message|null
-	return html_encode(name, max_length)
+	return html_encode(trim(name, max_length))
 
 //Filters out undesirable characters from names
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -109,7 +109,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			user << "The emergency shuttle has been disabled by Centcom."
 			return
 
-	call_reason = strip_html_properly(trim(call_reason))
+	call_reason = html_encode(trim(call_reason))
 
 	if(length(call_reason) < CALL_SHUTTLE_REASON_LENGTH)
 		user << "You must provide a reason."

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -417,5 +417,5 @@ var/datum/subsystem/ticker/ticker
 /datum/subsystem/ticker/proc/send_random_tip()
 	var/list/randomtips = file2list("config/tips.txt")
 	if(randomtips.len)
-		world << "<font color='purple'><b>Tip of the round: </b>[strip_html_properly(pick(randomtips))]</font>"
+		world << "<font color='purple'><b>Tip of the round: </b>[html_encode(pick(randomtips))]</font>"
 

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -299,4 +299,4 @@ var/list/pointers = list()
 	for(var/d in data)
 		var/val = data[d]
 		if(istext(val))
-			data[d] = strip_html_properly(val)
+			data[d] = html_encode(val)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -58,7 +58,7 @@
 	. = ..()
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
-		. += "<p>According to \the [src], you are now in <b>\"[strip_html_properly(A.name)]\"</b>.</p>"
+		. += "<p>According to \the [src], you are now in <b>\"[html_encode(A.name)]\"</b>.</p>"
 	var/datum/browser/popup = new(user, "blueprints", "[src]", 700, 500)
 	popup.set_content(.)
 	popup.open()
@@ -83,7 +83,7 @@
 	. = ..()
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
-		. += "<p>According to \the [src], you are now in <b>\"[strip_html_properly(A.name)]\"</b>.</p>"
+		. += "<p>According to \the [src], you are now in <b>\"[html_encode(A.name)]\"</b>.</p>"
 		. += "<p>You may <a href='?src=\ref[src];edit_area=1'> move an amendment</a> to the drawing.</p>"
 	var/datum/browser/popup = new(user, "blueprints", "[src]", 700, 500)
 	popup.set_content(.)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1032,7 +1032,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		note = replacetext(note, "<li>", "\[*\]")
 		note = replacetext(note, "<ul>", "\[list\]")
 		note = replacetext(note, "</ul>", "\[/list\]")
-		note = strip_html_properly(note)
+		note = html_encode(note)
 		notescanned = 1
 		user << "<span class='notice'>Paper scanned. Saved to PDA's notekeeper.</span>" //concept of scanning paper copyright brainoblivion 2009
 
@@ -1186,7 +1186,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 //ntrc handler proc
 /obj/item/device/pda/proc/msg_chat(channel as text, sender as text, message as text)
-	var/msg = "<b>[strip_html_properly(sender)]</b>| [strip_html_properly(message)]<br>"
+	var/msg = "<b>[html_encode(sender)]</b>| [html_encode(message)]<br>"
 	if(!channel)
 		for(var/C in ntrclog)
 			ntrclog[C] = msg + ntrclog[C]

--- a/code/game/objects/items/devices/PDA/chatroom.dm
+++ b/code/game/objects/items/devices/PDA/chatroom.dm
@@ -66,7 +66,7 @@ var/list/chatchannels = list(default_ntrc_chatroom.name = default_ntrc_chatroom)
 /datum/chatroom/proc/send_message(client,nick,message) //standard message
 	if(!message)
 		return 0
-	logs.Insert(1,"[strip_html_properly(nick)]> [strip_html_properly(message)]")
+	logs.Insert(1,"[html_encode(nick)]> [html_encode(message)]")
 	log_chat("[usr]/([usr.ckey]) as [nick] sent to [name]: [message]")
 	events.fireEvent("msg_chat",name,nick,message)
 	return 1

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -100,7 +100,7 @@
 /obj/item/device/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans)
 	if(mytape && recording)
 		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [strip_html_properly(message)]"
+		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [html_encode(message)]"
 
 /obj/item/device/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -10,7 +10,7 @@
 		return
 
 
-	message = trim(strip_html_properly(message))
+	message = trim(html_encode(message))
 	if(!can_speak(message))
 		return
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -182,7 +182,7 @@
 		return 0
 
 /proc/stars(n, pr)
-	n = strip_html_properly(n)
+	n = html_encode(n)
 	if (pr == null)
 		pr = 25
 	if (pr <= 0)


### PR DESCRIPTION
It was not as proper as the name would imply, and experience and amused redditors have taught me that writing a proper HTML-scrubbing function is a very hard task indeed.

Fixes #9900
