### PR TITLE
some mimic ranged mob fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -1,7 +1,3 @@
-//
-// Abstract Class
-//
-
 /mob/living/simple_animal/hostile/mimic
 	name = "crate"
 	desc = "A rectangular steel crate."
@@ -37,19 +33,10 @@
 	ghostize()
 	qdel(src)
 
-
-
-//
-// Crate Mimic
-//
-
-
 // Aggro when you try to open them. Will also pickup loot when spawns and drop it when dies.
 /mob/living/simple_animal/hostile/mimic/crate
-
 	attacktext = "bites"
 	speak_emote = list("clatters")
-
 	stop_automated_movement = 1
 	wander = 0
 	var/attempt_open = 0
@@ -96,7 +83,6 @@
 	icon_state = initial(icon_state)
 
 /mob/living/simple_animal/hostile/mimic/crate/death()
-
 	var/obj/structure/closet/crate/C = new(get_turf(src))
 	// Put loot in crate
 	for(var/obj/O in src)
@@ -113,21 +99,18 @@
 			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
 					"<span class='userdanger'>\The [src] knocks you down!</span>")
 
-//
-// Copy Mimic
-//
+
 
 var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/cable, /obj/structure/window)
 
 /mob/living/simple_animal/hostile/mimic/copy
-
 	health = 100
 	maxHealth = 100
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0
 
-/mob/living/simple_animal/hostile/mimic/copy/New(loc, var/obj/copy, var/mob/living/creator, var/destroy_original = 0)
+/mob/living/simple_animal/hostile/mimic/copy/New(loc, obj/copy, mob/living/creator, destroy_original = 0)
 	..(loc)
 	CopyObject(copy, creator, destroy_original)
 
@@ -137,13 +120,11 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		death()
 
 /mob/living/simple_animal/hostile/mimic/copy/death()
-
 	for(var/atom/movable/M in src)
 		M.loc = get_turf(src)
 	..()
 
 /mob/living/simple_animal/hostile/mimic/copy/ListTargets()
-	// Return a list of targets that isn't the creator
 	. = ..()
 	return . - creator
 
@@ -159,9 +140,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	return 0
 
 /mob/living/simple_animal/hostile/mimic/copy/proc/CopyObject(obj/O, mob/living/creator, destroy_original = 0)
-
 	if(destroy_original || CheckObject(O))
-
 		O.loc = src
 		name = O.name
 		desc = O.desc
@@ -169,7 +148,6 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		icon_state = O.icon_state
 		icon_living = icon_state
 		overlays = O.overlays
-
 		if(istype(O, /obj/structure) || istype(O, /obj/machinery))
 			health = (anchored * 50) + 50
 			destroy_objects = 1
@@ -183,15 +161,13 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 			melee_damage_lower = 2 + I.force
 			melee_damage_upper = 2 + I.force
 			move_to_delay = 2 * I.w_class + 1
-
 		maxHealth = health
 		if(creator)
-			src.creator = creator
+			creator = creator
 			faction += "\ref[creator]" // very unique
 		if(destroy_original)
 			qdel(O)
 		return 1
-	return
 
 /mob/living/simple_animal/hostile/mimic/copy/DestroySurroundings()
 	if(destroy_objects)
@@ -207,9 +183,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 				C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
 						"<span class='userdanger'>\The [src] knocks you down!</span>")
 
-//
-// Machine Mimics (Made by Malf AI)
-//
+
 
 /mob/living/simple_animal/hostile/mimic/copy/machine
 	speak = list("HUMANS ARE IMPERFECT!", "YOU SHALL BE ASSIMILATED!", "YOU ARE HARMING YOURSELF", "You have been deemed hazardous. Will you comply?", \
@@ -225,93 +199,57 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 			return 0
 	return ..()
 
-//
-//animated blasters, wands, etc
-//
+
 
 /mob/living/simple_animal/hostile/mimic/copy/ranged
-	name = "animated shooty gun"
-	desc = "there's something fishy here."
-	environment_smash = 0 //needed? seems weird for them to do so
-	ranged = 1
-	retreat_distance = 1 //just enough to shoot
-	minimum_distance = 6
-	projectiletype = /obj/item/projectile/magic/
-	projectilesound = 'sound/items/bikehorn.ogg'
-	casingtype = null
-	emote_see = list("aims menacingly")
 	var/obj/item/weapon/gun/TrueGun = null
-	var/obj/item/weapon/gun/magic/Zapstick = list()
-	var/obj/item/weapon/gun/projectile/Pewgun = list()
-	var/obj/item/weapon/gun/energy/Zapgun = list()
-
-/mob/living/simple_animal/hostile/mimic/copy/ranged/New(loc, var/obj/copy, var/mob/living/creator, var/destroy_original = 0)
-	..()
-
+	var/obj/item/weapon/gun/magic/Zapstick
+	var/obj/item/weapon/gun/projectile/Pewgun
+	var/obj/item/weapon/gun/energy/Zapgun
 
 /mob/living/simple_animal/hostile/mimic/copy/ranged/CopyObject(obj/O, mob/living/creator, destroy_original = 0)
-	if(destroy_original || CheckObject(O))
-
-		O.loc = src
-		name = O.name
-		desc = O.desc
-		icon = O.icon
-		icon_state = O.icon_state
-		icon_living = icon_state
-
-		if(istype(O, /obj/item/weapon/gun)) //leaving for sanity i guess
-			var/obj/item/weapon/gun/G = O
-			health = 15 * G.w_class
-			melee_damage_upper = G.force
-			melee_damage_lower = G.force - max(0, (G.force / 2))
-			move_to_delay = 2 * G.w_class + 1
-			projectilesound = G.fire_sound
-			TrueGun = G
-
-			if(istype(G, /obj/item/weapon/gun/magic))
-				Zapstick = G
-				var/obj/item/ammo_casing/magic/Zapshot = new Zapstick.ammo_type //this is done because ammo_type.proj_type can't be directly checked
-				projectiletype = Zapshot.projectile_type
-				qdel(Zapshot) //is this needed? i dare not risk piles of nullspace bullets
-
-			if(istype(G, /obj/item/weapon/gun/projectile))
-				Pewgun = G
-				var/obj/item/ammo_box/magazine/Pewmag = new Pewgun.mag_type //same problem, mag_type.ammo_type.proj_type can't be checked directly
-				var/obj/item/ammo_casing/Pewshot = new Pewmag.ammo_type
-				projectiletype = Pewshot.projectile_type
-				casingtype = Pewmag.ammo_type
-				qdel(Pewshot)
-				qdel(Pewmag)
-
-			if(istype(G, /obj/item/weapon/gun/energy))
-				Zapgun = G
-				var/selectfiresetting = Zapgun.select
-				var/obj/item/ammo_casing/energy/Energyammotype = Zapgun.ammo_type[selectfiresetting]
-				projectiletype = Energyammotype.projectile_type
-
-		maxHealth = health
-		if(creator)
-			src.creator = creator
-			faction += "\ref[creator]"
-		if(destroy_original)
-			qdel(O)
-		return 1
-	return
+	if(..())
+		emote_see = list("aims menacingly")
+		environment_smash = 0 //needed? seems weird for them to do so
+		ranged = 1
+		retreat_distance = 1 //just enough to shoot
+		minimum_distance = 6
+		var/obj/item/weapon/gun/G = O
+		melee_damage_upper = G.force
+		melee_damage_lower = G.force - max(0, (G.force / 2))
+		move_to_delay = 2 * G.w_class + 1
+		projectilesound = G.fire_sound
+		TrueGun = G
+		if(istype(G, /obj/item/weapon/gun/magic))
+			Zapstick = G
+			var/obj/item/ammo_casing/magic/M = Zapstick.ammo_type
+			projectiletype = initial(M.projectile_type)
+		if(istype(G, /obj/item/weapon/gun/projectile))
+			Pewgun = G
+			var/obj/item/ammo_box/magazine/M = Pewgun.mag_type
+			var/obj/item/ammo_casing/A = initial(M.ammo_type)
+			projectiletype = initial(A.projectile_type)
+			casingtype = initial(M.ammo_type)
+		if(istype(G, /obj/item/weapon/gun/energy))
+			Zapgun = G
+			var/selectfiresetting = Zapgun.select
+			var/obj/item/ammo_casing/energy/E = Zapgun.ammo_type[selectfiresetting]
+			projectiletype = initial(E.projectile_type)
 
 /mob/living/simple_animal/hostile/mimic/copy/ranged/OpenFire(the_target)
 	if(Zapgun)
-		if(Zapgun.power_supply) //sanity
+		if(Zapgun.power_supply)
 			var/obj/item/ammo_casing/energy/shot = Zapgun.ammo_type[Zapgun.select]
-			if(Zapgun.power_supply.charge >= shot.e_cost) //if she can zap
+			if(Zapgun.power_supply.charge >= shot.e_cost)
 				Zapgun.power_supply.use(shot.e_cost)
 				Zapgun.update_icon()
-				..() //zap 'em
-	if(Zapstick)
+				..()
+	else if(Zapstick)
 		if(Zapstick.charges)
 			Zapstick.charges--
 			Zapstick.update_icon()
 			..()
-	if(Pewgun)
+	else if(Pewgun)
 		if(Pewgun.chambered)
 			if(Pewgun.chambered.BB)
 				qdel(Pewgun.chambered.BB)
@@ -320,7 +258,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 				..()
 			else
 				visible_message("<span class='danger'>The <b>[src]</b> clears a jam!</span>")
-			Pewgun.chambered.loc = src.loc //rip revolver immersions, blame shotgun snowflake procs
+			Pewgun.chambered.loc = loc //rip revolver immersions, blame shotgun snowflake procs
 			Pewgun.chambered = null
 			if(Pewgun.magazine && Pewgun.magazine.stored_ammo.len)
 				Pewgun.chambered = Pewgun.magazine.get_round(0)
@@ -330,11 +268,10 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 			Pewgun.chambered = Pewgun.magazine.get_round(0)
 			Pewgun.chambered.loc = Pewgun
 			visible_message("<span class='danger'>The <b>[src]</b> cocks itself!</span>")
-
-	else //if somehow the mimic has no weapon
-		src.ranged = 0 //BANZAIIII
-		src.retreat_distance = 0
-		src.minimum_distance = 1
-	src.icon_state = TrueGun.icon_state
-	src.icon_living = TrueGun.icon_state
-	return
+	else
+		ranged = 0 //BANZAIIII
+		retreat_distance = 0
+		minimum_distance = 1
+		return
+	icon_state = TrueGun.icon_state
+	icon_living = TrueGun.icon_state


### PR DESCRIPTION
Mimic ranged crates will spawn as their parent if they are not created by a staff of animation.
Cleans a bit mimic.dm, copypaste and some bad code (like spawning some projectile types just to get a variable)
