### PR TITLE
Items have a variable burn time

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -115,6 +115,8 @@ var/global/list/datum/stack_recipe/uranium_recipes = list ( \
 	throw_range = 3
 	origin_tech = "plasmatech=2;materials=2"
 	sheettype = "plasma"
+	burn_state = 0
+	burntime = 5
 
 var/global/list/datum/stack_recipe/plasma_recipes = list ( \
 	new/datum/stack_recipe("plasma door", /obj/structure/mineral_door/transparent/plasma, 10, one_per_turf = 1, on_floor = 1), \
@@ -127,6 +129,16 @@ var/global/list/datum/stack_recipe/plasma_recipes = list ( \
 	pixel_x = rand(0,4)-4
 	pixel_y = rand(0,4)-4
 	..()
+
+/obj/item/stack/sheet/mineral/plasma/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
+		message_admins("Plasma sheets ignited by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("Plasma sheets ignited by [key_name(user)] in ([x],[y],[z])")
+		fire_act()
+
+/obj/item/stack/sheet/mineral/plasma/fire_act()
+	atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, amount*10)
+	qdel(src)
 
 /*
  * Gold

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -165,7 +165,7 @@
 	if(!burn_state)
 		burn_state = 1
 		SSobj.burning += src
-		burn_world_time = world.time + burntime*10
+		burn_world_time = world.time + burntime*rand(10,20)
 		if(global_overlay)
 			overlays += fire_overlay
 		return 1
@@ -174,7 +174,8 @@
 	for(var/obj/item/Item in contents) //Empty out the contents
 		Item.loc = src.loc
 		Item.fire_act() //Set them on fire, too
-	new /obj/effect/decal/cleanable/ash(src.loc)
+	var/obj/effect/decal/cleanable/ash/A = new(src.loc)
+	A.desc = "Looks like this used to be a [name] some time ago."
 	qdel(src)
 
 /obj/proc/extinguish()


### PR DESCRIPTION
- Object burn times vary between 1x-2x the value set for var/burntime
  - This way they don't all burn up at the same time. For muh immersions.
- Examined ashes from burned objects will reveal what they used to be
- Plasma sheets can burn now
