### PR TITLE
Fixes pre-prefixes in station names

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -68,6 +68,7 @@ var/religion_name = null
 	if (prob(10))
 		name = pick("Imperium", "Heretical", "Cuban", "Psychic", "Elegant", "Common", "Uncommon", "Rare", "Unique", "Houseruled", "Religious", "Atheist", "Traditional", "Houseruled", "Mad", "Super", "Ultra", "Secret", "Top Secret", "Deep", "Death", "Zybourne", "Central", "Main", "Government", "Uoi", "Fat", "Automated", "Experimental", "Augmented")
 		new_station_name = name + " "
+		name = ""
 
 	// Prefix
 	for(var/holiday_name in SSevent.holidays)


### PR DESCRIPTION
They were being doubled up whenever they were used. (i.e Top-Secret Top-Secret Base Gamma)
