### PR TITLE
Fixes asay and dsay not being ran thru log_admin

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -19,9 +19,13 @@
 	if (config.log_admin)
 		diary << "\[[time_stamp()]]ADMIN: [text]"
 
+/proc/log_adminsay(text)
+	if (config.log_adminchat)
+		log_admin("ASAY: [text]")
+		
 /proc/log_dsay(text)
 	if (config.log_adminchat)
-		diary << "\[[time_stamp()]]DSAY: [text]"
+		log_admin("DSAY: [text]")
 
 /proc/log_game(text)
 	if (config.log_game)
@@ -62,10 +66,6 @@
 /proc/log_attack(text)
 	if (config.log_attack)
 		diaryofmeanpeople << "\[[time_stamp()]]ATTACK: [text]"
-
-/proc/log_adminsay(text)
-	if (config.log_adminchat)
-		diary << "\[[time_stamp()]]ASAY: [text]"
 
 /proc/log_pda(text)
 	if (config.log_pda)


### PR DESCRIPTION
Mainly because I want to keep all admin actions under the ADMIN: tag because it's the easiest way to filter logs for admin actions relating to somebody.

Also so that it adds the entries to the admin log in the secrets tab so admins can see the current round's asay log (like they could before.)

This changes it from
`[time] ASAY:`
to 
`[time] ADMIN: ASAY:`
