### PR TITLE
Rainbow slimes finally obtainable

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -182,7 +182,9 @@
 			var/new_powerlevel = round(powerlevel / 4)
 			for(var/i=1,i<=4,i++)
 				var/mob/living/simple_animal/slime/M = new /mob/living/simple_animal/slime/(loc)
-				if(prob(mutation_chance))
+				if(mutation_chance >= 100)
+					M.colour = "rainbow"
+				else if(prob(mutation_chance))
 					M.colour = slime_mutation[rand(1,4)]
 				else
 					M.colour = colour

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -11,10 +11,9 @@
 
 /datum/chemical_reaction/slimespawn/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>"), 1)
 	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
 	S.loc = get_turf(holder.my_atom)
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
 
 /datum/chemical_reaction/slimeinaprov
 	name = "Slime epinephrine"
@@ -631,8 +630,7 @@
 
 /datum/chemical_reaction/slimeRNG/on_reaction(var/datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>"), 1)
 	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
 	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
 	S.loc = get_turf(holder.my_atom)
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -618,3 +618,21 @@
 	var/obj/P = new chosen
 	if(P)
 		P.loc = get_turf(holder.my_atom)
+
+//Rainbow :o)
+/datum/chemical_reaction/slimeRNG
+	name = "Random Core"
+	id = "slimerng"
+	result = null
+	required_reagents = list("plasma" = 1)
+	result_amount = 1
+	required_other = 1
+	required_container = /obj/item/slime_extract/rainbow
+
+/datum/chemical_reaction/slimeRNG/on_reaction(var/datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
+		O.show_message(text("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>"), 1)
+	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
+	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
+	S.loc = get_turf(holder.my_atom)

--- a/html/changelogs/incoming5643-rainbowslime.yml
+++ b/html/changelogs/incoming5643-rainbowslime.yml
@@ -1,0 +1,9 @@
+author: Incoming5643
+
+
+delete-after: True
+
+
+changes: 
+  - rscadd: "The secrets of the rainbow slimes have finally been revealed. To attain this rare blob you must breed a slime with a 100% mutation chance!"
+  - rscadd: "Rainbow slime cores will generate a randomly colored slime when injected with plasma. It's a good plan B if the slimes aren't cooperating in terms of colors. You can get any color slime this way, pray to the RNG!"


### PR DESCRIPTION
Rainbow slimes finally added to practical play. To get one you have to raise slimes through select breeding to 100 mutation chance. Even if you're blessed with RNG This will take a minimum of 14 generations of slime. Red slime can help speed this a bit, but then you're trading plasma for time. From the default mutation chance you'd have to drop 6 of these potions.

Rainbow slimes only split into more rainbow slimes.

Rainbow slime cores spawn a random colored slime with plasma, the practical use is to allow xenobiologists to get slimes from paths they didn't breed for initially if they practiced good slime eugenics along the way. You're still at the utter mercy of RNG though.

Mostly a bragging rights reward.
#708 I've avenged you at last!
