### PR TITLE
Removes unused changelog prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 script:
   - shopt -s globstar
   - (! grep 'step_[xy]' _maps/**/*.dmm)
-  - md5sum -c - <<< "29d5a6e23d172846354505e60ecfe7e7 *html/changelogs/example.yml"
+  - md5sum -c - <<< "49bc6b1b9ed56c83cceb6674bd97cb34 *html/changelogs/example.yml"
   - tools/check_filedirs.sh tgstation.dme
   - python tools/ss13_genchangelog.py html/changelog.html html/changelogs
   - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -18,7 +18,6 @@
 #   imagedel
 #   spellcheck (typo fixes)
 #   experiment
-#   tgs (TG-ported fixes?)
 #################################
 
 # Your name.  

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -21,7 +21,7 @@
 #################################
 
 # Your name.  
-author: N3X15
+author: "
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Example.yml has been edited so that if someone copies it but forgets to change the author, which has happened several times, it'll error out.
