### PR TITLE
Fixes a runtime with shreds when it is burnt.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -162,3 +162,4 @@
 /obj/effect/decal/cleanable/shreds/New()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
+	..()


### PR DESCRIPTION
Fixes cleanable/shreds/New() not calling its parent.

The runtime:
runtime error: Cannot read null.chem_temp
proc name: fire act (/obj/effect/decal/cleanable/fire_act)
  source file: cleanable.dm,40 
