### PR TITLE
Fixes aliens slashing cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -237,27 +237,25 @@
 	return
 
 /obj/machinery/camera/proc/deactivate(mob/user, displaymessage = 1) //this should be called toggle() but doing a find and replace for this would be ass
+	status = !status
+	cameranet.updateChunk(x, y, z)
+	var/change_msg = "deactivates"
+	if(!status)
+		icon_state = "[initial(icon_state)]1"
+	else
+		icon_state = initial(icon_state)
+		change_msg = "reactivates"
+		triggerCameraAlarm()
+		spawn(100)
+			cancelCameraAlarm()
 	if(displaymessage)
-		status = !status
-		if(!status)
-			if(user)
-				visible_message("<span class='danger'>[user] deactivates [src]!</span>")
-				add_hiddenprint(user)
-			else
-				visible_message("<span class='danger'>\The [src] deactivates!</span>")
-			icon_state = "[initial(icon_state)]1"
+		if(user)
+			visible_message("<span class='danger'>[user] [change_msg] [src]!</span>")
+			add_hiddenprint(user)
 		else
-			if(user)
-				visible_message("<span class='danger'>[user] reactivates [src]!</span>")
-				add_hiddenprint(user)
-			else
-				visible_message("<span class='danger'>\The [src] reactivates!</span>")
-			triggerCameraAlarm()
-			icon_state = initial(icon_state)
-			spawn(100)
-				cancelCameraAlarm()
+			visible_message("<span class='danger'>\The [src] [change_msg]!</span>")
+
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		cameranet.updateChunk(x, y, z)
 
 	// now disconnect anyone using the camera
 	//Apparently, this will disconnect anyone even if the camera was re-activated.


### PR DESCRIPTION
- cleans up camera deactivate(), the actual act of deactivating the camera doesn't depend on if we want to display a feedback message or not
- Aliens slashing cameras works now, fixes #10043
