### PR TITLE
Changes up the Bulldog Bioterror Dart

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -174,12 +174,11 @@
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/New()
 	..()
-	reagents.add_reagent("neurotoxin", 5)
-	reagents.add_reagent("morphine", 5)
-	reagents.add_reagent("spore", 5)
-	reagents.add_reagent("mutetoxin", 5) //;HELP OPS IN MAINT
-	reagents.add_reagent("initropidril", 5)
-	reagents.add_reagent("sodium_thiopental", 5)
+	reagents.add_reagent("neurotoxin", 6)
+	reagents.add_reagent("spore", 6)
+	reagents.add_reagent("mutetoxin", 6) //;HELP OPS IN MAINT
+	reagents.add_reagent("coniine", 6)
+	reagents.add_reagent("sodium_thiopental", 6)
 
 /obj/item/ammo_casing/a762
 	desc = "A 7.62mm bullet casing."


### PR DESCRIPTION
Initro replaced with Coniine.

After the buff to initro it became very good with these darts, and needed a bit of a nerf.

The morphine was removed for being really useless and kind of counterproductive with the Sodium Thiopental. The 5u of this was spread out among the other reagents, with 1 extra unit for each one, extending their duration by a few more ticks.
