### PR TITLE
Adds config option for allowing webclient.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -149,6 +149,9 @@
 	var/silent_ai = 0
 	var/silent_borg = 0
 
+	var/allowwebclient = 0
+	var/webclientmembersonly = 0
+
 	var/sandbox_autoclose = 0 // close the sandbox panel after spawning an item, potentially reducing griff
 
 	var/default_laws = 0 //Controls what laws the AI spawns with.
@@ -350,6 +353,10 @@
 						world.log = newlog
 				if("autoconvert_notes")
 					config.autoconvert_notes = 1
+				if("allow_webclient")
+					config.allowwebclient = 1
+				if("webclient_only_byond_members")
+					config.webclientmembersonly = 1
 				if("announce_admin_logout")
 					config.announce_admin_logout = 1
 				if("announce_admin_login")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -45,7 +45,7 @@
 
 /client/proc/is_content_unlocked()
 	if(!prefs.unlock_content)
-		src << "Become a BYOND member to access member-perks and features, as well as support the engine that makes this game possible. <a href='http://www.byond.com/membership'>Click Here to find out more</a>."
+		src << "Become a BYOND member to access member-perks and features, as well as support the engine that makes this game possible. Only 10 bucks for 3 months! <a href='http://www.byond.com/membership'>Click Here to find out more</a>."
 		return 0
 	return 1
 
@@ -92,7 +92,7 @@ var/next_external_rsc = 0
 
 	TopicData = null							//Prevent calls to client.Topic from connect
 
-	if(connection != "seeker")					//Invalid connection type.
+	if(connection != "seeker" && connection != "web")//Invalid connection type.
 		return null
 	if(byond_version < MIN_CLIENT_VERSION)		//Out of date client.
 		return null
@@ -121,6 +121,16 @@ var/next_external_rsc = 0
 	prefs.last_id = computer_id			//these are gonna be used for banning
 
 	. = ..()	//calls mob.Login()
+
+	if (connection == "web")
+		if (!config.allowwebclient)
+			src << "Web client is disabled"
+			del(src)
+			return 0
+		if (config.webclientmembersonly && !is_content_unlocked())
+			src << "Sorry, but the web client is restricted to byond members only."
+			del(src)
+			return 0
 
 	if( (world.address == address || !address) && !host )
 		host = key

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -127,7 +127,7 @@ var/next_external_rsc = 0
 			src << "Web client is disabled"
 			del(src)
 			return 0
-		if (config.webclientmembersonly && !is_content_unlocked())
+		if (config.webclientmembersonly && !IsByondMember()))
 			src << "Sorry, but the web client is restricted to byond members only."
 			del(src)
 			return 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -127,7 +127,7 @@ var/next_external_rsc = 0
 			src << "Web client is disabled"
 			del(src)
 			return 0
-		if (config.webclientmembersonly && !IsByondMember()))
+		if (config.webclientmembersonly && !IsByondMember())
 			src << "Sorry, but the web client is restricted to byond members only."
 			del(src)
 			return 0

--- a/config/config.txt
+++ b/config/config.txt
@@ -102,6 +102,14 @@ HOSTEDBY Yournamehere
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
 
+## Uncomment to allow web client connections
+#ALLOW_WEBCLIENT
+
+## Uncomment to restrict web client connections to byond members
+## This makes for a nice pay gate to cut down on ban evading, as the webclient's cid system isn't that great
+## byond membership starts at $10 for 3 months, so to use the webclient to evade, they would have sink 10 bucks in each evade.
+#WEBCLIENT_ONLY_BYOND_MEMBERS
+
 ## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 ## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)
 # USEWHITELIST


### PR DESCRIPTION
Also adds a config option to restrict webclient to byond members only.

The logic for restricting it to byond members only is that its easy to evade with the webclient, locking that behind a 10 dollar pay wall should curtail that mostly.

More advanced systems (like tracking cids by connection type, and cid bans by last 'seeker' connection, and requiring one recent seeker connection) could come later, but they would require special DB edits, so this will work while we flesh it out.
