### PR TITLE
Adds a water reaction to gold slimes + tweaks blacklist.

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -80,6 +80,9 @@
 	explosion(src.loc, -1, 0, 1+num_of_prizes, flame_range = 1+num_of_prizes)
 
 
+// ** BATTLE ** //
+
+
 /obj/machinery/computer/arcade/battle
 	name = "arcade machine"
 	desc = "Does not support Pinball."
@@ -292,7 +295,7 @@
 		src.updateUsrDialog()
 
 
-
+// *** THE ORION TRAIL ** //
 
 
 /obj/machinery/computer/arcade/orion_trail

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -35,8 +35,6 @@
 			/mob/living/simple_animal/hostile/syndicate/ranged,
 			/mob/living/simple_animal/hostile/syndicate/ranged/space,
 			/mob/living/simple_animal/hostile/alien/queen/large,
-			/mob/living/simple_animal/hostile/retaliate,
-			/mob/living/simple_animal/hostile/retaliate/clown,
 			/mob/living/simple_animal/hostile/mushroom,
 			/mob/living/simple_animal/hostile/asteroid,
 			/mob/living/simple_animal/hostile/asteroid/basilisk,
@@ -50,7 +48,15 @@
 			/mob/living/simple_animal/hostile/blob,
 			/mob/living/simple_animal/ascendant_shadowling
 			)//exclusion list for things you don't want the reaction to create.
-		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+		var/list/meancritters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+		var/list/nicecritters = list(typesof(/mob/living/simple_animal/pet),
+		                        /mob/living/simple_animal/crab,
+		                        /mob/living/simple_animal/mouse,
+		                        /mob/living/simple_animal/lizard,
+		                        /mob/living/simple_animal/parrot,
+		                        /mob/living/simple_animal/butterfly,
+		                        /mob/living/simple_animal/cow,
+		                        /mob/living/simple_animal/chicken) // and possible friendly mobs
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/area/my_area = get_area(T)
@@ -70,13 +76,22 @@
 		for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
 			C.flash_eyes()
 		for(var/i = 1, i <= amount_to_spawn, i++)
-			var/chosen = pick(critters)
-			var/mob/living/simple_animal/hostile/C = new chosen
-			C.faction |= mob_faction
-			C.loc = get_turf(holder.my_atom)
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(C, pick(NORTH,SOUTH,EAST,WEST))
+			if (reaction_name == "Friendly Gold Slime")
+				var/chosen = pick(nicecritters)
+				var/mob/living/simple_animal/C = new chosen
+				C.faction |= mob_faction
+				C.loc = get_turf(holder.my_atom)
+				if(prob(50))
+					for(var/j = 1, j <= rand(1, 3), j++)
+						step(C, pick(NORTH,SOUTH,EAST,WEST))
+			else
+				var/chosen = pick(meancritters)
+				var/mob/living/simple_animal/hostile/C = new chosen
+				C.faction |= mob_faction
+				C.loc = get_turf(holder.my_atom)
+				if(prob(50))
+					for(var/j = 1, j <= rand(1, 3), j++)
+						step(C, pick(NORTH,SOUTH,EAST,WEST))
 
 /datum/chemical_reaction/proc/goonchem_vortex(turf/simulated/T, setting_type, range)
 	for(var/atom/movable/X in orange(range, T))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -37,6 +37,7 @@
 			/mob/living/simple_animal/hostile/alien/queen/large,
 			/mob/living/simple_animal/hostile/mushroom,
 			/mob/living/simple_animal/hostile/asteroid,
+			/mob/living/simple_animal/hostile/retaliate,
 			/mob/living/simple_animal/hostile/asteroid/basilisk,
 			/mob/living/simple_animal/hostile/asteroid/goldgrub,
 			/mob/living/simple_animal/hostile/asteroid/goliath,
@@ -49,14 +50,14 @@
 			/mob/living/simple_animal/ascendant_shadowling
 			)//exclusion list for things you don't want the reaction to create.
 		var/list/meancritters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-		var/list/nicecritters = list(typesof(/mob/living/simple_animal/pet),
-		                        /mob/living/simple_animal/crab,
+		var/list/nicecritters = list(/mob/living/simple_animal/crab,
 		                        /mob/living/simple_animal/mouse,
 		                        /mob/living/simple_animal/lizard,
 		                        /mob/living/simple_animal/parrot,
 		                        /mob/living/simple_animal/butterfly,
 		                        /mob/living/simple_animal/cow,
 		                        /mob/living/simple_animal/chicken) // and possible friendly mobs
+		nicecritters += typesof(/mob/living/simple_animal/pet) - /mob/living/simple_animal/pet
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/area/my_area = get_area(T)

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -123,6 +123,23 @@
 
 		chemical_mob_spawn(holder, 1, "Lesser Gold Slime", "neutral")
 
+/datum/chemical_reaction/slimecritfriendly
+	name = "Slime Crit Friendly"
+	id = "m_tele5"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/gold
+	required_other = 1
+
+/datum/chemical_reaction/slimecritfriendly/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
+		O.show_message(text("<span class='danger'>The slime extract begins to vibrate adorably !</span>"), 1)
+	spawn(50)
+
+		chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
+
 //Silver
 /datum/chemical_reaction/slimebork
 	name = "Slime Bork"

--- a/html/changelogs/bgobandit - cutebiology.yml
+++ b/html/changelogs/bgobandit - cutebiology.yml
@@ -1,0 +1,6 @@
+author: bgobandit
+
+delete-after: True
+
+changes: 
+  - rscadd: "Nanotrasen scientists have achieved the tremendous breakthrough of injecting gold slime extracts with water. Pets ensued."


### PR DESCRIPTION
Changes in this PR:
- Adds a water reaction to gold slimes. This produces pets and/or other friendly/neutral mobs like parrots and crabs. For when you want your sentience potion army to be less horrifying and more adorable. (Fluff: Blood makes them carnivores, water does not.)
- Removes clowns from the non-friendly gold slime blacklist. If you are creating a game-breaking amount of clowns with gold slimes you probably deserved it, and there are worse things that can spawn anyway. HONK.
