### PR TITLE
Should fix loading from jobs.txt

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -373,16 +373,22 @@ var/datum/subsystem/job/SSjob
 
 
 /datum/subsystem/job/proc/setup_officer_positions()
-	var/officer_positions = 5 //Number of open security officer positions at round start
+	var/datum/job/J = SSjob.GetJob("Security Officer")
+	if(!J)
+		throw EXCEPTION("setup_officer_positions(): Security officer job is missing")
 
 	if(config.security_scaling_coeff > 0)
-		officer_positions = min(12, max(5, round(unassigned.len/config.security_scaling_coeff))) //Scale between 5 and 12 officers
-		var/datum/job/J = SSjob.GetJob("Security Officer")
-		if(J  || J.spawn_positions > 0)
+		if(J.spawn_positions > 0)
+			var/officer_positions = min(12, max(J.spawn_positions, round(unassigned.len/config.security_scaling_coeff))) //Scale between configured minimum and 12 officers
 			Debug("Setting open security officer positions to [officer_positions]")
 			J.total_positions = officer_positions
 			J.spawn_positions = officer_positions
-	for(var/i=officer_positions-5, i>0, i--) //Spawn some extra eqipment lockers if we have more than 5 officers
+
+	//Spawn some extra eqipment lockers if we have more than 5 officers
+	var/equip_needed = J.total_positions
+	if(equip_needed < 0) // -1: infinite available slots
+		equip_needed = 12
+	for(var/i=equip_needed-5, i>0, i--)
 		if(secequipment.len)
 			var/spawnloc = secequipment[1]
 			new /obj/structure/closet/secure_closet/security(spawnloc)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -202,7 +202,6 @@ var/datum/subsystem/job/SSjob
 /datum/subsystem/job/proc/DivideOccupations()
 	//Setup new player list and get the jobs list
 	Debug("Running DO")
-	SetupOccupations()
 
 	//Holder for Triumvirate is stored in the ticker, this just processes it
 	if(ticker)
@@ -397,8 +396,8 @@ var/datum/subsystem/job/SSjob
 	for(var/datum/job/J in occupations)
 		var/regex = "[J.title]=(-1|\\d+),(-1|\\d+)"
 		var/datum/regex/results = regex_find(jobstext, regex)
-		J.total_positions = results.str(2)
-		J.spawn_positions = results.str(3)
+		J.total_positions = text2num(results.str(2))
+		J.spawn_positions = text2num(results.str(3))
 
 /datum/subsystem/job/proc/HandleFeedbackGathering()
 	for(var/datum/job/job in occupations)

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -357,7 +357,7 @@
 	explanation_text = "Capture"
 
 /datum/objective/abductee/capture/New()
-	var/list/jobs = SSjob.occupations
+	var/list/jobs = SSjob.occupations.Copy()
 	for(var/datum/job/J in jobs)
 		if(J.current_positions < 1)
 			jobs -= J

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -88,7 +88,7 @@
 	//this is here because this has no client/prefs/brain whatever.
 	age = rand(AGE_MIN,AGE_MAX)
 	//job handling
-	var/list/jobs = SSjob.occupations
+	var/list/jobs = SSjob.occupations.Copy()
 	for(var/datum/job/J in jobs)
 		if(J.title == "Cyborg" || J.title == "AI" || J.title == "Chaplain" || J.title == "Mime")
 			jobs -= J

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -98,3 +98,4 @@ FoxPMcCloud = Game Master
 Xhuis = Game Master
 Astralenigma = Game Master
 Tokiko1 = Game Master
+SuperSayu = Game Master


### PR DESCRIPTION
The jobs controller's list of occupations was reset during roundstart which completely undid that whole load from file thing.  It also would have undone any admin edits done while sitting in the lobby.

Also fixed a couple instances where people thought that lists get copied with the = operator instead of passing by reference.

Also fixes security officer scaling.  Previously if you turned on security officer scaling the minimum was hard-set to 5.  The minimum should now be whatever is configured.

Should also spawn additional security closets if the number of security personnel is configured to be more than 5.
