### PR TITLE
Logging Syntax Improvement

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -21,7 +21,7 @@
 	attach(A2,user)
 	name = "[A.name]-[A2.name] assembly"
 	update_icon()
-	feedback_add_details("assembly_made","[name]")
+	feedback_add_details("assembly_made","[type]")
 
 /obj/item/device/assembly_holder/proc/attach(obj/item/device/assembly/A, mob/user)
 	if(!A.remove_item_from_storage(src))

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -78,7 +78,7 @@
 			if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
 				var/obj/item/weapon/reagent_containers/food/snacks/S = I
 				S.create_reagents(S.volume)
-				feedback_add_details("food_made","[S.name]")
+				feedback_add_details("food_made","[S.type]")
 				send_feedback = 0
 			var/list/parts = del_reqs(R, I)
 			for(var/A in parts)
@@ -93,7 +93,7 @@
 					I.reagents.reagent_list.Add(A)
 			I.CheckParts()
 			if(send_feedback)
-				feedback_add_details("object_crafted","[I.name]")
+				feedback_add_details("object_crafted","[I.type]")
 			return 1
 	return 0
 

--- a/code/modules/food&drinks/kitchen machinery/microwave.dm
+++ b/code/modules/food&drinks/kitchen machinery/microwave.dm
@@ -244,7 +244,7 @@
 			if(F.cooked_type)
 				var/obj/item/weapon/reagent_containers/food/snacks/S = new F.cooked_type (get_turf(src))
 				F.initialize_cooked_food(S, efficiency)
-				feedback_add_details("food_made","[F.name]")
+				feedback_add_details("food_made","[F.type]")
 			else
 				new /obj/item/weapon/reagent_containers/food/snacks/badrecipe(src)
 				if(dirty < 100)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -432,10 +432,10 @@ var/global/list/rockTurfEdgeCache
 		P.playDigSound()
 
 		if(do_after(user,P.digspeed, target = src))
-			if(istype(src, /turf/simulated/mineral)) 
+			if(istype(src, /turf/simulated/mineral))
 				user << "<span class='notice'>You finish cutting into the rock.</span>"
 				gets_drilled(user)
-				feedback_add_details("pick_used_mining","[P.name]")
+				feedback_add_details("pick_used_mining","[P.type]")
 	else
 		return attack_hand(user)
 	return
@@ -565,13 +565,13 @@ var/global/list/rockTurfEdgeCache
 
 		user << "<span class='notice'>You start digging...</span>"
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1) //FUCK YO RUSTLE I GOT'S THE DIGS SOUND HERE
-		
+
 		if(do_after(user, digging_speed, target = src))
-			if(istype(src, /turf/simulated/floor/plating/asteroid)) 
+			if(istype(src, /turf/simulated/floor/plating/asteroid))
 				user << "<span class='notice'>You dig a hole.</span>"
 				gets_dug()
-				feedback_add_details("pick_used_mining","[W.name]")
-		
+				feedback_add_details("pick_used_mining","[W.type]")
+
 	if(istype(W,/obj/item/weapon/storage/bag/ore))
 		var/obj/item/weapon/storage/bag/ore/S = W
 		if(S.collection_mode == 1)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -129,7 +129,7 @@ emp_act
 	var/obj/item/organ/limb/affecting = get_organ(ran_zone(user.zone_sel.selecting))
 	var/hit_area = parse_zone(affecting.name)
 	var/target_area = parse_zone(target_limb.name)
-	feedback_add_details("item_used_for_combat","[I.name]|[I.force]")
+	feedback_add_details("item_used_for_combat","[I.type]|[I.force]")
 	feedback_add_details("zone_targeted","[def_zone]")
 
 	if(dna)	// allows your species to affect the attacked_by code

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -130,7 +130,7 @@ emp_act
 	var/hit_area = parse_zone(affecting.name)
 	var/target_area = parse_zone(target_limb.name)
 	feedback_add_details("item_used_for_combat","[I.type]|[I.force]")
-	feedback_add_details("zone_targeted","[def_zone]")
+	feedback_add_details("zone_targeted","[target_area]")
 
 	if(dna)	// allows your species to affect the attacked_by code
 		return dna.species.spec_attacked_by(I,user,def_zone,affecting,hit_area,src.a_intent,target_limb,target_area,src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -42,7 +42,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/death(gibbed)
-	feedback_add_details("mobs_killed_mining","[src.name]")
+	feedback_add_details("mobs_killed_mining","[src.type]")
 	..(gibbed)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -43,7 +43,7 @@
 	if(charge < amount)	return 0
 	charge = (charge - amount)
 	if(!istype(loc, /obj/machinery/power/apc))
-		feedback_add_details("cell_used","[src.name]")
+		feedback_add_details("cell_used","[src.type]")
 	return 1
 
 // recharge the cell

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -232,7 +232,7 @@
 		user.update_inv_l_hand()
 	else
 		user.update_inv_r_hand()
-	feedback_add_details("gun_fired","[src.name]")
+	feedback_add_details("gun_fired","[src.type]")
 
 /obj/item/weapon/gun/attack(mob/M as mob, mob/user)
 	if(user.a_intent == "harm") //Flogging

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -10,7 +10,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimespawn/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
 	S.loc = get_turf(holder.my_atom)
 	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
@@ -25,7 +25,7 @@
 	required_container = /obj/item/slime_extract/grey
 
 /datum/chemical_reaction/slimeinaprov/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 /datum/chemical_reaction/slimemonkey
 	name = "Slime Monkey"
@@ -37,7 +37,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimemonkey/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/i = 1, i <= 3, i++)
 		var /obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = new /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 		M.loc = get_turf(holder.my_atom)
@@ -53,7 +53,7 @@
 	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 //Mutated Green
 /datum/chemical_reaction/slimemutate_unstable
@@ -67,7 +67,7 @@
 	mix_message = "<span class='info'>The mixture rapidly expands and contracts, its appearance shifting into a sickening green.</span>"
 
 /datum/chemical_reaction/slimemutate_unstable/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 //Metal
 /datum/chemical_reaction/slimemetal
@@ -80,7 +80,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimemetal/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal
 	M.amount = 15
 	M.loc = get_turf(holder.my_atom)
@@ -99,7 +99,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecrit/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
 	spawn(50)
@@ -116,7 +116,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecritlesser/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
 	spawn(50)
@@ -133,7 +133,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecritfriendly/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate adorably !</span>"), 1)
 	spawn(50)
@@ -152,7 +152,7 @@
 
 /datum/chemical_reaction/slimebork/on_reaction(datum/reagents/holder)
 
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/snacks,
 		/obj/item/weapon/reagent_containers/food/snacks/store/bread,
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
@@ -200,7 +200,7 @@
 
 /datum/chemical_reaction/slimebork2/on_reaction(datum/reagents/holder)
 
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/drinks)
 
 	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/drinks) - blocked
@@ -232,7 +232,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimefrost/on_reaction(datum/reagents/holder)
-		feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+		feedback_add_details("slime_cores_used","[type]")
 
 
 /datum/chemical_reaction/slimestabilizer
@@ -245,7 +245,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimestabilizer/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/weapon/slimestabilizer/P = new /obj/item/weapon/slimestabilizer
 	P.loc = get_turf(holder.my_atom)
 
@@ -262,7 +262,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimefreeze/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
 	spawn(50)
@@ -283,7 +283,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecasp/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 /datum/chemical_reaction/slimefire
 	name = "Slime fire"
@@ -295,7 +295,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimefire/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
 	spawn(50)
@@ -316,7 +316,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	empulse(get_turf(holder.my_atom), 3, 7)
 
 
@@ -330,7 +330,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecell/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/weapon/stock_parts/cell/high/slime/P = new /obj/item/weapon/stock_parts/cell/high/slime
 	P.loc = get_turf(holder.my_atom)
 
@@ -344,7 +344,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimeglow/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime begins to emit a soft light. Squeezing it will cause it to grow brightly.</span>"), 1)
 	var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
@@ -362,7 +362,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimepsteroid/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/weapon/slimesteroid/P = new /obj/item/weapon/slimesteroid
 	P.loc = get_turf(holder.my_atom)
 
@@ -376,7 +376,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimejam/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 
 //Dark Purple
@@ -390,24 +390,10 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimeplasma/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/stack/sheet/mineral/plasma/P = new /obj/item/stack/sheet/mineral/plasma
 	P.amount = 10
 	P.loc = get_turf(holder.my_atom)
-
-//Red
-/*/datum/chemical_reaction/slimeglycerol
-	name = "Slime Glycerol"
-	id = "m_glycerol"
-	result = "glycerol"
-	required_reagents = list("plasma" = 1)
-	result_amount = 8
-	required_container = /obj/item/slime_extract/red
-	required_other = 1
-
-/datum/chemical_reaction/slimeglycerol/on_reaction(var/datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-*/
 
 /datum/chemical_reaction/slimemutator
 	name = "Slime Mutator"
@@ -419,7 +405,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimemutator/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/weapon/slimemutator/P = new /obj/item/weapon/slimemutator
 	P.loc = get_turf(holder.my_atom)
 
@@ -433,7 +419,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimebloodlust/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/living/simple_animal/slime/slime in viewers(get_turf(holder.my_atom), null))
 		slime.rabid = 1
 		for(var/mob/O in viewers(get_turf(holder.my_atom), null))
@@ -450,7 +436,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimeppotion/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/slimepotion/P = new /obj/item/slimepotion
 	P.loc = get_turf(holder.my_atom)
 
@@ -466,7 +452,7 @@
 	required_container = /obj/item/slime_extract/black
 
 /datum/chemical_reaction/slimemutate2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 
 //Oil
 /datum/chemical_reaction/slimeexplosion
@@ -479,7 +465,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimeexplosion/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
 	spawn(50)
@@ -497,7 +483,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimepotion2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/slimepotion2/P = new /obj/item/slimepotion2
 	P.loc = get_turf(holder.my_atom)
 
@@ -512,7 +498,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimegolem/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
 	Z.loc = get_turf(holder.my_atom)
 	notify_ghosts("Golem rune created in [get_area(Z)].", 'sound/effects/ghost2.ogg')
@@ -528,7 +514,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimefloor2/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/stack/tile/bluespace/P = new /obj/item/stack/tile/bluespace
 	P.amount = 25
 	P.loc = get_turf(holder.my_atom)
@@ -544,7 +530,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecrystal/on_reaction(datum/reagents/holder, created_volume)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	if(holder.my_atom)
 		var/obj/item/bluespace_crystal/BC = new(get_turf(holder.my_atom))
 		BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
@@ -560,7 +546,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimepsteroid2/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/weapon/slimesteroid2/P = new /obj/item/weapon/slimesteroid2
 	P.loc = get_turf(holder.my_atom)
 
@@ -575,7 +561,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimestop/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/mob/mob = get_mob_by_key(holder.my_atom.fingerprintslast)
 	var/obj/effect/timestop/T = new /obj/effect/timestop
 	T.loc = get_turf(holder.my_atom)
@@ -593,7 +579,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimecamera/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/device/camera/P = new /obj/item/device/camera
 	P.loc = get_turf(holder.my_atom)
 	var/obj/item/device/camera_film/Z = new /obj/item/device/camera_film
@@ -609,7 +595,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimefloor/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/stack/tile/sepia/P = new /obj/item/stack/tile/sepia
 	P.amount = 25
 	P.loc = get_turf(holder.my_atom)
@@ -628,7 +614,7 @@
 	required_other = 1
 
 /datum/chemical_reaction/slimepaint/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/list/paints = typesof(/obj/item/weapon/paint) - /obj/item/weapon/paint
 	var/chosen = pick(paints)
 	var/obj/P = new chosen
@@ -646,7 +632,7 @@
 	required_container = /obj/item/slime_extract/rainbow
 
 /datum/chemical_reaction/slimeRNG/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
+	feedback_add_details("slime_cores_used","[type]")
 	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
 	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
 	S.loc = get_turf(holder.my_atom)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -278,7 +278,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
 								linked_lathe.m_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.materials[MAT_METAL]*(linked_destroy.decon_mod/10)))
 								linked_lathe.g_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.materials[MAT_GLASS]*(linked_destroy.decon_mod/10)))
-								feedback_add_details("item_deconstructed","[linked_destroy.loaded_item.name]")
+								feedback_add_details("item_deconstructed","[linked_destroy.loaded_item.type]")
 							linked_destroy.loaded_item = null
 						else
 							screen = 1.0
@@ -421,7 +421,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 									R = max((new_item.reliability/2), 0)
 								new_item.loc = linked_lathe.loc
 								if(!already_logged)
-									feedback_add_details("item_printed","[new_item.name]|[amount]")
+									feedback_add_details("item_printed","[new_item.type]|[amount]")
 									already_logged = 1
 						linked_lathe.busy = 0
 						screen = old_screen
@@ -476,7 +476,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							var/obj/item/new_item = new P(src)
 							new_item.reliability = R
 							new_item.loc = linked_imprinter.loc
-							feedback_add_details("circuit_printed","[new_item.name]")
+							feedback_add_details("circuit_printed","[new_item.type]")
 						linked_imprinter.busy = 0
 						screen = old_screen
 						updateUsrDialog()


### PR DESCRIPTION
Replaces many instances of .name being used instead of .type, leading to this:

![kp1devs](https://cloud.githubusercontent.com/assets/3827314/9256463/1f5a9658-41b5-11e5-92f7-37f13347fc8a.png)

Fixes #11184
