### PR TITLE
AI Malfunction round-end report mini-fix

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -5,7 +5,7 @@
 	name = "AI malfunction"
 	config_tag = "malfunction"
 	antag_flag = BE_MALF
-	required_players = 1
+	required_players = 25
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 30 //Same as AI minimum age

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -5,7 +5,7 @@
 	name = "AI malfunction"
 	config_tag = "malfunction"
 	antag_flag = BE_MALF
-	required_players = 25
+	required_players = 1
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 30 //Same as AI minimum age
@@ -285,13 +285,13 @@
 /datum/game_mode/proc/auto_declare_completion_malfunction()
 	if( malf_ai.len || istype(ticker.mode,/datum/game_mode/malfunction) )
 		var/text = "<br><FONT size=3><B>The malfunctioning AIs were:</B></FONT>"
-		var/module_text_temp = "<br><b>Purchased modules:</b><br>" //Added at the end
 		for(var/datum/mind/malf in malf_ai)
 			text += printplayer(malf, 1)
 			if(malf.current)
+				var/module_text_temp = "<br><b>Purchased modules:</b><br>" //Added at the end
 				var/mob/living/silicon/ai/AI = malf.current
 				for(var/datum/AI_Module/mod in AI.current_modules)
 					module_text_temp += mod.module_name + "<br>"
-		text += module_text_temp
+				text += module_text_temp
 		world << text
 	return 1


### PR DESCRIPTION
- Fixes an instance of a gibbed AI appearing to have purchased no
  modules.
- Now properly supports multiple Malf AIs.

<b>Round-end module reporting of gibbed/shunted AI still not supported.</b> That will require storing the list in the AI's mind rather than itself. Doing that properly is a bit more complicated, so I am leaving that to another PR, this one is intended to be a quick-fix solution.
