### PR TITLE
Girder deconstruction bugfix

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -145,11 +145,8 @@
 	return 2
 
 /obj/singularity_pull(S, current_size)
-	if(anchored)
-		if(current_size >= STAGE_FIVE)
-			anchored = 0
-			step_towards(src,S)
-	else step_towards(src,S)
+	if(!anchored || current_size >= STAGE_FIVE)
+		step_towards(src,S)
 
 /obj/proc/Deconstruct()
 	qdel(src)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -15,33 +15,52 @@
 
 /obj/structure/girder/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
-	if(istype(W, /obj/item/weapon/screwdriver) && state == GIRDER_DISPLACED)
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
-							"<span class='notice'>You start to disassemble the girder...</span>", "You hear clanking and banging noises.")
-		if(do_after(user, 40, target = src))
-			if(state == GIRDER_DISASSEMBLED)
-				return
-			state = GIRDER_DISASSEMBLED
-			user << "<span class='notice'>You disassemble the girder.</span>"
-			var/obj/item/stack/sheet/metal/M = new (loc, 2)
-			M.add_fingerprint(user)
-			qdel(src)
+	if(istype(W, /obj/item/weapon/screwdriver))
+		if(state == GIRDER_DISPLACED)
+			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
+								"<span class='notice'>You start to disassemble the girder...</span>", "You hear clanking and banging noises.")
+			if(do_after(user, 40, target = src))
+				if(state != GIRDER_DISPLACED)
+					return
+				state = GIRDER_DISASSEMBLED
+				user << "<span class='notice'>You disassemble the girder.</span>"
+				var/obj/item/stack/sheet/metal/M = new (loc, 2)
+				M.add_fingerprint(user)
+				qdel(src)
+		else if(state == GIRDER_REINF)
+			playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+			user << "<span class='notice'>You start unsecuring support struts...</span>"
+			if(do_after(user, 40, target = src))
+				if(state != GIRDER_REINF)
+					return
+				user << "<span class='notice'>You unsecure the support struts.</span>"
+				state = GIRDER_REINF_STRUTS
 
-	else if(istype(W, /obj/item/weapon/wrench) && state == GIRDER_DISPLACED)
-		if (!istype(src.loc, /turf/simulated/floor))
-			user << "<span class='warning'>A floor must be present to secure the girder!</span>"
-			return
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user << "<span class='notice'>You start securing the girder...</span>"
-		if(do_after(user, 40, target = src))
-			user << "<span class='notice'>You secure the girder.</span>"
-			var/obj/structure/girder/G = new (loc)
-			transfer_fingerprints_to(G)
-			qdel(src)
+	else if(istype(W, /obj/item/weapon/wrench))
+		if(state == GIRDER_DISPLACED)
+			if(!istype(loc, /turf/simulated/floor))
+				user << "<span class='warning'>A floor must be present to secure the girder!</span>"
+				return
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+			user << "<span class='notice'>You start securing the girder...</span>"
+			if(do_after(user, 40, target = src))
+				user << "<span class='notice'>You secure the girder.</span>"
+				var/obj/structure/girder/G = new (loc)
+				transfer_fingerprints_to(G)
+				qdel(src)
+		else if(state == GIRDER_NORMAL)
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+			user << "<span class='notice'>You start unsecuring the girder...</span>"
+			if(do_after(user, 40, target = src))
+				user << "<span class='notice'>You unsecure the girder.</span>"
+				var/obj/structure/girder/displaced/D = new (loc)
+				transfer_fingerprints_to(D)
+				qdel(src)
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
 		user << "<span class='notice'>You start slicing apart the girder...</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		if(do_after(user, 30, target = src))
 			user << "<span class='notice'>You slice apart the girder.</span>"
 			var/obj/item/stack/sheet/metal/M = new (loc, 2)
@@ -55,13 +74,6 @@
 		D.playDigSound()
 		qdel(src)
 
-	else if(istype(W, /obj/item/weapon/screwdriver) && state == GIRDER_REINF)
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user << "<span class='notice'>You start unsecuring support struts...</span>"
-		if(do_after(user, 40, target = src))
-			user << "<span class='notice'>You unsecure the support struts.</span>"
-			state = GIRDER_REINF_STRUTS
-
 	else if(istype(W, /obj/item/weapon/wirecutters) && state == GIRDER_REINF_STRUTS)
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 		user << "<span class='notice'>You start removing support struts...</span>"
@@ -70,15 +82,6 @@
 			new /obj/item/stack/sheet/plasteel(get_turf(src))
 			var/obj/structure/girder/G = new (loc)
 			transfer_fingerprints_to(G)
-			qdel(src)
-
-	else if(istype(W, /obj/item/weapon/wrench) && state == GIRDER_NORMAL && anchored )
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		user << "<span class='notice'>You start unsecuring the girder...</span>"
-		if(do_after(user, 40, target = src))
-			user << "<span class='notice'>You unsecure the girder.</span>"
-			var/obj/structure/girder/displaced/D = new (loc)
-			transfer_fingerprints_to(D)
 			qdel(src)
 
 	else if(istype(W, /obj/item/stack/sheet))
@@ -96,7 +99,7 @@
 		switch(S.type)
 
 			if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
-				if(!anchored)
+				if(state == GIRDER_DISPLACED)
 					if(S.get_amount() < 2)
 						user << "<span class='warning'>You need two sheets of metal to create a false wall!</span>"
 						return
@@ -119,16 +122,14 @@
 							return
 						S.use(2)
 						user << "<span class='notice'>You add the plating.</span>"
-						var/turf/Tsrc = get_turf(src)
-						Tsrc.ChangeTurf(/turf/simulated/wall)
-						for(var/turf/simulated/wall/X in Tsrc.loc)
-							if(X)
-								transfer_fingerprints_to(X)
+						var/turf/T = get_turf(src)
+						T.ChangeTurf(/turf/simulated/wall)
+						transfer_fingerprints_to(T)
 						qdel(src)
 					return
 
 			if(/obj/item/stack/sheet/plasteel)
-				if(!anchored)
+				if(state == GIRDER_DISPLACED)
 					if(S.amount < 2)
 						user << "<span class='warning'>You need at least two sheets to create a false wall!</span>"
 						return
@@ -142,22 +143,23 @@
 						transfer_fingerprints_to(FW)
 						qdel(src)
 				else
-					if (src.icon_state == "reinforced") //I cant believe someone would actually write this line of code...
-						if(S.amount < 1) return ..()
+					if(state == GIRDER_REINF)
+						if(S.amount < 1)
+							return
 						user << "<span class='notice'>You start finalizing the reinforced wall...</span>"
 						if(do_after(user, 50, target = src))
 							if(!src.loc || !S || S.amount < 1)
 								return
 							S.use(1)
 							user << "<span class='notice'>You fully reinforce the wall.</span>"
-							var/turf/Tsrc = get_turf(src)
-							Tsrc.ChangeTurf(/turf/simulated/wall/r_wall)
-							for(var/turf/simulated/wall/r_wall/X in Tsrc.loc)
-								if(X)	transfer_fingerprints_to(X)
+							var/turf/T = get_turf(src)
+							T.ChangeTurf(/turf/simulated/wall/r_wall)
+							transfer_fingerprints_to(T)
 							qdel(src)
 						return
 					else
-						if(S.amount < 1) return ..()
+						if(S.amount < 1)
+							return
 						user << "<span class='notice'>You start reinforcing the girder...</span>"
 						if (do_after(user, 60, target = src))
 							if(!src.loc || !S || S.amount < 1)
@@ -171,7 +173,7 @@
 
 		if(S.sheettype)
 			var/M = S.sheettype
-			if(!anchored)
+			if(state == GIRDER_DISPLACED)
 				if(S.amount < 2)
 					user << "<span class='warning'>You need at least two sheets to create a false wall!</span>"
 					return
@@ -182,17 +184,18 @@
 				transfer_fingerprints_to(FW)
 				qdel(src)
 			else
-				if(S.amount < 2) return ..()
+				if(S.amount < 2)
+					user << "<span class='warning'>You need at least two sheets to add plating!</span>"
+					return
 				user << "<span class='notice'>You start adding plating...</span>"
 				if (do_after(user, 40, target = src))
 					if(!src.loc || !S || S.amount < 2)
 						return
 					S.use(2)
 					user << "<span class='notice'>You add the plating.</span>"
-					var/turf/Tsrc = get_turf(src)
-					Tsrc.ChangeTurf(text2path("/turf/simulated/wall/mineral/[M]"))
-					for(var/turf/simulated/wall/mineral/X in Tsrc.loc)
-						if(X)	transfer_fingerprints_to(X)
+					var/turf/T = get_turf(src)
+					T.ChangeTurf(text2path("/turf/simulated/wall/mineral/[M]"))
+					transfer_fingerprints_to(T)
 					qdel(src)
 				return
 
@@ -223,7 +226,6 @@
 /obj/structure/girder/blob_act()
 	if(prob(40))
 		qdel(src)
-
 
 /obj/structure/girder/ex_act(severity, target)
 	switch(severity)
@@ -277,6 +279,9 @@
 			return
 	return
 
+
+//////////////////////////////////////////// cult girder //////////////////////////////////////////////
+
 /obj/structure/cultgirder
 	icon= 'icons/obj/cult.dmi'
 	icon_state= "cultgirder"
@@ -290,18 +295,18 @@
 		var/obj/item/weapon/weldingtool/WT = W
 		if(WT.remove_fuel(0,user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
-								"<span class='notice'>You start to disassemble the girder...</span>", "You hear welding and clanking.")
+			user << "<span class='notice'>You start slicing apart the girder...</span>"
 			if(do_after(user, 40, target = src))
 				if( !WT.isOn() )
 					return
-				user << "<span class='notice'>You disassemble the girder.</span>"
+				user << "<span class='notice'>You slice apart the girder.</span>"
 				var/obj/effect/decal/remains/human/R = new (get_turf(src))
 				transfer_fingerprints_to(R)
 				qdel(src)
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
 		user << "<span class='notice'>You start slicing apart the girder...</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		if(do_after(user, 30, target = src))
 			user << "<span class='notice'>You slice apart the girder.</span>"
 			var/obj/effect/decal/remains/human/R = new (get_turf(src))

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -45,6 +45,7 @@
 				anchored = 1
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		user.visible_message("[user] is slicing apart the [name]...", \
 							 "<span class='notice'>You are slicing apart the [name]...</span>")
 		if(do_after(user,30, target = src))
@@ -212,7 +213,7 @@
 			log_game("Plasma statue ignited by [key_name(Proj.firer)] in ([x],[y],[z])")
 		else
 			message_admins("Plasma statue ignited by [Proj]. No known firer.(<A HREF='?_src_=holder;adminmoreinfo=\ref[Proj.firer]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[Proj.firer]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-			log_game("Plasma statue ignited by [Proj] in ([x],[y],[z]). No known firer.")	
+			log_game("Plasma statue ignited by [Proj] in ([x],[y],[z]). No known firer.")
 	..()
 
 /obj/structure/statue/plasma/attackby(obj/item/weapon/W, mob/user, params)

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -121,7 +121,7 @@
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma
 	select_name = "plasma burst"
-	fire_sound = 'sound/weapons/Laser.ogg'
+	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 15
 	e_cost = 25
 


### PR DESCRIPTION
- Fixes plasma cutter firing sound, as well as lack of sound when slicing girder/statues.
- Rearrange girders.dm , replace "anchored" and "icon_state" checks with "state" checks. Remove some duplicate checks in attackby().
- Singularity_pull() no longer unanchors anchored objects (because it breaks the deconstruction of table/girder/statues/etc, and makes mechs pullable by mobs), but it still pulls them. Fixes #11082 
