### PR TITLE
[quickmerge]Fixes NTSL crashing the server.

### DIFF
--- a/code/__DATASTRUCTURES/stacks.dm
+++ b/code/__DATASTRUCTURES/stacks.dm
@@ -1,11 +1,3 @@
-
-//Both count as failures, and they don't equate to each other
-//this lets us do if(Pop()) without having to specifically check for underflow
-//same for if(Push()) and overflow
-#define STACK_OVERFLOW	-1
-#define STACK_UNDERFLOW	-2
-
-
 /datum/stack
 	var/list/stack = list()
 	var/max_elements = 0
@@ -19,18 +11,18 @@
 
 /datum/stack/proc/Pop()
 	if(is_empty())
-		return STACK_UNDERFLOW
+		return null
 	. = stack[stack.len]
 	stack.Cut(stack.len,0)
 
 /datum/stack/proc/Push(element)
 	if(max_elements && (stack.len+1 > max_elements))
-		return STACK_OVERFLOW
+		return null
 	stack += element
 
 /datum/stack/proc/Top()
 	if(is_empty())
-		return STACK_UNDERFLOW
+		return null
 	. = stack[stack.len]
 
 /datum/stack/proc/is_empty()


### PR DESCRIPTION
-2 doesn't fail a if () test.

```
        var/v = -2
        if (v)
            world << "if true"
        if (!v)
            world << "if not true"
        while (v)
            world << "while true"
            break
        while (!v)
            world << "while not true"
            break
```

```
if true
while true
```

This caused a while (stack.Pop()) loop to continue for ever.

I figured why get fancy, just returning null works. you can figure out what it means from context of what proc you called.
