### PR TITLE
Alternate Nerf to Reactive Teleport Armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -118,9 +118,8 @@ emp_act
 			if(!isturf(picked)) return
 			if(buckled)
 				buckled.unbuckle_mob()
-			src.loc = picked
-			Weaken(5)
-			radiation += 10
+			forceMove(picked)
+			Weaken(2)
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -119,6 +119,8 @@ emp_act
 			if(buckled)
 				buckled.unbuckle_mob()
 			src.loc = picked
+			Weaken(5)
+			radiation += 10
 			return 1
 	return 0
 


### PR DESCRIPTION
Instead of getting a chance to fling you into space, you're stunned for 2 seconds upon landing.

It no longer irradiates you, that was removed from the PR.
