### PR TITLE
Fixes runtime when spawning a sNPC

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -90,4 +90,4 @@ Head of Personnel
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind, list("Supply", "Service")) //tell underlings (suuply/service) they have a head
+	announce_head(H, list("Supply", "Service")) //tell underlings (suuply/service) they have a head

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -41,7 +41,7 @@ Chief Engineer
 	//Equip telebaton
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind, list("Engineering")) //tell underlings (engineering radio) they have a head
+	announce_head(H, list("Engineering")) //tell underlings (engineering radio) they have a head
 
 /*
 Station Engineer

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -169,8 +169,8 @@
 /datum/job/proc/config_check()
 	return 1
 
-/datum/job/proc/announce_head(var/datum/mind/o_mind, var/channels) //tells the given channel that the given mind is the new department head. See communications.dm for valid channels.
+/datum/job/proc/announce_head(var/mob/living/carbon/human/H, var/channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
 	spawn(4) //to allow some initialization
 		if(announcement_systems.len)
 			var/obj/machinery/announcement_system/announcer = pick(announcement_systems)
-			announcer.announce("NEWHEAD", o_mind.name, o_mind.assigned_role, channels)
+			announcer.announce("NEWHEAD", H.real_name, H.job, channels)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -35,7 +35,7 @@ Chief Medical Officer
 	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), slot_s_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind, list("Medical")) //tell underlings (medical radio) they have a head
+	announce_head(H, list("Medical")) //tell underlings (medical radio) they have a head
 
 /*
 Medical Doctor

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -37,7 +37,7 @@ Research Director
 	H.equip_to_slot_or_del(new /obj/item/device/laser_pointer(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(H), slot_in_backpack)
 
-	announce_head(H.mind, list("Science")) //tell underlings (science radio) they have a head
+	announce_head(H, list("Science")) //tell underlings (science radio) they have a head
 
 /*
 Scientist

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -52,7 +52,7 @@ Head of Security
 	L.implanted = 1
 	H.sec_hud_set_implants()
 
-	announce_head(H.mind, list("Security")) //tell underlings (security radio) they have a head
+	announce_head(H, list("Security")) //tell underlings (security radio) they have a head
 
 /*
 Warden

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -184,13 +184,11 @@ var/list/announcement_systems = list()
 	newhead = pick("OV#RL()D: \[UNKNOWN??\] DET*#CT)D!", "ER)#R - B*@ TEXT F*O(ND!", "AAS.exe is not responding. NanoOS is searching for a solution to the problem.")
 
 /obj/machinery/announcement_system/emp_act(severity)
-	if(stat & (NOPOWER|BROKEN))
-		..(severity)
-		return
-	act_up()
+	if(!(stat & (NOPOWER|BROKEN)))
+		act_up()
 	..(severity)
 
 /obj/machinery/announcement_system/emag_act()
-	..()
-	emagged = 1
-	act_up()
+	if(!emagged)
+		emagged = 1
+		act_up()


### PR DESCRIPTION
 that is a head and the announcer proc can't find any mind. Fixes #11050.

Small simplification in the emp_act() and emag_act() of the announcement_system.
