### PR TITLE
Trashbag can pick up ammo casings and reagent_containers/food/drinks again.

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -135,7 +135,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return
 
 /obj/item/clothing/mask/cigarette/afterattack(obj/item/weapon/reagent_containers/glass/glass, mob/user, proximity)
-	if(!proximity) return
+	if(!proximity || lit) //can't dip if cigarette is lit (it will heat the reagents in the glass instead)
+		return
 	if(istype(glass))	//you can dip cigarettes into beakers
 		var/transfered = glass.reagents.trans_to(src, chem_volume)
 		if(transfered)	//if reagents were transfered, show the message

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -86,14 +86,13 @@
 	return
 
 /obj/item/weapon/reagent_containers/food/drinks/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clothing/mask/cigarette)) //ciggies are weird
-		return
 	if(I.is_hot())
 		var/added_heat = (I.is_hot() / 100) //ishot returns a temperature
-		if(src.reagents)
-			src.reagents.chem_temp += added_heat
+		if(reagents)
+			reagents.chem_temp += added_heat
 			user << "<span class='notice'>You heat [src] with [I].</span>"
-			src.reagents.handle_reactions()
+			reagents.handle_reactions()
+	..()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Drinks. END

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -34,24 +34,26 @@
 		BB = new projectile_type(src)
 	return
 
-/obj/item/ammo_casing/attackby(obj/item/ammo_box/box, mob/user, params)
-	if (!istype(box, /obj/item/ammo_box))
-		return
-	if(isturf(src.loc))
-		var/boolets = 0
-		for(var/obj/item/ammo_casing/bullet in src.loc)
-			if (box.stored_ammo.len >= box.max_ammo)
-				break
-			if (bullet.BB)
-				if (box.give_round(bullet, 0))
-					boolets++
+/obj/item/ammo_casing/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/ammo_box))
+		var/obj/item/ammo_box/box = I
+		if(isturf(loc))
+			var/boolets = 0
+			for(var/obj/item/ammo_casing/bullet in loc)
+				if (box.stored_ammo.len >= box.max_ammo)
+					break
+				if (bullet.BB)
+					if (box.give_round(bullet, 0))
+						boolets++
+				else
+					continue
+			if (boolets > 0)
+				box.update_icon()
+				user << "<span class='notice'>You collect [boolets] shell\s. [box] now contains [box.stored_ammo.len] shell\s.</span>"
 			else
-				continue
-		if (boolets > 0)
-			box.update_icon()
-			user << "<span class='notice'>You collect [boolets] shell\s. [box] now contains [box.stored_ammo.len] shell\s.</span>"
-		else
-			user << "<span class='warning'>You fail to collect anything!</span>"
+				user << "<span class='warning'>You fail to collect anything!</span>"
+	else
+		..()
 
 //Boxes of ammo
 /obj/item/ammo_box

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -120,8 +120,6 @@
 			reagents.clear_reagents()
 
 /obj/item/weapon/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/clothing/mask/cigarette)) //ciggies are weird
-		return
 	var/hotness = I.is_hot()
 	if(hotness)
 		var/added_heat = (hotness / 100) //ishot returns a temperature

--- a/html/changelogs/phil235-BugFixBoogalooC.yml
+++ b/html/changelogs/phil235-BugFixBoogalooC.yml
@@ -1,0 +1,8 @@
+
+author: phil235
+
+delete-after: True
+
+changes: 
+  - rscdel: "Dipping cigarette (to asbsorb liquids) in a glass can now only be done with an unlit cigarette. Lit cigarette now heats up the glass content (like other heat sources)."
+  - bugfix: "Fixes trashbag not being able to pickup drinks and ammo casings."


### PR DESCRIPTION
Fixes #12110 
- Dipping a lit cigarette into a reagent container heats up the liquid (like every other heat sources) and only unlit cigarette can be dipped to absorb the liquids now.
