### PR TITLE
Adds Military Belts to the standard Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -514,6 +514,13 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/surgery
 	cost = 4
 
+/datum/uplink_item/device_tools/military_belt
+	name = "Military Belt"
+	desc = "A robust seven-slot red belt made for carrying a broad variety of weapons, ammunition and explosives"
+	item = /obj/item/weapon/storage/belt/military
+	cost = 5
+	excludefrom = list(/datum/game_mode/nuclear)
+	
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"
 	desc = "The syndicate medkit is a suspicious black and red. Included is a combat stimulant injector for rapid healing, a medical hud for quick identification of injured comrades, \

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -518,7 +518,7 @@ var/list/uplink_items = list()
 	name = "Military Belt"
 	desc = "A robust seven-slot red belt made for carrying a broad variety of weapons, ammunition and explosives"
 	item = /obj/item/weapon/storage/belt/military
-	cost = 5
+	cost = 3
 	excludefrom = list(/datum/game_mode/nuclear)
 	
 /datum/uplink_item/device_tools/medkit


### PR DESCRIPTION
They're pretty efficient and honestly cheap for the sheer amount of stuff they can hold.

Merciful inventory management for the traitors who need to carry a ton of extra magazines for their murder spree.

Excluded from Nuke because they get them for free and there is literally no reason to ever buy more.
