### PR TITLE
Fix for request console emergency broadcast runtime

### DIFF
--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -243,7 +243,8 @@ var/list/allowed_custom_spans = list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS
 		signal.data["verb_exclaim"]	= interpreter.GetCleanVar("$exclaim")
 		var/list/setspans 			= interpreter.GetCleanVar("$filters") //Save the span vector/list to a holder list
 		setspans &= allowed_custom_spans //Prune out any illegal ones. Go ahead, comment this line out. See the horror you can unleash!
-		signal.data["spans"]		= setspans //Apply it to the signal
+		if(islist(setspans)) //Previous comment block was right. Players cannot be trusted with ANYTHING. At all. Ever.
+			signal.data["spans"]	= setspans //Apply new span to the signal only if it is a valid list, made using vector() in the script.
 
 		// If the message is invalid, just don't broadcast it!
 		if(signal.data["message"] == "" || !signal.data["message"])


### PR DESCRIPTION
- Fixes #10441
- Ensures that any span changes set forth by NTSL scripts are valid
  lists with allowed values, preventing runtimes relating with invalid player input.
