### PR TITLE
Fixes infinite wumbo-ing

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -602,7 +602,7 @@
 /obj/item/asteroid/fugu_gland/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag && istype(target, /mob/living/simple_animal))
 		var/mob/living/simple_animal/A = target
-		if(A.buffed || A.type in banned_mobs || A.stat)
+		if(A.buffed || (A.type in banned_mobs) || A.stat)
 			user << "<span class='warning'>Something's interfering with the [src]'s effects. It's no use.</span>"
 			return
 		A.buffed++


### PR DESCRIPTION
Wumbo-sie was created and I thought I double checked this but evidently I didn't.

Stops people from spamming wumborian fugu glands on the same mob.

Fixes #11395
