### PR TITLE
Makes external archive only show pages of 250 books

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -173,7 +173,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	var/list/inventory = list()
 	var/checkoutperiod = 5 // In minutes
 	var/obj/machinery/libraryscanner/scanner // Book scanner that will be used when uploading books to the Archive
-	var/libcomp_menu = list("")
+	var/list/libcomp_menu = list("")
 	var/page = 1	//current page of the external archives 
 	var/bibledelay = 0 // LOL NO SPAM (1 minute delay) -- Doohl
 
@@ -263,7 +263,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 				dat += "<A href='?src=\ref[src];orderbyid=1'>(Order book by SS<sup>13</sup>BN)</A><BR><BR>"
 				dat += "<table>"
 				dat += "<tr><td>AUTHOR</td><td>TITLE</td><td>CATEGORY</td><td></td></tr>"
-				dat += libcomp_menu[clamp(page,1,libcomp_menu.len)]
+				dat += libcomp_menu[Clamp(page,1,libcomp_menu.len)]
 				dat += "<tr><td><A href='?src=\ref[src];page=[(max(1,page-1))]'>&lt;&lt;&lt;&lt;</A></td> <td></td> <td></td> <td><span style='text-align:right'><A href='?src=\ref[src];page=[(min(1,page+1))]'>&gt;&gt;&gt;&gt;</A></span></td></tr>"
 				dat += "</table>"
 			dat += "<BR><A href='?src=\ref[src];switchscreen=0'>(Return to main menu)</A><BR>"

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -174,6 +174,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	var/checkoutperiod = 5 // In minutes
 	var/obj/machinery/libraryscanner/scanner // Book scanner that will be used when uploading books to the Archive
 	var/libcomp_menu = list("")
+	var/page = 1	//current page of the external archives 
 	var/bibledelay = 0 // LOL NO SPAM (1 minute delay) -- Doohl
 
 /obj/machinery/computer/libraryconsole/bookmanagement/proc/build_library_menu()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -187,9 +187,10 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	
 	for(var/i in 1 to cachedbooks.len)
 		var/datum/cachedbook/C = cachedbooks[i]
-		page = round(i/250)+1
+		var/page = round(i/250)+1
 		if (libcomp_menu.len < page)
-			libcomp_menu[] = ""
+			libcomp_menu.len = page
+			libcomp_menu[page] = ""
 		libcomp_menu[page] += "<tr><td>[C.author]</td><td>[C.title]</td><td>[C.category]</td><td><A href='?src=\ref[src];targetid=[C.id]'>\[Order\]</A></td></tr>\n"
 
 /obj/machinery/computer/libraryconsole/bookmanagement/New()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -173,7 +173,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	var/list/inventory = list()
 	var/checkoutperiod = 5 // In minutes
 	var/obj/machinery/libraryscanner/scanner // Book scanner that will be used when uploading books to the Archive
-	var/libcomp_menu
+	var/libcomp_menu = list("")
 	var/bibledelay = 0 // LOL NO SPAM (1 minute delay) -- Doohl
 
 /obj/machinery/computer/libraryconsole/bookmanagement/proc/build_library_menu()
@@ -182,9 +182,14 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	load_library_db_to_cache()
 	if(!cachedbooks)
 		return
-	libcomp_menu = ""
-	for(var/datum/cachedbook/C in cachedbooks)
-		libcomp_menu += "<tr><td>[C.author]</td><td>[C.title]</td><td>[C.category]</td><td><A href='?src=\ref[src];targetid=[C.id]'>\[Order\]</A></td></tr>\n"
+	libcomp_menu = list("")
+	
+	for(var/i in 1 to cachedbooks.len)
+		var/datum/cachedbook/C = cachedbooks[i]
+		page = round(i/250)+1
+		if (libcomp_menu.len < page)
+			libcomp_menu[] = ""
+		libcomp_menu[page] += "<tr><td>[C.author]</td><td>[C.title]</td><td>[C.category]</td><td><A href='?src=\ref[src];targetid=[C.id]'>\[Order\]</A></td></tr>\n"
 
 /obj/machinery/computer/libraryconsole/bookmanagement/New()
 	..()
@@ -257,7 +262,8 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 				dat += "<A href='?src=\ref[src];orderbyid=1'>(Order book by SS<sup>13</sup>BN)</A><BR><BR>"
 				dat += "<table>"
 				dat += "<tr><td>AUTHOR</td><td>TITLE</td><td>CATEGORY</td><td></td></tr>"
-				dat += libcomp_menu
+				dat += libcomp_menu[clamp(page,1,libcomp_menu.len)]
+				dat += "<tr><td><A href='?src=\ref[src];page=[(max(1,page-1))]'>&lt;&lt;&lt;&lt;</A></td> <td></td> <td></td> <td><span style='text-align:right'><A href='?src=\ref[src];page=[(min(1,page+1))]'>&gt;&gt;&gt;&gt;</A></span></td></tr>"
 				dat += "</table>"
 			dat += "<BR><A href='?src=\ref[src];switchscreen=0'>(Return to main menu)</A><BR>"
 		if(5)
@@ -308,7 +314,8 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 		usr << browse(null, "window=library")
 		onclose(usr, "library")
 		return
-
+	if(href_list["page"] && screenstate == 4 && isnum(href_list["page"]))
+		page = text2num(href_list["page"])
 	if(href_list["switchscreen"])
 		switch(href_list["switchscreen"])
 			if("0")


### PR DESCRIPTION
250 because any less seemed like you would have to page too much to browse the archive.

All actions preserve the current page.

Page splitting and calculation is cached on first load of the external archive for that computer (has to be per-computer because the html is cached and it needs to have the src arg)
