### PR TITLE
Clothing with bomb armor are less likely to be shredded

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -452,7 +452,7 @@
 			shredded = -1 //Heat protection = Fireproof
 
 	else if(shock > 0)
-		if(prob(Clamp(shock,0,90)))
+		if(prob(max(shock-armor["bomb"],0)))
 			shredded = armor["bomb"] + 10 //It gets shredded, but it also absorbs the shock the clothes underneath would recieve by this amount
 		else
 			shredded = -1 //It survives explosion


### PR DESCRIPTION
Should have been this way from the start.

Resolves #10549 - Wizards shouldn't lose their robes if the bomb didn't crit them
