### PR TITLE
Character Limit Fix

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -235,7 +235,9 @@
 	return ""
 
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
-/proc/trim(text)
+/proc/trim(text, max_length)
+	if(max_length)
+		text = copytext(text, 1, max_length)
 	return trim_left(trim_right(text))
 
 //Returns a string with the first element of the string capitalized.


### PR DESCRIPTION
#9902 replaced /proc/strip_html_properly but the new code didn't actually have the character length check that the proc had.

I don't know if trim() is the best place for it or to put it in its own proc but I assume this was Miauw's intent because he is passing max_length into it.
