### PR TITLE
Hopefully fixes the heads of staff names appearing multiple times rev bug

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -400,7 +400,7 @@
 	var/list/heads = list()
 	for(var/mob/living/carbon/human/player in mob_list)
 		if(player.stat!=2 && player.mind && (player.mind.assigned_role in command_positions))
-			heads += player.mind
+			heads |= player.mind
 	return heads
 
 
@@ -411,7 +411,7 @@
 	var/list/heads = list()
 	for(var/mob/player in mob_list)
 		if(player.mind && (player.mind.assigned_role in command_positions))
-			heads += player.mind
+			heads |= player.mind
 	return heads
 
 //////////////////////////


### PR DESCRIPTION
**THIS IS NOT TESTED, BECAUSE IT REQUIRES MULTIPLE MINDS I HAVE NO IDEA HOW TO TEST IT, PLEASE ENLIGHTEN**

Relevant issue: https://github.com/tgstation/-tg-station/issues/12034.

The problem is in the get_all_heads() proc here: https://github.com/tgstation/-tg-station/blob/e3e6fc13a919ed50a1777471f44deaf04340be7e/code/game/gamemodes/game_mode.dm

If this code works like it should, it should check to see if a mind is already in the list before adding it to the list a second time. However, as above, it is not tested.
