### PR TITLE
Fixes empty message because of yelling

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -62,7 +62,7 @@ var/list/freqtospan = list(
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
-/atom/movable/proc/say_quote(input, list/spans)
+/atom/movable/proc/say_quote(input, list/spans=list())
 	if(!input)
 		return "says, \"...\""	//not the best solution, but it will stop a large number of runtimes. The cause is somewhere in the Tcomms code
 	var/ending = copytext(input, length(input))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -39,8 +39,7 @@
 	if(name != real_name)
 		alt_name = " (died as [real_name])"
 
-	var/spans = list()
-	message = src.say_quote(message, spans)
+	message = src.say_quote(message)
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>"
 
 	for(var/mob/M in player_list)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -39,7 +39,8 @@
 	if(name != real_name)
 		alt_name = " (died as [real_name])"
 
-	message = src.say_quote(message)
+	var/spans = list()
+	message = src.say_quote(message, spans)
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>"
 
 	for(var/mob/M in player_list)


### PR DESCRIPTION
Fixes #11203. The runtime was caused by say_quote being passed null instead of a list, this stops that
