### PR TITLE
Adjusting your jumpsuit now properly exposes your chest and/or arms as applicable.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -216,6 +216,7 @@ BLIND     // can't see anything
 	burn_state = -1 //Not Burnable
 
 //Under clothing
+
 /obj/item/clothing/under
 	icon = 'icons/obj/clothing/uniforms.dmi'
 	name = "under"
@@ -229,7 +230,7 @@ BLIND     // can't see anything
 	var/sensor_mode = 0	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
 	var/can_adjust = 1
 	var/adjusted = 0
-	var/modesty = 0 // 0 = exposes chest and arms, 1 = exposes arms only
+	var/alt_covers_chest = 0 // for adjusted/rolled-down jumpsuits, 0 = exposes chest and arms, 1 = exposes arms only
 	var/suit_color = null
 	var/obj/item/clothing/tie/hastie = null
 
@@ -367,7 +368,7 @@ atom/proc/generate_female_clothing(index,t_color,icon,type)
 		if(src.fitted != FEMALE_UNIFORM_TOP)
 			src.fitted = NO_FEMALE_UNIFORM
 		src.item_color += "_d"
-		if (src.modesty) // for the special snowflake suits that don't expose the chest when adjusted
+		if (alt_covers_chest) // for the special snowflake suits that don't expose the chest when adjusted
 			src.body_parts_covered = CHEST|GROIN|LEGS
 		else
 			src.body_parts_covered = GROIN|LEGS

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -229,6 +229,7 @@ BLIND     // can't see anything
 	var/sensor_mode = 0	/* 1 = Report living/dead, 2 = Report detailed damages, 3 = Report location */
 	var/can_adjust = 1
 	var/adjusted = 0
+	var/modesty = 0 // 0 = exposes chest and arms, 1 = exposes arms only
 	var/suit_color = null
 	var/obj/item/clothing/tie/hastie = null
 
@@ -359,12 +360,17 @@ atom/proc/generate_female_clothing(index,t_color,icon,type)
 		src.fitted = initial(fitted)
 		src.item_color = initial(item_color)
 		src.item_color = src.suit_color //colored jumpsuits are shit and break without this
+		src.body_parts_covered = CHEST|GROIN|LEGS|ARMS
 		usr << "<span class='notice'>You adjust the suit back to normal.</span>"
 		src.adjusted = 0
 	else
 		if(src.fitted != FEMALE_UNIFORM_TOP)
 			src.fitted = NO_FEMALE_UNIFORM
 		src.item_color += "_d"
+		if (src.modesty) // for the special snowflake suits that don't expose the chest when adjusted
+			src.body_parts_covered = CHEST|GROIN|LEGS
+		else
+			src.body_parts_covered = GROIN|LEGS
 		usr << "<span class='notice'>You adjust the suit to wear it more casually.</span>"
 		src.adjusted = 1
 	usr.update_inv_w_uniform()

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -6,7 +6,7 @@
 	icon_state = "barman"
 	item_state = "bar_suit"
 	item_color = "barman"
-	modesty = 1
+	alt_covers_chest = 1
 
 
 /obj/item/clothing/under/rank/captain //Alright, technically not a 'civilian' but its better then giving a .dm file for a single define.
@@ -47,7 +47,7 @@
 	desc = "A suit which is given only to the most <b>hardcore</b> cooks in space."
 	icon_state = "chef"
 	item_color = "chef"
-	modesty = 1
+	alt_covers_chest = 1
 
 
 /obj/item/clothing/under/rank/clown
@@ -123,7 +123,7 @@
 	item_state = "bluesuit"
 	item_color = "bluesuit"
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 
 /obj/item/clothing/under/lawyer/purpsuit
@@ -133,7 +133,7 @@
 	item_color = "lawyer_purp"
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 
 /obj/item/clothing/under/lawyer/blacksuit
@@ -143,7 +143,7 @@
 	item_state = "bar_suit"
 	item_color = "blacksuit"
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 
 /obj/item/clothing/under/rank/librarian

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -6,6 +6,7 @@
 	icon_state = "barman"
 	item_state = "bar_suit"
 	item_color = "barman"
+	modesty = 1
 
 
 /obj/item/clothing/under/rank/captain //Alright, technically not a 'civilian' but its better then giving a .dm file for a single define.
@@ -46,6 +47,7 @@
 	desc = "A suit which is given only to the most <b>hardcore</b> cooks in space."
 	icon_state = "chef"
 	item_color = "chef"
+	modesty = 1
 
 
 /obj/item/clothing/under/rank/clown
@@ -121,6 +123,7 @@
 	item_state = "bluesuit"
 	item_color = "bluesuit"
 	can_adjust = 1
+	modesty = 1
 
 
 /obj/item/clothing/under/lawyer/purpsuit
@@ -130,6 +133,7 @@
 	item_color = "lawyer_purp"
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = 1
+	modesty = 1
 
 
 /obj/item/clothing/under/lawyer/blacksuit
@@ -139,6 +143,7 @@
 	item_state = "bar_suit"
 	item_color = "blacksuit"
 	can_adjust = 1
+	modesty = 1
 
 
 /obj/item/clothing/under/rank/librarian

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -18,6 +18,7 @@
 	item_color = "rdwhimsy"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 	can_adjust = 1
+	modesty = 1
 
 /obj/item/clothing/under/rank/research_director/turtleneck
 	desc = "A dark purple turtleneck and tan khakis, for a director with a superior sense of style."
@@ -27,6 +28,7 @@
 	item_color = "rdturtle"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 	can_adjust = 1
+	modesty = 1
 
 /obj/item/clothing/under/rank/scientist
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has markings that denote the wearer as a scientist."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -18,7 +18,7 @@
 	item_color = "rdwhimsy"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/research_director/turtleneck
 	desc = "A dark purple turtleneck and tan khakis, for a director with a superior sense of style."
@@ -28,7 +28,7 @@
 	item_color = "rdturtle"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/scientist
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has markings that denote the wearer as a scientist."

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -17,7 +17,7 @@
 	item_color = "security"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/warden
 	name = "warden's jumpsuit"
@@ -27,7 +27,7 @@
 	item_color = "warden"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
-	modesty = 1
+	alt_covers_chest = 1
 
 /*
  * Detective
@@ -40,7 +40,7 @@
 	item_color = "detective"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/det/grey
 	name = "noir suit"
@@ -48,7 +48,7 @@
 	icon_state = "greydet"
 	item_state = "greydet"
 	item_color = "greydet"
-	modesty = 1
+	alt_covers_chest = 1
 
 /*
  * Head of Security
@@ -61,7 +61,7 @@
 	item_color = "hos"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 60
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/head_of_security/alt
 	name = "head of security's turtleneck"
@@ -80,7 +80,7 @@
 	icon_state = "officerblueclothes"
 	item_state = "officerblueclothes"
 	item_color = "officerblueclothes"
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/head_of_security/navyblue
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
@@ -88,7 +88,7 @@
 	icon_state = "hosblueclothes"
 	item_state = "hosblueclothes"
 	item_color = "hosblueclothes"
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/warden/navyblue
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Warden."
@@ -96,4 +96,4 @@
 	icon_state = "wardenblueclothes"
 	item_state = "wardenblueclothes"
 	item_color = "wardenblueclothes"
-	modesty = 1
+	alt_covers_chest = 1

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -17,6 +17,7 @@
 	item_color = "security"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
+	modesty = 1
 
 /obj/item/clothing/under/rank/warden
 	name = "warden's jumpsuit"
@@ -26,6 +27,7 @@
 	item_color = "warden"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
+	modesty = 1
 
 /*
  * Detective
@@ -38,6 +40,7 @@
 	item_color = "detective"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 50
+	modesty = 1
 
 /obj/item/clothing/under/rank/det/grey
 	name = "noir suit"
@@ -45,6 +48,7 @@
 	icon_state = "greydet"
 	item_state = "greydet"
 	item_color = "greydet"
+	modesty = 1
 
 /*
  * Head of Security
@@ -57,6 +61,7 @@
 	item_color = "hos"
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	strip_delay = 60
+	modesty = 1
 
 /obj/item/clothing/under/rank/head_of_security/alt
 	name = "head of security's turtleneck"
@@ -75,6 +80,7 @@
 	icon_state = "officerblueclothes"
 	item_state = "officerblueclothes"
 	item_color = "officerblueclothes"
+	modesty = 1
 
 /obj/item/clothing/under/rank/head_of_security/navyblue
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
@@ -82,6 +88,7 @@
 	icon_state = "hosblueclothes"
 	item_state = "hosblueclothes"
 	item_color = "hosblueclothes"
+	modesty = 1
 
 /obj/item/clothing/under/rank/warden/navyblue
 	desc = "The insignia on this uniform tells you that this uniform belongs to the Warden."
@@ -89,3 +96,4 @@
 	icon_state = "wardenblueclothes"
 	item_state = "wardenblueclothes"
 	item_color = "wardenblueclothes"
+	modesty = 1

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -94,7 +94,7 @@
 	icon_state = "officer"
 	item_state = "g_suit"
 	item_color = "officer"
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/rank/centcom_commander
 	desc = "It's a jumpsuit worn by Centcom's highest-tier Commanders."
@@ -469,7 +469,7 @@
 	item_color = "plaid_red"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/plaid_skirt/blue
 	name = "blue plaid skirt"
@@ -479,7 +479,7 @@
 	item_color = "plaid_blue"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/plaid_skirt/purple
 	name = "purple plaid skirt"
@@ -489,7 +489,7 @@
 	item_color = "plaid_purple"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = 1
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/jester
 	name = "jester suit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -94,6 +94,7 @@
 	icon_state = "officer"
 	item_state = "g_suit"
 	item_color = "officer"
+	modesty = 1
 
 /obj/item/clothing/under/rank/centcom_commander
 	desc = "It's a jumpsuit worn by Centcom's highest-tier Commanders."
@@ -468,6 +469,7 @@
 	item_color = "plaid_red"
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = 1
+	modesty = 1
 
 /obj/item/clothing/under/plaid_skirt/blue
 	name = "blue plaid skirt"
@@ -475,6 +477,9 @@
 	icon_state = "plaid_blue"
 	item_state = "plaid_blue"
 	item_color = "plaid_blue"
+	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = 1
+	modesty = 1
 
 /obj/item/clothing/under/plaid_skirt/purple
 	name = "purple plaid skirt"
@@ -482,6 +487,9 @@
 	icon_state = "plaid_purple"
 	item_state = "plaid_purple"
 	item_color = "plaid_purple"
+	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = 1
+	modesty = 1
 
 /obj/item/clothing/under/jester
 	name = "jester suit"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -6,7 +6,7 @@
 	item_color = "syndicate"
 	has_sensor = 0
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
-	modesty = 1
+	alt_covers_chest = 1
 
 /obj/item/clothing/under/syndicate/tacticool
 	name = "tacticool turtleneck"

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -6,6 +6,7 @@
 	item_color = "syndicate"
 	has_sensor = 0
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	modesty = 1
 
 /obj/item/clothing/under/syndicate/tacticool
 	name = "tacticool turtleneck"


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/5932.

As pointed in that issue report, some jumpsuits expose only the arms, some expose arms and chest. (please don't make any adjusted jumpsuits that expose any other configuration of parts for the love of fuck accounting for this was snowflakey enough) Jumpsuits have a boolean var to track this. It is set to 0 (exposes both) by default. If I missed any, let me know.
