### PR TITLE
Selective ooc muting

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -55,7 +55,7 @@
 						C << "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
 				else
 					C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
-			else
+			else if(!C.prefs.ignoring.Find(key))
 				C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
 
 /proc/toggle_ooc(toggle = null)
@@ -138,3 +138,23 @@ var/global/normal_ooc_colour = "#002eb8"
 		return
 
 	show_note(usr, null, 1)
+
+/client/proc/ignore_key(client)
+	var/client/C = client
+	prefs.ignoring ^= C.key
+	src << "You are [prefs.ignoring.Find(src.key) ? "now" : "no longer"] ignoring [C.key] on the OOC channel."
+	prefs.save_preferences()
+
+/client/verb/select_ignore()
+	set name = "Ignore"
+	set category = "OOC"
+	set desc ="Ignore a player's messages on the OOC channel"
+
+	var/list/keys = list()
+	for(var/mob/M in player_list)
+		if(M.client != src)
+			keys += M.client
+	var/selection = input("Please, select a player!", "Ignore", null, null) as null|anything in sortKey(keys)
+	if(!selection)
+		return
+	ignore_key(selection)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -55,7 +55,7 @@
 						C << "<span class='adminobserverooc'><span class='prefix'>OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message'>[msg]</span></span>"
 				else
 					C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message'>[msg]</span></span></font>"
-			else if(!C.prefs.ignoring.Find(key))
+			else if(!(C.key in prefs.ignoring))
 				C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message'>[msg]</span></span></font>"
 
 /proc/toggle_ooc(toggle = null)
@@ -141,8 +141,11 @@ var/global/normal_ooc_colour = "#002eb8"
 
 /client/proc/ignore_key(client)
 	var/client/C = client
-	prefs.ignoring ^= C.key
-	src << "You are [prefs.ignoring.Find(src.key) ? "now" : "no longer"] ignoring [C.key] on the OOC channel."
+	if(C.key in prefs.ignoring)
+		prefs.ignoring -= C.key
+	else
+		prefs.ignoring |= C.key
+	src << "You are [(C.key in prefs.ignoring) ? "now" : "no longer"] ignoring [C.key] on the OOC channel."
 	prefs.save_preferences()
 
 /client/verb/select_ignore()
@@ -150,11 +153,10 @@ var/global/normal_ooc_colour = "#002eb8"
 	set category = "OOC"
 	set desc ="Ignore a player's messages on the OOC channel"
 
-	var/list/keys = list()
-	for(var/mob/M in player_list)
-		if(M.client != src)
-			keys += M.client
-	var/selection = input("Please, select a player!", "Ignore", null, null) as null|anything in sortKey(keys)
+	var/selection = input("Please, select a player!", "Ignore", null, null) as null|anything in sortKey(clients)
 	if(!selection)
+		return
+	if(selection == src)
+		src << "You can't ignore yourself."
 		return
 	ignore_key(selection)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -94,6 +94,8 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 
 	var/unlock_content = 0
 
+	var/list/ignoring = list()
+
 /datum/preferences/New(client/C)
 	blood_type = random_blood_type()
 	custom_names["ai"] = pick(ai_names)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -106,6 +106,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["toggles"]			>> toggles
 	S["ghost_form"]			>> ghost_form
 	S["preferred_map"]		>> preferred_map
+	S["ignoring"]			>> ignoring
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -140,6 +141,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["chat_toggles"]		<< chat_toggles
 	S["ghost_form"]			<< ghost_form
 	S["preferred_map"]		<< preferred_map
+	S["ignoring"]			<< ignoring
 
 	return 1
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN	8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX	11
+#define SAVEFILE_VERSION_MAX	12
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
 	This proc checks if the current directory of the savefile S needs updating
@@ -36,6 +36,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 11)
 		chat_toggles = TOGGLES_DEFAULT_CHAT
 		toggles = TOGGLES_DEFAULT
+	if(current_version << 12)
+		ignoring = list()
 
 
 //should this proc get fairly long (say 3 versions long),

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -36,7 +36,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 11)
 		chat_toggles = TOGGLES_DEFAULT_CHAT
 		toggles = TOGGLES_DEFAULT
-	if(current_version << 12)
+	if(current_version < 12)
 		ignoring = list()
 
 

--- a/html/changelogs/Jordie0608 ignore.yml
+++ b/html/changelogs/Jordie0608 ignore.yml
@@ -1,0 +1,5 @@
+author: Jordie0608
+delete-after: True
+
+changes: 
+  - rscadd: "You can now selectively mute non-admin players from OOC with the Ignore verb in the OOC tab."


### PR DESCRIPTION
Adds ability for players to selectively ignore specific players's OOC messages. Messages from admins can't be ignored unless they're deadminned at the time. You can't ignore yourself.
