### PR TITLE
Fixes a compile option that, when enabled, makes for far easier qdel() debugging.

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -7,4 +7,5 @@
 #define QDEL_HINT_HARDDEL		3 //qdel should assume this object won't gc, and queue a hard delete using a hard reference.
 #define QDEL_HINT_HARDDEL_NOW	4 //qdel should assume this object won't gc, and hard del it post haste.
 #define QDEL_HINT_PUTINPOOL		5 //qdel will put this object in the atom pool.
-
+#define QDEL_HINT_FINDREFERENCE	6 //functionally identical to QDEL_HINT_QUEUE if TESTING is not enabled in _compiler_options.dm.
+								  //if TESTING is enabled, qdel will call this object's find_references() verb.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,5 +1,5 @@
 #define DEBUG					//Enables byond profiling and full runtime logs - note, this may also be defined in your .dme file
-#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
+//#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
 								//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,6 +1,5 @@
 #define DEBUG					//Enables byond profiling and full runtime logs - note, this may also be defined in your .dme file
-//#define dellogging			//Enables logging of forced del() calls (used for debugging)
-//#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
+#define TESTING				//Enables in-depth debug messages to runtime log (used for debugging)
 								//By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
@@ -46,15 +45,6 @@
 #define AI_VOX 1 // Comment out if you don't want VOX to be enabled and have players download the voice sounds.
 
 //Additional code for the above flags.
-#ifdef dellogging
-#warn compiling del logging. This will have additional overheads.	//will warn you if compiling with dellogging
-var/list/del_counter = list()
-/proc/log_del(datum/X)
-	if(istype(X)){del_counter[X.type]++;}
-	del(X)
-#define del(X) log_del(X)							//overrides all del() calls with log_del()
-#endif
-
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.
 #endif

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -25,7 +25,6 @@ var/datum/subsystem/garbage_collector/SSgarbage
 	var/list/didntgc = list()	// list of all types that have failed to GC associated with the number of times that's happened.
 								// the types are stored as strings
 
-
 /datum/subsystem/garbage_collector/New()
 	NEW_SS_GLOBAL(SSgarbage)
 
@@ -61,7 +60,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 		if(GCd_at_time > time_to_kill)
 			break // Everything else is newer, skip them
 
-		var/atom/A
+		var/datum/A
 		if (!istext(refID))
 			del(A)
 		else
@@ -76,7 +75,6 @@ var/datum/subsystem/garbage_collector/SSgarbage
 			else
 				++gcedlasttick
 				++totalgcs
-
 		queue.Cut(1, 2)
 
 
@@ -145,7 +143,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 #ifdef TESTING
 /client/var/running_find_references
 
-/atom/verb/find_references()
+/datum/verb/find_references()
 	set category = "Debug"
 	set name = "Find References"
 	set background = 1
@@ -163,18 +161,18 @@ var/datum/subsystem/garbage_collector/SSgarbage
 		return
 
 	// Remove this object from the list of things to be auto-deleted.
-	if(garbage)
-		garbage.destroyed -= "\ref[src]"
+	if(SSgarbage && ("\ref[src]" in SSgarbage.queue))
+		SSgarbage.queue -= "\ref[src]"
 
 	usr.client.running_find_references = type
 	testing("Beginning search for references to a [type].")
 	var/list/things = list()
 	for(var/client/thing)
-		things += thing
+		things |= thing
 	for(var/datum/thing)
-		things += thing
+		things |= thing
 	for(var/atom/thing)
-		things += thing
+		things |= thing
 	testing("Collected list of things in search for references to a [type]. ([things.len] Thing\s)")
 	for(var/datum/thing in things)
 		if(!usr.client.running_find_references) return
@@ -190,11 +188,11 @@ var/datum/subsystem/garbage_collector/SSgarbage
 
 /client/verb/purge_all_destroyed_objects()
 	set category = "Debug"
-	if(garbage)
-		while(garbage.destroyed.len)
-			var/datum/o = locate(garbage.destroyed[1])
+	if(SSgarbage)
+		while(SSgarbage.queue.len)
+			var/datum/o = locate(SSgarbage.queue[1])
 			if(istype(o) && o.gc_destroyed)
 				del(o)
-				garbage.dels++
-			garbage.destroyed.Cut(1, 2)
+				SSgarbage.totaldels++
+			SSgarbage.queue.Cut(1, 2)
 #endif


### PR DESCRIPTION
In _compile_options.dm, there is an option (`TESTING`) which, when enabled, allows one to, among other things, find all references to any datum. I'm sure that any of you who have dealt with a `qdel()` issue before can see the significance of such a thing.
Problem was, there were some outdated variable names in the code that gets compiled if `TESTING` is enabled that made the game unable to compile when it was enabled. This PR fixes those, and returns this powerful feature back to the hands of we coders.

~~I also intend to (maybe in this PR, maybe not) add some more useful `qdel()` debugging tools. Maybe some toggleable way to display references before `del()` is called? Who knows. This alone is a beautiful start.~~

I have also added two ways to show references while an object is being `qdel()`'d. The first is a new object verb `qdel_then_find_references()`, which does what you'd expect. This is a per-object thing, for testing when `qdel()` is called in a neutral situation.
The second way to show references is a new qdel hint, `QDEL_HINT_FINDREFERENCE`. When an object's `Destroy()` proc returns this hint and `TESTING` is enabled, qdel() will first call the object's `find_references()` verb, then will place the object in the queue. If `TESTING` is disabled, this hint is functionally identical to `QDEL_HINT_QUEUE`. This can be used for more intensive debugging, such as running a singularity through atmos to check for `qdel()` failures.

I also removed the now-redundant `dellogging` compile option, as its function is already included in the game in the form of `View del() log`.
