### PR TITLE
Set Transfer Amount for reagent containers now uses attack_self() instead of object verb

### DIFF
--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -168,7 +168,7 @@
 	icon_state = "misterjani"
 	item_state = "misterjani"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 
 /obj/item/weapon/watertank/janitor/make_noz()
 	return new /obj/item/weapon/reagent_containers/spray/mister/janitor(src)

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -62,7 +62,7 @@
 			user << "<span class='warning'>[src] is full.</span>"
 			return
 
-		var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 		user << "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>"
 
 	else if(target.is_open_container()) //Something like a glass. Player probably wants to transfer TO it.
@@ -107,7 +107,7 @@
 	throwforce = 10
 	amount_per_transfer_from_this = 20
 	materials = list(MAT_GOLD=1000)
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	volume = 150
 	flags = CONDUCT | OPENCONTAINER
 	spillable = 1
@@ -181,7 +181,7 @@
 	name = "Paper Cup"
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	volume = 10
 	spillable = 1
 

--- a/code/modules/food&drinks/food.dm
+++ b/code/modules/food&drinks/food.dm
@@ -2,7 +2,7 @@
 /// Food.
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/weapon/reagent_containers/food
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	volume = 50	//Sets the default container amount for all food items.
 	burn_state = 0 //Burnable
 

--- a/code/modules/food&drinks/food/condiment.dm
+++ b/code/modules/food&drinks/food/condiment.dm
@@ -67,7 +67,7 @@
 			user << "<span class='warning'>[src] is full!</span>"
 			return
 
-		var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 		user << "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>"
 
 	//Something like a glass or a food item. Player probably wants to transfer TO it.

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -37,7 +37,7 @@
 		if(M.reagents)
 			var/modifier = Clamp((1 - touch_protection), 0, 1)
 			var/amount = round(reac_volume*modifier, 0.1)
-			if(amount > 0.1)
+			if(amount >= 0.5)
 				M.reagents.add_reagent(id, amount)
 	return 1
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -37,7 +37,7 @@
 		if(M.reagents)
 			var/modifier = Clamp((1 - touch_protection), 0, 1)
 			var/amount = round(reac_volume*modifier, 0.1)
-			if(amount >= 1)
+			if(amount > 0.1)
 				M.reagents.add_reagent(id, amount)
 	return 1
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -5,27 +5,15 @@
 	icon_state = null
 	w_class = 1
 	var/amount_per_transfer_from_this = 5
-	var/possible_transfer_amounts = list(5,10,15,25,30)
+	var/list/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
 	var/list/list_reagents = null
 	var/spawned_disease = null
 	var/disease_amount = 20
 	var/spillable = 0
 
-/obj/item/weapon/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
-	set name = "Set transfer amount"
-	set category = "Object"
-	set src in range(0)
-	if(usr.incapacitated())
-		return
-	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
-	if (N)
-		amount_per_transfer_from_this = N
-
 /obj/item/weapon/reagent_containers/New(location, vol = 0)
 	..()
-	if (!possible_transfer_amounts)
-		src.verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
 	if (vol > 0)
 		volume = vol
 	create_reagents(volume)
@@ -37,7 +25,17 @@
 		reagents.add_reagent_list(list_reagents)
 
 /obj/item/weapon/reagent_containers/attack_self(mob/user)
-	return
+	if(possible_transfer_amounts.len)
+		var/i=0
+		for(var/A in possible_transfer_amounts)
+			i++
+			if(A == amount_per_transfer_from_this)
+				if(i<possible_transfer_amounts.len)
+					amount_per_transfer_from_this = possible_transfer_amounts[i+1]
+				else
+					amount_per_transfer_from_this = possible_transfer_amounts[1]
+				user << "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>"
+				return
 
 /obj/item/weapon/reagent_containers/attack(mob/M, mob/user, def_zone)
 	return

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -16,7 +16,7 @@ Borg Hypospray
 	icon_state = "borghypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	var/mode = 1
 	var/charge_cost = 50
 	var/charge_tick = 0

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -88,7 +88,7 @@
 			user << "<span class='notice'>[src] is full.</span>"
 			return
 
-		var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 		user << "<span class='notice'>You fill [src] with [trans] unit\s of the contents of [target].</span>"
 
 	else if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -6,7 +6,7 @@
 	icon_state = "hypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	var/ignore_flags = 0

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bandaid"
 	item_state = "bandaid"
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	volume = 50
 	apply_type = PATCH
 	apply_method = "apply"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "pill"
 	item_state = "pill"
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 	volume = 50
 	var/apply_type = INGEST
 	var/apply_method = "swallow"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -14,7 +14,7 @@
 	var/spray_currentrange = 3 //the range of tiles the sprayer will reach when in fixed mode.
 	amount_per_transfer_from_this = 5
 	volume = 250
-	possible_transfer_amounts = null
+	possible_transfer_amounts = list()
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user)
@@ -34,7 +34,7 @@
 			user << "<span class='notice'>\The [src] is full.</span>"
 			return
 
-		var/trans = A.reagents.trans_to(src, A:amount_per_transfer_from_this)
+		var/trans = A.reagents.trans_to(src, 50) //transfer 50u , using the spray's transfer amount would take too long to refill
 		user << "<span class='notice'>You fill \the [src] with [trans] units of the contents of \the [A].</span>"
 		return
 
@@ -103,7 +103,7 @@
 	set name = "Empty Spray Bottle"
 	set category = "Object"
 	set src in usr
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 	if (alert(usr, "Are you sure you want to empty that?", "Empty Bottle:", "Yes", "No") != "Yes")
 		return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -8,7 +8,7 @@
 	item_state = "syringe_0"
 	icon_state = "0"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = null	//list(5, 10, 15)
+	possible_transfer_amounts = list()
 	volume = 15
 	var/mode = SYRINGE_DRAW
 	var/busy = 0		// needed for delayed drawing of blood

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -7,9 +7,6 @@
 	anchored = 0
 	pressure_resistance = 2*ONE_ATMOSPHERE
 
-	var/amount_per_transfer_from_this = 10
-	var/possible_transfer_amounts = list(10,25,50,100)
-
 /obj/structure/reagent_dispensers/ex_act(severity, target)
 	switch(severity)
 		if(1)
@@ -35,19 +32,7 @@
 
 /obj/structure/reagent_dispensers/New()
 	create_reagents(1000)
-	if (!possible_transfer_amounts)
-		src.verbs -= /obj/structure/reagent_dispensers/verb/set_APTFT
 	..()
-
-/obj/structure/reagent_dispensers/verb/set_APTFT() //set amount_per_transfer_from_this
-	set name = "Set transfer amount"
-	set category = "Object"
-	set src in view(1)
-	if(usr.stat || !usr.canmove || usr.restrained())
-		return
-	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
-	if (N)
-		amount_per_transfer_from_this = N
 
 /obj/structure/reagent_dispensers/examine(mob/user)
 	..()
@@ -59,7 +44,6 @@
 	desc = "A watertank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
-	amount_per_transfer_from_this = 10
 
 /obj/structure/reagent_dispensers/watertank/New()
 	..()
@@ -93,7 +77,6 @@
 	desc = "A fueltank"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
-	amount_per_transfer_from_this = 10
 
 /obj/structure/reagent_dispensers/fueltank/New()
 	..()
@@ -132,7 +115,6 @@
 	icon_state = "peppertank"
 	anchored = 1
 	density = 0
-	amount_per_transfer_from_this = 45
 
 /obj/structure/reagent_dispensers/peppertank/New()
 	..()
@@ -142,10 +124,8 @@
 /obj/structure/reagent_dispensers/water_cooler
 	name = "Water-Cooler"
 	desc = "A machine that dispenses water to drink"
-	amount_per_transfer_from_this = 5
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "water_cooler"
-	possible_transfer_amounts = null
 	anchored = 1
 	var/cups = 50
 
@@ -180,7 +160,6 @@
 	desc = "A beer keg"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "beertankTEMP"
-	amount_per_transfer_from_this = 10
 
 /obj/structure/reagent_dispensers/beerkeg/New()
 	..()
@@ -195,7 +174,6 @@
 	desc = "A dispenser of virus food."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "virusfoodtank"
-	amount_per_transfer_from_this = 10
 	anchored = 1
 
 /obj/structure/reagent_dispensers/virusfood/New()

--- a/html/changelogs/phil235-TransferAmountChange.yml
+++ b/html/changelogs/phil235-TransferAmountChange.yml
@@ -1,0 +1,8 @@
+  
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "Changing the transfer amount of all reagent containers (beaker, bucket, glass) is now done by clicking them, similar to spray. Reagent dispensers (watertank, fueltank, pepperspray dispenser) no longer have their own transfer amounts and use the reagent container's transfer amount instead (except for sprays which get 50u for faster refilling)."
+


### PR DESCRIPTION
- Changing the transfer amount of all reagent containers (beaker, bucket, glass) is now done by clicking them, similar to spray. 
- Reagent dispensers (watertank, fueltank, pepperspray dispenser) no longer have their own transfer amounts and use the reagent container's transfer amount instead (except for sprays which get 50u for faster refilling).
- Removed object verb "Set Amount per transfer from this" for both reagent containers and reagent dispensers.
