### PR TITLE
Announcements made by AIs have their name attached

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -572,7 +572,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	if(!input || !user.canUseTopic(src))
 		return
 	if(is_silicon)
-		minor_announce(input)
+		minor_announce(input,"[user.name] Announces:")
 		ai_message_cooldown = 1
 		spawn(600)//One minute cooldown
 			ai_message_cooldown = 0


### PR DESCRIPTION
For example, it will use **LIES Announces:** of the generic **Attention:** header.
