### PR TITLE
Ghost HUD tweaks

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -274,7 +274,7 @@ so as to remain in compliance with the most up-to-date laws."
 
 
 //GHOSTS
-//TODO: expand this system to replace the pollCandidates Yes/No messages
+//TODO: expand this system to replace the pollCandidates/CheckAntagonist/"choose quickly"/etc Yes/No messages
 /obj/screen/alert/notify_cloning
 	name = "Revival"
 	desc = "Someone is trying to revive you. Re-enter your corpse if you want to be revived!"
@@ -291,15 +291,20 @@ so as to remain in compliance with the most up-to-date laws."
 	desc = "A body was created. You can enter it."
 	icon_state = "ghost_frame"
 	timeout = 300
-	var/jump_target = null
+	var/atom/jump_target = null
+	var/attack_not_jump = null
 
 /obj/screen/alert/notify_jump/Click()
 	if(!usr || !usr.client) return
 	if(!jump_target) return
 	var/mob/dead/observer/G = usr
-	var/turf/T = get_turf(jump_target)
-	if(T && isturf(T))
-		G.loc = T
+	if(!istype(G)) return
+	if(attack_not_jump)
+		jump_target.attack_ghost(G)
+	else
+		var/turf/T = get_turf(jump_target)
+		if(T && isturf(T))
+			G.loc = T
 
 //OBJECT-BASED
 

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -186,8 +186,8 @@
 	return
 
 
-/proc/makeNewConstruct(mob/living/simple_animal/construct/ctype, mob/target, mob/stoner = null, cultoverride = 0)
-	var/mob/living/simple_animal/construct/newstruct = new ctype(get_turf(target))
+/proc/makeNewConstruct(mob/living/simple_animal/construct/ctype, mob/target, mob/stoner = null, cultoverride = 0, loc_override = null)
+	var/mob/living/simple_animal/construct/newstruct = new ctype((loc_override) ? (loc_override) : (get_turf(target)))
 	newstruct.faction |= "\ref[stoner]"
 	newstruct.key = target.key
 	if(stoner && iscultist(stoner) || cultoverride)

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -22,7 +22,7 @@ var/global/posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/proc/ping_ghosts(msg)
 	if(!posibrain_notif_cooldown)
-		notify_ghosts("Positronic brain [msg] in [get_area(src)]! <a href=?src=\ref[src];activate=1>(Click to enter)</a>", 'sound/effects/ghost2.ogg', source = src)
+		notify_ghosts("Positronic brain [msg] in [get_area(src)]!", enter_link="<a href=?src=\ref[src];activate=1>(Click to enter)</a>", 'sound/effects/ghost2.ogg', source = src, attack_not_jump = 1)
 		posibrain_notif_cooldown = 1
 		spawn(askDelay) //Global one minute cooldown to avoid spam.
 			posibrain_notif_cooldown = 0

--- a/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
@@ -6,7 +6,7 @@
 	icon_state = "swarmer_unactivated"
 
 /obj/item/unactivated_swarmer/New()
-	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]! <a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src)
+	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src, attack_not_jump = 1)
 	..()
 
 /obj/item/unactivated_swarmer/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -19,7 +19,7 @@
 	..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A drone shell has been created in \the [A.name].", source = src)
+		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, attack_not_jump = 1)
 
 /obj/item/drone_shell/attack_ghost(mob/user)
 	if(jobban_isbanned(user,"drone"))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -326,17 +326,18 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 /mob/proc/reagent_check(datum/reagent/R) // utilized in the species code
 	return 1
 
-/proc/notify_ghosts(var/message, var/ghost_sound = null, var/atom/source = null, var/image/alert_overlay = null) //Easy notification of ghosts.
+/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/image/alert_overlay = null, var/attack_not_jump = 0) //Easy notification of ghosts.
 	for(var/mob/dead/observer/O in player_list)
 		if(O.client)
-			O << "<span class='ghostalert'>[message]<span>"
+			O << "<span class='ghostalert'>[message][(enter_link) ? " [enter_link]" : ""]<span>"
 			if(ghost_sound)
 				O << sound(ghost_sound)
 			if(source)
 				var/obj/screen/alert/notify_jump/A = O.throw_alert("\ref[source]_notify_jump", /obj/screen/alert/notify_jump)
 				if(A)
 					A.desc = message
-					A.jump_target = get_turf(source)
+					A.attack_not_jump = attack_not_jump
+					A.jump_target = source
 					if(!alert_overlay)
 						var/old_layer = source.layer
 						source.layer = FLOAT_LAYER

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -30,7 +30,7 @@
 	var/area/A = get_area(src)
 	if(A)
 		var/image/alert_overlay = image('icons/mob/mob.dmi', "harvester")
-		notify_ghosts("Nar-Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay)
+		notify_ghosts("Nar-Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, attack_not_jump = 1)
 
 	narsie_spawn_animation()
 
@@ -39,11 +39,8 @@
 
 
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
-	if(!(src in view()))
-		user << "Your soul is too far away."
-		return
-	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 0)
-	PoolOrNew(/obj/effect/particle_effect/smoke/sleeping, user.loc)
+	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 0, loc_override = src.loc)
+	PoolOrNew(/obj/effect/particle_effect/smoke/sleeping, src.loc)
 
 
 /obj/singularity/narsie/process()


### PR DESCRIPTION
Removes links in tooltips. Makes alerts work as clicks when applicable.

Fixes #12843
Fixes #12844
