### PR TITLE
Fixes plasmaman ignite mesage spam

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -434,9 +434,9 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 			var/total_moles = environment.total_moles()
 			if(total_moles)
 				if((environment.oxygen /total_moles) >= 0.01)
-					if(!H.on_fire)
-						H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
 					H.adjust_fire_stacks(0.5)
+					if(!H.on_fire && H.fire_stacks > 0)
+						H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
 					H.IgniteMob()
 	else
 		if(H.fire_stacks)


### PR DESCRIPTION
If the plasmaman was soaked in water (negative firestacks) it would keep spamming that the plasmaman ignites in the atmosphere despite them not actually being on fire.

Just for you @Shadowlight213 
