### PR TITLE
A stupid lazy fix but a needed fix. 

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -6,56 +6,54 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 	var/muzzled = is_muzzled()
 	var/m_type = 1
 	var/message
 
 	switch(act) //Alphabetical please
-		if ("deathgasp")
+		if ("deathgasp","deathgasps")
 			message = "<span class='name'>[src]</span> lets out a waning guttural screech, green blood bubbling from its maw..."
 			m_type = 2
 
-		if ("gnarl")
+		if ("gnarl","gnarls")
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> gnarls and shows its teeth.."
 				m_type = 2
 
-		if ("his")
+		if ("hiss","hisses")
 			if(!muzzled)
 				message = "<span class='name'>[src]</span> hisses."
 				m_type = 2
 
-		if ("moan")
+		if ("moan","moans")
 			message = "<span class='name'>[src]</span> moans!"
 			m_type = 2
 
-		if ("roar")
+		if ("roar","roars")
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> roars."
 				m_type = 2
 
-		if ("roll")
+		if ("roll","rolls")
 			if (!src.restrained())
 				message = "<span class='name'>[src]</span> rolls."
 				m_type = 1
 
-		if ("scratch")
+		if ("scratch","scratches")
 			if (!src.restrained())
 				message = "<span class='name'>[src]</span> scratches."
 				m_type = 1
 
-		if ("scretch")
+		if ("screech","screeches")
 			if (!muzzled)
-				message = "<span class='name'>[src]</span> scretches."
+				message = "<span class='name'>[src]</span> screeches."
 				m_type = 2
 
-		if ("shiver")
+		if ("shiver","shivers")
 			message = "<span class='name'>[src]</span> shivers."
 			m_type = 2
 
-		if ("sign")
+		if ("sign","signs")
 			if (!src.restrained())
 				message = text("<span class='name'>[src]</span> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
 				m_type = 1
@@ -65,7 +63,7 @@
 			m_type = 1
 
 		if ("help") //This is an exception
-			src << "Help for xenomorph emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow, burp, choke, chucke, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, gnarl, hiss, jump, laugh, look-atom, me, moan, nod, point-atom, roar, roll, scream, scratch, scretch, shake, shiver, sign-#, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tail, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
+			src << "Help for xenomorph emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow, burp, choke, chucke, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, giggle, glare-(none)/mob, gnarl, hiss, jump, laugh, look-atom, me, moan, nod, point-atom, roar, roll, scream, scratch, screech, shake, shiver, sign-#, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tail, tremble, twitch, twitch_s, wave, whimper, wink, yawn"
 
 		else
 			..(act)

--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -22,7 +22,7 @@
 				message = "<span class='name'>[src]</span> gnarls and shows its teeth.."
 				m_type = 2
 
-		if ("hiss")
+		if ("his")
 			if(!muzzled)
 				message = "<span class='name'>[src]</span> hisses."
 				m_type = 2

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -38,7 +38,7 @@
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> gnarls and shows its teeth.."
 				m_type = 2
-		if ("hiss")
+		if ("his")
 			message = "<span class='name'>[src]</span> hisses softly."
 			m_type = 1
 		if ("jump")

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -6,83 +6,81 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 	var/muzzled = is_muzzled()
 	var/m_type = 1
 	var/message
 
 	switch(act) //Alphabetically sorted please.
-		if ("burp")
+		if ("burp","burps")
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> burps."
 				m_type = 2
-		if ("choke")
+		if ("choke","chokes")
 			message = "<span class='name'>[src]</span> chokes."
 			m_type = 2
-		if ("collapse")
+		if ("collapse","collapses")
 			Paralyse(2)
 			message = "<span class='name'>[src]</span> collapses!"
 			m_type = 2
-		if ("dance")
+		if ("dance","dances")
 			if (!src.restrained())
 				message = "<span class='name'>[src]</span> dances around happily."
 				m_type = 1
-		if ("drool")
+		if ("drool","drools")
 			message = "<span class='name'>[src]</span> drools."
 			m_type = 1
-		if ("gasp")
+		if ("gasp","gasps")
 			message = "<span class='name'>[src]</span> gasps."
 			m_type = 2
-		if ("gnarl")
+		if ("gnarl","gnarls")
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> gnarls and shows its teeth.."
 				m_type = 2
-		if ("his")
+		if ("hiss","hisses")
 			message = "<span class='name'>[src]</span> hisses softly."
 			m_type = 1
-		if ("jump")
+		if ("jump","jumps")
 			message = "<span class='name'>[src]</span> jumps!"
 			m_type = 1
-		if ("moan")
+		if ("moan","moans")
 			message = "<span class='name'>[src]</span> moans!"
 			m_type = 2
-		if ("nod")
+		if ("nod","nods")
 			message = "<span class='name'>[src]</span> nods its head."
 			m_type = 1
-//		if ("roar")
-//			if (!muzzled)
-//				message = "<span class='name'>[src]</span> roars." Commenting out since larva shouldn't roar /N
-//				m_type = 2
-		if ("roll")
+		if ("roar","roars")
+			if (!muzzled)
+				message = "<span class='name'>[src]</span> softly roars."
+				m_type = 2
+		if ("roll","rolls")
 			if (!src.restrained())
 				message = "<span class='name'>[src]</span> rolls."
 				m_type = 1
-		if ("scratch")
+		if ("scratch","scratches")
 			if (!src.restrained())
 				message = "<span class='name'>[src]</span> scratches."
 				m_type = 1
-		if ("scretch")
+		if ("screech","screeches") //This orignally was called scretch, changing it. -Sum99
 			if (!muzzled)
-				message = "<span class='name'>[src]</span> scretches."
+				message = "<span class='name'>[src]</span> screeches."
 				m_type = 2
-		if ("shake")
+		if ("shake","shakes")
 			message = "<span class='name'>[src]</span> shakes its head."
 			m_type = 1
-		if ("shiver")
+		if ("shiver","shivers")
 			message = "<span class='name'>[src]</span> shivers."
 			m_type = 2
-		if ("sign")
+		if ("sign","signs")
 			if (!src.restrained())
 				message = text("<span class='name'>[src]</span> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
 				m_type = 1
-		if ("snore")
+		if ("snore","snores")
 			message = "<B>[src]</B> snores."
 			m_type = 2
-		if ("sulk")
+		if ("sulk","sulks")
 			message = "<span class='name'>[src]</span> sulks down sadly."
 			m_type = 1
-		if ("sway")
+		if ("sway","sways")
 			message = "<span class='name'>[src]</span> sways around dizzily."
 			m_type = 1
 		if ("tail")
@@ -91,13 +89,13 @@
 		if ("twitch")
 			message = "<span class='name'>[src]</span> twitches violently."
 			m_type = 1
-		if ("whimper")
+		if ("whimper","whimpers")
 			if (!muzzled)
 				message = "<span class='name'>[src]</span> whimpers."
 				m_type = 2
 
 		if ("help") //"The exception"
-			src << "Help for larva emotes. You can use these emotes with say \"*emote\":\n\nburp, choke, collapse, dance, drool, gasp, gnarl, hiss, jump, moan, nod, roll, scratch,\nscretch, shake, shiver, sign-#, sulk, sway, tail, twitch, whimper"
+			src << "Help for larva emotes. You can use these emotes with say \"*emote\":\n\nburp, choke, collapse, dance, drool, gasp, gnarl, hiss, jump, moan, nod, roll, roar, scratch, screech, shake, shiver, sign-#, sulk, sway, tail, twitch, whimper"
 
 		else
 			src << "<span class='info'>Unusable emote '[act]'. Say *help for a list.</span>"

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -6,8 +6,6 @@
 		var/t1 = findtext(act, "-", 1, null)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	if(src.stat == DEAD)
 		return
@@ -22,16 +20,16 @@
 			message = "<B>[src]</B> lets out a distressed noise."
 			m_type = 2
 
-		if ("beep")
+		if ("beep","beeps")
 			src << "You beep."
 			message = "<B>[src]</B> beeps."
 			m_type = 2
 
-		if ("blink")
+		if ("blink","blinks")
 			message = "<B>[src]</B> blinks."
 			m_type = 1
 
-		if ("boop")
+		if ("boop","boops")
 			src << "You boop."
 			message = "<B>[src]</B> boops."
 			m_type = 2
@@ -45,7 +43,7 @@
 			message = "<B>[src]</B> plays a loud tone."
 			m_type = 2
 
-		if ("whistle")
+		if ("whistle","whistles")
 			src << "You whistle."
 			message = "<B>[src]</B> whistles."
 			m_type = 2

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -10,9 +10,6 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
-
 	var/muzzled = is_muzzled()
 	//var/m_type = 1
 
@@ -27,7 +24,7 @@
 				message = "<B>[src]</B> is strumming the air and headbanging like a safari chimp."
 				m_type = 1
 
-		if ("blink")
+		if ("blink","blinks")
 			message = "<B>[src]</B> blinks."
 			m_type = 1
 
@@ -35,11 +32,11 @@
 			message = "<B>[src]</B> blinks rapidly."
 			m_type = 1
 
-		if ("blush")
+		if ("blush","blushes")
 			message = "<B>[src]</B> blushes."
 			m_type = 1
 
-		if ("bow")
+		if ("bow","bows")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -55,117 +52,117 @@
 					message = "<B>[src]</B> bows."
 			m_type = 1
 
-		if ("burp")
+		if ("burp","burps")
 			if (!muzzled)
 				..(act)
 
-		if ("choke")
+		if ("choke","chokes")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a strong noise."
 				m_type = 2
 
-		if ("chuckle")
+		if ("chuckle","chuckles")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
 
-		if ("clap")
+		if ("clap","claps")
 			if (!src.restrained())
 				message = "<B>[src]</B> claps."
 				m_type = 2
 
-		if ("cough")
+		if ("cough","coughs")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a strong noise."
 				m_type = 2
 
-		if ("deathgasp")
+		if ("deathgasp","deathgasps")
 			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
 			m_type = 1
 
-		if ("flap")
+		if ("flap","flaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps \his wings."
 				m_type = 2
 
-		if ("gasp")
+		if ("gasp","gasps")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a weak noise."
 				m_type = 2
 
-		if ("giggle")
+		if ("giggle","giggles")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
 
-		if ("laugh")
+		if ("laugh","laughs")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 
-		if ("nod")
+		if ("nod","nods")
 			message = "<B>[src]</B> nods."
 			m_type = 1
 
-		if ("scream")
+		if ("scream","screams")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a very loud noise."
 				m_type = 2
 
-		if ("shake")
+		if ("shake","shakes")
 			message = "<B>[src]</B> shakes \his head."
 			m_type = 1
 
-		if ("sneeze")
+		if ("sneeze","sneezes")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a strange noise."
 				m_type = 2
 
-		if ("sigh")
+		if ("sigh","sighs")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> sighs."
 				m_type = 2
 
-		if ("sniff")
+		if ("sniff","sniffs")
 			message = "<B>[src]</B> sniffs."
 			m_type = 2
 
-		if ("snore")
+		if ("snore","snores")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a noise."
 				m_type = 2
 
-		if ("whimper")
+		if ("whimper","whimpers")
 			if (!muzzled)
 				..(act)
 			else
 				message = "<B>[src]</B> makes a weak noise."
 				m_type = 2
 
-		if ("wink")
+		if ("wink","winks")
 			message = "<B>[src]</B> winks."
 			m_type = 1
 
-		if ("yawn")
+		if ("yawn","yawns")
 			if (!muzzled)
 				..(act)
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -6,8 +6,6 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	var/muzzled = is_muzzled()
 	//var/m_type = 1
@@ -28,29 +26,29 @@
 				message = "<B>[src]</B> flaps \his wings ANGRILY!"
 				m_type = 2
 
-		if ("choke")
+		if ("choke","chokes")
 			if (miming)
 				message = "<B>[src]</B> clutches \his throat desperately!"
 			else
 				..(act)
 
-		if ("chuckle")
+		if ("chuckle","chuckles")
 			if(miming)
 				message = "<B>[src]</B> appears to chuckle."
 			else
 				..(act)
 
-		if ("clap")
+		if ("clap","claps")
 			if (!src.restrained())
 				message = "<B>[src]</B> claps."
 				m_type = 2
 
-		if ("collapse")
+		if ("collapse","collapses")
 			Paralyse(2)
 			message = "<B>[src]</B> collapses!"
 			m_type = 2
 
-		if ("cough")
+		if ("cough","coughs")
 			if (miming)
 				message = "<B>[src]</B> appears to cough!"
 			else
@@ -61,7 +59,7 @@
 					message = "<B>[src]</B> makes a strong noise."
 					m_type = 2
 
-		if ("cry")
+		if ("cry","crys","cries") //I feel bad if people put s at the end of cry. -Sum99
 			if (miming)
 				message = "<B>[src]</B> cries."
 			else
@@ -101,7 +99,7 @@
 					return
 				message = "<B>[src]</B> [input]"
 
-		if ("dap")
+		if ("dap","daps")
 			m_type = 1
 			if (!src.restrained())
 				var/M = null
@@ -119,24 +117,24 @@
 			message = "<B>[src]</B> raises an eyebrow."
 			m_type = 1
 
-		if ("flap")
+		if ("flap","flaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps \his wings."
 				m_type = 2
 
-		if ("gasp")
+		if ("gasp","gasps")
 			if (miming)
 				message = "<B>[src]</B> appears to be gasping!"
 			else
 				..(act)
 
-		if ("giggle")
+		if ("giggle","giggles")
 			if (miming)
 				message = "<B>[src]</B> giggles silently!"
 			else
 				..(act)
 
-		if ("groan")
+		if ("groan","groans")
 			if (miming)
 				message = "<B>[src]</B> appears to groan!"
 			else
@@ -147,7 +145,7 @@
 					message = "<B>[src]</B> makes a loud noise."
 					m_type = 2
 
-		if ("grumble")
+		if ("grumble","grumbles")
 			if (!muzzled)
 				message = "<B>[src]</B> grumbles!"
 			else
@@ -171,7 +169,7 @@
 					else
 						message = "<B>[src]</B> holds out \his hand to [M]."
 
-		if ("hug")
+		if ("hug","hugs")
 			m_type = 1
 			if (!src.restrained())
 				var/M = null
@@ -215,14 +213,14 @@
 			else
 				message = "<B>[src]</B> [message]"
 
-		if ("moan")
+		if ("moan","moans")
 			if(miming)
 				message = "<B>[src]</B> appears to moan!"
 			else
 				message = "<B>[src]</B> moans!"
 				m_type = 2
 
-		if ("mumble")
+		if ("mumble","mumbles")
 			message = "<B>[src]</B> mumbles!"
 			m_type = 2
 
@@ -235,7 +233,7 @@
 				message = "<B>[src]</B> raises a hand."
 			m_type = 1
 
-		if ("salute")
+		if ("salute","salutes")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -251,27 +249,27 @@
 					message = "<B>[src]</b> salutes."
 			m_type = 1
 
-		if ("scream")
+		if ("scream","screams")
 			if (miming)
 				message = "<B>[src]</B> acts out a scream!"
 			else
 				..(act)
 
-		if ("shiver")
+		if ("shiver","shivers")
 			message = "<B>[src]</B> shivers."
 			m_type = 1
 
-		if ("shrug")
+		if ("shrug","shrugs")
 			message = "<B>[src]</B> shrugs."
 			m_type = 1
 
-		if ("sigh")
+		if ("sigh","sighs")
 			if(miming)
 				message = "<B>[src]</B> sighs."
 			else
 				..(act)
 
-		if ("signal")
+		if ("signal","signals")
 			if (!src.restrained())
 				var/t1 = round(text2num(param))
 				if (isnum(t1))
@@ -281,34 +279,34 @@
 						message = "<B>[src]</B> raises [t1] finger\s."
 			m_type = 1
 
-		if ("sneeze")
+		if ("sneeze","sneezes")
 			if (miming)
 				message = "<B>[src]</B> sneezes."
 			else
 				..(act)
 
-		if ("sniff")
+		if ("sniff","sniffs")
 			message = "<B>[src]</B> sniffs."
 			m_type = 2
 
-		if ("snore")
+		if ("snore","snores")
 			if (miming)
 				message = "<B>[src]</B> sleeps soundly."
 			else
 				..(act)
 
-		if ("whimper")
+		if ("whimper","whimpers")
 			if (miming)
 				message = "<B>[src]</B> appears hurt."
 			else
 				..(act)
 
-		if ("yawn")
+		if ("yawn","yawns")
 			if (!muzzled)
 				message = "<B>[src]</B> yawns."
 				m_type = 2
 
-		if("wag")
+		if("wag","wags")
 			if(dna && dna.species && (("tail_lizard" in dna.species.mutant_bodyparts) || (features["tail_human"] != "None")))
 				message = "<B>[src]</B> wags \his tail."
 				startTailWag()

--- a/code/modules/mob/living/carbon/monkey/emote.dm
+++ b/code/modules/mob/living/carbon/monkey/emote.dm
@@ -6,19 +6,17 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	var/muzzled = is_muzzled()
 	var/m_type = 1
 	var/message
 
 	switch(act) //Ooh ooh ah ah keep this alphabetical ooh ooh ah ah!
-		if ("deathgasp")
+		if ("deathgasp","deathgasps")
 			message = "<b>[src]</b> lets out a faint chimper as it collapses and stops moving..."
 			m_type = 1
 
-		if ("gnarl")
+		if ("gnarl","gnarls")
 			if (!muzzled)
 				message = "<B>[src]</B> gnarls and shows its teeth.."
 				m_type = 2
@@ -28,35 +26,35 @@
 				message = "<B>[src]</B> flails its paw."
 				m_type = 1
 
-		if ("moan")
+		if ("moan","moans")
 			message = "<B>[src]</B> moans!"
 			m_type = 2
 
-		if ("roar")
+		if ("roar","roars")
 			if (!muzzled)
 				message = "<B>[src]</B> roars."
 				m_type = 2
 
-		if ("roll")
+		if ("roll","rolls")
 			if (!src.restrained())
 				message = "<B>[src]</B> rolls."
 				m_type = 1
 
-		if ("scratch")
+		if ("scratch","scratches")
 			if (!src.restrained())
 				message = "<B>[src]</B> scratches."
 				m_type = 1
 
-		if ("scretch")
+		if ("screech","screeches")
 			if (!muzzled)
-				message = "<B>[src]</B> scretches."
+				message = "<B>[src]</B> screeches."
 				m_type = 2
 
-		if ("shiver")
+		if ("shiver","shivers")
 			message = "<B>[src]</B> shivers."
 			m_type = 2
 
-		if ("sign")
+		if ("sign","signs")
 			if (!src.restrained())
 				message = text("<B>[src]</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
 				m_type = 1
@@ -66,7 +64,7 @@
 			m_type = 1
 
 		if ("help") //Ooh ah ooh ooh this is an exception to alphabetical ooh ooh.
-			src << "Help for monkey emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, gnarl, giggle, glare-(none)/mob, grin, jump, laugh, look, me, moan, nod, paw, point-(atom), roar, roll, scream, scratch, scretch, shake, shiver, sigh, sign-#, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tail, tremble, twitch, twitch_s, wave whimper, wink, yawn"
+			src << "Help for monkey emotes. You can use these emotes with say \"*emote\":\n\naflap, airguitar, blink, blink_r, blush, bow-(none)/mob, burp, choke, chuckle, clap, collapse, cough, dance, deathgasp, drool, flap, frown, gasp, gnarl, giggle, glare-(none)/mob, grin, jump, laugh, look, me, moan, nod, paw, point-(atom), roar, roll, scream, scratch, screech, shake, shiver, sigh, sign-#, sit, smile, sneeze, sniff, snore, stare-(none)/mob, sulk, sway, tail, tremble, twitch, twitch_s, wave whimper, wink, yawn"
 
 		else
 			..(act)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -8,13 +8,10 @@
 
 	var/param = null
 
-	if (findtext(act, "-", 1, null))
+	if (findtext(act, "-", 1, null)) //Removes dashes for npcs "EMOTE-PLAYERNAME" or something like that, I ain't no AI coder. It's not for players. -Sum99
 		var/t1 = findtext(act, "-", 1, null)
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
-
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	switch(act)//Hello, how would you like to order? Alphabetically!
 		if ("aflap")
@@ -22,11 +19,11 @@
 				message = "<B>[src]</B> flaps its wings ANGRILY!"
 				m_type = 2
 
-		if ("blush")
+		if ("blush","blushes")
 			message = "<B>[src]</B> blushes."
 			m_type = 1
 
-		if ("bow")
+		if ("bow","bows")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -42,70 +39,70 @@
 					message = "<B>[src]</B> bows."
 			m_type = 1
 
-		if ("burp")
+		if ("burp","burps")
 			message = "<B>[src]</B> burps."
 			m_type = 2
 
-		if ("choke")
+		if ("choke","chokes")
 			message = "<B>[src]</B> chokes!"
 			m_type = 2
 
-		if ("chuckle")
+		if ("chuckle","chuckles")
 			message = "<B>[src]</B> chuckles."
 			m_type = 2
 
-		if ("collapse")
+		if ("collapse","collapses")
 			Paralyse(2)
 			message = "<B>[src]</B> collapses!"
 			m_type = 2
 
-		if ("cough")
+		if ("cough","coughs")
 			message = "<B>[src]</B> coughs!"
 			m_type = 2
 
-		if ("dance")
+		if ("dance","dances")
 			if (!src.restrained())
 				message = "<B>[src]</B> dances around happily."
 				m_type = 1
 
-		if ("deathgasp")
+		if ("deathgasp","deathgasps")
 			message = "<B>[src]</B> seizes up and falls limp, its eyes dead and lifeless..."
 			m_type = 1
 
-		if ("drool")
+		if ("drool","drools")
 			message = "<B>[src]</B> drools."
 			m_type = 1
 
-		if ("faint")
+		if ("faint","faints")
 			message = "<B>[src]</B> faints."
 			if(src.sleeping)
 				return //Can't faint while asleep
 			src.sleeping += 10 //Short-short nap
 			m_type = 1
 
-		if ("flap")
+		if ("flap","flaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps its wings."
 				m_type = 2
 
-		if ("flip")
+		if ("flip","flips")
 			if (!src.restrained() || !src.resting || !src.sleeping)
 				src.SpinAnimation(7,1)
 				m_type = 2
 
-		if ("frown")
+		if ("frown","frowns")
 			message = "<B>[src]</B> frowns."
 			m_type = 1
 
-		if ("gasp")
+		if ("gasp","gasps")
 			message = "<B>[src]</B> gasps!"
 			m_type = 2
 
-		if ("giggle")
+		if ("giggle","giggles")
 			message = "<B>[src]</B> giggles."
 			m_type = 2
 
-		if ("glare")
+		if ("glare","glares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -119,19 +116,19 @@
 			else
 				message = "<B>[src]</B> glares."
 
-		if ("grin")
+		if ("grin","grins")
 			message = "<B>[src]</B> grins."
 			m_type = 1
 
-		if ("jump")
+		if ("jump","jumps")
 			message = "<B>[src]</B> jumps!"
 			m_type = 1
 
-		if ("laugh")
+		if ("laugh","laughs")
 			message = "<B>[src]</B> laughs."
 			m_type = 2
 
-		if ("look")
+		if ("look","looks")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -158,11 +155,11 @@
 			else
 				message = "<B>[src]</B> [message]"
 
-		if ("nod")
+		if ("nod","nods")
 			message = "<B>[src]</B> nods."
 			m_type = 1
 
-		if ("point")
+		if ("point","points")
 			if (!src.restrained())
 				var/atom/M = null
 				if (param)
@@ -176,39 +173,39 @@
 					pointed(M)
 			m_type = 1
 
-		if ("scream")
+		if ("scream","screams")
 			message = "<B>[src]</B> screams!"
 			m_type = 2
 
-		if ("shake")
+		if ("shake","shakes")
 			message = "<B>[src]</B> shakes its head."
 			m_type = 1
 
-		if ("sigh")
+		if ("sigh","sighs")
 			message = "<B>[src]</B> sighs."
 			m_type = 2
 
-		if ("sit")
+		if ("sit","sits")
 			message = "<B>[src]</B> sits down."
 			m_type = 1
 
-		if ("smile")
+		if ("smile","smiles")
 			message = "<B>[src]</B> smiles."
 			m_type = 1
 
-		if ("sneeze")
+		if ("sneeze","sneezes")
 			message = "<B>[src]</B> sneezes."
 			m_type = 2
 
-		if ("sniff")
+		if ("sniff","sniffs")
 			message = "<B>[src]</B> sniffs."
 			m_type = 2
 
-		if ("snore")
+		if ("snore","snores")
 			message = "<B>[src]</B> snores."
 			m_type = 2
 
-		if ("stare")
+		if ("stare","stares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -222,19 +219,19 @@
 			else
 				message = "<B>[src]</B> stares."
 
-		if ("sulk")
+		if ("sulk","sulks")
 			message = "<B>[src]</B> sulks down sadly."
 			m_type = 1
 
-		if ("sway")
+		if ("sway","sways")
 			message = "<B>[src]</B> sways around dizzily."
 			m_type = 1
 
-		if ("tremble")
+		if ("tremble","trembles")
 			message = "<B>[src]</B> trembles in fear!"
 			m_type = 1
 
-		if ("twitch")
+		if ("twitch","twitches")
 			message = "<B>[src]</B> twitches violently."
 			m_type = 1
 
@@ -242,15 +239,15 @@
 			message = "<B>[src]</B> twitches."
 			m_type = 1
 
-		if ("wave")
+		if ("wave","waves")
 			message = "<B>[src]</B> waves."
 			m_type = 1
 
-		if ("whimper")
+		if ("whimper","whimpers")
 			message = "<B>[src]</B> whimpers."
 			m_type = 2
 
-		if ("yawn")
+		if ("yawn","yawns")
 			message = "<B>[src]</B> yawns."
 			m_type = 2
 

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -5,8 +5,6 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	switch(act)//01000001011011000111000001101000011000010110001001100101011101000110100101111010011001010110010000100001 (Seriously please keep it that way.)
 		if ("aflap")
@@ -15,7 +13,7 @@
 				m_type = 2
 			m_type = 1
 
-		if("beep")
+		if("beep","beeps")
 			var/M = null
 			if(param)
 				for (var/mob/A in view(1, src))
@@ -32,7 +30,7 @@
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 2
 
-		if ("bow")
+		if ("bow","bows")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -70,12 +68,12 @@
 			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
 			m_type = 2
 
-		if ("chime") //You have mail!
+		if ("chime","chimes") //You have mail!
 			message = "<B>[src]</B> chimes."
 			playsound(loc, 'sound/machines/chime.ogg', 50, 0)
 			m_type = 2
 
-		if ("clap")
+		if ("clap","claps")
 			if (!src.restrained())
 				message = "<B>[src]</B> claps."
 				m_type = 2
@@ -94,16 +92,16 @@
 				return
 			message = "<B>[src]</B> [input]"
 
-		if ("deathgasp")
+		if ("deathgasp","deathgasps")
 			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
 			m_type = 1
 
-		if ("flap")
+		if ("flap","flaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps \his wings."
 				m_type = 2
 
-		if ("glare")
+		if ("glare","glares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -117,12 +115,12 @@
 			else
 				message = "<B>[src]</B> glares."
 
-		if ("honk") //Honk!
+		if ("honk","honks") //Honk!
 			message = "<B>[src]</B> honks!"
 			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
 			m_type = 2
 
-		if ("look")
+		if ("look","looks")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -150,11 +148,11 @@
 			else
 				message = "<B>[src]</B> [message]"
 
-		if ("nod")
+		if ("nod","nods")
 			message = "<B>[src]</B> nods."
 			m_type = 1
 
-		if ("ping")
+		if ("ping","pings")
 			var/M = null
 			if(param)
 				for (var/mob/A in view(1, src))
@@ -175,7 +173,7 @@
 			playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 0)
 			m_type = 2
 
-		if ("salute")
+		if ("salute","salutes")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -191,7 +189,7 @@
 				else
 					message = "<B>[src]</b> salutes."
 
-		if ("stare")
+		if ("stare","stares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(1, src))
@@ -206,7 +204,7 @@
 				message = "<B>[src]</B> stares."
 			m_type = 1
 
-		if ("twitch")
+		if ("twitch","twitches")
 			message = "<B>[src]</B> twitches violently."
 			m_type = 1
 

--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -6,43 +6,41 @@
 		//param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
 
 	var/m_type = 1
 	var/regenerate_icons
 	var/message
 
 	switch(act) //Alphabetical please
-		if("bounce")
+		if("bounce","bounces")
 			message = "<B>The [src.name]</B> bounces in place."
 			m_type = 1
 
-		if("jiggle")
+		if("jiggle","jiggles")
 			message = "<B>The [src.name]</B> jiggles!"
 			m_type = 1
 
-		if("light")
+		if("light","lights")
 			message = "<B>The [src.name]</B> lights up for a bit, then stops."
 			m_type = 1
 
-		if("moan")
+		if("moan","moans")
 			message = "<B>The [src.name]</B> moans."
 			m_type = 2
 
-		if("shiver")
+		if("shiver","shivers")
 			message = "<B>The [src.name]</B> shivers."
 			m_type = 2
 
-		if("sway")
+		if("sway","sways")
 			message = "<B>The [src.name]</B> sways around dizzily."
 			m_type = 1
 
-		if("twitch")
+		if("twitch","twitches")
 			message = "<B>The [src.name]</B> twitches."
 			m_type = 1
 
-		if("vibrate")
+		if("vibrate","vibrates")
 			message = "<B>The [src.name]</B> vibrates!"
 			m_type = 1
 
@@ -50,7 +48,7 @@
 			mood = null
 			regenerate_icons = 1
 
-		if("smile")
+		if("smile","smiles")
 			mood = "mischevous"
 			regenerate_icons = 1
 
@@ -58,15 +56,15 @@
 			mood = ":33"
 			regenerate_icons = 1
 
-		if("pout")
+		if("pout","pouts")
 			mood = "pout"
 			regenerate_icons = 1
 
-		if("frown")
+		if("frown","frowns")
 			mood = "sad"
 			regenerate_icons = 1
 
-		if("scowl")
+		if("scowl","scowls")
 			mood = "angry"
 			regenerate_icons = 1
 

--- a/html/changelogs/Summoners99-hisssss.yml
+++ b/html/changelogs/Summoners99-hisssss.yml
@@ -1,0 +1,8 @@
+author: Summoner99
+  
+delete-after: True
+
+changes: 
+  - rscadd: "Added the *roar emote back to Alien Larva"
+  - bugfix: "Fixed aliens not being able to do the *hiss and *screech emotes"
+  - tweak: "Changed how the plural emote system works and now some emotes have plural versions, example is: *hiss and *hisses."


### PR DESCRIPTION
[Fixes SVN issue 1217... again.]

Instead of coding special snowflake code just for the purpose of *hiss for aliens, it was decided to do the change that wouldn't change anything but still work when you typed in *hiss.

What this fixes:

Instead of _hiss coming up as "_hi is a invalid command" it now works due to the shortening the requested emote s to *his.

[Related: I've had to shorten *hiss to *his before on 2013-02-26 back in the SVN days. I guess I come out of the woodwork to fix *hiss on aliens every couple years.]
