### PR TITLE
[BALANCE] Deathsquad Alterations (Armour|Nanites|AmmoBuff)

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1113,7 +1113,7 @@ var/global/list/g_fancy_list_of_types = null
 	M.equip_to_slot_or_del(new /obj/item/weapon/storage/box(M), slot_in_backpack)
 
 	M.equip_to_slot_or_del(new /obj/item/ammo_box/a357(M), slot_in_backpack)
-	M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/combat/nanites(M), slot_in_backpack)
+	M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/regular(M), slot_in_backpack)
 	M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/flashbangs(M), slot_in_backpack)
 	M.equip_to_slot_or_del(new /obj/item/device/flashlight(M), slot_in_backpack)
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -25,7 +25,7 @@
 	desc = "That's not red paint. That's real blood."
 	icon_state = "deathsquad"
 	item_state = "deathsquad"
-	armor = list(melee = 50, bullet = 40, laser = 30, energy = 50, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
@@ -40,7 +40,7 @@
 	icon_state = "deathsquad"
 	item_state = "swat_suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
-	armor = list(melee = 50, bullet = 40, laser = 30,energy = 50, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	slowdown = 1
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
@@ -53,7 +53,7 @@
 	icon_state = "beret_badge"
 	flags = STOPSPRESSUREDMAGE
 	flags_inv = 0
-	armor = list(melee = 50, bullet = 40, laser = 30, energy = 50, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
@@ -68,7 +68,7 @@
 	flags_inv = 0
 	w_class = 3
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
-	armor = list(melee = 50, bullet = 40, laser = 30,energy = 50, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 	slowdown = 1
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -167,7 +167,7 @@
 
 /obj/item/weapon/stock_parts/cell/pulse //80 pulse shots
 	name = "pulse rifle power cell"
-	maxcharge = 4000
+	maxcharge = 40000
 	rating = 3
 	chargerate = 1500
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -167,7 +167,7 @@
 
 /obj/item/weapon/stock_parts/cell/pulse //80 pulse shots
 	name = "pulse rifle power cell"
-	maxcharge = 16000
+	maxcharge = 4000
 	rating = 3
 	chargerate = 1500
 


### PR DESCRIPTION
This PR changes several aspects of the Deathsquad.

Firstly it removes the DS's access to medical nanites, these nanites simply made the operatives unkillable meaning the crew have no chance of killing a operative realistically. The nanites are replaced with a medkit

Secondly the DS's armour is buffed to return to the pre-nerf values (Inb4 HE'S BUFFING ARMOUR!)

(Old Armour: melee = 50, bullet = 40, laser = 30, energy = 50, bomb = 50)
(New Armour: melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100)

Finally the DS Pulse Rifle's ammo pool has been buffed back to 200 rounds, from 80.

Link to feedback thread: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=4253
