### PR TITLE
Some little fixes

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -62,6 +62,7 @@
 	return
 
 /mob/living/proc/handle_mutations_and_radiation()
+	radiation = 0 //so radiation don't accumulate in simple animals
 	return
 
 /mob/living/proc/handle_chemicals_in_body()

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -18,6 +18,7 @@
 	response_help   = "passes through"
 	response_disarm = "swings at"
 	response_harm   = "punches"
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -201,6 +201,10 @@
 				if(!atmos_suitable)
 					adjustBruteLoss(unsuitable_atmos_damage)
 
+		else
+			if(atmos_requirements["min_oxy"] || atmos_requirements["min_tox"] || atmos_requirements["min_n2"] || atmos_requirements["min_co2"])
+				adjustBruteLoss(unsuitable_atmos_damage)
+
 	handle_temperature_damage()
 
 /mob/living/simple_animal/proc/handle_temperature_damage()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -358,16 +358,16 @@
 
 /obj/singularity/proc/toxmob()
 	var/toxrange = 10
-	var/toxdamage = 4
+	var/toxpwr = 4
 	var/radiation = 15
 	var/radiationmin = 3
 	if (energy>200)
-		toxdamage += round((energy-150)/30,1)
+		toxpwr += round((energy-150)/30,1)
 		radiation += round((energy-150)/10,1)
 		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		M.irradiate(rand(radiationmin,radiation))
-		toxdamage = (toxdamage - (toxdamage*M.getarmor(null, "rad")))
+		var/toxdamage = (toxpwr - (toxpwr*M.getarmor(null, "rad")))
 		M.apply_damage(toxdamage, TOX)
 	return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -358,18 +358,13 @@
 
 /obj/singularity/proc/toxmob()
 	var/toxrange = 10
-	var/toxpwr = 4
 	var/radiation = 15
 	var/radiationmin = 3
 	if (energy>200)
-		toxpwr += round((energy-150)/30,1)
 		radiation += round((energy-150)/10,1)
 		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		M.irradiate(rand(radiationmin,radiation))
-		var/toxdamage = toxpwr - toxpwr*(M.getarmor(null, "rad")/100)
-		M.apply_damage(toxdamage, TOX)
-	return
 
 
 /obj/singularity/proc/combust_mobs()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -367,7 +367,7 @@
 		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		M.irradiate(rand(radiationmin,radiation))
-		var/toxdamage = (toxpwr - (toxpwr*M.getarmor(null, "rad")))
+		var/toxdamage = toxpwr - toxpwr*(M.getarmor(null, "rad")/100)
 		M.apply_damage(toxdamage, TOX)
 	return
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -361,14 +361,14 @@
 	var/toxdamage = 4
 	var/radiation = 15
 	var/radiationmin = 3
-	if (src.energy>200)
-		toxdamage = round(((src.energy-150)/50)*4,1)
-		radiation = round(((src.energy-150)/50)*5,1)
-		radiationmin = round((radiation/5),1)//
+	if (energy>200)
+		toxdamage += round((energy-150)/30,1)
+		radiation += round((energy-150)/10,1)
+		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		M.irradiate(rand(radiationmin,radiation))
 		toxdamage = (toxdamage - (toxdamage*M.getarmor(null, "rad")))
-		M.apply_effect(toxdamage, TOX)
+		M.apply_damage(toxdamage, TOX)
 	return
 
 


### PR DESCRIPTION
Removes the singularity's tox damage to mobs (that was not working previously). Adjusted its radiation values. Fixes #10096.
Fixes simple animals that needs to breath not taking damage from lack of gas to breath on space turfs.
Fixes revenant not being spaceworthy. Fixes #9192.
Fixes simple_animal accumulating radiation indefinitely because they are unaffected by it.
