### PR TITLE
Some fixes and stuff....

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -503,7 +503,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/lighter/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!isliving(M))
 		return
-	M.IgniteMob()
+	if(lit)
+		M.IgniteMob()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
 	if(lit && cig)
 		if(M == user)

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -123,6 +123,10 @@
 		imp_in.gib()
 		explosion(src,heavy,medium,weak,weak, flame_range = weak)
 		qdel(src)
+		return
+	timed_explosion()
+
+/obj/item/weapon/implant/explosive/proc/timed_explosion()
 	imp_in.visible_message("<span class = 'warning'>[imp_in] starts beeping ominously!</span>")
 	playsound(loc, 'sound/items/timer.ogg', 30, 0)
 	sleep(delay/4)
@@ -156,21 +160,7 @@
 		if(E != src)
 			qdel(E)
 	imp_in << "<span class='notice'>You activate your macrobomb implant.</span>"
-	imp_in.visible_message("<span class = 'warning'>[imp_in] starts beeping ominously!</span>")
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay/4)
-	if(imp_in.stat)
-		imp_in.visible_message("<span class = 'warning'>[imp_in] doubles over in pain!</span>")
-		imp_in.Weaken(7)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay/4)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay/4)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay/4)
-	imp_in.gib()
-	explosion(src,heavy,medium,weak,weak, flame_range = weak)
-	qdel(src)
+	timed_explosion()
 
 /obj/item/weapon/implant/chem
 	name = "chem implant"
@@ -254,7 +244,8 @@
 	return 1
 
 /obj/item/weapon/implant/loyalty/Destroy()
-	loc << "<span class='notice'><b>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</b></span>"
+	if(imp_in.stat != DEAD)
+		imp_in << "<span class='boldnotice'>You feel a sense of liberation as Nanotrasen's grip on your mind fades away.</span>"
 	..()
 
 /obj/item/weapon/implant/adrenalin

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -85,55 +85,48 @@
 
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
-	if(dna)
-		if(dna.species.handle_mutations_and_radiation(src))
-			..()
+	if(!dna || !dna.species.handle_mutations_and_radiation(src))
+		..()
 
 /mob/living/carbon/human/breathe()
-	if(dna)
-		dna.species.breathe(src)
+	if(!dna || !dna.species.breathe(src))
+		..()
 
-	return
+/mob/living/carbon/human/check_breath(datum/gas_mixture/breath)
+	if(!dna || !dna.species.check_breath(breath, src))
+		..()
 
 /mob/living/carbon/human/handle_environment(datum/gas_mixture/environment)
 	if(dna)
 		dna.species.handle_environment(environment, src)
 
-	return
-
 ///FIRE CODE
 /mob/living/carbon/human/handle_fire()
-	if(dna)
-		dna.species.handle_fire(src)
-	if(..())
-		return
-	var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
-	if(wear_suit)
-		if(wear_suit.max_heat_protection_temperature >= FIRE_SUIT_MAX_TEMP_PROTECT)
-			thermal_protection += (wear_suit.max_heat_protection_temperature*0.7)
-	if(head)
-		if(head.max_heat_protection_temperature >= FIRE_HELM_MAX_TEMP_PROTECT)
-			thermal_protection += (head.max_heat_protection_temperature*THERMAL_PROTECTION_HEAD)
-	thermal_protection = round(thermal_protection)
-	if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
-		return
-	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
-		bodytemperature += 11
-		return
-	else
-		bodytemperature += BODYTEMP_HEATING_MAX
-	return
+	if(!dna || !dna.species.handle_fire(src))
+		..()
+	if(on_fire)
+		var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
+		if(wear_suit)
+			if(wear_suit.max_heat_protection_temperature >= FIRE_SUIT_MAX_TEMP_PROTECT)
+				thermal_protection += (wear_suit.max_heat_protection_temperature*0.7)
+		if(head)
+			if(head.max_heat_protection_temperature >= FIRE_HELM_MAX_TEMP_PROTECT)
+				thermal_protection += (head.max_heat_protection_temperature*THERMAL_PROTECTION_HEAD)
+		thermal_protection = round(thermal_protection)
+		if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
+			return
+		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
+			bodytemperature += 11
+		else
+			bodytemperature += BODYTEMP_HEATING_MAX
+
 
 /mob/living/carbon/human/IgniteMob()
-	if(dna)
-		dna.species.IgniteMob(src)
-	else
+	if(!dna || !dna.species.IgniteMob(src))
 		..()
 
 /mob/living/carbon/human/ExtinguishMob()
-	if(dna)
-		dna.species.ExtinguishMob(src)
-	else
+	if(!dna || !dna.species.ExtinguishMob(src))
 		..()
 //END FIRE CODE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -782,7 +782,8 @@
 						randmutb(H)
 						domutcheck(H,null)
 						H.emote("gasp")
-		return 1
+		return 0
+	return 1
 
 ////////////////
 // MOVE SPEED //
@@ -1138,60 +1139,7 @@
 /////////////
 
 /datum/species/proc/breathe(var/mob/living/carbon/human/H)
-	if(H.reagents.has_reagent("lexorin")) return
-	if(istype(H.loc, /obj/machinery/atmospherics/unary/cryo_cell)) return
-
-	var/datum/gas_mixture/environment = H.loc.return_air()
-	var/datum/gas_mixture/breath
-	if(H.health <= config.health_threshold_crit)
-		H.losebreath++
-	if(H.losebreath>0) //Suffocating so do not take a breath
-		H.losebreath--
-		if (prob(10)) //Gasp per 10 ticks? Sounds about right.
-			spawn H.emote("gasp")
-		if(istype(H.loc, /obj/))
-			var/obj/location_as_object = H.loc
-			location_as_object.handle_internal_lifeform(H, 0)
-	else
-		//First, check for air from internal atmosphere (using an air tank and mask generally)
-		breath = H.get_breath_from_internal(BREATH_VOLUME) // Super hacky -- TLE
-		//breath = get_breath_from_internal(0.5) // Manually setting to old BREATH_VOLUME amount -- TLE
-
-		//No breath from internal atmosphere so get breath from location
-		if(!breath)
-			if(isobj(H.loc))
-				var/obj/location_as_object = H.loc
-				breath = location_as_object.handle_internal_lifeform(H, BREATH_VOLUME)
-			else if(isturf(H.loc))
-				var/breath_moles = 0
-				/*if(environment.return_pressure() > ONE_ATMOSPHERE)
-					// Loads of air around (pressure effect will be handled elsewhere), so lets just take a enough to fill our lungs at normal atmos pressure (using n = Pv/RT)
-					breath_moles = (ONE_ATMOSPHERE*BREATH_VOLUME/R_IDEAL_GAS_EQUATION*environment.temperature)
-				else*/
-					// Not enough air around, take a percentage of what's there to model this properly
-				breath_moles = environment.total_moles()*BREATH_PERCENTAGE
-
-				breath = H.loc.remove_air(breath_moles)
-
-				// Handle chem smoke effect  -- Doohl
-				if(!H.has_smoke_protection())
-					for(var/obj/effect/effect/smoke/chem/S in range(1, H))
-						if(S.reagents.total_volume && S.lifetime)
-							var/fraction = 1/S.max_lifetime
-							S.reagents.reaction(H,INGEST, fraction)
-							var/amount = round(S.reagents.total_volume*fraction,0.1)
-							S.reagents.copy_to(H, amount)
-							S.lifetime--
-
-		else //Still give containing object the chance to interact
-			if(istype(H.loc, /obj/))
-				var/obj/location_as_object = H.loc
-				location_as_object.handle_internal_lifeform(H, 0)
-
-	check_breath(breath, H)
-
-	if(breath)
-		H.loc.assume_air(breath)
+	return
 
 /datum/species/proc/check_breath(datum/gas_mixture/breath, var/mob/living/carbon/human/H)
 	if((H.status_flags & GODMODE))
@@ -1457,31 +1405,14 @@
 
 /datum/species/proc/handle_fire(var/mob/living/carbon/human/H)
 	if((HEATRES in specflags) || (NOFIRE in specflags))
-		return
-	if(H.fire_stacks < 0)
-		H.fire_stacks++ //If we've doused ourselves in water to avoid fire, dry off slowly
-		H.fire_stacks = min(0, H.fire_stacks)//So we dry ourselves back to default, nonflammable.
-	if(!H.on_fire)
-		return
-	var/datum/gas_mixture/G = H.loc.return_air() // Check if we're standing in an oxygenless environment
-	if(G.oxygen < 1)
-		ExtinguishMob(H) //If there's no oxygen in the tile we're on, put out the fire
-		return
-	var/turf/location = get_turf(H)
-	location.hotspot_expose(700, 50, 1)
+		return 1
 
 /datum/species/proc/IgniteMob(var/mob/living/carbon/human/H)
-	if(H.fire_stacks > 0 && !H.on_fire && !(HEATRES in specflags) && !(NOFIRE in specflags))
-		H.on_fire = 1
-		H.AddLuminosity(3)
-		H.update_fire()
+	if((HEATRES in specflags) || (NOFIRE in specflags))
+		return 1
 
 /datum/species/proc/ExtinguishMob(var/mob/living/carbon/human/H)
-	if(H.on_fire)
-		H.on_fire = 0
-		H.fire_stacks = 0
-		H.AddLuminosity(-3)
-		H.update_fire()
+	return
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -708,7 +708,7 @@ Sorry Giacom. Please don't be mad :(
 					"<span class='userdanger'>[src] tries to remove [who]'s [what.name].</span>")
 	what.add_fingerprint(src)
 	if(do_mob(src, who, what.strip_delay))
-		if(what && Adjacent(who))
+		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
 			who.unEquip(what)
 			add_logs(src, who, "stripped", addition="of [what]")
 
@@ -719,11 +719,14 @@ Sorry Giacom. Please don't be mad :(
 	if(what && (what.flags & NODROP))
 		src << "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>"
 		return
-	if(what && what.mob_can_equip(who, where, 1))
+	if(what)
+		if(!what.mob_can_equip(who, where, 1))
+			src << "<span class='warning'>\The [what.name] doesn't fit in that place!</span>"
+			return
 		visible_message("<span class='notice'>[src] tries to put [what] on [who].</span>")
 		if(do_mob(src, who, what.put_on_delay))
 			if(what && Adjacent(who))
-				src.unEquip(what)
+				unEquip(what)
 				who.equip_to_slot_if_possible(what, where, 0, 1)
 				add_logs(src, who, "equipped", object=what)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -121,14 +121,20 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-    fire_stacks = Clamp(fire_stacks + add_fire_stacks, min = -20, max = 20)
+	fire_stacks = Clamp(fire_stacks + add_fire_stacks, min = -20, max = 20)
+	if(on_fire && fire_stacks <= 0)
+		ExtinguishMob()
 
 /mob/living/proc/handle_fire()
-	if(fire_stacks < 0)
-		fire_stacks++ //If we've doused ourselves in water to avoid fire, dry off slowly
-		fire_stacks = min(0, fire_stacks)//So we dry ourselves back to default, nonflammable.
+	if(fire_stacks < 0) //If we've doused ourselves in water to avoid fire, dry off slowly
+		fire_stacks = min(0, fire_stacks + 1)//So we dry ourselves back to default, nonflammable.
 	if(!on_fire)
 		return 1
+	if(fire_stacks > 0)
+		adjust_fire_stacks(-0.2) //the fire is slowly consumed
+	else
+		ExtinguishMob()
+		return
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.oxygen < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -171,9 +171,6 @@
 		return
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(volume / 10))
-		if(M.fire_stacks <= 0)
-			M.ExtinguishMob()
-		return
 
 /datum/reagent/water/holywater
 	name = "Holy Water"

--- a/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
@@ -44,7 +44,8 @@
 
 /datum/reagent/clf3/on_mob_life(var/mob/living/M as mob)
 	M.adjust_fire_stacks(2)
-	M.adjustFireLoss(0.3*M.fire_stacks)
+	var/burndmg = max(0.3*M.fire_stacks, 0.3)
+	M.adjustFireLoss(burndmg)
 	..()
 
 /datum/reagent/clf3/reaction_turf(var/turf/simulated/T, var/volume)


### PR DESCRIPTION
- Fixes stripping an item from someone not checking if the item is still there after the delay. Should help with #10500.
- Same fix for pocket picking and removing embedded item.
- Adding a warning message when trying to put an item on someone in the wrong slot. Fixes #10519
- Fixes loyalty implant message upon destruction being sent to wrong/dead people. Fixes #10515
- Fire on carbon mobs (fire_stacks) will now slowly be consumed (no more forever-on-fire corpse).
- Can't lit a mob on fire with a lighter that isn't lit.
- Removing duplicate code in species.dm.
- You can no longer heal your burns by ingesting clf3 and dousing yourself with water repeatedly.
- Simplified micro/macro explosive implant's timed explosion code.
