### PR TITLE
removing the null in mob list warning

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -19,5 +19,4 @@ var/datum/subsystem/mobs/SSmob
 		if(thing)
 			thing:Life(seconds)
 			continue
-		WARNING("Found a null in the mob list. Removing.")
 		mob_list.Remove(thing)


### PR DESCRIPTION
Removes the warning of a null inside of the mob list, it was alerting for false positives.

If the list of the loop is modified, the loop won't take it into account.
