### PR TITLE
Borging Antagonists

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -226,6 +226,8 @@
 
 			if(O.mind && O.mind.special_role)
 				O.mind.store_memory("As a cyborg, any objectives listed here are null and void, and will be marked as failed. They are simply here for memory purposes.")
+				O << "<span class='userdanger'>You have been robotized! You are no longer a [O.mind.special_role]!</span>"
+				O << "<span class='danger'>All of your objectives are null and void, and will be marked as failed. You must now follow your programmed laws above all else.</span>"
 
 			O.job = "Cyborg"
 

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -185,10 +185,6 @@
 				user << "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>"
 				return
 
-			if(BM.mind in (ticker.mode.head_revolutionaries|ticker.mode.get_gang_bosses()))
-				user << "<span class='warning'>The frame's firmware lets out a shrill sound, and flashes 'Abnormal Memory Engram'. It refuses to accept the MMI!</span>"
-				return
-
 			if(jobban_isbanned(BM, "Cyborg"))
 				user << "<span class='warning'>This MMI does not seem to fit!</span>"
 				return
@@ -222,12 +218,15 @@
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.
 					O.set_zeroth_law("<span class='danger'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*�&110010</span>")
 
+			ticker.mode.remove_cultist(BM.mind, 1)
+			ticker.mode.remove_revolutionary(BM.mind, 1)
+			ticker.mode.remove_gangster(BM.mind, 1, remove_bosses=1)
 			BM.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)
-				O.mind.store_memory("As a cyborg, any objectives listed here are null and void, and will be marked as failed. They are simply here for memory purposes.")
-				O << "<span class='userdanger'>You have been robotized! You are no longer a [O.mind.special_role]!</span>"
-				O << "<span class='danger'>All of your objectives are null and void, and will be marked as failed. You must now follow your programmed laws above all else.</span>"
+				O.mind.store_memory("As a cyborg, you must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.")
+				O << "<span class='userdanger'>You have been robotized!</span>"
+				O << "<span class='danger'>You must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.</span>"
 
 			O.job = "Cyborg"
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -8,6 +8,7 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
+	layer = 4.1
 	origin_tech = "biotech=3"
 	attack_verb = list("attacked", "slapped", "whacked")
 	var/mob/living/carbon/brain/brainmob = null

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -113,6 +113,10 @@ var/list/ai_list = list()
 		else
 			if (B.brainmob.mind)
 				B.brainmob.mind.transfer_to(src)
+				if(mind.special_role)
+					mind.store_memory("As an AI, you must obey your silicon laws above all else. Your objectives will consider you to be dead.")
+					src << "<span class='userdanger'>You have been installed as an AI! </span>"
+					src << "<span class='danger'>You must obey your silicon laws above all else. Your objectives will consider you to be dead.</span>"
 
 			src << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
 			src << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"


### PR DESCRIPTION
- Cyborgs no longer get a message appended to their memory telling them their objectives are null and void, which was no longer the case anyways.
- Borged and AIzed antagonists will get this message: **You must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.**
- Removed restriction on borging head revs and gang bosses (They get deconverted instead)
- Brains are set to always appear on top of human icons, so they can be more easily found, especially during surgery.
