### PR TITLE
Removes self linging

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -372,8 +372,14 @@
 		if (ticker.mode.config_tag=="changeling" || ticker.mode.config_tag=="traitorchan")
 			text = uppertext(text)
 		text = "<i><b>[text]</b></i>: "
-		if (src in ticker.mode.changelings)
+		if ((src in ticker.mode.changelings) && special_role)
 			text += "<b>YES</b>|<a href='?src=\ref[src];changeling=clear'>no</a>"
+			if (objectives.len==0)
+				text += "<br>Objectives are empty! <a href='?src=\ref[src];changeling=autoobjectives'>Randomize!</a>"
+			if(changeling && changeling.stored_profiles.len && (current.real_name != changeling.first_prof.name) )
+				text += "<br><a href='?src=\ref[src];changeling=initialdna'>Transform to initial appearance.</a>"
+		else if(src in ticker.mode.changelings) //Station Aligned Changeling
+			text += "<b>YES (but not an antag)</b>|<a href='?src=\ref[src];changeling=clear'>no</a>"
 			if (objectives.len==0)
 				text += "<br>Objectives are empty! <a href='?src=\ref[src];changeling=autoobjectives'>Randomize!</a>"
 			if(changeling && changeling.stored_profiles.len && (current.real_name != changeling.first_prof.name) )

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -75,9 +75,6 @@
 	for(var/obj/item/organ/internal/I in src)
 		I.Insert(M, 1)
 
-	if(!origin && owner.mind)
-		origin = owner.mind
-
 	if(origin)
 		origin.transfer_to(M)
 		if(!origin.changeling)


### PR DESCRIPTION
Fixes a goofy bug(?) where if you let yourself be killed by an NPC headslug you, the dead guy getting gibbed, gain control of the resulting ling. While said ling would still technically be "station aligned" people could  use this to "add" changeling status to any other kind of antag, which is a really dangerous/hilarious situation.

Kudos and apologies to those that managed to figure this out.

---

Also fixes a misrepresentation the traitor panel where any changeling would be classified as an antagonist because the traitor panel is a close minded racist.
