### PR TITLE
Changes some names and discriptions of roundstart cells to be more acurate

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -87,6 +87,8 @@
 		cell = new /obj/item/weapon/stock_parts/cell(src)
 		cell.maxcharge = 7500
 		cell.charge = 7500
+		cell.name = "cyborg power cell"
+		cell.desc = "This cell has a power rating of 7500, and you should put it back in the borg."
 
 	if(lawupdate)
 		make_laws()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -53,7 +53,7 @@
 	req_access = list(access_engine_equip)
 	var/area/area
 	var/areastring = null
-	var/obj/item/weapon/stock_parts/cell/cell
+	var/obj/item/weapon/stock_parts/cell/apc
 	var/start_charge = 90				// initial cell charge %
 	var/cell_type = 2500				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -150,6 +150,10 @@
 	materials = list(MAT_GLASS=40)
 	rating = 2
 
+/obj/item/weapon/stock_parts/cell/crap/empty/New()
+	..()
+	charge = 0
+
 /obj/item/weapon/stock_parts/cell/apc
 	name = "heavy duty power cell"
 	desc = "An old proprietary cell format used in apcs. It has a power rating of 2500, and you should not swallow it."
@@ -157,8 +161,8 @@
 	maxcharge = 2500
 	materials = list(MAT_GLASS=40)
 	rating = 2
-
-/obj/item/weapon/stock_parts/cell/crap/empty/New()
+	
+/obj/item/weapon/stock_parts/cell/apc/empty/New()
 	..()
 	charge = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -150,6 +150,14 @@
 	materials = list(MAT_GLASS=40)
 	rating = 2
 
+/obj/item/weapon/stock_parts/cell/apc
+	name = "heavy duty power cell"
+	desc = "An old proprietary cell format used in apcs. It has a power rating of 2500, and you should not swallow it."
+	origin_tech = "powerstorage=1"
+	maxcharge = 2500
+	materials = list(MAT_GLASS=40)
+	rating = 2
+
 /obj/item/weapon/stock_parts/cell/crap/empty/New()
 	..()
 	charge = 0


### PR DESCRIPTION
Fixes #12327
just a new cell type for apcs (it would get varedited back to default power values anyway but readability.) and some var-edits to the one cell in the round-start cyborg wit the rest of its var-edits.
APPARENTLY MY CODE IS ABSOLUTELY TERRIBLE. 
