### PR TITLE
Ghosts can now move while orbiting themselves without breaking the orbit

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -108,8 +108,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 
 /mob/dead/observer/Move(NewLoc, direct)
-	if (orbiting)
-		stop_orbit()
 	if(NewLoc)
 		loc = NewLoc
 		for(var/obj/effect/step_trigger/S in NewLoc)


### PR DESCRIPTION
This check in Move() is not needed anymore, as orbit code handles all of that on it's own.

Removing it allows a ghost to move while orbiting itself without breaking the orbit.
