### PR TITLE
Per mob "Reaction Times"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -4,7 +4,22 @@
 */
 
 // 1 decisecond click delay (above and beyond mob/next_move)
+//This is mainly modified by click code, to modify click delays elsewhere, use next_move and changeNext_move()
 /mob/var/next_click	= 0
+
+// THESE DO NOT EFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+/mob/var/next_move_adjust = 0 //Amount to adjust action/click delays by, + or -
+/mob/var/next_move_modifier = 1 //Value to multiply action/click delays by
+
+
+//Delays the mob's next click/action by num deciseconds
+// eg: 10-3 = 7 deciseconds of delay
+// eg: 10*0.5 = 5 deciseconds of delay
+// DOES NOT EFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+
+/mob/proc/changeNext_move(num)
+	next_move = world.time + ((num+next_move_adjust)*next_move_modifier)
+
 
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to
@@ -124,9 +139,6 @@
 				W.afterattack(A,src,0,params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
-
-/mob/proc/changeNext_move(num)
-	next_move = world.time + num
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)
 /mob/proc/DblClickOn(atom/A, params)


### PR DESCRIPTION
<B> Code: </B>
- Adds `next_move_adjustment`, a decisecond + or - value that modifies how much click/action/interaction delays affect a mob
- Adds `next_move_modifier`, a multiplier value that modifies how much click/action/interaction delays affect a mob

<B>Examples (NOT IMPLEMENTED):</B>
- A mob that does very little damage, but has 0 click delay, the speed is then based on the user/AI's delay
- Vampires being twice as fast as people in reaction times, like they sometimes are in other media.
