### PR TITLE
Fixes an errant sanity check in slimeperson splitting

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -320,7 +320,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	return 0
 
 /datum/action/innate/swap_body/Activate()
-	if(!body || !istype(body) || !body.dna || !body.dna.species || !body.dna.species.id == "slime" || body.stat == DEAD || qdeleted(body))
+	if(!body || !istype(body) || !body.dna || !body.dna.species || body.dna.species.id != "slime" || body.stat == DEAD || qdeleted(body))
 		owner << "<span class='warning'>Something is wrong, you cannot sense your other body!</span>"
 		Remove(owner)
 		return

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -320,7 +320,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	return 0
 
 /datum/action/innate/swap_body/Activate()
-	if(!body || !istype(body) || !body.dna || !body.dna.species || !body.dna.species.id != "slime" || body.stat == DEAD || qdeleted(body))
+	if(!body || !istype(body) || !body.dna || !body.dna.species || !body.dna.species.id == "slime" || body.stat == DEAD || qdeleted(body))
 		owner << "<span class='warning'>Something is wrong, you cannot sense your other body!</span>"
 		Remove(owner)
 		return


### PR DESCRIPTION
I accidentally double negatived a sanity check on the new slime ability (#12476), thus making it only work if you're NOT a slime anymore.

Please just merge this and don't look me in the eyes.
