### PR TITLE
Removes cult scaling

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -55,8 +55,8 @@
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
 	required_players = 20
-	required_enemies = 6
-	recommended_enemies = 6
+	required_enemies = 4
+	recommended_enemies = 4
 	enemy_minimum_age = 14
 
 
@@ -82,10 +82,6 @@
 	else
 		cult_objectives += "eldergod"
 		cult_objectives += "sacrifice"
-
-	if(num_players() >= 30)
-		recommended_enemies = 9	// 3+3+3 - d' magic number o' magic numbars mon
-		acolytes_needed = 15
 
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs


### PR DESCRIPTION
Cults once again spawn with just four members.

Their objective (summon nar-sie with 9 people) doesn't scale, so it doesn't make much sense that their starting numbers would scale start with 9 people.

I don't think this will in any way fix cult, but the classic 4 starting members should at least provide a semblance of a round/gameplay instead of starting as a giant mob with their objectives complete.
