### PR TITLE
Mop progress bar now actually works.

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -47,9 +47,9 @@ obj/item/weapon/mop/proc/clean(turf/simulated/A)
 	if(istype(turf))
 		user.visible_message("[user] begins to clean \the [turf] with [src].", "<span class='notice'>You begin to clean \the [turf] with [src]...</span>")
 
-		if(do_after(user, mopspeed, target = src))
-			clean(turf)
+		if(do_after(user, src.mopspeed, target = turf))
 			user << "<span class='notice'>You finish mopping.</span>"
+			clean(turf)
 
 
 /obj/effect/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/10390. The problem wasn't that there was no do_after, the problem was that the loc was the wrong variable and might have been putting the bar IN NULLSPACE, FUCK.
