### PR TITLE
RnD Machines + Pizza bombs now use Wire datums

### DIFF
--- a/code/datums/wires/pizza_bomb.dm
+++ b/code/datums/wires/pizza_bomb.dm
@@ -1,0 +1,46 @@
+
+/datum/wires/pizza_bomb
+	random = 1
+	holder_type = /obj/item/device/pizza_bomb
+	wire_count = 4
+
+var/const/PIZZA_WIRE_DISARM = 1		// No boom
+
+
+/datum/wires/pizza_bomb/UpdatePulsed(index)
+	var/obj/item/device/pizza_bomb/P = holder
+	switch(index)
+		if(PIZZA_WIRE_DISARM)
+			var/was_primed = P.primed
+			P.disarm()
+			if(was_primed)
+				spawn(100) //Rearm after a short time
+					if(P)
+						P.arm()
+		else
+			if(!P.disarmed)
+				message_admins("a pizza bomb at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[P.loc.x];Y=[P.loc.y];Z=[P.loc.z]'>(JMP)</a> armed by [key_name_admin(P.armer)] has exploded via wire pulsing.")
+				log_game("a pizza bomb ([P.loc.x],[P.loc.y],[P.loc.z]) armed by [key_name(P.armer)] has exploded via wire pulsing.")
+				P.go_boom()
+
+
+/datum/wires/pizza_bomb/UpdateCut(index,mended)
+	var/obj/item/device/pizza_bomb/P = holder
+	switch(index)
+		if(PIZZA_WIRE_DISARM)
+			if(mended)
+				P.disarmed = 0
+			else
+				P.disarm()
+		else
+			if(!mended && !P.disarmed)
+				message_admins("a pizza bomb at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[P.loc.x];Y=[P.loc.y];Z=[P.loc.z]'>(JMP)</a> armed by [key_name_admin(P.armer)] has exploded via wire pulsing.")
+				log_game("a pizza bomb ([P.loc.x],[P.loc.y],[P.loc.z]) armed by [key_name(P.armer)] has exploded via wire pulsing.")
+				P.go_boom()
+
+
+/datum/wires/pizza_bomb/GetInteractWindow()
+	. = ..()
+	var/obj/item/device/pizza_bomb/P = holder
+	. += text("<br>The red light is [P.primed ? "on" : "off"].<br>")
+	. += text("The green light is [P.disarmed ? "on": "off"].<br>")

--- a/code/datums/wires/r_n_d.dm
+++ b/code/datums/wires/r_n_d.dm
@@ -1,0 +1,51 @@
+
+/datum/wires/r_n_d
+	random = 1
+	holder_type = /obj/machinery/r_n_d
+	wire_count = 6
+
+var/const/RD_WIRE_HACK = 1		// Hacks the r_n_d machine
+var/const/RD_WIRE_SHOCK = 2		// Shocks the user, 50% chance
+var/const/RD_WIRE_DISABLE = 4   // Disables the machine
+
+
+/datum/wires/r_n_d/CanUse(mob/living/L)
+	var/obj/machinery/r_n_d/R = holder
+	if(R.panel_open)
+		return 1
+	return 0
+
+
+/datum/wires/r_n_d/UpdatePulsed(index)
+	var/obj/machinery/r_n_d/R = holder
+	switch(index)
+		if(RD_WIRE_HACK)
+			R.hacked = !R.hacked
+		if(RD_WIRE_DISABLE)
+			R.disabled = !R.disabled
+		if(RD_WIRE_SHOCK)
+			var/Rshock = R.shocked
+			R.shocked = !R.shocked
+			spawn(100)
+				if(R)
+					R.shocked = Rshock
+
+
+/datum/wires/r_n_d/UpdateCut(index,mended)
+	var/obj/machinery/r_n_d/R = holder
+	switch(index)
+		if(RD_WIRE_HACK)
+			R.hacked = !mended
+		if(RD_WIRE_DISABLE)
+			R.disabled = !mended
+		if(RD_WIRE_SHOCK)
+			R.shocked = !mended
+
+
+/datum/wires/r_n_d/GetInteractWindow()
+	. = ..()
+	var/obj/machinery/r_n_d/R = holder
+	. += text("<br>The red light is [R.disabled ? "off" : "on"].<br>")
+	. += text("The green light is [R.shocked ? "off" : "on"].<br>")
+	. += text("The blue light is [R.hacked ? "off" : "on"].<br>")
+

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -206,6 +206,11 @@ var/const/POWER = 8
 	else
 		CRASH("[colour] is not a key in wires.")
 
+/datum/wires/proc/GetColour(index)
+	for(var/colour in wires)
+		if(wires[colour] == index)
+			return colour
+
 //
 // Is Index/Colour Cut procs
 //

--- a/code/game/objects/items/devices/pizza_bomb.dm
+++ b/code/game/objects/items/devices/pizza_bomb.dm
@@ -8,9 +8,8 @@
 	var/timer_set = 0
 	var/primed = 0
 	var/disarmed = 0
-	var/wires = list("orange", "green", "blue", "yellow", "aqua", "purple")
-	var/correct_wire
 	var/armer //Used for admin purposes
+	var/datum/wires/pizza_bomb/wires
 
 /obj/item/device/pizza_bomb/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is opening [src]! It looks like \he's hungry and looking for pizza.</span>")
@@ -44,16 +43,10 @@
 		desc = "A box suited for pizzas."
 		return
 	if(!primed)
-		name = "pizza bomb"
-		desc = "OH GOD THAT'S NOT A PIZZA"
-		icon_state = "pizzabox_bomb"
-		audible_message("<span class='warning'>\icon[src] *beep* *beep*</span>")
 		user << "<span class='danger'>That's no pizza! That's a bomb!</span>"
 		message_admins("[key_name_admin(usr)]<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A> (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) has triggered a pizza bomb armed by [key_name_admin(armer)] at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>(JMP)</a>.")
 		log_game("[key_name(usr)] has triggered a pizza bomb armed by [key_name(armer)] ([loc.x],[loc.y],[loc.z]).")
-		primed = 1
-		sleep(timer)
-		return go_boom()
+		arm()
 
 /obj/item/device/pizza_bomb/burn() //Instead of burning to ashes, it will just explode
 	go_boom()
@@ -61,52 +54,66 @@
 
 /obj/item/device/pizza_bomb/proc/go_boom()
 	if(disarmed)
-		visible_message("<span class='danger'>\icon[src] Sparks briefly jump out of the [correct_wire] wire on \the [src], but it's disarmed!")
+		visible_message("<span class='danger'>\icon[src] Sparks briefly jump out of \the [src], but it's disarmed!")
 		return
 	src.audible_message("\icon[src] <b>[src]</b> beeps, \"Enjoy the pizza!\"")
 	src.visible_message("<span class='userdanger'>\The [src] violently explodes!</span>")
 	explosion(src.loc,1,2,4,flame_range = 2) //Identical to a minibomb
 	qdel(src)
 
+
+/obj/item/device/pizza_bomb/attack_hand(mob/user)
+	if(loc == user || primed)
+		wires.Interact(user)
+	else
+		..()
+
+
 /obj/item/device/pizza_bomb/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weapon/wirecutters) && primed)
-		user << "<span class='danger'>Oh God, what wire do you cut?!</span>"
-		var/chosen_wire = input(user, "OH GOD OH GOD", "WHAT WIRE?!") in wires
-		if(!user.canUseTopic(src))
-			return
-		playsound(src, 'sound/items/Wirecutter.ogg', 50, 1, 1)
-		user.visible_message("<span class='warning'>[user] cuts the [chosen_wire] wire!</span>", "<span class='danger'>You cut the [chosen_wire] wire!</span>")
-		sleep(5)
-		if(chosen_wire == correct_wire)
-			src.audible_message("\icon[src] \The [src] suddenly stops beeping and seems lifeless.")
-			user << "<span class='notice'>You did it!</span>"
-			icon_state = "pizzabox_bomb_[correct_wire]"
-			name = "pizza bomb"
-			desc = "A devious contraption, made of a small explosive payload hooked up to pressure-sensitive wires. It's disarmed."
-			disarmed = 1
-			primed = 0
+	if(istype(I, /obj/item/weapon/wirecutters))
+		if(disarmed)
+			if(!in_range(user, src))
+				user << "<span class='warning'>You can't see the box well enough to cut the wires out!</span>"
+				return
+			user.visible_message("<span class='notice'>[user] starts removing the payload and wires from \the [src].</span>", "<span class='notice'>You start removing the payload and wires from \the [src]...</span>")
+			if(do_after(user, 40, target = src))
+				playsound(src, 'sound/items/Wirecutter.ogg', 50, 1, 1)
+				user.unEquip(src)
+				user.visible_message("<span class='notice'>[user] removes the insides of \the [src]!</span>", "<span class='notice'>You remove the insides of \the [src].</span>")
+				var/obj/item/stack/cable_coil/C = new /obj/item/stack/cable_coil(src.loc)
+				C.amount = 3
+				new /obj/item/weapon/bombcore/miniature(src.loc)
+				new /obj/item/pizzabox(src.loc)
+				qdel(src)
 			return
 		else
-			user << "<span class='userdanger'>WRONG WIRE!</span>"
-			go_boom()
+			attack_hand(user)
 			return
-	if(istype(I, /obj/item/weapon/wirecutters) && disarmed)
-		if(!in_range(user, src))
-			user << "<span class='warning'>You can't see the box well enough to cut the wires out!</span>"
-			return
-		user.visible_message("<span class='notice'>[user] starts removing the payload and wires from \the [src].</span>", "<span class='notice'>You start removing the payload and wires from \the [src]...</span>")
-		if(do_after(user, 40, target = src))
-			playsound(src, 'sound/items/Wirecutter.ogg', 50, 1, 1)
-			user.unEquip(src)
-			user.visible_message("<span class='notice'>[user] removes the insides of \the [src]!</span>", "<span class='notice'>You remove the insides of \the [src].</span>")
-			var/obj/item/stack/cable_coil/C = new /obj/item/stack/cable_coil(src.loc)
-			C.amount = 3
-			new /obj/item/weapon/bombcore/miniature(src.loc)
-			new /obj/item/pizzabox(src.loc)
-			qdel(src)
+	if(istype(I, /obj/item/device/multitool))
+		attack_hand(user)
 		return
+
 	..()
 
 /obj/item/device/pizza_bomb/New()
 	..()
-	correct_wire = pick(wires)
+	wires = new(src)
+
+
+/obj/item/device/pizza_bomb/proc/disarm()
+	audible_message("\icon[src] \The [src] suddenly stops beeping and seems lifeless.")
+	icon_state = "pizzabox_bomb_[wires.GetColour(PIZZA_WIRE_DISARM)]"
+	name = "pizza bomb"
+	desc = "A devious contraption, made of a small explosive payload hooked up to pressure-sensitive wires. It's disarmed."
+	disarmed = 1
+	primed = 0
+
+
+/obj/item/device/pizza_bomb/proc/arm()
+	name = "pizza bomb"
+	desc = "OH GOD THAT'S NOT A PIZZA"
+	icon_state = "pizzabox_bomb"
+	audible_message("<span class='warning'>\icon[src] *beep* *beep*</span>")
+	primed = 1
+	sleep(timer)
+	return go_boom()

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -13,94 +13,31 @@
 	var/hacked = 0
 	var/disabled = 0
 	var/shocked = 0
-	var/list/wires = list()
-	var/hack_wire
-	var/disable_wire
-	var/shock_wire
 	var/obj/machinery/computer/rdconsole/linked_console
+	var/datum/wires/r_n_d/wires
 
 /obj/machinery/r_n_d/New()
 	..()
-	wires["Red"] = 0
-	wires["Blue"] = 0
-	wires["Green"] = 0
-	wires["Yellow"] = 0
-	wires["Black"] = 0
-	wires["White"] = 0
-	var/list/w = list("Red","Blue","Green","Yellow","Black","White")
-	src.hack_wire = pick(w)
-	w -= src.hack_wire
-	src.shock_wire = pick(w)
-	w -= src.shock_wire
-	src.disable_wire = pick(w)
-	w -= src.disable_wire
+	wires = new(src)
 
-/obj/machinery/r_n_d/proc/
-	shock(mob/user, prb)
-		if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
-			return 0
-		if(!prob(prb))
-			return 0
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-		if (electrocute_mob(user, get_area(src), src, 0.7))
-			return 1
-		else
-			return 0
+/obj/machinery/r_n_d/proc/shock(mob/user, prb)
+	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
+		return 0
+	if(!prob(prb))
+		return 0
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(5, 1, src)
+	s.start()
+	if (electrocute_mob(user, get_area(src), src, 0.7))
+		return 1
+	else
+		return 0
 
 /obj/machinery/r_n_d/attack_hand(mob/user)
-	if (shocked)
+	if(shocked)
 		shock(user,50)
 	if(panel_open)
-		var/dat as text
-		dat += "[src.name] Wires:<BR>"
-		for(var/wire in src.wires)
-			dat += text("[wire] Wire: <A href='?src=\ref[src];wire=[wire];cut=1'>[src.wires[wire] ? "Mend" : "Cut"]</A> <A href='?src=\ref[src];wire=[wire];pulse=1'>Pulse</A><BR>")
-
-		dat += text("The red light is [src.disabled ? "off" : "on"].<BR>")
-		dat += text("The green light is [src.shocked ? "off" : "on"].<BR>")
-		dat += text("The blue light is [src.hacked ? "off" : "on"].<BR>")
-		user << browse("<HTML><HEAD><TITLE>[src.name] Hacking</TITLE></HEAD><BODY>[dat]</BODY></HTML>","window=hack_win")
-	return
+		wires.Interact(user)
 
 
-/obj/machinery/r_n_d/Topic(href, href_list)
-	if(..())
-		return
-	usr.set_machine(src)
-	src.add_fingerprint(usr)
-	if(href_list["pulse"])
-		var/temp_wire = href_list["wire"]
-		if (!istype(usr.get_active_hand(), /obj/item/device/multitool))
-			usr << "<span class='warning'>You need a multitool!</span>"
-		else
-			if(src.wires[temp_wire])
-				usr << "<span class='warning'>You can't pulse a cut wire!</span>"
-			else
-				if(src.hack_wire == href_list["wire"])
-					src.hacked = !src.hacked
-					spawn(100) src.hacked = !src.hacked
-				if(src.disable_wire == href_list["wire"])
-					src.disabled = !src.disabled
-					src.shock(usr,50)
-					spawn(100) src.disabled = !src.disabled
-				if(src.shock_wire == href_list["wire"])
-					src.shocked = !src.shocked
-					src.shock(usr,50)
-					spawn(100) src.shocked = !src.shocked
-	if(href_list["cut"])
-		if (!istype(usr.get_active_hand(), /obj/item/weapon/wirecutters))
-			usr << "<span class='warning'>You need wirecutters!</span>"
-		else
-			var/temp_wire = href_list["wire"]
-			wires[temp_wire] = !wires[temp_wire]
-			if(src.hack_wire == temp_wire)
-				src.hacked = !src.hacked
-			if(src.disable_wire == temp_wire)
-				src.disabled = !src.disabled
-				src.shock(usr,50)
-			if(src.shock_wire == temp_wire)
-				src.shocked = !src.shocked
-				src.shock(usr,50)
-	src.updateUsrDialog()
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -252,6 +252,8 @@
 #include "code\datums\wires\explosive.dm"
 #include "code\datums\wires\mulebot.dm"
 #include "code\datums\wires\particle_accelerator.dm"
+#include "code\datums\wires\pizza_bomb.dm"
+#include "code\datums\wires\r_n_d.dm"
 #include "code\datums\wires\radio.dm"
 #include "code\datums\wires\robot.dm"
 #include "code\datums\wires\syndicatebomb.dm"


### PR DESCRIPTION
## Content:
- Most functionality has remained the same
- Pizza bomb wires reduced from 1/6 chance to 1/4 chance to disarm (Like seriously 1/6? what's the point, just throw the bomb away)
- Pizza bombs now work with multitools
- RnD machines now work with multitools
## Code:
- Gutted and Proc'd a lot of stuff on `/pizza_bomb`
- RnD machine hacking interface is now a proper hacking window, not one of byond's ugly white ones
- Add `GetColour(index)` helper for wire datums, surprised this didn't exist, and I needed it to maintain a unique aspect of `/pizza_bomb` sprites
