### PR TITLE
Smooth out gliding so movement isn't (as) jerky

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -37,7 +37,6 @@
 	var/allow_Metadata = 0				// Metadata is supported.
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/fps = 10
-	var/Tickcomp = 0
 	var/allow_holidays = 0				//toggles whether holiday-specific content should be used
 
 	var/hostedby = null
@@ -308,8 +307,6 @@
 						fps = 10 / ticklag
 				if("fps")
 					fps = text2num(value)
-				if("tickcomp")
-					Tickcomp = 1
 				if("automute_on")
 					automute_on = 1
 				if("comms_key")

--- a/code/modules/admin/verbs/fps.dm
+++ b/code/modules/admin/verbs/fps.dm
@@ -15,11 +15,7 @@
 		if(alert(src, "You are setting fps to a high value:\n\t[fps] frames-per-second\n\tconfig.fps = [config.fps]","Warning!","Confirm","ABORT-ABORT-ABORT") != "Confirm")
 			return
 
-	switch(alert("Enable Tick Compensation?","Tick Comp is currently: [config.Tickcomp]","Enable","Disable"))
-		if("Enable")	config.Tickcomp = 1
-		else			config.Tickcomp = 0
-
-	var/msg = "[key_name(src)] has modified world.fps to [fps] and config.Tickcomp to [config.Tickcomp]"
+	var/msg = "[key_name(src)] has modified world.fps to [fps]"
 	log_admin(msg, 0)
 	message_admins(msg, 0)
 	feedback_add_details("admin_verb","TICKLAG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -195,20 +195,13 @@
 							M.animate_movement = 2
 							return
 
-
-		var/san_tick_lag = round(world.tick_lag, 0.1) //floating point imprecision means 0.9 != 0.9
-		var/rounded = round(move_delay, san_tick_lag) //Round move_delay up to the nearest multiple of tick_lag
-		if(rounded < move_delay)
-			rounded += san_tick_lag
-		move_delay = rounded
-
-		if(move_delay <= 0)
-			glide_size = 0
-		else
-			glide_size = world.icon_size / move_delay * san_tick_lag //assume icons are square
+		var/ticks = Ceiling(move_delay / world.tick_lag)
+		if(ticks <= 0)
+			ticks = 1
+		glide_size = world.icon_size / ticks //assume icons are square
 		mob.glide_size = glide_size
 
-		move_delay += (world.time - 0.01) //Floating point imprecision again
+		move_delay += world.time - 0.0001 //Ensure we're on the right tick even if there's rounding errors
 
 		if(mob.confused && IsEven(world.time))
 			step(mob, pick(cardinal))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -198,8 +198,16 @@
 		var/ticks = Ceiling(move_delay / world.tick_lag)
 		if(ticks <= 0)
 			ticks = 1
-		glide_size = world.icon_size / ticks //assume icons are square
-		mob.glide_size = glide_size
+		var/target_glide_size = world.icon_size / ticks
+
+		glide_size = target_glide_size
+		mob.glide_size = target_glide_size
+
+		//byond floor()'s glide_size, we want it to Ceiling(),
+		//but we don't want it to Ceiling() if they fix it to accept floating point numbers
+		if(glide_size != target_glide_size)
+			glide_size = Ceiling(target_glide_size)
+			mob.glide_size = glide_size
 
 		move_delay += world.time - 0.0001 //Ensure we're on the right tick even if there's rounding errors
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -145,9 +145,6 @@ ALLOW_HOLIDAYS
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.9
 
-## Defines if Tick Compensation is used.  It results in a minor slowdown of movement of all mobs, but attempts to result in a level movement speed across all ticks.  Recommended if tickrate is lowered.
-TICKCOMP 0
-
 ## Comment this out to disable automuting
 #AUTOMUTE_ON
 


### PR DESCRIPTION
Only applies to non-ghost, non-camera mob movement. Scales automatically to any fps and any move delay.

Also took this oppurtunity to remove tickcomp because it was USELESS and shit.

All the rounding is because of floating point imprecision. round(2.7, 0.9) != 2.7, for example. 2.7 + world.time would wind up being < than world.time 3 ticks later even though they should be equal.
