### PR TITLE
Fixes changing transfer amounts not working for shaker

### DIFF
--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -15,7 +15,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "rag"
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list(5)
+	possible_transfer_amounts = list()
 	volume = 5
 	spillable = 0
 

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -21,9 +21,6 @@
 	if (gulp_size < 5) gulp_size = 5
 	else gulp_size = max(round(reagents.total_volume / 5), 5)
 
-/obj/item/weapon/reagent_containers/food/drinks/attack_self(mob/user)
-	return
-
 /obj/item/weapon/reagent_containers/food/drinks/attack(mob/M, mob/user, def_zone)
 
 	if(!reagents || !reagents.total_volume)
@@ -199,7 +196,7 @@
 //	icon states.
 
 /obj/item/weapon/reagent_containers/food/drinks/shaker
-	name = "Shaker"
+	name = "shaker"
 	desc = "A metal shaker to mix drinks in."
 	icon_state = "shaker"
 	amount_per_transfer_from_this = 10

--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -512,11 +512,14 @@
 	icon_state = "shotglass"
 	gulp_size = 15
 	amount_per_transfer_from_this = 15
+	possible_transfer_amounts = list()
 	volume = 15
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass/on_reagent_change()
-	if (gulp_size < 15) gulp_size = 15
-	else gulp_size = max(round(reagents.total_volume / 15), 15)
+	if (gulp_size < 15)
+		gulp_size = 15
+	else
+		gulp_size = max(round(reagents.total_volume / 15), 15)
 
 	if (reagents.reagent_list.len > 0)
 		switch(reagents.get_master_reagent_id())

--- a/code/modules/food&drinks/food/condiment.dm
+++ b/code/modules/food&drinks/food/condiment.dm
@@ -25,10 +25,6 @@
 	 "cornoil" = list("oliveoil", "corn oil bottle", "A delicious oil used in cooking. Made from corn"),
 	 "sugar" = list("emptycondiment", "sugar bottle", "Tasty spacey sugar!"))
 
-
-/obj/item/weapon/reagent_containers/food/condiment/attack_self(mob/user)
-	return
-
 /obj/item/weapon/reagent_containers/food/condiment/attack(mob/M, mob/user, def_zone)
 
 	if(!reagents || !reagents.total_volume)
@@ -179,7 +175,7 @@
 	icon_state = "condi_empty"
 	volume = 10
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10)
+	possible_transfer_amounts = list()
 	possible_states = list("ketchup" = list("condi_ketchup", "Ketchup", "You feel more American already."), "capsaicin" = list("condi_hotsauce", "Hotsauce", "You can almost TASTE the stomach ulcers now!"), "soysauce" = list("condi_soysauce", "Soy Sauce", "A salty soy-based flavoring"), "frostoil" = list("condi_frostoil", "Coldsauce", "Leaves the tongue numb in it's passage"), "sodiumchloride" = list("condi_salt", "Salt Shaker", "Salt. From space oceans, presumably"), "blackpepper" = list("condi_pepper", "Pepper Mill", "Often used to flavor food or make people sneeze"), "cornoil" = list("condi_cornoil", "Corn Oil", "A delicious oil used in cooking. Made from corn"), "sugar" = list("condi_sugar", "Sugar", "Tasty spacey sugar!"))
 	var/originalname = "condiment" //Can't use initial(name) for this. This stores the name set by condimasters.
 


### PR DESCRIPTION
and drinking glass, and drinking bottles and condiment bottle. Fixes #12587
And remove the changing ability from damp rag and shot glass, since they only have one possible tranfer amount. 
Fixes the shaker's name being capitalized for no reason (and without an \improper ).
