### PR TITLE
Fixes Disposal unit climbing message when handcuffed

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -132,11 +132,12 @@
 
 	update()
 
-// mouse drop another mob or self
+// mouse drop self
 //
 /obj/machinery/disposal/MouseDrop_T(mob/living/target, mob/living/user)
 	if(istype(target) && user == target)
-		stuff_mob_in(target, user)
+		if(!user.incapacitated())
+			stuff_mob_in(target, user)
 
 /obj/machinery/disposal/proc/stuff_mob_in(mob/living/target, mob/living/user)
 	if(!iscarbon(user) && !user.ventcrawler) //only carbon and ventcrawlers can climb into disposal by themselves.


### PR DESCRIPTION
You already can't enter a disposal unit by yourself while cuffed (the do_mob() proc fails), but the message about "start to climb into" still appears. This fixes it.
