### PR TITLE
 Roundstart races as a config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -525,11 +525,10 @@
 					if(!cleared_default_races)
 						roundstart_species = list()
 						cleared_default_races = 1
-					var/race_name = lowertext(value)
-					for(var/speciestype in typesof(/datum/species) - /datum/species)
-						var/datum/species/S = new speciestype()
-						if(S.id == race_name)
-							roundstart_species[S.name] = S.type
+					var/race_id = lowertext(value)
+					for(var/species_id in species_list)
+						if(species_id == race_id)
+							roundstart_species[species_id] = species_list[species_id]
 				if("join_with_mutant_humans")
 					config.mutant_humans			= 1
 				if("assistant_cap")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -111,6 +111,8 @@
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
+	var/list/roundstart_races = list()	//races you can play as from the get go. If left undefined the game's roundstart var for species is used
+	var/cleared_default_races = 0		//used for sanity in clearing the old default list, not actually a config option
 	var/mutant_humans = 0				//players can pick mutant bodyparts for humans before joining the game
 
 	var/no_summon_guns		//No
@@ -519,6 +521,15 @@
 					config.silicon_max_law_amount	= text2num(value)
 				if("join_with_mutant_race")
 					config.mutant_races				= 1
+				if("roundstart_races")
+					if(!cleared_default_races)
+						roundstart_species = list()
+						cleared_default_races = 1
+					var/race_name = lowertext(value)
+					for(var/speciestype in typesof(/datum/species) - /datum/species)
+						var/datum/species/S = new speciestype()
+						if(S.id == race_name)
+							roundstart_species[S.name] = S.type
 				if("join_with_mutant_humans")
 					config.mutant_humans			= 1
 				if("assistant_cap")

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -474,7 +474,6 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	safe_toxins_max = 0
 	dangerous_existence = 1 //So so much
 	need_nutrition = 0 //Hard to eat through a helmet
-	roundstart = 1
 	var/skin = 0
 
 /datum/species/plasmaman/skin

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -252,9 +252,33 @@ SILICON_MAX_LAW_AMOUNT 12
 ## Uncomment to give players the choice of their species before they join the game
 #JOIN_WITH_MUTANT_RACE
 
-## Adding races to this list will allow them to be choosen while join_with_muntant_race is on
+
+## Roundstart Races
+##-------------------------------------------------------------------------------------------
+## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on
+
+## Disabling humans is possible but a bit buggy. Some code relies on the notion that white people exist in space.
 ROUNDSTART_RACES human
+
+## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
+#ROUNDSTART_RACES fly
+#ROUNDSTART_RACES plasmaman
+#ROUNDSTART_RACES shadow
+#ROUNDSTART_RACES shadowling
+
+## Races that are better than humans in some ways, but worse in others
+#ROUNDSTART_RACES jelly
+#ROUNDSTART_RACES golem
+#ROUNDSTART_RACES adamantine
+#ROUNDSTART_RACES abductor
+
+## Races that are straight upgrades. If these are on expect powergamers to always pick them
+#ROUNDSTART_RACES skeleton
+#ROUNDSTART_RACES zombie
+#ROUNDSTART_RACES slime
+#ROUNDSTART_RACES pod
+##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
 #JOIN_WITH_MUTANT_HUMANS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -252,6 +252,10 @@ SILICON_MAX_LAW_AMOUNT 12
 ## Uncomment to give players the choice of their species before they join the game
 #JOIN_WITH_MUTANT_RACE
 
+## Adding races to this list will allow them to be choosen while join_with_muntant_race is on
+ROUNDSTART_RACES human
+ROUNDSTART_RACES lizard
+
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
 #JOIN_WITH_MUTANT_HUMANS
 


### PR DESCRIPTION
There is now a config list in game_options.txt of which races should be playable at roundstart.

If the list is missing, it will default to which races are defined as roundstart in the species datums. Plasmamen have been removed from this list pending bugfixes.

If JOIN_WITH_MUTANT_RACE isn't set in config, humans only will still be enforced regardless.
