### PR TITLE
Fixes not being able to save the dna of corpses in the dna console.

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -52,7 +52,7 @@
 		. = on_losing(owner)
 
 /datum/mutation/human/proc/on_acquiring(mob/living/carbon/human/owner)
-	if(!owner || !istype(owner) || (src in owner.dna.mutations))
+	if(!owner || !istype(owner) || owner.stat == DEAD || (src in owner.dna.mutations))
 		return 1
 	if(species_allowed.len && !species_allowed.Find(owner.dna.species.id))
 		return 1
@@ -87,7 +87,7 @@
 
 /datum/mutation/human/proc/on_losing(mob/living/carbon/human/owner)
 	if(owner && istype(owner) && (owner.dna.mutations.Remove(src)))
-		if(text_lose_indication)
+		if(text_lose_indication && owner.stat != DEAD)
 			owner << text_lose_indication
 		if(visual_indicators.len)
 			var/list/mut_overlay = list()
@@ -381,7 +381,7 @@
 	. = owner.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/monkey/owner)
-	if(owner && istype(owner) && (owner.dna.mutations.Remove(src)))
+	if(owner && istype(owner) && owner.stat != DEAD && (owner.dna.mutations.Remove(src)))
 		. = owner.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
 
 

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -84,7 +84,7 @@
 				switch(viable_occupant.stat)
 					if(CONSCIOUS)	occupant_status += "<span class='good'>Conscious</span>"
 					if(UNCONSCIOUS)	occupant_status += "<span class='average'>Unconscious</span>"
-					else			occupant_status += "<span class='bad'>DEAD - Cannot Operate</span>"
+					else			occupant_status += "<span class='bad'>DEAD</span>"
 				occupant_status += "</div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Health:</div><div class='progressBar'><div style='width: [viable_occupant.health]%;' class='progressFill good'></div></div><div class='statusValue'>[viable_occupant.health] %</div></div>"
 				occupant_status += "<div class='line'><div class='statusLabel'>Radiation Level:</div><div class='progressBar'><div style='width: [viable_occupant.radiation]%;' class='progressFill bad'></div></div><div class='statusValue'>[viable_occupant.radiation] %</div></div>"
@@ -95,8 +95,6 @@
 			else
 				viable_occupant = null
 				occupant_status += "<span class='bad'>Invalid DNA structure</span></div></div>"
-			if (viable_occupant && viable_occupant.stat == DEAD)
-				viable_occupant = null // No editing the dead.
 		else
 			occupant_status += "<span class='bad'>No subject detected</span></div></div>"
 
@@ -202,7 +200,7 @@
 							temp_html += "<br>\tUI: No Data"
 						if(se)
 							temp_html += "<br>\tSE: [se] "
-							if(viable_occupant && viable_occupant.stat != DEAD)	temp_html += "<a href='?src=\ref[src];task=transferbuffer;num=[i];text=se'>Occupant</a> "
+							if(viable_occupant)	temp_html += "<a href='?src=\ref[src];task=transferbuffer;num=[i];text=se'>Occupant</a> "
 							else												temp_html += "<span class='linkOff'>Occupant</span> "
 							if(injectorready)									temp_html += "<a href='?src=\ref[src];task=injector;num=[i];text=se'>Injector</a>"
 							else												temp_html += "<span class='linkOff'>Injector</span>"
@@ -327,7 +325,7 @@
 				if(istype(buffer_slot))
 					buffer_slot.Cut()
 		if("transferbuffer")
-			if(num && viable_occupant && viable_occupant.stat != DEAD)
+			if(num && viable_occupant)
 				num = Clamp(num, 1, NUMBER_OF_BUFFERS)
 				var/list/buffer_slot = buffer[num]
 				if(istype(buffer_slot))                                                                                  //15 and 40 are just magic numbers that were here before so i didnt touch them, they are initial boundaries of damage
@@ -394,7 +392,7 @@
 				diskette.loc = get_turf(src)
 				diskette = null
 		if("pulseui","pulsese")
-			if(num && viable_occupant && connected && viable_occupant.stat != DEAD)
+			if(num && viable_occupant && connected)
 				radduration = Wrap(radduration, 1, RADIATION_DURATION_MAX+1)
 				radstrength = Wrap(radstrength, 1, RADIATION_STRENGTH_MAX+1)
 

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -18,9 +18,6 @@
 
 /obj/item/weapon/dnainjector/proc/inject(mob/living/carbon/M, mob/user)
 	if(M.has_dna() && !(M.disabilities & NOCLONE))
-		if(M.stat == DEAD)	//prevents dead people from having their DNA changed
-			user << "<span class='notice'>You can't modify [M]'s DNA while \he's dead.</span>"
-			return
 		M.radiation += rand(20/(damage_coeff  ** 2),50/(damage_coeff  ** 2))
 		var/log_msg = "[key_name(user)] injected [key_name(M)] with the [name]"
 		for(var/datum/mutation/human/HM in remove_mutations)

--- a/html/changelogs/phil235-DeadDna.yml
+++ b/html/changelogs/phil235-DeadDna.yml
@@ -1,0 +1,8 @@
+ 
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "You can modify the dna of corpses again."
+


### PR DESCRIPTION
- Fixes not being able to save the dna of corpses in the dna console. Fixes #9851
- <b>Corpses can now have their dna changed (but they don't acquire mutations). You can use a dna injector on them and modify their dna with the dna console.</b>
