### PR TITLE
Harvesters spawned by nar-sie are no longer culted

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -42,7 +42,7 @@
 	if(!(src in view()))
 		user << "Your soul is too far away."
 		return
-	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 1)
+	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 0)
 	PoolOrNew(/obj/effect/particle_effect/smoke/sleeping, user.loc)
 
 


### PR DESCRIPTION
1) It spams the round end report

2) They're not really on a team with the cultists, since Nar-Sie backstabs them all in the end (and in fact prioritizes eating cultists in his movement code).
