### PR TITLE
Port pizzastation autolathe improvements

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -39,6 +39,7 @@
 							"Construction",
 							"T-Comm",
 							"Security",
+							"Machinery",
 							"Medical",
 							"Misc"
 							)
@@ -373,7 +374,7 @@
 
 	if(hack)
 		for(var/datum/design/D in files.possible_designs)
-			if((D.build_type & 4) && ("hacked" in D.category))
+			if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
 				files.known_designs += D
 	else
 		for(var/datum/design/D in files.known_designs)

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell
-	category = list("Misc","Power Designs")
+	category = list("Misc","Power Designs","Machinery","initial")
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -22,7 +22,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/high
-	category = list("Misc","Power Designs")
+	category = list("Misc","Power Designs","Machinery","hacked")
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -22,7 +22,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/high
-	category = list("Misc","Power Designs","Machinery","hacked")
+	category = list("Misc","Power Designs")
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -32,7 +32,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 
 /datum/design/adv_capacitor
 	name = "Advanced Capacitor"
@@ -75,7 +75,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 
 /datum/design/adv_scanning
 	name = "Advanced Scanning Module"
@@ -118,7 +118,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 
 /datum/design/nano_mani
 	name = "Nano Manipulator"
@@ -161,7 +161,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 
 /datum/design/high_micro_laser
 	name = "High-Power Micro-Laser"
@@ -203,7 +203,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 
 /datum/design/adv_matter_bin
 	name = "Advanced Matter Bin"


### PR DESCRIPTION
Credit to octareenroon91, since I just stole his commits

Match the build_type to its defined bitflags.

Introduce the "Machinery" category to accept low-tier machine parts.
The designs in question already identify themselves as AUTOLATHE -
buildable.  They simply have no category.
