### PR TITLE
Revamps Bioterror Darts

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -303,10 +303,10 @@ var/list/uplink_items = list()
 	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/ammo/bulltoxin
-	name = "Drum Magazine - 12g Bioterror"
-	desc = "An alternative 8-round toxic magazine for use in the Bulldog shotgun. Contains debilitating toxins to make your target die an excruciatingly rapid death."
-	item = /obj/item/ammo_box/magazine/m12g/bioterror
+/datum/uplink_item/ammo/bioterror
+	name = "Box of Bioterror Syringes"
+	desc = "A box full of preloaded syringes, containing various chemicals that seize up the victim's motor and broca system , making it impossible for them to move or speak while in their system."
+	item = /obj/item/weapon/storage/box/syndie_kit/bioterror
 	cost = 6
 	gamemodes = list(/datum/game_mode/nuclear)
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -136,6 +136,20 @@
 	O.update_icon()
 	return
 
+/obj/item/weapon/storage/box/syndie_kit/bioterror
+	name = "bioterror syringe box"
+
+/obj/item/weapon/storage/box/syndie_kit/bioterror/New()
+	..()
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	new /obj/item/weapon/reagent_containers/syringe/bioterror(src)
+	return
+
 
 /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	name = "boxed adrenal implant (with injector)"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -221,6 +221,11 @@
 	desc = "Contains antiviral agents."
 	list_reagents = list("spaceacillin" = 15)
 
+/obj/item/weapon/reagent_containers/syringe/bioterror
+	name = "bioterror syringe"
+	desc = "Contains several paralyzing reagents."
+	list_reagents = list("neurotoxin" = 5, "mutetoxin" = 5, "sodium_thiopental" = 5)
+
 /obj/item/weapon/reagent_containers/syringe/stimulants
 	name = "Stimpack"
 	desc = "Contains stimulants."

--- a/html/changelogs/MMMiracles - biomemes.yml
+++ b/html/changelogs/MMMiracles - biomemes.yml
@@ -1,0 +1,9 @@
+ 
+author: MMMiracles
+
+
+delete-after: True
+
+changes: 
+  - tweak: "Revamps bioterror darts into a less-lethal, syringe form. Removed the coniine and spore toxins to keep it solely for quiet take-downs."
+


### PR DESCRIPTION
improve not remove!!!

Turns the bioterror rounds into a less-lethal syringe variant, removing the coniine and spore toxin from it all together.

Comes in a box of 7 syringes that can be loaded into the never used syringe gun or whatever else the OPs can come up with (invite the captain to a dinner and spike his food?).

Still viable for knocking out singular targets quietly, but harder to spam it into a crowd.
