### PR TITLE
Adds origin tech values to a lot of items.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -12,6 +12,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	item_state = "electronic"
 	w_class = 1.0
 	slot_flags = SLOT_ID | SLOT_BELT
+	origin_tech = "programming=2"
 
 	//Main variables
 	var/owner = null // String name of owner

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -14,6 +14,7 @@
 	item_state	= "camera_bug"
 	throw_speed	= 4
 	throw_range	= 20
+	origin_tech = "syndicate=3;engineering=;1"
 
 	var/obj/machinery/camera/current = null
 

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -9,6 +9,7 @@
 	force = 3
 	attack_verb = list("blown up", "exploded", "detonated")
 	materials = list(MAT_METAL=50, MAT_GLASS=30)
+	origin_tech = "syndicate=3;combat=2,"
 
 /obj/item/device/doorCharge/ex_act(severity, target)
 	switch(severity)

--- a/code/game/objects/items/holotape.dm
+++ b/code/game/objects/items/holotape.dm
@@ -11,6 +11,7 @@
 	var/tape_type = /obj/item/holotape
 	var/icon_base
 	var/charging = 0
+	origin_tech = "materials=1;engineering=1"
 
 /obj/item/holotape
 	icon = 'icons/obj/holotape.dmi'

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -9,6 +9,7 @@
 	strip_delay = 70
 	put_on_delay = 70
 	burn_state = -1 //Won't burn in fires
+	origin_tech = "magnets=2"
 
 /obj/item/clothing/shoes/magboots/verb/toggle()
 	set name = "Toggle Magboots"
@@ -52,3 +53,4 @@
 	name = "blood-red magboots"
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
+	origin_tech = "magnets=2,syndicate=3"

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -12,6 +12,7 @@
 	slot_flags = SLOT_BELT
 	var/scanning = 0
 	var/list/log = list()
+	origin_tech = "engineering=3"
 
 /obj/item/device/detective_scanner/attack_self(mob/user)
 	if(log.len && !scanning)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -12,7 +12,7 @@
 	slot_flags = SLOT_BELT
 	var/scanning = 0
 	var/list/log = list()
-	origin_tech = "engineering=3"
+	origin_tech = "engineering=3;biotech=2"
 
 /obj/item/device/detective_scanner/attack_self(mob/user)
 	if(log.len && !scanning)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -507,6 +507,7 @@
 	var/fieldsactive = 0
 	var/burst_time = 50
 	var/fieldlimit = 3
+	origin_tech = "magnets=2;combat=2"
 
 /obj/item/weapon/resonator/proc/CreateResonance(target, creator)
 	var/turf/T = get_turf(target)
@@ -724,6 +725,7 @@
 	throw_range = 5
 	var/loaded = 1
 	var/malfunctioning = 0
+	origin_tech = "biotech=4"
 
 /obj/item/weapon/lazarus_injector/afterattack(atom/target, mob/user, proximity_flag)
 	if(!loaded)
@@ -778,6 +780,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	var/cooldown = 0
+	origin_tech = "engineering=1;magnets=1"
 
 /obj/item/device/mining_scanner/attack_self(mob/user)
 	if(!user.client)
@@ -809,6 +812,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	var/cooldown = 0
+	origin_tech = "engineering=3;magnets=3"
 
 /obj/item/device/t_scanner/adv_mining_scanner/scan()
 	if(!cooldown)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -140,6 +140,7 @@
 	var/overheat_time = 16
 	var/recent_reload = 1
 	unique_rename = 1
+	origin_tech = "combat=2;powerstorage=1"
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
 	overheat = 1


### PR DESCRIPTION
Exactly what it says in the title. I tried to make most of these relatively low-impact. May add more if people suggest them. Here goes:

SYNDICATE ITEMS:
- Camera bug: Engineering 1, Syndicate 3
- Door charge: Combat 2, Syndicate 3
- Syndie magboots: Magnets 2, Syndicate 3

MINING ITEMS:
- Mining scanner: Engineering 1
- Advanced mining scanner: Engineering 3, Magnets 3
- Lazarus injector: Biotech 4
- Resonator: Magnets 2, Combat 2
- Kinetic accelerator: Combat 2, Power Manipulation 1

MISCELLANEOUS ITEMS:
- Magboots: Magnets 2 (how the FUCK did these not have this before?)
- Forensic scanner: Engineering 3, Biotech 1
- Holotape projectors: Materials 1, Engineering 1
- PDA: Programming 2
