### PR TITLE
Adds no-slip jackboots for Nuke Ops

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -479,12 +479,6 @@ var/list/uplink_items = list()
 	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/stealthy_tools/syndigaloshes/nuke
-	name = "Tactical No-Slip Brown Shoes"
-	desc = "These allow you to run on wet floors. They do not work on lubricated surfaces, but the manufacturer guarantees they're somehow better than the normal ones."
-	cost = 4 //but they aren't
-	gamemodes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent Identification Card"
 	desc = "Agent cards prevent artificial intelligences from tracking the wearer, and can copy access from other identification cards. The access is cumulative, so scanning one card does not erase the access gained from another. \
@@ -556,6 +550,13 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/belt/military
 	cost = 3
 	excludefrom = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/device_tools/nukegaloshes
+	name = "No-Slip Combat Boots"
+	desc = "These boots will allow the wearer to run on wet floors and slippery objects without falling down. They do not work on heavily lubricated surfaces."
+	item = /obj/item/clothing/shoes/nukegaloshes
+	cost = 2
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit
 	name = "Syndicate Combat Medic Kit"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -17,7 +17,7 @@
 	origin_tech = "syndicate=3"
 	burn_state = -1 //Won't burn in fires
 	
-/obj/item/clothing/shoes/sneakers/nukegaloshes
+/obj/item/clothing/shoes/nukegaloshes
 	desc = "Advanced combat boots utilizing proprietary 'No-Slip' technology."
 	name = "adhesion combat boots"
 	icon_state = "jackboots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -16,6 +16,17 @@
 	flags = NOSLIP
 	origin_tech = "syndicate=3"
 	burn_state = -1 //Won't burn in fires
+	
+/obj/item/clothing/shoes/sneakers/nukegaloshes
+	desc = "Advanced combat boots utilizing proprietary 'No-Slip' technology."
+	name = "adhesion combat boots"
+	icon_state = "jackboots"
+	item_state = "jackboots"
+	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
+	strip_delay = 70
+	flags = NOSLIP
+	origin_tech = "syndicate=3"
+	burn_state = -1 //Won't burn in fires
 
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"


### PR DESCRIPTION
E-Shield = 20TC
Belt full of bulldog ammunition = 8TC
Emag = 6TC

Getting destroyed by an assistant who watered up a pest can = Priceless

Seriously, with all the efforts to make NukeOps "fluke-proof" (Syndicate pins, Syndieborgs, etc.) why in the world would anyone take away their noslips and give them less defense against slip memes than the average traitor? 

I don't know why...  but to cut off any argument about it being non-thematic or something, I made them into jackboots unique to Nuclear mode. 

-- THESE JACKBOOTS COST 2TC AND FUNCTION SIMILAR TO REGULAR NOSLIPS --
