### PR TITLE
Rubber Shotgun Pellets

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -48,6 +48,15 @@
 	pellets = 5
 	variance = 0.8
 
+/obj/item/ammo_casing/shotgun/rubbershot
+	name = "rubber shot"
+	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	icon_state = "bshell"
+	projectile_type = /obj/item/projectile/bullet/rpellet
+	pellets = 5
+	variance = 0.8
+	materials = list(MAT_METAL=4000)
+
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -75,7 +75,7 @@
 /obj/item/ammo_box/magazine/internal/shotriot
 	name = "riot shotgun internal magazine"
 	desc = "Oh god, this shouldn't be here"
-	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	caliber = "shotgun"
 	max_ammo = 6
 	multiload = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -44,6 +44,9 @@
 /obj/item/projectile/bullet/heavybullet
 	damage = 35
 
+/obj/item/projectile/bullet/rpellet
+	damage = 3
+	stamina = 25
 
 /obj/item/projectile/bullet/stunshot //taser slugs for shotguns, nothing special
 	name = "stunshot"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -266,6 +266,14 @@
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
 	category = list("initial", "Security")
 
+/datum/design/rubbershot
+	name = "Rubber shot"
+	id = "rubber_shot"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot
+	category = list("initial", "Security")
+
 /datum/design/c38
 	name = "Speed loader (.38)"
 	id = "c38"


### PR DESCRIPTION
Adds rubber shotgun pellets, which deal 25 stamina damage per pellet and a minor amount of brute.  They spawn in the riot shotguns and can be produced at an autolathe.
There's only two riot shotguns, and it's only six each, plus security's been hit by a wall of nerfs to their crowd control ability, so I figure it shouldn't be hugely overpowered for security to have.  I'm not trying to make a big balance change.  The riot shotguns in the armory come pre-loaded with them, and more can be printed at an autolathe for 4000 metal.
