### PR TITLE
Medical records console gives your ID into your hand

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -211,7 +211,10 @@
 			src.temp = null
 		if(href_list["scan"])
 			if(src.scan)
-				src.scan.loc = src.loc
+				if(istype(usr,/mob/living/carbon/human) && !usr.get_active_hand())
+					usr.put_in_hands(scan)
+				else
+					scan.loc = get_turf(src)
 				src.scan = null
 			else
 				var/obj/item/I = usr.get_active_hand()


### PR DESCRIPTION
When you take your ID from the Medical Records Console, it now gives your ID into your active hand slot instead of being a dick about it and just spitting it on itself. Works now the same way as the HoP's identification console and security records console.

Inform me if there are any other consoles that need fixing so they all do the same thing.
