### PR TITLE
Fixes blob spore exploit

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -64,6 +64,8 @@
 			if(H.stat == DEAD)
 				Zombify(H)
 				break
+	if(factory && z != factory.z)
+		death()
 	..()
 
 /mob/living/simple_animal/hostile/blob/blobspore/proc/Zombify(mob/living/carbon/human/H)


### PR DESCRIPTION
If you lured them off the Z level they'd be lost forever without despawning, making it so the factory would not produce any more blobs. This fixes that.
