### PR TITLE
Adding Clonepod to Supply Blacklist, Fixes #12979

### DIFF
--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -219,7 +219,7 @@
 		/obj/singularity,
 		/obj/machinery/teleport/station,
 		/obj/machinery/teleport/hub,
-		/obj/machinery/telepad
+		/obj/machinery/telepad,
 		/obj/machinery/clonepod
 	)
 	if(A)

--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -220,6 +220,7 @@
 		/obj/machinery/teleport/station,
 		/obj/machinery/teleport/hub,
 		/obj/machinery/telepad
+		/obj/machinery/clonepod
 	)
 	if(A)
 		if(is_type_in_list(A, blacklist))


### PR DESCRIPTION
Added clonepod to the supply shuttle blacklist, fixing issue #12979 
Fixes #12979
