### PR TITLE
Removes admin announce and admin log from follow.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1531,8 +1531,6 @@
 		if(!isobserver(usr))	C.admin_ghost()
 		var/mob/dead/observer/A = C.mob
 		A.ManualFollow(M)
-		log_admin("[key_name(usr)] followed [key_name(M)]")
-		message_admins("[key_name_admin(usr)] followed [key_name_admin(M)]")
 
 	else if(href_list["adminplayerobservecoodjump"])
 		if(!isobserver(usr) && !check_rights(R_ADMIN))	return


### PR DESCRIPTION
This was only kept because it was the only easy way to claim an admin help.

Because starting to type a response to an admin help announces, this is no longer necessary
