### PR TITLE
 The further trials and tribulations of the supermatter sword bugfix

### DIFF
--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -157,12 +157,12 @@
 		if(!istype(T,/turf/space))
 			consume_turf(T)
 
-/obj/item/weapon/melee/supermatter_sword/afterattack(target, mob/user)
-	..()
+/obj/item/weapon/melee/supermatter_sword/afterattack(target, mob/user, proximity_flag)
 	if(user && target == user)
 		user.drop_item()
-	if(Adjacent(target))
+	if(proximity_flag)
 		consume_everything(target)
+	..()
 
 /obj/item/weapon/melee/supermatter_sword/throw_impact(target)
 	..()


### PR DESCRIPTION
Gives supermatter swords a better check for adjacency, and moves the parent code below the dust code to be extra sure <b>nothing escapes</b>.

I started up a test server and was smacking people to dust like a pro, armor or not.

:cl: Incoming5643
tweak: The supermatter sword was being far too kind in the hands of men. They should now have <b>the desired effect</b> when swung at people.
/:cl:
