### PR TITLE
RCD Conveyor Belts/Switches, Sorting Machine, Fast Machines subsystem

### DIFF
--- a/code/controllers/subsystem/fast_machines.dm
+++ b/code/controllers/subsystem/fast_machines.dm
@@ -1,0 +1,30 @@
+/*
+	This subsystem is for when you want a machine that processes faster than other machines.
+	Machines in this subsystem process every 0.5 seconds instead of every 2 seconds.
+*/
+
+var/datum/subsystem/fast_machines/SSfast_machine
+
+/datum/subsystem/fast_machines
+	name = "Fast Machines"
+	priority = 9
+	wait = 5
+
+	var/list/processing = list()
+
+/datum/subsystem/fast_machines/New()
+	NEW_SS_GLOBAL(SSfast_machine)
+
+
+/datum/subsystem/fast_machines/stat_entry()
+	..("M:[processing.len]")
+
+/datum/subsystem/fast_machines/fire()
+	var/seconds = wait * 0.1
+	for(var/thing in processing)
+		if(thing && (thing:process(seconds) != PROCESS_KILL))
+			if(thing:use_power)
+				thing:auto_use_power() //add back the power state
+			continue
+		processing.Remove(thing)
+

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1001,19 +1001,6 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/largecrate/mule
 	containername = "\improper MULEbot Crate"
 
-/datum/supply_packs/misc/conveyor
-	name = "Conveyor Assembly Crate"
-	contains = list(/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_construct,
-					/obj/item/conveyor_switch_construct,
-					/obj/item/weapon/paper/conveyor)
-	cost = 15
-	containername = "conveyor assembly crate"
-
 /datum/supply_packs/misc/watertank
 	name = "Water Tank Crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -47,7 +47,7 @@
 	var/autoclose = 1
 	var/obj/item/device/doorCharge/charge = null //If applied, causes an explosion upon opening the door
 	var/detonated = 0
-
+	rcd_deconstruct = 1
 	explosion_block = 1
 
 /obj/machinery/door/airlock/command

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -116,16 +116,23 @@ Class Procs:
 	var/mob/living/occupant = null
 	var/unsecuring_tool = /obj/item/weapon/wrench
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
+	var/fast_process = 0 // Process faster than other machines?
 
 /obj/machinery/New()
 	..()
 	machines += src
-	SSmachine.processing += src
+	if(fast_process)
+		SSfast_machine.processing += src
+	else
+		SSmachine.processing += src
 	power_change()
 
 /obj/machinery/Destroy()
 	machines.Remove(src)
-	SSmachine.processing -= src
+	if(fast_process)
+		SSfast_machine.processing -= src
+	else
+		SSmachine.processing -= src
 	if(occupant)
 		dropContents()
 	..()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -117,6 +117,7 @@ Class Procs:
 	var/unsecuring_tool = /obj/item/weapon/wrench
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/fast_process = 0 // Process faster than other machines?
+	var/rcd_deconstruct = 0 // Can an RCD deconstruct this?
 
 /obj/machinery/New()
 	..()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -16,6 +16,7 @@
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 	origin_tech = "magnets=1;engineering=1"
 	var/obj/machinery/telecomms/buffer // simple machine buffer for device linkage
+	var/obj/machinery/general_buffer // simple machine buffer for device linkage
 	hitsound = 'sound/weapons/tap.ogg'
 
 

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -278,6 +278,9 @@ RCD
 			mode = 6
 			user << "<span class='notice'>You change RCD's mode to 'Conveyor Switches'.</span>"
 		if(6)
+			mode = 7
+			user << "<span class='notice'>You change RCD's mode to 'Sorting Machines'.</span>"
+		if(7)
 			mode = 1
 			user << "<span class='notice'>You change RCD's mode to 'Floor & Walls'.</span>"
 
@@ -395,9 +398,12 @@ RCD
 						return 1
 				return 0
 
-			if(istype(A, /obj/machinery/door/airlock))
+			if(istype(A, /obj/machinery))
+				var/obj/machinery/M = A
+				if(!M.rcd_deconstruct)
+					return 0
 				if(checkResource(20, user))
-					user << "<span class='notice'>You start deconstructing airlock...</span>"
+					user << "<span class='notice'>You start deconstructing [A]...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50, target = A))
 						if(!useResource(20, user)) return 0
@@ -484,6 +490,21 @@ RCD
 						if(!useResource(5, user)) return 0
 						activate()
 						new/obj/machinery/conveyor_switch(A, rand(1000, 9999)) // generate a random ID for the switch
+						return 1
+					return 0
+				return 0
+		if (7)
+			if(istype(A, /turf/simulated/floor))
+				if(checkResource(5, user))
+					for(var/obj/machinery/mineral/sorting_machine/C in A)
+						user << "<span class='warning'>There is already a sorter there!</span>"
+						return 0
+					user << "<span class='notice'>You start building a sorting machine...</span>"
+					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+					if(do_after(user, 10, target = A))
+						if(!useResource(5, user)) return 0
+						activate()
+						new/obj/machinery/mineral/sorting_machine(A, user.dir) // face north, get a north facing belt, etc.
 						return 1
 					return 0
 				return 0

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -272,6 +272,12 @@ RCD
 			mode = 4
 			user << "<span class='notice'>You change RCD's mode to 'Grilles & Windows'.</span>"
 		if(4)
+			mode = 5
+			user << "<span class='notice'>You change RCD's mode to 'Conveyor Belts'.</span>"
+		if(5)
+			mode = 6
+			user << "<span class='notice'>You change RCD's mode to 'Conveyor Switches'.</span>"
+		if(6)
 			mode = 1
 			user << "<span class='notice'>You change RCD's mode to 'Floor & Walls'.</span>"
 
@@ -448,6 +454,36 @@ RCD
 						activate()
 						var/obj/structure/window/WD = new/obj/structure/window/fulltile(A.loc)
 						WD.anchored = 1
+						return 1
+					return 0
+				return 0
+		if (5)
+			if(istype(A, /turf/simulated/floor))
+				if(checkResource(5, user))
+					for(var/obj/machinery/conveyor/C in A)
+						user << "<span class='warning'>There is already a belt there!</span>"
+						return 0
+					user << "<span class='notice'>You start building a conveyor belt...</span>"
+					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+					if(do_after(user, 10, target = A))
+						if(!useResource(3, user)) return 0
+						activate()
+						new/obj/machinery/conveyor(A, user.dir) // face north, get a north facing belt, etc.
+						return 1
+					return 0
+				return 0
+		if (6)
+			if(istype(A, /turf/simulated/floor))
+				if(checkResource(5, user))
+					for(var/obj/machinery/conveyor_switch/C in A)
+						user << "<span class='warning'>There is already a switch there!</span>"
+						return 0
+					user << "<span class='notice'>You start building a conveyor switch...</span>"
+					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+					if(do_after(user, 10, target = A))
+						if(!useResource(5, user)) return 0
+						activate()
+						new/obj/machinery/conveyor_switch(A, rand(1000, 9999)) // generate a random ID for the switch
 						return 1
 					return 0
 				return 0

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -281,6 +281,9 @@ RCD
 			mode = 7
 			user << "<span class='notice'>You change RCD's mode to 'Sorting Machines'.</span>"
 		if(7)
+			mode = 8
+			user << "<span class='notice'>You change RCD's mode to 'Crafting Machines'.</span>"
+		if(8)
 			mode = 1
 			user << "<span class='notice'>You change RCD's mode to 'Floor & Walls'.</span>"
 
@@ -504,11 +507,25 @@ RCD
 					if(do_after(user, 10, target = A))
 						if(!useResource(5, user)) return 0
 						activate()
-						new/obj/machinery/mineral/sorting_machine(A, user.dir) // face north, get a north facing belt, etc.
+						new/obj/machinery/mineral/sorting_machine(A)
 						return 1
 					return 0
 				return 0
-
+		if (8)
+			if(istype(A, /turf/simulated/floor))
+				if(checkResource(5, user))
+					for(var/obj/machinery/mineral/crafting_machine/C in A)
+						user << "<span class='warning'>There is already a crafter there!</span>"
+						return 0
+					user << "<span class='notice'>You start building a crafting machine...</span>"
+					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
+					if(do_after(user, 10, target = A))
+						if(!useResource(5, user)) return 0
+						activate()
+						new/obj/machinery/mineral/crafting_machine(A)
+						return 1
+					return 0
+				return 0
 		else
 			user << "ERROR: RCD in MODE: [mode] attempted use by [user]. Send this text #coderbus or an admin."
 			return 0

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -198,6 +198,7 @@
 	var/selected_iron = 0
 	var/selected_clown = 0
 	var/on = 0 //0 = off, 1 =... oh you know!
+	fast_process = 1
 
 /obj/machinery/mineral/processing_unit/process()
 	var/i

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -69,6 +69,7 @@
 	var/stack_amt = 50; //ammount to stack before releassing
 	input_dir = EAST
 	output_dir = WEST
+	fast_process = 1
 
 /obj/machinery/mineral/stacking_machine/proc/process_sheet(obj/item/stack/sheet/inp)
 	if(!(inp.type in stack_list)) //It's the first of this sheet added

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -9,6 +9,7 @@
 	anchored = 1.0
 	input_dir = WEST
 	output_dir = EAST
+	fast_process = 1
 
 /obj/machinery/mineral/unloading_machine/process()
 	var/turf/T = get_step(src,input_dir)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -7,6 +7,7 @@
 	name = "conveyor belt"
 	desc = "A conveyor belt."
 	anchored = 1
+	fast_process = 1
 	var/operating = 0	// 1 if running forward, -1 if backwards, 0 if off
 	var/operable = 1	// true if can operate (no broken segments in this belt run)
 	var/forwards		// this is the default (forward) direction, set by the map dir
@@ -105,7 +106,7 @@
 	use_power(100)
 
 	affecting = loc.contents - src		// moved items will be all in loc
-	spawn(1)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
+	spawn(0)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
 		var/items_moved = 0
 		for(var/atom/movable/A in affecting)
 			if(!A.anchored)
@@ -208,6 +209,7 @@
 
 	var/list/conveyors		// the list of converyors that are controlled by this switch
 	anchored = 1
+	fast_process = 1
 
 
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -106,14 +106,14 @@
 	use_power(100)
 
 	affecting = loc.contents - src		// moved items will be all in loc
-	spawn(0)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
+	spawn(1)	// slight delay to prevent infinite propagation due to map order	//TODO: please no spawn() in process(). It's a very bad idea
 		var/items_moved = 0
 		for(var/atom/movable/A in affecting)
 			if(!A.anchored)
 				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
 					step(A,movedir)
 					items_moved++
-			if(items_moved >= 100)
+			if(items_moved >= 25)
 				break
 
 // attack with item, place item on conveyor

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -16,6 +16,7 @@
 	var/list/affecting	// the list of all items that will be moved this ptick
 	var/id = ""			// the control ID	- must match controller ID
 	var/verted = 1		// set to -1 to have the conveyour belt be inverted, so you can use the other corner icons
+	var/obj/machinery/conveyor_switch/boss_switch
 
 /obj/machinery/conveyor/centcom_auto
 	id = "round_end_belt"
@@ -111,7 +112,7 @@
 				if(A.loc == src.loc) // prevents the object from being affected if it's not currently here.
 					step(A,movedir)
 					items_moved++
-			if(items_moved >= 10)
+			if(items_moved >= 100)
 				break
 
 // attack with item, place item on conveyor
@@ -124,6 +125,20 @@
 		user << "<span class='notice'>You remove the conveyor belt.</span>"
 		qdel(src)
 		return
+	if(istype(I, /obj/item/device/multitool))
+		var/obj/item/device/multitool/T = I
+		if(istype(T.general_buffer, /obj/machinery/conveyor_switch))
+			var/obj/machinery/conveyor_switch/S = T.general_buffer
+			user << "You link [src] with the switch in [T]'s buffer."
+			if(boss_switch)
+				boss_switch.conveyors -= src
+			id = S.id
+			S.conveyors += src
+			boss_switch = S
+			return
+		else
+			user << "You need to have a conveyor switch in the buffer of [T]."
+			return
 	if(isrobot(user))	return //Carn: fix for borgs dropping their modules on conveyor belts
 	if(!user.drop_item())
 		user << "<span class='warning'>\The [I] is stuck to your hand, you cannot place it on the conveyor!</span>"
@@ -264,6 +279,10 @@
 		transfer_fingerprints_to(C)
 		user << "<span class='notice'>You deattach the conveyor switch.</span>"
 		qdel(src)
+	if(istype(I, /obj/item/device/multitool))
+		var/obj/item/device/multitool/T = I
+		user << "You copy [src]'s data to the buffer."
+		T.general_buffer = src
 
 /obj/machinery/conveyor_switch/oneway
 	convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)

--- a/code/modules/recycling/crafter.dm
+++ b/code/modules/recycling/crafter.dm
@@ -1,0 +1,122 @@
+/obj/machinery/mineral/crafting_machine
+	name = "crafting machine"
+	desc = "Crafts the object of choice."
+	icon = 'icons/obj/machines/mining_machines.dmi'
+	icon_state = "unloader"
+	density = 1
+	anchored = 1.0
+	input_dir = NORTH
+	output_dir = SOUTH
+	var/obj/item/crafted_object
+	var/sort_dir = 1
+	fast_process = 1
+	rcd_deconstruct = 1
+	var/datum/material_container/materials
+/obj/machinery/mineral/crafting_machine/New()
+	..()
+	materials = new /datum/material_container(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_URANIUM=1, MAT_PLASMA=1, MAT_BANANIUM=1),200000)
+
+/obj/machinery/mineral/crafting_machine/attackby(obj/item/W, mob/user, params)
+	..()
+	if(istype(W, /obj/item/device/multitool))
+		switch(sort_dir)
+			if(1)
+				input_dir = SOUTH
+				output_dir = NORTH
+				sort_dir = 2
+				user << "[src] now inputs from the south and outputs to the north."
+			if(2)
+				input_dir = EAST
+				output_dir = WEST
+				sort_dir = 3
+				user << "[src] now inputs from the east and outputs to the west."
+			if(3)
+				input_dir = WEST
+				output_dir = EAST
+				sort_dir = 4
+				user << "[src] now inputs from the west and outputs to the east."
+			if(4)
+				input_dir = NORTH
+				output_dir = SOUTH
+				sort_dir = 1
+				user << "[src] now inputs from the north and outputs to the south."
+		return
+	else if(istype(W, /obj/item))
+		var/obj/item/I = W
+		if(!I.materials.len || !I.materials)
+			user << "You cannot produce this object as it is not made out of any materials!"
+			return
+		user << "[src] will now craft [I]. Examine the machine to see the required materials."
+		crafted_object = new I.type(src)
+		return
+
+/obj/machinery/mineral/crafting_machine/process()
+	if(!crafted_object)
+		return
+	var/turf/T = get_step(src, input_dir)
+	if(T)
+		for(var/obj/item/S in T)
+			materials.insert_item(S)
+			qdel(S)
+	if(crafted_object)
+		if(materials.use_amount(crafted_object.materials))
+			var/obj/item/craft = new crafted_object.type()
+			unload_mineral(craft)
+
+/obj/machinery/mineral/crafting_machine/examine(mob/user)
+	..()
+	switch(input_dir)
+		if(NORTH)
+			user << "The input screen reads 'NORTH'."
+		if(SOUTH)
+			user << "The input screen reads 'SOUTH'."
+		if(EAST)
+			user << "The input screen reads 'EAST'."
+		if(WEST)
+			user << "The input screen reads 'WEST'."
+	switch(output_dir)
+		if(NORTH)
+			user << "The output screen reads 'NORTH'."
+		if(SOUTH)
+			user << "The output screen reads 'SOUTH'."
+		if(EAST)
+			user << "The output screen reads 'EAST'."
+		if(WEST)
+			user << "The output screen reads 'WEST'."
+	if(crafted_object)
+		user << "The machine is crafting [crafted_object.name]."
+		user << "It requires the following per production:"
+		if(crafted_object.materials[MAT_METAL])
+			user << " - [crafted_object.materials[MAT_METAL]]u of Metal"
+		if(crafted_object.materials[MAT_GLASS])
+			user << " - [crafted_object.materials[MAT_GLASS]]u of Glass"
+		if(crafted_object.materials[MAT_SILVER])
+			user << " - [crafted_object.materials[MAT_SILVER]]u of Silver"
+		if(crafted_object.materials[MAT_GOLD])
+			user << " - [crafted_object.materials[MAT_GOLD]]u of Gold"
+		if(crafted_object.materials[MAT_URANIUM])
+			user << " - [crafted_object.materials[MAT_URANIUM]]u of Uranium"
+		if(crafted_object.materials[MAT_DIAMOND])
+			user << " - [crafted_object.materials[MAT_DIAMOND]]u of Diamond"
+		if(crafted_object.materials[MAT_PLASMA])
+			user << " - [crafted_object.materials[MAT_PLASMA]]u of Plasma"
+		if(crafted_object.materials[MAT_BANANIUM])
+			user << " - [crafted_object.materials[MAT_BANANIUM]]u of Bananium"
+
+	user << "The machine has the following resources:"
+	if(materials.amount(MAT_METAL))
+		user << " - [materials.amount(MAT_METAL)]u of Metal"
+	if(materials.amount(MAT_GLASS))
+		user << " - [materials.amount(MAT_GLASS)]u of Glass"
+	if(materials.amount(MAT_SILVER))
+		user << " - [materials.amount(MAT_SILVER)]u of Silver"
+	if(materials.amount(MAT_GOLD))
+		user << " - [materials.amount(MAT_GOLD)]u of Gold"
+	if(materials.amount(MAT_URANIUM))
+		user << " - [materials.amount(MAT_URANIUM)]u of Uranium"
+	if(materials.amount(MAT_DIAMOND))
+		user << " - [materials.amount(MAT_DIAMOND)]u of Diamond"
+	if(materials.amount(MAT_PLASMA))
+		user << " - [materials.amount(MAT_PLASMA)]u of Plasma"
+	if(materials.amount(MAT_BANANIUM))
+		user << " - [materials.amount(MAT_BANANIUM)]u of Bananium"

--- a/code/modules/recycling/sorter.dm
+++ b/code/modules/recycling/sorter.dm
@@ -1,0 +1,76 @@
+/obj/machinery/mineral/sorting_machine
+	name = "sorting machine"
+	desc = "Sorts the objects of choice."
+	icon = 'icons/obj/machines/mining_machines.dmi'
+	icon_state = "stacker"
+	density = 1
+	anchored = 1.0
+	input_dir = NORTH
+	output_dir = SOUTH
+	var/obj/item/sorted_object
+	var/sort_dir = 1
+	fast_process = 1
+	rcd_deconstruct = 1
+
+/obj/machinery/mineral/sorting_machine/attackby(obj/item/W, mob/user, params)
+	..()
+	if(istype(W, /obj/item/device/multitool))
+		switch(sort_dir)
+			if(1)
+				input_dir = SOUTH
+				output_dir = NORTH
+				sort_dir = 2
+				user << "[src] now inputs from the south and outputs to the north."
+			if(2)
+				input_dir = EAST
+				output_dir = WEST
+				sort_dir = 3
+				user << "[src] now inputs from the east and outputs to the west."
+			if(3)
+				input_dir = WEST
+				output_dir = EAST
+				sort_dir = 4
+				user << "[src] now inputs from the west and outputs to the east."
+			if(4)
+				input_dir = NORTH
+				output_dir = SOUTH
+				sort_dir = 1
+				user << "[src] now inputs from the north and outputs to the south."
+		return
+	else if(istype(W, /obj/item))
+		var/obj/item/I = W
+		user << "[src] will now sort out [I]."
+		sorted_object = I
+		return
+
+/obj/machinery/mineral/sorting_machine/process()
+	if(!sorted_object)
+		return
+	var/turf/T = get_step(src, input_dir)
+	if(T)
+		for(var/obj/item/S in T)
+			if(istype(S, sorted_object.type))
+				unload_mineral(S)
+
+/obj/machinery/mineral/sorting_machine/examine(mob/user)
+	..()
+	switch(input_dir)
+		if(NORTH)
+			user << "The input screen reads 'NORTH'."
+		if(SOUTH)
+			user << "The input screen reads 'SOUTH'."
+		if(EAST)
+			user << "The input screen reads 'EAST'."
+		if(WEST)
+			user << "The input screen reads 'WEST'."
+	switch(output_dir)
+		if(NORTH)
+			user << "The output screen reads 'NORTH'."
+		if(SOUTH)
+			user << "The output screen reads 'SOUTH'."
+		if(EAST)
+			user << "The output screen reads 'EAST'."
+		if(WEST)
+			user << "The output screen reads 'WEST'."
+	if(sorted_object)
+		user << "The machine is sorting out [sorted_object.name]."

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -415,8 +415,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								if( new_item.type == /obj/item/weapon/storage/backpack/holding )
 									new_item.investigate_log("built by [key]","singulo")
 								new_item.reliability = R
-								new_item.materials[MAT_METAL] /= coeff
-								new_item.materials[MAT_GLASS] /= coeff
+								new_item.materials = being_built.materials
 								if(linked_lathe.hacked)
 									R = max((new_item.reliability/2), 0)
 								new_item.loc = linked_lathe.loc

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -129,6 +129,7 @@
 #include "code\controllers\subsystem\bots.dm"
 #include "code\controllers\subsystem\diseases.dm"
 #include "code\controllers\subsystem\events.dm"
+#include "code\controllers\subsystem\fast_machines.dm"
 #include "code\controllers\subsystem\garbage.dm"
 #include "code\controllers\subsystem\jobs.dm"
 #include "code\controllers\subsystem\lighting.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1428,6 +1428,7 @@
 #include "code\modules\recycling\conveyor2.dm"
 #include "code\modules\recycling\disposal-construction.dm"
 #include "code\modules\recycling\disposal.dm"
+#include "code\modules\recycling\sorter.dm"
 #include "code\modules\recycling\sortingmachinery.dm"
 #include "code\modules\research\circuitprinter.dm"
 #include "code\modules\research\designs.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1426,6 +1426,7 @@
 #include "code\modules\reagents\reagent_containers\spray.dm"
 #include "code\modules\reagents\reagent_containers\syringes.dm"
 #include "code\modules\recycling\conveyor2.dm"
+#include "code\modules\recycling\crafter.dm"
 #include "code\modules\recycling\disposal-construction.dm"
 #include "code\modules\recycling\disposal.dm"
 #include "code\modules\recycling\sorter.dm"


### PR DESCRIPTION
SUPPLEMENTARY VIDEO:
https://www.dropbox.com/s/a76xbzvjb7331ud/conveyorbelts.webm?dl=0

![qo0arnz](https://cloud.githubusercontent.com/assets/4081722/8635347/0deffd40-27d4-11e5-9489-e72f7da617a0.png)

HOW 2 BUILD CONVEYORS WITH THIS NEW SYSTEM:
You will need:
- RCD
- Multitool
- Brain

Step 1. Set RCD to Conveyor Belts mode
Step 2. Face the direction you want the belt to go in, either with moving in that direction or clicking with an empty hand in the direction you want to build in if you're building on the tile you're on.
Step 3. Click and watch your belt be made in the direction you were facing.
Step 4. Set RCD to Conveyor Switches mode
Step 5. Build a switch, and click on it with a multitool.
Step 6. Click on any belts you wanna link to that switch with the multitool.
Step 7. Pull switch.
Step 8. Factorio it up.

You can reassign belts to other switches by just clicking on a new switch with the multitool and clicking on a belt with the multitool again.

Belts can also move up to 25 items at a time now.

Belts move way way faster now.

Adds a Sorting Machine to the RCD. Click on it with an object to make it sort that object. Use with belts.
Use multitool on machine to adjust input/output direction.
video in action: https://www.dropbox.com/s/cgu2eem2p1gza7f/factorio.webm?dl=0

There is now a Fast Machines subsystem that processes every 0.5 seconds instead of 2 seconds. This is useful for when you want machines like Conveyor Belts that need to do their shit way faster.
