### PR TITLE
Astral Tiles 1.01 - Fun Removal

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -34,7 +34,7 @@
 							/obj/item/toy/owl										= 2,
 							/obj/item/toy/griffin									= 2,
 							/obj/item/weapon/coin/antagtoken						= 2,
-							/obj/item/stack/tile/fakespace							= 2,
+							/obj/item/stack/tile/fakespace/loaded					= 2,
 							)
 
 /obj/machinery/computer/arcade/New()

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -103,6 +103,8 @@
 	turf_type = /turf/simulated/floor/fakespace
 	burn_state = 0 //Burnable
 
+/obj/item/stack/tile/fakespace/loaded
+	amount = 30
 
 //High-traction
 /obj/item/stack/tile/noslip

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -99,7 +99,6 @@
 	singular_name = "astral carpet"
 	desc = "A piece of carpet with a convincing star pattern."
 	icon_state = "tile_space"
-	amount = 30
 	turf_type = /turf/simulated/floor/fakespace
 	burn_state = 0 //Burnable
 


### PR DESCRIPTION
Fixes getting 30 astral floor tiles every time you pry up one floor tile.

Thank you all for stress-testing my new content.

Fixes #11131 
