### PR TITLE
Lack of security now impacts head rev scaling

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -415,6 +415,24 @@
 			heads |= player.mind
 	return heads
 
+//////////////////////////////////////////////
+//Keeps track of all living security members//
+//////////////////////////////////////////////
+/datum/game_mode/proc/get_living_sec()
+	var/list/sec = list()
+	for(var/mob/living/carbon/human/player in mob_list)
+		if(player.stat!=2 && player.mind && (player.mind.assigned_role in security_positions))
+			sec |= player.mind
+
+////////////////////////////////////////
+//Keeps track of all  security members//
+////////////////////////////////////////
+/datum/game_mode/proc/get_all_sec()
+	var/list/sec = list()
+	for(var/mob/living/carbon/human/player in mob_list)
+		if(player.mind && (player.mind.assigned_role in security_positions))
+			sec |= player.mind
+
 //////////////////////////
 //Reports player logouts//
 //////////////////////////

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -60,8 +60,13 @@
 
 /datum/game_mode/revolution/post_setup()
 	var/list/heads = get_living_heads()
+	var/list/sec = get_living_sec()
+	var/weighted_score = min(max(round(heads.len - ((8 - sec.len) / 3)),1),max_headrevs)
 
-	while(heads.len < head_revolutionaries.len) //das vi danya
+	if(weighted_score < 1)
+		weighted_score = 1
+
+	while(weighted_score < head_revolutionaries.len) //das vi danya
 		var/datum/mind/trotsky = pick(head_revolutionaries)
 		antag_candidates += trotsky
 		head_revolutionaries -= trotsky
@@ -170,13 +175,14 @@
 ////////////////////////////////////////////
 /datum/game_mode/revolution/proc/check_heads()
 	var/list/heads = get_all_heads()
+	var/list/sec = get_all_sec()
 	if(heads_to_kill.len < heads.len)
 		var/list/new_heads = heads - heads_to_kill
 		for(var/datum/mind/head_mind in new_heads)
 			for(var/datum/mind/rev_mind in head_revolutionaries)
 				mark_for_death(rev_mind, head_mind)
 
-	if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < heads.len)
+	if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < round(heads.len - ((8 - sec.len) / 3)))
 		latejoin_headrev()
 
 ///////////////////////////////

--- a/html/changelogs/incoming5643-80winrate.yml
+++ b/html/changelogs/incoming5643-80winrate.yml
@@ -1,0 +1,8 @@
+author: Incoming5643
+
+delete-after: True
+
+changes: 
+  - rscadd: "The number of roundstart head revolutionaries nows depends on the roundstart security force as well as the roundstart heads"
+  - rscadd: "The maximum number of head revs is 3, the minimum is 1. If there is fewer than three station heads there will never be more than that number of head revs at roundstart. For every three vacant security roles (Head of Security/Warden/Security Officer/Detective) at roundstart the number of starting head revs will be reduced by 1."
+  - rscadd: "Head revolutionaries can be gained during play if the security/head roles are filled. They are drawn from existing revolutionaries."


### PR DESCRIPTION
The lack of security is now taken into account in revolution head revscaling.

The following formula is used:
![tex1_256x256_m_c71c938a4fb4bd71_14](https://cloud.githubusercontent.com/assets/4176358/10809936/08d3692e-7dd2-11e5-82d5-d03c3b20df65.png)
H is the number of heads
S is the number of security members (HoS, Warden, Sec Officers, and Dectective) 
Note that's not a [, it's the floor function

There are never more than 3 head revs, and never less than 1.
## 

Hard numbers (keep in mind the HoS counts as both a head and a security member):

5 heads:
Any sec besides the HoS: 3 head revs
No other sec: 2 head revs

4 heads:
5 or more sec: 3 head revs
4 to 2 sec: 2 head revs
1 or 0 sec: 1 head rev

3 heads:
8 sec (entire department filled): 3 head revs
7 to 5 sec: 2 head revs
4 or less sec: 1 head rev

2 heads:
8 sec (entire department filled): 2 head revs
Anything less: 1 head rev

1 head:
1 head rev

---

Keep in mind that an existing mechanic will create more head revs from revs if more heads join, and this now extends to if more sec joins as well. So even if a round begins with just one rev head, by the end it might have more.
