### PR TITLE
Tweaks mc's default dynamic wait buffer down a bit.

### DIFF
--- a/code/controllers/subsystems.dm
+++ b/code/controllers/subsystems.dm
@@ -15,7 +15,7 @@
 	var/dwait_upper = 20	//longest wait can be under dynamic_wait
 	var/dwait_lower = 5		//shortest wait can be under dynamic_wait
 	var/dwait_delta = 7		//How much should processing time effect dwait. or basically: wait = cost*dwait_delta
-	var/dwait_buffer = 1.5	//This number is subtracted from the processing time before calculating its new wait
+	var/dwait_buffer = 0.7	//This number is subtracted from the processing time before calculating its new wait
 
 	//things you will probably want to leave alone
 	var/can_fire = 0		//prevent fire() calls


### PR DESCRIPTION
dynamic wait buffer is the amount subtracted off of the process cost before calculating the new dynamic wait.

1.5 was too much and dynamic wait wasn't kicking in until after atmos was causing lag, 0.7 seems much better after testing on sybil.
