### PR TITLE
changes confusion to be less RNG garbage

### DIFF
--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -35,6 +35,6 @@ Bonus
 				M << "<span class='notice'>[pick("You feel confused.", "You forgot what you were thinking about.")]</span>"
 			else
 				M << "<span class='notice'>You are unable to think straight!</span>"
-				M.confused = min(100, M.confused + 2)
+				M.confused = min(100, M.confused + 8)
 
 	return

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -12,7 +12,7 @@
 		if(iscarbon(M))
 			if(!M.mind || !M.mind.changeling)
 				M.adjustEarDamage(0,30)
-				M.confused += 20
+				M.confused += 25
 				M.Jitter(50)
 			else
 				M << sound('sound/effects/screech.ogg')

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -40,7 +40,7 @@
 	var/turf/T = get_turf(src)
 	T.visible_message("<span class='disarm'>[src] emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in viewers(3, null))
-		flash_carbon(M, null, 2, 0)
+		flash_carbon(M, null, 5, 0)
 
 
 /obj/item/device/assembly/flash/proc/burn_out() //Made so you can override it if you want to have an invincible flash from R&D or something.
@@ -79,7 +79,7 @@
 	return 1
 
 
-/obj/item/device/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user = null, power = 5, targeted = 1)
+/obj/item/device/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user = null, power = 15, targeted = 1)
 	add_logs(user, M, "flashed", src)
 	if(user && targeted)
 		if(M.weakeyes)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -200,8 +200,15 @@
 							M.animate_movement = 2
 							return
 
-		if(mob.confused && IsEven(world.time))
-			step(mob, pick(cardinal))
+		if(mob.confused)
+			if(mob.confused > 100)
+				step(mob, pick(cardinal))
+			else if(prob(mob.confused / 2))
+				step(mob, angle2dir(dir2angle(direct) + pick(90, -90)))
+			else if(prob(mob.confused * 2))
+				step(mob, angle2dir(dir2angle(direct) + pick(45, -45)))
+			else
+				step(mob, direct)
 		else
 			. = ..()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -201,11 +201,11 @@
 							return
 
 		if(mob.confused)
-			if(mob.confused > 100)
+			if(mob.confused > 40)
 				step(mob, pick(cardinal))
-			else if(prob(mob.confused / 2))
+			else if(prob(mob.confused * 1.5))
 				step(mob, angle2dir(dir2angle(direct) + pick(90, -90)))
-			else if(prob(mob.confused * 2))
+			else if(prob(mob.confused * 3))
 				step(mob, angle2dir(dir2angle(direct) + pick(45, -45)))
 			else
 				step(mob, direct)

--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Drink-Reagents/Alcohols.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Drink-Reagents/Alcohols.dm
@@ -29,7 +29,7 @@
 		M.Dizzy(5)
 	if(current_cycle >= boozepwr*2.5 && prob(33))
 		if (!M.confused) M.confused = 1
-		M.confused += 3
+		M.confused += 2
 	if(current_cycle >= boozepwr*10 && prob(33))
 		M.adjustToxLoss(2)
 	..()


### PR DESCRIPTION
this makes confusion cause a mob to walk generally in the direction they're trying to go, based on a probability determined by how confused they are.
likely to affect the function of confusion items like flashes, because i balanced it around getting drunk and forgot about those.
not sure if i should center the probs around 10-30 and nerf ethanol, or increase the effects of everything else.
