### PR TITLE
Fixes your shield blocking the bullets when committing suicide with a

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -30,7 +30,7 @@
 	P.current = reflector_turf
 	P.yo = reflect_turf.y - reflector_turf.y
 	P.xo = reflect_turf.x - reflector_turf.x
-	P.kill_count = 50 //Keep the projectile healthy as long as its bouncing off things
+	P.range = initial(P.range) //Keep the projectile healthy as long as its bouncing off things
 	new_dir = 0
 	return - 1
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -40,29 +40,30 @@ emp_act
 	dna.species.on_hit(proj_type, src)
 
 /mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
-	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
-		if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
-			visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
-							"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
-			// Find a turf near or on the original location to bounce to
-			if(P.starting)
-				var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/new_y = P.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
-				var/turf/curloc = get_turf(src)
+	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself
+		if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+			if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
+				visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
+								"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")
+				// Find a turf near or on the original location to bounce to
+				if(P.starting)
+					var/new_x = P.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
+					var/new_y = P.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
+					var/turf/curloc = get_turf(src)
 
-				// redirect the projectile
-				P.original = locate(new_x, new_y, P.z)
-				P.starting = curloc
-				P.current = curloc
-				P.firer = src
-				P.yo = new_y - curloc.y
-				P.xo = new_x - curloc.x
+					// redirect the projectile
+					P.original = locate(new_x, new_y, P.z)
+					P.starting = curloc
+					P.current = curloc
+					P.firer = src
+					P.yo = new_y - curloc.y
+					P.xo = new_x - curloc.x
 
-			return -1 // complete projectile permutation
+				return -1 // complete projectile permutation
 
-	if(check_shields(P.damage, "the [P.name]", P, 0, P.armour_penetration))
-		P.on_hit(src, 100, def_zone)
-		return 2
+		if(check_shields(P.damage, "the [P.name]", P, 0, P.armour_penetration))
+			P.on_hit(src, 100, def_zone)
+			return 2
 	return (..(P , def_zone))
 
 /mob/living/carbon/human/proc/check_reflect(def_zone) //Reflection checks for anything in your l_hand, r_hand, or wear_suit based on the reflection chance of the object

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -25,7 +25,7 @@
 	var/nodamage = 0 //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	var/projectile_type = "/obj/item/projectile"
-	var/kill_count = 50 //This will de-increment every step. When 0, it will delete the projectile.
+	var/range = 50 //This will de-increment every step. When 0, it will delete the projectile.
 		//Effects
 	var/stun = 0
 	var/weaken = 0
@@ -39,19 +39,15 @@
 	var/jitter = 0
 	var/forcedodge = 0
 	// 1 to pass solid objects, 2 to pass solid turfs (results in bugs, bugs and tons of bugs)
-	var/range = 0
 
 /obj/item/projectile/New()
 	permutated = list()
 	return ..()
 
 /obj/item/projectile/proc/Range()
-	if(range)
-		range--
-		if(range <= 0)
-			on_range()
-	else
-		return
+	range--
+	if(range <= 0 && loc)
+		on_range()
 
 /obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
 	qdel(src)
@@ -125,13 +121,9 @@
 
 
 /obj/item/projectile/proc/fire()
-	spawn()
+	spawn(1)
 		while(loc)
-			if(kill_count < 1)
-				qdel(src)
-				return
 			if(!paused)
-				kill_count--
 				if((!( current ) || loc == current))
 					current = locate(Clamp(x+xo,1,world.maxx),Clamp(y+yo,1,world.maxy),z)
 				step_towards(src, current)
@@ -139,7 +131,7 @@
 					if(loc == get_turf(original))
 						if(!(original in permutated))
 							Bump(original, 1)
-			Range()
+				Range()
 			sleep(1)
 
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -30,7 +30,7 @@
 	icon_state = "xray"
 	damage = 15
 	irradiate = 30
-	kill_count = 15
+	range = 15
 	forcedodge = 1
 
 /obj/item/projectile/beam/disabler

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -130,11 +130,9 @@ obj/item/projectile/kinetic/New()
 		damage *= 4
 	..()
 
-/obj/item/projectile/kinetic/Range()
-	range--
-	if(range <= 0)
-		new /obj/item/effect/kinetic_blast(src.loc)
-		qdel(src)
+/obj/item/projectile/kinetic/on_range()
+	new /obj/item/effect/kinetic_blast(src.loc)
+	..()
 
 /obj/item/projectile/kinetic/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
… gun. Fixes #12219 (Also fixed when pointing the gun into your mouth manually)
- Merged kill_count and range var into a single var/range for obj/item/projectile.
- Simplified projectile/proc/Range().
- Fixes timestopped projectiles still calling Range() and thus being deleted despite being stopped.
- Fixes projectile being invisible when on the first tile in front of the shooter (which meant no sprite showing when shooting a target 1 tile away)
- Simplifies kinetic/Range()
- Fixes some objects spawned by on_range() appearing in null space when shooting a target exactly at the maximum range.
