### PR TITLE
Sets compile build to latest linux 508 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: c
 
 env:
     global:
-    - BYOND_MAJOR="507"
-    - BYOND_MINOR="1286"
+    - BYOND_MAJOR="508"
+    - BYOND_MINOR="1293"
     matrix:
     - DM_MAPFILE="tgstation2"
     - DM_MAPFILE="metastation"


### PR DESCRIPTION
It's stable enough to work safely with now and (unless I'm mistaken) is already running on the servers, so it's high time to take advantage of it's improvements.
http://www.byond.com/docs/notes/508.html
@Cheridan
