### PR TITLE
Cyborgs unlocking cover and AI unanchoring upon dying.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1083,8 +1083,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/plist = list()
 	var/list/namecounts = list()
 
-	if(user.stat == 2) //won't work if dead
-		return
+	if(user.stat == 2)
+		return //won't work if dead
 
 	if(src.aiPDA.toff)
 		user << "Turn on your receiver in order to send messages."
@@ -1124,8 +1124,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_toggle_pda_receiver()
 	set category = "AI Commands"
 	set name = "PDA - Toggle Sender/Receiver"
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 	if(!isnull(aiPDA))
 		aiPDA.toff = !aiPDA.toff
 		usr << "<span class='notice'>PDA sender/receiver toggled [(aiPDA.toff ? "Off" : "On")]!</span>"
@@ -1135,8 +1135,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_toggle_pda_silent()
 	set category = "AI Commands"
 	set name = "PDA - Toggle Ringer"
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 	if(!isnull(aiPDA))
 		//0
 		aiPDA.silent = !aiPDA.silent
@@ -1147,8 +1147,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_use_chatroom()
 	set category = "AI Commands"
 	set name = "PDA - Chatrooms"
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 	if(!isnull(aiPDA))
 		aiPDA.mode = 5
 		aiPDA.attack_self(src)
@@ -1156,8 +1156,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		usr << "You do not have a PDA. You should make an issue report about this."
 
 /mob/living/silicon/ai/proc/cmd_show_message_log(mob/user)
-	if(user.stat == 2) //won't work if dead
-		return
+	if(user.stat == 2)
+		return //won't work if dead
 	if(!isnull(aiPDA))
 		var/HTML = "<html><head><title>AI PDA Message Log</title></head><body>[aiPDA.tnote]</body></html>"
 		user << browse(HTML, "window=log;size=400x444;border=1;can_resize=1;can_close=1;can_minimize=0")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1083,8 +1083,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/list/plist = list()
 	var/list/namecounts = list()
 
-	if(user.stat == 2)
-		user << "You can't send PDA messages because you are dead!"
+	if(user.stat == 2) //won't work if dead
 		return
 
 	if(src.aiPDA.toff)
@@ -1125,8 +1124,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_toggle_pda_receiver()
 	set category = "AI Commands"
 	set name = "PDA - Toggle Sender/Receiver"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
+	if(usr.stat == 2) //won't work if dead
 		return
 	if(!isnull(aiPDA))
 		aiPDA.toff = !aiPDA.toff
@@ -1137,8 +1135,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_toggle_pda_silent()
 	set category = "AI Commands"
 	set name = "PDA - Toggle Ringer"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
+	if(usr.stat == 2) //won't work if dead
 		return
 	if(!isnull(aiPDA))
 		//0
@@ -1150,8 +1147,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /mob/living/silicon/ai/verb/cmd_use_chatroom()
 	set category = "AI Commands"
 	set name = "PDA - Chatrooms"
-	if(usr.stat == 2)
-		usr << "You can't do that because you are dead!"
+	if(usr.stat == 2) //won't work if dead
 		return
 	if(!isnull(aiPDA))
 		aiPDA.mode = 5
@@ -1160,8 +1156,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		usr << "You do not have a PDA. You should make an issue report about this."
 
 /mob/living/silicon/ai/proc/cmd_show_message_log(mob/user)
-	if(user.stat == 2)
-		user << "You can't do that because you are dead!"
+	if(user.stat == 2) //won't work if dead
 		return
 	if(!isnull(aiPDA))
 		var/HTML = "<html><head><title>AI PDA Message Log</title></head><body>[aiPDA.tnote]</body></html>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -300,8 +300,8 @@ var/list/ai_list = list()
 	onclose(src, "airoster")
 
 /mob/living/silicon/ai/proc/ai_call_shuttle()
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	if(istype(usr,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = src
 		if(AI.control_disabled)
@@ -329,8 +329,8 @@ var/list/ai_list = list()
 	set name = "Toggle Floor Bolts"
 	if(!isturf(loc)) // if their location isn't a turf
 		return // stop
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	anchored = !anchored // Toggles the anchor
 
 	src << "[anchored ? "<b>You are now anchored.</b>" : "<b>You are now unanchored.</b>"]"
@@ -341,8 +341,8 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/proc/ai_cancel_call()
 	set category = "Malfunction"
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	if(istype(usr,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = src
 		if(AI.control_disabled)
@@ -506,8 +506,8 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "Access Robot Control"
 	set desc = "Wirelessly control various automatic robots."
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 
 	if(control_disabled)
 		src << "Wireless communication is disabled."
@@ -622,8 +622,8 @@ var/list/ai_list = list()
 	cameraFollow = null
 	var/cameralist[0]
 
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 
 	var/mob/living/silicon/ai/U = usr
 
@@ -666,8 +666,8 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "AI Status"
 
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
 	for (var/obj/machinery/M in machines) //change status
@@ -690,8 +690,8 @@ var/list/ai_list = list()
 	set desc = "Change the default hologram available to AI to something else."
 	set category = "AI Commands"
 
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	var/input
 	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
 
@@ -787,8 +787,8 @@ var/list/ai_list = list()
 	set desc = "Allows you to change settings of your radio."
 	set category = "AI Commands"
 
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	src << "Accessing Subspace Transceiver control..."
 	if (radio)
 		radio.interact(src)
@@ -802,8 +802,8 @@ var/list/ai_list = list()
 	set desc = "Modify the default radio setting for your automatic announcements."
 	set category = "AI Commands"
 
-	if(stat == 2) //won't work if dead
-		return
+	if(stat == 2)
+		return //won't work if dead
 	set_autosay()
 
 /mob/living/silicon/ai/attack_slime(mob/living/simple_animal/slime/user)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -300,8 +300,7 @@ var/list/ai_list = list()
 	onclose(src, "airoster")
 
 /mob/living/silicon/ai/proc/ai_call_shuttle()
-	if(src.stat == DEAD)
-		src << "You can't call the shuttle because you are dead!"
+	if(stat == 2) //won't work if dead
 		return
 	if(istype(usr,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = src
@@ -330,6 +329,8 @@ var/list/ai_list = list()
 	set name = "Toggle Floor Bolts"
 	if(!isturf(loc)) // if their location isn't a turf
 		return // stop
+	if(stat == 2) //won't work if dead
+		return
 	anchored = !anchored // Toggles the anchor
 
 	src << "[anchored ? "<b>You are now anchored.</b>" : "<b>You are now unanchored.</b>"]"
@@ -340,8 +341,7 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/proc/ai_cancel_call()
 	set category = "Malfunction"
-	if(src.stat == 2)
-		src << "You can't send the shuttle back because you are dead!"
+	if(stat == 2) //won't work if dead
 		return
 	if(istype(usr,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = src
@@ -506,8 +506,7 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "Access Robot Control"
 	set desc = "Wirelessly control various automatic robots."
-	if(stat == 2)
-		src << "<span class='danger'>Critical error. System offline.</span>"
+	if(stat == 2) //won't work if dead
 		return
 
 	if(control_disabled)
@@ -623,8 +622,7 @@ var/list/ai_list = list()
 	cameraFollow = null
 	var/cameralist[0]
 
-	if(usr.stat == 2)
-		usr << "You can't change your camera network because you are dead!"
+	if(stat == 2) //won't work if dead
 		return
 
 	var/mob/living/silicon/ai/U = usr
@@ -668,8 +666,7 @@ var/list/ai_list = list()
 	set category = "AI Commands"
 	set name = "AI Status"
 
-	if(usr.stat == 2)
-		usr <<"You cannot change your emotional status because you are dead!"
+	if(stat == 2) //won't work if dead
 		return
 	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
 	var/emote = input("Please, select a status!", "AI Status", null, null) in ai_emotions
@@ -693,6 +690,8 @@ var/list/ai_list = list()
 	set desc = "Change the default hologram available to AI to something else."
 	set category = "AI Commands"
 
+	if(stat == 2) //won't work if dead
+		return
 	var/input
 	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
 
@@ -788,6 +787,8 @@ var/list/ai_list = list()
 	set desc = "Allows you to change settings of your radio."
 	set category = "AI Commands"
 
+	if(stat == 2) //won't work if dead
+		return
 	src << "Accessing Subspace Transceiver control..."
 	if (radio)
 		radio.interact(src)
@@ -801,6 +802,8 @@ var/list/ai_list = list()
 	set desc = "Modify the default radio setting for your automatic announcements."
 	set category = "AI Commands"
 
+	if(stat == 2) //won't work if dead
+		return
 	set_autosay()
 
 /mob/living/silicon/ai/attack_slime(mob/living/simple_animal/slime/user)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -8,6 +8,7 @@
 	else
 		icon_state = "ai_dead"
 
+	anchored = 0 //unbolt floorbolts
 	update_canmove()
 	if(src.eyeobj)
 		src.eyeobj.setLoc(get_turf(src))

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -100,7 +100,7 @@
 	set category = "AI Commands"
 	set name = "Toggle Camera Acceleration"
 
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 	acceleration = !acceleration
 	usr << "Camera acceleration has been toggled [acceleration ? "on" : "off"]."

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -100,5 +100,7 @@
 	set category = "AI Commands"
 	set name = "Toggle Camera Acceleration"
 
+	if(usr.stat == 2) //won't work if dead
+		return
 	acceleration = !acceleration
 	usr << "Camera acceleration has been toggled [acceleration ? "on" : "off"]."

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -2,8 +2,8 @@
 /mob/living/silicon/ai/proc/show_laws_verb()
 	set category = "AI Commands"
 	set name = "Show Laws"
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 	src.show_laws()
 
 /mob/living/silicon/ai/show_laws(everyone = 0)

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -2,6 +2,8 @@
 /mob/living/silicon/ai/proc/show_laws_verb()
 	set category = "AI Commands"
 	set name = "Show Laws"
+	if(usr.stat == 2) //won't work if dead
+		return
 	src.show_laws()
 
 /mob/living/silicon/ai/show_laws(everyone = 0)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -69,6 +69,8 @@ var/const/VOX_DELAY = 600
 	set desc = "Display a list of vocal words to announce to the crew."
 	set category = "AI Commands"
 
+	if(usr.stat == 2) //won't work if dead
+		return
 
 	var/dat = "Here is a list of words you can type into the 'Announcement' button to create sentences to vocally announce to everyone on the same level at you.<BR> \
 	<UL><LI>You can also click on the word to preview it.</LI>\

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -69,8 +69,8 @@ var/const/VOX_DELAY = 600
 	set desc = "Display a list of vocal words to announce to the crew."
 	set category = "AI Commands"
 
-	if(usr.stat == 2) //won't work if dead
-		return
+	if(usr.stat == 2)
+		return //won't work if dead
 
 	var/dat = "Here is a list of words you can type into the 'Announcement' button to create sentences to vocally announce to everyone on the same level at you.<BR> \
 	<UL><LI>You can also click on the word to preview it.</LI>\

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -23,6 +23,7 @@
 		return
 	if(!gibbed)
 		emote("deathgasp")
+	locked = 0 //unlock cover
 	stat = DEAD
 	update_canmove()
 	if(camera)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -1,6 +1,9 @@
 /mob/living/silicon/robot/verb/cmd_show_laws()
 	set category = "Robot Commands"
 	set name = "Show Laws"
+
+	if(usr.stat == DEAD)
+		return //won't work if dead
 	show_laws()
 
 /mob/living/silicon/robot/show_laws(everyone = 0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -255,6 +255,8 @@
 /mob/living/silicon/robot/verb/cmd_robot_alerts()
 	set category = "Robot Commands"
 	set name = "Show Alerts"
+	if(usr.stat == DEAD)
+		return //won't work if dead
 	robot_alerts()
 
 //for borg hotkeys, here module refers to borg inv slot, not core module
@@ -613,6 +615,8 @@
 	set category = "Robot Commands"
 	set name = "Unlock Cover"
 	set desc = "Unlocks your own cover if it is locked. You can not lock it again. A human will have to lock it for you."
+	if(stat == DEAD)
+		return //won't work if dead
 	if(locked)
 		switch(alert("You can not lock your cover again, are you sure?\n      (You can still ask for a human to lock it)", "Unlock Own Cover", "Yes", "No"))
 			if("Yes")
@@ -981,12 +985,17 @@
 	set category = "Robot Commands"
 	set name = "State Laws"
 
+	if(usr.stat == DEAD)
+		return //won't work if dead
 	checklaws()
 
 /mob/living/silicon/robot/verb/set_automatic_say_channel() //Borg version of setting the radio for autosay messages.
 	set name = "Set Auto Announce Mode"
 	set desc = "Modify the default radio setting for stating your laws."
 	set category = "Robot Commands"
+
+	if(usr.stat == DEAD)
+		return //won't work if dead
 	set_autosay()
 
 /mob/living/silicon/robot/proc/control_headlamp()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -131,6 +131,8 @@
 	set name = "Print Image"
 	set src in usr
 
+	if(usr.stat == DEAD)
+		return //won't work if dead
 	borgprint()
 
 /obj/item/device/camera/attack(mob/living/carbon/human/M, mob/user)


### PR DESCRIPTION
- Made cyborg cover unlock upon death.
- Made AI unanchor upon death.
- Added checks-if-dead to all cyborg and AI verbs.
- Removed "You can't do that because you're dead!" -messages from AI verbs.

As WJohn and GunHog discussed in the issue, this makes you able to kill a cyborg, have their cover be automatically opened from them dying, emagging them, then reviving them with them safely on your side. And the AI unanchoring itself upon dying allows a borg to bring them to the RD for repairs.

Fixes #11287
