### PR TITLE
Make EXPERI-Mentor SetTypeReactions() way more efficient

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -62,25 +62,22 @@
 		else
 			item_reactions["[I]"] = pick(SCANTYPE_POKE,SCANTYPE_IRRADIATE,SCANTYPE_GAS,SCANTYPE_HEAT,SCANTYPE_COLD,SCANTYPE_OBLITERATE)
 		if(ispath(I,/obj/item/weapon/stock_parts) || ispath(I,/obj/item/weapon/grenade/chem_grenade) || ispath(I,/obj/item/weapon/kitchen))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null) //check it's an actual usable item, in a hacky way
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
 				valid_items += 15
 				valid_items += I
 				probWeight++
-			qdel(tempCheck)
 
 		if(ispath(I,/obj/item/weapon/reagent_containers/food))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null) //check it's an actual usable item, in a hacky way
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
 				valid_items += rand(1,max(2,35-probWeight))
 				valid_items += I
-			qdel(tempCheck)
 
 		if(ispath(I,/obj/item/weapon/rcd) || ispath(I,/obj/item/weapon/grenade) || ispath(I,/obj/item/device/aicard) || ispath(I,/obj/item/weapon/storage/backpack/holding) || ispath(I,/obj/item/slime_extract) || ispath(I,/obj/item/device/onetankbomb) || ispath(I,/obj/item/device/transfer_valve))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null)
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null)
 				critical_items += I
-			qdel(tempCheck)
 
 
 /obj/machinery/r_n_d/experimentor/New()


### PR DESCRIPTION
Profiler stats: http://hastebin.com/oyegozeval.mel

Exploits an [undocumented feature](https://docs.google.com/document/pub?id=1HGkCp4eQU8Jp14Srh8Isuv_liehzV_XB6IcSUbVFFiY&embedded=true&revision=latest%22%22#h.d403aw6sdp8s) to reduce the impact of the EXPERI-Mentor's SetTypeReactions() proc; Basically, you don't need a new instance to check an initial var of a typepath, if you use initial() on a typecasted reference to the path.
