### PR TITLE
Ports goon tooltips made by Wirewraith

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -185,6 +185,15 @@
 	overlays += img
 	return
 
+
+/obj/screen/movable/action_button/MouseEntered(location,control,params)
+	openToolTip(usr,params,title = name,content = desc)
+
+
+/obj/screen/movable/action_button/MouseExited()
+	closeToolTip(usr)
+
+
 //This is the proc used to update all the action buttons. Properly defined in /mob/living/
 /mob/proc/update_action_buttons()
 	return

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -187,7 +187,7 @@
 
 
 /obj/screen/movable/action_button/MouseEntered(location,control,params)
-	openToolTip(usr,params,title = name,content = desc)
+	openToolTip(usr,src,params,title = name,content = desc)
 
 
 /obj/screen/movable/action_button/MouseExited()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -86,7 +86,7 @@
 
 
 /obj/screen/alert/MouseEntered(location,control,params)
-	openToolTip(usr,params,title = name,content = desc)
+	openToolTip(usr,src,params,title = name,content = desc)
 
 
 /obj/screen/alert/MouseExited()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -85,6 +85,14 @@
 	var/severity = 0
 
 
+/obj/screen/alert/MouseEntered(location,control,params)
+	openToolTip(usr,params,title = name,content = desc)
+
+
+/obj/screen/alert/MouseExited()
+	closeToolTip(usr)
+
+
 //Gas alerts
 /obj/screen/alert/oxy
 	name = "Choking (No O2)"

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -44,3 +44,8 @@
 	// Used by html_interface module.
 	var/hi_last_pos
 
+
+	//datum that controls the displaying and hiding of tooltips
+	var/datum/tooltip/tooltips
+
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -206,6 +206,12 @@ var/next_external_rsc = 0
 	if (config && config.autoconvert_notes)
 		convert_notes_sql(ckey)
 
+
+	//This is down here because of the browse() calls in tooltip/New()
+	if(!tooltips)
+		tooltips = new /datum/tooltip(src)
+
+
 //////////////
 //DISCONNECT//
 //////////////

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -1,0 +1,110 @@
+/*
+Tooltips v1.0 - 19/10/15
+Developed by Wire (#goonstation on irc.synirc.net)
+- Initial release
+
+Configuration:
+- Set control to the correct skin element (remember to actually place the skin element)
+- Set file to the correct path for the .html file (remember to actually place the html file)
+- Attach the datum to the user client on login, e.g.
+	/client/New()
+		src.tooltips = new /datum/tooltip(src)
+
+Usage:
+- Define mouse event procs on your (probably HUD) object and simply call the show and hide procs respectively:
+	/obj/screen/hud
+		MouseEntered(location, control, params)
+			usr.client.tooltip.show(params, title = src.name, content = src.desc)
+
+		MouseExited()
+			usr.client.tooltip.hide()
+
+Customization:
+- Theming can be done by passing the theme var to show() and using css in the html file to change the look
+- For your convenience some pre-made themes are included
+
+Notes:
+- You may have noticed 90% of the work is done via javascript on the client. Gotta save those cycles man.
+- This is entirely untested in any other codebase besides goonstation so I have no idea if it will port nicely. Good luck!
+*/
+
+
+/datum/tooltip
+	var
+		client/owner
+		control = "mainwindow.tooltip"
+		file = 'code/modules/tooltip/tooltip.html'
+		showing = 0
+		queueHide = 0
+
+
+	New(client/C)
+		if (C)
+			src.owner = C
+			src.owner << browse(src.file, "window=[src.control]")
+
+		..()
+
+
+	proc/show(params = null, title = null, content = null, theme = "default")
+		if (!params || (!title && !content) || !src.owner) return 0
+		src.showing = 1
+
+		//Format contents
+		if (title && content)
+			title = "<h1>[title]</h1>"
+			content = "<p>[content]</p>"
+		else if (title && !content)
+			title = "<p>[title]</p>"
+		else if (!title && content)
+			content = "<p>[content]</p>"
+
+		//Send stuff to the tooltip
+		src.owner << output(list2params(list(src.control, params, src.owner.view, "[title][content]", theme)), "[src.control]:tooltip.update")
+
+		//DEBUG
+		world << "SHOW() DEBUG"
+		world << "Tooltip Owner View: [src.owner.view]"
+		world << "Params: [params]"
+
+
+		//If a hide() was hit while we were showing, run hide() again to avoid stuck tooltips
+		src.showing = 0
+		if (src.queueHide)
+			src.hide()
+
+		return 1
+
+
+	proc/hide()
+		if (src.queueHide)
+			spawn(1)
+				winshow(src.owner, src.control, 0)
+		else
+			winshow(src.owner, src.control, 0)
+
+		src.queueHide = src.showing ? 1 : 0
+
+		return 1
+
+
+
+/client/var/datum/tooltip/tooltip
+/client/New()
+	..()
+	tooltip = new /datum/tooltip(src)
+
+
+/obj/screen/movable/action_button/MouseEntered(location,control,params)
+	usr.client.tooltip.show(params,title = name, content = desc)
+
+
+/obj/screen/movable/action_button/MouseExited()
+	usr.client.tooltip.hide()
+
+
+/mob/MouseEntered(location,control,params)
+	usr.client.tooltip.show(params,title = name, content = desc)
+
+/mob/MouseExited()
+	usr.client.tooltip.hide()

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -26,6 +26,7 @@ Customization:
 Notes:
 - You may have noticed 90% of the work is done via javascript on the client. Gotta save those cycles man.
 - This is entirely untested in any other codebase besides goonstation so I have no idea if it will port nicely. Good luck!
+	- After testing and discussion (Wire, Remie, MrPerson, AnturK) ToolTips are ok and work for /tg/station13
 */
 
 
@@ -62,12 +63,6 @@ Notes:
 		//Send stuff to the tooltip
 		src.owner << output(list2params(list(src.control, params, src.owner.view, "[title][content]", theme)), "[src.control]:tooltip.update")
 
-		//DEBUG
-		world << "SHOW() DEBUG"
-		world << "Tooltip Owner View: [src.owner.view]"
-		world << "Params: [params]"
-
-
 		//If a hide() was hit while we were showing, run hide() again to avoid stuck tooltips
 		src.showing = 0
 		if (src.queueHide)
@@ -89,22 +84,30 @@ Notes:
 
 
 
-/client/var/datum/tooltip/tooltip
-/client/New()
-	..()
-	tooltip = new /datum/tooltip(src)
+/* TG SPECIFIC CODE */
 
 
-/obj/screen/movable/action_button/MouseEntered(location,control,params)
-	usr.client.tooltip.show(params,title = name, content = desc)
+//Open a tooltip for user, at a location based on params
+//Theme is a CSS class in tooltip.html, by default this wrapper chooses a CSS class based on the user's UI_style (Midnight, Plasmafire, Retro)
+//Includes sanity.checks
+/proc/openToolTip(mob/user = null,params = null,title = "",content = "",theme = "")
+	if(istype(user))
+		if(user.client && user.client.tooltips)
+			if(!theme && user.client.prefs && user.client.prefs.UI_style)
+				theme = lowertext(user.client.prefs.UI_style)
+			if(!theme)
+				theme = "default"
+			user.client.tooltips.show(params,title,content,theme)
 
 
-/obj/screen/movable/action_button/MouseExited()
-	usr.client.tooltip.hide()
+//Arbitrarily close a user's tooltip
+//Includes sanity checks.
+/proc/closeToolTip(mob/user)
+	if(istype(user))
+		if(user.client && user.client.tooltips)
+			user.client.tooltips.hide()
 
 
-/mob/MouseEntered(location,control,params)
-	usr.client.tooltip.show(params,title = name, content = desc)
 
-/mob/MouseExited()
-	usr.client.tooltip.hide()
+
+

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -51,7 +51,6 @@
 		.colo-pod .wrap {border-color: #256fb9;}
 		.colo-pod .content {border-color: #000000; background-color: #000000;}
 		
-		
 		/* TG: Themes */
 		/* ScreenUI */
 		.midnight .wrap {border-color: #2B2B33;}
@@ -63,8 +62,7 @@
 		.retro .wrap {border-color: #005E00;}
 		.retro .content {color: #003366; border-color: #005E00; background-color: #00BD00;}
 		
-		
-		
+
 	</style>
 </head>
 <body>
@@ -74,33 +72,52 @@
 	<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 	<script type="text/javascript">
 		var tooltip = {
+			'tileSize': 32,
 			'control': '',
-			'params': '',
+			'params': {},
 			'clientView': 0,
 			'text': '',
 			'theme': '',
 			'padding': 2,
+			init: function(tileSize, control) {
+				tooltip.tileSize = parseInt(tileSize);
+				tooltip.control = control;
+			},
 			hide: function() {
-				window.location = 'byond://winset?id='+tooltip.controlName+';is-visible=false';
+				window.location = 'byond://winset?id='+tooltip.control+';is-visible=false';
 			},
 			updateCallback: function(map) {
 				if (typeof map === 'undefined' || !map) {return false;}
 
+				//alert(tooltip.params+' | '+tooltip.clientView+' | '+tooltip.text+' | '+tooltip.theme); //DEBUG
+
 				//Some reset stuff to avoid fringe issues with sizing
-				window.location = 'byond://winset?id='+tooltip.controlName+';anchor1=0,0;size=999x999';
+				window.location = 'byond://winset?id='+tooltip.control+';anchor1=0,0;size=999x999';
 
 				//Get the real icon size according to the client view
 				var mapWidth 		= map['view-size'].x,
 					mapHeight 		= map['view-size'].y,
 					tilesShown 		= (tooltip.clientView * 2) + 1,
 					realIconSize 	= mapWidth / tilesShown,
+					resizeRatio		= realIconSize / tooltip.tileSize,
 					//Calculate letterboxing offsets	
 					leftOffset 		= (map.size.x - mapWidth) / 2,
 					topOffset 		= (map.size.y - mapHeight) / 2;
 
-				//Parse out the tile locations from params screen-loc
-				var paramsA = tooltip.params.split(';');
-				if (paramsA.length < 3) {return false;}
+				//alert(realIconSize + ' | ' +tooltip.tileSize + ' | ' + resizeRatio); //DEBUG
+
+				//Parse out the tile and cursor locations from params (e.g. "icon-x=32;icon-y=29;screen-loc=3:10,15:29")
+				var paramsA = tooltip.params.cursor.split(';');
+				if (paramsA.length < 3) {return false;} //Sometimes screen-loc is never sent ahaha fuck you byond
+				//icon-x
+				var iconX = paramsA[0];
+				iconX = iconX.split('=');
+				iconX = parseInt(iconX[1]);
+				//icon-y
+				var iconY = paramsA[1];
+				iconY = iconY.split('=');
+				iconY = parseInt(iconY[1]);
+				//screen-loc
 				var screenLoc = paramsA[2];
 				screenLoc = screenLoc.split('=');
 				screenLoc = screenLoc[1].split(',');
@@ -110,16 +127,60 @@
 				if (!left || !top) {return false;}
 				screenLoc = left.split(':');
 				left = parseInt(screenLoc[0]);
+				var enteredX = parseInt(screenLoc[1]);
 				screenLoc = top.split(':');
 				top = parseInt(screenLoc[0]);
+				var enteredY = parseInt(screenLoc[1]);
+
+				//Screen loc offsets on objects (e.g. "WEST+0:6,NORTH-1:26") can royally mess with positioning depending on where the cursor enters
+				//This is a giant bitch to parse. Note that it only expects screen_loc in the format <west>,<north>.
+				var oScreenLoc = tooltip.params.screenLoc.split(','); //o for original ok
+
+				var west = oScreenLoc[0].split(':');
+				if (west.length > 1) { //Only if west has a pixel offset
+					var westOffset = parseInt(west[1]);
+					if (westOffset !== 0) {
+						if ((iconX + westOffset) !== enteredX) { //Cursor entered on the offset tile
+							left = left + (westOffset < 0 ? 1 : -1);
+						}
+						leftOffset = leftOffset + (westOffset * resizeRatio);
+					}
+				}
+
+				if (oScreenLoc.length > 1) { //If north is given
+					var north = oScreenLoc[1].split(':');
+					if (north.length > 1) { //Only if north has a pixel offset
+						var northOffset = parseInt(north[1]);
+						if (northOffset !== 0) {
+							if ((iconY + northOffset) === enteredY) { //Cursor entered on the original tile
+								top--;
+								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+							} else { //Cursor entered on the offset tile
+								if (northOffset < 0) { //Offset southwards
+									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatio);
+								} else { //Offset northwards
+									top--;
+									topOffset = topOffset - (northOffset * resizeRatio);
+								}
+							}
+						}
+					}
+				}
+
+				//Handle special cases (for fuck sake)
+				if (tooltip.special !== 'none') {
+					//Put yo special cases here
+				}
 
 				//Clamp values
 				left = (left < 0 ? 0 : (left > tilesShown ? tilesShown : left));
 				top = (top < 0 ? 0 : (top > tilesShown ? tilesShown : top));
 
-				//Calculate where on the screen the popup should appear (below the hovered tile) (the +2s are just for padding)
+				//Calculate where on the screen the popup should appear (below the hovered tile)
 				var posX = Math.round(((left - 1) * realIconSize) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
 				var posY = Math.round(((tilesShown - top + 1) * realIconSize) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
+
+				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
 
 				$('body').attr('class', tooltip.theme);
 
@@ -139,20 +200,19 @@
 				}
 
 				//Actually size, move and show the tooltip box
-				window.location = 'byond://winset?id='+tooltip.controlName+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
+				window.location = 'byond://winset?id='+tooltip.control+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
 
 				$content.on('mouseover', function() {
 					tooltip.hide();
 				});
 			},
-			update: function(control, params, clientView, text, theme) {
-				if (!tooltip.controlName) {tooltip.controlName = control;}
-
+			update: function(params, clientView, text, theme, special) {
 				//Assign our global object
-				tooltip.params = params;
+				tooltip.params = $.parseJSON(params);
 				tooltip.clientView = parseInt(clientView);
 				tooltip.text = text;
 				tooltip.theme = theme;
+				tooltip.special = special;
 
 				//Go get the map details
 				window.location = 'byond://winget?callback=tooltip.updateCallback;id=mapwindow.map;property=size,view-size';

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Tooltip</title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<style type="text/css">
+		body, html {
+			margin: 0;
+			padding: 0;
+			overflow: hidden;
+		}
+
+		.wrap {
+			position: absolute;
+			top: 0;
+			left: 0;
+			max-width: 298px;
+			border: 2px solid #1B2967;
+		}
+
+		.content {
+			font: bold 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
+			color: #ffffff;
+			padding: 8px;
+			border: 2px solid #0033CC;
+			background: #005CB8;
+		}
+
+		h1 {
+			margin: -5px 0 2px 0;
+			font-size: 1.2em;
+			line-height: 1.4;
+		}
+
+		p {
+			margin: 0;
+			line-height: 1.2;
+		}
+
+		/* Custom Themes */
+		.blob .wrap {border-color: #009900;}
+		.blob .content {border-color: #66FF00; background-color: #475E13;}
+
+		.wraith .wrap {border-color: #492136;}
+		.wraith .content {border-color: #331726; background-color: #471962;}
+
+		.pod .wrap {border-color: #052401;}
+		.pod .content {border-color: #326D29; background-color: #569F4B;}
+
+		.colo-pod .wrap {border-color: #256fb9;}
+		.colo-pod .content {border-color: #000000; background-color: #000000;}
+	</style>
+</head>
+<body>
+	<div id="wrap" class="wrap">
+		<div id="content" class="content"></div>
+	</div>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+	<script type="text/javascript">
+		var tooltip = {
+			'control': '',
+			'params': '',
+			'clientView': 0,
+			'text': '',
+			'theme': '',
+			'padding': 2,
+			hide: function() {
+				window.location = 'byond://winset?id='+tooltip.controlName+';is-visible=false';
+			},
+			updateCallback: function(map) {
+				if (typeof map === 'undefined' || !map) {return false;}
+
+				//Some reset stuff to avoid fringe issues with sizing
+				window.location = 'byond://winset?id='+tooltip.controlName+';anchor1=0,0;size=999x999';
+
+				//Get the real icon size according to the client view
+				var mapWidth 		= map['view-size'].x,
+					mapHeight 		= map['view-size'].y,
+					tilesShown 		= (tooltip.clientView * 2) + 1,
+					realIconSize 	= mapWidth / tilesShown,
+					//Calculate letterboxing offsets	
+					leftOffset 		= (map.size.x - mapWidth) / 2,
+					topOffset 		= (map.size.y - mapHeight) / 2;
+
+				//Parse out the tile locations from params screen-loc
+				var paramsA = tooltip.params.split(';');
+				if (paramsA.length < 3) {return false;}
+				var screenLoc = paramsA[2];
+				screenLoc = screenLoc.split('=');
+				screenLoc = screenLoc[1].split(',');
+				if (screenLoc.length < 2) {return false;}
+				var left = screenLoc[0];
+				var top = screenLoc[1];
+				if (!left || !top) {return false;}
+				screenLoc = left.split(':');
+				left = parseInt(screenLoc[0]);
+				screenLoc = top.split(':');
+				top = parseInt(screenLoc[0]);
+
+				//Clamp values
+				left = (left < 0 ? 0 : (left > tilesShown ? tilesShown : left));
+				top = (top < 0 ? 0 : (top > tilesShown ? tilesShown : top));
+
+				//Calculate where on the screen the popup should appear (below the hovered tile) (the +2s are just for padding)
+				var posX = Math.round(((left - 1) * realIconSize) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
+				var posY = Math.round(((tilesShown - top + 1) * realIconSize) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
+
+				$('body').attr('class', tooltip.theme);
+
+				var $content = $('#content'),
+					$wrap 	 = $('#wrap');
+				$wrap.attr('style', '');
+				$content.off('mouseover');
+				$content.html(tooltip.text);
+
+				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
+
+				var docWidth	= $wrap.outerWidth(),
+					docHeight	= $wrap.outerHeight();
+
+				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
+					posY = (posY - docHeight) - realIconSize - tooltip.padding;
+				}
+
+				//Actually size, move and show the tooltip box
+				window.location = 'byond://winset?id='+tooltip.controlName+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
+
+				$content.on('mouseover', function() {
+					tooltip.hide();
+				});
+			},
+			update: function(control, params, clientView, text, theme) {
+				if (!tooltip.controlName) {tooltip.controlName = control;}
+
+				//Assign our global object
+				tooltip.params = params;
+				tooltip.clientView = parseInt(clientView);
+				tooltip.text = text;
+				tooltip.theme = theme;
+
+				//Go get the map details
+				window.location = 'byond://winget?callback=tooltip.updateCallback;id=mapwindow.map;property=size,view-size';
+			},
+		};
+	</script>
+</body>
+</html>

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -50,6 +50,21 @@
 
 		.colo-pod .wrap {border-color: #256fb9;}
 		.colo-pod .content {border-color: #000000; background-color: #000000;}
+		
+		
+		/* TG: Themes */
+		/* ScreenUI */
+		.midnight .wrap {border-color: #2B2B33;}
+		.midnight .content {color: #6087A0; border-color: #2B2B33; background-color: #36363C;}
+		
+		.plasmafire .wrap {border-color: #21213D;}
+		.plasmafire .content {color: #FFA800 ; border-color: #21213D; background-color:#1D1D36;}
+
+		.retro .wrap {border-color: #005E00;}
+		.retro .content {color: #003366; border-color: #005E00; background-color: #00BD00;}
+		
+		
+		
 	</style>
 </head>
 <body>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1694,6 +1694,32 @@ window "mainwindow"
 		is-checked = false
 		group = ""
 		button-type = pushbox
+	elem "tooltip"
+		type = BROWSER
+		pos = 0,0
+		size = 999x999
+		anchor1 = none
+		anchor2 = none
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #ffffff
+		background-color = #000000
+		is-visible = false
+		is-disabled = false
+		is-transparent = false
+		is-default = false
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = ""
+		on-size = ""
+		show-history = false
+		show-url = false
+		auto-format = false
+		use-title = false
+		on-show = ""
+		on-hide = ""
 
 window "mapwindow"
 	elem "mapwindow"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1532,6 +1532,7 @@
 #include "code\modules\telesci\gps.dm"
 #include "code\modules\telesci\telepad.dm"
 #include "code\modules\telesci\telesci_computer.dm"
+#include "code\modules\tooltip\tooltip.dm"
 #include "code\orphaned procs\AStar.dm"
 #include "code\orphaned procs\dbcore.dm"
 #include "code\orphaned procs\priority_announce.dm"


### PR DESCRIPTION
- Port's Wirewraith's release of their Tooltips used on Goon.
- Adds Tooltips to Action Buttons, displaying their name, and if they have one, a description
- Adds Tooltips to Screen Alerts, displaying their name, and their description/helptext
- Adds two wrapper procs, one to open a tooltip, `openToolTip()` which if not supplied a theme will attempt to load a theme matching the user's UI_style string (reverting to "default" if it can't), and `closeToolTip()`, they consist mainly of sanity checks and the ui-theme default.
- Adds some CSS for the Midnight, Plasmafire and Retro style UI's, to make the tooltips blend into the UI more.

Credit for the tooltip system goes to @Wirewraith 

Examples (MOBS DONT ACTUALLY HAVE TOOLTIPS):
Midnight:
![midnight](http://i.imgur.com/0pFn4H5.png)

Plasmafire:
![plasmafire](http://i.imgur.com/dPs2ekR.png)

Retro (Remains ugly as sin):
![retro](http://i.imgur.com/WbW0hUF.png)

Screen Alerts (Midnight):
![screenalert](http://i.imgur.com/AC9j6pI.png)

Wirewraith's original .webm
https://dl.dropboxusercontent.com/u/14790486/ShareX/2015/10/2015-10-09_00-53-12.webm

~~~Very minor graphical glitch until https://github.com/tgstation/-tg-station/pull/12543 is merged, or Wirewraith releases his second version (He said he's fixing some stuff related to the issue on his end too)~~~ - Solved by Tooltips V1.1
