### PR TITLE
Storage Item Click Usability Improvement

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -168,6 +168,7 @@
 
 	if(display_contents_with_number)
 		for(var/datum/numbered_display/ND in display_contents)
+			ND.sample_object.mouse_opacity = 2
 			ND.sample_object.screen_loc = "[cx]:16,[cy]:16"
 			ND.sample_object.maptext = "<font color='white'>[(ND.number > 1)? "[ND.number]" : ""]</font>"
 			ND.sample_object.layer = 20
@@ -177,6 +178,7 @@
 				cy--
 	else
 		for(var/obj/O in contents)
+			O.mouse_opacity = 2 //This is here so storage items that spawn with contents correctly have the "click around item to equip"
 			O.screen_loc = "[cx]:16,[cy]:16"
 			O.maptext = ""
 			O.layer = 20
@@ -310,6 +312,7 @@
 		orient2hud(usr)
 		for(var/mob/M in can_see_contents())
 			show_to(M)
+	W.mouse_opacity = 2 //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	update_icon()
 	return 1
 
@@ -339,6 +342,7 @@
 		W.maptext = ""
 	W.on_exit_storage(src)
 	update_icon()
+	W.mouse_opacity = initial(W.mouse_opacity)
 	return 1
 
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -54,8 +54,10 @@
 /obj/item/weapon/robot_module/proc/fix_modules()
 	for(var/obj/item/I in modules)
 		I.flags |= NODROP
+		I.mouse_opacity = 2
 	if(emag)
 		emag.flags |= NODROP
+		emag.mouse_opacity = 2
 
 /obj/item/weapon/robot_module/proc/on_emag()
 	return


### PR DESCRIPTION
## Feature
- Clicking anywhere around an item in a storage item (Backpack, Box) now acts as if you clicked the item, correctly grabbing it from the storage item.
- Clicking anywhere around an item in a cyborg module now acts as if you clicked the item, correctly equipping it.
## Code
- Sets `mouse_opacity = 2` when an item is added to storage, to simulate clicking around it without hacks.
- Sets `mouse_opacity = 2` when orienting the screen objects, so backpacks/boxes etc. that spawn with contents also have this feature.
- Sets `mouse_opacity = initial(mouse_opacity)` when an item is removed from storage, to reset it back to normal.
- Sets `mouse_opacity = 2` in cyborg `fix_modules()` so Cyborg inventories also have this feature.

My initial version was so hacky lol, Store an assoc list of screen_coords of items in the storage UI element and jury-rig the player's click to the closest one, rofl.

Fixes #7927
