### PR TITLE
[Social experiment] Double Agents Don't Know They're Double Agents

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -611,7 +611,6 @@ var/list/uplink_items = list()
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	item = /obj/item/device/sbeacondrop/bomb
 	cost = 11
-	excludefrom = list(/datum/game_mode/traitor/double_agents)
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -1,13 +1,10 @@
 /datum/game_mode/traitor/double_agents
 	name = "double agents"
 	config_tag = "double_agents"
-	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Personnel", "Chief Medical Officer", "Research Director", "Chief Engineer", "Head of Security") // Human / Minor roles only.
 	required_players = 25
 	required_enemies = 5
 	recommended_enemies = 8
 	reroll_friendly = 0
-
-	traitor_name = "double agent"
 
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 6 // Six additional traitors
@@ -36,13 +33,17 @@
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = traitor
 		kill_objective.target = target_list[traitor]
-		kill_objective.explanation_text = "Assassinate [kill_objective.target.current.real_name], the [kill_objective.target.assigned_role], the double agent."
 		traitor.objectives += kill_objective
 
 		// Escape
-		var/datum/objective/escape/escape_objective = new
-		escape_objective.owner = traitor
-		traitor.objectives += escape_objective
+		if(issilicon(traitor.current))
+			var/datum/objective/survive/survive_objective = new
+			survive_objective.owner = traitor
+			traitor.objectives += survive_objective
+		else
+			var/datum/objective/escape/escape_objective = new
+			escape_objective.owner = traitor
+			traitor.objectives += escape_objective
 
 	else
 		..() // Give them standard objectives.


### PR DESCRIPTION
Removes outward tells that a double agent round isn't just a traitor round.

Players won't know if they're a double agent or a traitor if they happen to roll a kill objective + escape. DAs won't outwardly know that their targets are also DAs.

For the sake of mirroring traitors to avoid meta DAs gain syndicate bombs back (but shouldn't be any more apt to use them than normal traitors)

For the same reason nonimplanted heads and the AI are now capable of being DAs.

Paranoia from DA leaks back to traitor
Not going rambo mode for the 420noscope quick kill leaks from traitor to DA

Maybe, lets hope!
