### PR TITLE
Adds an IRC link to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 **Website:** http://www.tgstation13.org <BR>
 **Code:** https://github.com/tgstation/-tg-station <BR>
-**Wiki** http://tgstation13.org/wiki/Main_Page<BR>
-**IRC:** irc://irc.rizon.net/coderbus <BR>
+**Wiki** http://tgstation13.org/wiki/Main_Page <BR>
+**IRC:** irc://irc.rizon.net/coderbus or if you dont have an IRC client, you can click  [here](https://kiwiirc.com/client/irc.rizon.net:6667/?&theme=cli#coderbus).<BR>
+
 
 ##DOWNLOADING
 


### PR DESCRIPTION
Because some people don't know what an IRC client is or why that link doesn't go anywhere.
