### PR TITLE
Brings Tabling in line with newer stuns

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -124,7 +124,7 @@
 		if(!G.confirm())
 			return 0
 		G.affecting.loc = src.loc
-		G.affecting.Weaken(5)
+		G.affecting.Weaken(2)
 		G.affecting.visible_message("<span class='danger'>[G.assailant] pushes [G.affecting] onto [src].</span>", \
 									"<span class='userdanger'>[G.assailant] pushes [G.affecting] onto [src].</span>")
 		add_logs(G.assailant, G.affecting, "pushed")


### PR DESCRIPTION
Getting this in now while everyone's too busy fuming about EI NATH to notice.
Tabling someone currently lasts longer than a telebaton, and as long as a taser.  It's long enough to cuff and strip.

Tabling is still a decent stun, and will probably still be used by the robust in the roundstart tool storage brawl for the toolbelt.  It just won't end the fight.
