### PR TITLE
Unnecessary space removal from spans and messages

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -87,11 +87,11 @@
 	name = "Boxing"
 
 /datum/martial_art/boxing/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	A << "<span class='warning'> Can't disarm while boxing!</span>"
+	A << "<span class='warning'>Can't disarm while boxing!</span>"
 	return 1
 
 /datum/martial_art/boxing/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	A << "<span class='warning'> Can't grab while boxing!</span>"
+	A << "<span class='warning'>Can't grab while boxing!</span>"
 	return 1
 
 /datum/martial_art/boxing/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)

--- a/code/game/gamemodes/abduction/gland.dm
+++ b/code/game/gamemodes/abduction/gland.dm
@@ -92,7 +92,7 @@
 	for(var/mob/living/carbon/human/H in orange(4,T))
 		if(H == host)
 			continue
-		H << "<span class='alien'> You hear a buzz in your head </span>"
+		H << "<span class='alien'>You hear a buzz in your head </span>"
 		H.confused += 20
 
 /obj/item/gland/pop

--- a/code/game/gamemodes/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/abduction/machinery/experiment.dm
@@ -86,7 +86,7 @@
 		dat += "<a href='?src=\ref[src];experiment=3'>Analyze</a><br>"
 		dat += "</td></tr></table>"
 	else
-		dat += "<span class='linkOff'> Experiment </span>"
+		dat += "<span class='linkOff'>Experiment </span>"
 
 	if(!occupant)
 		dat += "<h3>Machine Unoccupied</h3>"

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -86,7 +86,7 @@
 	if(overmind && overmind.blob_reagent_datum)
 		adjustcolors(overmind.blob_reagent_datum.color)
 	H.loc = src
-	loc.visible_message("<span class='warning'> The corpse of [H.name] suddenly rises!</span>")
+	loc.visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	..(1)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -65,12 +65,12 @@
 
 /mob/camera/blob/proc/update_health()
 	if(blob_core)
-		hud_used.blobhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#e36600'>[round(blob_core.health)]</font></div>"
+		hud_used.blobhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#e36600'>[round(blob_core.health)]</font></div>"
 
 /mob/camera/blob/proc/add_points(var/points)
 	if(points != 0)
 		blob_points = Clamp(blob_points + points, 0, max_blob_points)
-		hud_used.blobpwrdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#82ed00'>[round(src.blob_points)]</font></div>"
+		hud_used.blobpwrdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#82ed00'>[round(src.blob_points)]</font></div>"
 
 /mob/camera/blob/say(var/message)
 	if (!message)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -99,7 +99,7 @@
 		C.post_status("alert", "lockdown")
 
 	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
-	src << "<span class = 'warning'>Lockdown Initiated.</span>"
+	src << "<span class='warning'>Lockdown Initiated.</span>"
 	malf_cooldown = 1
 	spawn(30)
 	malf_cooldown = 0
@@ -127,7 +127,7 @@
 			else if(!D.stat) //Opens only powered doors.
 				D.open() //Open everything!
 
-	src << "<span class = 'notice'>Lockdown Lifted.</span>"
+	src << "<span class='notice'>Lockdown Lifted.</span>"
 	malf_cooldown = 1
 	spawn(30)
 	malf_cooldown = 0

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -46,7 +46,7 @@
 
 
 /datum/game_mode/monkey/proc/greet_carrier(var/datum/mind/carrier)
-	carrier.current << "<B><span class = 'notice'>You are the Jungle Fever patient zero!!</B>"
+	carrier.current << "<B><span class='notice'>You are the Jungle Fever patient zero!!</B>"
 	carrier.current << "<b>You have been planted onto this station by the Animal Rights Consortium.</b>"
 	carrier.current << "<b>Soon the disease will transform you into an ape. Afterwards, you will be able spread the infection to others with a bite.</b>"
 	carrier.current << "<b>While your infection strain is undetectable by scanners, any other infectees will show up on medical equipment.</b>"

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -49,7 +49,7 @@
 		dat += "Captured Soul: [A.name]<br>"
 		dat += {"<A href='byond://?src=\ref[src];choice=Summon'>Summon Shade</A>"}
 		dat += "<br>"
-		dat += {"<a href='byond://?src=\ref[src];choice=Close'> Close</a>"}
+		dat += {"<a href='byond://?src=\ref[src];choice=Close'>Close</a>"}
 	user << browse(dat, "window=aicard")
 	onclose(user, "aicard")
 	return

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -277,12 +277,12 @@
 	dat += "<b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
 	dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup>"
 
-	dat += "<form name='search' action='?src=\ref[src]'> \
-	<input type='hidden' name='src' value='\ref[src]'> \
-	<input type='hidden' name='search' value='to_search'> \
-	<input type='hidden' name='menu' value='[AUTOLATHE_SEARCH_MENU]'> \
-	<input type='text' name='to_search'> \
-	<input type='submit' value='Search'> \
+	dat += "<form name='search' action='?src=\ref[src]'>\
+	<input type='hidden' name='src' value='\ref[src]'>\
+	<input type='hidden' name='search' value='to_search'>\
+	<input type='hidden' name='menu' value='[AUTOLATHE_SEARCH_MENU]'>\
+	<input type='text' name='to_search'>\
+	<input type='submit' value='Search'>\
 	</form><hr>"
 
 	var/line_length = 1

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -388,7 +388,7 @@ obj/machinery/bot/floorbot/process_scan(var/scan_target)
 /obj/machinery/bot/floorbot/proc/eattile(var/obj/item/stack/tile/plasteel/T)
 	if(!istype(T, /obj/item/stack/tile/plasteel))
 		return
-	visible_message("<span class='notice'> [src] begins to collect tiles.</span>")
+	visible_message("<span class='notice'>[src] begins to collect tiles.</span>")
 	mode = BOT_REPAIRING
 	spawn(20)
 		if(isnull(T))
@@ -409,7 +409,7 @@ obj/machinery/bot/floorbot/process_scan(var/scan_target)
 /obj/machinery/bot/floorbot/proc/maketile(var/obj/item/stack/sheet/metal/M)
 	if(!istype(M, /obj/item/stack/sheet/metal))
 		return
-	visible_message("<span class='notice'> [src] begins to create tiles.</span>")
+	visible_message("<span class='notice'>[src] begins to create tiles.</span>")
 	mode = BOT_REPAIRING
 	spawn(20)
 		if(isnull(M))

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -117,14 +117,14 @@ obj/machinery/bot/mulebot/bot_reset()
 				"<span class='notice'>You repair [src].</span>"
 			)
 		else
-			user << "<span class='notice'> [src] does not need a repair!</span>"
+			user << "<span class='warning'>[src] does not need a repair!</span>"
 	else if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/weapon/wirecutters))
 		if(open)
 			attack_hand(usr)
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1+I.force * 2))
 			unload(0)
-			user.visible_message("<span class='danger'> [user] knocks [load] off [src] with \the [I]!</span>", "<span class='danger'> You knock [load] off [src] with \the [I]!</span>")
+			user.visible_message("<span class='danger'>[user] knocks [load] off [src] with \the [I]!</span>", "<span class='danger'>You knock [load] off [src] with \the [I]!</span>")
 		else
 			user << "<span class='warning'>You hit [src] with \the [I] but to no effect!</span>"
 	else
@@ -154,7 +154,7 @@ obj/machinery/bot/mulebot/bot_reset()
 		if(prob(50) && !isnull(load))
 			unload(0)
 		if(prob(25))
-			visible_message("<span class='danger'> Something shorts out inside [src]!</span>")
+			visible_message("<span class='danger'>Something shorts out inside [src]!</span>")
 			wires.RandomCut()
 
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -156,7 +156,7 @@ Auto Patrol: []"},
 			if(open)
 				user << "<span class='danger'>Please close the access panel before locking it.</span>"
 			else
-				user << "<span class='danger'> Access denied.</span>"
+				user << "<span class='danger'>Access denied.</span>"
 	else
 		..()
 		if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm") // Any intent but harm will heal, so we shouldn't get angry.
@@ -173,7 +173,7 @@ Auto Patrol: []"},
 
 	if(emagged == 2)
 		if(user)
-			user << "<span class='danger'> You short out [src]'s target assessment circuits.</span>"
+			user << "<span class='danger'>You short out [src]'s target assessment circuits.</span>"
 			oldtarget_name = user.name
 		audible_message("<span class='danger'>[src] buzzes oddly!</span>")
 		declare_arrests = 0

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -308,11 +308,11 @@
 	if (istype(W, /obj/item/weapon/grab) && get_dist(src,user)<2)
 		var/obj/item/weapon/grab/G = W
 		if(G.state < GRAB_AGGRESSIVE)
-			user << "<span class='warning'> You need a better grip to do that!</span>"
+			user << "<span class='warning'>You need a better grip to do that!</span>"
 			return
 		G.affecting.loc = src.loc
 		G.affecting.Weaken(5)
-		visible_message("<span class='danger'> [G.assailant] puts [G.affecting] on the table.</span>")
+		visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on the table.</span>")
 		qdel(W)
 		return
 
@@ -435,7 +435,7 @@
 		return
 	else if (istype(W, /obj/item) && get_dist(src,user)<2)
 		user.drop_item(src)
-		visible_message("<span class='warning'> [user] dunks [W] into \the [src]!</span>", 3)
+		visible_message("<span class='warning'>[user] dunks [W] into \the [src]!</span>", 3)
 		return
 
 /obj/structure/holohoop/CanPass(atom/movable/mover, turf/target, height=0)
@@ -445,9 +445,9 @@
 			return
 		if(prob(50))
 			I.loc = src.loc
-			visible_message("<span class='warning'> Swish! \the [I] lands in \the [src].</span>", 3)
+			visible_message("<span class='warning'>Swish! \the [I] lands in \the [src].</span>", 3)
 		else
-			visible_message("<span class='danger'> \the [I] bounces off of \the [src]'s rim!</span>", 3)
+			visible_message("<span class='danger'>\the [I] bounces off of \the [src]'s rim!</span>", 3)
 		return 0
 	else
 		return ..(mover, target, height)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -97,7 +97,7 @@
 /obj/machinery/computer/attackby(I as obj, user as mob, params)
 	if(istype(I, /obj/item/weapon/screwdriver) && circuit)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		user << "<span class='notice'> You start to disconnect the monitor...</span>"
+		user << "<span class='notice'>You start to disconnect the monitor...</span>"
 		if(do_after(user, 20))
 			var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
 			A.circuit = circuit
@@ -106,12 +106,12 @@
 			for (var/obj/C in src)
 				C.loc = src.loc
 			if (src.stat & BROKEN)
-				user << "<span class='notice'> The broken glass falls out.</span>"
+				user << "<span class='notice'>The broken glass falls out.</span>"
 				new /obj/item/weapon/shard( src.loc )
 				A.state = 3
 				A.icon_state = "3"
 			else
-				user << "<span class='notice'> You disconnect the monitor.</span>"
+				user << "<span class='notice'>You disconnect the monitor.</span>"
 				A.state = 4
 				A.icon_state = "4"
 			qdel(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -565,16 +565,16 @@ About the new airlock wires panel:
 	if(src.isWireCut(AIRLOCK_WIRE_SAFETY))
 		t1 += text("Door force sensors not responding.</a><br>\n")
 	else if(src.safe)
-		t1 += text("Door safeties operating normally.  <A href='?src=\ref[];aiDisable=8'> Override?</a><br>\n",src)
+		t1 += text("Door safeties operating normally.  <A href='?src=\ref[];aiDisable=8'>Override?</a><br>\n",src)
 	else
-		t1 += text("Danger.  Door safeties disabled.  <A href='?src=\ref[];aiEnable=8'> Restore?</a><br>\n",src)
+		t1 += text("Danger.  Door safeties disabled.  <A href='?src=\ref[];aiEnable=8'>Restore?</a><br>\n",src)
 
 	if(src.isWireCut(AIRLOCK_WIRE_SPEED))
 		t1 += text("Door timing circuitry not responding.</a><br>\n")
 	else if(src.normalspeed)
-		t1 += text("Door timing circuitry operating normally.  <A href='?src=\ref[];aiDisable=9'> Override?</a><br>\n",src)
+		t1 += text("Door timing circuitry operating normally.  <A href='?src=\ref[];aiDisable=9'>Override?</a><br>\n",src)
 	else
-		t1 += text("Warning.  Door timing circuitry operating abnormally.  <A href='?src=\ref[];aiEnable=9'> Restore?</a><br>\n",src)
+		t1 += text("Warning.  Door timing circuitry operating abnormally.  <A href='?src=\ref[];aiEnable=9'>Restore?</a><br>\n",src)
 
 
 
@@ -973,9 +973,9 @@ About the new airlock wires panel:
 					qdel(src)
 					return
 		else if(hasPower())
-			user << "<span class='warning'> The airlock's motors resist your efforts to force it!</span>"
+			user << "<span class='warning'>The airlock's motors resist your efforts to force it!</span>"
 		else if(locked)
-			user << "<span class='warning'> The airlock's bolts prevent it from being forced!</span>"
+			user << "<span class='warning'>The airlock's bolts prevent it from being forced!</span>"
 		else if( !welded && !operating)
 			if(density)
 				if(beingcrowbarred == 0) //being fireaxe'd

--- a/code/game/machinery/embedded_controller/airlock_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_controller.dm
@@ -283,10 +283,10 @@
 <div class='statusDisplay'>
 <div class='line'><div class='statusLabel'>Current Status:</div><div class='statusValue'>[current_status]</div></div>
 <div class='line'>&nbsp;</div>
-<div class='line'><div class='statusLabel'> \> Chamber Pressure:</div><div class='statusValue'>[sensor_pressure] kPa</div></div>
-<div class='line'><div class='statusLabel'> \> Control Pump:</div><div class='statusValue'>[pump_status]</div></div>
-<div class='line'><div class='statusLabel'> \> Interior Door:</div><div class='statusValue'>[interior_status]</div></div>
-<div class='line'><div class='statusLabel'> \> Exterior Door:</div><div class='statusValue'>[exterior_status]</div></div>
+<div class='line'><div class='statusLabel'>\> Chamber Pressure:</div><div class='statusValue'>[sensor_pressure] kPa</div></div>
+<div class='line'><div class='statusLabel'>\> Control Pump:</div><div class='statusValue'>[pump_status]</div></div>
+<div class='line'><div class='statusLabel'>\> Interior Door:</div><div class='statusValue'>[interior_status]</div></div>
+<div class='line'><div class='statusLabel'>\> Exterior Door:</div><div class='statusValue'>[exterior_status]</div></div>
 </div>
 [state_options]"}
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -324,7 +324,7 @@ Class Procs:
 	. = !(state_open || panel_open || is_operational()) && istype(C)
 	if(.)
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-		visible_message("<span class = 'notice'>[usr] pry open \the [src].</span>", "<span class = 'notice'>You pry open \the [src].</span>")
+		visible_message("<span class='notice'>[usr] pry open \the [src].</span>", "<span class='notice'>You pry open \the [src].</span>")
 		open_machine()
 		return 1
 
@@ -383,7 +383,7 @@ Class Procs:
 			if(W.works_from_distance)
 				user << "<span class='notice'>Following parts detected in the machine:</span>"
 				for(var/var/obj/item/C in component_parts)
-					user << "<span class='notice'>    [C.name]</span>"
+					user << "<span class='notice'>   [C.name]</span>"
 			for(var/obj/item/weapon/stock_parts/A in component_parts)
 				for(var/D in CB.req_components)
 					if(ispath(A.type, D))
@@ -404,7 +404,7 @@ Class Procs:
 		else
 			user << "<span class='notice'>Following parts detected in the machine:</span>"
 			for(var/var/obj/item/C in component_parts)
-				user << "<span class='notice'>    [C.name]</span>"
+				user << "<span class='notice'>   [C.name]</span>"
 		if(shouldplaysound)
 			W.play_rped_sound()
 		return 1

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -141,7 +141,7 @@ Transponder Codes:<UL>"}
 			t += "<LI>[key] ... [codes[key]]"
 			t += "	<A href='byond://?src=\ref[src];edit=1;code=[key]'>Edit</A>"
 			t += "	<A href='byond://?src=\ref[src];delete=1;code=[key]'>Delete</A><BR>"
-		t += "	<A href='byond://?src=\ref[src];add=1;'> Add New</A><BR>"
+		t += "	<A href='byond://?src=\ref[src];add=1;'>Add New</A><BR>"
 		t+= "<UL></TT>"
 
 	var/datum/browser/popup = new(user, "navbeacon", "Navigation Beacon", 300, 400)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -478,9 +478,9 @@ var/list/obj/machinery/newscaster/allCasters = list()
 				dat+="<A href='?src=\ref[src];set_wanted_desc=1'>Description</A>: [msg] <BR>"
 				dat+="<A href='?src=\ref[src];set_attachment=1'>Attach Photo</A>: [(photo ? "Photo Attached" : "No Photo")]</BR>"
 				if(wanted_already)
-					dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'> [news_network.wanted_issue.scannedUser]</FONT><BR>"
+					dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'>[news_network.wanted_issue.scannedUser]</FONT><BR>"
 				else
-					dat+="<B>Wanted Issue will be created under prosecutor:</B><FONT COLOR='green'> [scanned_user]</FONT><BR>"
+					dat+="<B>Wanted Issue will be created under prosecutor:</B><FONT COLOR='green'>[scanned_user]</FONT><BR>"
 				dat+="<BR><A href='?src=\ref[src];submit_wanted=[end_param]'>[(wanted_already) ? ("Edit Issue") : ("Submit")]</A>"
 				if(wanted_already)
 					dat+="<BR><A href='?src=\ref[src];cancel_wanted=1'>Take down Issue</A>"

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -263,13 +263,13 @@
 			return
 		if(!anchored && !isinspace())
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'> You secure \the [src] to the floor!</span>"
+			user << "<span class='notice'>You secure \the [src] to the floor!</span>"
 			anchored = 1
 		else if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			user << "<span class='notice'> You unsecure \the [src] from the floor!</span>"
+			user << "<span class='notice'>You unsecure \the [src] from the floor!</span>"
 			if(active)
-				user << "<span class='notice'> \The [src] shuts off!</span>"
+				user << "<span class='notice'>\The [src] shuts off!</span>"
 				src.shields_down()
 			anchored = 0
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -168,7 +168,7 @@
 		dat+= "<HEAD><TITLE>Suit storage unit: Maintenance panel</TITLE></HEAD>"
 		dat+= "<B>Maintenance panel controls</B><HR>"
 		dat+= "The panel is ridden with controls, button and meters, labeled in strange signs and symbols that <BR>you cannot understand. Probably the manufactoring world's language.<BR> Among other things, a few controls catch your eye.<BR><BR>"
-		dat+= text("A small dial with a \"ë\" symbol embroidded on it. It's pointing towards a gauge that reads [].<BR> <A href='?src=\ref[];toggleUV=1'> Turn towards []</A><BR>",(src.issuperUV ? "15nm" : "185nm"),src,(src.issuperUV ? "185nm" : "15nm") )
+		dat+= text("A small dial with a \"ë\" symbol embroidded on it. It's pointing towards a gauge that reads [].<BR> <A href='?src=\ref[];toggleUV=1'>Turn towards []</A><BR>",(src.issuperUV ? "15nm" : "185nm"),src,(src.issuperUV ? "185nm" : "15nm") )
 		dat+= text("A thick old-style button, with 2 grimy LED lights next to it. The [] LED is on.<BR><A href='?src=\ref[];togglesafeties=1'>Press button</a>",(src.safetieson? "<font color='green'><B>GREEN</B></font>" : "<font color='red'><B>RED</B></font>"),src)
 		dat+= text("<HR><BR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close panel</A>", user)
 		//user << browse(dat, "window=ssu_m_panel;size=400x500")

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -43,7 +43,7 @@
 				return
 			L.loc = src
 			locked = L
-			user << "<span class = 'caution'>You insert the GPS device into the [name]'s slot.</span>"
+			user << "<span class='caution'>You insert the GPS device into the [name]'s slot.</span>"
 	else
 		..()
 	return
@@ -397,9 +397,9 @@
 			if(linked_stations.len < efficiency)
 				linked_stations.Add(M.buffer)
 				M.buffer = null
-				user << "<span class = 'caution'>You upload the data from the [W.name]'s buffer.</span>"
+				user << "<span class='caution'>You upload the data from the [W.name]'s buffer.</span>"
 			else
-				user << "<span class = 'alert'>This station can't hold more information, try to use better parts.</span>"
+				user << "<span class='alert'>This station can't hold more information, try to use better parts.</span>"
 	if(default_deconstruction_screwdriver(user, "controller-o", "controller", W))
 		update_icon()
 		return
@@ -413,11 +413,11 @@
 		if(istype(W, /obj/item/device/multitool))
 			var/obj/item/device/multitool/M = W
 			M.buffer = src
-			user << "<span class = 'caution'>You download the data to the [W.name]'s buffer.</span>"
+			user << "<span class='caution'>You download the data to the [W.name]'s buffer.</span>"
 			return
 		if(istype(W, /obj/item/weapon/wirecutters))
 			link_console_and_hub()
-			user << "<span class = 'caution'>You reconnect the station to nearby machinery.</span>"
+			user << "<span class='caution'>You reconnect the station to nearby machinery.</span>"
 			return
 
 /obj/machinery/teleport/station/attack_paw()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -139,7 +139,7 @@
 		var/amount = min(res_max_amount, resources[resource])
 		output += "<span class=\"res_name\">[material2name(resource)]: </span>[amount] cm&sup3;"
 		if(amount>0)
-			output += "<span style='font-size:80%;'> - Remove \[<a href='?src=\ref[src];remove_mat=1;material=[resource]'>1</a>\] | \[<a href='?src=\ref[src];remove_mat=10;material=[resource]'>10</a>\] | \[<a href='?src=\ref[src];remove_mat=[resources[resource] / MINERAL_MATERIAL_AMOUNT];material=[resource]'>All</a>\]</span>"
+			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=\ref[src];remove_mat=1;material=[resource]'>1</a>\] | \[<a href='?src=\ref[src];remove_mat=10;material=[resource]'>10</a>\] | \[<a href='?src=\ref[src];remove_mat=[resources[resource] / MINERAL_MATERIAL_AMOUNT];material=[resource]'>All</a>\]</span>"
 		output += "<br/>"
 	return output
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -84,7 +84,7 @@
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
 		. += "<p>According to \the [src], you are now in <b>\"[html_encode(A.name)]\"</b>.</p>"
-		. += "<p>You may <a href='?src=\ref[src];edit_area=1'> move an amendment</a> to the drawing.</p>"
+		. += "<p>You may <a href='?src=\ref[src];edit_area=1'>move an amendment</a> to the drawing.</p>"
 	var/datum/browser/popup = new(user, "blueprints", "[src]", 700, 500)
 	popup.set_content(.)
 	popup.open()

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -331,7 +331,7 @@ Code:
 				var/count = 0
 				for(var/obj/machinery/computer/monitor/pMon in powermonitors)
 					count++
-					menu += "<a href='byond://?src=\ref[src];choice=Power Select;target=[count]'> [pMon] </a><BR>"
+					menu += "<a href='byond://?src=\ref[src];choice=Power Select;target=[count]'>[pMon] </a><BR>"
 
 				menu += "</FONT>"
 

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -65,7 +65,7 @@
 			dat += "<br>"
 			dat += {"<a href='byond://?src=\ref[src];choice=Radio'>[A.radio_enabled ? "Disable" : "Enable"] Subspace Radio</a>"}
 			dat += "<br>"
-			dat += {"<a href='byond://?src=\ref[src];choice=Close'> Close</a>"}
+			dat += {"<a href='byond://?src=\ref[src];choice=Close'>Close</a>"}
 	user << browse(dat, "window=aicard")
 	onclose(user, "aicard")
 	return

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -80,10 +80,10 @@ MASS SPECTROMETER
 
 /obj/item/device/healthanalyzer/attack_self(mob/user)
 	if(!scanchems)
-		user << "<span class = 'notice'>You switch the health analyzer to scan chemical contents.</span>"
+		user << "<span class='notice'>You switch the health analyzer to scan chemical contents.</span>"
 		scanchems = 1
 	else
-		user << "<span class = 'notice'>You switch the health analyzer to check physical health.</span>"
+		user << "<span class='notice'>You switch the health analyzer to check physical health.</span>"
 		scanchems = 0
 	return
 /obj/item/device/healthanalyzer/attack(mob/living/M as mob, mob/living/carbon/human/user as mob)
@@ -198,9 +198,9 @@ MASS SPECTROMETER
 			if(H.reagents.reagent_list.len)
 				user << "<span class='notice'>Subject contains the following reagents:</span>"
 				for(var/datum/reagent/R in H.reagents.reagent_list)
-					user << "<span class='notice'>[R.volume] units of [R.name][R.overdosed == 1 ? "</span> - <span class = 'boldannounce'>OVERDOSING</span>" : ".</span>"]"
+					user << "<span class='notice'>[R.volume] units of [R.name][R.overdosed == 1 ? "</span> - <span class='boldannounce'>OVERDOSING</span>" : ".</span>"]"
 			else
-				user << "<span class = 'notice'>Subject contains no reagents.</span>"
+				user << "<span class='notice'>Subject contains no reagents.</span>"
 			if(H.reagents.addiction_list.len)
 				user << "<span class='boldannounce'>Subject is addicted to the following reagents:</span>"
 				for(var/datum/reagent/R in H.reagents.addiction_list)

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -18,7 +18,7 @@
 	item_state = "latexballon"
 	user.update_inv_r_hand()
 	user.update_inv_l_hand()
-	user << "<span class='notice'> You blow up [src] with [tank].</span>"
+	user << "<span class='notice'>You blow up [src] with [tank].</span>"
 	air_contents = tank.remove_air_volume(3)
 
 /obj/item/latexballon/proc/burst()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -168,7 +168,7 @@
 	src.bullets--
 	user.visible_message("<span class='danger'>[user] fires [src] at [target]!</span>", \
 						"<span class='danger'>You fire [src] at [target]!</span>", \
-						 "<span class='italics'> You hear a gunshot!</span>")
+						 "<span class='italics'>You hear a gunshot!</span>")
 
 /obj/item/toy/ammo/gun
 	name = "capgun ammo"
@@ -533,7 +533,7 @@
 	s.set_up(3, 1, src)
 	s.start()
 	new /obj/effect/decal/cleanable/ash(src.loc)
-	src.visible_message("<span class='suicide'> The [src.name] explodes!</span>","<span class='italics'>You hear a snap!</span>")
+	src.visible_message("<span class='suicide'>The [src.name] explodes!</span>","<span class='italics'>You hear a snap!</span>")
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)
 	qdel(src)
 

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -202,7 +202,7 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 			A.reagents.del_reagent("water")
 			A.reagents.add_reagent("holywater",water2holy)
 		if(A.reagents && A.reagents.has_reagent("unholywater")) //yeah yeah, copy pasted code - sue me
-			user << "<span class='notice'> You purify [A].</span>"
+			user << "<span class='notice'>You purify [A].</span>"
 			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
 			A.reagents.del_reagent("unholywater")
 			A.reagents.add_reagent("holywater",unholy2clean)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -16,7 +16,7 @@
 
 /obj/item/weapon/banhammer/attack(mob/M, mob/user)
 	M << "<font color='red'><b> You have been banned FOR NO REISIN by [user]<b></font>"
-	user << "<font color='red'> You have <b>BANNED</b> [M]</font>"
+	user << "<font color='red'>You have <b>BANNED</b> [M]</font>"
 	playsound(loc, 'sound/effects/adminhelp.ogg', 15) //keep it at 15% volume so people don't jump out of their skin too much
 
 

--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -50,7 +50,7 @@
 
 /obj/structure/sign/barsign/attack_hand(mob/user as mob)
 	if (!src.allowed(user))
-		user << "<span class = 'info'>Access denied.</span>"
+		user << "<span class='info'>Access denied.</span>"
 		return
 	if (broken)
 		user << "<span class ='danger'>The controls seem unresponsive.</span>"
@@ -62,7 +62,7 @@
 
 /obj/structure/sign/barsign/attackby(var/obj/item/I, var/mob/user)
 	if(!allowed(user))
-		user << "<span class = 'info'>Access denied.</span>"
+		user << "<span class='info'>Access denied.</span>"
 		return
 	if( istype(I, /obj/item/weapon/screwdriver))
 		if(!panel_open)

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -23,11 +23,11 @@
 
 	if (isrobot(user) || src.locked)
 		if(istype(O, /obj/item/device/multitool))
-			user << "<span class = 'caution'> Resetting circuitry...</span>"
+			user << "<span class='caution'>Resetting circuitry...</span>"
 			playsound(user, 'sound/machines/lockreset.ogg', 50, 1)
 			if(do_after(user, 20))
 				src.locked = 0
-				user << "<span class = 'caution'> You disable the locking modules.</span>"
+				user << "<span class='caution'>You disable the locking modules.</span>"
 				update_icon()
 			return
 		else if(istype(O, /obj/item/weapon))
@@ -43,7 +43,7 @@
 				user.do_attack_animation(src)
 				playsound(user, 'sound/effects/Glasshit.ogg', 100, 1) //We don't want this playing every time
 			if(W.force < 15)
-				user << "<span class = 'warning'> The cabinet's protective glass glances off the hit.</span>"
+				user << "<span class='warning'>The cabinet's protective glass glances off the hit.</span>"
 			else
 				src.hitstaken++
 				if(src.hitstaken == 4)
@@ -56,12 +56,12 @@
 	if (istype(O, /obj/item/weapon/twohanded/fireaxe) && src.localopened)
 		if(!fireaxe)
 			if(O:wielded)
-				user << "<span class = 'warning'> Unwield the axe first.</span>"
+				user << "<span class='warning'>Unwield the axe first.</span>"
 				return
 			fireaxe = O
 			user.drop_item()
 			src.contents += O
-			user << "<span class = 'caution'> You place the fire axe back in the [src.name].</span>"
+			user << "<span class='caution'>You place the fire axe back in the [src.name].</span>"
 			update_icon()
 		else
 			if(src.smashed)
@@ -84,11 +84,11 @@
 				spawn(10) update_icon()
 				return
 			else
-				user << "<span class = 'caution'> Resetting circuitry...</span>"
+				user << "<span class='caution'>Resetting circuitry...</span>"
 				playsound(user, 'sound/machines/lockenable.ogg', 50, 1)
 				if(do_after(user, 20))
 					src.locked = 1
-					user << "<span class = 'caution'> You re-enable the locking modules.</span>"
+					user << "<span class='caution'>You re-enable the locking modules.</span>"
 				return
 		else
 			localopened = !localopened
@@ -144,13 +144,13 @@
 		hasaxe = 1
 
 	if(src.locked)
-		user <<"<span class = 'warning'> The cabinet won't budge!</span>"
+		user <<"<span class='warning'>The cabinet won't budge!</span>"
 		return
 	if(localopened)
 		if(fireaxe)
 			user.put_in_hands(fireaxe)
 			fireaxe = null
-			user << "<span class = 'caution'> You take the fire axe from the [name].</span>"
+			user << "<span class='caution'>You take the fire axe from the [name].</span>"
 			src.add_fingerprint(user)
 			update_icon()
 		else
@@ -177,7 +177,7 @@
 /obj/structure/closet/fireaxecabinet/attack_tk(mob/user as mob)
 	if(localopened && fireaxe)
 		fireaxe.loc = loc
-		user << "<span class = 'caution'> You telekinetically remove the fire axe.</span>"
+		user << "<span class='caution'>You telekinetically remove the fire axe.</span>"
 		fireaxe = null
 		update_icon()
 		return
@@ -221,14 +221,14 @@
 
 /obj/structure/closet/fireaxecabinet/attack_ai(mob/user as mob)
 	if(src.smashed)
-		user << "<span class = 'warning'> The security of the cabinet is compromised.</span>"
+		user << "<span class='warning'>The security of the cabinet is compromised.</span>"
 		return
 	else
 		locked = !locked
 		if(locked)
-			user << "<span class = 'caution'> Cabinet locked.</span>"
+			user << "<span class='caution'>Cabinet locked.</span>"
 		else
-			user << "<span class = 'caution'> Cabinet unlocked.</span>"
+			user << "<span class='caution'>Cabinet unlocked.</span>"
 		return
 
 /obj/structure/closet/fireaxecabinet/update_icon() //Template: fireaxe[has fireaxe][is opened][hits taken][is smashed]. If you want the opening or closing animations, add "opening" or "closing" right after the numbers

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -436,7 +436,7 @@
 
 			if(mineral && mineral != "glass")
 				mineral = null //I know this is stupid, but until we change glass to a boolean it's how this code works.
-			user << "<span class='notice'> You change the paintjob on the airlock assembly.</span>"
+			user << "<span class='notice'>You change the paintjob on the airlock assembly.</span>"
 
 	else if(istype(W, /obj/item/weapon/weldingtool) && !anchored )
 		var/obj/item/weapon/weldingtool/WT = W
@@ -448,7 +448,7 @@
 			if(do_after(user, 40))
 				if( !WT.isOn() )
 					return
-				user << "<span class='notice'> You disassemble the airlock assembly.</span>"
+				user << "<span class='notice'>You disassemble the airlock assembly.</span>"
 				new /obj/item/stack/sheet/metal(get_turf(src), 4)
 				if (mineral)
 					if (mineral == "glass")
@@ -480,7 +480,7 @@
 			if(do_after(user, 40))
 				if( src.anchored )
 					return
-				user << "<span class='notice'> You secure the airlock assembly.</span>"
+				user << "<span class='notice'>You secure the airlock assembly.</span>"
 				src.name = "secured airlock assembly"
 				src.anchored = 1
 		else
@@ -494,7 +494,7 @@
 		if(do_after(user, 40))
 			if( !src.anchored )
 				return
-			user << "<span class='notice'> You unsecure the airlock assembly.</span>"
+			user << "<span class='notice'>You unsecure the airlock assembly.</span>"
 			src.name = "airlock assembly"
 			src.anchored = 0
 
@@ -520,7 +520,7 @@
 		if(do_after(user, 40))
 			if( src.state != 1 )
 				return
-			user << "<span class='notice'> You cut the wires from the airlock assembly.</span>"
+			user << "<span class='notice'>You cut the wires from the airlock assembly.</span>"
 			new/obj/item/stack/cable_coil(get_turf(user), 1)
 			src.state = 0
 			src.name = "secured airlock assembly"
@@ -535,7 +535,7 @@
 
 			user.drop_item()
 			W.loc = src
-			user << "<span class='notice'> You install the airlock electronics.</span>"
+			user << "<span class='notice'>You install the airlock electronics.</span>"
 			src.state = 2
 			src.name = "near finished airlock assembly"
 			src.electronics = W
@@ -549,7 +549,7 @@
 		if(do_after(user, 40))
 			if( src.state != 2 )
 				return
-			user << "<span class='notice'> You remove the airlock electronics.</span>"
+			user << "<span class='notice'>You remove the airlock electronics.</span>"
 			src.state = 1
 			src.name = "wired airlock assembly"
 			var/obj/item/weapon/airlock_electronics/ae
@@ -614,7 +614,7 @@
 
 		if(do_after(user, 40))
 			if(src.loc && state == 2)
-				user << "<span class='notice'> You finish the airlock.</span>"
+				user << "<span class='notice'>You finish the airlock.</span>"
 				var/obj/machinery/door/airlock/door
 				if(mineral == "glass")
 					door = new src.glass_type( src.loc )

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -348,20 +348,20 @@
 	if (istype(O, /obj/item/weapon/wrench))
 		if (!anchored && !isinspace())
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			user << "<span class='notice'> You begin to tighten \the [src] to the floor...</span>"
+			user << "<span class='notice'>You begin to tighten \the [src] to the floor...</span>"
 			if (do_after(user, 20))
 				user.visible_message( \
 					"[user] tightens \the [src]'s casters.", \
-					"<span class='notice'> You tighten \the [src]'s casters. Now it can be played again.</span>", \
+					"<span class='notice'>You tighten \the [src]'s casters. Now it can be played again.</span>", \
 					"<span class='italics'>You hear ratchet.</span>")
 				anchored = 1
 		else if(anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			user << "<span class='notice'> You begin to loosen \the [src]'s casters...</span>"
+			user << "<span class='notice'>You begin to loosen \the [src]'s casters...</span>"
 			if (do_after(user, 40))
 				user.visible_message( \
 					"[user] loosens \the [src]'s casters.", \
-					"<span class='notice'> You loosen \the [src]. Now it can be pulled somewhere else.</span>", \
+					"<span class='notice'>You loosen \the [src]. Now it can be pulled somewhere else.</span>", \
 					"<span class='italics'>You hear ratchet.</span>")
 				anchored = 0
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -235,7 +235,7 @@
 
 	else if(istype(I, /obj/item/weapon/wrench) && !anchored)
 		playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
-		user << "<span class='notice'> You begin to disassemble [src]...</span>"
+		user << "<span class='notice'>You begin to disassemble [src]...</span>"
 		if(do_after(user, 40))
 			if(disassembled)
 				return //Prevents multiple deconstruction attempts
@@ -256,7 +256,7 @@
 
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			disassembled = 1
-			user << "<span class='notice'> You successfully disassemble [src].</span>"
+			user << "<span class='notice'>You successfully disassemble [src].</span>"
 			qdel(src)
 
 	else

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -322,9 +322,9 @@ var/global/floorIsLava = 0
 			dat+="<A href='?src=\ref[src];ac_set_wanted_name=1'>Criminal Name</A>: [src.admincaster_wanted_message.criminal] <BR>"
 			dat+="<A href='?src=\ref[src];ac_set_wanted_desc=1'>Description</A>: [src.admincaster_wanted_message.body] <BR>"
 			if(wanted_already)
-				dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'> [news_network.wanted_issue.scannedUser]</FONT><BR>"
+				dat+="<B>Wanted Issue created by:</B><FONT COLOR='green'>[news_network.wanted_issue.scannedUser]</FONT><BR>"
 			else
-				dat+="<B>Wanted Issue will be created under prosecutor:</B><FONT COLOR='green'> [src.admincaster_signature]</FONT><BR>"
+				dat+="<B>Wanted Issue will be created under prosecutor:</B><FONT COLOR='green'>[src.admincaster_signature]</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_submit_wanted=[end_param]'>[(wanted_already) ? ("Edit Issue") : ("Submit")]</A>"
 			if(wanted_already)
 				dat+="<BR><A href='?src=\ref[src];ac_cancel_wanted=1'>Take down Issue</A>"

--- a/code/modules/admin/admin_memo.dm
+++ b/code/modules/admin/admin_memo.dm
@@ -37,7 +37,7 @@
 		var/savefile/F = new(MEMOFILE)
 		if(F)
 			for(var/ckey in F.dir)
-				src << "<center><span class='motd'><span class='prefix'>Admin Memo</span><span class='emote'> by [F[ckey]]</span></span></center>"
+				src << "<center><span class='motd'><span class='prefix'>Admin Memo</span><span class='emote'>by [F[ckey]]</span></span></center>"
 
 //delete your own or somebody else's memo
 /client/proc/admin_memo_delete()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1337,7 +1337,7 @@
 		sleep(5)
 		M.loc = pick(tdomeobserve)
 		spawn(50)
-			M << "<span class='adminnotice'> You have been sent to the Thunderdome.</span>"
+			M << "<span class='adminnotice'>You have been sent to the Thunderdome.</span>"
 		log_admin("[key_name(usr)] has sent [key_name(M)] to the thunderdome. (Observer.)")
 		message_admins("[key_name_admin(usr)] has sent [key_name_admin(M)] to the thunderdome. (Observer.)")
 

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -39,7 +39,7 @@
 
 /proc/Centcomm_announce(var/text , var/mob/Sender)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = "<span class='adminnotice'> <b><font color=orange>CENTCOM:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[Sender]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;traitor=\ref[Sender]'>TP</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
+	msg = "<span class='adminnotice'><b><font color=orange>CENTCOM:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[Sender]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;traitor=\ref[Sender]'>TP</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 	admins << msg
 
 /proc/Syndicate_announce(var/text , var/mob/Sender)
@@ -49,6 +49,6 @@
 
 /proc/Nuke_request(var/text , var/mob/Sender)
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
-	msg = "<span class='adminnotice'> <b><font color=orange>NUKE CODE REQUEST:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[Sender]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;traitor=\ref[Sender]'>TP</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
+	msg = "<span class='adminnotice'><b><font color=orange>NUKE CODE REQUEST:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[Sender]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;traitor=\ref[Sender]'>TP</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
 	admins << msg
 	admins << "<span class='adminnotice'><b>At this current time, the nuke must have the code manually set via varedit.</b></span>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -264,7 +264,7 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 				dat += "<b>Pull requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Yes" : "No"]</a><br>"
 				dat += "<b>Midround Antagonist:</b> <a href='?_src_=prefs;preference=allow_midround_antag'>[(toggles & MIDROUND_ANTAG) ? "Yes" : "No"]</a><br>"
 				if(config.allow_Metadata)
-					dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'> Edit </a><br>"
+					dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'>Edit </a><br>"
 
 				if(user.client)
 					if(user.client.holder)

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -81,7 +81,7 @@
 			return
 		var/refill = reagents.get_master_reagent_id()
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
-		user << "<span class='notice'> You transfer [trans] units of the solution to [target].</span>"
+		user << "<span class='notice'>You transfer [trans] units of the solution to [target].</span>"
 
 		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/mob/living/silicon/robot/bro = user

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -89,7 +89,7 @@
 			qdel(src)
 			return
 		else
-			usr << "<span class ='warning'> You must dry this first!</span>"
+			usr << "<span class ='warning'>You must dry this first!</span>"
 
 /obj/item/weapon/grown/log/steel
 	seed = /obj/item/seeds/steelmycelium
@@ -115,7 +115,7 @@
 
 /obj/item/weapon/grown/sunflower/attack(mob/M as mob, mob/user as mob)
 	M << "<font color='green'><b> [user] smacks you with a sunflower!</font><font color='yellow'><b>FLOWER POWER<b></font>"
-	user << "<font color='green'> Your sunflower's </font><font color='yellow'><b>FLOWER POWER</b></font><font color='green'> strikes [M]</font>"
+	user << "<font color='green'>Your sunflower's </font><font color='yellow'><b>FLOWER POWER</b></font><font color='green'>strikes [M]</font>"
 
 
 /obj/item/weapon/grown/novaflower

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -684,25 +684,25 @@
 	else if(istype(O, /obj/item/device/analyzer/plant_analyzer))
 		if(planted && myseed)
 			user << "*** <B>[myseed.plantname]</B> ***" //Carn: now reports the plants growing, not the seeds.
-			user << "-Plant Age: <span class='notice'> [age]</span>"
-			user << "-Plant Endurance: <span class='notice'> [myseed.endurance]</span>"
-			user << "-Plant Lifespan: <span class='notice'> [myseed.lifespan]</span>"
+			user << "-Plant Age: <span class='notice'>[age]</span>"
+			user << "-Plant Endurance: <span class='notice'>[myseed.endurance]</span>"
+			user << "-Plant Lifespan: <span class='notice'>[myseed.lifespan]</span>"
 			if(myseed.yield != -1)
-				user << "-Plant Yield: <span class='notice'> [myseed.yield]</span>"
-			user << "-Plant Production: <span class='notice'> [myseed.production]</span>"
+				user << "-Plant Yield: <span class='notice'>[myseed.yield]</span>"
+			user << "-Plant Production: <span class='notice'>[myseed.production]</span>"
 			if(myseed.potency != -1)
-				user << "-Plant Potency: <span class='notice'> [myseed.potency]</span>"
+				user << "-Plant Potency: <span class='notice'>[myseed.potency]</span>"
 			var/list/text_strings = myseed.get_analyzer_text()
 			if(text_strings)
 				for(var/string in text_strings)
 					user << string
 		else
 			user << "<B>No plant found.</B>"
-		user << "-Weed level: <span class='notice'> [weedlevel] / 10</span>"
-		user << "-Pest level: <span class='notice'> [pestlevel] / 10</span>"
-		user << "-Toxicity level: <span class='notice'> [toxic] / 100</span>"
-		user << "-Water level: <span class='notice'> [waterlevel] / [maxwater]</span>"
-		user << "-Nutrition level: <span class='notice'> [nutrilevel] / [maxnutri]</span>"
+		user << "-Weed level: <span class='notice'>[weedlevel] / 10</span>"
+		user << "-Pest level: <span class='notice'>[pestlevel] / 10</span>"
+		user << "-Toxicity level: <span class='notice'>[toxic] / 100</span>"
+		user << "-Water level: <span class='notice'>[waterlevel] / [maxwater]</span>"
+		user << "-Nutrition level: <span class='notice'>[nutrilevel] / [maxnutri]</span>"
 		user << ""
 
 	else if(istype(O, /obj/item/weapon/cultivator))

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -36,14 +36,14 @@
 /obj/item/seeds/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
 		user << "*** <B>[plantname]</B> ***"
-		user << "-Plant Endurance: <span class='notice'> [endurance]</span>"
-		user << "-Plant Lifespan: <span class='notice'> [lifespan]</span>"
-		user << "-Species Discovery Value: <span class='notice'> [rarity]</span>"
+		user << "-Plant Endurance: <span class='notice'>[endurance]</span>"
+		user << "-Plant Lifespan: <span class='notice'>[lifespan]</span>"
+		user << "-Species Discovery Value: <span class='notice'>[rarity]</span>"
 		if(yield != -1)
-			user << "-Plant Yield: <span class='notice'> [yield]</span>"
-		user << "-Plant Production: <span class='notice'> [production]</span>"
+			user << "-Plant Yield: <span class='notice'>[yield]</span>"
+		user << "-Plant Production: <span class='notice'>[production]</span>"
 		if(potency != -1)
-			user << "-Plant Potency: <span class='notice'> [potency]</span>"
+			user << "-Plant Potency: <span class='notice'>[potency]</span>"
 		var/list/text_strings = get_analyzer_text()
 		if(text_strings)
 			for(var/string in text_strings)

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -100,7 +100,7 @@
 			src << "Help for larva emotes. You can use these emotes with say \"*emote\":\n\nburp, choke, collapse, dance, drool, gasp, gnarl, hiss, jump, moan, nod, roll, scratch,\nscretch, shake, shiver, sign-#, sulk, sway, tail, twitch, whimper"
 
 		else
-			src << "<span class='info'> Unusable emote '[act]'. Say *help for a list.</span>"
+			src << "<span class='info'>Unusable emote '[act]'. Say *help for a list.</span>"
 
 	if ((message && src.stat == 0))
 		log_emote("[name]/[key] : [message]")

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -40,9 +40,9 @@
 	if(L.amount_grown >= L.max_grown)	//TODO ~Carn
 		L << "<span class='name'>You are growing into a beautiful alien! It is time to choose a caste.</span>"
 		L << "<span class='info'>There are three to choose from:"
-		L << "<span class='name'>Hunters</span> <span class='info'> are strong and agile, able to hunt away from the hive and rapidly move through ventilation shafts. Hunters generate plasma slowly and have low reserves.</span>"
-		L << "<span class='name'>Sentinels</span> <span class='info'> are tasked with protecting the hive and are deadly up close and at a range. They are not as physically imposing nor fast as the hunters.</span>"
-		L << "<span class='name'>Drones</span> <span class='info'> are the working class, offering the largest plasma storage and generation. They are the only caste which may evolve again, turning into the dreaded alien queen.</span>"
+		L << "<span class='name'>Hunters</span> <span class='info'>are strong and agile, able to hunt away from the hive and rapidly move through ventilation shafts. Hunters generate plasma slowly and have low reserves.</span>"
+		L << "<span class='name'>Sentinels</span> <span class='info'>are tasked with protecting the hive and are deadly up close and at a range. They are not as physically imposing nor fast as the hunters.</span>"
+		L << "<span class='name'>Drones</span> <span class='info'>are the working class, offering the largest plasma storage and generation. They are the only caste which may evolve again, turning into the dreaded alien queen.</span>"
 		var/alien_caste = alert(L, "Please choose which alien caste you shall belong to.",,"Hunter","Sentinel","Drone")
 
 		var/mob/living/carbon/alien/humanoid/new_xeno

--- a/code/modules/mob/living/carbon/alien/screen.dm
+++ b/code/modules/mob/living/carbon/alien/screen.dm
@@ -4,7 +4,7 @@
 
 /mob/living/carbon/alien/proc/updatePlasmaDisplay()
 	if(hud_used) //clientless aliens
-		hud_used.alien_plasma_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='magenta'>[round(storedPlasma)]</font></div>"
+		hud_used.alien_plasma_display.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='magenta'>[round(storedPlasma)]</font></div>"
 
 /mob/living/carbon/alien/larva/updatePlasmaDisplay()
 	return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -306,7 +306,7 @@
 	<BR><B>Left Hand:</B> <A href='?src=\ref[src];item=[slot_l_hand]'>		[(l_hand && !(l_hand.flags&ABSTRACT))		? l_hand	: "Nothing"]</A>
 	<BR><B>Right Hand:</B> <A href='?src=\ref[src];item=[slot_r_hand]'>		[(r_hand && !(r_hand.flags&ABSTRACT))		? r_hand	: "Nothing"]</A>"}
 
-	dat += "<BR><B>Back:</B> <A href='?src=\ref[src];item=[slot_back]'> [back ? back : "Nothing"]</A>"
+	dat += "<BR><B>Back:</B> <A href='?src=\ref[src];item=[slot_back]'>[back ? back : "Nothing"]</A>"
 
 	if(istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/weapon/tank))
 		dat += "<BR><A href='?src=\ref[src];internal=1'>[internal ? "Disable Internals" : "Set Internals"]</A>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -272,7 +272,7 @@
 			if(perpname)
 				var/datum/data/record/R = find_record("name", perpname, data_core.general)
 				if(R)
-					msg += "<span class = 'deptradio'>Rank:</span> [R.fields["rank"]]<br>"
+					msg += "<span class='deptradio'>Rank:</span> [R.fields["rank"]]<br>"
 					msg += "<a href='?src=\ref[src];hud=1;photo_front=1'>\[Front photo\]</a> "
 					msg += "<a href='?src=\ref[src];hud=1;photo_side=1'>\[Side photo\]</a><br>"
 				if(istype(H.glasses, /obj/item/clothing/glasses/hud/health) || istype(CIH,/obj/item/cybernetic_implant/eyes/hud/medical))
@@ -300,8 +300,8 @@
 						if(R)
 							criminal = R.fields["criminal"]
 
-						msg += "<span class = 'deptradio'>Criminal status:</span> <a href='?src=\ref[src];hud=s;status=1'>\[[criminal]\]</a>\n"
-						msg += "<span class = 'deptradio'>Security record:</span> <a href='?src=\ref[src];hud=s;view=1'>\[View\]</a> "
+						msg += "<span class='deptradio'>Criminal status:</span> <a href='?src=\ref[src];hud=s;status=1'>\[[criminal]\]</a>\n"
+						msg += "<span class='deptradio'>Security record:</span> <a href='?src=\ref[src];hud=s;view=1'>\[View\]</a> "
 						msg += "<a href='?src=\ref[src];hud=s;add_crime=1'>\[Add crime\]</a> "
 						msg += "<a href='?src=\ref[src];hud=s;view_comment=1'>\[View comment log\]</a> "
 						msg += "<a href='?src=\ref[src];hud=s;add_comment=1'>\[Add comment\]</a>\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -166,7 +166,7 @@
 
 /mob/living/carbon/human/blob_act()
 	if(stat == DEAD)	return
-	show_message("<span class='userdanger'> The blob attacks you!</span>")
+	show_message("<span class='userdanger'>The blob attacks you!</span>")
 	var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
 	var/obj/item/organ/limb/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -308,7 +308,7 @@
 		if(mind.changeling)
 			mind.changeling.regenerate()
 			hud_used.lingchemdisplay.invisibility = 0
-			hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"
+			hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"
 		else
 			hud_used.lingchemdisplay.invisibility = 101
 

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -145,7 +145,7 @@
 		if(mind.changeling)
 			mind.changeling.regenerate()
 			hud_used.lingchemdisplay.invisibility = 0
-			hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'> <font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"
+			hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"
 		else
 			hud_used.lingchemdisplay.invisibility = 101
 

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -632,9 +632,9 @@
 
 	var/dat = "<h3>Digital Messenger</h3>"
 	dat += {"<b>Signal/Receiver Status:</b> <A href='byond://?src=\ref[src];software=pdamessage;toggler=1'>
-	[(pda.toff) ? "<font color='red'> \[Off\]</font>" : "<font color='green'> \[On\]</font>"]</a><br>
+	[(pda.toff) ? "<font color='red'>\[Off\]</font>" : "<font color='green'>\[On\]</font>"]</a><br>
 	<b>Ringer Status:</b> <A href='byond://?src=\ref[src];software=pdamessage;ringer=1'>
-	[(pda.silent) ? "<font color='red'> \[Off\]</font>" : "<font color='green'> \[On\]</font>"]</a><br><br>"}
+	[(pda.silent) ? "<font color='red'>\[Off\]</font>" : "<font color='green'>\[On\]</font>"]</a><br><br>"}
 	dat += "<ul>"
 	if(!pda.toff)
 		for (var/obj/item/device/pda/P in sortNames(get_viewable_pdas()))

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -68,7 +68,7 @@
 		if( istype(inventory_head,/obj/item/clothing/head/helmet) && istype(inventory_back,/obj/item/clothing/suit/armor) )
 			if( O.force )
 				user << "<span class='warning'>[src] is wearing too much armor! You can't cause \him any damage.</span>"
-				visible_message("<span class='danger'> [user] hits [src] with [O], however [src] is too armored.</span>")
+				visible_message("<span class='danger'>[user] hits [src] with [O], however [src] is too armored.</span>")
 			else
 				user << "<span class='warning'>[src] is wearing too much armor! You can't reach \his skin.<span>"
 				visible_message("[user] gently taps [src] with [O].")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -346,16 +346,16 @@
 						MED.amount -= 1
 						if(MED.amount <= 0)
 							qdel(MED)
-						visible_message("<span class='notice'> [user] applies [MED] on [src].</span>")
+						visible_message("<span class='notice'>[user] applies [MED] on [src].</span>")
 						return
 					else
-						user << "<span class='notice'> [MED] won't help at all.</span>"
+						user << "<span class='notice'>[MED] won't help at all.</span>"
 						return
 			else
-				user << "<span class='notice'> [src] is at full health.</span>"
+				user << "<span class='notice'>[src] is at full health.</span>"
 				return
 		else
-			user << "<span class='notice'> [src] is dead, medical items won't bring it back to life.</span>"
+			user << "<span class='notice'>[src] is dead, medical items won't bring it back to life.</span>"
 			return
 
 	if((butcher_results) && (stat == DEAD))
@@ -494,11 +494,11 @@
 /mob/living/simple_animal/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/changed = 0
-	
+
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
 		ntransform.Scale(resize)
 		resize = RESIZE_DEFAULT_SIZE
-	
+
 	if(changed)
 		animate(src, transform = ntransform, time = 2, easing = EASE_IN|EASE_OUT)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -235,7 +235,7 @@
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
 			else
-				visible_message("<span class='warning'> [M] manages to wrestle \the [name] off!</span>")
+				visible_message("<span class='warning'>[M] manages to wrestle \the [name] off!</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 				discipline_slime(M)
@@ -247,7 +247,7 @@
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
 			else
-				visible_message("<span class='warning'> [M] manages to wrestle \the [name] off of [Victim]!</span>")
+				visible_message("<span class='warning'>[M] manages to wrestle \the [name] off of [Victim]!</span>")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 				discipline_slime(M)

--- a/code/modules/mob/new_player/poll.dm
+++ b/code/modules/mob/new_player/poll.dm
@@ -149,7 +149,7 @@
 							else
 								output += "[O.optiontext]<br>"
 						else
-							output += "<input type='radio' name='voteoptionid' value='[O.optionid]'> [O.optiontext]<br>"
+							output += "<input type='radio' name='voteoptionid' value='[O.optionid]'>[O.optiontext]<br>"
 				output += "</td></tr></table>"
 
 				if(!voted)	//Only make this a form if we have not voted yet
@@ -324,7 +324,7 @@
 							else
 								output += "[O.optiontext]<br>"
 						else
-							output += "<input type='checkbox' name='option_[O.optionid]' value='[O.optionid]'> [O.optiontext]<br>"
+							output += "<input type='checkbox' name='option_[O.optionid]' value='[O.optionid]'>[O.optiontext]<br>"
 				output += "</td></tr></table>"
 
 				if(!voted)	//Only make this a form if we have not voted yet

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -261,7 +261,7 @@ nanoui is used to open and update nano browser uis
 		head_content += "<script type='text/javascript' src='[filename]'></script> "
 
 	for (var/filename in stylesheets)
-		head_content += "<link rel='stylesheet' type='text/css' href='[filename]'> "
+		head_content += "<link rel='stylesheet' type='text/css' href='[filename]'>"
 
 	var/templatel_data[0]
 	for (var/key in templates)

--- a/code/modules/ninja/suit/suit_initialisation.dm
+++ b/code/modules/ninja/suit/suit_initialisation.dm
@@ -40,7 +40,7 @@
 						break
 					lock_suit(U,1)//Check for icons.
 					U.regenerate_icons()
-					U << "<span class='notice'> Linking neural-net interface...\nPattern</span>\green <B>GREEN</B><span class='notice'>, continuing operation.</span>"
+					U << "<span class='notice'>Linking neural-net interface...\nPattern</span>\green <B>GREEN</B><span class='notice'>, continuing operation.</span>"
 				if(4)
 					U << "<span class='notice'>VOID-shift device status: <B>ONLINE</B>.\nCLOAK-tech device status: <B>ONLINE</B>.</span>"
 				if(5)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -18,7 +18,7 @@
 
 /obj/machinery/power/supermatter_shard
 	name = "supermatter shard"
-	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure. <span class='danger'> You get headaches just from looking at it.</span>"
+	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure. <span class='danger'>You get headaches just from looking at it.</span>"
 	icon = 'icons/obj/supermatter.dmi'
 	icon_state = "darkmatter_shard"
 	density = 1
@@ -214,11 +214,11 @@
 	if(Adjacent(user))
 		return attack_hand(user)
 	else
-		user << "<span class = 'warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>"
+		user << "<span class='warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>"
 	return
 
 /obj/machinery/power/supermatter_shard/attack_ai(mob/user as mob)
-	user << "<span class = 'warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>"
+	user << "<span class='warning'>You attempt to interface with the control circuits but find they are not connected to your network. Maybe in a future firmware update.</span>"
 
 /obj/machinery/power/supermatter_shard/attack_hand(mob/living/user as mob)
 	if(!istype(user))

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -37,7 +37,7 @@
 		CB.update_icon()
 		num_unloaded++
 	if (num_unloaded)
-		user << "<span class = 'notice'>You unload [num_unloaded] shell\s from [src].</span>"
+		user << "<span class='notice'>You unload [num_unloaded] shell\s from [src].</span>"
 	else
 		user << "<span class='warning'>[src] is empty!</span>"
 
@@ -170,7 +170,7 @@
 			CB.update_icon()
 			num_unloaded++
 		if (num_unloaded)
-			user << "<span class = 'notice'>You unload [num_unloaded] shell\s from [src].</span>"
+			user << "<span class='notice'>You unload [num_unloaded] shell\s from [src].</span>"
 		else
 			user << "<span class='notice'>[src] is empty.</span>"
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -173,7 +173,7 @@
 		CB.update_icon()
 		num_unloaded++
 	if (num_unloaded)
-		user << "<span class = 'notice'>You break open \the [src] and unload [num_unloaded] shell\s.</span>"
+		user << "<span class='notice'>You break open \the [src] and unload [num_unloaded] shell\s.</span>"
 	else
 		user << "<span class='warning'>[src] is empty!</span>"
 

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -56,7 +56,7 @@
 	S.loc = user.loc
 
 	syringes.Remove(S)
-	user << "<span class = 'notice'>You unload [S] from \the [src].</span>"
+	user << "<span class='notice'>You unload [S] from \the [src].</span>"
 
 	return 1
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -268,7 +268,7 @@
 				S.icon = change.icon
 				if(H.mind)
 					H.mind.transfer_to(S)
-					S << "<span class = 'userdanger'>You are an animate statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved! Do not harm [firer.name], your creator.</span>"
+					S << "<span class='userdanger'>You are an animate statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved! Do not harm [firer.name], your creator.</span>"
 				H = change
 				H.loc = S
 				qdel(src)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -260,7 +260,7 @@ var/const/INGEST = 2
 					R.addiction_act_stage4(M)
 					R.addiction_stage++
 				if(R.addiction_stage > 40)
-					M << "<span class = 'notice'>You feel like you've gotten over your need for [R.name].</span>"
+					M << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
 					addiction_list.Remove(R)
 	addiction_tick++
 	update_total()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -115,26 +115,26 @@
 	return
 
 /datum/reagent/proc/overdose_start(var/mob/living/M as mob)
-	M << "<span class = 'userdanger'>You feel like you took too much of [name]!</span>"
+	M << "<span class='userdanger'>You feel like you took too much of [name]!</span>"
 	return
 
 /datum/reagent/proc/addiction_act_stage1(var/mob/living/M as mob)
 	if(prob(30))
-		M << "<span class = 'notice'>You feel like some [name] right about now.</span>"
+		M << "<span class='notice'>You feel like some [name] right about now.</span>"
 	return
 
 /datum/reagent/proc/addiction_act_stage2(var/mob/living/M as mob)
 	if(prob(30))
-		M << "<span class = 'notice'>You feel like you need [name]. You just can't get enough.</span>"
+		M << "<span class='notice'>You feel like you need [name]. You just can't get enough.</span>"
 	return
 
 /datum/reagent/proc/addiction_act_stage3(var/mob/living/M as mob)
 	if(prob(30))
-		M << "<span class = 'danger'>You have an intense craving for [name].</span>"
+		M << "<span class='danger'>You have an intense craving for [name].</span>"
 	return
 
 /datum/reagent/proc/addiction_act_stage4(var/mob/living/M as mob)
 	if(prob(30))
-		M << "<span class = 'boldannounce'>You're not feeling good at all! You really need some [name].</span>"
+		M << "<span class='boldannounce'>You're not feeling good at all! You really need some [name].</span>"
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -211,4 +211,4 @@
 	if(message_living && !issilicon(M))
 		totalmessage += message_living
 	totalmessage += "!"
-	M << "<span class = 'userdanger'>[totalmessage]</span>"
+	M << "<span class='userdanger'>[totalmessage]</span>"

--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
@@ -57,7 +57,7 @@
 	overdose_threshold = 200 // Hyperglycaemic shock
 
 /datum/reagent/consumable/sugar/overdose_start(var/mob/living/M as mob)
-	M << "<span class = 'userdanger'>You go into hyperglycaemic shock! Lay off the twinkies!</span>"
+	M << "<span class='userdanger'>You go into hyperglycaemic shock! Lay off the twinkies!</span>"
 	M.sleeping += 30
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -172,7 +172,7 @@
 	if(prob(20))
 		M.emote("laugh")
 	if(prob(33))
-		M.visible_message("<span class = 'danger'>[M]'s hands flip out and flail everywhere!</span>")
+		M.visible_message("<span class='danger'>[M]'s hands flip out and flail everywhere!</span>")
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -494,7 +494,7 @@
 			if(3)
 				var/mob/living/carbon/human/H = M
 				if(!H.heart_attack)
-					H.visible_message("<span class = 'userdanger'>[H] clutches at their chest as if their heart stopped!</span>")
+					H.visible_message("<span class='userdanger'>[H] clutches at their chest as if their heart stopped!</span>")
 					H.heart_attack = 1 // rip in pepperoni
 				else
 					H.losebreath += 10

--- a/code/modules/reagents/Chemistry-Recipes/Pyrotechnics.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Pyrotechnics.dm
@@ -59,7 +59,7 @@
 	required_reagents = list("blackpowder" = 1)
 	result_amount = 1
 	required_temp = 474
-	mix_message = "<span class = 'boldannounce'>Sparks start flying around the black powder!</span>"
+	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
 /datum/chemical_reaction/blackpowder_explosion/on_reaction(var/datum/reagents/holder, var/created_volume)
 	sleep(rand(50,100))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -110,7 +110,7 @@
 
 	if(istype(I, /obj/item/weapon/storage/bag/trash))
 		var/obj/item/weapon/storage/bag/trash/T = I
-		user << "<span class='warning'> You empty the bag.</span>"
+		user << "<span class='warning'>You empty the bag.</span>"
 		for(var/obj/item/O in T.contents)
 			T.remove_from_storage(O,src)
 		T.update_icon()
@@ -979,7 +979,7 @@
 			sortType = O.currTag
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 100, 1)
 			var/tag = uppertext(TAGGERLOCATIONS[O.currTag])
-			user << "<span class='warning'> Changed filter to [tag].</span>"
+			user << "<span class='warning'>Changed filter to [tag].</span>"
 			updatedesc()
 
 

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -145,7 +145,7 @@ Note: Must be placed west/left of and R&D console to function.
 	if (disabled)
 		return
 	if (!linked_console)
-		user << "<span class='warning'> The [src.name] must be linked to an R&D console first!</span>"
+		user << "<span class='warning'>The [src.name] must be linked to an R&D console first!</span>"
 		return 1
 	if (busy)
 		user << "<span class='warning'>The [src.name] is busy! Please wait for completion of previous operation.</span>"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -154,11 +154,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(istype(D, /obj/item/weapon/disk/tech_disk)) t_disk = D
 		else if (istype(D, /obj/item/weapon/disk/design_disk)) d_disk = D
 		else
-			user << "<span class='danger'> Machine cannot accept disks in that format.</span>"
+			user << "<span class='danger'>Machine cannot accept disks in that format.</span>"
 			return
 		user.drop_item()
 		D.loc = src
-		user << "<span class='notice'> You add the disk to the machine!</span>"
+		user << "<span class='notice'>You add the disk to the machine!</span>"
 	else
 		..()
 	src.updateUsrDialog()
@@ -168,7 +168,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	if(!emagged)
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		emagged = 1
-		user << "<span class='notice'> You disable the security protocols</span>"
+		user << "<span class='notice'>You disable the security protocols</span>"
 
 /obj/machinery/computer/rdconsole/Topic(href, href_list)
 	if(..())
@@ -237,7 +237,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	else if(href_list["eject_item"]) //Eject the item inside the destructive analyzer.
 		if(linked_destroy)
 			if(linked_destroy.busy)
-				usr << "<span class='danger'> The destructive analyzer is busy at the moment.</span>"
+				usr << "<span class='danger'>The destructive analyzer is busy at the moment.</span>"
 
 			else if(linked_destroy.loaded_item)
 				linked_destroy.loaded_item.loc = linked_destroy.loc
@@ -248,7 +248,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	else if(href_list["deconstruct"]) //Deconstruct the item in the destructive analyzer and update the research holder.
 		if(linked_destroy)
 			if(linked_destroy.busy)
-				usr << "<span class='danger'> The destructive analyzer is busy at the moment.</span>"
+				usr << "<span class='danger'>The destructive analyzer is busy at the moment.</span>"
 			else
 				var/choice = input("Proceeding will destroy loaded item.") in list("Proceed", "Cancel")
 				if(choice == "Cancel" || !linked_destroy) return
@@ -261,7 +261,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						linked_destroy.busy = 0
 						if(!linked_destroy.hacked)
 							if(!linked_destroy.loaded_item)
-								usr <<"<span class='danger'> The destructive analyzer appears to be empty.</span>"
+								usr <<"<span class='danger'>The destructive analyzer appears to be empty.</span>"
 								screen = 1.0
 								return
 							if((linked_destroy.loaded_item.reliability >= 99 - (linked_destroy.decon_mod * 3)) || linked_destroy.loaded_item.crit_fail)
@@ -307,7 +307,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	else if(href_list["sync"]) //Sync the research holder with all the R&D consoles in the game that aren't sync protected.
 		screen = 0.0
 		if(!sync)
-			usr << "<span class='danger'> You must connect to the network first!</span>"
+			usr << "<span class='danger'>You must connect to the network first!</span>"
 		else
 			griefProtection() //Putting this here because I dont trust the sync process
 			spawn(30)
@@ -753,7 +753,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 		if(1.7) //R&D device linkage
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=1.6'>Settings Menu</A><div class='statusDisplay'> "
+			dat += "<A href='?src=\ref[src];menu=1.6'>Settings Menu</A><div class='statusDisplay'>"
 			dat += "<h3>R&D Console Device Linkage Menu:</h3><BR>"
 			dat += "<A href='?src=\ref[src];find_device=1'>Re-sync with Nearby Devices</A><BR><BR>"
 			dat += "<h3>Linked Devices:</h3><BR>"
@@ -809,12 +809,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] / [linked_lathe.max_material_storage]<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<BR>"
 
-			dat += "<form name='search' action='?src=\ref[src]'> \
-			<input type='hidden' name='src' value='\ref[src]'> \
-			<input type='hidden' name='search' value='to_search'> \
-			<input type='hidden' name='type' value='proto'> \
-			<input type='text' name='to_search'> \
-			<input type='submit' value='Search'> \
+			dat += "<form name='search' action='?src=\ref[src]'>\
+			<input type='hidden' name='src' value='\ref[src]'>\
+			<input type='hidden' name='search' value='to_search'>\
+			<input type='hidden' name='type' value='proto'>\
+			<input type='text' name='to_search'>\
+			<input type='submit' value='Search'>\
 			</form><HR>"
 
 			dat += list_categories(linked_lathe.categories, 3.15)
@@ -963,12 +963,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
 
-			dat += "<form name='search' action='?src=\ref[src]'> \
-			<input type='hidden' name='src' value='\ref[src]'> \
-			<input type='hidden' name='search' value='to_search'> \
-			<input type='hidden' name='type' value='imprint'> \
-			<input type='text' name='to_search'> \
-			<input type='submit' value='Search'> \
+			dat += "<form name='search' action='?src=\ref[src]'>\
+			<input type='hidden' name='src' value='\ref[src]'>\
+			<input type='hidden' name='search' value='to_search'>\
+			<input type='hidden' name='type' value='imprint'>\
+			<input type='text' name='to_search'>\
+			<input type='submit' value='Search'>\
 			</form><HR>"
 
 			dat += list_categories(linked_imprinter.categories, 4.15)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -192,7 +192,7 @@
 	add_fingerprint(usr)
 	usr.set_machine(src)
 	if(!src.allowed(usr) && !emagged)
-		usr << "<span class='danger'> You do not have the required access level.</span>"
+		usr << "<span class='danger'>You do not have the required access level.</span>"
 		return
 
 	if(href_list["main"])
@@ -269,7 +269,7 @@
 				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
 					continue
 				dat += "[S.name] || "
-				dat += "<A href='?src=\ref[src];access=[S.server_id]'> Access Rights</A> | "
+				dat += "<A href='?src=\ref[src];access=[S.server_id]'>Access Rights</A> | "
 				dat += "<A href='?src=\ref[src];data=[S.server_id]'>Data Management</A>"
 				if(badmin) dat += " | <A href='?src=\ref[src];transfer=[S.server_id]'>Server-to-Server Transfer</A>"
 				dat += "<BR>"
@@ -310,7 +310,7 @@
 			dat += "[temp_server.name] Server to Server Transfer<BR><BR>"
 			dat += "Send Data to what server?<BR>"
 			for(var/obj/machinery/r_n_d/server/S in servers)
-				dat += "[S.name] <A href='?src=\ref[src];send_to=[S.server_id]'> (Transfer)</A><BR>"
+				dat += "[S.name] <A href='?src=\ref[src];send_to=[S.server_id]'>(Transfer)</A><BR>"
 			dat += "<HR><A href='?src=\ref[src];main=1'>Main Menu</A>"
 	user << browse("<TITLE>R&D Server Control</TITLE><HR>[dat]", "window=server_control;size=575x400")
 	onclose(user, "server_control")
@@ -325,7 +325,7 @@
 	if(!emagged)
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		emagged = 1
-		user << "<span class='notice'> You you disable the security protocols.</span>"
+		user << "<span class='notice'>You you disable the security protocols.</span>"
 
 /obj/machinery/r_n_d/server/robotics
 	name = "Robotics R&D Server"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -18,10 +18,10 @@
 /obj/item/slime_extract/attackby(obj/item/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/weapon/slimesteroid2))
 		if(enhanced == 1)
-			user << "<span class='warning'> This extract has already been enhanced!</span>"
+			user << "<span class='warning'>This extract has already been enhanced!</span>"
 			return ..()
 		if(Uses == 0)
-			user << "<span class='warning'> You can't enhance a used extract!</span>"
+			user << "<span class='warning'>You can't enhance a used extract!</span>"
 			return ..()
 		user <<"<span class='notice'>You apply the enhancer. It now has triple the amount of uses.</span>"
 		Uses = 3
@@ -138,8 +138,8 @@
 
 	M.docile = 1
 	M.nutrition = 700
-	M <<"<span class='warning'> You absorb the potion and feel your intense desire to feed melt away.</span>"
-	user <<"<span class='notice'> You feed the slime the potion, removing it's hunger and calming it.</span>"
+	M <<"<span class='warning'>You absorb the potion and feel your intense desire to feed melt away.</span>"
+	user <<"<span class='notice'>You feed the slime the potion, removing it's hunger and calming it.</span>"
 	var/newname = copytext(sanitize(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text),1,MAX_NAME_LEN)
 
 	if (!newname)
@@ -220,16 +220,16 @@
 
 /obj/item/weapon/slimesteroid/attack(mob/living/simple_animal/slime/M as mob, mob/user as mob)
 	if(!isslime(M))//If target is not a slime.
-		user << "<span class='warning'> The steroid only works on baby slimes!</span>"
+		user << "<span class='warning'>The steroid only works on baby slimes!</span>"
 		return ..()
 	if(M.is_adult) //Can't tame adults
-		user << "<span class='warning'> Only baby slimes can use the steroid!</span>"
+		user << "<span class='warning'>Only baby slimes can use the steroid!</span>"
 		return..()
 	if(M.stat)
-		user << "<span class='warning'> The slime is dead!</span>"
+		user << "<span class='warning'>The slime is dead!</span>"
 		return..()
 	if(M.cores == 3)
-		user <<"<span class='warning'> The slime already has the maximum amount of extract!</span>"
+		user <<"<span class='warning'>The slime already has the maximum amount of extract!</span>"
 		return..()
 
 	user <<"<span class='notice'>You feed the slime the steroid. It now has triple the amount of extract.</span>"
@@ -252,10 +252,10 @@
 	/*afterattack(obj/target, mob/user , flag)
 		if(istype(target, /obj/item/slime_extract))
 			if(target.enhanced == 1)
-				user << "<span class='warning'> This extract has already been enhanced!</span>"
+				user << "<span class='warning'>This extract has already been enhanced!</span>"
 				return ..()
 			if(target.Uses == 0)
-				user << "<span class='warning'> You can't enhance a used extract!</span>"
+				user << "<span class='warning'>You can't enhance a used extract!</span>"
 				return ..()
 			user <<"You apply the enhancer. It now has triple the amount of uses."
 			target.Uses = 3
@@ -271,13 +271,13 @@
 
 /obj/item/weapon/slimestabilizer/attack(mob/living/simple_animal/slime/M as mob, mob/user as mob)
 	if(!isslime(M))
-		user << "<span class='warning'> The stabilizer only works on slimes!</span>"
+		user << "<span class='warning'>The stabilizer only works on slimes!</span>"
 		return ..()
 	if(M.stat)
-		user << "<span class='warning'> The slime is dead!</span>"
+		user << "<span class='warning'>The slime is dead!</span>"
 		return..()
 	if(M.mutation_chance == 0)
-		user <<"<span class='warning'> The slime already has no chance of mutating!</span>"
+		user <<"<span class='warning'>The slime already has no chance of mutating!</span>"
 		return..()
 
 	user <<"<span class='notice'>You feed the slime the stabilizer. It is now less likely to mutate.</span>"
@@ -292,16 +292,16 @@
 
 /obj/item/weapon/slimemutator/attack(mob/living/simple_animal/slime/M as mob, mob/user as mob)
 	if(!isslime(M))
-		user << "<span class='warning'> The mutator only works on slimes!</span>"
+		user << "<span class='warning'>The mutator only works on slimes!</span>"
 		return ..()
 	if(M.stat)
-		user << "<span class='warning'> The slime is dead!</span>"
+		user << "<span class='warning'>The slime is dead!</span>"
 		return..()
 	if(M.mutator_used)
-		user << "<span class='warning'> This slime has already consumed a mutator, any more would be far too unstable!</span>"
+		user << "<span class='warning'>This slime has already consumed a mutator, any more would be far too unstable!</span>"
 		return..()
 	if(M.mutation_chance == 100)
-		user <<"<span class='warning'> The slime is already guaranteed to mutate!</span>"
+		user <<"<span class='warning'>The slime is already guaranteed to mutate!</span>"
 		return..()
 
 	user <<"<span class='notice'>You feed the slime the mutator. It is now more likely to mutate.</span>"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -544,7 +544,7 @@
 	if(!emagged)
 		src.req_access = list()
 		emagged = 1
-		user << "<span class='notice'> You fried the consoles ID checking system.</span>"
+		user << "<span class='notice'>You fried the consoles ID checking system.</span>"
 
 /obj/machinery/computer/shuttle/ferry
 	name = "transport ferry console"

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -35,7 +35,7 @@
 		if(istype(I, /obj/item/device/multitool))
 			var/obj/item/device/multitool/M = I
 			M.buffer = src
-			user << "<span class = 'caution'>You save the data in the [I.name]'s buffer.</span>"
+			user << "<span class='caution'>You save the data in the [I.name]'s buffer.</span>"
 
 	if(exchange_parts(user, I))
 		return
@@ -60,22 +60,22 @@
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		if(anchored)
 			anchored = 0
-			user << "<span class = 'caution'> \The [src] can now be moved.</span>"
+			user << "<span class='caution'>\The [src] can now be moved.</span>"
 		else if(!anchored)
 			anchored = 1
-			user << "<span class = 'caution'> \The [src] is now secured.</span>"
+			user << "<span class='caution'>\The [src] is now secured.</span>"
 	if(istype(W, /obj/item/weapon/screwdriver))
 		if(stage == 0)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
-			user << "<span class = 'caution'> You unscrew the telepad's tracking beacon.</span>"
+			user << "<span class='caution'>You unscrew the telepad's tracking beacon.</span>"
 			stage = 1
 		else if(stage == 1)
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
-			user << "<span class = 'caution'> You screw in the telepad's tracking beacon.</span>"
+			user << "<span class='caution'>You screw in the telepad's tracking beacon.</span>"
 			stage = 0
 	if(istype(W, /obj/item/weapon/weldingtool) && stage == 1)
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)
-		user << "<span class = 'caution'> You disassemble the telepad.</span>"
+		user << "<span class='caution'>You disassemble the telepad.</span>"
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		new /obj/item/stack/sheet/glass(get_turf(src))
 		qdel(src)
@@ -91,7 +91,7 @@
 
 /obj/item/device/telepad_beacon/attack_self(mob/user as mob)
 	if(user)
-		user << "<span class = 'caution'> Locked In</span>"
+		user << "<span class='caution'>Locked In</span>"
 		new /obj/machinery/telepad_cargo(user.loc)
 		playsound(src, 'sound/effects/pop.ogg', 100, 1, 1)
 		qdel(src)
@@ -142,11 +142,11 @@
 		if(mode == 0)
 			mode = 1
 			playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
-			user << "<span class = 'caution'> The telepad locator has become uncalibrated.</span>"
+			user << "<span class='caution'>The telepad locator has become uncalibrated.</span>"
 		else
 			mode = 0
 			playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
-			user << "<span class = 'caution'> You calibrate the telepad locator.</span>"
+			user << "<span class='caution'>You calibrate the telepad locator.</span>"
 
 /obj/item/weapon/rcs/emag_act(mob/user as mob)
 	if(!emagged)
@@ -154,4 +154,4 @@
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
-		user << "<span class = 'caution'> You emag the RCS. Click on it to toggle between modes.</span>"
+		user << "<span class='caution'>You emag the RCS. Click on it to toggle between modes.</span>"

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -74,7 +74,7 @@
 		if(M.buffer && istype(M.buffer, /obj/machinery/telepad))
 			telepad = M.buffer
 			M.buffer = null
-			user << "<span class = 'caution'>You upload the data from the [W.name]'s buffer.</span>"
+			user << "<span class='caution'>You upload the data from the [W.name]'s buffer.</span>"
 	else
 		..()
 


### PR DESCRIPTION
Removed unnecessary spaces in the following situations:
"span class = '" changed to "span class='"
"'> " changed to "'>"

Fixes this kind of stuff:
![sieppaa](https://cloud.githubusercontent.com/assets/5420151/8148002/5599dc74-128f-11e5-8780-1435af13005f.PNG)

Plus mulebot's one span class was changed to warning.
