### PR TITLE
Fixes a BUNCH of atmos shit

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -28,8 +28,8 @@ Pipelines + Other Objects -> Pipe network
 	var/list/obj/machinery/atmospherics/nodes = list()
 
 /obj/machinery/atmospherics/New()
-	..()
 	nodes.len = device_type
+	..()
 	SSair.atmos_machinery += src
 	SetInitDirections()
 	if(can_unwrench)

--- a/code/ATMOSPHERICS/components/components_base.dm
+++ b/code/ATMOSPHERICS/components/components_base.dm
@@ -11,9 +11,9 @@ On top of that, now people can add component-speciic procs/vars if they want!
 	var/list/datum/gas_mixture/airs = list()
 
 /obj/machinery/atmospherics/components/New()
-	..()
 	parents.len = device_type
 	airs.len = device_type
+	..()
 
 	for(DEVICE_TYPE_LOOP)
 		var/datum/gas_mixture/A = new

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -93,7 +93,7 @@
 
 	if(pump_direction & RELEASING)
 		icon_state = "vent_out"
-	if(pump_direction & SIPHONING)
+	else //pump_direction == SIPHONING
 		icon_state = "vent_in"
 
 /obj/machinery/atmospherics/components/unary/vent_pump/process_atmos()
@@ -130,7 +130,7 @@
 				loc.assume_air(removed)
 				air_update_turf()
 
-	if(pump_direction & SIPHONING) //external -> internal
+	else //external -> internal
 		var/pressure_delta = 10000
 		if(pressure_checks&EXT_BOUND)
 			pressure_delta = min(pressure_delta, (environment_pressure - external_pressure_bound))

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -76,7 +76,7 @@
 			amount += idle_power_usage
 		if (scrub_N2O)
 			amount += idle_power_usage
-	if(scrubbing & SIPHONING)
+	else //scrubbing == SIPHONING
 		amount = active_power_usage
 
 	if (widenet)
@@ -99,7 +99,7 @@
 
 	if(scrubbing & SCRUBBING)
 		icon_state = "scrub_on"
-	if(scrubbing & SIPHONING)
+	else //scrubbing == SIPHONING
 		icon_state = "scrub_purge"
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/set_frequency(new_frequency)
@@ -203,7 +203,7 @@
 			tile.assume_air(removed)
 			tile.air_update_turf()
 
-	if(scrubbing & SIPHONING) //Just siphoning all air
+	else //Just siphoning all air
 		if (air_contents.return_pressure()>=50*ONE_ATMOSPHERE)
 			return
 

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -208,8 +208,8 @@ var/pipenetwarnings = 10
 		GL += P.other_airs
 		for(var/obj/machinery/atmospherics/components/binary/valve/V in P.other_atmosmch)
 			if(V.open)
-				PL |= V.parents["p1"]
-				PL |= V.parents["p2"]
+				PL |= V.PARENT1
+				PL |= V.PARENT2
 		for(var/obj/machinery/atmospherics/components/unary/portables_connector/C in P.other_atmosmch)
 			if(C.connected_device)
 				GL += C.portableConnectorReturnAir()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -106,11 +106,11 @@
 		// update icon overlays only if displayed level has changed
 
 		if(hot_air)
-			var/datum/gas_mixture/circ2_air1 = circ2.airs["a1"]
+			var/datum/gas_mixture/circ2_air1 = circ2.AIR1
 			circ2_air1.merge(hot_air)
 
 		if(cold_air)
-			var/datum/gas_mixture/circ1_air1 = circ1.airs["a1"]
+			var/datum/gas_mixture/circ1_air1 = circ1.AIR1
 			circ1_air1.merge(cold_air)
 
 	var/genlev = max(0, min( round(11*lastgen / 100000), 11))
@@ -133,10 +133,10 @@
 	if(!powernet)
 		t += "<span class='bad'>Unable to connect to the power network!</span>"
 	else if(circ1 && circ2)
-		var/datum/gas_mixture/circ1_air1 = circ1.airs["a1"]
-		var/datum/gas_mixture/circ1_air2 = circ1.airs["a2"]
-		var/datum/gas_mixture/circ2_air1 = circ2.airs["a1"]
-		var/datum/gas_mixture/circ2_air2 = circ2.airs["a2"]
+		var/datum/gas_mixture/circ1_air1 = circ1.AIR1
+		var/datum/gas_mixture/circ1_air2 = circ1.AIR2
+		var/datum/gas_mixture/circ2_air1 = circ2.AIR1
+		var/datum/gas_mixture/circ2_air2 = circ2.AIR2
 
 		t += "<div class='statusDisplay'>"
 


### PR DESCRIPTION
Fixes a race condition causing roundstart runtimes with certain atmos components.
`/obj/machinery/New()` called `power_change()`, which one certain components called `update_icon_nopipes()`. `update_icon_nopipes()`, on those components, included a check for `NODE1` before `nodes.len` was set in `/obj/machinery/atmospherics/New()`. The solution was simple; I just moved the list initialization to /before/ `..()` was called.

Also fixes two separate but related issues regarding manual valves and the TEG.

I ALSO fixed roundstart atmos.(Fixes #11624)
