### PR TITLE
Tableclimbing & reagent runtime fixes

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -88,14 +88,15 @@
 	return
 
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0) return 1
+	if(height==0)
+		return 1
 
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
 	if(locate(/obj/structure/table) in get_turf(mover))
 		return 1
 	else
-		return 0
+		return !density
 
 /obj/structure/table/MouseDrop_T(atom/movable/O, mob/user)
 	if(ismob(O) && user == O && ishuman(user))
@@ -240,13 +241,15 @@
 	tableclimber = user
 	if(do_mob(user, user, climb_time))
 		if(src.loc) //Checking if table has been destroyed
-			user.pass_flags += PASSTABLE
-			step(user,get_dir(user,src.loc))
-			user.pass_flags -= PASSTABLE
-			user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
+			density = 0
+			if(step(user,get_dir(user,src.loc)))
+				user.visible_message("<span class='warning'>[user] climbs onto [src].</span>", \
 									"<span class='notice'>You climb onto [src].</span>")
-			add_logs(user, src, "climbed onto")
-			user.Stun(2)
+				add_logs(user, src, "climbed onto")
+				user.Stun(2)
+			else
+				user << "<span class='warning'>You fail to climb onto [src].</span>"
+			density = 1
 			tableclimber = null
 			return 1
 	tableclimber = null

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -93,6 +93,10 @@
 	if(!dna || !dna.species.handle_mutations_and_radiation(src))
 		..()
 
+/mob/living/carbon/human/handle_chemicals_in_body()
+	if(reagents)
+		reagents.metabolize(src, can_overdose=1)
+
 /mob/living/carbon/human/breathe()
 	if(!dna || !dna.species.breathe(src))
 		..()

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -42,6 +42,10 @@
 					emote("gasp")
 		..()
 
+/mob/living/carbon/monkey/handle_chemicals_in_body()
+	if(reagents)
+		reagents.metabolize(src, can_overdose=1)
+
 /mob/living/carbon/monkey/handle_breath_temperature(datum/gas_mixture/breath)
 	if(abs(310.15 - breath.temperature) > 50)
 		switch(breath.temperature)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -102,7 +102,7 @@
 				if (prob(25))
 					Paralyse(2)
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					add_logs(M, src, "pushed", admin=0)
+					add_logs(M, src, "pushed")
 					visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
 							"<span class='userdanger'>[M] has pushed down [src]!</span>")
 				else

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -213,7 +213,7 @@ var/const/PATCH = 4 //patches
 				return total_transfered
 */
 
-/datum/reagents/proc/metabolize(mob/M)
+/datum/reagents/proc/metabolize(mob/M, can_overdose = 0)
 	if(M)
 		chem_temp = M.bodytemperature
 		handle_reactions()
@@ -226,23 +226,24 @@ var/const/PATCH = 4 //patches
 			M = R.holder.my_atom
 		if(M && R)
 			if(M.reagent_check(R) != 1)
-				if(R.overdose_threshold)
-					if(R.volume >= R.overdose_threshold && !R.overdosed)
-						R.overdosed = 1
-						R.overdose_start(M)
-				if(R.addiction_threshold)
-					if(R.volume >= R.addiction_threshold && !is_type_in_list(R, addiction_list))
-						var/datum/reagent/new_reagent = new R.type()
-						addiction_list.Add(new_reagent)
-				if(R.overdosed)
-					R.overdose_process(M)
-				if(is_type_in_list(R,addiction_list))
-					for(var/datum/reagent/addicted_reagent in addiction_list)
-						if(istype(R, addicted_reagent))
-							addicted_reagent.addiction_stage = -15 // you're satisfied for a good while.
+				if(can_overdose)
+					if(R.overdose_threshold)
+						if(R.volume >= R.overdose_threshold && !R.overdosed)
+							R.overdosed = 1
+							R.overdose_start(M)
+					if(R.addiction_threshold)
+						if(R.volume >= R.addiction_threshold && !is_type_in_list(R, addiction_list))
+							var/datum/reagent/new_reagent = new R.type()
+							addiction_list.Add(new_reagent)
+					if(R.overdosed)
+						R.overdose_process(M)
+					if(is_type_in_list(R,addiction_list))
+						for(var/datum/reagent/addicted_reagent in addiction_list)
+							if(istype(R, addicted_reagent))
+								addicted_reagent.addiction_stage = -15 // you're satisfied for a good while.
 				R.on_mob_life(M)
 
-	if(addiction_tick == 6)
+	if(can_overdose && addiction_tick == 6)
 		addiction_tick = 1
 		for(var/A in addiction_list)
 			var/datum/reagent/R = A

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -243,29 +243,30 @@ var/const/PATCH = 4 //patches
 								addicted_reagent.addiction_stage = -15 // you're satisfied for a good while.
 				R.on_mob_life(M)
 
-	if(can_overdose && addiction_tick == 6)
-		addiction_tick = 1
-		for(var/A in addiction_list)
-			var/datum/reagent/R = A
-			if(M && R)
-				if(R.addiction_stage <= 0)
-					R.addiction_stage++
-				if(R.addiction_stage > 0 && R.addiction_stage <= 10)
-					R.addiction_act_stage1(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 10 && R.addiction_stage <= 20)
-					R.addiction_act_stage2(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 20 && R.addiction_stage <= 30)
-					R.addiction_act_stage3(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 30 && R.addiction_stage <= 40)
-					R.addiction_act_stage4(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 40)
-					M << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
-					addiction_list.Remove(R)
-	addiction_tick++
+	if(can_overdose)
+		if(addiction_tick == 6)
+			addiction_tick = 1
+			for(var/A in addiction_list)
+				var/datum/reagent/R = A
+				if(M && R)
+					if(R.addiction_stage <= 0)
+						R.addiction_stage++
+					if(R.addiction_stage > 0 && R.addiction_stage <= 10)
+						R.addiction_act_stage1(M)
+						R.addiction_stage++
+					if(R.addiction_stage > 10 && R.addiction_stage <= 20)
+						R.addiction_act_stage2(M)
+						R.addiction_stage++
+					if(R.addiction_stage > 20 && R.addiction_stage <= 30)
+						R.addiction_act_stage3(M)
+						R.addiction_stage++
+					if(R.addiction_stage > 30 && R.addiction_stage <= 40)
+						R.addiction_act_stage4(M)
+						R.addiction_stage++
+					if(R.addiction_stage > 40)
+						M << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
+						addiction_list.Remove(R)
+		addiction_tick++
 	update_total()
 
 /datum/reagents/process()

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -132,7 +132,7 @@
 	return
 
 /datum/reagent/drug/krokodil/addiction_act_stage4(mob/living/carbon/human/M)
-	if(!istype(M.dna.species, /datum/species/cosmetic_zombie))
+	if(M.dna && !istype(M.dna.species, /datum/species/cosmetic_zombie))
 		M << "<span class='userdanger'>Your skin falls off easily!</span>"
 		M.adjustBruteLoss(50*REM) // holy shit your skin just FELL THE FUCK OFF
 		hardset_dna(M, null, null, null, null, /datum/species/cosmetic_zombie)


### PR DESCRIPTION
- Fixes runtime in monkey/attack_hand()
- Fixes tableclimbing: no more success message when failing; you can no longer pass through barricade when tableclimbing. Fixes #6469. Fixes #6246.
- Fixes runtime with krokodil addiction
- Fixes xenomorph being addicted and overdosing on a reagent.
