### PR TITLE
Assembly qdel fix

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -25,13 +25,6 @@
 	var/const/WIRE_RADIO_RECEIVE = 8		//Allows Pulsed(1) to call Activate()
 	var/const/WIRE_RADIO_PULSE = 16		//Allows Pulse(1) to send a radio message
 
-/obj/item/device/assembly/Destroy()
-	qdel(connected)
-	connected = null
-	qdel(holder)
-	holder = null
-	return ..()
-
 /obj/item/device/assembly/proc/holder_movement()							//Called when the holder is moved
 	return
 


### PR DESCRIPTION
Fixes tank transfer bombs clogging the MC and multiple infinite loops with assembly deletion.
