### PR TITLE
Saline-Glucose IV drip blood replacement.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -231,7 +231,7 @@
 /datum/reagent/medicine/salglu_solution
 	name = "Saline-Glucose Solution"
 	id = "salglu_solution"
-	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage."
+	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage.  Can be used as a blood substitute on an IV drip."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -240,6 +240,16 @@
 	if(prob(33))
 		M.adjustBruteLoss(-0.5*REM)
 		M.adjustFireLoss(-0.5*REM)
+	..()
+
+/datum/reagent/medicine/salglu_solution/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(iscarbon(M) && method == INJECT)
+		var/mob/living/carbon/human/H = M
+		//The lower the blood of the patient, the better it is as a blood substitute.
+		var/efficiency = (560-H.vessel.get_reagent_amount("blood"))/700 + 0.2
+		efficiency = min(0.75,efficiency)
+		//As it's designed for an IV drip, make large injections not as effective as repeated small injections.
+		H.vessel.add_reagent("blood", efficiency * min(5,reac_volume))
 	..()
 
 /datum/reagent/medicine/mine_salve

--- a/html/changelogs/LordPidey.yml
+++ b/html/changelogs/LordPidey.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: LordPidey
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Nanotransen doctors have re-approved Saline-Glucose Solution for usage in IV drips, when blood supplies are low.  Simple pills will not suffice."


### PR DESCRIPTION
This adds the ability to use an IV drip of saline glucose to treat bloodloss.

It is more effective the lower the patients blood level, so it is bad for topping off, but good for treating critical patients.

It is never as effective as actual blood though.

It also can only be done by injection, so either stand there with a syringe, or use the IV drip, because pills won't cut it.
