### PR TITLE
Fixes Infinite Resources in Orion Trail

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -640,8 +640,8 @@
 	else if(href_list["sellcrew"]) //sell a crewmember
 		var/sold = remove_crewmember()
 		last_spaceport_action = "You sold your crewmember, [sold]!"
-		fuel += 15
-		food += 15
+		fuel += 7
+		food += 7
 		event()
 
 	else if(href_list["leave_spaceport"])


### PR DESCRIPTION
Slightly tweaks the profit margins made by selling crew - Flesh trade is no longer innately profitable.

Fixes #11682
