### PR TITLE
Buffs bulletproof vests back to 80

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -79,7 +79,7 @@
 	icon_state = "bulletproof"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	armor = list(melee = 15, bullet = 60, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
+	armor = list(melee = 15, bullet = 80, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
 	strip_delay = 70
 	put_on_delay = 50
 


### PR DESCRIPTION
> Ikarrus: Kor I want to rebuff bulletproof vests to 80
> Ikarrus: I need them for gang
> Kor: sure wynaut

Bulletproofs weren't so bad since they only protected the chest and didn't have any counterparts for any other part of the body. They're used in gang and the nerf pretty much made them useless.

Plus it's gotta compare to the ablative somehow :v:

Guy who nerfed them in the first place is okay with it.
