### PR TITLE
Fixes automatic map change causing lag

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -488,4 +488,5 @@ var/datum/subsystem/ticker/ticker
 	//map rotate chance defaults to 75% of the length of the round (in minutes)
 	if (!prob((world.time/600)*config.maprotatechancedelta))
 		return
-	maprotate()
+	spawn(-1) //compiling a map can lock up the mc for 30 to 60 seconds if we don't spawn
+		maprotate()


### PR DESCRIPTION
It would lock up the MC for around 30 seconds while it was compiling, meanwhile ticks are queuing.

After the map was compiled, there would be 15 mob ticks, 15 object subsystem ticks, 15 mechinery ticks, 60 atmo ticks, etc all queued up and would attempt to fire all at once.

Luckily this only happens near round end anyways, but still.

Fixes #12312
