### PR TITLE
Fixes nuke not standing down Delta

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -137,7 +137,8 @@ var/bomb_set
 					src.icon_state = "nuclearbomb2"
 					if(!src.safety)
 						bomb_set = 1//There can still be issues with this reseting when there are multiple bombs. Not a big deal tho for Nuke/N
-						src.previous_level = "[get_security_level()]"
+						var/current_level = get_security_level()
+						previous_level = "[current_level == "delta" ? "red" : current_level ]" //If a nuke is armed during Delta, it will stand down to Red Alert when disarmed.
 						set_security_level("delta")
 					else
 						bomb_set = 0
@@ -152,6 +153,7 @@ var/bomb_set
 				if(safety)
 					src.timing = 0
 					bomb_set = 0
+					set_security_level("[previous_level]")
 			if (href_list["anchor"])
 				if(!isinspace()&&(!immobile))
 					src.anchored = !( src.anchored )


### PR DESCRIPTION
Fixes #10087.
- When the nuke is disarmed via enabling the safety instead of the timer,
  it now properly stands down Delta Alert to whatever the level was
  previously.
- If the nuke is somehow armed during Delta Alert, the nuke will set the
  alert level to Red when disarmed.
