### PR TITLE
Captain's Space Armor Buff: Slowdown Removal and Armor Value Tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -21,7 +21,7 @@ Contains:
 	desc = "A special helmet designed for only the most fashionable of military figureheads."
 	flags_inv = HIDEFACE
 	permeability_coefficient = 0.01
-	armor = list(melee = 40, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)
+	armor = list(melee = 50, bullet = 40, laser = 50, energy = 10, bomb = 25, bio = 100, rad = 50)
 
 /obj/item/clothing/suit/space/captain
 	name = "captain's space suit"
@@ -30,7 +30,7 @@ Contains:
 	item_state = "capspacesuit"
 	w_class = 4
 	allowed = list(/obj/item/weapon/tank/internals, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs)
-	armor = list(melee = 40, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)
+	armor = list(melee = 50, bullet = 40, laser = 50, energy = 10, bomb = 25, bio = 100, rad = 50)
 
 
 	//Death squad armored space suits, not hardsuits!

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -30,7 +30,6 @@ Contains:
 	item_state = "capspacesuit"
 	w_class = 4
 	allowed = list(/obj/item/weapon/tank/internals, /obj/item/device/flashlight,/obj/item/weapon/gun/energy, /obj/item/weapon/gun/projectile, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs)
-	slowdown = 1
 	armor = list(melee = 40, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 100, rad = 50)
 
 

--- a/html/changelogs/Fox P McCloud - Capspace .yml
+++ b/html/changelogs/Fox P McCloud - Capspace .yml
@@ -1,0 +1,7 @@
+
+author: Fox P McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Removes the slowdown on Captain's Space Suit

--- a/html/changelogs/Fox P McCloud - Capspace .yml
+++ b/html/changelogs/Fox P McCloud - Capspace .yml
@@ -5,3 +5,4 @@ delete-after: True
 
 changes: 
   - tweak: "Removes the slowdown on Captain's Space Suit."
+  - tweak: "Reduces the armor values of Captain's space suit and helmet to match that of Captain's Carapace"

--- a/html/changelogs/Fox P McCloud - Capspace .yml
+++ b/html/changelogs/Fox P McCloud - Capspace .yml
@@ -4,4 +4,4 @@ author: Fox P McCloud
 delete-after: True
 
 changes: 
-  - tweak: "Removes the slowdown on Captain's Space Suit
+  - tweak: "Removes the slowdown on Captain's Space Suit."


### PR DESCRIPTION
- Removes the slowdown on Captain's spacesuit armor.
- Reduces the total armor protection values to match that of the Captain's Carapace.

Simply put, Captain is the highest risk job in the entire game--more people are gunning for you than any other head position and you have more responsibility compared to any of the other heads. If people aren't after your gun, medal, or disk, they'll kill you for your access to everything.

As such, I believe it's fair that he's compensated, armor wise, for this. Currently, Captain's space helmet is the 'best' overall helmet in the game in terms of armor values. Not only this, but it also has built in flash protection, so it offers additional utility in and of itself. Captain's space suit is also top notch in terms of armor values, but has one glaring weakness to keep it from being "viable" for day to day use (and has no compensatory utility): it has a nasty slowdown on it.

Removing the slowdown solidly puts Captain's space suit in the category of "best" overall armor on the station and, I feel, adequately compensates the Captain for the increased risks associated with the job.
