### PR TITLE
Massive Donksoft sale!!! Our prices cannot be matched!

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -183,7 +183,7 @@ var/list/uplink_items = list()
 	name = "Toy Submachine Gun"
 	desc = "A fully-loaded Donksoft bullpup submachine gun that fires riot grade rounds with a 20-round magazine."
 	item = /obj/item/weapon/gun/projectile/automatic/c20r/toy
-	cost = 12
+	cost = 8
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -191,7 +191,7 @@ var/list/uplink_items = list()
 	name = "Toy Machine Gun"
 	desc = "A fully-loaded Donksoft belt-fed machine gun. This weapon has a massive 50-round magazine of devastating riot grade darts, that can briefly incapacitate someone in just one volley."
 	item = /obj/item/weapon/gun/projectile/automatic/l6_saw/toy
-	cost = 30
+	cost = 12
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -357,7 +357,7 @@ var/list/uplink_items = list()
 	name = "Toy Gun (with Stun Darts)"
 	desc = "An innocent looking toy pistol designed to fire foam darts. Comes loaded with riot grade darts, to incapacitate a target."
 	item = /obj/item/weapon/gun/projectile/automatic/toy/pistol/riot
-	cost = 10
+	cost = 6
 	surplus = 10
 	excludefrom = list(/datum/game_mode/gang)
 

--- a/html/changelogs/fayrik-putadonksoftonit.yml
+++ b/html/changelogs/fayrik-putadonksoftonit.yml
@@ -1,0 +1,6 @@
+author: Fayrik
+
+delete-after: True
+
+changes: 
+  - tweak: "Syndicate Donksoft gear now costs less."


### PR DESCRIPTION
> ## GREAT REDUCTIONS ON ALL DONKSOFT GUNS AND DONKSOFT ACCESSORIES!
> 
> Re-enacting a great movie scene? Want to get revenge on a co-worker? Looking for the **best** replica guns on the market?
> 
> **Boy do we have a deal for you!**

So, I recently saw an admin event where the syndicate toy guns were used in place of real guns.
They worked fine, and the event ran smoothly, however the amount of weaponry spawned in would have cost more points than a regular nuke ops team would have.
(It's also worth noting the ops got super dunked.)

Currently, if you invest in one of these weapons, it takes the lion's share of TC, and it's your primary weapon. That's just silly.
These are meant to be a bad choice, not a "click here and instantly end your chance at success" level of bad, though.
If on the other hand, this PR makes them part of a regular tactic, then we revert it and I take another stab at pricing these things.
