### PR TITLE
RAD/EMP/Bomb Hardsuit messages

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -7,6 +7,8 @@ var/list/doppler_arrays = list()
 	icon_state = "tdoppler"
 	density = 1
 	anchored = 1
+	var/integrated = 0
+	var/max_dist = 100
 	verb_say = "states coldly"
 
 /obj/machinery/doppler_array/New()
@@ -56,38 +58,40 @@ var/list/doppler_arrays = list()
 	else
 		rotate()
 
-/obj/machinery/doppler_array/proc/sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,
+/obj/machinery/doppler_array/proc/sense_explosion(turf/epicenter,devastation_range,heavy_impact_range,light_impact_range,
 												  took,orig_dev_range,orig_heavy_range,orig_light_range)
-	if(stat & NOPOWER)	return
-	if(z != z0)			return
+	if(stat & NOPOWER)
+		return
+	var/turf/zone = get_turf(src)
 
-	var/dx = abs(x0-x)
-	var/dy = abs(y0-y)
-	var/distance
-	var/direct
+	if(zone.z != epicenter.z)
+		return
 
-	if(dx > dy)
-		distance = dx
-		if(x0 > x)	direct = EAST
-		else		direct = WEST
-	else
-		distance = dy
-		if(y0 > y)	direct = NORTH
-		else		direct = SOUTH
+	var/distance = get_dist(epicenter, zone)
+	var/direct = get_dir(epicenter, zone)
 
-	if(distance > 100)		return
-	if(!(direct & dir))	return
+	if(distance > max_dist)
+		return
+	if(!(direct & dir) && !integrated)
+		return
+
 
 	var/list/messages = list("Explosive disturbance detected.", \
-							 "Epicenter at: grid ([x0],[y0]). Temporal displacement of tachyons: [took] seconds.", \
+							 "Epicenter at: grid ([epicenter.x],[epicenter.y]). Temporal displacement of tachyons: [took] seconds.", \
 							 "Factual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
 
 	// If the bomb was capped, say it's theoretical size.
 	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)
 		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
 
-	for(var/message in messages)
-		say(message)
+	if(integrated)
+		var/obj/item/clothing/head/helmet/space/hardsuit/helm = loc
+		if(!helm || !istype(helm, /obj/item/clothing/head/helmet/space/hardsuit))
+			return
+		helm.display_visor_message("Explosion detected! Epicenter: [devastation_range], Outer: [heavy_impact_range], Shockwave: [light_impact_range]")
+	else
+		for(var/message in messages)
+			say(message)
 
 /obj/machinery/doppler_array/power_change()
 	if(stat & BROKEN)
@@ -99,3 +103,10 @@ var/list/doppler_arrays = list()
 		else
 			icon_state = "[initial(icon_state)]-off"
 			stat |= NOPOWER
+
+//Portable version, built into EOD equipment. It simply provides an explosion's three damage levels.
+/obj/machinery/doppler_array/integrated
+	name = "integrated tachyon-doppler module"
+	integrated = 1
+	max_dist = 21 //Should detect most explosions in hearing range.
+	use_power = 0

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -88,7 +88,7 @@ var/list/doppler_arrays = list()
 		var/obj/item/clothing/head/helmet/space/hardsuit/helm = loc
 		if(!helm || !istype(helm, /obj/item/clothing/head/helmet/space/hardsuit))
 			return
-		helm.display_visor_message("Explosion detected! Epicenter: [devastation_range], Outer: [heavy_impact_range], Shockwave: [light_impact_range]")
+		helm.display_visor_message("Explosion detected! Epicenter: [devastation_range], Outer: [heavy_impact_range], Shock: [light_impact_range]")
 	else
 		for(var/message in messages)
 			say(message)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -150,7 +150,7 @@
 		for(var/i,i<=doppler_arrays.len,i++)
 			var/obj/machinery/doppler_array/Array = doppler_arrays[i]
 			if(Array)
-				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
+				Array.sense_explosion(epicenter,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
 
 	return 1
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -46,7 +46,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
 	..()
-	display_visor_message("Radiation pulse detected! Magnitide: <span class='green'>[severity]</span> RADs.")
+	display_visor_message("Radiation pulse detected! Magnitude: <span class='green'>[severity]</span> RADs.")
 
 /obj/item/clothing/head/helmet/space/hardsuit/emp_act(severity)
 	..()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -39,6 +39,18 @@
 		user.AddLuminosity(-brightness_on)
 		SetLuminosity(brightness_on)
 
+/obj/item/clothing/head/helmet/space/hardsuit/proc/display_visor_message(var/msg)
+	if(msg && ishuman(loc))
+		loc << "\icon[src] <b><span class='robot'>[msg]</span></b>"
+
+/obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
+	..()
+	display_visor_message("Radiation pulse detected! Magnitide: [severity] RADs.")
+
+/obj/item/clothing/head/helmet/space/hardsuit/emp_act(severity)
+	..()
+	display_visor_message("[severity > 1 ? "Light" : "Heavy"] electromagnetic pulse detected!")
+
 
 /obj/item/clothing/suit/space/hardsuit
 	name = "hardsuit"
@@ -316,6 +328,11 @@
 	unacidable = 1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 100, bio = 100, rad = 60)
+	var/obj/machinery/doppler_array/integrated/bomb_radar
+
+/obj/item/clothing/head/helmet/space/hardsuit/rd/New()
+	..()
+	bomb_radar = new /obj/machinery/doppler_array/integrated(src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/rd/equipped(mob/user, slot)
 	user.scanner.Grant(user)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -40,16 +40,17 @@
 		SetLuminosity(brightness_on)
 
 /obj/item/clothing/head/helmet/space/hardsuit/proc/display_visor_message(var/msg)
-	if(msg && ishuman(loc))
-		loc << "\icon[src] <b><span class='robot'>[msg]</span></b>"
+	var/mob/wearer = loc
+	if(msg && ishuman(wearer))
+		wearer.show_message("\icon[src]<b><span class='robot'>[msg]</span></b>", 1)
 
 /obj/item/clothing/head/helmet/space/hardsuit/rad_act(severity)
 	..()
-	display_visor_message("Radiation pulse detected! Magnitide: [severity] RADs.")
+	display_visor_message("Radiation pulse detected! Magnitide: <span class='green'>[severity]</span> RADs.")
 
 /obj/item/clothing/head/helmet/space/hardsuit/emp_act(severity)
 	..()
-	display_visor_message("[severity > 1 ? "Light" : "Heavy"] electromagnetic pulse detected!")
+	display_visor_message("[severity > 1 ? "Light" : "Strong"] electromagnetic pulse detected!")
 
 
 /obj/item/clothing/suit/space/hardsuit


### PR DESCRIPTION
#### All hardsuits
- Hardsuits now provide a warning message for radiation and EMP events.
- Radiation messages provide the intensity of the radiation pulse.
- EMP messages indicate if the pulse is light or strong.
#### Prototype hardsuit
- Displays the size of nearby explosions. It is a simpler message than what the full doppler array provides, limited to 21 tile range instead of 100.

All messages are visual, and display on the suit's electronic visor. They show a neat little icon when you are wearing the helmet to signify that the helmet is the source of the message.

![image](https://cloud.githubusercontent.com/assets/4955510/10824779/d0f0976c-7e2f-11e5-84a6-e5cbaba382d7.png)
