### PR TITLE
Makes a few recipes no longer violate rules of matter

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes/Toxins.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Toxins.dm
@@ -70,26 +70,26 @@
 	name = "Chloral Hydrate"
 	id = "chloralhydrate"
 	result = "chloralhydrate"
-	required_reagents = list("ethanol" = 1, "chlorine" = 3, "water" = 1)
-	result_amount = 1
+	required_reagents = list("ethanol" = 1, "chlorine" = 1, "water" = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/mutetoxin //i'll just fit this in here snugly between other unfun chemicals :v
 	name = "Mute toxin"
 	id = "mutetoxin"
 	result = "mutetoxin"
-	required_reagents = list("uranium" = 2, "water" = 1, "carbon" = 1)
-	result_amount = 2
+	required_reagents = list("uranium" = 1, "water" = 1, "carbon" = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/zombiepowder
 	name = "Zombie Powder"
 	id = "zombiepowder"
 	result = "zombiepowder"
-	required_reagents = list("carpotoxin" = 5, "morphine" = 5, "copper" = 5)
-	result_amount = 2
+	required_reagents = list("carpotoxin" = 1, "morphine" = 1, "copper" = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/mindbreaker
 	name = "Mindbreaker Toxin"
 	id = "mindbreaker"
 	result = "mindbreaker"
 	required_reagents = list("silicon" = 1, "hydrogen" = 1, "charcoal" = 1)
-	result_amount = 5
+	result_amount = 3


### PR DESCRIPTION
somehow the following recipes were violating the rules of matter and were either creating/destroying matter, by having different input to output ratios instead of it being a 1:1 ratio

Mindbreaker (LSD)

Zombie Powder

Mute Toxin

Chloral Hydrate

this is out of line with the rest of the chems so I fixed it
