### PR TITLE
Adds some basic scaling, ~10% of crew, to shadowlings.

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -85,7 +85,8 @@ Made by Xhuis
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	var/shadowlings = 2 //How many shadowlings there are; hardcoded to 2
+	var/shadowlings = max(2, round(num_players()/10))
+
 
 	while(shadowlings)
 		var/datum/mind/shadow = pick(antag_candidates)


### PR DESCRIPTION
OOC: Drovidi Corv: I'm not sure why someone hasn't already added scaling
OOC: Amelius: Drovidi Corv, it's what I heard from Sticky and another admin, don't count on what I said being 100% correct. It could be people are just lazy.
OOC: Amelius: Maybe everyone thinks someone else is gonna do it
OOC: Incoming: that's why I haven't done it
OOC: Amelius: Just do it mate, it's gonna take like all of 5 seconds to do a flat 1/10 scaling.
OOC: Incoming: that and I don't really know what would be good balancing for it and I don't want to get accused of cocking things up
OOC: Amelius: According to Sticky, 1/10 works best.
OOC: Drovidi Corv: The rounds that have gone well have been 1/10 scaling
OOC: Amelius: And he runs SL modes every day usually
OOC: Amelius: Or every other
OOC: Drovidi Corv: It's even a pretty balanced winrate IIRC
OOC: Incoming: 1/10, what about number of thralls
OOC: Incoming: always 15?
OOC: Amelius: Flat 15 for onw.
OOC: Drovidi Corv: Flat 15's worked
OOC: Incoming: well alright if you guys say so give me a few moments here
