### PR TITLE
RTA is now more spacey!

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -108,7 +108,6 @@ emp_act
 							"<span class='userdanger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
 			var/list/turfs = new/list()
 			for(var/turf/T in orange(6, src))
-				if(istype(T,/turf/space)) continue
 				if(T.density) continue
 				if(T.x>world.maxx-6 || T.x<6)	continue
 				if(T.y>world.maxy-6 || T.y<6)	continue


### PR DESCRIPTION
- Removes the Reactive Teleport Armor's preference to avoid spacing the
  user.

This greatly increases the chance of the user being spaced if he is in range of space turfs.
