### PR TITLE
VV and VV Mass Modify now accept variables when editing a string

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -587,3 +587,44 @@ for(var/t in test_times)
 			return "#4B0082"
 		else
 			return "#FFFFFF"
+
+
+//This is a weird one:
+//It returns a list of all var names found in the string
+//These vars must be in the [var_name] format
+//It's only a proc because it's used in more than one place
+
+//Takes a string and a datum
+//The string is well, obviously the string being checked
+//The datum is used as a source for var names, to check validity
+//Otherwise every single word could technically be a variable!
+/proc/string2listofvars(var/t_string, var/datum/var_source)
+	if(!t_string || !var_source)
+		return list()
+
+	. = list()
+
+	var/var_found = findtext(t_string,"\[") //Not the actual variables, just a generic "should we even bother" check
+	if(var_found)
+		//Find var names
+
+		// "A dog said hi [name]!"
+		// text2list() --> list("A dog said hi ","name]!"
+		// list2text() --> "A dog said hi name]!"
+		// text2list() --> list("A","dog","said","hi","name]!")
+
+		t_string = replacetext(t_string,"\[","\[ ")//Necessary to resolve "word[var_name]" scenarios
+		var/list/list_value = text2list(t_string,"\[")
+		var/intermediate_stage = list2text(list_value)
+
+		list_value = text2list(intermediate_stage," ")
+		for(var/value in list_value)
+			if(findtext(value,"]"))
+				value = text2list(value,"]") //"name]!" --> list("name","!")
+				for(var/A in value)
+					if(var_source.vars.Find(A))
+						. += A
+
+
+
+

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -173,38 +173,117 @@
 		if("text")
 			var/new_value = input("Enter new text:","Text",O.vars[variable]) as text|null
 			if(new_value == null) return
+
+			var/process_vars = 0
+			var/unique = 0
+			if(findtext(new_value,"\["))
+				process_vars = alert(usr,"\[] detected in string, process as variables?","Process Variables?","Yes","No")
+				if(process_vars == "Yes")
+					process_vars = 1
+					unique = alert(usr,"Process vars unique to each instance, or same for all?","Variable Association","Unique","Same")
+					if(unique == "Unique")
+						unique = 1
+					else
+						unique = 0
+				else
+					process_vars = 0
+
+			var/pre_processing = new_value
+			var/list/varsvars = list()
+
+			if(process_vars)
+				varsvars = string2listofvars(new_value, O)
+				if(varsvars.len)
+					for(var/V in varsvars)
+						new_value = replacetext(new_value,"\[[V]]","[O.vars[V]]")
+
 			O.vars[variable] = new_value
 
+			//Convert the string vars for anything that's not O
 			if(method)
 				if(istype(O, /mob))
 					for(var/mob/M in mob_list)
 						if ( istype(M , O.type) )
-							M.vars[variable] = O.vars[variable]
+							new_value = pre_processing //reset new_value, ready to convert it uniquely for the next iteration
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[M.vars[V]]")
+								else
+									new_value = O.vars[variable] //We already processed the non-unique form for O, reuse it
+
+							M.vars[variable] = new_value
 
 				else if(istype(O, /obj))
 					for(var/obj/A in world)
 						if ( istype(A , O.type) )
-							A.vars[variable] = O.vars[variable]
+							new_value = pre_processing
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[A.vars[V]]")
+								else
+									new_value = O.vars[variable]
+
+							A.vars[variable] = new_value
 
 				else if(istype(O, /turf))
 					for(var/turf/A in world)
 						if ( istype(A , O.type) )
-							A.vars[variable] = O.vars[variable]
+							new_value = pre_processing
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[A.vars[V]]")
+								else
+									new_value = O.vars[variable]
+
+							A.vars[variable] = new_value
 			else
 				if(istype(O, /mob))
 					for(var/mob/M in mob_list)
 						if (M.type == O.type)
-							M.vars[variable] = O.vars[variable]
+							new_value = pre_processing
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[M.vars[V]]")
+								else
+									new_value = O.vars[variable]
+
+							M.vars[variable] = new_value
 
 				else if(istype(O, /obj))
 					for(var/obj/A in world)
 						if (A.type == O.type)
-							A.vars[variable] = O.vars[variable]
+							new_value = pre_processing
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[A.vars[V]]")
+								else
+									new_value = O.vars[variable]
+
+							A.vars[variable] = new_value
 
 				else if(istype(O, /turf))
 					for(var/turf/A in world)
 						if (A.type == O.type)
-							A.vars[variable] = O.vars[variable]
+							new_value = pre_processing
+
+							if(process_vars)
+								if(unique)
+									for(var/V in varsvars)
+										new_value = replacetext(new_value,"\[[V]]","[A.vars[V]]")
+								else
+									new_value = O.vars[variable]
+
+							A.vars[variable] = new_value
 
 		if("num")
 			var/new_value = input("Enter new number:","Num",\

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -28,7 +28,7 @@ var/list/VVckey_edit = list("key", "ckey")
 		src.modify_variables(ticker)
 		feedback_add_details("admin_verb","ETV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/mod_list_add_ass() //haha
+/client/proc/mod_list_add_ass(atom/O) //haha
 
 	var/class = "text"
 	if(src.holder && src.holder.marked_datum)
@@ -73,6 +73,14 @@ var/list/VVckey_edit = list("key", "ckey")
 			var_value = holder.marked_datum
 
 	if(!var_value) return
+
+	if(istext(var_value))
+		if(findtext(var_value,"\["))
+			var/process_vars = alert(usr,"\[] detected in string, process as variables?","Process Variables?","Yes","No")
+			if(process_vars == "Yes")
+				var/list/varsvars = string2listofvars(var_value, O)
+				for(var/V in varsvars)
+					var_value = replacetext(var_value,"\[[V]]","[O.vars[V]]")
 
 	return var_value
 
@@ -123,12 +131,18 @@ var/list/VVckey_edit = list("key", "ckey")
 
 	if(!var_value) return
 
+	if(istext(var_value))
+		if(findtext(var_value,"\["))
+			var/process_vars = alert(usr,"\[] detected in string, process as variables?","Process Variables?","Yes","No")
+			if(process_vars == "Yes")
+				var/list/varsvars = string2listofvars(var_value, O)
+				for(var/V in varsvars)
+					var_value = replacetext(var_value,"\[[V]]","[O.vars[V]]")
+
+	L += var_value
 	switch(alert("Would you like to associate a var with the list entry?",,"Yes","No"))
 		if("Yes")
-			L += var_value
-			L[var_value] = mod_list_add_ass() //haha
-		if("No")
-			L += var_value
+			L[var_value] = mod_list_add_ass(O) //haha
 	world.log << "### ListVarEdit by [src]: [O.type] [objectvar]: ADDED=[var_value]"
 	log_admin("[key_name(src)] modified [original_name]'s [objectvar]: ADDED=[var_value]")
 	message_admins("[key_name_admin(src)] modified [original_name]'s [objectvar]: ADDED=[var_value]")
@@ -289,6 +303,14 @@ var/list/VVckey_edit = list("key", "ckey")
 
 		if("text")
 			new_var = input("Enter new text:","Text") as text
+
+			if(findtext(new_var,"\["))
+				var/process_vars = alert(usr,"\[] detected in string, process as variables?","Process Variables?","Yes","No")
+				if(process_vars == "Yes")
+					var/list/varsvars = string2listofvars(new_var, O)
+					for(var/V in varsvars)
+						new_var = replacetext(new_var,"\[[V]]","[O.vars[V]]")
+
 			if(assoc)
 				L[assoc_key] = new_var
 			else
@@ -537,6 +559,14 @@ var/list/VVckey_edit = list("key", "ckey")
 		if("text")
 			var/var_new = input("Enter new text:","Text",O.vars[variable]) as null|text
 			if(var_new==null) return
+
+			if(findtext(var_new,"\["))
+				var/process_vars = alert(usr,"\[] detected in string, process as variables?","Process Variables?","Yes","No")
+				if(process_vars == "Yes")
+					var/list/varsvars = string2listofvars(var_new, O)
+					for(var/V in varsvars)
+						var_new = replacetext(var_new,"\[[V]]","[O.vars[V]]")
+
 			O.vars[variable] = var_new
 
 		if("num")

--- a/html/changelogs/RemieRichards-PR-11139.yml
+++ b/html/changelogs/RemieRichards-PR-11139.yml
@@ -1,0 +1,9 @@
+ 
+author: RemieRichards
+
+delete-after: True
+
+
+changes: 
+  - rscadd: "Modifying a string (Text) variable with View Variables or View Variables Mass Modify now allows you to embed variables like real byond strings, For example the variable real_name; you could set a text var to [real_name] and it would be replaced with the actual contents of the var,
+  This allows for Mass fixing of certain variables but it's also useful for badmin gimmickery"


### PR DESCRIPTION
## Feature
- When modifying a variable that is a string, you can now embed other variables in that string by surrounding the variable names with square brackets, eg (Pseudo code):

```
real_name = "Remie"
name = "Unknown"
name = [real_name]
name = "Remie"
```
- When modifying a list element that is text, you may also embed variables
- When modifying an associative list that's keys or elements are text, you may embed variables in the keys AND the elements
- When adding a new text variable to a list you can also embed variables
- When mass modifying a variable that is a string you can now embed other variables in that string by surrounding the variable names with square brackets. When doing this as a Mass Modify, you are asked whether the variables will all be fetched from the source datum (Meaning all instances get the same value) or whether they're all uniquely fetched from each instance
## Disclaimer

<B>The only variables that can be embedded in strings are the variables on the object you are currently VVing, which makes sense, but I just thought I'd make it clear</B>
## Code
- adds `string2listofvars()` which converts a string containing `"[var_name]s like this and [stuff]"` into a list of those variable names `list("var_name","stuff")`
- adds calls for `string2listofvars()` in the modify vars procs, and appropriate requests for user input.
- adds an atom argument to `mod_list_add_ass()` so that it TOO can use the variable embedding in strings feature, the atom is always the same atom that you VV'd
