### PR TITLE
Attack logging tweaks/cleanup

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -128,7 +128,7 @@ Proc for attack log creation, because really why not
 6 is additional information, anything that needs to be added
 */
 
-/proc/add_logs(mob/user, mob/target, what_done, var/admin=1, var/object=null, var/addition=null)
+/proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=null)
 	var/newhealthtxt = ""
 	if (target && isliving(target))
 		var/mob/living/L = target
@@ -137,5 +137,4 @@ Proc for attack log creation, because really why not
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Has [what_done] [target ? "[target.name][(ismob(target) && target.ckey) ? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition][newhealthtxt]</font>")
 	if(target && ismob(target))
 		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [what_done] by [user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition][newhealthtxt]</font>")
-	if(admin)
-		log_attack("[user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"] [what_done] [target ? "[target.name][(ismob(target) && target.ckey)? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition][newhealthtxt]")
+	log_attack("[user ? "[user.name][(ismob(user) && user.ckey) ? "([user.ckey])" : ""]" : "NON-EXISTANT SUBJECT"] [what_done] [target ? "[target.name][(ismob(target) && target.ckey)? "([target.ckey])" : ""]" : "NON-EXISTANT SUBJECT"][object ? " with [object]" : " "][addition][newhealthtxt]")

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -76,11 +76,12 @@
 	user.lastattacked = M
 	M.lastattacker = user
 
-	add_logs(user, M, "attacked", object=src.name, addition="(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
-
 	//spawn(1800)            // this wont work right
 	//	M.lastattacker = null
 	/////////////////////////
 	M.attacked_by(src, user, def_zone)
+
+	add_logs(user, M, "attacked", src.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 	add_fingerprint(user)
+
 	return 1

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -25,7 +25,7 @@
 	return
 
 /datum/martial_art/proc/basic_hit(var/mob/living/carbon/human/A,var/mob/living/carbon/human/D)
-	add_logs(A, D, "punched")
+
 	A.do_attack_animation(D)
 	var/damage = rand(0,9)
 
@@ -44,6 +44,7 @@
 		else
 			playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 			D.visible_message("<span class='warning'>[A] has attempted to [atk_verb] [D]!</span>")
+			add_logs(A, D, "attempted to [atk_verb]")
 			return 0
 
 	var/obj/item/organ/limb/affecting = D.get_organ(ran_zone(A.zone_sel.selecting))
@@ -58,6 +59,9 @@
 								"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>")
 
 	D.apply_damage(damage, BRUTE, affecting, armor_block)
+
+	add_logs(A, D, "punched")
+
 	if((D.stat != DEAD) && damage >= 9)
 		D.visible_message("<span class='danger'>[A] has weakened [D]!!</span>", \
 								"<span class='userdanger'>[A] has weakened [D]!</span>")
@@ -95,7 +99,7 @@
 	return 1
 
 /datum/martial_art/boxing/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(A, D, "punched")
+
 	A.do_attack_animation(D)
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
@@ -109,6 +113,7 @@
 		else
 			playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 			D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")
+			add_logs(A, D, "attempted to hit", atk_verb)
 			return 0
 
 
@@ -122,6 +127,7 @@
 								"<span class='userdanger'>[A] has hit [D] with a [atk_verb]!</span>")
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
+	add_logs(A, D, "punched")
 	if(D.getStaminaLoss() > 50)
 		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
 		if((D.stat != DEAD) && prob(knockout_prob))
@@ -151,13 +157,15 @@
 
 
 /datum/martial_art/wrestling/proc/Suplex(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(A, D, "suplexed")
+
 	D.visible_message("<span class='danger'>[A] suplexes [D]!</span>", \
 								"<span class='userdanger'>[A] suplexes [D]!</span>")
 	D.forceMove(A.loc)
 	var/armor_block = D.run_armor_check(null, "melee")
 	D.apply_damage(30, BRUTE, null, armor_block)
 	D.apply_effect(6, WEAKEN, armor_block)
+	add_logs(A, D, "suplexed")
+
 	A.SpinAnimation(10,1)
 
 	D.SpinAnimation(10,1)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -97,7 +97,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 				//Cutting this wire electrifies the door, so that the next person to touch the door without insulated gloves gets electrocuted.
 				if(A.secondsElectrified != -1)
 					A.shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-					add_logs(usr, A, "electrified", admin=0, addition="at [A.x],[A.y],[A.z]")
+					add_logs(usr, A, "electrified", addition="at [A.x],[A.y],[A.z]")
 					A.secondsElectrified = -1
 			else
 				if(A.secondsElectrified == -1)
@@ -164,7 +164,7 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			//one wire for electrifying the door. Sending a pulse through this electrifies the door for 30 seconds.
 			if(A.secondsElectrified==0)
 				A.shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-				add_logs(usr, A, "electrified", admin=0, addition="at [A.x],[A.y],[A.z]")
+				add_logs(usr, A, "electrified", addition="at [A.x],[A.y],[A.z]")
 				A.secondsElectrified = 30
 				spawn(10)
 					if(A)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -78,7 +78,7 @@
 /atom/proc/attack_hulk(mob/living/carbon/human/hulk, do_attack_animation = 0)
 	if(do_attack_animation)
 		hulk.changeNext_move(CLICK_CD_MELEE)
-		add_logs(hulk, src, "punched", "hulk powers", admin=0)
+		add_logs(hulk, src, "punched", "hulk powers")
 		hulk.do_attack_animation(src)
 	return
 

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -54,7 +54,6 @@
 	user << "<span class='notice'>We stealthily sting [target.name].</span>"
 	if(target.mind && target.mind.changeling)
 		target << "<span class='warning'>You feel a tiny prick.</span>"
-		add_logs(user, target, "unsuccessfully stung")
 	return 1
 
 
@@ -87,7 +86,7 @@
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(var/mob/user, var/mob/target)
-	add_logs(user, target, "stung", object="transformation sting", addition=" new identity is [selected_dna.real_name]")
+	add_logs(user, target, "stung", "transformation sting", " new identity is [selected_dna.real_name]")
 	var/datum/dna/NewDNA = selected_dna
 	if(ismonkey(target))
 		user << "<span class='notice'>We stealthily sting [target.name].</span>"
@@ -109,7 +108,7 @@
 		return user.mind.changeling.can_absorb_dna(user, target)
 
 /obj/effect/proc_holder/changeling/sting/extract_dna/sting_action(var/mob/user, var/mob/living/carbon/human/target)
-	add_logs(user, target, "stung", object="extraction sting")
+	add_logs(user, target, "stung", "extraction sting")
 	if(!(user.mind.changeling.has_dna(target.dna)))
 		user.mind.changeling.absorb_dna(target, user)
 	feedback_add_details("changeling_powers","ED")
@@ -124,7 +123,7 @@
 	dna_cost = 2
 
 /obj/effect/proc_holder/changeling/sting/mute/sting_action(var/mob/user, var/mob/living/carbon/target)
-	add_logs(user, target, "stung", object="mute sting")
+	add_logs(user, target, "stung", "mute sting")
 	target.silent += 30
 	feedback_add_details("changeling_powers","MS")
 	return 1
@@ -138,7 +137,7 @@
 	dna_cost = 1
 
 /obj/effect/proc_holder/changeling/sting/blind/sting_action(var/mob/user, var/mob/target)
-	add_logs(user, target, "stung", object="blind sting")
+	add_logs(user, target, "stung", "blind sting")
 	target << "<span class='danger'>Your eyes burn horrifically!</span>"
 	target.disabilities |= NEARSIGHT
 	target.eye_blind = 20
@@ -155,7 +154,7 @@
 	dna_cost = 1
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(var/mob/user, var/mob/living/carbon/target)
-	add_logs(user, target, "stung", object="LSD sting")
+	add_logs(user, target, "stung", "LSD sting")
 	spawn(rand(300,600))
 		if(target)
 			target.hallucination = max(400, target.hallucination)
@@ -171,7 +170,7 @@
 	dna_cost = 2
 
 /obj/effect/proc_holder/changeling/sting/cryo/sting_action(var/mob/user, var/mob/target)
-	add_logs(user, target, "stung", object="cryo sting")
+	add_logs(user, target, "stung", "cryo sting")
 	if(target.reagents)
 		target.reagents.add_reagent("frostoil", 30)
 	feedback_add_details("changeling_powers","CS")

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -490,13 +490,13 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 //		usr << browse(null, "window=tank")
 
 /obj/item/weapon/tome/attack(mob/living/M as mob, mob/living/user as mob)
-	add_logs(user, M, "smacked", object=src)
 	if(istype(M,/mob/dead))
 		M.invisibility = 0
 		user.visible_message( \
 			"<span class='danger'>[user] drags the ghost to our plane of reality!</span>", \
 			"<span class='danger'>You drag the ghost to our plane of reality!</span>" \
 		)
+		add_logs(user, M, "smacked", src)
 		return
 	if(!istype(M))
 		return
@@ -508,10 +508,12 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			var/holy2unholy = M.reagents.get_reagent_amount("holywater")
 			M.reagents.del_reagent("holywater")
 			M.reagents.add_reagent("unholywater",holy2unholy)
+			add_logs(user, M, "smacked", src, " removing the holy water from them")
 		return
 	M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit
 	M.visible_message("<span class='danger'>[user] beats [M] with the arcane tome!</span>", \
 					"<span class='userdanger'>[user] beats you with the tome, and you feel a searing heat inside you!</span>")
+	add_logs(user, M, "smacked", src)
 
 
 /obj/item/weapon/tome/attack_self(mob/living/user as mob)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -29,7 +29,7 @@
 		return ..()
 	if(istype(M, /mob/living/carbon/human/dummy))
 		return..()
-	add_logs(user, M, "captured [M.name]'s soul", object=src)
+	add_logs(user, M, "captured [M.name]'s soul", src)
 
 	transfer_soul("VICTIM", M, user)
 	return

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -167,7 +167,7 @@
 	M.changeNext_move(CLICK_CD_MELEE)
 	health -= M.melee_damage_upper
 	visible_message("<span class='danger'>[M] has [M.attacktext] [src]!</span>")
-	add_logs(M, src, "attacked", admin=0)
+	add_logs(M, src, "attacked")
 	if(prob(10))
 		new /obj/effect/decal/cleanable/oil(loc)
 	healthcheck()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -831,7 +831,7 @@ About the new airlock wires panel:
 						usr << text("The door is already electrified. You can't re-electrify it while it's already electrified.<br>\n")
 					else
 						shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-						add_logs(usr, src, "electrified", admin=0, addition="at [x],[y],[z]")
+						add_logs(usr, src, "electrified", addition="at [x],[y],[z]")
 						src.secondsElectrified = 30
 						spawn(10)
 							while (src.secondsElectrified>0)
@@ -850,7 +850,7 @@ About the new airlock wires panel:
 						usr << text("The door is already electrified. You can't re-electrify it while it's already electrified.<br>\n")
 					else
 						shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
-						add_logs(usr, src, "electrified", admin=0, addition="at [x],[y],[z]")
+						add_logs(usr, src, "electrified", addition="at [x],[y],[z]")
 						src.secondsElectrified = -1
 
 				if (8) // Not in order >.>

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -315,7 +315,7 @@
 		return
 	if(!(stat & BROKEN))
 		visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>")
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		take_damage(M.melee_damage_upper)
 	else
 		M << "<span class='danger'>That object is useless to you.</span>"
@@ -327,7 +327,7 @@
 	if(!(stat & BROKEN))
 		playsound(src.loc, 'sound/weapons/slash.ogg', 25, 1, -1)
 		visible_message("<span class='danger'>[M] has slashed at [src]!</span>")
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		take_damage(15)
 	else
 		M << "\green That object is useless to you."

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -314,7 +314,7 @@
 	if(M.melee_damage_upper == 0)	return
 	if(!(stat & BROKEN))
 		visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>")
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		//src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [M.name] ([M.ckey])</font>")
 		src.health -= M.melee_damage_upper
 		if (src.health <= 0)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -196,7 +196,7 @@
 	if(to_inject && occupant.reagents.get_reagent_amount(R.id) + to_inject <= inject_amount*2)
 		occupant_message("Injecting [occupant] with [to_inject] units of [R.name].")
 		log_message("Injecting [occupant] with [to_inject] units of [R.name].")
-		add_logs(chassis.occupant, occupant, "injected", object="[name] ([R] - [to_inject] units)")
+		add_logs(chassis.occupant, occupant, "injected", "[name] ([R] - [to_inject] units)")
 		SG.reagents.trans_id_to(occupant,R.id,to_inject)
 		update_equip_info()
 	return
@@ -328,7 +328,6 @@
 				if(M)
 					var/R
 					mechsyringe.visible_message("<span class=\"attack\"> [M] was hit by the syringe!</span>")
-					add_logs(originaloccupant, M, "shot", object="syringegun")
 					if(M.can_inject(null, 1))
 						if(mechsyringe.reagents)
 							for(var/datum/reagent/A in mechsyringe.reagents.reagent_list)
@@ -338,6 +337,7 @@
 						mechsyringe.icon = initial(mechsyringe.icon)
 						mechsyringe.reagents.trans_to(M, mechsyringe.reagents.total_volume)
 						M.take_organ_damage(2)
+						add_logs(originaloccupant, M, "shot", "syringegun")
 					break
 				else if(mechsyringe.loc == trg)
 					mechsyringe.icon_state = initial(mechsyringe.icon_state)

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -66,7 +66,7 @@
 			target.visible_message("<span class='danger'>[chassis] squeezes [target].</span>", \
 								"<span class='userdanger'>[chassis] squeezes [target].</span>",\
 								"<span class='italics'>You hear something crack.</span>")
-			add_logs(chassis.occupant, M, "attacked", object="[name]", addition="(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+			add_logs(chassis.occupant, M, "attacked", "[name]", "(INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 		else
 			step_away(M,chassis)
 			occupant_message("You push [target] out of the way.")
@@ -151,7 +151,6 @@
 /obj/item/mecha_parts/mecha_equipment/tool/drill/proc/drill_mob(mob/living/target, mob/user, var/drill_damage=80)
 	target.visible_message("<span class='danger'>[chassis] drills [target] with [src].</span>", \
 						"<span class='userdanger'>[chassis] drills [target] with [src].</span>")
-	add_logs(user, target, "attacked", object="[name]", addition="(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/limb/affecting = H.get_organ("chest")
@@ -162,6 +161,7 @@
 	if(target)
 		target.Paralyse(10)
 		target.updatehealth()
+	add_logs(user, target, "attacked", "[name]", "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 
 /obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill
 	name = "diamond-tipped exosuit drill"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -128,7 +128,7 @@
 	src.life -= 10
 	if(ismob(A))
 		var/mob/M = A
-		add_logs(firer, M, "shot", object="[src]")
+		add_logs(firer, M, "shot", "[src]")
 	if(life <= 0)
 		qdel(src)
 	return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -325,7 +325,7 @@
 		return
 	visible_message("<span class='danger'>[M.name] has hit [src].</span>")
 	take_damage(M.force, damtype)
-	add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
+	add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	return
 
 /obj/mecha/proc/range_action(atom/target)
@@ -546,12 +546,12 @@
 			src.take_damage(damage)
 			src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 			visible_message("<span class='danger'>[user] [user.attacktext] [src]!</span>")
-			add_logs(user, src, "attacked", admin=0)
+			add_logs(user, src, "attacked")
 		else
 			src.log_append_to_last("Armor saved.")
 			playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
 			visible_message("<span class='notice'>The [user] rebounds off [src.name]'s armor!</span>")
-			add_logs(user, src, "attacked", admin=0)
+			add_logs(user, src, "attacked")
 	return
 
 /obj/mecha/attack_tk()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -371,8 +371,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		user << "<span class='danger'>You cannot locate any organic eyes on this brain!</span>"
 		return
 
-	add_logs(user, M, "attacked", object="[src.name]", addition="(INTENT: [uppertext(user.a_intent)])")
-
 	src.add_fingerprint(user)
 
 	if(M != user)
@@ -391,6 +389,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 	else
 		M.take_organ_damage(7)
+
+	add_logs(user, M, "attacked", "[src.name]", "(INTENT: [uppertext(user.a_intent)])")
 
 	M.eye_blurry += rand(3,4)
 	M.eye_stat += rand(2,4)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -18,7 +18,7 @@
 	var/mob/living/silicon/ai/AI = locate(/mob/living/silicon/ai) in src
 	if(AI) //AI is on the card, implies user wants to upload it.
 		target.transfer_ai(AI_TRANS_FROM_CARD, user, AI, src)
-		add_logs(user, AI, "carded", object="[name]")
+		add_logs(user, AI, "carded", src)
 	else //No AI on the card, therefore the user wants to download one.
 		target.transfer_ai(AI_TRANS_TO_CARD, user, null, src)
 	update_state() //Whatever happened, update the card's state (icon, name) to match.

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -58,7 +58,7 @@
 
 
 /obj/item/device/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5, targeted = 1)
-	add_logs(user, M, "flashed", object="[src.name]")
+	add_logs(user, M, "flashed", src)
 	if(user && targeted)
 		if(M.weakeyes)
 			M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
@@ -89,7 +89,7 @@
 		return 1
 
 	else if(issilicon(M))
-		add_logs(user, M, "flashed", object="[src.name]")
+		add_logs(user, M, "flashed", src)
 		flick("e_flash", M.flash)
 		M.Weaken(rand(5,10))
 		user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the flash!</span>", "<span class='danger'>You overload [M]'s sensors with the flash!</span>")

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -313,7 +313,7 @@ obj/item/device/flashlight/lamp/bananalamp
 											"<span class='userdanger'>[user] blinks \the [src] at \the [A].")
 		if(ismob(A))
 			var/mob/M = A
-			add_logs(user, M, "attacked", object="EMP-light")
+			add_logs(user, M, "attacked", "EMP-light")
 		user << "\The [src] now has [emp_cur_charges] charge\s."
 		A.emp_act(1)
 	else

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -98,7 +98,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(user.zone_sel.selecting == "eyes")
-			add_logs(user, C, "shone in the eyes", object="laser pointer")
+			add_logs(user, C, "shone in the eyes", src)
 
 			var/severity = 1
 			if(prob(33))
@@ -123,7 +123,7 @@
 			S.Weaken(rand(5,10))
 			S << "<span class='danger'>Your sensors were overloaded by a laser!</span>"
 			outmsg = "<span class='notice'>You overload [S] by shining [src] at their sensors.</span>"
-			add_logs(user, S, "shone in the sensors", object="laser pointer")
+			add_logs(user, S, "shone in the sensors", src)
 		else
 			outmsg = "<span class='warning'>You fail to overload [S] by shining [src] at their sensors!</span>"
 
@@ -133,7 +133,7 @@
 		if(prob(effectchance * diode.rating))
 			C.emp_act(1)
 			outmsg = "<span class='notice'>You hit the lens of [C] with [src], temporarily disabling the camera!</span>"
-			add_logs(user, C, "EMPed", object="laser pointer")
+			add_logs(user, C, "EMPed", src)
 		else
 			outmsg = "<span class='warning'>You miss the lens of [C] with [src]!</span>"
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -37,7 +37,7 @@ effective or pretty fucking useless.
 		user << "<span class='danger'>The mind batterer has been burnt out!</span>"
 		return
 
-	add_logs(user, null, "knocked down people in the area", admin=0, object="[src]")
+	add_logs(user, null, "knocked down people in the area", src)
 
 	for(var/mob/living/carbon/human/M in orange(10, user))
 		spawn()
@@ -88,7 +88,7 @@ effective or pretty fucking useless.
 
 /obj/item/device/rad_laser/attack(mob/living/M as mob, mob/living/user as mob)
 	if(!used)
-		add_logs(user, M, "irradiated", object="[src.name]")
+		add_logs(user, M, "irradiated", src)
 		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>")
 		var/cooldown = round(max(100,(((intensity*8)-(wavelength/2))+(intensity*2))*10))
 		used = 1

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -22,7 +22,7 @@
 		if (O.client)
 			O.show_message("<span class='danger'>[user] has prodded [M] with an electrically-charged arm!</span>", 1,
 							 "<span class='italics'>You hear someone fall.</span>", 2)
-	add_logs(user, M, "stunned", object="[src.name]", addition="(INTENT: [uppertext(user.a_intent)])")
+	add_logs(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
 
 /obj/item/borg/overdrive
 	name = "overdrive"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -352,7 +352,7 @@
 			H.updatehealth() //forces health update before next life tick
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			add_logs(user, M, "stunned", object="defibrillator")
+			add_logs(user, M, "stunned", defib)
 			defib.deductcharge(revivecost)
 			cooldown = 1
 			busy = 0
@@ -386,7 +386,7 @@
 							if(!HU.stat)
 								HU.visible_message("<span class='warning'>[M] thrashes wildly, clutching at their chest!</span>", "<span class='userdanger'>You feel a horrible agony in your chest!</span>")
 						HU.apply_damage(50, BURN, "chest")
-						add_logs(user, M, "overloaded the heart of", object="defibrillator")
+						add_logs(user, M, "overloaded the heart of", defib)
 						M.Weaken(5)
 						M.Jitter(100)
 						defib.deductcharge(revivecost)
@@ -454,7 +454,7 @@
 							if(tplus > tloss)
 								H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
 							defib.deductcharge(revivecost)
-							add_logs(user, M, "revived", object="defibrillator")
+							add_logs(user, M, "revived", defib)
 						else
 							if (H.suiciding || (NOCLONE in H.mutations))
 								user.visible_message("<span class='warning'>[defib] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>")

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -52,7 +52,7 @@
 		var/mob/living/carbon/human/humantarget = target
 		if (!humantarget.can_inject(user, 1))
 			return
-	add_logs(user, target, "attempted to inject", object="[name]")
+	add_logs(user, target, "attempted to inject", src)
 
 	if(target != user)
 		target.visible_message("<span class='danger'>[user] is trying to inject [target] with [src]!</span>", "<span class='userdanger'>[user] is trying to inject [target] with [src]!</span>")
@@ -63,7 +63,7 @@
 	else
 		user << "<span class='notice'>You inject yourself with [src].</span>"
 
-	add_logs(user, target, "injected", object="[name]")
+	add_logs(user, target, "injected", src)
 
 	inject(target, user)	//Now we actually do the heavy lifting.
 	qdel(src)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -75,15 +75,8 @@
 		src.target = target
 		loc = null
 
-		if (ismob(target))
-			add_logs(user, target, "planted [name] on")
-			user.visible_message("<span class='warning'>[user.name] finished planting an explosive on [target.name].</span>", "<span class='notice'>You finish planting an explosive on [target.name].</span>")
-			message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) planted [src.name] on [key_name_admin(target)](<A HREF='?_src_=holder;adminmoreinfo=\ref[target]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[target]'>FLW</A>) with [timer] second fuse",0,1)
-			log_game("[key_name(user)] planted [src.name] on [key_name(target)] with [timer] second fuse")
-
-		else
-			message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) planted [src.name] on [target.name] at ([target.x],[target.y],[target.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>) with [timer] second fuse",0,1)
-			log_game("[key_name(user)] planted [src.name] on [target.name] at ([target.x],[target.y],[target.z]) with [timer] second fuse")
+		message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) planted [src.name] on [target.name] at ([target.x],[target.y],[target.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>) with [timer] second fuse",0,1)
+		log_game("[key_name(user)] planted [src.name] on [target.name] at ([target.x],[target.y],[target.z]) with [timer] second fuse")
 
 		target.overlays += image_overlay
 		user << "<span class='notice'>You plant the bomb. Timer counting down from [timer].</span>"

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -65,7 +65,7 @@
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)
-			add_logs(user, target, "flamethrowered", admin=0, addition="at [target.x],[target.y],[target.z]")
+			add_logs(user, target, "flamethrowered", src, "at [target.x],[target.y],[target.z]")
 			flame_turf(turflist)
 
 /obj/item/weapon/flamethrower/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -31,7 +31,7 @@
 				if(M.head && (M.head.flags & THICKMATERIAL))
 					return
 				M.visible_message("[user] has implanted [M].", "<span class='notice'>[user] implants you with the implant.</span>")
-				add_logs(user, M, "implanted", object="[name]")
+				add_logs(user, M, "implanted", src)
 				user << "<span class='notice'>You implant the implant into [M].</span>"
 				if(imp.implanted(M))
 					imp.loc = M

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -57,7 +57,7 @@
 			if(cooldown <= 0)
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 				target.Weaken(3)
-				add_logs(user, target, "stunned", object="classic baton")
+				add_logs(user, target, "stunned", src)
 				src.add_fingerprint(user)
 				target.visible_message("<span class ='danger'>[user] has knocked down [target] with \the [src]!</span>", \
 					"<span class ='userdanger'>[user] has knocked down [target] with \the [src]!</span>")

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -84,7 +84,7 @@
 		return
 	user.visible_message("<span class='danger'>[user] fires \the [src]!</span>", \
 			     "<span class='warning'>You fire \the [src]!</span>")
-	add_logs(user, target, "fired at", object="pneumatic cannon")
+	add_logs(user, target, "fired at", src)
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', (50 * pressureSetting), 1)
 	for(var/obj/item/ITD in loadedItems) //Item To Discharge
 		spawn(0)

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -130,7 +130,7 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 	if(user.mind && (user.mind.assigned_role == "Chaplain"))
 		chaplain = 1
 
-	add_logs(user, M, "attacked", object="[src.name]")
+
 
 	if (!user.IsAdvancedToolUser())
 		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
@@ -183,6 +183,7 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 			M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
 					"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
 			playsound(src.loc, "punch", 25, 1, -1)
+			add_logs(user, M, "attacked", src)
 
 	else if(M.stat == 2)
 		M.visible_message("<span class='danger'>[user] smacks [M]'s lifeless corpse with [src].</span>")

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -33,7 +33,7 @@
 		notify_ghosts("Someone has begun playing with a [src.name] in [get_area(src)]!")
 
 	planchette = input("Choose the letter.", "Seance!") in list("A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z")
-	add_logs(M, src, "picked a letter on", addition="which was \"[planchette]\".")
+	add_logs(M, src, "picked a letter on", " which was \"[planchette]\".")
 	cooldown = world.time
 	lastuser = M.ckey
 

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -43,7 +43,7 @@
 		if(!reagents || !reagents.total_volume)
 			return // The drink might be empty after the delay, such as by spam-feeding
 		M.visible_message("<span class='danger'>[user] feeds the contents of [src] to [M].</span>", "<span class='userdanger'>[user] feeds the contents of [src] to [M].</span>")
-		add_logs(user, M, "fed", object="[reagentlist(src)]")
+		add_logs(user, M, "fed", reagentlist(src))
 	var/fraction = min(gulp_size/reagents.total_volume, 1)
 	reagents.reaction(M, INGEST, fraction)
 	reagents.trans_to(M, gulp_size)

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -97,7 +97,7 @@
 				"<span class='userdanger'>[target] hits \himself with a bottle of [src.name][head_attack_message]!</span>")
 
 	//Attack logs
-	add_logs(user, target, "attacked", object="bottle")
+	add_logs(user, target, "attacked", src)
 
 	//The reagents in the bottle splash all over the target, thanks for the idea Nodrak
 	if(src.reagents)

--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -612,7 +612,7 @@
 	if(user.a_intent == "harm" && ismob(target) && target.reagents && reagents.total_volume)
 		target.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
 						"<span class='userdanger'>[user] splashes the contents of [src] onto [target]!</span>")
-		add_logs(user, target, "splashed", object="[src]")
+		add_logs(user, target, "splashed", src)
 		reagents.reaction(target, TOUCH)
 		reagents.clear_reagents()
 		return

--- a/code/modules/food&drinks/food/condiment.dm
+++ b/code/modules/food&drinks/food/condiment.dm
@@ -47,7 +47,7 @@
 		if(!reagents || !reagents.total_volume)
 			return // The condiment might be empty after the delay.
 		user.visible_message("<span class='warning'>[user] feeds [M] from [src].</span>")
-		add_logs(user, M, "fed", object="[reagentlist(src)]")
+		add_logs(user, M, "fed", reagentlist(src))
 
 	var/fraction = min(10/reagents.total_volume, 1)
 	reagents.reaction(M, INGEST, fraction)

--- a/code/modules/food&drinks/food/snacks.dm
+++ b/code/modules/food&drinks/food/snacks.dm
@@ -92,7 +92,7 @@
 
 				if(!do_mob(user, M))
 					return
-				add_logs(user, M, "fed", object="[reagentlist(src)]")
+				add_logs(user, M, "fed", reagentlist(src))
 				M.visible_message("<span class='danger'>[user] forces [M] to eat [src].</span>", \
 									"<span class='userdanger'>[user] feeds [M] to eat [src].</span>")
 

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -243,7 +243,7 @@
 	if(!..()) return
 	if(istype(M, /mob/living))
 		M << "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>"
-		add_logs(user, M, "attacked", object= "[src.name]")
+		add_logs(user, M, "attacked", src)
 
 		M.eye_blurry += force/7
 		if(prob(20))

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -561,7 +561,7 @@
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)
 				for(var/mob/living/L in src.loc)
-					add_logs(creator, L, "used a resonator field on", object="resonator")
+					add_logs(creator, L, "used a resonator field on", "resonator")
 					L << "<span class='danger'>The [src.name] ruptured with you in it!</span>"
 					L.adjustBruteLoss(resonance_damage)
 			else

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -36,7 +36,7 @@ In all, this is a lot like the monkey code. /N
 				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
 						"<span class='userdanger'>[M.name] bites [src]!</span>")
 				adjustBruteLoss(damage)
-				add_logs(M, src, "attacked", admin=0)
+				add_logs(M, src, "attacked")
 				updatehealth()
 			else
 				M << "<span class='warning'>[name] is too injured for that.</span>"
@@ -82,5 +82,5 @@ In all, this is a lot like the monkey code. /N
 		if(M.is_adult)
 			damage = rand(10, 40)
 		adjustBruteLoss(damage)
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		updatehealth()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -60,7 +60,7 @@
 						visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
 								"<span class='userdanger'>[M] has weakened [src]!</span>")
 					adjustBruteLoss(damage)
-					add_logs(M, src, "attacked", admin=0)
+					add_logs(M, src, "attacked")
 					updatehealth()
 				else
 					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
@@ -71,7 +71,7 @@
 					if (prob(5))
 						Paralyse(2)
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						add_logs(M, src, "pushed", admin=0)
+						add_logs(M, src, "pushed")
 						visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
 							"<span class='userdanger'>[M] has pushed down [src]!</span>")
 					else

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -57,7 +57,7 @@
 		var/damage = rand(1, 9)
 		if (prob(90))
 			playsound(loc, "punch", 25, 1, -1)
-			add_logs(M, src, "attacked", admin=0)
+			add_logs(M, src, "attacked")
 			visible_message("<span class='danger'>[M] has kicked [src]!</span>", \
 					"<span class='userdanger'>[M] has kicked [src]!</span>")
 			if ((stat != DEAD) && (damage > 4.9))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -262,7 +262,7 @@
 				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
 
-				add_logs(src, M, "thrown", admin=0, addition="from [start_T_descriptor] with the target [end_T_descriptor]")
+				add_logs(src, M, "thrown", addition="from [start_T_descriptor] with the target [end_T_descriptor]")
 
 	if(!item) return //Grab processing has a chance of returning null
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -746,7 +746,6 @@
 		return 0
 
 	if(C.cpr_time < world.time + 30)
-		add_logs(src, C, "CPRed")
 		visible_message("<span class='notice'>[src] is trying to perform CPR on [C.name]!</span>", \
 						"<span class='notice'>You try to perform CPR on [C.name]... Hold still!</span>")
 		if(!do_mob(src, C))
@@ -760,7 +759,7 @@
 			C.updatehealth()
 			src.visible_message("[src] performs CPR on [C.name]!", "<span class='notice'>You perform CPR on [C.name].</span>")
 			C << "<span class='unconscious'>You feel a breath of fresh air enter your lungs... It feels good...</span>"
-
+		add_logs(src, C, "CPRed")
 
 /mob/living/carbon/human/generateStaticOverlay()
 	var/image/staticOverlay = image(icon('icons/effects/effects.dmi', "static"), loc = src)

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -25,7 +25,7 @@
 				visible_message("<span class='danger'>[M] has wounded [src]!</span>", \
 					"<span class='userdanger'>[M] has wounded [src]!</span>")
 				apply_effect(4, WEAKEN, armor_block)
-				add_logs(M, src, "attacked", admin=0)
+				add_logs(M, src, "attacked")
 			updatehealth()
 
 		if(M.a_intent == "disarm")
@@ -33,7 +33,7 @@
 			if (randn <= 80)
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				Weaken(5)
-				add_logs(M, src, "tackled", admin=0)
+				add_logs(M, src, "tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 					"<span class='userdanger'>[M] has tackled down [src]!</span>")
 			else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -450,7 +450,7 @@ emp_act
 
 		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
 								"<span class='userdanger'>[M.name] has hit [src]!</span>")
-		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
+		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 
 	else
 		..()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -880,7 +880,6 @@
 			if(attacker_style && attacker_style.harm_act(M,H))
 				return 1
 			else
-				add_logs(M, H, "punched")
 				M.do_attack_animation(H)
 
 				var/atk_verb = "punch"
@@ -916,6 +915,7 @@
 								"<span class='userdanger'>[M] has [atk_verb]ed [H]!</span>")
 
 				H.apply_damage(damage, BRUTE, affecting, armor_block)
+				add_logs(M, H, "punched")
 				if((H.stat != DEAD) && damage >= 9)
 					H.visible_message("<span class='danger'>[M] has weakened [H]!</span>", \
 									"<span class='userdanger'>[M] has weakened [H]!</span>")

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -90,7 +90,7 @@
 									"<span class='userdanger'>[M] has knocked out [name]!</span>")
 							return
 				adjustBruteLoss(damage)
-				add_logs(M, src, "attacked", admin=0)
+				add_logs(M, src, "attacked")
 				updatehealth()
 			else
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
@@ -128,10 +128,11 @@
 				else
 					visible_message("<span class='danger'>[M] has slashed [name]!</span>", \
 							"<span class='userdanger'>[M] has slashed [name]!</span>")
-				add_logs(M, src, "attacked", admin=0)
+
 				if (stat != DEAD)
 					adjustBruteLoss(damage)
 					updatehealth()
+				add_logs(M, src, "attacked")
 			else
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to lunge at [name]!</span>", \
@@ -147,7 +148,7 @@
 				if(drop_item())
 					visible_message("<span class='danger'>[M] has disarmed [name]!</span>", \
 							"<span class='userdanger'>[M] has disarmed [name]!</span>")
-			add_logs(M, src, "disarmed", admin=0)
+			add_logs(M, src, "disarmed")
 			updatehealth()
 	return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -725,7 +725,7 @@ Sorry Giacom. Please don't be mad :(
 			if(what && Adjacent(who))
 				src.unEquip(what)
 				who.equip_to_slot_if_possible(what, where, 0, 1)
-				add_logs(src, who, "equipped", object=what)
+				add_logs(src, who, "equipped", what)
 
 /mob/living/singularity_act()
 	var/gain = 20

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -73,7 +73,7 @@
 		apply_damage(I.throwforce, dtype, zone, armor, I)
 
 		if(thrower)
-			add_logs(thrower, src, "hit", object="[I]")
+			add_logs(thrower, src, "hit", I)
 
 /mob/living/mech_melee_attack(obj/mecha/M)
 	if(M.occupant.a_intent == "harm")
@@ -94,10 +94,10 @@
 		updatehealth()
 		visible_message("<span class='danger'>[M.name] has hit [src]!</span>", \
 						"<span class='userdanger'>[M.name] has hit [src]!</span>")
-		add_logs(M.occupant, src, "attacked", object=M, addition="(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
+		add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	else
 		step_away(src,M)
-		add_logs(M.occupant, src, "pushed", object=M, admin=0)
+		add_logs(M.occupant, src, "pushed", M)
 		visible_message("<span class='warning'>[M] pushes [src] out of the way.</span>")
 
 		return
@@ -195,7 +195,7 @@
 		return // can't attack while eating!
 
 	if (stat != DEAD)
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
 				"<span class='userdanger'>The [M.name] glomps [src]!</span>")
@@ -211,7 +211,7 @@
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>\The [M] [M.attacktext] [src]!</span>", \
 						"<span class='userdanger'>\The [M] [M.attacktext] [src]!</span>")
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(M, src, "attacked")
 		return 1
 
 
@@ -230,7 +230,7 @@
 			return 0
 		M.do_attack_animation(src)
 		if (prob(75))
-			add_logs(M, src, "attacked", admin=0)
+			add_logs(M, src, "attacked")
 			playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
 			visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
 					"<span class='userdanger'>[M.name] bites [src]!</span>")
@@ -250,7 +250,7 @@
 		else
 			L.do_attack_animation(src)
 			if(prob(90))
-				add_logs(L, src, "attacked", admin=0)
+				add_logs(L, src, "attacked")
 				visible_message("<span class='danger'>[L.name] bites [src]!</span>", \
 						"<span class='userdanger'>[L.name] bites [src]!</span>")
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -624,7 +624,7 @@
 				step(src,get_dir(M,src))
 				spawn(5)
 					step(src,get_dir(M,src))
-				add_logs(M, src, "pushed", admin=0)
+				add_logs(M, src, "pushed")
 				playsound(loc, 'sound/weapons/pierce.ogg', 50, 1, -1)
 				visible_message("<span class='danger'>[M] has forced back [src]!</span>", \
 								"<span class='userdanger'>[M] has forced back [src]!</span>")

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -363,13 +363,13 @@
 	if(..()) //if harm or disarm intent
 		var/damage = rand(10, 20)
 		if (prob(90))
-			add_logs(M, src, "attacked", admin=0)
+			add_logs(M, src, "attacked")
 			playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 							"<span class='userdanger'>[M] has slashed at [src]!</span>")
 			if(prob(8))
 				flick("noise", flash)
-			add_logs(M, src, "attacked", admin=0)
+			add_logs(M, src, "attacked")
 			adjustBruteLoss(damage)
 			updatehealth()
 		else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -279,7 +279,7 @@
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
 			attack_threshold_check(harm_intent_damage)
-			add_logs(M, src, "attacked", admin=1)
+			add_logs(M, src, "attacked")
 			updatehealth()
 			return 1
 
@@ -302,14 +302,14 @@
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			visible_message("<span class='danger'>[M] [response_disarm] [name]!</span>", \
 					"<span class='userdanger'>[M] [response_disarm] [name]!</span>")
-			add_logs(M, src, "disarmed", admin=1)
+			add_logs(M, src, "disarmed")
 		else
 			var/damage = rand(15, 30)
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 					"<span class='userdanger'>[M] has slashed at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-			add_logs(M, src, "attacked", admin=1)
 			attack_threshold_check(damage)
+			add_logs(M, src, "attacked")
 		return 1
 
 /mob/living/simple_animal/attack_larva(mob/living/carbon/alien/larva/L as mob)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -54,7 +54,7 @@
 			M << "<span class='danger'>You feel a tiny prick!</span>"
 		. = 1
 
-	add_logs(user, M, "stabbed", object="[name]")
+	add_logs(user, M, "stabbed", src)
 
 /*
  * Sleepypens

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -80,9 +80,9 @@
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagent_note += R.id + " ("
 			reagent_note += num2text(R.volume) + ") "
-	add_logs(firer, L, "shot", object="[src]", addition=reagent_note)
 
 	L.on_hit(type)
+	add_logs(firer, L, "shot", src, reagent_note)
 	return L.apply_effects(stun, weaken, paralyze, irradiate, stutter, slur, eyeblur, drowsy, blocked, stamina, jitter)
 
 /obj/item/projectile/proc/vol_by_damage()

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -640,7 +640,7 @@
 				dead_mob_list -= M
 				living_mob_list |= list(M)
 				M.emote("gasp")
-				add_logs(M, M, "revived", object="strange reagent")
+				add_logs(M, M, "revived", src)
 	..()
 	return
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -96,9 +96,10 @@
 				R += A.id + " ("
 				R += num2text(A.volume) + "),"
 
-		if(thrower)
-			add_logs(thrower, M, "splashed", object="[R]")
+
 		reagents.reaction(target, TOUCH)
+		if(thrower)
+			add_logs(thrower, M, "splashed", R)
 
 	else if((!target.density || target.throwpass) && thrower && thrower.mind && thrower.mind.assigned_role == "Bartender")
 		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -62,7 +62,7 @@
 				for(var/datum/reagent/A in src.reagents.reagent_list)
 					R += A.id + " ("
 					R += num2text(A.volume) + "),"
-			add_logs(user, M, "squirted", object="[R]")
+			add_logs(user, M, "squirted", R)
 
 		trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 		user << "<span class='notice'>You transfer [trans] unit\s of the solution.</span>"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -52,8 +52,9 @@
 					for(var/datum/reagent/A in reagents.reagent_list)
 						R += A.id + " ("
 						R += num2text(A.volume) + "),"
-				add_logs(user, M, "splashed", object="[R]")
+
 				reagents.reaction(M, TOUCH)
+				add_logs(user, M, "splashed", R)
 				reagents.clear_reagents()
 				return
 
@@ -72,7 +73,7 @@
 			if(!do_mob(user, M)) return
 			if(!reagents.total_volume) return // The drink might be empty after the delay, such as by spam-feeding
 			M.visible_message("<span class='danger'>[user] feeds something to [M].</span>", "<span class='userdanger'>[user] feeds something to you.</span>")
-			add_logs(user, M, "fed", object="[reagentlist(src)]")
+			add_logs(user, M, "fed", reagentlist(src))
 			if(reagents.total_volume)
 				reagents.reaction(M, INGEST)
 				spawn(5)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -37,7 +37,7 @@
 
 			var/contained = english_list(injected)
 
-			add_logs(user, M, "injected", object="[src.name]", addition="([contained])")
+			add_logs(user, M, "injected", src, "([contained])")
 
 /obj/item/weapon/reagent_containers/hypospray/CMO
 	list_reagents = list("omnizine" = 30)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -40,7 +40,7 @@
 
 
 	user.unEquip(src) //icon update
-	add_logs(user, M, "fed", object="[reagentlist(src)]")
+	add_logs(user, M, "fed", reagentlist(src))
 	loc = M //Put the pill inside the mob. This fixes the issue where the pill appears to drop to the ground after someone eats it.
 
 	if(reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -149,7 +149,7 @@
 					rinject += R.name
 				var/contained = english_list(rinject)
 				var/mob/M = target
-				add_logs(user, M, "injected", object="[src.name]", addition="which had [contained]")
+				add_logs(user, M, "injected", src, addition="which had [contained]")
 				var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
 				reagents.reaction(target, INGEST, fraction)
 			if(ismob(target) && target == user)


### PR DESCRIPTION
Removed the "feature" to have something log in an atom's vv attack log, but not the file attack log. all attack log items will go to the file as well as vv.

Replaced all hard coded src.name/name for attack log's object argument with an actual object (src) except where it made more sense not to.

All attack logging _should_ happen AFTER damage is applied now.

Removed the confusing attack entry for when a changeling stings another changeling.

Tweaked how punch attack logs worked.

Removed snowflake attacklog for putting c4 on mobs (and related code), since you can't anymore
