### PR TITLE
Adds Mining Voucher to QM's Locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -11,6 +11,7 @@
 	new /obj/item/device/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/gloves/fingerless(src)
+	new /obj/item/weapon/mining_voucher(src)
 	new /obj/item/device/megaphone/cargo(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/clothing/mask/gas(src)

--- a/html/changelogs/Fox P McCloud - qmvoucher .yml
+++ b/html/changelogs/Fox P McCloud - qmvoucher .yml
@@ -1,0 +1,7 @@
+
+author: Fox P McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Adds a mining voucher to the Quartermaster's locker."


### PR DESCRIPTION
Adds a mining voucher to the QM's locker.

It really doesn't make any sense that the HoP gets a spare voucher to hand out, but the sub-manager of the department, who's more likely to interact directly with miners and such, does not.

Also, if QM wants to go mining, he can.
