### PR TITLE
Adds the ability to label blood packs.

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -53,6 +53,8 @@
 
 /obj/item/weapon/reagent_containers/blood/attackby(obj/item/I, mob/user, params)
 	if (istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/toy/crayon))
+		if(!user.canUseTopic(src))
+			return
 		var/t = stripped_input(user, "What would you like to label the blood pack?", name, null, 53)
 		if(user.get_active_hand() != I)
 			return

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -50,3 +50,16 @@
 	name = "empty blood pack"
 	desc = "Seems pretty useless... Maybe if there were a way to fill it?"
 	icon_state = "empty"
+
+/obj/item/weapon/reagent_containers/blood/attackby(obj/item/I, mob/user, params)
+	if (istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/toy/crayon))
+		var/t = stripped_input(user, "What would you like to label the blood pack?", name, null, 53)
+		if(user.get_active_hand() != I)
+			return
+		if(!in_range(src, user) && loc != user)
+			return
+		if(t)
+			name = "blood pack - [t]"
+		else
+			name = "blood pack"
+		return


### PR DESCRIPTION
16:02   Sweaterkittens  Code the ability to label bags of blood
16:03   Sweaterkittens  either a use in-hand or using a pen on it allows you to either pick from a list of suggestions or type in your own name
16:03   Sweaterkittens  that way empty blood bags that get filled can be labeled properly, as well as bags that are filled with something else

NEVER SAY I DO NOT LISTEN TO THE PEOPLE. This just updates its name, nothing fancy, but has obvious uses for people actually using the things.

GUYS AM I DOING THE FOLLOWING RIGHT:

:cl: bgobandit
rscadd: Blood packs can now be labeled with a pen.
/:cl:
