### PR TITLE
[Merge for the love of all that's decent in the world] Fixes the CATastrophe

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -13,7 +13,10 @@
 	use_skintones = 1
 
 /datum/species/human/qualifies_for_rank(var/rank, var/list/features)
-	if(features["tail_human"] == "None" && features["ears"] == "None")
+	if(!config.mutant_humans) //No mutie scum here
+		return 1
+
+	if((!features["tail_human"] || features["tail_human"] == "None") && (!features["ears"] || features["ears"] == "None"))
 		return 1	//Pure humans are always allowed in all roles.
 
 	//Mutants are not allowed in most roles.


### PR DESCRIPTION
If human mutants aren't allowed in configs they don't have to be tested for roles

Additionally the game will properly read a null feature as racially pure.

Fixes #10340
<img src="http://static.giantbomb.com/uploads/original/9/93770/2363671-snes_bubsy2.jpg"></img>
