### PR TITLE
Fixed Badmins being able to exceed the gang limit with excessive buttons

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -316,7 +316,7 @@
 				text += "<a href='?src=\ref[src];gangboss=\ref[G]'>gang leader</a>"
 			text += "<BR>"
 
-		if(gang_colors_pool)
+		if(gang_colors_pool.len)
 			text += "<a href='?src=\ref[src];gang=new'>Create New Gang</a>"
 
 		sections["gang"] = text

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -9,7 +9,8 @@
 	var/maxhealth = 200
 	var/health = 200
 	var/datum/gang/gang
-	var/operating = 0
+	var/operating = 0	//-1=broken, 0=standby, 1=takeover
+	var/warned = 0	//if this device has set off the warning at <3 minutes yet
 
 /obj/machinery/dominator/New()
 	..()
@@ -37,6 +38,13 @@
 	if(gang && isnum(gang.dom_timer))
 		if(gang.dom_timer > 0)
 			playsound(loc, 'sound/items/timer.ogg', 30, 0)
+			if(!warned && (gang.dom_timer < 180))
+				warned = 1
+				var/area/domloc = get_area(loc)
+				gang.message_gangtools("Less than 3 minutes remain in hostile takeover. Defend your dominator at [initial(domloc.name)]!")
+				for(var/datum/gang/G in ticker.mode.gangs)
+					if(G != gang)
+						G.message_gangtools("WARNING: [gang.name] Gang takeover imminent. Their dominator at [initial(domloc.name)] must be destroyed!",1,1)
 		else
 			SSmachine.processing -= src
 

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -36,7 +36,7 @@
 	..()
 
 /obj/item/weapon/pen/gang/proc/cooldown(datum/gang/gang)
-	var/cooldown_time = 300+(900*gang.bosses.len) // 1recruiter=2mins, 2recruiters=3.5mins, 3recruiters=5mins
+	var/cooldown_time = 600+(600*gang.bosses.len) // 1recruiter=2mins, 2recruiters=3mins, 3recruiters=4mins
 
 	cooldown = 1
 	icon_state = "pen_blink"
@@ -93,8 +93,11 @@
 
 	var/success
 	if(target.stat != DEAD)
-		if(ticker.mode.remove_gangster(target.mind,0,1))
-			success = 1
+		if(target.mind in ticker.mode.get_gangsters())
+			if(ticker.mode.remove_gangster(target.mind,0,1))
+				success = 1	//Was not a gang boss, convert as usual
+		else
+			success = 1	//Not a gangster, convert as usual
 
 	if(!target.mind)
 		return
@@ -102,7 +105,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.sec_hud_set_implants()
-		if(success && ticker.mode.add_gangster(target.mind,gang))
+		if(success && ticker.mode.add_gangster(target.mind,gang,0))
 			target.Paralyse(5)
 		else
 			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the influence of your enemies try to invade your mind!</span>")

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -328,7 +328,7 @@
 	if(members.len)
 		var/ping = "<span class='danger'><B><i>[gang.name] [(user.mind in ticker.mode.get_gang_bosses()) ? "Gang Boss" : "Lieutenant"]</i>: [message]</B></span>"
 		for(var/datum/mind/ganger in members)
-			if((ganger.current.z <= 2) && (ganger.current.stat == CONSCIOUS))
+			if(ganger.current && (ganger.current.z <= 2) && (ganger.current.stat == CONSCIOUS))
 				ganger.current << ping
 		for(var/mob/M in dead_mob_list)
 			M << ping
@@ -336,6 +336,8 @@
 
 
 /obj/item/device/gangtool/proc/register_device(var/mob/user)
+	if(gang)	//It's already been registered!
+		return
 	if((promotable && (user.mind in ticker.mode.get_gangsters())) || (user.mind in ticker.mode.get_gang_bosses()))
 		gang = user.mind.gang_datum
 		gang.gangtools += src
@@ -391,7 +393,7 @@
 		return 0
 	var/datum/station_state/end_state = new /datum/station_state()
 	end_state.count()
-	if((100 *  start_state.score(end_state)) < 70) //Shuttle cannot be recalled if the station is too damaged
+	if((100 *  start_state.score(end_state)) < 80) //Shuttle cannot be recalled if the station is too damaged
 		user << "<span class='warning'>\icon[src]Error: Station communication systems compromised. Unable to establish connection.</span>"
 		recalling = 0
 		return 0

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -20,7 +20,7 @@
 	if(!iscarbon(M))
 		return
 	if(user && imp)
-		if(M.head)
+		if(M.head && (M.head.flags & THICKMATERIAL))
 			user << "<span class='warning'>[M]'s [M.head.name] is in the way! Take it off first!</span>"
 			return
 		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
@@ -28,7 +28,7 @@
 		var/turf/T = get_turf(M)
 		if(T && (M == user || do_after(user, 50, target = M)))
 			if(user && M && (get_turf(M) == T) && src && imp)
-				if(M.head)
+				if(M.head && (M.head.flags & THICKMATERIAL))
 					return
 				M.visible_message("[user] has implanted [M].", "<span class='notice'>[user] implants you with the implant.</span>")
 				add_logs(user, M, "implanted", object="[name]")

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -399,7 +399,7 @@
 	if(candidates.len >= 2)
 		for(var/needs_assigned=2,needs_assigned>0,needs_assigned--)
 			H = pick(candidates)
-			if(gang_colors_pool)
+			if(gang_colors_pool.len)
 				var/datum/gang/newgang = new()
 				ticker.mode.gangs += newgang
 				H.mind.make_Gang(newgang)
@@ -590,9 +590,9 @@
 		temp.abductors |= list(agent_mind,scientist_mind)
 		temp.make_abductor_team(number,preset_scientist=scientist_mind,preset_agent=agent_mind)
 		temp.post_setup_team(number)
-		
+
 		ticker.mode.abductor_teams++
-		
+
 		if(ticker.mode.config_tag != "abduction")
 			ticker.mode.abductors |= temp.abductors
 

--- a/html/changelogs/ikarrus-gangtuning.yml
+++ b/html/changelogs/ikarrus-gangtuning.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed bug where gang messages would occasionally fail to send."
+  - bugfix: "Fixed bug that prevented implant breakers from recruiting security."
+  - tweak: "Implanters are now only blocked by helmets with THICKMATERIAL"

--- a/html/changelogs/ikarrus-gangtuning.yml
+++ b/html/changelogs/ikarrus-gangtuning.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: Ikarrus
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Additional Changes:
- Speeds up recruitment a bit 
- Fixed bug that prevented implant breakers from recruiting security
- Fixes runtime with gang messages sent to minds without mobs 
- Raised threshold of station damage before gang heads can no longer recall
- Implanters are now only blocked by helmets with THICKMATERIAL
