### PR TITLE
Player Parrots can now sit on a Human's shoulders.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -806,16 +806,11 @@
 
 	if(icon_state == "parrot_fly")
 		for(var/mob/living/carbon/human/H in view(src,1))
-			loc = get_turf(H)
-			H.buckled_mob = src
-			buckled = H
-			pixel_y = 9
-			pixel_x = pick(-8,8) //pick left or right shoulder
-			icon_state = "parrot_sit"
-			parrot_state = PARROT_PERCH
-			src << "<span class='notice'>You sit on [H]'s shoulder.</span>"
+			if(H.buckled_mob) //Already has a parrot, or is being eaten by a slime
+				continue
+			perch_on_human(H)
 			return
-		src << "<span class='warning'>There is nobody nearby to sit on!</span>"
+		src << "<span class='warning'>There is nobody nearby that you can sit on!</span>"
 	else
 		icon_state = "parrot_fly"
 		parrot_state = PARROT_WANDER
@@ -826,6 +821,18 @@
 		pixel_x = initial(pixel_x)
 		pixel_y = initial(pixel_y)
 
+
+
+/mob/living/simple_animal/parrot/proc/perch_on_human(mob/living/carbon/human/H)
+	if(!H)
+		return
+	loc = get_turf(H)
+	H.buckle_mob(src, force=1)
+	pixel_y = 9
+	pixel_x = pick(-8,8) //pick left or right shoulder
+	icon_state = "parrot_sit"
+	parrot_state = PARROT_PERCH
+	src << "<span class='notice'>You sit on [H]'s shoulder.</span>"
 
 
 /mob/living/simple_animal/parrot/proc/toggle_mode()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -112,7 +112,8 @@
 			  /mob/living/simple_animal/parrot/proc/steal_from_mob, \
 			  /mob/living/simple_animal/parrot/verb/drop_held_item_player, \
 			  /mob/living/simple_animal/parrot/proc/perch_player, \
-			  /mob/living/simple_animal/parrot/proc/toggle_mode)
+			  /mob/living/simple_animal/parrot/proc/toggle_mode,
+			  /mob/living/simple_animal/parrot/proc/perch_mob_player)
 
 
 /mob/living/simple_animal/parrot/death(gibbed)
@@ -120,6 +121,13 @@
 		held_item.loc = src.loc
 		held_item = null
 	walk(src,0)
+
+	if(buckled)
+		buckled.buckled_mob = null
+	buckled = null
+	pixel_x = initial(pixel_x)
+	pixel_y = initial(pixel_y)
+
 	..(gibbed)
 
 /mob/living/simple_animal/parrot/Stat()
@@ -787,6 +795,39 @@
 	src << "<span class='warning'>There is no perch nearby to sit on!</span>"
 	return
 
+
+/mob/living/simple_animal/parrot/proc/perch_mob_player()
+	set name = "Sit on Human's Shoulder"
+	set category = "Parrot"
+	set desc = "Sit on a nice comfy human being!"
+
+	if(stat || !client)
+		return
+
+	if(icon_state == "parrot_fly")
+		for(var/mob/living/carbon/human/H in view(src,1))
+			loc = get_turf(H)
+			H.buckled_mob = src
+			buckled = H
+			pixel_y = 9
+			pixel_x = pick(-8,8) //pick left or right shoulder
+			icon_state = "parrot_sit"
+			parrot_state = PARROT_PERCH
+			src << "<span class='notice'>You sit on [H]'s shoulder.</span>"
+			return
+		src << "<span class='warning'>There is nobody nearby to sit on!</span>"
+	else
+		icon_state = "parrot_fly"
+		parrot_state = PARROT_WANDER
+		if(buckled)
+			src << "<span class='notice'>You are no longer sitting on [buckled]'s shoulder.</span>"
+			buckled.buckled_mob = null
+		buckled = null
+		pixel_x = initial(pixel_x)
+		pixel_y = initial(pixel_y)
+
+
+
 /mob/living/simple_animal/parrot/proc/toggle_mode()
 	set name = "Toggle mode"
 	set category = "Parrot"
@@ -801,6 +842,7 @@
 	else
 		melee_damage_upper = parrot_damage_upper
 		a_intent = "harm"
+	src << "You will now [a_intent] others..."
 	return
 
 /*

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -46,6 +46,7 @@
 	return 1
 
 /mob/living/simple_animal/slime/proc/Feedon(mob/living/M)
+	M.unbuckle_mob(force=1) //Slimes rip other mobs (eg: shoulder parrots) off (Slimes Vs Slimes is already handled in CanFeedon())
 	if(M.buckle_mob(src, force=1))
 		M.visible_message("<span class='danger'>The [name] has latched onto [M]!</span>", \
 						"<span class='userdanger'>The [name] has latched onto [M]!</span>")


### PR DESCRIPTION
- Player Parrots can now sit on a Human's shoulders (It picks randomly between left and right shoulder)
- Player Parrots are now informed of their intent the moment they switch it, instead of having to go to the stat panel
- Slimes now rip any non-slime (Slimes are gentlemen and ladies, they take turns feeding :P) mob off of Humans, this means Shoulder Parrots don't make you immune to Slimes (rofl)

Inspired by the round I sat on Dante's shoulder as Poly, Shadowlight wanted it to made a real thing, so there you go.
![Dante](http://i.imgur.com/9wlNf1l.png)
