### PR TITLE
Revert "Removes alien driveby" (Again!)

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -104,8 +104,8 @@ var/const/MAX_ACTIVE_TIME = 400
 		Attach(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/Attach(mob/living/M)
-	if(!isliving(M))
-		return 0
+	if(!isliving(M)) return 0
+
 	if((!iscorgi(M) && !iscarbon(M)) || isalien(M))
 		return 0
 	if(attached)
@@ -114,17 +114,17 @@ var/const/MAX_ACTIVE_TIME = 400
 		attached++
 		spawn(MAX_IMPREGNATION_TIME)
 			attached = 0
-	if(M.getorgan(/obj/item/organ/internal/alien/hivenode))
-		return 0
-	if(M.getorgan(/obj/item/organ/internal/body_egg/alien_embryo))
-		return 0
-	if(loc == M)
-		return 0
-	if(stat != CONSCIOUS)
-		return 0
+
+	if(M.getorgan(/obj/item/organ/internal/alien/hivenode)) return 0
+	if(M.getorgan(/obj/item/organ/internal/body_egg/alien_embryo)) return 0
+
+	if(loc == M) return 0
+	if(stat != CONSCIOUS)	return 0
 	if(!sterile) M.take_organ_damage(strength,0) //done here so that even borgs and humans in helmets take damage
+
 	M.visible_message("<span class='danger'>[src] leaps at [M]'s face!</span>", \
 						"<span class='userdanger'>[src] leaps at [M]'s face!</span>")
+
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.is_mouth_covered(head_only = 1))
@@ -132,14 +132,13 @@ var/const/MAX_ACTIVE_TIME = 400
 								"<span class='userdanger'>[src] smashes against [H]'s [H.head]!</span>")
 			Die()
 			return 0
+
 	if(iscarbon(M))
 		var/mob/living/carbon/target = M
 		if(target.wear_mask)
-			if(prob(20))
-				return 0
+			if(prob(20))	return 0
 			var/obj/item/clothing/W = target.wear_mask
-			if(W.flags & NODROP)
-				return 0
+			if(W.flags & NODROP)	return 0
 			target.unEquip(W)
 
 			target.visible_message("<span class='danger'>[src] tears [W] off of [target]'s face!</span>", \
@@ -147,8 +146,8 @@ var/const/MAX_ACTIVE_TIME = 400
 
 		src.loc = target
 		target.equip_to_slot(src, slot_wear_mask,,0)
-		if(!sterile)
-			M.Weaken(1)
+
+		if(!sterile) M.Paralyse(MAX_IMPREGNATION_TIME/6) //something like 25 ticks = 20 seconds with the default settings
 	else if (iscorgi(M))
 		var/mob/living/simple_animal/pet/dog/corgi/C = M
 		loc = C


### PR DESCRIPTION
Reverts tgstation/-tg-station #12163

> "Yeah this is just awful, please revert before it's too late."
> 
> "have you ever uh considered
> how retarded this is"
> 
> "plz revert fam this nerf is smh"
> 
> "'Im just going to sidestep the whole "how bad a change is this" discussion"
> 
> "Change is pretty stupid"
> 
> "Why are you "testing this" by merging, when we had that whole thing that lets us test pr's WITHOUT MERGING?"
> 
> "Why leave the stun in at all when you are this salty"
> 
> "What the actual fucking flipping fuck I've never been this disgusted that something got merged before, not even removal of cigarette internals. Why would anyone think this was a good idea?
> Facehuggers take two minutes to implant. They're consumed the moment they land on someone's face, and if they're removed during those two minutes, the implantation is canceled. This means xenos need to flawlessly keep every infection victim down for the full two minutes to infect anyone, lest they get up for a split second and remove the facehugger.
> There're plenty of reasonable balance changes if you have a problem with facehuggers' being stun mines/throwing weapons in addition to xenos' way of reproducing, but this way of fixing it is just confusing (especially since there ISN'T A CHANGELOG ENTRY) and makes facehugging mechanically clumsy."
> 
> "Yay lets neuter our round ending antags that are not all that common anyways, despite no one thinking it was a good idea besides Aran and completely sidestepping our ability to test things without merging them. Quality."
> 
> " so there's a threat that I can't just walk up to with a fireaxe and beat to death?"
> 
> "this severely crippled early game hive play."
> 
> ":-1: xenos are supposed to be round enders. This is stupid."
> 
> "enjoy never getting victims as a queen unless you can find monkeys, or people line up for your spit."
> 
> "this turns alium into a test of who has a better ping: the alium clicking to stun someone or the target clicking to remove facehugger after getting up"
> 
> "Do not make dramatic balance changes like this."<-MSO
> 
> "But yea, this is just dumb. I feel no reason to repeat the reasons already given in this thread."
> 
> "by nerfing xeno's ability to implant people, you are going to have a lot more salty ghosts as there's going to be more corpses and less new xenos meaning more people in deadchat not getting back in the round."
> 
> "It's pretty obvious that aran asked raz to merge this"
> 
> "WHY. NO ONE WANTED THIS."
> "You still need to drag them down the instant they're facehugged and keep them down uninterrupted, at which point you may kill them because screw keeping these guys alive anymore, you'll have far too little time to do even that because of this change."
> 
> "t it would be nice if we could void the one week revert rule for this case due to it being merged without the majority consent of coderbus and the playerbase."
> 
> "Inb4 aran closes any reverts with "this is stupid""

_"It it would be nice if we could void the one week revert rule for this case due to it being merged without the majority consent of coderbus and the playerbase."_
