### PR TITLE
Microbombs and Macrobombs, Nuke Ops start with Microbombs once more

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -662,11 +662,11 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	cost = 8
 
-/datum/uplink_item/implants/explosive
-	name = "Explosive Implant"
-	desc = "An implant injected into the body, and later activated either manually or automatically upon death. Creates a moderately-sized fiery explosion. For those agents who know there is no going back."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	cost = 4
+/datum/uplink_item/implants/microbomb
+	name = "Microbomb Implant"
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. The more implants inside of you, the higher the explosive power."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
+	cost = 1
 
 
 //CYBERNETIC IMPLANTS
@@ -752,6 +752,12 @@ var/list/uplink_items = list()
 	name = "For showing that you are The Boss"
 	desc = "A useless red balloon with the syndicate logo on it, which can blow the deepest of covers."
 	item = /obj/item/toy/syndicateballoon
+	cost = 20
+
+/datum/uplink_item/implants/macrobomb
+	name = "Macrobomb Implant"
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. Maximum explosion power."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
 	cost = 20
 
 /datum/uplink_item/badass/random

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -180,7 +180,11 @@
 	U.hidden_uplink.uses = 20
 	synd_mob.equip_to_slot_or_del(U, slot_in_backpack)
 
-	var/obj/item/weapon/implant/weapons_auth/E = new/obj/item/weapon/implant/weapons_auth(synd_mob)
+	var/obj/item/weapon/implant/weapons_auth/W = new/obj/item/weapon/implant/weapons_auth(synd_mob)
+	W.imp_in = synd_mob
+	W.implanted = 1
+	W.implanted(synd_mob)
+	var/obj/item/weapon/implant/explosive/E = new/obj/item/weapon/implant/explosive(synd_mob)
 	E.imp_in = synd_mob
 	E.implanted = 1
 	E.implanted(synd_mob)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -116,7 +116,7 @@
 	medium = round(medium)
 	light = round(light)
 	imp_in.gib()
-	explosion(src,0,heavy,medium,light,light, flame_range = medium)
+	explosion(src,heavy,medium,light,light, flame_range = light)
 	qdel(src)
 
 /obj/item/weapon/implant/explosive/macro
@@ -129,7 +129,7 @@
 	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your macrobomb implant? This will cause you to explode and gib!", "Macrobomb Implant Confirmation", "Yes", "No") != "Yes")
 		return 0
 	imp_in.gib()
-	explosion(src,0,5,10,20,20, flame_range = 5)
+	explosion(src,5,10,20,20, flame_range = 20)
 	qdel(src)
 
 /obj/item/weapon/implant/chem

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -79,7 +79,7 @@
 	return dat
 
 /obj/item/weapon/implant/explosive
-	name = "explosive implant"
+	name = "microbomb implant"
 	desc = "And boom goes the weasel."
 	icon_state = "explosive"
 
@@ -101,12 +101,37 @@
 
 /obj/item/weapon/implant/explosive/activate(var/cause)
 	if(!cause || !imp_in)	return 0
-	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your explosive implant? This will cause you to explode and gib!", "Explosive Implant Confirmation", "Yes", "No") != "Yes")
+	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your microbomb implant? This will cause you to explode!", "Microbomb Implant Confirmation", "Yes", "No") != "Yes")
 		return 0
-	explosion(src,0,1,5,7,10, flame_range = 5)
-	if(imp_in)
+	var/light = 2
+	var/medium = 1
+	var/heavy = 0.5
+	for(var/obj/item/weapon/implant/explosive/E in imp_in)
+		heavy += 0.5
+		medium += 1
+		light += 2
+		if(E != src)
+			qdel(E)
+	heavy = round(heavy)
+	medium = round(medium)
+	light = round(light)
+	if(heavy >= 2)
 		imp_in.gib()
+	explosion(src,0,heavy,medium,light,light, flame_range = medium)
+	qdel(src)
 
+/obj/item/weapon/implant/explosive/macro
+	name = "macrobomb implant"
+	desc = "And boom goes the weasel. And everything else nearby."
+	icon_state = "explosive"
+
+/obj/item/weapon/implant/explosive/macro/activate(var/cause)
+	if(!cause || !imp_in)	return 0
+	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your macrobomb implant? This will cause you to explode and gib!", "Macrobomb Implant Confirmation", "Yes", "No") != "Yes")
+		return 0
+	imp_in.gib()
+	explosion(src,0,5,10,20,20, flame_range = 20)
+	qdel(src)
 
 /obj/item/weapon/implant/chem
 	name = "chem implant"

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -103,20 +103,19 @@
 	if(!cause || !imp_in)	return 0
 	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your microbomb implant? This will cause you to explode!", "Microbomb Implant Confirmation", "Yes", "No") != "Yes")
 		return 0
-	var/light = 2
-	var/medium = 1
-	var/heavy = 0.5
+	var/light = 1
+	var/medium = 0.5
+	var/heavy = 0.25
 	for(var/obj/item/weapon/implant/explosive/E in imp_in)
-		heavy += 0.5
-		medium += 1
-		light += 2
+		heavy += 0.25
+		medium += 0.5
+		light += 1
 		if(E != src)
 			qdel(E)
 	heavy = round(heavy)
 	medium = round(medium)
 	light = round(light)
-	if(heavy >= 2)
-		imp_in.gib()
+	imp_in.gib()
 	explosion(src,0,heavy,medium,light,light, flame_range = medium)
 	qdel(src)
 
@@ -130,7 +129,7 @@
 	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your macrobomb implant? This will cause you to explode and gib!", "Macrobomb Implant Confirmation", "Yes", "No") != "Yes")
 		return 0
 	imp_in.gib()
-	explosion(src,0,5,10,20,20, flame_range = 20)
+	explosion(src,0,5,10,20,20, flame_range = 5)
 	qdel(src)
 
 /obj/item/weapon/implant/chem

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -112,12 +112,22 @@
 	return
 */
 
-/obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	name = "Explosive Implant (with injector)"
+/obj/item/weapon/storage/box/syndie_kit/imp_microbomb
+	name = "Microbomb Implant (with injector)"
 
-/obj/item/weapon/storage/box/syndie_kit/imp_explosive/New()
+/obj/item/weapon/storage/box/syndie_kit/imp_microbomb/New()
 	var/obj/item/weapon/implanter/O = new(src)
 	O.imp = new /obj/item/weapon/implant/explosive(O)
+	O.update_icon()
+	..()
+	return
+
+/obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
+	name = "Macrobomb Implant (with injector)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_macrobomb/New()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/explosive/macro(O)
 	O.update_icon()
 	..()
 	return

--- a/html/changelogs/goofball-microbombs.yml
+++ b/html/changelogs/goofball-microbombs.yml
@@ -1,0 +1,11 @@
+# Your name.  
+author: Iamgoofball
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - rscadd: "Changes up how Explosive Implants work."
+  - rscadd: "They have become Microbomb Implants. They cost 1 TC each. Each implant you inject increases the size of the explosion."
+  - rscadd: "If you have 4 or more injected, you are guaranteed to be gibbed on activation." 
+  - rscadd: "A Macrobomb implant was added for 20 TC. It is the equivalent of injecting 20 microbombs."

--- a/html/changelogs/goofball-microbombs.yml
+++ b/html/changelogs/goofball-microbombs.yml
@@ -6,6 +6,6 @@ delete-after: True
 
 changes: 
   - rscadd: "Changes up how Explosive Implants work."
-  - rscadd: "They have become Microbomb Implants. They cost 1 TC each. Each implant you inject increases the size of the explosion."
-  - rscadd: "If you have 4 or more injected, you are guaranteed to be gibbed on activation." 
+  - rscadd: "They have become Microbomb Implants. They cost 1 TC each. Each implant you inject increases the size of the explosion. You gib on usage, regardless of explosion size."
   - rscadd: "A Macrobomb implant was added for 20 TC. It is the equivalent of injecting 20 microbombs."
+  - rscadd: "Nuke Ops start with microbomb implants again."


### PR DESCRIPTION
![nhfq0oc](https://cloud.githubusercontent.com/assets/4081722/8318905/1fb31ac2-19be-11e5-82a8-6a4080561133.jpg)
Changes up how Explosive Implants work.
They have become Microbomb Implants. They cost 1 TC each. Each implant you inject increases the size of the explosion. You gib when you activate them.
A Macrobomb implant was added for 20 TC, for those folks who want to buy 20 microbombs and inject them all. It is the equivalent of injecting 20 microbombs, aka 5, 10, 20, the maxcap.

Nuke ops start with microbomb implants again.

Supplementary video:
https://www.youtube.com/watch?v=s4VlruVG81w
