### PR TITLE
Due to recent shortages, justice helmets are more expensive

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -382,7 +382,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "Standard Justice Enforcer Crate"
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/mask/gas/sechailer)
-	cost = 30 //justice comes at a price. An expensive, noisy price.
+	cost = 80 //justice comes at a price. An expensive, noisy price.
 	containername = "justice enforcer crate"
 
 


### PR DESCRIPTION
Space Justice Warriors have been attacking freighters carrying the Justice Helmets, and they have been in low supply recently, resulting in an increase of price for justice enforcer crates. Reports from captured SJWs claim that the helmets offend them. Requests to ban the sale of justice helmets will be met with equally insulting responses.
- a huge faggot
