### PR TITLE
Xeno corrosive acid no longer spaces asteroid walls and floors.

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -479,9 +479,18 @@
 			T.dump_contents()
 			qdel(target)
 
+		if(istype(target, /turf/simulated/mineral))
+			var/turf/simulated/mineral/M = target
+			M.ChangeTurf(M.baseturf)
+
+		if(istype(target, /turf/simulated/floor))
+			var/turf/simulated/floor/F = target
+			F.ChangeTurf(F.baseturf)
+
 		if(istype(target, /turf/simulated/wall))
 			var/turf/simulated/wall/W = target
 			W.dismantle_wall(1)
+
 		else
 			qdel(target)
 


### PR DESCRIPTION
This makes it so that the Xeno Corrosive Acid spit no longer turns asteroid floors and walls into space turf. Tested it and it doesn't seem to break everything. Note, had to put it above the wall part in the code, otherwise it would make walls into space instead of dismantling them. Who knew.

Fixes #11548 
