### PR TITLE
Destroy() fixes

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -309,13 +309,6 @@
 		stat |= NOPOWER
 	update_icon_nopipes()
 
-/obj/machinery/atmospherics/components/unary/vent_pump/Destroy()
-	if(initial_loc)
-		initial_loc.air_vent_info -= id_tag
-		initial_loc.air_vent_names -= id_tag
-	..()
-
-
 /obj/machinery/atmospherics/components/unary/vent_pump/can_crawl_through()
 	return !welded
 

--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -1,4 +1,3 @@
-
 /atom/proc/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return null
 
@@ -91,18 +90,18 @@
 
 	var/turf/simulated/location = loc
 	if(!istype(location))
-		Kill()
+		qdel(src)
 		return
 
 	if(location.excited_group)
 		location.excited_group.reset_cooldowns()
 
 	if((temperature < FIRE_MINIMUM_TEMPERATURE_TO_EXIST) || (volume <= 1))
-		Kill()
+		qdel(src)
 		return
 
 	if(!(location.air) || location.air.toxins < 0.5 || location.air.oxygen < 0.5)
-		Kill()
+		qdel(src)
 		return
 
 	perform_exposure()
@@ -139,13 +138,8 @@
 			return 0*/
 	return 1
 
-// Garbage collect itself by nulling reference to it
-
-/obj/effect/hotspot/proc/Kill()
-	SetLuminosity(0)
-	PlaceInPool(src)
-
 /obj/effect/hotspot/Destroy()
+	SetLuminosity(0)
 	SSair.hotspots -= src
 	DestroyTurf()
 	if(istype(loc, /turf/simulated))

--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -139,6 +139,7 @@
 	return 1
 
 /obj/effect/hotspot/Destroy()
+	..()
 	SetLuminosity(0)
 	SSair.hotspots -= src
 	DestroyTurf()

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -67,11 +67,11 @@
 		air.toxins = toxins
 		air.temperature = temperature
 
-/turf/simulated/Del()
+/turf/simulated/Destroy()
 	visibilityChanged()
 	if(active_hotspot)
 		qdel(active_hotspot)
-	..()
+	return ..()
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)
 	if(!giver)	return 0

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -70,7 +70,7 @@
 /turf/simulated/Del()
 	visibilityChanged()
 	if(active_hotspot)
-		active_hotspot.Kill()
+		qdel(active_hotspot)
 	..()
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -290,4 +290,5 @@ so as to remain in compliance with the most up-to-date laws."
 		return usr.client.Click(master, location, control, params)
 
 /obj/screen/alert/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL //Don't destroy me, I have a family!

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -19,7 +19,7 @@ var/global/datum/controller/game_controller/master_controller = new()
 	if(master_controller != src)
 		if(istype(master_controller))
 			Recover()
-			master_controller.Del()
+			qdel(master_controller)
 		else
 			init_subtypes(/datum/subsystem, subsystems)
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -26,6 +26,10 @@ var/global/datum/controller/game_controller/master_controller = new()
 		master_controller = src
 	calculateGCD()
 
+/datum/controller/game_controller/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL_NOW
+
 
 /*
 calculate the longest number of ticks the MC can wait between each cycle without causing subsystems to not fire on schedule

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -188,9 +188,9 @@ var/list/diseases = typesof(/datum/disease) - /datum/disease
 	return type
 
 
-/datum/disease/Del()
+/datum/disease/Destroy()
 	SSdisease.processing.Remove(src)
-	..()
+	return ..()
 
 
 /datum/disease/proc/IsSpreadByTouch()

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -69,11 +69,11 @@ var/list/advance_cures = 	list(
 	..(process, D)
 	return
 
-/datum/disease/advance/Del()
+/datum/disease/advance/Destroy()
 	if(processing)
 		for(var/datum/symptom/S in symptoms)
 			S.End(src)
-	..()
+	return ..()
 
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -61,7 +61,7 @@
 
 	return
 
-/datum/disease/dnaspread/Del()
+/datum/disease/dnaspread/Destroy()
 	if (original_dna && transformed && affected_mob)
 		original_dna.transfer_identity(affected_mob, transfer_SE = 1)
 		affected_mob.real_name = affected_mob.dna.real_name
@@ -69,4 +69,4 @@
 		affected_mob.domutcheck()
 
 		affected_mob << "<span class='notice'>You feel more like yourself.</span>"
-	..()
+	return ..()

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -272,9 +272,9 @@ var/list/pointers = list()
 	..()
 	pointers += "\ref[src]"
 
-/datum/signal/Del()
+/datum/signal/Destroy()
 	pointers -= "\ref[src]"
-	..()
+	return ..()
 
 /datum/signal/proc/copy_from(datum/signal/model)
 	source = model.source

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -111,13 +111,13 @@
 	Radio.listening = 0 //Makes bot radios transmit only so no one hears things while adjacent to one.
 
 /obj/machinery/bot/Destroy()
+	SSbot.processing -= src
 	qdel(Radio)
 	qdel(botcard)
 	return ..()
 
 
 /obj/machinery/bot/proc/explode()
-	SSbot.processing -= src
 	qdel(src)
 
 /obj/machinery/bot/proc/healthcheck()

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -237,8 +237,7 @@ text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	qdel(src)
-	return
+	..()
 
 /obj/item/weapon/bucket_sensor/attackby(obj/item/W, mob/user as mob, params)
 	..()

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -441,7 +441,7 @@ Auto Patrol[]"},
 	s.start()
 
 	new /obj/effect/decal/cleanable/oil(loc)
-	qdel(src)
+	..()
 
 /obj/machinery/bot/ed209/proc/set_weapon()  //used to update the projectile type and firing sound
 	shoot_sound = 'sound/weapons/laser.ogg'

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -458,8 +458,7 @@ obj/machinery/bot/floorbot/process_scan(scan_target)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	qdel(src)
-	return
+	..()
 
 
 /obj/item/weapon/storage/toolbox/mechanical/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -523,8 +523,7 @@
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	qdel(src)
-	return
+	..()
 
 /obj/machinery/bot/medbot/proc/declare(crit_patient)
 	if(declare_cooldown)

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -838,7 +838,7 @@ var/global/mulebot_count = 0
 	s.start()
 
 	new /obj/effect/decal/cleanable/oil(loc)
-	qdel(src)
+	..()
 
 #undef SIGH
 #undef ANNOYED

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -376,7 +376,7 @@ Auto Patrol: []"},
 	s.start()
 
 	new /obj/effect/decal/cleanable/oil(loc)
-	qdel(src)
+	..()
 
 /obj/machinery/bot/secbot/attack_alien(var/mob/living/carbon/alien/user as mob)
 	..()

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -169,7 +169,7 @@
 					blackbox.messages += blackbox_msg
 
 	spawn(50)
-		PlaceInPool(virt)
+		qdel(virt)
 
 /proc/Broadcast_SimpleMessage(source, frequency, text, data, mob/M, compression, level)
 

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -339,7 +339,7 @@
 				G.temperature = 2
 			T.air_update_turf()
 			for(var/obj/effect/hotspot/H in T)
-				H.Kill()
+				qdel(H)
 				if(G.toxins)
 					G.nitrogen += (G.toxins)
 					G.toxins = 0

--- a/code/game/pooling/pool.dm
+++ b/code/game/pooling/pool.dm
@@ -16,8 +16,10 @@ To put a object back in the pool, call PlaceInPool(object)
 This will call destroy on the object, set its loc to null,
 and reset all of its vars to their default
 
-You can override your object's destroy to return QDEL_HINT_PLACEINPOOL
+You can override your object's destroy to return QDEL_HINT_PUTINPOOL
 to ensure its always placed in this pool (this will only be acted on if qdel calls destroy, and destroy will not get called twice)
+
+For almost all pooling purposes, it is better to use the QDEL hint than to pool it directly with PlaceInPool
 
 */
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -164,3 +164,7 @@ var/list/freqtospan = list(
 
 /atom/movable/virtualspeaker/GetRadio()
 	return radio
+
+/atom/movable/virtualspeaker/Destroy()
+	..()
+	return QDEL_HINT_PUTINPOOL

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -34,16 +34,14 @@
 		Entered(AM)
 
 /turf/Destroy()
-	return QDEL_HINT_HARDDEL_NOW
-
-// Adds the adjacent turfs to the current atmos processing
-/turf/Del()
+	// Adds the adjacent turfs to the current atmos processing
 	for(var/direction in cardinal)
 		if(atmos_adjacent_turfs & direction)
 			var/turf/simulated/T = get_step(src, direction)
 			if(istype(T))
 				SSair.add_to_active(T)
 	..()
+	return QDEL_HINT_HARDDEL_NOW
 
 /turf/attack_hand(mob/user)
 	user.Move_Pulled(src)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -309,6 +309,10 @@ var/global/dmm_suite/preloader/_preloader = null
 
 	. = ..()
 
+/dmm_suite/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL_NOW
+
 //////////////////
 //Preloader datum
 //////////////////
@@ -321,7 +325,7 @@ var/global/dmm_suite/preloader/_preloader = null
 /dmm_suite/preloader/New(list/the_attributes, path)
 	.=..()
 	if(!the_attributes.len)
-		Del()
+		qdel(src)
 		return
 	attributes = the_attributes
 	target_path = path
@@ -329,4 +333,4 @@ var/global/dmm_suite/preloader/_preloader = null
 /dmm_suite/preloader/proc/load(atom/what)
 	for(var/attribute in attributes)
 		what.vars[attribute] = attributes[attribute]
-	Del()
+	qdel(src)

--- a/code/modules/awaymissions/maploader/swapmaps.dm
+++ b/code/modules/awaymissions/maploader/swapmaps.dm
@@ -163,7 +163,7 @@ swapmap
 		z2=z?(z):1
 		AllocateSwapMap()
 
-	Del()
+	Destroy()
 		// a temporary datum for a chunk can be deleted outright
 		// for others, some cleanup is necessary
 		if(!ischunk)
@@ -186,6 +186,7 @@ swapmap
 				if(x2>=world.maxx || y2>=world.maxy || z2>=world.maxz) CutXYZ()
 				qdel(areas)
 		..()
+		return QDEL_HINT_HARDDEL_NOW
 
 	/*
 		Savefile format:

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -27,6 +27,7 @@ obj/effect/dummy/slaughter/relaymove(mob/user, direction)
 	return
 
 /obj/effect/dummy/slaughter/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL
 
 

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -69,12 +69,6 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-
-/obj/item/weapon/katana/energy/Del()
-	qdel(spark_system)
-	spark_system = null
-	..()
-
 /obj/item/weapon/katana/energy/Destroy()
 	qdel(spark_system)
 	spark_system = null

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -64,6 +64,7 @@
 	return //don't want the emitters to miss
 
 /obj/item/projectile/beam/emitter/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL
 
 /obj/item/projectile/lasertag

--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Food-Reagents.dm
@@ -332,7 +332,7 @@
 		lowertemp.temperature = max( min(lowertemp.temperature-2000,lowertemp.temperature / 2) ,0)
 		lowertemp.react()
 		T.assume_air(lowertemp)
-		hotspot.Kill()
+		qdel(hotspot)
 
 /datum/reagent/consumable/enzyme
 	name = "Universal Enzyme"

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -127,7 +127,7 @@
 			var/datum/gas_mixture/G = T.air
 			G.temperature = max(min(G.temperature-(CT*1000),G.temperature/CT),0)
 			G.react()
-			hotspot.Kill()
+			qdel(hotspot)
 	return
 
 /*


### PR DESCRIPTION
Vent pumps now return a QDEL hint properly
Fixes lack of parent calling and weird pooling things
Removes every last out of place Del() call or definition. In places where I was unsure if the harddel was needed, I made the Destroy() return QDEL_HINT_HARDDEL_NOW to preserve functionality.
