### PR TITLE
Fixes an edgelord case in double agent 

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -30,10 +30,17 @@
 	if(target_list.len && target_list[traitor]) // Is a double agent
 
 		// Assassinate
-		var/datum/objective/assassinate/kill_objective = new
-		kill_objective.owner = traitor
-		kill_objective.target = target_list[traitor]
-		traitor.objectives += kill_objective
+		var/datum/mind/target_mind = target_list[traitor]
+		if(issilicon(target_mind.current))
+			var/datum/objective/destroy/destroy_objective = new
+			destroy_objective.owner = traitor
+			destroy_objective.target = target_mind
+			traitor.objectives += destroy_objective
+		else
+			var/datum/objective/assassinate/kill_objective = new
+			kill_objective.owner = traitor
+			kill_objective.target = target_mind
+			traitor.objectives += kill_objective
 
 		// Escape
 		if(issilicon(traitor.current))


### PR DESCRIPTION
A double agent tasked with killing a double agent AI could meta that the mode was in fact double agents because the flavor text for killing an AI is different in traitor than it is in DA.

Meant to throw this in the original pull, but it got merged too fast. :laughing: 
