### PR TITLE
Golems no longer take damage from attacking with glass shards.

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -298,7 +298,7 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(!H.gloves)
+		if(!H.gloves && !(PIERCEIMMUNE in H.dna.species.specflags)) // golems, etc
 			H << "<span class='warning'>[src] cuts into your hand!</span>"
 			var/organ = (H.hand ? "l_" : "r_") + "arm"
 			var/obj/item/organ/limb/affecting = H.get_organ(organ)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/10119.

Simple shit, golems have a PIERCEIMMUNE flag that is supposed to handle cases like this but glass code's afterattack did not handle it. 
