### PR TITLE
[BALANCE] Remove Alien Hunters Leap Ability

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -80,10 +80,10 @@
 	adding += using
 	action_intent = using
 
-	if(istype(mymob, /mob/living/carbon/alien/humanoid/hunter))
-		mymob.leap_icon = new /obj/screen/alien/leap()
-		mymob.leap_icon.screen_loc = ui_alien_storage_r
-		adding += mymob.leap_icon
+//	if(istype(mymob, /mob/living/carbon/alien/humanoid/hunter))
+//		mymob.leap_icon = new /obj/screen/alien/leap()
+//		mymob.leap_icon.screen_loc = ui_alien_storage_r
+//		adding += mymob.leap_icon
 
 	using = new /obj/screen/mov_intent()
 	using.icon = 'icons/mob/screen_alien.dmi'


### PR DESCRIPTION
This PR removes the ability for Alien Hunters to leap.

---

Alien Hunters are in their own right already a powerful entity on the station, their ability to move at the fastest in game movement speed and their ability to instantly stun a target in melee range makes them a master of melee combat. This is fair.

However Leap upsets this balance, leaping is extreamly powerful as it actually allows the Hunter to not only move at a faster movement rate, but also it allows it to instantly take down almost any human opponent instantly.

A competent hunter using leap can shut down and take down entire groups of people, I've even once witnessed a team of ERT be taken down by a single Hunter.
