### PR TITLE
Fixes text gurbling in coms console and shuttle call's priority announcement

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -118,9 +118,9 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
-		emergency.request(null, 0.5, signal_origin, emergency_reason, 1)
+		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
 	else
-		emergency.request(null, 1, signal_origin, emergency_reason, 0)
+		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
 
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle.")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -577,7 +577,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		spawn(600)//One minute cooldown
 			ai_message_cooldown = 0
 	else
-		priority_announce(input, null, 'sound/misc/announce.ogg', "Captain")
+		priority_announce(html_decode(input), null, 'sound/misc/announce.ogg', "Captain")
 		message_cooldown = 1
 		spawn(600)//One minute cooldown
 			message_cooldown = 0


### PR DESCRIPTION
I don't want to have to find everything that uses priority_announce() and make it strip the input at the source, this seems like a better way.
