### PR TITLE
Only spawn dominators in gang areas

### DIFF
--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -280,7 +280,7 @@
 						usr << "<span class='warning'>There's not enough room here!</span>"
 						return
 
-				if(usrarea.type in gang.territory | gang.territory_new)
+				if(usrarea.type in gang.territory|gang.territory_new)
 					if(gang.points >= 30)
 						item_type = /obj/machinery/dominator
 						usr << "<span class='notice'>The <b>dominator</b> will secure your gang's dominance over the station. Turn it on when you are ready to defend it.</span>"

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -280,10 +280,13 @@
 						usr << "<span class='warning'>There's not enough room here!</span>"
 						return
 
-				if(gang.points >= 30)
-					item_type = /obj/machinery/dominator
-					usr << "<span class='notice'>The <b>dominator</b> will secure your gang's dominance over the station. Turn it on when you are ready to defend it.</span>"
-					pointcost = 30
+				if(usrarea.type in gang.territory | gang.territory_new)
+					if(gang.points >= 30)
+						item_type = /obj/machinery/dominator
+						usr << "<span class='notice'>The <b>dominator</b> will secure your gang's dominance over the station. Turn it on when you are ready to defend it.</span>"
+						pointcost = 30
+				else
+					usr << "<span class='notice'>The <b>dominator</b> can be spawned only on territory controlled by your gang.</span>"
 
 		if(item_type)
 			gang.points -= pointcost


### PR DESCRIPTION
Makes dominators spawnable only in areas under gangs control
Fixes https://github.com/tgstation/-tg-station/issues/11297
Fixes https://github.com/tgstation/-tg-station/pull/11302
