### PR TITLE
Fixes orbit breaking on shuttle move.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1357,8 +1357,11 @@ B --><-- A
 	var/angle = 0
 	var/matrix/initial_transform = matrix(transform)
 
-	while(orbiting && orbiting.loc && orbitid == myid && (lockinorbit || loc == lastloc))
-		loc = get_turf(orbiting.loc)
+	while(orbiting && orbiting.loc && orbitid == myid)
+		var/targetloc = get_turf(orbiting)
+		if (!lockinorbit && loc != lastloc && loc != targetloc)
+			break
+		loc = targetloc
 		lastloc = loc
 		angle += angle_increment
 
@@ -1368,9 +1371,9 @@ B --><-- A
 			shift.Turn(angle)
 		else
 			shift.Turn(-angle)
-		animate(src,transform = shift,2)
+		animate(src, transform = shift, 2)
 		sleep(0.6) //the effect breaks above 0.6 delay
-	animate(src,transform = initial_transform,2)
+	animate(src, transform = initial_transform, 2)
 
 
 /atom/movable/proc/stop_orbit()


### PR DESCRIPTION
Fixes #12160
I moved this check out of the while because I didn't want to have to trigger two separate calls to get_turf.
Also fixes an edge case where orbiting a turf could cause runtimes.
