### PR TITLE
Flashes and Flashers

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -74,6 +74,11 @@
 	if (bulb.broken || (last_flash && world.time < src.last_flash + 150))
 		return
 
+	if(!bulb.flash_recharge(30)) //Bulb can burn out if it's used too often too fast
+		power_change()
+		return
+	bulb.times_used ++
+
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[base_state]_flash", src)
 	last_flash = world.time
@@ -110,13 +115,6 @@
 		var/mob/living/carbon/M = AM
 		if (M.m_intent != "walk" && anchored)
 			flash()
-
-/obj/machinery/flasher/portable/flash()
-	if(!..())
-		return
-	if(prob(4))	//Small chance to burn out on use
-		bulb.burn_out()
-		power_change()
 
 /obj/machinery/flasher/portable/attackby(obj/item/weapon/W, mob/user, params)
 	if (istype(W, /obj/item/weapon/wrench))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -34,7 +34,7 @@
 		return 0
 
 	var/deciseconds_passed = world.time - last_used
-	for(var/seconds = deciseconds_passed/interval, seconds>=interval, seconds-=interval) //get 1 charge every interval
+	for(var/seconds = deciseconds_passed/10, seconds>=interval, seconds-=interval) //get 1 charge every interval
 		times_used--
 
 	last_used = world.time
@@ -103,7 +103,7 @@
 		return 0
 	user.visible_message("<span class='disarm'>[user]'s flash emits a blinding light!</span>", "<span class='danger'>Your flash emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
-		flash_carbon(M, user, 2, 0)
+		flash_carbon(M, user, 1, 0)
 
 
 /obj/item/device/flash/emp_act(severity)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -28,21 +28,21 @@
 	visible_message("The [src.name] burns out!")
 
 
-/obj/item/device/flash/proc/flash_recharge(var/mob/user)
-	if(prob(times_used * 2))	//if you use it 5 times in a minute it has a 10% chance to break!
+/obj/item/device/flash/proc/flash_recharge(var/interval=10)
+	if(prob(times_used * 3)) //The more often it's used in a short span of time the more likely it will burn out
 		burn_out()
 		return 0
 
 	var/deciseconds_passed = world.time - last_used
-	for(var/seconds = deciseconds_passed/10, seconds>=10, seconds-=10) //get 1 charge every 10 seconds
+	for(var/seconds = deciseconds_passed/interval, seconds>=interval, seconds-=interval) //get 1 charge every interval
 		times_used--
 
 	last_used = world.time
 	times_used = max(0, times_used) //sanity
-
+	return 1
 
 /obj/item/device/flash/proc/try_use_flash(var/mob/user = null)
-	flash_recharge(user)
+	flash_recharge(10)
 
 	if(broken)
 		return 0
@@ -103,7 +103,7 @@
 		return 0
 	user.visible_message("<span class='disarm'>[user]'s flash emits a blinding light!</span>", "<span class='danger'>Your flash emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
-		flash_carbon(M, user, 3, 0)
+		flash_carbon(M, user, 2, 0)
 
 
 /obj/item/device/flash/emp_act(severity)
@@ -124,7 +124,9 @@
 					var/resisted
 					if(!isloyal(M))
 						if(user.mind in ticker.mode.head_revolutionaries)
-							if(!ticker.mode.add_revolutionary(M.mind))
+							if(ticker.mode.add_revolutionary(M.mind))
+								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+							else
 								resisted = 1
 					else
 						resisted = 1

--- a/html/changelogs/ikarrus-flashers.yml
+++ b/html/changelogs/ikarrus-flashers.yml
@@ -1,0 +1,7 @@
+
+author: Ikarrus
+
+delete-after: True
+
+changes: 
+  - tweak: "Mounted and portable flashers can now only be burned out from overuse, similar to flashes."


### PR DESCRIPTION
##### Machine Flashers
- No longer have a flat 4% burn out chance that was essentially making it useless even in calm times. Instead, they use the same cooldown system flashes have.
  - They have a "charge interval" of 30 seconds, as opposed to handheld flashes' 10.
##### Handheld Flashes
- AOE flash confusion time reduced to 1 tick
- Chance of burnout from overuse is increased
  - Successful rev conversions don't count as a "use", so revheads should still be able to convert without much worry.
