### PR TITLE
Adds hotkey for resist

### DIFF
--- a/html/changelogs/freerealestate - RESIST.yml
+++ b/html/changelogs/freerealestate - RESIST.yml
@@ -1,0 +1,6 @@
+author: freerealestate
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added resist hotkeys for borgs and humans. With hotkeys mode, use CTRL+C or C as a human and CTRL+C, C or END as a borg. With hotkeys mode off, use CTRL+C as a human and END as a borg."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -170,7 +170,6 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+4 = toggle intents
 \tDEL = pull
 \tINS = toggle intents
-\tEND = resist
 \tPGUP = cycle active modules
 \tPGDN = activate held object
 </font>"}

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -91,6 +91,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tm = me
 \tt = say
 \to = OOC
+\tc = resist
 \tx = swap-hand
 \tz = activate held object (or y)
 \tf = cycle-intents-left
@@ -110,6 +111,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+q = drop
 \tCtrl+e = equip
 \tCtrl+r = throw
+\tCtrl+c = resist
 \tCtrl+x = swap-hand
 \tCtrl+z = activate held object (or Ctrl+y)
 \tCtrl+f = cycle-intents-left
@@ -140,6 +142,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tq = unequip active module
 \tt = say
 \tx = cycle active modules
+\tc = resist
 \tz = activate held object (or y)
 \tf = cycle-intents-left
 \tg = cycle-intents-right
@@ -157,6 +160,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+w = up
 \tCtrl+q = unequip active module
 \tCtrl+x = cycle active modules
+\tCtrl+c = resist
 \tCtrl+z = activate held object (or Ctrl+y)
 \tCtrl+f = cycle-intents-left
 \tCtrl+g = cycle-intents-right
@@ -166,6 +170,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tCtrl+4 = toggle intents
 \tDEL = pull
 \tINS = toggle intents
+\tEND = resist
 \tPGUP = cycle active modules
 \tPGDN = activate held object
 </font>"}

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1233,8 +1233,6 @@ window "chemdispenser"
 		keep-aspect = false
 		align = center
 		text-wrap = false
-		allow-html = false
-		letterbox = true
 	elem "eject"
 		type = BUTTON
 		pos = 264,4
@@ -1401,8 +1399,6 @@ window "chemdispenser"
 		keep-aspect = false
 		align = center
 		text-wrap = false
-		allow-html = false
-		letterbox = true
 	elem "child1"
 		type = CHILD
 		pos = 0,40
@@ -1524,8 +1520,6 @@ window "chemdispenser_reagents"
 		keep-aspect = false
 		align = center
 		text-wrap = false
-		allow-html = false
-		letterbox = true
 
 window "mainwindow"
 	elem "mainwindow"
@@ -1736,8 +1730,6 @@ window "mapwindow"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
-		letterbox = true
-		zoom = 0
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
@@ -2266,6 +2258,4 @@ window "infowindow"
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 		on-tab = ""
-		prefix-color = none
-		suffix-color = none
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -16,10 +16,6 @@ macro "borghotkeymode"
 		command = ".southeast"
 		is-disabled = false
 	elem 
-		name = "SOUTHWEST"
-		command = "resist"
-		is-disabled = false
-	elem 
 		name = "NORTHWEST"
 		command = "unequip-module"
 		is-disabled = false

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -16,6 +16,10 @@ macro "borghotkeymode"
 		command = ".southeast"
 		is-disabled = false
 	elem 
+		name = "SOUTHWEST"
+		command = "resist"
+		is-disabled = false
+	elem 
 		name = "NORTHWEST"
 		command = "unequip-module"
 		is-disabled = false
@@ -98,6 +102,14 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+A+REP"
 		command = ".west"
+		is-disabled = false
+	elem 
+		name = "C"
+		command = "resist"
+		is-disabled = false
+	elem 
+		name = "CTRL+C"
+		command = "resist"
 		is-disabled = false
 	elem 
 		name = "D+REP"
@@ -298,6 +310,10 @@ macro "macro"
 		command = ".west"
 		is-disabled = false
 	elem 
+		name = "CTRL+C"
+		command = "resist"
+		is-disabled = false
+	elem 
 		name = "CTRL+D+REP"
 		command = ".east"
 		is-disabled = false
@@ -484,6 +500,14 @@ macro "hotkeymode"
 		command = ".west"
 		is-disabled = false
 	elem 
+		name = "C"
+		command = "resist"
+		is-disabled = false
+	elem 
+		name = "CTRL+C"
+		command = "resist"
+		is-disabled = false
+	elem 
 		name = "D+REP"
 		command = ".east"
 		is-disabled = false
@@ -638,6 +662,10 @@ macro "borgmacro"
 		command = ".southeast"
 		is-disabled = false
 	elem 
+		name = "SOUTHWEST"
+		command = "resist"
+		is-disabled = false
+	elem 
 		name = "NORTHWEST"
 		command = "unequip-module"
 		is-disabled = false
@@ -700,6 +728,10 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+A+REP"
 		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+C"
+		command = "resist"
 		is-disabled = false
 	elem 
 		name = "CTRL+D+REP"
@@ -1201,6 +1233,8 @@ window "chemdispenser"
 		keep-aspect = false
 		align = center
 		text-wrap = false
+		allow-html = false
+		letterbox = true
 	elem "eject"
 		type = BUTTON
 		pos = 264,4
@@ -1367,6 +1401,8 @@ window "chemdispenser"
 		keep-aspect = false
 		align = center
 		text-wrap = false
+		allow-html = false
+		letterbox = true
 	elem "child1"
 		type = CHILD
 		pos = 0,40
@@ -1488,6 +1524,8 @@ window "chemdispenser_reagents"
 		keep-aspect = false
 		align = center
 		text-wrap = false
+		allow-html = false
+		letterbox = true
 
 window "mainwindow"
 	elem "mainwindow"
@@ -1698,6 +1736,8 @@ window "mapwindow"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
+		letterbox = true
+		zoom = 0
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
@@ -2226,4 +2266,6 @@ window "infowindow"
 		on-show = ".winset\"rpane.infob.is-visible=true;rpane.browseb.is-visible=true?rpane.infob.pos=130,0:rpane.infob.pos=65,0 rpane.textb.is-visible=true rpane.infob.is-checked=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=infowindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=false;rpane.browseb.is-visible=true?rpane.browseb.is-checked=true rpane.rpanewindow.left=browserwindow:rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0 rpane.rpanewindow.left=\""
 		on-tab = ""
+		prefix-color = none
+		suffix-color = none
 


### PR DESCRIPTION
After some talk here https://github.com/tgstation/-tg-station/pull/10592#issuecomment-121295723, I decided to add a hotkey for resist in the hopes that maybe if grabs were easier to fend off (without having to run out of them) that tabling could be buffed a small amount from where it's at right now. Plus, it seems odd that most of the UI buttons have hotkeys but resist doesn't, when there are enough reachable keys still free for it to have one.

This also makes it easier for borgs to unbuckle from chairs, as they no longer have to type "resist" or find the verb in the panel in the top right.

The hotkey is C with hotkeys mode on and ctrl+C with it off.
