### PR TITLE
Fix consistency issues with eyeball screwdrivers

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -375,6 +375,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 	src.add_fingerprint(user)
 
+	playsound(loc, src.hitsound, 30, 1, -1)
+
 	if(M != user)
 		M.visible_message("<span class='danger'>[user] has stabbed [M] in the eye with [src]!</span>", \
 							"<span class='userdanger'>[user] stabs you in the eye with [src]!</span>")
@@ -393,19 +395,19 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		M.take_organ_damage(7)
 
 	M.eye_blurry += rand(2,3) //adds 2 or 3 blurriness with each eyestab
-	M.eye_stat += rand(1,2) //between 10 or 5 eyestabs are necessary to become nearsighted
+	M.eye_stat += rand(1,2) //between 5 and 10 eyestabs are necessary to become nearsighted
 	if (M.eye_stat >= 10)
-		M.eye_blurry += 5+(0.1*M.eye_blurry)//once nearsighted, each stab adds more blurriness based on current blurriness
-		if(M.disabilities != NEARSIGHT)
+		M.eye_blurry += 5+(0.1*M.eye_blurry) //once nearsighted, extra blurriness is added per stab based on current blurrinesss
+		if (!M.disabilities & (NEARSIGHT | BLIND))
 			M.disabilities |= NEARSIGHT
-			M << "<span class='danger'>Your eyes start to bleed profusely!</span>"//hints the victim has become nearsighted
-		if(prob(25))//25% chance of being stunned with an extra 5 blur added to vision
-			if(!(M.stat)) //we don't stun if already stunned to discourage chainstunning
+			M << "<span class='danger'>You become nearsighted!</span>"
+		if(prob(20)) //20% chance of being stunned and an extra 5 blurryness added
+			if(!(M.stat)) //we don't stun if already stunned to limit chainstunning
 				M.Paralyse(1)
 				M.Weaken(2)
-				M << "<span class='danger'>You collapse in pain!</span>"
 			M.eye_blurry += 5
-		if (prob(M.eye_stat - 5 + 1)) //For a 10% chance to go blind, maximum 14 stabs, minimum 7. Increases with each stab.
+
+		if (prob(M.eye_stat - 5 + 1) && !(M.disabilities & BLIND)) //Minimum 7 stabs for a 10% chance to go blind, maximum 14 stabs. Chance increases with each stab.
 			if(M.stat != 2)
 				M << "<span class='danger'>You go blind!</span>"
 			M.disabilities |= BLIND

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -386,35 +386,26 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(is_human_victim)
 		var/mob/living/carbon/human/U = M
 		var/obj/item/organ/limb/affecting = U.get_organ("head")
-		world << "7 damage has been taken to [U]'s head."
 		if(affecting.take_damage(7))
 			U.update_damage_overlays(0)
 
 	else
 		M.take_organ_damage(7)
 
-	M.eye_blurry += rand(3,4)
-	if (M.eye_stat < 10)
-		world << "[M]'s eye blurriness is now [M.eye_blurry]"
+	M.eye_blurry += rand(2,3) //adds 2 or 3 blurriness with each eyestab
 	M.eye_stat += rand(1,2) //5 or 10 eyestabs are necessary to become nearsighted
-	world << "[M]'s eye stat is now [M.eye_stat]"
 	if (M.eye_stat >= 10)
-		M.eye_blurry += 5+(0.1*M.eye_blurry)
+		M.eye_blurry += 5+(0.1*M.eye_blurry) //if nearsighted, each stab adds extra blurriness based on current blurriness
 		if(M.disabilities != NEARSIGHT)
 			M.disabilities |= NEARSIGHT
-			world << "[M] is now nearsighted due to having an eye stat at or above 10: [M.eye_stat]!"
-			(!(M.stat))
-				M << "<span class='danger'>Your eyes start to bleed profusely!</span>"//warns the victim they're nearsighted
-		if(prob(30))//30% chance of being stunned and an extra 10 blur added to vision
-			world << "[M] has passed the 30% probability check and will be paralysed, weakened and further blinded."
-			if(M.stat != 2)
-				M.Paralyse(1) //we don't paralyse or weaken if already stunned to prevent chainstunning
+			M << "<span class='danger'>Your vision is a mess!</span>"//warns the victim they've become nearsighted
+		if(prob(25))//25% chance of being stunned and an extra 5 blur added to vision
+			if(!(M.stat)) //we don't paralyse or weaken if already stunned to discourage chainstunning
+				M.Paralyse(1)
 				M.Weaken(2)
-				M << "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>"
-			M.eye_blurry += 10
-			world << "[M]'s eye blurriness had 10 added to it for a total of [M.eye_blurry]"
-		if (prob(M.eye_stat - 10 + 1)) //chance to go blind, currently 5 or 6 stabs after going nearsighted grants 10% per stab
-			world << "[M] has gone blind at a [(prob(M.eye_stat - 10 + 1))]% chance!"
+				M << "<span class='danger'>You collapse in pain!</span>"
+			M.eye_blurry += 5
+		if (prob(M.eye_stat - 10 + 1)) //chance to go blind. after 6 stabs while nearsighted, there's a 10% chance to go blind that keeps increasing with each stab
 			if(M.stat != 2)
 				M << "<span class='danger'>You go blind!</span>"
 			M.disabilities |= BLIND

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -386,6 +386,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(is_human_victim)
 		var/mob/living/carbon/human/U = M
 		var/obj/item/organ/limb/affecting = U.get_organ("head")
+		world << "7 damage has been taken to [U]'s head."
 		if(affecting.take_damage(7))
 			U.update_damage_overlays(0)
 
@@ -393,20 +394,27 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		M.take_organ_damage(7)
 
 	M.eye_blurry += rand(3,4)
-	M.eye_stat += rand(2,4)
+	if (M.eye_stat < 10)
+		world << "[M]'s eye blurriness is now [M.eye_blurry]"
+	M.eye_stat += rand(1,2) //5 or 10 eyestabs are necessary to become nearsighted
+	world << "[M]'s eye stat is now [M.eye_stat]"
 	if (M.eye_stat >= 10)
-		M.eye_blurry += 15+(0.1*M.eye_blurry)
-		M.disabilities |= NEARSIGHT
-		if(M.stat != 2)
-			M << "<span class='danger'>Your eyes start to bleed profusely!</span>"
-		if(prob(50))
+		M.eye_blurry += 5+(0.1*M.eye_blurry)
+		if(M.disabilities != NEARSIGHT)
+			M.disabilities |= NEARSIGHT
+			world << "[M] is now nearsighted due to having an eye stat at or above 10: [M.eye_stat]!"
+			(!(M.stat))
+				M << "<span class='danger'>Your eyes start to bleed profusely!</span>"//warns the victim they're nearsighted
+		if(prob(30))//30% chance of being stunned and an extra 10 blur added to vision
+			world << "[M] has passed the 30% probability check and will be paralysed, weakened and further blinded."
 			if(M.stat != 2)
-				if(M.drop_item())
-					M << "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>"
+				M.Paralyse(1) //we don't paralyse or weaken if already stunned to prevent chainstunning
+				M.Weaken(2)
+				M << "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>"
 			M.eye_blurry += 10
-			M.Paralyse(1)
-			M.Weaken(2)
-		if (prob(M.eye_stat - 10 + 1))
+			world << "[M]'s eye blurriness had 10 added to it for a total of [M.eye_blurry]"
+		if (prob(M.eye_stat - 10 + 1)) //chance to go blind, currently 5 or 6 stabs after going nearsighted grants 10% per stab
+			world << "[M] has gone blind at a [(prob(M.eye_stat - 10 + 1))]% chance!"
 			if(M.stat != 2)
 				M << "<span class='danger'>You go blind!</span>"
 			M.disabilities |= BLIND

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -394,20 +394,23 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	else
 		M.take_organ_damage(7)
 
-	M.eye_blurry += rand(2,3) //adds 2 or 3 blurriness with each eyestab
-	M.eye_stat += rand(1,2) //between 5 and 10 eyestabs are necessary to become nearsighted
+	M.eye_blurry += rand(3,4)
+	M.eye_stat += rand(2,4)
 	if (M.eye_stat >= 10)
-		M.eye_blurry += 5+(0.1*M.eye_blurry) //once nearsighted, extra blurriness is added per stab based on current blurrinesss
-		if (!M.disabilities & (NEARSIGHT | BLIND))
+		M.eye_blurry += 15+(0.1*M.eye_blurry)
+		if(M.stat != 2)
+			M << "<span class='danger'>Your eyes start to bleed profusely!</span>"
+		if (!(M.disabilities & (NEARSIGHT | BLIND)))
 			M.disabilities |= NEARSIGHT
 			M << "<span class='danger'>You become nearsighted!</span>"
-		if(prob(20)) //20% chance of being stunned and an extra 5 blurryness added
-			if(!(M.stat)) //we don't stun if already stunned to limit chainstunning
-				M.Paralyse(1)
-				M.Weaken(2)
-			M.eye_blurry += 5
-
-		if (prob(M.eye_stat - 5 + 1) && !(M.disabilities & BLIND)) //Minimum 7 stabs for a 10% chance to go blind, maximum 14 stabs. Chance increases with each stab.
+		if(prob(50))
+			if(M.stat != 2)
+				if(M.drop_item())
+					M << "<span class='danger'>You drop what you're holding and clutch at your eyes!</span>"
+			M.eye_blurry += 10
+			M.Paralyse(1)
+			M.Weaken(2)
+		if (prob(M.eye_stat - 10 + 1) && !(M.disabilities & BLIND))
 			if(M.stat != 2)
 				M << "<span class='danger'>You go blind!</span>"
 			M.disabilities |= BLIND

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -393,19 +393,19 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		M.take_organ_damage(7)
 
 	M.eye_blurry += rand(2,3) //adds 2 or 3 blurriness with each eyestab
-	M.eye_stat += rand(1,2) //5 or 10 eyestabs are necessary to become nearsighted
+	M.eye_stat += rand(1,2) //between 10 or 5 eyestabs are necessary to become nearsighted
 	if (M.eye_stat >= 10)
-		M.eye_blurry += 5+(0.1*M.eye_blurry) //if nearsighted, each stab adds extra blurriness based on current blurriness
+		M.eye_blurry += 5+(0.1*M.eye_blurry)//once nearsighted, each stab adds more blurriness based on current blurriness
 		if(M.disabilities != NEARSIGHT)
 			M.disabilities |= NEARSIGHT
-			M << "<span class='danger'>Your vision is a mess!</span>"//warns the victim they've become nearsighted
-		if(prob(25))//25% chance of being stunned and an extra 5 blur added to vision
-			if(!(M.stat)) //we don't paralyse or weaken if already stunned to discourage chainstunning
+			M << "<span class='danger'>Your eyes start to bleed profusely!</span>"//hints the victim has become nearsighted
+		if(prob(25))//25% chance of being stunned with an extra 5 blur added to vision
+			if(!(M.stat)) //we don't stun if already stunned to discourage chainstunning
 				M.Paralyse(1)
 				M.Weaken(2)
 				M << "<span class='danger'>You collapse in pain!</span>"
 			M.eye_blurry += 5
-		if (prob(M.eye_stat - 10 + 1)) //chance to go blind. after 6 stabs while nearsighted, there's a 10% chance to go blind that keeps increasing with each stab
+		if (prob(M.eye_stat - 5 + 1)) //For a 10% chance to go blind, maximum 14 stabs, minimum 7. Increases with each stab.
 			if(M.stat != 2)
 				M << "<span class='danger'>You go blind!</span>"
 			M.disabilities |= BLIND


### PR DESCRIPTION
- Eyeball stabs now play an attack sound, like most other attacks.
- Nearsightedness will only be applied once, rather than every non-blinding attack (and not at all if the victim is already blind)
- Blinding will only be applied once, ditto.

Thanks @freerealestate for getting this started.
