### PR TITLE
Makes magic bolts properly unblockable

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -4,6 +4,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
+	flags = NOSHIELD
 	flag = "magic"
 
 /obj/item/projectile/magic/death


### PR DESCRIPTION
Their effects still happened even if they were blocked so this really just amounts to removing a false hope message.

Fixes #12046
