### PR TITLE
Reduces Loyalty Firing Pin tech requirement

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -103,7 +103,6 @@
 	desc = "This Security firing pin authorizes the weapon for only loyalty-implanted users."
 	icon_state = "firing_pin_loyalty"
 	req_implant = /obj/item/weapon/implant/loyalty
-	pin_removeable = 1
 
 /obj/item/device/firing_pin/implant/pindicate
 	name = "syndicate firing pin"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -103,6 +103,7 @@
 	desc = "This Security firing pin authorizes the weapon for only loyalty-implanted users."
 	icon_state = "firing_pin_loyalty"
 	req_implant = /obj/item/weapon/implant/loyalty
+	pin_removeable = 1
 
 /obj/item/device/firing_pin/implant/pindicate
 	name = "syndicate firing pin"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -16,7 +16,7 @@
 	name = "loyalty firing pin"
 	desc = "This is a security firing pin which only authorizes users who are loyalty-implanted."
 	id = "pin_loyalty"
-	req_tech = list("combat" = 6, "materials" = 6, "powerstorage" = 3)
+	req_tech = list("combat" = 5, "materials" = 6, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 600, MAT_DIAMOND = 600, MAT_URANIUM = 200)
 	build_path = /obj/item/device/firing_pin/implant/loyalty


### PR DESCRIPTION
Loyalty firing pins now require Combat 5 instead of 6. 
- This makes it possible to build them once mining drops off minerals, instead of also requiring Combat Shotguns to unlock.

~~Loyalty pins can now be replaced by other pins.~~
- ~~The intent here is to enable use of a weapon by loyal users, but still have a somewhat easy to disable a weapon by inserting a test range pin, or a generic/emagged pin for anyone to use it once more.~~

:cl: Gun Hog
tweak: The Combat tech requirement for Loyalty Firing Pins has been reduced from 6 to 5.
/:cl:
