### PR TITLE
Admins can now reject shitty adminhelps

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -122,6 +122,14 @@ var/datum/subsystem/garbage_collector/SSgarbage
 			else
 				SSgarbage.Queue(A)
 
+// Returns 1 if the object has been queued for deletion.
+/proc/qdeleted(var/datum/A)
+	if (!istype(A))
+		return 0
+	if (A.gc_destroyed)
+		return 1
+	return 0
+
 // Default implementation of clean-up code.
 // This should be overridden to remove all references pointing to the object being destroyed.
 // Return true if the the GC controller should allow the object to continue existing. (Useful if pooling objects.)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,0 +1,71 @@
+var/datum/subsystem/timer/SStimer
+
+/datum/subsystem/timer
+	name = "timer"
+	wait = 5
+	priority = 1
+
+	var/list/datum/timedevent/processing
+
+
+/datum/subsystem/timer/New()
+	NEW_SS_GLOBAL(SStimer)
+	processing = list()
+
+
+/datum/subsystem/timer/stat_entry(msg)
+	..("P:[processing.len]")
+
+/datum/subsystem/timer/fire()
+	if (!processing.len)
+		can_fire = 0 //nothing to do, lets stop firing.
+		return
+	for (var/datum/timedevent/event in processing)
+		//                    hacky i know, but its the only way to ensure this works with clients
+		if (!event.thingToCall || qdeleted(event.thingToCall))
+			qdel(event)
+		if (event.timeToRun <= world.time)
+			spawn(-1)
+				call(event.thingToCall,event.procToCall)(arglist(event.argList))
+			qdel(event)
+
+/datum/timedevent
+	var/thingToCall
+	var/procToCall
+	var/timeToRun
+	var/argList
+	var/id
+	var/static/nextid = 1
+
+/datum/timedevent/New()
+	id = nextid
+	nextid++
+
+/datum/timedevent/Destroy()
+	SStimer.processing -= src
+
+/proc/addtimer(var/thingToCall, var/procToCall, var/wait, var/argList = list())
+	if (!SStimer) //can't run timers before the mc has been created
+		return
+	if (!thingToCall || !procToCall || wait <= 0)
+		return
+	if (!SStimer.can_fire)
+		SStimer.can_fire = 1
+		SStimer.next_fire = world.time + SStimer.wait
+
+	var/datum/timedevent/event = new()
+	event.thingToCall = thingToCall
+	event.procToCall = procToCall
+	event.timeToRun = world.time + wait
+	event.argList = argList
+
+	SStimer.processing += event
+
+	return event.id
+
+/proc/deltimer(var/id)
+	for (var/datum/timedevent/event in SStimer.processing)
+		if (event.id == id)
+			qdel(event)
+			return 1
+	return 0

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,7 +1,7 @@
 var/datum/subsystem/timer/SStimer
 
 /datum/subsystem/timer
-	name = "timer"
+	name = "Timer"
 	wait = 5
 	priority = 1
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -5,8 +5,27 @@
 		message_admins("[usr.key] has attempted to override the admin panel!")
 		log_admin("[key_name(usr)] tried to use the admin panel without authorization.")
 		return
+	if(href_list["rejectadminhelp"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/client/C = locate(href_list["rejectadminhelp"])
+		if(!C)
+			return
+		if (deltimer(C.adminhelptimerid))
+			C.giveadminhelpverb()
 
-	if(href_list["makeAntag"])
+		C << 'sound/effects/adminhelp.ogg'
+
+		C << "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>"
+		C << "<font color='red'><b>Your admin help was rejected.</b> The adminhelp verb has been returned to you so that you may try again</font>"
+		C << "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting."
+		C << "(Note: the admins may have rejected your adminhelp purely just to give you back the adminhelp verb)"
+
+		message_admins("[key_name_admin(usr)] Rejected [C.key]'s admin help. [C.key]'s Adminhelp verb has been returned to them")
+		log_admin("[key_name(usr)] Rejected [C.key]'s admin help")
+
+
+	else if(href_list["makeAntag"])
 		if (!ticker.mode)
 			usr << "<span class='danger'>Not until the round starts!</span>"
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -19,7 +19,6 @@
 		C << "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>"
 		C << "<font color='red'><b>Your admin help was rejected.</b> The adminhelp verb has been returned to you so that you may try again</font>"
 		C << "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting."
-		C << "(Note: the admins may have rejected your adminhelp purely just to give you back the adminhelp verb)"
 
 		message_admins("[key_name_admin(usr)] Rejected [C.key]'s admin help. [C.key]'s Adminhelp verb has been returned to them")
 		log_admin("[key_name(usr)] Rejected [C.key]'s admin help")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -1,7 +1,13 @@
+/client/var/adminhelptimerid = 0
 
+/client/proc/giveadminhelpverb()
+	src.verbs |= /client/verb/adminhelp
+	adminhelptimerid = 0
 
 //This is a list of words which are ignored by the parser when comparing message contents for names. MUST BE IN LOWER CASE!
 var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","alien","as")
+
+
 
 /client/verb/adminhelp(msg as text)
 	set category = "Admin"
@@ -18,16 +24,15 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
-	//remove out adminhelp verb temporarily to prevent spamming of admins.
-	src.verbs -= /client/verb/adminhelp
-	spawn(1200)
-		src.verbs += /client/verb/adminhelp	// 2 minute cool-down for adminhelps
-
 	//clean the input msg
 	if(!msg)	return
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	if(!msg)	return
 	var/original_msg = msg
+
+	//remove out adminhelp verb temporarily to prevent spamming of admins.
+	src.verbs -= /client/verb/adminhelp
+	adminhelptimerid = addtimer(src,"giveadminhelpverb",1200) //2 minute cooldown of admin helps
 
 	//explode the input msg into a list
 	var/list/msglist = text2list(msg, " ")
@@ -85,7 +90,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(!mob)	return						//this doesn't happen
 
 	var/ref_mob = "\ref[mob]"
-	msg = "<span class='adminnotice'><b><font color=red>HELP: </font>[key_name_admin(src)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=[ref_mob]'>FLW</A>) (<A HREF='?_src_=holder;traitor=[ref_mob]'>TP</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]</span>"
+	var/ref_client = "\ref[src]"
+	msg = "<span class='adminnotice'><b><font color=red>HELP: </font>[key_name_admin(src)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=[ref_mob]'>FLW</A>) (<A HREF='?_src_=holder;traitor=[ref_mob]'>TP</A>)[ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""] (<A HREF='?_src_=holder;rejectadminhelp=[ref_client]'>REJT</A>):</b> [msg]</span>"
 
 	//send this msg to all admins
 

--- a/html/changelogs/MrStonedOne-PR-10083.yml
+++ b/html/changelogs/MrStonedOne-PR-10083.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Admins can now reject poor adminhelps. This will tell the player how to construct a useful adminhelp and give them back their adminhelp verb"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -141,6 +141,7 @@
 #include "code\controllers\subsystem\shuttles.dm"
 #include "code\controllers\subsystem\sun.dm"
 #include "code\controllers\subsystem\ticker.dm"
+#include "code\controllers\subsystem\timer.dm"
 #include "code\controllers\subsystem\voting.dm"
 #include "code\controllers\subsystem\shuttles\emergency.dm"
 #include "code\controllers\subsystem\shuttles\supply.dm"


### PR DESCRIPTION
This is done as a (REJT) button on admin helps. This allows the admin to tell the user that they made a shit adminhelp. It also returns the adminhelp verb back to the user.

In order to do the latter part, I had to make a simple timers subsystem. This is designed for timed events that one may want to cancel or otherwise control later. It has a resolution of 5ds(0.5 seconds) but this can be easily changed.

![image](https://cloud.githubusercontent.com/assets/7069733/8273360/cdde1350-181e-11e5-9079-4496946a2da9.png)
