### PR TITLE
Add a game log entry for damp rags

### DIFF
--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -28,6 +28,9 @@
 			reagents.reaction(C, INGEST)
 			reagents.trans_to(C, reagents.total_volume)
 			C.visible_message("<span class='danger'>[user] has smothered \the [C] with \the [src]!</span>", "<span class='userdanger'>[user] has smothered you with \the [src]!</span>", "<span class='italics'>You hear some struggling and muffled cries of surprise.</span>")
+			var/reagentlist = pretty_string_from_reagent_list(A.reagents)
+			log_game("[key_name(user)] smothered [key_name(A)] with a damp rag containing [reagentlist]")
+			log_attack("[key_name(user)] smothered [key_name(A)] with a damp rag containing [reagentlist]")
 		else
 			reagents.reaction(C, TOUCH)
 			reagents.clear_reagents()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -108,3 +108,10 @@
 		M << "<span class='boldannounce'>You're not feeling good at all! You really need some [name].</span>"
 	return
 
+/proc/pretty_string_from_reagent_list(var/list/reagent_list)
+	//Convert reagent list to a printable string for logging etc
+	var/result = "| "
+	for (var/datum/reagent/R in reagent_list)
+		result += "[R.name], [R.volume] | "
+
+	return result


### PR DESCRIPTION
Damp rags left no trace of their use, this adds logging of user and target and the reagents contained

fixes #10879

Still need to test if the reagents print properly yet.
