### PR TITLE
Some fixes with Bump()

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -702,6 +702,7 @@ obj/machinery/bot/proc/bot_reset()
 
 
 /obj/machinery/bot/Bump(M as mob|obj) //Leave no door unopened!
+	. = ..()
 	if((istype(M, /obj/machinery/door/airlock) ||  istype(M, /obj/machinery/door/window)) && (!isnull(botcard)))
 		var/obj/machinery/door/D = M
 		if(D.check_access(botcard))
@@ -711,4 +712,3 @@ obj/machinery/bot/proc/bot_reset()
 		var/mob/living/Mb = M
 		loc = Mb.loc
 		frustration = 0
-	return

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -747,7 +747,7 @@ obj/machinery/bot/mulebot/bot_reset()
 				M.stop_pulling()
 				M.Stun(8)
 				M.Weaken(5)
-	..()
+	return ..()
 
 /obj/machinery/bot/mulebot/alter_health()
 	return get_turf(src)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -21,7 +21,7 @@
 	var/datum/action/mecha/mech_toggle_phasing/phasing_action = new
 
 /obj/mecha/combat/phazon/Bump(atom/obstacle)
-	if(phasing && get_charge()>=phasing_energy_drain)
+	if(phasing && get_charge()>=phasing_energy_drain && !throwing)
 		spawn()
 			if(can_move)
 				can_move = 0

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -445,23 +445,19 @@
 		playsound(src,stepsound,40,1)
 	return result
 
-/obj/mecha/Bump(var/atom/obstacle)
-//	src.inertia_dir = null
-	if(istype(obstacle, /obj))
-		var/obj/O = obstacle
-		if(istype(O, /obj/effect/portal)) //derpfix
-			anchored = 0
-			O.Crossed(src)
-			src.anchored = 1
-		else if(!O.anchored)
-			step(obstacle, dir)
-		else //I have no idea why I disabled this
-			obstacle.Bumped(src)
-	else if(istype(obstacle, /mob))
-		step(obstacle, dir)
-	else
+/obj/mecha/Bump(var/atom/obstacle, yes)
+	if(yes)
+		if(throwing)
+			..()
+			return
 		obstacle.Bumped(src)
-	return
+		if(istype(obstacle, /obj))
+			var/obj/O = obstacle
+			if(!O.anchored)
+				step(obstacle, dir)
+		else if(istype(obstacle, /mob))
+			step(obstacle, dir)
+
 
 ///////////////////////////////////
 ////////  Internal damage  ////////

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -447,10 +447,8 @@
 
 /obj/mecha/Bump(var/atom/obstacle, yes)
 	if(yes)
-		if(throwing)
-			..()
+		if(..()) //mech was thrown
 			return
-		obstacle.Bumped(src)
 		if(istype(obstacle, /obj))
 			var/obj/O = obstacle
 			if(!O.anchored)


### PR DESCRIPTION
Fixes Bump() of mechs and bots not handling some throwing cases correctly.
Mecha/Bump() now calls Bumped() in all cases, as it should.
