### PR TITLE
Pneumatic Nerf

### DIFF
--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -132,7 +132,7 @@
 	desc = "A gas-powered, object-firing cannon made out of common parts."
 	force = 5
 	w_class = 3
-	maxWeightClass = 10
+	maxWeightClass = 7
 	gasPerThrow = 5
 
 /datum/table_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but


### PR DESCRIPTION
Just for the consistency of improvised weapon power. These things still serve a purpose without (arguably) being the most powerful ranged weapon available to the crew. 

New max weight is 7, down from 10.
