### PR TITLE
Dragging an item onto itself === clicking it

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -5,8 +5,10 @@
 	recieving object instead, so that's the default action.  This allows you to drag
 	almost anything into a trash can.
 */
-/atom/MouseDrop(atom/over)
+/atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	if(!usr || !over) return
+	if(over == src)
+		return usr.client.Click(src, src_location, src_control, params)
 	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows
 
 	over.MouseDrop_T(src,usr)


### PR DESCRIPTION
Someone on singulo pointed out that in combat, it's hard to click things while moving because if you hold your mouse down for any length of time or twitched it hard enough, it would move and count as a drag and do nothing.
