### PR TITLE
Fixes the do_after progress bar appearing on a coin when flipping+throwing it

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -326,7 +326,9 @@
 		flick("coin_[cmineral]_flip", src)
 		icon_state = "coin_[cmineral]_[coinflip]"
 		playsound(user.loc, 'sound/items/coinflip.ogg', 50, 1)
-		if(do_after(user, 15, target = src))
+		var/oldloc = loc
+		sleep(15)
+		if(loc == oldloc && user && !user.incapacitated())
 			user.visible_message("[user] has flipped [src]. It lands on [coinflip].", \
 								 "<span class='notice'>You flip [src]. It lands on [coinflip].</span>", \
 								 "<span class='italics'>You hear the clattering of loose change.</span>")


### PR DESCRIPTION
Fixes #11136
There's no code called when the checks fail so we have no reason to use do_after() that checks stuff every 3 deciseconds. I replaced it by a simple sleep(15) and then some checks.
