### PR TITLE
Spawn panel improvements

### DIFF
--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -1,4 +1,8 @@
-/var/create_object_html = null
+var/create_object_html = null
+var/list/create_object_forms = list(
+	/obj, /obj/structure, /obj/machinery, /obj/effect,
+	/obj/item, /obj/item/clothing, /obj/item/stack,
+	/obj/item/weapon, /obj/item/weapon/reagent_containers, /obj/item/weapon/gun)
 
 /datum/admins/proc/create_object(mob/user)
 	if (!create_object_html)
@@ -11,18 +15,13 @@
 
 
 /datum/admins/proc/quick_create_object(mob/user)
+	var/path = input("Select the path of the object you wish to create.", "Path", /obj) in create_object_forms
+	var/html_form = create_object_forms[path]
 
-	var/quick_create_object_html = null
-	var/pathtext = null
+	if (!html_form)
+		var/objectjs = list2text(typesof(path), ";")
+		html_form = file2text('html/create_object.html')
+		html_form = replacetext(html_form, "null /* object types */", "\"[objectjs]\"")
+		create_object_forms[path] = html_form
 
-	pathtext = input("Select the path of the object you wish to create.", "Path", "/obj") in list("/obj","/obj/structure","/obj/effect","/obj/item","/obj/item/clothing","/obj/item/weapon/reagent_containers/food","/obj/item/weapon","/obj/item/weapon/gun","/obj/machinery","/obj/item/stack")
-
-	var path = text2path(pathtext)
-
-	if (!quick_create_object_html)
-		var/objectjs = null
-		objectjs = list2text(typesof(path), ";")
-		quick_create_object_html = file2text('html/create_object.html')
-		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
-
-	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")
+	user << browse(replacetext(html_form, "/* ref src */", "\ref[src]"), "window=qco[path];size=425x475")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -1,7 +1,7 @@
 var/create_object_html = null
 var/list/create_object_forms = list(
 	/obj, /obj/structure, /obj/machinery, /obj/effect,
-	/obj/item, /obj/item/clothing, /obj/item/stack,
+	/obj/item, /obj/item/clothing, /obj/item/stack, /obj/item/device,
 	/obj/item/weapon, /obj/item/weapon/reagent_containers, /obj/item/weapon/gun)
 
 /datum/admins/proc/create_object(mob/user)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1793,41 +1793,36 @@
 		if(!obj_dir || !(obj_dir in list(1,2,4,8,5,6,9,10)))
 			obj_dir = 2
 		var/obj_name = sanitize(href_list["object_name"])
+
+
+		var/atom/target //Where the object will be spawned
 		var/where = href_list["object_where"]
 		if (!( where in list("onfloor","inhand","inmarked") ))
 			where = "onfloor"
 
-		if( where == "inhand" )
-			usr << "Support for inhand not available yet. Will spawn on floor."
-			where = "onfloor"
 
-		if ( where == "inhand" )	//Can only give when human or monkey
-			if ( !( ishuman(usr) || ismonkey(usr) ) )
-				usr << "Can only spawn in hand when you're a human or a monkey."
-				where = "onfloor"
-			else if ( usr.get_active_hand() )
-				usr << "Your active hand is full. Spawning on floor."
-				where = "onfloor"
+		switch(where)
+			if("inhand")
+				if (!iscarbon(usr) && !isrobot(usr))
+					usr << "Can only spawn in hand when you're a carbon mob or cyborg."
+					where = "onfloor"
+				target = usr
 
-		if ( where == "inmarked" )
-			if ( !marked_datum )
-				usr << "You don't have any object marked. Abandoning spawn."
-				return
-			else
-				if ( !istype(marked_datum,/atom) )
-					usr << "The object you have marked cannot be used as a target. Target must be of type /atom. Abandoning spawn."
-					return
-
-		var/atom/target //Where the object will be spawned
-		switch ( where )
-			if ( "onfloor" )
-				switch (href_list["offset_type"])
+			if("onfloor")
+				switch(href_list["offset_type"])
 					if ("absolute")
 						target = locate(0 + X,0 + Y,0 + Z)
 					if ("relative")
 						target = locate(loc.x + X,loc.y + Y,loc.z + Z)
-			if ( "inmarked" )
-				target = marked_datum
+			if("inmarked")
+				if(!marked_datum)
+					usr << "You don't have any object marked. Abandoning spawn."
+					return
+				else if(!istype(marked_datum,/atom))
+					usr << "The object you have marked cannot be used as a target. Target must be of type /atom. Abandoning spawn."
+					return
+				else
+					target = marked_datum
 
 		if(target)
 			for (var/path in paths)
@@ -1835,9 +1830,8 @@
 					if(path in typesof(/turf))
 						var/turf/O = target
 						var/turf/N = O.ChangeTurf(path)
-						if(N)
-							if(obj_name)
-								N.name = obj_name
+						if(N && obj_name)
+							N.name = obj_name
 					else
 						var/atom/O = new path(target)
 						if(O)
@@ -1847,6 +1841,18 @@
 								if(istype(O,/mob))
 									var/mob/M = O
 									M.real_name = obj_name
+							if(where == "inhand" && isliving(usr) && istype(O, /obj/item))
+								var/mob/living/L = usr
+								var/obj/item/I = O
+								L.put_in_hands(I)
+								if(isrobot(L))
+									var/mob/living/silicon/robot/R = L
+									if(R.module)
+										R.module.modules += I
+										I.loc = R.module
+										R.module.rebuild()
+										R.activate_module(I)
+
 
 		if (number == 1)
 			log_admin("[key_name(usr)] created a [english_list(paths)]")

--- a/html/create_object.html
+++ b/html/create_object.html
@@ -39,7 +39,7 @@
 		Where: 
 			<select name='object_where' style="width:320px">
 				<option value='onfloor'>On floor below own mob</option>
-				<!-- <option value='inhand'>In own mob's hand</option> -->
+				<option value='inhand'>In own mob's hand</option>
 				<option value='inmarked'>In marked object</option>
 			</select>
 		<br><br>
@@ -54,7 +54,6 @@
 		var objects = object_paths == null ? new Array() : object_paths.split(";");
 		
 		document.spawner.filter.focus();
-		populateList(objects);
 		
 		function populateList(from_list)
 		{
@@ -72,11 +71,6 @@
 		
 		function updateSearch()
 		{
-			if (old_search == document.spawner.filter.value)
-			{
-				return;
-			}
-			
 			old_search = document.spawner.filter.value;
 			
 			


### PR DESCRIPTION
Spawn panel starts empty. Use "Search" to fill it with paths. This speeds up the panel on big path lists A LOT.

"In own mob's hand" spawn option is now enabled. It tries to put spawned item in your mob's hand and drops it on mob's turf if that fails. When used on borgs it adds spawned item to borg's modules and activates it.
