### PR TITLE
Adds forensics and toy crates to cargo.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -233,6 +233,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	containername = "disabler crate"
 
+/datum/supply_packs/security/forensics
+	name = "Forensics Crate"
+	contains = list(/obj/item/device/detective_scanner,
+	                /obj/item/weapon/storage/box/evidence,
+	                /obj/item/device/camera,
+	                /obj/item/device/taperecorder,
+	                /obj/item/toy/crayon/white,
+	                /obj/item/clothing/head/det_hat)
+	cost = 20
+	containername ="forensics crate"
+
 ///// Armory stuff
 
 /datum/supply_packs/security/armory
@@ -1219,6 +1230,26 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "crate"	//let's keep it subtle, eh?
 	contraband = 1
 
+/datum/supply_packs/misc/randomised/toys
+	name = "Toy Crate"
+	num_contained = 5
+	contains = list(/obj/item/toy/spinningtoy,
+	                /obj/item/toy/sword,
+	                /obj/item/toy/foamblade,
+	                /obj/item/toy/AI,
+	                /obj/item/toy/owl,
+	                /obj/item/toy/griffin,
+	                /obj/item/toy/nuke,
+	                /obj/item/toy/minimeteor,
+	                /obj/item/toy/carpplushie,
+	                /obj/item/weapon/coin/antagtoken,
+	                /obj/item/stack/tile/fakespace,
+	                /obj/item/weapon/gun/projectile/shotgun/toy/crossbow,
+	                /obj/item/toy/redbutton)
+
+	cost = 50 // or play the arcade machines ya lazy bum
+	containername ="toy crate"
+
 /datum/supply_packs/misc/autodrobe
 	name = "Autodrobe Supply Crate"
 	contains = list(/obj/item/weapon/vending_refill/autodrobe,
@@ -1280,3 +1311,4 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 40
 	containername = "foam force pistols crate"
 	contraband = 1
+

--- a/html/changelogs/bgobandit - newcrates.yml
+++ b/html/changelogs/bgobandit - newcrates.yml
@@ -1,0 +1,4 @@
+author: bgobandit
+delete-after: True
+changes: 
+  - rscadd: "CentComm now offers its cargo department toys, as well as detective gear so their boss can figure out which tech wasted all the points on them."


### PR DESCRIPTION
Offers two new crates from Cargo based on feedback.

Detective Crate: J_Madison on the forums: "The detective's scanner cannot be replaced and all it takes is two good sprays of acid to prevent any forensic crimes from being solved." Contains a scanner, evidence bags, camera, recorder, white crayon and fedora. Gun not included, if you lose your gun as detective you don't deserve another one. 

Toy crate: 50 points, 5 random toys. For the burning of points and the spreading of !!FUN!!
