### PR TITLE
Fixes icon blinking on level five singularities

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -222,8 +222,9 @@
 			allowed_size = STAGE_FOUR
 		if(2000 to INFINITY)
 			allowed_size = STAGE_FIVE
-		if((3000 to INFINITY) && consumedSupermatter)
-			allowed_size = STAGE_SIX
+		if(3000 to INFINITY)
+			if(consumedSupermatter)
+				allowed_size = STAGE_SIX
 	if(current_size != allowed_size)
 		expand()
 	return 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -225,7 +225,6 @@
 				allowed_size = STAGE_SIX
 			else
 				allowed_size = STAGE_FIVE
-			allowed_size = STAGE_FIVE
 	if(current_size != allowed_size)
 		expand()
 	return 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -221,10 +221,11 @@
 		if(1000 to 1999)
 			allowed_size = STAGE_FOUR
 		if(2000 to INFINITY)
-			allowed_size = STAGE_FIVE
-		if(3000 to INFINITY)
-			if(consumedSupermatter)
+			if(energy >= 3000 && consumedSupermatter)
 				allowed_size = STAGE_SIX
+			else
+				allowed_size = STAGE_FIVE
+			allowed_size = STAGE_FIVE
 	if(current_size != allowed_size)
 		expand()
 	return 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -211,8 +211,6 @@
 		investigate_log("collapsed.","singulo")
 		qdel(src)
 		return 0
-	if(energy > 2999 && !consumedSupermatter)
-		energy = 2000
 	switch(energy)//Some of these numbers might need to be changed up later -Mport
 		if(1 to 199)
 			allowed_size = STAGE_ONE
@@ -222,9 +220,9 @@
 			allowed_size = STAGE_THREE
 		if(1000 to 1999)
 			allowed_size = STAGE_FOUR
-		if(2000 to 2999)
+		if(2000 to INFINITY)
 			allowed_size = STAGE_FIVE
-		if(3000 to INFINITY)
+		if((3000 to INFINITY) && consumedSupermatter)
 			allowed_size = STAGE_SIX
 	if(current_size != allowed_size)
 		expand()


### PR DESCRIPTION
What had happened: when stage six was added stage five's survivability took a stealth nerf, because any time the singularity reached enough energy to go six but hadn't eaten a supermatter shard (read: almost ever time) it would be force set to 2000 energy.

The problem: 2000 energy is the verge of stage four, so every time this hard set was hit (and for a hungry singulo this could be every consume check) the energy would be set to 2000. Then, at the same time, the singulo would suffer a little energy loss, momentarily become level four. Then, still all the same breath here, any new items would be eaten, pushing it back into level five.

Thus the singulo blinked.

As far as I can tell this was an unreported issue.
