### PR TITLE
RnD update

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -24,10 +24,13 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/points_per_decisecond = 0.005	//points gained every decisecond
 	var/points_per_slip = 2				//points gained per slip returned
 	var/points_per_crate = 5			//points gained per crate returned
-	var/points_per_intel = 100			//points gained per intel returned
+	var/points_per_intel = 250			//points gained per intel returned
 	var/points_per_plasma = 5			//points gained per plasma returned
+	var/points_per_design = 25			//points gained per max reliability research design returned (only for initilally unreliable designs)
 	var/centcom_message = ""			//Remarks from Centcom on how well you checked the last order.
-	var/list/discoveredPlants = list()	//Unique typepaths for unusual things we've already sent CentComm, associated with their potencies
+	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentComm, associated with their potencies
+	var/list/techLevels = list()
+	var/list/researchDesigns = list()
 	var/list/shoppinglist = list()
 	var/list/requestlist = list()
 	var/list/supply_packs = list()
@@ -306,7 +309,7 @@ var/datum/subsystem/shuttle/SSshuttle
 		var/obj/structure/largecrate/LC = Crate
 		LC.manifest = slip
 		LC.update_icon()
-	
+
 	return Crate
 
 /datum/subsystem/shuttle/proc/generateSupplyOrder(packId, _orderedby, _orderedbyRank, _comment)

--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -143,6 +143,32 @@
 				if(istype(thing, /obj/item/documents/syndicate))
 					++intel_count
 
+				// Sell tech levels
+				if(istype(thing, /obj/item/weapon/disk/tech_disk))
+					var/obj/item/weapon/disk/tech_disk/disk = thing
+					if(!disk.stored) continue
+					var/datum/tech/tech = disk.stored
+
+					var/cost = tech.getCost(SSshuttle.techLevels[tech.id])
+					if(cost)
+						SSshuttle.techLevels[tech.id] = tech.level
+						SSshuttle.points += cost
+						msg += "<font color=green>+[cost]</font>: [tech.name] - new data.<BR>"
+
+				// Sell max reliablity designs
+				if(istype(thing, /obj/item/weapon/disk/design_disk))
+					var/obj/item/weapon/disk/design_disk/disk = thing
+					if(!disk.blueprint) continue
+					var/datum/design/design = disk.blueprint
+					if(design.id in SSshuttle.researchDesigns) continue
+
+					if(initial(design.reliability) < 100 && design.reliability >= 100)
+						// Maxed out reliability designs only.
+						SSshuttle.points += SSshuttle.points_per_design
+						SSshuttle.researchDesigns += design.id
+						msg += "<font color=green>+[SSshuttle.points_per_design]</font>: Reliable [design.name] design.<BR>"
+
+				// Sell exotic plants
 				if(istype(thing, /obj/item/seeds))
 					var/obj/item/seeds/S = thing
 					if(S.rarity == 0) // Mundane species

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -83,3 +83,11 @@
 /obj/item/weapon/implantcase/weapons_auth/New()
 	imp = new /obj/item/weapon/implant/weapons_auth(src)
 	..()
+
+/obj/item/weapon/implantcase/adrenaline
+	name = "implant case - 'Adrenaline'"
+	desc = "A glass case containing an adrenaline implant."
+
+/obj/item/weapon/implantcase/adrenaline/New()
+	imp = new /obj/item/weapon/implant/adrenalin(src)
+	..()

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -111,15 +111,27 @@
 //////////Cybernetic Implants////////////
 /////////////////////////////////////////
 
+/datum/design/cyberimp_welding
+	name = "Welding Shield implant"
+	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
+	id = "ci-welding"
+	req_tech = list("materials" = 4, "biotech" = 2)
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 40
+	materials = list(MAT_METAL = 200, MAT_GLASS = 400)
+	build_path = /obj/item/organ/internal/cyberimp/eyes/shield
+	category = list("Misc", "Medical Designs")
+
 /datum/design/cyberimp_medical_hud
 	name = "Medical HUD implant"
 	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
 	id = "ci-medhud"
 	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 4)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 50
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 500, MAT_GOLD = 500)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/medical
-	category = list("Medical Designs")
+	category = list("Misc", "Medical Designs")
 
 /datum/design/cyberimp_security_hud
 	name = "Security HUD implant"
@@ -127,9 +139,10 @@
 	id = "ci-sechud"
 	req_tech = list("materials" = 6, "programming" = 5, "biotech" = 4, "combat" = 2)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 50
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 750, MAT_GOLD = 750)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/security
-	category = list("Medical Designs")
+	category = list("Misc", "Medical Designs")
 
 /datum/design/cyberimp_xray
 	name = "X-Ray implant"
@@ -137,9 +150,10 @@
 	id = "ci-xray"
 	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 6, "magnets" = 5)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/xray
-	category = list("Medical Designs")
+	category = list("Misc", "Medical Designs")
 
 /datum/design/cyberimp_thermals
 	name = "Thermals implant"
@@ -147,9 +161,10 @@
 	id = "ci-thermals"
 	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 5, "magnets" = 5, "syndicate" = 5)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/thermals
-	category = list("Medical Designs")
+	category = list("Misc", "Medical Designs")
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop implant"
@@ -157,6 +172,7 @@
 	id = "ci-antidrop"
 	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 5)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 400, MAT_GOLD = 400)
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_drop
 	category = list("Medical Designs")
@@ -167,6 +183,7 @@
 	id = "ci-antistun"
 	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 500, MAT_GOLD = 1000)
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
 	category = list("Medical Designs")
@@ -177,6 +194,7 @@
 	id = "ci-nutriment"
 	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 5)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 40
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/organ/internal/cyberimp/chest/nutriment
 	category = list("Medical Designs")
@@ -187,6 +205,7 @@
 	id = "ci-nutrimentplus"
 	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 50
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 750)
 	build_path = /obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	category = list("Medical Designs")
@@ -197,6 +216,52 @@
 	id = "ci-reviver"
 	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 7, "syndicate" = 4)
 	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/internal/cyberimp/chest/reviver
+	category = list("Misc", "Medical Designs")
+
+
+/////////////////////////////////////////
+////////////Regular Implants/////////////
+/////////////////////////////////////////
+
+/datum/design/implanter
+	name = "Implanter"
+	desc = "A sterile automatic implant injector."
+	id = "implanter"
+	req_tech = list("materials" = 1, "programming" = 2, "biotech" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 600, MAT_GLASS = 200)
+	build_path = /obj/item/weapon/implanter
+	category = list("Medical Designs")
+
+/datum/design/implantcase
+	name = "Implant Case"
+	desc = "A glass case containing an implant."
+	id = "implantcase"
+	req_tech = list("materials" = 1, "biotech" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/implantcase
+	category = list("Medical Designs")
+
+/datum/design/implant_freedom
+	name = "Freedom Implant Case"
+	desc = "A glass case containing an implant."
+	id = "implant_freedom"
+	req_tech = list("materials" = 2, "biotech" = 3, "magnets" = 3, "syndicate" = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 500, MAT_GOLD = 250)
+	build_path = /obj/item/weapon/implantcase/freedom
+	category = list("Medical Designs")
+
+/datum/design/implant_adrenalin
+	name = "Adrenalin Implant Case"
+	desc = "A glass case containing an implant."
+	id = "implant_adrenalin"
+	req_tech = list("materials" = 2, "biotech" = 5, "combat" = 3, "syndicate" = 6)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 500, MAT_GOLD = 500, MAT_URANIUM = 100, MAT_DIAMOND = 200)
+	build_path = /obj/item/weapon/implantcase/adrenaline
 	category = list("Medical Designs")

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -715,11 +715,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				dat += "<A href='?src=\ref[src];menu=1.5'>Load Design to Disk</A>"
 			else
 				dat += "Name: [d_disk.blueprint.name]<BR>"
-				dat += "Level: [Clamp((d_disk.blueprint.reliability + rand(-15,15)), 0, 100)]<BR>"
-				switch(d_disk.blueprint.build_type)
-					if(IMPRINTER) dat += "Lathe Type: Circuit Imprinter<BR>"
-					if(PROTOLATHE) dat += "Lathe Type: Proto-lathe<BR>"
-					if(AUTOLATHE) dat += "Lathe Type: Auto-lathe<BR>"
+				dat += "Level: [d_disk.blueprint.reliability]<BR>"
+				var/b_type = d_disk.blueprint.build_type
+				if(b_type)
+					dat += "Lathe Types:<BR>"
+					if(b_type & IMPRINTER) dat += "Circuit Imprinter<BR>"
+					if(b_type & PROTOLATHE) dat += "Proto-lathe<BR>"
+					if(b_type & AUTOLATHE) dat += "Auto-lathe<BR>"
+					if(b_type & MECHFAB) dat += "Mech Fabricator<BR>"
 				dat += "Required Materials:<BR>"
 				for(var/M in d_disk.blueprint.materials)
 					if(copytext(M, 1, 2) == "$") dat += "* [copytext(M, 2)] x [d_disk.blueprint.materials[M]]<BR>"
@@ -790,7 +793,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "Origin Tech:<BR>"
 			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 			for(var/T in temp_tech)
-				dat += "* [CallTechName(T)] [temp_tech[T]]<BR>"
+				dat += "* [CallTechName(T)] [temp_tech[T]]"
+				for(var/datum/tech/F in files.known_tech)
+					if(F.name == CallTechName(T))
+						dat += " (Current: [F.level])"
+						break
+				dat += "<BR>"
 			dat += "</div>Options: "
 			dat += "<A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A>"
 			dat += "<A href='?src=\ref[src];eject_item=1'>Eject Item</A>"
@@ -1102,4 +1110,4 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/experiment
 	name = "E.X.P.E.R.I-MENTOR R&D Console"
 	desc = "A console used to interface with R&D tools."
-	id = 1
+	id = 3

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -190,6 +190,7 @@ research holder datum.
 	var/desc = "description"			//General description of what it does and what it makes.
 	var/id = "id"						//An easily referenced ID. Must be alphanumeric, lower-case, and no symbols.
 	var/level = 1						//A simple number scale of the research level. Level 0 = Secret tech.
+	var/rare = 1						//How much CentCom wants to get that tech. Used in supply shuttle tech cost calculation.
 	var/list/req_tech = list()			//List of ids associated values of techs required to research this tech. "id" = #
 
 
@@ -209,6 +210,7 @@ research holder datum.
 	name = "Plasma Research"
 	desc = "Research into the mysterious substance colloqually known as 'plasma'."
 	id = "plasmatech"
+	rare = 3
 
 /datum/tech/powerstorage
 	name = "Power Manipulation Technology"
@@ -219,6 +221,7 @@ research holder datum.
 	name = "'Blue-space' Research"
 	desc = "Research into the sub-reality known as 'blue-space'"
 	id = "bluespace"
+	rare = 2
 
 /datum/tech/biotech
 	name = "Biological Technology"
@@ -244,6 +247,8 @@ research holder datum.
 	name = "Illegal Technologies Research"
 	desc = "The study of technologies that violate Nanotrassen regulations."
 	id = "syndicate"
+	rare = 4
+
 
 /*
 /datum/tech/arcane
@@ -271,6 +276,26 @@ research holder datum.
 	id = "robotics"
 	req_tech = list("materials" = 3, "programming" = 3)
 */
+
+
+/datum/tech/proc/getCost(var/current_level = null)
+	// Calculates tech disk's supply points sell cost
+	if(!current_level)
+		current_level = initial(level)
+
+	if(current_level >= level)
+		return 0
+
+	var/cost = 0
+	var/i
+	for(i=current_level+1, i<=level, i++)
+		if(i == initial(level))
+			continue
+		cost += i*5*rare
+
+	return cost
+
+
 
 
 /obj/item/weapon/disk/tech_disk

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -121,7 +121,8 @@
 	origin_tech = "materials=4;biotech=3"
 	implant_color = "#101010"
 	flash_protect = 2
-	// Welding with thermals will still hurt your eyes a bit.
+	aug_message = null
+	eye_color = "fff"
 
 /obj/item/organ/internal/cyberimp/eyes/shield/emp_act(severity)
 	return

--- a/html/changelogs/c0-RnDupdate.yml
+++ b/html/changelogs/c0-RnDupdate.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: CoreOverload
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a new low-tech eye cyberimplant in RnD - welding shield implant."
+  - rscadd: "Implanter and empty implant case added to protolathe."
+  - rscadd: "You can sell tech disks and maxed reliability design disks in cargo for supply points."
+  - tweak: "DA menu shows current research levels."
+  - tweak: "You can print cyberimplants in updated mech fab."


### PR DESCRIPTION
- DA menu shows current research levels. Small but really useful thing.
- You can sell research data disks and maxed reliablity design disks for supply points in cargo.
- Syndicate intel sell cost in cargo buffed to 250. Same cost as 50 plasma stack.
- You can print cyberimplants in updated mech fab.
- Added low-tech cyber implant - welding shield. It's cheap, it protects you from welders and flashes, but you need surgery to install it. Mostly pointless until #11058 would allow you to install more than one implant in eyes.
- Implanter and empty implant case added to protolathe.
- Added two syndie implants to protolathe. Freedom is Illegal 5, Adrenal is Illegal 6.

Tech cost is calculated as sum of all the tech levels cost except level 1. Tech level: 5 \* level \* multiplier, multiplier is 4 for illegal, 3 for plasma, 2 for bluespace, 1 for everything else. Materials 7 tech disk would be 5*(2+3+4+5+6+7) = 135 supply points.
