### PR TITLE
ID into PDA without PDA in your inventory and a few other similar things

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -790,10 +790,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			remove_id()
 		else
 			usr << "<span class='warning'>This PDA does not have an ID in it!</span>"
-	if (usr.restrained())
-		usr << "<span class='warning'>You cannot do that while restrained!</span>"
-	else
-		return
 
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = "Object"
@@ -808,9 +804,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			remove_id()
 		else
 			usr << "<span class='warning'>This PDA does not have an ID in it!</span>"
-	else
-		usr << "<span class='warning'>You cannot do that while restrained!</span>"
-
 
 /obj/item/device/pda/verb/verb_remove_pen()
 	set category = "Object"
@@ -832,8 +825,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			O.loc = get_turf(src)
 		else
 			usr << "<span class='warning'>This PDA does not have a pen in it!</span>"
-	else
-		usr << "<span class='warning'>You cannot do that while restrained!</span>"
 
 /obj/item/device/pda/proc/id_check(mob/user, choice as num)//To check for IDs; 1 for in-pda use, 2 for out of pda use.
 	if(choice == 1)
@@ -882,11 +873,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
 			if(((src in user.contents) && (C in user.contents)) || (istype(loc, /turf) && in_range(src, user) && (C in user.contents)) )
-				if(user.canUseTopic(src))//If they can still act.
-					if(!id_check(user, 2))
-						return
-					user << "<span class='notice'>You put the ID into \the [src]'s slot.</span>"
-					updateSelfDialog()//Update self dialog on success.
+				if(!id_check(user, 2))
+					return
+				user << "<span class='notice'>You put the ID into \the [src]'s slot.</span>"
+				updateSelfDialog()//Update self dialog on success.
 			return	//Return in case of failed check or when successful.
 		updateSelfDialog()//For the non-input related code.
 	else if(istype(C, /obj/item/device/paicard) && !src.pai)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -237,7 +237,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(user && ismob(user))
 		if(user.incapacitated())
 			return 0
-		if(loc == user)
+		else
 			return 1
 	return 0
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -233,14 +233,6 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/proc/update_label()
 	name = "PDA-[owner] ([ownjob])" //Name generalisation
 
-/obj/item/device/pda/proc/can_use(mob/user)
-	if(user && ismob(user))
-		if(user.incapacitated())
-			return 0
-		else
-			return 1
-	return 0
-
 /obj/item/device/pda/GetAccess()
 	if(id)
 		return id.GetAccess()
@@ -252,7 +244,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/MouseDrop(obj/over_object, src_location, over_location)
 	var/mob/M = usr
-	if((!istype(over_object, /obj/screen)) && can_use(M))
+	if((!istype(over_object, /obj/screen)) && usr.canUseTopic(src))
 		return attack_self(M)
 	return
 
@@ -450,9 +442,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	..()
 	var/mob/living/U = usr
 	//Looking for master was kind of pointless since PDAs don't appear to have one.
-	//if ((src in U.contents) || ( istype(loc, /turf) && in_range(src, U) ) )
 
-	if(can_use(U)) //Why reinvent the wheel? There's a proc that does exactly that.
+	if(usr.canUseTopic(src))
 		add_fingerprint(U)
 		U.set_machine(src)
 
@@ -710,7 +701,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		return
 	if (!in_range(src, U) && loc != U)
 		return
-	if(!can_use(U))
+	if(!U.canUseTopic(src))
 		return
 	if(emped)
 		t = Gibberish(t, 100)
@@ -794,13 +785,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if(can_use(usr))
+	if(usr.canUseTopic(src))
 		if(id)
 			remove_id()
 		else
 			usr << "<span class='warning'>This PDA does not have an ID in it!</span>"
-	else
+	if (usr.restrained())
 		usr << "<span class='warning'>You cannot do that while restrained!</span>"
+	else
+		return
 
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = "Object"
@@ -810,7 +803,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if ( can_use(usr) )
+	if (usr.canUseTopic(src))
 		if(id)
 			remove_id()
 		else
@@ -827,7 +820,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(issilicon(usr))
 		return
 
-	if ( can_use(usr) )
+	if (usr.canUseTopic(src))
 		var/obj/item/weapon/pen/O = locate() in src
 		if(O)
 			if (istype(loc, /mob))
@@ -889,7 +882,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		else
 			//Basic safety check. If either both objects are held by user or PDA is on ground and card is in hand.
 			if(((src in user.contents) && (C in user.contents)) || (istype(loc, /turf) && in_range(src, user) && (C in user.contents)) )
-				if( can_use(user) )//If they can still act.
+				if(user.canUseTopic(src))//If they can still act.
 					if(!id_check(user, 2))
 						return
 					user << "<span class='notice'>You put the ID into \the [src]'s slot.</span>"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -260,9 +260,6 @@
 		var/obj/item/device/flashlight/seclite/S = A
 		if(can_flashlight)
 			if(!F)
-				if(user.l_hand != src && user.r_hand != src)
-					user << "<span class='warning'>You'll need [src] in your hands to do that!</span>"
-					return
 				if(!user.unEquip(A))
 					return
 				user << "<span class='notice'>You click [S] into place on [src].</span>"
@@ -276,9 +273,6 @@
 
 	if(istype(A, /obj/item/weapon/screwdriver))
 		if(F)
-			if(user.l_hand != src && user.r_hand != src)
-				user << "<span class='warning'>You'll need [src] in your hands to do that!</span>"
-				return
 			for(var/obj/item/device/flashlight/seclite/S in src)
 				user << "<span class='notice'>You unscrew the seclite from [src].</span>"
 				F = null

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -65,9 +65,6 @@
 		var/obj/item/weapon/suppressor/S = A
 		if(can_suppress)
 			if(!suppressed)
-				if(user.l_hand != src && user.r_hand != src)
-					user << "<span class='notice'>You'll need [src] in your hands to do that.</span>"
-					return
 				if(!user.unEquip(A))
 					return
 				user << "<span class='notice'>You screw [S] onto [src].</span>"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,6 +8,7 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 Optimumtact = Host
+kingofkosmos = Game Master
 MrStonedOne = Game Master
 microscopics = Game Master
 Gun Hog = Game Master


### PR DESCRIPTION
Enables putting an ID into a PDA when the PDA is not in your inventory, e.g. the floor. This was probably an unreported bug because [this comment says it should work](https://github.com/tgstation/-tg-station/blob/d454eae1b1f84c2dac30bc29ee1c0917572c1897/code/game/objects/items/devices/PDA/PDA.dm#L890) but it doesn't.

Also fixes another unreported bug of altclicking a PDA on the floor to eject an ID, it always gave the message "You cannot do that while restrained!".

Also removes the same must-be-in-hands-requirements from attaching seclite to taser, and suppressor to gun, since every other item-combining action in the game can happen while the item is lying on the floor.
