### PR TITLE
Mech & vending machine fixes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1,3 +1,7 @@
+#define STANDARD_CHARGE 1
+#define CONTRABAND_CHARGE 2
+#define COIN_CHARGE 3
+
 /datum/data/vending_product
 	var/product_name = "generic"
 	var/product_path = null
@@ -47,8 +51,6 @@
 	var/obj/item/weapon/coin/coin
 	var/datum/wires/vending/wires = null
 
-	var/dish_quants = list()  //used by the snack machine's custom compartment to count dishes.
-
 	var/obj/item/weapon/vending_refill/refill_canister = null		//The type of refill canisters used by this machine.
 
 /obj/machinery/vending/New()
@@ -82,12 +84,6 @@
 	coin = null
 	..()
 
-
-/obj/machinery/vending/snack/Destroy()
-	for(var/obj/item/weapon/reagent_containers/food/snacks/S in contents)
-		S.loc = get_turf(src)
-	..()
-
 /obj/machinery/vending/RefreshParts()         //Better would be to make constructable child
 	if(component_parts)
 		product_records = list()
@@ -97,9 +93,9 @@
 		build_inventory(contraband, 1, start_empty = 1)
 		build_inventory(premium, 0, 1, start_empty = 1)
 		for(var/obj/item/weapon/vending_refill/VR in component_parts)
-			refill_inventory(VR, product_records)
-			refill_inventory(VR, coin_records)
-			refill_inventory(VR, hidden_records)
+			refill_inventory(VR, product_records, STANDARD_CHARGE)
+			refill_inventory(VR, coin_records, COIN_CHARGE)
+			refill_inventory(VR, hidden_records, CONTRABAND_CHARGE)
 
 /obj/machinery/vending/ex_act(severity, target)
 	..()
@@ -136,99 +132,33 @@
 		else
 			product_records += R
 
-/obj/machinery/vending/proc/refill_inventory(obj/item/weapon/vending_refill/refill, datum/data/vending_product/machine)
+/obj/machinery/vending/proc/refill_inventory(obj/item/weapon/vending_refill/refill, datum/data/vending_product/machine, var/charge_type = STANDARD_CHARGE)
 	var/total = 0
-
 	var/to_restock = 0
+
 	for(var/datum/data/vending_product/machine_content in machine)
-		if(machine_content.amount == 0 && refill.charges > 0)
+		if(machine_content.amount == 0 && refill.charges[charge_type] > 0)
 			machine_content.amount++
-			refill.charges--
+			refill.charges[charge_type]--
 			total++
 		to_restock += machine_content.max_amount - machine_content.amount
-	if(to_restock <= refill.charges)
+	if(to_restock <= refill.charges[charge_type])
 		for(var/datum/data/vending_product/machine_content in machine)
 			machine_content.amount = machine_content.max_amount
-		refill.charges -= to_restock
+		refill.charges[charge_type] -= to_restock
 		total += to_restock
 	else
-		var/tmp_charges = refill.charges
+		var/tmp_charges = refill.charges[charge_type]
 		for(var/datum/data/vending_product/machine_content in machine)
-			if(refill.charges == 0)
+			if(refill.charges[charge_type] == 0)
 				break
 			var/restock = Ceiling(((machine_content.max_amount - machine_content.amount)/to_restock)*tmp_charges)
-			if(restock > refill.charges)
-				restock = refill.charges
+			if(restock > refill.charges[charge_type])
+				restock = refill.charges[charge_type]
 			machine_content.amount += restock
-			refill.charges -= restock
+			refill.charges[charge_type] -= restock
 			total += restock
 	return total
-
-/obj/machinery/vending/snack/attackby(obj/item/weapon/W, mob/user, params)
-	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks))
-		if(!compartment_access_check(user))
-			return
-		if(junk_check(W))
-			if(!iscompartmentfull(user))
-				if(!user.drop_item())
-					return
-				W.loc = src
-				food_load(W)
-				user << "<span class='notice'>You insert [W] into [src]'s chef compartment.</span>"
-		else
-			user << "<span class='notice'>[src]'s chef compartment does not accept junk food.</span>"
-		return
-
-	if(istype(W, /obj/item/weapon/storage/bag/tray))
-		if(!compartment_access_check(user))
-			return
-		var/obj/item/weapon/storage/T = W
-		var/loaded = 0
-		var/denied_items = 0
-		for(var/obj/item/weapon/reagent_containers/food/snacks/S in T.contents)
-			if(iscompartmentfull(user))
-				break
-			if(junk_check(S))
-				T.remove_from_storage(S, src)
-				food_load(S)
-				loaded++
-			else
-				denied_items++
-		if(denied_items)
-			user << "<span class='notice'>[src] refuses some items.</span>"
-		if(loaded)
-			user << "<span class='notice'>You insert [loaded] dishes into [src]'s chef compartment.</span>"
-		updateUsrDialog()
-		return
-
-	..()
-
-/obj/machinery/vending/snack/proc/compartment_access_check(user)
-	req_access_txt = chef_compartment_access
-	if(!allowed(user) && !emagged && scan_id)
-		user << "<span class='warning'>[src]'s chef compartment blinks red: Access denied.</span>"
-		req_access_txt = "0"
-		return 0
-	req_access_txt = "0"
-	return 1
-
-/obj/machinery/vending/snack/proc/junk_check(obj/item/weapon/reagent_containers/food/snacks/S)
-	if(S.junkiness)
-		return 0
-	return 1
-
-/obj/machinery/vending/snack/proc/iscompartmentfull(mob/user)
-	if(contents.len >= 30) // no more than 30 dishes can fit inside
-		user << "<span class='warning'>[src]'s chef compartment is full.</span>"
-		return 1
-	return 0
-
-/obj/machinery/vending/snack/proc/food_load(obj/item/weapon/reagent_containers/food/snacks/S)
-	if(dish_quants[S.name])
-		dish_quants[S.name]++
-	else
-		dish_quants[S.name] = 1
-	sortList(dish_quants)
 
 /obj/machinery/vending/attackby(obj/item/weapon/W, mob/user, params)
 	if(panel_open)
@@ -263,7 +193,7 @@
 		else if(panel_open)
 			//if the panel is open we attempt to refill the machine
 			var/obj/item/weapon/vending_refill/canister = W
-			if(canister.charges == 0)
+			if(canister.charges[STANDARD_CHARGE] == 0)
 				user << "<span class='notice'>This [canister.name] is empty!</span>"
 			else
 				var/transfered = refill_inventory(canister,product_records,user)
@@ -279,21 +209,22 @@
 
 
 /obj/machinery/vending/default_deconstruction_crowbar(obj/item/O)
-	var/list/all_products = product_records + hidden_records + coin_records
-	for(var/datum/data/vending_product/machine_content in all_products)
-		while(machine_content.amount !=0)
-			var/safety = 0 //to avoid infinite loop
-			for(var/obj/item/weapon/vending_refill/VR in component_parts)
-				safety++
-				if(VR.charges < initial(VR.charges))
-					VR.charges++
-					machine_content.amount--
-					if(!machine_content.amount)
-						break
-				else
-					safety--
-			if(safety <= 0)
-				break
+	var/product_list = list(product_records, hidden_records, coin_records)
+	for(var/i=1, i<=3, i++)
+		for(var/datum/data/vending_product/machine_content in product_list[i])
+			while(machine_content.amount !=0)
+				var/safety = 0 //to avoid infinite loop
+				for(var/obj/item/weapon/vending_refill/VR in component_parts)
+					safety++
+					if(VR.charges[i] < VR.init_charges[i])
+						VR.charges[i]++
+						machine_content.amount--
+						if(!machine_content.amount)
+							break
+					else
+						safety--
+				if(safety <= 0) // all refill canisters are full
+					break
 	..()
 
 /obj/machinery/vending/emag_act(mob/user)
@@ -349,15 +280,6 @@
 				dat += "[coin]&nbsp;&nbsp;<a href='byond://?src=\ref[src];remove_coin=1'>Remove</a>"
 			else
 				dat += "<i>No coin</i>&nbsp;&nbsp;<span class='linkOff'>Remove</span>"
-		if(istype(src, /obj/machinery/vending/snack))
-			dat += "<h3>Chef's Food Selection</h3>"
-			dat += "<div class='statusDisplay'>"
-			for (var/O in dish_quants)
-				if(dish_quants[O] > 0)
-					var/N = dish_quants[O]
-					dat += "<a href='byond://?src=\ref[src];dispense=[sanitize(O)]'>Dispense</A> "
-					dat += "<B>[capitalize(O)]: [N]</B><br>"
-			dat += "</div>"
 	user.set_machine(src)
 	if(seconds_electrified && !(stat & NOPOWER))
 		if(shock(user, 100))
@@ -404,23 +326,6 @@
 
 
 	usr.set_machine(src)
-
-	if((href_list["dispense"]) && (vend_ready))
-		var/N = href_list["dispense"]
-		if(dish_quants[N] <= 0) // Sanity check, there are probably ways to press the button when it shouldn't be possible.
-			return
-		vend_ready = 0
-		use_power(5)
-
-		spawn(vend_delay)
-			dish_quants[N] = max(dish_quants[N] - 1, 0)
-			for(var/obj/O in contents)
-				if(O.name == N)
-					O.loc = src.loc
-					break
-			vend_ready = 1
-			updateUsrDialog()
-		return
 
 	if((href_list["vend"]) && (vend_ready))
 		if(panel_open)
@@ -637,8 +542,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/cream = 4,/obj/item/weapon/reagent_containers/food/drinks/soda_cans/tonic = 8,
 					/obj/item/weapon/reagent_containers/food/drinks/soda_cans/cola = 8, /obj/item/weapon/reagent_containers/food/drinks/soda_cans/sodawater = 15,
 					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 30,/obj/item/weapon/reagent_containers/food/drinks/ice = 10,
-					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass = 8)
-	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/tea = 10)
+					/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass = 12)
+	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/tea = 12)
 	vend_delay = 15
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
@@ -659,7 +564,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	icon_vend = "coffee-vend"
 	vend_delay = 34
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/coffee = 25,/obj/item/weapon/reagent_containers/food/drinks/tea = 25,/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 25)
-	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/ice = 10)
+	contraband = list(/obj/item/weapon/reagent_containers/food/drinks/ice = 12)
 	refill_canister = /obj/item/weapon/vending_refill/coffee
 
 /obj/machinery/vending/snack
@@ -668,12 +573,11 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	product_slogans = "Try our new nougat bar!;Twice the calories for half the price!"
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Oh my god it's so juicy!;Have a snack.;Snacks are good for you!;Have some more Getmore!;Best quality snacks straight from mars.;We love chocolate!;Try our new jerky!"
 	icon_state = "snack"
-	products = list(/obj/item/weapon/reagent_containers/food/snacks/candy = 5,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 5,/obj/item/weapon/reagent_containers/food/snacks/chips =5,
-					/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 5,/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 5,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 5,
-					/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 5)
-	contraband = list(/obj/item/weapon/reagent_containers/food/snacks/syndicake = 7)
+	products = list(/obj/item/weapon/reagent_containers/food/snacks/candy = 6,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 6,/obj/item/weapon/reagent_containers/food/snacks/chips =6,
+					/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 6,/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 6,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 6,
+					/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 6)
+	contraband = list(/obj/item/weapon/reagent_containers/food/snacks/syndicake = 6)
 	refill_canister = /obj/item/weapon/vending_refill/snack
-	var/chef_compartment_access = "28"
 
 /obj/machinery/vending/sustenance
 	name = "\improper Sustenance Vendor"
@@ -735,14 +639,14 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	icon_state = "cigs"
 	products = list(/obj/item/weapon/storage/fancy/cigarettes = 5,
 					/obj/item/weapon/storage/fancy/cigarettes/cigpack_uplift = 3,
-					/obj/item/weapon/storage/fancy/cigarettes/cigpack_robust = 2,
+					/obj/item/weapon/storage/fancy/cigarettes/cigpack_robust = 3,
 					/obj/item/weapon/storage/fancy/cigarettes/cigpack_carp = 3,
 					/obj/item/weapon/storage/fancy/cigarettes/cigpack_midori = 3,
 					/obj/item/weapon/storage/box/matches = 10,
 					/obj/item/weapon/lighter/greyscale = 4,
 					/obj/item/weapon/storage/fancy/rollingpapers = 5)
-	contraband = list(/obj/item/weapon/lighter = 4)
-	premium = list(/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold = 2, \
+	contraband = list(/obj/item/weapon/lighter = 3)
+	premium = list(/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold = 3, \
 	/obj/item/weapon/storage/fancy/cigarettes/cigars = 1, /obj/item/weapon/storage/fancy/cigarettes/cigars/havana = 1, /obj/item/weapon/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/weapon/vending_refill/cigarette
 
@@ -867,8 +771,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/clothing/under/maid = 1, /obj/item/clothing/under/janimaid = 1,/obj/item/clothing/glasses/cold=1,/obj/item/clothing/glasses/heat=1,
 					/obj/item/clothing/suit/whitedress = 1,
 					/obj/item/clothing/under/jester = 1, /obj/item/clothing/head/jester = 1)
-	contraband = list(/obj/item/clothing/suit/judgerobe = 1,/obj/item/clothing/head/powdered_wig = 1,/obj/item/weapon/gun/magic/wand = 1,/obj/item/clothing/glasses/sunglasses/garb = 1)
-	premium = list(/obj/item/clothing/suit/hgpirate = 1, /obj/item/clothing/head/hgpiratecap = 1, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman = 1)
+	contraband = list(/obj/item/clothing/suit/judgerobe = 1,/obj/item/clothing/head/powdered_wig = 1,/obj/item/weapon/gun/magic/wand = 2,/obj/item/clothing/glasses/sunglasses/garb = 2)
+	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman = 1)
 	refill_canister = /obj/item/weapon/vending_refill/autodrobe
 
 /obj/machinery/vending/dinnerware
@@ -934,8 +838,8 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/weapon/scalpel = 2,/obj/item/weapon/circular_saw = 2,/obj/item/weapon/tank/internals/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,
 					/obj/item/weapon/screwdriver = 5,/obj/item/weapon/crowbar = 5)
 
-//This one's from NTstation
-//don't forget to change the refill size if you change the machine's contents!
+
+//DON'T FORGET TO CHANGE THE REFILL SIZE IF YOU CHANGE THE MACHINE'S CONTENTS!
 /obj/machinery/vending/clothing
 	name = "ClothesMate" //renamed to make the slogan rhyme
 	desc = "A vending machine for clothing."
@@ -963,7 +867,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	/obj/item/clothing/suit/ianshirt=1,/obj/item/clothing/shoes/laceup=2,/obj/item/clothing/shoes/sneakers/black=4,
 	/obj/item/clothing/shoes/sandal=1, /obj/item/clothing/gloves/fingerless=2,/obj/item/clothing/glasses/orange=1,/obj/item/clothing/glasses/red=1,
 	/obj/item/weapon/storage/belt/fannypack=1, /obj/item/weapon/storage/belt/fannypack/blue=1, /obj/item/weapon/storage/belt/fannypack/red=1)
-	contraband = list(/obj/item/clothing/under/syndicate/tacticool=1,/obj/item/clothing/mask/balaclava=1,/obj/item/clothing/head/ushanka=1,/obj/item/clothing/under/soviet=1,/obj/item/weapon/storage/belt/fannypack/black=1)
+	contraband = list(/obj/item/clothing/under/syndicate/tacticool=1,/obj/item/clothing/mask/balaclava=1,/obj/item/clothing/head/ushanka=1,/obj/item/clothing/under/soviet=1,/obj/item/weapon/storage/belt/fannypack/black=2)
 	premium = list(/obj/item/clothing/under/suit_jacket/checkered=1,/obj/item/clothing/head/mailman=1,/obj/item/clothing/under/rank/mailman=1,/obj/item/clothing/suit/jacket/leather=1,/obj/item/clothing/suit/jacket/leather/overcoat=1,/obj/item/clothing/under/pants/mustangjeans=1)
 	refill_canister = /obj/item/weapon/vending_refill/clothing
 
+#undef STANDARD_CHARGE
+#undef CONTRABAND_CHARGE
+#undef COIN_CHARGE

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -46,7 +46,7 @@
 		else
 			chassis.occupant << sound('sound/mecha/critdestr.ogg',volume=50)
 		chassis = null
-	..()
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/proc/critfail()
 	if(chassis)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -32,7 +32,7 @@
 	SSobj.processing.Remove(src)
 	for(var/atom/movable/AM in src)
 		AM.forceMove(get_turf(src))
-	..()
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/Exit(atom/movable/O)
 	return 0
@@ -75,6 +75,7 @@
 	log_message("[patient] ejected. Life support functions disabled.")
 	patient.reset_view()
 	SSobj.processing.Remove(src)
+	patient = null
 	update_equip_info()
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/detach()
@@ -82,7 +83,6 @@
 		occupant_message("<span class='warning'>Unable to detach [src] - equipment occupied!</span>")
 		return
 	SSobj.processing.Remove(src)
-	update_equip_info()
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/get_equip_info()
@@ -188,15 +188,15 @@
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/update_equip_info()
 	if(..())
-		send_byjax(chassis.occupant,"msleeper.browser","lossinfo",get_patient_dam())
-		send_byjax(chassis.occupant,"msleeper.browser","reagents",get_patient_reagents())
-		send_byjax(chassis.occupant,"msleeper.browser","injectwith",get_available_reagents())
+		if(patient)
+			send_byjax(chassis.occupant,"msleeper.browser","lossinfo",get_patient_dam())
+			send_byjax(chassis.occupant,"msleeper.browser","reagents",get_patient_reagents())
+			send_byjax(chassis.occupant,"msleeper.browser","injectwith",get_available_reagents())
 		return 1
 	return
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/container_resist()
 	go_out()
-
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/process()
 	if(!chassis)
@@ -259,7 +259,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/syringe_gun/Destroy()
 	SSobj.processing.Remove(src)
-	..()
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/syringe_gun/critfail()
 	..()
@@ -505,6 +505,7 @@
 		occupant_message("<span class=\"alert\">Reagent processing stopped.</a>")
 		log_message("Reagent processing stopped.")
 		SSobj.processing.Remove(src)
+		return
 	if(anyprob(reliability))
 		critfail()
 	var/amount = synth_speed / processed_reagents.len

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -205,7 +205,7 @@
 	SSobj.processing.Remove(src)
 	if(chassis)
 		chassis.overlays -= droid_overlay
-	..()
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/repair_droid/attach(obj/mecha/M as obj)
 	..()

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -317,7 +317,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/cable_layer/Destroy()
 	chassis.events.clearEvent("onMove",event)
-	..()
+	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/cable_layer/action(var/obj/item/stack/cable_coil/target)
 	if(!action_checks(target))

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -139,7 +139,7 @@
 	spark_system = null
 
 	mechas_list -= src //global mech list
-	..()
+	return ..()
 
 ////////////////////////
 ////// Helpers /////////

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -12,6 +12,7 @@
 	wreckage = /obj/structure/mecha_wreckage/ripley
 	var/list/cargo = new
 	var/cargo_capacity = 15
+	var/hides = 0
 
 /obj/mecha/working/ripley/Move()
 	. = ..()
@@ -23,15 +24,14 @@
 	update_pressure()
 
 /obj/mecha/working/ripley/Destroy()
-	var/hides = round((initial(damage_absorption["brute"]) - damage_absorption["brute"])*10)
-	for(var/i=0, i < hides, i++)
+	for(var/i=1, i <= hides, i++)
 		new /obj/item/asteroid/goliath_hide(loc) //If a goliath-plated ripley gets killed, all the plates drop
 	damage_absorption["brute"] =  initial(damage_absorption["brute"])
 	for(var/atom/movable/A in cargo)
 		A.loc = loc
 		step_rand(A)
 	cargo.Cut()
-	..()
+	return ..()
 
 /obj/mecha/working/ripley/go_out()
 	..()
@@ -47,12 +47,12 @@
 
 /obj/mecha/working/ripley/update_icon()
 	..()
-	if (damage_absorption["brute"] < 0.6 && damage_absorption["brute"] > 0.3)
+	if (hides)
 		overlays = null
-		overlays += image("icon" = "mecha.dmi", "icon_state" = "ripley-g-open")
-	else if (damage_absorption.["brute"] == 0.3)
-		overlays = null
-		overlays += image("icon" = "mecha.dmi", "icon_state" = "ripley-g-full-open")
+		if(hides < 3)
+			overlays += image("icon" = "mecha.dmi", "icon_state" = occupant ? "ripley-g" : "ripley-g-open")
+		else
+			overlays += image("icon" = "mecha.dmi", "icon_state" = occupant ? "ripley-g-full" : "ripley-g-full-open")
 
 
 /obj/mecha/working/ripley/firefighter

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -709,7 +709,7 @@
 
 				<h2>Microwave:</h2>
 				Use it to cook or boil food ingredients (meats, doughs, egg, spaghetti, donkpocket, etc...).
-				It can cook multiple items at once. Use the higher power settings for faster (and riskier) cooking.
+				It can cook multiple items at once.
 
 				<h2>Processor:</h2>
 				Use it to process certain ingredients (meat into faggot, doughslice into spaghetti, potato into fries,etc...)
@@ -733,6 +733,8 @@
 				<b>Donuts:</b> 1u sugar + 1 pastry base<br>
 				<b>Fries:</b> Process potato.
 
+				<h2>Sharing your food:</h2>
+				You can put your meals on your kitchen counter or load them in the snack vending machines.
 				</body>
 				</html>
 			"}

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -12,18 +12,20 @@
 	throw_range = 7
 	w_class = 4.0
 
-	var/charges = 0		//how many restocking "charges" the refill has
+	var/charges = list(0, 0, 0)	//how many restocking "charges" the refill has for standard/contraband/coin products
+	var/init_charges = list(0, 0, 0)
+
 
 /obj/item/weapon/vending_refill/New(amt = -1)
 	..()
 	name = "\improper [machine_name] restocking unit"
 	if(isnum(amt) && amt > -1)
-		charges = amt
+		charges[1] = amt
 
 /obj/item/weapon/vending_refill/examine(mob/user)
 	..()
-	if(charges)
-		user << "It can restock [charges] item(s)."
+	if(charges[1] > 0)
+		user << "It can restock [charges[1]] item(s)."
 	else
 		user << "It's empty!"
 
@@ -32,33 +34,40 @@
 /obj/item/weapon/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"
 	icon_state = "refill_booze"
-	charges = 54//of 162
+	charges = list(52, 4, 0)//of 156 standard, 12 contraband
+	init_charges = list(52, 4, 0)
 
 /obj/item/weapon/vending_refill/coffee
 	machine_name = "Solar's Best Hot Drinks"
 	icon_state = "refill_joe"
-	charges = 28//of 85
+	charges = list(25, 4, 0)//of 75 standard, 12 contraband
+	init_charges = list(25, 4, 0)
 
 /obj/item/weapon/vending_refill/snack
 	machine_name = "Getmore Chocolate Corp"
-	charges = 14//of 42
+	charges = list(12, 2, 0)//of 36 standard, 6 contraband
+	init_charges = list(12, 2, 0)
 
 /obj/item/weapon/vending_refill/cola
 	machine_name = "Robust Softdrinks"
 	icon_state = "refill_cola"
-	charges = 22//of 66
+	charges = list(20, 2, 0)//of 60 standard, 6 contraband
+	init_charges = list(20, 2, 0)
 
 /obj/item/weapon/vending_refill/cigarette
 	machine_name = "ShadyCigs Deluxe"
 	icon_state = "refill_smoke"
-	charges = 14// of 42
+	charges = list(12, 1, 2)// of 36 standard, 3 contraband, 6 premium
+	init_charges = list(12, 1, 2)
 
 /obj/item/weapon/vending_refill/autodrobe
 	machine_name = "AutoDrobe"
 	icon_state = "refill_costume"
-	charges = 29// of 87
+	charges = list(25, 2, 3)// of 75 standard, 6 contraband, 9 premium
+	init_charges = list(25, 2, 3)
 
 /obj/item/weapon/vending_refill/clothing
 	machine_name = "ClothesMate"
 	icon_state = "refill_clothes"
-	charges = 30// of 90
+	charges = list(29, 2, 2)// of 85 standard, 6 contraband, 6 premium
+	init_charges = list(29, 2, 2)

--- a/code/modules/food&drinks/kitchen machinery/microwave.dm
+++ b/code/modules/food&drinks/kitchen machinery/microwave.dm
@@ -14,7 +14,6 @@
 	var/broken = 0 // ={0,1,2} How broken is it???
 	var/max_n_of_items = 10 // whatever fat fuck made this a global var needs to look at themselves in the mirror sometime
 	var/efficiency = 0
-	var/microwavepower = 1
 
 
 // see code/modules/food/recipes_microwave.dm for recipes
@@ -203,12 +202,6 @@
 			dat = "<h3>Ingredients:</h3>[dat]</div>"
 		dat += "<A href='?src=\ref[src];action=cook'>Turn on</A>"
 		dat += "<A href='?src=\ref[src];action=dispose'>Eject ingredients</A><BR>"
-		dat += "Microwave Power: [microwavepower*200]W<BR>"
-		dat += "<A href='?src=\ref[src];action=power;amount=1'>200W</A>"
-		dat += "<A href='?src=\ref[src];action=power;amount=2'>400W</A>"
-		dat += "<A href='?src=\ref[src];action=power;amount=3'>600W</A>"
-		dat += "<A href='?src=\ref[src];action=power;amount=4'>800W</A>"
-		dat += "<A href='?src=\ref[src];action=power;amount=5'>1000W</A><BR>"
 
 	var/datum/browser/popup = new(user, "microwave", name, 300, 300)
 	popup.set_content(dat)
@@ -224,7 +217,7 @@
 		return
 	start()
 
-	if (prob(max(microwavepower*5/efficiency-5,dirty*5))) //a clean unupgraded microwave on lowest power has no risk of failure
+	if (prob(max(5/efficiency-5,dirty*5))) //a clean unupgraded microwave has no risk of failure
 		muck_start()
 		if (!microwaving(4))
 			muck_finish()
@@ -265,7 +258,7 @@
 		if (stat & (NOPOWER|BROKEN))
 			return 0
 		use_power(500)
-		sleep(max(14-2*microwavepower-2*efficiency,2)) // standard power means sleep(10). The higher the power and the better the efficiency, the faster the cooking
+		sleep(max(12-2*efficiency,2)) // standard microwave means sleep(10). The better the efficiency, the faster the cooking
 	return 1
 
 /obj/machinery/microwave/proc/has_extra_item()
@@ -340,10 +333,5 @@
 
 		if ("dispose")
 			dispose()
-		if ("power")
-			var/amount = text2num(href_list["amount"])
-			if(amount<1 || amount>5)
-				return
-			microwavepower = amount
 	updateUsrDialog()
 	return

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -468,26 +468,21 @@
 				user << "<span class='warning'>You can't improve [C] any further!</span>"
 				return
 		if(istype(target, /obj/mecha/working/ripley))
-			var/obj/mecha/D = target
+			var/obj/mecha/working/ripley/D = target
 			var/list/damage_absorption = D.damage_absorption
-			if(damage_absorption["brute"] > 0.3)
+			if(D.hides < 3)
+				D.hides++
 				damage_absorption["brute"] = max(damage_absorption["brute"] - 0.1, 0.3)
 				damage_absorption["bullet"] = damage_absorption["bullet"] - 0.05
 				damage_absorption["fire"] = damage_absorption["fire"] - 0.05
 				damage_absorption["laser"] = damage_absorption["laser"] - 0.025
 				user << "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>"
-				qdel(src)
-				if(D.icon_state == "ripley-open")
-					D.overlays += image("icon"="mecha.dmi", "icon_state"="ripley-g-open")
-					D.desc = "Autonomous Power Loader Unit. Its armour is enhanced with some goliath hide plates."
+				D.update_icon()
+				if(D.hides == 3)
+					D.desc = "Autonomous Power Loader Unit. It's wearing a fearsome carapace entirely composed of goliath hide plates - its pilot must be an experienced monster hunter."
 				else
-					user << "<span class='info'>You can't add armour onto the mech while someone is inside!</span>"
-				if(damage_absorption.["brute"] == 0.3)
-					if(D.icon_state == "ripley-open")
-						D.overlays += image("icon"="mecha.dmi", "icon_state"="ripley-g-full-open")
-						D.desc = "Autonomous Power Loader Unit. It's wearing a fearsome carapace entirely composed of goliath hide plates - the pilot must be an experienced monster hunter."
-					else
-						user << "<span class='warning'>You can't add armour onto the mech while someone is inside!</span>"
+					D.desc = "Autonomous Power Loader Unit. Its armour is enhanced with some goliath hide plates."
+				qdel(src)
 			else
 				user << "<span class='warning'>You can't improve [D] any further!</span>"
 				return


### PR DESCRIPTION
Vending fixes:
- Give refill canisters three separate charge values for standard, contraband(hacked) and premium(coin) items. So that next time someone increases the amount of items in a vending machine w/o updating the refill  charges (looking at you /vending/clothing), it will affect the items in the same product list instead of only contraband. This will prevent wrong charge amounts to standard items from going unnoticed (because only changing hidden items amount). (I also changed a warning comment to be in capital letters for visibility)
- I also updated the charges of the refill canisters to the correct amounts. Fixes #10207 

Cooking:
- Adding a mention about being able to load food into snack vending machines in the cook book.
- Removed the power setting of the microwave. The microwave upgrades makes it unneeded.

Mech fixes:
- Fixes goliath hide overlay on ripley not updating correctly. Fixes #10773 
- Simplifies the code for goliath hide application on ripley mech.(adding hides var to ripley)
- Fixes some mech equipment's Destroy not calling return ..()
- Fixes mech sleeper not reset its patient var when ejecting the patient. Fixes #10776 
- Removed unnedded update_equip_info( in sleeper/detach()
- Fixes an oversight in syringe_gun/process().
