### PR TITLE
Changed the effects of alcohol to be more realistic.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Drink-Reagents/Alcohols.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Consumable-Reagents/Drink-Reagents/Alcohols.dm
@@ -23,15 +23,17 @@
 
 /datum/reagent/consumable/ethanol/on_mob_life(mob/living/M)
 	M.jitteriness = max(M.jitteriness-5,0)
-	if(current_cycle >= boozepwr)
-		if (!M.slurring) M.slurring = 1
-		M.slurring += 4
-		M.Dizzy(5)
-	if(current_cycle >= boozepwr*2.5 && prob(33))
-		if (!M.confused) M.confused = 1
-		M.confused += 3
-	if(current_cycle >= boozepwr*10 && prob(33))
-		M.adjustToxLoss(2)
+	if(current_cycle >= boozepwr*0.5)
+		var/drunk_value = sqrt(volume*1000/boozepwr)
+		if(volume >= boozepwr*0.2)
+			if(M.slurring < drunk_value)
+				M.slurring += 4
+			M.Dizzy(drunk_value)
+		if(volume >= boozepwr*0.8)
+			if(M.confused < drunk_value)
+				M.confused += 3
+		if(volume >= boozepwr*3.8)
+			M.adjustToxLoss(1)
 	..()
 	return
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/html/changelogs/phil235-AlcoholTweak.yml
+++ b/html/changelogs/phil235-AlcoholTweak.yml
@@ -1,0 +1,8 @@
+  
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "Changed the effects of alcohol to be more realistic. The effects of alcohol now appear twice as fast. Drunkenness now scales with how much alcohol is in you, not how long you've been drinking. This means drinking very little but continuously no longer makes you very drunk, or confused/slurring for a long time or give you alcohol poisoning. The dizziness and slurring effects now properly scale with how drunk you are (and dizziness is generally more pronounced)."
+


### PR DESCRIPTION
- The effects of alcohol now appear twice as fast
- Drunkenness now scales with how much alcohol is in you, not how long you've been drinking. This means drinking very little but continuously no longer makes you very drunk, dizzy/slurring for a long time or give you alcohol poisoning.
- The dizziness and slurring effects now properly scale with how drunk you are (and dizziness is generally more pronounced).
- Alcohol poisoning now stops when the amount of alcohol in you gets below the threshold level (unlike reagent overdose).
- One downside of this change is that you can avoid getting drunk by drinking a little bit of each type of alcohol, instead of a lot of one type.
