### PR TITLE
New shuttle loan event + fixes

### DIFF
--- a/code/datums/diseases/fluspanish.dm
+++ b/code/datums/diseases/fluspanish.dm
@@ -11,7 +11,7 @@
 	desc = "If left untreated the subject will burn to death for being a heretic."
 	severity = DANGEROUS
 
-/datum/disease/inquisition/stage_act()
+/datum/disease/fluspanish/stage_act()
 	..()
 	switch(stage)
 		if(2)

--- a/code/modules/events/camerafailure.dm
+++ b/code/modules/events/camerafailure.dm
@@ -16,5 +16,6 @@
 	while(prob(round(100/iterations)))
 		while(!("SS13" in C.network))
 			C = pick(cameranet.cameras)
-		C.deactivate(null, 0)
+		if(C.status)
+			C.deactivate(null, 0)
 		iterations *= 2.5

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -1,24 +1,24 @@
 #define HIJACK_SYNDIE 1
 #define RUSKY_PARTY 2
 #define SPIDER_GIFT 3
-#define DEPARTMENT_RESUPPLY 4
+#define ANTIDOTE_NEEDED 4
 
 /datum/round_event_control/shuttle_loan
 	name = "Shuttle loan"
 	typepath = /datum/round_event/shuttle_loan
 	max_occurrences = 1
-	earliest_start = 0
+	earliest_start = 4000
 
 /datum/round_event/shuttle_loan
 	endWhen = 500
 	var/dispatch_type = 4
 	var/bonus_points = 100
-	var/thanks_msg = "Have some supply points as thanks (the shuttle will be returned in 5 minutes)."
+	var/thanks_msg = "The cargo shuttle should return in five minutes. Have some supply points for your trouble."
 	var/dispatched = 0
 	announceWhen	= 1
 
 /datum/round_event/shuttle_loan/start()
-	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, DEPARTMENT_RESUPPLY)
+	dispatch_type = pick(HIJACK_SYNDIE, RUSKY_PARTY, SPIDER_GIFT, ANTIDOTE_NEEDED)
 
 /datum/round_event/shuttle_loan/announce()
 	SSshuttle.shuttle_loan = src
@@ -29,10 +29,8 @@
 			priority_announce("Cargo: A group of angry russians want to have a party, can you send them your cargo shuttle then make them disappear?","Centcom Russian Outreach Program")
 		if(SPIDER_GIFT)
 			priority_announce("Cargo: The Spider Clan has sent us a mysterious gift, can we ship it to you to see what's inside?","Centcom Diplomatic Corps")
-		if(DEPARTMENT_RESUPPLY)
-			priority_announce("Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?","Centcom Supply Department")
-			thanks_msg = "The shuttle will be returned in 5 minutes."
-			bonus_points = 0
+		if(ANTIDOTE_NEEDED)
+			priority_announce("Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples.", "Centcom Research Initiatives")
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(thanks_msg, "Cargo shuttle commandeered by Centcom.")
@@ -43,18 +41,22 @@
 
 	SSshuttle.supply.sell()
 	SSshuttle.supply.enterTransit()
-	SSshuttle.supply.mode = SHUTTLE_RECALL
+	if(SSshuttle.supply.z != ZLEVEL_STATION)
+		SSshuttle.supply.mode = SHUTTLE_CALL
+		SSshuttle.supply.destination = SSshuttle.getDock("supply_home")
+	else
+		SSshuttle.supply.mode = SHUTTLE_RECALL
 	SSshuttle.supply.setTimer(3000)
 
 	switch(dispatch_type)
 		if(HIJACK_SYNDIE)
-			SSshuttle.centcom_message += "<font color=blue>Syndicate hijack team incoming.</font>"
+			SSshuttle.centcom_message += "Syndicate hijack team incoming."
 		if(RUSKY_PARTY)
-			SSshuttle.centcom_message += "<font color=blue>Partying Russians incoming.</font>"
+			SSshuttle.centcom_message += "Partying Russians incoming."
 		if(SPIDER_GIFT)
-			SSshuttle.centcom_message += "<font color=blue>Spider Clan gift incoming.</font>"
-		if(DEPARTMENT_RESUPPLY)
-			SSshuttle.centcom_message += "<font color=blue>Department resupply incoming.</font>"
+			SSshuttle.centcom_message += "Spider Clan gift incoming."
+		if(ANTIDOTE_NEEDED)
+			SSshuttle.centcom_message += "Virus samples incoming."
 
 /datum/round_event/shuttle_loan/tick()
 	if(dispatched)
@@ -80,7 +82,6 @@
 		var/list/shuttle_spawns = list()
 		switch(dispatch_type)
 			if(HIJACK_SYNDIE)
-				SSshuttle.generateSupplyOrder(/datum/supply_packs/emergency/specialops, "Syndicate")
 
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
@@ -90,7 +91,6 @@
 					shuttle_spawns.Add(/mob/living/simple_animal/hostile/syndicate)
 
 			if(RUSKY_PARTY)
-				SSshuttle.generateSupplyOrder(/datum/supply_packs/organic/party, "Russian Confederation")
 
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/russian)
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/russian/ranged)	//drops a mateba
@@ -101,7 +101,6 @@
 					shuttle_spawns.Add(/mob/living/simple_animal/hostile/bear)
 
 			if(SPIDER_GIFT)
-				SSshuttle.generateSupplyOrder(/datum/supply_packs/emergency/specialops, "Spider Clan")
 
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/poison/giant_spider)
 				shuttle_spawns.Add(/mob/living/simple_animal/hostile/poison/giant_spider)
@@ -127,26 +126,27 @@
 				T = pick(empty_shuttle_turfs)
 				new /obj/effect/spider/stickyweb(T)
 
-			if(DEPARTMENT_RESUPPLY)
-				var/list/crate_types = list(
-					/datum/supply_packs/emergency/evac,
-					/datum/supply_packs/security/supplies,
-					/datum/supply_packs/organic/food,
-					/datum/supply_packs/emergency/weedcontrol,
-					/datum/supply_packs/engineering/tools,
-					/datum/supply_packs/engineering/engiequipment,
-					/datum/supply_packs/science/robotics,
-					/datum/supply_packs/science/plasma,
-					/datum/supply_packs/medical/supplies
-					)
 
-				for(var/spawn_type in crate_types)
-					SSshuttle.generateSupplyOrder(spawn_type, "Centcom")
+			if(ANTIDOTE_NEEDED)
+				var/virus_type = pick(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/fluspanish)
+				var/turf/T
+				for(var/i=0, i<10, i++)
+					if(prob(15))
+						shuttle_spawns.Add(/obj/item/weapon/reagent_containers/glass/bottle)
+					else if(prob(15))
+						shuttle_spawns.Add(/obj/item/weapon/reagent_containers/syringe)
+					else if(prob(25))
+						shuttle_spawns.Add(/obj/item/weapon/shard)
+					T = pick_n_take(empty_shuttle_turfs)
+					var/obj/effect/decal/cleanable/blood/b = new(T)
+					var/datum/disease/D = new virus_type()
+					D.longevity = 1000
+					b.viruses += D
+					D.holder = b
+				shuttle_spawns.Add(/obj/structure/closet/crate)
+				shuttle_spawns.Add(/obj/item/weapon/reagent_containers/glass/bottle/pierrot_throat)
+				shuttle_spawns.Add(/obj/item/weapon/reagent_containers/glass/bottle/magnitis)
 
-				for(var/i=0,i<3,i++)
-					var/turf/T = pick(empty_shuttle_turfs)
-					var/spawn_type = pick(/obj/effect/decal/cleanable/flour, /obj/effect/decal/cleanable/robot_debris, /obj/effect/decal/cleanable/oil)
-					new spawn_type(T)
 
 		var/false_positive = 0
 		while(shuttle_spawns.len && empty_shuttle_turfs.len)
@@ -157,7 +157,6 @@
 
 			var/spawn_type = pick_n_take(shuttle_spawns)
 			new spawn_type(T)
-
 
 #undef HIJACK_SYNDIE
 #undef RUSKY_PARTY

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -291,3 +291,9 @@
 	desc = "A small bottle. Contains a sample of invasive Apidae."
 	icon_state = "bottle3"
 	spawned_disease = /datum/disease/beesease
+
+/obj/item/weapon/reagent_containers/glass/bottle/fluspanish
+	name = "Spanish flu culture bottle"
+	desc = "A small bottle. Contains a sample of Inquisitius."
+	icon_state = "bottle3"
+	spawned_disease = /datum/disease/fluspanish


### PR DESCRIPTION
- Fixes shuttle loan events not bringing anything to the station. The objects created for the event were destroyed at Centcom.
- Removes supply order crates from shuttle loan events. These were pretty unintuitive, as you needed to accept the crates separately.
- Adds a new shuttle loan event: Centcom wants you to help in a virus research program. I feel this is a more controlled way of bringing diseases on the station compared to the disease outbreak event.
- Fixes camera failure event
- Fixes spanish flu, adds spanish flu culture bottle

Fixes #7832
