### PR TITLE
Reverts #10619, Adds Logging and Context to Admin's Who Command

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -15,6 +15,9 @@
 				var/entry = "\t[C.key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
+				if (isnewplayer(C.mob))
+					entry += " - <font color='darkgray'><b>In Lobby</b></font>"
+				else
 					entry += " - Playing as [C.mob.real_name]"
 					switch(C.mob.stat)
 						if(UNCONSCIOUS)
@@ -30,7 +33,7 @@
 								entry += " - <font color='black'><b>DEAD</b></font>"
 					if(is_special_character(C.mob))
 						entry += " - <b><font color='red'>Antagonist</font></b>"
-					entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
+				entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 				Lines += entry
 		else//If they don't have +ADMIN, only show hidden admins
 			for(var/client/C in clients)

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -1,4 +1,3 @@
-
 /client/verb/who()
 	set name = "Who"
 	set category = "OOC"
@@ -8,11 +7,38 @@
 	var/list/Lines = list()
 
 	if(holder)
-		for(var/client/C in clients)
-			var/entry = "\t[C.key]"
-			if(C.holder && C.holder.fakekey)
-				entry += " <i>(as [C.holder.fakekey])</i>"
-			Lines += entry
+		if (check_rights(R_ADMIN,0))//If they have +ADMIN, their ghost can see players IC names and statuses.
+			for(var/client/C in clients)
+				var/entry = "\t[C.key]"
+				if(C.holder && C.holder.fakekey)
+					entry += " <i>(as [C.holder.fakekey])</i>"
+				if (isobserver(src.mob))
+					var/mob/dead/observer/G = src.mob
+					if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
+						log_admin("[key_name(usr)] checked advanced who in-round")
+					entry += " - Playing as [C.mob.real_name]"
+					switch(C.mob.stat)
+						if(UNCONSCIOUS)
+							entry += " - <font color='darkgray'><b>Unconscious</b></font>"
+						if(DEAD)
+							if(isobserver(C.mob))
+								var/mob/dead/observer/O = C.mob
+								if(O.started_as_observer)
+									entry += " - <font color='gray'>Observing</font>"
+								else
+									entry += " - <font color='black'><b>DEAD</b></font>"
+							else
+								entry += " - <font color='black'><b>DEAD</b></font>"
+					if(is_special_character(C.mob))
+						entry += " - <b><font color='red'>Antagonist</font></b>"
+					entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
+				Lines += entry
+		else//If they don't have +ADMIN, only show hidden admins
+			for(var/client/C in clients)
+				var/entry = "\t[C.key]"
+				if(C.holder && C.holder.fakekey)
+					entry += " <i>(as [C.holder.fakekey])</i>"
+				Lines += entry
 	else
 		for(var/client/C in clients)
 			if(C.holder && C.holder.fakekey)

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -7,15 +7,14 @@
 	var/list/Lines = list()
 
 	if(holder)
-		if (check_rights(R_ADMIN,0))//If they have +ADMIN, their ghost can see players IC names and statuses.
+		if (check_rights(R_ADMIN,0) && isobserver(src.mob))//If they have +ADMIN and are a ghost they can see players IC names and statuses.
+			var/mob/dead/observer/G = src.mob
+			if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
+				log_admin("[key_name(usr)] checked advanced who in-round")
 			for(var/client/C in clients)
 				var/entry = "\t[C.key]"
 				if(C.holder && C.holder.fakekey)
 					entry += " <i>(as [C.holder.fakekey])</i>"
-				if (isobserver(src.mob))
-					var/mob/dead/observer/G = src.mob
-					if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
-						log_admin("[key_name(usr)] checked advanced who in-round")
 					entry += " - Playing as [C.mob.real_name]"
 					switch(C.mob.stat)
 						if(UNCONSCIOUS)

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -264,7 +264,11 @@
 				M_job = "New player"
 
 			else if(isobserver(M))
-				M_job = "Ghost"
+				var/mob/dead/observer/O = M
+				if(O.started_as_observer)//Did they get BTFO or are they just not trying?
+					M_job = "Observer"
+				else
+					M_job = "Ghost"
 
 			var/M_name = html_encode(M.name)
 			var/M_rname = html_encode(M.real_name)


### PR DESCRIPTION
Pictured: The new who command logic at work. Lobby Screen/Playing, ghosted from body, observer.
![Literally Who](http://i.imgur.com/xIrAXfM.png)
There is no log for who when used by an admin as a roundstart observer. This helps lighten the load on the log itself, but also the redundancy of saying "Hey, this person has information they can easily obtain by looking at the game window itself."

Also, Maintainers: I'd like this PR left open for a few days to give the entire admin team a chance to give me feedback on this.
