### PR TITLE
Fixes dna runtimes

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -91,8 +91,9 @@
 	brainmob.real_name = L.real_name
 	if(L.has_dna())
 		var/mob/living/carbon/C = L
-		brainmob.dna = C.dna
-		brainmob.dna.holder = brainmob
+		if(!brainmob.dna)
+			brainmob.dna = new /datum/dna(brainmob)
+		C.dna.copy_dna(brainmob.dna)
 	brainmob.container = src
 
 	if(ishuman(L))

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -58,8 +58,9 @@
 	brainmob.timeofhostdeath = L.timeofdeath
 	if(L.has_dna())
 		var/mob/living/carbon/C = L
-		brainmob.dna = C.dna
-		brainmob.dna.holder = brainmob
+		if(!brainmob.dna)
+			brainmob.dna = new /datum/dna(brainmob)
+		C.dna.copy_dna(brainmob.dna)
 	if(L.mind)
 		L.mind.transfer_to(brainmob)
 	brainmob << "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>"

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -61,8 +61,9 @@ var/global/posibrain_notif_cooldown = 0
 	brainmob.real_name = C.real_name
 	brainmob.dna = C.dna
 	if(C.has_dna())
-		brainmob.dna = C.dna
-		brainmob.dna.holder = brainmob
+		if(!brainmob.dna)
+			brainmob.dna = new /datum/dna(brainmob)
+		C.dna.copy_dna(brainmob.dna)
 	brainmob.timeofhostdeath = C.timeofdeath
 	brainmob.stat = 0
 	if(brainmob.mind)


### PR DESCRIPTION
Fixes brains sharing their dna with another carbon, which causes runtimes when the carbon and its dna is deleted. This is pretty urgent since it causes loads of runtimes everytime someone is debrained and their brain destroyed (brain cake, gibbing), because of all the life() calls.
