### PR TITLE
Makes the minimum required version a #define

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -59,7 +59,7 @@ var/list/del_counter = list()
 #warn compiling in TESTING mode. testing() debug messages will be visible.
 #endif
 
-#define MIN_COMPILER_VERSION 507
+#define MIN_COMPILER_VERSION 508
 #if DM_VERSION < MIN_COMPILER_VERSION //Update this whenever you need to take advantage of more recent byond features
 #error Your version of BYOND is too out-of-date to compile this project. Go to byond.com/download and update.
 #endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -59,15 +59,9 @@ var/list/del_counter = list()
 #warn compiling in TESTING mode. testing() debug messages will be visible.
 #endif
 
-//SYSTEM TOGGLES - these allow you to compile the game without some of the laggier systems if your server cannot cope with demand
-/* Not yet coded
-#define USE_DYNAMIC_GRAVITY		//Enables the dynamic gravity system
-#define USE_DYNAMIC_LIGHTING	//Enables the dynamic lighting system
-#define USE_DYNAMIC_ATMOS		//Enables the dynamic atmos system
-*/
-
-#define USE_BYGEX
-
-#if DM_VERSION < 508 //Update this whenever you need to take advantage of more recent byond features
+#define MIN_COMPILER_VERSION 507
+#if DM_VERSION < MIN_COMPILER_VERSION //Update this whenever you need to take advantage of more recent byond features
 #error Your version of BYOND is too out-of-date to compile this project. Go to byond.com/download and update.
 #endif
+
+#define USE_BYGEX


### PR DESCRIPTION
should really be a define

~~~also reduces the minimum required version to the actual minimum required version, that being 507, instead of a beta build.~~~
the whole point of this warning is to prevent people from making issues and seeking help for something resolved by updating, making the required version a beta build will only make that problem worse. (issue #55465798: my byond is updated but i get the out of date warning???)
