### PR TITLE
Mobs can no longer ventcrawl while buckled or handcuffed

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -203,7 +203,7 @@ Pipelines + Other Objects -> Pipe network
 	if(!(direction & initialize_directions)) //cant go this way.
 		return
 
-	if(buckled_mob) // fixes buckle ventcrawl edgecase fuck bug
+	if(buckled_mob == user) // fixes buckle ventcrawl edgecase fuck bug
 		return
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -203,6 +203,9 @@ Pipelines + Other Objects -> Pipe network
 	if(!(direction & initialize_directions)) //cant go this way.
 		return
 
+	if(buckled_mob) // fixes buckle ventcrawl edgecase fuck bug
+		return
+
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)
 	if(target_move)
 		if(is_type_in_list(target_move, ventcrawl_machinery) && target_move.can_crawl_through())

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -12,6 +12,9 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/components/unary
 	if(lying)
 		src << "You can't vent crawl while you're stunned!"
 		return
+	if(restrained())
+		src << "You can't vent crawl while you're restrained!"
+		return
 
 	var/obj/machinery/atmospherics/components/unary/vent_found
 


### PR DESCRIPTION
- Mobs cannot ventcrawl while buckled to a pipe. Fixes https://github.com/tgstation/-tg-station/issues/9890. It is a bit of a band-aid fix but it is a fix.
- Fixes a related bug: mobs cannot attempt to ventcrawl when they are handcuffed. (It didn't exactly work, as handcuffs are items and it gets stopped at the "do you have items" check, but you shouldn't receive a "You begin crawling into the ventilation system..." message when handcuffed, and now you do not.)
