### PR TITLE
Nerfs xray gun

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,6 +91,7 @@
 	icon = 'icons/obj/doors/vault.dmi'
 	opacity = 1
 	doortype = /obj/structure/door_assembly/door_assembly_vault
+	explosion_block = 2
 
 /obj/machinery/door/airlock/glass_large
 	name = "glass airlock"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -108,7 +108,6 @@
 		loc = target_turf
 		if(A)
 			permutated.Add(A)
-		Range()
 		return 0
 	else
 		if(A && A.density && !ismob(A) && !(A.flags & ON_BORDER)) //if we hit a dense non-border obj or dense turf then we also hit one of the mobs on that tile.

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -30,7 +30,13 @@
 	icon_state = "xray"
 	damage = 15
 	irradiate = 30
+	range = 15
 	forcedodge = 1
+
+/obj/item/projectile/beam/xray/on_hit(var/atom/target)
+	. = ..()
+	var/absorption = 1 + 6 * target.explosion_block
+	range = max(range-absorption,1) //hitting something reduces the range.
 
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -33,13 +33,6 @@
 	range = 15
 	forcedodge = 1
 
-/obj/item/projectile/beam/xray/on_hit(var/atom/target)
-	. = ..()
-	var/absorption = 1 + 2 * target.explosion_block
-	damage = max(damage - absorption,5) //hitting something reduces the damage.
-	irradiate = max(irradiate - 2*absorption,10)
-
-
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -35,8 +35,10 @@
 
 /obj/item/projectile/beam/xray/on_hit(var/atom/target)
 	. = ..()
-	var/absorption = 1 + 6 * target.explosion_block
-	range = max(range-absorption,1) //hitting something reduces the range.
+	var/absorption = 1 + 2 * target.explosion_block
+	damage = max(damage - absorption,5) //hitting something reduces the damage.
+	irradiate = max(irradiate - 2*absorption,10)
+
 
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"

--- a/html/changelogs/phil235-XrayGunNerf.yml
+++ b/html/changelogs/phil235-XrayGunNerf.yml
@@ -3,4 +3,4 @@ author: phil235
 delete-after: True
 
 changes: 
-  - rscdel: "Nerfed the xray gun. Its range is now 15 tiles and is lowered by things it hits. Super resistant obstacles such as reinforced walls and high security airlocks block the projectile completely. Other resistant obstacles such as walls or airlocks reduces the range greatly. It takes two normal walls/airlocks or five softer targets to stop the projectile at point blank."
+  - rscdel: "Nerfed the xray gun. Its range is now 15 tiles. Its damage is reduced when it pass through solid things (mobs, airlocks, walls) but can never go below 33% of its original damage."

--- a/html/changelogs/phil235-XrayGunNerf.yml
+++ b/html/changelogs/phil235-XrayGunNerf.yml
@@ -3,4 +3,4 @@ author: phil235
 delete-after: True
 
 changes: 
-  - rscdel: "Nerfed the xray gun. Its range is now 15 tiles. Its damage is reduced when it pass through solid things (mobs, airlocks, walls) but can never go below 33% of its original damage."
+  - rscdel: "Nerfed the xray gun. Its range is now 15 tiles."

--- a/html/changelogs/phil235-XrayGunNerf.yml
+++ b/html/changelogs/phil235-XrayGunNerf.yml
@@ -1,0 +1,6 @@
+author: phil235
+
+delete-after: True
+
+changes: 
+  - rscdel: "Nerfed the xray gun. Its range is now 15 tiles and is lowered by things it hits. Super resistant obstacles such as reinforced walls and high security airlocks block the projectile completely. Other resistant obstacles such as walls or airlocks reduces the range greatly. It takes two normal walls/airlocks or five softer targets to stop the projectile at point blank."


### PR DESCRIPTION
- Nerfs xray gun by giving it a shorter range Fixes #9923. Fixes #6928.
  Its range is now 15 tiles.
- Fixes projectile with a range having their range drop faster than it should when passing through things.
- Make vault airlock more explosion resistant (explosion_block var) for consistency.
