### PR TITLE
Massively buffs timestop effects

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -422,6 +422,7 @@
 	pixel_x = -64
 	pixel_y = -64
 	unacidable = 1
+	mouse_opacity = 0
 	var/mob/living/immune = list() // the one who creates the timestop is immune
 	var/freezerange = 2
 	var/duration = 140

--- a/html/changelogs/Joan-Timestop.yml
+++ b/html/changelogs/Joan-Timestop.yml
@@ -1,0 +1,7 @@
+
+author: Joan
+
+delete-after: True
+
+changes: 
+  - bugfix: "You can now click on things under timestop effects, instead of clicking the effect and looking like a fool."


### PR DESCRIPTION
> You can no longer click on the timestop effect itself.

That means you can heal yourself, hit people, etc, without hitting the timestop effect and looking like an absolute dork.
