### PR TITLE
Explosion size increase because why not

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -1,11 +1,5 @@
 //TODO: Flash range does nothing currently
 
-//A very crude linear approximatiaon of pythagoras theorem.
-/proc/cheap_pythag(var/dx, var/dy)
-	dx = abs(dx); dy = abs(dy);
-	if(dx>=dy)	return dx + (0.5*dy)	//The longest side add half the shortest side approximates the hypotenuse
-	else		return dy + (0.5*dx)
-
 /proc/trange(var/Dist=0,var/turf/Center=null)//alternative to range (ONLY processes turfs and thus less intensive)
 	if(Center==null) return
 
@@ -89,7 +83,7 @@
 
 		for(var/turf/T in trange(max_range, epicenter))
 
-			var/dist = cheap_pythag(T.x - x0,T.y - y0)
+			var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 
 			if(config.reactionary_explosions)
 				var/turf/Trajectory = T
@@ -192,7 +186,7 @@
 	var/list/wipe_colours = list()
 	for(var/turf/T in trange(max_range, epicenter))
 		wipe_colours += T
-		var/dist = cheap_pythag(T.x - x0, T.y - y0)
+		var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 
 		if(newmode == "Yes")
 			var/turf/TT = T


### PR DESCRIPTION
Removed the proc cheap_pythag() because it's slower than cheap_hypoteneuse() by a little bit and, more importantly, the values it gives are really off. Explosions are, on average, about a tile or two smaller than they're mathematically supposed to be. Like a tile 9 squares apart would get a value of 7.

Some pics because I know you guys will ask
Current:
http://puu.sh/iXiAk/8f8c9b616c.png
http://puu.sh/iXiB8/f28c0b5a3d.png
http://puu.sh/iXiCW/bad17224a7.png

Proposed:
http://puu.sh/iXiAP/3c98f4c704.png
http://puu.sh/iXiBs/e7d026483d.png
http://puu.sh/iXiDp/08eca53691.png
