### PR TITLE
Fixes Bibles Not Revealing Runes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -669,7 +669,7 @@ var/list/sacrificed = list()
 	if (istype(W,/obj/item/weapon/paper/talisman))
 		rad = 4
 		go = 1
-	if (istype(W,/obj/item/weapon/nullrod))
+	if (istype(W,/obj/item/weapon/storage/book/bible))
 		rad = 1
 		go = 1
 	if(go)
@@ -678,7 +678,7 @@ var/list/sacrificed = list()
 				R.invisibility=0
 			S=1
 	if(S)
-		if(istype(W,/obj/item/weapon/nullrod))
+		if(istype(W,/obj/item/weapon/storage/book/bible))
 			usr << "<span class='danger'>Arcane markings suddenly glow from underneath a thin layer of dust!</span>"
 			return
 		if(istype(W,/obj/effect/rune))

--- a/html/changelogs/Fox P McCloud - runereveal .yml
+++ b/html/changelogs/Fox P McCloud - runereveal .yml
@@ -1,0 +1,7 @@
+
+author: Fox P McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes Bibles/holy books not properly revealing runes."


### PR DESCRIPTION
Fixes: https://github.com/tgstation/-tg-station/issues/11559

Bibles currently do not reveal runes, as this was originally a function of the null rod...that said, when it was changed to the Bible, apparently someone forgot to change the reveal runes proc.
