### PR TITLE
Syndicate bomb payloads will now detonate if set on fire

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -182,10 +182,15 @@
 	item_state = "eshield0"
 	w_class = 3
 	origin_tech = "syndicate=6;combat=5"
+	burn_state = 0 //Burnable (but the casing isn't)
 	var/adminlog = null
 
 /obj/item/weapon/bombcore/ex_act(severity, target) //Little boom can chain a big boom
 	src.detonate()
+
+/obj/item/weapon/bombcore/burn()
+	src.detonate()
+	..()
 
 /obj/item/weapon/bombcore/proc/detonate()
 	if(adminlog)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -4,6 +4,7 @@
 	icon_state = "cardboard"
 	health = 10
 	mob_storage_capacity = 1
+	burn_state = 0 //Burnable
 	burntime = 20
 	can_weld_shut = 0
 	cutting_tool = /obj/item/weapon/wirecutters

--- a/html/changelogs/incoming_booms.yml
+++ b/html/changelogs/incoming_booms.yml
@@ -1,0 +1,6 @@
+
+author: Incoming5643
+delete-after: True
+
+changes: 
+  - rscadd: "Syndicate bomb payloads will now detonate if set on fire long enough. Note that the casings for the bombs is fireproof, so if you want to set fire to a bombcore you'll need to remove it from the case first (cut all wires, then crowbar it out). A reassurance from our explosives department: it is, and always has been, impossible to detonate a syndicate bomb that isn't ticking with wirecutters alone."


### PR DESCRIPTION
![tex1_128x128_c6be487244d870d3_14](https://cloud.githubusercontent.com/assets/4176358/10619297/dc4fd5a8-7742-11e5-8459-ac03d6575165.png)

Note that the casings for the bombs is fireproof, so if you want to set fire to a bombcore you'll need to remove it from the case first.

Fixes #12468 while I'm here to avoid another box pull
