### PR TITLE
Bugfix And Feature addition. Chameleon And Stealth Mutations

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -364,7 +364,8 @@
 	if(T.lighting_lumcount <= 2)
 		owner.alpha -= 25
 	else
-		owner.alpha = round(255 * 0.80)
+		if(!owner.dna.check_mutation("Chameleon"))
+			owner.alpha = round(255 * 0.80)
 
 /datum/mutation/human/stealth/on_losing(mob/living/carbon/human/owner)
 	if(..())

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -364,7 +364,7 @@
 	if(T.lighting_lumcount <= 2)
 		owner.alpha -= 25
 	else
-		if(!owner.dna.check_mutation("Chameleon"))
+		if(!owner.dna.check_mutation(CHAMELEON))
 			owner.alpha = round(255 * 0.80)
 
 /datum/mutation/human/stealth/on_losing(mob/living/carbon/human/owner)


### PR DESCRIPTION
Bug: Noticed this a while ago that the Chameleon And the Stealth(Cloak Of Darkness) Dont work together. As the stealth mutation will instantly change the players visibility to visible. So i have added a check to see if the player has the Chameleon mutation and if they dont THEN change their visibility to visible

Feature: Due to the checks nature having both mutations will cause you to go invisible double speed in the dark
