### PR TITLE
Fixes a bunch of revenant stuff, again.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -810,7 +810,8 @@
 /obj/machinery/alarm/emag_act(mob/user)
 	if(!emagged)
 		src.emagged = 1
-		user.visible_message("<span class='warning'>Sparks fly out of the [src]!</span>", "<span class='notice'>You emag the [src], disabling its safeties.</span>")
+		if(user)
+			user.visible_message("<span class='warning'>Sparks fly out of the [src]!</span>", "<span class='notice'>You emag the [src], disabling its safeties.</span>")
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)
 		return
 
@@ -938,7 +939,8 @@ FIRE ALARM
 /obj/machinery/firealarm/emag_act(mob/user)
 	if(!emagged)
 		src.emagged = 1
-		user.visible_message("<span class='warning'>Sparks fly out of the [src]!</span>", "<span class='notice'>You emag the [src], disabling its thermal sensors.</span>")
+		if(user)
+			user.visible_message("<span class='warning'>Sparks fly out of the [src]!</span>", "<span class='notice'>You emag the [src], disabling its thermal sensors.</span>")
 		playsound(src.loc, 'sound/effects/sparks4.ogg', 50, 1)
 		return
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -141,7 +141,7 @@ Class Procs:
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)
-		use_power(750/severity)
+		use_power(7500/severity)
 
 		var/obj/effect/overlay/pulse2 = new/obj/effect/overlay ( src.loc )
 		pulse2.icon = 'icons/effects/effects.dmi'

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -141,7 +141,7 @@ Class Procs:
 
 /obj/machinery/emp_act(severity)
 	if(use_power && stat == 0)
-		use_power(7500/severity)
+		use_power(750/severity)
 
 		var/obj/effect/overlay/pulse2 = new/obj/effect/overlay ( src.loc )
 		pulse2.icon = 'icons/effects/effects.dmi'

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1092,7 +1092,7 @@ Status: []<BR>"},
 		user << "<span class='danger'>You short out the turret controls' access analysis module.</span>"
 		emagged = 1
 		locked = 0
-		if(user.machine==src)
+		if(user && user.machine==src)
 			src.attack_hand(user)
 
 /obj/machinery/turretid/attack_ai(mob/user)

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -190,7 +190,6 @@
 
 /mob/living/simple_animal/revenant/proc/giveSpells()
 	if(src.mind)
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/revenant_harvest
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/revenant_transmit
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_light
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_defile

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -82,16 +82,16 @@
 		return
 	A.attack_ghost(src)
 	if(ishuman(A) && in_range(src, A))
-		src.Harvest(A)
+		Harvest(A)
 
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
-	if(!src.castcheck(0))
+	if(!castcheck(0))
 		return
-	if(src.draining)
+	if(draining)
 		src << "<span class='warning'>You are already siphoning the essence of a soul!</span>"
 		return
-	if(target in src.drained_mobs)
+	if(target in drained_mobs)
 		src << "<span class='warning'>[target]'s soul is dead and empty.</span>"
 		return
 	if(!target.stat)
@@ -99,16 +99,16 @@
 		if(prob(10))
 			target << "You feel as if you are being watched."
 		return
-	src.draining = 1
-	src.essence_drained = 2
+	draining = 1
+	essence_drained = 2
 	src << "<span class='notice'>You search for the soul of [target].</span>"
 	if(do_after(src, 10, 3, 0, target)) //did they get deleted in that second?
 		if(target.ckey)
 			src << "<span class='notice'>Their soul burns with intelligence.</span>"
-			src.essence_drained += 2
+			essence_drained += 2
 		if(target.stat != DEAD)
 			src << "<span class='notice'>Their soul blazes with life!</span>"
-			src.essence_drained += 2
+			essence_drained += 2
 		else
 			src << "<span class='notice'>Their soul is weak and faltering.</span>"
 		if(do_after(src, 20, 6, 0, target)) //did they get deleted NOW?
@@ -120,10 +120,6 @@
 				if(5 to INFINITY)
 					src << "<span class='info'>Such a feast! [target] will yield much essence to you.</span>"
 			if(do_after(src, 30, 9, 0, target)) //how about now
-				if(!in_range(src, target))
-					src << "<span class='warning'>You are not close enough to siphon [target]'s soul. The link has been broken.</span>"
-					draining = 0
-					return
 				if(!target.stat)
 					src << "<span class='warning'>They are now powerful enough to fight off your draining.</span>"
 					target << "<span class='boldannounce'>You feel something tugging across your body before subsiding.</span>"
@@ -132,18 +128,22 @@
 				src << "<span class='danger'>You begin siphoning essence from [target]'s soul.</span>"
 				if(target.stat != DEAD)
 					target << "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>"
-				src.icon_state = "revenant_draining"
-				src.reveal(65)
-				src.stun(65)
+				icon_state = "revenant_draining"
+				reveal(65)
+				stun(65)
 				target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, their skin turning an ashy gray.</span>")
 				target.Beam(src,icon_state="drain_life",icon='icons/effects/effects.dmi',time=60)
 				if(target) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
-					src.change_essence_amount(essence_drained * 5, 0, target)
+					change_essence_amount(essence_drained * 5, 0, target)
 					src << "<span class='info'>[target]'s soul has been considerably weakened and will yield no more essence for the time being.</span>"
 					target.visible_message("<span class='warning'>[target] gently slumps back onto the ground.</span>")
-					src.drained_mobs.Add(target)
+					drained_mobs.Add(target)
 					target.death(0)
-				src.icon_state = "revenant_idle"
+				icon_state = "revenant_idle"
+			else
+				src << "<span class='warning'>You are not close enough to siphon [target]'s soul. The link has been broken.</span>"
+				draining = 0
+				return
 	draining = 0
 	return
 

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -229,68 +229,64 @@
 
 
 /mob/living/simple_animal/revenant/proc/castcheck(essence_cost)
-	var/mob/living/simple_animal/revenant/user = usr
-	if(!istype(user) || !user)
+	if(!src)
 		return
-	var/turf/T = get_turf(usr)
+	var/turf/T = get_turf(src)
 	if(istype(T, /turf/simulated/wall))
-		user << "<span class='warning'>You cannot use abilities from inside of a wall.</span>"
+		src << "<span class='warning'>You cannot use abilities from inside of a wall.</span>"
 		return 0
-	if(!user.change_essence_amount(essence_cost, 1))
-		user << "<span class='warning'>You lack the essence to use that ability.</span>"
+	if(src.inhibited)
+		src << "<span class='warning'>Your powers have been suppressed by nulling energy!</span>"
 		return 0
-	if(user.inhibited)
-		user << "<span class='warning'>Your powers have been suppressed by nulling energy!</span>"
+	if(!src.change_essence_amount(essence_cost, 1))
+		src << "<span class='warning'>You lack the essence to use that ability.</span>"
 		return 0
 	return 1
 
 
 
 /mob/living/simple_animal/revenant/proc/change_essence_amount(essence_amt, silent = 0, source = null)
-	var/mob/living/simple_animal/revenant/user = usr
-	if(!istype(usr) || !usr)
+	if(!src)
 		return
-	if(user.essence + essence_amt <= 0)
+	if(essence + essence_amt <= 0)
 		return
-	user.essence += essence_amt
-	user.essence = max(0, user.essence)
+	essence += essence_amt
+	essence = max(0, essence)
 	if(essence_amt > 0)
-		user.essence_accumulated += essence_amt
-		user.essence_accumulated = max(0, user.essence_accumulated)
+		essence_accumulated += essence_amt
+		essence_accumulated = max(0, essence_accumulated)
 	if(!silent)
 		if(essence_amt > 0)
-			user << "<span class='notice'>Gained [essence_amt]E from [source].</span>"
+			src << "<span class='notice'>Gained [essence_amt]E from [source].</span>"
 		else
-			user << "<span class='danger'>Lost [essence_amt]E from [source].</span>"
+			src << "<span class='danger'>Lost [essence_amt]E from [source].</span>"
 	return 1
 
 
 
 /mob/living/simple_animal/revenant/proc/reveal(time)
-	var/mob/living/simple_animal/revenant/R = usr
-	if(!istype(usr) || !usr)
+	if(!src)
 		return
 	if(time <= 0)
 		return
-	R.revealed = 1
-	R.invisibility = 0
-	R << "<span class='warning'>You have been revealed.</span>"
+	revealed = 1
+	invisibility = 0
+	src << "<span class='warning'>You have been revealed.</span>"
 	spawn(time)
-		R.revealed = 0
-		R.invisibility = INVISIBILITY_OBSERVER
-		R << "<span class='notice'>You are once more concealed.</span>"
+		revealed = 0
+		invisibility = INVISIBILITY_OBSERVER
+		src << "<span class='notice'>You are once more concealed.</span>"
 
 /mob/living/simple_animal/revenant/proc/stun(time)
-	var/mob/living/simple_animal/revenant/R = usr
-	if(!istype(usr) || !usr)
+	if(!src)
 		return
 	if(time <= 0)
 		return
-	R.notransform = 1
-	R << "<span class='warning'>You cannot move!</span>"
+	notransform = 1
+	src << "<span class='warning'>You cannot move!</span>"
 	spawn(time)
-		R.notransform = 0
-		R << "<span class='notice'>You can move again!</span>"
+		notransform = 0
+		src << "<span class='notice'>You can move again!</span>"
 
 
 

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -82,74 +82,69 @@
 		return
 	A.attack_ghost(src)
 	if(ishuman(A) && in_range(src, A))
-		Harvest(A, src)
+		src.Harvest(A)
 
 
-/mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/tar, mob/living/simple_animal/revenant/user = usr)
-	if(!user.castcheck(0))
+/mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
+	if(!src.castcheck(0))
 		return
-	var/mob/living/carbon/human/target = tar
-	if(user.draining)
-		user << "<span class='warning'>You are already siphoning the essence of a soul!</span>"
+	if(src.draining)
+		src << "<span class='warning'>You are already siphoning the essence of a soul!</span>"
 		return
-	if(target in user.drained_mobs)
-		user << "<span class='warning'>[target]'s soul is dead and empty.</span>"
+	if(target in src.drained_mobs)
+		src << "<span class='warning'>[target]'s soul is dead and empty.</span>"
 		return
 	if(!target.stat)
-		user << "<span class='notice'>This being's soul is too strong to harvest.</span>"
+		src << "<span class='notice'>This being's soul is too strong to harvest.</span>"
 		if(prob(10))
 			target << "You feel as if you are being watched."
 		return
-	draining = 1
-	essence_drained = 2
-	user << "<span class='notice'>You search for the soul of [target].</span>"
-	sleep(10)
-	if(target) //did they get deleted in that second?
+	src.draining = 1
+	src.essence_drained = 2
+	src << "<span class='notice'>You search for the soul of [target].</span>"
+	if(do_after(src, 10, 3, 0, target)) //did they get deleted in that second?
 		if(target.ckey)
-			user << "<span class='notice'>Their soul burns with intelligence.</span>"
-			essence_drained += 2
+			src << "<span class='notice'>Their soul burns with intelligence.</span>"
+			src.essence_drained += 2
 		if(target.stat != DEAD)
-			user << "<span class='notice'>Their soul blazes with life!</span>"
-			essence_drained += 2
+			src << "<span class='notice'>Their soul blazes with life!</span>"
+			src.essence_drained += 2
 		else
-			user << "<span class='notice'>Their soul is weak and faltering.</span>"
-		sleep(20)
-		if(target) //did they get deleted NOW?
+			src << "<span class='notice'>Their soul is weak and faltering.</span>"
+		if(do_after(src, 20, 6, 0, target)) //did they get deleted NOW?
 			switch(essence_drained)
 				if(1 to 2)
-					user << "<span class='info'>[target] will not yield much essence. Still, every bit counts.</span>"
+					src << "<span class='info'>[target] will not yield much essence. Still, every bit counts.</span>"
 				if(3 to 4)
-					user << "<span class='info'>[target] will yield an average amount of essence.</span>"
+					src << "<span class='info'>[target] will yield an average amount of essence.</span>"
 				if(5 to INFINITY)
-					user << "<span class='info'>Such a feast! [target] will yield much essence to you.</span>"
-			sleep(30)
-			if(target) //how about now
-				if(!in_range(user, target))
-					user << "<span class='warning'>You are not close enough to siphon [target]'s soul. The link has been broken.</span>"
+					src << "<span class='info'>Such a feast! [target] will yield much essence to you.</span>"
+			if(do_after(src, 30, 9, 0, target)) //how about now
+				if(!in_range(src, target))
+					src << "<span class='warning'>You are not close enough to siphon [target]'s soul. The link has been broken.</span>"
 					draining = 0
 					return
 				if(!target.stat)
-					user << "<span class='warning'>They are now powerful enough to fight off your draining.</span>"
+					src << "<span class='warning'>They are now powerful enough to fight off your draining.</span>"
 					target << "<span class='boldannounce'>You feel something tugging across your body before subsiding.</span>"
 					draining = 0
 					return //hey, wait a minute...
-				user << "<span class='danger'>You begin siphoning essence from [target]'s soul.</span>"
+				src << "<span class='danger'>You begin siphoning essence from [target]'s soul.</span>"
 				if(target.stat != DEAD)
 					target << "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>"
-				user.icon_state = "revenant_draining"
-				user.reveal(65)
-				user.stun(65)
+				src.icon_state = "revenant_draining"
+				src.reveal(65)
+				src.stun(65)
 				target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, their skin turning an ashy gray.</span>")
-				target.Beam(user,icon_state="drain_life",icon='icons/effects/effects.dmi',time=60)
+				target.Beam(src,icon_state="drain_life",icon='icons/effects/effects.dmi',time=60)
 				if(target) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
-					user.change_essence_amount(essence_drained * 5, 0, target)
-					user << "<span class='info'>[target]'s soul has been considerably weakened and will yield no more essence for the time being.</span>"
+					src.change_essence_amount(essence_drained * 5, 0, target)
+					src << "<span class='info'>[target]'s soul has been considerably weakened and will yield no more essence for the time being.</span>"
 					target.visible_message("<span class='warning'>[target] gently slumps back onto the ground.</span>")
-					drained_mobs.Add(target)
+					src.drained_mobs.Add(target)
 					target.death(0)
-				user.icon_state = "revenant_idle"
-				draining = 0
-		draining = 0
+				src.icon_state = "revenant_idle"
+	draining = 0
 	return
 
 

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -86,7 +86,7 @@
 
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/tar, mob/living/simple_animal/revenant/user = usr)
-	if(!user.castcheck(-30))
+	if(!user.castcheck(0))
 		return
 	var/mob/living/carbon/human/target = tar
 	if(user.draining)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -10,7 +10,7 @@
 /obj/effect/proc_holder/spell/targeted/revenant_harvest/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	for(var/mob/living/carbon/human/target in targets)
 		spawn(0)
-			user.Harvest(target, user)
+			user.Harvest(target)
 
 
 //Transmit: the revemant's only direct way to communicate. Sends a single message silently to a single mob for 5E.
@@ -146,7 +146,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant_malf/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(locked)
-		if(!user.castcheck(-35))
+		if(!user.castcheck(-50))
 			charge_counter = charge_max
 			return
 		user << "<span class='info'>You have unlocked Malfunction!</span>"
@@ -176,12 +176,12 @@
 				human << "<span class='deadsay'>You feel a burst of cold throughout your body...</span>"
 				human.emp_act(2)
 			for(var/obj/machinery/mach in T.contents)
-				switch(rand(1,6))
-					if(1)
+				switch(rand(1,10))
+					if(1 to 3)
 						mach.emp_act(1)
-					if(2 to 3)
+					if(4 to 9)
 						mach.emp_act(2)
-					if(4)
+					if(10)
 						mach.emag_act(null)
 	user.reveal(reveal)
 	user.stun(stun)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -169,6 +169,6 @@
 			for(var/obj/machinery/mach in T.contents)
 				if(prob(10))
 					mach.emag_act(null)
-			empulse(user.loc, 3, 5)
+	empulse(user.loc, 3, 5)
 	user.reveal(reveal)
 	user.stun(stun)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -43,7 +43,7 @@
 	clothes_req = 0
 	range = 1
 	var/reveal = 80
-	var/stun = 10
+	var/stun = 20
 	var/locked = 1
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant_light/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
@@ -95,7 +95,7 @@
 	clothes_req = 0
 	range = 1
 	var/reveal = 100
-	var/stun = 10
+	var/stun = 20
 	var/locked = 1
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant_defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
@@ -117,9 +117,9 @@
 		spawn(0)
 			if(T.flags & NOJAUNT)
 				T.flags -= NOJAUNT
-			if(!istype(T, /turf/simulated/wall/cult) && istype(T, /turf/simulated/wall) && prob(30))
+			if(!istype(T, /turf/simulated/wall/cult) && istype(T, /turf/simulated/wall) && prob(40))
 				T.ChangeTurf(/turf/simulated/wall/cult)
-			if(!istype(T, /turf/simulated/floor/engine/cult) && istype(T, /turf/simulated/floor) && prob(30))
+			if(!istype(T, /turf/simulated/floor/engine/cult) && istype(T, /turf/simulated/floor) && prob(40))
 				T.ChangeTurf(/turf/simulated/floor/engine/cult)
 			for(var/mob/living/carbon/human/human in T.contents)
 				human << "<span class='warning'>You suddenly feel tired.</span>"
@@ -166,22 +166,9 @@
 					bot.locked = 0
 					bot.open = 1
 					bot.Emag(null)
-			for(var/mob/living/silicon/robot/robot in T.contents)
-				robot.visible_message("<span class='warning'>[robot] lets out an alarm!</span>", \
-									  "<span class='boldannounce'>01001111 01010110 01000101 01010010 01001100 01001111 01000001 01000100</span>") //Translates to "OVERLOAD"
-				robot << 'sound/misc/interference.ogg'
-				robot.emp_act(2)
-				playsound(robot, 'sound/machines/warning-buzzer.ogg', 50, 1)
-			for(var/mob/living/carbon/human/human in T.contents)
-				human << "<span class='deadsay'>You feel a burst of cold throughout your body...</span>"
-				human.emp_act(2)
 			for(var/obj/machinery/mach in T.contents)
-				switch(rand(1,10))
-					if(1 to 3)
-						mach.emp_act(1)
-					if(4 to 9)
-						mach.emp_act(2)
-					if(10)
-						mach.emag_act(null)
+				if(prob(10))
+					mach.emag_act(null)
+			empulse(user.loc, 3, 5)
 	user.reveal(reveal)
 	user.stun(stun)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -1,102 +1,29 @@
 //Harvest Essence: The bread and butter of the revenant. The basic way of harvesting additional essence.
 /obj/effect/proc_holder/spell/targeted/revenant_harvest
-	name = "Harvest (0E)"
+	name = "Harvest"
 	desc = "Siphons the lingering spectral essence from a human, empowering yourself."
 	panel = "Revenant Abilities"
-	charge_max = 100 //Short cooldown
+	charge_max = 0 //No cooldown
 	clothes_req = 0
 	range = 1
-	var/essence_drained = 0
-	var/draining
-	var/list/drained_mobs = list() //Cannot harvest the same mob twice
 
 /obj/effect/proc_holder/spell/targeted/revenant_harvest/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
-	if(!user.castcheck(0))
-		charge_counter = charge_max
-		return
 	for(var/mob/living/carbon/human/target in targets)
 		spawn(0)
-			if(draining)
-				user << "<span class='warning'>You are already siphoning the essence of a soul!</span>"
-				charge_counter = charge_max
-				return
-			if(target in drained_mobs)
-				user << "<span class='warning'>[target]'s soul is dead and empty.</span>"
-				charge_counter = charge_max
-				return
-			if(!target.stat)
-				user << "<span class='notice'>This being's soul is too strong to harvest.</span>"
-				if(prob(10))
-					target << "You feel as if you are being watched."
-				return
-			draining = 1
-			essence_drained = 2
-			user << "<span class='notice'>You search for the soul of [target].</span>"
-			sleep(10)
-			if(target.ckey)
-				user << "<span class='notice'>Their soul burns with intelligence.</span>"
-				essence_drained += 2
-			if(target.stat != DEAD)
-				user << "<span class='notice'>Their soul blazes with life!</span>"
-				essence_drained += 2
-			else
-				user << "<span class='notice'>Their soul is weak and faltering.</span>"
-			sleep(20)
-			switch(essence_drained)
-				if(1 to 2)
-					user << "<span class='info'>[target] will not yield much essence. Still, every bit counts.</span>"
-				if(3 to 4)
-					user << "<span class='info'>[target] will yield an average amount of essence.</span>"
-				if(5 to INFINITY)
-					user << "<span class='info'>Such a feast! [target] will yield much essence to you.</span>"
-			sleep(30)
-			if(!in_range(user, target))
-				user << "<span class='warning'>You are not close enough to siphon [target]'s soul. The link has been broken.</span>"
-				draining = 0
-				return
-			if(!target.stat)
-				user << "<span class='warning'>They are now powerful enough to fight off your draining.</span>"
-				target << "<span class='boldannounce'>You feel something tugging across your body before subsiding.</span>"
-				return //hey, wait a minute...
-			user << "<span class='danger'>You begin siphoning essence from [target]'s soul.</span>"
-			if(target.stat != DEAD)
-				target << "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>"
-			user.icon_state = "revenant_draining"
-			user.reveal(65,1)
-			target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, their skin turning an ashy gray.</span>")
-			target.Beam(user,icon_state="drain_life",icon='icons/effects/effects.dmi',time=60)
-			target.death(0)
-			target.visible_message("<span class='warning'>[target] gently slumps back onto the ground.</span>")
-			user.icon_state = "revenant_idle"
-			user.change_essence_amount(essence_drained * 5, 0, target)
-			user << "<span class='info'>[target]'s soul has been considerably weakened and will yield no more essence for the time being.</span>"
-			drained_mobs.Add(target)
-			draining = 0
+			user.Harvest(target, user)
 
 
 //Transmit: the revemant's only direct way to communicate. Sends a single message silently to a single mob for 5E.
 /obj/effect/proc_holder/spell/targeted/revenant_transmit
-	name = "Transmit (5E)"
+	name = "Transmit"
 	desc = "Telepathically transmits a message to the target."
-	panel = "Revenant Abilities (Locked)"
-	charge_max = 50
+	panel = "Revenant Abilities"
+	charge_max = 0
 	clothes_req = 0
-	range = -1
-	include_user = 1
-	var/locked = 1
+	range = 7
+	include_user = 0
 
 /obj/effect/proc_holder/spell/targeted/revenant_transmit/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
-	if(!user.castcheck(-5))
-		charge_counter = charge_max
-		return
-	if(locked)
-		usr << "<span class='info'>You have unlocked Transmit!</span>"
-		locked = 0
-		charge_counter = charge_max
-		panel = "Revenant Abilities"
-		range = 7
-		include_user = 0
-		return
 	for(var/mob/living/M in targets)
 		spawn(0)
 			var/msg = stripped_input(usr, "What do you wish to tell [M]?", null, "")
@@ -115,6 +42,8 @@
 	charge_max = 200
 	clothes_req = 0
 	range = 1
+	var/reveal = 80
+	var/stun = 10
 	var/locked = 1
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant_light/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
@@ -126,7 +55,7 @@
 		name = "Overload Lights (20E)"
 		panel = "Revenant Abilities"
 		locked = 0
-		range = 5
+		range = 6
 		charge_counter = charge_max
 		return
 	if(!user.castcheck(-20))
@@ -153,29 +82,32 @@
 						z.set_up(4, 1, M)
 						z.start()
 						playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
-	user.reveal(80)
+	user.reveal(reveal)
+	user.stun(stun)
 
 
 //Defile: Corrupts nearby stuff, unblesses floor tiles.
 /obj/effect/proc_holder/spell/aoe_turf/revenant_defile
-	name = "Defile (40E)"
-	desc = "Twists and corrupts certain nearby objects. Also dispels holy auras on floors, but not salt lines."
+	name = "Defile (35E)"
+	desc = "Twists and corrupts the nearby area. Also dispels holy auras on floors, but not salt lines."
 	panel = "Revenant Abilities (Locked)"
 	charge_max = 200
 	clothes_req = 0
 	range = 1
+	var/reveal = 100
+	var/stun = 10
 	var/locked = 1
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant_defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(locked)
-		if(!user.castcheck(-40))
+		if(!user.castcheck(-35))
 			charge_counter = charge_max
 			return
 		user << "<span class='info'>You have unlocked Defile!</span>"
 		name = "Defile (20E)"
 		panel = "Revenant Abilities"
 		locked = 0
-		range = 4
+		range = 3
 		charge_counter = charge_max
 		return
 	if(!user.castcheck(-20))
@@ -185,22 +117,71 @@
 		spawn(0)
 			if(T.flags & NOJAUNT)
 				T.flags -= NOJAUNT
-			for(var/obj/machinery/bot/bot in T.contents)
-				bot.locked = 0
-				bot.open = 1
-				bot.emagged = 2
-				bot.Emag(null)
+			if(!istype(T, /turf/simulated/wall/cult) && istype(T, /turf/simulated/wall) && prob(30))
+				T.ChangeTurf(/turf/simulated/wall/cult)
+			if(!istype(T, /turf/simulated/floor/engine/cult) && istype(T, /turf/simulated/floor) && prob(30))
+				T.ChangeTurf(/turf/simulated/floor/engine/cult)
 			for(var/mob/living/carbon/human/human in T.contents)
 				human << "<span class='warning'>You suddenly feel tired.</span>"
-				human.adjustStaminaLoss(50)
+				human.adjustStaminaLoss(35)
+			for(var/obj/structure/window/window in T.contents)
+				window.hit(rand(50,125))
+			for(var/obj/machinery/light/light in T.contents)
+				light.flicker() //spooky
+	user.reveal(reveal)
+	user.stun(stun)
+
+
+//Malfunction: Makes bad stuff happen to robots and machines.
+/obj/effect/proc_holder/spell/aoe_turf/revenant_malf
+	name = "Malfunction (50E)"
+	desc = "Corrupts and damages nearby machines and mechanical objects."
+	panel = "Revenant Abilities (Locked)"
+	charge_max = 150
+	clothes_req = 0
+	range = 1
+	var/reveal = 60
+	var/stun = 30
+	var/locked = 1
+
+/obj/effect/proc_holder/spell/aoe_turf/revenant_malf/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
+	if(locked)
+		if(!user.castcheck(-35))
+			charge_counter = charge_max
+			return
+		user << "<span class='info'>You have unlocked Malfunction!</span>"
+		name = "Malfunction (15E)"
+		panel = "Revenant Abilities"
+		locked = 0
+		range = 4
+		charge_counter = charge_max
+		return
+	if(!user.castcheck(-15))
+		charge_counter = charge_max
+		return
+	for(var/turf/T in targets)
+		spawn(0)
+			for(var/obj/machinery/bot/bot in T.contents)
+				if(!bot.emagged)
+					bot.locked = 0
+					bot.open = 1
+					bot.Emag(null)
 			for(var/mob/living/silicon/robot/robot in T.contents)
 				robot.visible_message("<span class='warning'>[robot] lets out an alarm!</span>", \
 									  "<span class='boldannounce'>01001111 01010110 01000101 01010010 01001100 01001111 01000001 01000100</span>") //Translates to "OVERLOAD"
 				robot << 'sound/misc/interference.ogg'
 				robot.emp_act(2)
 				playsound(robot, 'sound/machines/warning-buzzer.ogg', 50, 1)
-			for(var/obj/structure/window/window in T.contents)
-				window.hit(rand(50,200))
-			for(var/obj/machinery/light/light in T.contents)
-				light.flicker() //spooky
-	user.reveal(100)
+			for(var/mob/living/carbon/human/human in T.contents)
+				human << "<span class='deadsay'>You feel a burst of cold throughout your body...</span>"
+				human.emp_act(2)
+			for(var/obj/machinery/mach in T.contents)
+				switch(rand(1,6))
+					if(1)
+						mach.emp_act(1)
+					if(2 to 3)
+						mach.emp_act(2)
+					if(4)
+						mach.emag_act(null)
+	user.reveal(reveal)
+	user.stun(stun)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -1,18 +1,3 @@
-//Harvest Essence: The bread and butter of the revenant. The basic way of harvesting additional essence.
-/obj/effect/proc_holder/spell/targeted/revenant_harvest
-	name = "Harvest"
-	desc = "Siphons the lingering spectral essence from a human, empowering yourself."
-	panel = "Revenant Abilities"
-	charge_max = 0 //No cooldown
-	clothes_req = 0
-	range = 1
-
-/obj/effect/proc_holder/spell/targeted/revenant_harvest/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
-	for(var/mob/living/carbon/human/target in targets)
-		spawn(0)
-			user.Harvest(target)
-
-
 //Transmit: the revemant's only direct way to communicate. Sends a single message silently to a single mob for 5E.
 /obj/effect/proc_holder/spell/targeted/revenant_transmit
 	name = "Transmit"

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -264,4 +264,5 @@
 	if(!emagged)
 		locked = 0
 		emagged = 1
-		user.visible_message("[user.name] emags the [src.name].","<span class='notice'>You short out the lock.</span>")
+		if(user)
+			user.visible_message("[user.name] emags the [src.name].","<span class='notice'>You short out the lock.</span>")

--- a/html/changelogs/revenants.yml
+++ b/html/changelogs/revenants.yml
@@ -1,0 +1,10 @@
+author: Joan
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added a new revenant ability; Malfunction. It does bad stuff to machines."
+  - tweak: "Defile and Overload Lights now briefly stun the revenant."
+  - tweak: "You can now Harvest a target by clicking on them while next to them."
+  - bugfix: "Harvest no longer leaves you draining if the target is deleted mid-drain attempt."
+  - rscdel: "Defile no longer emags bots or disables cyborgs, Malfunction does that now."

--- a/html/changelogs/revenants.yml
+++ b/html/changelogs/revenants.yml
@@ -6,5 +6,5 @@ changes:
   - rscadd: "Added a new revenant ability; Malfunction. It does bad stuff to machines."
   - tweak: "Defile and Overload Lights now briefly stun the revenant."
   - tweak: "You can now Harvest a target by clicking on them while next to them."
-  - bugfix: "Harvest no longer leaves you draining if the target is deleted mid-drain attempt."
+  - bugfix: "Harvesting no longer leaves you draining if the target is deleted mid-drain attempt."
   - rscdel: "Defile no longer emags bots or disables cyborgs, Malfunction does that now."


### PR DESCRIPTION
Splits Defile into two abilities, Defile and Malfunction.

> Harvest now can be activated by clicking the target while in range.
> Defile affects a 7x7 area, damaging windows, tiring humans, and corrupting tiles.
> Malfunction affects a 9x9 area, emping it, emagging bots, and possibly(10%) emagging machines.
> Defile and Overload Lights now briefly stun you so you can't just trigger and run instantly.
> Fixed a bunch of Harvest bugs.
