### PR TITLE
Syndicate bundle balance [DNM]

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -218,3 +218,7 @@
 /obj/item/device/sbeacondrop/bomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb
+
+/obj/item/device/sbeacondrop/powersink
+	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
+	droptype = /obj/item/device/powersink

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,20 +2,23 @@
 
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
-	switch (pickweight(list("bloodyspai" = 1, "stealth" = 1, "bond" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "lordsingulo" = 1, "darklord" = 1)))
+	switch (pickweight(list("bloodyspai" = 3, "stealth" = 3, "bond" = 1, "screwed" = 3, "sabotage" = 3, "guns" = 1, "murder" = 2, "implant" = 2, "hacker" = 2, "lordsingulo" = 2, "darklord" = 1)))
 		if("bloodyspai")
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/clothing/mask/gas/voice(src)
 			new /obj/item/weapon/card/id/syndicate(src)
-			new /obj/item/weapon/card/id/syndicate(src)
 			new /obj/item/clothing/shoes/sneakers/syndigaloshes(src)
 			new /obj/item/device/camera_bug(src)
+			new /obj/item/device/multitool/ai_detect(src)
+			new /obj/item/device/encryptionkey/syndicate(src)
 			return
 
 		if("stealth")
 			new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow(src)
 			new /obj/item/weapon/pen/sleepy(src)
+			new /obj/item/device/rad_laser(src)
 			new /obj/item/device/chameleon(src)
+			new /obj/item/weapon/soap/syndie(src)
 			return
 
 		if("bond")
@@ -30,9 +33,10 @@
 		if("screwed")
 			new /obj/item/device/sbeacondrop/bomb(src)
 			new /obj/item/weapon/grenade/syndieminibomb(src)
-			new /obj/item/device/powersink(src)
+			new /obj/item/device/sbeacondrop/powersink(src)
 			new /obj/item/clothing/suit/space/syndicate/black/red(src)
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
+			new /obj/item/device/encryptionkey/syndicate(src)
 			return
 
 		if("guns")
@@ -66,6 +70,7 @@
 			new /obj/item/weapon/card/emag(src)
 			new /obj/item/device/encryptionkey/binary(src)
 			new /obj/item/weapon/aiModule/toyAI(src)
+			new /obj/item/device/multitool/ai_detect(src)
 			return
 
 		if("lordsingulo")
@@ -74,6 +79,15 @@
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			new /obj/item/weapon/card/emag(src)
 			return
+
+		if("sabotage")
+			new /obj/item/weapon/c4 (src)
+			new /obj/item/weapon/c4 (src)
+			new /obj/item/device/doorCharge(src)
+			new /obj/item/device/doorCharge(src)
+			new /obj/item/device/camera_bug(src)
+			new /obj/item/device/sbeacondrop/powersink(src)
+			new /obj/item/weapon/cartridge/syndicate(src)
 
 		if("darklord")
 			new /obj/item/weapon/melee/energy/sword/saber(src)


### PR DESCRIPTION
BUCKLE UP KIDS, THERE'S GONNA BE SOME CONTROVERSY IN THESE HERE WATERS

All of this PR is tentative. All of it is subject to change.

tl;dr: Syndicate bundles have been very neglected in light of new items, TC costs and such. I have made a few changes. Here are some of them.

NEW BUNDLE:

Sabotage! Designed for traitors to sabotage the station. Tentative contents:
- A powersink
- Two C4s
- Two door charges
- A camera bug
- A Detomax

NEW WEIGHTS (compared to before, where everything had the same chance):

3: 
- Fake Nuke Ops
- Spy
- Stealth
- Sabotage

2: 
- Implant
- Hacker
- Singularity
- Murder

1:
- Bond
- Guns
- Sith Lord (the worst of the lot, literally a DOUBLE ESWORD MURDERBONER LASTING 10 MINUTES TIME bundle, I want to remove it entirely but preliminary feedback was negative)

NEW ITEMS:
- AI detector and Syndicate encryption key added to Spy bundle to make it suck less. Removed one agent card because there were two.
- Radioactive laser and soap added to Stealth bundle, which took a lot of nerfs with ebow AND sleepypen being nerfed.
- Syndicate encryption key added to Fake Nuke Ops bundle.
- AI detector added to Hacker bundle.

ADD YOUR THOUGHTS BELOW OR DON'T BITCH WHEN THEY GO THROUGH.
