### PR TITLE
Minor QoL changes to cargo (plus ideas for more)

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -140,6 +140,7 @@
 	name = "space parts & space vendors cartridge"
 	desc = "Perfect for the Quartermaster on the go!"
 	icon_state = "cart-q"
+	access_quartermaster = 1
 	bot_access_flags = MULE_BOT
 
 /obj/item/weapon/cartridge/head
@@ -655,6 +656,10 @@ Code:
 			powmonitor = powermonitors[pnum]
 			loc:mode = 433
 			mode = 433
+
+		if("Supply Orders")
+			loc:mode =47
+			mode = 47
 
 		if("Newscaster Access")
 			mode = 53

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -234,6 +234,7 @@
 	potency = 10
 	plant_type = 0
 	growthstages = 6
+	rarity = 10
 
 /obj/item/seeds/eggplantseed
 	name = "pack of eggplant seeds"
@@ -389,6 +390,7 @@
 	oneharvest = 1
 	potency = 20
 	growthstages = 3
+	rarity = 10
 
 /obj/item/seeds/poppyseed
 	name = "pack of poppy seeds"
@@ -736,6 +738,7 @@
 	oneharvest = 1
 	growthstages = 3
 	plant_type = 2
+	rarity = 20
 
 /obj/item/seeds/glowshroom
 	name = "pack of glowshroom mycelium"
@@ -912,6 +915,7 @@
 	oneharvest = 1
 	growthstages = 3
 	plant_type = 0
+	rarity = 20
 
 /obj/item/seeds/appleseed
 	name = "pack of apple seeds"
@@ -1081,6 +1085,7 @@
 	potency = 10
 	plant_type = 0
 	growthstages = 6
+	rarity = 20
 
 /obj/item/seeds/pumpkinseed
 	name = "pack of pumpkin seeds"
@@ -1114,6 +1119,7 @@
 	potency = 10
 	plant_type = 0
 	growthstages = 3
+	rarity = 20
 
 /obj/item/seeds/limeseed
 	name = "pack of lime seeds"
@@ -1250,6 +1256,7 @@
 	potency = 10
 	plant_type = 0
 	growthstages = 2
+	rarity = 10
 
 /obj/item/seeds/cocoapodseed
 	name = "pack of cocoa pod seeds"
@@ -1315,6 +1322,7 @@
 	potency = 10
 	plant_type = 0
 	growthstages = 5
+	rarity = 10
 
 /obj/item/seeds/kudzuseed
 	name = "pack of kudzu seeds"


### PR DESCRIPTION
Changes so far in this PR:
- The QM and cargo techs did not get the quartermaster PDA module, which lets people monitor orders (but not make them) remotely. Only the captain and HoP did, despite the fact that IT'S CALLED 'QUARTERMASTER' IN THE CODE. This is stupid and is now fixed.
- Rarity values added for mutated plants that did not have it.

What I want to do and am welcoming suggestions for:
- Give the QM (not cargo techs) the upgraded quartermaster PDA module hinted at in the fluff text, which allows them to make orders from their PDA. However, this will require coding help.
- Give cargonians more stuff to ship back for points.
- Give fluff text to the console so that cargo can get a hint as to shit they can ship back for points.
- Add a counter of how many points cargo has earned from shit shipped back, and rewards for certain levels (100 points, 250 points, 500 points).
