### PR TITLE
Fixes syndie poison kits not being able to hold what they come with

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -173,6 +173,7 @@
 
 /obj/item/weapon/storage/box/syndie_kit/chemical
 	name = "boxed chemical kit"
+	storage_slots = 14
 
 /obj/item/weapon/storage/box/syndie_kit/chemical/New()
 	..()


### PR DESCRIPTION
Fixes  #11069
By making the poison kit box hold 14 items max for the even count.
