### PR TITLE
Armour Penetration and Armour Damage Reduction nerf

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -36,6 +36,7 @@
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)
 	var/slowdown = 0 // How much clothing is slowing you down. Negative values speeds you up
 	var/list/armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	var/armour_penetration = 0 //percentage of armour effectiveness to remove
 	var/list/allowed = null //suit storage stuff.
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 	var/strip_delay = 40

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -53,7 +53,7 @@
 
 		var/mob/living/carbon/human/H = target
 		var/headarmor = 0 // Target's head armor
-		armor_block = H.run_armor_check(affecting, "melee") // For normal attack damage
+		armor_block = H.run_armor_check(affecting, "melee","","",armour_penetration) // For normal attack damage
 
 		//If they have a hat/helmet and the user is targeting their head.
 		if(istype(H.head, /obj/item/clothing/head) && affecting == "head")
@@ -77,6 +77,7 @@
 	armor_duration /= 10
 
 	//Apply the damage!
+	armor_block = max(90,armor_block)
 	target.apply_damage(force, BRUTE, affecting, armor_block)
 
 	// You are going to knock someone out for longer if they are not wearing a helmet.

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -14,7 +14,7 @@
 					"<span class='userdanger'>[M] has lunged at [src]!</span>")
 				return 0
 			var/obj/item/organ/limb/affecting = get_organ(ran_zone(M.zone_sel.selecting))
-			var/armor_block = run_armor_check(affecting, "melee")
+			var/armor_block = run_armor_check(affecting, "melee","","",10)
 
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -151,8 +151,9 @@ emp_act
 		else
 			return 0
 
-		var/armor = run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>")
-		if(armor >= 100)	return 0
+		var/armor = run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>", I.armour_penetration)
+		armor = min(90,armor) //cap damage reduction at 90%
+
 		var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 		apply_damage(I.force, I.damtype, affecting, armor , I)
@@ -384,8 +385,6 @@ emp_act
 		var/armor = run_armor_check(affecting, "melee")
 		apply_damage(damage, BRUTE, affecting, armor)
 		updatehealth()
-/*		if(armor >= 2) //why is this here?
-		return */
 
 
 /mob/living/carbon/human/attack_larva(mob/living/carbon/alien/larva/L as mob)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -923,8 +923,8 @@
 	else
 		return 0
 
-	var/armor = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>")
-	if(armor >= 100)	return 0
+	var/armor = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>",I.armour_penetration)
+	armor = max(90,armor) //cap damage reduction at 90%
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 	apply_damage(I.force, I.damtype, affecting, armor, H)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -1,5 +1,14 @@
-/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = null, soften_text = null)
+/mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = null, soften_text = null, var/armour_penetration, var/penetrated_text)
 	var/armor = getarmor(def_zone, attack_flag)
+
+	//the if "armor" check is because this is used for everything on /living, including humans
+	if(armor && armour_penetration)
+		armor = max(0, armor - armour_penetration)
+		if(penetrated_text)
+			src << "<span class='userdanger'>[penetrated_text]</span>"
+		else
+			src << "<span class='userdanger'>Your armor was penetrated!</span>"
+
 	if(armor >= 100)
 		if(absorb_text)
 			src << "<span class='userdanger'>[absorb_text]</span>"
@@ -20,7 +29,7 @@
 	return
 
 /mob/living/bullet_act(obj/item/projectile/P, def_zone)
-	var/armor = run_armor_check(def_zone, P.flag)
+	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
 	if(!P.nodamage)
 		apply_damage(P.damage, P.damage_type, def_zone, armor)
 	return P.on_hit(src, armor, def_zone)
@@ -60,7 +69,7 @@
 
 		visible_message("<span class='danger'>[src] has been hit by [I].</span>", \
 						"<span class='userdanger'>[src] has been hit by [I].</span>")
-		var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].")
+		var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].",I.armour_penetration)
 		apply_damage(I.throwforce, dtype, zone, armor, I)
 		if(!I.fingerprintslast)
 			return

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -6,6 +6,7 @@
 	item_state = "energy_katana"
 	force = 40
 	throwforce = 20
+	armour_penetration = 15
 	var/datum/effect/effect/system/spark_spread/spark_system
 
 /obj/item/weapon/katana/energy/afterattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/html/changelogs/RemieRichards-ArmourPenetration.yml
+++ b/html/changelogs/RemieRichards-ArmourPenetration.yml
@@ -1,0 +1,10 @@
+  
+author: RemieRichards
+
+delete-after: True
+
+changes: 
+  - tweak: "Cumulative armour damage resistance is now capped at 90%, you will now always take at bare minimum, 10% of the incoming damage."
+  - rscadd: "Added a system for Armour Penetration to items, it works by temporarily (It does NOT damage the armour or anything) reducing the armour values by the AP value during the attack instance."
+  - rscadd: "The formula for AP is Armour-ArmourPenetration = AdjustedArmour and AdjustedArmour is used for all the remaining calculations instead of Armour (Eg: 80 Melee - 15 AP = 65 Melee)."
+  - rscadd: "The Ninja's Energy Katana has 15 AP, Xenomorphs have an inbuilt AP of 10."


### PR DESCRIPTION
- Armour damage reduction is now capped at 90% of the incoming damage, you will now, with the best armour setup in the game take 10% of the incoming damage.
- armour_penetration variable added to /item, this is counted for melee weapon and projectiles (AP ammo when?)
- Xenomorphs have a fixed 10 armour_penetration per melee attack
- The Ninja's Energy Katana has a 15 armour_penetration value (This both makes it stronger for them AND much better for any crew member who manages to turn it against them, as it will now pierce his suit too!)

Inspired by the Bay PR which uses horrible RNGesus to deal with armour penetration, since we use pure "80 armour = 80% damage reduction" maths, the armour penetration here does the same (80% armour - 20% armour_penetration = 60% armour)
