### PR TITLE
Multiple medibots no longer cause overdosing.

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -485,7 +485,7 @@
 			"<span class='userdanger'>[src] is trying to inject you!</span>")
 
 		spawn(30)
-			if ((get_dist(src, patient) <= 1) && (on))
+			if ((get_dist(src, patient) <= 1) && (on) && assess_patient(patient)) //Must assess patient again to prevent overdose from stacked medibots, as THEY HUNT IN PACKS!!
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 						var/fraction = min(injection_amount/reagent_glass.reagents.total_volume, 1)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -485,7 +485,7 @@
 			"<span class='userdanger'>[src] is trying to inject you!</span>")
 
 		spawn(30)
-			if ((get_dist(src, patient) <= 1) && (on) && assess_patient(patient)) //Must assess patient again to prevent overdose from stacked medibots, as THEY HUNT IN PACKS!!
+			if ((get_dist(src, patient) <= 1) && (on) && assess_patient(patient))
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 						var/fraction = min(injection_amount/reagent_glass.reagents.total_volume, 1)
@@ -496,6 +496,8 @@
 				C.visible_message("<span class='danger'>[src] injects [patient] with its syringe!</span>", \
 					"<span class='userdanger'>[src] injects you with its syringe!</span>")
 				patient = null
+			else
+				visible_message("[src] retracts its syringe.")
 
 			mode = BOT_IDLE
 			updateicon()


### PR DESCRIPTION
- Medibots now re-assess the patient before dosing meds to avoid
  overdose injections.
- Fixes #10241.
