### PR TITLE
Adds the ability to access game preferences while not in lobby

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -665,8 +665,6 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 	return 0
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
-	if(!istype(user, /mob/new_player))	return
-
 	if(href_list["jobbancheck"])
 		var/job = sanitizeSQL(href_list["jobbancheck"])
 		var/sql_ckey = sanitizeSQL(user.ckey)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -104,15 +104,6 @@
 		src << "You will no longer prayer sounds."
 	feedback_add_details("admin_verb", "PSounds")
 
-/client/verb/togglePRs()
-	set name = "Show/Hide Pull Request Announcements"
-	set category = "Preferences"
-	set desc = "Toggles receiving a notification when new pull requests are created."
-	prefs.chat_toggles ^= CHAT_PULLR
-	prefs.save_preferences()
-	src << "You will [(prefs.chat_toggles & CHAT_PULLR) ? "now" : "no longer"] see new pull request announcements."
-	feedback_add_details("admin_verb","TPullR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /client/verb/togglemidroundantag()
 	set name = "Toggle Midround Antagonist"
 	set category = "Preferences"
@@ -214,25 +205,6 @@
 		src.ambience_playing = 0
 	feedback_add_details("admin_verb", "SAmbi") //If you are copy-pasting this, I bet you read this comment expecting to see the same thing :^)
 
-//be special
-/client/verb/toggle_be_special(role in be_special_flags)
-	set name = "Toggle SpecialRole Candidacy"
-	set category = "Preferences"
-	set desc = "Toggles which special roles you would like to be a candidate for, during events."
-	var/role_flag = be_special_flags[role]
-	if(!role_flag)	return
-	prefs.be_special ^= role_flag
-	prefs.save_preferences()
-	src << "You will [(prefs.be_special & role_flag) ? "now" : "no longer"] be considered for [role] events (where possible)."
-	feedback_add_details("admin_verb","TBeSpecial") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/verb/toggle_member_publicity()
-	set name = "Toggle Membership Publicity"
-	set category = "Preferences"
-	set desc = "Toggles whether other players can see that you are a BYOND member (OOC blag icon/colours)."
-	prefs.toggles ^= MEMBER_PUBLIC
-	prefs.save_preferences()
-	src << "Others can[(prefs.toggles & MEMBER_PUBLIC) ? "" : "not"] see whether you are a byond member."
 
 var/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_red","ghost_black", \
 							"ghost_blue","ghost_yellow","ghost_green","ghost_pink", \
@@ -259,3 +231,9 @@ var/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_
 	src << "[(prefs.toggles & INTENT_STYLE) ? "Clicking directly on intents selects them." : "Clicking on intents rotates selection clockwise."]"
 	prefs.save_preferences()
 	feedback_add_details("admin_verb","ITENTS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/verb/setup_character()
+	set name = "Game Preferences"
+	set category = "Preferences"
+	set desc = "Allows you to access the Setup Character screen. Changes to your character won't take effect until next round, but other changes will."
+	prefs.ShowChoices(usr)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -236,4 +236,5 @@ var/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_
 	set name = "Game Preferences"
 	set category = "Preferences"
 	set desc = "Allows you to access the Setup Character screen. Changes to your character won't take effect until next round, but other changes will."
+	prefs.current_tab = 1
 	prefs.ShowChoices(usr)

--- a/html/changelogs/MrStonedOne THIS WAS ONLY A VERB AWAY.yml
+++ b/html/changelogs/MrStonedOne THIS WAS ONLY A VERB AWAY.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MrStonedOne
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You may now access the setup character screen when not in the lobby via the game preferences verb in the preferences tab"


### PR DESCRIPTION
Also removed a few preferences_toggles verbs that are no longer needed.

Haven't tested this too much yet, but from what I can tell, no ill effects of doing this have been observed.

Edit: also:

**_THIS WAS JUST A VERB AND 1 TYPE CHECK REMOVAL AWAY FROM BEING A THING**_

WHY DID IT TAKE UNTIL NOW??????

![game prefs](https://cloud.githubusercontent.com/assets/7069733/10732483/8f11a676-7bb7-11e5-9620-514050f68923.PNG)

Changes to your character won't take effect until after you've respawned (if admins enable it) or round restarts.

Changes to the ui scheme take effect next time you change mobs or reconnect.

Changes to your ghost sprite won't take effect until the next time you reconnect or you re-enter/re-leave body.

Everything else takes effect immediately
