### PR TITLE
tank suicide now drops items in hand, shreds clothing

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -27,6 +27,9 @@
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	sleep(3)
 	if (H && !qdeleted(H))
+		H.drop_l_hand()
+		H.drop_r_hand()
+		H.shred_clothing(1,150)
 		H.gib()
 	return
 


### PR DESCRIPTION
This reduces (but does not eliminate) the chance of items being removed from the round by a suicide.

Fixes #12013 
