### PR TITLE
Suit Sensor Fixes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -212,17 +212,19 @@ BLIND     // can't see anything
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/fitted = FEMALE_UNIFORM_FULL // For use in alternate clothing styles for women
 	var/has_sensor = 1//For the crew computer 2 = unable to change mode
-	var/sensor_mode = 0
+	var/random_sensor = 1
+	var/sensor_mode = 0	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
 	var/can_adjust = 1
 	var/adjusted = 0
 	var/suit_color = null
-
-		/*
-		1 = Report living/dead
-		2 = Report detailed damages
-		3 = Report location
-		*/
 	var/obj/item/clothing/tie/hastie = null
+
+/obj/item/clothing/under/New()
+	if(random_sensor)
+		sensor_mode = pick(0,1,2,3)
+	adjusted = 0
+	suit_color = item_color
+	..()
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)
 	attachTie(I, user)
@@ -383,12 +385,6 @@ atom/proc/generate_female_clothing(index,t_color,icon,type)
 		if(istype(loc, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = loc
 			H.update_inv_w_uniform(0)
-
-/obj/item/clothing/under/New()
-	sensor_mode = pick(0,1,2,3)
-	adjusted = 0
-	suit_color = item_color
-	..()
 
 /obj/item/clothing/proc/weldingvisortoggle()			//Malk: proc to toggle welding visors on helmets, masks, goggles, etc.
 	if(can_use(usr))

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -7,6 +7,8 @@
 	desc = "It's a plain jumpsuit. It has a small dial on the wrist."
 	action_button_name = "Change"
 	origin_tech = "syndicate=3"
+	sensor_mode = 0 //Hey who's this guy on the Syndicate Shuttle??
+	random_sensor = 0
 	var/list/clothing_choices = list()
 	var/malfunctioning = 0
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -54,6 +54,7 @@
 	item_color = "prisoner"
 	has_sensor = 2
 	sensor_mode = 3
+	random_sensor = 0
 
 /obj/item/clothing/under/rank/mailman
 	name = "mailman's jumpsuit"

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -27,7 +27,7 @@
 			new /obj/item/weapon/reagent_containers/food/drinks/bottle/rum(src)
 			new /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia(src)
 			new /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey(src)
-			new /obj/item/weapon/lighter/zippo(src)
+			new /obj/item/weapon/lighter(src)
 		if(6 to 10)
 			new /obj/item/weapon/bedsheet(src)
 			new /obj/item/weapon/kitchen/knife(src)


### PR DESCRIPTION
-Chameleon jumpsuit sensors now start off
-Fixes unreported(?) bug where prisoner jumpsuits would start randomized when they are supposed to be always-on.
