### PR TITLE
Ghost role spawners for mappers

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -30,6 +30,7 @@
 	var/corpseoxy = null //set suffocation damage on the corpse
 	var/roundstart = TRUE
 	var/death = TRUE
+	var/flavour_text = "The mapper forgot to set this!"
 	density = 1
 
 /obj/effect/landmark/corpse/initialize()
@@ -100,6 +101,7 @@
 		M.equip_to_slot_or_del(W, slot_wear_id)
 	if(ckey)
 		M.ckey = ckey
+		M << "[flavour_text]"
 	qdel(src)
 
 /obj/effect/landmark/corpse/AICorpse/createCorpse() //Creates a corrupted AI
@@ -296,6 +298,7 @@
 	name = "sleeper"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
+	flavour_text = "You are a Nanotrasen Commander!"
 
 /obj/effect/landmark/corpse/attack_ghost(mob/user)
 	var/ghost_role = alert("Become [mobname]? (Warning, You can no longer be cloned!)",,"Yes","No")

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -28,19 +28,30 @@
 	var/corpsehusk = null
 	var/corpsebrute = null //set brute damage on the corpse
 	var/corpseoxy = null //set suffocation damage on the corpse
+	var/roundstart = TRUE
+	var/death = TRUE
+	density = 1
 
 /obj/effect/landmark/corpse/initialize()
-	createCorpse()
+	if(roundstart)
+		createCorpse(death = src.death)
+	else
+		return
 
-/obj/effect/landmark/corpse/proc/createCorpse() //Creates a mob and checks for gear in each slot before attempting to equip it.
+/obj/effect/landmark/corpse/New()
+	..()
+	invisibility = 0
+
+/obj/effect/landmark/corpse/proc/createCorpse(death, ckey) //Creates a mob and checks for gear in each slot before attempting to equip it.
 	var/mob/living/carbon/human/M = new /mob/living/carbon/human (src.loc)
 	M.real_name = src.name
 	M.gender = src.mobgender
 	if(mob_species)
 		M.set_species(mob_species)
-	M.death(1) //Kills the new mob
-	if(src.corpsehusk)
-		M.Drain()
+	if(death)
+		M.death(1) //Kills the new mob
+		if(src.corpsehusk)
+			M.Drain()
 	M.adjustBruteLoss(src.corpsebrute)
 	M.adjustOxyLoss(src.corpseoxy)
 	if(src.corpseuniform)
@@ -87,6 +98,8 @@
 		W.registered_name = M.real_name
 		W.update_label()
 		M.equip_to_slot_or_del(W, slot_wear_id)
+	if(ckey)
+		M.ckey = ckey
 	qdel(src)
 
 /obj/effect/landmark/corpse/AICorpse/createCorpse() //Creates a corrupted AI
@@ -276,3 +289,16 @@
 	corpseid = 1
 	corpseidjob = "Commander"
 	corpseidaccess = "Captain"
+
+/obj/effect/landmark/corpse/commander/alive
+	death = FALSE
+	roundstart = FALSE
+	name = "sleeper"
+	icon = 'icons/obj/Cryogenic2.dmi'
+	icon_state = "sleeper"
+
+/obj/effect/landmark/corpse/attack_ghost(mob/user)
+	var/ghost_role = alert("Become [mobname]? (Warning, You can no longer be cloned!)",,"Yes","No")
+	if(ghost_role == "No")
+		return
+	createCorpse(death = src.death, ckey = user.ckey)


### PR DESCRIPTION
Lets you make a custom landmark (gear, mob name, species, etc) that will spawn a ghost as a mob and give it some flavour text as to its new role.

Intended for use in stuff like away missions, space ruins, etc, if you want to have a player be a lost astronaut or strange hermit or whatever.

TODO: More comments explaining stuff, use the mob name var again, make a few example landmarks.
