### PR TITLE
Logging improvements

### DIFF
--- a/code/game/objects/radiation.dm
+++ b/code/game/objects/radiation.dm
@@ -4,14 +4,11 @@
 	if(!istype(epicenter, /turf))
 		epicenter = get_turf(epicenter.loc)
 
-	if(log)
-		message_admins("Radiation pulse with size ([heavy_range], [light_range]) and severity [severity] in area [epicenter.loc.name] ")
-		log_game("Radiation pulse with size ([heavy_range], [light_range]) and severity [severity] in area [epicenter.loc.name] ")
-
 	if(heavy_range > light_range)
 		light_range = heavy_range
 
 	var/light_severity = severity * 0.5
+	var/bother_admins = 0
 	for(var/atom/T in range(light_range, epicenter))
 		var/distance = get_dist(epicenter, T)
 		if(distance < 0)
@@ -25,6 +22,14 @@
 				T.rad_act(light_severity)
 		else if(distance <= light_range)
 			T.rad_act(light_severity)
+		if(isliving(T))
+			bother_admins = 1
+
+	if(log)
+		log_game("Radiation pulse with size ([heavy_range], [light_range]) and severity [severity] in area [epicenter.loc.name] ")
+		if(bother_admins)
+			message_admins("Radiation pulse with size ([heavy_range], [light_range]) and severity [severity] in area [epicenter.loc.name] <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>(JMP)</a>")
+
 	return 1
 
 /atom/proc/rad_act(var/severity)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -158,10 +158,10 @@
 		terminal.dismantle(user)
 
 	//crowbarring it !
-	default_deconstruction_crowbar(I)
-	message_admins("[src] has been deconstructed by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-	log_game("[src] has been deconstructed by [key_name(user)]")
-	investigate_log("SMES deconstructed by [key_name(user)]","singulo")
+	if(default_deconstruction_crowbar(I))
+		message_admins("[src] has been deconstructed by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
+		log_game("[src] has been deconstructed by [key_name(user)]")
+		investigate_log("SMES deconstructed by [key_name(user)]","singulo")
 
 /obj/machinery/power/smes/Destroy()
 	if(ticker && ticker.current_state == GAME_STATE_PLAYING)


### PR DESCRIPTION
Fixes SMES deconstruction logging.
Radiation will no longer message admins unless a living mob is hit.
All rad pulses will still be saved to logs.
Also adds a JMP link to the rad pulse message.

Fixes #12442
Fixes #12609
