### PR TITLE
Explosion cinematics no longer delay round end

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -293,7 +293,7 @@ var/datum/subsystem/ticker/ticker
 					cinematic.icon_state = "summary_selfdes"
 	//If its actually the end of the round, wait for it to end.
 	//Otherwise if its a verb it will continue on afterwards.
-	sleep(300)
+	spawn(300)
 
 	if(cinematic)	qdel(cinematic)		//end the cinematic
 	if(temp_buckle)	qdel(temp_buckle)	//release everybody

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -294,9 +294,8 @@ var/datum/subsystem/ticker/ticker
 	//If its actually the end of the round, wait for it to end.
 	//Otherwise if its a verb it will continue on afterwards.
 	spawn(300)
-
-	if(cinematic)	qdel(cinematic)		//end the cinematic
-	if(temp_buckle)	qdel(temp_buckle)	//release everybody
+		if(cinematic)	qdel(cinematic)		//end the cinematic
+		if(temp_buckle)	qdel(temp_buckle)	//release everybody
 	return
 
 


### PR DESCRIPTION
This starts the round end process as the station is exploding, not 30 seconds after, because OOC doesn't wait for the round-end report so there's no point delaying it.
