### PR TITLE
Adding Charge and Staff of Healing to the spellbook + category reshuffle

### DIFF
--- a/code/datums/spells/charge.dm
+++ b/code/datums/spells/charge.dm
@@ -34,7 +34,7 @@
 						burnt_out = 1
 					charged_item = M
 					break
-			else if(istype(item, /obj/item/weapon/spellbook/oneuse))
+			else if(istype(item, /obj/item/weapon/spellbook))
 				if(istype(item, /obj/item/weapon/spellbook/oneuse))
 					var/obj/item/weapon/spellbook/oneuse/I = item
 					if(prob(80))

--- a/code/datums/spells/charge.dm
+++ b/code/datums/spells/charge.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/targeted/charge
 	name = "Charge"
-	desc = "This spell can be used to charge up spent magical artifacts, among other things."
+	desc = "This spell can be used to recharge a variety of things in your hands, from magical artifacts to electrical components. A creative wizard can even use it to grant magical power to a fellow magic user."
 
 	school = "transmutation"
 	charge_max = 600
@@ -35,14 +35,19 @@
 					charged_item = M
 					break
 			else if(istype(item, /obj/item/weapon/spellbook/oneuse))
-				var/obj/item/weapon/spellbook/oneuse/I = item
-				if(prob(80))
-					user.visible_message("<span class='warning'>[I] catches fire!</span>")
-					qdel(I)
+				if(istype(item, /obj/item/weapon/spellbook/oneuse))
+					var/obj/item/weapon/spellbook/oneuse/I = item
+					if(prob(80))
+						user.visible_message("<span class='warning'>[I] catches fire!</span>")
+						qdel(I)
+					else
+						I.used = 0
+						charged_item = I
+						break
 				else
-					I.used = 0
-					charged_item = I
-					break
+					user << "<span class='caution'>Glowing red letters appear on the front cover...</span>"
+					user << "<span class='warning'>[pick("NICE TRY BUT NO!","CLEVER BUT NOT CLEVER ENOUGH!", "SUCH FLAGRANT CHEESING IS WHY WE ACCEPTED YOUR APPLICATION!", "CUTE!", "YOU DIDN'T THINK IT'D BE THAT EASY, DID YOU?")]</span>"
+					burnt_out = 1
 			else if(istype(item, /obj/item/weapon/gun/magic))
 				var/obj/item/weapon/gun/magic/I = item
 				if(prob(80) && !I.can_charge)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -3,7 +3,7 @@
 
 	var/spell_type = null
 	var/desc = ""
-	var/category = "Offensive Spells"
+	var/category = "Offensive"
 	var/log_name = "XX" //What it shows up as in logs
 	var/cost = 2
 	var/refundable = 1
@@ -102,6 +102,7 @@
 	name = "Magic Missile"
 	spell_type = /obj/effect/proc_holder/spell/targeted/projectile/magic_missile
 	log_name = "MM"
+	category = "Defensive"
 
 /datum/spellbook_entry/disintegrate
 	name = "Disintegrate"
@@ -112,24 +113,26 @@
 	name = "Disable Tech"
 	spell_type = /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech
 	log_name = "DT"
-	category = "Utility Spells"
+	category = "Defensive"
 	cost = 1
 
 /datum/spellbook_entry/repulse
 	name = "Repulse"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/repulse
 	log_name = "RP"
+	category = "Defensive"
 
 /datum/spellbook_entry/timestop
 	name = "Time Stop"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	log_name = "TS"
+	category = "Defensive"
 
 /datum/spellbook_entry/smoke
 	name = "Smoke"
 	spell_type = /obj/effect/proc_holder/spell/targeted/smoke
 	log_name = "SM"
-	category = "Utility Spells"
+	category = "Defensive"
 	cost = 1
 
 /datum/spellbook_entry/blind
@@ -142,44 +145,43 @@
 	name = "Mindswap"
 	spell_type = /obj/effect/proc_holder/spell/targeted/mind_transfer
 	log_name = "MT"
-	category = "Utility Spells"
+	category = "Mobility"
 
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/forcewall
 	log_name = "FW"
-	category = "Utility Spells"
+	category = "Defensive"
 	cost = 1
 
 /datum/spellbook_entry/blink
 	name = "Blink"
 	spell_type = /obj/effect/proc_holder/spell/targeted/turf_teleport/blink
 	log_name = "BL"
-	category = "Utility Spells"
+	category = "Mobility"
 
 /datum/spellbook_entry/teleport
 	name = "Teleport"
 	spell_type = /obj/effect/proc_holder/spell/targeted/area_teleport/teleport
 	log_name = "TP"
-	category = "Utility Spells"
+	category = "Mobility"
 
 /datum/spellbook_entry/mutate
 	name = "Mutate"
 	spell_type = /obj/effect/proc_holder/spell/targeted/genetic/mutate
 	log_name = "MU"
-	category = "Utility Spells"
 
 /datum/spellbook_entry/jaunt
 	name = "Ethereal Jaunt"
 	spell_type = /obj/effect/proc_holder/spell/targeted/ethereal_jaunt
 	log_name = "EJ"
-	category = "Utility Spells"
+	category = "Mobility"
 
 /datum/spellbook_entry/knock
 	name = "Knock"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/knock
 	log_name = "KN"
-	category = "Utility Spells"
+	category = "Mobility"
 	cost = 1
 
 /datum/spellbook_entry/fleshtostone
@@ -191,28 +193,33 @@
 	name = "Summon Item"
 	spell_type = /obj/effect/proc_holder/spell/targeted/summonitem
 	log_name = "IS"
-	category = "Utility Spells"
+	category = "Assistance"
 	cost = 1
 
 /datum/spellbook_entry/lichdom
 	name = "Bind Soul"
 	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
 	log_name = "LD"
+	category = "Defensive"
 
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
 	spell_type = /obj/effect/proc_holder/spell/targeted/lightning
 	log_name = "LB"
-	cost = 2
 
 /datum/spellbook_entry/barnyard
 	name = "Barnyard Curse"
 	spell_type = /obj/effect/proc_holder/spell/targeted/barnyardcurse
 	log_name = "BC"
 
+/datum/spellbook_entry/charge
+	name = "Charge"
+	spell_type = /obj/effect/proc_holder/spell/targeted/charge
+	log_name = "CH"
+	category = "Assistance"
+	cost = 1
 /datum/spellbook_entry/item
 	name = "Buy Item"
-	category = "Artifacts"
 	refundable = 0
 	buy_word = "Summon"
 	var/item_path= null
@@ -243,6 +250,7 @@
 	desc = "An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines."
 	item_path = /obj/item/weapon/gun/magic/staff/animate
 	log_name = "SA"
+	category = "Assistance"
 
 /datum/spellbook_entry/item/staffchaos
 	name = "Staff of Chaos"
@@ -256,12 +264,22 @@
 	item_path = /obj/item/weapon/gun/magic/staff/door
 	log_name = "SD"
 	cost = 1
+	category = "Mobility"
+
+/datum/spellbook_entry/item/staffhealing
+	name = "Staff of Healing"
+	desc = "An altruistic staff that can heal the lame and raise the dead."
+	item_path = /obj/item/weapon/gun/magic/staff/healing
+	log_name = "SH"
+	cost = 1
+	category = "Defensive"
 
 /datum/spellbook_entry/item/scryingorb
 	name = "Scrying Orb"
 	desc = "An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to spy upon the station with ease. In addition, buying it will permanently grant you x-ray vision."
 	item_path = /obj/item/weapon/scrying
 	log_name = "SO"
+	category = "Defensive"
 
 /datum/spellbook_entry/item/scryingorb/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	if(..())
@@ -274,6 +292,7 @@
 	desc = "Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Artificer allows you to create arcane machines for the captured souls to pilot."
 	item_path = /obj/item/weapon/storage/belt/soulstone/full
 	log_name = "SS"
+	category = "Assistance"
 
 /datum/spellbook_entry/item/soulstones/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	. =..()
@@ -286,18 +305,21 @@
 	desc = "A Necromantic stone is able to resurrect three dead individuals as skeletal thralls for you to command."
 	item_path = /obj/item/device/necromantic_stone
 	log_name = "NS"
+	category = "Assistance"
 
 /datum/spellbook_entry/item/wands
 	name = "Wand Assortment"
-	desc = "A collection of wands that allow for a wide variety of utility. Wands do not recharge, so be conservative in use. Comes in a handy belt."
+	desc = "A collection of wands that allow for a wide variety of utility. Wands have a limited number of charges, so be conservative in use. Comes in a handy belt."
 	item_path = /obj/item/weapon/storage/belt/wands/full
 	log_name = "WA"
+	category = "Defensive"
 
 /datum/spellbook_entry/item/armor
 	name = "Mastercrafted Armor Set"
 	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space."
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	log_name = "HS"
+	category = "Defensive"
 
 /datum/spellbook_entry/item/armor/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book)
 	. = ..()
@@ -310,6 +332,7 @@
 	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."
 	item_path = /obj/item/weapon/antag_spawner/contract
 	log_name = "CT"
+	category = "Assistance"
 
 /datum/spellbook_entry/item/bloodbottle
 	name = "Bottle of Blood"
@@ -317,6 +340,7 @@
 	item_path = /obj/item/weapon/antag_spawner/slaughter_demon
 	log_name = "BB"
 	limit = 3
+	category = "Assistance"
 
 /datum/spellbook_entry/summon
 	name = "Summon Stuff"
@@ -469,17 +493,26 @@
 /obj/item/weapon/spellbook/proc/GetCategoryHeader(category)
 	var/dat = ""
 	switch(category)
-		if("Offensive Spells")
-			dat += "Spells that can be reused endlessly.<BR>"
-			dat += "The number after the spell name is the cooldown time.<BR>"
+		if("Offensive")
+			dat += "Spells and items geared towards debilitating and destroying.<BR><BR>"
+			dat += "Items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+			dat += "For spells: the number after the spell name is the cooldown time.<BR>"
 			dat += "You can reduce this number by spending more points on the spell.<BR>"
-		if("Utility Spells")
-			dat += "Spells that can be reused endlessly.<BR>"
-			dat += "The number after the spell name is the cooldown time.<BR>"
+		if("Defensive")
+			dat += "Spells and items geared towards improving your survivabilty or reducing foes ability to attack.<BR><BR>"
+			dat += "Items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+			dat += "For spells: the number after the spell name is the cooldown time.<BR>"
 			dat += "You can reduce this number by spending more points on the spell.<BR>"
-		if("Artifacts")
-			dat += "Powerful items imbued with eldritch magics. Summoning one will count towards your maximum number of uses.<BR>"
-			dat += "These items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+		if("Mobility")
+			dat += "Spells and items geared towards improving your ability to move. It is a good idea to take at least one.<BR><BR>"
+			dat += "Items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+			dat += "For spells: the number after the spell name is the cooldown time.<BR>"
+			dat += "You can reduce this number by spending more points on the spell.<BR>"
+		if("Assistance")
+			dat += "Spells and items geared towards bringing in outside forces to aid you or improving upon your other items and abilties.<BR><BR>"
+			dat += "Items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+			dat += "For spells: the number after the spell name is the cooldown time.<BR>"
+			dat += "You can reduce this number by spending more points on the spell.<BR>"
 		if("Challenges")
 			dat += "The Wizard Federation typically has hard limits on the potency and number of spells brought to the station based on risk.<BR>"
 			dat += "Arming the station against you will increases the risk, but will grant you one more charge for your spellbook.<BR>"
@@ -524,7 +557,7 @@
 		cat_dat[category] = "<hr>"
 		dat += "<li><a [tab==category?"class=selected":""] href='byond://?src=\ref[src];page=[category]'>[category]</a></li>"
 
-	dat += "<li><a><b>Uses remaining : [uses]</b></a></li>"
+	dat += "<li><a><b>Points remaining : [uses]</b></a></li>"
 	dat += "</ul>"
 
 	var/datum/spellbook_entry/E
@@ -548,7 +581,7 @@
 		dat += cat_dat[category]
 		dat += "</div>"
 
-	user << browse(wrap(dat), "window=spellbook;size=600x300")
+	user << browse(wrap(dat), "window=spellbook;size=700x500")
 	onclose(user, "spellbook")
 	return
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -25,6 +25,9 @@
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
 
+/obj/item/weapon/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
+	return
+
 /obj/item/weapon/gun/magic/staff/chaos
 	name = "staff of chaos"
 	desc = "An artefact that spits bolts of chaotic magic that can potentially do anything."

--- a/html/changelogs/Incoming-spellshuffle.yml
+++ b/html/changelogs/Incoming-spellshuffle.yml
@@ -1,0 +1,7 @@
+author: Incoming5643
+delete-after: True
+
+changes: 
+  - rscadd: "The spell Charge has been added to the spellbook. It can be used to extend the life of magic and energy weapons and even reset the cooldowns of held wizards! It cannot reset your own cooldowns."
+  - rscadd: "The Staff of Healing has been added to the spellbook. Heals all damage and raises the dead! Can't be used on yourself however."
+  - bugfix: "The exploit that allowed you to use the staff of healing on yourself by suicide has been fixed."


### PR DESCRIPTION
The Staff of Healing is now selectable for a cost of 1 in the spellbook

The spell "Charge" is now selectable for a cost of 2 in the spellbook

The spellbook's category system has been reworked to help deal with the huge scroll bars it previously had and help identify to wizards what needs spells and items serve. The spellbook window is also larger by default.

The new categories are:

Offensive:
Fireball
Disintegrate
Blind
Mutate
Flesh to Stone
Lightning Bolt
Curse of the Barnyard
Staff of Change
Staff of Chaos

Defensive:
Magic Missile
Disable Tech
Repulse
Stop Time
Smoke
Forcewall
Bind Soul
Staff of Healing
Scrying Orb
Wand Assortment
Armor Set

Mobility:
Mind Transfer
Blink
Teleport
Ethereal Jaunt
Knock
Staff of Door Creation

Assistance:
Instant Summons
Charge
Staff of Animation
Soul Stone Shards + Artificer
Necromantic Stone
Apprentice Contract
Bottle of Blood

Fixes an unreported bug where targeting your mouth with a staff of healing allowed self healing through suicide.

Adds an easter egg to clever wizards who try to charge the spellbook to get more charges.
