### PR TITLE
Adds a Syringe to the Uplink Poison/Chemical kit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -31,7 +31,7 @@ var/list/uplink_items = list()
 
 	//Filtered version
 	var/list/filtered_uplink_items = list()
-	
+
 	for(var/category in uplink_items)
 		for(var/datum/uplink_item/I in uplink_items[category])
 			if(I.gamemodes.len)
@@ -406,7 +406,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/traitor_chem_bottle
 	name = "Poison Kit"
-	desc = "An assortment of deadly chemicals packed into a compact box. Hard to utilize if there is no method of application."
+	desc = "An assortment of deadly chemicals packed into a compact box. Comes with a syringe for more precise application."
 	item = /obj/item/weapon/storage/box/syndie_kit/chemical
 	cost = 6
 	surplus = 50

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -227,6 +227,7 @@
 	new /obj/item/weapon/reagent_containers/glass/bottle/coniine(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/curare(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/amanitin(src)
+	new /obj/item/weapon/reagent_containers/syringe(src)
 	return
 
 /obj/item/weapon/storage/box/syndie_kit/nuke

--- a/html/changelogs/torger597-PR-12945.yml
+++ b/html/changelogs/torger597-PR-12945.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: torger597
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a syringe to boxed poison kits."


### PR DESCRIPTION
Useful for:
1: Poisoning food.
2: Injecting Chemicals directly rather than being forced to feed someone
from a bottle.
