### PR TITLE
Adds surgery to remove surgically attached chainsaws

### DIFF
--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -98,7 +98,7 @@
 		user << "<span class='warning'>You can't fit the chainsaw in while [target]'s hands are full!</span>"
 		return 0
 	else
-		user.visible_message("[user] finshes installing the chainsaw!", "<span class='notice'>You install the chainsaw.</span>")
+		user.visible_message("[user] finishes installing the chainsaw!", "<span class='notice'>You install the chainsaw.</span>")
 		user.unEquip(tool)
 		qdel(tool)
 		var/obj/item/weapon/mounted_chainsaw/sawarms = new(target)
@@ -134,5 +134,5 @@
 	for(var/obj/item/weapon/mounted_chainsaw/V in hands)
 		qdel(V)
 		new /obj/item/weapon/twohanded/required/chainsaw(get_turf(target))
-		user.visible_message("[user] carefully saws [target]'s arms free of the chainsaw.", "<span class='notice'>You remove the chainsaw.</span>")
+		user.visible_message("[user] carefully saws [target]'s arm free of the chainsaw.", "<span class='notice'>You remove the chainsaw.</span>")
 		return 1

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -127,7 +127,7 @@
 	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 
 /datum/surgery_step/chainsaw_removal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to check [target] for a chainsaw to remove.", "<span class='notice'>You check [target] for a chainsaw to remove...</span>")
+	user.visible_message("[user] begins sawing the chainsaw off of [target]'s arms.", "<span class='notice'>You begin removing [target]'s chainsaw...</span>")
 
 /datum/surgery_step/chainsaw_removal/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/list/hands = get_both_hands(target)

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -77,31 +77,62 @@
 
 
 /datum/surgery/chainsaw
-        name = "chainsaw augmentation"
-        steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders,
-        /datum/surgery_step/incise, /datum/surgery_step/chainsaw)
-        species = list(/mob/living/carbon/human)
-        possible_locs = list("r_arm", "l_arm")
-        requires_organic_bodypart = 0
+	name = "chainsaw augmentation"
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders,
+	/datum/surgery_step/incise, /datum/surgery_step/chainsaw)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list("r_arm", "l_arm")
+	requires_organic_bodypart = 0
 
 
 /datum/surgery_step/chainsaw
-        time = 64
-        name = "insert chainsaw"
-        implements = list(/obj/item/weapon/twohanded/required/chainsaw = 100)
+	time = 64
+	name = "insert chainsaw"
+	implements = list(/obj/item/weapon/twohanded/required/chainsaw = 100)
 
 /datum/surgery_step/chainsaw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-        user.visible_message("[user] begins to install the chainsaw onto [target].", "<span class='notice'>You begin to install the chainsaw onto [target]...</span>")
+	user.visible_message("[user] begins to install the chainsaw onto [target].", "<span class='notice'>You begin to install the chainsaw onto [target]...</span>")
 
 /datum/surgery_step/chainsaw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-        if(target.l_hand && target.r_hand)
-                user << "<span class='warning'>You can't fit the chainsaw in while [target]'s hands are full!</span>"
-                return 0
-        else
-                user.visible_message("[user] finshes installing the chainsaw!", "<span class='notice'>You install the chainsaw.</span>")
-                user.unEquip(tool)
-                qdel(tool)
-                var/obj/item/weapon/mounted_chainsaw/sawarms = new(target)
-                target.put_in_hands(sawarms)
+	if(target.l_hand && target.r_hand)
+		user << "<span class='warning'>You can't fit the chainsaw in while [target]'s hands are full!</span>"
+		return 0
+	else
+		user.visible_message("[user] finshes installing the chainsaw!", "<span class='notice'>You install the chainsaw.</span>")
+		user.unEquip(tool)
+		qdel(tool)
+		var/obj/item/weapon/mounted_chainsaw/sawarms = new(target)
+		target.put_in_hands(sawarms)
 
-                return 1
+		return 1
+
+/datum/surgery/chainsaw_removal
+	name = "chainsaw removal"
+	steps = list(/datum/surgery_step/chainsaw_removal)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list("r_arm", "l_arm")
+	requires_organic_bodypart = 0
+
+/datum/surgery/chainsaw_removal/can_start(mob/user, mob/living/carbon/target)
+	var/list/hands = get_both_hands(target)
+	var/M = locate(/obj/item/weapon/mounted_chainsaw) in hands
+	if(M)
+		return 1//can continue surgery
+	else
+		return 0//surgery will never be available
+
+/datum/surgery_step/chainsaw_removal
+	time = 128
+	name = "saw off chainsaw"
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+
+/datum/surgery_step/chainsaw_removal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	user.visible_message("[user] begins to check [target] for a chainsaw to remove.", "<span class='notice'>You check [target] for a chainsaw to remove...</span>")
+
+/datum/surgery_step/chainsaw_removal/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/list/hands = get_both_hands(target)
+	for(var/obj/item/weapon/mounted_chainsaw/V in hands)
+		qdel(V)
+		new /obj/item/weapon/twohanded/required/chainsaw(get_turf(target))
+		user.visible_message("[user] carefully saws [target]'s arms free of the chainsaw.", "<span class='notice'>You remove the chainsaw.</span>")
+		return 1


### PR DESCRIPTION
Also fixes the indentation on the surgery to add chainsaws. It was a bunch of spaces, now it's neat tabs.

Allows you to remove chainsaws that have been surgically attached. The only step is using a saw. You can use the standard surgical saw and all normal ghetto analogues (such as armblades or cleavers), as well as _other chainsaws and arm-mounted chainsaws._ Enjoy your chainsaw arm highlander.

Fixes #12785 
