### PR TITLE
Adds materials to ore

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -29,6 +29,7 @@ Mineral Sheets
 	throw_speed = 3
 	throw_range = 5
 	origin_tech = "materials=1"
+	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 	sheettype = "sandstone"
 
 var/global/list/datum/stack_recipe/sandstone_recipes = list ( \
@@ -251,7 +252,8 @@ var/global/list/datum/stack_recipe/clown_recipes = list ( \
 	w_class = 3
 	throw_speed = 1
 	throw_range = 3
-	origin_tech = "materials=5"
+	origin_tech = "materials=6"
+	materials = list(MAT_URANIUM=3000)
 
 /*
  * Adamantine

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -22,6 +22,7 @@
 	icon_state = "Uranium ore"
 	origin_tech = "materials=5"
 	points = 18
+	materials = list(MAT_URANIUM=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/uranium
 
 /obj/item/weapon/ore/iron
@@ -29,6 +30,7 @@
 	icon_state = "Iron ore"
 	origin_tech = "materials=1"
 	points = 1
+	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/metal
 
 /obj/item/weapon/ore/glass
@@ -36,7 +38,7 @@
 	icon_state = "Glass ore"
 	origin_tech = "materials=1"
 	points = 1
-	materials = list(MAT_GLASS = 100)
+	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/glass
 
 /obj/item/weapon/ore/glass/attack_self(mob/living/user)
@@ -61,8 +63,9 @@
 /obj/item/weapon/ore/plasma
 	name = "plasma ore"
 	icon_state = "Plasma ore"
-	origin_tech = "materials=2"
+	origin_tech = "plasmatech=2;materials=2"
 	points = 36
+	materials = list(MAT_PLASMA=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/plasma
 
 /obj/item/weapon/ore/plasma/attackby(obj/item/I, mob/user, params)
@@ -79,6 +82,7 @@
 	icon_state = "Silver ore"
 	origin_tech = "materials=3"
 	points = 18
+	materials = list(MAT_SILVER=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/silver
 
 /obj/item/weapon/ore/gold
@@ -86,6 +90,7 @@
 	icon_state = "Gold ore"
 	origin_tech = "materials=4"
 	points = 18
+	materials = list(MAT_GOLD=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/gold
 
 /obj/item/weapon/ore/diamond
@@ -93,6 +98,7 @@
 	icon_state = "Diamond ore"
 	origin_tech = "materials=6"
 	points = 36
+	materials = list(MAT_DIAMOND=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/diamond
 
 /obj/item/weapon/ore/bananium
@@ -100,6 +106,7 @@
 	icon_state = "Clown ore"
 	origin_tech = "materials=4"
 	points = 27
+	materials = list(MAT_BANANIUM=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/bananium
 
 /obj/item/weapon/ore/slag
@@ -219,7 +226,7 @@
 	flags = CONDUCT
 	force = 1
 	throwforce = 2
-	w_class = 1
+	w_class = 1.0
 	var/string_attached
 	var/list/sideslist = list("heads","tails")
 	var/cmineral = null
@@ -237,43 +244,36 @@
 /obj/item/weapon/coin/gold
 	cmineral = "gold"
 	icon_state = "coin_gold_heads"
-	materials = list(MAT_GOLD = 400)
 	value = 160
 
 /obj/item/weapon/coin/silver
 	cmineral = "silver"
 	icon_state = "coin_silver_heads"
-	materials = list(MAT_SILVER = 400)
 	value = 40
 
 /obj/item/weapon/coin/diamond
 	cmineral = "diamond"
 	icon_state = "coin_diamond_heads"
-	materials = list(MAT_DIAMOND = 400)
 	value = 120
 
 /obj/item/weapon/coin/iron
 	cmineral = "iron"
 	icon_state = "coin_iron_heads"
-	materials = list(MAT_METAL = 400)
 	value = 20
 
 /obj/item/weapon/coin/plasma
 	cmineral = "plasma"
 	icon_state = "coin_plasma_heads"
-	materials = list(MAT_PLASMA = 400)
 	value = 80
 
 /obj/item/weapon/coin/uranium
 	cmineral = "uranium"
 	icon_state = "coin_uranium_heads"
-	materials = list(MAT_URANIUM = 400)
 	value = 160
 
 /obj/item/weapon/coin/clown
 	cmineral = "bananium"
 	icon_state = "coin_bananium_heads"
-	materials = list(MAT_BANANIUM = 400)
 	value = 600 //makes the clown cri
 
 /obj/item/weapon/coin/adamantine

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -226,7 +226,7 @@
 	flags = CONDUCT
 	force = 1
 	throwforce = 2
-	w_class = 1.0
+	w_class = 1
 	var/string_attached
 	var/list/sideslist = list("heads","tails")
 	var/cmineral = null
@@ -245,36 +245,43 @@
 	cmineral = "gold"
 	icon_state = "coin_gold_heads"
 	value = 160
+	materials = list(MAT_GOLD = 400)
 
 /obj/item/weapon/coin/silver
 	cmineral = "silver"
 	icon_state = "coin_silver_heads"
 	value = 40
+	materials = list(MAT_SILVER = 400)
 
 /obj/item/weapon/coin/diamond
 	cmineral = "diamond"
 	icon_state = "coin_diamond_heads"
 	value = 120
+	materials = list(MAT_DIAMOND = 400)
 
 /obj/item/weapon/coin/iron
 	cmineral = "iron"
 	icon_state = "coin_iron_heads"
 	value = 20
+	materials = list(MAT_METAL = 400)
 
 /obj/item/weapon/coin/plasma
 	cmineral = "plasma"
 	icon_state = "coin_plasma_heads"
 	value = 80
+	materials = list(MAT_PLASMA = 400)
 
 /obj/item/weapon/coin/uranium
 	cmineral = "uranium"
 	icon_state = "coin_uranium_heads"
 	value = 160
+	materials = list(MAT_URANIUM = 400)
 
 /obj/item/weapon/coin/clown
 	cmineral = "bananium"
 	icon_state = "coin_bananium_heads"
 	value = 600 //makes the clown cri
+	materials = list(MAT_BANANIUM = 400)
 
 /obj/item/weapon/coin/adamantine
 	cmineral = "adamantine"


### PR DESCRIPTION
It makes sense for uranium ore to have uranium in it.

This update means you can feed sand and raw iron ore to autolathe. You can use crusher as ghetto smelter too.

Also updated plasma ore tech levels to match plasma sheet levels and adds glass amount to sandstone.
