### PR TITLE
Request Console Radio Notifications

### DIFF
--- a/html/changelogs/Ikarrus-youcannotoutruntheradio.yml
+++ b/html/changelogs/Ikarrus-youcannotoutruntheradio.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Request Console message sent to major departments will now be broadcasted on that department's radio."
+  - rscadd: "Request Consoles can be used to quicly declare a security, medical, or engineering emergency."


### PR DESCRIPTION
![screenshot 2015-06-19 21 24 29](https://cloud.githubusercontent.com/assets/9098006/8266002/a04b29a2-16d2-11e5-9b30-fb3ffa7ddbd3.png)
So now that machines can talk on radio, we have a way to allow players to send messages on department radios without eavesdropping on them. This also means you'll have a better alternative than trying to speak over everyone else in general radio.
- Request Console messages sent to major departments will now be broadcasted on that department's radio. Major departments include:
  - Bridge
  - Security
  - Medbay
  - Engineering
  - Science
  - Cargo Bay
- You can now call for emergency assistance with just one click from request consoles, which will either radio security, medical, or engineering to your location.
  - This function has a 5 minute cooldown between uses during which the RC it was triggered from will flash red showing where it was triggered from
- RCs don't automatically print papers any more
