### PR TITLE
[HC] electrocution damage no longer capped

### DIFF
--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -93,6 +93,6 @@
 
 /datum/powernet/proc/get_electrocute_damage()
 	if(avail >= 1000)
-		return Clamp(round(avail/10000), 10, 90) + rand(-5,5)
+		return Clamp(round(avail/10000), 10, INFINITY) + rand(-5,5)
 	else
 		return 0


### PR DESCRIPTION
removing a hugbox every PR

this was one of those safety changes I guess got made because someone bumped into an electrocuted grille after the traitor station engineers bypassed the SMES cells and hardwired solars and singuloth directly into the power grid in order to get those sweet electrocution kills
