### PR TITLE
Buffs laser damage from 20 to 25 burn damage.

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -224,7 +224,7 @@
 	icon_state = "blob"
 	luminosity = 0
 	health = 21
-	maxhealth = 25
+	maxhealth = 26
 	health_regen = 1
 	brute_resist = 4
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,7 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 20
+	damage = 25
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	flag = "laser"


### PR DESCRIPTION
The laser gun is basically one of the least imposing weapons on the station. Someone throwing glass shards is almost more menacing than someone with a laser gun.

Basically he only thing its good at vs players is shooting already downed targets. 

This makes the laser gun a bit more viable in humanoid vs humanoid combat and makes it look less like a glorified flashlight. 
:cl: 
Buffs laser rifle damage from 20 to 25 burn damage
/:cl:
