### PR TITLE
Hopefully reduces singulag from pipenet reconstruction

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -27,6 +27,8 @@ Pipelines + Other Objects -> Pipe network
 	var/device_type = 0
 	var/list/obj/machinery/atmospherics/nodes = list()
 
+	var/pipenet_rebuild_requested = 0
+
 /obj/machinery/atmospherics/New()
 	nodes.len = device_type
 	..()
@@ -272,3 +274,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1
+
+/obj/machinery/atmospherics/process_atmos()
+	if(pipenet_rebuild_requested)
+		build_network()

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -277,4 +277,5 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/process_atmos()
 	if(pipenet_rebuild_requested)
+		pipenet_rebuild_requested = 0
 		build_network()

--- a/code/ATMOSPHERICS/pipes/pipes.dm
+++ b/code/ATMOSPHERICS/pipes/pipes.dm
@@ -22,7 +22,7 @@
 	var/obj/machinery/atmospherics/oldN = NODE_I
 	..()
 	if(oldN)
-		oldN.build_network()
+		oldN.pipenet_rebuild_requested = 1
 
 /obj/machinery/atmospherics/pipe/update_icon() //overridden by manifolds
 	if(NODE1&&NODE2)


### PR DESCRIPTION
@Aranclanos this has a chance that it will break everything and I haven't yet tested it (I will when I'm home); whether this gets merged is obviously up to you

Reasons this may not work and may break everything:
- Something called by something other than SSair touches a parent (completely possible)
- Some machinery's process_atmos doesn't call ..() (also completely possible)
- Probably a bunch of other shit (highly likely)

I threw this together on my phone in school because of how easy it was to make these changes. Once I get home and can test it, I'll be able to see how much this affects lag.
This works by, instead of immediately rebuilding its nodes' pipenet as soon as a pipe is destroyed, simply queueing a rebuild in its nodes for the next SSair call. If I'm correct, and pipenets are only accessed by SSair and process_atmos (boy I hope so,) then this will reduce lag with no ill effects.
