### PR TITLE
Adds a new tool, ColonCatcher.py

### DIFF
--- a/tools/ColonCatcher/2015-10-25-colon_operator_log.txt
+++ b/tools/ColonCatcher/2015-10-25-colon_operator_log.txt
@@ -1,0 +1,434 @@
+..code\world.dm Lines: 27, 28, 98?, 102?, 119?, 149?, 230? Total Colons: 7
+..code\ATMOSPHERICS\atmospherics.dm Lines: 213? Total Colons: 1
+..code\ATMOSPHERICS\components\binary_devices\dp_vent_pump.dm Lines: 137? Total Colons: 1
+..code\ATMOSPHERICS\components\binary_devices\passive_gate.dm Lines: 134?, 163? Total Colons: 2
+..code\ATMOSPHERICS\components\binary_devices\pump.dm Lines: 43?, 139?, 167? Total Colons: 3
+..code\ATMOSPHERICS\components\binary_devices\valve.dm Lines: 25?, 33?, 38? Total Colons: 3
+..code\ATMOSPHERICS\components\binary_devices\volume_pump.dm Lines: 42?, 136?, 163? Total Colons: 3
+..code\ATMOSPHERICS\components\trinary_devices\filter.dm Lines: 66?, 69?, 214? Total Colons: 3
+..code\ATMOSPHERICS\components\trinary_devices\mixer.dm Lines: 36?, 39?, 151? Total Colons: 3
+..code\ATMOSPHERICS\components\unary_devices\cryo.dm Lines: 152?, 187?, 189, 190, 312?, 313? Total Colons: 7
+..code\ATMOSPHERICS\components\unary_devices\Freezer.dm Lines: 82?, 205? Total Colons: 2
+..code\ATMOSPHERICS\components\unary_devices\vent_pump.dm Lines: 175?, 196?, 197?, 228? Total Colons: 4
+..code\ATMOSPHERICS\components\unary_devices\vent_scrubber.dm Lines: 140?, 141? Total Colons: 2
+..code\ATMOSPHERICS\pipes\manifold.dm Lines: 28? Total Colons: 1
+..code\ATMOSPHERICS\pipes\manifold4w.dm Lines: 19? Total Colons: 1
+..code\ATMOSPHERICS\pipes\pipes.dm Lines: 30?, 32?, 33?, 34?, 43? Total Colons: 5
+..code\ATMOSPHERICS\pipes\heat_exchange\manifold.dm Lines: 25?, 51? Total Colons: 2
+..code\controllers\subsystem\air.dm Lines: 100 Total Colons: 1
+..code\controllers\subsystem\bots.dm Lines: 18, 20 Total Colons: 2
+..code\controllers\subsystem\diseases.dm Lines: 18 Total Colons: 1
+..code\controllers\subsystem\events.dm Lines: 41, 199?, 200? Total Colons: 3
+..code\controllers\subsystem\jobs.dm Lines: 370? Total Colons: 1
+..code\controllers\subsystem\machines.dm Lines: 41, 42, 43 Total Colons: 3
+..code\controllers\subsystem\mobs.dm Lines: 20 Total Colons: 1
+..code\controllers\subsystem\objects.dm Lines: 37 Total Colons: 1
+..code\controllers\subsystem\shuttles.dm Lines: 251?, 253, 261?, 262?, 284, 285 Total Colons: 6
+..code\controllers\subsystem\ticker.dm Lines: 382?, 405? Total Colons: 4
+..code\controllers\subsystem\voting.dm Lines: 203?, 211? Total Colons: 2
+..code\controllers\subsystem\shuttles\emergency.dm Lines: 52?, 65? Total Colons: 4
+..code\controllers\subsystem\shuttles\supply.dm Lines: 97, 316?, 347?, 488?, 505? Total Colons: 10
+..code\datums\browser.dm Lines: 79? Total Colons: 1
+..code\datums\datacore.dm Lines: 91?, 127?, 132?, 137?, 142?, 147?, 152?, 157?, 163?, 169?, 259? Total Colons: 23
+..code\datums\datumvars.dm Lines: 57?, 93 Total Colons: 3
+..code\datums\material_container.dm Lines: 194? Total Colons: 1
+..code\datums\mind.dm Lines: 228?, 229?, 290?, 581?, 633, 634, 643, 648, 720?, 1243, 1244, 1245 Total Colons: 13
+..code\datums\mutations.dm Lines: 34?, 135?, 329? Total Colons: 3
+..code\datums\recipe.dm Lines: 52?, 114?, 115? Total Colons: 3
+..code\datums\diseases\_disease.dm Lines: 125? Total Colons: 1
+..code\datums\helper_datums\teleport.dm Lines: 63?, 64?, 74?, 75? Total Colons: 4
+..code\datums\helper_datums\topic_input.dm Lines: 23?, 27?, 31?, 35?, 42?, 46?, 50?, 56?, 60? Total Colons: 9
+..code\datums\spells\dumbfire.dm Lines: 43 Total Colons: 1
+..code\datums\spells\knock.dm Lines: 21 Total Colons: 1
+..code\datums\spells\projectile.dm Lines: 35 Total Colons: 1
+..code\datums\wires\airlock.dm Lines: 37?, 38?, 39?, 40?, 41?, 42?, 43? Total Colons: 7
+..code\datums\wires\alarm.dm Lines: 21? Total Colons: 3
+..code\datums\wires\apc.dm Lines: 13? Total Colons: 3
+..code\datums\wires\autolathe.dm Lines: 13? Total Colons: 3
+..code\datums\wires\particle_accelerator.dm Lines: 50? Total Colons: 1
+..code\datums\wires\pizza_bomb.dm Lines: 45?, 46? Total Colons: 2
+..code\datums\wires\robot.dm Lines: 16?, 17?, 18? Total Colons: 4
+..code\datums\wires\r_n_d.dm Lines: 48?, 49?, 50? Total Colons: 3
+..code\datums\wires\syndicatebomb.dm Lines: 46?, 75? Total Colons: 2
+..code\datums\wires\vending.dm Lines: 28?, 29?, 30?, 31? Total Colons: 4
+..code\datums\wires\wires.dm Lines: 119?, 121? Total Colons: 2
+..code\game\atoms.dm Lines: 297? Total Colons: 1
+..code\game\atoms_movable.dm Lines: 181?, 182?, 216? Total Colons: 3
+..code\game\communications.dm Lines: 288 Total Colons: 3
+..code\game\data_huds.dm Lines: 35? Total Colons: 1
+..code\game\dna.dm Lines: 231? Total Colons: 1
+..code\game\say.dm Lines: 45?, 49? Total Colons: 2
+..code\game\sound.dm Lines: 72? Total Colons: 1
+..code\game\gamemodes\antag_spawner.dm Lines: 103, 104 Total Colons: 3
+..code\game\gamemodes\objective.dm Lines: 84?, 112?, 139?, 172?, 201?, 433, 806 Total Colons: 7
+..code\game\gamemodes\abduction\abduction_gear.dm Lines: 159? Total Colons: 1
+..code\game\gamemodes\abduction\machinery\experiment.dm Lines: 41?, 107? Total Colons: 2
+..code\game\gamemodes\blob\blob_finish.dm Lines: 47? Total Colons: 1
+..code\game\gamemodes\blob\blob_report.dm Lines: 64, 70, 76, 85 Total Colons: 4
+..code\game\gamemodes\changeling\evolution_menu.dm Lines: 59? Total Colons: 3
+..code\game\gamemodes\changeling\powers\adrenaline.dm Lines: 12? Total Colons: 1
+..code\game\gamemodes\changeling\powers\mutations.dm Lines: 83? Total Colons: 1
+..code\game\gamemodes\cult\cult.dm Lines: 44? Total Colons: 1
+..code\game\gamemodes\cult\runes.dm Lines: 705?, 706? Total Colons: 2
+..code\game\gamemodes\gang\dominator.dm Lines: 101?, 187? Total Colons: 2
+..code\game\gamemodes\gang\gang.dm Lines: 261?, 266? Total Colons: 2
+..code\game\gamemodes\gang\gang_datum.dm Lines: 43?, 53?, 121? Total Colons: 3
+..code\game\gamemodes\gang\gang_pen.dm Lines: 59? Total Colons: 1
+..code\game\gamemodes\gang\recaller.dm Lines: 48?, 51? Total Colons: 4
+..code\game\gamemodes\malfunction\malfunction.dm Lines: 63, 64, 65, 185, 188, 189, 192, 204, 205, 216, 218, 219, 221, 233, 234 Total Colons: 15
+..code\game\gamemodes\meteor\meteors.dm Lines: 177? Total Colons: 2
+..code\game\gamemodes\nuclear\nuclearbomb.dm Lines: 197?, 212?, 215?, 217?, 220?, 222?, 265?, 359, 359?, 360, 365, 383? Total Colons: 25
+..code\game\gamemodes\revolution\revolution.dm Lines: 265?, 266?, 286? Total Colons: 3
+..code\game\gamemodes\shadowling\shadowling.dm Lines: 304? Total Colons: 1
+..code\game\gamemodes\traitor\traitor.dm Lines: 335? Total Colons: 1
+..code\game\gamemodes\wizard\artefact.dm Lines: 148? Total Colons: 1
+..code\game\gamemodes\wizard\rightandwrong.dm Lines: 9?, 10?, 11? Total Colons: 3
+..code\game\gamemodes\wizard\soulstone.dm Lines: 123, 195 Total Colons: 2
+..code\game\gamemodes\wizard\spellbook.dm Lines: 93?, 512?, 533? Total Colons: 3
+..code\game\gamemodes\wizard\wizard.dm Lines: 183?, 258, 261, 264, 278? Total Colons: 5
+..code\game\machinery\airlock_control.dm Lines: 59?, 60? Total Colons: 2
+..code\game\machinery\ai_slipper.dm Lines: 39?, 67, 77?, 93? Total Colons: 5
+..code\game\machinery\alarm.dm Lines: 134?, 135?, 730?, 742?, 895?, 934?, 1056?, 1071?, 1127?, 1128? Total Colons: 16
+..code\game\machinery\announcement_system.dm Lines: 45?, 47?, 136?, 137? Total Colons: 4
+..code\game\machinery\atmo_control.dm Lines: 273?, 284?, 396? Total Colons: 3
+..code\game\machinery\autolathe.dm Lines: 139?, 178?, 187?, 295?, 322?, 336?, 345? Total Colons: 10
+..code\game\machinery\Beacon.dm Lines: 31? Total Colons: 1
+..code\game\machinery\buttons.dm Lines: 22?, 23? Total Colons: 4
+..code\game\machinery\cell_charger.dm Lines: 15?, 31?, 64? Total Colons: 4
+..code\game\machinery\cloning.dm Lines: 88?, 92? Total Colons: 2
+..code\game\machinery\constructable_frame.dm Lines: 48?, 90?, 94?, 99?, 102?, 475? Total Colons: 8
+..code\game\machinery\deployable.dm Lines: 92 Total Colons: 1
+..code\game\machinery\dna_scanner.dm Lines: 44?, 48?, 57? Total Colons: 3
+..code\game\machinery\droneDispenser.dm Lines: 190? Total Colons: 1
+..code\game\machinery\iv_drip.dm Lines: 192?, 200?, 210? Total Colons: 3
+..code\game\machinery\lightswitch.dm Lines: 41? Total Colons: 1
+..code\game\machinery\machinery.dm Lines: 372?, 375? Total Colons: 2
+..code\game\machinery\magnet.dm Lines: 53?, 275?, 279? Total Colons: 3
+..code\game\machinery\navbeacon.dm Lines: 63?, 84?, 92?, 122?, 130? Total Colons: 6
+..code\game\machinery\newscaster.dm Lines: 205?, 206?, 291?, 304?, 311?, 318?, 319?, 372, 391?, 409?, 420?, 423, 424?, 430?, 431?, 436, 460?, 465?, 486, 614?, 724?, 727?, 922 Total Colons: 27
+..code\game\machinery\overview.dm Lines: 98, 167?, 243, 292? Total Colons: 4
+..code\game\machinery\portable_turret.dm Lines: 162?, 164?, 169?, 170?, 171?, 172?, 173?, 183?, 285?, 862?, 864?, 869?, 870?, 871?, 872?, 873?, 877?, 889?, 891?, 896?, 897?, 898?, 899?, 900?, 910?, 968?, 1049?, 1085, 1097?, 1098? Total Colons: 32
+..code\game\machinery\recharger.dm Lines: 19? Total Colons: 1
+..code\game\machinery\rechargestation.dm Lines: 122?, 124? Total Colons: 2
+..code\game\machinery\recycler.dm Lines: 43?, 44?, 45?, 84? Total Colons: 4
+..code\game\machinery\requests_console.dm Lines: 201?, 202?, 212?, 213? Total Colons: 4
+..code\game\machinery\robot_fabricator.dm Lines: 21, 23, 24, 25, 28 Total Colons: 5
+..code\game\machinery\shieldgen.dm Lines: 247?, 261?, 263?, 441? Total Colons: 4
+..code\game\machinery\Sleeper.dm Lines: 142?, 156?, 162? Total Colons: 4
+..code\game\machinery\slotmachine.dm Lines: 219?, 265?, 271? Total Colons: 3
+..code\game\machinery\spaceheater.dm Lines: 33?, 35?, 37?, 69?, 89?, 107? Total Colons: 9
+..code\game\machinery\status_display.dm Lines: 167 Total Colons: 4
+..code\game\machinery\suit_storage_unit.dm Lines: 199?, 200?, 212?, 215?, 218?, 221?, 227?, 231?, 232?, 519? Total Colons: 12
+..code\game\machinery\syndicatebeacon.dm Lines: 151? Total Colons: 1
+..code\game\machinery\syndicatebomb.dm Lines: 22?, 53?, 77?, 323?, 326? Total Colons: 6
+..code\game\machinery\teleporter.dm Lines: 69?, 442? Total Colons: 3
+..code\game\machinery\turrets.dm Lines: 542?, 578, 590?, 591? Total Colons: 6
+..code\game\machinery\vending.dm Lines: 248?, 323? Total Colons: 2
+..code\game\machinery\atmoalter\canister.dm Lines: 248, 289?, 290?, 291?, 292?, 295?, 297? Total Colons: 7
+..code\game\machinery\atmoalter\pump.dm Lines: 109? Total Colons: 3
+..code\game\machinery\atmoalter\scrubber.dm Lines: 127?, 203? Total Colons: 3
+..code\game\machinery\bots\bots.dm Lines: 244?, 337?, 338?, 340?, 416?, 481? Total Colons: 6
+..code\game\machinery\bots\cleanbot.dm Lines: 84?, 85?, 87?, 88?, 109? Total Colons: 6
+..code\game\machinery\bots\ed209bot.dm Lines: 107?, 109?, 115?, 116?, 117?, 118?, 119?, 120?, 155?, 258?, 456? Total Colons: 12
+..code\game\machinery\bots\floorbot.dm Lines: 104?, 105?, 107?, 109?, 110?, 111?, 112?, 113?, 114?, 115?, 116?, 147?, 360? Total Colons: 13
+..code\game\machinery\bots\medbot.dm Lines: 147?, 148?, 154?, 171?, 173?, 174?, 175?, 176?, 177?, 231?, 320?, 532? Total Colons: 12
+..code\game\machinery\bots\mulebot.dm Lines: 99?, 147?, 187?, 209?, 210?, 211?, 225?, 226?, 227?, 228?, 249?, 282?, 346?, 354?, 363?, 535? Total Colons: 17
+..code\game\machinery\bots\secbot.dm Lines: 97?, 99?, 104?, 105?, 106?, 107?, 108?, 109?, 142?, 222? Total Colons: 11
+..code\game\machinery\camera\camera.dm Lines: 141?, 151?, 152? Total Colons: 3
+..code\game\machinery\camera\tracking.dm Lines: 19?, 83? Total Colons: 2
+..code\game\machinery\computer\arcade.dm Lines: 860?, 862?, 863?, 871? Total Colons: 6
+..code\game\machinery\computer\camera.dm Lines: 56? Total Colons: 1
+..code\game\machinery\computer\camera_advanced.dm Lines: 154? Total Colons: 1
+..code\game\machinery\computer\card.dm Lines: 148?, 164?, 209?, 364?, 372?, 390? Total Colons: 6
+..code\game\machinery\computer\cloning.dm Lines: 146? Total Colons: 1
+..code\game\machinery\computer\communications.dm Lines: 106, 148?, 272?, 428?, 429?, 430, 453?, 468?, 531?, 532?, 533, 554? Total Colons: 12
+..code\game\machinery\computer\crew.dm Lines: 153?, 158?, 169? Total Colons: 3
+..code\game\machinery\computer\dna_console.dm Lines: 94?, 139?, 141?, 143?, 181? Total Colons: 5
+..code\game\machinery\computer\medical.dm Lines: 40?, 46, 153? Total Colons: 4
+..code\game\machinery\computer\message.dm Lines: 73?, 76?, 131?, 150? Total Colons: 4
+..code\game\machinery\computer\Operating.dm Lines: 50? Total Colons: 1
+..code\game\machinery\computer\pod.dm Lines: 56? Total Colons: 2
+..code\game\machinery\computer\robot.dm Lines: 65?, 107?, 109?, 110?, 112?, 114? Total Colons: 6
+..code\game\machinery\computer\security.dm Lines: 49?, 62, 117, 130, 275, 285 Total Colons: 7
+..code\game\machinery\computer\shuttle.dm Lines: 24, 25, 28, 30, 33, 34, 47, 48, 60 Total Colons: 9
+..code\game\machinery\computer\station_alert.dm Lines: 73? Total Colons: 1
+..code\game\machinery\doors\airlock.dm Lines: 790?, 791?, 800?, 801?, 809?, 877, 888 Total Colons: 7
+..code\game\machinery\doors\airlock_electronics.dm Lines: 81 Total Colons: 1
+..code\game\machinery\doors\brigdoors.dm Lines: 123?, 158?, 247 Total Colons: 7
+..code\game\machinery\doors\firedoor.dm Lines: 49?, 69 Total Colons: 2
+..code\game\machinery\doors\windowdoor.dm Lines: 188?, 200, 276? Total Colons: 3
+..code\game\machinery\embedded_controller\access_controller.dm Lines: 295?, 297? Total Colons: 2
+..code\game\machinery\embedded_controller\airlock_controller.dm Lines: 258?, 259?, 260?, 261? Total Colons: 4
+..code\game\machinery\pipe\construction.dm Lines: 134?, 162? Total Colons: 2
+..code\game\machinery\telecomms\machine_interactions.dm Lines: 57?, 64?, 159?, 160?, 161?, 184?, 220? Total Colons: 7
+..code\game\mecha\mecha.dm Lines: 561?, 582?, 838?, 843?, 935?, 936?, 937?, 986?, 987? Total Colons: 11
+..code\game\mecha\mecha_control_console.dm Lines: 72? Total Colons: 1
+..code\game\mecha\mecha_topic.dm Lines: 33?, 34?, 36?, 40?, 90?, 164?, 168?, 190?, 197? Total Colons: 21
+..code\game\mecha\mecha_wreckage.dm Lines: 25?, 42? Total Colons: 2
+..code\game\mecha\mech_fabricator.dm Lines: 120?, 132?, 237? Total Colons: 6
+..code\game\mecha\combat\combat.dm Lines: 65?, 67? Total Colons: 3
+..code\game\mecha\combat\durand.dm Lines: 38?, 50? Total Colons: 2
+..code\game\mecha\combat\gygax.dm Lines: 69?, 74?, 105? Total Colons: 3
+..code\game\mecha\combat\honker.dm Lines: 32?, 33?, 35? Total Colons: 14
+..code\game\mecha\combat\marauder.dm Lines: 70?, 158?, 160? Total Colons: 5
+..code\game\mecha\combat\phazon.dm Lines: 39?, 97?, 98? Total Colons: 3
+..code\game\mecha\equipment\mecha_equipment.dm Lines: 57? Total Colons: 3
+..code\game\mecha\equipment\tools\medical_tools.dm Lines: 96, 96?, 129?, 249?, 333?, 366, 370?, 371? Total Colons: 20
+..code\game\mecha\equipment\tools\mining_tools.dm Lines: 40, 51 Total Colons: 2
+..code\game\mecha\equipment\tools\other_tools.dm Lines: 132?, 160?, 182?, 222?, 328?, 406, 406?, 446? Total Colons: 10
+..code\game\mecha\equipment\tools\work_tools.dm Lines: 329?, 350?, 351?, 368, 368? Total Colons: 7
+..code\game\mecha\equipment\weapons\weapons.dm Lines: 208? Total Colons: 1
+..code\game\mecha\working\ripley.dm Lines: 53?, 55? Total Colons: 2
+..code\game\objects\explosion.dm Lines: 11?, 12?, 68? Total Colons: 5
+..code\game\objects\items.dm Lines: 213? Total Colons: 1
+..code\game\objects\items\candle.dm Lines: 23? Total Colons: 1
+..code\game\objects\items\crayons.dm Lines: 117, 171?, 172?, 173?, 210? Total Colons: 5
+..code\game\objects\items\toys.dm Lines: 133?, 187?, 234?, 452?, 471? Total Colons: 6
+..code\game\objects\items\devices\aicard.dm Lines: 83?, 85?, 129?, 138? Total Colons: 4
+..code\game\objects\items\devices\flashlight.dm Lines: 60? Total Colons: 2
+..code\game\objects\items\devices\geiger_counter.dm Lines: 93? Total Colons: 1
+..code\game\objects\items\devices\paicard.dm Lines: 40?, 41? Total Colons: 2
+..code\game\objects\items\devices\scanners.dm Lines: 123?, 137?, 139?, 141?, 143?, 147?, 149, 164?, 212?, 396? Total Colons: 11
+..code\game\objects\items\devices\taperecorder.dm Lines: 28?, 97, 117, 142 Total Colons: 4
+..code\game\objects\items\devices\transfer_valve.dm Lines: 69?, 102 Total Colons: 6
+..code\game\objects\items\devices\PDA\cart.dm Lines: 241, 245, 275, 292?, 293?, 294, 348?, 424, 435, 473?, 499?, 533?, 546?, 557?, 585, 594, 601, 605, 606, 609, 610, 611, 612, 631, 642?, 649?, 702?, 703?, 705?, 706?, 707?, 708?, 709?, 711, 712, 713, 716, 717, 718 Total Colons: 44
+..code\game\objects\items\devices\PDA\PDA.dm Lines: 298?, 299?, 330?, 356?, 358?, 360?, 364?, 378?, 382?, 383?, 388, 390, 392, 618, 619, 631, 632, 692, 693, 918, 1010?, 1036, 1039, 1131?, 1143? Total Colons: 25
+..code\game\objects\items\devices\radio\electropack.dm Lines: 129? Total Colons: 1
+..code\game\objects\items\devices\radio\radio.dm Lines: 136?, 137, 137?, 138, 138?, 139, 140, 141, 143, 144, 146, 147?, 148, 148?, 149, 150, 151, 153, 154, 155 Total Colons: 22
+..code\game\objects\items\robot\robot_parts.dm Lines: 137, 143, 150, 258?, 259?, 261?, 262?, 263?, 264? Total Colons: 11
+..code\game\objects\items\robot\robot_upgrades.dm Lines: 250? Total Colons: 1
+..code\game\objects\items\stacks\sheets\glass.dm Lines: 303? Total Colons: 1
+..code\game\objects\items\weapons\AI_modules.dm Lines: 37?, 72?, 73?, 74? Total Colons: 4
+..code\game\objects\items\weapons\cards_ids.dm Lines: 115?, 118?, 148? Total Colons: 6
+..code\game\objects\items\weapons\cigs_lighters.dm Lines: 479?, 496? Total Colons: 2
+..code\game\objects\items\weapons\cosmetics.dm Lines: 36?, 54? Total Colons: 2
+..code\game\objects\items\weapons\defib.dm Lines: 470?, 485?, 487?, 489?, 491?, 508?, 527?, 530? Total Colons: 8
+..code\game\objects\items\weapons\explosives.dm Lines: 57? Total Colons: 1
+..code\game\objects\items\weapons\extinguisher.dm Lines: 45?, 46? Total Colons: 2
+..code\game\objects\items\weapons\flamethrower.dm Lines: 90?, 128? Total Colons: 2
+..code\game\objects\items\weapons\handcuffs.dm Lines: 208? Total Colons: 1
+..code\game\objects\items\weapons\RCD.dm Lines: 500, 505 Total Colons: 4
+..code\game\objects\items\weapons\singularityhammer.dm Lines: 42 Total Colons: 1
+..code\game\objects\items\weapons\stunbaton.dm Lines: 94? Total Colons: 1
+..code\game\objects\items\weapons\grenades\chem_grenade.dm Lines: 60? Total Colons: 1
+..code\game\objects\items\weapons\grenades\grenade.dm Lines: 49? Total Colons: 1
+..code\game\objects\items\weapons\implants\implantchair.dm Lines: 46?, 47?, 49? Total Colons: 5
+..code\game\objects\items\weapons\implants\implantpad.dm Lines: 56 Total Colons: 1
+..code\game\objects\items\weapons\storage\book.dm Lines: 180 Total Colons: 1
+..code\game\objects\items\weapons\storage\fancy.dm Lines: 39? Total Colons: 1
+..code\game\objects\items\weapons\storage\secure.dm Lines: 32?, 39?, 84? Total Colons: 3
+..code\game\objects\items\weapons\storage\storage.dm Lines: 177? Total Colons: 1
+..code\game\objects\items\weapons\tanks\jetpack.dm Lines: 26?, 44?, 151? Total Colons: 3
+..code\game\objects\items\weapons\tanks\tanks.dm Lines: 121?, 122? Total Colons: 2
+..code\game\objects\items\weapons\tanks\watertank.dm Lines: 177?, 178? Total Colons: 2
+..code\game\objects\structures\ai_core.dm Lines: 212?, 213? Total Colons: 2
+..code\game\objects\structures\displaycase.dm Lines: 119?, 128?, 130? Total Colons: 3
+..code\game\objects\structures\fireaxe.dm Lines: 129? Total Colons: 1
+..code\game\objects\structures\grille.dm Lines: 148?, 149? Total Colons: 2
+..code\game\objects\structures\musician.dm Lines: 50?, 130?, 132? Total Colons: 3
+..code\game\objects\structures\safe.dm Lines: 78?, 98?, 104?, 188? Total Colons: 4
+..code\game\objects\structures\tank_dispenser.dm Lines: 43?, 44? Total Colons: 2
+..code\game\objects\structures\watercloset.dm Lines: 51?, 54? Total Colons: 3
+..code\game\objects\structures\windoor_assembly.dm Lines: 50? Total Colons: 1
+..code\game\objects\structures\window.dm Lines: 197?, 199?, 201?, 206?, 207?, 211?, 215?, 218?, 222?, 223?, 425? Total Colons: 11
+..code\game\objects\structures\beds_chairs\bed.dm Lines: 129? Total Colons: 1
+..code\game\objects\structures\crates_lockers\closets.dm Lines: 66?, 234?, 241?, 243?, 392? Total Colons: 6
+..code\game\objects\structures\transit_tubes\station.dm Lines: 130? Total Colons: 1
+..code\game\objects\structures\transit_tubes\transit_tube_construction.dm Lines: 41?, 43? Total Colons: 2
+..code\game\turfs\turf.dm Lines: 137, 248?, 250? Total Colons: 4
+..code\game\turfs\space\space.dm Lines: 114?, 125? Total Colons: 2
+..code\game\verbs\ooc.dm Lines: 44?, 53?, 55?, 57?, 69? Total Colons: 6
+..code\LINDA\LINDA_turf_tile.dm Lines: 458?, 463? Total Colons: 2
+..code\modules\admin\admin.dm Lines: 30?, 62?, 63?, 64?, 65?, 66?, 67?, 122, 129, 141, 192?, 205?, 212?, 246, 262?, 277?, 288?, 292, 293?, 300?, 301?, 306, 334?, 352, 415?, 442?, 550?, 551?, 676?, 677?, 696? Total Colons: 35
+..code\modules\admin\admin_verbs.dm Lines: 441?, 442? Total Colons: 2
+..code\modules\admin\create_poll.dm Lines: 25?, 26?, 94?, 95? Total Colons: 4
+..code\modules\admin\newbanjob.dm Lines: 216? Total Colons: 2
+..code\modules\admin\player_panel.dm Lines: 111?, 113?, 119?, 123?, 129?, 155?, 160?, 166?, 181?, 186?, 195?, 207?, 219?, 228?, 240?, 249?, 258?, 269?, 284?, 297? Total Colons: 36
+..code\modules\admin\sql_notes.dm Lines: 153 Total Colons: 2
+..code\modules\admin\topic.dm Lines: 299?, 310?, 341?, 348?, 349?, 447?, 986?, 1559?, 1561?, 1589?, 1796?, 1797?, 1798?, 1800?, 1982?, 2093?, 2096?, 2101?, 2102? Total Colons: 21
+..code\modules\admin\DB ban\functions.dm Lines: 93, 94, 95, 127?, 131?, 304, 305, 306, 441? Total Colons: 20
+..code\modules\admin\verbs\adminjump.dm Lines: 91, 127 Total Colons: 2
+..code\modules\admin\verbs\deadsay.dm Lines: 24? Total Colons: 1
+..code\modules\admin\verbs\debug.dm Lines: 82?, 86?, 89?, 112?, 116?, 289, 306, 498, 501 Total Colons: 9
+..code\modules\admin\verbs\diagnostics.dm Lines: 15?, 81 Total Colons: 5
+..code\modules\admin\verbs\massmodvar.dm Lines: 132 Total Colons: 1
+..code\modules\admin\verbs\modifyvariables.dm Lines: 542 Total Colons: 1
+..code\modules\admin\verbs\one_click_antag.dm Lines: 333?, 478?, 481?, 484?, 487?, 490?, 493?, 496?, 517? Total Colons: 9
+..code\modules\admin\verbs\panicbunker.dm Lines: 10?, 11? Total Colons: 2
+..code\modules\admin\verbs\randomverbs.dm Lines: 38?, 114?, 116?, 117?, 189?, 212?, 409?, 448?, 721?, 722?, 799, 804, 810, 816, 822, 828, 834, 840, 846, 852, 858, 864, 870, 876, 882, 888, 894, 900 Total Colons: 28
+..code\modules\assembly\bomb.dm Lines: 44 Total Colons: 1
+..code\modules\assembly\doorcontrol.dm Lines: 62? Total Colons: 1
+..code\modules\assembly\health.dm Lines: 77? Total Colons: 1
+..code\modules\assembly\infrared.dm Lines: 24?, 110? Total Colons: 3
+..code\modules\assembly\mousetrap.dm Lines: 30?, 127? Total Colons: 2
+..code\modules\assembly\proximity.dm Lines: 26?, 109?, 110? Total Colons: 3
+..code\modules\assembly\signaler.dm Lines: 142? Total Colons: 1
+..code\modules\assembly\timer.dm Lines: 75? Total Colons: 1
+..code\modules\assembly\voice.dm Lines: 32? Total Colons: 1
+..code\modules\awaymissions\maploader\reader.dm Lines: 262? Total Colons: 1
+..code\modules\awaymissions\maploader\swapmaps.dm Lines: 152, 153, 154, 161?, 162?, 163?, 343?, 356?, 362?, 385? Total Colons: 19
+..code\modules\client\client procs.dm Lines: 36, 36?, 177? Total Colons: 3
+..code\modules\client\preferences.dm Lines: 129?, 130?, 151?, 161?, 166?, 186?, 335?, 336?, 337?, 338?, 339?, 340?, 341?, 342?, 343?, 349?, 350?, 353?, 356?, 397?, 523? Total Colons: 21
+..code\modules\client\preferences_toggles.dm Lines: 7?, 16?, 25?, 34?, 43?, 54?, 64?, 74?, 83?, 92?, 113?, 122?, 172?, 226?, 235?, 259? Total Colons: 16
+..code\modules\clothing\clothing.dm Lines: 357? Total Colons: 1
+..code\modules\clothing\glasses\engine_goggles.dm Lines: 83?, 108? Total Colons: 2
+..code\modules\clothing\head\helmet.dm Lines: 240? Total Colons: 1
+..code\modules\clothing\head\soft_caps.dm Lines: 45? Total Colons: 1
+..code\modules\clothing\masks\gasmask.dm Lines: 66? Total Colons: 1
+..code\modules\clothing\masks\miscellaneous.dm Lines: 56? Total Colons: 1
+..code\modules\clothing\shoes\bananashoes.dm Lines: 59?, 65? Total Colons: 3
+..code\modules\clothing\shoes\magboots.dm Lines: 32?, 41? Total Colons: 2
+..code\modules\clothing\spacesuits\chronosuit.dm Lines: 146, 151, 152, 153, 158, 172, 175, 176, 177 Total Colons: 9
+..code\modules\crafting\table.dm Lines: 15, 59, 113, 126, 143, 167 Total Colons: 6
+..code\modules\detectivework\detective_work.dm Lines: 16? Total Colons: 1
+..code\modules\events\event.dm Lines: 37 Total Colons: 2
+..code\modules\events\shuttle_loan.dm Lines: 195, 196 Total Colons: 2
+..code\modules\flufftext\Hallucination.dm Lines: 47?, 49?, 51? Total Colons: 3
+..code\modules\food&drinks\food\customizables.dm Lines: 37? Total Colons: 1
+..code\modules\food&drinks\kitchen machinery\gibber.dm Lines: 165? Total Colons: 1
+..code\modules\food&drinks\kitchen machinery\monkeyrecycler.dm Lines: 72? Total Colons: 1
+..code\modules\food&drinks\kitchen machinery\processor.dm Lines: 198? Total Colons: 1
+..code\modules\games\cards.dm Lines: 177?, 211?, 225? Total Colons: 3
+..code\modules\holiday\easter.dm Lines: 77? Total Colons: 1
+..code\modules\html_interface\html_interface.dm Lines: 292? Total Colons: 1
+..code\modules\hydroponics\grown.dm Lines: 704 Total Colons: 1
+..code\modules\hydroponics\growninedible.dm Lines: 71, 194? Total Colons: 2
+..code\modules\hydroponics\hydroponics.dm Lines: 642?, 836? Total Colons: 2
+..code\modules\hydroponics\seeds.dm Lines: 1377?, 1378? Total Colons: 2
+..code\modules\library\lib_items.dm Lines: 186? Total Colons: 1
+..code\modules\library\lib_machines.dm Lines: 519 Total Colons: 1
+..code\modules\lighting\lighting_system.dm Lines: 254 Total Colons: 1
+..code\modules\mob\inventory.dm Lines: 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 170 Total Colons: 22
+..code\modules\mob\login.dm Lines: 6? Total Colons: 1
+..code\modules\mob\mob.dm Lines: 329?, 599?, 690, 756? Total Colons: 5
+..code\modules\mob\mob_helpers.dm Lines: 485? Total Colons: 2
+..code\modules\mob\transform_procs.dm Lines: 295 Total Colons: 1
+..code\modules\mob\dead\observer\observer.dm Lines: 285? Total Colons: 1
+..code\modules\mob\living\living.dm Lines: 181?, 359?, 402 Total Colons: 3
+..code\modules\mob\living\say.dm Lines: 116? Total Colons: 1
+..code\modules\mob\living\carbon\carbon.dm Lines: 114, 286?, 288?, 291?, 310?, 311?, 322?, 323?, 566? Total Colons: 12
+..code\modules\mob\living\carbon\life.dm Lines: 468? Total Colons: 1
+..code\modules\mob\living\carbon\alien\humanoid\emote.dm Lines: 60? Total Colons: 1
+..code\modules\mob\living\carbon\alien\humanoid\humanoid.dm Lines: 93? Total Colons: 2
+..code\modules\mob\living\carbon\alien\humanoid\caste\hunter.dm Lines: 43?, 46? Total Colons: 2
+..code\modules\mob\living\carbon\alien\larva\emote.dm Lines: 79? Total Colons: 1
+..code\modules\mob\living\carbon\brain\MMI.dm Lines: 131?, 132? Total Colons: 2
+..code\modules\mob\living\carbon\human\examine.dm Lines: 48?, 55?, 62?, 69?, 76?, 83?, 90?, 97?, 115?, 122?, 129?, 136? Total Colons: 12
+..code\modules\mob\living\carbon\human\human.dm Lines: 87?, 96?, 192?, 194?, 196?, 200?, 205?, 210?, 215?, 219?, 221?, 223?, 231?, 236?, 241?, 248?, 250?, 252?, 253?, 254?, 324?, 325?, 341?, 563?, 734? Total Colons: 26
+..code\modules\mob\living\carbon\human\human_attackalien.dm Lines: 10? Total Colons: 1
+..code\modules\mob\living\carbon\human\inventory.dm Lines: 223?, 234?, 238?, 246?, 250?, 254? Total Colons: 6
+..code\modules\mob\living\carbon\human\species.dm Lines: 115?, 117?, 126?, 329?, 673? Total Colons: 5
+..code\modules\mob\living\carbon\human\update_icons.dm Lines: 112?, 186?, 479? Total Colons: 4
+..code\modules\mob\living\carbon\human\whisper.dm Lines: 43? Total Colons: 1
+..code\modules\mob\living\carbon\monkey\emote.dm Lines: 60? Total Colons: 1
+..code\modules\mob\living\silicon\silicon.dm Lines: 129, 324? Total Colons: 2
+..code\modules\mob\living\silicon\ai\ai.dm Lines: 255?, 280?, 281?, 341?, 530?, 532?, 585?, 593? Total Colons: 9
+..code\modules\mob\living\silicon\ai\life.dm Lines: 73, 75, 78, 80, 96, 97, 121, 145, 150, 166 Total Colons: 10
+..code\modules\mob\living\silicon\ai\say.dm Lines: 15? Total Colons: 2
+..code\modules\mob\living\silicon\ai\freelook\eye.dm Lines: 106? Total Colons: 1
+..code\modules\mob\living\silicon\pai\pai.dm Lines: 161, 181 Total Colons: 2
+..code\modules\mob\living\silicon\pai\software.dm Lines: 220?, 277?, 279?, 281?, 317?, 410?, 415?, 422?, 434, 434?, 435, 436, 436?, 437, 437?, 438, 438?, 439, 439?, 440, 442, 443, 444, 445, 446, 550, 557? Total Colons: 29
+..code\modules\mob\living\silicon\robot\examine.dm Lines: 29?, 31? Total Colons: 2
+..code\modules\mob\living\silicon\robot\inventory.dm Lines: 54, 62, 70 Total Colons: 3
+..code\modules\mob\living\silicon\robot\laws.dm Lines: 47? Total Colons: 1
+..code\modules\mob\living\silicon\robot\life.dm Lines: 173, 175, 177 Total Colons: 3
+..code\modules\mob\living\silicon\robot\robot.dm Lines: 259?, 393?, 492?, 545?, 806?, 1034? Total Colons: 8
+..code\modules\mob\living\simple_animal\parrot.dm Lines: 412?, 414? Total Colons: 2
+..code\modules\mob\living\simple_animal\worm.dm Lines: 74? Total Colons: 1
+..code\modules\mob\living\simple_animal\friendly\drone\interaction.dm Lines: 103? Total Colons: 2
+..code\modules\mob\living\simple_animal\friendly\drone\verbs.dm Lines: 25? Total Colons: 1
+..code\modules\mob\living\simple_animal\friendly\drone\_drone.dm Lines: 123?, 130?, 137?, 144? Total Colons: 4
+..code\modules\mob\living\simple_animal\hostile\hostile.dm Lines: 255, 256 Total Colons: 4
+..code\modules\mob\living\simple_animal\morph\morph.dm Lines: 183? Total Colons: 1
+..code\modules\mob\living\simple_animal\slime\death.dm Lines: 15? Total Colons: 1
+..code\modules\mob\living\simple_animal\slime\life.dm Lines: 190? Total Colons: 1
+..code\modules\mob\living\simple_animal\slime\powers.dm Lines: 75? Total Colons: 1
+..code\modules\mob\living\simple_animal\slime\slime.dm Lines: 79?, 80?, 90? Total Colons: 3
+..code\modules\mob\new_player\new_player.dm Lines: 27, 29, 44?, 69?, 73? Total Colons: 5
+..code\modules\mob\new_player\poll.dm Lines: 12?, 29?, 478? Total Colons: 3
+..code\modules\nano\JSON Reader.dm Lines: 71 Total Colons: 2
+..code\modules\nano\nanoui.dm Lines: 304? Total Colons: 1
+..code\modules\ninja\admin_ninja_verbs.dm Lines: 30, 32 Total Colons: 2
+..code\modules\ninja\ninja_event.dm Lines: 141? Total Colons: 1
+..code\modules\ninja\suit\gloves.dm Lines: 80?, 87? Total Colons: 2
+..code\modules\ninja\suit\mask.dm Lines: 116?, 129?, 132?, 139? Total Colons: 4
+..code\modules\ninja\suit\ninjaDrainAct.dm Lines: 128?, 159? Total Colons: 2
+..code\modules\ninja\suit\suit.dm Lines: 75?, 79?, 116?, 172? Total Colons: 4
+..code\modules\ninja\suit\suit_attackby.dm Lines: 10?, 12?, 19? Total Colons: 3
+..code\modules\ninja\suit\suit_initialisation.dm Lines: 84 Total Colons: 1
+..code\modules\ninja\suit\n_suit_verbs\energy_net_nets.dm Lines: 64, 65, 112?, 131 Total Colons: 4
+..code\modules\ninja\suit\n_suit_verbs\ninja_stars.dm Lines: 12? Total Colons: 1
+..code\modules\paperwork\filingcabinet.dm Lines: 57? Total Colons: 1
+..code\modules\paperwork\folders.dm Lines: 43? Total Colons: 1
+..code\modules\paperwork\paper.dm Lines: 86? Total Colons: 1
+..code\modules\paperwork\paperbin.dm Lines: 97? Total Colons: 1
+..code\modules\paperwork\photocopier.dm Lines: 123?, 264?, 268? Total Colons: 5
+..code\modules\paperwork\photography.dm Lines: 66?, 67?, 79?, 183, 184, 189, 190, 217, 217?, 219, 219? Total Colons: 14
+..code\modules\power\apc.dm Lines: 128?, 129?, 133, 148, 199?, 201?, 202?, 262?, 454?, 469?, 474, 647, 647?, 664?, 671?, 715?, 838, 839, 840, 1184, 1221? Total Colons: 25
+..code\modules\power\cable.dm Lines: 108?, 293?, 564? Total Colons: 3
+..code\modules\power\generator.dm Lines: 117? Total Colons: 2
+..code\modules\power\gravitygenerator.dm Lines: 230?, 250?, 258?, 264?, 279?, 280?, 287? Total Colons: 7
+..code\modules\power\lighting.dm Lines: 261?, 440? Total Colons: 2
+..code\modules\power\port_gen.dm Lines: 89?, 273? Total Colons: 2
+..code\modules\power\smes.dm Lines: 57, 419? Total Colons: 4
+..code\modules\power\solar.dm Lines: 388?, 391? Total Colons: 2
+..code\modules\power\turbine.dm Lines: 308?, 365?, 367?, 369? Total Colons: 5
+..code\modules\power\antimatter\control.dm Lines: 267? Total Colons: 1
+..code\modules\power\antimatter\shielding.dm Lines: 119 Total Colons: 1
+..code\modules\power\singularity\collector.dm Lines: 44?, 45?, 46?, 98? Total Colons: 6
+..code\modules\power\singularity\emitter.dm Lines: 252? Total Colons: 1
+..code\modules\power\singularity\singularity.dm Lines: 117?, 236? Total Colons: 2
+..code\modules\power\singularity\particle_accelerator\particle.dm Lines: 42 Total Colons: 1
+..code\modules\power\singularity\particle_accelerator\particle_accelerator.dm Lines: 364 Total Colons: 1
+..code\modules\power\singularity\particle_accelerator\particle_control.dm Lines: 215?, 216?, 217? Total Colons: 6
+..code\modules\procedural mapping\mapGenerator.dm Lines: 153? Total Colons: 1
+..code\modules\projectiles\ammunition.dm Lines: 29?, 30?, 155? Total Colons: 3
+..code\modules\projectiles\gun.dm Lines: 108?, 110?, 310? Total Colons: 3
+..code\modules\projectiles\ammunition\magazines.dm Lines: 173? Total Colons: 1
+..code\modules\projectiles\guns\magic\wand.dm Lines: 25? Total Colons: 1
+..code\modules\projectiles\guns\projectile\automatic.dm Lines: 28?, 109?, 127?, 160?, 165?, 250? Total Colons: 11
+..code\modules\projectiles\guns\projectile\launchers.dm Lines: 49? Total Colons: 1
+..code\modules\projectiles\guns\projectile\pistol.dm Lines: 15?, 36? Total Colons: 3
+..code\modules\projectiles\guns\projectile\shotgun.dm Lines: 30?, 63?, 114?, 282? Total Colons: 4
+..code\modules\projectiles\guns\projectile\toy.dm Lines: 33? Total Colons: 1
+..code\modules\reagents\Chemistry-Machinery.dm Lines: 85?, 89, 90, 97, 330?, 350?, 367?, 368?, 512?, 551?, 665?, 705?, 708?, 788, 867?, 910?, 1248?, 1286?, 1508?, 1510?, 1511?, 1512? Total Colons: 24
+..code\modules\reagents\Chemistry-Recipes.dm Lines: 46? Total Colons: 1
+..code\modules\reagents\reagent_containers.dm Lines: 64? Total Colons: 1
+..code\modules\reagents\Chemistry-Reagents\Consumable-Reagents\Food-Reagents.dm Lines: 331 Total Colons: 2
+..code\modules\reagents\reagent_containers\spray.dm Lines: 97?, 98?, 99?, 177? Total Colons: 4
+..code\modules\recycling\disposal-construction.dm Lines: 86?, 91? Total Colons: 2
+..code\modules\recycling\disposal-structures.dm Lines: 240? Total Colons: 1
+..code\modules\recycling\disposal-unit.dm Lines: 82? Total Colons: 1
+..code\modules\recycling\sortingmachinery.dm Lines: 217? Total Colons: 1
+..code\modules\research\experimentor.dm Lines: 253? Total Colons: 1
+..code\modules\research\message_server.dm Lines: 130? Total Colons: 2
+..code\modules\shuttle\shuttle.dm Lines: 266?, 270?, 515?, 522?, 547?, 564? Total Colons: 8
+..code\modules\surgery\organs\augments_internal.dm Lines: 33?, 76?, 77?, 94? Total Colons: 4
+..code\modules\telesci\telesci_computer.dm Lines: 46?, 122?, 269? Total Colons: 4
+..code\modules\tooltip\tooltip.dm Lines: 90? Total Colons: 1
+..code\modules\vehicles\VehicleBase.dm Lines: 101?, 103?, 105?, 107? Total Colons: 4
+..code\modules\vehicles\VehicleClickInteractions.dm Lines: 128?, 157?, 186?, 214?, 252?, 254?, 257?, 259?, 262?, 264?, 267?, 269?, 272?, 274? Total Colons: 14
+..code\modules\vehicles\VehicleDefense.dm Lines: 31? Total Colons: 1
+..code\orphaned procs\dbcore.dm Lines: 79? Total Colons: 5
+..code\orphaned procs\statistics.dm Lines: 63, 64, 98, 99 Total Colons: 4
+..code\_onclick\other_mobs.dm Lines: 89 Total Colons: 1
+..code\_onclick\hud\action.dm Lines: 184? Total Colons: 1
+..code\_onclick\hud\alien.dm Lines: 90? Total Colons: 1
+..code\_onclick\hud\alien_larva.dm Lines: 16? Total Colons: 1
+..code\_onclick\hud\human.dm Lines: 59? Total Colons: 1
+..code\_onclick\hud\monkey.dm Lines: 17? Total Colons: 1
+..code\__DATASTRUCTURES\priority_queue.dm Lines: 33? Total Colons: 1
+..code\__DATASTRUCTURES\stacks.dm Lines: 29? Total Colons: 1
+..code\__HELPERS\game.dm Lines: 216? Total Colons: 1
+..code\__HELPERS\icons.dm Lines: 216?, 233?, 386?, 389?, 392?, 425?, 439?, 456?, 526?, 557?, 559?, 601?, 607?, 635?, 636?, 637?, 638?, 715, 752, 757, 762, 763, 764, 765, 774, 786, 787, 809?, 828?, 839? Total Colons: 38
+..code\__HELPERS\icon_smoothing.dm Lines: 176?, 178? Total Colons: 2
+..code\__HELPERS\lists.dm Lines: 201?, 206?, 214? Total Colons: 3
+..code\__HELPERS\maths.dm Lines: 13?, 18?, 35?, 39? Total Colons: 4
+..code\__HELPERS\mobs.dm Lines: 137?, 139?, 140? Total Colons: 11
+..code\__HELPERS\names.dm Lines: 63?, 174? Total Colons: 3
+..code\__HELPERS\sanitize_values.dm Lines: 34? Total Colons: 1
+..code\__HELPERS\text.dm Lines: 157?, 350? Total Colons: 2
+..code\__HELPERS\type2type.dm Lines: 68?, 143?, 381? Total Colons: 5
+..code\__HELPERS\unsorted.dm Lines: 41?, 573, 904, 991? Total Colons: 4
+..code\__HELPERS\sorts\__main.dm Lines: 2?, 57?, 391, 491, 585? Total Colons: 5
+433/1564 files have colons in them

--- a/tools/ColonCatcher/ColonCatcher.py
+++ b/tools/ColonCatcher/ColonCatcher.py
@@ -1,0 +1,162 @@
+
+# Colon Locater and Reporter, by RemieRichards V1.0 - 25/10/15
+
+# Locates the byond operator ":", which is largely frowned upon due to the fact it ignores any type safety.
+# This tool produces a .txt of "filenames line,line?,line totalcolons" (where line? represents a colon in a ternary operation) from all
+# .dm files in the /code directory of an SS13 codebase, but can work on any Byond project if you modify scan_dir and real_dir
+# the .txt take's todays date in reverse order and adds -colon_operator_log to the end, eg: "2015/10/25-colon_operator_log.txt"
+
+import sys
+import os
+from datetime import date
+
+
+#Climbs up from /tools/ColonCatcher and along to ../code
+scan_dir = "code" #used later to truncate log file paths
+real_dir = os.path.abspath("../../"+scan_dir)
+
+
+#Scan a directory, scanning any dm files it finds
+def colon_scan_dir(scan_dir):
+    if os.path.exists(scan_dir):
+        if os.path.isdir(scan_dir):
+
+            output_str = ""
+
+            files_scanned = 0
+            files_with_colons = 0
+            for root, dirs, files in os.walk(scan_dir):
+                for f in files:
+                    print str(f)
+                    scan_result = scan_dm_file(os.path.join(root, f))
+                    files_scanned += 1
+                    if scan_result:
+                        output_str += scan_result+"\n"
+                        files_with_colons += 1
+            output_str += str(files_with_colons) + "/" + str(files_scanned) + " files have colons in them"
+
+            todays_file = str(date.today())+"-colon_operator_log.txt"
+            output_file = open(todays_file, "w") #w so it overrides existing files for today, there should only really be one file per day
+            output_file.write(output_str)
+
+
+
+#Scan one file, returning a string as a "report" or if there are no colons, False
+def scan_dm_file(_file):
+    
+    if not _file.endswith(".dm"):
+        return False
+    
+    with open(_file, "r") as dm_file:
+        characters = dm_file.read()
+
+        line_num = 1
+        colon_count = 0
+        last_char = ""
+
+        in_embed_statement = 0        # [ ... ]  num due to embeds in embeds
+        in_multiline_comment = 0      #/* ... */ num due to /* /* */ */
+        in_singleline_comment = False #// ... \n 
+        in_string = False             # " ... "
+        ternary_on_line = False       #If there's a ? anywhere on the line, used to report "false"-positives
+
+        lines_with_colons = []
+
+        for char in characters:
+            #Line info
+            if char == "\n" or char == "\r":
+                if not in_string:
+                    ternary_on_line = False #Stop any old ternary operation
+                    line_num += 1
+                    in_embed_statement = 0
+
+            #Not in a comment
+            if (not in_singleline_comment) and (in_multiline_comment == 0):
+                #Not in a string
+                if not in_string:
+                    if last_char == "/":
+                        if char == "/":
+                            in_singleline_comment = True
+                        if char == "*":
+                            in_multiline_comment += 1
+                    if char == "\"":
+                        in_string = True
+
+                #In a string
+                else:
+                    if char == "\"": #Only " ends a string, as byond supports multiline strings
+                        if last_char != "\\": #make sure it's a real " not an escaped one (\")
+                            in_string = False
+
+                    #It's not an embedded statment if it's not in a string
+                    if char == "[":
+                        in_embed_statement += 1
+                    if char == "]":
+                        in_embed_statement -= 1
+                        in_embed_statement = max(in_embed_statement,0)
+
+                #ternary statements, True when in_embed_statement+in_string OR when not in_string
+                if char == "?":
+                    if in_string:
+                        if in_embed_statement != 0:
+                            ternary_on_line = True
+                    else:
+                        ternary_on_line = True
+
+                #A Colon!
+                #If we're in a string, but not embedded: Ok, it's just rawtext
+                #If we're in a string, and embedded but NOT in a ternary operation: Bad, guaranteed to be a : used to avoid typechecks
+                #If we're in a string, and embedded AND in a ternary operation: Potentially Bad, this could be a : used to avoid typechecks (bad) or the middle : of the ternary operation (generally ok)
+
+                if char == ":":
+                    if not in_string:
+                        colon_count += 1
+                        data = str(line_num)
+                        if ternary_on_line:
+                            data += "?"
+                        if not data in lines_with_colons: #only add the line twice if it's like: 76, 76? (eg: a "bad" colon and a ternary colon)
+                            lines_with_colons.append(data)
+                    else:
+                        if in_embed_statement != 0:
+                            colon_count += 1
+                            data = str(line_num)
+                            if ternary_on_line:
+                                data += "?"
+                            if not data in lines_with_colons:
+                                lines_with_colons.append(data)
+        
+            #In a comment
+            else:
+                if char == "/":
+                    if last_char == "*":
+                        in_multiline_comment -= 1
+                        in_multiline_comment = max(in_multiline_comment,0)
+
+                if char == "\n" or char == "\r":
+                    in_singleline_comment = False
+    
+
+            if char != "": #Spaces aren't useful to us
+                last_char = char
+
+
+        if colon_count:
+            file_report = ".."+scan_dir+str(_file).split(scan_dir)[1]+" " #crop it down to ..\code\DIR\FILE.dm, everything else is developer specific
+
+            first = True
+            for line in lines_with_colons:            
+                if first:
+                    first = False
+                    file_report += "Lines: "+line
+                else:
+                    file_report += ", "+line
+
+            file_report += " Total Colons: "+str(colon_count)
+            return file_report
+        else:
+            return False
+
+
+        
+colon_scan_dir(real_dir)
+print "Done!"


### PR DESCRIPTION
<B>ColonCatcher.py</B>
ColonCatcher.py finds all colons that are used to avoid typesafety (Bad colons! very bad!) and ones used in ternary operations (1. because @MrPerson said to, 2. because the logic of avoiding all ternary colons is CRAZY complex)

<B>Output Format:</B>
filename (truncated down to just SS13 related stuff) line, line?, line (Line? represents a ternary operator colon) and then the total colons, 
eg: `..code\world.dm Lines: 27, 28, 98?, 102?, 119?, 149?, 230? Total Colons: 7`
These files are saved as "currentdate-colon_operator_log.txt" where currentdate is today's date (25/10/2015) in reverse (2015/10/25)

Also included is today's log, as an example, it's the latest master (as of just before pushing this PR) and reported: "433/1564 files have colons in them"
