### PR TITLE
Slipping while buckled, some fixes

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -238,14 +238,6 @@
 		step(src, direction)
 		update_mob()
 		handle_rotation()
-		if(istype(src.loc, /turf/simulated))
-			var/turf/simulated/T = src.loc
-			if(T.wet == 2)	//Lube! Fall off!
-				playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-				buckled_mob.Stun(7)
-				buckled_mob.Weaken(7)
-				unbuckle_mob()
-				step(src, dir)
 		move_delay = 1
 		spawn(2)
 			move_delay = 0
@@ -299,11 +291,6 @@
 			if(EAST)
 				buckled_mob.pixel_x = -12
 				buckled_mob.pixel_y = 7
-
-
-/obj/structure/stool/bed/chair/janicart/bullet_act(obj/item/projectile/Proj)
-	if(buckled_mob)
-		buckled_mob.bullet_act(Proj)
 
 /obj/item/key
 	name = "key"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -24,14 +24,12 @@
 /obj/structure/stool/bed/Move(atom/newloc, direct) //Some bed children move
 	. = ..()
 	if(buckled_mob)
-		buckled_mob.buckled = null
 		if(!buckled_mob.Move(loc, direct))
 			loc = buckled_mob.loc //we gotta go back
 			last_move = buckled_mob.last_move
 			inertia_dir = last_move
 			buckled_mob.inertia_dir = last_move
 			. = 0
-		buckled_mob.buckled = src
 
 /obj/structure/stool/bed/Process_Spacemove(movement_dir = 0)
 	if(buckled_mob)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -44,14 +44,13 @@
 	..()
 	if (istype(A,/mob/living/carbon))
 		var/mob/living/carbon/M = A
-		if(M.lying)	return
-		switch (src.wet)
+		switch(wet)
 			if(1) //wet floor
-				if(!M.slip(4, 2, null, (NO_SLIP_WHEN_WALKING|STEP)))
+				if(!M.slip(4, 2, null, NO_SLIP_WHEN_WALKING))
 					M.inertia_dir = 0
 				return
 			if(2) //lube
-				M.slip(0, 7, null, (STEP|SLIDE|GALOSHES_DONT_HELP))
+				M.slip(0, 7, null, (SLIDE|GALOSHES_DONT_HELP))
 
 /turf/simulated/ChangeTurf(var/path)
 	. = ..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -224,38 +224,43 @@
 	if(has_gravity(src))
 		playsound(src, "bodyfall", 50, 1)
 
-/turf/handle_slip(mob/slipper, s_amount, w_amount, obj/O, lube)
+/turf/handle_slip(mob/living/carbon/C, s_amount, w_amount, obj/O, lube)
 	if(has_gravity(src))
-		var/mob/living/carbon/M = slipper
-		if (M.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
-			return 0
-		if(!M.lying && (M.status_flags & CANWEAKEN)) // we slip those who are standing and can fall.
-			if(O)
-				M << "<span class='notice'>You slipped on the [O.name]!</span>"
-			else
-				M << "<span class='notice'>You slipped!</span>"
-			M.attack_log += "\[[time_stamp()]\] <font color='orange'>Slipped[O ? " on the [O.name]" : ""][(lube&SLIDE)? " (LUBE)" : ""]!</font>"
-			playsound(M.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+		var/obj/buckled_obj
+		var/oldlying = C.lying
+		if(C.buckled)
+			buckled_obj = C.buckled
+			if(!(lube&GALOSHES_DONT_HELP)) //can't slip while buckled unless it's lube.
+				return 0
+		else
+			if(C.lying || !(C.status_flags & CANWEAKEN)) // can't slip unbuckled mob if they're lying or can't fall.
+				return 0
+			if(C.m_intent=="walk" && (lube&NO_SLIP_WHEN_WALKING))
+				return 0
 
-			M.accident(M.l_hand)
-			M.accident(M.r_hand)
+		C << "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>"
 
-			var/olddir = M.dir
-			M.Stun(s_amount)
-			M.Weaken(w_amount)
-			M.stop_pulling()
-			if(lube&SLIDE)
-				for(var/i=1, i<5, i++)
-					spawn (i)
-						step(M, olddir)
-						M.spin(1,1)
-				if(M.lying) //did I fall over?
-					M.adjustBruteLoss(2)
+		C.attack_log += "\[[time_stamp()]\] <font color='orange'>Slipped[O ? " on the [O.name]" : ""][(lube&SLIDE)? " (LUBE)" : ""]!</font>"
+		playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 
+		C.accident(C.l_hand)
+		C.accident(C.r_hand)
 
-
-			return 1
-	return 0 // no success. Used in clown pda and wet floors
+		var/olddir = C.dir
+		C.Stun(s_amount)
+		C.Weaken(w_amount)
+		C.stop_pulling()
+		if(buckled_obj)
+			buckled_obj.unbuckle_mob()
+			step(buckled_obj, olddir)
+		else if(lube&SLIDE)
+			for(var/i=1, i<5, i++)
+				spawn (i)
+					step(C, olddir)
+					C.spin(1,1)
+		if(C.lying != oldlying) //did we actually fall?
+			C.adjustBruteLoss(2)
+		return 1
 
 /turf/singularity_act()
 	if(intact)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -335,11 +335,10 @@
 	return "trails_2"
 
 var/const/NO_SLIP_WHEN_WALKING = 1
-var/const/STEP = 2
-var/const/SLIDE = 4
-var/const/GALOSHES_DONT_HELP = 8
+var/const/SLIDE = 2
+var/const/GALOSHES_DONT_HELP = 4
 /mob/living/carbon/slip(s_amount, w_amount, obj/O, lube)
-	loc.handle_slip(src, s_amount, w_amount, O, lube)
+	return loc.handle_slip(src, s_amount, w_amount, O, lube)
 
 /mob/living/carbon/fall(forced)
     loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
@@ -505,7 +504,7 @@ var/const/GALOSHES_DONT_HELP = 8
 		return 1
 
 /mob/living/carbon/proc/accident(obj/item/I)
-	if(!I || (I.flags & NODROP))
+	if(!I || (I.flags & (NODROP|ABSTRACT)))
 		return
 
 	unEquip(I)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -83,7 +83,7 @@
 	var/a_intent = "help"//Living
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null
-	var/obj/structure/stool/bed/buckled = null//Living
+	var/obj/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living
 	var/obj/item/weapon/storage/s_active = null//Carbon

--- a/html/changelogs/phil235 - JanicartFixes.yml
+++ b/html/changelogs/phil235 - JanicartFixes.yml
@@ -1,0 +1,7 @@
+
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "Janicart rider no longer slip on wet floor or bananas. Moving on a floor tile with lube while buckled (chair, roller bed, etc) will make you fall off."


### PR DESCRIPTION
- Fixes slipping on water while riding janicart. Fixes #8441 . Fixes #10408 .
- The handle_slip() proc now also handles cases where the mob is buckled. If you are buckled and slip on lube (or something that ignores galoshes) you get unbuckled and stunned and the buckle object moves one step (no slides unlike when unbuckled).
- You can thus slip on lube while buckled to a chair or a roller bed. (relevant to #6168)
- Fixes getting hit by abstract held items when slipping.
- Fixes janicart rider getting hit twice by bullets. Fixes #9300 
- Removing the STEP constant var in slipping code, it's no longer used.
- Fixes carbon/slip() not returning the correct value.
- Changed var/obj/structure/stool/bed/buckled to var/obj/buckled since buckled can now technically be any obj.
- Removes hacky unbuckling/buckling in bed/Move()
