### PR TITLE
Fixes #11752, resets CLF3's metab. rate to 4u instead of 0.5u

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
@@ -39,7 +39,7 @@
 	description = "Makes a temporary 3x3 fireball when it comes into existence, so be careful when mixing. ClF3 applied to a surface burns things that wouldn't otherwise burn, sometimes through the very floors of the station and exposing it to the vacuum of space."
 	reagent_state = LIQUID
 	color = "#FF0000"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = 4
 
 /datum/reagent/clf3/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(2)


### PR DESCRIPTION
@phil235 you forgot to keep it at 4u, which is why CLF3 does so much damage over time

it's supposed to do a lot of damage but metabolize really really fast

you accidentally made it do a lot of damage but metabolize really slowly

Fixes #11752
