### PR TITLE
Security Lockers now start with Security Helmets.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -112,6 +112,7 @@
 	new /obj/item/weapon/grenade/flashbang(src)
 	new /obj/item/weapon/storage/belt/security/full(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+	new /obj/item/clothing/head/helmet/sec(src)
 
 /obj/structure/closet/secure_closet/security/sec
 


### PR DESCRIPTION
They have everything else, but no security helmets.

This made no sense.
