### PR TITLE
Changeling Changes

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -80,7 +80,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/list/team_objectives = typesof(/datum/objective/changeling_team_objective) - /datum/objective/changeling_team_objective
 	var/list/possible_team_objectives = list()
 	for(var/datum/objective/changeling_team_objective/T in team_objectives)
-		if(changelings.len > initial(T.min_lings))
+		if(changelings.len >= initial(T.min_lings))
 			possible_team_objectives += T
 
 	if(possible_team_objectives.len && prob(20*changelings.len))

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -172,7 +172,9 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		team_objective.owner = changeling
 		changeling.objectives += team_objective
 
-	..(changeling,1)
+		..(changeling,1)
+	else
+		..(changeling,0)
 
 
 /datum/game_mode/proc/greet_changeling(datum/mind/changeling, you_are=1)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -40,6 +40,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	var/const/changeling_amount = 4 //hard limit on changelings if scaling is turned off
 
+	var/changeling_team_objective_type = null //If this is not null, we hand our this objective to all lings
+
 /datum/game_mode/changeling/announce()
 	world << "<b>The current game mode is - Changeling!</b>"
 	world << "<b>There are alien changelings on the station. Do not let the changelings succeed!</b>"
@@ -72,6 +74,18 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		return 0
 
 /datum/game_mode/changeling/post_setup()
+
+	//Decide if it's ok for the lings to have a team objective
+	//And then set it up to be handed out in forge_changeling_objectives
+	var/list/team_objectives = typesof(/datum/objective/changeling_team_objective) - /datum/objective/changeling_team_objective
+	var/list/possible_team_objectives = list()
+	for(var/datum/objective/changeling_team_objective/T in team_objectives)
+		if(changelings.len > initial(T.min_lings))
+			possible_team_objectives += T
+
+	if(possible_team_objectives.len && prob(20*changelings.len))
+		changeling_team_objective_type = pick(possible_team_objectives)
+
 	for(var/datum/mind/changeling in changelings)
 		log_game("[changeling.key] (ckey) has been selected as a changeling")
 		changeling.current.make_changeling()
@@ -92,11 +106,10 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 					if(!(character.job in restricted_jobs))
 						character.mind.make_Changling()
 
-/datum/game_mode/proc/forge_changeling_objectives(datum/mind/changeling)
+/datum/game_mode/proc/forge_changeling_objectives(datum/mind/changeling, var/team_mode = 0)
 	//OBJECTIVES - random traitor objectives. Unique objectives "steal brain" and "identity theft".
 	//No escape alone because changelings aren't suited for it and it'd probably just lead to rampant robusting
 	//If it seems like they'd be able to do it in play, add a 10% chance to have to escape alone
-
 
 	var/datum/objective/absorb/absorb_objective = new
 	absorb_objective.owner = changeling
@@ -108,12 +121,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		steal_objective.owner = changeling
 		steal_objective.find_target()
 		changeling.objectives += steal_objective
-	else
-		var/datum/objective/debrain/debrain_objective = new
-		debrain_objective.owner = changeling
-		debrain_objective.find_target()
-		changeling.objectives += debrain_objective
-
 
 	var/list/active_ais = active_ais()
 	if(active_ais.len && prob(100/joined_player_list.len))
@@ -125,12 +132,18 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		if(prob(70))
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = changeling
-			kill_objective.find_target()
+			if(team_mode) //No backstabbing while in a team
+				kill_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+			else
+				kill_objective.find_target()
 			changeling.objectives += kill_objective
 		else
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = changeling
-			maroon_objective.find_target()
+			if(team_mode)
+				maroon_objective.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+			else
+				maroon_objective.find_target()
 			changeling.objectives += maroon_objective
 
 			if (!(locate(/datum/objective/escape) in changeling.objectives))
@@ -150,7 +163,17 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			identity_theft.owner = changeling
 			identity_theft.find_target()
 			changeling.objectives += identity_theft
-	return
+
+
+
+/datum/game_mode/changeling/forge_changeling_objectives(datum/mind/changeling)
+	if(changeling_team_objective_type)
+		var/datum/objective/changeling_team_objective/team_objective = new changeling_team_objective_type
+		team_objective.owner = changeling
+		changeling.objectives += team_objective
+
+	..(changeling,1)
+
 
 /datum/game_mode/proc/greet_changeling(datum/mind/changeling, you_are=1)
 	if (you_are)
@@ -237,8 +260,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/dna_max = 4 //How many extra DNA strands the changeling can store for transformation.
 	var/absorbedcount = 1 //We would require at least 1 sample of compatible DNA to have taken on the form of a human.
 	var/chem_charges = 20
-	var/chem_storage = 50
-	var/chem_recharge_rate = 0.5
+	var/chem_storage = 75
+	var/chem_recharge_rate = 1
 	var/chem_recharge_slowdown = 0
 	var/sting_range = 2
 	var/changelingID = "Changeling"

--- a/code/game/gamemodes/changeling/powers/chameleon_skin.dm
+++ b/code/game/gamemodes/changeling/powers/chameleon_skin.dm
@@ -1,0 +1,26 @@
+/obj/effect/proc_holder/changeling/chameleon_skin
+	name = "Chameleon Skin"
+	desc = "Our skin pigmentation rapidly changes to suit our current environment."
+	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
+	dna_cost = 2
+	chemical_cost = 25
+	req_human = 1
+	genetic_damage = 10
+	max_genetic_damage = 50
+
+
+/obj/effect/proc_holder/changeling/chameleon_skin/sting_action(mob/user)
+	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = 1
+	if(!istype(H))
+		return
+	var/datum/mutation/human/HM = mutations_list[CHAMELEON]
+	if(H.dna && H.dna.mutations)
+		if(HM in H.dna.mutations)
+			HM.force_lose(H)
+		else
+			HM.force_give(H)
+
+	feedback_add_details("changeling_powers","CS")
+	return 1
+
+

--- a/code/game/gamemodes/changeling/powers/mimic_voice.dm
+++ b/code/game/gamemodes/changeling/powers/mimic_voice.dm
@@ -22,7 +22,7 @@
 
 	changeling.mimicing = mimic_voice
 	changeling.chem_recharge_slowdown += 0.5
-	user << "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>, this will stop us from regenerating chemicals while active.</span>"
-	user << "<span class='notice'>Use this power again to return to our original voice and reproduce chemicals again.</span>"
+	user << "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>, this will slow down regenerating chemicals while active.</span>"
+	user << "<span class='notice'>Use this power again to return to our original voice and return chemical production to normal levels.</span>"
 
 	feedback_add_details("changeling_powers","MV")

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -159,7 +159,12 @@
 			return
 
 		if(A.hasPower())
-			user << "<span class='warning'>The airlock's motors resist our efforts to force it!</span>"
+			if(A.locked)
+				user << "<span class='warning'>The airlock's bolts prevent it from being forced!</span>"
+				return
+			user << "<span class='warning'>The airlock's motors are resisting, this may take time...</span>"
+			if(do_after(user, 100, target = A))
+				A.open(2)
 			return
 
 		else if(A.locked)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -679,12 +679,12 @@ var/global/list/possible_items_special = list()
 /datum/objective/changeling_team_objective/impersonate_heads/New(var/text)
 	..()
 
-	var/needed_heads = 0
+	//Needed heads is between min_lings and the maximum possible amount of command roles
+	//So at the time of writing, rand(3,5), it's also capped by the amount of lings there are
+	//Because you can't fill 5 head roles with 3 lings
 
-	//Heads amount is between min lings and the amount of heads possible
-	var/max_lings = ticker.mode.changelings.len
-	needed_heads = Clamp(needed_heads,min_lings,max_lings)
-	needed_heads = min(command_positions.len,needed_heads)
+	var/needed_heads = rand(min_lings,command_positions.len)
+	needed_heads = min(ticker.mode.changelings.len,needed_heads)
 
 	for(var/datum/mind/possible_head in ticker.minds)
 		if(possible_head in ticker.mode.changelings) //Looking at you HoP.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -687,6 +687,8 @@ var/global/list/possible_items_special = list()
 	needed_heads = min(command_positions.len,needed_heads)
 
 	for(var/datum/mind/possible_head in ticker.minds)
+		if(possible_head in ticker.mode.changelings) //Looking at you HoP.
+			continue
 		if(possible_head.assigned_job.title in command_positions)
 			if(needed_heads)
 				head_minds += possible_head

--- a/html/changelogs/RemieRichards-PR-11148.yml
+++ b/html/changelogs/RemieRichards-PR-11148.yml
@@ -1,0 +1,14 @@
+
+author: RemieRichards
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added Changeling Team Objectives, these are handed out to all lings, with the chance of a round having one being 20*number_of_lings% (3 lings = 60%)"
+  - rscadd: "Impersonate Department (Team Objective): As many members of a department as can reasonably be picked are chosen for the lings to kill, replace and escape as"
+  - rscadd: "Impersonate Heads (Team Objective): 3 to 6 Heads of Staff are chosen for the lings to kill, replace and escape as"
+  - tweak: "If the Changelings have a Team Objective, their usual Kill, Maroon, Etc. objectives will not pick other changelings, to discourage backstabbing in teamling"
+  - tweak: "Changeling Engorged Glands is now the default storage and regen rate, Engorged Glands remains for an extra boost"
+  - rscadd: "Armblades can now be used to open powered doors, however it takes 10 seconds of the changeling standing still, Their ability to instantly open unpowered doors remains unchanged"
+  - rscdel: "Debrain objective is no longer handed out to lings, it's as good as broken these days"
+  - rscadd: "Changelings may now purchase a togglable version of the Chameleon Skin genetics mutation, for 2 DNA"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -308,6 +308,7 @@
 #include "code\game\gamemodes\changeling\powers\absorb.dm"
 #include "code\game\gamemodes\changeling\powers\adrenaline.dm"
 #include "code\game\gamemodes\changeling\powers\augmented_eyesight.dm"
+#include "code\game\gamemodes\changeling\powers\chameleon_skin.dm"
 #include "code\game\gamemodes\changeling\powers\digitalcamo.dm"
 #include "code\game\gamemodes\changeling\powers\fakedeath.dm"
 #include "code\game\gamemodes\changeling\powers\fleshmend.dm"


### PR DESCRIPTION
## Content
- Changelings now have a chance to roll a special team objective (only 2 at the moment) the chance is `20*number_of_lings` 
- Changelings have no chance to roll a "backstab" (Ling vs Ling) objective if they have a team objective
- Debrain objective has been removed (it still exists, but is not handed out) as it's basically broken
- Engorged glands stats are now the default, engorged glands still functions as normal, adding 25 chem cap and doubling production
- Armblades may now break open powered doors after a 10 second wait (With progress bar)
- Changelings can now purchase Chameleon skin, which allows them to toggle on or off the genetics mutation "Chameleon skin" which slowly makes them invisible while stood still
- Minor adjustments to mimic voice text to line up with changes to chem stats
## Team Objectives
- <B>Impersonate Department:</B> A department is chosen, as many members of this department as possible (based on their roundstart amount, number of lings, etc.) are chosen to be targets that the changelings need to kill, replace, and escape as, The departments available for this are: Security, Medical, Engineering and Science ("Civilian" is too broad to be classed as a department)
  Impersonate Department does NOT pick the heads of that department.
- <B>Impersonate Heads:</B> Like Impersonate Department, except the "department" is always the Heads of Staff, the people who can be chosen by this are: Captain, Head of Personnel, Head of Security, Research Director, Chief Engineer and Chief Medical Officer. The lings must kill, replace and escape as these staff members. The amount of heads is always between 3 and 6 (3 the minimum amount of lings for this objective to be available, and 6 the number of command slots)

This is partially based on feedback from various different forum threads.
Some of this will obviously clash with other proposed changes/PRs.
