### PR TITLE
Fixes some runtimes

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -104,6 +104,8 @@
 			throwing = 0
 			throw_impact(A)
 			. = 1
+			if(!A || qdeleted(A))
+				return
 		A.Bumped(src)
 
 

--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -26,8 +26,9 @@
 
 /obj/effect/proc_holder/changeling/augmented_eyesight/on_refund(mob/user)
 	var/obj/item/organ/internal/cyberimp/eyes/O = user.getorganslot("eye_ling")
-	O.Remove(user)
-	qdel(O)
+	if(O)
+		O.Remove(user)
+		qdel(O)
 
 
 

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -32,9 +32,10 @@
 			H.remove_all_embedded_objects()
 
 		for(var/i = 0, i < 10, i++) //The healing itself - doesn't heal toxin damage (that's anatomic panacea) and effectiveness decreases with each use in a short timespan
-			user.adjustBruteLoss(-10 / recent_uses)
-			user.adjustOxyLoss(-10 / recent_uses)
-			user.adjustFireLoss(-10 / recent_uses)
+			if(user)
+				user.adjustBruteLoss(-10 / recent_uses)
+				user.adjustOxyLoss(-10 / recent_uses)
+				user.adjustFireLoss(-10 / recent_uses)
 			sleep(10)
 
 	feedback_add_details("changeling_powers","RR")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -188,7 +188,7 @@
 		if(iscarbon(target))
 			if(uses)
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
-				var/mob/living/carbon/human/C = target
+				var/mob/living/carbon/C = target
 				user.visible_message("<span class='danger'>[user] sprays [src] into the face of [target]!</span>")
 				target << "<span class='userdanger'>[user] sprays [src] into your face!</span>"
 				if(C.client)
@@ -197,9 +197,11 @@
 					if(C.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
 						C.confused = max(C.confused, 3)
 						C.Weaken(3)
-				C.lip_style = "spray_face"
-				C.lip_color = colour
-				C.update_body()
+				if(ishuman(C))
+					var/mob/living/carbon/human/H = C
+					H.lip_style = "spray_face"
+					H.lip_color = colour
+					H.update_body()
 				uses = max(0,uses-10)
 		..()
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -799,6 +799,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	var/datum/signal/signal = src.telecomms_process()
 
+	if(!P || qdeleted(P) || !U) //in case the PDA or mob gets destroyed during telecomms_process()
+		return
+
 	var/useTC = 0
 	if(signal)
 		if(signal.data["done"])

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -336,7 +336,8 @@
 			M.client.screen -= W
 
 	if(ismob(loc))
-		W.dropped(usr)
+		var/mob/M = loc
+		W.dropped(M)
 	W.layer = initial(W.layer)
 	W.loc = new_location
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -203,6 +203,8 @@
 
 	if(burst_size > 1)
 		for(var/i = 1 to burst_size)
+			if(!user)
+				break
 			if(!issilicon(user))
 				if( i>1 && !(src in get_both_hands(user))) //for burst firing
 					break
@@ -240,10 +242,11 @@
 		spawn(fire_delay)
 			semicd = 0
 
-	if(user.hand)
-		user.update_inv_l_hand()
-	else
-		user.update_inv_r_hand()
+	if(user)
+		if(user.hand)
+			user.update_inv_l_hand()
+		else
+			user.update_inv_r_hand()
 	feedback_add_details("gun_fired","[src.type]")
 
 /obj/item/weapon/gun/attack(mob/M as mob, mob/user)


### PR DESCRIPTION
Fixes runtimes with augmented_eyesight refund, atom/movable/Bump(), f…leshmend, spraycans, PDA messaging, remove_from_storage(), and gun burstfiring.

The related runtimes:

runtime error: Cannot execute null.AddLuminosity().
proc name: dropped (/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/dropped)
  source file: grown.dm,1218
  usr: null
  src: the glowshroom cluster (/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom)

runtime error: Cannot execute null.adjustBruteLoss().
proc name: sting action (/obj/effect/proc_holder/changeling/fleshmend/sting_action)
  source file: fleshmend.dm,35
  usr: null
  src: Fleshmend (/obj/effect/proc_holder/changeling/fleshmend)

runtime error: Cannot execute null.Remove().
proc name: on refund (/obj/effect/proc_holder/changeling/augmented_eyesight/on_refund)
  source file: augmented_eyesight.dm,29
  usr: Richter Schwarz (/mob/living/carbon/human)
  src: Augmented Eyesight (/obj/effect/proc_holder/changeling/augmented_eyesight)

runtime error: Cannot execute null.Bumped().
proc name: Bump (/atom/movable/Bump)
  source file: atoms_movable.dm,107
  usr: 0
  src: the wrench (/obj/item/weapon/wrench)

runtime error: Cannot read null.hand
proc name: process fire (/obj/item/weapon/gun/proc/process_fire)
  source file: gun.dm,243
  usr: null
  src: the \'Type U3\' Uzi (/obj/item/weapon/gun/projectile/automatic/mini_uzi)

runtime error: Cannot read null.z
proc name: create message (/obj/item/device/pda/proc/create_message)
  source file: PDA.dm,807
  usr: Bryant Bailey (/mob/living/carbon/human)
  src: PDA-Bryant Bailey (Assistant) (/obj/item/device/pda)
