### PR TITLE
adds resize to the list of fun required vars

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -6,7 +6,7 @@ var/list/forbidden_varedit_object_types = list(
 									)
 
 var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y", "force_ending")
-var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays")
+var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays", "resize")
 var/list/VVckey_edit = list("key", "ckey")
 
 /*


### PR DESCRIPTION
Editing the resize var is technically an icon var, so it should require +fun

other then that, it should still require +fun, its too fun
