### PR TITLE
3 New Direction Helper Procs

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -177,3 +177,11 @@
 #define MAT_URANIUM		"$uranium"
 #define MAT_PLASMA		"$plasma"
 #define MAT_BANANIUM	"$bananium"
+
+
+//check_target_facings() return defines
+#define FACING_FAILED											0
+#define FACING_SAME_DIR											1
+#define FACING_EACHOTHER										2
+#define FACING_INIT_FACING_TARGET_TARGET_FACING_PERPENDICULAR	3 //Do I win the most informative but also most stupid define award?
+

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1288,13 +1288,13 @@ var/list/WALLITEMS = list(
 	That said, this proc should not be used if the change facing proc of the click code is overriden at the same time*/
 	if(!ismob(target) || target.lying)
 	//Make sure we are not doing this for things that can't have a logical direction to the players given that the target would be on their side
-		return
+		return FACING_FAILED
 	if(initator.dir == target.dir) //mobs are facing the same direction
-		return 1
-	if(initator.dir + 4 == target.dir || initator.dir - 4 == target.dir) //mobs are facing each other
-		return 2
+		return FACING_SAME_DIR
+	if(is_A_facing_B(initator,target) && is_A_facing_B(target,initator)) //mobs are facing each other
+		return FACING_EACHOTHER
 	if(initator.dir + 2 == target.dir || initator.dir - 2 == target.dir || initator.dir + 6 == target.dir || initator.dir - 6 == target.dir) //Initating mob is looking at the target, while the target mob is looking in a direction perpendicular to the 1st
-		return 3
+		return FACING_INIT_FACING_TARGET_TARGET_FACING_PERPENDICULAR
 
 /proc/random_step(atom/movable/AM, steps, chance)
 	var/initial_chance = chance
@@ -1342,3 +1342,55 @@ var/list/WALLITEMS = list(
 		return 1
 	return 0
 
+
+
+//Get the dir to the RIGHT of dir if they were on a clock
+//NORTH --> NORTHEAST
+/proc/get_clockwise_dir(dir)
+	. = angle2dir(dir2angle(dir)+45)
+
+//Get the dir to the LEFT of dir if they were on a clock
+//NORTH --> NORTHWEST
+/proc/get_anticlockwise_dir(dir)
+	. = angle2dir(dir2angle(dir)-45)
+
+
+//Compare A's dir, the clockwise dir of A and the anticlockwise dir of A
+//To the opposite dir of the dir returned by get_dir(B,A)
+//If one of them is a match, then A is facing B
+/proc/is_A_facing_B(atom/A,atom/B)
+	if(!istype(A) || !istype(B))
+		return 0
+	if(istype(A, /mob/living))
+		var/mob/living/LA = A
+		if(LA.lying)
+			return 0
+	var/goal_dir = angle2dir(dir2angle(get_dir(B,A)+180))
+	var/clockwise_A_dir = get_clockwise_dir(A.dir)
+	var/anticlockwise_A_dir = get_anticlockwise_dir(B.dir)
+
+	if(A.dir == goal_dir || clockwise_A_dir == goal_dir || anticlockwise_A_dir == goal_dir)
+		return 1
+	return 0
+
+
+/*
+rough example of the "cone" made by the 3 dirs checked
+
+ B
+  \
+   \
+    >
+      <
+       \
+        \
+B --><-- A
+        /
+       /
+      <
+     >
+    /
+   /
+ B
+
+*/


### PR DESCRIPTION
## Additions
- Adds `get_clockwise_dir(arg1)`, returns the dir one to the right (clockwise) of `arg1`, if directions were a clock, eg: `NORTH` --> `NORTHEAST`
- Adds `get_anticlockwise_dir(arg1)`, returns the dir one to the left (anticlockwise) of `arg1`, if directions were a clock, eg: `NORTH` --> `NORTHWEST`
- Adds `is_A_facing_B(arg1,arg2)`, checks if `arg1` is facing `arg2`, in a cone including the two dirs either side of `arg1`'s actual dir (the clockwise and anticlockwise of `arg1`'s dir)
## Improvements
- Improves `check_target_facings()`' "we're both facing eachother" case to use `is_A_facing_B()`, so that it works on a cone instead of just cardinals.
- Improves `check_target_facings()` to return defines, instead of magic numbers
