### PR TITLE
Timestop Cooldown increased by 33.33333333333%

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -159,7 +159,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	name = "Stop Time"
 	desc = "This spell stops time for everyone except for you, allowing you to move freely while your enemies and even projectiles are frozen."
-	charge_max = 300
+	charge_max = 400
 	clothes_req = 1
 	invocation = "TOKI WO TOMARE"
 	invocation_type = "shout"


### PR DESCRIPTION
Timestop's recent buff  #12495 demands a counterbalance

Currently timestop is a massive offensive and defensive powerhouse. You lock down an area and make yourself virtually unkillable for the duration while getting free reign to murder anyone caught in its massive area without recourse.

This isn't an "I ded" issue, but I played with timestop even before its buff and it was already deliciously OP. Between MM, Lightning, Jaunt, and Timestop, I could sit on the bridge with a fire axe and take on the entire station with an endless rolling wave of stuns, immunity, and undodgeable murder. Of those spells Timestop is the obvious candidate for a fix. It's a fun spell but if you're going to package invulnerability and a massive stun into a single package, it deserves a higher cooldown.

Specifically, this pushes the default cooldown from 30 seconds to 40. "Efficiency" versions of the spell get a de facto buff by keeping the "minimum cooldown" the same.
