### PR TITLE
Mob buckled to mulebots

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -70,17 +70,16 @@
 	#define BOT_MOVING			9	// for clean/floor/med bots, when moving.
 	#define BOT_HEALING			10	// healing people (medbots)
 	#define BOT_RESPONDING		11	// responding to a call from the AI
-	#define BOT_LOADING			12	// loading/unloading
-	#define BOT_DELIVER			13	// moving to deliver
-	#define BOT_GO_HOME			14	// returning to home
-	#define BOT_BLOCKED			15	// blocked
-	#define BOT_NAV				16	// computing navigation
-	#define BOT_WAIT_FOR_NAV	17	// waiting for nav computation
-	#define BOT_NO_ROUTE		18	// no destination beacon found (or no route)
+	#define BOT_DELIVER			12	// moving to deliver
+	#define BOT_GO_HOME			13	// returning to home
+	#define BOT_BLOCKED			14	// blocked
+	#define BOT_NAV				15	// computing navigation
+	#define BOT_WAIT_FOR_NAV	16	// waiting for nav computation
+	#define BOT_NO_ROUTE		17	// no destination beacon found (or no route)
 	var/list/mode_name = list("In Pursuit","Preparing to Arrest", "Arresting", \
 	"Beginning Patrol", "Patrolling", "Summoned by PDA", \
 	"Cleaning", "Repairing", "Proceeding to work site", "Healing", \
-	"Proceeding to AI waypoint", "Loading/Unloading", "Navigating to Delivery Location", "Navigating to Home", \
+	"Proceeding to AI waypoint", "Navigating to Delivery Location", "Navigating to Home", \
 	"Waiting for clear path", "Calculating navigation path", "Pinging beacon network", "Unable to reach destination")
 	//This holds text for what the bot is mode doing, reported on the remote bot control interface.
 

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -486,11 +486,12 @@ obj/machinery/bot/mulebot/CanPass(atom/movable/mover, turf/target, height=1.5)
 	if(M.buckled)
 		return 0
 	var/turf/T = get_turf(src)
-	density = 0
-	var/can_step = step_towards(M, T)
-	density = 1
-	if(!can_step)
-		return 0
+	if(M.loc != T)
+		density = 0
+		var/can_step = step_towards(M, T)
+		density = 1
+		if(!can_step)
+			return 0
 	return ..()
 
 
@@ -802,11 +803,10 @@ obj/machinery/bot/mulebot/CanPass(atom/movable/mover, turf/target, height=1.5)
 
 // player on mulebot attempted to move
 /obj/machinery/bot/mulebot/relaymove(mob/user)
-	if(user.stat)
+	if(user.incapacitated())
 		return
 	if(load == user)
 		unload(0)
-	return
 
 
 //Update navigation data. Called when commanded to deliver, return home, or a route update is needed...

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -87,14 +87,12 @@ obj/machinery/bot/mulebot/bot_reset()
 obj/machinery/bot/mulebot/Move(atom/newloc, direct)
 	. = ..()
 	if(buckled_mob)
-		buckled_mob.buckled = null
 		if(!buckled_mob.Move(loc, direct))
 			loc = buckled_mob.loc //we gotta go back
 			last_move = buckled_mob.last_move
 			inertia_dir = last_move
 			buckled_mob.inertia_dir = last_move
 			. = 0
-		buckled_mob.buckled = src
 
 obj/machinery/bot/mulebot/Process_Spacemove(movement_dir = 0)
 	if(buckled_mob)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -6,6 +6,11 @@
 
 var/global/mulebot_count = 0
 
+
+#define SIGH 0
+#define ANNOYED 1
+#define DELIGHT 2
+
 /obj/machinery/bot/mulebot
 	name = "\improper MULEbot"
 	desc = "A Multiple Utility Load Effector bot."
@@ -22,13 +27,15 @@ var/global/mulebot_count = 0
 	bot_type = MULE_BOT
 	model = "MULE"
 	blood_DNA = list()
+	can_buckle = 1
+	buckle_lying = 0
 
 	suffix = ""
 
 	var/turf/target				// this is turf to navigate to (location of beacon)
 	var/loaddir = 0				// this the direction to unload onto/load from
 	var/home_destination = "" 	// tag of home beacon
-	req_access = list(access_cargo) 
+	req_access = list(access_cargo)
 
 	mode = BOT_IDLE
 
@@ -76,6 +83,28 @@ obj/machinery/bot/mulebot/bot_reset()
 	..()
 	reached_target = 0
 
+
+obj/machinery/bot/mulebot/Move(atom/newloc, direct)
+	. = ..()
+	if(buckled_mob)
+		buckled_mob.buckled = null
+		if(!buckled_mob.Move(loc, direct))
+			loc = buckled_mob.loc //we gotta go back
+			last_move = buckled_mob.last_move
+			inertia_dir = last_move
+			buckled_mob.inertia_dir = last_move
+			. = 0
+		buckled_mob.buckled = src
+
+obj/machinery/bot/mulebot/Process_Spacemove(movement_dir = 0)
+	if(buckled_mob)
+		return buckled_mob.Process_Spacemove(movement_dir)
+	return ..()
+
+obj/machinery/bot/mulebot/CanPass(atom/movable/mover, turf/target, height=1.5)
+	if(mover == buckled_mob)
+		return 1
+	return ..()
 
 // attack by item
 // emag : lock/unlock,
@@ -183,8 +212,6 @@ obj/machinery/bot/mulebot/bot_reset()
 		switch(mode)
 			if(BOT_IDLE)
 				dat += "<span class='good'>Ready</span>"
-			if(BOT_LOADING)
-				dat += "<span class='good'>[mode_name[BOT_LOADING]]</span>"
 			if(BOT_DELIVER)
 				dat += "<span class='good'>[mode_name[BOT_DELIVER]]</span>"
 			if(BOT_GO_HOME)
@@ -358,7 +385,7 @@ obj/machinery/bot/mulebot/bot_reset()
 				updateDialog()
 
 		if("unload")
-			if(load && mode !=1)
+			if(load && mode != BOT_HUNT)
 				if(loc == target)
 					unload(loaddir)
 				else
@@ -379,7 +406,6 @@ obj/machinery/bot/mulebot/bot_reset()
 
 
 
-
 // returns true if the bot has power
 /obj/machinery/bot/mulebot/proc/has_power()
 	return !open && cell && cell.charge > 0 && wires.HasPower()
@@ -393,65 +419,92 @@ obj/machinery/bot/mulebot/bot_reset()
 		user << "<span class='danger'>Access denied.</span>"
 		return 0
 
+/obj/machinery/bot/mulebot/proc/buzz(type)
+	switch(type)
+		if(SIGH)
+			visible_message("[src] makes a sighing buzz.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
+			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		if(ANNOYED)
+			visible_message("[src] makes an annoyed buzzing sound.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
+			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+		if(DELIGHT)
+			visible_message("[src] makes a delighted ping!", "<span class='italics'>You hear a ping.</span>")
+			playsound(loc, 'sound/machines/ping.ogg', 50, 0)
+
+
 // mousedrop a crate to load the bot
 // can load anything if emagged
+/obj/machinery/bot/mulebot/MouseDrop_T(atom/movable/AM, mob/user)
 
-/obj/machinery/bot/mulebot/MouseDrop_T(atom/movable/C, mob/user)
-
-	if(user.stat)
+	if(user.incapacitated() || user.lying)
 		return
 
-	if (!on || !istype(C)|| C.anchored || get_dist(user, src) > 1 || get_dist(src,C) > 1 )
+	if (!istype(AM))
 		return
 
-	if(load)
-		return
-
-	load(C)
-
+	load(AM)
 
 // called to load a crate
-/obj/machinery/bot/mulebot/proc/load(atom/movable/C)
-	if(wires.LoadCheck() && !istype(C,/obj/structure/closet/crate))
-		visible_message("[src] makes a sighing buzz.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
-		playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
-		return		// if not emagged, only allow crates to be loaded
-
-	//I'm sure someone will come along and ask why this is here... well people were dragging screen items onto the mule, and that was not cool.
-	//So this is a simple fix that only allows a selection of item types to be considered. Further narrowing-down is below.
-	if(!istype(C,/obj/item) && !istype(C,/obj/machinery) && !istype(C,/obj/structure) && !ismob(C))
-		return
-	if(!isturf(C.loc)) //To prevent the loading from stuff from someone's inventory, which wouldn't get handled properly.
+/obj/machinery/bot/mulebot/proc/load(atom/movable/AM)
+	if(load ||  AM.anchored)
 		return
 
-	if(get_dist(C, src) > 1 || load || !on)
+	if(!isturf(AM.loc)) //To prevent the loading from stuff from someone's inventory or screen icons.
 		return
-	mode = BOT_LOADING
 
-	// if a create, close before loading
-	var/obj/structure/closet/crate/crate = C
-	if(istype(crate))
-		crate.close()
+	var/obj/structure/closet/crate/CRATE
+	if(istype(AM,/obj/structure/closet/crate))
+		CRATE = AM
+	else
+		if(wires.LoadCheck())
+			buzz(SIGH)
+			return		// if not emagged, only allow crates to be loaded
 
-	C.loc = loc
-	sleep(2)
-	if(C.loc != loc) //To prevent you from going onto more thano ne bot.
-		return
-	C.loc = src
-	load = C
+	if(CRATE) // if it's a crate, close before loading
+		CRATE.close()
 
-	C.pixel_y += 9
-	if(C.layer < layer)
-		C.layer = layer + 0.1
-	overlays += C
+	if(isobj(AM))
+		var/obj/O = AM
+		if(O.buckled_mob || (locate(/mob) in AM)) //can't load non crates objects with mobs buckled to it or inside it.
+			buzz(SIGH)
+			return
 
-	if(ismob(C))
-		var/mob/M = C
-		if(M.client)
-			M.client.perspective = EYE_PERSPECTIVE
-			M.client.eye = src
+	if(isliving(AM))
+		if(!buckle_mob(AM))
+			return
+	else
+		AM.loc = src
+		AM.pixel_y += 9
+		if(AM.layer < layer)
+			AM.layer = layer + 0.1
+		overlays += AM
 
+	load= AM
 	mode = BOT_IDLE
+
+/obj/machinery/bot/mulebot/buckle_mob(mob/living/M)
+	if(M.buckled)
+		return 0
+	var/turf/T = get_turf(src)
+	density = 0
+	var/can_step = step_towards(M, T)
+	density = 1
+	if(!can_step)
+		return 0
+	return ..()
+
+
+/obj/machinery/bot/mulebot/post_buckle_mob(mob/living/M)
+	if(M == buckled_mob) //post buckling
+		M.pixel_y = initial(M.pixel_y) + 9
+		if(M.layer < layer)
+			M.layer = layer + 0.1
+
+	else //post unbuckling
+		load = null
+		M.layer = initial(M.layer)
+		M.pixel_y = initial(M.pixel_y)
+
 
 // called to unload the bot
 // argument is optional direction to unload
@@ -460,18 +513,16 @@ obj/machinery/bot/mulebot/bot_reset()
 	if(!load)
 		return
 
-	mode = BOT_LOADING
+	mode = BOT_IDLE
+
 	overlays.Cut()
 
-	if(ismob(load))
-		var/mob/M = load
-		if(M.client)
-			M.client.perspective = MOB_PERSPECTIVE
-			M.client.eye = src
-
+	if(buckled_mob)
+		unbuckle_mob()
+		return
 
 	load.loc = loc
-	load.pixel_y -= 9
+	load.pixel_y = initial(load.pixel_y)
 	load.layer = initial(load.layer)
 	if(dirn)
 		var/turf/T = loc
@@ -481,22 +532,7 @@ obj/machinery/bot/mulebot/bot_reset()
 
 	load = null
 
-	// in case non-load items end up in contents, dump every else too
-	// this seems to happen sometimes due to race conditions
-	// with items dropping as mobs are loaded
 
-	for(var/atom/movable/AM in src)
-		if(AM == cell || istype(AM , botcard) || AM == Radio) continue
-
-		AM.loc = loc
-		AM.layer = initial(AM.layer)
-		AM.pixel_y = initial(AM.pixel_y)
-		if(ismob(AM))
-			var/mob/M = AM
-			if(M.client)
-				M.client.perspective = MOB_PERSPECTIVE
-				M.client.eye = src
-	mode = BOT_IDLE
 
 /obj/machinery/bot/mulebot/call_bot()
 	..()
@@ -536,13 +572,13 @@ obj/machinery/bot/mulebot/bot_reset()
 	if(refresh) updateDialog()
 
 /obj/machinery/bot/mulebot/proc/process_bot()
-	//if(mode) world << "Mode: [mode]"
+
+	if(!on)
+		return
 
 	switch(mode)
 		if(BOT_IDLE)		// idle
 			icon_state = "mulebot0"
-			return
-		if(BOT_LOADING)		// loading/unloading
 			return
 
 		if(BOT_DELIVER,BOT_GO_HOME,BOT_BLOCKED)		// navigating to deliver,home, or blocked
@@ -603,26 +639,22 @@ obj/machinery/bot/mulebot/bot_reset()
 						blockcount++
 						mode = BOT_BLOCKED
 						if(blockcount == 3)
-							visible_message("[src] makes an annoyed buzzing sound.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
-							playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+							buzz(ANNOYED)
 
 						if(blockcount > 10)	// attempt 10 times before recomputing
 							// find new path excluding blocked turf
-							visible_message("[src] makes a sighing buzz.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
-							playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+							buzz(SIGH)
 
 							spawn(2)
 								calc_path(next)
 								if(path.len > 0)
-									visible_message("[src] makes a delighted ping!", "<span class='italics'>You hear a ping.</span>")
-									playsound(loc, 'sound/machines/ping.ogg', 50, 0)
+									buzz(DELIGHT)
 								mode = BOT_BLOCKED
 							mode = BOT_WAIT_FOR_NAV
 							return
 						return
 				else
-					visible_message("[src] makes an annoyed buzzing sound.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
-					playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+					buzz(ANNOYED)
 					//world << "Bad turf."
 					mode = BOT_NAV
 					return
@@ -641,20 +673,12 @@ obj/machinery/bot/mulebot/bot_reset()
 				if(path.len > 0)
 					blockcount = 0
 					mode = BOT_BLOCKED
-					visible_message("[src] makes a delighted ping!", "<span class='italics'>You hear a ping.</span>")
-					playsound(loc, 'sound/machines/ping.ogg', 50, 0)
+					buzz(DELIGHT)
 
 				else
-					visible_message("[src] makes a sighing buzz.", "<span class='italics'>You hear an electronic buzzing sound.</span>")
-					playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
+					buzz(SIGH)
 
 					mode = BOT_NO_ROUTE
-		//if(6)
-			//world << "Pending path calc."
-		//if(7)
-			//world << "No dest / no route."
-
-	return
 
 
 // calculates a path to the current destination
@@ -673,6 +697,8 @@ obj/machinery/bot/mulebot/bot_reset()
 
 // starts bot moving to current destination
 /obj/machinery/bot/mulebot/proc/start()
+	if(!on)
+		return
 	if(destination == home_destination)
 		mode = BOT_GO_HOME
 	else
@@ -683,6 +709,8 @@ obj/machinery/bot/mulebot/bot_reset()
 // starts bot moving to home
 // sends a beacon query to find
 /obj/machinery/bot/mulebot/proc/start_home()
+	if(!on)
+		return
 	spawn(0)
 		set_destination(home_destination)
 		mode = BOT_BLOCKED
@@ -719,7 +747,7 @@ obj/machinery/bot/mulebot/bot_reset()
 							break
 				else			// otherwise, look for crates only
 					AM = locate(/obj/structure/closet/crate) in get_step(loc,loaddir)
-				if(AM)
+				if(AM && AM.Adjacent(src))
 					load(AM)
 					if(report_delivery)
 						speak("Now loading [load] at <b>[get_area(src)]</b>.", radio_frequency)
@@ -828,5 +856,12 @@ obj/machinery/bot/mulebot/bot_reset()
 	s.start()
 
 	new /obj/effect/decal/cleanable/oil(loc)
-	unload(0)
 	qdel(src)
+
+/obj/machinery/bot/mulebot/Destroy()
+	unload(0)
+	return ..()
+
+#undef SIGH
+#undef ANNOYED
+#undef DELIGHT

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -93,7 +93,9 @@
 
 	else if(istype(A, /mob/living)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(!M.lying && !ismonkey(M) && !isslime(M))	//If your not laying down, or a small creature, no pass.
+		if(M.buckled && istype(M.buckled, /obj/machinery/bot/mulebot)) // mulebot passenger gets a free pass.
+			return 1
+		if(!M.lying && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
 			return 0
 	return ..()
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -72,7 +72,7 @@
 
 //Wrapper procs that handle sanity and user feedback
 /obj/proc/user_buckle_mob(mob/living/M, mob/user)
-	if(!user.Adjacent(M) || user.restrained() || user.lying || user.stat)
+	if(!user.Adjacent(M) || user.lying || user.incapacitated())
 		return
 
 	add_fingerprint(user)


### PR DESCRIPTION
- Changes how mulebots handle loading mobs. It now buckles them to the bot. Fixes #11099 Fixes #9082
- You can no longer load objects containing mobs or with mobs buckled to them.
- Some simplification in mulebot code (buzzing sound code)
- Loading is now instantaneous and the mode BOT_LOADING is removed.
- The mulebot can no longer do certain stuff while off.
- Removing unneeded comments.
- Fixes mulebot loading/unloading being possible through border windows.
- Fixes mulebot not dropping its loaded cargo when qdel'd (wasn't a problem for explosion but for alien acid for example)
- All ventcrawlers (xeno, monkey, drone, slime) and tiny mob (mouse, lizard, butterfly, etc) can now pass through plastic flaps without lying down (instead of just monkey and slime previously).
