### PR TITLE
Swaps Guardian HUD button locations

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -707,11 +707,11 @@
 	adding += using
 
 	using = new /obj/screen/guardian/ToggleLight()
-	using.screen_loc = ui_back
+	using.screen_loc = ui_inventory
 	adding += using
 
 	using = new /obj/screen/guardian/Communicate()
-	using.screen_loc = ui_inventory
+	using.screen_loc = ui_back
 	adding += using
 
 	mymob.client.screen = list()


### PR DESCRIPTION
Specifically the communicate button is now in the center near manifest/recall and the toggle light button is now off in the corner.

Reasoning being your most used buttons should be near each other rather than other ends of the screen.
