### PR TITLE
Rebalances RCD construction costs around metal construction menu costs

### DIFF
--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -212,7 +212,7 @@ var/hsboxspawn = 1
 			if("hsbrcd")
 				if(!hsboxspawn) return
 
-				new/obj/item/weapon/rcd{matter=30;canRwall=1}(usr.loc)
+				new/obj/item/weapon/rcd{matter=30;canRturf=1}(usr.loc)
 
 			//
 			// New sandbox airlock maker

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -26,16 +26,43 @@ RCD
 	var/max_matter = 160
 	var/working = 0
 	var/mode = 1
-	var/canRwall = 0
+	var/canRturf = 0
 	var/disabled = 0
 	var/airlock_type = /obj/machinery/door/airlock
 	var/advanced_airlock_setting = 1 //Set to 1 if you want more paintjobs available
 	var/sheetmultiplier	= 4			 //Controls the amount of matter added for each glass/metal sheet, triple for plasteel
+	var/plasteelmultiplier = 3 //Plasteel is worth 3 times more than glass or metal
 
 	var/list/conf_access = null
 	var/use_one_access = 0 //If the airlock should require ALL or only ONE of the listed accesses.
 	var/last_configurator = null
 	var/locked = 1
+
+	/* Construction costs */
+
+	var/wallcost = 16
+	var/floorcost = 2
+	var/grillecost = 4
+	var/windowcost = 8
+	var/airlockcost = 16
+	var/deconwallcost = 26
+	var/deconfloorcost = 33
+	var/decongrillecost = 4
+	var/deconwindowcost = 8
+	var/deconairlockcost = 32
+
+	/* Build delays (deciseconds) */
+
+	var/walldelay = 20
+	var/floordelay = null //space wind's a bitch
+	var/grilledelay = 40
+	var/windowdelay = 40
+	var/airlockdelay = 50
+	var/deconwalldelay = 40
+	var/deconfloordelay = 50
+	var/decongrilledelay = null //as rapid as wirecutters
+	var/deconwindowdelay = 50
+	var/deconairlockdelay = 50
 
 /obj/item/weapon/rcd/verb/change_airlock_access()
 	set name = "Change Airlock Access"
@@ -230,7 +257,7 @@ RCD
 	else if(istype(W, /obj/item/stack/sheet/metal) || istype(W, /obj/item/stack/sheet/glass))
 		loaded = loadwithsheets(W, sheetmultiplier, user)
 	else if(istype(W, /obj/item/stack/sheet/plasteel))
-		loaded = loadwithsheets(W, 3*sheetmultiplier, user) //Plasteel is worth 3 times more than glass or metal
+		loaded = loadwithsheets(W, plasteelmultiplier*sheetmultiplier, user) //Plasteel is worth 3 times more than glass or metal
 	if(loaded)
 		user << "<span class='notice'>The RCD now holds [matter]/[max_matter] matter-units.</span>"
 		desc = "A RCD. It currently holds [matter]/[max_matter] matter-units."
@@ -294,7 +321,7 @@ RCD
 		if(1)
 			if(istype(A, /turf/space))
 				var/turf/space/S = A
-				if(useResource(2, user))
+				if(useResource(floorcost, user))
 					user << "<span class='notice'>You start building floor...</span>"
 					activate()
 					S.ChangeTurf(/turf/simulated/floor/plating)
@@ -303,11 +330,11 @@ RCD
 
 			if(istype(A, /turf/simulated/floor))
 				var/turf/simulated/floor/F = A
-				if(checkResource(16, user))
+				if(checkResource(wallcost, user))
 					user << "<span class='notice'>You start building wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 20, target = A))
-						if(!useResource(16, user)) return 0
+					if(do_after(user, walldelay, target = A))
+						if(!useResource(wallcost, user)) return 0
 						activate()
 						F.ChangeTurf(/turf/simulated/wall)
 						return 1
@@ -315,7 +342,7 @@ RCD
 
 		if(2)
 			if(istype(A, /turf/simulated/floor))
-				if(checkResource(16, user))
+				if(checkResource(airlockcost, user))
 					var/door_check = 1
 					for(var/obj/machinery/door/D in A)
 						if(!D.sub_door)
@@ -325,8 +352,8 @@ RCD
 					if(door_check)
 						user << "<span class='notice'>You start building airlock...</span>"
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-						if(do_after(user, 50, target = A))
-							if(!useResource(16, user)) return 0
+						if(do_after(user, airlockdelay, target = A))
+							if(!useResource(airlockcost, user)) return 0
 							activate()
 							var/obj/machinery/door/airlock/T = new airlock_type( A )
 
@@ -345,7 +372,7 @@ RCD
 
 							if(!T.checkForMultipleDoors())
 								qdel(T)
-								useResource(-16, user)
+								useResource(-airlockcost, user)
 								return 0
 							T.autoclose = 1
 							return 1
@@ -358,13 +385,13 @@ RCD
 		if(3)
 			if(istype(A, /turf/simulated/wall))
 				var/turf/simulated/wall/W = A
-				if(istype(W, /turf/simulated/wall/r_wall) && !canRwall)
+				if(istype(W, /turf/simulated/wall/r_wall) && !canRturf)
 					return 0
-				if(checkResource(27, user))
+				if(checkResource(deconwallcost, user))
 					user << "<span class='notice'>You start deconstructing wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 40, target = A))
-						if(!useResource(27, user)) return 0
+					if(do_after(user, deconwalldelay, target = A))
+						if(!useResource(deconwallcost, user)) return 0
 						activate()
 						W.ChangeTurf(/turf/simulated/floor/plating)
 						return 1
@@ -372,63 +399,64 @@ RCD
 
 			if(istype(A, /turf/simulated/floor))
 				var/turf/simulated/floor/F = A
+				if(istype(F, /turf/simulated/floor/engine) && !canRturf)
+					return 0
 				if(istype(F, F.baseturf))
 					user << "<span class='notice'>You can't dig any deeper!</span>"
 					return 0
-				else if(checkResource(12, user))
+				else if(checkResource(deconfloorcost, user))
 					user << "<span class='notice'>You start deconstructing floor...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 50, target = A))
-						if(!useResource(12, user)) return 0
+					if(do_after(user, deconfloordelay, target = A))
+						if(!useResource(deconfloorcost, user)) return 0
 						activate()
 						F.ChangeTurf(F.baseturf)
 						return 1
 				return 0
 
 			if(istype(A, /obj/machinery/door/airlock))
-				if(checkResource(32, user))
+				if(checkResource(deconairlockcost, user))
 					user << "<span class='notice'>You start deconstructing airlock...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 50, target = A))
-						if(!useResource(32, user)) return 0
+					if(do_after(user, deconairlockdelay, target = A))
+						if(!useResource(deconairlockcost, user)) return 0
 						activate()
 						qdel(A)
 						return 1
 				return	0
 
 			if(istype(A, /obj/structure/window))
-				if(checkResource(8, user))
+				if(checkResource(deconwindowcost, user))
 					user << "<span class='notice'>You start deconstructing the window...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 50, target = A))
-						if(!useResource(8, user)) return 0
+					if(do_after(user, deconwindowdelay, target = A))
+						if(!useResource(deconwindowcost, user)) return 0
 						activate()
 						qdel(A)
 						return 1
 				return	0
 
 			if(istype(A, /obj/structure/grille))
-				if(checkResource(4, user))
-					user << "<span class='notice'>You start deconstructing the grille...</span>"
-					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 50, target = A))
-						if(!useResource(4, user)) return 0
+				var/obj/structure/grille/G = A
+				if(!G.shock(user, 90)) //if it's shocked, try to shock them
+					if(useResource(decongrillecost, user))
+						user << "<span class='notice'>You start deconstructing the grille...</span>"
 						activate()
+						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						qdel(A)
 						return 1
-				return	0
-			return 0
+					return 0
 
 		if (4)
 			if(istype(A, /turf/simulated/floor))
-				if(checkResource(4, user))
+				if(checkResource(grillecost, user))
 					for(var/obj/structure/grille/GRILLE in A)
 						user << "<span class='warning'>There is already a grille there!</span>"
 						return 0
 					user << "<span class='notice'>You start building a grille...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 40, target = A))
-						if(!useResource(4, user)) return 0
+					if(do_after(user, grilledelay, target = A))
+						if(!useResource(grillecost, user)) return 0
 						activate()
 						var/obj/structure/grille/G = new/obj/structure/grille(A)
 						G.anchored = 1
@@ -436,12 +464,12 @@ RCD
 					return 0
 				return 0
 			if(istype(A, /obj/structure/grille))
-				if(checkResource(8, user))
+				if(checkResource(windowcost, user))
 					user << "<span class='notice'>You start building a window...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-					if(do_after(user, 40, target = A))
+					if(do_after(user, windowdelay, target = A))
 						if(locate(/obj/structure/window) in A.loc) return 0
-						if(!useResource(8, user)) return 0
+						if(!useResource(windowcost, user)) return 0
 						activate()
 						var/obj/structure/window/WD = new/obj/structure/window/fulltile(A.loc)
 						WD.anchored = 1
@@ -474,8 +502,8 @@ RCD
 
 /obj/item/weapon/rcd/borg/New()
 	..()
-	desc = "A device used to rapidly build walls/floor."
-	canRwall = 1
+	desc = "A device used to rapidly build walls and floors."
+	canRturf = 1
 
 /obj/item/weapon/rcd/loaded
 	matter = 160
@@ -484,7 +512,7 @@ RCD
 	name = "combat RCD"
 	max_matter = 500
 	matter = 500
-	canRwall = 1
+	canRturf = 1
 
 /obj/item/weapon/rcd_ammo
 	name = "compressed matter cartridge"
@@ -500,4 +528,4 @@ RCD
 	var/ammoamt = 40
 
 /obj/item/weapon/rcd_ammo/large
-	ammoamt = 200
+	ammoamt = 160

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -199,7 +199,7 @@ RCD
 
 
 /obj/item/weapon/rcd/New()
-	desc = "A RCD. It currently holds [matter]/[max_matter] matter-units."
+	desc = "An RCD. It currently holds [matter]/[max_matter] matter-units."
 	src.spark_system = new /datum/effect/effect/system/spark_spread
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
@@ -294,7 +294,7 @@ RCD
 		if(1)
 			if(istype(A, /turf/space))
 				var/turf/space/S = A
-				if(useResource(1, user))
+				if(useResource(2, user))
 					user << "<span class='notice'>You start building floor...</span>"
 					activate()
 					S.ChangeTurf(/turf/simulated/floor/plating)
@@ -303,11 +303,11 @@ RCD
 
 			if(istype(A, /turf/simulated/floor))
 				var/turf/simulated/floor/F = A
-				if(checkResource(3, user))
+				if(checkResource(16, user))
 					user << "<span class='notice'>You start building wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 20, target = A))
-						if(!useResource(3, user)) return 0
+						if(!useResource(16, user)) return 0
 						activate()
 						F.ChangeTurf(/turf/simulated/wall)
 						return 1
@@ -315,7 +315,7 @@ RCD
 
 		if(2)
 			if(istype(A, /turf/simulated/floor))
-				if(checkResource(10, user))
+				if(checkResource(16, user))
 					var/door_check = 1
 					for(var/obj/machinery/door/D in A)
 						if(!D.sub_door)
@@ -326,7 +326,7 @@ RCD
 						user << "<span class='notice'>You start building airlock...</span>"
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						if(do_after(user, 50, target = A))
-							if(!useResource(10, user)) return 0
+							if(!useResource(16, user)) return 0
 							activate()
 							var/obj/machinery/door/airlock/T = new airlock_type( A )
 
@@ -345,7 +345,7 @@ RCD
 
 							if(!T.checkForMultipleDoors())
 								qdel(T)
-								useResource(-10, user)
+								useResource(-16, user)
 								return 0
 							T.autoclose = 1
 							return 1
@@ -360,11 +360,11 @@ RCD
 				var/turf/simulated/wall/W = A
 				if(istype(W, /turf/simulated/wall/r_wall) && !canRwall)
 					return 0
-				if(checkResource(5, user))
+				if(checkResource(27, user))
 					user << "<span class='notice'>You start deconstructing wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 40, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(27, user)) return 0
 						activate()
 						W.ChangeTurf(/turf/simulated/floor/plating)
 						return 1
@@ -375,44 +375,44 @@ RCD
 				if(istype(F, F.baseturf))
 					user << "<span class='notice'>You can't dig any deeper!</span>"
 					return 0
-				else if(checkResource(5, user))
+				else if(checkResource(12, user))
 					user << "<span class='notice'>You start deconstructing floor...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(12, user)) return 0
 						activate()
 						F.ChangeTurf(F.baseturf)
 						return 1
 				return 0
 
 			if(istype(A, /obj/machinery/door/airlock))
-				if(checkResource(20, user))
+				if(checkResource(32, user))
 					user << "<span class='notice'>You start deconstructing airlock...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50, target = A))
-						if(!useResource(20, user)) return 0
+						if(!useResource(32, user)) return 0
 						activate()
 						qdel(A)
 						return 1
 				return	0
 
 			if(istype(A, /obj/structure/window))
-				if(checkResource(5, user))
+				if(checkResource(8, user))
 					user << "<span class='notice'>You start deconstructing the window...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(8, user)) return 0
 						activate()
 						qdel(A)
 						return 1
 				return	0
 
 			if(istype(A, /obj/structure/grille))
-				if(checkResource(5, user))
+				if(checkResource(4, user))
 					user << "<span class='notice'>You start deconstructing the grille...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(4, user)) return 0
 						activate()
 						qdel(A)
 						return 1
@@ -421,14 +421,14 @@ RCD
 
 		if (4)
 			if(istype(A, /turf/simulated/floor))
-				if(checkResource(5, user))
+				if(checkResource(4, user))
 					for(var/obj/structure/grille/GRILLE in A)
 						user << "<span class='warning'>There is already a grille there!</span>"
 						return 0
 					user << "<span class='notice'>You start building a grille...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 40, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(4, user)) return 0
 						activate()
 						var/obj/structure/grille/G = new/obj/structure/grille(A)
 						G.anchored = 1
@@ -436,12 +436,12 @@ RCD
 					return 0
 				return 0
 			if(istype(A, /obj/structure/grille))
-				if(checkResource(5, user))
+				if(checkResource(8, user))
 					user << "<span class='notice'>You start building a window...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 40, target = A))
 						if(locate(/obj/structure/window) in A.loc) return 0
-						if(!useResource(5, user)) return 0
+						if(!useResource(8, user)) return 0
 						activate()
 						var/obj/structure/window/WD = new/obj/structure/window/fulltile(A.loc)
 						WD.anchored = 1
@@ -457,7 +457,7 @@ RCD
 	if(matter < amount)
 		return 0
 	matter -= amount
-	desc = "A RCD. It currently holds [matter]/[max_matter] matter-units."
+	desc = "An RCD. It currently holds [matter]/[max_matter] matter-units."
 	return 1
 
 /obj/item/weapon/rcd/proc/checkResource(amount, mob/user)
@@ -496,8 +496,8 @@ RCD
 	density = 0
 	anchored = 0.0
 	origin_tech = "materials=2"
-	materials = list(MAT_METAL=16000, MAT_GLASS=8000)
-	var/ammoamt = 20
+	materials = list(MAT_METAL=3000, MAT_GLASS=2000)
+	var/ammoamt = 40
 
 /obj/item/weapon/rcd_ammo/large
-	ammoamt = 100
+	ammoamt = 200

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -45,11 +45,12 @@
 	icon_state = "medicalcrate"
 
 /obj/structure/closet/crate/rcd
-	desc = "A crate for the storage of the RCD."
+	desc = "A crate for the storage of an RCD."
 	name = "\improper RCD crate"
 
 /obj/structure/closet/crate/rcd/New()
 	..()
+	new /obj/item/weapon/rcd_ammo(src)
 	new /obj/item/weapon/rcd_ammo(src)
 	new /obj/item/weapon/rcd_ammo(src)
 	new /obj/item/weapon/rcd_ammo(src)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -190,7 +190,7 @@
 	name = "Compressed matter cardridge"
 	id = "rcd_ammo"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
+	materials = list(MAT_METAL = 3000, MAT_GLASS=2000)
 	build_path = /obj/item/weapon/rcd_ammo
 	category = list("initial","Construction")
 


### PR DESCRIPTION
- Made costs and delays variables
- Made plasteel multiplier a variable
- Made shocked grilles shock unprotected RCD users
- Made grilles deconstruct instantly so the RCD isn't outdone by wirecutters
- Made the RCD unable to deconstruct reinforced floors (not that this really affects anything, just a neat consistency thing)
- Changed canRwall var to canRturf to indicate it covers both r walls and r floors
- Changed large matter cartridge matter amount to 160 so it can still fit in the RCD (I had previously set it to 200 not realising it wouldn't fit)
- Added fourth matter cartridge to RCD crate (one spawns in EVA) so it once again holds enough cartridges to fully load it

If you're wondering how I determined the cost values I used, the spreadsheet I used is [here](https://docs.google.com/spreadsheets/d/1ZvhRNn8KsnABcP-y2jEMV2BXq1Mqv2onKI5cQM_e9UE/edit?usp=sharing).

This pull was motivated by personal experience with the RCD being too powerful (e.g. able to build 53 walls per 50 sheets of metal inserted, as opposed to 10 by hand), and prompted by [this](https://tgstation13.org/phpBB/viewtopic.php?f=10&t=4360) feedback thread. I was a proponent of the pull to buff the RCD and wanted to be the one to fix the problems with it to make sure it was still a viable tool for construction.
