### PR TITLE
Makes Built-in Floor Tiles Pass through the GC

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -42,6 +42,12 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	if(floor_tile)
 		builtin_tile = new floor_tile
 
+/turf/simulated/floor/Destroy()
+	if(builtin_tile)
+		qdel(builtin_tile)
+		builtin_tile = null
+	return ..()
+
 /turf/simulated/floor/ex_act(severity, target)
 	..()
 	if(target == src)


### PR DESCRIPTION
Simply put, make the built in floor tiles pass through the GC.

These are technically being garbage-collected naturally, so this is actually slower, overall, than just leaving them be, but after a conversation with @MrPerson, it was determined that having them pass through the GC would be better, even with the performance hit.
