### PR TITLE
Fixes runtime with do_after()'s that don't use a target.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -732,15 +732,16 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	for (var/i = 1 to numticks)
 		if(user.client)
 			progbar = make_progress_bar(i, numticks, target)
-			user.client.images |= progbar
+			if(progbar)
+				user.client.images |= progbar
 		sleep(delayfraction)
 		if(!user || user.stat || user.weakened || user.stunned  || !(user.loc == Uloc))
-			if(user && user.client)
+			if(user && user.client && progbar)
 				user.client.images -= progbar
 			return 0
 
 		if(Tloc && (!target || Tloc != target.loc)) //Tloc not set when we don't want to track target
-			if(user && user.client)
+			if(user && user.client && progbar)
 				user.client.images -= progbar
 			return 0 // Target no longer exists or has moved
 
@@ -749,18 +750,18 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			//i.e the hand is used to insert some item/tool into the construction
 			if(!holdingnull)
 				if(!holding)
-					if(user && user.client)
+					if(user && user.client && progbar)
 						user.client.images -= progbar
 					return 0
 			if(user.get_active_hand() != holding)
-				if(user && user.client)
+				if(user && user.client && progbar)
 					user.client.images -= progbar
 				return 0
-			if(user && user.client)
+			if(user && user.client && progbar)
 				user.client.images -= progbar
-		if(user && user.client)
+		if(user && user.client && progbar)
 			user.client.images -= progbar
-	if(user && user.client)
+	if(user && user.client && progbar)
 		user.client.images -= progbar
 	return 1
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -65,7 +65,7 @@
 		else
 			user.visible_message("<span class='warning'>[user] begins to do [H]'s lips with \the [src].</span>", \
 								 "<span class='notice'>You begin to apply \the [src] on [H]'s lips...</span>")
-			if(do_after(user, 20, target = H) && do_after(H, 20, 5, 0))	//user needs to keep their active hand, H does not.
+			if(do_after(user, 20, target = H))
 				user.visible_message("[user] does [H]'s lips with \the [src].", \
 									 "<span class='notice'>You apply \the [src] on [H]'s lips.</span>")
 				H.lip_style = "lipstick"

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -31,6 +31,9 @@
 			user << "<span class='caution'>You place the [F.name] back in the [name].</span>"
 			update_icon()
 			return
+		else if(glass_hp > 0)
+			toggle_open()
+
 	else if(istype(I, /obj/item/weapon))
 		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/weapon/W = I
@@ -122,7 +125,7 @@
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
 	user << "<span class = 'caution'> Resetting circuitry...</span>"
 	playsound(src, 'sound/machines/locktoggle.ogg', 50, 1)
-	if(do_after(user, 20))
+	if(do_after(user, 20, target = src))
 		user << "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>"
 		locked = !locked
 		update_icon()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -224,7 +224,7 @@
 			if(WT.remove_fuel(0,user))
 				user << "<span class='notice'>You begin repairing [src]...</span>"
 				playsound(loc, 'sound/items/Welder.ogg', 40, 1)
-				if(do_after(user, 40))
+				if(do_after(user, 40, target = src))
 					health = maxhealth
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 		else

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -49,7 +49,7 @@
 						if("Cannibalize")
 							if(D.health < D.maxHealth)
 								D.visible_message("[D] begins to cannibalize parts from [src].", "<span class='notice'>You begin to cannibalize parts from [src]...</span>")
-								if(do_after(D, 60,5,0))
+								if(do_after(D, 60,5,0, target = src))
 									D.visible_message("[D] repairs itself using [src]'s remains!", "<span class='notice'>You repair yourself using [src]'s remains.</span>")
 									D.adjustBruteLoss(-src.maxHealth)
 									new /obj/effect/decal/cleanable/oil/streak(get_turf(src))

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -391,7 +391,7 @@
 /obj/machinery/power/solar_control/attackby(I as obj, user as mob, params)
 	if(istype(I, /obj/item/weapon/screwdriver))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		if(do_after(user, 20))
+		if(do_after(user, 20, target = src))
 			if (src.stat & BROKEN)
 				user << "<span class='notice'>The broken glass falls out.</span>"
 				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )


### PR DESCRIPTION
- Fixes runtime with do_after()'s that don't use a target (caused by progress bar). Fixes #10167 
- Adding missing "target=src" to a couple do_after() calls.
- You can now close a fire axe cabinet by clicking it with a full hand (if it's not broken/locked)
