### PR TITLE
Mech gas tank leak fix

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -133,7 +133,11 @@
 	equipment.Cut()
 	cell = null
 	internal_tank = null
-	qdel(cabin_air)
+	if(loc)
+		loc.assume_air(cabin_air)
+		air_update_turf()
+	else
+		del(cabin_air)
 	cabin_air = null
 	qdel(spark_system)
 	spark_system = null
@@ -234,6 +238,7 @@
 				var/datum/gas_mixture/leaked_gas = int_tank_air.remove_ratio(0.10)
 				if(loc)
 					loc.assume_air(leaked_gas)
+					air_update_turf()
 				else
 					del(leaked_gas)
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -71,12 +71,12 @@
 			take_damage(damage)
 			check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 			visible_message("<span class='danger'>[user] [user.attacktext] [src]!</span>")
-			add_logs(user, src, "attacked", admin=0)
+			add_logs(user, src, "attacked")
 		else
 			src.log_append_to_last("Armor saved.")
 			playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
 			visible_message("<span class='notice'>The [user] rebounds off [src.name]'s armor!</span>")
-			add_logs(user, src, "attacked", admin=0)
+			add_logs(user, src, "attacked")
 	return
 
 /obj/mecha/attack_tk()


### PR DESCRIPTION
Readds mech cabin air being dropped on the turf when the mech is destroyed.
Fixes turf not updating its air when a mech dropped air on it (either via gas tank leak or cabin air dump). Fixes #10757 
Fixes runtime with mech/attack_animal's add_logs()
