### PR TITLE
Fixes custom cult structure in library backroom

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -24,6 +24,7 @@
 	name = "desk"
 	desc = "A desk covered in arcane manuscripts and tomes in unknown languages. Looking at the text makes your skin crawl"
 	icon_state = "tomealtar"
+	luminosity = 1
 
 /obj/effect/gateway
 	name = "gateway"


### PR DESCRIPTION
fixes  #11463
Used this issue to clean over my old tortoisegit skills failed in naming branch but nothing else.
Add a simple 1 tile lighting of the structure
