### PR TITLE
Admin Verb: Offer Control

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -383,7 +383,6 @@
 /proc/pollCandidates(var/Question, var/jobbanType, var/datum/game_mode/gametypeCheck, var/be_special_flag = 0, var/poll_time = 300)
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
-	var/seconds = poll_time/10
 	if (!Question)
 		Question = "Would you like to be a special role?"
 
@@ -401,7 +400,7 @@
 				continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg' //Alerting them to their consideration
-			switch(alert(G,Question,"Please answer in [seconds] seconds!","Yes","No"))
+			switch(alert(G,Question,"Please answer in [poll_time/10] seconds!","Yes","No"))
 				if("Yes")
 					G << "<span class='notice'>Choice registered: Yes.</span>"
 					if((world.time-time_passed)>poll_time)//If more than 30 game seconds passed.

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -380,9 +380,10 @@
 
 	return new /datum/projectile_data(src_x, src_y, time, distance, power_x, power_y, dest_x, dest_y)
 
-/proc/pollCandidates(var/Question, var/jobbanType, var/datum/game_mode/gametypeCheck, var/be_special_flag = 0)
+/proc/pollCandidates(var/Question, var/jobbanType, var/datum/game_mode/gametypeCheck, var/be_special_flag = 0, var/poll_time = 300)
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
+	var/seconds = poll_time/10
 	if (!Question)
 		Question = "Would you like to be a special role?"
 
@@ -400,10 +401,10 @@
 				continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg' //Alerting them to their consideration
-			switch(alert(G,Question,"Please answer in 30 seconds!","Yes","No"))
+			switch(alert(G,Question,"Please answer in [seconds] seconds!","Yes","No"))
 				if("Yes")
 					G << "<span class='notice'>Choice registered: Yes.</span>"
-					if((world.time-time_passed)>300)//If more than 30 game seconds passed.
+					if((world.time-time_passed)>poll_time)//If more than 30 game seconds passed.
 						G << "<span class='danger'>Sorry, you were too late for the consideration!</span>"
 						G << 'sound/machines/buzz-sigh.ogg'
 						return
@@ -413,7 +414,7 @@
 					return
 				else
 					return
-	sleep(300)
+	sleep(poll_time)
 
 	//Check all our candidates, to make sure they didn't log off during the 30 second wait period.
 	for(var/mob/dead/observer/G in candidates)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -601,20 +601,20 @@ body
 				usr << "This can only be used on instances of type /mob"
 				return
 			M << "Control of your mob has been offered to dead players."
-			log_admin("[key_name_admin(usr)] has offered control of [M.real_name][key_name_admin(M)] to ghosts.")
-			message_admins("[key_name_admin(usr)] has offered control of [M.real_name][key_name_admin(M)] to ghosts")
+			log_admin("[key_name_admin(usr)] has offered control of [M.real_name]([key_name_admin(M)]) to ghosts.")
+			message_admins("[key_name_admin(usr)] has offered control of [M.real_name]([key_name_admin(M)]) to ghosts")
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
 			var/mob/dead/observer/theghost = null
 
 			if(candidates.len)
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
-				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name][key_name_admin(M)]")
+				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name]([key_name_admin(M)])")
 				M.ghostize()
 				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."
-				message_admins("No ghosts were willing to take control of [M.real_name][key_name_admin(M)]")
+				message_admins("No ghosts were willing to take control of ([M.real_name][key_name_admin(M)])")
 
 		else if(href_list["delall"])
 			if(!check_rights(R_DEBUG|R_SERVER))	return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -607,17 +607,12 @@ body
 			var/mob/dead/observer/theghost = null
 
 			if(candidates.len)
-				for(var/mob/j in candidates)
-					if(!j || !j.client)
-						candidates.Remove(j)
-						continue
-					theghost = j
+				theghost = pick(candidates)
 					M << "Your mob has been taken over by a ghost!"
 					usr << "[theghost.key] has taken over [M.real_name]."
 					message_admins("<span class='notice'>[key_name(theghost)] has taken control of [M.real_name]</span>")
 					M.ghostize()
 					M.key = theghost.key
-					break
 			else
 				M << "There were no ghosts willing to take control."
 				message_admins("<span class='notice'>No ghosts were willing to take control of [M.real_name]</span>")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -602,7 +602,7 @@ body
 				return
 			M << "Control of your mob has been offered to dead players."
 			log_admin("[key_name(usr)] has offered control of [M.real_name] to ghosts.")
-			message_admins("<span class='notice'>[key_name(usr)] has offered control of [M.real_name] to ghosts</span>")
+			message_admins("[key_name(usr)] has offered control of [M.real_name] to ghosts")
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
 			var/mob/dead/observer/theghost = null
 
@@ -610,12 +610,12 @@ body
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
 				usr << "[theghost.key] has taken over [M.real_name]."
-				message_admins("<span class='notice'>[key_name(theghost)] has taken control of [M.real_name]</span>")
+				message_admins("[key_name(theghost)] has taken control of [M.real_name]")
 				M.ghostize()
 				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."
-				message_admins("<span class='notice'>No ghosts were willing to take control of [M.real_name]</span>")
+				message_admins("No ghosts were willing to take control of [M.real_name]")
 
 		else if(href_list["delall"])
 			if(!check_rights(R_DEBUG|R_SERVER))	return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -608,11 +608,11 @@ body
 
 			if(candidates.len)
 				theghost = pick(candidates)
-					M << "Your mob has been taken over by a ghost!"
-					usr << "[theghost.key] has taken over [M.real_name]."
-					message_admins("<span class='notice'>[key_name(theghost)] has taken control of [M.real_name]</span>")
-					M.ghostize()
-					M.key = theghost.key
+				M << "Your mob has been taken over by a ghost!"
+				usr << "[theghost.key] has taken over [M.real_name]."
+				message_admins("<span class='notice'>[key_name(theghost)] has taken control of [M.real_name]</span>")
+				M.ghostize()
+				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."
 				message_admins("<span class='notice'>No ghosts were willing to take control of [M.real_name]</span>")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -891,37 +891,6 @@ body
 				return
 
 			usr << "You can only put humans on purrbation."
-		else if(href_list["purrbation"])
-			if(!check_rights(R_SPAWN))	return
-
-			var/mob/living/carbon/human/H = locate(href_list["purrbation"])
-			if(!istype(H))
-				usr << "This can only be done to instances of type /mob/living/carbon/human"
-				return
-
-			if(!H)
-				usr << "Mob doesn't exist anymore"
-				return
-
-			if(H.dna && H.dna.species.id == "human")
-				if(H.dna.features["tail_human"] == "None" || H.dna.features["ears"] == "None")
-					usr << "Put [H] on purrbation."
-					H << "You suddenly feel valid."
-					log_admin("[key_name(usr)] has put [key_name(H)] on purrbation.")
-					message_admins("<span class='notice'>[key_name(usr)] has put [key_name(H)] on purrbation.</span>")
-					H.dna.features["tail_human"] = "Cat"
-					H.dna.features["ears"] = "Cat"
-				else
-					usr << "Removed [H] from purrbation."
-					H << "You suddenly don't feel valid anymore."
-					log_admin("[key_name(usr)] has removed [key_name(H)] from purrbation.")
-					message_admins("<span class='notice'>[key_name(usr)] has removed [key_name(H)] from purrbation.</span>")
-					H.dna.features["tail_human"] = "None"
-					H.dna.features["ears"] = "None"
-				H.regenerate_icons()
-				return
-
-			usr << "You can only put humans on purrbation."
 
 		else if(href_list["adjustDamage"] && href_list["mobToDamage"])
 			if(!check_rights(0))	return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -601,20 +601,20 @@ body
 				usr << "This can only be used on instances of type /mob"
 				return
 			M << "Control of your mob has been offered to dead players."
-			log_admin("[key_name_admin(usr)] has offered control of [M.real_name]([key_name_admin(M)]) to ghosts.")
-			message_admins("[key_name_admin(usr)] has offered control of [M.real_name]([key_name_admin(M)]) to ghosts")
+			log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
+			message_admins("[key_name_admin(usr)] has offered control of ([key_name_admin(M)]) to ghosts")
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
 			var/mob/dead/observer/theghost = null
 
 			if(candidates.len)
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
-				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name]([key_name_admin(M)])")
+				message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(M)])")
 				M.ghostize()
 				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."
-				message_admins("No ghosts were willing to take control of ([M.real_name][key_name_admin(M)])")
+				message_admins("No ghosts were willing to take control of [key_name_admin(M)])")
 
 		else if(href_list["delall"])
 			if(!check_rights(R_DEBUG|R_SERVER))	return

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -601,16 +601,15 @@ body
 				usr << "This can only be used on instances of type /mob"
 				return
 			M << "Control of your mob has been offered to dead players."
-			log_admin("[key_name(usr)] has offered control of [M.real_name] to ghosts.")
-			message_admins("[key_name(usr)] has offered control of [M.real_name] to ghosts")
+			log_admin("[key_name_admin(usr)] has offered control of [M.real_name] to ghosts.")
+			message_admins("[key_name_admin(usr)] has offered control of [M.real_name] to ghosts")
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
 			var/mob/dead/observer/theghost = null
 
 			if(candidates.len)
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
-				usr << "[theghost.key] has taken over [M.real_name]."
-				message_admins("[key_name(theghost)] has taken control of [M.real_name]")
+				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name]")
 				M.ghostize()
 				M.key = theghost.key
 			else

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -603,35 +603,21 @@ body
 			M << "Control of your mob has been offered to dead players."
 			log_admin("[key_name(usr)] has offered control of [M.real_name] to ghosts.")
 			message_admins("<span class='notice'>[key_name(usr)] has offered control of [M.real_name] to ghosts</span>")
-			var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
+			var/mob/dead/observer/theghost = null
 
-			shuffle(candidates)
-
-			var/time_passed = world.time
-			var/list/consenting_candidates = list()
-
-			for(var/candidate in candidates)
-
-				spawn(0)
-					switch(alert(candidate, "Would you like to play as [M.real_name]? Please choose quickly!","Confirmation","Yes","No"))
-						if("Yes")
-							if((world.time-time_passed)>=100 || !src)
-								return
-							consenting_candidates += candidate
-
-			sleep(100)
-
-			if(!M)
-				return
-
-			if(consenting_candidates.len)
-				var/client/C = null
-				C = pick(consenting_candidates)
-				M << "Your mob has been taken over by a ghost!"
-				usr << "[C.key] has taken over [M.real_name]."
-				message_admins("<span class='notice'>[key_name(C)] has taken control of [M.real_name]</span>")
-				M.ghostize()
-				M.key = C.key
+			if(candidates.len)
+				for(var/mob/j in candidates)
+					if(!j || !j.client)
+						candidates.Remove(j)
+						continue
+					theghost = j
+					M << "Your mob has been taken over by a ghost!"
+					usr << "[theghost.key] has taken over [M.real_name]."
+					message_admins("<span class='notice'>[key_name(theghost)] has taken control of [M.real_name]</span>")
+					M.ghostize()
+					M.key = theghost.key
+					break
 			else
 				M << "There were no ghosts willing to take control."
 				message_admins("<span class='notice'>No ghosts were willing to take control of [M.real_name]</span>")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -601,20 +601,20 @@ body
 				usr << "This can only be used on instances of type /mob"
 				return
 			M << "Control of your mob has been offered to dead players."
-			log_admin("[key_name_admin(usr)] has offered control of [M.real_name] to ghosts.")
-			message_admins("[key_name_admin(usr)] has offered control of [M.real_name] to ghosts")
+			log_admin("[key_name_admin(usr)] has offered control of [M.real_name][key_name_admin(M)] to ghosts.")
+			message_admins("[key_name_admin(usr)] has offered control of [M.real_name][key_name_admin(M)] to ghosts")
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", "pAI", null, FALSE, 100)
 			var/mob/dead/observer/theghost = null
 
 			if(candidates.len)
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
-				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name]")
+				message_admins("[key_name_admin(theghost)] has taken control of [M.real_name][key_name_admin(M)]")
 				M.ghostize()
 				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."
-				message_admins("No ghosts were willing to take control of [M.real_name]")
+				message_admins("No ghosts were willing to take control of [M.real_name][key_name_admin(M)]")
 
 		else if(href_list["delall"])
 			if(!check_rights(R_DEBUG|R_SERVER))	return

--- a/html/changelogs/Kor-PR-Control.yml
+++ b/html/changelogs/Kor-PR-Control.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kor
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "A new admin command, "Offer Control to Ghosts," can be found in the view variables menu. It will randomly select a willing candidate from among dead players, providing a fair method of replacing antagonists."

--- a/html/changelogs/Kor-PR-Control.yml
+++ b/html/changelogs/Kor-PR-Control.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "A new admin command, "Offer Control to Ghosts," can be found in the view variables menu. It will randomly select a willing candidate from among dead players, providing a fair method of replacing antagonists."
+  - rscadd: "A new admin command, Offer Control to Ghosts, can be found in the view variables menu. It will randomly select a willing candidate from among dead players, providing a fair method of replacing antagonists."


### PR DESCRIPTION
As requested by Saegrimr. 

New verb "Offer Control to Ghosts" in the VV drop down menu that will allow admins to offer control of a mob to dead players ("Would you like to play as X?")

Intended to be a random/fair way to assign ghosts to replace antagonists that go afk/need to leave etc.
