### PR TITLE
Stops glass shards from hurting you in space

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -326,7 +326,7 @@
 	..()
 
 /obj/item/weapon/shard/Crossed(mob/AM)
-	if(istype(AM))
+	if(istype(AM) && has_gravity(loc))
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM


### PR DESCRIPTION
Crossing a glass shard in space without shoes won't hurt and stun the user anymore.
