### PR TITLE
Refactor mob movement delay calculation

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -43,7 +43,6 @@
 	var/allow_Metadata = 0				// Metadata is supported.
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/fps = 10
-	var/Tickcomp = 0
 	var/allow_holidays = 0				//toggles whether holiday-specific content should be used
 
 	var/hostedby = null
@@ -331,8 +330,6 @@
 						fps = 10 / ticklag
 				if("fps")
 					fps = text2num(value)
-				if("tickcomp")
-					Tickcomp = 1
 				if("automute_on")
 					automute_on = 1
 				if("comms_key")

--- a/code/modules/admin/verbs/fps.dm
+++ b/code/modules/admin/verbs/fps.dm
@@ -15,11 +15,7 @@
 		if(alert(src, "You are setting fps to a high value:\n\t[fps] frames-per-second\n\tconfig.fps = [config.fps]","Warning!","Confirm","ABORT-ABORT-ABORT") != "Confirm")
 			return
 
-	switch(alert("Enable Tick Compensation?","Tick Comp is currently: [config.Tickcomp]","Enable","Disable"))
-		if("Enable")	config.Tickcomp = 1
-		else			config.Tickcomp = 0
-
-	var/msg = "[key_name(src)] has modified world.fps to [fps] and config.Tickcomp to [config.Tickcomp]"
+	var/msg = "[key_name(src)] has modified world.fps to [fps]"
 	log_admin(msg, 0)
 	message_admins(msg, 0)
 	feedback_add_details("admin_verb","TICKLAG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -37,7 +37,7 @@
 			src.bodytemperature += 2
 
 /mob/living/carbon/movement_delay()
-	. = 0
+	. = ..()
 	if(legcuffed)
 		. += legcuffed.slowdown
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -821,7 +821,7 @@
 ////////////////
 
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
-	var/mspeed = 0
+	. = 0
 
 	if(!(H.status_flags & IGNORESLOWDOWN))
 
@@ -843,39 +843,37 @@
 				if(P.allow_thrust(0.01, H))
 					hasjetpack = 1
 
-			mspeed = -1 - hasjetpack
+			. = -1 - hasjetpack
 
 		if(grav || !hasjetpack)
 			var/health_deficiency = (100 - H.health + H.staminaloss)
 			if(health_deficiency >= 40)
-				mspeed += (health_deficiency / 25)
+				. += (health_deficiency / 25)
 
 			var/hungry = (500 - H.nutrition) / 5	//So overeat would be 100 and default level would be 80
 			if(hungry >= 70)
-				mspeed += hungry / 50
+				. += hungry / 50
 
 			if(H.wear_suit)
-				mspeed += H.wear_suit.slowdown
+				. += H.wear_suit.slowdown
 			if(H.shoes)
-				mspeed += H.shoes.slowdown
+				. += H.shoes.slowdown
 			if(H.back)
-				mspeed += H.back.slowdown
+				. += H.back.slowdown
 
 			if((H.disabilities & FAT))
-				mspeed += 1.5
+				. += 1.5
 			if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-				mspeed += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
+				. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
 
-			mspeed += speedmod
+			. += speedmod
 
 		if(grav)
 			if(H.status_flags & GOTTAGOFAST)
-				mspeed -= 1
+				. -= 1
 
 			if(H.status_flags & GOTTAGOREALLYFAST)
-				mspeed -= 2
-
-	return mspeed
+				. -= 2
 
 //////////////////
 // ATTACK PROCS //

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -43,18 +43,21 @@
 		hud.add_to_hud(src)
 
 /mob/living/carbon/monkey/movement_delay()
-	var/tally = 0
 	if(reagents)
-		if(reagents.has_reagent("morphine")) return -1
+		if(reagents.has_reagent("morphine"))
+			return -1
 
-		if(reagents.has_reagent("nuka_cola")) return -1
+		if(reagents.has_reagent("nuka_cola"))
+			return -1
 
+	. = ..()
 	var/health_deficiency = (100 - health)
-	if(health_deficiency >= 45) tally += (health_deficiency / 25)
+	if(health_deficiency >= 45)
+		. += (health_deficiency / 25)
 
 	if (bodytemperature < 283.222)
-		tally += (283.222 - bodytemperature) / 10 * 1.75
-	return tally+config.monkey_delay
+		. += (283.222 - bodytemperature) / 10 * 1.75
+	return . + config.monkey_delay
 
 /mob/living/carbon/monkey/attack_paw(mob/living/M)
 	if(..()) //successful monkey bite.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -577,6 +577,19 @@ Sorry Giacom. Please don't be mad :(
 		// It's ugly. But everything related to inventory/storage is. -- c0
 		s_active.close(src)
 
+/mob/living/movement_delay()
+	. = ..()
+	if(isturf(loc))
+		var/turf/T = loc
+		. += T.slowdown
+	switch(m_intent)
+		if("run")
+			if(drowsyness > 0)
+				. += 6
+			. += config.run_speed
+		if("walk")
+			. += config.walk_speed
+
 /mob/living/proc/makeTrail(turf/T, mob/living/M)
 	if(!has_gravity(M))
 		return

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,13 +6,12 @@
 	if(..())	return 1
 	return 0
 
- //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()
-	var/tally = 0 //Incase I need to add stuff other than "speed" later
+	. = ..()
 
-	tally = speed
+	. += speed
 
-	return tally+config.robot_delay
+	. += config.robot_delay
 
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -587,7 +587,8 @@
 /mob/living/simple_animal/parrot/movement_delay()
 	if(client && stat == CONSCIOUS && parrot_state != "parrot_fly")
 		icon_state = "parrot_fly"
-	..()
+		//Because the most appropriate place to set icon_state is movement_delay(), clearly
+	return ..()
 
 /mob/living/simple_animal/parrot/proc/isStuck()
 	//Check to see if the parrot is stuck due to things like windows or doors or windowdoors

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -370,11 +370,11 @@
 	..()
 
 /mob/living/simple_animal/movement_delay()
-	var/tally = 0 //Incase I need to add stuff other than "speed" later
+	. = ..()
 
-	tally = speed
+	. = speed
 
-	return tally+config.animal_delay
+	. += config.animal_delay
 
 /mob/living/simple_animal/Stat()
 	..()

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -101,26 +101,26 @@
 	if(bodytemperature >= 330.23) // 135 F
 		return -1	// slimes become supercharged at high temperatures
 
-	var/tally = 0
+	. = ..()
 
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 45)
-		tally += (health_deficiency / 25)
+		. += (health_deficiency / 25)
 
 	if(bodytemperature < 183.222)
-		tally += (283.222 - bodytemperature) / 10 * 1.75
+		. += (283.222 - bodytemperature) / 10 * 1.75
 
 	if(reagents)
 		if(reagents.has_reagent("morphine")) // morphine slows slimes down
-			tally *= 2
+			. *= 2
 
 		if(reagents.has_reagent("frostoil")) // Frostoil also makes them move VEEERRYYYYY slow
-			tally *= 5
+			. *= 5
 
 	if(health <= 0) // if damaged, the slime moves twice as slow
-		tally *= 2
+		. *= 2
 
-	return tally + config.slime_delay
+	. += config.slime_delay
 
 /mob/living/simple_animal/slime/ObjBump(obj/O)
 	if(!client && powerlevel > 0)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -92,7 +92,7 @@
 
 
 /client/Move(n, direct)
-	if(!mob)
+	if(!mob || !mob.loc)
 		return 0
 	if(mob.notransform)
 		return 0	//This is sota the goto stop mobs from moving var
@@ -138,89 +138,70 @@
 	if(!mob.Process_Spacemove(direct))
 		return 0
 
-	if(isturf(mob.loc))
-
-
-		var/turf/T = mob.loc
-		move_delay = world.time//set move delay
-
-		move_delay += T.slowdown
-
-		if(mob.restrained())	//Why being pulled while cuffed prevents you from moving
-			for(var/mob/M in range(1, mob))
-				if(M.pulling == mob)
-					if(!M.incapacitated() && mob.Adjacent(M))
-						src << "<span class='warning'>You're restrained! You can't move!</span>"
-						move_delay += 10
-						return 0
-					else
-						M.stop_pulling()
-
-		switch(mob.m_intent)
-			if("run")
-				if(mob.drowsyness > 0)
-					move_delay += 6
-				move_delay += config.run_speed
-			if("walk")
-				move_delay += config.walk_speed
-		move_delay += mob.movement_delay()
-
-		if(config.Tickcomp)
-			move_delay -= 1.3
-			var/tickcomp = (1 / (world.tick_lag)) * 1.3
-			move_delay = move_delay + tickcomp
-
-		//We are now going to move
-		moving = 1
-		//Something with pulling things
-		if(locate(/obj/item/weapon/grab, mob))
-			move_delay = max(move_delay, world.time + 7)
-			var/list/L = mob.ret_grab()
-			if(istype(L, /list))
-				if(L.len == 2)
-					L -= mob
-					var/mob/M = L[1]
-					if(M)
-						if ((get_dist(mob, M) <= 1 || M.loc == mob.loc))
-							. = ..()
-							if (isturf(M.loc))
-								var/diag = get_dir(mob, M)
-								if ((diag - 1) & diag)
-								else
-									diag = null
-								if ((get_dist(mob, M) > 1 || diag))
-									step(M, get_dir(M.loc, T))
+	if(mob.restrained())	//Why being pulled while cuffed prevents you from moving
+		for(var/mob/M in orange(1, mob))
+			if(M.pulling == mob)
+				if(!M.incapacitated() && mob.Adjacent(M))
+					src << "<span class='warning'>You're restrained! You can't move!</span>"
+					move_delay = world.time + 10
+					return 0
 				else
-					for(var/mob/M in L)
-						M.other_mobs = 1
-						if(mob != M)
-							M.animate_movement = 3
-					for(var/mob/M in L)
-						spawn( 0 )
-							step(M, direct)
-							return
-						spawn( 1 )
-							M.other_mobs = null
-							M.animate_movement = 2
-							return
+					M.stop_pulling()
 
-		if(mob.confused)
-			if(mob.confused > 40)
-				step(mob, pick(cardinal))
-			else if(prob(mob.confused * 1.5))
-				step(mob, angle2dir(dir2angle(direct) + pick(90, -90)))
-			else if(prob(mob.confused * 3))
-				step(mob, angle2dir(dir2angle(direct) + pick(45, -45)))
+
+	//We are now going to move
+	moving = 1
+	move_delay = mob.movement_delay() + world.time
+
+	//Something with pulling things
+	if(locate(/obj/item/weapon/grab, mob))
+		move_delay = max(move_delay, world.time + 7)
+		var/list/L = mob.ret_grab()
+		if(istype(L, /list))
+			if(L.len == 2)
+				L -= mob
+				var/mob/M = L[1]
+				if(M)
+					if ((get_dist(mob, M) <= 1 || M.loc == mob.loc))
+						. = ..()
+						if (isturf(M.loc))
+							var/diag = get_dir(mob, M)
+							if ((diag - 1) & diag)
+							else
+								diag = null
+							if ((get_dist(mob, M) > 1 || diag))
+								step(M, get_dir(M.loc, mob.loc))
 			else
-				step(mob, direct)
+				for(var/mob/M in L)
+					M.other_mobs = 1
+					if(mob != M)
+						M.animate_movement = 3
+				for(var/mob/M in L)
+					spawn( 0 )
+						step(M, direct)
+						return
+					spawn( 1 )
+						M.other_mobs = null
+						M.animate_movement = 2
+						return
+
+	if(mob.confused)
+		if(mob.confused > 40)
+			step(mob, pick(cardinal))
+		else if(prob(mob.confused * 1.5))
+			step(mob, angle2dir(dir2angle(direct) + pick(90, -90)))
+		else if(prob(mob.confused * 3))
+			step(mob, angle2dir(dir2angle(direct) + pick(45, -45)))
 		else
-			. = ..()
+			step(mob, direct)
+	else
+		. = ..()
 
-		moving = 0
-		if(mob && .)
-			mob.throwing = 0
+	moving = 0
+	if(mob && .)
+		mob.throwing = 0
 
-		return .
+	return .
 
 
 ///Process_Grab()

--- a/config/config.txt
+++ b/config/config.txt
@@ -156,9 +156,6 @@ ALLOW_HOLIDAYS
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.9
 
-## Defines if Tick Compensation is used.  It results in a minor slowdown of movement of all mobs, but attempts to result in a level movement speed across all ticks.  Recommended if tickrate is lowered.
-TICKCOMP 0
-
 ## Comment this out to disable automuting
 #AUTOMUTE_ON
 


### PR DESCRIPTION
Basic premise: Get all mob movement delays calculated in movement_delay() instead of having half of them in Client/Move(). Except for the slowdown from grabbing, which is so shit I can't even. The idea here is to eventually have the NPC movements be at the same speed as client-initiated ones.

Let's try this again: Removes TickComp because it's a useless pile of shit that's based on a false idea of how BYOND's ticks and tile-based movement work.
