### PR TITLE
Walking mushroom fixes/tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -25,6 +25,7 @@
 	speed = 1
 	ventcrawler = 2
 	robust_searching = 1
+	unique_name = 1
 	speak_emote = list("squeaks")
 	var/powerlevel = 0 //Tracks our general strength level gained from eating other shrooms
 	var/bruised = 0 //If someone tries to cheat the system by attacking a shroom to lower its health, punish them so that it wont award levels to shrooms that eat it
@@ -158,6 +159,6 @@
 	for(counter=0, counter<=powerlevel, counter++)
 		var/obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice/S = new /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice(src.loc)
 		S.reagents.add_reagent("mushroomhallucinogen", powerlevel)
-		S.reagents.add_reagent("doctorsdelight", powerlevel)
+		S.reagents.add_reagent("omnizine", powerlevel)
 		S.reagents.add_reagent("synaptizine", powerlevel)
 	qdel(src)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/11800.

Walking mushrooms have unique numbers to make mushroom fights/identifying strong mushrooms easier. In addition, the Doctor's Delight in huge mushroom slices has been replaced with omnizine. The max one slice can contain is 9 omnizine, so overdose is not a concern unless someone is stuffing their face with mushroom, in which case they get what they deserve.
