### PR TITLE
Finishes the never actually finished forbidden steal item system

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -348,7 +348,7 @@ var/global/list/possible_items = list()
 /datum/objective/steal/find_target()
 	var/approved_targets = list()
 	for(var/datum/objective_item/possible_item in possible_items)
-		if(is_unique_objective(possible_item.targetitem))
+		if(is_unique_objective(possible_item.targetitem) && !(owner.current.mind.assigned_role in possible_item.excludefromjob))
 			approved_targets += possible_item
 	return set_target(safepick(possible_items))
 


### PR DESCRIPTION
Items to steal should not come up for jobs that readily had access to said items.

The bulk of this was done a long time ago by @Cheridan , they just never dropped the final line in for some reason

Fixes #10247 
Fixes #4195
