### PR TITLE
More Attack Animations

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -323,9 +323,9 @@
 /proc/flick_overlay(image/I, list/show_to, duration)
 	for(var/client/C in show_to)
 		C.images += I
-	sleep(duration)
-	for(var/client/C in show_to)
-		C.images -= I
+	spawn(duration)
+		for(var/client/C in show_to)
+			C.images -= I
 
 /proc/get_active_player_count()
 	// Get active players who are playing in the round

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -114,7 +114,8 @@
 /mob/living/carbon/human/interactive/bullet_act(var/obj/item/projectile/P)
 	var/potentialAssault = locate(/mob/living) in view(2,P.starting)
 	if(potentialAssault)
-		attacked_by(P,potentialAssault)
+		retal = 1
+		retal_target = potentialAssault
 	..()
 
 /mob/living/carbon/human/interactive/New()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -796,8 +796,8 @@ Sorry Giacom. Please don't be mad :(
 			if(M.client)
 				viewing |= M.client
 		flick_overlay(I,viewing,5)
-		animate(I, pixel_z = 16, alpha = 125, 5)
-
+		I.pixel_z = 16 //lift it up...
+		animate(I, pixel_z = 0, alpha = 125, 3) //smash it down into them!
 
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -792,7 +792,7 @@ Sorry Giacom. Please don't be mad :(
 			I = image(r_hand.icon,A,r_hand.icon_state,A.layer+1)
 	if(I)
 		var/list/viewing = list()
-		for(var/mob/M in view(A))
+		for(var/mob/M in viewers(A))
 			if(M.client)
 				viewing |= M.client
 		flick_overlay(I,viewing,5)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -797,7 +797,7 @@ Sorry Giacom. Please don't be mad :(
 				viewing |= M.client
 		flick_overlay(I,viewing,5)
 		I.pixel_z = 16 //lift it up...
-		animate(I, pixel_z = 0, alpha = 125, 3) //smash it down into them!
+		animate(I, pixel_z = 0, alpha = 125, time = 3) //smash it down into them!
 
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -796,6 +796,7 @@ Sorry Giacom. Please don't be mad :(
 			if(M.client)
 				viewing |= M.client
 		flick_overlay(I,viewing,5)
+		animate(I, pixel_z = 16, alpha = 125, 5)
 
 
 /mob/living/proc/do_jitter_animation(jitteriness)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -782,6 +782,22 @@ Sorry Giacom. Please don't be mad :(
 	..(A, final_pixel_y)
 	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure to restart it in next life().
 
+	//Show an image of the wielded weapon over the person who got dunked.
+	var/image/I
+	if(hand)
+		if(l_hand)
+			I = image(l_hand.icon,A,l_hand.icon_state,A.layer+1)
+	else
+		if(r_hand)
+			I = image(r_hand.icon,A,r_hand.icon_state,A.layer+1)
+	if(I)
+		var/list/viewing = list()
+		for(var/mob/M in view(A))
+			if(M.client)
+				viewing |= M.client
+		flick_overlay(I,viewing,5)
+
+
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)
 	var/pixel_x_diff = rand(-amplitude, amplitude)


### PR DESCRIPTION
- Melee weapons used in combat now appear over the victim for 3/10ths of a second.
- Fixes SNPCs thinking a ranged attack was a melee attack, causing this new animation to trigger for guns, rofl, sawu accidentally reused a proc to avoid writing 2 lines... yeah, haha.
- `flick_overlay()` now uses `spawn()` instead of `sleep()` so that `animate()` and other effects can be called on the image while it is displayed.

I feel this is appropriate as when you see combat you already see "X hits Y with the Z" so showing a picture of Z is no more information, it's just a better way of conveying the same information.

![combat2](https://cloud.githubusercontent.com/assets/4043781/8475604/39961472-20b1-11e5-8680-20c7004207b2.gif)
