### PR TITLE
Status panel cleanup

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -113,8 +113,8 @@
 	..()
 	if(statpanel("Status"))
 		if(blob_core)
-			stat(null, "Core Health: [blob_core.health]")
-		stat(null, "Power Stored: [blob_points]/[max_blob_points]")
+			stat("Core Health: [blob_core.health]", null)
+		stat("Power Stored: [blob_points]/[max_blob_points]", null)
 
 /mob/camera/blob/Move(NewLoc, Dir = 0)
 	var/obj/effect/blob/B = locate() in range("3x3", NewLoc)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -131,7 +131,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Station Time: [worldtime2text()]")
+		stat("Station Time: [worldtime2text()]", null)
 		if(ticker)
 			if(ticker.mode)
 				//world << "DEBUG: ticker not null"
@@ -139,11 +139,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					var/datum/game_mode/malfunction/malf = ticker.mode
 					//world << "DEBUG: malf mode ticker test"
 					if(malf.malf_mode_declared && (malf.apcs > 0))
-						stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
+						stat("Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]", null)
 
 				for(var/datum/gang/G in ticker.mode.gangs)
 					if(isnum(G.dom_timer))
-						stat(null, "[G.name] Gang Takeover: [max(G.dom_timer, 0)]")
+						stat("[G.name] Gang Takeover: [max(G.dom_timer, 0)]", null)
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -142,9 +142,7 @@
 	..()
 
 	if(statpanel("Status"))
-		stat(null, "Intent: [a_intent]")
-		stat(null, "Move Mode: [m_intent]")
-		stat(null, "Plasma Stored: [getPlasma()]/[max_plasma]")
+		stat("Plasma Stored: [getPlasma()]/[max_plasma]", null)
 
 	add_abilities_to_panel()
 

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -30,7 +30,7 @@
 /mob/living/carbon/alien/larva/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Progress: [amount_grown]/[max_grown]")
+		stat("Progress: [amount_grown]/[max_grown]")
 
 /mob/living/carbon/alien/larva/adjustToxLoss(amount)
 	if(stat != DEAD)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -61,14 +61,6 @@
 			if(malf.malf_mode_declared && (malf.apcs > 0))
 				stat("Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]", null)
 
-		if (internal)
-			if (!internal.air_contents)
-				qdel(internal)
-			else
-				stat("")
-				stat("Internal Atmosphere Source:", internal.name)
-				stat("Tank Pressure:", "[round(internal.air_contents.return_pressure(),0.1)]")
-				stat("Distribution Pressure:", "[round(internal.distribute_pressure,0.1)]")
 		if(mind)
 			if(mind.changeling)
 				stat("Chemical Storage:", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -56,25 +56,23 @@
 	..()
 
 	if(statpanel("Status"))
-		stat(null, "Intent: [a_intent]")
-		stat(null, "Move Mode: [m_intent]")
-		stat("")
 		if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			if(malf.malf_mode_declared && (malf.apcs > 0))
-				stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
+				stat("Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]", null)
 
 		if (internal)
 			if (!internal.air_contents)
 				qdel(internal)
 			else
-				stat("Internal Atmosphere Source: [internal.name]")
-				stat("Tank Pressure: [round(internal.air_contents.return_pressure(),0.1)]")
-				stat("Distribution Pressure: [round(internal.distribute_pressure,0.1)]")
+				stat("")
+				stat("Internal Atmosphere Source:", internal.name)
+				stat("Tank Pressure:", "[round(internal.air_contents.return_pressure(),0.1)]")
+				stat("Distribution Pressure:", "[round(internal.distribute_pressure,0.1)]")
 		if(mind)
 			if(mind.changeling)
-				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")
-				stat("Absorbed DNA", mind.changeling.absorbedcount)
+				stat("Chemical Storage:", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")
+				stat("Absorbed DNA:", mind.changeling.absorbedcount)
 
 
 	//NINJACODE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,6 +58,7 @@
 	if(statpanel("Status"))
 		stat(null, "Intent: [a_intent]")
 		stat(null, "Move Mode: [m_intent]")
+		stat("")
 		if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			if(malf.malf_mode_declared && (malf.apcs > 0))
@@ -67,9 +68,9 @@
 			if (!internal.air_contents)
 				qdel(internal)
 			else
-				stat("Internal Atmosphere Info", internal.name)
-				stat("Tank Pressure", internal.air_contents.return_pressure())
-				stat("Distribution Pressure", internal.distribute_pressure)
+				stat("Internal Atmosphere Source: [internal.name]")
+				stat("Tank Pressure: [round(internal.air_contents.return_pressure(),0.1)]")
+				stat("Distribution Pressure: [round(internal.distribute_pressure,0.1)]")
 		if(mind)
 			if(mind.changeling)
 				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -170,8 +170,6 @@
 /mob/living/carbon/monkey/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Intent: [a_intent]")
-		stat(null, "Move Mode: [m_intent]")
 		if(client && mind)
 			if(mind.changeling)
 				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -854,7 +854,7 @@ Sorry Giacom. Please don't be mad :(
 			if(ticker.mode)
 				for(var/datum/gang/G in ticker.mode.gangs)
 					if(isnum(G.dom_timer))
-						stat(null, "[G.name] Gang Takeover: [max(G.dom_timer, 0)]")
+						stat("[G.name] Gang Takeover: [max(G.dom_timer, 0)]", null)
 
 /mob/living/cancel_camera()
 	..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -231,12 +231,12 @@ var/list/ai_list = list()
 			var/datum/game_mode/malfunction/malf = ticker.mode
 			for (var/datum/mind/malfai in malf.malf_ai)
 				if ((mind == malfai) && (malf.apcs > 0))
-					stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds")
+					stat("Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds", null)
 
 		if(!stat)
-			stat(null, text("System integrity: [(health+100)/2]%"))
-			stat(null, "Station Time: [worldtime2text()]")
-			stat(null, text("Connected cyborgs: [connected_robots.len]"))
+			stat("System integrity: [(health+100)/2]%", null)
+			stat("Station Time: [worldtime2text()]", null)
+			stat("Connected cyborgs: [connected_robots.len]", null)
 			var/area/borg_area
 			for(var/mob/living/silicon/robot/R in connected_robots)
 				borg_area = get_area(R)
@@ -246,10 +246,10 @@ var/list/ai_list = list()
 				else if(!R.cell || R.cell.charge <= 0)
 					robot_status = "DEPOWERED"
 				//Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
-				stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "Empty"] | \
- 				Module: [R.designation] | Loc: [borg_area.name] | Status: [robot_status]"))
+				stat("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "Empty"] | \
+ 				Module: [R.designation] | Loc: [borg_area.name] | Status: [robot_status]", null)
 		else
-			stat(null, text("Systems nonfunctional"))
+			stat("Systems nonfunctional", null)
 
 /mob/living/silicon/ai/canUseTopic()
 	if(stat)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -82,11 +82,11 @@
 	if(statpanel("Status"))
 		if(src.silence_time)
 			var/timeleft = round((silence_time - world.timeofday)/10 ,1)
-			stat(null, "Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+			stat("Communications system reboot in -[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]", null)
 		if(!src.stat)
-			stat(null, text("System integrity: [(src.health+100)/2]%"))
+			stat("System integrity: [(src.health+100)/2]%", null)
 		else
-			stat(null, text("Systems nonfunctional"))
+			stat("Systems nonfunctional", null)
 
 /mob/living/silicon/pai/check_eye(mob/user)
 	if (!src.current)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -305,16 +305,16 @@
 			for (var/datum/mind/malfai in malf.malf_ai)
 				if(connected_ai)
 					if((connected_ai.mind == malfai) && (malf.apcs > 0))
-						stat(null, "Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds")
+						stat("Time until station control secured: [max(malf.AI_win_timeleft/malf.apcs, 0)] seconds", null)
 				else if(malf.malf_mode_declared && (malf.apcs > 0))
-					stat(null, "Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]")
+					stat("Time left: [max(malf.AI_win_timeleft/malf.apcs, 0)]", null)
 
 		if(cell)
-			stat(null, text("Charge Left: [cell.charge]/[cell.maxcharge]"))
+			stat("Charge Left: [cell.charge]/[cell.maxcharge]", null)
 		else
-			stat(null, text("No Cell Inserted!"))
+			stat("No Cell Inserted!", null)
 
-		stat(null, "Station Time: [worldtime2text()]")
+		stat("Station Time: [worldtime2text()]", null)
 		if(module)
 			internal = locate(/obj/item/weapon/tank/jetpack) in module.modules
 			if(internal)
@@ -323,7 +323,7 @@
 			for (var/datum/robot_energy_storage/st in module.storages)
 				stat("[st.name]: [st.energy]/[st.max_energy]")
 		if(connected_ai)
-			stat(null, text("Master AI: [connected_ai.name]"))
+			stat("Master AI: [connected_ai.name]", null)
 
 /mob/living/silicon/robot/restrained()
 	return 0

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -125,7 +125,6 @@
 	..()
 	if(statpanel("Status"))
 		stat("Held Item", held_item)
-		stat("Mode",a_intent)
 
 /mob/living/simple_animal/parrot/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
 	if(speaker != src && prob(20)) //Dont imitate ourselves

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -83,7 +83,7 @@
 /mob/living/simple_animal/revenant/Stat()
 	..()
 	if(statpanel("Status"))
-		stat(null, "Current essence: [essence]E")
+		stat("Current essence: [essence]E", null)
 
 /mob/living/simple_animal/revenant/New()
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -386,7 +386,7 @@
 	..()
 
 	if(statpanel("Status"))
-		stat(null, "Health: [round((health / maxHealth) * 100)]%")
+		stat("Health: [round((health / maxHealth) * 100)]%", null)
 		return 1
 
 /mob/living/simple_animal/death(gibbed)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -691,7 +691,7 @@ var/list/slot_equipment_priority = list( \
 	..()
 
 	if(statpanel("Status"))
-		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
+		stat("Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]", null)
 		var/ETA
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_RECALL)
@@ -706,7 +706,7 @@ var/list/slot_equipment_priority = list( \
 				ETA = "ERR"
 		if(ETA)
 			var/timeleft = SSshuttle.emergency.timeLeft()
-			stat(null, "[ETA]-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+			stat("[ETA] - [(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]", null)
 
 
 	if(client && client.holder)


### PR DESCRIPTION
Removed the intent and move mode info since they're already displayed to the player on the game screen at all times.

Removed internals stuff. A new system of alarming the user about low pressure in internals is coming up and it's just kinda weird that you just know the accurate pressure at all times without looking.

Current:
![sieppaa](https://cloud.githubusercontent.com/assets/5420151/8775446/14decfa4-2ef1-11e5-90d7-4d2486738238.PNG)

New (UPDATED):
![sieppaa](https://cloud.githubusercontent.com/assets/5420151/8775380/457f6250-2ef0-11e5-993c-1bfbc1c6fab2.PNG)
