### PR TITLE
Fixes Beakers unable to transfer their reagents to other objects the mob is holding

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -165,7 +165,7 @@
 					src.throwing = 0
 			if(isobj(A))
 				if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
-					src.throw_impact(A)
+					src.throw_impact(A,thrower)
 					src.throwing = 0
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower)
@@ -214,7 +214,7 @@
 	//done throwing, either because it hit something or it finished moving
 	src.throwing = 0
 	if(isobj(src))
-		src.throw_impact(get_turf(src))
+		src.throw_impact(get_turf(src),thrower)
 
 	return 1
 

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -112,6 +112,7 @@
 	possible_transfer_amounts = null
 	volume = 150
 	flags = CONDUCT | OPENCONTAINER
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/golden_cup/tournament_26_06_2011
 	desc = "A golden cup. It will be presented to a winner of tournament 26 june and name of the winner will be graved on it."
@@ -127,6 +128,7 @@
 	desc = "Careful, the beverage you're about to enjoy is extremely hot."
 	icon_state = "coffee"
 	list_reagents = list("coffee" = 30)
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/tea
 	name = "Duke Purple Tea"
@@ -134,12 +136,14 @@
 	icon_state = "tea"
 	item_state = "coffee"
 	list_reagents = list("tea" = 30)
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/ice
 	name = "Ice Cup"
 	desc = "Careful, cold ice, do not chew."
 	icon_state = "coffee"
 	list_reagents = list("ice" = 30)
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/h_chocolate
 	name = "Dutch Hot Coco"
@@ -147,6 +151,7 @@
 	icon_state = "tea"
 	item_state = "coffee"
 	list_reagents = list("hot_coco" = 30, "sugar" = 5)
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen
 	name = "Cup Ramen"
@@ -173,6 +178,7 @@
 	icon_state = "water_cup_e"
 	possible_transfer_amounts = null
 	volume = 10
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/sillycup/on_reagent_change()
 	if(reagents.total_volume)
@@ -211,6 +217,7 @@
 	desc = "A cup with the british flag emblazoned on it."
 	icon_state = "britcup"
 	volume = 30
+	spillable = 1
 
 //////////////////////////soda_cans//
 //These are in their own group to be used as IED's in /obj/item/weapon/grenade/ghettobomb.dm

--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -8,6 +8,7 @@
 	volume = 50
 	burn_state = 0 //Burnable
 	burntime = 5
+	spillable = 1
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/fire_act()
 	if(!reagents.total_volume)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -100,12 +100,12 @@
 			add_logs(thrower, M, "splashed", object="[R]")
 		reagents.reaction(target, TOUCH)
 
-	else if(!target.density || target.throwpass)
-		if(thrower && thrower.mind && thrower.mind.assigned_role == "Bartender")
-			visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
-			return
+	else if((!target.density || target.throwpass) && thrower && thrower.mind && thrower.mind.assigned_role == "Bartender")
+		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
+		return
 
 	else
 		visible_message("<span class='notice'>[src] spills its contents all over [target].</span>")
 		reagents.reaction(target, TOUCH)
+
 	reagents.clear_reagents()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -10,6 +10,7 @@
 	var/list/list_reagents = null
 	var/spawned_disease = null
 	var/disease_amount = 20
+	var/spillable = 0
 
 /obj/item/weapon/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
@@ -81,7 +82,7 @@
 /obj/item/weapon/reagent_containers/throw_impact(atom/target,mob/thrower)
 	..()
 
-	if(!reagents.total_volume || !is_open_container())
+	if(!reagents.total_volume || !spillable)
 		return
 
 	if(ismob(target) && target.reagents)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -34,7 +34,7 @@
 
 
 /obj/item/weapon/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
-	if((!proximity) || !check_allowed_items(target,1)) return
+	if((!proximity) || !check_allowed_items(target,target_self=1)) return
 
 	if(ismob(target) && target.reagents && reagents.total_volume)
 		var/mob/M = target

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -4,6 +4,7 @@
 	possible_transfer_amounts = list(5, 10, 15, 25, 30, 50)
 	volume = 50
 	flags = OPENCONTAINER
+	spillable = 1
 
 	can_be_placed_into = list(
 		/obj/machinery/chem_master/,

--- a/html/changelogs/ikarrus-fixes.yml
+++ b/html/changelogs/ikarrus-fixes.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed items that logically shouldn't spill, spilling their contents when thrown"
+  - bugfix: "Fixed Bartender's non-spilling powers"
+  - bugfix: "Fixed thrown beakers not applying their contents onto floors"
+  - bugfix: "Fixed unable to transfer reagents between beakers you are holding"
+  - bugfix: "Fixed bombs shredding clothes that should have been protected by covering clothes"


### PR DESCRIPTION
Fixes #10346 
Fixes #10359
Fixes #10363 - Changes it to check for a spillable var instead of the OPENCONTAINER flag with encompasses a lot more than necessary
