### PR TITLE
New red slime speed potion

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -395,6 +395,8 @@
 	P.amount = 10
 	P.loc = get_turf(holder.my_atom)
 
+//Red
+
 /datum/chemical_reaction/slimemutator
 	name = "Slime Mutator"
 	id = "m_slimemutator"
@@ -424,6 +426,22 @@
 		slime.rabid = 1
 		for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 			O.show_message(text("<span class='danger'>The [slime] is driven into a frenzy!</span>"), 1)
+
+
+/datum/chemical_reaction/slimespeed
+	name = "Slime Speed"
+	id = "m_speed"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/red
+	required_other = 1
+
+/datum/chemical_reaction/slimemutator/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/speed/P = new /obj/item/slimepotion/speed
+	P.loc = get_turf(holder.my_atom)
+
 
 //Pink
 /datum/chemical_reaction/docility

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -297,7 +297,21 @@
 	M.mutator_used = TRUE
 	qdel(src)
 
+/obj/item/slimepotion/speed
+	name = "slime speed potion"
+	desc = "A potent chemical mix that will remove the slowdown from any item."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle3"
 
+/obj/item/slimepotion/speed/afterattack(obj/item/C, mob/user)
+	..()
+	if(C.slowdown <= 0)
+		user << "<span class='warning'>The [C] can't be made any faster!</span>"
+		return..()
+	user <<"<span class='notice'>You slather the red gunk over the [C], making it faster.</span>"
+	C.color = "#FF0000"
+	C.slowdown = 0
+	qdel(src)
 
 ////////Adamantine Golem stuff I dunno where else to put it
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -305,7 +305,7 @@
 
 /obj/item/slimepotion/speed/afterattack(obj/item/C, mob/user)
 	..()
-	if(!istype(C, /obj/item))
+	if(!istype(C))
 		user << "<span class='warning'>The potion can only be used on items!</span>"
 		return
 	if(C.slowdown <= 0)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -305,6 +305,9 @@
 
 /obj/item/slimepotion/speed/afterattack(obj/item/C, mob/user)
 	..()
+	if(!istype(C, /obj/item))
+		user << "<span class='warning'>The potion can only be used on items!</span>"
+		return
 	if(C.slowdown <= 0)
 		user << "<span class='warning'>The [C] can't be made any faster!</span>"
 		return..()

--- a/html/changelogs/Kor-RED.yml
+++ b/html/changelogs/Kor-RED.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kor
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Using water with a red slime extract will now yield a speed potion. Using the speed potion on an item of clothing will paint it red and remove its slowdown."


### PR DESCRIPTION
Using water on a red slime extract will yield a speed potion.

Applying that speed potion to an item will paint it red and remove its slowdown.
