### PR TITLE
Fixes Orion Trail Take 2

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -424,7 +424,6 @@
 			name = "The Orion Trail"
 			desc = "Learn how our ancestors got to Orion, and have fun in the process!"
 
-
 	else if(event)
 		dat = eventdat
 	else if(playing)
@@ -454,7 +453,8 @@
 	return
 
 /obj/machinery/computer/arcade/orion_trail/Topic(href, href_list)
-	if(..())
+	. = ..()
+	if(.)
 		return
 	if(href_list["close"])
 		usr.unset_machine()
@@ -979,6 +979,7 @@
 
 /obj/machinery/computer/arcade/orion_trail/proc/win()
 	playing = 0
+	turns = 1
 	say("Congratulations, you made it to Orion!")
 	if(emagged)
 		new /obj/item/weapon/orion_ship(src.loc)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -92,3 +92,4 @@ Dunc = Game Master
 MMMiracles = Game Master
 bear1ake = Game Master
 CoreOverload = Game Master
+Jalleo = Game Master


### PR DESCRIPTION
properly the error was a rogue ! in the top of the topic that was suggested by error when it wasn't needed. This doesn't fix the href exploit.

Also re-added myself to the admin.txt
