### PR TITLE
Animals are now listed properly on cargo manifests.

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -287,7 +287,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	if(istype(Crate, /obj/structure/closet/critter)) // critter crates do not actually spawn mobs yet and have no contains var, but the manifest still needs to list them
 		var/obj/structure/closet/critter/CritCrate = Crate
 		if(CritCrate.content_mob)
-			var/obj/crittername = CritCrate.content_mob
+			var/mob/crittername = CritCrate.content_mob
 			slip.info += "<li>[initial(crittername.name)]</li>"
 
 	if((errors & MANIFEST_ERROR_ITEM))

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -284,6 +284,12 @@ var/datum/subsystem/shuttle/SSshuttle
 			A:amount = object.amount
 		slip.info += "<li>[A.name]</li>"	//add the item to the manifest (even if it was misplaced)
 
+	if(istype(Crate, /obj/structure/closet/critter)) // critter crates do not actually spawn mobs yet and have no contains var, but the manifest still needs to list them
+		var/obj/structure/closet/critter/CritCrate = Crate
+		if(CritCrate.content_mob)
+			var/obj/crittername = CritCrate.content_mob
+			slip.info += "<li>[initial(crittername.name)]</li>"
+
 	if((errors & MANIFEST_ERROR_ITEM))
 		//secure and large crates cannot lose items
 		if(findtext("[object.containertype]", "/secure/") || findtext("[object.containertype]","/largecrate/"))
@@ -306,7 +312,7 @@ var/datum/subsystem/shuttle/SSshuttle
 		var/obj/structure/largecrate/LC = Crate
 		LC.manifest = slip
 		LC.update_icon()
-	
+
 	return Crate
 
 /datum/subsystem/shuttle/proc/generateSupplyOrder(packId, _orderedby, _orderedbyRank, _comment)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/6392.

The issue, basically: Critter crates do not actually contain animals when the manifest is being created, presumably because mobs would break the shuttle. As a result, animals ordered through cargo are not listed on the supply manifest, causing much confusion and salt from quartermasters who reject the orders.

Currently critter crates cannot get errors. I am fine with leaving it that way if you're fine with it.
