### PR TITLE
Slaughter demon fixes and Summoning limit

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -10,11 +10,12 @@
 	var/surplus = -1 // -1 for infinite, not used by anything atm
 	var/obj/effect/proc_holder/spell/S = null //Since spellbooks can be used by only one person anyway we can track the actual spell
 	var/buy_word = "Learn"
+	var/limit //used to prevent a spellbook_entry from being bought more than X times with one wizard spellbook
 
 /datum/spellbook_entry/proc/IsAvailible() // For config prefs / gamemode restrictions - these are round applied
 	return 1
 /datum/spellbook_entry/proc/CanBuy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) // Specific circumstances
-	if(book.uses<cost)
+	if(book.uses<cost || limit == 0)
 		return 0
 	return 1
 /datum/spellbook_entry/proc/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) //return 1 on success
@@ -302,6 +303,7 @@
 	desc = "A bottle of magically infused blood, the smell of which will attract extradimensional beings when broken. Be careful though, the kinds of creatures summoned by blood magic are indiscriminate in their killing, and you yourself may become a victim."
 	item_path = /obj/item/weapon/antag_spawner/slaughter_demon
 	log_name = "BB"
+	limit = 3
 
 /datum/spellbook_entry/summon
 	name = "Summon Stuff"
@@ -432,11 +434,17 @@
 			user << "<span class='warning'>The contract has been used, you can't get your points back now!</span>"
 		else
 			user << "<span class='notice'>You feed the contract back into the spellbook, refunding your points.</span>"
-			src.uses++
+			uses++
+			for(var/datum/spellbook_entry/item/contract/CT in entries)
+				if(!isnull(CT.limit))
+					CT.limit++
 			qdel(O)
 	if(istype(O, /obj/item/weapon/antag_spawner/slaughter_demon))
 		user << "<span class='notice'>On second thought, maybe summoning a demon is a bad idea. You refund your points.</span>"
-		src.uses++
+		uses++
+		for(var/datum/spellbook_entry/item/bloodbottle/BB in entries)
+			if(!isnull(BB.limit))
+				BB.limit++
 		qdel(O)
 
 /obj/item/weapon/spellbook/proc/GetCategoryHeader(category)
@@ -545,12 +553,16 @@
 			E = entries[text2num(href_list["buy"])]
 			if(E && E.CanBuy(H,src))
 				if(E.Buy(H,src))
+					if(E.limit)
+						E.limit--
 					uses -= E.cost
 		else if(href_list["refund"])
 			E = entries[text2num(href_list["refund"])]
 			if(E && E.refundable)
 				var/result = E.Refund(H,src)
 				if(result > 0)
+					if(!isnull(E.limit))
+						E.limit += result
 					uses += result
 		else if(href_list["page"])
 			tab = sanitize(href_list["page"])

--- a/code/modules/mob/living/simple_animal/slaughter/slaughter.dm
+++ b/code/modules/mob/living/simple_animal/slaughter/slaughter.dm
@@ -11,6 +11,7 @@
 	response_harm   = "punches"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "daemon"
+	icon_living = "daemon"
 	speed = 0
 	a_intent = "harm"
 	stop_automated_movement = 1
@@ -76,7 +77,7 @@
 			src.phased = TRUE
 			src.holder = holder
 			if(src.kidnapped)
-				src << "<B>You being to feast on [kidnapped]. You can not move while you are doing this.</B>"
+				src << "<B>You begin to feast on [kidnapped]. You can not move while you are doing this.</B>"
 				src.eating = TRUE
 				playsound(get_turf(src),'sound/magic/Demon_consume.ogg', 100, 1)
 				sleep(30)


### PR DESCRIPTION
Fixes typo in a slaughter demon message. Fixes #10045 
Fixes slaughter demon icon upon being admin healed/revived. Fixes #10058 
Add the "limit" var to datum/spellbook_entry to limit the amount of times it can be bought by the wizard. It's currently only used to limit wizard from summoning more than 3 slaughter demons.

This is an updated version of (#10151).
