### PR TITLE
Huge Left4Zed buff

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -230,9 +230,9 @@
 	if (mutmod == 2)
 		if(prob(50))		//50%
 			mutate()
-		else if(prob(75))	//37.5%
+		else if(prob(50))	//25%
 			hardmutate()
-		else if(prob(10))	//1/80
+		else if(prob(50))	//12.5%
 			mutatespecie()
 		return
 	return


### PR DESCRIPTION
Adjusts the mutation probabilities of Left4Zed.

No changes for the regular stat mutations.
Large stat mutations lowered to 25% from 37.5%.
Species mutation chance increased to 12.5% from 1.25%.

That means that 1 in 8 harvests will result in a species mutation. Previously, this was 1 in 80. It still has the 0 yield penalty.

This should make species mutations easier to get, especially for less experienced players. You'll still want mutagen/radium/somatorays for those 100 potency plants though.
