### PR TITLE
Ice cream and cones now contain proper reagents.

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
+++ b/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
@@ -6,7 +6,7 @@
 #define CONE_CHOC 6
 
 /obj/machinery/icecream_vat
-	name = "icecream vat"
+	name = "ice cream vat"
 	desc = "Ding-aling ding dong. Get your Nanotrasen-approved ice cream!"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "icecream_vat"
@@ -60,6 +60,9 @@
 	reagents.add_reagent("flour", 5)
 	reagents.add_reagent("sugar", 5)
 	reagents.add_reagent("ice", 5)
+	reagents.add_reagent("cocoa", 5)
+	reagents.add_reagent("berryjuice", 5)
+	reagents.add_reagent("singulo", 5)
 
 /obj/machinery/icecream_vat/attack_hand(mob/user)
 	user.set_machine(src)
@@ -92,18 +95,18 @@
 		var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = O
 		if(!I.ice_creamed)
 			if(product_types[dispense_flavour] > 0)
-				src.visible_message("\icon[src] <span class='info'>[user] scoops delicious [flavour_name] icecream into [I].</span>")
+				src.visible_message("\icon[src] <span class='info'>[user] scoops delicious [flavour_name] ice cream into [I].</span>")
 				product_types[dispense_flavour] -= 1
-
+				I.flavour_type = flavour_name
 				I.add_ice_cream(flavour_name)
 			//	if(beaker)
 			//		beaker.reagents.trans_to(I, 10)
 				if(I.reagents.total_volume < 10)
 					I.reagents.add_reagent("sugar", 10 - I.reagents.total_volume)
 			else
-				user << "<span class='warning'>There is not enough icecream left!</span>"
+				user << "<span class='warning'>There is not enough ice cream left!</span>"
 		else
-			user << "<span class='notice'>[O] already has icecream in it.</span>"
+			user << "<span class='notice'>[O] already has ice cream in it.</span>"
 		return 1
 	else if(O.is_open_container())
 		return
@@ -134,7 +137,7 @@
 	if(href_list["select"])
 		dispense_flavour = text2num(href_list["select"])
 		flavour_name = get_flavour_name(dispense_flavour)
-		src.visible_message("<span class='notice'>[usr] sets [src] to dispense [flavour_name] flavoured icecream.</span>")
+		src.visible_message("<span class='notice'>[usr] sets [src] to dispense [flavour_name] flavoured ice cream.</span>")
 
 	if(href_list["cone"])
 		var/dispense_cone = text2num(href_list["cone"])
@@ -144,6 +147,12 @@
 			var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = new(src.loc)
 			I.cone_type = cone_name
 			I.icon_state = "icecream_cone_[cone_name]"
+			switch (I.cone_type)
+				if ("waffle")
+					I.reagents.add_reagent("nutriment", 1)
+				if ("chocolate")
+					I.reagents.add_reagent("cocoa", 1) // chocolate ain't as nutritious kids
+
 			I.desc = "Delicious [cone_name] cone, but no ice cream."
 			src.visible_message("<span class='info'>[usr] dispenses a crunchy [cone_name] cone from [src].</span>")
 		else
@@ -175,16 +184,28 @@
 	layer = 3.1
 	var/ice_creamed = 0
 	var/cone_type
+	var/flavour_type
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/New()
 	create_reagents(20)
-	reagents.add_reagent("nutriment", 5)
+	reagents.add_reagent("nutriment", 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/proc/add_ice_cream(var/flavour_name)
 	name = "[flavour_name] icecream"
 	src.overlays += "icecream_[flavour_name]"
-	desc = "Delicious [cone_type] cone with a dollop of [flavour_name] ice cream."
+	switch (flavour_type) // adding the actual reagents advertised in the ingredient list
+		if ("vanilla")
+			desc = "A delicious [cone_type] cone filled with vanilla ice cream. All the other ice creams take content from it."
+		if ("chocolate")
+			desc = "A delicious [cone_type] cone filled with chocolate ice cream. Surprisingly, made with real cocoa."
+			reagents.add_reagent("cocoa", 2)
+		if ("strawberry")
+			desc = "A delicious [cone_type] cone filled with strawberry ice cream. Definitely not made with real strawberries."
+			reagents.add_reagent("berryjuice", 2)
+		if ("blue")
+			desc = "A delicious [cone_type] cone filled with blue ice cream. Made with real... blue?"
+			reagents.add_reagent("singulo", 2)
 	ice_creamed = 1
 
 #undef ICECREAM_VANILLA

--- a/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
+++ b/code/modules/food&drinks/kitchen machinery/icecream_vat.dm
@@ -70,12 +70,12 @@
 
 /obj/machinery/icecream_vat/interact(mob/user)
 	var/dat
-	dat += "<b>ICECREAM</b><br><div class='statusDisplay'>"
+	dat += "<b>ICE CREAM</b><br><div class='statusDisplay'>"
 	dat += "<b>Dispensing: [flavour_name] icecream </b> <br><br>"
-	dat += "<b>Vanilla icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_VANILLA]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=5'><b>x5</b></a> [product_types[ICECREAM_VANILLA]] scoops left. (Ingredients: milk, ice)<br>"
-	dat += "<b>Strawberry icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_STRAWBERRY]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=5'><b>x5</b></a> [product_types[ICECREAM_STRAWBERRY]] dollops left. (Ingredients: milk, ice, berry juice)<br>"
-	dat += "<b>Chocolate icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_CHOCOLATE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=5'><b>x5</b></a> [product_types[ICECREAM_CHOCOLATE]] dollops left. (Ingredients: milk, ice, coco powder)<br>"
-	dat += "<b>Blue icecream:</b> <a href='?src=\ref[src];select=[ICECREAM_BLUE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=5'><b>x5</b></a> [product_types[ICECREAM_BLUE]] dollops left. (Ingredients: milk, ice, singulo)<br></div>"
+	dat += "<b>Vanilla ice cream:</b> <a href='?src=\ref[src];select=[ICECREAM_VANILLA]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_VANILLA];amount=5'><b>x5</b></a> [product_types[ICECREAM_VANILLA]] scoops left. (Ingredients: milk, ice)<br>"
+	dat += "<b>Strawberry ice cream:</b> <a href='?src=\ref[src];select=[ICECREAM_STRAWBERRY]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_STRAWBERRY];amount=5'><b>x5</b></a> [product_types[ICECREAM_STRAWBERRY]] dollops left. (Ingredients: milk, ice, berry juice)<br>"
+	dat += "<b>Chocolate ice cream:</b> <a href='?src=\ref[src];select=[ICECREAM_CHOCOLATE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_CHOCOLATE];amount=5'><b>x5</b></a> [product_types[ICECREAM_CHOCOLATE]] dollops left. (Ingredients: milk, ice, coco powder)<br>"
+	dat += "<b>Blue ice cream:</b> <a href='?src=\ref[src];select=[ICECREAM_BLUE]'><b>Select</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[ICECREAM_BLUE];amount=5'><b>x5</b></a> [product_types[ICECREAM_BLUE]] dollops left. (Ingredients: milk, ice, singulo)<br></div>"
 	dat += "<br><b>CONES</b><br><div class='statusDisplay'>"
 	dat += "<b>Waffle cones:</b> <a href='?src=\ref[src];cone=[CONE_WAFFLE]'><b>Dispense</b></a> <a href='?src=\ref[src];make=[CONE_WAFFLE];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[CONE_WAFFLE];amount=5'><b>x5</b></a> [product_types[CONE_WAFFLE]] cones left. (Ingredients: flour, sugar)<br>"
 	dat += "<b>Chocolate cones:</b> <a href='?src=\ref[src];cone=[CONE_CHOC]'><b>Dispense</b></a> <a href='?src=\ref[src];make=[CONE_CHOC];amount=1'><b>Make</b></a> <a href='?src=\ref[src];make=[CONE_CHOC];amount=5'><b>x5</b></a> [product_types[CONE_CHOC]] cones left. (Ingredients: flour, sugar, coco powder)<br></div>"
@@ -97,7 +97,6 @@
 			if(product_types[dispense_flavour] > 0)
 				src.visible_message("\icon[src] <span class='info'>[user] scoops delicious [flavour_name] ice cream into [I].</span>")
 				product_types[dispense_flavour] -= 1
-				I.flavour_type = flavour_name
 				I.add_ice_cream(flavour_name)
 			//	if(beaker)
 			//		beaker.reagents.trans_to(I, 10)
@@ -184,7 +183,6 @@
 	layer = 3.1
 	var/ice_creamed = 0
 	var/cone_type
-	var/flavour_type
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/New()
@@ -194,7 +192,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/icecream/proc/add_ice_cream(var/flavour_name)
 	name = "[flavour_name] icecream"
 	src.overlays += "icecream_[flavour_name]"
-	switch (flavour_type) // adding the actual reagents advertised in the ingredient list
+	switch (flavour_name) // adding the actual reagents advertised in the ingredient list
 		if ("vanilla")
 			desc = "A delicious [cone_type] cone filled with vanilla ice cream. All the other ice creams take content from it."
 		if ("chocolate")

--- a/html/changelogs/bgobandit - weallscreamforreagents.yml
+++ b/html/changelogs/bgobandit - weallscreamforreagents.yml
@@ -1,0 +1,5 @@
+
+author: bgobandit
+delete-after: True
+changes: 
+  - rscadd: "After multiple complaints from WaffleCo food activists, Nanotrasen has added real chocolate, berry juice and blue flavouring to its ice cream products."


### PR DESCRIPTION
Fixes the bug where ice cream cones did not actually contain any of the reagents advertised on the machine, nor did the machine itself. This has bugged me literally since the ice cream machine was added and now I can (sort of) into code and NOW IT IS FIXED.

Reagents are pretty self-explanatory: cocoa for chocolate, berry juice for strawberry, singulo drink for blue (this was how it was before; it's also in bluespace tomatoes for whatever it's worth). Waffle cones get 1 vitamin just like waffles do, chocolate cones instead get 1 cocoa (shit ain't healthy yo),
