### PR TITLE
Praetorian Promotion Fix

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -85,7 +85,7 @@
 /obj/effect/proc_holder/alien/royal/queen/promote
 	name = "Create Royal Parasite"
 	desc = "Produce a royal parasite to grant one of your children the honor of being your Praetorian."
-	plasma_cost = 450 //Plasma cost used on promotion, not spawning the parasite.
+	plasma_cost = 500 //Plasma cost used on promotion, not spawning the parasite.
 
 	action_icon_state = "alien_queen_promote"
 
@@ -118,7 +118,7 @@
 	flags = ABSTRACT|NODROP
 	icon = 'icons/mob/alien.dmi'
 
-/obj/item/queenpromote/attack(mob/living/M, mob/living/user)
+/obj/item/queenpromote/attack(mob/living/M, mob/living/carbon/alien/humanoid/user)
 	if(!isalienadult(M) || istype(M, /mob/living/carbon/alien/humanoid/royal))
 		user << "<span class='noticealien'>You may only use this with your adult, non-royal children!</span>"
 		return
@@ -128,8 +128,8 @@
 
 	var/mob/living/carbon/alien/humanoid/A = M
 	if(A.stat == CONSCIOUS && A.mind && A.key)
-		if(!A.usePlasma(450))
-			user << "<span class='noticealien'>You must have 450 plasma stored to use this!</span>"
+		if(!user.usePlasma(500))
+			user << "<span class='noticealien'>You must have 500 plasma stored to use this!</span>"
 			return
 
 		A << "<span class='noticealien'>The queen has granted you a promotion to Praetorian!</span>"


### PR DESCRIPTION
Fixes #12205.
- Was trying to use up the target's plasma instead of the user's.
- Raises the cost back to 500, as was intended by WJ.
