### PR TITLE
Adds Stabilized Omnizine to Medical Cyborgs

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -277,7 +277,7 @@
 	imp_in.update_canmove()
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
-	imp_in.reagents.add_reagent("omnizine", 10)
+	imp_in.reagents.add_reagent("stabilized_omnizine", 10)
 	imp_in.reagents.add_reagent("stimulants", 10)
 
 

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -896,7 +896,7 @@ datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
 
 /datum/reagent/medicine/stablilized_omnizine
 	name = "Stabilized Omnizine"
-	id = "omnizine"
+	id = "stabilized_omnizine"
 	description = "Heals 1 of each damage type a cycle. A safe variation to prevent overdosing."
 	reagent_state = LIQUID
 	color = "#C8A5DC"

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -893,3 +893,19 @@ datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
 	M.adjustFireLoss(2*REM)
 	..()
 	return
+
+/datum/reagent/medicine/stablilized_omnizine
+	name = "Stabilized Omnizine"
+	id = "omnizine"
+	description = "Heals 1 of each damage type a cycle. A safe variation to prevent overdosing."
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/stablilized_omnizine/on_mob_life(mob/living/M)
+	M.adjustToxLoss(-0.5*REM)
+	M.adjustOxyLoss(-0.5*REM)
+	M.adjustBruteLoss(-0.5*REM)
+	M.adjustFireLoss(-0.5*REM)
+	..()
+	return

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -23,8 +23,7 @@ Borg Hypospray
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "antitoxin", "epinephrine", "spaceacillin")
-	//var/list/reagent_ids = list("salbutamol", "salglu_solution", "salglu_solution", "charcoal", "ephedrine", "spaceacillin")
+	var/list/reagent_ids = list("stabilized_omnizine", "antitoxin", "epinephrine", "spaceacillin")
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
 


### PR DESCRIPTION
Replaces the current selection of bastardized trekchems with an overdoseless Omnizine variant. This avoids meaningless tedium and is a throwback to the arguably much more streamlined Doctor's Delight rendition. 

This also replaces the Omnizine in the Adrenal Implant to fix an unreported edge case issue involving accidental overdose.
