### PR TITLE
Several further tweaks to AI camera balance.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -8,7 +8,7 @@
 	active_power_usage = 10
 	layer = 5
 
-	var/health = 30
+	var/health = 50
 	var/list/network = list("SS13")
 	var/c_tag = null
 	var/c_tag_order = 999
@@ -230,6 +230,7 @@
 			user.changeNext_move(CLICK_CD_MELEE)
 			visible_message("<span class='warning'>[user] hits [src] with [W]!</span>", "<span class='warning'>You hit [src] with [W]!</span>")
 			health = max(0, health - W.force)
+			user.do_attack_animation(src)
 			if(!health && status)
 				triggerCameraAlarm()
 				deactivate(user, 1)
@@ -245,7 +246,6 @@
 			else
 				visible_message("<span class='danger'>\The [src] deactivates!</span>")
 			icon_state = "[initial(icon_state)]1"
-
 		else
 			if(user)
 				visible_message("<span class='danger'>[user] reactivates [src]!</span>")
@@ -257,6 +257,7 @@
 			spawn(100)
 				cancelCameraAlarm()
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
+		cameranet.updateChunk(x, y, z)
 
 	// now disconnect anyone using the camera
 	//Apparently, this will disconnect anyone even if the camera was re-activated.

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -73,6 +73,7 @@
 			var/thisemp = emped //Take note of which EMP this proc is for
 			spawn(900)
 				if(loc) //qdel limbo
+					triggerCameraAlarm() //camera alarm triggers even if multiple EMPs are in effect.
 					if(emped == thisemp) //Only fix it if the camera hasn't been EMP'd again
 						network = previous_network
 						icon_state = initial(icon_state)
@@ -80,7 +81,6 @@
 						if(can_use())
 							cameranet.addCamera(src)
 						emped = 0 //Resets the consecutive EMP count
-						triggerCameraAlarm()
 						spawn(100)
 							cancelCameraAlarm()
 			for(var/mob/O in mob_list)
@@ -226,7 +226,7 @@
 		L.laser_act(src, user)
 
 	else
-		if(W.force > 10) //fairly simplistic, but will do for now.
+		if(W.force >= 10) //fairly simplistic, but will do for now.
 			user.changeNext_move(CLICK_CD_MELEE)
 			visible_message("<span class='warning'>[user] hits [src] with [W]!</span>", "<span class='warning'>You hit [src] with [W]!</span>")
 			health = max(0, health - W.force)
@@ -345,6 +345,11 @@
 	busy = 0
 	return 0
 
+/obj/machinery/camera/bullet_act(var/obj/item/projectile/proj)
+	if(proj.damage_type == BRUTE)
+		health = max(0, health - proj.damage)
+		if(!health && status)
+			deactivate(user, 1)
 
 /obj/machinery/camera/portable //Cameras which are placed inside of things, such as helmets.
 	var/turf/prev_turf

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -8,7 +8,7 @@
 	active_power_usage = 10
 	layer = 5
 
-	var/health = 50
+	var/health = 30
 	var/list/network = list("SS13")
 	var/c_tag = null
 	var/c_tag_order = 999
@@ -231,6 +231,7 @@
 			visible_message("<span class='warning'>[user] hits [src] with [W]!</span>", "<span class='warning'>You hit [src] with [W]!</span>")
 			health = max(0, health - W.force)
 			if(!health && status)
+				triggerCameraAlarm()
 				deactivate(user, 1)
 	return
 
@@ -270,7 +271,6 @@
 	alarm_on = 1
 	for(var/mob/living/silicon/S in mob_list)
 		S.triggerAlarm("Camera", get_area(src), list(src), src)
-
 
 /obj/machinery/camera/proc/cancelCameraAlarm()
 	alarm_on = 0
@@ -349,7 +349,8 @@
 	if(proj.damage_type == BRUTE)
 		health = max(0, health - proj.damage)
 		if(!health && status)
-			deactivate(user, 1)
+			triggerCameraAlarm()
+			deactivate(null, 1)
 
 /obj/machinery/camera/portable //Cameras which are placed inside of things, such as helmets.
 	var/turf/prev_turf

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -120,6 +120,7 @@
 					tracking = 0
 					return
 				else
+					sleep(10)
 					continue
 			
 			else

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -105,16 +105,18 @@
 
 	var/cameraticks = 0
 	spawn(0)
-		while (U.cameraFollow == target)
-			if (U.cameraFollow == null)
+		while(U.cameraFollow == target)
+			if(U.cameraFollow == null)
 				return
 
-			if (!target.can_track(usr))
+			if(!target.can_track(usr))
 				U.tracking = 1
-				U << "<span class='warning'>Target is not near any active cameras.</span>"
+				if(!cameraticks)
+					U << "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>"
 				cameraticks++
 				if(cameraticks > 9)
 					U.cameraFollow = null
+					U << "<span class='warning'>Unable to reacquire, cancelling track...</span>"
 					tracking = 0
 					return
 				else

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -85,3 +85,5 @@ You can use . or # instead of : for radio channels. Building this habit reduces 
 While pulling something, clicking on a tile with an empty hand will move it to that tile. No more getting stuck in maint while dragging something!
 Things that override clicks like decks of cards or paper bins can still be picked up by dragging them to your character. Equipped things that override click can be unequipped by dragging it to an empty hand.
 In the job selection menu, from the lobby, you can use right click on the "Low/Medium/High" priority button to make it cycle backwards.
+If you stay out of camera range for 10 seconds, the AI's track on you will break.
+You can shoot cameras with bullets to disable them remotely.

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -87,3 +87,4 @@ Things that override clicks like decks of cards or paper bins can still be picke
 In the job selection menu, from the lobby, you can use right click on the "Low/Medium/High" priority button to make it cycle backwards.
 If you stay out of camera range for 10 seconds, the AI's track on you will break.
 You can shoot cameras with bullets to disable them remotely.
+Disabling a camera with wirecutters will not cause a camera alarm, but bludgeoning it will.

--- a/html/changelogs/Miauw-AINerfTweaks.yml
+++ b/html/changelogs/Miauw-AINerfTweaks.yml
@@ -4,3 +4,4 @@ changes:
   - tweak: "Bullets can now damage cameras."
   - tweak: "Camera alarms now trigger 90 seconds after the first EMP pulse, instead of when all EMP pulses run out."
   - tweak: "Makes the force required to damage cameras greater than or equal to ten instead of greater than ten."
+  - tweak: "Camera alarms now trigger when cameras are disabled with brute force or bullets."

--- a/html/changelogs/Miauw-AINerfTweaks.yml
+++ b/html/changelogs/Miauw-AINerfTweaks.yml
@@ -1,0 +1,6 @@
+author: Miauw
+delete-after: True
+changes:
+  - tweak: "Bullets can now damage cameras."
+  - tweak: "Camera alarms now trigger 90 seconds after the first EMP pulse, instead of when all EMP pulses run out."
+  - tweak: "Makes the force required to damage cameras greater than or equal to ten instead of greater than ten."


### PR DESCRIPTION
- Camera alarms will now trigger when the first EMP runs out.
- Bullets can now damage cameras.
- Makes the force required to damage cameras >= 10 instead of > 10.
- Adds three camera-related tips.
- Camera alarms now trigger when the camera is disabled with brute force or bullets.
- Tracking will no longer spam the AI with "unable to track" messages when the target is outside of camera range.

comes with a changelog!
