### PR TITLE
Changeling Buff

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,7 +1,7 @@
 
 #define LING_FAKEDEATH_TIME					400 //40 seconds
 #define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
-
+#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
 var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,3 +1,8 @@
+
+#define LING_FAKEDEATH_TIME					400 //40 seconds
+#define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
+
+
 var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 
 /datum/game_mode
@@ -261,9 +266,14 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	absorbed_dna.len = dna_max
 
 
-/datum/changeling/proc/regenerate()
-	chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), chem_storage)
-	geneticdamage = max(0, geneticdamage-1)
+/datum/changeling/proc/regenerate(var/mob/living/carbon/the_ling)
+	if(istype(the_ling))
+		if(the_ling.stat == DEAD)
+			chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), (chem_storage*0.5))
+			geneticdamage = max(LING_DEAD_GENETICDAMAGE_HEAL_CAP,geneticdamage-1)
+		else //not dead? no chem/geneticdamage caps.
+			chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), chem_storage)
+			geneticdamage = max(0, geneticdamage-1)
 
 
 /datum/changeling/proc/get_dna(var/dna_owner)

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -63,6 +63,27 @@
 
 		target.mind.show_memory(src, 0) //I can read your mind, kekeke. Output all their notes.
 
+		//Some of target's recent speech, so the changeling can attempt to imitate them better.
+		//Recent as opposed to all because rounds tend to have a LOT of text.
+		var/list/recent_speech = list()
+
+		if(target.say_log.len > LING_ABSORB_RECENT_SPEECH)
+			recent_speech = target.say_log.Copy(target.say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list
+		else
+			for(var/spoken_memory in target.say_log)
+				if(recent_speech.len >= LING_ABSORB_RECENT_SPEECH)
+					break
+				recent_speech += spoken_memory
+
+		if(recent_speech.len)
+			user.mind.store_memory("<B>Some of [target]'s speech patterns, we should study these to better impersonate them!</B>")
+			user << "<span class='boldnotice'>Some of [target]'s speech patterns, we should study these to better impersonate them!</span>"
+			for(var/spoken_memory in recent_speech)
+				user.mind.store_memory("\"[spoken_memory]\"")
+				user << "<span class='notice'>\"[spoken_memory]\"</span>"
+			user.mind.store_memory("<B>We have no more knowledge of [target]'s speech patterns.</B>")
+			user << "<span class='boldnotice'>We have no more knowledge of [target]'s speech patterns.</span>"
+
 		if(target.mind.changeling)//If the target was a changeling, suck out their extra juice and objective points!
 			changeling.chem_charges += min(target.mind.changeling.chem_charges, changeling.chem_storage)
 			changeling.absorbedcount += (target.mind.changeling.absorbedcount)

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -16,7 +16,7 @@
 	if(user.stat != DEAD)
 		user.emote("deathgasp")
 		user.tod = worldtime2text()
-	spawn(800)
+	spawn(LING_FAKEDEATH_TIME)
 		if(user && user.mind && user.mind.changeling && user.mind.changeling.purchasedpowers)
 			user << "<span class='notice'>We are ready to regenerate.</span>"
 			user.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -302,7 +302,7 @@
 /mob/living/carbon/human/handle_changeling()
 	if(mind && hud_used)
 		if(mind.changeling)
-			mind.changeling.regenerate()
+			mind.changeling.regenerate(src)
 			hud_used.lingchemdisplay.invisibility = 0
 			hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"
 		else

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -8,9 +8,10 @@
 		return
 
 	if(..())
-		//Updates the number of stored chemicals for powers
-		handle_changeling()
-		return 1
+		. = 1
+
+	//Updates the number of stored chemicals for powers
+	handle_changeling()
 
 ///////////////
 // BREATHING //

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -54,8 +54,6 @@
 	if(client)
 		handle_regular_hud_updates()
 
-	return .
-
 
 
 /mob/living/proc/handle_breathing()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -46,3 +46,5 @@
 	var/last_played_vent
 
 	var/smoke_delay = 0 //used to prevent spam with smoke reagent reaction on mob.
+
+	var/list/say_log = list() //a log of what we've said, plain text, no spans or junk, essentially just each individual "message"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -87,7 +87,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 		return
 
 	if(!can_speak_vocal(message))
-		src << "<span class='warning'>You find yourself unable to speak!</span>" 
+		src << "<span class='warning'>You find yourself unable to speak!</span>"
 		return
 
 	message = treat_message(message)
@@ -96,6 +96,9 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 	if(!message)
 		return
+
+	//Log of what we've said, plain message, no spans or junk
+	say_log += message
 
 	var/message_range = 7
 	var/radio_return = radio(message, message_mode, spans)

--- a/html/changelogs/RemieRichards-PR-10599.yml
+++ b/html/changelogs/RemieRichards-PR-10599.yml
@@ -6,5 +6,6 @@ delete-after: True
 changes: 
   - tweak: "Changelings now regenerate chemicals and geneticdamage while dead, but only up to specific caps (50% of their max chem storage, and 50 geneticdamage)"
   - tweak: "Fakedeath's length has been reduced from 80s dead (1 minute 20) to 40s dead"
+  - rscadd: "Changelings now get to see the last 8 messages the person they absorbed said, to allow them to better impersonate their victim's speech patterns"
   
   

--- a/html/changelogs/RemieRichards-PR-10599.yml
+++ b/html/changelogs/RemieRichards-PR-10599.yml
@@ -1,0 +1,10 @@
+
+author: RemieRichards
+
+delete-after: True
+
+changes: 
+  - tweak: "Changelings now regenerate chemicals and geneticdamage while dead, but only up to specific caps (50% of their max chem storage, and 50 geneticdamage)"
+  - tweak: "Fakedeath's length has been reduced from 80s dead (1 minute 20) to 40s dead"
+  
+  


### PR DESCRIPTION
## Gameplay changes:
- Changelings now regenerate chemicals while dead, up to half and ONLY HALF of their maximum storage (taking into account their storage upgrades, if applicable)
- Changelings now repair `geneticdamage` while dead, with the lowest value they can be taken to being 50, this number is arbitrary but was based on half the value at which fakedeath stops working for too much `geneticdamage`
- Changeling fakedeath timer is now halved, down from 80 seconds (1 minute 20 seconds) to 40 seconds.
- Changelings now get to see the last 8 messages the people they've absorbed have said (if they didn't say 8, you get how ever many they said):

![ling_memory_speech](http://i.imgur.com/N7cguCv.png)
## Code changes:
- `regenerate()` for the changeling datum now takes a mob argument, so we can check if it's dead or not, so we can apply caps if necessary (It takes a mob argument because the changeling datum jumps around just like the mind datum and there's no one unified method for finding a mob from a changeling besides just adding an arg)
- Life no longer `return .`s because it's redundant and adds a tiny bit of overhead.
- `/living` mobs now record the things they've said in a list, clean text.
