### PR TITLE
Clickable re-enter corpse links

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -441,7 +441,7 @@
 
 			var/mob/dead/observer/ghost = occupant.get_ghost()
 			if(ghost)
-				ghost << "<span class='ghostalert'>Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
+				ghost << "<span class='ghostalert'>Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
 				ghost << sound('sound/effects/genetics.ogg')
 	return 1
 

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -420,6 +420,12 @@
 
 		open_machine()
 
+/obj/machinery/dna_scannernew/Topic(href, href_list)
+	if(href_list["reenter"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.reenter_corpse(ghost)
+
 /obj/machinery/dna_scannernew/close_machine()
 	if(!state_open)
 		return 0
@@ -435,7 +441,7 @@
 
 			var/mob/dead/observer/ghost = occupant.get_ghost()
 			if(ghost)
-				ghost << "<span class='ghostalert'>Your corpse has been placed into a cloning scanner. Return to your body if you want to be cloned!</span> (Verbs -> Ghost -> Re-enter corpse)"
+				ghost << "<span class='ghostalert'>Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
 				ghost << sound('sound/effects/genetics.ogg')
 	return 1
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -478,6 +478,12 @@ datum/reagent/shadowling_blindness_smoke //Blinds non-shadowlings, heals shadowl
 	include_user = 0
 	var/list/thralls_in_world = list()
 
+/obj/effect/proc_holder/spell/targeted/reviveThrall/Topic(href, href_list)
+	if(href_list["reenter"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.reenter_corpse(ghost)
+
 /obj/effect/proc_holder/spell/targeted/reviveThrall/cast(list/targets)
 	for(var/mob/living/carbon/human/thrallToRevive in targets)
 		if(!is_thrall(thrallToRevive))
@@ -492,7 +498,7 @@ datum/reagent/shadowling_blindness_smoke //Blinds non-shadowlings, heals shadowl
 							"<span class='shadowling'>You crouch over the body of your thrall and begin gathering energy...</span>")
 		var/mob/dead/observer/ghost = thrallToRevive.get_ghost()
 		if(ghost)
-			ghost << "<span class='ghostalert'>Your masters are resuscitating you! Return to your corpse if you wish to be brought to life.</span> (Verbs -> Ghost -> Re-enter corpse)"
+			ghost << "<span class='ghostalert'>Your masters are resuscitating you! Re-enter your corpse if you wish to be brought to life.</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
 			ghost << 'sound/effects/genetics.ogg'
 		if(!do_mob(usr, thrallToRevive, 100))
 			usr << "<span class='warning'>Your concentration snaps. The flow of energy ebbs.</span>"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -406,7 +406,7 @@
 				return
 			var/mob/dead/observer/ghost = H.get_ghost()
 			if(ghost)
-				ghost << "<span class='ghostalert'>Your heart is being defibrillated. Re-enter your corpse if you want to be revived!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
+				ghost << "<span class='ghostalert'>Your heart is being defibrillated. Re-enter your corpse if you want to be revived! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
 				ghost << 'sound/effects/genetics.ogg'
 			user.visible_message("<span class='warning'>[user] begins to place [src] on [M.name]'s chest.</span>", "<span class='warning'>You begin to place [src] on [M.name]'s chest...</span>")
 			busy = 1

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -323,6 +323,12 @@
 	else
 		return 1
 
+/obj/item/weapon/twohanded/shockpaddles/Topic(href, href_list)
+	if(href_list["reenter"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.reenter_corpse(ghost)
+
 /obj/item/weapon/twohanded/shockpaddles/attack(mob/M, mob/user)
 	var/halfwaycritdeath = (config.health_threshold_crit + config.health_threshold_dead) / 2
 
@@ -400,7 +406,7 @@
 				return
 			var/mob/dead/observer/ghost = H.get_ghost()
 			if(ghost)
-				ghost << "<span class='ghostalert'>Your heart is being defibrillated. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)"
+				ghost << "<span class='ghostalert'>Your heart is being defibrillated. Re-enter your corpse if you want to be revived!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
 				ghost << 'sound/effects/genetics.ogg'
 			user.visible_message("<span class='warning'>[user] begins to place [src] on [M.name]'s chest.</span>", "<span class='warning'>You begin to place [src] on [M.name]'s chest...</span>")
 			busy = 1

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -31,6 +31,12 @@
 	else
 		icon_state = "mmi_empty"
 
+/obj/item/device/mmi/Topic(href, href_list)
+	if(href_list["reenter"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.reenter_corpse(ghost)
+
 /obj/item/device/mmi/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(O,/obj/item/organ/brain)) //Time to stick a brain in it --NEO
@@ -49,7 +55,7 @@
 			var/mob/dead/observer/ghost = B.get_ghost()
 			if(ghost)
 				if(ghost.client)
-					ghost << "<span class='ghostalert'>Someone has put your brain in a MMI. Return to your body!</span> (Verbs -> Ghost -> Re-enter corpse)"
+					ghost << "<span class='ghostalert'>Someone has put your brain in a MMI!</span> <a href=?src=\ref[src];reenter=1>(Click to enter)</a>"
 					ghost << sound('sound/effects/genetics.ogg')
 		visible_message("[user] sticks \a [newbrain] into \the [src].")
 

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -23,7 +23,7 @@ var/global/posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/proc/ping_ghosts(msg)
 	if(!posibrain_notif_cooldown)
-		notify_ghosts("<span class='ghostalert'>Positronic brain [msg] in [get_area(src)]!</span> <a href=?src=\ref[src];activate=1>(Click to enter)</a>", 'sound/effects/ghost2.ogg')
+		notify_ghosts("Positronic brain [msg] in [get_area(src)]! <a href=?src=\ref[src];activate=1>(Click to enter)</a>", 'sound/effects/ghost2.ogg')
 		posibrain_notif_cooldown = 1
 		spawn(askDelay) //Global one minute cooldown to avoid spam.
 			posibrain_notif_cooldown = 0

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -23,7 +23,7 @@ var/global/posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/proc/ping_ghosts(msg)
 	if(!posibrain_notif_cooldown)
-		notify_ghosts("Positronic Brain [msg] in [get_area(src)]. <a href=?src=\ref[src];activate=1>(Enter)</a>")
+		notify_ghosts("<span class='ghostalert'>Positronic brain [msg] in [get_area(src)]!</span> <a href=?src=\ref[src];activate=1>(Click to enter)</a>", 'sound/effects/ghost2.ogg')
 		posibrain_notif_cooldown = 1
 		spawn(askDelay) //Global one minute cooldown to avoid spam.
 			posibrain_notif_cooldown = 0

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -614,6 +614,12 @@
 	..()
 	return
 
+/datum/reagent/medicine/strange_reagent/Topic(href, href_list)
+	if(href_list["reenter"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.reenter_corpse(ghost)
+
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
@@ -630,9 +636,13 @@
 		var/mob/dead/observer/ghost = M.get_ghost()
 		M.visible_message("<span class='warning'>[M]'s body convulses a bit.</span>")
 		if(!M.suiciding && !(NOCLONE in M.mutations))
+			if(!M)
+				return
 			if(ghost)
-				ghost << "<span class='ghostalert'>Someone is trying to revive you. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)"
+				ghost << "<span class='ghostalert'>Someone is trying to revive you. Re-enter your corpse if you want to be revived!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
 				ghost << sound('sound/effects/genetics.ogg')
+				spawn (100) //so the ghost has time to re-enter
+					return
 			else
 				M.stat = 1
 				M.adjustOxyLoss(-20)

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -639,7 +639,7 @@
 			if(!M)
 				return
 			if(ghost)
-				ghost << "<span class='ghostalert'>Someone is trying to revive you. Re-enter your corpse if you want to be revived!</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
+				ghost << "<span class='ghostalert'>Someone is trying to revive you. Re-enter your corpse if you want to be revived! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
 				ghost << sound('sound/effects/genetics.ogg')
 				spawn (100) //so the ghost has time to re-enter
 					return


### PR DESCRIPTION
Player doesn't have to navigate through the ghost tab anymore, they can re-enter their corpse just by clicking on the link.

Fixes #8980

![sieppaa](https://cloud.githubusercontent.com/assets/5420151/8855195/7bc3c6a2-316c-11e5-91c4-1bb083fe9aeb.PNG)
