### PR TITLE
Department Heads joining late or at roundstart will have their department underlings notified

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -390,6 +390,7 @@ var/datum/subsystem/job/SSjob
 		else //We ran out of spare locker spawns!
 			break
 
+
 /datum/subsystem/job/proc/LoadJobs(jobsfile) //ran during round setup, reads info from jobs.txt -- Urist
 	if(!config.load_jobs_from_txt)
 		return 0

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -96,4 +96,5 @@ Head of Personnel
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind) //tell underlings they have a head
+	spawn(2) //to wait for initialization stuff
+		announce_head(H.mind, list(":u", ":v")) //tell underlings (cargo and service radio) they have a head

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -95,3 +95,5 @@ Head of Personnel
 	else
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
+
+	announce_head(H.mind) //tell underlings they have a head

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -42,6 +42,8 @@ Chief Engineer
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
+	announce_head(H.mind) //tell underlings they have a head
+
 /*
 Station Engineer
 */

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -42,7 +42,8 @@ Chief Engineer
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind) //tell underlings they have a head
+	spawn(2) //to wait for initialization stuff
+		announce_head(H.mind, list(":e")) //tell underlings (engineering radio) they have a head
 
 /*
 Station Engineer

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -180,4 +180,4 @@
 			if(p_job.department_head)
 				for(var/head in p_job.department_head)
 					if(head == o_mind.assigned_role)
-						p_mind.current << "<span class = 'notice'>[o_mind.name] is your department head! </span>"
+						p_mind.current << "<span class = 'boldannounce'>[head] [o_mind.name] is your department head! </span>"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -173,11 +173,11 @@
 /datum/job/proc/config_check()
 	return 1
 
-/datum/job/proc/announce_head(var/datum/mind/o_mind) //Announces to underlings of the mind's assigned job that the mind is their head.
-	for(var/datum/mind/p_mind in ticker.minds)
-		if(p_mind.current && p_mind.current.stat != DEAD)
-			var/datum/job/p_job = SSjob.GetJob(p_mind.assigned_role)
-			if(p_job.department_head)
-				for(var/head in p_job.department_head)
-					if(head == o_mind.assigned_role)
-						p_mind.current << "<span class = 'boldannounce'>[head] [o_mind.name] is your department head! </span>"
+/datum/job/proc/announce_head(var/datum/mind/o_mind, var/channel) //tells the given channel that the given mind is the new department head. Channel must be given like so: ":n" for science, etc.
+	var/ailist[] = list()
+	for (var/mob/living/silicon/ai/A in living_mob_list)
+		ailist += A
+	if (ailist.len)
+		for(var/a_channel in channel)
+			var/mob/living/silicon/ai/announcer = pick(ailist)
+			announcer.say("[a_channel] [o_mind.name], [o_mind.assigned_role], is the new department head.")

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -172,3 +172,12 @@
 
 /datum/job/proc/config_check()
 	return 1
+
+/datum/job/proc/announce_head(var/datum/mind/o_mind) //Announces to underlings of the mind's assigned job that the mind is their head.
+	for(var/datum/mind/p_mind in ticker.minds)
+		if(p_mind.current && p_mind.current.stat != DEAD)
+			var/datum/job/p_job = SSjob.GetJob(p_mind.assigned_role)
+			if(p_job.department_head)
+				for(var/head in p_job.department_head)
+					if(head == o_mind.assigned_role)
+						p_mind.current << "<span class = 'notice'>[o_mind.name] is your department head! </span>"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -38,7 +38,8 @@ Chief Medical Officer
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind) //tell underlings they have a head
+	spawn(2) //to wait for initialization stuff
+		announce_head(H.mind, list(":m")) //tell underlings (medical radio) they have a head
 
 /*
 Medical Doctor

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -38,6 +38,8 @@ Chief Medical Officer
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
+	announce_head(H.mind) //tell underlings they have a head
+
 /*
 Medical Doctor
 */

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -40,7 +40,8 @@ Research Director
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind) //tell underlings they have a head
+	spawn(2) //to wait for initialization stuff
+		announce_head(H.mind, list(":n")) //tell underlings (science radio) they have a head
 
 /*
 Scientist

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -40,6 +40,8 @@ Research Director
 	if(H.backbag == 2 || H.backbag == 3)
 		H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
+	announce_head(H.mind) //tell underlings they have a head
+
 /*
 Scientist
 */

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -55,6 +55,8 @@ Head of Security
 	L.implanted = 1
 	H.sec_hud_set_implants()
 
+	announce_head(H.mind) //tell underlings they have a head
+
 /*
 Warden
 */

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -55,7 +55,8 @@ Head of Security
 	L.implanted = 1
 	H.sec_hud_set_implants()
 
-	announce_head(H.mind) //tell underlings they have a head
+	spawn(2) //to wait for initialization stuff
+		announce_head(H.mind, list(":s")) //tell underlings (security radio) they have a head
 
 /*
 Warden

--- a/html/changelogs/Chiefwaffles-Who_is_my_boss.yml
+++ b/html/changelogs/Chiefwaffles-Who_is_my_boss.yml
@@ -1,0 +1,6 @@
+author: Chiefwaffles
+
+delete-after: True
+
+changes: 
+  - rscadd: "Department Heads, on arrival, (latejoin or start) now have their name announced to their underlings."

--- a/html/changelogs/Chiefwaffles-Who_is_my_boss.yml
+++ b/html/changelogs/Chiefwaffles-Who_is_my_boss.yml
@@ -3,4 +3,4 @@ author: Chiefwaffles
 delete-after: True
 
 changes: 
-  - rscadd: "Department Heads, on arrival, (latejoin or start) now have their name announced to their underlings."
+  - rscadd: "Department Heads, on arrival, (latejoin or start) will now have their name broadcasted on their department's channel(s)."


### PR DESCRIPTION
**This is both my first pull request and my actual first foray into byond coding!**
So expect (and please point out) horrible things.

The system now works in a way very similar to the AI late-join announcements. When a new head joins, the AI will announce to the respective department radios: "Person McScience, Research Director, is the new department head"

This also works for things like HoP who have control over two departments - the AI will announce his presence to both channels.

Two main flaws with this approach:
- Can get a bit spammy for the AI at roundstart
- Doesn't work without an AI

Heads that will notify their underlings:
- Head of Security
- Research Director
- Head of Personnel (Notifies all of Cargo and Citizen jobs)
- Chief Medical Officer
- Chief Engineer
