### PR TITLE
Fixes Broken C4s

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -70,7 +70,7 @@
 	user << "<span class='notice'>You start planting the bomb...</span>"
 
 	if(do_after(user, 50) && in_range(user, target))
-		if(!user.unEquip(target))
+		if(!user.unEquip(src))
 			return
 		src.target = target
 		loc = null


### PR DESCRIPTION
Trying to place a C4 on an object will currently only move the object onto your tile, and produce a runtime. This was because the code was trying to get you to drop the target rather than the C4.
