### PR TITLE
Pause before drag-drop-emptying container to the floor

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -196,6 +196,10 @@
 	flags |= NOJAUNT
 
 /turf/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)
+	if(src_object.contents.len)
+		usr << "<span class='notice'>You start dumping out the contents...</span>"
+		if(!do_after(usr,20,target=src))
+			return 0
 	for(var/obj/item/I in src_object)
 		src_object.remove_from_storage(I, src) //No check needed, put everything inside
 	return 1

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -198,7 +198,7 @@
 /turf/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)
 	if(src_object.contents.len)
 		usr << "<span class='notice'>You start dumping out the contents...</span>"
-		if(!do_after(usr,20,target=src))
+		if(!do_after(usr,20,target=src_object))
 			return 0
 	for(var/obj/item/I in src_object)
 		src_object.remove_from_storage(I, src) //No check needed, put everything inside


### PR DESCRIPTION
Adds a two second do_after-pause when emptying a container's contents to the floor. This is to help it from happening by accident.

Fixes #10532
(at least partially)
