### PR TITLE
Makes restart votes not restart the server if admins are online

### DIFF
--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -118,10 +118,14 @@ var/datum/subsystem/vote/SSvote
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in admins)
-			if(!C.is_afk())
-				active_admins++
-		if(active_admins <= 0)
+			if(!C.is_afk() && check_rights_for(C, R_SERVER))
+				active_admins = 1
+				break
+		if(!active_admins)
 			world.Reboot("Restart vote successful.", "end_error", "restart vote")
+		else
+			world << "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>"
+			message_admins("A restart vote has passed, but there are active admins on with +server, so it has been canceled. If you wish, you may restart the server.")
 
 	return .
 

--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -116,7 +116,18 @@ var/datum/subsystem/vote/SSvote
 					else
 						master_mode = .
 	if(restart)
-		world.Reboot("Restart vote successful.", "end_error", "restart vote")
+		if(!admins.len)
+			return
+		var/total_admins
+		var/afk_admins
+		for(var/client/C in admins)
+			total_admins++
+			if(C.is_afk())
+				afk_admins++
+		var/active_admins
+		active_admins = total_admins - afk_admins
+		if(active_admins <= 0)
+			world.Reboot("Restart vote successful.", "end_error", "restart vote")
 
 	return .
 

--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -116,16 +116,10 @@ var/datum/subsystem/vote/SSvote
 					else
 						master_mode = .
 	if(restart)
-		if(!admins.len)
-			return
-		var/total_admins
-		var/afk_admins
+		var/active_admins = 0
 		for(var/client/C in admins)
-			total_admins++
-			if(C.is_afk())
-				afk_admins++
-		var/active_admins
-		active_admins = total_admins - afk_admins
+			if(!C.is_afk())
+				active_admins++
 		if(active_admins <= 0)
 			world.Reboot("Restart vote successful.", "end_error", "restart vote")
 


### PR DESCRIPTION
Restart votes exist to restart the server if something goes horribly wrong and it needs to be restarted, not because "I ded, restart"

If admins are on, they can already restart the server with verbs if something goes horribly wrong and the server needs to be toasted.  Therefore, the restart vote will pass if they are online but do nothing.

It also checks if the admins are afk so votes will still go through if you have a bunch of afk admins
