### PR TITLE
Stops fire alarms from triggering every tick

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1111,7 +1111,8 @@ FIRE ALARM
 	if (stat & (NOPOWER|BROKEN))  // can't activate alarm if it's unpowered or broken.
 		return
 	var/area/A = get_area(src)
-	A.firealert(src)
+	if(!A.fire)
+		A.firealert(src)
 	//playsound(src.loc, 'sound/ambience/signal.ogg', 75, 0)
 	return
 


### PR DESCRIPTION
This was triggering fire alarms every tick whenever there was a fire,
which lagged quite a bit. Thanks to Aranclanos for pointing this out.
