### PR TITLE
Fixes reboot world in dd or client side debugging tools acting odd.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -130,6 +130,9 @@
 #undef CHAT_PULLR
 
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
+	if (reason == 1) //special reboot, do none of the normal stuff
+		world << "<span class='boldannounce'>Rebooting World immediately due to host request</span>"
+		return ..(1)
 	var/delay
 	if(time)
 		delay = time

--- a/code/world.dm
+++ b/code/world.dm
@@ -129,8 +129,12 @@
 						C << "<span class='announce'>PR: [input["announce"]]</span>"
 #undef CHAT_PULLR
 
+#define R_SERVER	16
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if (reason == 1) //special reboot, do none of the normal stuff
+		if (usr)
+			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
+			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")
 		world << "<span class='boldannounce'>Rebooting World immediately due to host request</span>"
 		return ..(1)
 	var/delay
@@ -169,7 +173,7 @@
 			C << link("byond://[config.server]")
 	..(0)
 
-
+#undef R_SERVER
 /world/proc/load_mode()
 	var/list/Lines = file2list("data/mode.txt")
 	if(Lines.len)

--- a/code/world.dm
+++ b/code/world.dm
@@ -129,7 +129,6 @@
 						C << "<span class='announce'>PR: [input["announce"]]</span>"
 #undef CHAT_PULLR
 
-#define R_SERVER	16
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if (reason == 1) //special reboot, do none of the normal stuff
 		if (usr)
@@ -173,7 +172,6 @@
 			C << link("byond://[config.server]")
 	..(0)
 
-#undef R_SERVER
 /world/proc/load_mode()
 	var/list/Lines = file2list("data/mode.txt")
 	if(Lines.len)


### PR DESCRIPTION
Using the server->reboot option in client side debugging tools will sleep the current proc and call world.Reboot(1).

These cases should immediately reboot with no code to clog it up so that admins with client side debugging tools can restart the world even if its hung. (this being the reason i gave all admins client side debugging tools)

It used to act this way, but something changed and now it restarts with a 25 second delay, preventing the restart if something is hanging the server. 
