### PR TITLE
DNA Restoration Virus Symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -133,7 +133,7 @@ Bonus
 	Very high level.
 
 Bonus
-	Heals celluar damage, treats radiation, cleans SE of non-power mutations.
+	Heals brain damage, treats radiation, cleans SE of non-power mutations.
 
 //////////////////////////////////////
 */
@@ -150,7 +150,7 @@ Bonus
 /datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
 
 	var/amt_healed = rand(5, 10)
-	M.adjustCloneLoss(-amt_healed)
+	M.adjustBrainLoss(-amt_healed)
 	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
 	var/list/unclean_mutations = (not_good_mutations|bad_mutations) - mutations_list[RACEMUT]
 	M.dna.remove_mutation_group(unclean_mutations)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -120,3 +120,39 @@ Bonus
 
 /datum/symptom/heal/longevity/Start(datum/disease/advance/A)
 	longevity = rand(initial(longevity) - 5, initial(longevity) + 5)
+
+/*
+//////////////////////////////////////
+
+	DNA Restoration
+
+	Not well hidden.
+	Lowers resistance minorly.
+	Does not affect stage speed.
+	Decreases transmittablity greatly.
+	Very high level.
+
+Bonus
+	Heals celluar damage, treats radiation, cleans SE of non-power mutations.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/heal/dna
+
+	name = "Deoxyribonucleic Acid Restoration"
+	stealth = -1
+	resistance = -1
+	stage_speed = 0
+	transmittable = -3
+	level = 5
+
+/datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
+
+	var/amt_healed = rand(5, 10)
+	M.adjustCloneLoss(-amt_healed)
+	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
+	var/list/unclean_mutations = (not_good_mutations|bad_mutations) - mutations_list[RACEMUT]
+	M.dna.remove_mutation_group(unclean_mutations)
+	M.radiation = max(M.radiation - 3, 0)
+	return 1


### PR DESCRIPTION
Adds a new virus symptom: DNA Restoration. This is a replacement for DNA Aide, which was removed.
- Heals <b>brainloss</b> damage.
- Reduces radiation (but not toxin damage)
- Cleanse the SE of unwanted mutations, but does not affect power mutations.

~~This is a work in progress.~~ The bonus listed here is not finalized, and is subject to change/buffs/nerfs.

The code is not optimized, and I am sure to have made mistakes, so I will correct them as the PR matures. Basic testing confirms it is performing its intended function so far.
