### PR TITLE
Fixes flashbanged mmis in mechs losing access to most mech functions

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -114,7 +114,7 @@
 			else
 				outmsg = "<span class='warning'>You fail to blind [C] by shining [src] at their eyes!</span>"
 
-	//robots and AI
+	//robots
 	else if(isrobot(target))
 		var/mob/living/silicon/S = target
 		//20% chance to actually hit the sensors

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -115,7 +115,7 @@
 				outmsg = "<span class='warning'>You fail to blind [C] by shining [src] at their eyes!</span>"
 
 	//robots and AI
-	else if(issilicon(target))
+	else if(isrobot(target))
 		var/mob/living/silicon/S = target
 		//20% chance to actually hit the sensors
 		if(prob(effectchance * diode.rating))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -53,6 +53,12 @@
 	waterlevel = maxwater
 	nutrilevel = 3
 
+/obj/machinery/hydroponics/Destroy()
+	if(myseed)
+		qdel(myseed)
+		myseed = null
+	return ..()
+
 /obj/machinery/hydroponics/constructable/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "hydrotray3", "hydrotray3", I))
 		return

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -38,3 +38,9 @@
 
 /mob/living/carbon/brain/UnarmedAttack(atom/A)//Stops runtimes due to attack_animal being the default
 	return
+
+/mob/living/carbon/brain/check_ear_prot()
+	return 1
+
+/mob/living/carbon/brain/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
+	return // no eyes, no flashing

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -469,6 +469,9 @@
 	if(affect_silicon)
 		return ..()
 
+/mob/living/silicon/check_ear_prot()
+	return 1
+
 /mob/living/silicon/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/changed = 0

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -46,7 +46,8 @@
 	reac_volume = ..()
 	M.apply_damage(0.6*reac_volume, TOX)
 	M.hallucination += 0.6*reac_volume
-	M.reagents.add_reagent("spore", 0.4*reac_volume)
+	if(M.reagents)
+		M.reagents.add_reagent("spore", 0.4*reac_volume)
 
 /datum/reagent/blob/lexorin_jelly //does tons of oxygen damage and a little brute
 	name = "Lexorin Jelly"
@@ -82,7 +83,8 @@
 	reac_volume = ..()
 	M.apply_damage(0.4*reac_volume, BURN)
 	M.adjustStaminaLoss(0.4*reac_volume)
-	M.reagents.add_reagent("frostoil", 0.4*reac_volume)
+	if(M.reagents)
+		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
 
 /datum/reagent/blob/dark_matter //does brute damage and throws or pulls nearby objects at the target
 	name = "Dark Matter"


### PR DESCRIPTION
- Fixes being able to stun AI and MMI forever with flashbang, preventing them from using their mech. Brain mobs can no longer get flashed or flashbanged. Silicons are no longer affected by the sound bang of the flashbang (since they have no ears). Fixes #12615 
- Fixes a runtime with two blob reagents.
- Fixes a reference not being removed when hydro tray is destroyed.
- Laser pointer can no longer weaken AIs (no eyes).
