### PR TITLE
Reduce enthralling time by 3 seconds per phase

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -237,7 +237,7 @@
 					usr << "<span class='notice'>You begin rearranging [target]'s memories.</span>"
 					usr.visible_message("<span class='danger'>[usr]'s eyes flare brightly.</span>")
 					target << "<span class='boldannounce'>Your head cries out. The veil of reality begins to crumple and something evil bleeds through.</span>" //Ow the edge
-			if(!do_mob(usr, target, 100)) //around 30 seconds total for enthralling, 45 for someone with a loyalty implant
+			if(!do_mob(usr, target, 70)) //around 30 seconds total for enthralling, 45 for someone with a loyalty implant
 				usr << "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>"
 				target << "<span class='userdanger'>A spike of pain drives into your head, wiping your memory. You aren't sure what's happened, but you feel a faint sense of revulsion.</span>"
 				enthralling = 0

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -237,7 +237,7 @@
 					usr << "<span class='notice'>You begin rearranging [target]'s memories.</span>"
 					usr.visible_message("<span class='danger'>[usr]'s eyes flare brightly.</span>")
 					target << "<span class='boldannounce'>Your head cries out. The veil of reality begins to crumple and something evil bleeds through.</span>" //Ow the edge
-			if(!do_mob(usr, target, 70)) //around 30 seconds total for enthralling, 45 for someone with a loyalty implant
+			if(!do_mob(usr, target, 70)) //around 21 seconds total for enthralling, 36 for someone with a loyalty implant
 				usr << "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>"
 				target << "<span class='userdanger'>A spike of pain drives into your head, wiping your memory. You aren't sure what's happened, but you feel a faint sense of revulsion.</span>"
 				enthralling = 0


### PR DESCRIPTION
For a reduction of enthralling time from 30 seconds to 21 seconds. Loyalty implants still add 15 seconds and will take 36 seconds total. 

When you account for the time you also need to take cuffs the target, remove their headset, and then kidnap them to a secure location, it takes an obscene amount of time to convert people. Then one of your thralls bumps you, or moves your target by accident, or the buggy lighting system acts up and you have to escape a bugged out light tile, or one of your thralls doesn't realize he has night vision and turns his flashlight back on, etc....

Every time I've played Shadowling the middle and lategame has always been "hiding in a secret room channeling victims for an eternity". It's not fun for Shadowlings, its not fun for victims who literally have to sit in a line waiting to be enthralled, and everything I've seen in rounds indicates that Shadowlings still need some help... so let's start with this low-hanging fruit. 
