### PR TITLE
Fixes some runtimes, syndiborg module and  grenade launcher

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -294,7 +294,7 @@ var/list/blood_splatter_icons = list()
 	return add_blood_list(M)
 
 /obj/item/add_blood(mob/living/carbon/M)
-	var/blood_count = blood_DNA ? 0 : blood_DNA.len
+	var/blood_count = !blood_DNA ? 0 : blood_DNA.len
 	if(!..())
 		return 0
 	//apply the blood-splatter overlay if it isn't already in there

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -280,22 +280,22 @@ var/list/blood_splatter_icons = list()
 
 //returns 1 if made bloody, returns 0 otherwise
 /atom/proc/add_blood(mob/living/carbon/M)
+	if(!M || !M.has_dna() || rejects_blood())
+		return 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(NOBLOOD in H.dna.species.specflags)
 			return 0
-	if(rejects_blood() || !M.has_dna())
-		return 0
 	return 1
 
 /obj/add_blood(mob/living/carbon/M)
-	if(..() == 0)
+	if(!..())
 		return 0
 	return add_blood_list(M)
 
 /obj/item/add_blood(mob/living/carbon/M)
-	var/blood_count = blood_DNA == null ? 0 : blood_DNA.len
-	if(..() == 0)
+	var/blood_count = blood_DNA ? 0 : blood_DNA.len
+	if(!..())
 		return 0
 	//apply the blood-splatter overlay if it isn't already in there
 	if(!blood_count && initial(icon) && initial(icon_state))
@@ -312,14 +312,14 @@ var/list/blood_splatter_icons = list()
 	return 1 //we applied blood to the item
 
 /obj/item/clothing/gloves/add_blood(mob/living/carbon/M)
-	if(..() == 0)
+	if(!..())
 		return 0
 	transfer_blood = rand(2, 4)
 	bloody_hands_mob = M
 	return 1
 
 /turf/simulated/add_blood(mob/living/carbon/human/M)
-	if(..() == 0)
+	if(!..())
 		return 0
 
 	var/obj/effect/decal/cleanable/blood/B = locate() in contents	//check for existing blood splatter
@@ -330,7 +330,7 @@ var/list/blood_splatter_icons = list()
 	return 1 //we bloodied the floor
 
 /mob/living/carbon/human/add_blood(mob/living/carbon/M)
-	if(..() == 0)
+	if(!..())
 		return 0
 	add_blood_list(M)
 	bloody_hands = rand(2, 4)

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -77,7 +77,7 @@
 						<b>Airtank:</b> [M.return_pressure()]kPa<br>
 						<b>Pilot:</b> [M.occupant||"None"]<br>
 						<b>Location:</b> [get_area(M)||"Unknown"]<br>
-						<b>Active equipment:</b> [M.selected||"None"]"}
+						<b>Active equipment:</b> [M.selected||"None"]<br>"}
 	if(istype(M, /obj/mecha/working/ripley))
 		var/obj/mecha/working/ripley/RM = M
 		answer += "<b>Used cargo space:</b> [RM.cargo.len/RM.cargo_capacity*100]%<br>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -74,6 +74,7 @@ var/list/ai_list = list()
 	var/obj/machinery/camera/portable/builtInCamera
 
 /mob/living/silicon/ai/New(loc, var/datum/ai_laws/L, var/obj/item/device/mmi/B, var/safety = 0)
+	..()
 	rename_self("ai", 1)
 	name = real_name
 	anchored = 1
@@ -144,8 +145,7 @@ var/list/ai_list = list()
 
 	builtInCamera = new /obj/machinery/camera/portable(src)
 	builtInCamera.network = list("SS13")
-	..()
-	return
+
 
 /mob/living/silicon/ai/Destroy()
 	ai_list -= src

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1134,7 +1134,7 @@
 						Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
 						<i>Help the operatives secure the disk at all costs!</i></b>"
 
-/mob/living/silicon/robot/syndicate/New(loc)
+/mob/living/silicon/robot/syndicate/medical/New(loc)
 	..()
 	module = new /obj/item/weapon/robot_module/syndicate_medical(src)
 	spawn(5)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -94,14 +94,14 @@
 	return
 
 /mob/living/simple_animal/hostile/proc/PickTarget(list/Targets)//Step 3, pick amongst the possible, attackable targets
-	if(!Targets.len)//We didnt find nothin!
-		return
 	if(target != null)//If we already have a target, but are told to pick again, calculate the lowest distance between all possible, and pick from the lowest distance targets
 		for(var/atom/A in Targets)
 			var/target_dist = get_dist(src, target)
 			var/possible_target_distance = get_dist(src, A)
 			if(target_dist < possible_target_distance)
 				Targets -= A
+	if(!Targets.len)//We didnt find nothin!
+		return
 	var/chosen_target = pick(Targets)//Pick the remaining targets (if any) at random
 	return chosen_target
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -138,7 +138,8 @@
 			var/mob/living/M = user
 			if (M.disabilities & CLUMSY && prob(40))
 				user << "<span class='userdanger'>You shoot yourself in the foot with \the [src]!</span>"
-				process_fire(user,user,0,params)
+				var/shot_leg = pick("l_leg", "r_leg")
+				process_fire(user,user,0,params, zone_override = shot_leg)
 				M.drop_item()
 				return
 
@@ -182,7 +183,7 @@
 	return 0
 
 
-/obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params)
+/obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override)
 	add_fingerprint(user)
 
 	if(semicd)
@@ -200,7 +201,7 @@
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
 			if(chambered)
-				if(!chambered.fire(target, user, params, , suppressed))
+				if(!chambered.fire(target, user, params, , suppressed, zone_override))
 					shoot_with_empty_chamber(user)
 					break
 				else
@@ -216,7 +217,7 @@
 			sleep(fire_delay)
 	else
 		if(chambered)
-			if(!chambered.fire(target, user, params, , suppressed))
+			if(!chambered.fire(target, user, params, , suppressed, zone_override))
 				shoot_with_empty_chamber(user)
 				return
 			else

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -25,6 +25,7 @@
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
+	pin = /obj/item/device/firing_pin
 
 /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg/attack_self()
 	return

--- a/html/changelogs/phil235-AddbloodRuntimeFix.yml
+++ b/html/changelogs/phil235-AddbloodRuntimeFix.yml
@@ -1,0 +1,8 @@
+ 
+author: phil235
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed the syndicate cyborg's grenade launcher."
+


### PR DESCRIPTION
- Fixes runtimes with add_blood() and add_blood_list()
- Fixes some formatting in the mech control console window.
- Fixes runtimes when building an AI (mind transfer from mmi to ai was called before the AI's hud_list was set)
- Fixes syndicate cyborg not starting with the correct module. Fixes #12033. (mistake in #11809)
- Fixes syndiborg not being able to use their grenade launcher. Fixes #12024.
- Fixes runtime with gun process_fire() (some code was reverted by accident in #11877)
- Fixes a runtime with hostile simple animal's PickTarget().
