### PR TITLE
Removes Suicide Status

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -436,9 +436,6 @@
 				msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
 				continue //AFK client
 			if(L.stat)
-				if(L.suiciding)	//Suicider
-					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<span class='boldannounce'>Suicide</span>)\n"
-					continue //Disconnected client
 				if(L.stat == UNCONSCIOUS)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dying)\n"
 					continue //Unconscious
@@ -450,12 +447,7 @@
 		for(var/mob/dead/observer/D in mob_list)
 			if(D.mind && D.mind.current == L)
 				if(L.stat == DEAD)
-					if(L.suiciding)	//Suicider
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='boldannounce'>Suicide</span>)\n"
-						continue //Disconnected client
-					else
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (Dead)\n"
-						continue //Dead mob, ghost abandoned
+					msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (Dead)\n"
 				else
 					if(D.can_reenter_corpse)
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='boldannounce'>This shouldn't appear.</span>)\n"

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -368,9 +368,6 @@
 	if(C.stat == 2)
 		return 0 //welp too late for them!
 
-	if(C.suiciding)
-		return 0 //Kevorkian school of robotic medical assistants.
-
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)
 		return 1
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -190,7 +190,6 @@
 
 	H.set_cloned_appearance()
 
-	H.suiciding = 0
 	src.attempting = 0
 	return 1
 
@@ -204,7 +203,7 @@
 		return
 
 	if((src.occupant) && (src.occupant.loc == src))
-		if((src.occupant.stat == DEAD) || (src.occupant.suiciding) || !occupant.key)  //Autoeject corpses and suiciding dudes.
+		if((src.occupant.stat == DEAD) || !occupant.key)  //Autoeject corpses
 			src.locked = 0
 			src.go_out()
 			src.connected_message("Clone Rejected: Deceased.")

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -356,9 +356,6 @@
 	if (!subject.getorgan(/obj/item/organ/internal/brain))
 		scantemp = "<font class='bad'>No signs of intelligence detected.</font>"
 		return
-	if (subject.suiciding == 1)
-		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
-		return
 	if ((subject.disabilities & NOCLONE) && (src.scanner.scan_level < 2))
 		scantemp = "<font class='bad'>Subject no longer contains the fundamental materials required to create a living clone.</font>"
 		return

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -115,7 +115,6 @@
 				else
 					flush = 1
 					for(var/mob/living/silicon/ai/A in src)
-						A.suiciding = 1
 						A << "Your core files are being wiped!"
 						while (A.stat != 2)
 							A.adjustOxyLoss(2)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -481,7 +481,7 @@
 
 						var/failed = null
 
-						if (H.suiciding || (H.disabilities & NOCLONE))
+						if (H.disabilities & NOCLONE)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>"
 						else if ((tplus > tlimit) || !H.getorgan(/obj/item/organ/internal/heart))
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return. Further attempts futile.</span>"

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,5 +1,3 @@
-/mob/var/suiciding = 0
-
 /mob/living/carbon/human/verb/suicide()
 	set hidden = 1
 	if(!canSuicide())
@@ -8,7 +6,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
@@ -71,12 +68,10 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		visible_message("<span class='danger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>", \
 						"<span class='userdanger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>")
 		spawn(50)
 			death(0)
-			suiciding = 0
 
 /mob/living/carbon/monkey/verb/suicide()
 	set hidden = 1
@@ -86,7 +81,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		//instead of killing them instantly, just put them at -175 health and let 'em gasp for a while
 		visible_message("<span class='danger'>[src] is attempting to bite \his tongue. It looks like \he's trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is attempting to bite \his tongue. It looks like \he's trying to commit suicide.</span>")
@@ -102,7 +96,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>")
 		//put em at -175
@@ -118,7 +111,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		visible_message("<span class='danger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is powering down. It looks like \he's trying to commit suicide.</span>")
 		//put em at -175
@@ -147,7 +139,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		visible_message("<span class='danger'>[src] is thrashing wildly! It looks like \he's trying to commit suicide.</span>", \
 				"<span class='userdanger'>[src] is thrashing wildly! It looks like \he's trying to commit suicide.</span>", \
 				"<span class='italics'>You hear thrashing.</span>")
@@ -164,7 +155,6 @@
 	if(!canSuicide())
 		return
 	if(confirm == "Yes")
-		suiciding = 1
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like \he's lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like \he's lost the will to live.</span>")
 		death(0)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -47,6 +47,7 @@
 
 				updatehealth()
 				death(0)
+				ghostize(0)
 				return
 
 		var/suicide_message = pick("[src] is attempting to bite \his tongue off! It looks like \he's trying to commit suicide.", \
@@ -59,6 +60,7 @@
 		adjustOxyLoss(max(200 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 		death(0)
+		ghostize(0)
 
 /mob/living/carbon/brain/verb/suicide()
 	set hidden = 1
@@ -72,6 +74,7 @@
 						"<span class='userdanger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>")
 		spawn(50)
 			death(0)
+			ghostize(0)
 
 /mob/living/carbon/monkey/verb/suicide()
 	set hidden = 1
@@ -87,6 +90,7 @@
 		adjustOxyLoss(max(200- getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 		death(0)
+		ghostize(0)
 
 /mob/living/silicon/ai/verb/suicide()
 	set hidden = 1
@@ -102,6 +106,7 @@
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 		death(0)
+		ghostize(0)
 
 /mob/living/silicon/robot/verb/suicide()
 	set hidden = 1
@@ -117,6 +122,7 @@
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 		death(0)
+		ghostize(0)
 
 /mob/living/silicon/pai/verb/suicide()
 	set category = "pAI Commands"
@@ -128,6 +134,7 @@
 		var/turf/T = get_turf(src.loc)
 		T.visible_message("<span class='notice'>[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\"</span>", "<span class='notice'>[src] bleeps electronically.</span>")
 		death(0)
+		ghostize(0)
 	else
 		src << "Aborting suicide attempt."
 
@@ -146,6 +153,7 @@
 		adjustOxyLoss(max(200 - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 		death(0)
+		ghostize(0)
 
 /mob/living/simple_animal/verb/suicide()
 	set hidden = 1
@@ -158,7 +166,7 @@
 		visible_message("<span class='danger'>[src] begins to fall down. It looks like \he's lost the will to live.</span>", \
 						"<span class='userdanger'>[src] begins to fall down. It looks like \he's lost the will to live.</span>")
 		death(0)
-
+		ghostize(0)
 
 /mob/living/proc/canSuicide()
 	if(stat == CONSCIOUS)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -868,12 +868,12 @@
 						make_podman = 1
 						break
 				else
-					if(M.ckey == ckey && M.stat == 2 && !M.suiciding)
+					if(M.ckey == ckey && M.stat == 2)
 						make_podman = 1
 						break
 		else //If the player has ghosted from his corpse before blood was drawn, his ckey is no longer attached to the mob, so we need to match up the cloned player through the mind key
 			for(var/mob/M in player_list)
-				if(mind && M.mind && ckey(M.mind.key) == ckey(mind.key) && M.ckey && M.client && M.stat == 2 && !M.suiciding)
+				if(mind && M.mind && ckey(M.mind.key) == ckey(mind.key) && M.ckey && M.client && M.stat == 2)
 					if(istype(M, /mob/dead/observer))
 						var/mob/dead/observer/O = M
 						if(!O.can_reenter_corpse)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -17,6 +17,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghsot - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
+	var/do_not_resusitate = 0 //Player has a corpse but doesn't want to play, bodies will revive, but will end up souless
 	var/atom/movable/following = null
 	var/fun_verbs = 0
 	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
@@ -146,6 +147,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				for(var/datum/gang/G in ticker.mode.gangs)
 					if(isnum(G.dom_timer))
 						stat(null, "[G.name] Gang Takeover: [max(G.dom_timer, 0)]")
+
+/mob/dead/observer/verb/do_not_resuscitate()
+	set category = "Ghost"
+	set name = "Quit Round"
+	set desc= "Tells players that you're done playing for the round and don't want to be revived."
+
+	if(!can_reenter_corpse)
+		src << "<span class='notice'>You are already set to do not resuscitate.</span>"
+		return
+	if(alert(src, "Setting this option will keep you from reentering your body for the rest of the round. You cannot take this choice back!", "Do Not Resuscitate", "Proceed", "Nevermind!") == "Nevermind!")
+		return
+	can_reenter_corpse = 0
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -17,7 +17,6 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghsot - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
-	var/do_not_resusitate = 0 //Player has a corpse but doesn't want to play, bodies will revive, but will end up souless
 	var/atom/movable/following = null
 	var/fun_verbs = 0
 	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -167,8 +167,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		B.data["mind"] = src.mind
 	if(ckey)
 		B.data["ckey"] = src.ckey
-	if(!suiciding)
-		B.data["cloneable"] = 1
+	B.data["cloneable"] = 1
 	B.data["blood_type"] = copytext(src.dna.blood_type,1,0)
 	B.data["gender"] = src.gender
 	B.data["real_name"] = src.real_name

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -174,8 +174,6 @@
 	if(stat == DEAD || (status_flags & FAKEDEATH))
 		appears_dead = 1
 		if(getorgan(/obj/item/organ/internal/brain))//Only perform these checks if there is no brain
-			if(suiciding)
-				msg += "<span class='warning'>[t_He] appears to have commited suicide... there is no hope of recovery.</span>\n"
 			msg += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive; there are no signs of life"
 			if(!key)
 				var/foundghost = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -461,7 +461,6 @@ Sorry Giacom. Please don't be mad :(
 	heal_overall_damage(1000, 1000)
 	ExtinguishMob()
 	fire_stacks = 0
-	suiciding = 0
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 		C.handcuffed = initial(C.handcuffed)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -51,8 +51,6 @@
 		var/datum/mutation/human/race/R = mutations_list[RACEMUT]
 		O.dna.struc_enzymes = R.set_se(O.dna.struc_enzymes, on=1)//we don't want to keep the race block inactive
 
-	if(suiciding)
-		O.suiciding = suiciding
 	O.loc = loc
 	O.a_intent = "harm"
 
@@ -169,9 +167,6 @@
 		var/datum/mutation/human/race/R = mutations_list[RACEMUT]
 		O.dna.struc_enzymes = R.set_se(O.dna.struc_enzymes, on=0)//we don't want to keep the race block active
 		O.domutcheck()
-
-	if(suiciding)
-		O.suiciding = suiciding
 
 	O.loc = loc
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -51,7 +51,6 @@
 	if(ismob(target))
 		var/old_stat = target.stat
 		target.revive()
-		target.suiciding = 0
 		if(!target.ckey)
 			for(var/mob/dead/observer/ghost in player_list)
 				if(target.real_name == ghost.real_name)

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -690,7 +690,7 @@
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			return
 		M.visible_message("<span class='warning'>[M]'s body convulses a bit.</span>")
-		if(!M.suiciding && !(M.disabilities & NOCLONE))
+		if(!(M.disabilities & NOCLONE))
 			if(!M)
 				return
 			if(M.notify_ghost_cloning())

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -229,8 +229,6 @@
 		return
 	if(owner.stat != UNCONSCIOUS)
 		return
-	if(owner.suiciding)
-		return
 
 	revive_cost = 0
 	reviving = 1


### PR DESCRIPTION
You can still commit suicide, but even after committing suicide you can be revived.

Adds Quit Round/Do Not Resuscitate. This is a ghost verb you can use to tell people "I'm done with this round but I don't want to leave the server". This can be set regardless of how you died. Once you set this status most forms of revives will fail and the few that don't will just leave a catatonic body as if you live ghosted. Your corpse will appear as if your ghost didn't exist. Once you opt into this, you can't back out.

There's a million ways to kill yourself without suiciding, so this helps clear up confusion on what the dead's intentions are.
