### PR TITLE
Fix turbine

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -348,7 +348,7 @@
 		locate_machinery()
 
 /obj/machinery/computer/turbine_computer/locate_machinery()
-	compressor = locate(/obj/machinery/power/compressor) in range(5)
+	compressor = locate(/obj/machinery/power/compressor) in range(5, src)
 
 /obj/machinery/computer/turbine_computer/attack_hand(var/mob/user as mob)
 	if(..())

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -84,10 +84,9 @@
 
 /obj/machinery/power/compressor/initialize()
 	..()
-	spawn(10)
-		locate_machinery()
-		if(!turbine)
-			stat |= BROKEN
+	locate_machinery()
+	if(!turbine)
+		stat |= BROKEN
 
 
 #define COMPFRICTION 5e5
@@ -206,10 +205,9 @@
 
 /obj/machinery/power/turbine/initialize()
 	..()
-	spawn(10)
-		locate_machinery()
-		if(!compressor)
-			stat |= BROKEN
+	locate_machinery()
+	if(!compressor)
+		stat |= BROKEN
 
 /obj/machinery/power/turbine/RefreshParts()
 	var/P = 0


### PR DESCRIPTION
Fixes 2 turbine bugs
- Race condition rendered turbine broken at roundstart by #11489. This is because the turbine and compressor run process() soon after initalization, and were doing it before they had located their machinery.

Here's a helpful (somewhat simplified) visualization of what was going wrong:

```
| Time | Proc 1             | Proc 2             |
|------+--------------------+--------------------|
|    0 | initialize turbine |                    |
|    1 | spawn(10)          |                    |
|    2 |                    | process() turbine  |
|    3 |                    | oops no machinery  |
|    4 |                    | set turbine broken |
|    5 | locate_machinery() |                    |
```
- Could not locate compressor when using the turbine computer from the north on Box (has been a bug since forever). Turns out the computer was checking for the compressor 5 tiles away from the _user_ and not the computer itself.
