### PR TITLE
Fixes runtime involving air meters

### DIFF
--- a/code/ATMOSPHERICS/pipes/pipes.dm
+++ b/code/ATMOSPHERICS/pipes/pipes.dm
@@ -25,6 +25,7 @@
 		air_update_turf()
 
 /obj/machinery/atmospherics/pipe/return_air()
+	build_network()
 	return parent.air
 
 /obj/machinery/atmospherics/pipe/build_network()


### PR DESCRIPTION
```
proc name: return air (/obj/machinery/atmospherics/pipe/return_air)
  source file: pipes.dm,28
  usr: null
  src: the air supply pipe (/obj/machinery/atmospherics/pipe/simple/supply/hidden)
  call stack:
the air supply pipe (/obj/machinery/atmospherics/pipe/simple/supply/hidden): return air()
the gas flow meter (/obj/machinery/meter): process atmos(1.53)
Air (/datum/subsystem/air): process atmos machinery()
Air (/datum/subsystem/air): fire()
/datum/controller/game_control... (/datum/controller/game_controller): process()
```

```
The following runtime has occured 323 time(s).
runtime error: Cannot read null.air
proc name: return air (/obj/machinery/atmospherics/pipe/return_air)
  source file: pipes.dm,28
  usr: null
  src: the air supply pipe (/obj/machinery/atmospherics/pipe/simple/supply/hidden)
```

That's from yesterday's runtime log. return_air() would often return null if a pipe had no parent for whatever reason. build_network() checks for a parent and builds a pipeline if there is none. This should prevent null from being passed.

Fixes point 11 of #6351.
