### PR TITLE
Fixes untoggled switchblade force

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -166,16 +166,16 @@
 	icon_state = "switchblade"
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
-	force = 20
+	force = 3
 	w_class = 2
-	throwforce = 15
+	throwforce = 5
 	throw_speed = 3
 	throw_range = 6
 	materials = list(MAT_METAL=12000)
 	origin_tech = "materials=1"
 	hitsound = 'sound/weapons/Genhit.ogg'
 	attack_verb = list("stubbed", "poked")
-	var/extended
+	var/extended = 0
 
 /obj/item/weapon/switchblade/attack_self(mob/user)
 	extended = !extended
@@ -183,12 +183,12 @@
 	if(extended)
 		force = 20
 		w_class = 3
-		throwforce = 15
+		throwforce = 23
 		icon_state = "switchblade_ext"
 		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 	else
-		force = 1
+		force = 3
 		w_class = 2
 		throwforce = 5
 		icon_state = "switchblade"


### PR DESCRIPTION
> Fixes switchblades having 20 force and 15 throwforce while unextended until toggled for the first time.
> Increases throwforce while toggled on(from 15 to 23)
> Increases force while toggled off(from 1 to 3 BUT YOU STILL SHOULDN'T STAB WITH IT)

I can't believe people never noticed this, sheesh.
