### PR TITLE
del log verb no longer inside of the show debug verbs

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -126,7 +126,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/debugNatureMapGenerator,
 	/client/proc/check_bomb_impacts,
 	/proc/machine_upgrade,
-	/client/proc/populate_world
+	/client/proc/populate_world,
+	/client/proc/cmd_display_del_log
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,
@@ -203,7 +204,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/reset_all_tcs,
 	/client/proc/panicbunker,
 	/client/proc/admin_change_sec_level,
-	/client/proc/toggle_nuke
+	/client/proc/toggle_nuke,
+	/client/proc/cmd_display_del_log
 	)
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -142,7 +142,6 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/disable_communication
 	src.verbs += /client/proc/print_pointers
 	src.verbs += /client/proc/count_movable_instances
-	src.verbs += /client/proc/cmd_display_del_log
 	//src.verbs += /client/proc/cmd_admin_rejuvenate
 
 	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
Moves the del log verb away from the show debug verbs option, now being available from the getgo
