### PR TITLE
Research scanner fixes

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -320,7 +320,6 @@
 	owner << "<span class='notice'> Research analyzer deactivated.</span>"
 
 /datum/action/innate/scan_mode/Grant(mob/living/T)
-	devices += 1
 	..(T)
 
 /datum/action/innate/scan_mode/CheckRemoval(mob/living/user)
@@ -330,4 +329,5 @@
 
 /datum/action/innate/scan_mode/Remove(mob/living/T)
 	owner.research_scanner = 0
+	active = 0
 	..(T)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -39,11 +39,12 @@
 
 /obj/item/clothing/glasses/science/equipped(mob/user, slot)
 	if(slot == slot_glasses)
+		user.scanner.devices += 1
 		user.scanner.Grant(user)
 	..(user, slot)
 
 /obj/item/clothing/glasses/science/dropped(mob/user)
-	user.scanner.devices -= 1
+	user.scanner.devices = max(0, user.scanner.devices - 1)
 	..(user)
 
 /obj/item/clothing/glasses/night

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -321,6 +321,7 @@
 /obj/item/clothing/head/helmet/space/hardsuit/rd/equipped(mob/living/carbon/human/user, slot)
 	..(user, slot)
 	user.scanner.Grant(user)
+	user.scanner.devices += 1
 	if(user.glasses && istype(user.glasses, /obj/item/clothing/glasses/hud/diagnostic))
 		user << ("<span class='warning'>Your [user.glasses] prevents you using [src]'s diagnostic visor HUD.</span>")
 	else
@@ -330,7 +331,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/rd/dropped(mob/living/carbon/human/user)
 	..(user)
-	user.scanner.devices -= 1
+	user.scanner.devices = max(0, user.scanner.devices - 1)
 	if(onboard_hud_enabled && !(user.glasses && istype(user.glasses, /obj/item/clothing/glasses/hud/diagnostic)))
 		var/datum/atom_hud/DHUD = huds[DATA_HUD_DIAGNOSTIC]
 		DHUD.remove_hud_from(user)


### PR DESCRIPTION
- Fixes a bug in which fumbling around with more than one scanner device
  equipped at a time can cause weird bugs either preventing their use or
  vise versa.
- Fixes a bug where removing a scanner with it active requires two clicks
  to activate it again.

Please notify me if you discover any other oddities.
