### PR TITLE
Fixes typo with box of hugs message, adds one second cooldown to hugging it

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -109,7 +109,7 @@
 /obj/item/weapon/storage/box/syringes
 	name = "box of syringes"
 	desc = "A box full of syringes."
-	desc = "A biohazard alert warning is printed on the box"
+	desc = "A biohazard warning is printed on the box."
 	icon_state = "syringe"
 
 /obj/item/weapon/storage/box/syringes/New()
@@ -166,7 +166,7 @@
 
 /obj/item/weapon/storage/box/injectors
 	name = "box of DNA injectors"
-	desc = "This box contains injectors it seems."
+	desc = "This box contains injectors, it seems."
 
 /obj/item/weapon/storage/box/injectors/New()
 	..()
@@ -179,7 +179,7 @@
 
 /obj/item/weapon/storage/box/flashbangs
 	name = "box of flashbangs (WARNING)"
-	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness or deafness in repeated use.</B>"
+	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness or deafness with repeated use.</B>"
 	icon_state = "flashbang"
 
 /obj/item/weapon/storage/box/flashbangs/New()
@@ -194,7 +194,7 @@
 
 /obj/item/weapon/storage/box/flashes
 	name = "box of flashbulbs"
-	desc = "<B>WARNING: Flashes can cause serious eye damage, protective eyewear is required.</B>"
+	desc = "<B>WARNING: Flashes can cause serious eye damage. Protective eyewear is required for use.</B>"
 	icon_state = "flashbang"
 
 /obj/item/weapon/storage/box/flashes/New()
@@ -208,7 +208,7 @@
 
 /obj/item/weapon/storage/box/teargas
 	name = "box of tear gas grenades (WARNING)"
-	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness and skin irritation.</B>"
+	desc = "<B>WARNING: These devices are extremely dangerous and can cause skin irritation and blindness.</B>"
 	icon_state = "flashbang"
 
 /obj/item/weapon/storage/box/teargas/New()
@@ -222,8 +222,8 @@
 	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
 
 /obj/item/weapon/storage/box/emps
-	name = "box of emp grenades"
-	desc = "A box with 5 emp grenades."
+	name = "box of EMP grenades"
+	desc = "A box of five EMP grenades."
 	icon_state = "flashbang"
 
 /obj/item/weapon/storage/box/emps/New()
@@ -236,7 +236,7 @@
 
 /obj/item/weapon/storage/box/trackimp
 	name = "boxed tracking implant kit"
-	desc = "Box full of scum-bag tracking utensils."
+	desc = "Box full of scumbag tracking utensils."
 	icon_state = "implant"
 
 /obj/item/weapon/storage/box/trackimp/New()
@@ -266,7 +266,7 @@
 
 /obj/item/weapon/storage/box/exileimp
 	name = "boxed exile implant kit"
-	desc = "Box of exile implants. It has a picture of a clown being booted through the Gateway."
+	desc = "Box of exile implants. It has a picture of a clown being booted through a Gateway on the front."
 	icon_state = "implant"
 
 /obj/item/weapon/storage/box/exileimp/New()
@@ -321,7 +321,7 @@
 
 /obj/item/weapon/storage/box/cups
 	name = "box of paper cups"
-	desc = "It has pictures of paper cups on the front."
+	desc = "It has a picture of paper cups on the front."
 
 /obj/item/weapon/storage/box/cups/New()
 	..()
@@ -363,7 +363,7 @@
 
 /obj/item/weapon/storage/box/permits
 	name = "box of construction permits"
-	desc = "A box for containing construction permits, used to officially declare built rooms as additions to the station."
+	desc = "A box containing construction permits, used to officially declare newly built rooms as additions to the station."
 	icon_state = "id"
 
 /obj/item/weapon/storage/box/permits/New() //There's only a few, so blueprints are still useful beyond setting every room's name to PRIMARY FART STORAGE
@@ -405,7 +405,7 @@
 
 /obj/item/weapon/storage/box/prisoner
 	name = "box of prisoner IDs"
-	desc = "Take away their last shred of dignity, their name."
+	desc = "Take away their last shred of dignity: their name."
 	icon_state = "id"
 
 /obj/item/weapon/storage/box/prisoner/New()
@@ -504,7 +504,7 @@
 
 /obj/item/weapon/storage/box/pillbottles
 	name = "box of pill bottles"
-	desc = "It has pictures of pill bottles on its front."
+	desc = "It has pictures of pill bottles on the front."
 	icon_state = "pillbox"
 
 /obj/item/weapon/storage/box/pillbottles/New()
@@ -591,7 +591,7 @@
 
 /obj/item/weapon/storage/box/deputy
 	name = "box of deputy armbands"
-	desc = "To be issued to those authorized to act as deputy of security."
+	desc = "To be issued to those authorized to act as deputies of security."
 
 /obj/item/weapon/storage/box/deputy/New()
 	..()
@@ -605,7 +605,7 @@
 
 /obj/item/weapon/storage/box/metalfoam
 	name = "box of metal foam grenades"
-	desc = "To be used to rapidly seal hull breaches"
+	desc = "To be used to rapidly seal hull breaches."
 	icon_state = "flashbang"
 
 /obj/item/weapon/storage/box/metalfoam/New()
@@ -624,13 +624,18 @@
 	desc = "A special box for sensitive people."
 	icon_state = "hugbox"
 	foldable = null
+	var/cooldown = 0
 
 /obj/item/weapon/storage/box/hug/attack_self(mob/user)
-	..()
-	user.changeNext_move(CLICK_CD_MELEE)
-	playsound(loc, "rustle", 50, 1, -5)
-	user.visible_message("<span class='notice'>[user] hugs the [src].</span>","<span class='notice'>You hug the [src].</span>")
-	return
+	if (cooldown < world.time)
+		cooldown = (world.time + 10) // Sets cooldown at 1 second
+		..()
+		user.changeNext_move(CLICK_CD_MELEE)
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -5)
+		user.visible_message("<span class='notice'>[user] hugs \the [src].</span>","<span class='notice'>You hug \the [src].</span>")
+		return
+	else
+		return
 
 /obj/item/weapon/storage/box/hug/medical/New()
 	..()


### PR DESCRIPTION
- Changes hug sound to the mob hug sound (seemed to fit the item better than the generic storage rustle)
- Tweaks a few of the descriptions in boxes.dm to read better, which I did while waiting for the code to compile

I don't mind changing any of the superfluous stuff back if people find a problem with it. The main thing is fixing the typo and adding the small cooldown to prevent spam.

Fixes #10692 

To do:
- [ ] Add cooldown to attack_self hotkey
- [ ] Remove object cooldown
