### PR TITLE
Lava turf

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -180,6 +180,7 @@
 	baseturf = /turf/simulated/floor/plating/lava //lava all the way down
 	slowdown = 2
 	var/processing = 0
+        luminosity = 1
 
 /turf/simulated/floor/plating/lava/airless
 	oxygen = 0

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -159,14 +159,6 @@
 	nitrogen = 0
 	temperature = TCMB
 
-/turf/simulated/floor/plating/lava
-	icon_state = "lava"
-
-/turf/simulated/floor/plating/lava/airless
-	oxygen = 0
-	nitrogen = 0
-	temperature = TCMB
-
 /turf/simulated/floor/plating/abductor
 	name = "alien floor"
 	icon_state = "alienpod1"
@@ -174,3 +166,34 @@
 /turf/simulated/floor/plating/abductor/New()
 	..()
 	icon_state = "alienpod[rand(1,9)]"
+
+/turf/simulated/floor/plating/lava
+	name = "lava"
+	icon_state = "lava"
+	baseturf = /turf/simulated/floor/plating/lava //lava all the way down
+	slowdown = 2
+
+/turf/simulated/floor/plating/lava/airless
+	oxygen = 0
+	nitrogen = 0
+	temperature = TCMB
+
+/turf/simulated/floor/plating/lava/Entered(atom/movable/AM)
+	if(!istype(AM))
+		return
+	if(istype(AM, /obj))
+		var/obj/O = AM
+		if(O.burn_state == -1)
+			O.burn_state = 0 //Even fireproof things burn up in lava
+		O.fire_act()
+	else if (istype(AM, /mob/living))
+		var/mob/living/L = AM
+		L.adjustFireLoss(20)
+		L.adjust_fire_stacks(20)
+		L.IgniteMob()
+
+/turf/simulated/floor/plating/lava/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/weapon/RCD))
+		return ..()
+	else
+		return

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -193,7 +193,4 @@
 		L.IgniteMob()
 
 /turf/simulated/floor/plating/lava/attackby(obj/item/C, mob/user, params)
-	if(istype(C, /obj/item/weapon/RCD))
-		return ..()
-	else
-		return
+	return

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -180,7 +180,7 @@
 	baseturf = /turf/simulated/floor/plating/lava //lava all the way down
 	slowdown = 2
 	var/processing = 0
-        luminosity = 1
+	luminosity = 1
 
 /turf/simulated/floor/plating/lava/airless
 	oxygen = 0

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -167,11 +167,19 @@
 	..()
 	icon_state = "alienpod[rand(1,9)]"
 
+
+
+
+
+///LAVA
+
+
 /turf/simulated/floor/plating/lava
 	name = "lava"
 	icon_state = "lava"
 	baseturf = /turf/simulated/floor/plating/lava //lava all the way down
 	slowdown = 2
+	var/processing = 0
 
 /turf/simulated/floor/plating/lava/airless
 	oxygen = 0
@@ -179,18 +187,36 @@
 	temperature = TCMB
 
 /turf/simulated/floor/plating/lava/Entered(atom/movable/AM)
-	if(!istype(AM))
-		return
-	if(istype(AM, /obj))
-		var/obj/O = AM
-		if(O.burn_state == -1)
-			O.burn_state = 0 //Even fireproof things burn up in lava
-		O.fire_act()
-	else if (istype(AM, /mob/living))
-		var/mob/living/L = AM
-		L.adjustFireLoss(20)
-		L.adjust_fire_stacks(20)
-		L.IgniteMob()
+	burn_stuff()
+	if(!processing)
+		processing = 1
+		SSobj.processing |= src
 
-/turf/simulated/floor/plating/lava/attackby(obj/item/C, mob/user, params)
+/turf/simulated/floor/plating/lava/process()
+	if(!contents)
+		processing = 0
+		SSobj.processing.Remove(src)
+		return
+	burn_stuff()
+
+/turf/simulated/floor/plating/lava/proc/burn_stuff()
+	for(var/atom/movable/AM in contents)
+		if(!istype(AM))
+			return
+		if(istype(AM, /obj))
+			var/obj/O = AM
+			if(istype(O, /obj/effect/decal/cleanable/ash)) //So we don't get stuck burning the same ash pile forever
+				qdel(O)
+				return
+			if(O.burn_state == -1)
+				O.burn_state = 0 //Even fireproof things burn up in lava
+			O.fire_act()
+		else if (istype(AM, /mob/living))
+			var/mob/living/L = AM
+			L.adjustFireLoss(20)
+			L.adjust_fire_stacks(20)
+			L.IgniteMob()
+
+
+/turf/simulated/floor/plating/lava/attackby(obj/item/C, mob/user, params) //Lava isn't a good foundation to build on
 	return


### PR DESCRIPTION
Ignites (max firestacks) and damages mobs (20 burn damage) that move through it. This means firesuit proofs will only partially protect you.

Ignites objects that enter it (even fireproof objects)

Slows movement of mobs trying to move through it.

Can't build on it

To do in future updates or in this PR if it sits long enough: Ways to build on lava, use WJs new/better lava icons

Let me know if you want anything tweaked Ausops

:cl: Kor
rscadd: Added a lava turf. Expect to see it in away missions or in admin "events"
/:cl:
