### PR TITLE
Fixes sleepy pen triggering morphine overdose message.

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -69,12 +69,12 @@
 	if(..())
 		if(reagents.total_volume)
 			if(M.reagents)
-				reagents.trans_to(M, 55)
+				reagents.trans_to(M, reagents.total_volume)
 
 
 /obj/item/weapon/pen/sleepy/New()
-	create_reagents(55)
-	reagents.add_reagent("morphine", 30)
+	create_reagents(45)
+	reagents.add_reagent("morphine", 20)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
 	..()


### PR DESCRIPTION
Having enough morphine to trigger the overdose message is bad for stealth...
Morphine amount reduced from 30 to 20u. That's still plenty of sleepy time. (around 3-4 minutes?)
Relevant thread: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=3780
