### PR TITLE
Improves speed of redraw_lighting()

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -176,25 +176,13 @@ Acts like a normal vent, but has an input AND output.
 		pump_direction = 1
 
 	if("set_input_pressure" in signal.data)
-		input_pressure_min = Clamp(
-			text2num(signal.data["set_input_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		input_pressure_min = Clamp(text2num(signal.data["set_input_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("set_output_pressure" in signal.data)
-		output_pressure_max = Clamp(
-			text2num(signal.data["set_output_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		output_pressure_max = Clamp(text2num(signal.data["set_output_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("set_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(
-			text2num(signal.data["set_external_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("status" in signal.data)
 		spawn(2)

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -124,11 +124,7 @@ Passive gate is similar to the regular pump except:
 		on = !on
 
 	if("set_output_pressure" in signal.data)
-		target_pressure = Clamp(
-			text2num(signal.data["set_output_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		target_pressure = Clamp(text2num(signal.data["set_output_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -129,11 +129,7 @@ Thus, the two variables affect pump operation are set in New():
 		on = !on
 
 	if("set_output_pressure" in signal.data)
-		target_pressure = Clamp(
-			text2num(signal.data["set_output_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		target_pressure = Clamp(text2num(signal.data["set_output_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -126,11 +126,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	if("set_transfer_rate" in signal.data)
 		var/datum/gas_mixture/air1 = AIR1
-		transfer_rate = Clamp(
-			text2num(signal.data["set_transfer_rate"]),
-			0,
-			air1.volume
-		)
+		transfer_rate = Clamp(text2num(signal.data["set_transfer_rate"]),0,air1.volume)
 
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -231,32 +231,16 @@
 		pump_direction = text2num(signal.data["direction"])
 
 	if("set_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(
-			text2num(signal.data["set_internal_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		internal_pressure_bound = Clamp(text2num(signal.data["set_internal_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("set_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(
-			text2num(signal.data["set_external_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		external_pressure_bound = Clamp(text2num(signal.data["set_external_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("adjust_internal_pressure" in signal.data)
-		internal_pressure_bound = Clamp(
-			internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		internal_pressure_bound = Clamp(internal_pressure_bound + text2num(signal.data["adjust_internal_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("adjust_external_pressure" in signal.data)
-		external_pressure_bound = Clamp(
-			external_pressure_bound + text2num(signal.data["adjust_external_pressure"]),
-			0,
-			ONE_ATMOSPHERE*50
-		)
+		external_pressure_bound = Clamp(external_pressure_bound + text2num(signal.data["adjust_external_pressure"]),0,ONE_ATMOSPHERE*50)
 
 	if("init" in signal.data)
 		name = signal.data["init"]

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -20,8 +20,7 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 /proc/Ceiling(x)
 	return -round(-x)
 
-/proc/Clamp(val, min, max)
-	return max(min, min(val, max))
+#define Clamp(CLVALUE,CLMIN,CLMAX) ( max( (CLMIN), min((CLVALUE), (CLMAX)) ) )
 
 // cotangent
 /proc/Cot(x)

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -314,12 +314,12 @@
 				newalpha = 0
 
 		if(lighting_object.alpha != newalpha)
-			var/change_time = LIGHTING_TIME
 			if(instantly)
-				change_time = 0
-			animate(lighting_object, alpha = newalpha, time = change_time)
+				lighting_object.alpha = newalpha
+			else
+				animate(lighting_object, alpha = newalpha, time = LIGHTING_TIME)
 			if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA) //Doesn't actually make it darker or anything, just tells byond you can't see the tile
-				animate(luminosity = 0, time = 0)
+				luminosity = 0
 
 	lighting_changed = 0
 


### PR DESCRIPTION
No longer uses animate() when unneeded, because animate() is slow.
Also turns Clamp() into a macro to reduce proccall overhead.

The whitespace changes in atmos are needed because of the way the
preprocessor handles macros.

Thank you MrPerson for helping with this.
