### PR TITLE
Fixes lighter-related bugs.

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -120,7 +120,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/attackby(obj/item/weapon/W, mob/user, params)
 	..()
-	if(!lit && smoketime > 0)
+	if(!lit && smoketime > 0 && is_hot(W))
 		var/lighting_text = is_lighter(W,user)
 		if(lighting_text)
 			light(lighting_text)
@@ -143,10 +143,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/lighting_text = null
 	if(istype(O, /obj/item/weapon/weldingtool))
 		lighting_text = "<span class='notice'>[user] casually lights the [name] with [O], what a badass.</span>"
+	else if(istype(O, /obj/item/weapon/lighter/greyscale)) // we have to check for this first -- zippo lighters are default
+		lighting_text = "<span class='notice'>After some fiddling, [user] manages to light their [name] with [O].</span>"
 	else if(istype(O, /obj/item/weapon/lighter))
 		lighting_text = "<span class='rose'>With a single flick of their wrist, [user] smoothly lights their [name] with [O]. Damn they're cool.</span>"
-	else if(istype(O, /obj/item/weapon/lighter/greyscale))
-		lighting_text = "<span class='notice'>After some fiddling, [user] manages to light their [name] with [O].</span>"
 	else if(istype(O, /obj/item/weapon/melee/energy))
 		lighting_text = "<span class='warning'>[user] swings their [O], barely missing their nose. They light their [name] in the process.</span>"
 	else if(istype(O, /obj/item/device/assembly/igniter))

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -155,6 +155,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = 2
+
 	materials = list(MAT_METAL=70, MAT_GLASS=30)
 	origin_tech = "engineering=1"
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/10611. Cheap lighters now use proper flavor text.

Fixes bug where you could light cigarettes with unlit lighters, welders, eswords, flares, whatever. As these items do not all use the same variable for being on, this runs off is_hot().
