### PR TITLE
Removes Classified Report from Blob gamemode

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -18,7 +18,6 @@ var/list/blob_nodes = list()
 	round_ends_with_antag_death = 1
 	restricted_jobs = list("Cyborg", "AI")
 
-	var/declared = 0
 	var/burst = 0
 
 	var/cores_to_spawn = 1
@@ -191,7 +190,6 @@ var/list/blob_nodes = list()
 	switch(stage)
 		if (0)
 			//send_intercept(1)  Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
-			declared = 1
 
 		if (1)
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -189,8 +189,9 @@ var/list/blob_nodes = list()
 /datum/game_mode/blob/proc/stage(stage)
 
 	switch(stage)
-		if (0)
-			send_intercept(1)
+/*		if (0)
+			send_intercept(1) //Temporarily unused - see stage 0 comment
+*/
 		if (1)
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -190,7 +190,7 @@ var/list/blob_nodes = list()
 
 	switch(stage)
 		if (0)
-			send_intercept(1)
+			//send_intercept(1)  Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
 			declared = 1
 
 		if (1)

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -170,10 +170,11 @@ var/list/blob_nodes = list()
 
 		burst_blobs()
 
-		// Stage 0
+/*
+		// Stage 0			Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
 		sleep(wait_time)
 		stage(0)
-
+*/
 		// Stage 1
 		sleep(wait_time)
 		stage(1)
@@ -189,8 +190,7 @@ var/list/blob_nodes = list()
 
 	switch(stage)
 		if (0)
-			//send_intercept(1)  Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
-			return
+			send_intercept(1)
 		if (1)
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -190,7 +190,7 @@ var/list/blob_nodes = list()
 	switch(stage)
 		if (0)
 			//send_intercept(1)  Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
-
+			return
 		if (1)
 			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -6,7 +6,7 @@
 		if(0)
 			..()
 			return
-		if(1)
+/*		if(1) // Report is temporarily unused. see comment on stage 0 in blob.dm
 			intercepttext += "<FONT size = 3><B>NanoTrasen Update</B>: Biohazard Alert.</FONT><HR>"
 			intercepttext += "Reports indicate the probable transfer of a biohazardous agent onto [station_name()] during the last crew deployment cycle.<BR>"
 			intercepttext += "Preliminary analysis of the organism classifies it as a level 5 biohazard. Its origin is unknown.<BR>"
@@ -17,7 +17,7 @@
 			intercepttext += " 3. If found, use any neccesary means to contain the organism.<BR>"
 			intercepttext += " 4. Avoid damage to the capital infrastructure of the station.<BR>"
 			intercepttext += "<BR>Note in the event of a quarantine breach or uncontrolled spread of the biohazard, the directive 7-10 may be upgraded to a directive 7-12.<BR>"
-			intercepttext += "Message ends."
+			intercepttext += "Message ends."*/
 		if(2)
 			var/nukecode = rand(10000, 99999)
 			for(var/obj/machinery/nuclearbomb/bomb in world)


### PR DESCRIPTION
Also removes a pointless unused var.

Keeping the actual report code in, so in the future if we add reports to other gamemodes, it can be re-added.
People immediately scream BLOB from the report. It's useless keeping it a secret if its the only roundtype the report is in.
