### PR TITLE
Xenobio console fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -33,3 +33,10 @@
 /mob/living/simple_animal/slime/gib()
 	death(1)
 	qdel(src)
+
+
+/mob/living/simple_animal/slime/Destroy()
+	for(var/obj/machinery/computer/camera_advanced/xenobio/X in machines)
+		if(src in X.stored_slimes)
+			X.stored_slimes -= src
+	return ..()

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -7,7 +7,7 @@
 
 /mob/camera/aiEye/remote/xenobio/setLoc(var/t)
 	var/area/new_area = get_area(t)
-	if(new_area && new_area.name == "Xenobiology Lab" || new_area && istype(new_area, /area/toxins/xenobiology ))
+	if(new_area && new_area.name == "Xenobiology Lab" || istype(new_area, /area/toxins/xenobiology ))
 		return ..()
 	else
 		return

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -121,6 +121,8 @@
 			if(X.stored_slimes.len >= X.max_slimes)
 				break
 			if(!S.ckey)
+				if(S.buckled)
+					S.Feedstop(silent=1)
 				S.visible_message("[S] vanishes in a flash of light!")
 				S.loc = X
 				X.stored_slimes += S
@@ -138,7 +140,7 @@
 	var/obj/machinery/computer/camera_advanced/xenobio/X = target
 
 	if(cameranet.checkTurfVis(remote_eye.loc))
-		if(X.monkeys > 0)
+		if(X.monkeys >= 1)
 			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(remote_eye.loc)
 			food.LAssailant = C
 			X.monkeys --


### PR DESCRIPTION
Fixes slimes getting warped out while feeding interacting a bit oddly (I'm not sure why, but I believe this how I ended up inside the console)

Fixes being able to spend fractions of a monkey cube for a full monkey

Fixes a potential issue where the stored_slimes list could get messed up if an adult slime split while inside the machine.
