### PR TITLE
saving atmos one letter at a time

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -119,7 +119,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/components/trinary/mxer/attack_hand(mob/user)
+/obj/machinery/atmospherics/components/trinary/mixer/attack_hand(mob/user)
 	if(..())
 		return
 


### PR DESCRIPTION
fixes a typo that prevents the nanoUI coming up when interacting with the gas mixer
