### PR TITLE
Adds ether

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -16,10 +16,10 @@
 	var/initial_bin_rating = 1
 	var/min_health = 25
 	var/list/injection_chems = list() //list of injectable chems except ephedrine, coz ephedrine is always avalible
-	var/list/possible_chems = list(list("morphine", "salbutamol", "salglu_solution"),
-								   list("morphine", "salbutamol", "salglu_solution", "oculine"),
-								   list("morphine", "salbutamol", "salglu_solution", "oculine", "charcoal", "mutadone", "mannitol", "pen_acid"),
-								   list("morphine", "salbutamol", "salglu_solution", "oculine", "charcoal", "mutadone", "mannitol", "omnizine"))
+	var/list/possible_chems = list(list("ether", "salbutamol", "salglu_solution"),
+								   list("ether", "salbutamol", "salglu_solution", "oculine"),
+								   list("ether", "salbutamol", "salglu_solution", "oculine", "charcoal", "mutadone", "mannitol", "pen_acid"),
+								   list("ether", "salbutamol", "salglu_solution", "oculine", "charcoal", "mutadone", "mannitol", "omnizine"))
 /obj/machinery/sleeper/New()
 	..()
 	component_parts = list()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1047,14 +1047,14 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 	..()
 	reagents.add_reagent("nutriment", 1)
 	reagents.add_reagent("charcoal", 3+round(potency / 3, 1))
-	reagents.add_reagent("morphine", 3+round(potency / 3, 1))
+	reagents.add_reagent("ether", 3+round(potency / 3, 1))
 	bitesize = 1 + round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	. = ..()
 	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
 		user << "<span class='info'>- Anti-Toxin: <i>[reagents.get_reagent_amount("charcoal")]%</i></span>"
-		user << "<span class='info'>- Morphine: <i>[reagents.get_reagent_amount("morphine")]%</i></span>"
+		user << "<span class='info'>- Ether: <i>[reagents.get_reagent_amount("ether")]%</i></span>"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/amanita
 	seed = /obj/item/seeds/amanitamycelium

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -61,7 +61,7 @@
 	melee_damage_upper = 10
 	poison_per_bite = 10
 	var/atom/cocoon_target
-	poison_type = "morphine"
+	poison_type = "ether"
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -73,7 +73,7 @@
 
 /obj/item/weapon/pen/sleepy/New()
 	create_reagents(55)
-	reagents.add_reagent("morphine", 30)
+	reagents.add_reagent("ether", 30)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
 	..()

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -166,7 +166,7 @@
 /obj/item/ammo_casing/shotgun/dart/bioterror/New()
 	..()
 	reagents.add_reagent("neurotoxin", 5)
-	reagents.add_reagent("morphine", 5)
+	reagents.add_reagent("ether", 5)
 	reagents.add_reagent("spore", 5)
 	reagents.add_reagent("mutetoxin", 5) //;HELP OPS IN MAINT
 	reagents.add_reagent("initropidril", 5)

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -525,6 +525,20 @@
 	..()
 	return
 
+datum/reagent/medicine/ether //morphine except good
+	name = "Ether"
+	id = "ether"
+	description = "Will eventually knock you out if you take too much."
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+
+datum/reagent/medicine/ether/on_mob_life(var/mob/living/M as mob)
+	if(current_cycle >= 12)
+		M.sleeping += 1
+	..()
+	return
+
 /datum/reagent/medicine/oculine
 	name = "Oculine"
 	id = "oculine"

--- a/code/modules/reagents/Chemistry-Recipes/Medicine.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Medicine.dm
@@ -193,5 +193,9 @@
 	required_reagents = list("stable_plasma" = 1, "acetone" = 1, "mutagen" = 1)
 	result_amount = 3
 
-
-
+/datum/chemical_reaction/ether
+	name = "Ether"
+	id = "ether"
+	result = "ether"
+	required_reagents = list("sacid" = 1, "ethanol" = 1, "oxygen" = 1)
+	result_amount = 3

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -92,6 +92,12 @@
 	icon_state = "pill8"
 	list_reagents = list("morphine" = 30)
 	roundstart = 1
+/obj/item/weapon/reagent_containers/pill/ether
+	name = "ether pill"
+	desc = "Commonly used to effectively treat insomnia."
+	icon_state = "pill8"
+	list_reagents = list("ether" = 30)
+	roundstart = 1
 /obj/item/weapon/reagent_containers/pill/stimulant
 	name = "stimulant pill"
 	desc = "Often taken by overworked employees, athletes, and the inebriated. You'll snap to attention immediately!"


### PR DESCRIPTION
Ether is a chemical ported from Goonstation that functions identically to morphine, minus the speed. I don't know who to give credit to for making it, but thank you to Marquesas for giving me permission to implement it. If I were to guess who added it, it would be SpyGuy, because Cogwerks is currently very very busy.

Ether is created with sacid, ethanol, and oxygen.

All instances where morphine was used for its sleep inducing properties have been replaced with ether. To name them, sleepers, reishi, spiders, bioterror ammo, and sleepy pens.

An ether pill has been added for future convenience to mappers and coders.
