### PR TITLE
Makes the calibres on bullet casings only readable up close

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -27,7 +27,7 @@
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
-	desc = "[initial(desc)][BB ? "" : " This one is spent"]"
+	desc += "[BB ? "" : " This one is spent."]"
 
 /obj/item/ammo_casing/proc/newshot() //For energy weapons, shotgun shells and wands (!).
 	if (!BB)
@@ -52,6 +52,14 @@
 			user << "<span class='notice'>You collect [boolets] shell\s. [box] now contains [box.stored_ammo.len] shell\s.</span>"
 		else
 			user << "<span class='warning'>You fail to collect anything!</span>"
+
+/obj/item/ammo_casing/examine(mob/user)
+	if(in_range(user, src))
+		desc = "[initial(desc)]"
+		update_icon()
+	else if (!(istype(src, /obj/item/ammo_casing/shotgun) || istype(src, /obj/item/ammo_casing/caseless)))
+		desc = "A bullet casing." //only generically named/sprited casings have unspecific descriptions from a distance
+	..()
 
 //Boxes of ammo
 /obj/item/ammo_box


### PR DESCRIPTION
Someone was (rightly or wrongly) complaining that one of the ways nuke ops were metagamed was by examining the shell casings their weapons left for specific calibres. It always bugged me slightly you could tell a bullet's calibre from across the room when nearly every casing has the same sprite and the same name, so I thought it would make an easy coding exercise to change it so you need to be beside the case. This makes it take slightly longer to examine all the casings in a room.

Doesn't affect shotgun shells or caseless projectiles (e.g. foam darts) as they have their own unique names and sprites anyway.

Let me know if I could've coded this in a better way.
