### PR TITLE
You can't exchange documents if you are to commit sudoku

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -462,6 +462,7 @@ var/global/list/possible_items_special = list()
 
 /datum/objective/steal/exchange
 	dangerrating = 10
+	martyr_compatible = 0
 
 /datum/objective/steal/exchange/proc/set_faction(faction,otheragent)
 	target = otheragent


### PR DESCRIPTION
Fixes #10883
The exchange objective didn't have the martyr_compatible var, soooo yeah.
