### PR TITLE
Gang Update: Last Refactor Bug Edition

### DIFF
--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -91,6 +91,8 @@
 				timer = world.time
 				send2irc("Server", "The Emergency Shuttle has docked with the station.")
 				priority_announce("The Emergency Shuttle has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+				for(var/datum/gang/G in ticker.mode.gangs)
+					G.dom_attempts = min(1,G.dom_attempts)	//Gangs only have one attempt left if the shuttle has docked with the station to prevent suffering from dominator delays
 		if(SHUTTLE_DOCKED)
 			if(time_left <= 0 && SSshuttle.emergencyNoEscape)
 				priority_announce("Hostile enviroment detected. Departure has been postponed indefinitely pending conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")

--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -91,8 +91,14 @@
 				timer = world.time
 				send2irc("Server", "The Emergency Shuttle has docked with the station.")
 				priority_announce("The Emergency Shuttle has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+
+				//Gangs only have one attempt left if the shuttle has docked with the station to prevent suffering from dominator delays
 				for(var/datum/gang/G in ticker.mode.gangs)
-					G.dom_attempts = min(1,G.dom_attempts)	//Gangs only have one attempt left if the shuttle has docked with the station to prevent suffering from dominator delays
+					if(isnum(G.dom_timer))
+						G.dom_attempts = 0
+					else
+						G.dom_attempts = min(1,G.dom_attempts)
+
 		if(SHUTTLE_DOCKED)
 			if(time_left <= 0 && SSshuttle.emergencyNoEscape)
 				priority_announce("Hostile enviroment detected. Departure has been postponed indefinitely pending conflict resolution.", null, 'sound/misc/notice1.ogg', "Priority")

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -55,8 +55,10 @@ var/datum/atom_hud/huds = list( \
 //MOB PROCS
 /mob/proc/reload_huds()
 	var/gang_huds = list()
-	for(var/datum/gang/G in ticker.mode.gangs)
-		gang_huds += G.ganghud
+	if(ticker.mode)
+		for(var/datum/gang/G in ticker.mode.gangs)
+			gang_huds += G.ganghud
+
 	for(var/datum/atom_hud/hud in (huds|gang_huds))
 		if(src in hud.hudusers)
 			hud.add_hud_to(src)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -306,19 +306,18 @@
 			text += "|"
 			if(src in (G.bosses))
 				text += "<B>GANG LEADER</B>"
+				text += "|Equipment: <a href='?src=\ref[src];gang=equip'>give</a>"
+				var/list/L = current.get_contents()
+				var/obj/item/device/gangtool/gangtool = locate() in L
+				if (gangtool)
+					text += "|<a href='?src=\ref[src];gang=takeequip'>take</a>"
+
 			else
 				text += "<a href='?src=\ref[src];gangboss=\ref[G]'>gang leader</a>"
 			text += "<BR>"
 
 		if(gang_colors_pool)
 			text += "<a href='?src=\ref[src];gang=new'>Create New Gang</a>"
-
-		if(src in ticker.mode.get_gang_bosses())
-			text += "<br>Equipment: <a href='?src=\ref[src];gang=equip'>give</a>"
-			var/list/L = current.get_contents()
-			var/obj/item/device/gangtool/gangtool = locate() in L
-			if (gangtool)
-				text += "|<a href='?src=\ref[src];gang=takeequip'>take</a>"
 
 		sections["gang"] = text
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -224,7 +224,7 @@
 		alert("Not before round-start!", "Alert")
 		return
 
-	var/out = ""
+	var/out = "<B>[name]</B>[(current&&(current.real_name!=name))?" (as [current.real_name])":""]<br>"
 	out += "Mind currently owned by key: [key] [active?"(synced)":"(not synced)"]<br>"
 	out += "Assigned role: [assigned_role]. <a href='?src=\ref[src];role_edit=1'>Edit</a><br>"
 	out += "Faction and special role: <b><font color='red'>[special_role]</font></b><br>"
@@ -583,9 +583,8 @@
 
 	out += "<a href='?src=\ref[src];obj_announce=1'>Announce objectives</a><br><br>"
 
-	var/datum/browser/popup = new(usr, "edit_memory[src]", "<B>[name]</B>[(current&&(current.real_name!=name))?" (as [current.real_name])":""]", 500, 600)
-	popup.set_content(out)
-	popup.open()
+	usr << browse(out, "window=edit_memory[src];size=500x600")
+
 
 /datum/mind/Topic(href, href_list)
 	if(!check_rights(R_ADMIN))	return

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -164,6 +164,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 		gangster_mind.current.Stun(5)
 	gangster_mind.current << "<FONT size=3 color=red><B>You are now a member of the [G.name] Gang!</B></FONT>"
 	gangster_mind.current << "<font color='red'>Help your bosses take over the station by claiming territory with <b>special spraycans</b> only they can provide. Simply spray on any unclaimed area of the station.</font>"
+	gangster_mind.current << "<font color='red'>Their ultimate objective is to take over the station with a Dominator machine.</font>"
 	gangster_mind.current << "<font color='red'>You can identify your bosses by their <b>red \[G\] icon</b>.</font>"
 	gangster_mind.current.attack_log += "\[[time_stamp()]\] <font color='red'>Has been converted to the [G.name] Gang!</font>"
 	gangster_mind.special_role = "[G.name] Gangster"
@@ -175,12 +176,20 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 /datum/game_mode/proc/remove_gangster(datum/mind/gangster_mind, var/beingborged, var/silent, var/remove_bosses=0)
 	var/datum/gang/gang = gangster_mind.gang_datum
 	if(!gang)
-		return
+		return 0
+
+	var/removed
 
 	for(var/datum/gang/G in gangs)
-		G.gangsters -= gangster_mind
-		if(remove_bosses)
+		if(gangster_mind in G.gangsters)
+			G.gangsters -= gangster_mind
+			removed = 1
+		if(remove_bosses && (gangster_mind in G.bosses))
 			G.bosses -= gangster_mind
+			removed = 1
+
+	if(!removed)
+		return 0
 
 	gangster_mind.special_role = null
 	gangster_mind.gang_datum = null
@@ -200,6 +209,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 			gangster_mind.current << "<FONT size=3 color=red><B>You have been reformed! You are no longer a gangster!</B><BR>You try as hard as you can, but you can't seem to recall any of the identities of your former gangsters...</FONT>"
 
 	gang.remove_gang_hud(gangster_mind)
+	return 1
 
 ////////////////
 //Helper Procs//

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -55,13 +55,10 @@
 	ganghud.leave_hud(defector_mind.current)
 	ticker.mode.set_antag_hud(defector_mind.current, null)
 
-/datum/gang/proc/domination(var/modifier=1,var/obj/dominator)
+/datum/gang/proc/domination(var/modifier=1)
 	dom_timer = max(300,900 - ((round((territory.len/start_state.num_territories)*200, 1) - 60) * 15)) * modifier
-	if(dominator)
-		var/area/domloc = get_area(dominator.loc)
-		priority_announce("Network breach detected in [initial(domloc.name)]. The [src] Gang is attempting to seize control of the station!","Network Alert")
-		set_security_level("delta")
-		SSshuttle.emergencyNoEscape = 1
+	set_security_level("delta")
+	SSshuttle.emergencyNoEscape = 1
 
 //////////////////////////////////////////// OUTFITS
 
@@ -74,7 +71,7 @@
 		return 0
 
 	var/gang_style_list = list("Gang Colors","Black Suits","White Suits","Leather Jackets","Leather Overcoats","Puffer Jackets","Military Jackets","Tactical Turtlenecks","Soviet Uniforms")
-	if(!style && gangtool.boss)	//Only the boss gets to pick a style
+	if(!style && (user.mind in ticker.mode.get_gang_bosses()))	//Only the boss gets to pick a style
 		style = input("Pick an outfit style.", "Pick Style") as null|anything in gang_style_list
 
 	if(gangtool.can_use(user) && (gangtool.outfits >= 1))

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -91,8 +91,10 @@
 		if(I != src)
 			qdel(I)
 
+	var/success
 	if(target.stat != DEAD)
-		ticker.mode.remove_gangster(target.mind,0,1)
+		if(ticker.mode.remove_gangster(target.mind,0,1))
+			success = 1
 
 	if(!target.mind)
 		return
@@ -100,11 +102,14 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.sec_hud_set_implants()
-		if(ticker.mode.add_gangster(target.mind,gang))
+		if(success && ticker.mode.add_gangster(target.mind,gang))
 			target.Paralyse(5)
 		else
 			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the influence of your enemies try to invade your mind!</span>")
 	qdel(src)
+
+/obj/item/weapon/implanter/gang/
+	name = "implanter-gang"
 
 /obj/item/weapon/implanter/gang/New(loc,var/gang)
 	if(!gang)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -306,6 +306,7 @@
 			if("outfit")
 				if(outfits > 0)
 					if(gang.gang_outfit(usr,src))
+						usr << "<span class='notice'><b>Gang Outfits</b> can act as armor with moderate protection against ballistic and melee attacks. Every gangster wearing one will also help grow your gang's influence.</span>"
 						outfits -= 1
 			if("ping")
 				ping_gang(usr)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -86,8 +86,8 @@
 			else
 				dat += "10mm Ammo<br>"
 
-			dat += "(50 Influence) "
-			if(points >= 50)
+			dat += "(60 Influence) "
+			if(points >= 60)
 				dat += "<a href='?src=\ref[src];purchase=uzi'>Uzi SMG</a><br>"
 			else
 				dat += "Uzi SMG<br>"
@@ -218,9 +218,9 @@
 					item_type = /obj/item/ammo_box/magazine/m10mm
 					pointcost = 10
 			if("uzi")
-				if(gang.points >= 50)
+				if(gang.points >= 60)
 					item_type = /obj/item/weapon/gun/projectile/automatic/mini_uzi
-					pointcost = 50
+					pointcost = 60
 			if("9mmammo")
 				if(gang.points >= 40)
 					item_type = /obj/item/ammo_box/magazine/uzim9mm

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -10,7 +10,6 @@
 	throw_range = 7
 	flags = CONDUCT
 	var/datum/gang/gang //Which gang uses this?
-	var/boss = 1 //If this gangtool belongs to the big boss
 	var/recalling = 0
 	var/outfits = 3
 	var/free_pen = 0
@@ -32,17 +31,21 @@
 				dat += "Give this device to another member of your organization to use to promote them to Lieutenant.<br><br>"
 				dat += "If this is meant as a spare device for yourself:<br>"
 			dat += "<a href='?src=\ref[src];register=1'>Register Device as Spare</a><br>"
-		else if (promotable && user.mind.gang_datum.bosses.len < 3)
-			dat += "You have been selected for a promotion!<br>"
-			dat += "<a href='?src=\ref[src];register=1'>Accept Promotion</a><br>"
+		else if (promotable)
+			if(user.mind.gang_datum.bosses.len < 3)
+				dat += "You have been selected for a promotion!<br>"
+				dat += "<a href='?src=\ref[src];register=1'>Accept Promotion</a><br>"
+			else
+				dat += "No promotions available: All positions filled.<br>"
 		else
-			dat += "No promotions available: All positions filled.<br>"
+			dat += "This device is not authorized to promote.<br>"
 	else
 		if(isnum(gang.dom_timer))
 			dat += "<center><font color='red'>Takeover In Progress:<br><B>[gang.dom_timer] seconds remain</B></font></center>"
 
+		var/isboss = (user.mind in ticker.mode.get_gang_bosses())
 		var/points = gang.points
-		dat += "Registration: <B>[gang.name] Gang [boss ? "Boss" : "Lieutenant"]</B><br>"
+		dat += "Registration: <B>[gang.name] Gang [isboss ? "Boss" : "Lieutenant"]</B><br>"
 		dat += "Organization Size: <B>[gang.gangsters.len + gang.bosses.len]</B> | Station Control: <B>[round((gang.territory.len/start_state.num_territories)*100, 1)]%</B><br>"
 		dat += "Gang Influence: <B>[points]</B><br>"
 		dat += "Time until Influence grows: <B>[(points >= 999) ? ("--:--") : (time2text(ticker.mode.gang_points.next_point_time - world.time, "mm:ss"))]</B><br>"
@@ -54,7 +57,7 @@
 			dat += "<a href='?src=\ref[src];choice=outfit'>Create Armored Gang Outfit</a><br>"
 		else
 			dat += "<b>Create Gang Outfit</b> (Restocking)<br>"
-		if(boss)
+		if(user.mind in ticker.mode.get_gang_bosses())
 			dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
 
 		dat += "<br>"
@@ -77,7 +80,7 @@
 			else
 				dat += "10mm Pistol<br>"
 
-			dat += "(10 Influence) "
+			dat += "&nbsp;&#8627;(10 Influence) "
 			if(points >= 10)
 				dat += "<a href='?src=\ref[src];purchase=10mmammo'>10mm Ammo</a><br>"
 			else
@@ -85,15 +88,15 @@
 
 			dat += "(50 Influence) "
 			if(points >= 50)
-				dat += "<a href='?src=\ref[src];purchase=uzi'>Mini Uzi</a><br>"
+				dat += "<a href='?src=\ref[src];purchase=uzi'>Uzi SMG</a><br>"
 			else
-				dat += "Mini Uzi<br>"
+				dat += "Uzi SMG<br>"
 
-			dat += "(20 Influence) "
-			if(points >= 20)
+			dat += "&nbsp;&#8627;(40 Influence) "
+			if(points >= 40)
 				dat += "<a href='?src=\ref[src];purchase=9mmammo'>Uzi Ammo</a><br>"
 			else
-				dat += "Uzi Magazine<br>"
+				dat += "Uzi Ammo<br>"
 
 			dat += "<br>"
 
@@ -155,7 +158,7 @@
 			dat += "Recruitment Pen<br>"
 
 		var/gangtooltext = "Spare Gangtool"
-		if(boss && gang.bosses.len < 3)
+		if((user.mind in ticker.mode.get_gang_bosses()) && gang.bosses.len < 3)
 			gangtooltext = "Promote a Gangster"
 		dat += "(10 Influence) "
 		if(points >= 10)
@@ -176,7 +179,7 @@
 	dat += "<br>"
 	dat += "<a href='?src=\ref[src];choice=refresh'>Refresh</a><br>"
 
-	var/datum/browser/popup = new(user, "gangtool", "Welcome to GangTool v3.0", 340, 625)
+	var/datum/browser/popup = new(user, "gangtool", "Welcome to GangTool v3.2", 340, 625)
 	popup.set_content(dat)
 	popup.open()
 
@@ -219,9 +222,9 @@
 					item_type = /obj/item/weapon/gun/projectile/automatic/mini_uzi
 					pointcost = 50
 			if("9mmammo")
-				if(gang.points >= 20)
+				if(gang.points >= 40)
 					item_type = /obj/item/ammo_box/magazine/uzim9mm
-					pointcost = 20
+					pointcost = 40
 			if("scroll")
 				if(gang.points >= 30)
 					item_type = /obj/item/weapon/sleeping_carp_scroll
@@ -255,7 +258,7 @@
 					pointcost = 10
 			if("gangtool")
 				if(gang.points >= 10)
-					if(boss)
+					if(usr.mind in ticker.mode.get_gang_bosses())
 						item_type = /obj/item/device/gangtool/spare/lt
 						if(gang.bosses.len < 3)
 							usr << "<span class='notice'><b>Gangtools</b> allow you to promote a gangster to be your Lieutenant, enabling them to recruit and purchase items like you. Simply have them register the gangtool. You may promote up to [3-gang.bosses.len] more Lieutenants</span>"
@@ -298,7 +301,7 @@
 	else if(href_list["choice"])
 		switch(href_list["choice"])
 			if("recall")
-				if(boss)
+				if(usr.mind in ticker.mode.get_gang_bosses())
 					recall(usr)
 			if("outfit")
 				if(outfits > 0)
@@ -322,7 +325,7 @@
 	members += gang.gangsters
 	members += gang.bosses
 	if(members.len)
-		var/ping = "<span class='danger'><B><i>[gang.name] [boss ? "Gang Boss" : "Lieutenant"]</i>: [message]</B></span>"
+		var/ping = "<span class='danger'><B><i>[gang.name] [(user.mind in ticker.mode.get_gang_bosses()) ? "Gang Boss" : "Lieutenant"]</i>: [message]</B></span>"
 		for(var/datum/mind/ganger in members)
 			if((ganger.current.z <= 2) && (ganger.current.stat == CONSCIOUS))
 				ganger.current << ping
@@ -408,18 +411,24 @@
 
 /obj/item/device/gangtool/proc/can_use(mob/living/carbon/human/user)
 	if(!istype(user))
-		return
+		return 0
 	if(user.restrained() || user.lying || user.stat || user.stunned || user.weakened)
-		return
+		return 0
 	if(!(src in user.contents))
-		return
-	if(user.mind)
-		if(gang && !(user.mind in gang.bosses))
-			return
-		return 1
+		return 0
+	if(!user.mind)
+		return 0
+
+	if(gang)	//If it's already registered, only let the gang's bosses use this
+		if(user.mind in gang.bosses)
+			return 1
+	else	//If it's not registered, any gangster can use this to register
+		if(user.mind in ticker.mode.get_all_gangsters())
+			return 1
+
+	return 0
 
 /obj/item/device/gangtool/spare
-	boss = 0
 	outfits = 1
 
 /obj/item/device/gangtool/spare/lt

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -43,7 +43,7 @@ Blobs are extremely powerful and are impossible to defeat alone. Communicate wit
 You can fight blob pieces diagonally, as they can only expand onto adjacent tiles in cardinal directions.
 Security huds and secglass huds can tell you if someone is implanted with a loyalty implant. Use this to your advantage in a revolution.
 Loyalty implants can only prevent someone from being turned into a cultist: unlike revolutionaries, it will not de-cult them if they have already been converted.
-Loyalty implants can only prevent someone from being turned into a gangster: unlike revolutionaries, it will not de-gang them if they have already been recruited.
+Loyalty implants will break when used to de-convert a gangster. You will need to use two if you want to prevent them from being re-recruited.
 Don't neglect upgrading your machines with the machine parts produced by research! These can seriously improve the efficiency of your equipment.
 Cyborgs are impervious to fires and temperature, and can walk in a blazing inferno without worry. Don't shy away from setting the whole station on fire as a malfunctioning or rogue AI!
 The heads of staff, especially the Head of Security and the Captain, are usually extremely difficult to kill. If one of them is your target as a traitor, plan carefully.
@@ -89,4 +89,4 @@ In the job selection menu, from the lobby, you can use right click on the "Low/M
 If you stay out of camera range for 10 seconds, the AI's track on you will break.
 You can shoot cameras with bullets to disable them remotely.
 Disabling a camera with wirecutters will not cause a camera alarm, but bludgeoning it will.
-Gangs derive their power from their presence. Cleaning up gang tags is the best way to prevent them from growing out of control.
+Gangs derive their power from their presence and notoriety. Cleaning up gang tags is the best way to slow their growth.

--- a/html/changelogs/ikarrus-gangfixlastoneipromise.yml
+++ b/html/changelogs/ikarrus-gangfixlastoneipromise.yml
@@ -33,6 +33,7 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
+  - tweak: "Increased Uzi SMG cost to 60 influence."
   - tweak: "Increased Uzi ammo cost to 40 influence."
   - tweak: "Domination attempt limit is reduced to 1 per gang while the shuttle is docked with the station."
   - tweak: "Gang bosses can promote and recall the shuttle using spare gangtools"

--- a/html/changelogs/ikarrus-gangfixlastoneipromise.yml
+++ b/html/changelogs/ikarrus-gangfixlastoneipromise.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Ikarrus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Increased Uzi ammo cost to 40 influence."
+  - tweak: "Domination attempt limit is reduced to 1 per gang while the shuttle is docked with the station."
+  - tweak: "Gang bosses can promote and recall the shuttle using spare gangtools"
+  - bugfix: "Fixed Gang bosses getting deconverted with head trauma"


### PR DESCRIPTION
We successfully ran a full gang round on Sybil, but with just one non-roundbreaking bug. This PR closes the final hole caused by the refractor and tweaks a few other things. I'm confident after this gang can be hands-off for a little while.
- Fixed Gang bosses getting deconverted with head trauma
- Increased Uzi SMG cost to 60 influence.
- Increased Uzi ammo cost to 40 influence.
- Domination attempt limits are reduced to 1 per gang while the shuttle is docked with the station.
- Gang bosses can promote and recall the shuttle using spare gangtools
- Improved help text!
