### PR TITLE
Fixes Announcements Garbling

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -76,7 +76,7 @@
 // Used to get a properly sanitized input, of max_length
 /proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN)
 	var/name = input(user, message, title, default) as text|null
-	return html_encode(trim(name, max_length)) //trim is "inside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
+	return trim(html_encode(name), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
 // Used to get a properly sanitized multiline input, of max_length
 /proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -112,7 +112,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			user << "The emergency shuttle has been disabled by Centcom."
 			return
 
-	call_reason = html_encode(trim(call_reason))
+	call_reason = trim(html_encode(call_reason))
 
 	if(length(call_reason) < CALL_SHUTTLE_REASON_LENGTH)
 		user << "You must provide a reason."


### PR DESCRIPTION
Maybe... Doubtfully... But I wanted to give it a try since I'm tired of my glorious pronouncements garbled in &39

Fixes https://github.com/tgstation/-tg-station/issues/10040
Fixes https://github.com/tgstation/-tg-station/issues/10514

If I actually fixed it then I should get a medal for best coding by someone who can't code. My logic was that WHISPER works just fine with apostrophes and ampersands but shuttle call reasons, announcements, etc. would get that garbled text when using apostrophes and ampersands.

With whispers trim is on the "inside", with stripped_input that is used for these announcements trim is on the "outside". It makes intuitive sense to me that whoever wrote that stripped_input comment might have gotten things flipped since if trim is on the inside, and it allows single symbols to pass through, then there's nothing to filter html_encode from spewing that garbage out.

If this isn't the correct fix then at least I should be close enough that someone can point me in the right direction or explain why whispering works fine but announcements do not. 
