### PR TITLE
Make objects being dragged immune to pressure differentials (space wind)

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -290,7 +290,7 @@
 /atom/movable/var/pressure_resistance = 5
 
 /atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
-	if(!anchored)
+	if(!anchored && !pulledby)
 		if(pressure_difference > pressure_resistance)
 			spawn step(src, direction)
 		return 1

--- a/html/changelogs/MrP space wind dragging.yml
+++ b/html/changelogs/MrP space wind dragging.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MrPerson
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Objects being dragged will no longer get shoved out of your grasp by space wind. Retrieving dead bodies should be possible."


### PR DESCRIPTION
While not a solution to space wind being shit, this is just a good change that should have been done anyway to make dragging dead/dying people back onto the station from a hull breach less annoying. Also closets and other dense shit are still annoying because the wind pushes you into the closet, which pushes it backwards and out of your grasp, which is annoying and stupid, but there's no really good way to fix that right now.
