### PR TITLE
Corrects the Escape Alone text

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -186,7 +186,7 @@
 
 
 /datum/objective/hijack
-	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody.
+	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody."
 	dangerrating = 25
 	martyr_compatible = 0 //Technically you won't get both anyway.
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -186,7 +186,7 @@
 
 
 /datum/objective/hijack
-	explanation_text = "Hijack the emergency shuttle by ensuring that only non-Nanotrasen entities are aboard and not in the shuttle brig."
+	explanation_text = "Hijack the emergency shuttle by ensuring that only non-Nanotrasen entities escape alive, aboard, and not in the shuttle brig."
 	dangerrating = 25
 	martyr_compatible = 0 //Technically you won't get both anyway.
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -186,7 +186,7 @@
 
 
 /datum/objective/hijack
-	explanation_text = "Hijack the emergency shuttle by ensuring that only syndicate agents escape aboard it."
+	explanation_text = "Hijack the emergency shuttle by ensuring that only non-Nanotrasen entities are aboard and not in the shuttle brig."
 	dangerrating = 25
 	martyr_compatible = 0 //Technically you won't get both anyway.
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -186,7 +186,7 @@
 
 
 /datum/objective/hijack
-	explanation_text = "Hijack the emergency shuttle by ensuring that only non-Nanotrasen entities escape alive, aboard, and not in the shuttle brig."
+	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody.
 	dangerrating = 25
 	martyr_compatible = 0 //Technically you won't get both anyway.
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -186,7 +186,7 @@
 
 
 /datum/objective/hijack
-	explanation_text = "Hijack the emergency shuttle by escaping alone."
+	explanation_text = "Hijack the emergency shuttle by ensuring that only syndicate agents escape aboard it."
 	dangerrating = 25
 	martyr_compatible = 0 //Technically you won't get both anyway.
 


### PR DESCRIPTION
A while ago, Escape Alone was updated so that you could bring as many antagonists on the shuttle with you as you liked, but the description doesn't hint that this is the case. This PR fixes that
