### PR TITLE
Changes the targeting code for hostile animals

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -45,13 +45,6 @@
 #define GRAB_KILL		5
 
 
-//Hostile Mob Stances
-#define HOSTILE_STANCE_IDLE			1
-//#define HOSTILE_STANCE_ALERT		2 //Was only used by bears
-#define HOSTILE_STANCE_ATTACK		3
-#define HOSTILE_STANCE_ATTACKING	4
-//#define HOSTILE_STANCE_TIRED		5 //Was also only used by bears
-
 //Hostile Mob AI Status
 #define AI_ON		1
 #define AI_SLEEP	2

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -47,7 +47,7 @@
 
 //Hostile Mob AI Status
 #define AI_ON		1
-#define AI_SLEEP	2
+#define AI_IDLE	2
 #define AI_OFF		3
 
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -623,7 +623,7 @@
 	if(istype(I, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/W = I
 		if(W.welding && !stat)
-			if(stance != HOSTILE_STANCE_IDLE)
+			if(AIStatus == AI_ON)
 				user << "<span class='info'>[src] is moving around too much to repair!</span>"
 				return
 			if(maxHealth == health)

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -41,8 +41,10 @@
 	var/plants_off = 0
 
 /mob/living/simple_animal/hostile/alien/drone/handle_automated_action()
+	if(!..()) //AIStatus is off
+		return
 	plant_cooldown--
-	if(AIStatus == AI_SLEEP)
+	if(AIStatus == AI_IDLE)
 		if(!plants_off && prob(10) && plant_cooldown<=0)
 			plant_cooldown = initial(plant_cooldown)
 			SpreadPlants()
@@ -86,9 +88,11 @@
 	var/plant_cooldown = 30
 
 /mob/living/simple_animal/hostile/alien/queen/handle_automated_action()
+	if(!..()) //AIStatus is off
+		return
 	egg_cooldown--
 	plant_cooldown--
-	if(AIStatus == AI_SLEEP)
+	if(AIStatus == AI_IDLE)
 		if(!plants_off && prob(10) && plant_cooldown<=0)
 			plant_cooldown = initial(plant_cooldown)
 			SpreadPlants()

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -40,14 +40,12 @@
 	var/plant_cooldown = 30
 	var/plants_off = 0
 
-/mob/living/simple_animal/hostile/alien/drone/Life()
-	..()
-	if(!stat)
-		plant_cooldown--
-		if(stance==HOSTILE_STANCE_IDLE)
-			if(!plants_off && prob(10) && plant_cooldown<=0)
-				plant_cooldown = initial(plant_cooldown)
-				SpreadPlants()
+/mob/living/simple_animal/hostile/alien/drone/handle_automated_action()
+	plant_cooldown--
+	if(AIStatus == AI_SLEEP)
+		if(!plants_off && prob(10) && plant_cooldown<=0)
+			plant_cooldown = initial(plant_cooldown)
+			SpreadPlants()
 
 /mob/living/simple_animal/hostile/alien/sentinel
 	name = "alien sentinel"
@@ -87,18 +85,16 @@
 	var/egg_cooldown = 30
 	var/plant_cooldown = 30
 
-/mob/living/simple_animal/hostile/alien/queen/Life()
-	..()
-	if(!stat)
-		egg_cooldown--
-		plant_cooldown--
-		if(stance==HOSTILE_STANCE_IDLE)
-			if(!plants_off && prob(10) && plant_cooldown<=0)
-				plant_cooldown = initial(plant_cooldown)
-				SpreadPlants()
-			if(!sterile && prob(10) && egg_cooldown<=0)
-				egg_cooldown = initial(egg_cooldown)
-				LayEggs()
+/mob/living/simple_animal/hostile/alien/queen/handle_automated_action()
+	egg_cooldown--
+	plant_cooldown--
+	if(AIStatus == AI_SLEEP)
+		if(!plants_off && prob(10) && plant_cooldown<=0)
+			plant_cooldown = initial(plant_cooldown)
+			SpreadPlants()
+		if(!sterile && prob(10) && egg_cooldown<=0)
+			egg_cooldown = initial(egg_cooldown)
+			LayEggs()
 
 /mob/living/simple_animal/hostile/alien/proc/SpreadPlants()
 	if(!isturf(loc) || istype(loc, /turf/space))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -78,7 +78,9 @@
 	move_to_delay = 5
 
 /mob/living/simple_animal/hostile/poison/giant_spider/handle_automated_action()
-	if(AIStatus == AI_SLEEP)
+	if(!..()) //AIStatus is off
+		return 0
+	if(AIStatus == AI_IDLE)
 		//1% chance to skitter madly away
 		if(!busy && prob(1))
 			stop_automated_movement = 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -77,20 +77,16 @@
 	poison_per_bite = 5
 	move_to_delay = 5
 
-/mob/living/simple_animal/hostile/poison/giant_spider/Life()
-	..()
-	if(!stat && !ckey)
-		if(stance == HOSTILE_STANCE_IDLE)
-			//1% chance to skitter madly away
-			if(!busy && prob(1))
-				/*var/list/move_targets = list()
-				for(var/turf/T in orange(20, src))
-					move_targets.Add(T)*/
-				stop_automated_movement = 1
-				Goto(pick(orange(20, src)), move_to_delay)
-				spawn(50)
-					stop_automated_movement = 0
-					walk(src,0)
+/mob/living/simple_animal/hostile/poison/giant_spider/handle_automated_action()
+	if(AIStatus == AI_SLEEP)
+		//1% chance to skitter madly away
+		if(!busy && prob(1))
+			stop_automated_movement = 1
+			Goto(pick(orange(20, src)), move_to_delay)
+			spawn(50)
+				stop_automated_movement = 0
+				walk(src,0)
+		return 1
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/GiveUp(C)
 	spawn(100)
@@ -100,53 +96,50 @@
 			busy = 0
 			stop_automated_movement = 0
 
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/Life()
-	..()
-	if(!stat && !ckey)
-		if(stance == HOSTILE_STANCE_IDLE)
-			var/list/can_see = view(src, 10)
-			//30% chance to stop wandering and do something
-			if(!busy && prob(30))
-				//first, check for potential food nearby to cocoon
-				for(var/mob/living/C in can_see)
-					if(C.stat && !istype(C,/mob/living/simple_animal/hostile/poison/giant_spider))
-						cocoon_target = C
-						busy = MOVING_TO_TARGET
-						Goto(C, move_to_delay)
-						//give up if we can't reach them after 10 seconds
-						GiveUp(C)
-						return
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/handle_automated_action()
+	if(..())
+		var/list/can_see = view(src, 10)
+		if(!busy && prob(30))	//30% chance to stop wandering and do something
+			//first, check for potential food nearby to cocoon
+			for(var/mob/living/C in can_see)
+				if(C.stat && !istype(C,/mob/living/simple_animal/hostile/poison/giant_spider))
+					cocoon_target = C
+					busy = MOVING_TO_TARGET
+					Goto(C, move_to_delay)
+					//give up if we can't reach them after 10 seconds
+					GiveUp(C)
+					return
 
-				//second, spin a sticky spiderweb on this tile
-				var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
-				if(!W)
-					Web()
+			//second, spin a sticky spiderweb on this tile
+			var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
+			if(!W)
+				Web()
+			else
+				//third, lay an egg cluster there
+				if(fed)
+					LayEggs()
 				else
-					//third, lay an egg cluster there
-					if(fed)
-						LayEggs()
-					else
-						//fourthly, cocoon any nearby items so those pesky pinkskins can't use them
-						for(var/obj/O in can_see)
+					//fourthly, cocoon any nearby items so those pesky pinkskins can't use them
+					for(var/obj/O in can_see)
 
-							if(O.anchored)
-								continue
+						if(O.anchored)
+							continue
 
-							if(istype(O, /obj/item) || istype(O, /obj/structure) || istype(O, /obj/machinery))
-								cocoon_target = O
-								busy = MOVING_TO_TARGET
-								stop_automated_movement = 1
-								Goto(O, move_to_delay)
-								//give up if we can't reach them after 10 seconds
-								GiveUp(O)
+						if(istype(O, /obj/item) || istype(O, /obj/structure) || istype(O, /obj/machinery))
+							cocoon_target = O
+							busy = MOVING_TO_TARGET
+							stop_automated_movement = 1
+							Goto(O, move_to_delay)
+							//give up if we can't reach them after 10 seconds
+							GiveUp(O)
 
-			else if(busy == MOVING_TO_TARGET && cocoon_target)
-				if(get_dist(src, cocoon_target) <= 1)
-					Wrap()
+		else if(busy == MOVING_TO_TARGET && cocoon_target)
+			if(get_dist(src, cocoon_target) <= 1)
+				Wrap()
 
-		else
-			busy = 0
-			stop_automated_movement = 0
+	else
+		busy = 0
+		stop_automated_movement = 0
 
 /mob/living/simple_animal/hostile/poison/giant_spider/verb/Web()
 	set name = "Lay Web"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -2,7 +2,6 @@
 	faction = list("hostile")
 	stop_automated_movement_when_pulled = 0
 	environment_smash = 1 //Set to 1 to break closets,tables,racks, etc; 2 for walls; 3 for rwalls
-	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
 	var/atom/target
 	var/ranged = 0
 	var/rapid = 0
@@ -36,39 +35,35 @@
 
 /mob/living/simple_animal/hostile/Life()
 
-	. = ..()
-	if(!.) //dead
+	if(..()) //alive
+		if(ranged)
+			ranged_cooldown--
+		if(ckey) //player controlled
+			return 0
+		if(AIStatus == AI_OFF)
+			return 0
+		var/list/possible_targets = ListTargets() //we look around for potential targets and make it a list for later use.
+
+		if(environment_smash)
+			EscapeConfinement()
+
+		if(!AICanContinue(possible_targets))
+			return 0
+
+		DestroySurroundings()
+		if(!MoveToTarget(possible_targets))     //if we lose our target
+			if(AIShouldSleep(possible_targets))	// we try to acquire a new one
+				AIStatus = AI_SLEEP				// otherwise we go to sleep
+	else //dead
 		walk(src, 0) //stops walking
 		return 0
-	if(ranged)
-		ranged_cooldown--
-	if(client)
-		return 0
-	if(!AICanContinue())
-		return 0
-	if(!stat)
-		switch(stance)
-			if(HOSTILE_STANCE_IDLE)
-				if(environment_smash)
-					EscapeConfinement()
-				FindTarget()
-
-			if(HOSTILE_STANCE_ATTACK)
-				MoveToTarget()
-				DestroySurroundings()
-
-			if(HOSTILE_STANCE_ATTACKING)
-				AttackTarget()
-				DestroySurroundings()
-
-		if(AIShouldSleep())
-			AIStatus = AI_SLEEP
 
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
 
 /mob/living/simple_animal/hostile/proc/ListTargets()//Step 1, find out what we can see
+	world << "DEBUG: ListTargets()"
 	var/list/L = list()
 	if(!search_objects)
 		var/list/Mobs = hearers(vision_range, src) - src //Remove self, so we don't suicide
@@ -81,19 +76,19 @@
 		L += Objects
 	return L
 
-/mob/living/simple_animal/hostile/proc/FindTarget()//Step 2, filter down possible targets to things we actually care about
+/mob/living/simple_animal/hostile/proc/FindTarget(var/list/possible_targets, var/HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
+	world << "DEBUG: FindTarget()"
 	var/list/Targets = list()
-	var/Target
-	for(var/atom/A in ListTargets())
+	if(!HasTargetsList)
+		possible_targets = ListTargets()
+	for(var/atom/A in possible_targets)
 		if(Found(A))//Just in case people want to override targetting
-			var/list/FoundTarget = list()
-			FoundTarget += A
-			Targets = FoundTarget
+			Targets = list(A)
 			break
 		if(CanAttack(A))//Can we attack it?
 			Targets += A
 			continue
-	Target = PickTarget(Targets)
+	var/Target = PickTarget(Targets)
 	GiveTarget(Target)
 	return Target //We now have a target
 
@@ -101,18 +96,19 @@
 	return
 
 /mob/living/simple_animal/hostile/proc/PickTarget(list/Targets)//Step 3, pick amongst the possible, attackable targets
+	if(!Targets.len)//We didnt find nothin!
+		return
 	if(target != null)//If we already have a target, but are told to pick again, calculate the lowest distance between all possible, and pick from the lowest distance targets
 		for(var/atom/A in Targets)
 			var/target_dist = get_dist(src, target)
 			var/possible_target_distance = get_dist(src, A)
 			if(target_dist < possible_target_distance)
 				Targets -= A
-	if(!Targets.len)//We didnt find nothin!
-		return
 	var/chosen_target = pick(Targets)//Pick the remaining targets (if any) at random
 	return chosen_target
 
 /mob/living/simple_animal/hostile/CanAttack(atom/the_target)//Can we actually attack a possible target?
+	world << "DEBUG: CanAttack()"
 	if(see_invisible < the_target.invisibility)//Target's invisible to us, forget it
 		return 0
 	if(search_objects < 2)
@@ -150,15 +146,15 @@
 	target = new_target
 	if(target != null)
 		Aggro()
-		stance = HOSTILE_STANCE_ATTACK
-	return
+		return 1
 
-/mob/living/simple_animal/hostile/proc/MoveToTarget()//Step 5, handle movement between us and our target
+/mob/living/simple_animal/hostile/proc/MoveToTarget(var/list/possible_targets)//Step 5, handle movement between us and our target
+	world << "DEBUG: MoveToTarget()"
 	stop_automated_movement = 1
 	if(!target || !CanAttack(target))
 		LoseTarget()
-		return
-	if(target in ListTargets())
+		return 0
+	if(target in possible_targets)
 		var/target_distance = get_dist(src,target)
 		if(ranged)//We ranged? Shoot at em
 			if(target_distance >= 2 && ranged_cooldown <= 0)//But make sure they're a tile away at least, and our range attack is off cooldown
@@ -172,46 +168,33 @@
 			Goto(target,move_to_delay,minimum_distance)
 		if(isturf(loc) && target.Adjacent(src))	//If they're next to us, attack
 			AttackingTarget()
-		return
+		return 1
 	if(environment_smash)
 		if(target.loc != null && get_dist(src, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
 			if(environment_smash >= 2)//If we're capable of smashing through walls, forget about vision completely after finding our target
 				Goto(target,move_to_delay,minimum_distance)
 				FindHidden()
-				return
+				return 1
 			else
 				if(FindHidden())
-					return
+					return 1
 	LoseTarget()
+	return 0
 
 /mob/living/simple_animal/hostile/proc/Goto(target, delay, minimum_distance)
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(damage)
 	..(damage)
-	if(!client && !stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
+	if(!ckey && !stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			search_objects = 0
 			target = null
-		if(stance == HOSTILE_STANCE_IDLE)//If we took damage while idle, immediately attempt to find the source of it so we find a living target
-			Aggro()
+		if(AIStatus == AI_SLEEP)
+			AIStatus = AI_ON
 			FindTarget()
-		if(stance == HOSTILE_STANCE_ATTACK)//No more pulling a mob forever and having a second player attack it, it can switch targets now if it finds a more suitable one
-			if(target != null && prob(40))
-				FindTarget()
-
-/mob/living/simple_animal/hostile/proc/AttackTarget()
-
-	stop_automated_movement = 1
-	if(!target || !CanAttack(target))
-		LoseTarget()
-		return 0
-	if(!(target in ListTargets()))
-		LoseTarget()
-		return 0
-	if(isturf(loc) && target.Adjacent(src))
-		AttackingTarget()
-		return 1
+		else if(target != null && prob(40))//No more pulling a mob forever and having a second player attack it, it can switch targets now if it finds a more suitable one
+			FindTarget()
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
 	target.attack_animal(src)
@@ -229,7 +212,7 @@
 	taunt_chance = initial(taunt_chance)
 
 /mob/living/simple_animal/hostile/proc/LoseTarget()
-	stance = HOSTILE_STANCE_IDLE
+	world << "DEBUG: LoseTarget()"
 	target = null
 	walk(src, 0)
 	LoseAggro()
@@ -309,6 +292,7 @@
 	return
 
 /mob/living/simple_animal/hostile/proc/FindHidden()
+	world << "DEBUG: FindHidden()"
 	if(istype(target.loc, /obj/structure/closet) || istype(target.loc, /obj/machinery/disposal) || istype(target.loc, /obj/machinery/sleeper))
 		var/atom/A = target.loc
 		Goto(A,move_to_delay,minimum_distance)
@@ -325,30 +309,16 @@
 
 
 ////// AI Status ///////
-/mob/living/simple_animal/hostile/proc/AICanContinue()
+/mob/living/simple_animal/hostile/proc/AICanContinue(var/list/possible_targets)
 	switch(AIStatus)
 		if(AI_ON)
 			. = 1
 		if(AI_SLEEP)
-			if(AIShouldWake())
+			if(FindTarget(possible_targets, 1))
 				. = 1
 				AIStatus = AI_ON //Wake up for more than one Life() cycle.
 			else
 				. = 0
-		if(AI_OFF)
-			. = 0
 
-
-//Returns 1 if the AI should wake up
-//Returns 0 if the AI should remain asleep
-/mob/living/simple_animal/hostile/proc/AIShouldWake()
-	. = 0
-	if(FindTarget())
-		. = 1
-
-
-//Convenience
-/mob/living/simple_animal/hostile/proc/AIShouldSleep()
-	. = !(AIShouldWake())
-	if(. && stance != HOSTILE_STANCE_IDLE) //This proc was called before LoseTarget().
-		LoseTarget()
+/mob/living/simple_animal/hostile/proc/AIShouldSleep(var/list/possible_targets)
+	return !FindTarget(possible_targets, 1)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -359,7 +359,7 @@
 /mob/living/simple_animal/hostile/asteroid/goliath/proc/handle_preattack()
 	if(ranged_cooldown <= 2 && !pre_attack)
 		pre_attack++
-	if(!pre_attack || stat || AIStatus == AI_SLEEP)
+	if(!pre_attack || stat || AIStatus == AI_IDLE)
 		return
 	icon_state = "Goliath_preattack"
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -87,16 +87,12 @@
 	temperature = 50
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)
-	target = new_target
-	if(target != null)
-		Aggro()
-		stance = HOSTILE_STANCE_ATTACK
+	if(..()) //we have a target
 		if(isliving(target))
 			var/mob/living/L = target
 			if(L.bodytemperature > 200)
 				L.bodytemperature = 200
 				visible_message("<span class='danger'>The [src.name]'s stare chills [L.name] to the bone!</span>")
-	return
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/ex_act(severity, target)
 	switch(severity)
@@ -154,17 +150,14 @@
 	if(target != null)
 		if(istype(target, /obj/item/weapon/ore))
 			visible_message("<span class='notice'>The [src.name] looks at [target.name] with hungry eyes.</span>")
-			stance = HOSTILE_STANCE_ATTACK
-			return
-		if(isliving(target))
+
+		else if(isliving(target))
 			Aggro()
-			stance = HOSTILE_STANCE_ATTACK
 			visible_message("<span class='danger'>The [src.name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10
 			minimum_distance = 10
 			Burrow()
-			return
-	return
+
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/AttackingTarget()
 	if(istype(target, /obj/item/weapon/ore))
@@ -366,7 +359,7 @@
 /mob/living/simple_animal/hostile/asteroid/goliath/proc/handle_preattack()
 	if(ranged_cooldown <= 2 && !pre_attack)
 		pre_attack++
-	if(!pre_attack || stat || stance == HOSTILE_STANCE_IDLE)
+	if(!pre_attack || stat || AIStatus == AI_SLEEP)
 		return
 	icon_state = "Goliath_preattack"
 

--- a/code/modules/mob/living/simple_animal/morph/morph.dm
+++ b/code/modules/mob/living/simple_animal/morph/morph.dm
@@ -35,7 +35,7 @@
 /mob/living/simple_animal/hostile/morph/examine(mob/user)
 	if(morphed)
 		form.examine(user) // Refactor examine to return desc so it's static? Not sure if worth it
-		if(get_dist(user,src)<=3) 
+		if(get_dist(user,src)<=3)
 			user << "<span class='notice'>Looks odd!</span>"
 	else
 		..()
@@ -61,7 +61,7 @@
 /mob/living/simple_animal/hostile/morph/proc/assume(atom/movable/target)
 	morphed = 1
 	form = target
-	
+
 	//anim(loc,src,'icons/mob/mob.dmi',,"morph",,src.dir) No effect better than shit effect
 
 	//Todo : update to .appearance once 508 hits
@@ -89,9 +89,9 @@
 		return
 	morphed = 0
 	form = null
-	
-	//anim(loc,src,'icons/mob/mob.dmi',,"morph",,src.dir) 
-	
+
+	//anim(loc,src,'icons/mob/mob.dmi',,"morph",,src.dir)
+
 	name = initial(name)
 	icon = initial(icon)
 	icon_state = initial(icon_state)
@@ -127,7 +127,7 @@
 /mob/living/simple_animal/hostile/morph/LoseAggro()
 	vision_range = idle_vision_range
 
-/mob/living/simple_animal/hostile/morph/AIShouldSleep()
+/mob/living/simple_animal/hostile/morph/AIShouldSleep(var/list/possible_targets)
 	. = ..()
 	if(.)
 		var/list/things = list()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -74,10 +74,10 @@
 	health = Clamp(health, 0, maxHealth)
 
 /mob/living/simple_animal/Life()
-	if(..())
-		if(!client && !stat)
+	if(..()) //alive
+		if(!ckey)
 			handle_automated_movement()
-
+			handle_automated_action()
 			handle_automated_speech()
 		return 1
 
@@ -113,6 +113,9 @@
 
 	if(druggy)
 		druggy = 0
+
+/mob/living/simple_animal/proc/handle_automated_action()
+	return
 
 /mob/living/simple_animal/proc/handle_automated_movement()
 	if(!stop_automated_movement && wander)


### PR DESCRIPTION
- to be a bit more efficient. AIStatus and stance vars are now only one var. The idle stance is fused with the AI_SLEEP status (which is renamed AI_IDLE). hostile/life() now only calls ListTargets() once per cycle (we save a list of targets then use that instead of calling the proc again). This will help with #9624.
- Alien animals no longer plant egg/weed when player controlled (even if disconnected). Fixes #10570
  Created the proc handle_automated_action() for simple_animals , currently used by hostile animal targeting,  by giant spiders (cocoon stuff) and alien animals (weed planting). 
- Player controlled hostile animals no longer starts targetting things again when the player disconnects. Fixes #9664 
