### PR TITLE
atmos stuff that nobody understands anyway

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -53,7 +53,6 @@ Pipelines + Other Objects -> Pipe network
 //object initializion. done well after air is setup (build_network needs all pipes to be init'ed with atmosinit before hand)
 /obj/machinery/atmospherics/initialize()
 	..()
-	build_network() //make sure to build our pipe nets
 
 /obj/machinery/atmospherics/proc/SetInitDirections()
 	return
@@ -171,8 +170,8 @@ Pipelines + Other Objects -> Pipe network
 	if(can_unwrench)
 		color = obj_color
 		pipe_color = obj_color
-		stored.dir = D				  //need to define them here, because the obj directions...
-		stored.pipe_type = pipe_type  //... were not set at the time the stored pipe was created
+		stored.dir = D
+		stored.pipe_type = pipe_type
 		stored.color = obj_color
 	var/turf/T = loc
 	level = T.intact ? 2 : 1

--- a/code/ATMOSPHERICS/components/components_base.dm
+++ b/code/ATMOSPHERICS/components/components_base.dm
@@ -134,7 +134,7 @@ Pipenet stuff; housekeeping
 		for(var/I = 1; I <= device_type; I++)
 			if(nodes["n[I]"])
 				if(parents["p[I]"] == reference)
-					return list("n" = nodes["n[I]"])
+					return list(nodes["n[I]"])
 
 	var/list/obj/machinery/atmospherics/return_nodes = list()
 	for(var/I = 1; I <= device_type; I++)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -197,7 +197,11 @@ var/datum/subsystem/air/SSair
 		warning("There are [active_turfs.len] active turfs at roundstart, this is a mapping error caused by a difference of the air between the adjacent turfs.")
 
 /datum/subsystem/air/proc/setup_atmos_machinery(z_level)
-	for (var/obj/machinery/atmospherics/AM in atmos_machinery)
+	for(var/obj/machinery/atmospherics/AM in atmos_machinery)
 		if (z_level && AM.z != z_level)
 			continue
 		AM.atmosinit()
+	for(var/obj/machinery/atmospherics/AM in atmos_machinery)
+		if (z_level && AM.z != z_level)
+			continue
+		AM.build_network()


### PR DESCRIPTION
Removes the  build_network() under initialize() in atmos machinery
Fixes a typo in components_base.dm where pipeline_expansion() would return just a "n" instead of an actual node
Roundstart atmos machinery setup will run a secondary loop to create the pipenets, after the first loop sets up the connection nodes
