### PR TITLE
Fixes spacevine controller not spawning during event.

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -9,7 +9,7 @@
 
 	for(var/area/hallway/A in world)
 		for(var/turf/simulated/F in A)
-			if(!F.density && !F.contents.len)
+			if(!F.density || !F.contents.len)
 				turfs += F
 
 	if(turfs.len) //Pick a turf to spawn at if we can


### PR DESCRIPTION
As it says on the tin. This fixes the spacevine controller not spawning during the spacevine event. Tested it and it works now.

Fixes #11135 
