### PR TITLE
Fixes hisspering (whisper bug)

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -90,9 +90,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 		src << "<span class='warning'>You find yourself unable to speak!</span>"
 		return
 
-	if(message_mode != MODE_WHISPER) { //whisper() calls treat_message(); double process results in "hisspering"
+	if(message_mode != MODE_WHISPER) //whisper() calls treat_message(); double process results in "hisspering"
 		message = treat_message(message)
-	}
 	var/spans = list()
 	spans += get_spans()
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -90,7 +90,9 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 		src << "<span class='warning'>You find yourself unable to speak!</span>"
 		return
 
-	message = treat_message(message)
+	if(message_mode != MODE_WHISPER) { //whisper() calls treat_message(); double process results in "hisspering"
+		message = treat_message(message)
+	}
 	var/spans = list()
 	spans += get_spans()
 

--- a/html/changelogs/SvartaSvansen-hisspering.yml
+++ b/html/changelogs/SvartaSvansen-hisspering.yml
@@ -1,0 +1,6 @@
+author: SvartaSvansen
+
+delete-after: True
+
+changes: 
+  - bugfix: "Sent those unruly lizards to mandatory courses in whispering etiquette. Hisspering is now a thing of the past."

--- a/html/changelogs/SvartaSvansen-hisspering.yml
+++ b/html/changelogs/SvartaSvansen-hisspering.yml
@@ -1,6 +1,0 @@
-author: SvartaSvansen
-
-delete-after: True
-
-changes: 
-  - bugfix: "Sent those unruly lizards to mandatory courses in whispering etiquette. Hisspering is now a thing of the past."


### PR DESCRIPTION
Have you ever had this happen to you? A lizard walks up to you and tells you a secret, but does so with some unnecessssssssssssssssssarily sssssssssibiliant whissssssssspering in your ear? Annoying? Yes! Rude? You bet!

Well, fear not! Soon this hisssssssssssssssssspering phenomenon will be a thing of the past! We'll send those unruly lizards to mandatory classes in reptilian whispering etiquette and teach them how not to blow their spittle into others' ears and cause them headaches! You're a Nanotrasen employee for heaven's sake, not a leaky tire!

Note: Not all lizards hissper. Only those that whisper using :w. Hisspering is where one "s" turns into nine instead of three and is the result of say() and whisper() both processing the message with speech effects. Slurring, stuttering, and derpspeech are processed twice as well.

Note: Sorry to those lizards who find hisspering sexy. It's not worth the headaches of the whole rest of the crew.
