### PR TITLE
Justice Enforcer Security Crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -376,6 +376,15 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 30
 	containername = "security clothing crate"
 
+/////// Joke Crate Inbound
+
+/datum/supply_packs/security/justiceinbound
+	name = "Standard Justice Enforcer Crate"
+	contains = list(/obj/item/clothing/head/helmet/justice,
+					/obj/item/clothing/mask/gas/sechailer)
+	cost = 30 //justice comes at a price. An expensive, noisy price.
+	containername = "justice enforcer crate"
+
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////

--- a/html/changelogs/MMMiracles-thesoundofdapolice.yml
+++ b/html/changelogs/MMMiracles-thesoundofdapolice.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MMMiracles
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds a new crate to cargo in the security section, for when desperate times call for desperate measures."
+


### PR DESCRIPTION
So apparently this magnificent helmet (made by dannos I think) was added awhile ago, and has seen slim in-game use. This adds a crate to the manifest for when security really needs to get their LAW on.

:rotating_light:Example of proper law enforcement:rotating_light:
![justiceserved](https://cloud.githubusercontent.com/assets/9276171/8365620/4f15cf22-1b5c-11e5-9b2b-9bbda4c716f6.png)

The crate comes with 1 siren helmet and 1 sechailer for 30 points, security access-locked. It'd cost cargo 150 points to supply an entire 5-man security team with these incase cargo feels generous and security feels extra special that day. Combine with sec segways to become the ultimate security task force.
