### PR TITLE
Adds several new reagent reactions to hydroponics.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -542,6 +542,12 @@
 		adjustToxic(-round(S.get_reagent_amount("plantbgone") * 6))
 		adjustWeeds(-rand(4,8))
 
+	// why, just why
+	if(S.has_reagent("napalm", 1))
+		adjustHealth(-round(S.get_reagent_amount("napalm") * 6))
+		adjustToxic(-round(S.get_reagent_amount("napalm") * 7))
+		adjustWeeds(-rand(5,9))
+
 	//Weed Spray
 	if(S.has_reagent("weedkiller", 1))
 		adjustToxic(round(S.get_reagent_amount("weedkiller") * 0.5))
@@ -564,6 +570,18 @@
 		adjustNutri(round(S.get_reagent_amount("ammonia") * 1))
 		adjustSYield(round(S.get_reagent_amount("ammonia") * 0.01))
 
+	// Saltpetre is used for gardening IRL, to simplify highly, it speeds up growth and strengthens plants
+	if(S.has_reagent("saltpetre", 1))
+		adjustHealth(round(S.get_reagent_amount("saltpetre") * 0.25))
+		adjustSProduct(-round(S.get_reagent_amount("saltpetre") * 0.02))
+		adjustSPot(round(S.get_reagent_amount("saltpetre") * 0.01))
+
+	// Ash is also used IRL in gardening, as a fertilizer enhancer and weed killer
+	if(S.has_reagent("ash", 1))
+		adjustHealth(round(S.get_reagent_amount("ash") * 0.25))
+		adjustNutri(round(S.get_reagent_amount("ash") * 0.5))
+		adjustWeeds(-1)
+
 	// This is more bad ass, and pests get hurt by the corrosive nature of it, not the plant.
 	if(S.has_reagent("diethylamine", 1))
 		adjustHealth(round(S.get_reagent_amount("diethylamine") * 1))
@@ -575,6 +593,20 @@
 	if(S.has_reagent("nutriment", 1))
 		adjustHealth(round(S.get_reagent_amount("nutriment") * 0.5))
 		adjustNutri(round(S.get_reagent_amount("nutriment") * 1))
+
+	// Compost for EVERYTHING
+	if(S.has_reagent("virusfood", 1))
+		adjustNutri(round(S.get_reagent_amount("virusfood") * 0.5))
+		adjustHealth(-round(S.get_reagent_amount("virusfood") * 0.5))
+
+	// FEED ME
+	if(S.has_reagent("blood", 1))
+		adjustNutri(round(S.get_reagent_amount("blood") * 1))
+		adjustPests(rand(2,4))
+
+	// FEED ME SEYMOUR
+	if(S.has_reagent("strangereagent", 1))
+		spawnplant()
 
 	// The best stuff there is. For testing/debugging.
 	if(S.has_reagent("adminordrazine", 1))
@@ -964,6 +996,12 @@
 		myseed.potency += adjustamt
 		myseed.potency = max(myseed.potency, 0)
 		myseed.potency = min(myseed.potency, 100)
+
+/obj/machinery/hydroponics/proc/spawnplant() // why would you put strange reagent in a hydro tray you monster I bet you also feed them blood
+	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
+	var/chosen = pick(livingplants)
+	var/mob/living/simple_animal/hostile/C = new chosen
+	C.faction = list("plants")
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!


### PR DESCRIPTION
Exactly what it says in the title. The new reactions are as follows. Suggestions for tweaks or -- especially -- for new reactions are appreciated.
- Saltpetre: Used in gardening IRL. Slightly reduces the production stat -- plants grow faster -- and even more slightly increases potency. Basically makes plants better in almost every way. I can adjust the numbers down if this is too OP.
- Ash: Also used in gardening IRL. A weak fertilizer that also kills weeds.
- Virus food: Adds nutriment, but decreases health. "But why would you ever use virus food?" Water plus milk, easy shit to get, maybe you're the chef, maybe you're making a maint garden, who knows. Ideally the fertilizer machines would be ID-locked to botanists only, always found it silly that they weren't, maybe I'll add that to the PR.
- Napalm: Kills the shit out of plants faster than Plant-B-Gone.
- Blood: Adds nutrient, but significantly increases the amount of pests. FEED ME
- Strange Reagent: Spawns a hostile pine tree or killer tomato. For traitoring, or for dumbasses. FEED ME, SEYMOUR! (Eventually I want to make an actual living plant sprite along the lines of Audrey II for this, that feeds on blood, but for that I need a spriter.)
