### PR TITLE
Targeting hotkeys

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -398,6 +398,36 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 			else
 				hud_used.action_intent.icon_state = "help"
 
+/mob/verb/target_zone_change(input as text)
+	set name = "target-zone"
+	set hidden = 1
+
+	if(src.zone_sel)
+		var/obj/screen/zone_sel/Target = src.zone_sel
+		var/old_selecting = Target.selecting
+		switch(input)
+			if("r_leg")
+				Target.selecting = "r_leg"
+			if("l_leg")
+				Target.selecting = "l_leg"
+			if("r_arm")
+				Target.selecting = "r_arm"
+			if("l_arm")
+				Target.selecting = "l_arm"
+			if("chest")
+				Target.selecting = "chest"
+			if("groin")
+				Target.selecting = "groin"
+			if("head")
+				Target.selecting = "head"
+			if("eyes")
+				Target.selecting = "eyes"
+			if("mouth")
+				Target.selecting = "mouth"
+
+		if(old_selecting != Target.selecting)
+			Target.update_icon()
+
 /proc/is_blind(A)
 	if(ismob(A))
 		var/mob/B = A

--- a/html/changelogs/delimusca-hotkeys.yml
+++ b/html/changelogs/delimusca-hotkeys.yml
@@ -1,0 +1,7 @@
+author: Delimusca
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added hotkeys for changing your limb targeting zone to the numpad."
+

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -108,14 +108,6 @@ macro "borghotkeymode"
 		command = "resist"
 		is-disabled = false
 	elem 
-		name = "O"
-		command = "ooc"
-		is-disabled = false
-	elem 
-		name = "CTRL+O"
-		command = "ooc"
-		is-disabled = false
-	elem 
 		name = "D+REP"
 		command = ".east"
 		is-disabled = false
@@ -138,6 +130,14 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+G"
 		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "O"
+		command = "ooc"
+		is-disabled = false
+	elem 
+		name = "CTRL+O"
+		command = "ooc"
 		is-disabled = false
 	elem 
 		name = "Q"
@@ -190,6 +190,42 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "NUMPAD1"
+		command = "target-zone r_leg"
+		is-disabled = false
+	elem 
+		name = "NUMPAD2"
+		command = "target-zone groin"
+		is-disabled = false
+	elem 
+		name = "NUMPAD3"
+		command = "target-zone l_leg"
+		is-disabled = false
+	elem 
+		name = "NUMPAD4"
+		command = "target-zone r_arm"
+		is-disabled = false
+	elem 
+		name = "NUMPAD5"
+		command = "target-zone chest"
+		is-disabled = false
+	elem 
+		name = "NUMPAD6"
+		command = "target-zone l_arm"
+		is-disabled = false
+	elem 
+		name = "NUMPAD7"
+		command = "target-zone eyes"
+		is-disabled = false
+	elem 
+		name = "NUMPAD8"
+		command = "target-zone head"
+		is-disabled = false
+	elem 
+		name = "NUMPAD9"
+		command = "target-zone mouth"
 		is-disabled = false
 	elem 
 		name = "F1"
@@ -334,6 +370,10 @@ macro "macro"
 		command = "a-intent right"
 		is-disabled = false
 	elem 
+		name = "CTRL+O"
+		command = "ooc"
+		is-disabled = false
+	elem 
 		name = "CTRL+Q"
 		command = ".northwest"
 		is-disabled = false
@@ -362,6 +402,42 @@ macro "macro"
 		command = "Activate-Held-Object"
 		is-disabled = false
 	elem 
+		name = "CTRL+NUMPAD1"
+		command = "target-zone r_leg"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD2"
+		command = "target-zone groin"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD3"
+		command = "target-zone l_leg"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD4"
+		command = "target-zone r_arm"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD5"
+		command = "target-zone chest"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD6"
+		command = "target-zone l_arm"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD7"
+		command = "target-zone eyes"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD8"
+		command = "target-zone head"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD9"
+		command = "target-zone mouth"
+		is-disabled = false
+	elem 
 		name = "F1"
 		command = "adminhelp"
 		is-disabled = false
@@ -380,10 +456,6 @@ macro "macro"
 	elem 
 		name = "F5"
 		command = "Aghost"
-		is-disabled = false
-	elem 
-		name = "CTRL+O"
-		command = "ooc"
 		is-disabled = false
 	elem 
 		name = "F6"
@@ -620,6 +692,42 @@ macro "hotkeymode"
 		command = "Activate-Held-Object"
 		is-disabled = false
 	elem 
+		name = "NUMPAD1"
+		command = "target-zone r_leg"
+		is-disabled = false
+	elem 
+		name = "NUMPAD2"
+		command = "target-zone groin"
+		is-disabled = false
+	elem 
+		name = "NUMPAD3"
+		command = "target-zone l_leg"
+		is-disabled = false
+	elem 
+		name = "NUMPAD4"
+		command = "target-zone r_arm"
+		is-disabled = false
+	elem 
+		name = "NUMPAD5"
+		command = "target-zone chest"
+		is-disabled = false
+	elem 
+		name = "NUMPAD6"
+		command = "target-zone l_arm"
+		is-disabled = false
+	elem 
+		name = "NUMPAD7"
+		command = "target-zone eyes"
+		is-disabled = false
+	elem 
+		name = "NUMPAD8"
+		command = "target-zone head"
+		is-disabled = false
+	elem 
+		name = "NUMPAD9"
+		command = "target-zone mouth"
+		is-disabled = false
+	elem 
 		name = "F1"
 		command = "adminhelp"
 		is-disabled = false
@@ -742,10 +850,6 @@ macro "borgmacro"
 		command = "resist"
 		is-disabled = false
 	elem 
-		name = "CTRL+O"
-		command = "ooc"
-		is-disabled = false
-	elem 
 		name = "CTRL+D+REP"
 		command = ".east"
 		is-disabled = false
@@ -756,6 +860,10 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+G"
 		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "CTRL+O"
+		command = "ooc"
 		is-disabled = false
 	elem 
 		name = "CTRL+Q"
@@ -780,6 +888,42 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD1"
+		command = "target-zone r_leg"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD2"
+		command = "target-zone groin"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD3"
+		command = "target-zone l_leg"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD4"
+		command = "target-zone r_arm"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD5"
+		command = "target-zone chest"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD6"
+		command = "target-zone l_arm"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD7"
+		command = "target-zone eyes"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD8"
+		command = "target-zone head"
+		is-disabled = false
+	elem 
+		name = "CTRL+NUMPAD9"
+		command = "target-zone mouth"
 		is-disabled = false
 	elem 
 		name = "F1"


### PR DESCRIPTION
a little side thing i made while i was working on RightClick().
puts hotkeys for targeting areas on the numpad.
tested on carbons, silicons and simples, seems to work fine.

1|2|3 is rleg|groin|lleg;
4|5|6 is rarm|chest|larm;
7|8|9 is eyes|head|mouth.
