### PR TITLE
[Ready] Fixes the 2 minutes of interface lag (such as ready button not working) when a client connects.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -67,6 +67,7 @@ calculate the longest number of ticks the MC can wait between each cycle without
 		sleep(-1)
 
 	crewmonitor.generateMiniMaps()
+	populate_asset_cache()
 
 	world << "<span class='boldannounce'>Initializations complete</span>"
 

--- a/code/controllers/subsystem/nanoUI.dm
+++ b/code/controllers/subsystem/nanoUI.dm
@@ -30,7 +30,7 @@ var/datum/subsystem/nano/SSnano
 			//Ignore directories
 			if(copytext(filename, length(filename)) != "/")
 				if(fexists(path + filename))
-					asset_files.Add(fcopy_rsc(path + filename))
+					asset_files[filename] = fcopy_rsc(path + filename)
 
 
 /datum/subsystem/nano/stat_entry()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -77,6 +77,10 @@ var/global/datum/crewmonitor/crewmonitor = new
 	src.jobs = jobs
 	src.interfaces = list()
 	src.data = list()
+	register_asset("crewmonitor.js",'crew.js')
+	register_asset("crewmonitor.css",'crew.css')
+	for (var/z = 1 to world.maxz)
+		register_asset("minimap_[z].png", file("[getMinimapFile(z)].png"))
 
 /datum/crewmonitor/Destroy()
 	if (src.interfaces)
@@ -87,6 +91,8 @@ var/global/datum/crewmonitor/crewmonitor = new
 	return ..()
 
 /datum/crewmonitor/proc/show(mob/mob, z)
+	if (mob.client)
+		sendResources(mob.client)
 	if (!z) z = mob.z
 
 	if (z > 0 && src.interfaces)
@@ -260,10 +266,11 @@ var/global/datum/crewmonitor/crewmonitor = new
 		sendResources(C)
 	initialized = TRUE
 
-/datum/crewmonitor/proc/sendResources(client/C)
-	C << browse_rsc('crew.js', "crewmonitor.js")
-	C << browse_rsc('crew.css', "crewmonitor.css")
-	for (var/z = 1 to world.maxz) C << browse_rsc(file("[getMinimapFile(z)].png"), "minimap_[z].png")
+/datum/crewmonitor/proc/sendResources(var/client/client)
+	send_asset(client, "crewmonitor.js")
+	send_asset(client, "crewmonitor.css")
+	for (var/z = 1 to world.maxz)
+		send_asset(client, "minimap_[z].png")
 
 /datum/crewmonitor/proc/getMinimapFile(z)
 	return "data/minimaps/map_[z]"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -257,8 +257,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	return
 
 /obj/item/device/pda/attack_self(mob/user)
-	var/datum/asset/simple/pda/assetcache = new()
-	send_asset_list(user, assetcache.assets, verify = FALSE)
+	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/pda)
+	assets.send(user)
+
 	user.set_machine(src)
 
 	if(active_uplink_check(user))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -256,9 +256,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		return attack_self(M)
 	return
 
-//NOTE: graphic resources are loaded on client login
 /obj/item/device/pda/attack_self(mob/user)
-
+	var/datum/asset/simple/pda/assetcache = new()
+	send_asset_list(user, assetcache.assets, verify = FALSE)
 	user.set_machine(src)
 
 	if(active_uplink_check(user))

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -1,0 +1,174 @@
+#define ASSET_CACHE_SEND_TIMEOUT 25 // Amount of time MAX to send an asset, if this get exceeded we cancel the sleeping.
+
+//List of ALL assets for the above, format is list(filename = asset).
+/var/global/list/asset_cache = list()
+
+/client
+	var/list/cache = list() // List of all assets sent to this client by the asset cache.
+	var/list/completed_asset_jobs = list() // List of all completed jobs, awaiting acknowledgement.
+	var/list/sending = list()
+	var/last_asset_job = 0 // Last job done.
+
+//This proc sends the asset to the client, but only if it needs it.
+/proc/send_asset(var/client/client, var/asset_name, var/verify = TRUE)
+	if(!istype(client))
+		if(ismob(client))
+			var/mob/M = client
+			if(M.client)
+				client = M.client
+
+			else
+				return 0
+
+		else
+			return 0
+
+	if(client.cache.Find(asset_name) || client.sending.Find(asset_name))
+		return 0
+
+	client << browse_rsc(asset_cache[asset_name], asset_name)
+	if(!verify || !winexists(client, "asset_cache_browser")) // Can't access the asset cache browser, rip.
+		client.cache += asset_name
+		return 1
+
+	client.sending |= asset_name
+	var/job = ++client.last_asset_job
+
+	client << browse({"
+	<script>
+		window.location.href="?asset_cache_confirm_arrival=[job]"
+	</script>
+	"}, "window=asset_cache_browser")
+
+	var/t = 0
+	var/timeout_time = ASSET_CACHE_SEND_TIMEOUT * client.sending.len
+	while(client && !client.completed_asset_jobs.Find(job) && t < timeout_time) // Reception is handled in Topic()
+		sleep(1) // Lock up the caller until this is received.
+		t++
+
+	if(client)
+		client.sending -= asset_name
+		client.cache |= asset_name
+		client.completed_asset_jobs -= job
+
+	return 1
+
+/proc/send_asset_list(var/client/client, var/list/asset_list, var/verify = TRUE)
+	if(!istype(client))
+		if(ismob(client))
+			var/mob/M = client
+			if(M.client)
+				client = M.client
+
+			else
+				return 0
+
+		else
+			return 0
+
+	var/list/unreceived = asset_list - (client.cache + client.sending)
+	if(!unreceived || !unreceived.len)
+		return 0
+
+	for(var/asset in unreceived)
+		client << browse_rsc(asset_cache[asset], asset)
+
+	if(!verify || !winexists(client, "asset_cache_browser")) // Can't access the asset cache browser, rip.
+		client.cache += unreceived
+		return 1
+
+	client.sending |= unreceived
+	var/job = ++client.last_asset_job
+
+	client << browse({"
+	<script>
+		window.location.href="?asset_cache_confirm_arrival=[job]"
+	</script>
+	"}, "window=asset_cache_browser")
+
+	var/t = 0
+	var/timeout_time = ASSET_CACHE_SEND_TIMEOUT * client.sending.len
+	while(client && !client.completed_asset_jobs.Find(job) && t < timeout_time) // Reception is handled in Topic()
+		sleep(1) // Lock up the caller until this is received.
+		t++
+
+	if(client)
+		client.sending -= unreceived
+		client.cache |= unreceived
+		client.completed_asset_jobs -= job
+
+	return 1
+
+//This proc "registers" an asset, it adds it to the cache for further use, you cannot touch it from this point on or you'll fuck things up.
+//if it's an icon or something be careful, you'll have to copy it before further use.
+/proc/register_asset(var/asset_name, var/asset)
+	asset_cache |= asset_name
+	asset_cache[asset_name] = asset
+
+
+//From here on out it's populating the asset cache.
+
+/proc/populate_asset_cache()
+	for(var/type in typesof(/datum/asset) - list(/datum/asset, /datum/asset/simple))
+		var/datum/asset/A = new type()
+		A.register()
+
+//These datums are used to populate the asset cache, the proc "register()" does this.
+/datum/asset/proc/register()
+	return
+
+//If you don't need anything complicated.
+/datum/asset/simple
+	var/assets = list()
+
+/datum/asset/simple/register()
+	for(var/asset_name in assets)
+		register_asset(asset_name, assets[asset_name])
+
+//DEFINITIONS FOR ASSET DATUMS START HERE.
+
+
+/datum/asset/simple/pda
+	assets = list(
+		"pda_atmos.png"			= 'icons/pda_icons/pda_atmos.png',
+		"pda_back.png"			= 'icons/pda_icons/pda_back.png',
+		"pda_bell.png"			= 'icons/pda_icons/pda_bell.png',
+		"pda_blank.png"			= 'icons/pda_icons/pda_blank.png',
+		"pda_boom.png"			= 'icons/pda_icons/pda_boom.png',
+		"pda_bucket.png"		= 'icons/pda_icons/pda_bucket.png',
+		"pda_medbot.png"		= 'icons/pda_icons/pda_medbot.png',
+		"pda_floorbot.png"		= 'icons/pda_icons/pda_floorbot.png',
+		"pda_cleanbot.png"		= 'icons/pda_icons/pda_cleanbot.png',
+		"pda_crate.png"			= 'icons/pda_icons/pda_crate.png',
+		"pda_cuffs.png"			= 'icons/pda_icons/pda_cuffs.png',
+		"pda_eject.png"			= 'icons/pda_icons/pda_eject.png',
+		"pda_exit.png"			= 'icons/pda_icons/pda_exit.png',
+		"pda_flashlight.png"	= 'icons/pda_icons/pda_flashlight.png',
+		"pda_honk.png"			= 'icons/pda_icons/pda_honk.png',
+		"pda_mail.png"			= 'icons/pda_icons/pda_mail.png',
+		"pda_medical.png"		= 'icons/pda_icons/pda_medical.png',
+		"pda_menu.png"			= 'icons/pda_icons/pda_menu.png',
+		"pda_mule.png"			= 'icons/pda_icons/pda_mule.png',
+		"pda_notes.png"			= 'icons/pda_icons/pda_notes.png',
+		"pda_power.png"			= 'icons/pda_icons/pda_power.png',
+		"pda_rdoor.png"			= 'icons/pda_icons/pda_rdoor.png',
+		"pda_reagent.png"		= 'icons/pda_icons/pda_reagent.png',
+		"pda_refresh.png"		= 'icons/pda_icons/pda_refresh.png',
+		"pda_scanner.png"		= 'icons/pda_icons/pda_scanner.png',
+		"pda_signaler.png"		= 'icons/pda_icons/pda_signaler.png',
+		"pda_status.png"		= 'icons/pda_icons/pda_status.png'
+	)
+
+
+//Registers HTML Interface assets.
+/datum/asset/HTML_interface/register()
+	for(var/path in typesof(/datum/html_interface))
+		var/datum/html_interface/hi = new path()
+		hi.registerResources()
+
+
+//Registers NanoUI assets.
+/datum/asset/NanoUI/register()
+	for(var/path in typesof(/datum/html_interface))
+		var/datum/html_interface/hi = new path()
+		hi.registerResources()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -22,7 +22,11 @@
 /client/Topic(href, href_list, hsrc)
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
-
+	if(href_list["asset_cache_confirm_arrival"])
+		src << "ASSET JOB [href_list["asset_cache_confirm_arrival"]] ARRIVED."
+		var/job = text2num(href_list["asset_cache_confirm_arrival"])
+		completed_asset_jobs += job
+		return
 	//Admin PM
 	if(href_list["priv_msg"])
 		if (href_list["ahelp_reply"])
@@ -205,6 +209,9 @@ var/next_external_rsc = 0
 
 	if (config && config.autoconvert_notes)
 		convert_notes_sql(ckey)
+
+	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
+		src << "<span class='warning'>Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you.</span>"
 
 
 	//This is down here because of the browse() calls in tooltip/New()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -324,29 +324,18 @@ var/next_external_rsc = 0
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
-
-	// Preload the crew monitor. This needs to be done due to BYOND bug http://www.byond.com/forum/?post=1487244
-	spawn
-		if (crewmonitor && crewmonitor.initialized)
-			crewmonitor.sendResources(src)
-
-	//Send nanoui files to client
-	SSnano.send_resources(src)
+	//get the common files
 	getFiles(
 		'html/search.js',
 		'html/panels.css',
 		'html/browser/common.css',
 		'html/browser/scannernew.css',
 		'html/browser/playeroptions.css',
-		'icons/stamp_icons/large_stamp-clown.png',
-		'icons/stamp_icons/large_stamp-deny.png',
-		'icons/stamp_icons/large_stamp-ok.png',
-		'icons/stamp_icons/large_stamp-hop.png',
-		'icons/stamp_icons/large_stamp-cmo.png',
-		'icons/stamp_icons/large_stamp-ce.png',
-		'icons/stamp_icons/large_stamp-hos.png',
-		'icons/stamp_icons/large_stamp-rd.png',
-		'icons/stamp_icons/large_stamp-cap.png',
-		'icons/stamp_icons/large_stamp-qm.png',
-		'icons/stamp_icons/large_stamp-law.png'
 		)
+
+	//Send nanoui files to client
+	SSnano.send_resources(src)
+
+	//Precache the client with all other assets slowly, so as to not block other browse() calls
+	getFilesSlow(src, asset_cache, register_asset = FALSE)
+

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -23,7 +23,7 @@
 	if(!usr || usr != mob)	//stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
 	if(href_list["asset_cache_confirm_arrival"])
-		src << "ASSET JOB [href_list["asset_cache_confirm_arrival"]] ARRIVED."
+		//src << "ASSET JOB [href_list["asset_cache_confirm_arrival"]] ARRIVED."
 		var/job = text2num(href_list["asset_cache_confirm_arrival"])
 		completed_asset_jobs += job
 		return

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -318,13 +318,6 @@ var/next_external_rsc = 0
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()
 
-	spawn
-		// Preload the HTML interface. This needs to be done due to BYOND bug http://www.byond.com/forum/?post=1487244
-		var/datum/html_interface/hi
-		for (var/type in typesof(/datum/html_interface))
-			hi = new type(null)
-			hi.sendResources(src)
-
 	// Preload the crew monitor. This needs to be done due to BYOND bug http://www.byond.com/forum/?post=1487244
 	spawn
 		if (crewmonitor && crewmonitor.initialized)
@@ -338,33 +331,6 @@ var/next_external_rsc = 0
 		'html/browser/common.css',
 		'html/browser/scannernew.css',
 		'html/browser/playeroptions.css',
-		'icons/pda_icons/pda_atmos.png',
-		'icons/pda_icons/pda_back.png',
-		'icons/pda_icons/pda_bell.png',
-		'icons/pda_icons/pda_blank.png',
-		'icons/pda_icons/pda_boom.png',
-		'icons/pda_icons/pda_bucket.png',
-		'icons/pda_icons/pda_medbot.png',
-		'icons/pda_icons/pda_floorbot.png',
-		'icons/pda_icons/pda_cleanbot.png',
-		'icons/pda_icons/pda_crate.png',
-		'icons/pda_icons/pda_cuffs.png',
-		'icons/pda_icons/pda_eject.png',
-		'icons/pda_icons/pda_exit.png',
-		'icons/pda_icons/pda_flashlight.png',
-		'icons/pda_icons/pda_honk.png',
-		'icons/pda_icons/pda_mail.png',
-		'icons/pda_icons/pda_medical.png',
-		'icons/pda_icons/pda_menu.png',
-		'icons/pda_icons/pda_mule.png',
-		'icons/pda_icons/pda_notes.png',
-		'icons/pda_icons/pda_power.png',
-		'icons/pda_icons/pda_rdoor.png',
-		'icons/pda_icons/pda_reagent.png',
-		'icons/pda_icons/pda_refresh.png',
-		'icons/pda_icons/pda_scanner.png',
-		'icons/pda_icons/pda_signaler.png',
-		'icons/pda_icons/pda_status.png',
 		'icons/stamp_icons/large_stamp-clown.png',
 		'icons/stamp_icons/large_stamp-deny.png',
 		'icons/stamp_icons/large_stamp-ok.png',

--- a/code/modules/html_interface/cards/cards.dm
+++ b/code/modules/html_interface/cards/cards.dm
@@ -7,8 +7,7 @@
 	src.head = src.head + "<link rel=\"stylesheet\" type=\"text/css\" href=\"cards.css\" />"
 	src.updateLayout("<div id=\"headbar\"></div><div class=\"wrapper\"><table><tr><td style=\"vertical-align: middle;\"><div id=\"hand\"></div></td></tr></table></div>")
 
-/datum/html_interface/cards/sendResources(client/client)
-	. = ..() // we need the default resources
-
-	client << browse_rsc('cards.css')
-	client << browse_rsc('cards.png')
+/datum/html_interface/cards/registerResources(var/list/resources = list())
+	resources["cards.css"] = 'cards.css'
+	resources["cards.png"] = 'cards.png'
+	..(resources)

--- a/code/modules/html_interface/html_interface.dm
+++ b/code/modules/html_interface/html_interface.dm
@@ -63,6 +63,8 @@ Closes the interface on all clients.
 When working with byond:// links make sure to reference the HTML interface object and NOT the original object. Topic() will still be called on
 your object, but it will pass through the HTML interface first allowing interception at a higher level.
 
+If you want to use custom resources(images/css/js) with an existing interface:
+You have to use modules/client/asset_cache to ensure they get sent BEFORE the interface opens
 
 	** Sample code **
 
@@ -105,6 +107,10 @@ mob/verb/test()
 	// The initial height of the browser control, used when the window is first shown to a client.
 	var/height
 
+	// A type associated list of assets the interface needs.
+	//Sent to the client when the interface opens on the client for the first time.
+	var/static/asset_list = list()
+
 /datum/html_interface/New(atom/ref, title, width = 700, height = 480, head = "")
 	html_interfaces.Add(src)
 
@@ -126,12 +132,19 @@ mob/verb/test()
 /*                 * Hooks */
 /datum/html_interface/proc/specificRenderTitle(datum/html_interface_client/hclient, ignore_cache = FALSE)
 
-/datum/html_interface/proc/sendResources(client/client)
-	client << browse_rsc('js/jquery.min.js', "jquery.min.js")
-	client << browse_rsc('js/bootstrap.min.js', "bootstrap.min.js")
-	client << browse_rsc('css/bootstrap.min.css', "bootstrap.min.css")
-	client << browse_rsc('css/html_interface.css', "html_interface.css")
-	client << browse_rsc('js/html_interface.js', "html_interface.js")
+//if you need to override this, either call ..() or add your resources to asset_list
+/datum/html_interface/proc/registerResources(var/list/resources = list())
+	resources["jquery.min.js"] = 'js/jquery.min.js'
+	resources["bootstrap.min.js"] = 'js/bootstrap.min.js'
+	resources["bootstrap.min.css"] = 'css/bootstrap.min.css'
+	resources["html_interface.css"] = 'css/html_interface.css'
+	resources["html_interface.js"] = 'js/html_interface.js'
+	var/assetlist = list()
+	for (var/R in resources)
+		register_asset(R,resources[R])
+		assetlist += R
+
+	asset_list[type] = assetlist
 
 /datum/html_interface/proc/createWindow(datum/html_interface_client/hclient)
 	winclone(hclient.client, "window", "browser_\ref[src]")
@@ -207,10 +220,7 @@ mob/verb/test()
 	hclient = getClient(hclient, TRUE)
 
 	if (istype(hclient))
-		// This needs to be commented out due to BYOND bug http://www.byond.com/forum/?post=1487244
-		// /client/proc/send_resources() executes this per client to avoid the bug, but by using it here files may be deleted just as the HTML is loaded,
-		// causing file not found errors.
-//		src.sendResources(hclient.client)
+		send_asset_list(hclient.client,asset_list[type], TRUE)
 
 		if (!winexists(hclient.client, "browser_\ref[src]"))
 			src.createWindow(hclient)

--- a/code/modules/html_interface/nanotrasen/nanotrasen.dm
+++ b/code/modules/html_interface/nanotrasen/nanotrasen.dm
@@ -29,12 +29,11 @@ The client is optional and may be a /mob, /client or /html_interface_client obje
 	// Update the title in our custom header (in addition to default functionality)
 	winset(hclient.client, "browser_\ref[src].uiTitle", list2params(list("text" = "[src.title]")))
 
-/datum/html_interface/nanotrasen/sendResources(client/client)
-	. = ..() // we need the default resources
-
-	client << browse_rsc('uiBg.png')
-	client << browse_rsc('uiBgcenter.png')
-	client << browse_rsc('nanotrasen.css')
+/datum/html_interface/nanotrasen/registerResources(var/list/resources = list())
+	resources["uiBg.png"] = 'uiBg.png'
+	resources["uiBgcenter.png"] = 'uiBgcenter.png'
+	resources["nanotrasen.css"] = 'nanotrasen.css'
+	..(resources)
 
 /datum/html_interface/nanotrasen/createWindow(datum/html_interface_client/hclient)
 	. = ..() // we want the default window

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -208,5 +208,4 @@
 
 //Send all needed nano ui files to the client
 /datum/subsystem/nano/proc/send_resources(client)
-	for(var/file in asset_files)
-		client << browse_rsc(file)
+	getFilesSlow(client, asset_files)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -51,6 +51,9 @@
 
 /obj/item/weapon/paper/examine(mob/user)
 	..()
+	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/paper)
+	assets.send(user)
+
 	if(istype(src, /obj/item/weapon/paper/talisman)) //Talismans cannot be read
 		if(!iscultist(user) && !user.stat)
 			user << "<span class='danger'>There are indecipherable images scrawled on the paper in what looks to be... <i>blood?</i></span>"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1606,6 +1606,32 @@ window "mainwindow"
 		macro = "macro"
 		menu = "menu"
 		on-close = ""
+	elem "asset_cache_browser"
+		type = BROWSER
+		pos = 424,208
+		size = 1x1
+		anchor1 = none
+		anchor2 = none
+		font-family = ""
+		font-size = 0
+		font-style = ""
+		text-color = #000000
+		background-color = none
+		is-visible = false
+		is-disabled = false
+		is-transparent = false
+		is-default = false
+		border = none
+		drop-zone = false
+		right-click = false
+		saved-params = ""
+		on-size = ""
+		show-history = false
+		show-url = false
+		auto-format = true
+		use-title = false
+		on-show = ""
+		on-hide = ""
 	elem "hotkey_toggle"
 		type = BUTTON
 		pos = 560,420

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -923,6 +923,7 @@
 #include "code\modules\awaymissions\mission_code\spacebattle.dm"
 #include "code\modules\awaymissions\mission_code\stationCollision.dm"
 #include "code\modules\awaymissions\mission_code\wildwest.dm"
+#include "code\modules\client\asset_cache.dm"
 #include "code\modules\client\client defines.dm"
 #include "code\modules\client\client procs.dm"
 #include "code\modules\client\message.dm"


### PR DESCRIPTION
This is a port of /vg/'s asset cache system. Thanks @PJB3005

Byond will queue all browse(), browse_rsc(), and winset() calls to the client, to ensure they load in order, and ensure any resources from a browse_rsc call (css/html/js) are already at the client by the time any html windows loads.

How ever, each file/call is processed separately, and byond will wait for the reply from the client before it will send the next file.

Our current system sends all of these html resource files to the client at once when they connect, this is the sole cause of the lag when a client connects. Byond will not send the client a file it already has, but it has to ask the client first, and it does so one file at a time, waiting for a reply from the client before sending the next request down the pipe.

This system fixes that.

Basically it works like this:
Client connects: nothing happens, no massive queuing of browse_rsc() calls, so no interface delay
Client opens a asset_cache controlled html based interface
Asset cache gets notified by the html based interface what assets the client needs to have.
Asset cache checks to see if it's sent that client those files.
Asset cache sends the missing ones, adding them to the list of assets the client has.

This basically spreads out the delay to when you first open a window that uses resources, where it is much more manageable. But ensures it doesn't queue these calls more than once for a given client on a given connection. (this list is stored on the /client/ so that if they re-connect on a different version it doesn't break things)

I've kinda done a halfass port without too much thought, I see some room for improvement to better fit /tg/'s coding style and make the system more flexible. I'm PRing this because if I don't, it will never get finished.

PDAs and html_interface has been imported into the new system lazily to test. at 100ms fake lag, client interface lag on connection went from **35 seconds to ~~16~~ 2 seconds**. ~~Nanoui hasn't been imported, and once it is, that should drop down to almost nothing.~~

I'm going to hold off on properly adding nanoui into this system, until after the bay nanoui port. The current implementation prevents it from causing the lag, but might cause oddites if a first time user or somebody with a cache opens a nano ui window in the first 60 seconds of connecting.

I tested crew monitor, pdas, cryo, apcs, coms console, medical record, security record,

no runtimes or odd errors.

:cl:
bugfix: fixes interfaces (like the "ready" button) being unresponsive for the first minute or two after connecting.
/:cl:
