### PR TITLE
Removes Captain's Age Requirement and his Antag Block

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -17,7 +17,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	config_tag = "changeling"
 	antag_flag = BE_CHANGELING
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -17,7 +17,7 @@
 
 /proc/is_convertable_to_cult(datum/mind/mind)
 	if(!istype(mind))	return 0
-	if(istype(mind.current, /mob/living/carbon/human) && (mind.assigned_role in list("Captain", "Chaplain")))	return 0
+	if(istype(mind.current, /mob/living/carbon/human) && (mind.assigned_role in list("Chaplain")))	return 0
 	if(isloyal(mind.current))
 		return 0
 	if (ticker.mode.name == "cult")		//redundent?
@@ -52,7 +52,7 @@
 	name = "cult"
 	config_tag = "cult"
 	antag_flag = BE_CULTIST
-	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel")
 	protected_jobs = list()
 	required_players = 20
 	required_enemies = 4

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -72,7 +72,7 @@ Made by Xhuis
 	required_enemies = 2
 	recommended_enemies = 2
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security")
 
 /datum/game_mode/shadowling/announce()
 	world << "<b>The current game mode is - Shadowling!</b>"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,7 +11,7 @@
 	config_tag = "traitor"
 	antag_flag = BE_TRAITOR
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")//AI", Currently out of the list as malf does not work for shit
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security")//AI", Currently out of the list as malf does not work for shit
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -12,7 +12,6 @@ Captain
 	supervisors = "Nanotrasen officials and Space law"
 	selection_color = "#ccccff"
 	req_admin_notify = 1
-	minimal_player_age = 14
 
 	outfit = /datum/outfit/job/captain
 


### PR DESCRIPTION
# Hear me out here, this isn't a meme joke PR. This is a legitimate PR.

The captain is the easiest job on the station for a new player.
They have unrestricted access to everything.
They have a single job that teaches them the basics of inventory management and movement, and takes 5 seconds. (Move away from the desk, walk to the nuke disk, and pick it up.)
They don't have to worry about not being allowed somewhere, and therefore can learn any section of the game without any trouble.
They can give orders and ask for whatever they want, and be granted it.
They have less responsibility than the newbie job cargo tech.
If it's a nuke round, he'll have people trying to take his disk, teaching him the basics of combat in our highly competitive Counter-Strike in Space roundtype.

It's the perfect newbie job. Other low-rp servers encourage new players to be the Captain, because every server basically has the same deal. Even the heavy-RP servers don't have any dedicated thing for captains to do. It is THE do-whatever job. Even moreso than the Assistant.

**What if they break X important thing?**
Okay. it gets broken, the crew chews him out for it, and since rounds are 30 minutes to an hour, the round will probably be over. He'll learn to not do whatever he did again. Whatever he did he could of also done as the job that handles that X important thing in general, so what's the big deal? He could of done it by accident too if he was that job.

**It's too stressful and hard of a job!**
No it isn't. Look at the reasons posted above.

**He'll murder everyone with his gun/equipment!**
If a new player can play Engineer(has access to the singularity), atmos tech(can accidentally let loose plasma), Scientist(has access to BOMBS, SLIMES, TONS OF GUNS), Chemist(Even MORE deadly shit), Chef(has a GIBBER), then I think a single gun isn't really too much of a worry.

PS: If a job is so imbalanced because of a single item in their possession, then don't you think maybe we should consider nerfing that item?

**What if he loses his ID to traitor mcstealsalot?**
Well, he learns his mistake, and next time he doesn't lose his ID. He could of had his ID stolen as any other job, and if Traitor McStealsALot wants the captain's ID and all access, he can probably get the captain's ID and all access regardless of the captain being a new player or not.
# Onto the reasoning for the antag block removal:

They literally don't have anything important to do. The only important part is the nuke disk, which is(as mentioned above) a 5 second job. After that they're done with all the shit they need to do. They can do whatever they want at this point, with no responsibilities that any of the other 4 heads of staff can't do themselves. So why stop them from being antag?

**If you say the captain's gun, then let's reiterate:**
If a job is so imbalanced because of a single item in their possession, then don't you think maybe we should consider nerfing that item?

And that's even ignoring the fact that Traitors, Changelings, and pretty much every antag has STRONGER weapons than the captain's gun available to them.
