### PR TITLE
Gang tags no longer rotate based on the user's dir

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -5,6 +5,7 @@
 	icon_state = "rune1"
 	layer = 2.1
 	anchored = 1
+	var/do_icon_rotate = TRUE
 
 /obj/effect/decal/cleanable/crayon/examine()
 	set src in view(2)
@@ -22,14 +23,16 @@
 		type = pick(gang_name_pool)
 	icon_state = type
 
-	var/matrix/M = matrix()
-	M.Turn(rotation)
-	src.transform = M
+	if(rotation && do_icon_rotate)
+		var/matrix/M = matrix()
+		M.Turn(rotation)
+		src.transform = M
 
 	color = main
 
 /obj/effect/decal/cleanable/crayon/gang
 	layer = 3.6 //Harder to hide
+	do_icon_rotate = FALSE //These are designed to always face south, so no rotation please.
 	var/datum/gang/gang
 
 /obj/effect/decal/cleanable/crayon/gang/New(location, var/datum/gang/G, var/e_name = "gang tag", var/rotation = 0)


### PR DESCRIPTION
Fixes #11039 
## Content:
- Gang tags no longer rotate based on the user's `dir` like other graffiti, the sprites for gang tags were not designed to rotate, and should not follow the default behaviour.
## Code:
- `effect/decal/crayon` now has a `do_icon_rotate` var, defaulting to true, which decided if they obey the `rotation` argument
- `effect/decal/crayon/gang` has `do_icon_rotate = FALSE`, so they don't rotate
- `effect/decal/crayon` now only makes a matrix and turns it if there's actually a non-0 value for the `rotation` argument 
