### PR TITLE
Nerfs L6 SAW from 60 damage to 25 damage.

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -184,7 +184,7 @@
 	desc = "A 7.62mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/midbullet2 //4 shots to crit
 
 /obj/item/ammo_casing/a556
 	desc = "A 5.56mm bullet casing."


### PR DESCRIPTION
It fires in 5 rounds bursts, has a 50 bullet magazine and is currently capable of critting in 2 shots even with full bulletproof armour. In addition to being a nuke op weapon, it's one of the guns spawned by summon guns. Doesn't offer a lot of counterplay. Two shots isn't much of an opportunity to dodge, especially with lag.

Don't really know if people will agree with this nerf, but I thought I'd make a PR just in case.
