### PR TITLE
Even more xenobiology fixes and tweaks

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -373,6 +373,7 @@ MASS SPECTROMETER
 
 /obj/item/device/slime_scanner
 	name = "slime scanner"
+	desc = "A device that analyzes a slime's internal composition and measures its stats."
 	icon_state = "adv_spectrometer"
 	item_state = "analyzer"
 	origin_tech = "biotech=1"

--- a/code/modules/food&drinks/food/snacks_meat.dm
+++ b/code/modules/food&drinks/food/snacks_meat.dm
@@ -130,11 +130,15 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/afterattack(obj/O, mob/user,proximity)
 	if(!proximity) return
-	if(istype(O,/obj/structure/sink) && !wrapped)
-		user << "<span class='notice'>You place [src] under a stream of water...</span>"
-		user.drop_item()
-		loc = get_turf(O)
-		return Expand()
+	if(istype(O,/obj/structure/sink))
+		if (wrapped)
+			user << "<span class='notice'>You need to unwrap [src] first!</span>"
+			return
+		else
+			user << "<span class='notice'>You place [src] under a stream of water...</span>"
+			user.drop_item()
+			loc = get_turf(O)
+			return Expand()
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/attack_self(mob/user)

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -165,6 +165,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/pizzaslice,
 		/obj/item/weapon/reagent_containers/food/snacks/salad,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat/slab,
 		/obj/item/weapon/reagent_containers/food/snacks/soup,
 		/obj/item/weapon/reagent_containers/food/snacks/grown,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom,
@@ -392,7 +393,7 @@
 /datum/chemical_reaction/slimeplasma/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/stack/sheet/mineral/plasma/P = new /obj/item/stack/sheet/mineral/plasma
-	P.amount = 10
+	P.amount = 3
 	P.loc = get_turf(holder.my_atom)
 
 /datum/chemical_reaction/slimemutator


### PR DESCRIPTION
- Added an error message for using wrapped monkeycubes on a sink, currently this gives a misleading "You fill the monkey cube from the sink" message.
- Added meat slabs to the silver slime food reaction blacklist, to prevent endless slabs of "-meat" from being spawned
- Added description to slime scanner, which previously had none
- Nerfed dark purple slime extract plasma sheets down to 3 sheets/extract, from 10. NOW HEAR ME OUT: I play xenobio a lot. Currently, one dark purple slime is enough to last you the whole fucking round, even if you make fucktons of golems and sentience potions and silver slime food. Even this is quite a lot of plasma for xenobiology purposes -- 60 liquid units per extract. I may up this to 5, undecided (5 is the statue amount) but no more.
