### PR TITLE
Removes Revenants hearing Dsay

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -26,7 +26,7 @@
 	for (var/mob/M in player_list)
 		if (istype(M, /mob/new_player))
 			continue
-		if (M.stat == DEAD || istype(M, /mob/living/simple_animal/revenant) || (M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
+		if (M.stat == DEAD || (M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
 			M.show_message(rendered, 2)
 
 	feedback_add_details("admin_verb","D") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
Revenants being able to communicate with both deadchat and humans was agreed upon by admins as being bad.
Hearing deadchat was never fully implemented, only them hearing dsay
Fixes #12020 
