### PR TITLE
Increases TC cost of Bioterror darts

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -305,7 +305,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo/bulltoxin
 	name = "Drum Magazine - 12g Bioterror"
-	desc = "An alternative 8-round toxic magazine for use in the Bulldog shotgun. Contains debilitating toxins to make your target die an excruicatingly rapid death."
+	desc = "An alternative 8-round toxic magazine for use in the Bulldog shotgun. Contains debilitating toxins to make your target die an excruciatingly rapid death."
 	item = /obj/item/ammo_box/magazine/m12g/bioterror
 	cost = 6
 	gamemodes = list(/datum/game_mode/nuclear)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -305,9 +305,9 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo/bulltoxin
 	name = "Drum Magazine - 12g Bioterror"
-	desc = "An alternative 8-round toxic magazine for use in the Bulldog shotgun. Contains debilitating toxins to make your target die an agonizing death."
+	desc = "An alternative 8-round toxic magazine for use in the Bulldog shotgun. Contains debilitating toxins to make your target die an excruicatingly rapid death."
 	item = /obj/item/ammo_box/magazine/m12g/bioterror
-	cost = 3
+	cost = 6
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/carbine


### PR DESCRIPTION
Bioterror: 3TC
Taser darts: 3TC

Crew status: Wrecked every time

Bioterror darts have been increased to 6TC a mag (despite pressure to increase to 8), seeing as they're effectively 1-hit kills in the average combat situation.
