### PR TITLE
The staff of change projectile will qdel the mob instead of manually …

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -19,4 +19,5 @@ var/datum/subsystem/mobs/SSmob
 		if(thing)
 			thing:Life(seconds)
 			continue
+		WARNING("Found a null in the mob list. Removing.")
 		mob_list.Remove(thing)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -243,7 +243,7 @@
 
 			new_mob << "<B>Your form morphs into that of a [randomize].</B>"
 
-			del(M)
+			qdel(M)
 			return new_mob
 
 /obj/item/projectile/magic/animate


### PR DESCRIPTION
…deleting it.

Added a warning for when the mob controller removes a null from the mob list.
