### PR TITLE
Implant tweaks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -754,12 +754,6 @@ var/list/uplink_items = list()
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
 
-/datum/uplink_item/implants/macrobomb
-	name = "Macrobomb Implant"
-	desc = "An implant injected into the body, and later activated either manually or automatically upon death. Maximum explosion power."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
-	cost = 20
-
 /datum/uplink_item/badass/random
 	name = "Random Item"
 	desc = "Picking this choice will send you a random item from the list. Useful for when you cannot think of a strategy to finish your objectives with."

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -115,6 +115,8 @@
 	heavy = round(heavy)
 	medium = round(medium)
 	light = round(light)
+	imp_in.visible_message("<span class = 'userdanger'>[imp_in] starts beeping ominously!</span>") // oh shit son get the fuck out of there
+	sleep(50)
 	imp_in.gib()
 	explosion(src,heavy,medium,light,light, flame_range = light)
 	qdel(src)
@@ -128,6 +130,8 @@
 	if(!cause || !imp_in)	return 0
 	if(cause == "action_button" && alert(imp_in, "Are you sure you want to activate your macrobomb implant? This will cause you to explode and gib!", "Macrobomb Implant Confirmation", "Yes", "No") != "Yes")
 		return 0
+	imp_in.visible_message("<span class = 'userdanger'>[imp_in] starts beeping ominously!</span>") // oh shit son get the fuck out of there
+	sleep(150)
 	imp_in.gib()
 	explosion(src,5,10,20,20, flame_range = 20)
 	qdel(src)


### PR DESCRIPTION
You can no longer buy macrobombs.

They still exist for the adminbus and for when I add them to deathsquaddies.

Microbombs now have a delay of 5 seconds before they go off, with a warning to those around them.

This lets them be used for denying loot and gives the others a chance to dodge instead of "lol u ded now"

Macrobombs have a 15 second delay.
