### PR TITLE
Removes Horseheading from Summon Magic

### DIFF
--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -2,7 +2,7 @@
 
 /proc/rightandwrong(var/summon_type, var/mob/user, var/survivor_probability) //0 = Summon Guns, 1 = Summon Magic
 	var/list/gunslist 			= list("taser","egun","laser","revolver","detective","c20r","nuclear","deagle","gyrojet","pulse","suppressed","cannon","doublebarrel","shotgun","combatshotgun","bulldog","mateba","sabr","crossbow","saw","car","boltaction","speargun","arg","uzi")
-	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor", "special")
+	var/list/magiclist 			= list("fireball","smoke","blind","mindswap","forcewall","knock","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffchange", "staffhealing", "armor", "scrying","staffdoor", "special")
 	var/list/magicspeciallist	= list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos", "necromantic")
 
 	if(user) //in this case either someone holding a spellbook or a badmin
@@ -108,8 +108,6 @@
 					new /obj/item/weapon/spellbook/oneuse/forcewall(get_turf(H))
 				if("knock")
 					new /obj/item/weapon/spellbook/oneuse/knock(get_turf(H))
-				if("horsemask")
-					new /obj/item/weapon/spellbook/oneuse/barnyard(get_turf(H))
 				if("charge")
 					new /obj/item/weapon/spellbook/oneuse/charge(get_turf(H))
 				if("summonitem")


### PR DESCRIPTION
Do I even need to explain this? Stupid griff spell, contributes nothing of value, extremely annoying and can only be treated by Chemistry. Also has a hilarious habit of producing undroppable masks if someone afflicted by the curse gets transformed.

EVERY summon magic round there is someone doing this. Unfunny old as fuck joke spell that should go. Nothing of value will be lost.
