### PR TITLE
Nerfs bombs by increasing the pressure needed to achieve bigger explosions.

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -26,7 +26,7 @@
 #define TANK_LEAK_PRESSURE					(30.*ONE_ATMOSPHERE)	//Tank starts leaking
 #define TANK_RUPTURE_PRESSURE				(40.*ONE_ATMOSPHERE)	//Tank spills all contents into atmosphere
 #define TANK_FRAGMENT_PRESSURE				(50.*ONE_ATMOSPHERE)	//Boom 3x3 base explosion
-#define TANK_FRAGMENT_SCALE	    			(10.*ONE_ATMOSPHERE)	//+1 for each SCALE kPa aboe threshold
+#define TANK_FRAGMENT_SCALE	    			(30.*ONE_ATMOSPHERE)	//+1 for each SCALE kPa aboe threshold
 #define MINIMUM_AIR_RATIO_TO_SUSPEND		0.005	//Minimum ratio of air that must move to/from a tile to suspend group processing
 #define MINIMUM_AIR_TO_SUSPEND				(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND)	//Minimum amount of air that has to move before a group processing can be suspended
 #define MINIMUM_MOLES_DELTA_TO_MOVE			(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND) //Either this must be active


### PR DESCRIPTION
Ausops has backed this Pr and has offered to test it over the weekend. The idea is to make max caps harder to achieve even with fastmos rather than lower the bomb cap.

I'm not completely sure if I'm doing this correctly or if other values need to be adjusted, so feedback welcome.
