### PR TITLE
Mirror race change fix

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -111,14 +111,16 @@
 
 /obj/structure/mirror/magic/New()
 	if(!choosable_races.len)
-		for(var/datum/species/S in typesof(/datum/species) - /datum/species)
+		for(var/speciestype in typesof(/datum/species) - /datum/species)
+			var/datum/species/S = new speciestype()
 			if(!(S.id in races_blacklist))
-				choosable_races += S
+				choosable_races += S.id
 	..()
 
 /obj/structure/mirror/magic/badmin/New()
-	for(var/datum/species/S in typesof(/datum/species) - /datum/species)
-		choosable_races += S
+	for(var/speciestype in typesof(/datum/species) - /datum/species)
+		var/datum/species/S = new speciestype()
+		choosable_races += S.id
 	..()
 
 /obj/structure/mirror/magic/attack_hand(mob/user as mob)

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -10,9 +10,10 @@
 	var/all_the_same = 0
 	var/all_species = list()
 
-	for(var/datum/species/S in typesof(/datum/species) - /datum/species)
+	for(var/speciestype in typesof(/datum/species) - /datum/species)
+		var/datum/species/S = new speciestype()
 		if(!S.dangerous_existence)
-			all_species += S
+			all_species += speciestype
 
 	var/new_species = pick(all_species)
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -227,9 +227,10 @@
 					ready_dna(H)
 					if(H.dna && prob(50))
 						var/list/all_species = list()
-						for(var/datum/species/S in typesof(/datum/species) - /datum/species)
+						for(var/speciestype in typesof(/datum/species) - /datum/species)
+							var/datum/species/S = new speciestype()
 							if(!S.dangerous_existence)
-								all_species += S
+								all_species += speciestype
 						hardset_dna(H, null, null, null, null, pick(all_species))
 					H.update_icons()
 				else


### PR DESCRIPTION
- Fixes the wizard magic mirror race change. Fixes #9953
- Fixes the "race swap" wizard event.
- Fixes the wabbajack proc (staff of change) runtiming when trying to change the target's race.

(All caused by #9431)
