### PR TITLE
re-enable tank suicide, but retain body and all objects

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -25,11 +25,10 @@
 	user.visible_message("<span class='suicide'>[user] is putting the [src]'s valve to their lips! I don't think they're gonna stop!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (H && !qdeleted(H))
-		spawn(0)
-			for(var/obj/item/W in H)
-				H.unEquip(W)
-				if(prob(50))
-					step(W, pick(alldirs))
+		for(var/obj/item/W in H)
+			H.unEquip(W)
+			if(prob(50))
+				step(W, pick(alldirs))
 		H.hair_style = "Bald"
 		H.update_hair()
 		H.blood_max = 5

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -26,10 +26,10 @@
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (H && !qdeleted(H))
 		spawn(0)
-		for(var/obj/item/W in H)
-			H.unEquip(W)
-			if(prob(50))
-				step(W, pick(alldirs))
+			for(var/obj/item/W in H)
+				H.unEquip(W)
+				if(prob(50))
+					step(W, pick(alldirs))
 		H.hair_style = "Bald"
 		H.update_hair()
 		H.blood_max = 5

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -25,20 +25,16 @@
 	user.visible_message("<span class='suicide'>[user] is putting the [src]'s valve to their lips! I don't think they're gonna stop!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
 	if (H && !qdeleted(H))
-		for(var/obj/item/W in (H.contents))
+		spawn(0)
+		for(var/obj/item/W in H)
 			H.unEquip(W)
-			if (H.client)
-				H.client.screen -= W
-			if (W)
-				W.loc = H.loc
-				W.dropped(H)
-				if(prob(50))
-					step(W, pick(alldirs))
+			if(prob(50))
+				step(W, pick(alldirs))
 		H.hair_style = "Bald"
 		H.update_hair()
 		H.blood_max = 5
 		gibs(H.loc, H.viruses, H.dna)
-		H.adjustBruteLoss(9001) //to make the body super-bloody
+		H.adjustBruteLoss(1000) //to make the body super-bloody
 
 	return (BRUTELOSS)
 

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -21,8 +21,25 @@
 	var/volume = 70
 
 /obj/item/weapon/tank/suicide_act(mob/user)
+	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='suicide'>[user] is putting the [src]'s valve to their lips! I don't think they're gonna stop!</span>")
 	playsound(loc, 'sound/effects/spray.ogg', 10, 1, -3)
+	if (H && !qdeleted(H))
+		for(var/obj/item/W in (H.contents))
+			H.unEquip(W)
+			if (H.client)
+				H.client.screen -= W
+			if (W)
+				W.loc = H.loc
+				W.dropped(H)
+				if(prob(50))
+					step(W, pick(alldirs))
+		H.hair_style = "Bald"
+		H.update_hair()
+		H.blood_max = 5
+		gibs(H.loc, H.viruses, H.dna)
+		H.adjustBruteLoss(9001) //to make the body super-bloody
+
 	return (BRUTELOSS)
 
 /obj/item/weapon/tank/New()


### PR DESCRIPTION
Controversial for some reason.

Lets people make a mess but retains all of their items and leaves an (ugly) corpse for debraining or chestbursting or headslugging or what have you.
