### PR TITLE
Fixes #11281 nonalpha dbnote search

### DIFF
--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -147,7 +147,8 @@
 		var/search
 		output += "<center><a href='?_src_=holder;addnoteempty=1'>\[Add Note\]</a></center>"
 		output += ruler
-		index = sanitizeSQL(index)
+		if(!isnum(index))
+			index = sanitizeSQL(index)
 		switch(index)
 			if(1)
 				search = "^."


### PR DESCRIPTION
Fixes #11281, num values were being sanitized, making the search '^'
