### PR TITLE
Changes map generation time at roundstart

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -62,6 +62,8 @@ calculate the longest number of ticks the MC can wait between each cycle without
 		S.Initialize(world.timeofday, zlevel)
 		sleep(-1)
 
+	crewmonitor.generateMiniMaps()
+
 	world << "<span class='boldannounce'>Initializations complete</span>"
 
 	world.sleep_offline = 1

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -68,7 +68,6 @@ var/datum/subsystem/ticker/ticker
 			timeLeft = config.lobby_countdown * 10
 			world << "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>"
 			world << "Please, setup your character and select ready. Game will start in [config.lobby_countdown] seconds"
-			crewmonitor.generateMiniMaps() // start generating minimaps (this is a background process)
 			current_state = GAME_STATE_PREGAME
 
 		if(GAME_STATE_PREGAME)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -253,15 +253,12 @@ var/global/datum/crewmonitor/crewmonitor = new
 	procqueue.schedule(50, crewmonitor, "update", z)
 
 /datum/crewmonitor/proc/generateMiniMaps()
-	spawn
-		for (var/z = 1 to world.maxz) src.generateMiniMap(z)
-
-		world << "<span class='boldannounce'>All minimaps have been generated."
-
-		for (var/client/C in clients)
-			src.sendResources(C)
-
-		src.initialized = TRUE
+	for(var/z = 1 to world.maxz)
+		generateMiniMap(z)
+	world << "<span class='boldannounce'>All minimaps have been generated."
+	for(var/client/C in clients)
+		sendResources(C)
+	initialized = TRUE
 
 /datum/crewmonitor/proc/sendResources(client/C)
 	C << browse_rsc('crew.js', "crewmonitor.js")


### PR DESCRIPTION
Moves the minimap generation to the initialization list, instead of being calculated after it.

Removes the spawn from it too.

so basically that 'all minimaps have been generated' comes BEFORE the 'all initializations completed'
