### PR TITLE
Lowers cost of Syndicate Encryption Key and Uplink Implant [balance]

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -551,7 +551,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Encryption Key"
 	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
 	item = /obj/item/device/encryptionkey/syndicate
-	cost = 5
+	cost = 2 //Nowhere near as useful as the Binary Key!
 	surplus = 75
 
 /datum/uplink_item/device_tools/ai_detector
@@ -653,7 +653,7 @@ var/list/uplink_items = list()
 	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 10 telecrystals. \
 	The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	cost = 20
+	cost = 14
 	surplus = 0
 
 /datum/uplink_item/implants/adrenal


### PR DESCRIPTION
The syndicate encryption key: A cool idea to help traitors work together and collaborate to take down targets.

Never, ever used.

Now it will still never, ever be used, but the poor souls who take it every time in vain hope will pay less (2TC down from 5) to soliloquy into dead air.

The uplink Implant: an awesome idea in theory - but in practice, again, never taken. Cutting your TC in half for the ability to buy some stuff in the permabrig is planning to fail, not planning to win, and that's no good.

Now, traitors who buy the (14 TC down from 20) still have enough to buy other kit, such as an emag, or an AI monitor and camera bug, or a minibomb, whilst still not being able to purchase WMDs and revolvers.
