### PR TITLE
Finishes the never actually finished forbidden steal item system Part 2

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -350,7 +350,7 @@ var/global/list/possible_items = list()
 	for(var/datum/objective_item/possible_item in possible_items)
 		if(is_unique_objective(possible_item.targetitem) && !(owner.current.mind.assigned_role in possible_item.excludefromjob))
 			approved_targets += possible_item
-	return set_target(safepick(possible_items))
+	return set_target(safepick(approved_targets))
 
 /datum/objective/steal/proc/set_target(var/datum/objective_item/item)
 	if(item)


### PR DESCRIPTION
Objective assignment was choosing from a different list than the one that was actually prepared

Kudos to @Profakos for catching this back in #10251 

Also makes the proc is_unique_objective() actually work, which prevents someone from geting two steal objectives for the same item.
