### PR TITLE
Fixes burn kits containing salicyclic acid pills. Adds new burn medication.

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -45,8 +45,8 @@
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
-	new /obj/item/weapon/reagent_containers/syringe/silver_sulf(src)
-	new /obj/item/weapon/reagent_containers/syringe/silver_sulf(src)
+	new /obj/item/weapon/reagent_containers/pill/oxandrolone(src)
+	new /obj/item/weapon/reagent_containers/pill/oxandrolone(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
 	return

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -45,8 +45,8 @@
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
-	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
-	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/syringe/silver_sulf(src)
+	new /obj/item/weapon/reagent_containers/syringe/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
 	return

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -45,8 +45,8 @@
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
 	new /obj/item/weapon/reagent_containers/pill/patch/silver_sulf(src)
-	new /obj/item/weapon/reagent_containers/pill/salicyclic(src)
-	new /obj/item/weapon/reagent_containers/pill/salicyclic(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
+	new /obj/item/weapon/reagent_containers/pill/kelotane(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
 	new /obj/item/device/healthanalyzer(src)
 	return

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -173,12 +173,35 @@
 		if(method == INGEST)
 			M.adjustToxLoss(0.5*volume)
 			if(show_message)
-				M << "<span class='notice'>You probably shouldn't have eaten that. Maybe you should of splashed it on, or applied a patch?</span>"
+				M << "<span class='notice'>You probably shouldn't have eaten that. Maybe you should have splashed it on, or applied a patch?</span>"
 	..()
 	return
 
 /datum/reagent/medicine/silver_sulfadiazine/on_mob_life(mob/living/M)
 	M.adjustFireLoss(-2*REM)
+	..()
+	return
+
+/datum/reagent/medicine/oxandrolone
+	name = "Oxandrolone"
+	id = "oxandrolone"
+	description = "Stimulates healing of severe burns. If you have more than 50 burn damage, it heals 2 units; otherwise, 0.5. If overdosed it will exacerbate existing burns, causing burn and brute damage."
+	reagent_state = LIQUID
+	color = "#f7ffa5"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 25
+
+/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/M)
+	if(M.getFireLoss() > 50)
+		M.adjustFireLoss(-2*REM)
+	else
+		M.adjustFireLoss(-0.5*REM)
+	..()
+	return
+
+/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/M)
+	M.adjustFireLoss(2.5*REM) // it's going to be healing either 2 or 0.5
+	M.adjustBruteLoss(0.5*REM)
 	..()
 	return
 

--- a/code/modules/reagents/Chemistry-Recipes/Medicine.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Medicine.dm
@@ -102,6 +102,12 @@
 	required_reagents = list("sodium" = 1, "phenol" = 1, "carbon" = 1, "oxygen" = 1, "sacid" = 1)
 	result_amount = 5
 
+/datum/chemical_reaction/oxandrolone
+	name = "Oxandrolone"
+	id = "oxandrolone"
+	result = "oxandrolone"
+	required_reagents = list("carbon" = 3, "phenol" = 1, "hydrogen" = 1, "oxygen" = 1)
+	result_amount = 6
 
 /datum/chemical_reaction/salbutamol
 	name = "Salbutamol"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -133,6 +133,12 @@
 	icon_state = "pill5"
 	list_reagents = list("sal_acid" = 24)
 	roundstart = 1
+/obj/item/weapon/reagent_containers/pill/oxandrolone
+	name = "oxandrolone pill"
+	desc = "Used to stimulate burn healing."
+	icon_state = "pill5"
+	list_reagents = list("oxandrolone" = 24)
+	roundstart = 1
 
 /obj/item/weapon/reagent_containers/pill/insulin
 	name = "insulin pill"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -134,6 +134,13 @@
 	list_reagents = list("sal_acid" = 24)
 	roundstart = 1
 
+/obj/item/weapon/reagent_containers/pill/kelotane
+	name = "kelotane pill"
+	desc = "Catalyzes the healing of burns."
+	icon_state = "pill5"
+	list_reagents = list("kelotane" = 20)
+	roundstart = 1
+
 /obj/item/weapon/reagent_containers/pill/insulin
 	name = "insulin pill"
 	desc = "Handles hyperglycaemic coma."

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -134,13 +134,6 @@
 	list_reagents = list("sal_acid" = 24)
 	roundstart = 1
 
-/obj/item/weapon/reagent_containers/pill/kelotane
-	name = "kelotane pill"
-	desc = "Catalyzes the healing of burns."
-	icon_state = "pill5"
-	list_reagents = list("kelotane" = 20)
-	roundstart = 1
-
 /obj/item/weapon/reagent_containers/pill/insulin
 	name = "insulin pill"
 	desc = "Handles hyperglycaemic coma."

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -216,11 +216,6 @@
 	desc = "Contains charcoal."
 	list_reagents = list("charcoal" = 15)
 
-/obj/item/weapon/reagent_containers/syringe/silver_sulf
-	name = "syringe (silver sulfadiazine)"
-	desc = "Contains silver sulfadiazine."
-	list_reagents = list("silver_sulfadiazine" = 15)
-
 /obj/item/weapon/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"
 	desc = "Contains antiviral agents."

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -216,6 +216,11 @@
 	desc = "Contains charcoal."
 	list_reagents = list("charcoal" = 15)
 
+/obj/item/weapon/reagent_containers/syringe/silver_sulf
+	name = "syringe (charcoal)"
+	desc = "Contains silver sulfadiazine."
+	list_reagents = list("silver_sulfadiazine" = 15)
+
 /obj/item/weapon/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"
 	desc = "Contains antiviral agents."

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -217,7 +217,7 @@
 	list_reagents = list("charcoal" = 15)
 
 /obj/item/weapon/reagent_containers/syringe/silver_sulf
-	name = "syringe (charcoal)"
+	name = "syringe (silver sulfadiazine)"
 	desc = "Contains silver sulfadiazine."
 	list_reagents = list("silver_sulfadiazine" = 15)
 

--- a/html/changelogs/bgobandit - salicyclicassblastusa.yml
+++ b/html/changelogs/bgobandit - salicyclicassblastusa.yml
@@ -1,0 +1,7 @@
+author: bgobandit
+
+delete-after: True
+
+changes: 
+  - bugfix: "Overheard at CentComm: 'This burn kit said salicyclic acid would heal my burns! WHO MADE THIS SHIT?' A muffled honking is heard in the background. (Burn first-aid kits now contain an appropriate burn pill.)"
+  - rscadd: "Oxandrolone, a new burn healing medication, has been added to burn first-aid kits and to chemistry. Ingesting 25 units or more causes burn and brute damage."


### PR DESCRIPTION
Burn kits currently contain patches and salicyclic acid pills. Salicyclic acid heals brute damage, not burn. 

Changes in this PR:
- Adds a new burn medication, oxandrolone. Recipe: 3 parts carbon, 1 part hydrogen, 1 part oxygen, 1 part phenol. Oxandrolone works by stimulating the healing of severe burns. This is how it works IRL: http://www.ncbi.nlm.nih.gov/pmc/articles/PMC1421286/
- Unlike salicyclic, oxandrolone is more effective the more severe a burn is. 2 units if your burn damage > 50, 0.5 unit otherwise. Gameplay-wise, this should be useful for those who are really fucked up, but returns will diminish quickly once they're OK.
- Overdose threshold: 25. Upon overdose, oxandrolone exacerbates internal burns and injuries, increasing burn and brute damage. The numbers can be tweaked if necessary.
- 24-unit oxandrolone pills are included in burn first aid kits. 
- Changelog added.
