### PR TITLE
Remove taser firing delay

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -59,7 +59,6 @@
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = 200
-	delay = 15
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gunshot.ogg'

--- a/html/changelogs/ttttaser.yml
+++ b/html/changelogs/ttttaser.yml
@@ -1,0 +1,4 @@
+author: oranges
+delete-after: True
+changes: 
+  - tweaks: "Engineers in nanotrasen's safety equipment department announced the release of a new and improved version of the X25 taser trigger, previous triggers, which suffered from a long line of misfire problems were recalled enmasse. Nanotrasen refused to comment on rumours that the previous trigger design was the work of a saboteur."


### PR DESCRIPTION
Making the game unintuitive as fuck and annoying as shit is not a balance
change, I'm frankly quite suprised it was merged in the first place

In the future don't nerf the interface as a balance fix
