### PR TITLE
[BALANCE] Reduces Weight Size of Sechailer Gas Mask

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -50,6 +50,7 @@
 	ignore_maskadjust = 0
 	flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	flags_inv = HIDEFACE
+	w_class = 2.0
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACE
 	flags_cover = MASKCOVERSMOUTH


### PR DESCRIPTION
This PR reduces the weight size of the Sechailer, and the subsequent Death Squad mask, down from a weight size of three to a weight size of two.

The main reason for this is inventory management, for security space is at a premium and being able to place your gasmask inside your personal box saves on space.

This is simply a quality of life change, however there may be some contention towards is.
