### PR TITLE
Fixes airlock not closing super fast when timing wire is pulsed 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1096,7 +1096,7 @@ About the new airlock wires panel:
 		spawn(150)
 			autoclose()
 	else if(autoclose && !normalspeed)
-		spawn(5)
+		spawn(11)
 			autoclose()
 
 	return ..()
@@ -1148,8 +1148,9 @@ About the new airlock wires panel:
 	operating = 0
 	air_update_turf(1)
 	update_freelook_sight()
-	if(locate(/mob/living) in get_turf(src))
-		open()
+	if(safe)
+		if(locate(/mob/living) in get_turf(src))
+			open()
 	return 1
 
 /obj/machinery/door/airlock/New()


### PR DESCRIPTION
…or disabled by AI. 
Also, when the door safety is off, the door will not automatically reopen when it detects a mob on its tile. It is to avoid that the airlock stunlocks and automatically kills the mob, which would buff malf AI a lot. The AI can  stunlock and repeatedly crush a mob but it has to be done manually. Fixes #7039
