### PR TITLE
R&D and Misc Fixes/Tweaks

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -226,8 +226,7 @@
 						var/list/materials_used = list(MAT_METAL=metal_cost/coeff, MAT_GLASS=glass_cost/coeff)
 						materials.use_amount(materials_used)
 						var/obj/item/new_item = new being_built.build_path(T)
-						new_item.materials[MAT_METAL] /= coeff
-						new_item.materials[MAT_GLASS] /= coeff
+						new_item.materials = materials_used.Copy()
 						new_item.autolathe_crafted(src)
 					busy = 0
 					src.updateUsrDialog()

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -141,8 +141,8 @@
 	if(!src.holder)
 		src << "Only administrators may use this command."
 		return
-	var/area/A = input(usr, "Pick an area.", "Pick an area") in sortedAreas
-	if(A)
+	var/area/A = input(usr, "Pick an area.", "Pick an area") in sortedAreas|null
+	if(A && istype(A))
 		admin_forcemove(M, pick(get_area_turfs(A)))
 		feedback_add_details("admin_verb","SMOB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		log_admin("[key_name(usr)] teleported [key_name(M)] to [A]")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -499,10 +499,12 @@ BLIND     // can't see anything
 		usr.update_inv_glasses()
 	if(istype(src, /obj/item/clothing/mask))
 		usr.update_inv_wear_mask()
+	if(istype(usr, /mob/living/carbon))
+		var/mob/living/carbon/C = usr
+		C.head_update(src) //updates based on the HIDE_ flags and fixes the sec hud
 
 /obj/item/clothing/proc/can_use(mob/user)
 	if(user && ismob(user))
 		if(!user.incapacitated())
 			return 1
 	return 0
-

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -161,7 +161,7 @@ proc/CallMaterialName(ID)
 			return
 		D.loc = src
 		user << "<span class='notice'>You add the disk to the machine!</span>"
-	else
+	else if(!(linked_destroy && linked_destroy.busy) && !(linked_lathe && linked_lathe.busy) && !(linked_imprinter && linked_imprinter.busy))
 		..()
 	src.updateUsrDialog()
 	return
@@ -407,8 +407,7 @@ proc/CallMaterialName(ID)
 								if( new_item.type == /obj/item/weapon/storage/backpack/holding )
 									new_item.investigate_log("built by [key]","singulo")
 								new_item.reliability = R
-								new_item.materials[MAT_METAL] /= coeff
-								new_item.materials[MAT_GLASS] /= coeff
+								new_item.materials = efficient_mats.Copy()
 								if(linked_lathe.hacked)
 									R = max((new_item.reliability/2), 0)
 								new_item.loc = linked_lathe.loc


### PR DESCRIPTION
Fixes invisible gasmask exploit.
Fixes mineral duplication exploit in protolathe.
You can no longer break a RD Console while a linked machine is busy.
Adds cancel button to admin Send To.

Fixes #12729
Fixes #12197
Fixes #11741
Fixes #11449
