### PR TITLE
Blob changes to make reagent blob more counter-play friendly

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -89,22 +89,22 @@
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	..(1)
-	// On death, create a small smoke of harmful gas (s-Acid)
-	var/datum/effect/effect/system/chem_smoke_spread/S = new
-	var/turf/location = get_turf(src)
+	if(!is_zombie) 	// On death, create a small smoke of harmful gas
+		var/datum/effect/effect/system/chem_smoke_spread/S = new
+		var/turf/location = get_turf(src)
 
-	// Create the reagents to put into the air
-	create_reagents(25)
+		// Create the reagents to put into the air
+		create_reagents(25)
 
-	if(overmind && overmind.blob_reagent_datum)
-		reagents.add_reagent(overmind.blob_reagent_datum.id, 25)
-	else
-		reagents.add_reagent("spore", 25)
+		if(overmind && overmind.blob_reagent_datum)
+			reagents.add_reagent(overmind.blob_reagent_datum.id, 25)
+		else
+			reagents.add_reagent("spore", 25)
 
-	// Attach the smoke spreader and setup/start it.
-	S.attach(location)
-	S.set_up(reagents, 1, 1, location, 15, 1) // only 1-2 smoke cloud
-	S.start()
+		// Attach the smoke spreader and setup/start it.
+		S.attach(location)
+		S.set_up(reagents, 1, 1, location, 15, 1) // only 1-2 smoke cloud
+		S.start()
 
 	ghostize()
 	qdel(src)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -170,7 +170,7 @@
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
-	set name = "Create Blobbernaut (20)"
+	set name = "Create Blobbernaut (0)"
 	set desc = "Create a powerful blob-being, a Blobbernaut"
 
 	var/turf/T = get_turf(src)
@@ -185,9 +185,6 @@
 
 	if(!istype(B, /obj/effect/blob/factory))
 		src << "Unable to use this blob, find a factory blob."
-		return
-
-	if(!can_buy(20))
 		return
 
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
@@ -276,7 +273,8 @@
 	last_attack = world.time
 	OB.expand(T, 0, blob_reagent_datum.color)
 	for(var/mob/living/L in T)
-		blob_reagent_datum.reaction_mob(L, TOUCH)
+		if(!prob(L.run_armor_check(pick("chest","head"), "bio")))
+			blob_reagent_datum.reaction_mob(L, TOUCH)
 	OB.color = blob_reagent_datum.color
 	return
 

--- a/html/changelogs/incoming5643-blobs-up-big-time.yml
+++ b/html/changelogs/incoming5643-blobs-up-big-time.yml
@@ -1,0 +1,10 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "A couple of nerfs (and a buff) for blobs to make reagent blob play more survivable:"
+  - rscdel: "Blob zombies no longer release gas on death, but zombieless blob chicken nuggets still do."
+  - rscdel: "Clothes with some biological defense (like labcoats) now have a chance to negate the chemical effects of blob attacks. Armor with perfect biological armor (like spacesuits and biosuits) won't be affected by blob chem attacks at all."
+  - experiment: "This protection doesn't extend to clouds of blob gas, wear internals! Likewise blob attacks do minor brute damage even if their chem component is blocked."
+  - rscadd: "Creating a blobbernaut is now free (Due to previous nerfs and the loss of a factory node being a pretty big cost in itself)."


### PR DESCRIPTION
- Blob zombies no longer release gas on death, but zombieless blob chicken nuggets still do.
- Clothes with some biological defense (like labcoats) now have a chance to negate the chemical effects of blob attacks. Armor with perfect biological armor (like spacesuits and biosuits) won't be affected by blob chem attacks at all. [This protection doesn't extend to clouds of blob gas. Likewise blob attacks do minor brute damage even if their chem component is blocked.]
- Creating a blobbernaut is now free (Due to previous nerfs and the loss of a factory node being a pretty big cost in itself).

Ideas thrown at wall to see what sticks per request of @Iamgoofball 
