### PR TITLE
Adds optional runtime logging

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -337,6 +337,11 @@
 					config.irc_first_connection_alert = 1
 				if("aggressive_changelog")
 					config.aggressive_changelog = 1
+				if("log_runtimes")
+					var/newlog = file("data/logs/runtimes/runtime-[time2text(world.realtime, "YYYY-MM-DD")].log")
+					if (world.log != newlog)
+						world.log << "Now logging runtimes to data/logs/runtimes/runtime-[time2text(world.realtime, "YYYY-MM-DD")].log"
+						world.log = newlog
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -191,3 +191,6 @@ NOTIFY_NEW_PLAYER_AGE 0
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG
+
+## Uncomment to have the game log runtimes to the log folder. (Note: this disables normal output in dd/ds, so it should be left off for testing.
+#LOG_RUNTIMES


### PR DESCRIPTION
Logs runtimes to file, changing runtime location at the end of the day, etc.

Has a config option that defaults to off to keep it from bugging coders.

The file format is to match what the server-tools already does to make it compatible with that (where all it would really do is just change the file over at the end of the day).

This is needed because the server isn't crashing as often, and having 10 days of runtime logs over 6 updates inside one file isn't really useful.
