### PR TITLE
[BALANCE] Increase roundstart TC's to 30 from 20.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -737,7 +737,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Bundle"
 	desc = "Syndicate Bundles are specialised groups of items that arrive in a plain box. These items are collectively worth more than 20 telecrystals, but you do not know which specialisation you will receive."
 	item = /obj/item/weapon/storage/box/syndicate
-	cost = 20
+	cost = 30
 	excludefrom = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 
 /datum/uplink_item/badass/syndiecards
@@ -760,13 +760,13 @@ var/list/uplink_items = list()
 	name = "For showing that you are The Boss"
 	desc = "A useless red balloon with the syndicate logo on it, which can blow the deepest of covers."
 	item = /obj/item/toy/syndicateballoon
-	cost = 20
+	cost = 30
 
 /datum/uplink_item/implants/macrobomb
 	name = "Macrobomb Implant"
 	desc = "An implant injected into the body, and later activated either manually or automatically upon death. Maximum explosion power."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
-	cost = 20
+	cost = 30
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/badass/random
@@ -796,8 +796,8 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/surplus_crate
 	name = "Syndicate Surplus Crate"
-	desc = "A crate containing 50 telecrystals worth of random syndicate leftovers."
-	cost = 20
+	desc = "A crate containing 60 telecrystals worth of random syndicate leftovers."
+	cost = 30
 	item = /obj/item/weapon/storage/box/syndicate
 	excludefrom = list(/datum/game_mode/nuclear)
 
@@ -809,8 +809,8 @@ var/list/uplink_items = list()
 		buyable_items += temp_uplink_list[category]
 	var/list/bought_items = list()
 	U.uses -= cost
-	U.used_TC = 20
-	var/remaining_TC = 50
+	U.used_TC = 30
+	var/remaining_TC = 60
 
 	var/datum/uplink_item/I
 	while(remaining_TC)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -608,7 +608,7 @@ var/list/uplink_items = list()
 	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	item = /obj/item/device/sbeacondrop/bomb
-	cost = 11
+	cost = 16
 	excludefrom = list(/datum/game_mode/traitor/double_agents)
 
 /datum/uplink_item/device_tools/rad_laser

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -10,7 +10,7 @@ var/list/world_uplinks = list()
 
 /obj/item/device/uplink
 	var/welcome = "Syndicate Uplink Console:"	// Welcoming menu message
-	var/uses = 20								// Numbers of crystals
+	var/uses = 30								// Numbers of crystals
 	// List of items not to shove in their hands.
 	var/purchase_log = ""
 	var/show_description = null

--- a/html/changelogs/Steelpoint-PR-TCIncrease.yml
+++ b/html/changelogs/Steelpoint-PR-TCIncrease.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Steelpoint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Upped Traitor and Double Agent telecrystals from 20 to 30."
+  - tweak: "Increased the price of the syndicate bomb to 16 telecrystals to compensate for the increased overall telecrystals."


### PR DESCRIPTION
As the title says, traitors and double agents now get 30 telecrystals from round start instead of 20.

In addition the syndicate bomb is increased in price to 16 telecrystals.
