### PR TITLE
Tweaks space drug overdose and space drug blob effect.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -166,6 +166,7 @@
 /datum/reagent/blob/spacedrugs/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
 	if(method == TOUCH)
 		var/ratio = volume/25
+		M.hallucination += 20*ratio
 		M.reagents.add_reagent("space_drugs", 15*ratio)
 		M.apply_damage(10*ratio, TOX)
 

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -10,7 +10,7 @@
 	id = "space_drugs"
 	description = "An illegal chemical compound used as drug."
 	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 25
+	overdose_threshold = 30
 
 /datum/reagent/drug/space_drugs/on_mob_life(var/mob/living/M as mob)
 	M.druggy = max(M.druggy, 15)
@@ -22,11 +22,13 @@
 	..()
 	return
 
+/datum/reagent/drug/space_drugs/overdose_start(var/mob/living/M as mob)
+	M << "<span class='userdanger'>You start tripping hard!</span>"
+
+
 /datum/reagent/drug/space_drugs/overdose_process(var/mob/living/M as mob)
-	if(prob(20))
-		M.hallucination = max(M.hallucination, 5)
-	M.adjustBrainLoss(0.25*REM)
-	M.adjustToxLoss(0.25*REM)
+	if(M.hallucination < volume && prob(20))
+		M.hallucination += 5
 	..()
 	return
 

--- a/html/changelogs/phil235-SpaceDrugOverdoseTweak.yml
+++ b/html/changelogs/phil235-SpaceDrugOverdoseTweak.yml
@@ -1,0 +1,8 @@
+
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "Space drug overdose no longer cause brute/brain damage but you hallucinate more. Space Drug Blob now makes you hallucinate even if you don't overdose on its space drug."
+


### PR DESCRIPTION
Alternative to #9742 
Space drug overdose threshold  raised from 25 to 30. 
Remove the brain and brute damage from space drug overdose effects.
To compensate this tiny nerf to space drugs blob I added a direct hallucination effect upon being touched by that blob.
