### PR TITLE
Shadowling: Removes Pre-Hatch Enthralling

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -132,7 +132,6 @@ Made by Xhuis
 /datum/game_mode/proc/finalize_shadowling(datum/mind/shadow_mind)
 	var/mob/living/carbon/human/S = shadow_mind.current
 	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_hatch(null))
-	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/enthrall(null))
 	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_hivemind(null))
 	spawn(0)
 		update_shadow_icons_added(shadow_mind)

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -90,6 +90,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H << "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>"
 				H.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_hatch)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/enthrall(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flashfreeze(null))

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -132,7 +132,7 @@
 	desc = "A gas-powered, object-firing cannon made out of common parts."
 	force = 5
 	w_class = 3
-	maxWeightClass = 7
+	maxWeightClass = 10
 	gasPerThrow = 5
 
 /datum/table_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -132,7 +132,7 @@
 	desc = "A gas-powered, object-firing cannon made out of common parts."
 	force = 5
 	w_class = 3
-	maxWeightClass = 10
+	maxWeightClass = 7
 	gasPerThrow = 5
 
 /datum/table_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but


### PR DESCRIPTION
Based on my feedback thread here:

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=4851

It encourages a completely awful playstyle for a troubled game mode. Most idiots appear to be under the assumption that if they just stunprod, cablecuff, and then attempt to enthrall, then security can't arrest or punish them for anything worse than kidnapping. That is until the victim (if rescued in time) claims that his attacker was a shadowling and/or security implants them as a precaution and then summarily executes the Sling for resisting the implant.

Pre-Hatch Thralling is a dichotomy. Either you have the items/chems and the knowhow to successfully and silently convert people in which case you have 0 incentive to actually -play- as the antag you've been chosen for... or you don't have those things and pre-hatch thralling is worse in every way, serving only as bait for new/bad players who fall into the aforementioned trap. 

Nobody wins with pre-hatch thralling and it continues the cycle of bad shadowlings since these idiots never actually learn to play the antag. Pre-Hatchers who "succeed" by destroying comms, using chems, etc. just appeal to the very worst of powergaming while still depriving the station of a compelling antagonist.
