### PR TITLE
Changes Admin OOC color to use Magenta

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -29,7 +29,7 @@ em						{font-style: normal;	font-weight: bold;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #aca82d;}
-.secradio				{color: #b22222;}
+.secradio				{color: #e60073;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}
 .suppradio				{color: #a8732b;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -17,7 +17,7 @@ em						{font-style: normal;	font-weight: bold;}
 
 .ooc					{					font-weight: bold;}
 .adminobserverooc		{color: #0099cc;	font-weight: bold;}
-.adminooc				{color: #b82e00;	font-weight: bold;}
+.adminooc				{color: #e60073;	font-weight: bold;}
 
 .adminobserver			{color: #996600;	font-weight: bold;}
 .admin					{color: #386aff;	font-weight: bold;}
@@ -29,7 +29,7 @@ em						{font-style: normal;	font-weight: bold;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
 .comradio				{color: #aca82d;}
-.secradio				{color: #e60073;}
+.secradio				{color: #b22222;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}
 .suppradio				{color: #a8732b;}


### PR DESCRIPTION
(Image is slightly outdated but uses the same colors)
![screenshot 2015-07-03 09 33 42](https://cloud.githubusercontent.com/assets/9098006/8501862/e2aebfe0-2166-11e5-8f64-7aa4027f8f70.png)
This makes it stand out more from attack text, warning text, and security radio text.
