### PR TITLE
Removes dirt from walking on tiles

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -25,9 +25,6 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1))
 		A.clean_blood()
 		A.thermite = 0
-		var/turf/simulated/floor/F = A
-		if(istype(F))
-			F.dirt = 0
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
 				qdel(O)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -181,9 +181,6 @@
 		var/turf/tile = loc
 		if(isturf(tile))
 			tile.clean_blood()
-			if (istype(tile, /turf/simulated/floor))
-				var/turf/simulated/floor/F = tile
-				F.dirt = 0
 			for(var/A in tile)
 				if(istype(A, /obj/effect))
 					if(is_cleanable(A))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -32,8 +32,6 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/obj/item/stack/tile/builtin_tile = null //needed for performance reasons when the singularity rips off floor tiles
 	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	var/list/burnt_states = list()
-	var/dirt = 0
-	var/ignoredirt = 0
 
 /turf/simulated/floor/New()
 	..()
@@ -166,23 +164,6 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 /turf/simulated/floor/narsie_act()
 	if(prob(20))
 		ChangeTurf(/turf/simulated/floor/plasteel/cult)
-
-/turf/simulated/floor/Entered(atom/A, atom/OL)
-	..()
-	if(!ignoredirt)
-		if(has_gravity(src))
-			if(istype(A,/mob/living/carbon))
-				var/mob/living/carbon/M = A
-				if(M.lying)	return
-				if(prob(80))
-					dirt++
-				var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt, src)
-				if(dirt >= 100)
-					if(!dirtoverlay)
-						dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
-						dirtoverlay.alpha = 10
-					else if(dirt > 100)
-						dirtoverlay.alpha = min(dirtoverlay.alpha+10, 200)
 
 /turf/simulated/floor/can_have_cabling()
 	return !burnt & !broken & !lava

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -26,7 +26,6 @@
 	icon_state = "grass"
 	floor_tile = /obj/item/stack/tile/grass
 	broken_states = list("sand")
-	ignoredirt = 1
 
 /turf/simulated/floor/grass/New()
 	..()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -21,7 +21,6 @@
 /turf/simulated/floor/plating/beach
 	name = "Beach"
 	icon = 'icons/misc/beach.dmi'
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/beach/ex_act(severity, target)
 	contents_explosion(severity, target)
@@ -43,13 +42,11 @@
 	..()
 	name = "Iron Sand"
 	icon_state = "ironsand[rand(1,15)]"
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/snow
 	name = "snow"
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/snow/ex_act(severity, target)
 	contents_explosion(severity, target)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -66,7 +66,6 @@
 	color = "#aa77aa"
 	icon_state = "vinefloor"
 	broken_states = list()
-	ignoredirt = 1
 
 
 //All of this shit is useless for vines

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -509,7 +509,6 @@ var/global/list/rockTurfEdgeCache
 	icon_state = "asteroid"
 	icon_plating = "asteroid"
 	var/dug = 0       //0 = has not yet been dug, 1 = has already been dug
-	ignoredirt = 1
 
 /turf/simulated/floor/plating/asteroid/airless
 	oxygen = 0.01

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -862,9 +862,6 @@
 			var/turf/tile = loc
 			if(isturf(tile))
 				tile.clean_blood()
-				if (istype(tile, /turf/simulated/floor))
-					var/turf/simulated/floor/F = tile
-					F.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
 						if(is_cleanable(A))

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -646,10 +646,6 @@
 
 		for(var/mob/living/simple_animal/slime/M in T)
 			M.adjustToxLoss(rand(5,10))
-	if(istype(T, /turf/simulated/floor))
-		var/turf/simulated/floor/F = T
-		if(reac_volume >= 1)
-			F.dirt = 0
 
 /datum/reagent/space_cleaner/reaction_mob(mob/M, method=TOUCH, reac_volume)
 	if(method == TOUCH || VAPOR)


### PR DESCRIPTION
This feature adds no fun and actually does nothing but annoys late-round high-pop janitors. Janitor is already busy with all the blood that appears everywhere as station slowly descends into the depths of chaos, there is no reason to add more work for him.

Code-wize, this feature was a dirty code segment that was running every time anything moved, and that's bad I think.
