### PR TITLE
Change w_class of Power Cells from 3.0 to 2

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -9,7 +9,7 @@
 	throwforce = 5.0
 	throw_speed = 2
 	throw_range = 5
-	w_class = 3.0
+	w_class = 2.0 //is that a power cell in your pocket, or are you happy to see me?
 	var/charge = 0	// note %age conveted to actual charge in New
 	var/maxcharge = 1000
 	materials = list(MAT_METAL=700, MAT_GLASS=50)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -9,7 +9,7 @@
 	throwforce = 5.0
 	throw_speed = 2
 	throw_range = 5
-	w_class = 2.0 //is that a power cell in your pocket, or are you happy to see me?
+	w_class = 2.0
 	var/charge = 0	// note %age conveted to actual charge in New
 	var/maxcharge = 1000
 	materials = list(MAT_METAL=700, MAT_GLASS=50)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -9,7 +9,7 @@
 	throwforce = 5.0
 	throw_speed = 2
 	throw_range = 5
-	w_class = 2.0
+	w_class = 2
 	var/charge = 0	// note %age conveted to actual charge in New
 	var/maxcharge = 1000
 	materials = list(MAT_METAL=700, MAT_GLASS=50)


### PR DESCRIPTION
This allows you to put any power cell in a box/pockets/etc.

It makes sense both in terms of how big it looks and mechanics. I don't really see any reason not to let you fit power cells in your pockets. This should really just make the lives of engineers a bit easier.
