### PR TITLE
Fixes dropable bloodcrawl hands

### DIFF
--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -95,7 +95,7 @@ obj/effect/dummy/slaughter/relaymove(mob/user, direction)
 	name = "blood crawl"
 	desc = "You are unable to hold anything while in this form."
 	icon = 'icons/effects/blood.dmi'
-	flags = NODROP
+	flags = NODROP|ABSTRACT
 
 /mob/living/proc/phasein(obj/effect/decal/cleanable/B)
 	if(src.notransform)


### PR DESCRIPTION
You need both NODROP (don't let me take this off or drop it) and ABSTRACT (this isn't something other people should be able to interact with) when the item is something you keep in your hands.

Fixes #12641
