### PR TITLE
Changed cloning ghost notifications to be less copypasta/snowfake

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -420,12 +420,6 @@
 
 		open_machine()
 
-/obj/machinery/dna_scannernew/Topic(href, href_list)
-	if(href_list["reenter"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
-			ghost.reenter_corpse(ghost)
-
 /obj/machinery/dna_scannernew/close_machine()
 	if(!state_open)
 		return 0
@@ -439,10 +433,7 @@
 			|| locate(/obj/machinery/computer/cloning, get_step(src, EAST)) \
 			|| locate(/obj/machinery/computer/cloning, get_step(src, WEST)))
 
-			var/mob/dead/observer/ghost = occupant.get_ghost()
-			if(ghost)
-				ghost << "<span class='ghostalert'>Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
-				ghost << sound('sound/effects/genetics.ogg')
+			occupant.notify_ghost_cloning()
 	return 1
 
 /obj/machinery/dna_scannernew/open_machine()

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -477,12 +477,6 @@ datum/reagent/shadowling_blindness_smoke //Blinds non-shadowlings, heals shadowl
 	include_user = 0
 	var/list/thralls_in_world = list()
 
-/obj/effect/proc_holder/spell/targeted/reviveThrall/Topic(href, href_list)
-	if(href_list["reenter"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
-			ghost.reenter_corpse(ghost)
-
 /obj/effect/proc_holder/spell/targeted/reviveThrall/cast(list/targets)
 	for(var/mob/living/carbon/human/thrallToRevive in targets)
 		if(!is_thrall(thrallToRevive))
@@ -495,10 +489,8 @@ datum/reagent/shadowling_blindness_smoke //Blinds non-shadowlings, heals shadowl
 			return
 		usr.visible_message("<span class='danger'>[usr] kneels over [thrallToRevive], placing their hands on \his chest.</span>", \
 							"<span class='shadowling'>You crouch over the body of your thrall and begin gathering energy...</span>")
-		var/mob/dead/observer/ghost = thrallToRevive.get_ghost()
-		if(ghost)
-			ghost << "<span class='ghostalert'>Your masters are resuscitating you! Re-enter your corpse if you wish to be brought to life.</span> <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a>"
-			ghost << 'sound/effects/genetics.ogg'
+		thrallToRevive.notify_ghost_cloning("Your masters are resuscitating you! Re-enter your corpse if you wish to be brought to life.")
+
 		if(!do_mob(usr, thrallToRevive, 100))
 			usr << "<span class='warning'>Your concentration snaps. The flow of energy ebbs.</span>"
 			charge_counter= charge_max

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -323,12 +323,6 @@
 	else
 		return 1
 
-/obj/item/weapon/twohanded/shockpaddles/Topic(href, href_list)
-	if(href_list["reenter"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
-			ghost.reenter_corpse(ghost)
-
 /obj/item/weapon/twohanded/shockpaddles/attack(mob/M, mob/user)
 	var/halfwaycritdeath = (config.health_threshold_crit + config.health_threshold_dead) / 2
 
@@ -404,10 +398,8 @@
 				busy = 0
 				update_icon()
 				return
-			var/mob/dead/observer/ghost = H.get_ghost()
-			if(ghost)
-				ghost << "<span class='ghostalert'>Your heart is being defibrillated. Re-enter your corpse if you want to be revived! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
-				ghost << 'sound/effects/genetics.ogg'
+			H.notify_ghost_cloning("Your heart is being defibrillated. Re-enter your corpse if you want to be revived!")
+
 			user.visible_message("<span class='warning'>[user] begins to place [src] on [M.name]'s chest.</span>", "<span class='warning'>You begin to place [src] on [M.name]'s chest...</span>")
 			busy = 1
 			update_icon()
@@ -432,11 +424,10 @@
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-						for(var/obj/item/organ/limb/O in H.organs)
-							total_brute	+= O.brute_dam
-							total_burn	+= O.burn_dam
-						ghost = H.get_ghost()
-						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
+						total_brute	= H.getBruteLoss()
+						total_burn	= H.getFireLoss()
+
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !H.get_ghost() && tplus < tlimit && !(NOCLONE in H.mutations))
 							//If the body has been fixed so that they would not be in crit when defibbed, give them oxyloss to put them back into crit
 							if (H.health > halfwaycritdeath)
 								H.adjustOxyLoss(H.health - halfwaycritdeath)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -167,6 +167,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	mind.current.key = key
 	return 1
 
+/mob/dead/observer/proc/notify_cloning(var/message, var/sound)
+	if(message)
+		src << "<span class='ghostalert'>[message]</span>"
+	src << "<span class='ghostalert'><a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
+	if(sound)
+		src << sound(sound)
+
 /mob/dead/observer/proc/dead_tele()
 	set category = "Ghost"
 	set name = "Teleport"
@@ -363,8 +370,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return ..()
 
 /mob/dead/observer/Topic(href, href_list)
-	if(href_list["follow"])
-		var/atom/movable/target = locate(href_list["follow"])
-		if((usr == src) && istype(target) && (target != src)) //for safety against href exploits
-			ManualFollow(target)
-
+	..()
+	if(usr == src)
+		if(href_list["follow"])
+			var/atom/movable/target = locate(href_list["follow"])
+			if(istype(target) && (target != src))
+				ManualFollow(target)
+		if(href_list["reenter"])
+			reenter_corpse()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -31,12 +31,6 @@
 	else
 		icon_state = "mmi_empty"
 
-/obj/item/device/mmi/Topic(href, href_list)
-	if(href_list["reenter"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
-			ghost.reenter_corpse(ghost)
-
 /obj/item/device/mmi/attackby(obj/item/O, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(istype(O,/obj/item/organ/brain)) //Time to stick a brain in it --NEO
@@ -52,11 +46,7 @@
 			return
 		var/mob/living/carbon/brain/B = newbrain.brainmob
 		if(!B.key)
-			var/mob/dead/observer/ghost = B.get_ghost()
-			if(ghost)
-				if(ghost.client)
-					ghost << "<span class='ghostalert'>Someone has put your brain in a MMI!</span> <a href=?src=\ref[src];reenter=1>(Click to enter)</a>"
-					ghost << sound('sound/effects/genetics.ogg')
+			B.notify_ghost_cloning("Someone has put your brain in a MMI!")
 		visible_message("[user] sticks \a [newbrain] into \the [src].")
 
 		brainmob = newbrain.brainmob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -946,6 +946,14 @@ var/list/slot_equipment_priority = list( \
 					return G
 				break
 
+/mob/proc/notify_ghost_cloning(var/message = "Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!", var/sound = 'sound/effects/genetics.ogg')
+	var/mob/dead/observer/ghost = get_ghost()
+	if(ghost)
+		ghost.notify_cloning(message, sound)
+		return ghost
+
+
+
 /mob/proc/adjustEarDamage()
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -223,7 +223,7 @@
 		M.adjustFireLoss(-0.5*REM)
 	..()
 	return
-	
+
 /datum/reagent/medicine/mine_salve
 	name = "Miner's Salve"
 	id = "mine_salve"
@@ -240,7 +240,7 @@
 	M.adjustFireLoss(-0.25*REM)
 	..()
 	return
-	
+
 /datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, volume, show_message = 1)
 	if(iscarbon(M))
 		if(method == TOUCH)
@@ -253,7 +253,7 @@
 			M.AdjustWeakened(2)
 	..()
 	return
-	
+
 /datum/reagent/medicine/mine_salve/on_mob_delete(mob/living/M)
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
@@ -650,11 +650,6 @@
 	..()
 	return
 
-/datum/reagent/medicine/strange_reagent/Topic(href, href_list)
-	if(href_list["reenter"])
-		var/mob/dead/observer/ghost = usr
-		if(istype(ghost))
-			ghost.reenter_corpse(ghost)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
@@ -669,14 +664,11 @@
 		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100)
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			return
-		var/mob/dead/observer/ghost = M.get_ghost()
 		M.visible_message("<span class='warning'>[M]'s body convulses a bit.</span>")
 		if(!M.suiciding && !(NOCLONE in M.mutations))
 			if(!M)
 				return
-			if(ghost)
-				ghost << "<span class='ghostalert'>Someone is trying to revive you. Re-enter your corpse if you want to be revived! <a href=?src=\ref[src];reenter=1>(Click to re-enter)</a></span>"
-				ghost << sound('sound/effects/genetics.ogg')
+			if(M.notify_ghost_cloning("Someone is trying to revive you. Re-enter your corpse if you want to be revived!"))
 				spawn (100) //so the ghost has time to re-enter
 					return
 			else

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -91,3 +91,4 @@ drovidicorv = Game Master
 Dunc = Game Master
 MMMiracles = Game Master
 bear1ake = Game Master
+CoreOverload = Game Master


### PR DESCRIPTION
Using mob.notify_ghost_cloning(message, sound) on any mob will tell mob's ghost to re-enter body. Works on ghosts themselves too.

Message and sound vars are optional, message defaults to "Your corpse has been placed into a cloning scanner. Re-enter your corpse if you want to be cloned!", sound defaults to genetics beep.
