### PR TITLE
Gang Mode Tweaks

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -25,10 +25,12 @@
 
 	var/datum/game_mode/gang/mode = ticker.mode
 	var/time = null
-	if(isnum(mode.A_timer))
-		time = max(mode.A_timer, 0)
-	if(isnum(mode.B_timer))
-		time = max(mode.B_timer, 0)
+	if(gang == "A")
+		if(isnum(mode.A_timer))
+			time = max(mode.A_timer, 0)
+	if(gang == "B")
+		if(isnum(mode.B_timer))
+			time = max(mode.B_timer, 0)
 	if(isnum(time))
 		if(time > 0)
 			user << "<span class='notice'>Hostile Takeover in progress. Estimated [time] seconds remain.</span>"
@@ -70,8 +72,6 @@
 		qdel(src)
 
 /obj/machinery/dominator/proc/set_broken()
-	if(!gang)
-		return
 	var/datum/game_mode/gang/mode = ticker.mode
 	if(gang == "A")
 		mode.A_timer = "OFFLINE"
@@ -85,6 +85,8 @@
 			priority_announce("Hostile enviroment resolved. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
 		else
 			priority_announce("All hostile activity within station systems have ceased.","Network Alert")
+	if(gang)
+		ticker.mode.message_gangtools(((gang=="A") ? ticker.mode.A_tools : ticker.mode.B_tools),"Hostile takeover cancelled: Dominator is no longer operational.",1,1)
 	SetLuminosity(0)
 	icon_state = "dominator-broken"
 	broken = 1
@@ -154,7 +156,7 @@
 		return
 
 	var/time = max(180,900 - ((round((gang_territory/start_state.num_territories)*200, 1) - 60) * 15))
-	if(alert(user,"With [round((gang_territory/start_state.num_territories)*100, 1)]% station control, a takeover will require [time] seconds.\nThe entire station will likely be alerted once it starts.\nYour gang must be prepared to defend this device throughout the duration.\nAre you ready?","Confirmation","Yes","No") == "Yes")
+	if(alert(user,"With [round((gang_territory/start_state.num_territories)*100, 1)]% station control, a takeover will require [time] seconds.\nYour gang will be unable to gain influence while it is active.\nThe entire station will likely be alerted to it once it starts.\nAre you ready?","Confirm","Ready","Later") == "Ready")
 		if ((!in_range(src, user) || !istype(src.loc, /turf)))
 			return 0
 		var/area/srcloc = get_area(src.loc)
@@ -163,6 +165,7 @@
 		src.name = "[gang_name(gang)] Gang [src.name]"
 		healthcheck(0)
 		operating = 1
+		ticker.mode.message_gangtools(((gang=="A") ? ticker.mode.A_tools : ticker.mode.B_tools),"Hostile takeover in progress: Estimated [time] seconds until victory.")
 
 /obj/machinery/dominator/attack_alien(mob/living/user)
 	user.do_attack_animation(src)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -245,12 +245,12 @@
 	else if(gang == "B")
 		members += ticker.mode.B_bosses | ticker.mode.B_gang
 	if(members.len)
-		var/ping = "[boss ? "Gang Boss" : "Gang Lieutenant"]: [message]"
+		var/ping = "<span class='danger'><B><i>[gang_name(gang)] [boss ? "Gang Boss" : "Gang Lieutenant"]</i>: [message]</B></span>"
 		for(var/datum/mind/ganger in members)
 			if(ganger.current.z <= 2)
-				ganger.current << "<span class='danger'><b>[ping]</B></span>"
+				ganger.current << ping
 		for(var/mob/M in dead_mob_list)
-			M << "<span class='danger'><B>[gang_name(gang)] [ping]</B></span>"
+			M << ping
 		log_game("[key_name(user)] Messaged [gang_name(gang)] Gang ([gang]): [message].")
 
 

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -13,6 +13,7 @@
 	var/boss = 1 //If it has the power to promote gang members
 	var/recalling = 0
 	var/promotions = 0
+	var/outfits = 5
 
 /obj/item/device/gangtool/New() //Initialize supply point income if it hasn't already been started
 	if(!ticker.mode.gang_points)
@@ -48,10 +49,16 @@
 
 		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B> | Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
+		if(outfits > 0)
+			dat += "<a href='?src=\ref[src];choice=outfit'>Create Gang Outfit</a><br>"
+		else
+			dat += "<b>Create Gang Outfit</b> (Restocking)<br>"
 		dat += "<a href='?src=\ref[src];choice=ping'>Send Gang-wide Message</a><br>"
 		if(gangmode)
 			dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
+
 		dat += "<br>"
+
 		dat += "Influence: <B>[points]</B><br>"
 		dat += "Time until Influence grows: <B>[(points >= 999) ? ("--:--") : (time2text(ticker.mode.gang_points.next_point_time - world.time, "mm:ss"))]</B><br>"
 		dat += "<hr>"
@@ -84,23 +91,17 @@
 		dat += "<br>"
 		dat += "<B>Purchase Utilities:</B><br>"
 
-		dat += "(10 Influence) "
-		if(points >= 10)
+		dat += "(5 Influence) "
+		if(points >= 5)
 			dat += "<a href='?src=\ref[src];purchase=spraycan'><b>Territory Spraycan</b></a><br>"
 		else
 			dat += "<b>Territory Spraycan</b><br>"
-
-		dat += "(1 Influence) "
-		if(points >= 1)
-			dat += "<a href='?src=\ref[src];purchase=outfit'>Gang Outfit</a><br>"
-		else
-			dat += "<b>Gang Outfit</b><br>"
 
 		dat += "(10 Influence) "
 		if(points >= 10)
 			dat += "<a href='?src=\ref[src];purchase=vest'>Bulletproof Vest</a><br>"
 		else
-			dat += "<b>Bulletproof Vest</b><br>"
+			dat += "Bulletproof Vest<br>"
 
 		dat += "(30 Influence) "
 		if(points >= 30)
@@ -121,14 +122,14 @@
 			dat += "(50 Influence) "
 			if(points >= 50)
 				dat += "<a href='?src=\ref[src];purchase=dominator'><b>Station Dominator</b></a><br>"
-				dat += "<i>(Estimated Takeover Time: [round(max(180,900 - ((round((gang_territory/start_state.num_territories)*200, 10) - 60) * 15))/60,1)] minutes)</i><br>"
 			else
 				dat += "Station Dominator<br>"
+			dat += "<i>(Estimated Takeover Time: [round(max(180,900 - ((round((gang_territory/start_state.num_territories)*200, 10) - 60) * 15))/60,1)] minutes)</i><br>"
 
 	dat += "<br>"
 	dat += "<a href='?src=\ref[src];choice=refresh'>Refresh</a><br>"
 
-	var/datum/browser/popup = new(user, "gangtool", "Welcome to GangTool v0.4", 350, 550)
+	var/datum/browser/popup = new(user, "gangtool", "Welcome to GangTool v0.4", 340, 600)
 	popup.set_content(dat)
 	popup.open()
 
@@ -150,14 +151,10 @@
 		var/points = ((gang == "A") ? ticker.mode.gang_points.A : ticker.mode.gang_points.B)
 		var/item_type
 		switch(href_list["purchase"])
-			if("outfit")
-				if(points >= 1)
-					item_type = ticker.mode.gang_outfit(usr,src,gang)
-					points = 1
 			if("spraycan")
-				if(points >= 10)
+				if(points >= 5)
 					item_type = /obj/item/toy/crayon/spraycan/gang
-					points = 10
+					points = 5
 			if("switchblade")
 				if(points >= 10)
 					item_type = /obj/item/weapon/switchblade
@@ -193,18 +190,18 @@
 					if(isnum((gang == "A") ? mode.A_timer : mode.B_timer))
 						return
 
-					var/fail = 0
 					var/usrarea = get_area(usr.loc)
 					var/usrturf = get_turf(usr.loc)
 					if(istype(usrarea,/area/space) || istype(usrturf,/turf/space) || usr.z != 1)
 						usr << "<span class='warning'>You can only use this on the station!</span>"
-						fail = 1
+						return
+
 					for(var/obj/obj in usrturf)
 						if(obj.density)
 							usr << "<span class='warning'>There's not enough room here!</span>"
-							fail = 1
-							break
-					if(!fail && points >= 50)
+							return
+
+					if(points >= 50)
 						item_type = /obj/machinery/dominator
 						points = 50
 
@@ -222,6 +219,10 @@
 
 	else if(href_list["choice"])
 		switch(href_list["choice"])
+			if("outfit")
+				if(outfits > 0)
+					ticker.mode.gang_outfit(usr,src,gang)
+					outfits -= 1
 			if("recall")
 				recall(usr)
 			if("ping")

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -49,7 +49,8 @@
 		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Administrator" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B> | Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
 		dat += "<a href='?src=\ref[src];choice=ping'>Send Gang-wide Message</a><br>"
-		dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
+		if(gangmode)
+			dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 		dat += "<br>"
 		dat += "Influence: <B>[points]</B><br>"
 		dat += "Time until Influence grows: <B>[(points >= 999) ? ("--:--") : (time2text(ticker.mode.gang_points.next_point_time - world.time, "mm:ss"))]</B><br>"
@@ -243,13 +244,13 @@
 	else if(gang == "B")
 		members += ticker.mode.B_bosses | ticker.mode.B_gang
 	if(members.len)
-		var/ping = "<b>[boss ? "Gang Boss" : "Gang Lieutenant"]:</b> [message]"
+		var/ping = "[boss ? "Gang Boss" : "Gang Lieutenant"]: [message]"
 		for(var/datum/mind/ganger in members)
 			if(ganger.current.z <= 2)
-				ganger.current << "<span class='danger'>[ping]</span>"
+				ganger.current << "<span class='danger'><b>[ping]</B></span>"
 		for(var/mob/M in dead_mob_list)
-			M << "<span class='danger'><B>[gang_name(gang)]</B> [ping]</span>"
-		log_game("[key_name(user)] sent a global message to the [gang_name(gang)] Gang ([gang]): [message].")
+			M << "<span class='danger'><B>[gang_name(gang)] [ping]</B></span>"
+		log_game("[key_name(user)] Messaged [gang_name(gang)] Gang ([gang]): [message].")
 
 
 /obj/item/device/gangtool/proc/register_device(var/mob/user)
@@ -292,6 +293,9 @@
 
 /obj/item/device/gangtool/proc/recall(mob/user)
 	if(recalling || !can_use(user))
+		return
+
+	if(!istype(ticker.mode, /datum/game_mode/gang))
 		return
 
 	recalling = 1

--- a/code/game/gamemodes/intercept_report.dm
+++ b/code/game/gamemodes/intercept_report.dm
@@ -228,9 +228,9 @@
 	*/
 
 /datum/intercept_text/proc/build_gang(datum/mind/correct_person)
-	src.text += "<BR><BR>We have recieved reports of a sudden increase of criminal activity in close proximity to our operations within your sector."
-	src.text += "Ensure law and order is maintained on the station and be on the lookout for unusually territorial behavior from the crew."
-	src.text += "In the event of a full-scale takeover attempt, sensitive research items are to be secured and the station evacuated ASAP."
+	src.text += "<BR><BR>We have reports of criminal activity in close proximity to our operations within your sector."
+	src.text += "Ensure law and order is maintained on the station and be on the lookout for aggressive factionalism within the crew."
+	src.text += "In the event of a full-scale criminal takeover threat, sensitive research items are to be secured and the station evacuated ASAP."
 	src.text += "<BR><HR>"
 
 /datum/intercept_text/proc/build_wizard(datum/mind/correct_person)
@@ -289,3 +289,4 @@
 	*/
 	src.text += "These lifeforms are associated with the <B><U>[orgname1] [orgname2]</U></B> and may be attempting to acquire sensitive materials on their behalf.  "
 	src.text += "Please take care not to alarm the crew, as <B><U>[cname]</U></B> may take advantage of a panic situation. Remember, they can be anybody, suspect everybody!"
+	src.text += "<BR><HR>"

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -112,7 +112,7 @@
 		return
 	cooldown = 1
 	icon_state = "pen_blink"
-	spawn(600)
+	spawn(1200)
 		cooldown = 0
 		icon_state = "pen"
 		var/mob/M = get(src, /mob)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -95,24 +95,22 @@
 					if(user.mind in ticker.mode.A_bosses)
 						if(ticker.mode.add_gangster(M.mind,"A"))
 							M.Paralyse(5)
-							cooldown(ticker.mode.A_gang.len, )
+							cooldown(max(0,ticker.mode.B_gang.len - ticker.mode.A_gang.len))
 						else
 							user << "<span class='warning'>This mind is resistant to recruitment!</span>"
 					else if(user.mind in ticker.mode.B_bosses)
 						if(ticker.mode.add_gangster(M.mind,"B"))
 							M.Paralyse(5)
-							cooldown(ticker.mode.B_gang.len)
+							cooldown(max(0,ticker.mode.A_gang.len - ticker.mode.B_gang.len))
 						else
 							user << "<span class='warning'>This mind is resistant to recruitment!</span>"
 				else
 					user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
 
 /obj/item/weapon/pen/gang/proc/cooldown(modifier)
-	if(!modifier)
-		return
 	cooldown = 1
 	icon_state = "pen_blink"
-	spawn(1200)
+	spawn(max(50,1200-(modifier*100)))
 		cooldown = 0
 		icon_state = "pen"
 		var/mob/M = get(src, /mob)

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -31,7 +31,6 @@
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/midbullet
 
-
 /obj/item/ammo_casing/shotgun
 	name = "shotgun slug"
 	desc = "A 12 gauge lead slug."

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -157,11 +157,11 @@
 	..()
 	icon_state = "c20r45-[round(ammo_count(),2)]"
 
-obj/item/ammo_box/magazine/tommygunm45
-	name = "drum magazine (.45)"
+obj/item/ammo_box/magazine/tommygunm9mm
+	name = "drum magazine (9mm)"
 	icon_state = "drum45"
-	ammo_type = /obj/item/ammo_casing/c45
-	caliber = ".45"
+	ammo_type = /obj/item/ammo_casing/c9mm
+	caliber = "9mm"
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/m50

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -231,13 +231,13 @@
 
 /obj/item/weapon/gun/projectile/automatic/tommygun
 	name = "thompson SMG"
-	desc = "A genuine 'Chicago Typewriter'."
+	desc = "Based on the classic 'Chicago Typewriter'."
 	icon_state = "tommygun"
 	item_state = "shotgun"
 	w_class = 5
 	slot_flags = 0
 	origin_tech = "combat=5;materials=1;syndicate=2"
-	mag_type = /obj/item/ammo_box/magazine/tommygunm45
+	mag_type = /obj/item/ammo_box/magazine/tommygunm9mm
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	can_suppress = 0
 	burst_size = 4

--- a/html/changelogs/Ikarrus-gangtweaks.yml
+++ b/html/changelogs/Ikarrus-gangtweaks.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "White suits added to gang outfits"
+  - tweak: "Gang outfits are now free, but are now limited in stock (that replenishes over time)"
+  - tweak: "While attempting a Hostile Takeover, gangs do not gain influence. Instead, the takeover timer will be reduced by how many territories they control."
+  - tweak: "Spraycan cost reduced to 5 influence."
+  - tweak: "Recruitment Pen cooldown increased to 2 minutes, but is reduced if the enemy gang has more members than yours."
+  - tweak: "Tommy guns no longer deal stamina damage."
+  - rscdel: "Gangtools can no longer recall the shuttle if the game mode is not Gang War"


### PR DESCRIPTION
#### Major Changes
- Recruitment Pen cooldown increased to 2 minutes, but is reduced by 10 seconds for every member the enemy has more than yours.
  - e.g. Your gang has 5 members, and the enemy has 8. You would be getting a 30 second reduction on your cooldown.
- Gang spray can cost reduced to 5 influence
- While attempting a Hostile Takeover, gangs do not gain influence. Instead, the takeover timer will be reduced by how many territories they control.
- Tommy guns no longer deal stamina damage.
#### Minor Changes
- White suits added to gang outfits
- Gang outfits are now free, but are now limited in stock (that replenishes over time)
- Gangtools can no longer recall the shuttle if the game mode is not Gang War
- Fixed dominators reporting the wrong time on examine()
- Bugfixes, writing and formatting tweaks
