### PR TITLE
Stops bullet casings from being recyclable

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -16,7 +16,7 @@ var/const/SAFETY_COOLDOWN = 100
 	var/amount_produced = 1
 	var/probability_mod = 1
 	var/extra_materials = 0
-	var/list/blacklist = list(/obj/item/pipe, /obj/item/pipe_meter, /obj/structure/disposalconstruct, /obj/item/weapon/reagent_containers, /obj/item/weapon/paper, /obj/item/stack/, /obj/item/weapon/pen, /obj/item/weapon/storage/, /obj/item/clothing/mask/cigarette) // Don't allow us to grind things we can poop out at 200 a second for free.
+	var/list/blacklist = list(/obj/item/pipe, /obj/item/pipe_meter, /obj/structure/disposalconstruct, /obj/item/weapon/reagent_containers, /obj/item/weapon/paper, /obj/item/stack/, /obj/item/weapon/pen, /obj/item/weapon/storage/, /obj/item/clothing/mask/cigarette, /obj/item/ammo_casing, /obj/item/projectile) // Don't allow us to grind things we can poop out at 200 a second for free.
 
 /obj/machinery/recycler/New()
 	// On us


### PR DESCRIPTION
Adds bullet casings to the recycler's blacklist because they're ridiculously easy to get a hold of, and if you put the box back in the autolathe they're free too.
Seemed a bit silly.
