### PR TITLE
AI damage and dying indicators

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -833,6 +833,6 @@ var/list/ai_list = list()
 	return // no eyes, no flashing
 
 /mob/living/silicon/ai/attackby(obj/item/weapon/W, mob/user, params)
-	if(W.force && W.damtype != STAMINA) //only sparks if real damage is dealt.
+	if(W.force && W.damtype != STAMINA && src.stat != DEAD) //only sparks if real damage is dealt.
 		spark_system.start()
 	return ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -826,3 +826,11 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
 	return // no eyes, no flashing
+
+/mob/living/silicon/ai/attackby(obj/item/weapon/W, mob/user, params)
+	if(W.force && W.damtype != STAMINA) //only sparks if real damage is dealt.
+		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
+		spark_system.set_up(5, 0, src)
+		spark_system.attach(src)
+		spark_system.start()
+	return ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -37,6 +37,7 @@ var/list/ai_list = list()
 	var/obj/item/device/multitool/aiMulti = null
 	var/obj/machinery/bot/Bot
 	var/tracking = 0 //this is 1 if the AI is currently tracking somebody, but the track has not yet been completed.
+	var/datum/effect/effect/system/spark_spread/spark_system//So they can initialize sparks whenever/N
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker
@@ -81,6 +82,10 @@ var/list/ai_list = list()
 	loc = loc
 
 	holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo1"))
+
+	spark_system = new /datum/effect/effect/system/spark_spread()
+	spark_system.set_up(5, 0, src)
+	spark_system.attach(src)
 
 	if(L)
 		if (istype(L, /datum/ai_laws))
@@ -829,8 +834,5 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/attackby(obj/item/weapon/W, mob/user, params)
 	if(W.force && W.damtype != STAMINA) //only sparks if real damage is dealt.
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread
-		spark_system.set_up(5, 0, src)
-		spark_system.attach(src)
 		spark_system.start()
 	return ..()

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -1,5 +1,8 @@
 /mob/living/silicon/ai/death(gibbed)
-	if(stat == DEAD)	return
+	if(stat == DEAD)
+		return
+	if(!gibbed)
+		emote("me", 1, "sparks and its screen flickers, its systems slowly coming to a halt.")
 	stat = DEAD
 
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -556,7 +556,7 @@
 			user << "<span class='notice'>You fill the toner level of [src] to its max capacity.</span>"
 
 	else
-		if(W.force && W.damtype != STAMINA) //only sparks if real damage is dealt.
+		if(W.force && W.damtype != STAMINA && src.stat != DEAD) //only sparks if real damage is dealt.
 			spark_system.start()
 		return ..()
 


### PR DESCRIPTION
- AI now sparks when taking damage, similar to other silicons.
- AI and borgs no longer spark if they're already dead.
- AI now has a dying emote:

"**D.O.O.R.K.N.O.B.** _sparks and its screen flickers, its systems slowly coming to a halt._"

(This emote is more just a placeholder, hoping to get better suggestions!)
