### PR TITLE
Fixes Lings ALWAYS rolling a backstab objective

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -116,6 +116,14 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	//No escape alone because changelings aren't suited for it and it'd probably just lead to rampant robusting
 	//If it seems like they'd be able to do it in play, add a 10% chance to have to escape alone
 
+	var/escape_objective_possible = TRUE
+
+	//if there's a team objective, check if it's compatible with escape objectives
+	for(var/datum/objective/changeling_team_objective/CTO in changeling.objectives)
+		if(!CTO.escape_objective_compatible)
+			escape_objective_possible = FALSE
+			break
+
 	var/datum/objective/absorb/absorb_objective = new
 	absorb_objective.owner = changeling
 	absorb_objective.gen_amount_goal(6, 8)
@@ -151,14 +159,15 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 				maroon_objective.find_target()
 			changeling.objectives += maroon_objective
 
-			if (!(locate(/datum/objective/escape) in changeling.objectives))
+			if (!(locate(/datum/objective/escape) in changeling.objectives) && escape_objective_possible)
 				var/datum/objective/escape/escape_with_identity/identity_theft = new
 				identity_theft.owner = changeling
 				identity_theft.target = maroon_objective.target
 				identity_theft.update_explanation_text()
 				changeling.objectives += identity_theft
+				escape_objective_possible = FALSE
 
-	if (!(locate(/datum/objective/escape) in changeling.objectives))
+	if (!(locate(/datum/objective/escape) in changeling.objectives) && escape_objective_possible)
 		if(prob(50))
 			var/datum/objective/escape/escape_objective = new
 			escape_objective.owner = changeling
@@ -166,8 +175,12 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 		else
 			var/datum/objective/escape/escape_with_identity/identity_theft = new
 			identity_theft.owner = changeling
-			identity_theft.find_target()
+			if(team_mode)
+				identity_theft.find_target_by_role(role = "Changeling", role_type = 1, invert = 1)
+			else
+				identity_theft.find_target()
 			changeling.objectives += identity_theft
+		escape_objective_possible = FALSE
 
 
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -68,7 +68,7 @@
 /datum/objective/assassinate/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
 		target_role_type = role_type
-	..(role, role_type)
+	..()
 	return target
 
 /datum/objective/assassinate/check_completion()
@@ -93,7 +93,7 @@
 /datum/objective/mutiny/find_target_by_role(role, role_type=0,invert=0)
 	if(!invert)
 		target_role_type = role_type
-	..(role, role_type)
+	..()
 	return target
 
 /datum/objective/mutiny/check_completion()
@@ -123,7 +123,7 @@
 /datum/objective/maroon/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
 		target_role_type = role_type
-	..(role, role_type)
+	..()
 	return target
 
 /datum/objective/maroon/check_completion()
@@ -149,7 +149,7 @@
 /datum/objective/debrain/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
 		target_role_type = role_type
-	..(role, role_type)
+	..()
 	return target
 
 /datum/objective/debrain/check_completion()
@@ -183,7 +183,7 @@
 /datum/objective/protect/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
 		target_role_type = role_type
-	..(role, role_type)
+	..()
 	return target
 
 /datum/objective/protect/check_completion()
@@ -668,7 +668,7 @@ var/global/list/possible_items_special = list()
 	martyr_compatible = 0	//Suicide is not teamwork!
 	explanation_text = "Changeling Friendship!"
 	var/min_lings = 3 //Minimum amount of lings for this team objective to be possible
-
+	var/escape_objective_compatible = FALSE
 
 
 //Impersonate department


### PR DESCRIPTION
Because some ancient coder decided to specify arguments to `..()` causing it to ignore my new argument, where it would normally automatically add it.

This is also that last (obvious) bug with the new changeling changes, YAY.
