### PR TITLE
Adds a proc to allow any /atom/movable to smoothly orbit an /atom

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1406,21 +1406,23 @@ B --><-- A
 		return
 	orbiting = A
 	var/angle = 0
+	var/matrix/initial_transform = matrix(transform)
 	spawn
 		while(orbiting)
 			loc = orbiting.loc
 
 			angle += angle_increment
 
-			var/matrix/shift = matrix()
+			var/matrix/shift = matrix(initial_transform)
 			shift.Translate(radius,0)
 			if(clockwise)
 				shift.Turn(angle)
 			else
 				shift.Turn(-angle)
-			transform = shift
+			animate(src,transform = shift,2)
 
 			sleep(0.6) //the effect breaks above 0.6 delay
+		animate(src,transform = initial_transform,2)
 
 
 /atom/movable/proc/stop_orbit()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1394,3 +1394,36 @@ B --><-- A
  B
 
 */
+
+
+/atom/movable/var/atom/orbiting = null
+//This is just so you can stop an orbit.
+//orbit() can run without it (swap orbiting for A)
+//but then you can never stop it and that's just silly.
+
+/atom/movable/proc/orbit(atom/A, radius = 10, clockwise = 1, angle_increment = 15)
+	if(!istype(A))
+		return
+	orbiting = A
+	var/angle = 0
+	spawn
+		while(orbiting)
+			loc = orbiting.loc
+
+			angle += angle_increment
+
+			var/matrix/shift = matrix()
+			shift.Translate(radius,0)
+			if(clockwise)
+				shift.Turn(angle)
+			else
+				shift.Turn(-angle)
+			transform = shift
+
+			sleep(0.6) //the effect breaks above 0.6 delay
+
+
+/atom/movable/proc/stop_orbit()
+	if(orbiting)
+		loc = get_turf(orbiting)
+		orbiting = null


### PR DESCRIPTION
- Adds `/atom/movable/proc/orbit()` a proc to allow any `/atom/movable` to orbit any `/atom`
- Adds `/atom/movable/proc/stop_orbit()` a proc to tell an orbiting `/atom/movable` to stop orbiting

Shouldn't lag because it's a while loop + client side matrices maths.
Correctly maintains any matrix operations that happened to the atom before it orbits, and resets back to it should the orbit stop.

Examples:
(These are produced by a loop calling the proc 100 times on 100 different circles objects)
1 - Generic Orbits, just lots of them:
![1](http://i.imgur.com/XbGV6Nc.gif)
2 - Orbits who's radius is the iterator `i` in the loop:
![2](http://i.imgur.com/lNVtsnI.gif)
3 - I left some broken code running, 1300 circles go:
![3](http://i.imgur.com/C0XQvjc.gif)
## It's MUCH smoother than this, but gifcam sucks ass.
