### PR TITLE
Out-of-date compiler error string

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -61,7 +61,7 @@ var/list/del_counter = list()
 
 #define MIN_COMPILER_VERSION 508
 #if DM_VERSION < MIN_COMPILER_VERSION //Update this whenever you need to take advantage of more recent byond features
-#error Your version of BYOND is too out-of-date to compile this project. Go to byond.com/download and update.
+#error Your version of BYOND is too out-of-date to compile this project. Go to byond.com/download and update. As for August of 2015, it uses the BETA version of BYOND.
 #endif
 
 #define USE_BYGEX


### PR DESCRIPTION
Adds an extra string on the out-of-date compile error: "As for August of 2015, it uses the BETA version of BYOND."

Hopefully we'll remember to remove it. hehehe
