### PR TITLE
Beam Code Cleanup

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -1,0 +1,94 @@
+//Beam Datum and effect
+/datum/beam
+	var/atom/origin = null
+	var/atom/target = null
+	var/list/elements = list()
+	var/icon/base_icon = null
+	var/icon
+	var/icon_state
+	var/max_distance = 0
+	var/endtime = 0
+	var/sleep_time = 3
+	var/finished = 0
+	var/target_oldloc = null
+	var/origin_oldloc = null
+	var/beam_type = /obj/effect/ebeam //must be subtype
+
+/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam)
+	endtime = world.time+time
+	origin = beam_origin
+	origin_oldloc = origin.loc
+	target = beam_target
+	target_oldloc = target.loc
+	max_distance = maxdistance
+	base_icon = new(beam_icon,beam_icon_state)
+	icon = beam_icon
+	icon_state = beam_icon_state
+	beam_type = btype
+
+/datum/beam/proc/Start()
+	Draw()
+	while(!finished && target && world.time<endtime && get_dist(origin,target)<max_distance && origin.z == target.z)
+		if(origin.loc != origin_oldloc || target.loc != target_oldloc)
+			Reset()
+			Draw()
+		sleep(sleep_time)
+	qdel(src)
+
+/datum/beam/proc/End()
+	finished = 1
+
+/datum/beam/proc/Reset()
+	for(var/obj/effect/ebeam/B in elements)
+		qdel(B)
+
+/datum/beam/Destroy()
+	Reset()
+	target = null
+	origin = null
+	return ..()
+
+/datum/beam/proc/Draw()
+	var/Angle=round(Get_Angle(origin,target))
+
+	var/matrix/rot_matrix = matrix()
+	rot_matrix.Turn(Angle)
+
+	var/DX=(32*target.x+target.pixel_x)-(32*origin.x+origin.pixel_x)
+	var/DY=(32*target.y+target.pixel_y)-(32*origin.y+origin.pixel_y)
+	var/N=0
+	var/length=round(sqrt((DX)**2+(DY)**2))
+	
+	for(N,N<length,N+=32)
+		var/obj/effect/ebeam/X= new beam_type(origin.loc)
+		X.owner=src
+		elements |= X
+		if(N+32>length)
+			var/icon/II=new(icon,icon_state)
+			II.DrawBox(null,1,(length-N),32,32)
+			X.icon=II
+		else X.icon=base_icon
+		X.transform = rot_matrix
+		var/Pixel_x=round(sin(Angle)+32*sin(Angle)*(N+16)/32)
+		var/Pixel_y=round(cos(Angle)+32*cos(Angle)*(N+16)/32)
+		if(DX==0) Pixel_x=0
+		if(DY==0) Pixel_y=0
+		var/a
+		if(abs(Pixel_x)>32)
+			a = Pixel_x > 0 ? round(Pixel_x/32) : Ceiling(Pixel_x/32)
+			X.x += a
+			Pixel_x %= 32
+		if(abs(Pixel_y)>32)
+			a = Pixel_y > 0 ? round(Pixel_y/32) : Ceiling(Pixel_y/32)
+			X.y += a
+			Pixel_y %= 32
+
+		X.pixel_x=Pixel_x
+		X.pixel_y=Pixel_y
+
+/obj/effect/ebeam
+	var/datum/beam/owner
+
+/obj/effect/ebeam/Destroy()
+	owner = null
+	return ..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -146,9 +146,6 @@
 			found += A.search_contents_for(path,filter_path)
 	return found
 
-
-
-
 /*
 Beam code by Gunbuddy
 
@@ -157,65 +154,17 @@ once at a time per source will cause graphical errors.
 Also, the icon used for the beam will have to be vertical and 32x32.
 The math involved assumes that the icon is vertical to begin with so unless you want to adjust the math,
 its easier to just keep the beam vertical.
+BeamTarget represents the target for the beam, basically just means the other end.
+Time is the duration to draw the beam
+Icon is obviously which icon to use for the beam, default is beam.dmi
+Icon_state is what icon state is used. Default is b_beam which is a blue beam.
+Maxdistance is the longest range the beam will persist before it gives up.
 */
-/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=50, maxdistance=10)
-	//BeamTarget represents the target for the beam, basically just means the other end.
-	//Time is the duration to draw the beam
-	//Icon is obviously which icon to use for the beam, default is beam.dmi
-	//Icon_state is what icon state is used. Default is b_beam which is a blue beam.
-	//Maxdistance is the longest range the beam will persist before it gives up.
-	var/EndTime=world.time+time
-	while(BeamTarget&&world.time<EndTime&&get_dist(src,BeamTarget)<maxdistance&&z==BeamTarget.z)
-	//If the BeamTarget gets deleted, the time expires, or the BeamTarget gets out
-	//of range or to another z-level, then the beam will stop.  Otherwise it will
-	//continue to draw.
-
-		dir=get_dir(src,BeamTarget)	//Causes the source of the beam to rotate to continuosly face the BeamTarget.
-
-		for(var/obj/effect/overlay/beam/O in ultra_range(10,src,1))	//This section erases the previously drawn beam because I found it was easier to
-			if(O.BeamSource==src)				//just draw another instance of the beam instead of trying to manipulate all the
-				qdel(O)							//pieces to a new orientation.
-		var/Angle=round(Get_Angle(src,BeamTarget))
-		var/icon/I=new(icon,icon_state)
-		I.Turn(Angle)
-		var/DX=(32*BeamTarget.x+BeamTarget.pixel_x)-(32*x+pixel_x)
-		var/DY=(32*BeamTarget.y+BeamTarget.pixel_y)-(32*y+pixel_y)
-		var/N=0
-		var/length=round(sqrt((DX)**2+(DY)**2))
-		for(N,N<length,N+=32)
-			var/obj/effect/overlay/beam/X=new(loc)
-			X.BeamSource=src
-			if(N+32>length)
-				var/icon/II=new(icon,icon_state)
-				II.DrawBox(null,1,(length-N),32,32)
-				II.Turn(Angle)
-				X.icon=II
-			else X.icon=I
-			var/Pixel_x=round(sin(Angle)+32*sin(Angle)*(N+16)/32)
-			var/Pixel_y=round(cos(Angle)+32*cos(Angle)*(N+16)/32)
-			if(DX==0) Pixel_x=0
-			if(DY==0) Pixel_y=0
-			if(Pixel_x>32)
-				for(var/a=0, a<=Pixel_x,a+=32)
-					X.x++
-					Pixel_x-=32
-			if(Pixel_x<-32)
-				for(var/a=0, a>=Pixel_x,a-=32)
-					X.x--
-					Pixel_x+=32
-			if(Pixel_y>32)
-				for(var/a=0, a<=Pixel_y,a+=32)
-					X.y++
-					Pixel_y-=32
-			if(Pixel_y<-32)
-				for(var/a=0, a>=Pixel_y,a-=32)
-					X.y--
-					Pixel_y+=32
-			X.pixel_x=Pixel_x
-			X.pixel_y=Pixel_y
-		sleep(3)	//Changing this to a lower value will cause the beam to follow more smoothly with movement, but it will also be more laggy.
-					//I've found that 3 ticks provided a nice balance for my use.
-	for(var/obj/effect/overlay/beam/O in ultra_range(10,src,1)) if(O.BeamSource==src) qdel(O)
+/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=50, maxdistance=10,beam_type=/obj/effect/ebeam)
+	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type)
+	spawn(0)
+		newbeam.Start()
+	return newbeam
 
 /atom/proc/examine(mob/user)
 	//This reformat names to get a/an properly working on item descriptions when they are bloody

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -161,6 +161,7 @@
 #include "code\controllers\subsystem\shuttles\emergency.dm"
 #include "code\controllers\subsystem\shuttles\supply.dm"
 #include "code\datums\ai_laws.dm"
+#include "code\datums\beam.dm"
 #include "code\datums\browser.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"


### PR DESCRIPTION
Allows for more than one from the same source, specific beam types, stopping it before duration passes. Also removes some redundant loops.
