### PR TITLE
Mobs that are anchored or buckled to something anchored no longer float in no gravity.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -673,10 +673,13 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/float(on)
 	if(throwing)
 		return
-	if(on && !floating)
+	var/fixed = 0
+	if(anchored || (buckled && buckled.anchored))
+		fixed = 1
+	if(on && !floating && !fixed)
 		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
 		floating = 1
-	else if(!on && floating)
+	else if(((!on || fixed) && floating))
 		var/final_pixel_y = get_standard_pixel_y_offset(lying)
 		animate(src, pixel_y = final_pixel_y, time = 10)
 		floating = 0

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -330,8 +330,6 @@
 				continue
 			if(AM.density)
 				if(AM.anchored)
-					if(istype(AM, /obj/item/projectile)) //"You grab the bullet and push off of it!" No
-						continue
 					return 1
 				if(pulling == AM)
 					continue


### PR DESCRIPTION
This fixes the floating AI (at least when it's anchored). Fixes #4036.

Also, this removes an istype check in mob/process_spacemove() since projectiles are no longer anchored objects.
