### PR TITLE
Fixes bio-bags not showing up where they're supposed to.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -17,7 +17,7 @@
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/virology( src )
 	new /obj/item/clothing/head/bio_hood/virology( src )
-
+	new /obj/item/weapon/storage/bag/bio( src )
 
 /obj/structure/closet/l3closet/security
 	icon_state = "bio_sec"
@@ -47,3 +47,4 @@
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/scientist( src )
 	new /obj/item/clothing/head/bio_hood/scientist( src )
+	new /obj/item/weapon/storage/bag/bio( src )


### PR DESCRIPTION
APPARENTLY THERE ARE SPECIAL SNOWFLAKE VARIETALS OF L3 LOCKERS FOR EVERY DEPARTMENT AND THEY ALL HAVE UNIQUE LISTS OF SHIT
