### PR TITLE
Posibrain possession fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -29,14 +29,12 @@ var/global/posibrain_notif_cooldown = 0
 			posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/attack_self(mob/user)
-	if(used)
-		user << "[src]'s activation switch is locked, it appears to already have been programmed!"
-		return
 	if(brainmob && !brainmob.key && !notified)
-		//Start the process of notified for a new user.
+		//Start the process of requesting a new ghost.
 		user << "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>"
 		ping_ghosts("requested")
 		notified = 1
+		used = 0
 		update_icon()
 		spawn(askDelay) //Seperate from the global cooldown.
 			notified = 0
@@ -123,7 +121,7 @@ var/global/posibrain_notif_cooldown = 0
 			if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responsive.</span>\n"
 			if(DEAD)			msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
 	else
-		msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
+		msg += "<span class='deadsay'>It appears to be completely inactive. The reset light is blinking.</span>\n"
 	msg += "<span class='info'>*---------*</span>"
 	usr << msg
 	return

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -9,6 +9,7 @@ var/global/posibrain_notif_cooldown = 0
 	origin_tech = "biotech=3;programming=2"
 	var/notified = 0
 	var/askDelay = 10 * 60 * 1
+	var/used = 0 //Prevents split personality virus. May be reset if personality deletion code is added.
 	brainmob = null
 	req_access = list(access_robotics)
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
@@ -28,6 +29,9 @@ var/global/posibrain_notif_cooldown = 0
 			posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/attack_self(mob/user)
+	if(used)
+		user << "[src]'s activation switch is locked, it appears to already have been programmed!"
+		return
 	if(brainmob && !brainmob.key && !notified)
 		//Start the process of notified for a new user.
 		user << "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>"
@@ -47,7 +51,7 @@ var/global/posibrain_notif_cooldown = 0
 
 //Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
 /obj/item/device/mmi/posibrain/proc/activate(mob/user)
-	if((brainmob && brainmob.key) || jobban_isbanned(user,"posibrain"))
+	if(used || (brainmob && brainmob.key) || jobban_isbanned(user,"posibrain"))
 		return
 
 	var/posi_ask = alert("Become a positronic brain? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")
@@ -81,7 +85,7 @@ var/global/posibrain_notif_cooldown = 0
 	return
 
 /obj/item/device/mmi/posibrain/proc/transfer_personality(mob/candidate)
-	if(brainmob && brainmob.key) //Prevents hostile takeover if two ghosts get the prompt or link for the same brain.
+	if(used || (brainmob && brainmob.key)) //Prevents hostile takeover if two ghosts get the prompt or link for the same brain.
 		candidate << "This brain has already been taken! Please try your possesion again later!"
 		return
 	notified = 0
@@ -97,6 +101,7 @@ var/global/posibrain_notif_cooldown = 0
 
 	visible_message("<span class='notice'>The positronic brain chimes quietly.</span>")
 	update_icon()
+	used = 1
 
 
 /obj/item/device/mmi/posibrain/examine()


### PR DESCRIPTION
- Ghosts can no longer take the posibrain of another player, even if
  that player ghosts.
- Fixes a bug in which androids can gain additional players in the same
  body.
- Fixes #11331.

_100% player reference free PR_

<b>Probably works as intended. Probably.</b>
