### PR TITLE
Lichmode nerf fixes

### DIFF
--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -53,10 +53,11 @@
 			if(!marked_item || qdeleted(marked_item)) //Wait nevermind
 				user << "<span class='warning'>Your phylactery is gone!</span>"
 				return
+				
+			var/turf/user_turf = get_turf(user)
+			var/turf/item_turf = get_turf(marked_item)
 
-			var/turf/item_loc = get_turf(marked_item)
-
-			if(user.z != item_loc.z)
+			if(user_turf.z != item_turf.z)
 				user << "<span class='warning'>Your phylactery is out of range!</span>"
 				return
 
@@ -64,7 +65,7 @@
 				var/mob/dead/observer/O = user
 				O.reenter_corpse()
 
-			var/mob/living/carbon/human/lich = new /mob/living/carbon/human(item_loc)
+			var/mob/living/carbon/human/lich = new /mob/living/carbon/human(item_turf)
 
 			lich.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(lich), slot_shoes)
 			lich.equip_to_slot_or_del(new /obj/item/clothing/under/color/black(lich), slot_w_uniform)
@@ -85,10 +86,10 @@
 					var/mob/living/carbon/C = old_body
 					for(var/obj/item/W in C)
 						C.unEquip(W)
-				var/wheres_wizdo = dir2text(get_dir(get_turf(old_body), item_loc))
+				var/wheres_wizdo = dir2text(get_dir(get_turf(old_body), item_turf))
 				if(wheres_wizdo)
 					old_body.visible_message("<span class='warning'>Suddenly [old_body.name]'s corpse falls to pieces! You see a strange energy rise from the remains, and speed off towards the [wheres_wizdo]!</span>")
-					old_body.Beam(item_loc,icon_state="drain_life",icon='icons/effects/effects.dmi',time=10+10*resurrections,maxdistance=INFINITY)
+					old_body.Beam(item_turf,icon_state="drain_life",icon='icons/effects/effects.dmi',time=10+10*resurrections,maxdistance=INFINITY)
 				old_body.dust()
 
 		if(!marked_item) //linking item to the spell

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -53,7 +53,10 @@
 			if(!marked_item || qdeleted(marked_item)) //Wait nevermind
 				user << "<span class='warning'>Your phylactery is gone!</span>"
 				return
-			else if(user.z != marked_item.z)
+
+			var/turf/item_loc = get_turf(marked_item)
+
+			else if(user.z != item_loc.z)
 				user << "<span class='warning'>Your phylactery is out of range!</span>"
 				return
 
@@ -61,7 +64,7 @@
 				var/mob/dead/observer/O = user
 				O.reenter_corpse()
 
-			var/mob/living/carbon/human/lich = new /mob/living/carbon/human(get_turf(marked_item))
+			var/mob/living/carbon/human/lich = new /mob/living/carbon/human(item_loc)
 
 			lich.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(lich), slot_shoes)
 			lich.equip_to_slot_or_del(new /obj/item/clothing/under/color/black(lich), slot_w_uniform)
@@ -82,10 +85,10 @@
 					var/mob/living/carbon/C = old_body
 					for(var/obj/item/W in C)
 						C.unEquip(W)
-				var/wheres_wizdo = dir2text(get_dir(get_turf(old_body), get_turf(marked_item)))
+				var/wheres_wizdo = dir2text(get_dir(get_turf(old_body), item_loc))
 				if(wheres_wizdo)
 					old_body.visible_message("<span class='warning'>Suddenly [old_body.name]'s corpse falls to pieces! You see a strange energy rise from the remains, and speed off towards the [wheres_wizdo]!</span>")
-					old_body.Beam(marked_item,icon_state="drain_life",icon='icons/effects/effects.dmi',time=10+10*resurrections,maxdistance=INFINITY)
+					old_body.Beam(item_loc,icon_state="drain_life",icon='icons/effects/effects.dmi',time=10+10*resurrections,maxdistance=INFINITY)
 				old_body.dust()
 
 		if(!marked_item) //linking item to the spell

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -56,7 +56,7 @@
 
 			var/turf/item_loc = get_turf(marked_item)
 
-			else if(user.z != item_loc.z)
+			if(user.z != item_loc.z)
 				user << "<span class='warning'>Your phylactery is out of range!</span>"
 				return
 


### PR DESCRIPTION
Fixes some errors relating to z-level checks to deal with liches hiding their item in other things. Until this is pulled any phylo will fail to resurrect a lich unless it WASN'T placed in a container/structure. This is a thing that happens roughly 100% of the time.

<s>Please don't speed merge (haha) this until the runtimes for today are available, because the person who found this error said he didn't see a message, which here would imply a runtime that I haven't yet fixed.</s> Disregard there was no runtime, merge at will.
