### PR TITLE
Minor Gang Tweaks

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -243,6 +243,7 @@ var/datum/subsystem/ticker/ticker
 				if("gang war") //Gang Domination (just show the override screen)
 					cinematic.icon_state = "intro_malf_still"
 					flick("intro_malf",cinematic)
+					sleep(70)
 				if("fake") //The round isn't over, we're just freaking people out for fun
 					flick("intro_nuke",cinematic)
 					sleep(35)

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -172,6 +172,10 @@
 		if (!tempgang.dom_attempts || !in_range(src, user) || !istype(src.loc, /turf))
 			return 0
 
+		var/area/A = get_area(loc)
+		var/locname = initial(A.name)
+		priority_announce("Network breach detected in [locname]. The [gang.name] Gang is attempting to seize control of the station!","Network Alert")
+
 		gang = tempgang
 		gang.dom_attempts --
 		gang.domination()
@@ -179,9 +183,7 @@
 		healthcheck(0)
 		operating = 1
 		SSmachine.processing += src
-		var/area/A = get_area(loc)
-		var/locname = initial(A.name)
-		priority_announce("Network breach detected in [locname]. The [gang.name] Gang is attempting to seize control of the station!","Network Alert")
+
 		gang.message_gangtools("Hostile takeover in progress: Estimated [time] minutes until victory.[gang.dom_attempts ? "" : " This is your final attempt."]")
 		for(var/datum/gang/G in ticker.mode.gangs)
 			if(G != gang)


### PR DESCRIPTION
- Ads delay to gang victory printout. Gives the cinematic time to finish first.
- Centcom announcement comes before alert change when a domination begins.
