### PR TITLE
Removes some annoying inventory tetris with storages in storages

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -90,8 +90,8 @@
 			update_inv_r_hand(0)
 		return
 
-	// operate two levels deep here (item in backpack in src; NOT item in box in backpack in src)
-	if(!isturf(A) && A == loc || (A in contents) || (A.loc in contents))
+	// operate three levels deep here (item in backpack in src; item in box in backpack in src, not any deeper)
+	if(!isturf(A) && A == loc || (A in contents) || (A.loc in contents) || (A.loc && (A.loc.loc in contents)))
 		// No adjacency needed
 		if(W)
 			var/resolved = A.attackby(W,src)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -1,8 +1,8 @@
-// To clarify:
-// For use_to_pickup and allow_quick_gather functionality,
-// see item/attackby() (/game/objects/items.dm)
-// Do not remove this functionality without good reason, cough reagent_containers cough.
-// -Sayu
+// External storage-related logic:
+// /mob/proc/ClickOn() in /_onclick/click.dm - clicking items in storages
+// /mob/living/Move() in /modules/mob/living/living.dm - hiding storage boxes on mob movement
+// /item/attackby() in /game/objects/items.dm - use_to_pickup and allow_quick_gather functionality
+// -- c0
 
 
 /obj/item/weapon/storage
@@ -42,11 +42,11 @@
 			show_to(M)
 			return
 
-		if(!( M.restrained() ) && !( M.stat ))
-			if(!( istype(over_object, /obj/screen) ))
+		if(!M.restrained() && !M.stat)
+			if(!istype(over_object, /obj/screen))
 				return content_can_dump(over_object, M)
 
-			if(!(loc == usr) || (loc && loc.loc == usr))
+			if(loc != usr || (loc && loc.loc == usr))
 				return
 
 			playsound(loc, "rustle", 50, 1, -5)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -570,7 +570,8 @@ Sorry Giacom. Please don't be mad :(
 	else
 		stop_pulling()
 		. = ..()
-	if ((s_active && !( s_active in contents ) ))
+	if (s_active && !(s_active in contents) && !(s_active.loc in contents))
+		// It's ugly. But everything related to inventory/storage is. -- c0
 		s_active.close(src)
 
 	for(var/mob/living/simple_animal/slime/M in oview(1,src))


### PR DESCRIPTION
You can now take your gas mask from your box without the need to pull the box out of backpack.
- This is essential for two upcoming features: pockets in clothing and storage implant.
