### PR TITLE
[NERF/ARMOUR] Lowers Sec Beret Defence To Helmet Value

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -101,7 +101,7 @@
 	name = "security beret"
 	desc = "A robust beret with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficent protection."
 	icon_state = "beret_badge"
-	armor = list(melee = 30, bullet = 25, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 25, bullet = 15, laser = 25,energy = 10, bomb = 25, bio = 0, rad = 0)
 	strip_delay = 60
 
 /obj/item/clothing/head/beret/sec/navyhos


### PR DESCRIPTION
Inb4 he's touching armour!

This PR lowers the Beret to match the Security Helmet in protection value.

When Kor nerfed all armour values he forgot to nerf the Sec Beret, making it the superior head defence item.

The values are: melee = 25, bullet = 15, laser = 25,energy = 10, bomb = 25, bio = 0, rad = 0
