### PR TITLE
Ports bay's pickup mobs system, with modifications (WIP DNM ETC)

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -1,0 +1,66 @@
+// Helper object for picking simple mobs up, mostly ported from Bay.
+
+/obj/item/weapon/holder
+	name = "holder"
+	desc = "You shouldn't ever see this."
+	var/mob/living/storedmob // the mob corresponding to the holder
+
+/mob/living/var/holder_type
+/mob/living/proc/get_scooped(var/mob/living/carbon/grabber)
+	if(!holder_type || buckled)
+		return
+
+	var/obj/item/weapon/holder/H = new holder_type(loc)
+	H.storedmob = src
+	H.name = loc.name
+	grabber.put_in_hands(H)
+	src.loc = H
+	H.attack_hand(grabber)
+
+	grabber << "<span class='notice'>You scoop up [src].</span>"
+	src << "<span class='warning'>[grabber] scoops you up!</span>"
+	return
+
+/obj/item/weapon/holder/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	for(var/mob/M in src.contents)
+		M.attackby(W,user)
+
+/obj/item/weapon/holder/dropped(mob/living/user as mob)
+	contents -= storedmob
+	storedmob.loc = get_turf(src)
+	storedmob.reset_view()
+	storedmob.dir = SOUTH //Looks better
+	storedmob = null
+	qdel(src)
+	..()
+
+
+/obj/item/weapon/holder/proc/escape()
+	if(istype(loc, /mob/living))
+		var/mob/living/L = loc
+		L << "<span class='warning'>[storedmob] is trying to escape!</span>"
+		if(!do_after(storedmob, 50, target = L))
+			return
+		L.unEquip(src)
+		L.drop_item()
+		L.visible_message("<span class='warning'>[storedmob] wriggles free!</span>")
+
+/obj/item/weapon/holder/relaymove()
+	escape()
+
+/obj/item/weapon/holder/container_resist()
+	escape()
+
+// Mobs that can be held
+
+/obj/item/weapon/holder/cat
+	name = "cat"
+	desc = "Kitty!!"
+	icon_state = "cat"
+
+/obj/item/weapon/holder/drone
+	name = "drone (hiding)"
+	desc = "This drone is scared and has curled up into a ball."
+	icon = 'icons/mob/drone.dmi'
+	icon_state = "drone_maint_hat"
+	origin_tech = "magnets=3;engineering=5"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -23,6 +23,7 @@
 	var/turns_since_scan = 0
 	var/mob/living/simple_animal/mouse/movement_target
 	gold_core_spawnable = 2
+	holder_type = /obj/item/weapon/holder/cat
 
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/pet/cat/Runtime
@@ -33,6 +34,16 @@
 	icon_dead = "cat_dead"
 	gender = FEMALE
 	gold_core_spawnable = 0
+
+/mob/living/simple_animal/pet/cat/attack_hand(mob/living/carbon/human/M as mob)
+	if(M.a_intent == "grab")
+		if(!istype(M) || !Adjacent(M))
+			return ..()
+		M << "<span class='notice'>You pick [src] up.</span>"
+		get_scooped(M)
+		return
+	else
+		return ..()
 
 /mob/living/simple_animal/pet/cat/Life()
 	//MICE!

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -37,6 +37,7 @@
 	voice_name = "synthesized chirp"
 	languages = DRONE
 	mob_size = MOB_SIZE_SMALL
+	holder_type = /obj/item/weapon/holder/drone
 	has_unlimited_silicon_privilege = 1
 	staticOverlays = list()
 	var/staticChoice = "static"

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -27,42 +27,9 @@
 	qdel(src)
 
 
-//DRONE HOLDER
-/obj/item/clothing/head/drone_holder//Only exists in someones hand.or on their head
-	name = "drone (hiding)"
-	desc = "This drone is scared and has curled up into a ball."
-	icon = 'icons/mob/drone.dmi'
-	icon_state = "drone_maint_hat"
-	var/mob/living/simple_animal/drone/drone //stored drone
+//DRONE HAT
 
-/obj/item/clothing/head/drone_holder/proc/uncurl()
-	if(!drone)
-		return
-
-	if(istype(loc, /mob/living))
-		var/mob/living/L = loc
-		L << "<span class='warning'>[drone] is trying to escape!</span>"
-		if(!do_after(drone, 50, target = L))
-			return
-		L.unEquip(src)
-
-	contents -= drone
-	drone.loc = get_turf(src)
-	drone.reset_view()
-	drone.dir = SOUTH //Looks better
-	drone.visible_message("<span class='warning'>[drone] uncurls!</span>")
-	drone = null
-	qdel(src)
-
-
-/obj/item/clothing/head/drone_holder/relaymove()
-	uncurl()
-
-/obj/item/clothing/head/drone_holder/container_resist()
-	uncurl()
-
-
-/obj/item/clothing/head/drone_holder/proc/updateVisualAppearence(mob/living/simple_animal/drone/D)
+/obj/item/weapon/holder/drone/proc/updateVisualAppearence(mob/living/simple_animal/drone/D)
 	if(!D)
 		return
 	icon_state = "[D.visualAppearence]_hat"

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -83,12 +83,7 @@
 		user << "<span class='notice'>You pick [src] up.</span>"
 		drop_l_hand()
 		drop_r_hand()
-		var/obj/item/clothing/head/drone_holder/DH = new /obj/item/clothing/head/drone_holder(src)
-		DH.updateVisualAppearence(src)
-		DH.contents += src
-		DH.drone = src
-		user.put_in_hands(DH)
-		src.loc = DH
+		get_scooped(user)
 		return
 
 	..()


### PR DESCRIPTION
DONE:
- Ported Bay's system for picking up mobs
- Refactored drones into this system (as one of the mobs in bay's system was drones.

TODO:
- Sprites. Either I do some wizardry mentioned in #coderbus where sprites are automatically generated, or (more likely) manually generate inhands and obj sprites for all supported mobs
- Fix known bugs with throwing and probably tabling/disposaling/putting in containers
- Add more mobs
