### PR TITLE
Changes the default Delta alert text to something more generic

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -67,7 +67,7 @@ ALERT_BLUE_UPTO The station has received reliable information about possible hos
 ALERT_BLUE_DOWNTO The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.
 ALERT_RED_UPTO There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised.
 ALERT_RED_DOWNTO The self-destruct mechanism has been deactivated, there is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised.
-ALERT_DELTA The station's self-destruct mechanism has been engaged. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.
+ALERT_DELTA The station is at risk of total destruction. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.
 
 
 


### PR DESCRIPTION
This fixes the whole "Ops arm the bomb and Delta says the self-destruct mechanism is armed" thing that's bugged the fuck out of me for months.

Also, this lets us use Delta as a catch-all "OH FUCK THE SAIYANS SCREWED" thing.
