### PR TITLE
Ninja Invisiblity Fixes

### DIFF
--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -3,20 +3,22 @@
 
 Contents:
 - Stealth Verbs
-- Stealth Icon Stuff
 
 */
 
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_stealth()
 	var/mob/living/carbon/human/U = affecting
+	if(!U)
+		return
 	if(s_active)
 		cancel_stealth()
 	else
-		spawn(0)
-			anim(U.loc,U,'icons/mob/mob.dmi',,"cloak",,U.dir)
+		if(cell.charge <= 0)
+			U << "<span class='warning'>You don't have enough power to enable Stealth!</span>"
+			return
 		s_active=!s_active
-		U.alpha = 0
+		animate(U, U.alpha = 0,time = 15)
 		U.visible_message("<span class='warning'>[U.name] vanishes into thin air!</span>", \
 						"<span class='notice'>You are now invisible to normal detection.</span>")
 	return
@@ -24,11 +26,11 @@ Contents:
 
 /obj/item/clothing/suit/space/space_ninja/proc/cancel_stealth()
 	var/mob/living/carbon/human/U = affecting
+	if(!U)
+		return 0
 	if(s_active)
-		spawn(0)
-			anim(U.loc,U,'icons/mob/mob.dmi',,"uncloak",,U.dir)
 		s_active=!s_active
-		U.alpha = 255
+		animate(U, U.alpha = 255, time = 15)
 		U.visible_message("<span class='warning'>[U.name] appears from thin air!</span>", \
 						"<span class='notice'>You are now visible.</span>")
 		return 1
@@ -44,35 +46,4 @@ Contents:
 		toggle_stealth()
 	else
 		affecting << "<span class='danger'>Stealth does not appear to work!</span>"
-
-
-//Allows the mob to grab a stealth icon.
-/mob/proc/NinjaStealthActive(atom/A)//A is the atom which we are using as the overlay.
-	invisibility = INVISIBILITY_LEVEL_TWO//Set ninja invis to 2.
-	var/icon/opacity_icon = new(A.icon, A.icon_state)
-	var/icon/alpha_mask = getIconMask(src)
-	var/icon/alpha_mask_2 = new('icons/effects/effects.dmi', "at_shield1")
-	alpha_mask.AddAlphaMask(alpha_mask_2)
-	opacity_icon.AddAlphaMask(alpha_mask)
-	for(var/i=0,i<5,i++)//And now we add it as overlays. It's faster than creating an icon and then merging it.
-		var/image/I = image("icon" = opacity_icon, "icon_state" = A.icon_state, "layer" = layer+0.8)//So it's above other stuff but below weapons and the like.
-		switch(i)//Now to determine offset so the result is somewhat blurred.
-			if(1)
-				I.pixel_x -= 1
-			if(2)
-				I.pixel_x += 1
-			if(3)
-				I.pixel_y -= 1
-			if(4)
-				I.pixel_y += 1
-
-		overlays += I//And finally add the overlay.
-	overlays += image("icon"='icons/effects/effects.dmi',"icon_state" ="electricity","layer" = layer+0.9)
-
-//When ninja steal malfunctions.
-/mob/proc/NinjaStealthMalf()
-	invisibility = 0//Set ninja invis to 0.
-	overlays += image("icon"='icons/effects/effects.dmi',"icon_state" ="electricity","layer" = layer+0.9)
-	playsound(loc, 'sound/effects/stealthoff.ogg', 75, 1)
-
 

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -83,7 +83,6 @@ Contents:
 	cell.charge = 9000
 
 
-
 /obj/item/clothing/suit/space/space_ninja/Destroy()
 	if(affecting)
 		affecting << browse(null, "window=hack spideros")

--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -4,25 +4,27 @@
 	set background = BACKGROUND_ENABLED
 
 	//Runs in the background while the suit is initialized.
-	spawn while(cell.charge)
+	//Requires charge or stealth to process.
+	spawn while(cell.charge || s_active)
 
-		//Let's check for some safeties.
 		if(s_initialized && !affecting)
 			terminate()//Kills the suit and attached objects.
 		if(!s_initialized)
-			return//When turned off the proc stops.
+			return
 
-		//Now let's do the normal processing.
-		if(s_coold)
-			s_coold--//Checks for ability s_cooldown first.
+		if(cell.charge)
+			if(s_coold)
+				s_coold--//Checks for ability s_cooldown first.
 
-		var/A = s_cost//s_cost is the default energy cost each ntick, usually 5.
-		if(s_active)//If stealth is active.
-			A += s_acost
-		cell.charge-=A
+			var/A = s_cost//s_cost is the default energy cost each ntick, usually 5.
+			if(s_active)//If stealth is active.
+				A += s_acost
+			cell.charge-=A
 
-		if(!cell.charge)
+		if(cell.charge <= 0)
 			cell.charge=0
 			cancel_stealth()
 
 		sleep(10)//Checks every second.
+
+


### PR DESCRIPTION
- Ninja invisibility now turns off when charge is <= 0
- Ninja invisibility now only turns on if the cell has charge
- Ninja cloaking/uncloaking effects moved from ancient anim() proc to byond's animate() proc

Fixes #8756
Fixes #10148 
Fixes #8249 - Well not really, but this isn't true any more (at all?)
