### PR TITLE
Add Syndicate surgery bag to uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -501,6 +501,12 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/toolbox/syndicate
 	cost = 1
 
+/datum/uplink_item/device_tools/surgerybag
+	name = "Syndicate Surgery Dufflebag"
+	desc = "The Syndicate surgery dufflebag is a toolkit containing all surgery tools, surgical drapes, a Syndicate brand MMI, a straitjacket, and a muzzle."
+	item = /obj/item/weapon/storage/backpack/dufflebag/syndiesurgery
+	cost = 5
+
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"
 	desc = "The syndicate medkit is a suspicious black and red. Included is a combat stimulant injector for rapid healing, a medical hud for quick identification of injured comrades, \

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -199,7 +199,9 @@
 			if(!user.unEquip(W))
 				return
 
+			var/syndiemmi = 0
 			if(istype(W, /obj/item/device/mmi/syndie))
+				syndiemmi = 1
 				aisync = 0
 				lawsync = 0
 				O.laws = new /datum/ai_laws/syndicate_override
@@ -216,7 +218,7 @@
 				O.notify_ai(1)
 				if(forced_ai)
 					O.connected_ai = forced_ai
-			if(!lawsync)
+			if(!lawsync && !syndiemmi)
 				O.lawupdate = 0
 				O.make_laws()
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -199,9 +199,7 @@
 			if(!user.unEquip(W))
 				return
 
-			var/syndiemmi = 0
-			if(istype(W, /obj/item/device/mmi/syndie))
-				syndiemmi = 1
+			if(M.syndiemmi)
 				aisync = 0
 				lawsync = 0
 				O.laws = new /datum/ai_laws/syndicate_override
@@ -218,7 +216,7 @@
 				O.notify_ai(1)
 				if(forced_ai)
 					O.connected_ai = forced_ai
-			if(!lawsync && !syndiemmi)
+			if(!lawsync && !M.syndiemmi)
 				O.lawupdate = 0
 				O.make_laws()
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -199,6 +199,13 @@
 			if(!user.unEquip(W))
 				return
 
+			var/syndiemmi = 0
+			if(istype(W, /obj/item/device/mmi/syndie))
+				syndiemmi = 1
+				aisync = 0
+				lawsync = 0
+				O.laws = new /datum/ai_laws/syndicate_override
+
 			O.invisibility = 0
 			//Transfer debug settings to new mob
 			O.custom_name = created_name
@@ -211,7 +218,7 @@
 				O.notify_ai(1)
 				if(forced_ai)
 					O.connected_ai = forced_ai
-			if(!lawsync)
+			if(!lawsync && !syndiemmi)
 				O.lawupdate = 0
 				O.make_laws()
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -199,9 +199,7 @@
 			if(!user.unEquip(W))
 				return
 
-			var/syndiemmi = 0
 			if(istype(W, /obj/item/device/mmi/syndie))
-				syndiemmi = 1
 				aisync = 0
 				lawsync = 0
 				O.laws = new /datum/ai_laws/syndicate_override
@@ -218,7 +216,7 @@
 				O.notify_ai(1)
 				if(forced_ai)
 					O.connected_ai = forced_ai
-			if(!lawsync && !syndiemmi)
+			if(!lawsync)
 				O.lawupdate = 0
 				O.make_laws()
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -330,6 +330,27 @@
 	new /obj/item/ammo_box/magazine/m12g/dragon(src)
 	return
 
+/obj/item/weapon/storage/backpack/dufflebag/syndiesurgery
+	name = "Syndicate surgery dufflebag"
+	desc = "A menacingly looking dufflebag for holding surgery tools."
+	icon_state = "duffle-syndiemed"
+	item_state = "duffle-syndiemed"
+	storage_slots = 10
+
+/obj/item/weapon/storage/backpack/dufflebag/syndiesurgery/New()
+	..()
+	contents = list()
+	new /obj/item/weapon/scalpel(src)
+	new /obj/item/weapon/hemostat(src)
+	new /obj/item/weapon/retractor(src)
+	new /obj/item/weapon/circular_saw(src)
+	new /obj/item/weapon/surgicaldrill(src)
+	new /obj/item/weapon/cautery(src)
+	new /obj/item/weapon/surgical_drapes(src)
+	new /obj/item/clothing/suit/straight_jacket(src)
+	new /obj/item/clothing/mask/muzzle(src)
+	new /obj/item/device/mmi/syndie(src)
+	return
 
 /obj/item/weapon/storage/backpack/dufflebag/captain
 	name = "captain's dufflebag"
@@ -362,3 +383,4 @@
 	desc = "A large dufflebag for holding lots of funny gags!"
 	icon_state = "duffle-clown"
 	item_state = "duffle-clown"
+

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -149,6 +149,10 @@
 					user << "<span class='warning'>This MMI does not seem to fit!</span>"
 					return
 
+				if(istype(P, /obj/item/device/mmi/syndie))
+					user << "<span class='warning'>This MMI does not seem to fit!</span>"
+					return
+
 				if(!M.brainmob.mind)
 					user << "<span class='warning'>This MMI is mindless!</span>"
 					return

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -149,7 +149,7 @@
 					user << "<span class='warning'>This MMI does not seem to fit!</span>"
 					return
 
-				if(istype(P, /obj/item/device/mmi/syndie))
+				if(M.syndiemmi)
 					user << "<span class='warning'>This MMI does not seem to fit!</span>"
 					return
 

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -182,3 +182,7 @@
 		else
 			user << "<span class='notice'>The MMI indicates the brain is active.</span>"
 
+
+/obj/item/device/mmi/syndie
+	name = "Syndicate Man-Machine Interface"
+	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs created with it, but doesn't fit in Nanotrasen AI cores."

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -14,6 +14,7 @@
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.
 
 	var/locked = 0
+	var/syndiemmi = 0 //Whether or not this is a Syndicate MMI
 	var/mob/living/carbon/brain/brainmob = null //The current occupant.
 	var/mob/living/silicon/robot = null //Appears unused.
 	var/obj/mecha = null //This does not appear to be used outside of reference in mecha.dm.
@@ -186,3 +187,4 @@
 /obj/item/device/mmi/syndie
 	name = "Syndicate Man-Machine Interface"
 	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs created with it, but doesn't fit in Nanotrasen AI cores."
+	syndiemmi = 1


### PR DESCRIPTION
- Adds a Syndicate surgery bag to uplinks, letting you order it for 5 TC
- It contains drapes, all surgery tools, a straitjacket, a muzzle, and a Syndicate MMI
- The Syndicate MMI functions like any other MMI but can't be placed in an AI core, and if inserted into a cyborg body, the cyborg will be unlinked and will have Syndicate laws (same as when you emag a normal borg)
