### PR TITLE
Fixes for lighter, heart attack, defib, light fixture and other stuff

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -479,7 +479,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				if(prob(75))
 					user.visible_message("After a few attempts, [user] manages to light [src].", "<span class='notice'>After a few attempts, you manage to light [src].</span>")
 				else
-					user.adjustFireLoss(5)
+					var/hitzone = user.r_hand == src ? "r_hand" : "l_hand"
+					user.apply_damage(5, BURN, hitzone)
 					user.visible_message("<span class='warning'>After a few attempts, [user] manages to light [src] - they however burn their finger in the process.</span>", "<span class='warning'>You burn yourself while lighting the lighter!</span>")
 
 			user.AddLuminosity(1)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -325,7 +325,6 @@
 
 /obj/item/weapon/twohanded/shockpaddles/attack(mob/M, mob/user)
 	var/halfwaycritdeath = (config.health_threshold_crit + config.health_threshold_dead) / 2
-	var/mob/living/carbon/human/H = M
 
 	if(busy)
 		return
@@ -343,6 +342,7 @@
 		user << "<span class='warning'>The instructions on [defib] don't mention how to revive that...</span>"
 		return
 	else
+		var/mob/living/carbon/human/H = M
 		if(user.a_intent == "disarm" && !defib.safety)
 			busy = 1
 			H.visible_message("<span class='danger'>[user] has touched [H.name] with [src]!</span>", \
@@ -422,11 +422,7 @@
 								busy = 0
 								update_icon()
 								return
-					if(H.heart_attack)
-						H.heart_attack = 0
-						user.visible_message("<span class='notice'>[defib] pings: Patient's heart is now beating again.</span>")
-						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-					if(H.stat == 2)
+					if(H.stat == DEAD)
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
@@ -447,7 +443,7 @@
 								H.adjustBruteLoss((mobhealth - halfwaycritdeath) * (total_brute / overall_damage))
 							user.visible_message("<span class='notice'>[defib] pings: Resuscitation successful.</span>")
 							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
-							H.stat = 1
+							H.stat = UNCONSCIOUS
 							dead_mob_list -= H
 							living_mob_list |= list(H)
 							H.emote("gasp")
@@ -469,6 +465,10 @@
 						update_icon()
 						cooldown = 1
 						defib.cooldowncheck(user)
+					else if(H.heart_attack)
+						H.heart_attack = 0
+						user.visible_message("<span class='notice'>[defib] pings: Patient's heart is now beating again.</span>")
+						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 					else
 						user.visible_message("<span class='warning'>[defib] buzzes: Patient is not in a valid state. Operation aborted.</span>")
 						playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -78,23 +78,21 @@
 	shock_damage *= siemens_coeff
 	if (shock_damage<1)
 		return 0
-	src.take_overall_damage(0,shock_damage)
+	take_overall_damage(0,shock_damage)
 	//src.burn_skin(shock_damage)
 	//src.adjustFireLoss(shock_damage) //burn_skin will do this for us
 	//src.updatehealth()
-	src.visible_message(
+	visible_message(
 		"<span class='danger'>[src] was shocked by \the [source]!</span>", \
 		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
 		"<span class='italics'>You hear a heavy electrical crack.</span>" \
 	)
-	if(prob(25) && heart_attack)
-		heart_attack = 0
 	jitteriness += 1000 //High numbers for violent convulsions
 	do_jitter_animation(jitteriness)
 	stuttering += 2
 	Stun(2)
 	spawn(20)
-		src.jitteriness -= 990 //Still jittery, but vastly less
+		jitteriness = max(jitteriness - 990, 10) //Still jittery, but vastly less
 		Stun(3)
 		Weaken(3)
 	return shock_damage
@@ -370,12 +368,6 @@ var/const/GALOSHES_DONT_HELP = 8
 
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
-
-
-/mob/living/carbon/revive()
-	heart_attack = 0
-	..()
-	return
 
 /mob/living/carbon/blob_act()
 	if (stat == DEAD)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -19,7 +19,6 @@
 	var/obj/item/head = null
 
 	var/datum/dna/dna = null//Carbon
-	var/heart_attack = 0
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -22,6 +22,7 @@
 	stat = DEAD
 	dizziness = 0
 	jitteriness = 0
+	heart_attack = 0
 
 	if(istype(loc, /obj/mecha))
 		var/obj/mecha/M = loc

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -272,6 +272,11 @@
 		if(gloves)
 			var/obj/item/clothing/gloves/G = gloves
 			siemens_coeff = G.siemens_coefficient
+	if(heart_attack)
+		if(shock_damage * siemens_coeff >= 1 && prob(25))
+			heart_attack = 0
+			if(stat == CONSCIOUS)
+				src << "<span class='notice'>You feel your heart beating again!</span>"
 	return ..(shock_damage,source,siemens_coeff)
 
 /mob/living/carbon/human/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -52,3 +52,5 @@
 	var/datum/martial_art/martial_art = null
 
 	var/name_override //For temporary visible name changes
+
+	var/heart_attack = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -42,6 +42,9 @@
 			for(var/datum/mutation/human/HM in dna.mutations)
 				HM.on_life(src)
 
+		//heart attack stuff
+		handle_heart()
+
 		//Stuff jammed in your limbs hurts
 		handle_embedded_objects()
 	//Update our name based on whether our face is obscured/disfigured
@@ -338,13 +341,12 @@
 				if(!has_embedded_objects())
 					clear_alert("embeddedobject")
 
-/mob/living/carbon/human/handle_heart()
+/mob/living/carbon/human/proc/handle_heart()
 	if(!heart_attack)
 		return
 	else
 		losebreath += 5
 		adjustOxyLoss(5)
 		adjustBruteLoss(1)
-	return
 
 #undef HUMAN_MAX_OXYLOSS

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -10,10 +10,7 @@
 	if(..())
 		//Updates the number of stored chemicals for powers
 		handle_changeling()
-		//Heart Attacks, etc.
-		handle_heart()
-
-		. = 1
+		return 1
 
 ///////////////
 // BREATHING //
@@ -238,8 +235,6 @@
 	if(reagents)
 		reagents.metabolize(src)
 
-/mob/living/carbon/proc/handle_heart()
-	return
 
 /mob/living/carbon/handle_stomach()
 	spawn(0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -471,7 +471,7 @@
 // if hands aren't protected and the light is on, burn the player
 
 /obj/machinery/light/attack_hand(mob/living/carbon/human/user)
-
+	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
 
 	if(status == LIGHT_EMPTY)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -80,7 +80,6 @@
 			user << "<span class='userdanger'>[src] blows up in your face!</span>"
 			user.take_organ_damage(0,20)
 			user.unEquip(src)
-			qdel(src)
 			return 0
 	..()
 

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -493,13 +493,15 @@
 				M.losebreath += 10
 				M.adjustOxyLoss(rand(5,25))
 			if(3)
-				var/mob/living/carbon/human/H = M
-				if(!H.heart_attack)
-					H.visible_message("<span class='userdanger'>[H] clutches at their chest as if their heart stopped!</span>")
-					H.heart_attack = 1 // rip in pepperoni
-				else
-					H.losebreath += 10
-					H.adjustOxyLoss(rand(5,25))
+				if(istype(M, /mob/living/carbon/human))
+					var/mob/living/carbon/human/H = M
+					if(!H.heart_attack)
+						H.heart_attack = 1 // rip in pepperoni
+						if(H.stat == CONSCIOUS)
+							H.visible_message("<span class='userdanger'>[H] clutches at their chest as if their heart stopped!</span>")
+					else
+						H.losebreath += 10
+						H.adjustOxyLoss(rand(5,25))
 	..()
 
 /datum/reagent/toxin/pancuronium

--- a/code/modules/surgery/organs/cybernetic_implants.dm
+++ b/code/modules/surgery/organs/cybernetic_implants.dm
@@ -366,10 +366,14 @@
 	else
 		cooldown += 200
 
-	if(prob(50 / severity))
-		owner.heart_attack = 1
-		spawn(600 / severity)
-			owner.heart_attack = 0
+	if(istype(owner, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = owner
+		if(H.stat != DEAD && prob(50 / severity))
+			H.heart_attack = 1
+			spawn(600 / severity)
+				H.heart_attack = 0
+				if(H.stat == CONSCIOUS)
+					H << "<span class='notice'>You feel your heart beating again!</span>"
 
 
 //BOX O' IMPLANTS


### PR DESCRIPTION
- Modified detective revolver isn't deleted anymore when it misfires. (stolen from #9888)
- Heart attack: Moved heart attack var (and changed related code accordingly) from carbon to human since non humans have no use for it. I also added some feedback message when you recover from a heart attack. Fixes #10276 
- Added a click cooldown on touching a light fixture. Fixes #9576
- Burning yourself with a lighter now burns only the arm holding the lighter. Fixes #10451
- Fixes incorrect message when defibbing heart attack patient. Fixes #10277
