### PR TITLE
Adds fingerprint transfer for machine deconstruction; logs SMES

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -336,6 +336,7 @@ Class Procs:
 		deconstruction()
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
 		var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(src.loc)
+		transfer_fingerprints_to(M)
 		M.state = 2
 		M.icon_state = "box_1"
 		for(var/obj/item/I in component_parts)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -159,6 +159,9 @@
 
 	//crowbarring it !
 	default_deconstruction_crowbar(I)
+	message_admins("[src] has been deconstructed by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+	log_game("src] has been deconstructed by [key_name(user)]")
+	investigate_log("SMES deconstructed by [key_name(user)]","singulo")
 
 /obj/machinery/power/smes/Destroy()
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -160,7 +160,7 @@
 	//crowbarring it !
 	default_deconstruction_crowbar(I)
 	message_admins("[src] has been deconstructed by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("src] has been deconstructed by [key_name(user)]")
+	log_game("[src] has been deconstructed by [key_name(user)]")
 	investigate_log("SMES deconstructed by [key_name(user)]","singulo")
 
 /obj/machinery/power/smes/Destroy()


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/10413.
- All machine deconstruction transfers fingerprints to the machine frame created.
- SMES has logging for the player who deconstructed it, as well as singulo logging. No longer can disgruntled CEs "hold the power hostage" undetected.
