### PR TITLE
Fixes shade attack text to be applicable to everything

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -16,7 +16,7 @@
 	speak_chance = 1
 	melee_damage_lower = 5
 	melee_damage_upper = 15
-	attacktext = "drains the life from"
+	attacktext = "metaphysically strikes"
 	minbodytemp = 0
 	maxbodytemp = 4000
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)


### PR DESCRIPTION
Fixes #11884

On all levels but physical, I am a ghost. 
**_(DRAINS)**_
