### PR TITLE
Finishes carnmc's shuttle rotation feature.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -380,38 +380,3 @@
 
 	return new /datum/projectile_data(src_x, src_y, time, distance, power_x, power_y, dest_x, dest_y)
 
-/proc/getRotationFromDirs(dir1, dir2)
-	return getDegreesFromDir(dir2)-getDegreesFromDir(dir1)
-
-/proc/getDirFromRotation(rotation, olddir)
-	return getDirFromDegrees(rotation+getDegreesFromDir(olddir))
-
-/proc/getDirFromDegrees(degrees)
-	if (degrees < 0)
-		degrees += 360
-	if (degrees >= 360)
-		degrees %= 360
-	if (degrees == 360)
-		degrees = 0
-	switch(degrees)
-		if (0)
-			return NORTH
-		if (90)
-			return EAST
-		if (180)
-			return SOUTH
-		if (270)
-			return WEST
-
-
-/proc/getDegreesFromDir(dir)
-	switch(dir)
-		if (NORTH)
-			return 0
-		if (EAST)
-			return 90
-		if (SOUTH)
-			return 180
-		if (WEST)
-			return 270
-	return 0

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -379,3 +379,39 @@
 	var/dest_y = src_y + distance*cos(rotation);
 
 	return new /datum/projectile_data(src_x, src_y, time, distance, power_x, power_y, dest_x, dest_y)
+
+/proc/getRotationFromDirs(dir1, dir2)
+	return getDegreesFromDir(dir2)-getDegreesFromDir(dir1)
+
+/proc/getDirFromRotation(rotation, olddir)
+	return getDirFromDegrees(rotation+getDegreesFromDir(olddir))
+
+/proc/getDirFromDegrees(degrees)
+	if (degrees < 0)
+		degrees += 360
+	if (degrees >= 360)
+		degrees %= 360
+	if (degrees == 360)
+		degrees = 0
+	switch(degrees)
+		if (0)
+			return NORTH
+		if (90)
+			return EAST
+		if (180)
+			return SOUTH
+		if (270)
+			return WEST
+
+
+/proc/getDegreesFromDir(dir)
+	switch(dir)
+		if (NORTH)
+			return 0
+		if (EAST)
+			return 90
+		if (SOUTH)
+			return 180
+		if (WEST)
+			return 270
+	return 0

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -63,3 +63,9 @@
 	if(T.dir != dir)
 		T.dir = dir
 	return T
+
+//why don't shuttle walls habe smoothwall? now i gotta do rotation the dirty way
+/turf/simulated/wall/shuttle/shuttleRotate(rotation)
+	var/matrix/M = matrix(transform)
+	M.Turn(rotation)
+	transform = M

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -62,10 +62,15 @@
 		T.color = color
 	if(T.dir != dir)
 		T.dir = dir
+	T.transform = transform
 	return T
+
+/turf/simulated/wall/shuttle/copyTurf(turf/T)
+	. = ..()
+	T.transform = transform
 
 //why don't shuttle walls habe smoothwall? now i gotta do rotation the dirty way
 /turf/simulated/wall/shuttle/shuttleRotate(rotation)
-	var/matrix/M = matrix(transform)
+	var/matrix/M = transform
 	M.Turn(rotation)
 	transform = M

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -21,7 +21,9 @@
 		return
 	icon_state = "off"
 
-
+//prevents shuttles attempting to rotate this since it messes up sprites
+/obj/machinery/gateway/shuttleRotate()
+	return
 
 //this is da important part wot makes things go
 /obj/machinery/gateway/centerstation

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -964,3 +964,7 @@ var/list/slot_equipment_priority = list( \
 	if(isliving(src))
 		spell.action.Grant(src)
 	return
+
+//override to avoid rotating pixel_xy on mobs
+/mob/shuttleRotate(rotation)
+	dir = getDirFromRotation(rotation, dir)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -967,4 +967,4 @@ var/list/slot_equipment_priority = list( \
 
 //override to avoid rotating pixel_xy on mobs
 /mob/shuttleRotate(rotation)
-	dir = getDirFromRotation(rotation, dir)
+	dir = angle2dir(rotation+dir2angle(dir))

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -36,6 +36,10 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	..()
 	icon_state = "[get_status()]_[sprite_number]"
 
+//prevents shuttles attempting to rotate this since it messes up sprites
+/obj/machinery/gravity_generator/shuttleRotate()
+	return
+
 /obj/machinery/gravity_generator/proc/get_status()
 	return "off"
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -22,7 +22,8 @@
 /obj/docking_port/Destroy()
 	return QDEL_HINT_LETMELIVE
 
-
+/obj/docking_port/shuttleRotate()
+	return //we don't rotate with shuttles via this code.
 //returns a list(x0,y0, x1,y1) where points 0 and 1 are bounding corners of the projected rectangle
 /obj/docking_port/proc/return_coords(_x, _y, _dir)
 	if(!_dir)
@@ -267,6 +268,22 @@
 	else
 		WARNING("shuttle \"[id]\" could not enter transit space. S0=[S0 ? S0.id : "null"] S1=[S1 ? S1.id : "null"]")
 
+//default shuttleRotate
+/atom/proc/shuttleRotate(rotation)
+	dir = getDirFromRotation(rotation, dir)
+
+	//we need to rotate the pixel offsets too.
+	if (pixel_x || pixel_y)
+		if (rotation < 0)
+			rotation += 360
+		for (var/turntimes=rotation/90;turntimes>0;turntimes--)
+			var/oldPX = pixel_x
+			var/oldPY = pixel_y
+			pixel_x = oldPY
+			pixel_y = (oldPX*(-1))
+
+
+
 //this is the main proc. It instantly moves our mobile port to stationary port S1
 //it handles all the generic behaviour, such as sanity checks, closing doors on the shuttle, stunning mobs, etc
 /obj/docking_port/mobile/proc/dock(obj/docking_port/stationary/S1)
@@ -315,6 +332,18 @@
 		if(!T1)
 			continue
 
+
+		//lighting stuff
+		T1.redraw_lighting()
+		SSair.remove_from_active(T1)
+		T1.CalculateAdjacentTurfs()
+		SSair.add_to_active(T1,1)
+
+		T0.redraw_lighting()
+		SSair.remove_from_active(T0)
+		T0.CalculateAdjacentTurfs()
+		SSair.add_to_active(T0,1)
+
 		T0.copyTurf(T1)
 		areaInstance.contents += T1
 
@@ -324,54 +353,49 @@
 			Ts1.copy_air_with_tile(T0)
 
 		//move mobile to new location
-		loc = S1.loc
-		dir = S1.dir
 
-		//move all objects
-		for(var/obj/O in T0)
-			if(O.invisibility >= 101)
-				continue
-			if(O == T0.lighting_object)
-				continue
-			O.loc = T1
 
-			//close open doors
-			if(istype(O, /obj/machinery/door))
-				var/obj/machinery/door/Door = O
-				spawn(-1)
-					if(Door)
-						Door.close()
 
-		for(var/mob/M in T0)
-			if(!M.move_on_shuttle)
-				continue
-			M.loc = T1
+		for(var/atom/movable/AM in T0)
+			if (dir != S1.dir)
+				AM.shuttleRotate(getRotationFromDirs(dir,S1.dir))
 
-			//docking turbulence
-			if(M.client)
-				spawn(0)
-					if(M.buckled)
-						shake_camera(M, 2, 1) // turn it down a bit come on
-					else
-						shake_camera(M, 7, 1)
-			if(istype(M, /mob/living/carbon))
-				if(!M.buckled)
-					M.Weaken(3)
+			if (istype(AM,/obj))
+				var/obj/O = AM
+				if(O.invisibility >= 101)
+					continue
+				if(O == T0.lighting_object)
+					continue
+				O.loc = T1
+
+				//close open doors
+				if(istype(O, /obj/machinery/door))
+					var/obj/machinery/door/Door = O
+					spawn(-1)
+						if(Door)
+							Door.close()
+			else if (istype(AM,/mob))
+				var/mob/M = AM
+				if(!M.move_on_shuttle)
+					continue
+				M.loc = T1
+
+				//docking turbulence
+				if(M.client)
+					spawn(0)
+						if(M.buckled)
+							shake_camera(M, 2, 1) // turn it down a bit come on
+						else
+							shake_camera(M, 7, 1)
+				if(istype(M, /mob/living/carbon))
+					if(!M.buckled)
+						M.Weaken(3)
 
 		T0.ChangeTurf(turf_type)
-
-	//air system updates
-	for(var/turf/T1 in L1)
-		T1.redraw_lighting()
-		SSair.remove_from_active(T1)
-		T1.CalculateAdjacentTurfs()
-		SSair.add_to_active(T1,1)
-
-	for(var/turf/T0 in L0)
-		T0.redraw_lighting()
-		SSair.remove_from_active(T0)
-		T0.CalculateAdjacentTurfs()
-		SSair.add_to_active(T0,1)
+		if (dir != S1.dir)
+			T1.shuttleRotate(getRotationFromDirs(dir,S1.dir))
+	loc = S1.loc
+	dir = S1.dir
 
 /*
 	if(istype(S1, /obj/docking_port/stationary/transit))
@@ -380,6 +404,8 @@
 			T.pushdirection = d
 			T.update_icon()
 */
+
+
 
 /obj/docking_port/mobile/proc/findTransitDock()
 	var/obj/docking_port/stationary/transit/T = SSshuttle.getDock("[id]_transit")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -270,7 +270,7 @@
 
 //default shuttleRotate
 /atom/proc/shuttleRotate(rotation)
-	dir = getDirFromRotation(rotation, dir)
+	dir = angle2dir(rotation+dir2angle(dir))
 
 	//we need to rotate the pixel offsets too.
 	if (pixel_x || pixel_y)
@@ -312,6 +312,13 @@
 
 	var/list/L0 = return_ordered_turfs(x, y, z, dir, areaInstance)
 	var/list/L1 = return_ordered_turfs(S1.x, S1.y, S1.z, S1.dir)
+
+	var/rotation = dir2angle(S1.dir)-dir2angle(dir)
+	if ((rotation % 90) != 0)
+		rotation += (rotation % 90) //diagonal rotations not allowed, round up
+	rotation = SimplifyDegrees(rotation)
+
+
 
 	//remove area surrounding docking port
 	if(areaInstance.contents.len)
@@ -357,8 +364,8 @@
 
 
 		for(var/atom/movable/AM in T0)
-			if (dir != S1.dir)
-				AM.shuttleRotate(getRotationFromDirs(dir,S1.dir))
+			if (rotation)
+				AM.shuttleRotate(rotation)
 
 			if (istype(AM,/obj))
 				var/obj/O = AM
@@ -392,8 +399,8 @@
 						M.Weaken(3)
 
 		T0.ChangeTurf(turf_type)
-		if (dir != S1.dir)
-			T1.shuttleRotate(getRotationFromDirs(dir,S1.dir))
+		if (rotation)
+			T1.shuttleRotate(rotation)
 	loc = S1.loc
 	dir = S1.dir
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -274,8 +274,8 @@
 	dir = angle2dir(rotation+dir2angle(dir))
 
 	//resmooth if need be.
-	if(A.smooth)
-		smooth_icon(A)
+	if(smooth)
+		smooth_icon(src)
 
 	//rotate the pixel offsets too.
 	if (pixel_x || pixel_y)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -270,9 +270,14 @@
 
 //default shuttleRotate
 /atom/proc/shuttleRotate(rotation)
+	//rotate our direction
 	dir = angle2dir(rotation+dir2angle(dir))
 
-	//we need to rotate the pixel offsets too.
+	//resmooth if need be.
+	if(A.smooth)
+		smooth_icon(A)
+
+	//rotate the pixel offsets too.
 	if (pixel_x || pixel_y)
 		if (rotation < 0)
 			rotation += 360


### PR DESCRIPTION
Under carn shuttles, When shuttles dock at a docking port that is not the same direction as them, they rotate their bounding box, and they do magic i don't understand to rotate where the turfs get placed.

But it doesn't rotate the items or smoothwall or handle pixel_xy or any of that.

This fixes that.

Shuttle rotation will call /atom/proc/shuttleRotate(degrees)
Default behavior handles most cases, and overrides handle edge cases.

Shuttle walls don't smooth wall or obey directions, so I just rotate their icon using matrix transform, its dirty but it works.

![space station 13 2015-07-19 001851](https://cloud.githubusercontent.com/assets/7069733/8765294/86fca0da-2dba-11e5-9ad0-dd5ef5287c0f.png)
![space station 13 2015-07-19 013657](https://cloud.githubusercontent.com/assets/7069733/8765295/870032b8-2dba-11e5-838f-c5e1c0937248.png)

To utilize, just change one of the shuttle's stationary docking port's dir to anything besides the shuttle's mobile docking port's dir

On box, the station docking port for the eshuttle is in the space turf just right of the top general access airlock (the one below the sec airlock)

On meta, the station docking port for the eshuttle is in the space turf just below the right most airlock

View the turf's contents in VV to see it.

To make the second picture, I moved the station's docking port object to inside the cargo external airlock's turf (not inside the airlock itself, that would break shit) then I changed its dir from east to north.
