### PR TITLE
Fixes item embedding not working.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -258,7 +258,7 @@ its easier to just keep the beam vertical.
 /atom/proc/fire_act()
 	return
 
-/atom/proc/hitby(atom/movable/AM, skip, var/hitpush)
+/atom/proc/hitby(atom/movable/AM, skipcatch, hitpush)
 	if(density && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav.
 		spawn(2)
 			step(AM,  turn(AM.dir, 180))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -155,10 +155,10 @@
 /atom/movable/proc/throw_impact(atom/hit_atom)
 	return hit_atom.hitby(src)
 
-/atom/movable/hitby(atom/movable/AM, skip, var/hitpush = 1)
+/atom/movable/hitby(atom/movable/AM, skipcatch, hitpush = 1)
 	if(!anchored && hitpush)
 		step(src, AM.dir)
-	return ..()
+	..()
 
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0)
 	if(!target || !src || (flags & NODROP))	return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -476,7 +476,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/itempush = 1
 	if(w_class < 4)
 		itempush = 0 //too light to push anything
-	return A.hitby(src,thrownby, 0, itempush)
+	return A.hitby(src, 0, itempush)
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1)
 	thrownby = thrower

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -1,5 +1,5 @@
-/mob/living/carbon/alien/hitby(atom/movable/AM)
-	..(AM, skip = 1)
+/mob/living/carbon/alien/hitby(atom/movable/AM, skipcatch, hitpush)
+	..(AM, skipcatch = 1, hitpush = 0)
 
 
 /*Code for aliens attacking aliens. Because aliens act on a hivemind, I don't see them as very aggressive with each other.

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,5 +1,5 @@
-/mob/living/carbon/hitby(atom/movable/AM, skip)
-	if(!skip)	//ugly, but easy
+/mob/living/carbon/hitby(atom/movable/AM, skipcatch, hitpush = 1)
+	if(!skipcatch)	//ugly, but easy
 		if(in_throw_mode && !get_active_hand())	//empty active hand and we're in throw mode
 			if(canmove && !restrained())
 				if(istype(AM, /obj/item))
@@ -9,7 +9,7 @@
 						visible_message("<span class='warning'>[src] catches [I]!</span>")
 						throw_mode_off()
 						return 1
-	return ..()
+	..()
 
 /mob/living/carbon/throw_impact(atom/hit_atom)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -455,6 +455,8 @@ emp_act
 		..()
 
 /mob/living/carbon/human/hitby(atom/movable/AM)
+	var/hitpush = 1
+	var/skipcatch = 0
 	if(AM.throw_speed >= EMBED_THROWSPEED_THRESHOLD)
 		if(istype(AM, /obj/item))
 			var/obj/item/I = AM
@@ -467,5 +469,6 @@ emp_act
 					I.loc = src
 					L.take_damage(I.w_class*I.embedded_impact_pain_multiplier)
 					visible_message("<span class='danger'>\the [I.name] embeds itself in [src]'s [L.getDisplayName()]!</span>","<span class='userdanger'>\the [I.name] embeds itself in your [L.getDisplayName()]!</span>")
-					return
-	return ..()
+					hitpush = 0
+					skipcatch = 1 //can't catch the now embedded item
+	return ..(AM, skipcatch, hitpush)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -455,7 +455,7 @@ emp_act
 		..()
 
 /mob/living/carbon/human/hitby(atom/movable/AM)
-	if(throw_speed >= EMBED_THROWSPEED_THRESHOLD)
+	if(AM.throw_speed >= EMBED_THROWSPEED_THRESHOLD)
 		if(istype(AM, /obj/item))
 			var/obj/item/I = AM
 			if(can_embed(I))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -44,7 +44,7 @@
 		else
 				return 0
 
-/mob/living/hitby(atom/movable/AM)
+/mob/living/hitby(atom/movable/AM, skipcatch, hitpush = 1)
 	if(istype(AM, /obj/item))
 		var/obj/item/I = AM
 		var/zone = ran_zone("chest", 65)//Hits a random part of the body, geared towards the chest
@@ -75,7 +75,7 @@
 			add_logs(I.thrownby, src, "hit", I)
 	else
 		playsound(loc, 'sound/weapons/genhit.ogg', 50, 1, -1)
-	return ..()
+	..()
 
 /mob/living/mech_melee_attack(obj/mecha/M)
 	if(M.occupant.a_intent == "harm")


### PR DESCRIPTION
- Fixes #11117
- Fixes not getting the 'hit' message, damage and sound (and logging) when the item embeds itself in a human.
- Throwing a big item at an alien no longer pushes it.
- If a thrown item embeds itself in you, it doesn't also push you.
- Fixes an old argument in item/throw_impact() that I forgot to remove.
- Rename the skip argument of hitby() to skipcatch (more explicit). 
