### PR TITLE
[QOL] Expanded Admin Descriptions For ERT Deployment

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -450,17 +450,17 @@
 
 // CENTCOM RESPONSE TEAM
 /datum/admins/proc/makeEmergencyresponseteam()
-	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Guns)", "Amber: Full ERT (Energy Guns)", "Red: Elite ERT (Pulse Guns)", "Delta: Deathsquad")
+	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Armoury Access)", "Amber: Full ERT (Armoury Access)", "Red: Elite ERT (Armoury Access + Pulse Guns)", "Delta: Deathsquad")
 	if(!alert)
 		return
 	switch(alert)
 		if("Delta: Deathsquad")
 			return makeDeathsquad()
-		if("Red: Elite ERT (Pulse Guns)")
+		if("Red: Elite ERT (Armoury Access + Pulse Weapons)")
 			alert = "Red"
-		if("Amber: Full ERT (Energy Guns)")
+		if("Amber: Full ERT (Armoury Access)")
 			alert = "Amber"
-		if("Blue: Light ERT (No Guns)")
+		if("Blue: Light ERT (No Armoury Access)")
 			alert = "Blue"
 		if("Green: Centcom Official")
 			return makeOfficial()

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -450,7 +450,7 @@
 
 // CENTCOM RESPONSE TEAM
 /datum/admins/proc/makeEmergencyresponseteam()
-	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT", "Amber: Full ERT", "Red: Elite ERT", "Delta: Deathsquad")
+	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Guns)", "Amber: Full ERT (Energy Guns)", "Red: Elite ERT (Pulse Guns)", "Delta: Deathsquad")
 	if(!alert)
 		return
 	switch(alert)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -456,11 +456,11 @@
 	switch(alert)
 		if("Delta: Deathsquad")
 			return makeDeathsquad()
-		if("Red: Elite ERT")
+		if("Red: Elite ERT (Pulse Guns)")
 			alert = "Red"
-		if("Amber: Full ERT")
+		if("Amber: Full ERT (Energy Guns)")
 			alert = "Amber"
-		if("Blue: Light ERT")
+		if("Blue: Light ERT (No Guns)")
 			alert = "Blue"
 		if("Green: Centcom Official")
 			return makeOfficial()

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -450,7 +450,7 @@
 
 // CENTCOM RESPONSE TEAM
 /datum/admins/proc/makeEmergencyresponseteam()
-	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Armoury Access)", "Amber: Full ERT (Armoury Access)", "Red: Elite ERT (Armoury Access + Pulse Guns)", "Delta: Deathsquad")
+	var/alert = input("Which team should we send?", "Select Response Level") as null|anything in list("Green: Centcom Official", "Blue: Light ERT (No Armoury Access)", "Amber: Full ERT (Armoury Access)", "Red: Elite ERT (Armoury Access + Pulse Weapons)", "Delta: Deathsquad")
 	if(!alert)
 		return
 	switch(alert)


### PR DESCRIPTION
This PR adds a quick extra description of what each level of the ERT deployment has in difference with one another. This is meant to help admins tell what the differences between each ERT deployment are.

The changed descriptions are:
- Blue: Light ERT (No Armoury Access)
- Amber: Full ERT (Armoury Access)
- Red: Elite ERT (Armoury Access + Pulse Guns)
