### PR TITLE
Changes mob swap to use Move(). 

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -99,22 +99,23 @@ Sorry Giacom. Please don't be mad :(
 		if(loc && !loc.Adjacent(M.loc))
 			return 1
 		now_pushing = 1
-		//TODO: Make this use Move(). we're pretty much recreating it here.
-		//it could be done by setting one of the locs to null to make Move() work, then setting it back and Move() the other mob
 		var/oldloc = loc
-		loc = M.loc
-		M.loc = oldloc
-		M.LAssailant = src
+		var/oldMloc = M.loc
 
-		for(var/mob/living/simple_animal/slime/slime in view(1,M))
-			if(slime.Victim == M)
-				slime.UpdateFeed()
 
-		//cross any movable atoms on either turf
-		for(var/atom/movable/AM in loc)
-			AM.Crossed(src)
-		for(var/atom/movable/AM in oldloc)
-			AM.Crossed(M)
+		var/M_passmob = (M.pass_flags & PASSMOB) // we give PASSMOB to both mobs to avoid bumping other mobs during swap.
+		var/src_passmob = (pass_flags & PASSMOB)
+		M.pass_flags |= PASSMOB
+		pass_flags |= PASSMOB
+
+		M.Move(oldloc)
+		Move(oldMloc)
+
+		if(!src_passmob)
+			pass_flags -= PASSMOB
+		if(!M_passmob)
+			M.pass_flags -= PASSMOB
+
 		now_pushing = 0
 		return 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -112,9 +112,9 @@ Sorry Giacom. Please don't be mad :(
 		Move(oldMloc)
 
 		if(!src_passmob)
-			pass_flags -= PASSMOB
+			pass_flags &= ~PASSMOB
 		if(!M_passmob)
-			M.pass_flags -= PASSMOB
+			M.pass_flags &= ~PASSMOB
 
 		now_pushing = 0
 		return 1

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -25,7 +25,7 @@
 
 	var/list/surgeries = list()	//a list of surgery datums. generally empty, they're added when the player wants them.
 
-	var/now_pushing = null
+	var/now_pushing = null //used by living/Bump() and living/PushAM() to prevent potential infinite loop.
 
 	var/cameraFollow = null
 


### PR DESCRIPTION
This fixes mob swapping not respecting pass_flags and density, not making mobs slip.
Fixes #5403
Fixes #5933
Fixes #9341

What the code does is simply give both mobs the PASSMOB flag to avoid possible collisions with other mobs and each other, then call Move() for both, and then remove the flag.
