### PR TITLE
Fixes improvised shotgun being deleted when tablecrafted.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -61,7 +61,7 @@
 		qdel(G.pin)
 		G.pin = null
 		visible_message("[G] can now fit a new pin, but old one was destroyed in the process.")
-	qdel(src)
+		qdel(src)
 
 /obj/item/weapon/gun/examine(mob/user)
 	..()


### PR DESCRIPTION
Fixes #10499 
