### PR TITLE
Gang Update: Implants Edition

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -328,11 +328,11 @@
 			carbon_mob.silent = max(carbon_mob.silent, 5)
 			carbon_mob.flash_eyes(1, 1)
 		gangster_mind.current.Stun(5)
-	gangster_mind.current << "<FONT size=3 color=red><B>You are now a member of the [gang=="A" ? gang_name("A") : gang_name("B")] Gang!</B></FONT>"
+	gangster_mind.current << "<FONT size=3 color=red><B>You are now a member of the [gang_name(gang)] Gang!</B></FONT>"
 	gangster_mind.current << "<font color='red'>Help your bosses take over the station by claiming territory with <b>special spraycans</b> only they can provide. Simply spray on any unclaimed area of the station.</font>"
 	gangster_mind.current << "<font color='red'>You can identify your bosses by their <b>red \[G\] icon</b>.</font>"
-	gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has been converted to the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]!</font>"
-	gangster_mind.special_role = "[gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]"
+	gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has been converted to the [gang_name(gang)] Gang ([gang])!</font>"
+	gangster_mind.special_role = "[gang_name(gang)] Gang ([gang])"
 	update_gang_icons_added(gangster_mind,gang)
 	return 2
 ////////////////////////////////////////////////////////////////////
@@ -363,13 +363,13 @@
 
 	gangster_mind.special_role = null
 	if(silent < 2)
-		gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has reformed and defected from the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"]!</font>"
+		gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has reformed and defected from the [gang_name(gang)] Gang ([gang])!</font>"
 
 		if(beingborged)
 			if(!silent)
 				gangster_mind.current.visible_message("The frame beeps contentedly from the MMI before initalizing it.")
 			gangster_mind.current << "<FONT size=3 color=red><B>The frame's firmware detects and deletes your criminal behavior! You are no longer a gangster!</B></FONT>"
-			message_admins("[key_name_admin(gangster_mind.current)] <A HREF='?_src_=holder;adminmoreinfo=\ref[gangster_mind.current]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[gangster_mind.current]'>FLW</A>) has been borged while being a member of the [gang=="A" ? "[gang_name("A")] Gang (A)" : "[gang_name("B")] Gang (B)"] Gang. They are no longer a gangster.")
+			message_admins("[key_name_admin(gangster_mind.current)] <A HREF='?_src_=holder;adminmoreinfo=\ref[gangster_mind.current]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[gangster_mind.current]'>FLW</A>) has been borged while being a member of the [gang_name(gang)] Gang ([gang]). They are no longer a gangster.")
 		else
 			if(!silent)
 				gangster_mind.current.Paralyse(5)
@@ -420,7 +420,7 @@
 	if(!finished)
 		world << "<FONT size=3 color=red><B>The station was [station_was_nuked ? "destroyed!" : "evacuated before either gang could claim it!"]</B></FONT>"
 	else
-		world << "<FONT size=3 color=red><B>The [finished=="A" ? gang_name("A") : gang_name("B")] Gang successfully performed a hostile takeover of the station!!</B></FONT>"
+		world << "<FONT size=3 color=red><B>The [get_gang_bosses(finished)] Gang successfully performed a hostile takeover of the station!!</B></FONT>"
 	..()
 	return 1
 

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -191,9 +191,7 @@
 		. += 1
 	else
 		gangtool.register_device(mob)
-		mob << "The <b>Gangtool</b> in your [where] will allow you to use your influence to purchase weapons and equipment and communicate with your gangsters."
-		if(isboss)
-			mob << "<b>As the Gang Boss</b> you also have the power to recall the emergency shuttle from anywhere on the station."
+		mob << "The <b>Gangtool</b> in your [where] will allow you to purchase weapons and equipment, send messages to your gang, and recall the emergency shuttle from anywhere on the station."
 
 	var/where2 = mob.equip_in_one_of_slots(T, slots)
 	if (!where2)

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -6,10 +6,11 @@
 	var/cooldown
 
 /obj/item/weapon/pen/gang/attack(mob/living/M, mob/user)
-	if(!istype(M))	return
-	if(..(M,user,1))
-		if(ishuman(M) && ishuman(user) && M.stat != DEAD)
-			if(user.mind && ((user.mind in ticker.mode.A_bosses) || (user.mind in ticker.mode.B_bosses)))
+	if(!istype(M))
+		return
+	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
+		if(user.mind && ((user.mind in ticker.mode.A_bosses) || (user.mind in ticker.mode.B_bosses)))
+			if(..(M,user,1))
 				if(cooldown)
 					user << "<span class='warning'>[src] needs more time to recharge before it can be used.</span>"
 					return
@@ -35,6 +36,8 @@
 								user << "<span class='warning'>This mind is resistant to recruitment!</span>"
 							else
 								user << "<span class='warning'>This mind has already been recruited into a gang!</span>"
+			return
+	..()
 
 /obj/item/weapon/pen/gang/proc/cooldown(modifier)
 	cooldown = 1

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -44,3 +44,72 @@
 		icon_state = "pen"
 		var/mob/M = get(src, /mob)
 		M << "<span class='notice'>\icon[src] [src][(src.loc == M)?(""):(" in your [src.loc]")] vibrates softly.</span>"
+
+
+/obj/item/weapon/implant/gang
+	name = "gang implant"
+	desc = "Makes you a gangster or such."
+	activated = 0
+
+/obj/item/weapon/implant/gang/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Criminal Loyalty Implant<BR>
+				<b>Life:</b> A few seconds after injection.<BR>
+				<b>Important Notes:</b> Illegal<BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a small pod of nanobots that change the host's brain to be loyal to a certain organization.<BR>
+				<b>Special Features:</b> This device will also emit a small EMP pulse, destroying any other implants within the host's brain.<BR>
+				<b>Integrity:</b> Implant's EMP function will destroy itself in the process."}
+	return dat
+
+
+//////////////
+// IMPLANTS //
+//////////////
+
+/obj/item/weapon/implant/gang
+	name = "gang implant"
+	desc = "Makes you a gangster or such."
+	activated = 0
+	var/gang
+
+/obj/item/weapon/implant/gang/New(loc,var/setgang)
+	..()
+	gang = setgang
+
+/obj/item/weapon/implant/gang/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Criminal Loyalty Implant<BR>
+				<b>Life:</b> A few seconds after injection.<BR>
+				<b>Important Notes:</b> Illegal<BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a small pod of nanobots that change the host's brain to be loyal to a certain organization.<BR>
+				<b>Special Features:</b> This device will also emit a small EMP pulse, destroying any other implants within the host's brain.<BR>
+				<b>Integrity:</b> Implant's EMP function will destroy itself in the process."}
+	return dat
+
+/obj/item/weapon/implant/gang/implanted(mob/target)
+	..()
+	for(var/obj/item/weapon/implant/I in target)
+		if(I != src)
+			qdel(I)
+
+	ticker.mode.remove_gangster(target.mind,0,1,1)
+	if(ticker.mode.add_gangster(target.mind,gang))
+		target.Paralyse(5)
+	else
+		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the influence of your enemies try to invade your mind!</span>")
+	qdel(src)
+
+/obj/item/weapon/implanter/gang
+	name = "implanter-gang"
+
+/obj/item/weapon/implanter/gang/New(loc,var/gang)
+	if(!gang)
+		qdel(src)
+		return
+	imp = new /obj/item/weapon/implant/gang(src,gang)
+	..()
+	update_icon()

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -46,24 +46,6 @@
 		M << "<span class='notice'>\icon[src] [src][(src.loc == M)?(""):(" in your [src.loc]")] vibrates softly.</span>"
 
 
-/obj/item/weapon/implant/gang
-	name = "gang implant"
-	desc = "Makes you a gangster or such."
-	activated = 0
-
-/obj/item/weapon/implant/gang/get_data()
-	var/dat = {"<b>Implant Specifications:</b><BR>
-				<b>Name:</b> Criminal Loyalty Implant<BR>
-				<b>Life:</b> A few seconds after injection.<BR>
-				<b>Important Notes:</b> Illegal<BR>
-				<HR>
-				<b>Implant Details:</b><BR>
-				<b>Function:</b> Contains a small pod of nanobots that change the host's brain to be loyal to a certain organization.<BR>
-				<b>Special Features:</b> This device will also emit a small EMP pulse, destroying any other implants within the host's brain.<BR>
-				<b>Integrity:</b> Implant's EMP function will destroy itself in the process."}
-	return dat
-
-
 //////////////
 // IMPLANTS //
 //////////////
@@ -102,9 +84,6 @@
 	else
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the influence of your enemies try to invade your mind!</span>")
 	qdel(src)
-
-/obj/item/weapon/implanter/gang
-	name = "implanter-gang"
 
 /obj/item/weapon/implanter/gang/New(loc,var/gang)
 	if(!gang)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -239,6 +239,7 @@
 			if("pen")
 				if(points >= 50)
 					item_type = /obj/item/weapon/pen/gang
+					usr << "<span class='notice'>More <b>recruitmen pens</b> will allow you to recruit gangsters faster. Only gang leaders can recruit with pens.</span>"
 					points = 50
 			if("implant")
 				if(points >= 10)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -25,8 +25,6 @@
 	if (!can_use(user))
 		return
 
-	var/gang_bosses = ((gang == "A")? ticker.mode.A_bosses.len : ticker.mode.B_bosses.len)
-
 	var/dat
 	if(!gang)
 		dat += "This device is not registered.<br><br>"
@@ -36,7 +34,7 @@
 		if(istype(ticker.mode, /datum/game_mode/gang))
 			gangmode = ticker.mode
 
-		var/gang_size = gang_bosses + ((gang == "A")? ticker.mode.A_gang.len : ticker.mode.B_gang.len)
+		var/gang_size = ((gang == "A")? (ticker.mode.A_bosses.len+ticker.mode.A_gang.len) : (ticker.mode.B_bosses.len+ticker.mode.B_gang.len))
 		var/gang_territory = ((gang == "A")? ticker.mode.A_territory.len : ticker.mode.B_territory.len)
 		var/points = ((gang == "A") ? ticker.mode.gang_points.A : ticker.mode.gang_points.B)
 		var/timer
@@ -45,7 +43,7 @@
 			if(isnum(timer))
 				dat += "<center><font color='red'>Takeover In Progress:<br><B>[timer] seconds remain</B></font></center><br>"
 
-		dat += "Registration: <B>[(gang == "A")? gang_name("A") : gang_name("B")] Gang [boss ? "Boss" : "Lieutenant"]</B><br>"
+		dat += "Registration: <B>[gang_name(gang)] Gang [boss ? "Boss" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang_size]</B> | Station Control: <B>[round((gang_territory/start_state.num_territories)*100, 1)]%</B><br>"
 		dat += "Gang Influence: <B>[points]</B> | Outfit Stock: <B>[outfits]</B><br>"
 		dat += "Time until Influence grows: <B>[(points >= 999) ? ("--:--") : (time2text(ticker.mode.gang_points.next_point_time - world.time, "mm:ss"))]</B><br>"
@@ -245,7 +243,7 @@
 			if("implant")
 				if(points >= 10)
 					item_type = /obj/item/weapon/implanter/gang
-					usr << "<span class='notice'>The <b>implant breaker</b> destroys all other implants within the target before trying to recruit them to your gang. Implant is destroyed after one use.</span>"
+					usr << "<span class='notice'>The <b>implant breaker</b> is a single-use device that destroys all implants within the target before trying to recruit them to your gang. Also works on enemy gangsters.</span>"
 					points = 10
 			if("gangtool")
 				if(points >= 30)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -55,7 +55,7 @@
 			dat += "<a href='?src=\ref[src];choice=outfit'>Create Armored Gang Outfit</a><br>"
 		else
 			dat += "<b>Create Gang Outfit</b> (Restocking)<br>"
-		if(gangmode && boss)
+		if(gangmode)
 			dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 
 		dat += "<br>"
@@ -184,6 +184,10 @@
 
 	add_fingerprint(usr)
 
+	if(recalling)
+		usr << "<span class='warning'>Device is busy. Shuttle recall in progress.</span>"
+		return
+
 	if(href_list["register"])
 		register_device(usr)
 
@@ -294,8 +298,7 @@
 	else if(href_list["choice"])
 		switch(href_list["choice"])
 			if("recall")
-				if(boss)
-					recall(usr)
+				recall(usr)
 			if("outfit")
 				if(outfits > 0)
 					if(ticker.mode.gang_outfit(usr,src,gang))

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -241,12 +241,12 @@
 	if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(target))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
-	if(target.mind in ticker.mode.revolutionaries)
-		ticker.mode.remove_revolutionary(target.mind)
 	if(target.mind in (ticker.mode.A_gang | ticker.mode.B_gang))
 		ticker.mode.remove_gangster(target.mind,exclude_bosses=1)
 		target.visible_message("<span class='warning'>[src] was destroyed in the process!</span>", "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
-		return
+		return 0
+	if(target.mind in ticker.mode.revolutionaries)
+		ticker.mode.remove_revolutionary(target.mind)
 	if(target.mind in ticker.mode.cult)
 		target << "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>"
 	else

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -238,17 +238,24 @@
 
 /obj/item/weapon/implant/loyalty/implanted(mob/target)
 	..()
-	if((target.mind in ticker.mode.head_revolutionaries) || is_shadow_or_thrall(target))
+	if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(target))
 		target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		return 0
 	if(target.mind in ticker.mode.revolutionaries)
 		ticker.mode.remove_revolutionary(target.mind)
-	if(target.mind in (ticker.mode.cult| ticker.mode.A_bosses | ticker.mode.B_bosses | ticker.mode.A_gang | ticker.mode.B_gang))
+	if(target.mind in (ticker.mode.A_gang | ticker.mode.B_gang))
+		ticker.mode.remove_gangster(target.mind,exclude_bosses=1)
+		target.visible_message("<span class='warning'>[src] was destroyed in the process!</span>", "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
+		return
+	if(target.mind in ticker.mode.cult)
 		target << "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>"
 	else
 		target << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"
 	return 1
 
+/obj/item/weapon/implant/loyalty/Destroy()
+	loc << "<span class='notice'><b>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</b></span>"
+	..()
 
 /obj/item/weapon/implant/adrenalin
 	name = "adrenal implant"

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -20,11 +20,16 @@
 	if(!iscarbon(M))
 		return
 	if(user && imp)
+		if(M.head)
+			user << "<span class='warning'>[M]'s [M.head.name] is in the way! Take it off first!</span>"
+			return
 		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
 
 		var/turf/T = get_turf(M)
 		if(T && (M == user || do_after(user, 50, target = M)))
 			if(user && M && (get_turf(M) == T) && src && imp)
+				if(M.head)
+					return
 				M.visible_message("[user] has implanted [M].", "<span class='notice'>[user] implants you with the implant.</span>")
 				add_logs(user, M, "implanted", object="[name]")
 				user << "<span class='notice'>You implant the implant into [M].</span>"

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -26,8 +26,6 @@
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
 		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
-		if(istype(I, /obj/item/weapon/implant/loyalty))
-			target << "<span class='notice'><b>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</b></span>"
 		qdel(I)
 		if(istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target

--- a/html/changelogs/ikarrus-penis.yml
+++ b/html/changelogs/ikarrus-penis.yml
@@ -34,7 +34,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "Multiple gang leaders are spawned at round start, the number which depends on server population"
-  - tweak: "Only the gang boss can recall the shuttle"
   - rscdel: "Gangsters can no longer be promoted mid-game."
   - rscadd: "Security can once again deconvert gangsters with loyalty implants"
   - rscadd: "Added an Implant Breaker item to the gangtool as a purchasable item for 10 influence each<BR>* They are a one-use item that destroys all implants in the target, including loyalty implants<BR>* They will also attempt to recruit the target before destroying itself"

--- a/html/changelogs/ikarrus-penis.yml
+++ b/html/changelogs/ikarrus-penis.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Multiple gang leaders are spawned at round start, the number which depends on server population"
+  - tweak: "Only the gang boss can recall the shuttle"
+  - rscdel: "Gangsters can no longer be promoted mid-game."
+  - rscadd: "Security can once again deconvert gangsters with loyalty implants"
+  - rscadd: "Added an Implant Breaker item to the gangtool as a purchasable item for 10 influence each<BR>* They are a one-use item that destroys all implants in the target, including loyalty implants<BR>* They will also attempt to recruit the target before destroying itself"
+  - rscdel: "Implanters no longer work if the target is wearing headgear. Remove them first."

--- a/html/changelogs/ikarrus-penis.yml
+++ b/html/changelogs/ikarrus-penis.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Ikarrus
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
### Loyalty & Gang Implants
- Security can once again deconvert gangsters with loyalty implants
  - A message is shown if the deconversion destroys the implant in the process
- Added an Implant Breaker item to the gangtool as a purchasable item for 10 influence each
  - They are a one-use item that destroys all implants in the target, including loyalty implants
  - They will also attempt to recruit the target before destroying itself
  - Can recruit enemy gangsters
  - As this is an implanter it requires the target to remain still for a few seconds to administer it
- Implanters no longer work if the target is wearing headgear. Remove them first
### Gang Leaders
- Multiple gang leaders are spawned at round start, the number which depends on server population
  - 1 to 3 leaders per gang
  - Only one boss per gang, the rest are lieutenants
- Gangsters can no longer be promoted mid-game.
### Minor Changes
- Added help text whenever you buy certain items from the gangtool
- Spare gangtools now cost 30 influence for everyone
  - They no longer give you a free pen
- Increases domination limit back to 3
- Purchased outfits are automatically equipped in your hand, if possible
- Gang boss has a 3 minute window at round start to select an outfit style. If he doesn't select one, the his lieutenants may pick one. No gang outfits can be created without a style picked first.
  - This is just to give the gang boss the first opportunity to pick an outfit style for his gang
- You can now see how many outfits your gangtool has in stock
- Outfits are no longer used up if you cancel the style selection prompt
- Loyalty implant destruction message has been moved to its Destroy()
