### PR TITLE
Internals action button

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -227,7 +227,6 @@ var/datum/global_hud/global_hud = new()
 			mymob.client.screen += mymob.zone_sel				//This one is a special snowflake
 			mymob.client.screen += mymob.healths				//As are the rest of these.
 			mymob.client.screen += mymob.healthdoll
-			mymob.client.screen += mymob.internals
 			mymob.client.screen += lingstingdisplay
 			mymob.client.screen += lingchemdisplay
 
@@ -272,7 +271,6 @@ var/datum/global_hud/global_hud = new()
 			mymob.client.screen -= mymob.zone_sel	//zone_sel is a mob variable for some reason.
 			mymob.client.screen -= mymob.healths
 			mymob.client.screen -= mymob.healthdoll
-			mymob.client.screen -= mymob.internals
 			mymob.client.screen -= lingstingdisplay
 			mymob.client.screen -= lingchemdisplay
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -253,9 +253,6 @@
 	hotkeybuttons += mymob.throw_icon
 
 
-	mymob.internals = new /obj/screen/internals()
-	mymob.internals.screen_loc = ui_internal
-
 	mymob.healths = new /obj/screen()
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
@@ -307,7 +304,7 @@
 
 	mymob.client.screen = list()
 
-	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.internals, mymob.healths, mymob.healthdoll, mymob.pullin, mymob.blind, mymob.flash, mymob.damageoverlay, lingchemdisplay, lingstingdisplay) //, mymob.hands, mymob.rest, mymob.sleep) //, mymob.mach )
+	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.healths, mymob.healthdoll, mymob.pullin, mymob.blind, mymob.flash, mymob.damageoverlay, lingchemdisplay, lingstingdisplay) //, mymob.hands, mymob.rest, mymob.sleep) //, mymob.mach )
 	mymob.client.screen += adding + hotkeybuttons
 	mymob.client.screen += mymob.client.void
 	inventory_shown = 0;

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -95,9 +95,6 @@
 	mymob.throw_icon.icon = ui_style
 	mymob.throw_icon.screen_loc = ui_drop_throw
 
-	mymob.internals = new /obj/screen/internals()
-	mymob.internals.screen_loc = ui_internal
-
 	mymob.healths = new /obj/screen()
 	mymob.healths.icon_state = "health0"
 	mymob.healths.name = "health"
@@ -149,6 +146,6 @@
 	using.screen_loc = ui_pull_resist
 	adding += using
 
-	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.internals, mymob.healths, mymob.pullin, mymob.blind, mymob.flash, lingchemdisplay, lingstingdisplay) //, mymob.hands, mymob.rest, mymob.sleep, mymob.mach )
+	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.healths, mymob.pullin, mymob.blind, mymob.flash, lingchemdisplay, lingstingdisplay) //, mymob.hands, mymob.rest, mymob.sleep, mymob.mach )
 	mymob.client.screen += adding + other
 	mymob.client.screen += mymob.client.void

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -92,57 +92,7 @@
 
 /obj/screen/internals
 	name = "toggle internals"
-	icon_state = "internal0"
-
-/obj/screen/internals/Click()
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(!C.incapacitated())
-			if(C.internal)
-				C.internal = null
-				C << "<span class='notice'>You are no longer running on internals.</span>"
-				icon_state = "internal0"
-			else
-				if(!istype(C.wear_mask, /obj/item/clothing/mask))
-					C << "<span class='warning'>You are not wearing an internals mask!</span>"
-					return 1
-				else
-					var/obj/item/clothing/mask/M = C.wear_mask
-					if(M.mask_adjusted) // if mask on face but pushed down
-						M.adjustmask(C) // adjust it back
-					if( !(M.flags & MASKINTERNALS) )
-						C << "<span class='warning'>You are not wearing an internals mask!</span>"
-						return
-					if(istype(C.l_hand, /obj/item/weapon/tank))
-						C << "<span class='notice'>You are now running on internals from the [C.l_hand] on your left hand.</span>"
-						C.internal = C.l_hand
-					else if(istype(C.r_hand, /obj/item/weapon/tank))
-						C << "<span class='notice'>You are now running on internals from the [C.r_hand] on your right hand.</span>"
-						C.internal = C.r_hand
-					else if(ishuman(C))
-						var/mob/living/carbon/human/H = C
-						if(istype(H.s_store, /obj/item/weapon/tank))
-							H << "<span class='notice'>You are now running on internals from the [H.s_store] on your [H.wear_suit].</span>"
-							H.internal = H.s_store
-						else if(istype(H.belt, /obj/item/weapon/tank))
-							H << "<span class='notice'>You are now running on internals from the [H.belt] on your belt.</span>"
-							H.internal = H.belt
-						else if(istype(H.l_store, /obj/item/weapon/tank))
-							H << "<span class='notice'>You are now running on internals from the [H.l_store] in your left pocket.</span>"
-							H.internal = H.l_store
-						else if(istype(H.r_store, /obj/item/weapon/tank))
-							H << "<span class='notice'>You are now running on internals from the [H.r_store] in your right pocket.</span>"
-							H.internal = H.r_store
-
-					//Seperate so CO2 jetpacks are a little less cumbersome.
-					if(!C.internal && istype(C.back, /obj/item/weapon/tank))
-						C << "<span class='notice'>You are now running on internals from the [C.back] on your back.</span>"
-						C.internal = C.back
-
-					if(C.internal)
-						icon_state = "internal1"
-					else
-						C << "<span class='warning'>You don't have an oxygen tank!</span>"
+	icon_state = null
 
 /obj/screen/mov_intent
 	name = "run/walk toggle"

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -38,7 +38,7 @@
 	DD.holder = src
 	if(DD.disease_flags & CAN_CARRY && prob(5))
 		DD.carrier = 1
-	
+
 	//Copy properties over. This is so edited diseases persist.
 	var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars")
 	for(var/V in DD.vars)
@@ -49,7 +49,7 @@
 			DD.vars[V] = L.Copy()
 		else
 			DD.vars[V] = D.vars[V]
-	
+
 	DD.affected_mob.med_hud_set_status()
 
 
@@ -127,7 +127,7 @@
 					Cl = M.wear_mask
 					passed = prob((Cl.permeability_coefficient*100) - 1)
 
-	if(!passed && (D.spread_flags & AIRBORNE) && !internals)
+	if(!passed && (D.spread_flags & AIRBORNE))
 		passed = (prob((50*D.permeability_mod) - 1))
 
 	if(passed)

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -169,8 +169,6 @@ var/hsboxspawn = 1
 				P.back.layer = 20
 				P.update_inv_back()
 				P.internal = P.back
-				if(P.internals)
-					P.internals.icon_state = "internal1"
 
 			if("hsbscrubber") // This is beyond its normal capability but this is sandbox and you spawned one, I assume you need it
 				var/obj/hsb = new/obj/machinery/portable_atmospherics/scrubber{volume_rate=50*ONE_ATMOSPHERE;on=1}(usr.loc)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -147,7 +147,6 @@
 		return 0
 	else
 		R.module.modules += new/obj/item/weapon/tank/jetpack/carbondioxide(R.module)
-		for(var/obj/item/weapon/tank/jetpack/carbondioxide in R.module.modules)
 		R.jetpackoverlay = 1
 		R.module.rebuild()
 		return 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -148,7 +148,6 @@
 	else
 		R.module.modules += new/obj/item/weapon/tank/jetpack/carbondioxide(R.module)
 		for(var/obj/item/weapon/tank/jetpack/carbondioxide in R.module.modules)
-			R.internals = src
 		R.jetpackoverlay = 1
 		R.module.rebuild()
 		return 1

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -1,3 +1,17 @@
+/obj/item/weapon/tank/internals/jetpack
+	name = "Jet pack Internals connector"
+	desc = "a connector port to hook jetpacks to internals masks"
+	icon_state = "emergency"
+	action_button_name = "Toggle Jetpack Internals"
+	action_button_internal = 1
+	volume = 0 //we use the jetpack's tank, so this has no need
+
+/obj/item/weapon/tank/internals/jetpack/ui_action_click()
+	var/obj/item/weapon/tank/jetpack/JP = loc
+	if (istype(JP))
+		JP.toggle_internals()
+
+
 /obj/item/weapon/tank/jetpack
 	name = "jetpack (empty)"
 	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution."
@@ -10,11 +24,13 @@
 	var/on = 0.0
 	var/stabilization_on = 0
 	var/volume_rate = 500              //Needed for borg jetpack transfer
+	var/obj/item/weapon/tank/internals/jetpack/Internals
 
 /obj/item/weapon/tank/jetpack/New()
 	..()
 	ion_trail = new /datum/effect/effect/system/ion_trail_follow()
 	ion_trail.set_up(src)
+	Internals = new /obj/item/weapon/tank/internals/jetpack(src)
 
 
 /obj/item/weapon/tank/jetpack/verb/toggle_rockets()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -18,22 +18,21 @@
 
 /obj/item/weapon/tank/proc/toggle_internals()
 	var/mob/living/carbon/C = usr
-	if(iscarbon(usr))
+	if(iscarbon(C))
 		if(!istype(C.wear_mask, /obj/item/clothing/mask))
-			C << "<span class='warning'>You are not wearing an internals mask!</span>"
+			usr << "<span class='warning'>You need to be wearing an internals mask!</span>"
 			return
 		else
 			var/obj/item/clothing/mask/M = C.wear_mask
 			if(M.mask_adjusted) // if mask on face but pushed down
 				M.adjustmask(C) // adjust it back
-		var/mob/living/carbon/location = loc
-		if(location.internal == src)
-			location.internal = null
-			usr << "<span class='notice'>You close \the [src]'s internals valve.</span>"
+		if(C.internal == src)
+			C.internal = null
+			usr << "<span class='notice'>You stop running on internals.</span>"
 		else
-			if(location.wear_mask && (location.wear_mask.flags & MASKINTERNALS))
-				location.internal = src
-				usr << "<span class='notice'>You open \the [src]'s internals valve.</span>"
+			if(C.wear_mask && (C.wear_mask.flags & MASKINTERNALS))
+				C.internal = src
+				usr << "<span class='notice'>You start running on internals from \the [src].</span>"
 			else
 				usr << "<span class='warning'>You need to be wearing an internals mask!</span>"
 

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -10,6 +10,34 @@
 /*
  * Oxygen
  */
+/obj/item/weapon/tank/internals
+	action_button_name = "Toggle Internals"
+
+/obj/item/weapon/tank/internals/ui_action_click()
+	toggle_internals()
+
+/obj/item/weapon/tank/proc/toggle_internals()
+	var/mob/living/carbon/C = usr
+	if(iscarbon(usr))
+		if(!istype(C.wear_mask, /obj/item/clothing/mask))
+			C << "<span class='warning'>You are not wearing an internals mask!</span>"
+			return
+		else
+			var/obj/item/clothing/mask/M = C.wear_mask
+			if(M.mask_adjusted) // if mask on face but pushed down
+				M.adjustmask(C) // adjust it back
+		var/mob/living/carbon/location = loc
+		if(location.internal == src)
+			location.internal = null
+			usr << "<span class='notice'>You close \the [src]'s internals valve.</span>"
+		else
+			if(location.wear_mask && (location.wear_mask.flags & MASKINTERNALS))
+				location.internal = src
+				usr << "<span class='notice'>You open \the [src]'s internals valve.</span>"
+			else
+				usr << "<span class='warning'>You need to be wearing an internals mask!</span>"
+
+
 /obj/item/weapon/tank/internals/oxygen
 	name = "oxygen tank"
 	desc = "A tank of oxygen."

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -153,18 +153,13 @@
 				var/mob/living/carbon/location = loc
 				if(location.internal == src)
 					location.internal = null
-					location.internals.icon_state = "internal0"
-					usr << "<span class='notice'>You close the tank release valve.</span>"
-					if (location.internals)
-						location.internals.icon_state = "internal0"
+					usr << "<span class='notice'>You stop running on internals.</span>"
 				else
 					if(location.wear_mask && (location.wear_mask.flags & MASKINTERNALS))
 						location.internal = src
-						usr << "<span class='notice'>You open \the [src] valve.</span>"
-						if (location.internals)
-							location.internals.icon_state = "internal1"
+						usr << "<span class='notice'>You start running on internals from \the [src].</span>"
 					else
-						usr << "<span class='warning'>You need something to connect to \the [src]!</span>"
+						usr << "<span class='warning'>You need to be wearing an internals mask!</span>"
 
 		src.add_fingerprint(usr)
 /*

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -335,15 +335,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 					ninja_spawn += L
 			new_character.equip_space_ninja()
 			new_character.internal = new_character.s_store
-			new_character.internals.icon_state = "internal1"
 			if(ninja_spawn.len)
 				var/obj/effect/landmark/ninja_spawn_here = pick(ninja_spawn)
 				new_character.loc = ninja_spawn_here.loc
 /* DEATH SQUADS
 		if("Death Commando")//Leaves them at late-join spawn.
 			new_character.equip_death_commando()
-			new_character.internal = new_character.s_store
-			new_character.internals.icon_state = "internal1"*/
+			new_character.internal = new_character.s_store*/
 
 		else//They may also be a cyborg or AI.
 			switch(new_character.mind.assigned_role)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -335,12 +335,8 @@
 				if(do_mob(usr, src, POCKET_STRIP_DELAY))
 					if(internal)
 						internal = null
-						if(internals)
-							internals.icon_state = "internal0"
 					else if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
 						internal = ITEM
-						if(internals)
-							internals.icon_state = "internal1"
 
 					visible_message("<span class='danger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>", \
 									"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,6 +58,7 @@
 	if(statpanel("Status"))
 		stat(null, "Intent: [a_intent]")
 		stat(null, "Move Mode: [m_intent]")
+		stat("")
 		if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			if(malf.malf_mode_declared && (malf.apcs > 0))
@@ -67,9 +68,9 @@
 			if (!internal.air_contents)
 				qdel(internal)
 			else
-				stat("Internal Atmosphere Info", internal.name)
-				stat("Tank Pressure", internal.air_contents.return_pressure())
-				stat("Distribution Pressure", internal.distribute_pressure)
+				stat("Internal Atmosphere Source: [internal.name]")
+				stat("Tank Pressure: [internal.air_contents.return_pressure()]")
+				stat("Distribution Pressure: [internal.distribute_pressure]")
 		if(mind)
 			if(mind.changeling)
 				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -69,8 +69,8 @@
 				qdel(internal)
 			else
 				stat("Internal Atmosphere Source: [internal.name]")
-				stat("Tank Pressure: [internal.air_contents.return_pressure()]")
-				stat("Distribution Pressure: [internal.distribute_pressure]")
+				stat("Tank Pressure: [round(internal.air_contents.return_pressure(),0.1)]")
+				stat("Distribution Pressure: [round(internal.distribute_pressure,0.1)]")
 		if(mind)
 			if(mind.changeling)
 				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -283,8 +283,6 @@
 		if(I.flags & BLOCKHAIR)
 			update_hair(0)	//rebuild hair
 		if(internal)
-			if(internals)
-				internals.icon_state = "internal0"
 			internal = null
 		sec_hud_set_ID()
 		update_inv_wear_mask(0)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -194,12 +194,8 @@
 		if (!wear_mask || !(wear_mask.flags & MASKINTERNALS) )
 			internal = null
 		if(internal)
-			if (internals)
-				internals.icon_state = "internal1"
 			return internal.remove_air_volume(volume_needed)
 		else
-			if (internals)
-				internals.icon_state = "internal0"
 	return
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -13,7 +13,6 @@
 	var/obj/screen/blind = null
 	var/obj/screen/hands = null
 	var/obj/screen/pullin = null
-	var/obj/screen/internals = null
 	var/obj/screen/i_select = null
 	var/obj/screen/m_select = null
 	var/obj/screen/healths = null

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -151,8 +151,6 @@ Contents:
 		N.randomize_param()
 
 	Ninja.internal = Ninja.s_store
-	if(Ninja.internals)
-		Ninja.internals.icon_state = "internal1"
 
 	if(Ninja.mind != Mind)			//something has gone wrong!
 		ERROR("The ninja wasn't assigned the right mind. ;ç;")


### PR DESCRIPTION
Makes internals toggle through clicking the tank's action button, it'll appear like any other action button; when you're holding a tank or have it in any slot. Jetpacks (except inbuilt ones) produce two action buttons, one for internals and one for toggling the jetpack stabilization.

Also changes the status panel to have the internals-stuff stand out a bit more and removes the old toggle internals -button since it's not needed anymore.

Video:
http://webmshare.com/1LdGP

A huge thank you to MrStonedOne and MrPerson for helping me out!
