### PR TITLE
Supermatter sword fixes

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -134,6 +134,8 @@
 	item_state = "supermatter_sword"
 	slot_flags = null
 	w_class = 4
+	force = 0.001
+	armour_penetration = 1000
 	var/obj/machinery/power/supermatter_shard/shard
 	var/balanced = 1
 


### PR DESCRIPTION
Adds a tiny force and a huge armour_penetriation to the supermatter sword.

Some bits of attack code had been sparing people because they assumed that a force 0 weapon couldn't do any harm.
