### PR TITLE
Adds boundary checks for stack sheets inserting

### DIFF
--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -60,9 +60,15 @@
 	return 0
 
 /datum/material_container/proc/insert_stack(obj/item/stack/S, amt = 0)
-	if(!amt)
+	if(amt <= 0)
+		return 0
+	if(amt > S.amount)
 		amt = S.amount
+
 	var/material_amt = get_item_material_amount(S)
+	if(!material_amt)
+		return 0
+
 	amt = min(amt, round(((max_amount - total_amount) / material_amt)))
 	if(!amt)
 		return 0

--- a/code/modules/clothing/shoes/bananashoes.dm
+++ b/code/modules/clothing/shoes/bananashoes.dm
@@ -37,13 +37,17 @@
 		user << "<span class='notice'>You cannot retrieve any bananium from the prototype shoes.</span>"
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/attackby(obj/item/O, mob/user, params)
+	if(!istype(O,/obj/item/stack/sheet))
+		return
 	if(!bananium.get_item_material_amount(O))
 		user << "<span class='notice'>This item has no bananium!</span>"
 		return
 	if(!user.unEquip(O))
 		user << "<span class='notice'>You can't drop [O]!</span>"
 		return
-	var/sheet_amount = bananium.insert_stack(O)
+
+	var/obj/item/stack/sheet/S = O
+	var/sheet_amount = bananium.insert_stack(O,S.amount)
 	if(sheet_amount)
 		user << "<span class='notice'>You insert [sheet_amount] bananium sheets into the prototype shoes.</span>"
 	else

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -119,11 +119,12 @@ Note: Must be placed west/left of and R&D console to function.
 	if(!amount_inserted)
 		return 1
 	else
+		var/stack_name = stack.name
 		busy = 1
 		use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount_inserted/10)))
 		user << "<span class='notice'>You add [amount_inserted] sheets to the [src.name].</span>"
-		overlays += "protolathe_[stack.name]"
+		overlays += "protolathe_[stack_name]"
 		sleep(10)
-		overlays -= "protolathe_[stack.name]"
+		overlays -= "protolathe_[stack_name]"
 		busy = 0
 	updateUsrDialog()

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -104,10 +104,12 @@ Note: Must be placed west/left of and R&D console to function.
 		return
 	if (stat)
 		return 1
-	if(istype(O,/obj/item/stack/sheet))
-		if(!materials.has_space( materials.get_item_material_amount(O) ))
-			user << "<span class='warning'>The [src.name]'s material bin is full! Please remove material before adding more.</span>"
-			return 1
+	if(!istype(O,/obj/item/stack/sheet))
+		return 1
+
+	if(!materials.has_space( materials.get_item_material_amount(O) ))
+		user << "<span class='warning'>The [src.name]'s material bin is full! Please remove material before adding more.</span>"
+		return 1
 
 	var/obj/item/stack/sheet/stack = O
 	var/amount = round(input("How many sheets do you want to add?") as num)//No decimals
@@ -115,7 +117,6 @@ Note: Must be placed west/left of and R&D console to function.
 		return
 	var/amount_inserted = materials.insert_stack(O,amount)
 	if(!amount_inserted)
-		user << "<span class='warning'>You could not insert [O], it has no usable materials.</span>"
 		return 1
 	else
 		busy = 1


### PR DESCRIPTION
- _Added boundary checks for stack sheets inserting_

Fixes #11732, by preventing the insertion of inexistant sheets or negative amount of sheets.
Also, reallowed to enter 0 at the "Amount of sheets to insert" dialog without it consuming the whole stack
- _Limited material inserting to stack sheets for the protolathe and banana shoes_

Since the code doesn't seem to decide between only allowing sheets insertion or any object with usable material in it, i've limited it to the former.
The latter can be achieved quite easily with the existing code if it's the way to go.

This also prevent the weird "Amount of sheets to insert" appearing for objects other than stacks (and the related runtimes).
