### PR TITLE
An attempt to reduce singulo lag from power wires destruction. 2nd attempt.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -432,12 +432,15 @@ By design, d1 is the smallest direction and d2 is the highest
 				P.disconnect_from_network() //remove from current network (and delete powernet)
 		return
 
+	var/obj/O = P_list[1]
 	// remove the cut cable from its turf and powernet, so that it doesn't get count in propagate_network worklist
 	loc = null
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
-	var/datum/powernet/newPN = new()// creates a new powernet...
-	propagate_network(P_list[1], newPN)//... and propagates it to the other side of the cable
+	spawn(0) //so we don't rebuild the network X times when singulo/explosion destroys a line of X cables
+		if(O && !qdeleted(O))
+			var/datum/powernet/newPN = new()// creates a new powernet...
+			propagate_network(O, newPN)//... and propagates it to the other side of the cable
 
 	// Disconnect machines connected to nodes
 	if(d1 == 0) // if we cut a node (O-X) cable


### PR DESCRIPTION
Make it so the code doesn't rebuild (propagate_network()) the wire network X times when singulo/explosion destroys a line of X cables at once. Salvaged from #9493.
I tested it locally. I got no runtimes and a loose singularity now calls propagate_network() 5 times less on average (and thus less CPU used overall).

Here's the profile results when releasing the singularity (admin-possessed so it does roughly the same destruction):
BEFORE:

```
cut_cable_from_powernet(): Calls 600 ; Self CPU 0.008 ; Total CPU/Real Time 7.307
propagate_network(): Calls 333 ; Self CPU 3.5 ; Total CPU/Real Time 7.28
```

AFTER:

```
cut_cable_from_powernet(): Calls 763 ; Self CPU 0.015 ; Total CPU/Real Time 0.728
propagate_network(): Calls 69 ; Self CPU 0.339 ; Total CPU/Real Time 0.698
```
