### PR TITLE
Removes topic limiter. Increases responsiveness in all uis.

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -26,10 +26,8 @@
 		////////////
 		//SECURITY//
 		////////////
-	var/next_allowed_topic_time = 10
 	// comment out the line below when debugging locally to enable the options & messages menu
 	control_freak = 1
-
 
 		////////////////////////////////////
 		//things that require the database//

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -1,7 +1,6 @@
 	////////////
 	//SECURITY//
 	////////////
-#define TOPIC_SPAM_DELAY	2		//2 ticks is about 2/10ths of a second; it was 4 ticks, but that caused too many clicks to be lost due to lag
 #define UPLOAD_LIMIT		1048576	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
 #define MIN_CLIENT_VERSION	0		//Just an ambiguously low version for now, I don't want to suddenly stop people playing.
 									//I would just like the code ready should it ever need to be used.
@@ -23,11 +22,6 @@
 /client/Topic(href, href_list, hsrc)
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
-
-	//Reduces spamming of links by dropping calls that happen during the delay period
-	if(next_allowed_topic_time > world.time)
-		return
-	next_allowed_topic_time = world.time + TOPIC_SPAM_DELAY
 
 	//Admin PM
 	if(href_list["priv_msg"])


### PR DESCRIPTION
Topics are no longer limited to once per 2ds per client.

This **_massively**_ improves responsiveness by not dropping clicks when trying to browse through menus.

Anything that could cause lag or otherwise should be limited needs to do that in its own topic, not bog down the rest of us.

Please let me know if you can think of anything that HAS to be limited in this PR otherwise, I say we find out by field testing.

Oh, and I confirmed, if you put a tank in a canister, hit open valve, close valve, eject tank, the close valve gets ignored every time, but the eject tank tends to not get ignored.
