### PR TITLE
Add a tool to ensure no excess file dirs are defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
   - shopt -s globstar
   - (! grep 'step_[xy]' _maps/**/*.dmm)
   - md5sum -c - <<< "29d5a6e23d172846354505e60ecfe7e7 *html/changelogs/example.yml"
+  - tools/check_filedirs.sh tgstation.dme
   - python tools/ss13_genchangelog.py html/changelog.html html/changelogs
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
   - bash dm.sh -M${DM_MAPFILE} tgstation.dme

--- a/tools/check_filedirs.sh
+++ b/tools/check_filedirs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [ -n "$1" ]
+then
+    dme=$1
+else
+    echo "Specify a DME to check"
+    exit 1
+fi
+
+if [[ $(awk '/BEGIN_FILE_DIR/{flag=1;next}/END_FILE_DIR/{flag=0}flag' $dme | wc -l) -ne 1 ]]
+then
+    echo "File DIR was ticked, please untick it, see: https://tgstation13.org/phpBB/viewtopic.php?f=5&t=321 for more"
+    exit 1
+fi
+


### PR DESCRIPTION
Also plugs script into the travis buildchain

This enforces that the file dir option is left unticked as per https://tgstation13.org/phpBB/viewtopic.php?f=5&t=321
