### PR TITLE
Jetpack speed changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -738,7 +738,7 @@
 				if(P.allow_thrust(0.01, H))
 					hasjetpack = 1
 
-			mspeed = 1 - hasjetpack
+			mspeed = -1 - hasjetpack
 
 		if(grav || !hasjetpack)
 			var/health_deficiency = (100 - H.health + H.staminaloss)
@@ -763,11 +763,12 @@
 
 			mspeed += speedmod
 
-	if(H.status_flags & GOTTAGOFAST)
-		mspeed -= 1
+		if(grav)
+			if(H.status_flags & GOTTAGOFAST)
+				mspeed -= 1
 
-	if(H.status_flags & GOTTAGOREALLYFAST)
-		mspeed -= 2
+			if(H.status_flags & GOTTAGOREALLYFAST)
+				mspeed -= 2
 
 	return mspeed
 

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,7 +7,8 @@
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
-MrStonedOne = Host
+Optimumtact = Host
+MrStonedOne = Game Master
 microscopics = Game Master
 Gun Hog = Game Master
 KorPhaeron = Game Master

--- a/html/changelogs/oranges_nevernottimetofast.yml
+++ b/html/changelogs/oranges_nevernottimetofast.yml
@@ -1,0 +1,4 @@
+author: oranges
+delete-after: True
+changes: 
+  - tweak rscadd: "Thanks to a breakthrough in directed vector thrusting, all nanotrasen brand jetpacks have been greatly improved in speed and handling"


### PR DESCRIPTION
being in zero grav now gives a -1 speedup (as if you had gottagofast)
being in zero grav with a jetpack gives -2 (gottagoreallyfast)

SPEED FLAGS NOW ONLY APPLY IN SITUATIONS WITH GRAVITY

I guess
fixes #10166
