### PR TITLE
Fixes the DNA Spread virus not transforming victims when spread from those who were already transformed

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -40,7 +40,7 @@
 		DD.carrier = 1
 
 	//Copy properties over. This is so edited diseases persist.
-	var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars")
+	var/list/skipped = list("affected_mob","holder","carrier","stage","type","parent_type","vars","transformed")
 	for(var/V in DD.vars)
 		if(V in skipped)
 			continue


### PR DESCRIPTION
The transformed var was being carried over, which caused the virus to think that it had already changed the infected into the carried DNA and do nothing
