### PR TITLE
REMOVES ALIEN LARVAS

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/larva/update_icons.dm
@@ -24,5 +24,5 @@
 /mob/living/carbon/alien/larva/update_transform() //All this is handled in update_icons()
 	return update_icons()
 
-/mob/living/carbon/larva/update_inv_handcuffed()
+/mob/living/carbon/alien/larva/update_inv_handcuffed()
 	return


### PR DESCRIPTION
Removes an incorrect type path, mob/living/carbon/larva, unused. It was just a typo.

hooonk
