### PR TITLE
Fixes machine frame not dropping all /obj/item upon deconstruction.

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -140,8 +140,8 @@
 					user << "<span class='notice'>You remove the circuit board.</span>"
 				else
 					user << "<span class='notice'>You remove the circuit board and other components.</span>"
-					for(var/obj/item/I in components)
-						I.loc = src.loc
+					for(var/atom/movable/A in components)
+						A.loc = src.loc
 				desc = initial(desc)
 				req_components = null
 				components = null

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -140,8 +140,8 @@
 					user << "<span class='notice'>You remove the circuit board.</span>"
 				else
 					user << "<span class='notice'>You remove the circuit board and other components.</span>"
-					for(var/obj/item/weapon/W in components)
-						W.loc = src.loc
+					for(var/obj/item/I in components)
+						I.loc = src.loc
 				desc = initial(desc)
 				req_components = null
 				components = null


### PR DESCRIPTION
Deconstructing a machine frame will now properly drop all /atom/movable (instead of only /obj/item/weapon), it fixes the bug where bluespace crystals are not being dropped.
Fixes #9959 
