### PR TITLE
Engiborgs can no longer make stunprods with their wirecutter module.

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -121,7 +121,7 @@
 		qdel(I)
 		qdel(src)
 
-	else if(istype(I, /obj/item/weapon/wirecutters))
+	else if(istype(I, /obj/item/weapon/wirecutters) && !(I.flags & NODROP))
 		var/obj/item/weapon/melee/baton/cattleprod/P = new /obj/item/weapon/melee/baton/cattleprod
 
 		if(!remove_item_from_storage(user))
@@ -221,7 +221,7 @@
 
 /obj/item/weapon/cane
 	name = "cane"
-	desc = "A cane used by a true gentlemen. Or a clown."
+	desc = "A cane used by a true gentleman. Or a clown."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "cane"
 	item_state = "stick"
@@ -232,7 +232,7 @@
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
 
 /obj/item/weapon/staff
-	name = "wizards staff"
+	name = "wizard staff"
 	desc = "Apparently a staff used by the wizard."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "staff"


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/7880.

@Cheridan said in the old attempt at fixing this to make it check for NODROP as borg modules use that. (Because someone's going to ask: Attaching cable alone to a rod doesn't work anymore. It uses cable restraints, which borgs don't have.)

Fixes a grammatical error with canes.
