### PR TITLE
Fixes asteroid turfs showing up as "mineral deposit."

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -85,7 +85,7 @@ var/global/list/rockTurfEdgeCache
 	new src.type(T)
 
 /turf/simulated/mineral/random
-	name = "mineral deposit"
+	name = "rock"
 	icon_state = "rock"
 	var/mineralSpawnChanceList = list(
 		"Uranium" = 5, "Diamond" = 1, "Gold" = 10,


### PR DESCRIPTION
Basically, the generic name for an asteroid turf chosen for a potential mineral spawn was "mineral deposit," regardless of whether a mineral actually spawned there, leaving the asteroid full of a bunch of empty turfs still called "mineral deposit." This bugged the shit out of me, it is now fixed.

Something I want feedback on: should I also remove the names showing up for mineral deposits? It kind of defeats the purpose of the mine scanner when you can mouse over the asteroid and find everything; others may not agree.
