### PR TITLE
Buffs mining picks and drills

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -54,7 +54,7 @@
 	item_state = "pickaxe"
 	w_class = 4.0
 	m_amt = 3750 //one sheet, but where can you make them?
-	var/digspeed = 40
+	var/digspeed = 25
 	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
@@ -74,7 +74,7 @@
 	name = "mining drill"
 	icon_state = "handdrill"
 	item_state = "jackhammer"
-	digspeed = 25 //available from roundstart, faster than a pickaxe.
+	digspeed = 15
 	digsound = list('sound/weapons/drill.ogg')
 	hitsound = 'sound/weapons/drill.ogg'
 	origin_tech = "materials=2;powerstorage=3;engineering=2"


### PR DESCRIPTION
Mining is really, really, really slow compared to the rest of the game at this point. With the swing towards faster rounds, speeding up mining 's tools seems like a good idea.

Everything now goes down half a second a level.

Picks now take 2.5 seconds to mine instead of 4.

This is not the place to discuss the Crusher.
