### PR TITLE
Fixes drone and cyborg not being affected by mounted flashers.

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -88,7 +88,7 @@
 		if (get_dist(src, L) > range)
 			continue
 
-		if(L.flash_eyes())
+		if(L.flash_eyes(affect_silicon = 1))
 			L.Weaken(strength)
 			if(L.weakeyes)
 				L.Weaken(strength * 1.5)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -34,8 +34,7 @@
 		M.Stun(15)
 		M.eye_stat += 8
 
-	if(M.flash_eyes())
-		M.eye_stat += rand(1, 3)
+	if(M.flash_eyes(affect_silicon = 1))
 		M.Stun(max(10/distance, 3))
 		M.Weaken(max(10/distance, 3))
 

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -14,8 +14,8 @@
 		// Make a quick flash
 		var/turf/T = get_turf(src)
 		playsound(T, 'sound/effects/phasein.ogg', 100, 1)
-		for(var/mob/living/carbon/human/M in viewers(T, null))
-			M.flash_eyes()
+		for(var/mob/living/carbon/C in viewers(T, null))
+			C.flash_eyes()
 
 		for(var/i=1, i<=deliveryamt, i++)
 			var/atom/movable/x = new spawner_type

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -162,6 +162,7 @@
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
 	var/change_icons = 1
 	var/can_off_process = 0
+	var/light_intensity = 2 //how powerful the emitted light is when used.
 
 /obj/item/weapon/weldingtool/New()
 	..()
@@ -289,7 +290,7 @@
 		reagents.remove_reagent("welding_fuel", amount)
 		check_fuel()
 		if(M)
-			M.flash_eyes(2)
+			M.flash_eyes(light_intensity)
 		return 1
 	else
 		if(M)
@@ -409,7 +410,7 @@
 
 /obj/item/weapon/weldingtool/experimental
 	name = "experimental welding tool"
-	desc = "An experimental welder capable of self-fuel generation."
+	desc = "An experimental welder capable of self-fuel generation and less harmful to the eyes."
 	icon_state = "exwelder"
 	item_state = "exwelder"
 	max_fuel = 40
@@ -418,6 +419,7 @@
 	var/last_gen = 0
 	change_icons = 0
 	can_off_process = 1
+	light_intensity = 1
 
 
 //Proc to make the experimental welder generate fuel, optimized as fuck -Sieve

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -43,9 +43,9 @@
 				priority_announce("Massive bluespace translocation detected.", "Anomaly Alert")
 
 				var/list/flashers = list()
-				for(var/mob/living/carbon/human/M in viewers(TO, null))
-					if(M.flash_eyes())
-						flashers += M
+				for(var/mob/living/carbon/C in viewers(TO, null))
+					if(C.flash_eyes())
+						flashers += C
 
 				var/y_distance = TO.y - FROM.y
 				var/x_distance = TO.x - FROM.x

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -153,7 +153,7 @@
 
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-/mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0)
+/mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
 	var/damage = intensity - check_eye_prot()
 	if(..()) // we've been flashed
 		if(weakeyes)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -687,7 +687,7 @@ Sorry Giacom. Please don't be mad :(
 		floating = 0
 
 //called when the mob receives a bright flash
-/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0)
+/mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
 	if(check_eye_prot() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		flick("e_flash", flash)
 		return 1

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -823,3 +823,6 @@ var/list/ai_list = list()
 		loc = card//Throw AI into the card.
 		src << "You have been downloaded to a mobile storage device. Remote device connection severed."
 		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."
+
+/mob/living/silicon/ai/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
+	return // no eyes, no flashing

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -422,12 +422,13 @@
 /mob/living/silicon/setEarDamage()
 	return
 
-/mob/living/silicon/check_eye_prot()
-	return 2
-
 /mob/living/silicon/proc/GetPhoto()
 	if (aicamera)
 		return aicamera.selectpicture(aicamera)
 
 /mob/living/silicon/grabbedby(mob/living/user)
 	return
+
+/mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
+	if(affect_silicon)
+		return ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -173,8 +173,9 @@
 		if(cleared)
 			src << "--- [class] alarm in [A.name] has been cleared."
 
-/mob/living/simple_animal/drone/check_eye_prot()
-	return 2
-
 /mob/living/simple_animal/drone/handle_temperature_damage()
 	return
+
+/mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
+	if(affect_silicon)
+		return ..()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -67,8 +67,8 @@
 
 		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
-		for(var/mob/living/carbon/human/H in viewers(get_turf(holder.my_atom), null))
-			H.flash_eyes()
+		for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
+			C.flash_eyes()
 		for(var/i = 1, i <= amount_to_spawn, i++)
 			var/chosen = pick(critters)
 			var/mob/living/simple_animal/hostile/C = new chosen

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -159,8 +159,8 @@
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
-	for(var/mob/living/carbon/human/M in viewers(get_turf(holder.my_atom), null))
-		M.flash_eyes()
+	for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
+		C.flash_eyes()
 
 	for(var/i = 1, i <= 4 + rand(1,2), i++)
 		var/chosen = pick(borks)
@@ -191,7 +191,7 @@
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
-	for(var/mob/living/carbon/human/M in viewers(get_turf(holder.my_atom), null))
+	for(var/mob/living/carbon/M in viewers(get_turf(holder.my_atom), null))
 		M.flash_eyes()
 
 	for(var/i = 1, i <= 4 + rand(1,2), i++)


### PR DESCRIPTION
- Fixes #10111 
- Remove eye stat damage from flashbang's bang() proc (eye damage is already handled in carbon/flash_eyes()).
- Changed many flash producing effect to affect all carbons instead of only humans.
- The experimental weldingtool now produces less light than regular welding tool and can be used safely with only sunglasses.
