### PR TITLE
No access restrictions on crematorium button

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -207,7 +207,7 @@
 	icon_state = "launcher"
 	skin = "launcher"
 	device_type = /obj/item/device/assembly/control/crematorium
-	req_access = list(access_crematorium)
+	req_access = list()
 	id = 1
 
 /obj/item/wallframe/button


### PR DESCRIPTION
It's more or less a requirement to use during changeling (other than using the kitchen) and there are few ways to dispose of bodies in general now that space loops back so much.

So no ID lock on the machine.
