### PR TITLE
[FLUFF|BALANCE] Security Officers Sec Breathmask in Internals Box

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -160,6 +160,7 @@ Security Officer
 	default_headset = /obj/item/device/radio/headset/headset_sec/alt
 	default_backpack = /obj/item/weapon/storage/backpack/security
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
+	default_storagebox = /obj/item/weapon/storage/box/security
 
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_weapons, access_forensics_lockers)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_weapons) //But see /datum/job/warden/get_access()

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -76,6 +76,16 @@
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	return
 
+/obj/item/weapon/storage/box/security
+
+/obj/item/weapon/storage/box/security/New()
+	..()
+	contents = list()
+	new /obj/item/clothing/mask/gas/sechailer(src)
+	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
+	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+	return
+
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains sterile latex gloves."

--- a/html/changelogs/Steelpoint-PR-#10687.yml
+++ b/html/changelogs/Steelpoint-PR-#10687.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Steelpoint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Security Officers now spawn with a security breathmask in their internals box."


### PR DESCRIPTION
As the title states, Security Officers now spawn with a security breath-mask in their internals box instead of a normal breath-mask

Changelog included. 
