### PR TITLE
Stops mindless revenants from despawning

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -181,21 +181,10 @@
 			src.mind.objectives += objective2
 			src << "<b>Objective #2</b>: [objective2.explanation_text]"
 			ticker.mode.traitors |= src.mind //Necessary for announcing
-		if(!src.giveSpells())
-			message_admins("Revenant was created but has no mind. Trying again in ten seconds.")
-			spawn(100)
-				if(!src.giveSpells())
-					message_admins("Revenant still has no mind. Deleting...")
-					qdel(src)
-
-/mob/living/simple_animal/revenant/proc/giveSpells()
-	if(src.mind)
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/revenant_transmit
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_light
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_defile
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_malf
-		return 1
-	return 0
+		mob_spell_list += new /obj/effect/proc_holder/spell/targeted/revenant_transmit
+		mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_light
+		mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_defile
+		mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_malf
 
 /mob/living/simple_animal/revenant/death()
 	..(1)


### PR DESCRIPTION
Instead of deleting revenants because when their mind couldn't be given spells, the spells are given to the mob like with statues and constructs. Mindless revenants only happen when directly spawned by an admin, and having to put a mob into them within 10 seconds is a bit fiddly.
