### PR TITLE
Little QoL thing for slimeperson splitting

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -326,7 +326,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 		return
 	if(body.stat == UNCONSCIOUS)
 		owner << "<span class='warning'>You sense this body has passed out for some reason. Best to stay away.</span>"
-
+		return
+		
 	owner.mind.transfer_to(body)
 
 /*

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -324,6 +324,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 		owner << "<span class='warning'>Something is wrong, you cannot sense your other body!</span>"
 		Remove(owner)
 		return
+	if(body.stat == UNCONSCIOUS)
+		owner << "<span class='warning'>You sense this body has passed out for some reason. Best to stay away.</span>"
 
 	owner.mind.transfer_to(body)
 


### PR DESCRIPTION
I assumed the flag AB_CHECK_ALIVE meant you could use the ability while unconscious, since you're not dead. 

The way that flag actually works however is that it fails if you aren't conscious. The swap into ability had no such check for unconsciousness, meaning a slime person could swap into a crited body then be stuck there.

Seemed like a really cheap way to die
