### PR TITLE
Securitron assembly fix

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -464,8 +464,7 @@ Auto Patrol: []"},
 			return
 		build_step++
 		user << "<span class='notice'>You complete the Securitron! Beep boop.</span>"
-		var/obj/machinery/bot/secbot/S = new /obj/machinery/bot/secbot
-		S.loc = get_turf(src)
+		var/obj/machinery/bot/secbot/S = new /obj/machinery/bot/secbot(get_turf(src))
 		S.name = created_name
 		qdel(I)
 		qdel(src)


### PR DESCRIPTION
- Fixes handcrafted securitrons being "unpowered".
- Fixes #12265
