### PR TITLE
Fixes stomach rumbling message, large xenoqueen unconscious icon, stamina stacking on aliens 

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -84,7 +84,9 @@
 	overlays.Cut()
 	if(stat == DEAD)
 		icon_state = "queen_dead"
-	else if(stat == UNCONSCIOUS || lying || resting)
+	else if((stat == UNCONSCIOUS && !sleeping) || weakened)
+		icon_state = "queen_l"
+	else if(sleeping || lying || resting)
 		icon_state = "queen_sleep"
 	else
 		icon_state = "queen_s"

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -64,4 +64,5 @@
 	return 1
 
 /mob/living/carbon/alien/CheckStamina()
+	setStaminaLoss(max((staminaloss - 2), 0))
 	return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -38,9 +38,10 @@
 /mob/living/carbon/relaymove(var/mob/user, direction)
 	if(user in src.stomach_contents)
 		if(prob(40))
-			audible_message("<span class='warning'>You hear something rumbling inside [src]'s stomach...</span>", \
-						 "<span class='warning'>You hear something rumbling.</span>", 4,\
-						  "<span class='userdanger'>Something is rumbling inside your stomach!</span>")
+			if(prob(25))
+				audible_message("<span class='warning'>You hear something rumbling inside [src]'s stomach...</span>", \
+							 "<span class='warning'>You hear something rumbling.</span>", 4,\
+							  "<span class='userdanger'>Something is rumbling inside your stomach!</span>")
 			var/obj/item/I = user.get_active_hand()
 			if(I && I.force)
 				var/d = rand(round(I.force / 4), I.force)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -159,8 +159,8 @@ var/next_mob_id = 0
 	var/range = 7
 	if(hearing_distance)
 		range = hearing_distance
-	var/msg = message
 	for(var/mob/M in get_hearers_in_view(range, src))
+		var/msg = message
 		if(self_message && M==src)
 			msg = self_message
 		M.show_message( msg, 2, deaf_message, 1)


### PR DESCRIPTION
Fixes wrong message when a mob moves while inside another mob's stomach (problem was with audible_message proc). And also make the message appear less often. Fixes #9718 
Fixes large xenoqueen having wrong icon when unconscious. Fixes #9708 
Aliens now naturally recover from stamina damage. Fixes #10042 
