### PR TITLE
Fixes remotely detonating planted c4 with signaler.

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -28,7 +28,7 @@ var/const/WIRE_EXPLODE = 1
 
 /datum/wires/explosive/c4/explode()
 	var/obj/item/weapon/c4/P = holder
-	P.explode(get_turf(P))
+	P.explode()
 
 
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -220,53 +220,6 @@ Class Procs:
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 
-/mob/proc/canUseTopic() //TODO: once finished, place these procs on the respective mob files
-	return
-
-/mob/dead/observer/canUseTopic()
-	if(check_rights(R_ADMIN, 0))
-		return
-
-/mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
-	if(incapacitated())
-		return
-	if(no_dextery)
-		if(be_close && in_range(M, src))
-			return 1
-	else
-		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
-	return
-
-/mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
-	if(incapacitated() || lying )
-		return
-	if(!Adjacent(M))
-		if((be_close == 0) && (dna.check_mutation(TK)))
-			if(tkMaxRangeCheck(src, M))
-				return 1
-		return
-	if(!isturf(M.loc) && M.loc != src)
-		return
-	return 1
-
-/mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
-	if(stat)
-		return
-	if(be_close && !in_range(M, src))
-		return
-	//stop AIs from leaving windows open and using then after they lose vision
-	//apc_override is needed here because AIs use their own APC when powerless
-	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
-	if(cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
-		return
-	return 1
-
-/mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
-	if(stat || lockcharge || stunned || weakened)
-		return
-	if(be_close && !in_range(M, src))
-		return
-	return 1
 
 /obj/machinery/attack_ai(mob/user)
 	if(isrobot(user))

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -67,20 +67,20 @@
 		timer = newtime
 		user << "Timer set for [timer] seconds."
 
-/obj/item/weapon/c4/afterattack(atom/movable/target, mob/user, flag)
+/obj/item/weapon/c4/afterattack(atom/movable/AM, mob/user, flag)
 	if (!flag)
 		return
-	if (ismob(target) || istype(target, /obj/item/weapon/storage/))
+	if (ismob(AM) || istype(AM, /obj/item/weapon/storage/))
 		return
-	if(loc == target)
+	if(loc == AM)
 		return
 
 	user << "<span class='notice'>You start planting the bomb...</span>"
 
-	if(do_after(user, 50, target = target) && in_range(user, target))
+	if(do_after(user, 50, target = AM))
 		if(!user.unEquip(src))
 			return
-		src.target = target
+		src.target = AM
 		loc = null
 
 		message_admins("[key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) planted [src.name] on [target.name] at ([target.x],[target.y],[target.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>) with [timer] second fuse",0,1)
@@ -89,16 +89,21 @@
 		target.overlays += image_overlay
 		user << "<span class='notice'>You plant the bomb. Timer counting down from [timer].</span>"
 		spawn(timer*10)
-			if(target && !target.gc_destroyed)
-				explode(get_turf(target))
-			else
-				qdel(src)
+			explode()
 
-/obj/item/weapon/c4/proc/explode(turf/location)
-	location.ex_act(2, target)
-	explosion(location,0,0,3)
+/obj/item/weapon/c4/proc/explode()
+	if(qdeleted(src))
+		return
+	var/turf/location
 	if(target)
-		target.overlays -= image_overlay
+		if(!qdeleted(target))
+			location = get_turf(target)
+			target.overlays -= image_overlay
+	else
+		location = get_turf(src)
+	if(location)
+		location.ex_act(2, target)
+		explosion(location,0,0,3)
 	qdel(src)
 
 /obj/item/weapon/c4/attack(mob/M, mob/user, def_zone)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -418,3 +418,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 		if(DATA_HUD_MEDICAL_ADVANCED)
 			data_hud_seen = 0
+
+/mob/dead/observer/canUseTopic()
+	if(check_rights(R_ADMIN, 0))
+		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -842,3 +842,15 @@
 			if(M.client)
 				viewing += M.client
 		flick_overlay(image(icon,src,"electrocuted_generic",MOB_LAYER+1), viewing, anim_duration)
+
+/mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
+	if(incapacitated() || lying )
+		return
+	if(!Adjacent(M))
+		if((be_close == 0) && (dna.check_mutation(TK)))
+			if(tkMaxRangeCheck(src, M))
+				return 1
+		return
+	if(!isturf(M.loc) && M.loc != src)
+		return
+	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -918,3 +918,13 @@ Sorry Giacom. Please don't be mad :(
 			butcher_results.Remove(path) //In case you want to have things like simple_animals drop their butcher results on gib, so it won't double up below.
 	visible_message("<span class='notice'>[user] butchers [src].</span>")
 	gib()
+
+/mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
+	if(incapacitated())
+		return
+	if(no_dextery)
+		if(be_close && in_range(M, src))
+			return 1
+	else
+		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
+	return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -843,3 +843,15 @@ var/list/ai_list = list()
 
 /mob/living/silicon/ai/can_buckle()
 	return 0
+
+/mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
+	if(stat)
+		return
+	if(be_close && !in_range(M, src))
+		return
+	//stop AIs from leaving windows open and using then after they lose vision
+	//apc_override is needed here because AIs use their own APC when powerless
+	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
+	if(cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
+		return
+	return 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1160,3 +1160,10 @@
 			connected_ai << "<br><br><span class='notice'>NOTICE - Cyborg module change detected: [name] has loaded the [designation] module.</span><br>"
 		if(3) //New Name
 			connected_ai << "<br><br><span class='notice'>NOTICE - Cyborg reclassification detected: [oldname] is now designated as [newname].</span><br>"
+
+/mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
+	if(stat || lockcharge || stunned || weakened)
+		return
+	if(be_close && !in_range(M, src))
+		return
+	return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1010,3 +1010,7 @@ var/list/slot_equipment_priority = list( \
 //can the mob be unbuckled from something by default?
 /mob/proc/can_unbuckle()
 	return 1
+
+//Can the mob use Topic to interact with machines
+/mob/proc/canUseTopic()
+	return


### PR DESCRIPTION
- It was due to a runtime in c4 explosion code. Fixes #12951
  - I also changed the name of the first argument of c4/afterattack() from "target" to "AM" to avoid confusion.
  - Removed an in_range(user, target) check when planting c4 since the do_after() already checks that both the user and target's loc do not change.
- Move CanUseTopic() procs to the correct files.

:cl:
bugfix: Remotely detonating a planted c4 with a signaler now works again.
/:cl:
