### PR TITLE
some simple Bugfixes

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -57,6 +57,9 @@
 	..()
 	SSair.hotspots += src
 	perform_exposure()
+	dir = pick(cardinal)
+	air_update_turf()
+
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/simulated/location = loc
@@ -165,12 +168,6 @@
 			else
 				T.to_be_destroyed = 0
 				T.max_fire_temperature_sustained = 0
-
-/obj/effect/hotspot/New()
-	..()
-	dir = pick(cardinal)
-	air_update_turf()
-	return
 
 /obj/effect/hotspot/Crossed(mob/living/L)
 	..()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1397,7 +1397,6 @@ B --><-- A
 	if(!x_dimension || !y_dimension)
 		return
 
-	//Get out of here, punk ass kids calling procs needlessly
 	if((x_dimension == world.icon_size) && (y_dimension == world.icon_size))
 		return I
 

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -46,8 +46,7 @@
 					src.attack_hand(usr)
 		else
 			user << "<span class='danger'>Access denied.</span>"
-			return
-	return
+
 
 /obj/machinery/ai_slipper/attack_ai(mob/user)
 	return attack_hand(user)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -926,9 +926,9 @@ FIRE ALARM
 	..()
 
 /obj/machinery/firealarm/attackby(obj/item/W, mob/user, params)
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 
-	if (istype(W, /obj/item/weapon/screwdriver) && buildstage == 2)
+	if(istype(W, /obj/item/weapon/screwdriver) && buildstage == 2)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		panel_open = !panel_open
 		user << "<span class='notice'>The wires have been [panel_open ? "exposed" : "unexposed"].</span>"
@@ -938,12 +938,13 @@ FIRE ALARM
 	if(panel_open)
 		switch(buildstage)
 			if(2)
-				if (istype(W, /obj/item/device/multitool))
+				if(istype(W, /obj/item/device/multitool))
 					src.detecting = !( src.detecting )
 					if (src.detecting)
 						user.visible_message("[user] has reconnected [src]'s detecting unit!", "<span class='notice'>You reconnect [src]'s detecting unit.</span>")
 					else
 						user.visible_message("[user] has disconnected [src]'s detecting unit!", "<span class='notice'>You disconnect [src]'s detecting unit.</span>")
+					return
 
 				else if (istype(W, /obj/item/weapon/wirecutters))
 					buildstage = 1
@@ -953,18 +954,18 @@ FIRE ALARM
 					coil.loc = user.loc
 					user << "<span class='notice'>You cut the wires from \the [src].</span>"
 					update_icon()
+					return
 			if(1)
 				if(istype(W, /obj/item/stack/cable_coil))
 					var/obj/item/stack/cable_coil/coil = W
 					if(coil.get_amount() < 5)
 						user << "<span class='warning'>You need more cable for this!</span>"
-						return
-
-					coil.use(5)
-
-					buildstage = 2
-					user << "<span class='notice'>You wire \the [src].</span>"
-					update_icon()
+					else
+						coil.use(5)
+						buildstage = 2
+						user << "<span class='notice'>You wire \the [src].</span>"
+						update_icon()
+					return
 
 				else if(istype(W, /obj/item/weapon/crowbar))
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
@@ -979,12 +980,14 @@ FIRE ALARM
 								new /obj/item/weapon/electronics/firealarm(user.loc)
 							buildstage = 0
 							update_icon()
+					return
 			if(0)
 				if(istype(W, /obj/item/weapon/electronics/firealarm))
 					user << "<span class='notice'>You insert the circuit.</span>"
 					qdel(W)
 					buildstage = 1
 					update_icon()
+					return
 
 				else if(istype(W, /obj/item/weapon/wrench))
 					user.visible_message("[user] removes the fire alarm assembly from the wall.", \
@@ -993,9 +996,8 @@ FIRE ALARM
 					frame.loc = user.loc
 					playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 					qdel(src)
-		return
-
-	return
+					return
+	return ..()
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -90,6 +90,9 @@ var/list/announcement_systems = list()
 			user << "<span class='notice'>You reset [src]'s firmware.</span>"
 			broken = 0
 			update_icon()
+			return
+
+	return ..()
 
 /obj/machinery/announcement_system/attack_hand(mob/user)
 	if(can_be_used_by(user))

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -239,10 +239,9 @@ update_flag
 
 /obj/machinery/portable_atmospherics/canister/attackby(obj/item/weapon/W, mob/user, params)
 	if(!istype(W, /obj/item/weapon/wrench) && !istype(W, /obj/item/weapon/tank) && !istype(W, /obj/item/device/analyzer) && !istype(W, /obj/item/device/pda))
-		visible_message("<span class='danger'>[user] hits \the [src] with a [W]!</span>")
 		investigate_log("was smacked with \a [W] by [key_name(user)]", "atmos")
-		src.health -= W.force
-		src.add_fingerprint(user)
+		health -= W.force
+		add_fingerprint(user)
 		healthcheck()
 
 	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/weapon/tank/jetpack))

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -102,8 +102,8 @@
 				"<span class='italics'>You hear ratchet.</span>")
 			new /obj/item/pipe_meter(src.loc)
 			qdel(src)
-		return
-	..()
+	else
+		..()
 
 /obj/machinery/meter/attack_ai(mob/user)
 	return src.attack_hand(user)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -100,4 +100,5 @@
 	else if ((istype(W, /obj/item/device/analyzer)) && get_dist(user, src) <= 1)
 		atmosanalyzer_scan(air_contents, user)
 
-	return
+	else
+		..()

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -74,60 +74,6 @@
 		SSshuttle.emergency.setTimer(100)
 		emagged = 1
 
-/obj/structure/plasticflaps	//HOW DO YOU CALL THOSE THINGS ANYWAY
-	name = "plastic flaps"
-	desc = "Definitely can't get past those. No way."
-	icon = 'icons/obj/stationobjs.dmi'	//Change this.
-	icon_state = "plasticflaps"
-	density = 0
-	anchored = 1
-	layer = 4
-
-/obj/structure/plasticflaps/CanPass(atom/movable/A, turf/T)
-	if(istype(A) && A.checkpass(PASSGLASS))
-		return prob(60)
-
-	var/obj/structure/stool/bed/B = A
-	if (istype(A, /obj/structure/stool/bed) && (B.buckled_mob || B.density))//if it's a bed/chair and is dense or someone is buckled, it will not pass
-		return 0
-
-	else if(istype(A, /mob/living)) // You Shall Not Pass!
-		var/mob/living/M = A
-		if(M.buckled && istype(M.buckled, /obj/machinery/bot/mulebot)) // mulebot passenger gets a free pass.
-			return 1
-		if(!M.lying && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
-			return 0
-	return ..()
-
-/obj/structure/plasticflaps/ex_act(severity)
-	..()
-	switch(severity)
-		if (1)
-			qdel(src)
-		if (2)
-			if (prob(50))
-				qdel(src)
-		if (3)
-			if (prob(5))
-				qdel(src)
-
-/obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
-	name = "airtight plastic flaps"
-	desc = "Heavy duty, airtight, plastic flaps."
-
-/obj/structure/plasticflaps/mining/New() //set the turf below the flaps to block air
-	var/turf/T = get_turf(loc)
-	if(T)
-		T.blocks_air = 1
-	..()
-
-/obj/structure/plasticflaps/mining/Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor //wow this is terrible
-	var/turf/T = get_turf(loc)
-	if(T)
-		if(istype(T, /turf/simulated/floor))
-			T.blocks_air = 0
-	return ..()
-
 /obj/machinery/computer/supplycomp
 	name = "supply shuttle console"
 	desc = "Used to order supplies."

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -63,56 +63,56 @@ for reference:
 	var/health = 100
 	var/maxhealth = 100
 
+/obj/structure/barricade/wooden/attack_animal(mob/living/simple_animal/M)
+	M.changeNext_move(CLICK_CD_MELEE)
+	M.do_attack_animation(src)
+	if(M.melee_damage_upper == 0 || (M.melee_damage_type != BRUTE && M.melee_damage_type != BURN))
+		return
+	visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>")
+	add_logs(M, src, "attacked")
+	take_damage(M.melee_damage_upper)
+
+obj/structure/barricade/wooden/proc/take_damage(damage, leave_debris=1, message)
+	health -= damage
+	if(health <= 0)
+		if(message)
+			visible_message(message)
+		else
+			visible_message("<span class='warning'>The barricade is smashed apart!</span>")
+		if(leave_debris)
+			new /obj/item/stack/sheet/mineral/wood(get_turf(src), 3)
+		qdel(src)
+
 /obj/structure/barricade/wooden/attackby(obj/item/W, mob/user, params)
-	user.changeNext_move(CLICK_CD_MELEE)
 	if (istype(W, /obj/item/stack/sheet/mineral/wood))
-		if (src.health < src.maxhealth)
+		if (health < maxhealth)
 			visible_message("[user] begins to repair \the [src]!", "<span class='notice'>You begin to repair \the [src]...</span>")
 			if(do_after(user,20, target = src))
-				src.health = src.maxhealth
+				health = maxhealth
 				W:use(1)
 				visible_message("[user] repairs \the [src]!", "<span class='notice'>You repair \the [src].</span>")
-				return
-		else
-			return
-		return
 	else
+		..()
+		var/damage = 0
 		switch(W.damtype)
 			if("fire")
-				src.health -= W.force * 1
+				damage = W.force * 1
 			if("brute")
-				src.health -= W.force * 0.75
-			else
-		if (src.health <= 0)
-			visible_message("<span class='warning'>The barricade is smashed apart!</span>")
-			new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-			new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-			new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-			qdel(src)
-		..()
+				damage = W.force * 0.75
+		take_damage(damage)
+
 
 /obj/structure/barricade/wooden/ex_act(severity, target)
 	switch(severity)
 		if(1)
 			visible_message("<span class='warning'>The barricade is blown apart!</span>")
 			qdel(src)
-			return
 		if(2)
-			src.health -= 25
-			if (src.health <= 0)
-				visible_message("<span class='warning'>The barricade is blown apart!</span>")
-				new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-				new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-				new /obj/item/stack/sheet/mineral/wood(get_turf(src))
-				qdel(src)
-			return
+			take_damage(25, message = "<span class='warning'>The barricade is blown apart!</span>")
 
 /obj/structure/barricade/wooden/blob_act()
-	src.health -= 25
-	if (src.health <= 0)
-		visible_message("<span class='warning'>The blob eats through the barricade!</span>")
-		qdel(src)
-	return
+	take_damage(25, message = "<span class='warning'>The blob eats through the barricade!</span>")
+
 
 /obj/structure/barricade/wooden/CanPass(atom/movable/mover, turf/target, height=0)//So bullets will fly over and stuff.
 	if(height==0)
@@ -148,17 +148,22 @@ for reference:
 
 	src.icon_state = "barrier[src.locked]"
 
+/obj/machinery/deployable/barrier/proc/take_damage(damage)
+	health -= damage
+	if(health <= 0)
+		explode()
+
 /obj/machinery/deployable/barrier/attackby(obj/item/weapon/W, mob/user, params)
 	if (W.GetID())
 		if (src.allowed(user))
-			if	(src.emagged < 2)
-				src.locked = !src.locked
-				src.anchored = !src.anchored
-				src.icon_state = "barrier[src.locked]"
-				if ((src.locked == 1) && (src.emagged < 2))
+			if	(emagged < 2)
+				locked = !locked
+				anchored = !anchored
+				icon_state = "barrier[locked]"
+				if ((locked == 1) && (emagged < 2))
 					user << "Barrier lock toggled on."
 					return
-				else if ((src.locked == 0) && (src.emagged < 2))
+				else if ((locked == 0) && (emagged < 2))
 					user << "Barrier lock toggled off."
 					return
 			else
@@ -169,28 +174,27 @@ for reference:
 				return
 		return
 	else if (istype(W, /obj/item/weapon/wrench))
-		if (src.health < src.maxhealth)
-			src.health = src.maxhealth
-			src.emagged = 0
-			src.req_access = list(access_security)
+		if (health < maxhealth)
+			health = maxhealth
+			emagged = 0
+			req_access = list(access_security)
 			visible_message("<span class='danger'>[user] repairs \the [src]!</span>")
 			return
 		else if (src.emagged > 0)
-			src.emagged = 0
-			src.req_access = list(access_security)
+			emagged = 0
+			req_access = list(access_security)
 			visible_message("<span class='danger'>[user] repairs \the [src]!</span>")
 			return
 		return
 	else
+		..()
+		var/damage = 0
 		switch(W.damtype)
 			if("fire")
-				src.health -= W.force * 0.75
+				damage = W.force * 0.75
 			if("brute")
-				src.health -= W.force * 0.5
-			else
-		if (src.health <= 0)
-			src.explode()
-		..()
+				damage = W.force * 0.5
+		take_damage(damage)
 
 /obj/machinery/deployable/emag_act(mob/user)
 	if (src.emagged == 0)
@@ -214,13 +218,10 @@ for reference:
 /obj/machinery/deployable/barrier/ex_act(severity)
 	switch(severity)
 		if(1)
-			src.explode()
-			return
+			explode()
 		if(2)
-			src.health -= 25
-			if (src.health <= 0)
-				src.explode()
-			return
+			take_damage(25)
+
 
 /obj/machinery/deployable/barrier/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))
@@ -231,10 +232,7 @@ for reference:
 		icon_state = "barrier[src.locked]"
 
 /obj/machinery/deployable/barrier/blob_act()
-	src.health -= 25
-	if (src.health <= 0)
-		src.explode()
-	return
+	take_damage(25)
 
 /obj/machinery/deployable/barrier/CanPass(atom/movable/mover, turf/target, height=0)//So bullets will fly over and stuff.
 	if(height==0)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -111,7 +111,7 @@ obj/structure/barricade/wooden/proc/take_damage(damage, leave_debris=1, message)
 			take_damage(25, message = "<span class='warning'>The barricade is blown apart!</span>")
 
 /obj/structure/barricade/wooden/blob_act()
-	take_damage(25, message = "<span class='warning'>The blob eats through the barricade!</span>")
+	take_damage(25, leave_debris = 0, message = "<span class='warning'>The blob eats through the barricade!</span>")
 
 
 /obj/structure/barricade/wooden/CanPass(atom/movable/mover, turf/target, height=0)//So bullets will fly over and stuff.

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -31,6 +31,8 @@ var/list/doppler_arrays = list()
 			power_change()
 			user << "<span class='notice'>You unfasten [src].</span>"
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+	else
+		..()
 
 /obj/machinery/doppler_array/verb/rotate()
 	set name = "Rotate Tachyon-doppler Dish"

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -130,6 +130,10 @@ Class Procs:
 		dropContents()
 	return ..()
 
+/obj/machinery/attackby(obj/item/weapon/W, mob/user, params)
+	user.changeNext_move(CLICK_CD_MELEE)
+	..()
+
 /obj/machinery/proc/locate_machinery()
 	return
 
@@ -285,7 +289,7 @@ Class Procs:
 //set_machine must be 0 if clicking the machinery doesn't bring up a dialog
 /obj/machinery/attack_hand(mob/user, check_power = 1, set_machine = 1)
 	if(..())// unbuckling etc
-		return 1 
+		return 1
 	if(user.lying || user.stat)
 		return 1
 	if(!user.IsAdvancedToolUser())

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -34,35 +34,13 @@
 	return !density
 
 /obj/machinery/shield/attackby(obj/item/weapon/W, mob/user, params)
-	if(!istype(W)) return
-
-	//Calculate damage
-	var/aforce = W.force
-	if(W.damtype == BRUTE || W.damtype == BURN)
-		src.health -= aforce
-
-	//Play a fitting sound
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 75, 1)
-
-
-	if (src.health <= 0)
-		visible_message("<span class='notice'>[src] dissipates.</span>")
-		qdel(src)
-		return
-
-	opacity = 1
-	spawn(20) if(src) opacity = 0
 	..()
+	if(W.damtype == BRUTE || W.damtype == BURN)
+		take_damage(W.force)
 
 /obj/machinery/shield/bullet_act(obj/item/projectile/Proj)
-	health -= Proj.damage
 	..()
-	if(health <=0)
-		visible_message("<span class='notice'>The [src] dissipates.</span>")
-		qdel(src)
-		return
-	opacity = 1
-	spawn(20) if(src) opacity = 0
+	take_damage(Proj.damage)
 
 /obj/machinery/shield/ex_act(severity, target)
 	switch(severity)
@@ -90,33 +68,24 @@
 
 
 /obj/machinery/shield/hitby(AM as mob|obj)
-
-	//Super realistic, resource-intensive, real-time damage calculations.
 	var/tforce = 0
 	if(ismob(AM))
 		tforce = 40
 	else
-		tforce = AM:throwforce
+		var/obj/O = AM
+		tforce = O.throwforce
+	..()
+	take_damage(tforce)
 
-	src.health -= tforce
-
-	//This seemed to be the best sound for hitting a force field.
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 100, 1)
-
-	//Handle the destruction of the shield
-	if (src.health <= 0)
+/obj/machinery/shield/proc/take_damage(damage)
+	playsound(loc, 'sound/effects/EMPulse.ogg', 75, 1)
+	opacity = 1
+	spawn(20)
+		opacity = 0
+	health -= damage
+	if(health <= 0)
 		visible_message("<span class='notice'>[src] dissipates.</span>")
 		qdel(src)
-		return
-
-	//The shield becomes dense to absorb the blow.. purely asthetic.
-	opacity = 1
-	spawn(20) if(src) opacity = 0
-
-	..()
-	return
-
-
 
 /obj/machinery/shieldgen
 		name = "anti-breach shielding projector"
@@ -505,7 +474,6 @@
 /obj/machinery/shieldwallgen/bullet_act(obj/item/projectile/Proj)
 	storedpower -= Proj.damage
 	..()
-	return
 
 
 //////////////Containment Field START
@@ -520,7 +488,6 @@
 		luminosity = 3
 		var/needs_power = 0
 		var/active = 1
-//		var/power = 10
 		var/delay = 5
 		var/last_active
 		var/mob/U
@@ -547,7 +514,7 @@
 		if(!(gen_primary.active)||!(gen_secondary.active))
 			qdel(src)
 			return
-//
+
 		if(prob(50))
 			gen_primary.storedpower -= 10
 		else

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -73,7 +73,7 @@
 			user.unset_machine()
 	else
 		..()
-	return
+
 
 /obj/machinery/space_heater/attack_hand(mob/user)
 	src.add_fingerprint(user)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -1,0 +1,58 @@
+
+/obj/structure/plasticflaps	//HOW DO YOU CALL THOSE THINGS ANYWAY
+	name = "plastic flaps"
+	desc = "Definitely can't get past those. No way."
+	icon = 'icons/obj/stationobjs.dmi'	//Change this.
+	icon_state = "plasticflaps"
+	density = 0
+	anchored = 1
+	layer = 4
+
+/obj/structure/plasticflaps/CanPass(atom/movable/A, turf/T)
+	if(istype(A) && A.checkpass(PASSGLASS))
+		return prob(60)
+
+	var/obj/structure/stool/bed/B = A
+	if (istype(A, /obj/structure/stool/bed) && (B.buckled_mob || B.density))//if it's a bed/chair and is dense or someone is buckled, it will not pass
+		return 0
+
+	else if(istype(A, /mob/living)) // You Shall Not Pass!
+		var/mob/living/M = A
+		if(M.buckled && istype(M.buckled, /obj/machinery/bot/mulebot)) // mulebot passenger gets a free pass.
+			return 1
+		if(!M.lying && !M.ventcrawler && M.mob_size != MOB_SIZE_TINY)	//If your not laying down, or a ventcrawler or a small creature, no pass.
+			return 0
+	return ..()
+
+/obj/structure/plasticflaps/attackby(obj/item/weapon/W, mob/user, params)
+	user.changeNext_move(CLICK_CD_MELEE)
+	..()
+
+/obj/structure/plasticflaps/ex_act(severity)
+	..()
+	switch(severity)
+		if (1)
+			qdel(src)
+		if (2)
+			if (prob(50))
+				qdel(src)
+		if (3)
+			if (prob(5))
+				qdel(src)
+
+/obj/structure/plasticflaps/mining //A specific type for mining that doesn't allow airflow because of them damn crates
+	name = "airtight plastic flaps"
+	desc = "Heavy duty, airtight, plastic flaps."
+
+/obj/structure/plasticflaps/mining/New() //set the turf below the flaps to block air
+	var/turf/T = get_turf(loc)
+	if(T)
+		T.blocks_air = 1
+	..()
+
+/obj/structure/plasticflaps/mining/Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor //wow this is terrible
+	var/turf/T = get_turf(loc)
+	if(T)
+		if(istype(T, /turf/simulated/floor))
+			T.blocks_air = 0
+	return ..()

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -138,21 +138,6 @@
 		PlasmaBurn(500)
 	..()
 
-/*
-/turf/simulated/wall/mineral/proc/shock()
-	if (electrocute_mob(user, C, src))
-		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(5, 1, src)
-		s.start()
-		return 1
-	else
-		return 0
-
-/turf/simulated/wall/mineral/proc/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if((mineral == "gold") || (mineral == "silver"))
-		if(shocked)
-			shock()
-*/
 
 /turf/simulated/wall/mineral/wood
 	name = "wooden wall"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -52,17 +52,11 @@
 	if(usr.canmove && !usr.stat && !usr.restrained() && can_toggle)
 		if(world.time > cooldown + toggle_cooldown)
 			cooldown = world.time
+			up = !up
 			if(up)
-				up = !up
-				flags |= (visor_flags)
-				flags_inv |= (visor_flags_inv)
-				icon_state = initial(icon_state)
-				usr << "[toggle_message] \the [src]."
-				usr.update_inv_head()
-			else
-				up = !up
 				flags &= ~(visor_flags)
 				flags_inv &= ~(visor_flags_inv)
+				flags_cover &= 0
 				icon_state = "[initial(icon_state)]up"
 				usr << "[alt_toggle_message] \the [src]"
 				usr.update_inv_head()
@@ -70,6 +64,14 @@
 					while(up)
 						playsound(src.loc, "[active_sound]", 100, 0, 4)
 						sleep(15)
+			else
+				flags |= (visor_flags)
+				flags_inv |= (visor_flags_inv)
+				flags_cover = initial(flags_cover)
+				icon_state = initial(icon_state)
+				usr << "[toggle_message] \the [src]."
+				usr.update_inv_head()
+
 
 /obj/item/clothing/head/helmet/justice
 	name = "helmet of justice"

--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -56,46 +56,49 @@
 		else
 			possible_tools += I.type
 	possible_tools += table_contents
-	var/i = R.tools.len
-	var/I
-	for(var/A in R.tools)
-		I = possible_tools.Find(A)
-		if(I)
-			possible_tools.Cut(I, I+1)
-			i--
-		else
-			break
-	return !i
+	main_loop:
+		for(var/A in R.tools)
+			for(var/I in possible_tools)
+				if(ispath(I,A))
+					possible_tools -= I
+					continue main_loop
+			return 0
+	return 1
 
 /obj/structure/table/proc/construct_item(mob/user, datum/table_recipe/R)
 	check_table()
 	var/send_feedback = 1
-	if(check_contents(R) && check_tools(user, R))
-		if(do_after(user, R.time, target = src))
-			if(!check_contents(R) || !check_tools(user, R))
+	if(check_contents(R))
+		if(check_tools(user, R))
+			if(do_after(user, R.time, target = src))
+				if(!check_contents(R))
+					return ", missing component."
+				if(!check_tools(user, R))
+					return ", missing tool."
+				var/atom/movable/I = new R.result (loc)
+				if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
+					var/obj/item/weapon/reagent_containers/food/snacks/S = I
+					S.create_reagents(S.volume)
+					feedback_add_details("food_made","[S.type]")
+					send_feedback = 0
+				var/list/parts = del_reqs(R, I)
+				for(var/A in parts)
+					if(istype(A, /obj/item))
+						var/atom/movable/B = A
+						B.loc = I
+						B.pixel_x = initial(B.pixel_x)
+						B.pixel_y = initial(B.pixel_y)
+					else
+						if(!I.reagents)
+							I.reagents = new /datum/reagents()
+						I.reagents.reagent_list.Add(A)
+				I.CheckParts()
+				if(send_feedback)
+					feedback_add_details("object_crafted","[I.type]")
 				return 0
-			var/atom/movable/I = new R.result (loc)
-			if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
-				var/obj/item/weapon/reagent_containers/food/snacks/S = I
-				S.create_reagents(S.volume)
-				feedback_add_details("food_made","[S.type]")
-				send_feedback = 0
-			var/list/parts = del_reqs(R, I)
-			for(var/A in parts)
-				if(istype(A, /obj/item))
-					var/atom/movable/B = A
-					B.loc = I
-					B.pixel_x = initial(B.pixel_x)
-					B.pixel_y = initial(B.pixel_y)
-				else
-					if(!I.reagents)
-						I.reagents = new /datum/reagents()
-					I.reagents.reagent_list.Add(A)
-			I.CheckParts()
-			if(send_feedback)
-				feedback_add_details("object_crafted","[I.type]")
-			return 1
-	return 0
+			return "."
+		return ", missing tool."
+	return ", missing component."
 
 /obj/structure/table/proc/del_reqs(datum/table_recipe/R, atom/movable/resultobject)
 	var/list/Deletion = list()
@@ -224,10 +227,11 @@
 		var/datum/table_recipe/TR = locate(href_list["make"])
 		busy = 1
 		interact(usr)
-		if(construct_item(usr, TR))
+		var/fail_msg = construct_item(usr, TR)
+		if(!fail_msg)
 			usr << "<span class='notice'>[TR.name] constructed.</span>"
 		else
-			usr << "<span class ='warning'>Construction failed.</span>"
+			usr << "<span class ='warning'>Construction failed[fail_msg]</span>"
 		busy = 0
 		interact(usr)
 	if(href_list["forwardCat"])

--- a/code/modules/food&drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food&drinks/recipes/tablecraft/recipes_misc.dm
@@ -147,7 +147,7 @@
 /datum/table_recipe/fuegoburrito
 	name ="Fuego plasma burrito"
 	reqs = list(
-		/obj/item/weapon/reagent_containers/food/snacks/tortilla = 1,,
+		/obj/item/weapon/reagent_containers/food/snacks/tortilla = 1,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili = 2,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/soybeans = 1
 	)

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -138,7 +138,6 @@
 
 
 /obj/machinery/power/am_control_unit/attackby(obj/item/W, mob/user, params)
-	if(!istype(W) || !user) return
 	if(istype(W, /obj/item/weapon/wrench))
 		if(!anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
@@ -177,7 +176,7 @@
 		stability -= W.force/2
 		check_stability()
 	..()
-	return
+
 
 
 /obj/machinery/power/am_control_unit/attack_hand(mob/user)

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -126,13 +126,10 @@
 
 
 /obj/machinery/am_shielding/attackby(obj/item/W, mob/user, params)
-	if(!istype(W) || !user) return
 	if(W.force > 10)
 		stability -= W.force/2
 		check_stability()
 	..()
-	return
-
 
 
 //Call this to link a detected shilding unit to the controller

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -557,22 +557,16 @@
 				opened = 1
 			update_icon()
 	else
-		if (	((stat & BROKEN) || malfhack) \
-				&& !opened \
-				&& W.force >= 5 \
-				&& W.w_class >= 3 \
-				&& prob(20) )
+		if((!opened && wiresexposed && wires.IsInteractionTool(W)) || (issilicon(user) && !(stat & BROKEN) &&!malfhack))
+			return attack_hand(user)
+
+		..()
+		if( ((stat & BROKEN) || malfhack) && !opened && W.force >= 5 && W.w_class >= 3 && prob(20) )
 			opened = 2
 			user.visible_message("<span class='warning'>[user.name] has knocked down the APC cover  with the [W.name].</span>", \
 				"<span class='danger'>You knock down the APC cover with your [W.name]!</span>", \
 				"<span class='italics'>You hear bang.</span>")
 			update_icon()
-		else
-			if (istype(user, /mob/living/silicon))
-				return src.attack_hand(user)
-			if (!opened && wiresexposed && wires.IsInteractionTool(W))
-				return src.attack_hand(user)
-			..()
 
 /obj/machinery/power/apc/emag_act(mob/user)
 	if(!emagged && !malfhack)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -54,80 +54,68 @@
 			user << "The casing is closed."
 
 /obj/machinery/light_construct/attackby(obj/item/weapon/W, mob/user, params)
-	src.add_fingerprint(user)
-	if (istype(W, /obj/item/weapon/wrench))
-		if (src.stage == 1)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			usr << "<span class='notice'>You begin deconstructing [src]...</span>"
-			if (!do_after(usr, 30, target = src))
+	add_fingerprint(user)
+	switch(stage)
+		if(1)
+			if(istype(W, /obj/item/weapon/wrench))
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+				usr << "<span class='notice'>You begin deconstructing [src]...</span>"
+				if (!do_after(usr, 30, target = src))
+					return
+				new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
+				user.visible_message("[user.name] deconstructs [src].", \
+					"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
+				playsound(src.loc, 'sound/items/Deconstruct.ogg', 75, 1)
+				qdel(src)
 				return
-			new /obj/item/stack/sheet/metal( get_turf(src.loc), sheets_refunded )
-			user.visible_message("[user.name] deconstructs [src].", \
-				"<span class='notice'>You deconstruct [src].</span>", "<span class='italics'>You hear a ratchet.</span>")
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 75, 1)
-			qdel(src)
-		if (src.stage == 2)
-			usr << "<span class='warning'>You have to remove the wires first!</span>"
-			return
 
-		if (src.stage == 3)
-			usr << "<span class='warning'>You have to unscrew the case first!</span>"
-			return
+			if(istype(W, /obj/item/stack/cable_coil))
+				var/obj/item/stack/cable_coil/coil = W
+				if(coil.use(1))
+					switch(fixture_type)
+						if ("tube")
+							icon_state = "tube-construct-stage2"
+						if("bulb")
+							icon_state = "bulb-construct-stage2"
+					stage = 2
+					user.visible_message("[user.name] adds wires to [src].", \
+						"<span class='notice'>You add wires to [src].</span>")
+				else
+					user << "<span class='warning'>You need one length of cable to wire [src]!</span>"
+				return
+		if(2)
+			if(istype(W, /obj/item/weapon/wrench))
+				usr << "<span class='warning'>You have to remove the wires first!</span>"
+				return
 
-	if(istype(W, /obj/item/weapon/wirecutters))
-		if (src.stage != 2) return
-		src.stage = 1
-		switch(fixture_type)
-			if ("tube")
-				src.icon_state = "tube-construct-stage1"
-			if("bulb")
-				src.icon_state = "bulb-construct-stage1"
-		new /obj/item/stack/cable_coil(get_turf(src.loc), 1, "red")
-		user.visible_message("[user.name] removes the wiring from [src].", \
-			"<span class='notice'>You remove the wiring from [src].</span>", "<span class='italics'>You hear clicking.</span>")
-		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		return
+			if(istype(W, /obj/item/weapon/wirecutters))
+				stage = 1
+				switch(fixture_type)
+					if ("tube")
+						icon_state = "tube-construct-stage1"
+					if("bulb")
+						icon_state = "bulb-construct-stage1"
+				new /obj/item/stack/cable_coil(get_turf(loc), 1, "red")
+				user.visible_message("[user.name] removes the wiring from [src].", \
+					"<span class='notice'>You remove the wiring from [src].</span>", "<span class='italics'>You hear clicking.</span>")
+				playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
+				return
 
-	if(istype(W, /obj/item/stack/cable_coil))
-		if (src.stage != 1) return
-		var/obj/item/stack/cable_coil/coil = W
-		if (coil.use(1))
-			switch(fixture_type)
-				if ("tube")
-					src.icon_state = "tube-construct-stage2"
-				if("bulb")
-					src.icon_state = "bulb-construct-stage2"
-			src.stage = 2
-			user.visible_message("[user.name] adds wires to [src].", \
-				"<span class='notice'>You add wires to [src].</span>")
-		else
-			user << "<span class='warning'>You need one length of cable to wire [src]!</span>"
-		return
-
-	if(istype(W, /obj/item/weapon/screwdriver))
-		if (src.stage == 2)
-			switch(fixture_type)
-				if ("tube")
-					src.icon_state = "tube-empty"
-				if("bulb")
-					src.icon_state = "bulb-empty"
-			src.stage = 3
-			user.visible_message("[user.name] closes [src]'s casing.", \
-				"<span class='notice'>You close [src]'s casing.</span>", "<span class='italics'>You hear screwing.</span>")
-			playsound(src.loc, 'sound/items/Screwdriver.ogg', 75, 1)
-
-			switch(fixture_type)
-
-				if("tube")
-					newlight = new /obj/machinery/light/built(src.loc)
-				if ("bulb")
-					newlight = new /obj/machinery/light/small/built(src.loc)
-
-			newlight.dir = src.dir
-			src.transfer_fingerprints_to(newlight)
-			qdel(src)
-			return
+			if(istype(W, /obj/item/weapon/screwdriver))
+				user.visible_message("[user.name] closes [src]'s casing.", \
+					"<span class='notice'>You close [src]'s casing.</span>", "<span class='italics'>You hear screwing.</span>")
+				playsound(loc, 'sound/items/Screwdriver.ogg', 75, 1)
+				switch(fixture_type)
+					if("tube")
+						newlight = new /obj/machinery/light/built(loc)
+					if ("bulb")
+						newlight = new /obj/machinery/light/small/built(loc)
+				newlight.dir = dir
+				transfer_fingerprints_to(newlight)
+				qdel(src)
+				return
 	..()
+
 
 /obj/machinery/light_construct/small
 	name = "small light fixture frame"
@@ -323,7 +311,7 @@
 		//If xenos decide they want to smash a light bulb with a toolbox, who am I to stop them? /N
 
 	else if(status != LIGHT_BROKEN && status != LIGHT_EMPTY)
-
+		user.changeNext_move(CLICK_CD_MELEE)
 		user.do_attack_animation(src)
 		if(W.damtype == STAMINA)
 			return
@@ -357,9 +345,7 @@
 					newlight.icon_state = "bulb-construct-stage2"
 			newlight.dir = src.dir
 			newlight.stage = 2
-			newlight.fingerprints = src.fingerprints
-			newlight.fingerprintshidden = src.fingerprintshidden
-			newlight.fingerprintslast = src.fingerprintslast
+			transfer_fingerprints_to(newlight)
 			qdel(src)
 			return
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -150,7 +150,6 @@ field_generator power level display
 					return
 	else
 		..()
-		return
 
 
 /obj/machinery/field/generator/emp_act()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -144,11 +144,11 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user, params)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(istool(W))
 		if(src.process_tool_hit(W,user))
 			return
 	..()
-	return
 
 
 /obj/structure/particle_accelerator/Move()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -160,8 +160,11 @@
 		user << "<span class='warning'>No cups left!</span>"
 		return
 	cups--
-	user.put_in_hands(new /obj/item/weapon/reagent_containers/food/drinks/sillycup)
-	user.visible_message("[user] gets a cup from [src].","<span class='notice'>You get a cup from [src].</span>")
+	var/obj/item/weapon/reagent_containers/food/drinks/sillycup/SC = new(loc)
+	if(Adjacent(user)) //not TK
+		user.put_in_hands(SC)
+		user.visible_message("[user] gets a cup from [src].","<span class='notice'>You get a cup from [src].</span>")
+
 
 /obj/structure/reagent_dispensers/water_cooler/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/paper))

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -367,9 +367,9 @@
 	unacidable = 1
 	layer = TURF_LAYER
 
-	New()
-		..()
-		SSobj.processing |= src
+/obj/effect/golemrune/New()
+	..()
+	SSobj.processing |= src
 
 /obj/effect/golemrune/process()
 	var/mob/dead/observer/ghost
@@ -397,6 +397,7 @@
 	G.set_species(/datum/species/golem/adamantine)
 	G.set_cloned_appearance()
 	G.real_name = "Adamantine Golem ([rand(1, 1000)])"
+	G.name = G.real_name
 	G.dna.unique_enzymes = G.dna.generate_unique_enzymes()
 	G.dna.species.auto_equip(G)
 	G.loc = src.loc

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -751,6 +751,7 @@
 #include "code\game\objects\structures\musician.dm"
 #include "code\game\objects\structures\noticeboard.dm"
 #include "code\game\objects\structures\OpTable.dm"
+#include "code\game\objects\structures\plasticflaps.dm"
 #include "code\game\objects\structures\safe.dm"
 #include "code\game\objects\structures\showcase.dm"
 #include "code\game\objects\structures\signs.dm"


### PR DESCRIPTION
- Fixes hotspot having two New() procs. Fixes #12238 .
- Fixes many machines and a few structure not having a cooldown when attacked with an item. Fixes #11417 .
- Fixes not being able to eat or be facehugged when wearing riot helmet with visor up. Fixes #11866 .
- Fixes not being able to use child of the tool type for craft recipes requiring tools. Fixes #9523
- Tablecrafting failure message now tells you what caused the failure (missing tool, missing component)
- Fixes fuego plasma burrito recipe. Fixes #12090 .
- Fixes being able to grab cups from water cooler with telekinesis, putting the cup directly in your hand. Fixes #11867 .
- Fixes golem appearing with their old human name for a split second. Fixes #10421 .
- Some changes to make code more OOP (take_damage() proc for barricade, shieldgen, etc)
- Some tweaks to light tube building code.
- Removed unneeded comment. Fixes #11031.
- Moved plasticflaps code into its own file in the structure folder, there's no reason for it to be in  code/game/machinery/computer/shuttle.dm)
- Fixes simple animal not being able to attack wooden barricade. Fixes #12232.
