### PR TITLE
Enables job restrictions for roundstart catpeople even if the config is off

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -13,9 +13,6 @@
 	use_skintones = 1
 
 /datum/species/human/qualifies_for_rank(rank, list/features)
-	if(!config.mutant_humans) //No mutie scum here
-		return 1
-
 	if((!features["tail_human"] || features["tail_human"] == "None") && (!features["ears"] || features["ears"] == "None"))
 		return 1	//Pure humans are always allowed in all roles.
 


### PR DESCRIPTION
No fun allowed.
This code was a hotfix done to stop the catastrophe when people were randomly becoming catpeople
