### PR TITLE
Disallow nulls in the lighting system's lights list

### DIFF
--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -58,6 +58,8 @@
 		remove_effect()
 		owner.light = null
 		owner = null
+	if(changed)
+		SSlighting.changed_lights -= src
 	return ..()
 
 //Check a light to see if its effect needs reprocessing. If it does, remove any old effect and create a new one


### PR DESCRIPTION
This bug isn't reproducable so no, I'm not sure this will fix it. It's still a good idea to do this though.

Best guess as to what happened: A light was deleted pre-round. The garbage ss del()'d the light before the lighting system's first tick, so a null got into the lighting ss's lights list. This broke the whole system directly from roundstart and caused the thousands of "can't run null.check()" runtime errors from yesterday.
