### PR TITLE
More Dynamic wait tweaks.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -103,9 +103,9 @@ calculate the longest number of ticks the MC can wait between each cycle without
 							SS.cost = MC_AVERAGE(SS.cost, world.timeofday - timer)
 							if (SS.dynamic_wait)
 								var/oldwait = SS.wait
-								var/GlobalCostDelta = (SSCostPerSecond-(SS.cost/SS.wait))/(SS.wait/10)-1
-								var/NewWait = MC_AVERAGE(oldwait,(SS.cost-1.5+GlobalCostDelta)*SS.dwait_delta)
-								SS.wait = Clamp(round(NewWait,0.1),SS.dwait_lower,SS.dwait_upper)
+								var/GlobalCostDelta = (SSCostPerSecond-(SS.cost/(SS.wait/10)))-1
+								var/NewWait = MC_AVERAGE(oldwait,(SS.cost-SS.dwait_buffer+GlobalCostDelta)*SS.dwait_delta)
+								SS.wait = Clamp(round(NewWait,world.tick_lag),SS.dwait_lower,SS.dwait_upper)
 								if (oldwait != SS.wait)
 									calculateGCD()
 							SS.next_fire += SS.wait

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -5,7 +5,6 @@ var/datum/subsystem/air/SSair
 	priority = 20
 	wait = 5
 	dynamic_wait = 1
-	dwait_lower = 5
 	dwait_upper = 50
 
 	var/cost_turfs = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -6,7 +6,9 @@ var/datum/subsystem/garbage_collector/SSgarbage
 	wait = 5
 	priority = -1
 	dynamic_wait = 1
-	dwait_delta = 5
+	dwait_upper = 50
+	dwait_delta = 10
+	dwait_buffer = 0
 
 	var/collection_timeout = 300// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object
 	var/max_run_time = 1		// how long, in deciseconds, can we run before waiting for the next tick

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -7,7 +7,7 @@ var/datum/subsystem/lighting/SSlighting
 	wait = 5
 	priority = 1
 	dynamic_wait = 1
-	dwait_delta = 1
+	dwait_delta = 3
 
 	var/list/changed_lights = list()		//list of all datum/light_source that need updating
 	var/changed_lights_workload = 0			//stats on the largest number of lights (max changed_lights.len)

--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -5,10 +5,17 @@
 	var/name				//name of the subsystem
 	var/priority = 0		//priority affects order of initialization. Higher priorities are initialized first, lower priorities later. Can be decimal and negative values.
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
+
+	//Dynamic Wait - A system for scaling a subsystem's fire rate based on lag
+	//The algorithm is: (cost-dwait_buffer+AvgCostOfAllOtherSSPerSecond)*dwait_delta
+	//defaults are pretty sane for most use cases.
+	//you can change how quickly it starts scaling back with dwait_buffer,
+	//and you can change how much it scales back with dwait_delta
 	var/dynamic_wait = 0	//changes the wait based on the amount of time it took to process
 	var/dwait_upper = 20	//longest wait can be under dynamic_wait
 	var/dwait_lower = 5		//shortest wait can be under dynamic_wait
-	var/dwait_delta = 3		//How much should processing time effect dwait. or basically: wait = cost*dwait_delta
+	var/dwait_delta = 7		//How much should processing time effect dwait. or basically: wait = cost*dwait_delta
+	var/dwait_buffer = 1.5	//This number is subtracted from the processing time before calculating its new wait
 
 	//things you will probably want to leave alone
 	var/can_fire = 0		//prevent fire() calls


### PR DESCRIPTION
I messed up a step in the algo and made it so it was decreasing in its slowdown effect with more lag, not increasing as I had intended. This also had the side effect of making it kick in before the subsystem was causing lag.

I've also made the -1.5 magic number in the algo configurable. its was a simple buffer of cost the subsystem is allowed to use that isn't counted against it in dwait.

I also raised the default amount it scales up from 3 to 7.

Basically I'm trying to better increase the curve so its lower on the low end, and higher on the high end.

I has graph:

Y axis (up/down) is what dwait would be in ds, X axis is how long the subsystem is taking to process in ds.
(this is for the air subsystem)
**Red is old, Blue is new.**
Solid is average normal round.
Dotted line shows what would they would be if the singulo was free and actively eating/throwing items.

![image](https://cloud.githubusercontent.com/assets/7069733/8632881/f737ba64-2762-11e5-8a9d-7f934c1de454.png)
