### PR TITLE
Prevents APC placing in large areas to stop lag

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -1,4 +1,5 @@
 // APC HULL
+#define AREA_SIZE_LIMIT 8192
 
 /obj/item/apc_frame
 	name = "\improper APC frame"
@@ -21,14 +22,17 @@
 		return
 	var/turf/loc = get_turf(usr)
 	var/area/A = loc.loc
+	if (A.contents.len >= AREA_SIZE_LIMIT) 
+		usr << "<span class='warning'>This area is too large!</span>"
+		return
 	if (!istype(loc, /turf/simulated/floor))
-		usr << "<span class='warning'>APC cannot be placed on this spot!</span>"
+		usr << "<span class='warning'>APCs cannot be placed on this spot!</span>"
 		return
 	if (A.requires_power == 0 || istype(A, /area/space))
-		usr << "<span class='warning'>APC cannot be placed in this area!</span>"
+		usr << "<span class='warning'>APCs cannot be placed in this area!</span>"
 		return
 	if (A.get_apc())
-		usr << "<span class='warning'>This area already has APC!</span>"
+		usr << "<span class='warning'>This area already has an APC!</span>"
 		return //only one APC per area
 	for(var/obj/machinery/power/terminal/T in loc)
 		if (T.master)

--- a/html/changelogs/spasticVerbalizer-APCAreaSizeCheck.yml
+++ b/html/changelogs/spasticVerbalizer-APCAreaSizeCheck.yml
@@ -1,0 +1,37 @@
+
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: spasticVerbalizer
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "APC placing in large areas such as the mine is now prevented in order to stop lag."


### PR DESCRIPTION
Fixes #9905 
The exact limit is 8192 tiles, 1/8th of a z-level, is that big enough?

Also fixes some grammar errors in the APC error messages
