### PR TITLE
Blob code tweaks (with less commits)

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A huge, pulsating yellow mass."
-	health = 200
-	fire_resist = 2
+	health = 400
+	maxhealth = 400
 	explosion_block = 6
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
 	var/resource_delay = 0
@@ -68,7 +68,7 @@
 		if(resource_delay <= world.time)
 			resource_delay = world.time + 10 // 1 second
 			overmind.add_points(point_rate)
-	health = min(initial(health), health + 1)
+	health = min(maxhealth, health+health_regen)
 	if(overmind)
 		overmind.update_health()
 	pulseLoop(0)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_factory"
 	desc = "A thick spire of tendrils."
-	health = 100
-	fire_resist = 2
+	health = 200
+	maxhealth = 200
 	var/list/spores = list()
 	var/max_spores = 3
 	var/spore_delay = 0

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A large, pulsating yellow mass."
-	health = 100
-	fire_resist = 2
+	health = 200
+	maxhealth = 200
 
 /obj/effect/blob/node/New(loc, var/h = 100)
 	blob_nodes += src

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	desc = "A thin spire of slightly swaying tendrils."
-	health = 30
-	fire_resist = 2
+	health = 60
+	maxhealth = 60
 	var/resource_delay = 0
 
 /obj/effect/blob/resource/update_icon()

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -3,9 +3,9 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_idle"
 	desc = "A solid wall of slightly twitching tendrils."
-	health = 75
+	health = 150
+	maxhealth = 150
 	explosion_block = 3
-	fire_resist = 2
 
 
 /obj/effect/blob/shield/update_icon()
@@ -16,6 +16,9 @@
 
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
+
+/obj/effect/blob/shield/CanAtmosPass(turf/T)
+	return 0
 
 /obj/effect/blob/shield/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1

--- a/code/game/gamemodes/blob/blobs/storage.dm
+++ b/code/game/gamemodes/blob/blobs/storage.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	desc = "A huge, smooth mass supported by tendrils."
-	health = 30
-	fire_resist = 2
+	health = 60
+	maxhealth = 60
 
 /obj/effect/blob/storage/update_icon()
 	if(health <= 0)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -13,9 +13,8 @@
 		bang(get_turf(M), M)
 
 	for(var/obj/effect/blob/B in get_hear(8,flashbang_turf))     		//Blob damage here
-		var/damage = round(30/(get_dist(B,get_turf(src))+1))
-		B.health -= damage
-		B.update_icon()
+		var/damage = round(40/(get_dist(B,get_turf(src))+1))
+		B.take_damage(damage, BURN)
 	qdel(src)
 
 /obj/item/weapon/grenade/flashbang/proc/bang(turf/T , mob/living/M)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -93,5 +93,5 @@ MMMiracles = Game Master
 bear1ake = Game Master
 CoreOverload = Game Master
 Jalleo = Game Master
-
+Anonus Tanir = Game Master
 FoxPMcCloud = Game Master


### PR DESCRIPTION
Copy of @Anonus 's Blob tweak PR #11616, with less commits.

> Old pr #11555
> 
>    Blob shields now actually block atmos thank me later
>    Blob space expansion now always applies blob_act() even if it doesn't expand into the space tile, >also it makes a sound if it fails so you know it's comin after ya
> 
> Makes blob code use a maxhealth var(health system 2 return of the health system)
> Makes a var much less useful via health changes(this isn't a buff or a nerf it'll have the same results)
> Blob health regen is now also a var.
> Adds self to admins.txt
