### PR TITLE
Allows drones to use 'pick up' and watertanks

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -44,6 +44,7 @@
 #define slot_s_store		17
 #define slot_in_backpack	18
 #define slot_legcuffed		19
+#define slot_drone_storage	20
 
 //Cant seem to find a mob bitflags area other than the powers one
 

--- a/code/_onclick/hud/drones.dm
+++ b/code/_onclick/hud/drones.dm
@@ -44,7 +44,7 @@
 	inv_box.icon = ui_style
 	inv_box.icon_state = "suit_storage"
 	inv_box.screen_loc = ui_drone_storage
-	inv_box.slot_id = "drone_storage_slot"
+	inv_box.slot_id = slot_drone_storage
 	inv_box.layer = 19
 	adding += inv_box
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -359,7 +359,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(usr.stat || usr.restrained() || !Adjacent(usr) || usr.stunned || usr.weakened || usr.lying)
 		return
 
-	if(ishuman(usr) || ismonkey(usr))
+	if(ishuman(usr) || ismonkey(usr) || isdrone(usr))
 		if(usr.get_active_hand() == null)
 			usr.UnarmedAttack(src) // Let me know if this has any problems -Giacom | Actually let me know now.  -Sayu
 		/*

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -359,17 +359,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(usr.stat || usr.restrained() || !Adjacent(usr) || usr.stunned || usr.weakened || usr.lying)
 		return
 
-	if(ishuman(usr) || ismonkey(usr) || isdrone(usr))
-		if(usr.get_active_hand() == null)
-			usr.UnarmedAttack(src) // Let me know if this has any problems -Giacom | Actually let me know now.  -Sayu
-		/*
-		if(usr.get_active_hand() == null)
-			src.attack_hand(usr)
-		else
-			usr << "\red You already have something in your hand."
-		*/
-	else
-		usr << "<span class='warning'>This mob type can't use this verb!</span>"
+	if(usr.get_active_hand() == null) // Let me know if this has any problems -Yota
+		usr.UnarmedAttack(src)
 
 //This proc is executed when someone clicks the on-screen UI button. To make the UI button show, set the 'action_button_name'.
 //The default action is attack_self().

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -98,9 +98,11 @@
 		return
 	..()
 
-/mob/proc/getWatertankSlot() return slot_back
+/mob/proc/getWatertankSlot()
+	return slot_back
 
-/mob/living/simple_animal/drone/getWatertankSlot() return slot_drone_storage
+/mob/living/simple_animal/drone/getWatertankSlot()
+	return slot_drone_storage
 
 // This mister item is intended as an extension of the watertank and always attached to it.
 // Therefore, it's designed to be "locked" to the player's hands or extended back onto

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -25,8 +25,8 @@
 /obj/item/weapon/watertank/verb/toggle_mister()
 	set name = "Toggle Mister"
 	set category = "Object"
-	if (usr.get_item_by_slot(slot_back) != src && usr.get_item_by_slot(slot_drone_storage) != src)
-		usr << "<span class='warning'>The watertank needs to be on your back to use!</span>"
+	if (usr.get_item_by_slot(usr.getWatertankSlot()) != src)
+		usr << "<span class='warning'>The watertank must be worn properly to use!</span>"
 		return
 	if(usr.incapacitated())
 		return
@@ -75,8 +75,8 @@
 	..()
 
 /obj/item/weapon/watertank/MouseDrop(obj/over_object)
-	if(ishuman(src.loc) || isdrone(src.loc))
-		var/mob/living/carbon/human/H = src.loc
+	var/mob/H = src.loc
+	if(istype(H))
 		switch(over_object.name)
 			if("r_hand")
 				if(H.r_hand)
@@ -97,6 +97,10 @@
 		remove_noz()
 		return
 	..()
+
+/mob/proc/getWatertankSlot() return slot_back
+
+/mob/living/simple_animal/drone/getWatertankSlot() return slot_drone_storage
 
 // This mister item is intended as an extension of the watertank and always attached to it.
 // Therefore, it's designed to be "locked" to the player's hands or extended back onto

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -25,7 +25,7 @@
 /obj/item/weapon/watertank/verb/toggle_mister()
 	set name = "Toggle Mister"
 	set category = "Object"
-	if (usr.get_item_by_slot(slot_back) != src && usr.get_item_by_slot("drone_storage_slot") != src)
+	if (usr.get_item_by_slot(slot_back) != src && usr.get_item_by_slot(slot_drone_storage) != src)
 		usr << "<span class='warning'>The watertank needs to be on your back to use!</span>"
 		return
 	if(usr.incapacitated())

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -25,7 +25,7 @@
 /obj/item/weapon/watertank/verb/toggle_mister()
 	set name = "Toggle Mister"
 	set category = "Object"
-	if (usr.get_item_by_slot(slot_back) != src)
+	if (usr.get_item_by_slot(slot_back) != src && usr.get_item_by_slot("drone_storage_slot") != src)
 		usr << "<span class='warning'>The watertank needs to be on your back to use!</span>"
 		return
 	if(usr.incapacitated())
@@ -75,7 +75,7 @@
 	..()
 
 /obj/item/weapon/watertank/MouseDrop(obj/over_object)
-	if(ishuman(src.loc))
+	if(ishuman(src.loc) || isdrone(src.loc))
 		var/mob/living/carbon/human/H = src.loc
 		switch(over_object.name)
 			if("r_hand")

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -71,7 +71,7 @@
 
 	if(default_storage)
 		var/obj/item/I = new default_storage(src)
-		equip_to_slot_or_del(I, "drone_storage_slot")
+		equip_to_slot_or_del(I, slot_drone_storage)
 	if(default_hatmask)
 		var/obj/item/I = new default_hatmask(src)
 		equip_to_slot_or_del(I, slot_head)

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -64,7 +64,7 @@
 			if(!((I.slot_flags & SLOT_HEAD) || (I.slot_flags & SLOT_MASK)))
 				return 0
 			return 1
-		if("drone_storage_slot")
+		if(slot_drone_storage)
 			if(internal_storage)
 				return 0
 			return 1
@@ -75,7 +75,7 @@
 	switch(slot_id)
 		if(slot_head)
 			return head
-		if("drone_storage_slot")
+		if(slot_drone_storage)
 			return internal_storage
 	..()
 
@@ -99,7 +99,7 @@
 		if(slot_head)
 			head = I
 			update_inv_head()
-		if("drone_storage_slot")
+		if(slot_drone_storage)
 			internal_storage = I
 			update_inv_internal_storage()
 		else

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -135,6 +135,6 @@
 	else if (istype(T) && T.can_be_inserted(I,1)) // If carrying storage item like toolbox
 		T.handle_item_insertion(I)
 	else if(!internal_storage)
-		equip_to_slot(I, "drone_storage_slot")
+		equip_to_slot(I, slot_drone_storage)
 	else
 		usr << "<span class='warning'>You are unable to equip that!</span>"


### PR DESCRIPTION
- Enables use of the pick-up verb for drones. (Fixes #12896 )
- Allows watertanks to be used from a drone's internal storage slot.
- Fixes issue where drones could not remove watertanks from their internal storage. (Fixes #6139)
- Replaces the `"drone_storage_slot"` magic string with a new macro.

:cl:
bugfix: Drones can now use the pick-up verb, and watertanks no longer get jammed in their internal storage.
/:cl:
