### PR TITLE
Producible Emitter Boards at R&D

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -32,6 +32,16 @@
 	build_path = /obj/item/weapon/circuitboard/turbine_computer
 	category = list ("Engineering Machinery")
 
+/datum/design/emitter
+	name = "Machine Design (Emitter Board)"
+	desc = "The circuit board for an emitter."
+	id = "emitter"
+	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 5)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/emitter
+	category = list ("Engineering Machinery")
+
 /datum/design/power_compressor
 	name = "Machine Design (Power Compressor Board)"
 	desc = "The circuit board for a power compressor."

--- a/html/changelogs/Fox P McCloud - Emitterboard .yml
+++ b/html/changelogs/Fox P McCloud - Emitterboard .yml
@@ -1,0 +1,7 @@
+
+author: Fox P McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Adds the emitter board to to the circuit imprinter for R&D."


### PR DESCRIPTION
Simply put, allows the emitter board to be producible at R&D.

This seems like a bit of an oversight; currently every single machine that has a circuit board is able to be produced in R&D---with one glaring exception: the emitter board. This corrects that.

Fixes  #11327

Tech requirements:
- Programming: 4
- Power storage: 5
- Engineering: 5
