### PR TITLE
[Ready] Fixes map loader incorrectly detecting x size in maps

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -64,9 +64,10 @@ var/global/dmm_suite/preloader/_preloader = null
 		var/z_depth = length(zgrid)
 
 		//if exceeding the world max x or y, increase it
-		var/x_depth = length(copytext(zgrid,1,findtext(zgrid,"\n",2,0)))/key_len
-		if(world.maxx<x_depth)
-			world.maxx=x_depth
+		var/x_depth = length(copytext(zgrid,1,findtext(zgrid,"\n",2,0)))
+		var/x_tilecount = x_depth/key_len
+		if(world.maxx<x_tilecount)
+			world.maxx=x_tilecount
 
 		var/y_depth = z_depth / (x_depth+1)//x_depth + 1 because we're counting the '\n' characters in z_depth
 		if(world.maxy<y_depth)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -64,7 +64,7 @@ var/global/dmm_suite/preloader/_preloader = null
 		var/z_depth = length(zgrid)
 
 		//if exceeding the world max x or y, increase it
-		var/x_depth = length(copytext(zgrid,1,findtext(zgrid,"\n",2,0)))
+		var/x_depth = length(copytext(zgrid,1,findtext(zgrid,"\n",2,0)))/key_len
 		if(world.maxx<x_depth)
 			world.maxx=x_depth
 


### PR DESCRIPTION
Map files are defined in two parts,

First it defines variables, each being a list of what should in a tile, including the area, turf, and anything that should be in those areas or turfs

a = (/turf/space,/area/space)
b = (/obj/structure/table/reinforced,/turf/space,/area/space)

then it defines the map by marking tiles based on their letter.

aaaaaaa
aabbaaa
abbbbaa
abbabab
abbabab
abababb

Each letter points to one of the variables above, and represents 1 tile of the game. Mapped in order, first letter is 1,1,1 second letter is 2,1,1, etc. (it might be flipped, I can't remember, but you get the idea)

If it can't fit each unique possible tile combination, it automatically converts to 2 letters for the variables, not one, going up to 4 letters for the variables.

The issue, is the map loader was assuming the length of the variables was always 1 letter.

fixes #12846

:cl:
Fix: Away mission loading will no longer improperly expand the width of the game world to two times the size of the away mission map.
Tweak: This should also improve the speed of loading away missions, since the game doesn't have to resize the world
/:cl:
