### PR TITLE
Adds a config option for the round end restart delay and raises default from 25 to 90

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -15,6 +15,7 @@
 	var/station_name = null				// station name (the name of the station in-game)
 	var/server_suffix = 0				// generate numeric suffix based on server port
 	var/lobby_countdown = 120			// In between round countdown.
+	var/round_end_countdown = 25		// Post round murder death kill countdown
 
 	var/log_ooc = 0						// log OOC channel
 	var/log_access = 0					// log login/logout
@@ -236,6 +237,8 @@
 					config.use_age_restriction_for_jobs = 1
 				if("lobby_countdown")
 					config.lobby_countdown = text2num(value)
+				if("round_end_countdown")
+					config.round_end_countdown = text2num(value)
 				if("log_ooc")
 					config.log_ooc = 1
 				if("log_access")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -7,7 +7,6 @@ var/datum/subsystem/ticker/ticker
 	can_fire = 1
 	priority = 0
 
-	var/restart_timeout = 250				//delay when restarting server
 	var/current_state = GAME_STATE_STARTUP	//state of current round (used by process()) Use the defines GAME_STATE_* !
 	var/force_ending = 0					//Round was ended by admin intervention
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -142,7 +142,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 	if(time)
 		delay = time
 	else
-		delay = ticker.restart_timeout
+		delay = config.round_end_countdown * 10
 	if(ticker.delay_end)
 		world << "<span class='boldannounce'>An admin has delayed the round end.</span>"
 		return
@@ -190,7 +190,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 	join_motd = file2text("config/motd.txt")
 
 /world/proc/load_configuration()
-	protected_config = new /datum/protected_configuration() 
+	protected_config = new /datum/protected_configuration()
 	config = new /datum/configuration()
 	config.load("config/config.txt")
 	config.load("config/game_options.txt","game_options")

--- a/config/config.txt
+++ b/config/config.txt
@@ -7,6 +7,9 @@ STATIONNAME Space Station 13
 # Lobby time: This is the amount of time between rounds that players have to setup their characters and be ready.
 LOBBY_COUNTDOWN 120
 
+# Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
+ROUND_END_COUNTDOWN 90
+
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 

--- a/html/changelogs/MrStonedOne murder death kill.yml
+++ b/html/changelogs/MrStonedOne murder death kill.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MrStonedOne
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The round end restart delay can now be configured by server operators. New servers will default to 90 seconds while old servers will default to the old 25 seconds until they import the config option to their server."


### PR DESCRIPTION
This should enable more murder death kill at round end before the next round starts.

New servers will default to the new 90 seconds while old servers will still default to the old 25 seconds until they import the config option to their server.
