### PR TITLE
Double Agents Hotfix

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -35,11 +35,13 @@
 			var/datum/objective/destroy/destroy_objective = new
 			destroy_objective.owner = traitor
 			destroy_objective.target = target_mind
+			destroy_objective.update_explanation_text()
 			traitor.objectives += destroy_objective
 		else
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = traitor
 			kill_objective.target = target_mind
+			kill_objective.update_explanation_text()
 			traitor.objectives += kill_objective
 
 		// Escape


### PR DESCRIPTION
Because DA manually assigns targets instead of using find_target() the proc update_explanation_text() wasn't firing and thus the DAs couldn't figure out who they had to kill (though in actuality the objective was still fully functional). 

I missed this because DA never used find_target(), the explanation text was just manually set (use the proc guys)

My bad!

Fixes  #10904
