### PR TITLE
Plasma cutter tweaks

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -122,12 +122,12 @@
 	projectile_type = /obj/item/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/Laser.ogg'
-	delay = 10
+	delay = 15
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv
 	projectile_type = /obj/item/projectile/plasma/adv
-	delay = 8
+	delay = 10
 	e_cost = 10
 
 /obj/item/ammo_casing/energy/wormhole

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -204,29 +204,31 @@ obj/item/projectile/kinetic/New()
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
 	damage = 5
-	range = 1
+	range = 3
 
 /obj/item/projectile/plasma/New()
 	var/turf/proj_turf = get_turf(src)
 	if(!istype(proj_turf, /turf))
 		return
 	var/datum/gas_mixture/environment = proj_turf.return_air()
-	var/pressure = environment.return_pressure()
-	if(pressure < 30)
-		name = "full strength plasma blast"
-		damage *= 3
-		range += 3
+	if(environment)
+		var/pressure = environment.return_pressure()
+		if(pressure < 30)
+			name = "full strength plasma blast"
+			damage *= 3
 	..()
 
 /obj/item/projectile/plasma/on_hit(atom/target)
+	. = ..()
 	if(istype(target, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = target
 		M.gets_drilled(firer)
-	return ..()
+		range = max(range - 1, 1)
+		return -1
 
 /obj/item/projectile/plasma/adv
-	range = 2
+	range = 5
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 10
-	range = 3
+	range = 6

--- a/html/changelogs/phil235-PlasmaCutterChange.yml
+++ b/html/changelogs/phil235-PlasmaCutterChange.yml
@@ -1,0 +1,8 @@
+
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "The plasma cutter's fire rate is now a bit lower but its projectile can pierce multiple asteroid walls and its range isn't lowered in pressurized environment anymore."
+


### PR DESCRIPTION
Plasma cutter's fire rate is now a bit slower but its projectile can pierce multiple asteroid walls(2 for normal cutter, 3 for advanced). Its range is no longer reduced in pressurized environment (so the projectile is no longer invisible). Fixes #9236.
