### PR TITLE
Bug fix boogaloo, etc...

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -14,6 +14,14 @@
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
+	if(butcher_results && stat == DEAD) //can we butcher it?
+		var/sharpness = I.is_sharp()
+		if(sharpness)
+			user << "<span class='notice'>You begin to butcher [src]...</span>"
+			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
+			if(do_mob(user, src, 80/sharpness))
+				harvest(user)
+			return
 	I.attack(src, user)
 
 /mob/living/proc/attacked_by(obj/item/I, mob/living/user, def_zone)
@@ -38,16 +46,6 @@
 	if(message_verb)
 		visible_message("<span class='danger'>[attack_message]</span>",
 		"<span class='userdanger'>[attack_message]</span>")
-
-	if((butcher_results) && (stat == DEAD))
-		var/sharpness = I.is_sharp()
-		if(sharpness)
-			user.changeNext_move(CLICK_CD_MELEE)
-			user << "<span class='notice'>You begin to butcher [src]...</span>"
-			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
-			if(do_mob(user, src, 80/sharpness))
-				harvest(user)
-			return
 
 /mob/living/simple_animal/attacked_by(var/obj/item/I, var/mob/living/user)
 	if(!I.force)

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -32,6 +32,8 @@
 			target.ExtinguishMob()
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
+			if(target.pulledby)
+				target.pulledby.stop_pulling()
 			jaunt_disappear(animation, target)
 			target.loc = holder
 			target.notransform=0 //mob is safely inside holder now, no need for protection.

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -26,11 +26,6 @@
 /obj/effect/decal/cleanable/greenglow
 	name = "green glow"
 
-/obj/effect/decal/cleanable/greenglow/New()
-	..()
-	spawn(1200)// 2 minutes
-		qdel(src)
-
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return
 

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -35,7 +35,8 @@
 //If the delay is short, just blow up already jeez
 	if(delay <= 7)
 		explosion(src,heavy,medium,weak,weak, flame_range = weak)
-		imp_in.gib()
+		if(imp_in)
+			imp_in.gib()
 		qdel(src)
 		return
 	timed_explosion()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -35,16 +35,14 @@
 
 /obj/item/weapon/melee/baton/proc/deductcharge(chrgdeductamt)
 	if(bcell)
-		if(bcell.charge < (hitcost+chrgdeductamt)) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
-			status = 0
-			update_icon()
-			playsound(loc, "sparks", 75, 1, -1)
-		if(bcell.use(chrgdeductamt))
-			return 1
-		else
-			return 0
-
-
+		. = bcell.use(chrgdeductamt)
+		if(bcell.charge >= hitcost) // If after the deduction the baton doesn't have enough charge for a stun hit it turns off.
+			return
+	if(status)
+		status = 0
+		update_icon()
+		playsound(loc, "sparks", 75, 1, -1)
+	return 0
 
 
 /obj/item/weapon/melee/baton/update_icon()
@@ -59,7 +57,7 @@
 	..()
 	if(bcell)
 		user <<"<span class='notice'>The baton is [round(bcell.percent())]% charged.</span>"
-	if(!bcell)
+	else
 		user <<"<span class='warning'>The baton does not have a power source installed.</span>"
 
 /obj/item/weapon/melee/baton/attackby(obj/item/weapon/W, mob/user, params)
@@ -122,20 +120,26 @@
 
 	if(user.a_intent != "harm")
 		if(status)
-			user.do_attack_animation(L)
-			baton_stun(L, user)
-		else
-			L.visible_message("<span class='warning'>[user] has prodded [L] with [src]. Luckily it was off.</span>", \
-							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
-			return
+			if(baton_stun(L, user))
+				user.do_attack_animation(L)
+				return
+		L.visible_message("<span class='warning'>[user] has prodded [L] with [src]. Luckily it was off.</span>", \
+						"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
 	else
 		if(status)
 			baton_stun(L, user)
 		..()
 
 
-
 /obj/item/weapon/melee/baton/proc/baton_stun(mob/living/L, mob/user)
+	if(isrobot(loc))
+		var/mob/living/silicon/robot/R = loc
+		if(!R || !R.cell || !R.cell.use(hitcost))
+			return 0
+	else
+		if(!deductcharge(hitcost))
+			return 0
+
 	user.lastattacked = L
 	L.lastattacker = user
 
@@ -147,22 +151,15 @@
 							"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
-	if(isrobot(loc))
-		var/mob/living/silicon/robot/R = loc
-		if(R && R.cell)
-			R.cell.use(hitcost)
-	else
-		deductcharge(hitcost)
-
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.forcesay(hit_appends)
 
 	add_logs(user, L, "stunned")
+	return 1
 
 /obj/item/weapon/melee/baton/emp_act(severity)
-	if(bcell)
-		deductcharge(1000 / severity)
+	if(deductcharge(1000 / severity))
 		if(bcell.reliability != 100 && prob(50/severity))
 			bcell.reliability -= 10 / severity
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -581,6 +581,8 @@ Sorry Giacom. Please don't be mad :(
 		M.UpdateFeed(src)
 
 /mob/living/proc/makeTrail(turf/T, mob/living/M)
+	if(!has_gravity(M))
+		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if((NOBLOOD in H.dna.species.specflags) || (!H.blood_max) || (H.bleedsuppress))

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -232,7 +232,7 @@
 	..()
 	if(istype(target, /mob/living))
 		src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]\
-		[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
+		[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)

--- a/code/modules/mob/living/simple_animal/morph/morph.dm
+++ b/code/modules/mob/living/simple_animal/morph/morph.dm
@@ -30,6 +30,7 @@
 	wander = 0
 	attacktext = "glomps"
 	attack_sound = 'sound/effects/blobattack.ogg'
+	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab = 2)
 
 	var/morphed = 0
 	var/atom/movable/form = null
@@ -120,27 +121,13 @@
 	speed = initial(speed)
 
 	morph_time = world.time + MORPH_COOLDOWN
-	return
 
-/mob/living/simple_animal/hostile/morph/death()
+/mob/living/simple_animal/hostile/morph/death(gibbed)
 	if(morphed)
 		visible_message("<span class='warning'>[src] twists and dissolves into a pile of green flesh!</span>", \
 						"<span class='userdanger'>Your skin ruptures! Your flesh breaks apart! No disguise can ward off de--</span>")
 		restore()
-
-	//Dump eaten stuff
-	for(var/obj/O in src)
-		O.loc = loc
-		var/eject_dir = pick(alldirs)
-		if(step(O, eject_dir))
-			if(prob(50))
-				step(O, eject_dir)
-
-	for(var/mob/M in src)
-		M.loc = loc
-
-	..(0)
-	return
+	..(gibbed)
 
 /mob/living/simple_animal/hostile/morph/Aggro() // automated only
 	..()
@@ -178,12 +165,27 @@
 		if(!I.anchored)
 			if(do_after(src,20, target = I))
 				visible_message("<span class='warning'>[src] swallows [target] whole!</span>")
-				if(contents.len<50)
-					I.loc = src
-				else
-					qdel(I)
+				I.loc = src
 			return
 	target.attack_animal(src)
+
+/mob/living/simple_animal/hostile/morph/harvest(mob/living/user)
+	if(qdeleted(src))
+		return
+	if(contents.len)
+		var/amount = min(contents.len, 10)
+		for(var/atom/movable/AM in src)
+			if(amount)
+				amount--
+				AM.loc = loc
+				if(prob(90))
+					spawn(3)
+						step(AM, pick(alldirs))
+			else
+				break
+		visible_message("<span class='notice'>[user] [contents.len?"extracts some of":"empties"] the content of [src].</span>")
+	else
+		..()
 
 /mob/living/simple_animal/hostile/morph/update_action_buttons() //So all eaten objects are not counted every life
 	return

--- a/code/modules/mob/living/simple_animal/morph/morph.dm
+++ b/code/modules/mob/living/simple_animal/morph/morph.dm
@@ -131,6 +131,10 @@
 	//Dump eaten stuff
 	for(var/obj/O in src)
 		O.loc = loc
+		var/eject_dir = pick(alldirs)
+		if(step(O, eject_dir))
+			if(prob(50))
+				step(O, eject_dir)
 
 	for(var/mob/M in src)
 		M.loc = loc
@@ -169,12 +173,15 @@
 				L.loc = src
 				adjustBruteLoss(-50)
 			return
-	if(istype(target,/obj/item)) // Eat items just to be annoying
+	else if(istype(target,/obj/item)) // Eat items just to be annoying
 		var/obj/item/I = target
 		if(!I.anchored)
 			if(do_after(src,20, target = I))
 				visible_message("<span class='warning'>[src] swallows [target] whole!</span>")
-				I.loc = src
+				if(contents.len<50)
+					I.loc = src
+				else
+					qdel(I)
 			return
 	target.attack_animal(src)
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -38,6 +38,9 @@
 
 
 /obj/item/weapon/hand_labeler/attack_self(mob/user)
+	if(!user.IsAdvancedToolUser())
+		user << "<span class='warning'>You don't have the dexterity to use [src]!</span>"
+		return
 	mode = !mode
 	icon_state = "labeler[mode]"
 	if(mode)

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -454,7 +454,9 @@
 
 /datum/reagent/carbon/reaction_turf(turf/T, reac_volume)
 	if(!istype(T, /turf/space))
-		new /obj/effect/decal/cleanable/dirt(T)
+		var/obj/effect/decal/cleanable/dirt/D = locate() in T.contents
+		if(!D)
+			new /obj/effect/decal/cleanable/dirt(T)
 
 /datum/reagent/chlorine
 	name = "Chlorine"
@@ -530,8 +532,10 @@
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!istype(T, /turf/space))
-			var/obj/effect/decal/cleanable/reagentdecal = new/obj/effect/decal/cleanable/greenglow(T)
-			reagentdecal.reagents.add_reagent("radium", reac_volume)
+			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
+			if(!GG)
+				GG = new/obj/effect/decal/cleanable/greenglow(T)
+			GG.reagents.add_reagent("radium", reac_volume)
 
 /datum/reagent/sterilizine
 	name = "Sterilizine"
@@ -574,8 +578,10 @@
 /datum/reagent/uranium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
 		if(!istype(T, /turf/space))
-			var/obj/effect/decal/cleanable/reagentdecal = new/obj/effect/decal/cleanable/greenglow(T)
-			reagentdecal.reagents.add_reagent("uranium", reac_volume)
+			var/obj/effect/decal/cleanable/greenglow/GG = locate() in T.contents
+			if(!GG)
+				GG = new/obj/effect/decal/cleanable/greenglow(T)
+			GG.reagents.add_reagent("uranium", reac_volume)
 
 /datum/reagent/aluminium
 	name = "Aluminium"

--- a/html/changelogs/phil235-BugFixBoogalooB.yml
+++ b/html/changelogs/phil235-BugFixBoogalooB.yml
@@ -1,0 +1,8 @@
+ 
+author: phil235
+
+delete-after: True
+
+changes: 
+  - rscdel: "Morphs no longer automatically drop the things they swallowed, you have to butcher their corpse to retrieve their contents."
+  - bugfix: "butchering a corpse no longer also attacks it."


### PR DESCRIPTION
- Fixes not being able to move during jaunting if you are cuffed and pulled. Fixes #12138 
- Greenglow decal no longer disappears after 2 minutes.
- Fixes runtime with explosive implant activation.
- Fixes stunbaton infinite cell charge, the baton now turns off if you try using it after its cell has been deleted somehow. Fixes #12211.
- Fixes bloody pulled mob leaving a blood trail in zero G. Fixes #12214 
- Shortens the guardian battlecry message when attacking to lower chat spam. Fixes #12243
  <s>\* Items in Morph now disperses a bit on death instead of being all on the same tile.
- <b>After reaching a limit of 50 items, morph swallowing items deletes them instead of putting them inside the morph.</b></s>
- Monkeys can no longer modify the hand labeller's text to communicate. Fixes #12141 
- Fixes carbon,radium,uranium 's reaction_turf creating multiple decal on a tile, it now checks if there's already a decal of the relevant type and (for radium and uranium) only transfers reagent to it if it finds one.
- Fixes butchering, it no longer does both an attack and butchering at the same time.
- Morph no longer automatically drop its content on death, you have to butcher it to retrieve the content, 10 items at a time.
- And those items are spread in a one tile radius to avoid having too many things on one tile).  Fixes #12180
- The morph also drops generic meat (and gibs) during final butchering (it's only because it needed to drop something to be able to be butchered, feel free to change the meat to something else)
