### PR TITLE
Fixes teleporter hub and console deconstruction

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -25,6 +25,7 @@
 	if (power_station)
 		power_station.teleporter_console = null
 		power_station = null
+	..()
 
 /obj/machinery/computer/teleporter/proc/link_power_station()
 	if(power_station)
@@ -268,6 +269,7 @@
 	if (power_station)
 		power_station.teleporter_hub = null
 		power_station = null
+	..()
 
 /obj/machinery/teleport/hub/RefreshParts()
 	var/A = 0


### PR DESCRIPTION
Teleporter console and hub components did not call ..() in their
Destroy(), making it possible to spawn multiple machine frames by using a
crowbar rapidly in the few seconds it takes for the hub component to be
deleted.
- Adds missing parent calls to fix the issue.

NOTE: Other machines or entities may also have this issue. Reference this PR to have any other such occurrences added here.

Fixes #11251 
