### PR TITLE
Reinforced windows and windoors are a bit more resistant to fires and blasts

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -9,6 +9,7 @@
 	flags = ON_BORDER
 	opacity = 0
 	var/obj/item/weapon/airlock_electronics/electronics = null
+	var/reinf = 0
 
 /obj/machinery/door/window/New()
 	..()
@@ -184,7 +185,7 @@
 	..()
 
 /obj/machinery/door/window/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > T0C + 800)
+	if(exposed_temperature > T0C + (reinf ? 1600 : 800))
 		take_damage(round(exposed_volume / 200))
 	..()
 
@@ -380,6 +381,8 @@
 	base_state = "leftsecure"
 	var/id = null
 	health = 300.0 //Stronger doors for prison (regular window door health is 200)
+	reinf = 1
+	explosion_block = 1
 
 
 /obj/machinery/door/window/northleft

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -102,6 +102,10 @@
 						if(D.density && D.explosion_block)
 							dist += D.explosion_block
 
+					for(var/obj/structure/window/W in Trajectory)
+						if(W.reinf && W.fulltile)
+							dist += W.explosion_block
+
 			var/flame_dist = 0
 			var/throw_dist = dist
 
@@ -204,6 +208,10 @@
 				for(var/obj/machinery/door/D in TT)
 					if(D.density && D.explosion_block)
 						dist += D.explosion_block
+
+				for(var/obj/structure/window/W in TT)
+					if(W.explosion_block && W.fulltile)
+						dist += W.explosion_block
 
 		if(dist < dev)
 			T.color = "red"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -409,7 +409,7 @@
 		overlays += crack_overlay
 
 /obj/structure/window/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > T0C + 800)
+	if(exposed_temperature > T0C + (reinf ? 1600 : 800))
 		hit(round(exposed_volume / 100), 0)
 	..()
 
@@ -421,6 +421,7 @@
 	icon_state = "rwindow"
 	reinf = 1
 	maxhealth = 50
+	explosion_block = 1
 
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
@@ -472,3 +473,4 @@
 	reinf = 1
 	smooth = 1
 	canSmoothWith = null
+	explosion_block = 1

--- a/html/changelogs/ikarrus-honkl.yml
+++ b/html/changelogs/ikarrus-honkl.yml
@@ -1,0 +1,6 @@
+author: Ikarrus
+
+delete-after: True
+
+changes: 
+  - tweak: "Reinforced windows and windoors are a bit more resistant to fires and blasts."


### PR DESCRIPTION
- Regular windows & windoors: 1073k Heat Resist
- Reinforced windows & windoors: 1873k Heat Resist
- Reinforced windows & windoors will count as walls for blast range calculation (The lowest possible value)
