### PR TITLE
Add the note about cyborg objectives before transferring the mind so …

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -222,10 +222,10 @@
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.
 					O.set_zeroth_law("<span class='danger'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*�&110010</span>")
 
-			BM.mind.transfer_to(O)
-
 			if(O.mind && O.mind.special_role)
 				O.mind.store_memory("As a cyborg, any objectives listed here are null and void, and will be marked as failed. They are simply here for memory purposes.")
+
+			BM.mind.transfer_to(O)
 
 			O.job = "Cyborg"
 


### PR DESCRIPTION
…it shows up when their memory is printed out to them.

Some players were thinking they still had objectives to follow because they didn't see the line.
