### PR TITLE
Spray changes

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -35,7 +35,7 @@
 				else
 					amount_per_transfer_from_this = possible_transfer_amounts[1]
 				user << "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>"
-				return
+				return 1
 
 /obj/item/weapon/reagent_containers/attack(mob/M, mob/user, def_zone)
 	return

--- a/html/changelogs/phil235-SprayChange.yml
+++ b/html/changelogs/phil235-SprayChange.yml
@@ -1,0 +1,7 @@
+ 
+author: phil235
+
+delete-after: True
+
+changes: 
+  - tweak: "Spray puffs no longer react with every turf and objects they cross, it now can only hit one thing but it reacts with the full volume of the puff instead of a fraction. It hits dense mob it crosses and is stopped by it. If it isn't stopped it reacts with the clicked target or with the turf it is on if target was out of range. Spray range is now consistent with transfer amount: highest amount means highest range. The low transfer amount of the spray cleaner is now 3 units instead of 5 to compensate for the nerf."


### PR DESCRIPTION
<b>Spray puffs no longer react with every turf and objects they cross, it now can only hit one thing</b> but it reacts with the full volume of the puff instead of a fraction. Fixes #12382

It hits dense mob it crosses and is stopped by it.
If it isn't stopped it reacts with the clicked target or with the turf it is on if target was out of range.

Spray range is now consistent with transfer amount: highest amount means highest range. The low transfer amount of the spray cleaner is now 3 units instead of 5 to compensate for the nerf.
