### PR TITLE
Fire now does more burn damage scaling up with the fire stacks you have

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -141,6 +141,9 @@
 		return
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(700, 50, 1)
+	if(istype(src, /mob/living/carbon))
+		var/mob/living/carbon/C = src
+		C.adjustFireLoss(0.3*M.fire_stacks)
 
 /mob/living/fire_act()
 	adjust_fire_stacks(0.5)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -143,7 +143,7 @@
 	location.hotspot_expose(700, 50, 1)
 	if(istype(src, /mob/living/carbon))
 		var/mob/living/carbon/C = src
-		C.adjustFireLoss(0.3*M.fire_stacks)
+		C.adjustFireLoss(0.3*fire_stacks)
 
 /mob/living/fire_act()
 	adjust_fire_stacks(0.5)


### PR DESCRIPTION
It can now scale up to 6 burn damage at max fire stacks. I might change this to scaling up to 4 burn damage.

People are complaining that fire is damn near useless and that being on fire is easy to fight and most of the time completely ignorable, so this should help with the disco inferno.

Idea stolen from goonchem's fire damage scaling up with firestacks.
