### PR TITLE
Changes smoke to behave more like foam.

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -213,15 +213,15 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 		if(smoke_spread)
 			if(smoke_spread == 1)
 				var/datum/effect/effect/system/smoke_spread/smoke = new
-				smoke.set_up(smoke_amt, 0, location, smoke_amt == 1 ? 15 : 0) // if more than one smoke, spread it around
+				smoke.set_up(smoke_amt, location)
 				smoke.start()
 			else if(smoke_spread == 2)
 				var/datum/effect/effect/system/smoke_spread/bad/smoke = new
-				smoke.set_up(smoke_amt, 0, location, smoke_amt == 1 ? 15 : 0) // same here
+				smoke.set_up(smoke_amt, location)
 				smoke.start()
 			else if(smoke_spread == 3)
 				var/datum/effect/effect/system/smoke_spread/sleeping/smoke = new
-				smoke.set_up(smoke_amt, 0, location, smoke_amt == 1 ? 15 : 0) // same here
+				smoke.set_up(smoke_amt, location)
 				smoke.start()
 
 

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -134,4 +134,4 @@
 	cooldown_min = 20 //25 deciseconds reduction per rank
 
 	smoke_spread = 3
-	smoke_amt = 10
+	smoke_amt = 4

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -67,7 +67,7 @@
 	cooldown_min = 20 //25 deciseconds reduction per rank
 
 	smoke_spread = 2
-	smoke_amt = 10
+	smoke_amt = 4
 
 	action_icon_state = "smoke"
 
@@ -101,7 +101,7 @@
 
 
 	smoke_spread = 1
-	smoke_amt = 1
+	smoke_amt = 0
 
 	inner_tele_radius = 0
 	outer_tele_radius = 6
@@ -133,7 +133,7 @@
 	cooldown_min = 200 //100 deciseconds reduction per rank
 
 	smoke_spread = 1
-	smoke_amt = 5
+	smoke_amt = 2
 	sound1="sound/magic/Teleport_diss.ogg"
 	sound2="sound/magic/Teleport_app.ogg"
 

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -104,7 +104,7 @@
 
 	// Attach the smoke spreader and setup/start it.
 	S.attach(location)
-	S.set_up(reagents, 1, 1, location, 15, 1) // only 1 smoke cloud
+	S.set_up(reagents, 0, location, silent=1)
 	S.start()
 
 	ghostize()

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -403,9 +403,7 @@
 		var/datum/effect/effect/system/smoke_spread/chem/S = new
 		S.attach(B)
 		if(S)
-			S.set_up(B.reagents, 10, 0, B.loc)
-			S.start()
-			sleep(10)
+			S.set_up(B.reagents, 4, 0, B.loc)
 			S.start()
 		qdel(B)
 

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -24,7 +24,7 @@
 
 /obj/mecha/combat/marauder/New()
 	..()
-	smoke_system.set_up(3, 0, src)
+	smoke_system.set_up(3, src)
 	smoke_system.attach(src)
 
 /obj/mecha/combat/marauder/Destroy()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -1,5 +1,5 @@
 // Foam
-// Similar to smoke, but spreads out more
+// Similar to smoke, but slower and mobs absorb its reagent through their exposed skin.
 
 /obj/effect/effect/foam
 	name = "foam"

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -1,21 +1,20 @@
 /////////////////////////////////////////////
 //// SMOKE SYSTEMS
-// direct can be optionally added when set_up, to make the smoke always travel in one direction
-// in case you wanted a vent to always smoke north for example
 /////////////////////////////////////////////
 
 /obj/effect/effect/smoke
 	name = "smoke"
 	icon = 'icons/effects/96x96.dmi'
+	icon_state = "smoke"
 	pixel_x = -32
 	pixel_y = -32
-	icon_state = "smoke"
-	opacity = 1
-	anchored = 0
+	opacity = 0
+	anchored = 1
 	mouse_opacity = 0
-	var/steps = 0
+	animate_movement = 0
+	var/amount = 4
 	var/lifetime = 5
-	var/direction
+	var/opaque = 1 //whether the smoke can block the view when in enough amount
 
 
 /obj/effect/effect/smoke/proc/fade_out(frames = 16)
@@ -32,7 +31,7 @@
 	..()
 	create_reagents(500)
 	SSobj.processing |= src
-	lifetime += rand(-1,1)
+
 
 /obj/effect/effect/smoke/Destroy()
 	SSobj.processing.Remove(src)
@@ -50,64 +49,69 @@
 	if(lifetime < 1)
 		kill_smoke()
 		return 0
-	if(steps >= 1)
-		step(src,direction)
-		steps--
+	for(var/mob/living/L in range(0,src))
+		smoke_mob(L)
 	return 1
 
-/obj/effect/effect/smoke/Crossed(mob/living/M)
-	if(!istype(M))
-		return
-	smoke_mob(M)
-
-/obj/effect/effect/smoke/proc/smoke_mob(mob/living/carbon/M)
-	if(!istype(M))
+/obj/effect/effect/smoke/proc/smoke_mob(mob/living/carbon/C)
+	if(!istype(C))
 		return 0
 	if(lifetime<1)
 		return 0
-	if(M.internal != null || (M.wear_mask && (M.wear_mask.flags & BLOCK_GAS_SMOKE_EFFECT)))
+	if(C.internal != null || C.has_smoke_protection())
 		return 0
-	if(M.smoke_delay)
+	if(C.smoke_delay)
 		return 0
-	M.smoke_delay++
+	C.smoke_delay++
 	spawn(10)
-		if(M)
-			M.smoke_delay = 0
+		if(C)
+			C.smoke_delay = 0
 	return 1
 
+/obj/effect/effect/smoke/proc/spread_smoke()
+	var/turf/t_loc = get_turf(src)
+	var/list/newsmokes = list()
+	for(var/turf/T in t_loc.GetAtmosAdjacentTurfs())
+		var/obj/effect/effect/smoke/foundsmoke = locate() in T //Don't spread smoke where there's already smoke!
+		if(foundsmoke)
+			continue
+		for(var/mob/living/L in T)
+			smoke_mob(L)
+		var/obj/effect/effect/smoke/S = new type(T)
+		reagents.copy_to(S, reagents.total_volume)
+		S.dir = pick(cardinal)
+		S.amount = amount-1
+		S.color = color
+		S.lifetime = lifetime
+		if(S.amount>0)
+			if(opaque)
+				S.opacity = 1
+			newsmokes.Add(S)
+
+	if(newsmokes.len)
+		spawn(1) //the smoke spreads rapidly but not instantly
+			for(var/obj/effect/effect/smoke/SM in newsmokes)
+				SM.spread_smoke()
 
 
 /datum/effect/effect/system/smoke_spread
-	var/direction
+	var/amount = 10
 	var/smoke_type = /obj/effect/effect/smoke
 
-/datum/effect/effect/system/smoke_spread/set_up(n = 5, c = 0, loca, direct)
-	if(n > 20)
-		n = 20
-	number = n
-	cardinals = c
-	if(istype(loca, /turf/))
+/datum/effect/effect/system/smoke_spread/set_up(radius = 5, loca)
+	if(isturf(loca))
 		location = loca
 	else
 		location = get_turf(loca)
-	if(direct)
-		direction = direct
+	amount = radius
 
 /datum/effect/effect/system/smoke_spread/start()
-	for(var/i=0, i<src.number, i++)
-		if(holder)
-			src.location = get_turf(holder)
-		var/obj/effect/effect/smoke/S = PoolOrNew(smoke_type, location)
-		if(!direction)
-			if(src.cardinals)
-				S.direction = pick(cardinal)
-			else
-				S.direction = pick(alldirs)
-		else
-			S.direction = direction
-		S.steps = pick(0,1,1,1,2,2,2,3)
-		S.process()
-
+	if(holder)
+		location = get_turf(holder)
+	var/obj/effect/effect/smoke/S = new smoke_type(location)
+	S.amount = amount
+	if(S.amount)
+		S.spread_smoke()
 
 
 /////////////////////////////////////////////
@@ -117,16 +121,12 @@
 /obj/effect/effect/smoke/bad
 	lifetime = 8
 
-/obj/effect/effect/smoke/bad/process()
-	if(..())
-		for(var/mob/living/carbon/M in range(1,src))
-			smoke_mob(M)
-
 /obj/effect/effect/smoke/bad/smoke_mob(mob/living/carbon/M)
 	if(..())
 		M.drop_item()
 		M.adjustOxyLoss(1)
 		M.emote("cough")
+		return 1
 
 /obj/effect/effect/smoke/bad/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0) return 1
@@ -140,41 +140,104 @@
 /datum/effect/effect/system/smoke_spread/bad
 	smoke_type = /obj/effect/effect/smoke/bad
 
+/////////////////////////////////////////////
+// Nanofrost smoke
+/////////////////////////////////////////////
+
+/obj/effect/effect/smoke/freezing
+	name = "nanofrost smoke"
+	color = "#B2FFFF"
+	opaque = 0
+
+/datum/effect/effect/system/smoke_spread/freezing
+	smoke_type = /obj/effect/effect/smoke/freezing
+	var/blast = 0
+
+/datum/effect/effect/system/smoke_spread/freezing/proc/Chilled(atom/A)
+	if(istype(A, /turf/simulated))
+		var/turf/simulated/T = A
+		if(T.air)
+			var/datum/gas_mixture/G = T.air
+			if(get_dist(T, location) < 2) // Otherwise we'll get silliness like people using Nanofrost to kill people through walls with cold air
+				G.temperature = 2
+			T.air_update_turf()
+			for(var/obj/effect/hotspot/H in T)
+				qdel(H)
+				if(G.toxins)
+					G.nitrogen += (G.toxins)
+					G.toxins = 0
+		for(var/obj/machinery/atmospherics/components/unary/U in T)
+			if(!isnull(U.welded) && !U.welded) //must be an unwelded vent pump or vent scrubber.
+				U.welded = 1
+				U.update_icon()
+				U.visible_message("<span class='danger'>[U] was frozen shut!</span>")
+		for(var/mob/living/L in T)
+			L.ExtinguishMob()
+		for(var/obj/item/Item in T)
+			Item.extinguish()
+	return
+
+/datum/effect/effect/system/smoke_spread/freezing/set_up(radius = 5, loca, blasting = 0)
+	..()
+	blast = blasting
+
+/datum/effect/effect/system/smoke_spread/freezing/start()
+	if(blast)
+		for(var/turf/T in trange(2, location))
+			Chilled(T)
+	..()
+
+
+
+/////////////////////////////////////////////
+// Sleep smoke
+/////////////////////////////////////////////
+
+/obj/effect/effect/smoke/sleeping
+	color = "#9C3636"
+	lifetime = 10
+
+/obj/effect/effect/smoke/sleeping/smoke_mob(mob/living/carbon/M)
+	if(..())
+		M.drop_item()
+		M.sleeping = max(M.sleeping,10)
+		M.emote("cough")
+		return 1
+
+/datum/effect/effect/system/smoke_spread/sleeping
+	smoke_type = /obj/effect/effect/smoke/sleeping
 
 /////////////////////////////////////////////
 // Chem smoke
 /////////////////////////////////////////////
 
 /obj/effect/effect/smoke/chem
-	icon = 'icons/effects/chemsmoke.dmi'
-	icon_state = ""
 	lifetime = 10
+
 
 /obj/effect/effect/smoke/chem/process()
 	if(..())
+		var/turf/T = get_turf(src)
 		var/fraction = 1/initial(lifetime)
-		for(var/obj/O in range(1,src))
-			if(O.type == src.type)
+		for(var/atom/movable/AM in T)
+			if(AM.type == src.type)
 				continue
-			reagents.reaction(O, VAPOR, fraction)
+			reagents.reaction(AM, TOUCH, fraction)
 
-		for(var/turf/T in range(1,src))
-			reagents.reaction(T, VAPOR, fraction)
-
-		var/hit = 0
-		for(var/mob/living/L in range(1,src))
-			hit += smoke_mob(L)
-		if(hit)
-			lifetime++ //this is so the decrease from mobs hit and the natural decrease don't cumulate.
+		reagents.reaction(T, TOUCH, fraction)
+		return 1
 
 /obj/effect/effect/smoke/chem/smoke_mob(mob/living/carbon/M)
 	if(lifetime<1)
 		return 0
 	if(!istype(M))
 		return 0
+	var/mob/living/carbon/C = M
+	if(C.internal != null || C.has_smoke_protection())
+		return 0
 	var/fraction = 1/initial(lifetime)
-	reagents.reaction(M, VAPOR, fraction)
-	lifetime--
+	reagents.copy_to(C, fraction*reagents.total_volume)
+	reagents.reaction(M, INGEST, fraction)
 	return 1
 
 
@@ -191,20 +254,16 @@
 	R.my_atom = chemholder
 
 /datum/effect/effect/system/smoke_spread/chem/Destroy()
+	qdel(chemholder)
 	chemholder = null
 	return ..()
 
-/datum/effect/effect/system/smoke_spread/chem/set_up(datum/reagents/carry = null, n = 5, c = 0, loca, direct, silent = 0)
-	if(n > 20)
-		n = 20
-	number = n
-	cardinals = c
+/datum/effect/effect/system/smoke_spread/chem/set_up(datum/reagents/carry = null, radius = 1, loca, silent = 0)
 	if(istype(loca, /turf/))
 		location = loca
 	else
 		location = get_turf(loca)
-	if(direct)
-		direction = direct
+	amount = radius
 	carry.copy_to(chemholder, 4*carry.total_volume) //The smoke holds 4 times the total reagents volume for balance purposes.
 
 	if(!silent)
@@ -231,64 +290,17 @@
 
 
 /datum/effect/effect/system/smoke_spread/chem/start()
-
 	var/color = mix_color_from_reagents(chemholder.reagents.reagent_list)
+	if(holder)
+		location = get_turf(holder)
+	var/obj/effect/effect/smoke/chem/S = new smoke_type(location)
 
-	for(var/i=0, i<src.number, i++)
-		if(holder)
-			src.location = get_turf(holder)
-		var/obj/effect/effect/smoke/chem/S = PoolOrNew(smoke_type, location)
-		if(!direction)
-			if(src.cardinals)
-				S.direction = pick(cardinal)
-			else
-				S.direction = pick(alldirs)
-		else
-			S.direction = direction
-		if(number == 1)
-			S.steps = 0
-		else if(number<=5)
-			S.steps = pick(0,1,1)
-		else if(number<=10)
-			S.steps = pick(0,1,1,1,2)
-		else
-			S.steps = pick(0,1,1,1,2,2,2,3)
+	if(chemholder.reagents.total_volume > 1) // can't split 1 very well
+		chemholder.reagents.copy_to(S, chemholder.reagents.total_volume)
 
-		if(chemholder.reagents.total_volume > 1) // can't split 1 very well
-			chemholder.reagents.copy_to(S, chemholder.reagents.total_volume/number) // copy reagents to each smoke, divide evenly
+	if(color)
+		S.color = color // give the smoke color, if it has any to begin with
+	S.amount = amount
+	if(S.amount)
+		S.spread_smoke() //calling process right now so the smoke immediately attacks mobs.
 
-		if(color)
-			S.color = color // give the smoke color, if it has any to begin with
-		else
-			// if no color, just use the old smoke icon
-			S.icon = 'icons/effects/96x96.dmi'
-			S.icon_state = "smoke"
-
-		S.process() //calling process right now so the smoke immediately attacks mobs.
-
-/////////////////////////////////////////////
-// Sleep smoke
-/////////////////////////////////////////////
-
-/obj/effect/effect/smoke/sleeping
-	color = "#9C3636"
-	lifetime = 10
-
-/obj/effect/effect/smoke/sleeping/process()
-	if(..())
-		for(var/mob/living/carbon/M in range(1,src))
-			smoke_mob(M)
-
-/obj/effect/effect/smoke/sleeping/smoke_mob(mob/living/carbon/M)
-	if(..())
-		if(M.internal != null || (M.wear_mask && (M.wear_mask.flags & BLOCK_GAS_SMOKE_EFFECT)))
-			return
-		else
-			M.drop_item()
-			M.sleeping = max(M.sleeping,10)
-			M.emote("cough")
-
-
-/datum/effect/effect/system/smoke_spread/sleeping
-	smoke_type = /obj/effect/effect/smoke/sleeping
-	var/obj/chemholder

--- a/code/game/objects/effects/explosion_particles.dm
+++ b/code/game/objects/effects/explosion_particles.dm
@@ -66,5 +66,5 @@
 	P.start()
 	spawn(5)
 		var/datum/effect/effect/system/smoke_spread/S = new
-		S.set_up(5,0,location,null)
+		S.set_up(2,location)
 		S.start()

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -359,7 +359,6 @@
 	B1.reagents.add_reagent("potassium", 40)
 	B2.reagents.add_reagent("phosphorus", 40)
 	B2.reagents.add_reagent("sugar", 40)
-	B1.reagents.add_reagent("condensedcapsaicin", 20)
 
 	beakers += B1
 	beakers += B2

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -19,11 +19,9 @@
 /obj/item/weapon/grenade/smokebomb/prime()
 	update_mob()
 	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-	src.smoke.set_up(10, 0, usr.loc)
-	spawn(0)
-		src.smoke.start()
-		sleep(10)
-		src.smoke.start()
+	smoke.set_up(4, usr.loc)
+	smoke.start()
+
 
 	for(var/obj/effect/blob/B in view(8,src))
 		var/damage = round(30/(get_dist(B,src)+1))

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -59,7 +59,7 @@
 		return
 
 	var/datum/effect/effect/system/smoke_spread/smoke = new
-	smoke.set_up(5, 0, user.loc)
+	smoke.set_up(2, user.loc)
 	smoke.attach(user)
 	smoke.start()
 	var/list/L = list()

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -312,7 +312,7 @@
 
 /obj/effect/nanofrost_container/proc/Smoke()
 	var/datum/effect/effect/system/smoke_spread/freezing/S = new
-	S.set_up(6, 0, loc, null, 1)
+	S.set_up(2, src.loc, blasting=1)
 	S.start()
 	var/obj/effect/decal/cleanable/flour/F = new /obj/effect/decal/cleanable/flour(src.loc)
 	F.color = "#B2FFFF"
@@ -320,50 +320,6 @@
 	F.desc = "Residue left behind from a nanofrost detonation. Perhaps there was a fire here?"
 	playsound(src,'sound/effects/bamf.ogg',100,1)
 	qdel(src)
-
-/obj/effect/effect/smoke/freezing
-	name = "nanofrost smoke"
-	opacity = 0
-	color = "#B2FFFF"
-
-/datum/effect/effect/system/smoke_spread/freezing
-	smoke_type = /obj/effect/effect/smoke/freezing
-	var/blast = 0
-
-/datum/effect/effect/system/smoke_spread/freezing/proc/Chilled(atom/A)
-	if(istype(A, /turf/simulated))
-		var/turf/simulated/T = A
-		if(T.air)
-			var/datum/gas_mixture/G = T.air
-			if(get_dist(T, location) < 2) // Otherwise we'll get silliness like people using Nanofrost to kill people through walls with cold air
-				G.temperature = 2
-			T.air_update_turf()
-			for(var/obj/effect/hotspot/H in T)
-				qdel(H)
-				if(G.toxins)
-					G.nitrogen += (G.toxins)
-					G.toxins = 0
-		for(var/obj/machinery/atmospherics/components/unary/U in T)
-			if(!isnull(U.welded) && !U.welded) //must be an unwelded vent pump or vent scrubber.
-				U.welded = 1
-				U.update_icon()
-				U.visible_message("<span class='danger'>[U] was frozen shut!</span>")
-		for(var/mob/living/L in T)
-			L.ExtinguishMob()
-		for(var/obj/item/Item in T)
-			Item.extinguish()
-	return
-
-/datum/effect/effect/system/smoke_spread/freezing/set_up(n = 5, c = 0, loca, direct, blasting = 0)
-	..()
-	blast = blasting
-
-/datum/effect/effect/system/smoke_spread/freezing/start()
-	if(blast)
-		for(var/turf/T in trange(2, location))
-			Chilled(T)
-	..()
-
 
 #undef EXTINGUISHER
 #undef NANOFROST

--- a/code/game/objects/structures/hivebot.dm
+++ b/code/game/objects/structures/hivebot.dm
@@ -11,7 +11,7 @@
 /obj/structure/hivebot_beacon/New()
 	..()
 	var/datum/effect/effect/system/smoke_spread/smoke = new
-	smoke.set_up(5, 0, src.loc)
+	smoke.set_up(2, loc)
 	smoke.start()
 	visible_message("<span class='boldannounce'>The [src] warps in!</span>")
 	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -35,7 +35,7 @@
 			R.add_reagent(pick(gunk), 50)
 
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
-			smoke.set_up(R, rand(1, 2), 0, vent, 0, silent = 1)
+			smoke.set_up(R, 1, vent, silent = 1)
 			playsound(vent.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 			smoke.start()
 			qdel(R)

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -52,5 +52,5 @@
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		var/datum/effect/effect/system/smoke_spread/smoke = new
-		smoke.set_up(max(1,1), 0, H.loc)
+		smoke.set_up(0, H.loc)
 		smoke.start()

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -29,7 +29,7 @@
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		var/datum/effect/effect/system/smoke_spread/smoke = new
-		smoke.set_up(max(1,1), 0, H.loc)
+		smoke.set_up(0, H.loc)
 		smoke.start()
 
 //---//
@@ -61,7 +61,7 @@
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		var/datum/effect/effect/system/smoke_spread/smoke = new
-		smoke.set_up(max(1,1), 0, H.loc)
+		smoke.set_up(0, H.loc)
 		smoke.start()
 
 //---//
@@ -93,5 +93,5 @@
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		var/datum/effect/effect/system/smoke_spread/smoke = new
-		smoke.set_up(max(1,1), 0, H.loc)
+		smoke.set_up(0, H.loc)
 		smoke.start()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -69,16 +69,6 @@
 
 				breath = loc.remove_air(breath_moles)
 
-				//Harmful gasses
-				if(!has_smoke_protection())
-					for(var/obj/effect/effect/smoke/chem/S in range(1, src))
-						if(S.reagents.total_volume && S.lifetime)
-							var/fraction = 1/initial(S.lifetime)
-							S.reagents.reaction(src,INGEST, fraction)
-							var/amount = round(S.reagents.total_volume*fraction,0.1)
-							S.reagents.copy_to(src, amount)
-							S.lifetime--
-
 		else //Breathe from loc as obj again
 			if(istype(loc, /obj/))
 				var/obj/loc_as_obj = loc

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_smoke.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_smoke.dm
@@ -10,7 +10,7 @@
 	if(!ninjacost(0,N_SMOKE_BOMB))
 		var/mob/living/carbon/human/H = affecting
 		var/datum/effect/effect/system/smoke_spread/bad/smoke = new
-		smoke.set_up(10, 0, H.loc)
+		smoke.set_up(4, H.loc)
 		smoke.start()
 		playsound(H.loc, 'sound/effects/bamf.ogg', 50, 2)
 		s_bombs--

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -937,7 +937,7 @@
 				src.malfhack = 1
 				update_icon()
 				var/datum/effect/effect/system/smoke_spread/smoke = new
-				smoke.set_up(3, 0, src.loc)
+				smoke.set_up(1, src.loc)
 				smoke.attach(src)
 				smoke.start()
 				var/datum/effect/effect/system/spark_spread/s = new

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -124,7 +124,7 @@
 /obj/item/weapon/gun/magic/wand/teleport/zap_self(mob/living/user)
 	do_teleport(user, user, 10)
 	var/datum/effect/effect/system/smoke_spread/smoke = new
-	smoke.set_up(10, 0, user.loc)
+	smoke.set_up(3, user.loc)
 	smoke.start()
 	charges--
 	..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -82,7 +82,7 @@
 			teleammount++
 			do_teleport(stuff, stuff, 10)
 			var/datum/effect/effect/system/smoke_spread/smoke = new
-			smoke.set_up(max(round(10 - teleammount),1), 0, stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
+			smoke.set_up(max(round(4 - teleammount),0), stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
 			smoke.start()
 
 /obj/item/projectile/magic/door

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -2,7 +2,7 @@
 
 var/const/TOUCH = 1 //splashing
 var/const/INGEST = 2 //injection, ingestion
-var/const/VAPOR = 3 //smoke, foam, spray, blob attack
+var/const/VAPOR = 3 //foam, spray, blob attack
 var/const/PATCH = 4 //patches
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/Chemistry-Recipes/Pyrotechnics.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Pyrotechnics.dm
@@ -222,13 +222,13 @@
 	if(holder.has_reagent("stabilizing_agent"))
 		return
 	holder.remove_reagent("smoke_powder", created_volume)
-	var/smoke_amount = round(Clamp(created_volume/5, 1, 20),1)
+	var/smoke_radius = round(sqrt(created_volume / 2), 1)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect/effect/system/smoke_spread/chem/S = new
 	S.attach(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 	if(S)
-		S.set_up(holder, smoke_amount, 0, location)
+		S.set_up(holder, smoke_radius, 0, location)
 		S.start()
 	if(holder && holder.my_atom)
 		holder.clear_reagents()
@@ -245,12 +245,12 @@
 
 /datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	var/smoke_amount = round(Clamp(created_volume/5, 1, 20),1)
+	var/smoke_radius = round(sqrt(created_volume / 2), 1)
 	var/datum/effect/effect/system/smoke_spread/chem/S = new
 	S.attach(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 	if(S)
-		S.set_up(holder, smoke_amount, 0, location)
+		S.set_up(holder, smoke_radius, 0, location)
 		S.start()
 	if(holder && holder.my_atom)
 		holder.clear_reagents()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -230,7 +230,7 @@
 
 /obj/machinery/r_n_d/experimentor/proc/throwSmoke(turf/where)
 	var/datum/effect/effect/system/smoke_spread/smoke = new
-	smoke.set_up(1,0, where, 0)
+	smoke.set_up(0, where)
 	smoke.start()
 
 /obj/machinery/r_n_d/experimentor/proc/pickWeighted(list/from)
@@ -320,7 +320,7 @@
 			R.add_reagent(chosenchem , 50)
 			investigate_log("Experimentor has released [chosenchem] smoke.", "experimentor")
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
-			smoke.set_up(R, 1, 0, src, 0, silent = 1)
+			smoke.set_up(R, 0, src, silent = 1)
 			playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 			smoke.start()
 			qdel(R)
@@ -332,7 +332,7 @@
 			R.my_atom = src
 			R.add_reagent(chosenchem , 50)
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
-			smoke.set_up(R, 1, 0, src, 0, silent = 1)
+			smoke.set_up(R, 0, src, silent = 1)
 			playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 			smoke.start()
 			qdel(R)
@@ -419,7 +419,7 @@
 			R.add_reagent("frostoil" , 50)
 			investigate_log("Experimentor has released frostoil gas.", "experimentor")
 			var/datum/effect/effect/system/smoke_spread/chem/smoke = new
-			smoke.set_up(R, 1, 0, src, 0, silent = 1)
+			smoke.set_up(R, 0, src, silent = 1)
 			playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 			smoke.start()
 			qdel(R)
@@ -441,7 +441,7 @@
 		if(prob(EFFECT_PROB_MEDIUM-badThingCoeff))
 			visible_message("<span class='warning'>[src] malfunctions, releasing a flurry of chilly air as [exp_on] pops out!</span>")
 			var/datum/effect/effect/system/smoke_spread/smoke = new
-			smoke.set_up(1,0, src.loc, 0)
+			smoke.set_up(0, src.loc)
 			smoke.start()
 			ejectItem()
 	////////////////////////////////////////////////////////////////////////////////////////////////
@@ -643,7 +643,7 @@
 
 /obj/item/weapon/relic/proc/throwSmoke(turf/where)
 	var/datum/effect/effect/system/smoke_spread/smoke = new
-	smoke.set_up(1,0, where, 0)
+	smoke.set_up(0, where)
 	smoke.start()
 
 /obj/item/weapon/relic/proc/corgicannon(mob/user)


### PR DESCRIPTION
- Each covered tile has one smoke cloud. This makes smoke clouds much less random, especially in terms of reagent application. It also makes smoke viable as a concealment tactic.
- Also smoke reaction now uses the TOUCH method instead of VAPOR, to differentiate smoke and foam. Mob without internals or gas masks also ingests reagents in the smoke.
- Moved nanofrost smoke code to effects/effect_system/effects_smoke.dm
