### PR TITLE
Fixes huge lag during meteor waves.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -217,6 +217,9 @@
 			break
 		dist_travelled++
 		dist_since_sleep++
+
+		if(dist_travelled > 600) //safety to prevent infinite while loop.
+			break
 		if(dist_since_sleep >= speed)
 			dist_since_sleep = 0
 			sleep(1)

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -165,8 +165,7 @@
 
 /obj/effect/meteor/proc/make_debris()
 	for(var/throws = dropamt, throws > 0, throws--)
-		var/obj/item/O = new meteordrop(get_turf(src))
-		O.throw_at(dest, 5, 10)
+		new meteordrop(get_turf(src))
 
 /obj/effect/meteor/proc/meteor_effect(sound=1)
 	if(sound)


### PR DESCRIPTION
Adding a safety check to throw_at()'s while loop to prevent an infinite loop. It happened whenever the object was stuck in a space loop (broken space cube). Now throw_at()'s loop automatically stops after 600 iterations (the object moved 600 tiles). Lag also reduced by not automatically throwing the meteor debris (ores, meat, etc) that the meteor spawns.

Fixes #9746
