### PR TITLE
Orbit fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1438,7 +1438,7 @@ B --><-- A
 	var/angle = 0
 	var/matrix/initial_transform = matrix(transform)
 	spawn
-		while(orbiting && orbiting.loc && orbitid = myid && (!lockinorbit || loc == lastloc))
+		while(orbiting && orbiting.loc && orbitid == myid && (!lockinorbit || loc == lastloc))
 			loc = get_turf(orbiting.loc)
 			lastloc = loc
 			angle += angle_increment


### PR DESCRIPTION
Fixes orbiting an atom that is not on a turf blocking the orbit
Fixes #11783
Fixes loc changes while orbiting as ghost not breaking orbit like movement does.
Fixes #11777
Fixes Orbit being called in quick succession on the same atom breaking the transform
(unreported)
Fixes all other edge cases with multiple orbit calls in quick succession.
