### PR TITLE
Makes it so only advanced tool users can use tablecrafting.

### DIFF
--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -6,7 +6,7 @@
 
 
 /obj/structure/table/MouseDrop(atom/over)
-	if(over != usr)
+	if(over != usr || !usr.IsAdvancedToolUser())
 		return
 	interact(usr)
 


### PR DESCRIPTION
As it says in the title. This PR makes it so that only advanced tool users can use tablecrafting. Thus Xeno's cannot anymore.

Fixes #12570 
