### PR TITLE
Suit sensors are maxed by default.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -218,8 +218,8 @@ BLIND     // can't see anything
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	var/fitted = FEMALE_UNIFORM_FULL // For use in alternate clothing styles for women
 	var/has_sensor = 1//For the crew computer 2 = unable to change mode
-	var/random_sensor = 1
-	var/sensor_mode = 0	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
+	var/random_sensor = 0
+	var/sensor_mode = 3	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
 	var/can_adjust = 1
 	var/adjusted = 0
 	var/suit_color = null


### PR DESCRIPTION
This will make many medical players happy, because now they don't have to screech about sensors.

"But people will be able to find me easier round start if im their objective!"

They already have your Job Name, so they know where to look already. Just shut off your sensors at round start if you really don't want them.

90% of non-antags might as well have their sensors up anyways.
