### PR TITLE
Remove pointless .gitignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@
 *.dmb
 *.rsc
 *.lk
-*.int
 *.backup
-*.int

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
   - shopt -s globstar
   - (! grep 'step_[xy]' _maps/**/*.dmm)
   - md5sum -c - <<< "29d5a6e23d172846354505e60ecfe7e7 *html/changelogs/example.yml"
+  - md5sum -c - <<< "0af969f671fba6cf9696c78cd175a14a *tgstation.int"
   - tools/check_filedirs.sh tgstation.dme
   - python tools/ss13_genchangelog.py html/changelog.html html/changelogs
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup


### PR DESCRIPTION
You cannot .gitignore a file that has already been committed to the
repository - it's designed only for files that are not tracked at all.

If you want to ignore your local changes to a tracked file you need to run
the following command

git update-index --assume-unchanged tgstation.int

This works for your local repo only, so relies on the user being diligent
enough to run it

In the meantime this adds another .travis check that the tgstation.int
file remains unchanged, so people don't commit changes to it by accident
