### PR TITLE
Fixes the shadowling helmet not being spaceworthy

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_items.dm
+++ b/code/game/gamemodes/shadowling/shadowling_items.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/under/shadowling
 	name = "blackened flesh"
-	desc = "Black, chitonous skin."
+	desc = "Black, chitinous skin."
 	item_state = "golem"
 	origin_tech = null
 	icon_state = "golem"
@@ -11,7 +11,7 @@
 
 /obj/item/clothing/suit/space/shadowling
 	name = "chitin shell"
-	desc = "Dark, semi-transparent shell. Protects against vacuum, but not against the light of the stars." //Still takes damage from spacewalking but is immune to space itself
+	desc = "A dark, semi-transparent shell. Protects against vacuum, but not against the light of the stars." //Still takes damage from spacewalking but is immune to space itself
 	icon_state = "golem"
 	item_state = "golem"
 	body_parts_covered = FULL_BODY //Shadowlings are immune to space
@@ -60,9 +60,13 @@
 	desc = "A helmet-like enclosure of the head."
 	icon_state = "golem"
 	item_state = null
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	origin_tech = null
 	unacidable = 1
-	flags = ABSTRACT | NODROP
+	flags = ABSTRACT | NODROP | STOPSPRESSUREDMAGE
 
 
 /obj/item/clothing/glasses/night/shadowling


### PR DESCRIPTION
Despite it being almost meaningless, the Shadowling helmet is now spaceworthy.

This also changes a few descriptions on the off chance someone examines the items (Spelling/Grammar).

Fixes #11177
