### PR TITLE
[quick merge] Revert "Fixes overexcited TTV reporting"

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -194,11 +194,10 @@
 
 		var/bomb_message = "[log_str1] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name]</a>  [log_str2][log_attacher] [log_str3][last_touch_info]"
 
-		if(tank_one.volume != tank_two.volume) //Equivilent volume prior to mixing means the bomb has probably been fouled by a valve opening already
-			bombers += bomb_message
+		bombers += bomb_message
 
-			message_admins(bomb_message, 0, 1)
-			log_game("[log_str1] [A.name]([A.x],[A.y],[A.z]) [log_str2] [log_str3]")
+		message_admins(bomb_message, 0, 1)
+		log_game("[log_str1] [A.name]([A.x],[A.y],[A.z]) [log_str2] [log_str3]")
 		merge_gases()
 		spawn(20) // In case one tank bursts
 			for (var/i=0,i<5,i++)


### PR DESCRIPTION
Revert's #9745

This prevented bomb openings from getting logged or admins from getting notified when somebody opened a bomb valve. I had to look at href logs to find a griffer

(Protip: the volume of the tanks will always be 70, no matter what is in it.)
