### PR TITLE
Dwarves can vent crawl.

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -280,18 +280,22 @@
 /datum/mutation/human/dwarfism
 
 	name = "Dwarfism"
-	quality = MINOR_NEGATIVE
+	quality = POSITIVE
+	get_chance = 15
+	lowest_value = 256 * 12
 	text_gain_indication = "<span class='notice'>Everything around you seems to grow..</span>"
 	text_lose_indication = "<span class='notice'>Everything around you seems to shrink..</span>"
 
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())	return
 	owner.resize = 0.8
+	owner.ventcrawler = 1
 	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>")
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())	return
 	owner.resize = 1.25
+	owner.ventcrawler = 0
 	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>")
 
 /datum/mutation/human/clumsy


### PR DESCRIPTION
This would allow anyone with the dwarf mutation to crawl through vents.
This is balanced by the fact that they can not bring anything with them
and suffer pressure damage while in the pipes (just like for monkey vent
crawling).
I should mention that the two "balances" aren't additions, but already implemented parts of vent crawling.
