### PR TITLE
Projectile blocking fixes

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -153,7 +153,7 @@
 /mob/living/silicon/bullet_act(obj/item/projectile/Proj)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		adjustBruteLoss(Proj.damage)
-	Proj.on_hit(src,2)
+	Proj.on_hit(src)
 	return 2
 
 /mob/living/silicon/apply_effect(effect = 0,effecttype = STUN, blocked = 0)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -61,7 +61,7 @@
 		return
 	if(Proj.damage_type == BURN || Proj.damage_type == BRUTE)
 		adjustBruteLoss(Proj.damage)
-	Proj.on_hit(src, 0)
+	Proj.on_hit(src)
 	return 0
 
 /mob/living/simple_animal/construct/narsie_act()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -254,7 +254,7 @@
 	if(!Proj)
 		return
 	apply_damage(Proj.damage, Proj.damage_type)
-	Proj.on_hit(src, 0)
+	Proj.on_hit(src)
 	return 0
 
 /mob/living/simple_animal/adjustFireLoss(amount)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -167,7 +167,7 @@
 	attacked += 10
 	if((Proj.damage_type == BURN))
 		adjustBruteLoss(-abs(Proj.damage)) //fire projectiles heals slimes.
-		Proj.on_hit(src, 0)
+		Proj.on_hit(src)
 	else
 		..(Proj)
 	return 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -60,19 +60,20 @@
 	if(!isliving(target))
 		return 0
 	var/mob/living/L = target
-
-	var/organ_hit_text = ""
-	if(L.has_limbs)
-		organ_hit_text = " in \the [parse_zone(def_zone)]"
-	if(suppressed)
-		playsound(loc, hitsound, 5, 1, -1)
-		L << "<span class='userdanger'>You're shot by \a [src][organ_hit_text]!</span>"
-	else
-		if(hitsound)
-			var/volume = vol_by_damage()
-			playsound(loc, hitsound, volume, 1, -1)
-		L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
-							"<span class='userdanger'>[L] is hit by \a [src][organ_hit_text]!</span>")	//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+	if(blocked != 100) // not completely blocked
+		var/organ_hit_text = ""
+		if(L.has_limbs)
+			organ_hit_text = " in \the [parse_zone(def_zone)]"
+		if(suppressed)
+			playsound(loc, hitsound, 5, 1, -1)
+			L << "<span class='userdanger'>You're shot by \a [src][organ_hit_text]!</span>"
+		else
+			if(hitsound)
+				var/volume = vol_by_damage()
+				playsound(loc, hitsound, volume, 1, -1)
+			L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
+								"<span class='userdanger'>[L] is hit by \a [src][organ_hit_text]!</span>")	//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
+		L.on_hit(type)
 
 	var/reagent_note
 	if(reagents && reagents.reagent_list)
@@ -81,7 +82,6 @@
 			reagent_note += R.id + " ("
 			reagent_note += num2text(R.volume) + ") "
 
-	L.on_hit(type)
 	add_logs(firer, L, "shot", src, reagent_note)
 	return L.apply_effects(stun, weaken, paralyze, irradiate, stutter, slur, eyeblur, drowsy, blocked, stamina, jitter)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -125,19 +125,19 @@
 	create_reagents(50)
 
 /obj/item/projectile/bullet/dart/on_hit(atom/target, blocked = 0, hit_zone)
-	var/deflect = 0
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
-		if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
-			..()
-			reagents.trans_to(M, reagents.total_volume)
-			return 1
-		else
-			deflect = 1
-			target.visible_message("<span class='danger'>The [name] was deflected!</span>", \
-								   "<span class='userdanger'>You were protected against the [name]!</span>")
-	if(!deflect)
-		..()
+		if(blocked != 100) // not completely blocked
+			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+				..()
+				reagents.trans_to(M, reagents.total_volume)
+				return 1
+			else
+				blocked = 100
+				target.visible_message("<span class='danger'>The [name] was deflected!</span>", \
+									   "<span class='userdanger'>You were protected against the [name]!</span>")
+
+	..(target, blocked, hit_zone)
 	flags &= ~NOREACT
 	reagents.handle_reactions()
 	return 1

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -22,7 +22,6 @@
 	damage = 10
 	damage_type = BRUTE
 	nodamage = 0
-	flag = "magic"
 
 /obj/item/projectile/magic/fireball/Range()
 	var/mob/living/L = locate(/mob/living) in (range(src, 1) - firer)
@@ -45,7 +44,6 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	flag = "magic"
 
 /obj/item/projectile/magic/resurrection/on_hit(mob/living/carbon/target)
 	. = ..()
@@ -69,7 +67,6 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	flag = "magic"
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
@@ -93,7 +90,6 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	flag = "magic"
 
 /obj/item/projectile/magic/door/on_hit(atom/target)
 	. = ..()
@@ -114,7 +110,6 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = 1
-	flag = "magic"
 
 /obj/item/projectile/magic/change/on_hit(atom/change)
 	. = ..()
@@ -257,7 +252,6 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = 1
-	flag = "magic"
 
 /obj/item/projectile/magic/animate/Bump(atom/change)
 	..()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -25,7 +25,6 @@
 	name ="explosive bolt"
 	icon_state= "bolter"
 	damage = 50
-	flag = "bullet"
 
 /obj/item/projectile/bullet/gyro/on_hit(atom/target, blocked = 0)
 	..()
@@ -37,7 +36,6 @@
 	desc = "USE A WEEL GUN"
 	icon_state= "bolter"
 	damage = 60
-	flag = "bullet"
 
 /obj/item/projectile/bullet/a40mm/on_hit(atom/target, blocked = 0)
 	..()


### PR DESCRIPTION
- Removes some unneeded code(flag = "magic" when already inheriting it from parent, adding a 0 argument to on_hit when it already defaults to 0).
- Fixes syringe dart not respecting shield blocking. Fixes #10969 
- Projectile doesn't show the hit message anymore if 100% blocked (shield blocking mostly) so you only get the block message. (but the hit is still logged)
- Fixes deflected dart projectiles not being logged.
