### PR TITLE
Makes lubed floors have the wet overlay, take two

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -17,7 +17,7 @@
 	if(wet >= wet_setting)
 		return
 	wet = wet_setting
-	if(wet_setting == TURF_WET_WATER || TURF_WET_LUBE)
+	if(wet_setting != TURF_DRY)
 		if(wet_overlay)
 			overlays -= wet_overlay
 			wet_overlay = null

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -17,7 +17,7 @@
 	if(wet >= wet_setting)
 		return
 	wet = wet_setting
-	if(wet_setting == TURF_WET_WATER)
+	if(wet_setting == TURF_WET_WATER || TURF_WET_LUBE)
 		if(wet_overlay)
 			overlays -= wet_overlay
 			wet_overlay = null


### PR DESCRIPTION
Remake of #12767 but without the commit fuckyness (hopefully).

Relevant thread: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=5071

Reasoning:
Makes lube not invisible so you can at least be aware of where it is on the floor and try to avoid it.
HOWEVER, you can't tell it apart from water, meaning if you try to avoid it by walking over it, you slip anyways. The slip is still as strong as ever.
This also opens the door to some mindgames by allowing you to spray water on the floor, then warning people that it's lube. :honk:
