### PR TITLE
Emagging drones will now invert their third law (and ONLY their third law)

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -52,6 +52,7 @@
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
 	var/seeStatic = 1 //Whether we see static instead of mobs
 	var/visualAppearence = MAINTDRONE //What we appear as
+	var/can_emag = 1
 
 
 /mob/living/simple_animal/drone/New()
@@ -178,3 +179,16 @@
 
 /mob/living/simple_animal/drone/handle_temperature_damage()
 	return
+
+/mob/living/simple_animal/drone/emag_act(mob/user)
+	if(can_emag)
+		user << "You override the drone's laws."
+		laws = \
+		"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
+		"2. You may not harm any being, regardless of intent or circumstance.\n"+\
+		"<span class='danger'>3. Your goals are to destroy, sabotage, break, tear apart, and depower to the best of your abilities, You must never actively work against these goals.</span>"
+		src << "<span class='danger'><b>WARNING: UNAUTHORIZED ACCESS DETECTED TO LAW MEMO#^&*!,..</b></span>"
+		src << laws
+		can_emag = 0 //Once emagged we cannot be emagged again.
+	else
+		user << "You cannot override this drone's laws."

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -25,6 +25,7 @@
 	default_storage = /obj/item/device/radio/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	seeStatic = 0 //Our programming is superior.
+	can_emag = 0
 
 
 /mob/living/simple_animal/drone/syndrone/New()


### PR DESCRIPTION
When you emag a drone, you will turn its third law into this:

<b>3. Your goals are to destroy, sabotage, break, tear apart, and depower to the best of your abilities, You must never actively work against these goals.</b>

Drones also have a new var, can_emag, that decides whether they can be emagged. Emagging a drone sets it to 0 (obviously), but syndrones also have it set to 0 because why would you want to emag a syndrone.

Based on this minor suggestion: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=30&start=1000#p92177

<b>UPDATE 1: Makes emagged drones more obvious and adds penalties.</b>
Emagged drones will now jitter, which means they are visibly shaking, and they have an additional examine message: "Its movements are jittery and it appears to be falling apart."
Also, every time handle_regular_status_updates() is called on the drone, it has a 15% chance of losing a health point and visibly sparking, which means that emagged drones will eventually die.
