### PR TITLE
Buffs Shadowling scaling to actually be a threat

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -85,7 +85,7 @@ Made by Xhuis
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	var/shadowlings = max(2, round(num_players()/20))
+	var/shadowlings = max(3, round(num_players()/14))
 
 
 	while(shadowlings)


### PR DESCRIPTION
2 shadowlings for a 55 person crew is a joke. This will get you 3 slings by default, 4 at 56 players, and one more for every 14 more players beyond that. 

This is a HUGE issue for shadowlings that makes the game type a complete dud. Plus nobody is going to learn how to play the damn role if getting picked is almost as rare as being a wizard.
