### PR TITLE
Syndicate toolboxes now come with insulated gloves 

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -80,9 +80,9 @@
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool/largetank(src)
 	new /obj/item/weapon/crowbar/red(src)
-	new /obj/item/stack/cable_coil(src, 30, "red")
 	new /obj/item/weapon/wirecutters(src, "red")
 	new /obj/item/device/multitool(src)
+	new /obj/item/clothing/gloves/color/yellow/syndicate(src)
 
 /obj/item/weapon/storage/toolbox/drone
 	name = "mechanical toolbox"

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -82,7 +82,7 @@
 	new /obj/item/weapon/crowbar/red(src)
 	new /obj/item/weapon/wirecutters(src, "red")
 	new /obj/item/device/multitool(src)
-	new /obj/item/clothing/gloves/color/yellow/syndicate(src)
+	new /obj/item/clothing/gloves/color/red/insulated(src)
 
 /obj/item/weapon/storage/toolbox/drone
 	name = "mechanical toolbox"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -8,11 +8,6 @@
 	item_color="yellow"
 	burn_state = -1 //Won't burn in fires
 
-/obj/item/clothing/gloves/color/yellow/syndicate //Actually red, this is what you get when you just arbitrarily decide that one color is better than the rest!
-	icon_state = "red"
-	item_state = "redgloves"
-	item_color = "red"
-
 /obj/item/clothing/gloves/color/yellow/fake
 	desc = "These gloves will protect the wearer from electric shock. They don't feel like rubber..."
 	siemens_coefficient = 1
@@ -70,6 +65,13 @@
 	icon_state = "red"
 	item_state = "redgloves"
 	item_color = "red"
+
+/obj/item/clothing/gloves/color/red/insulated
+	name = "insulated gloves"
+	desc = "These gloves will protect the wearer from electric shock."
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
+	burn_state = -1 //Won't burn in fires
 
 /obj/item/clothing/gloves/color/rainbow
 	name = "rainbow gloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -8,6 +8,11 @@
 	item_color="yellow"
 	burn_state = -1 //Won't burn in fires
 
+/obj/item/clothing/gloves/color/yellow/syndicate //Actually red, this is what you get when you just arbitrarily decide that one color is better than the rest!
+	icon_state = "red"
+	item_state = "redgloves"
+	item_color = "red"
+
 /obj/item/clothing/gloves/color/yellow/fake
 	desc = "These gloves will protect the wearer from electric shock. They don't feel like rubber..."
 	siemens_coefficient = 1

--- a/html/changelogs/incoming5643-noglovenolove.yml
+++ b/html/changelogs/incoming5643-noglovenolove.yml
@@ -1,0 +1,6 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "Syndicate toolboxes now come with never before seen red insulated gloves."


### PR DESCRIPTION
(that look like red gloves). Wires are lost as a consequence. Changelog included.

Fixes #10937
