### PR TITLE
Slows down nutrition loss in Slime People

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -208,10 +208,10 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 			H << "<span class='danger'>You feel empty!</span>"
 
 	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
-		if(S.volume < 100)
+		if(S.volume < 200)
 			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
-				H.reagents.add_reagent("slimejelly", 0.5)
-				H.nutrition -= 5
+				H.reagents.add_reagent("slimejelly", 1)
+				H.nutrition -= 2
 		if(S.volume < 50)
 			if(prob(5))
 				H << "<span class='danger'>You feel drained!</span>"

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -208,7 +208,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 			H << "<span class='danger'>You feel empty!</span>"
 
 	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
-		if(S.volume < 200)
+		if(S.volume < 100)
 			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
 				H.reagents.add_reagent("slimejelly", 0.5)
 				H.nutrition -= 2.5

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -254,8 +254,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 				H << "<span class='notice'>You feel very bloated!</span>"
 		if(S.volume < 200)
 			if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
-				H.reagents.add_reagent("slimejelly", 0.5)
-				H.nutrition -= 5
+				H.reagents.add_reagent("slimejelly", 1)
+				H.nutrition -= 2
 
 	..()
 

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -210,8 +210,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
 		if(S.volume < 200)
 			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
-				H.reagents.add_reagent("slimejelly", 1)
-				H.nutrition -= 2
+				H.reagents.add_reagent("slimejelly", 0.5)
+				H.nutrition -= 2.5
 		if(S.volume < 50)
 			if(prob(5))
 				H << "<span class='danger'>You feel drained!</span>"
@@ -254,8 +254,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 				H << "<span class='notice'>You feel very bloated!</span>"
 		if(S.volume < 200)
 			if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
-				H.reagents.add_reagent("slimejelly", 1)
-				H.nutrition -= 2
+				H.reagents.add_reagent("slimejelly", 0.5)
+				H.nutrition -= 2.5
 
 	..()
 


### PR DESCRIPTION
Two problems:

1) Being a slime person devoured your nutrition status and within a short period of time would have you on death's door. It took nearly 10 minutes of cryotherapy and food being shoved into my mouth to save my life as a slime person who never even got a nutrition starvation warning.

2) You will never have enough slime for splitting unless you have an odysseus copy your slime jelly and then shoot you full of needles with it. 

This PR attempts to fix both issues by making the nutrient loss slower and the slime gain faster and capable of reaching 200 when you can split.
