### PR TITLE
Locker unlocks if you attack it with an empty hand

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -289,7 +289,7 @@
 		return
 
 	if(!toggle())
-		user << "<span class='notice'>You cannot close the locker!</span>"
+		togglelock(user)
 		return
 
 // tk grab then use on self


### PR DESCRIPTION
If you try to open a locked locker with an empty hand with simply clicking, it sends an error message "You cannot close the locker!" which made no sense. You had to alt-click the locker to unlock it first.

Now it's changed back to be more intuitive: if you click it with an empty hand, it unlocks the locker, and everything works as it used to.
