### PR TITLE
Some bugfixes with qdel

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -46,6 +46,7 @@
 		if(T.client)
 			T.client.screen -= button
 		qdel(button)
+		button = null
 	T.actions.Remove(src)
 	T.update_action_buttons()
 	owner = null

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -14,10 +14,6 @@
 /mob/camera/experience_pressure_difference()
 	return
 
-/mob/camera/Destroy()
-	..()
-	qdel(src)
-
 /mob/camera/Login()
 	..()
 	update_interface()


### PR DESCRIPTION
Fixes action button not updating correctly sometimes (b/c the change …from del to qdel means the button wasn't null after Removal which fucks with the action update procs) Fixes #11313

Fixes infinite loop when deleting a camera mob.(Destroy calls qdel which calls Destroy) Fixes #11329
