### PR TITLE
Increases Folder Exchange Trigger

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -108,7 +108,7 @@
 		var/is_hijacker = prob(10)
 		var/martyr_chance = prob(20)
 		var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-		if(!exchange_blue && traitors.len >= 5) 	//Set up an exchange if there are enough traitors
+		if(!exchange_blue && traitors.len >= 8) 	//Set up an exchange if there are enough traitors
 			if(!exchange_red)
 				exchange_red = traitor
 			else


### PR DESCRIPTION
The number of traitors required to trigger a folder exchange objective is increased from 5 to 8. 

The purpose of antagonists is to antagonize. These objectives provide 0 interactivity with the crew and completely dis-incentivize any antagonistic act against the station. Within 5 minutes either two traitors have greentext and the only way they can lose it is by actually conducting antagonistic acts, or one traitor shoots another traitor in the face and spaces the body to secure their own greentext, in which case they still have 0 interactivity with the rest of the crew.

With the current minimum of 5 traitors, you see a folder exchange in almost every traitor round and unless these traitors willfully risk their greentext by going off-objective then you've got 40% of traitors neutralized at roundstart, leaving just 3 traitors to be the driving force behind a round. One of those traitors will be AFK at roundstart and won't even know they're a traitor, the other will be the RD who has to "steal" a hand teleporter... you can see where I'm going with this. Exchanges are too often a proximate cause for traitor rounds where absolutely nothing happens. 

This change preserves the exchange and the hard work someone put into it, but ensures the objective only appears when there's a sufficient number of traitors to antagonize the station if the two folderbuddies decide to peacefully greentext.
