### PR TITLE
ease-of-use smoking improvements

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -75,6 +75,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	M.IgniteMob()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
 	if(lit && cig && user.a_intent == "help")
+		if(cig.lit)
+			user << "<span class='notice'>The [cig.name] is already lit.</span>"
 		if(M == user)
 			cig.attackby(src, user)
 		else
@@ -248,6 +250,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return ..()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
 	if(lit && cig && user.a_intent == "help")
+		if(cig.lit)
+			user << "<span class='notice'>The [cig.name] is already lit.</span>"
 		if(M == user)
 			cig.attackby(src, user)
 		else

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -74,7 +74,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 	M.IgniteMob()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
-	if(lit && cig)
+	if(lit && cig && user.a_intent == "help")
 		if(M == user)
 			cig.attackby(src, user)
 		else
@@ -85,7 +85,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/proc/help_light_cig(mob/living/carbon/M, mob/living/carbon/user)
 	if(!iscarbon(M))
 		return
-	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_sel.selecting == "mouth")
+	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette))
 		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
 		return cig
 
@@ -247,7 +247,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!istype(M))
 		return ..()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
-	if(lit && cig)
+	if(lit && cig && user.a_intent == "help")
 		if(M == user)
 			cig.attackby(src, user)
 		else
@@ -354,6 +354,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 100
 	var/packeditem = 0
 
+/obj/item/clothing/mask/cigarette/pipe/New()
+	..()
+	name = "empty [initial(name)]"
+
 /obj/item/clothing/mask/cigarette/pipe/process()
 	var/turf/location = get_turf(src)
 	smoketime--
@@ -432,10 +436,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cobpipeoff"
 	smoketime = 0
 
-/obj/item/clothing/mask/cigarette/pipe/cobpipe/New()
-	..()
-	name = "empty [initial(name)]"
-
 
 /////////
 //ZIPPO//
@@ -507,7 +507,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit)
 		M.IgniteMob()
 	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
-	if(lit && cig)
+	if(lit && cig && user.a_intent == "help")
+		if(cig.lit)
+			user << "<span class='notice'>The [cig.name] is already lit.</span>"
 		if(M == user)
 			cig.attackby(src, user)
 		else

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -124,7 +124,7 @@
 		return
 	var/obj/item/clothing/mask/cigarette/cig = locate(/obj/item/clothing/mask/cigarette) in contents
 	if(cig)
-		if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
+		if(M == user && contents.len > 0 && !user.wear_mask)
 			var/obj/item/clothing/mask/cigarette/W = cig
 			remove_from_storage(W, M)
 			M.equip_to_slot_if_possible(W, slot_wear_mask)


### PR DESCRIPTION
this removes the mouth targeting requirements for quick smoking, and uses help intent instead.
no longer do you need to click that tiny mouth targeting zone to be a pro chainsmoker, or help someone light up.
detectives everywhere are sure to approve. :smoking: 

also moved a possibly misplaced thing on pipes.
