### PR TITLE
Adds 48x48 (1.5x zoom) and 96x96 (3x zoom) mode

### DIFF
--- a/html/changelogs/Incoming-EXTREMECLOSEUP.yml
+++ b/html/changelogs/Incoming-EXTREMECLOSEUP.yml
@@ -1,0 +1,8 @@
+
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "48x48 pixel mode (x1.5 zoom) has been added to the Icons menu (top left). While playing in 32x32 or 64x64 will still provide a clearer looking station, for those of us with resolutions that fall into the gap between the two zooms this can provide a more consistant looking station than stretch to fit."
+  - rscadd: "96x96 pixel mode (x3 zoom) has also been added for our players who enjoy looking at spacemen on their 4k monitors at a crisp and consistent scale."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -883,9 +883,27 @@ menu "menu"
 		group = "size"
 		is-disabled = false
 		saved-params = "is-checked"
+	elem "icon96"
+		name = "&96x96 (3x)"
+		command = ".winset \"mapwindow.map.icon-size=96\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
 	elem "icon64"
 		name = "&64x64 (2x)"
 		command = ".winset \"mapwindow.map.icon-size=64\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
+	elem "icon48"
+		name = "&48x48 (1.5x)"
+		command = ".winset \"mapwindow.map.icon-size=48\""
 		category = "&Icons"
 		is-checked = false
 		can-check = true


### PR DESCRIPTION
48x48 pixel mode (x1.5 zoom) has been added to the Icons menu (top left). While playing in 32x32 or 64x64 will still provide a clearer looking station, for those of us with resolutions that fall into the gap between the two zooms this can provide a more consistent looking station than stretch to fit.

96x96 pixel mode (x3 zoom) has also been added for our players who enjoy looking at spacemen on their 4k monitors at a crisp and consistent scale.

If I had known it was this easy I'd have done this a long time ago.
