### PR TITLE
Some disposal fixes

### DIFF
--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -59,7 +59,6 @@
 	if(!D.trunk)
 		D.expel(src)	// no trunk connected, so expel immediately
 		return
-
 	loc = D.trunk
 	active = 1
 	dir = DOWN
@@ -122,11 +121,9 @@
 	playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
 
 // called to vent all gas in holder to a location
-/obj/structure/disposalholder/proc/vent_gas(atom/location)
-	if(location)
-		location.assume_air(gas)  // vent all gas to turf
-	air_update_turf()
-	return
+/obj/structure/disposalholder/proc/vent_gas(turf/T)
+	T.assume_air(gas)
+	T.air_update_turf()
 
 /obj/structure/disposalholder/allow_drop()
 	return 1
@@ -636,6 +633,16 @@
 
 	update()
 	return
+
+/obj/structure/disposalpipe/trunk/Destroy()
+	if(linked)
+		if(istype(linked, /obj/structure/disposaloutlet))
+			var/obj/structure/disposaloutlet/D = linked
+			D.trunk = null
+		else if(istype(linked, /obj/machinery/disposal))
+			var/obj/machinery/disposal/D = linked
+			D.trunk = null
+	..()
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
 	linked = null


### PR DESCRIPTION
Adds a Destroy() for the disposal pipe trunk.
Fixes vent_gas() from the disposal holder from trying to update the air while GCed.
This will stop mobs from getting stuck in nullspace under a really specific situation (trunk getting deleted while getting flushed).
