### PR TITLE
More interactive screen alerts and workarounds for the resist-button

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -185,6 +185,11 @@ or something covering your eyes."
 If you're feeling frisky, click yourself in help intent to pull the object out."
 	icon_state = "embeddedobject"
 
+/obj/screen/alert/embeddedobject/Click()
+	if(isliving(usr))
+		var/mob/living/carbon/human/M = usr
+		return M.help_shake_act(M)
+
 /obj/screen/alert/asleep
 	name = "Asleep"
 	desc = "You've fallen asleep. Wait a bit and you should wake up. Unless you don't, considering how helpless you are."
@@ -302,10 +307,23 @@ so as to remain in compliance with the most up-to-date laws."
 	name = "Buckled"
 	desc = "You've been buckled to something and can't move. Click the alert to unbuckle unless you're handcuffed."
 
-/obj/screen/alert/handcuffed // Not used right now.
+/obj/screen/alert/handcuffed
 	name = "Handcuffed"
 	desc = "You're handcuffed and can't act. If anyone drags you, you won't be able to move. Click the alert to free yourself."
 
+/obj/screen/alert/handcuffed/Click()
+	if(isliving(usr))
+		var/mob/living/L = usr
+		return L.resist()
+
+/obj/screen/alert/legcuffed
+	name = "Legcuffed"
+	desc = "You're legcuffed, which slows you down considerably. Click the alert to free yourself."
+
+/obj/screen/alert/legcuffed/Click()
+	if(isliving(usr))
+		var/mob/living/L = usr
+		return L.resist()
 // PRIVATE = only edit, use, or override these if you're editing the system as a whole
 
 // Re-render all alerts - also called in /datum/hud/show_hud() because it's needed there

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -437,6 +437,12 @@
 	return
 
 
+/obj/machinery/suit_storage_unit/relaymove(mob/user)
+	if(user.stat || !isturf(loc))
+		return
+	container_resist()
+
+
 /obj/machinery/suit_storage_unit/container_resist()
 	var/mob/living/user = usr
 	if(islocked)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -280,7 +280,7 @@
 	if(user.stat || !isturf(loc))
 		return
 	if(!open())
-		user << "<span class='notice'>It won't budge!</span>"
+		container_resist()
 		if(world.time > lastbang+5)
 			lastbang = world.time
 			for(var/mob/M in get_hearers_in_view(src, null))

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -41,6 +41,12 @@
 /obj/structure/bodycontainer/alter_health()
 	return src.loc
 
+/obj/structure/bodycontainer/relaymove(mob/user)
+	if(user.stat || !isturf(loc))
+		return
+	if(!open())
+		open()
+
 /obj/structure/bodycontainer/attack_paw(mob/user)
 	return src.attack_hand(user)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -392,9 +392,11 @@ Please contact me on #coderbus IRC. ~Carnie x
 
 /mob/living/carbon/human/update_inv_legcuffed()
 	remove_overlay(LEGCUFF_LAYER)
+	clear_alert("legcuffed")
 	if(legcuffed)
 		overlays_standing[LEGCUFF_LAYER] = image("icon"='icons/mob/mob.dmi', "icon_state"="legcuff1", "layer"=-LEGCUFF_LAYER)
-	apply_overlay(LEGCUFF_LAYER)
+		apply_overlay(LEGCUFF_LAYER)
+		throw_alert("legcuffed", /obj/screen/alert/legcuffed, new_master = src.legcuffed)
 
 
 /mob/living/carbon/human/update_hud()	//TODO: do away with this if possible

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -129,10 +129,12 @@
 
 /mob/living/carbon/update_inv_handcuffed()
 	remove_overlay(HANDCUFF_LAYER)
+	clear_alert("handcuffed")
 	if(handcuffed)
 		drop_r_hand()
 		drop_l_hand()
 		stop_pulling()	//TODO: should be handled elsewhere
+		throw_alert("handcuffed", /obj/screen/alert/handcuffed, new_master = src.handcuffed)
 		if(hud_used)	//hud handcuff icons
 			var/obj/screen/inventory/R = hud_used.r_hand_hud_object
 			var/obj/screen/inventory/L = hud_used.l_hand_hud_object


### PR DESCRIPTION
- When handcuffed, a handcuffed-alert appears and clicking it is the same as clicking on resist. Same with legcuffing. Works like buckling: the cuff-object is shown as the alert-icon.
- Moving while in a Suit Storage Unit or welded/locked locker or morgue tray is now the equivalent of pressing resist.
- Embedded object -alert can be clicked to examine yourself so you can remove the object.

My goal here is to both make the alerts as interactive as possible and ultimately remove the resist-button.

The only thing still bugging me here is that if you get cuffed with zipties, the icon in the alert shows up as a broken ziptie. But it's not that big of a deal if you could think of the icon as showing you how you COULD break the ziptie. So it's kind of a suggestion-icon instead of an alert-icon in that case.
