### PR TITLE
Adds syndiesoap to gangtools

### DIFF
--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -135,6 +135,12 @@
 			dat += "<a href='?src=\ref[src];purchase=spraycan'>Territory Spraycan</a><br>"
 		else
 			dat += "Territory Spraycan<br>"
+			
+		dat += "(5 Influence) "
+		if(points >= 5)
+			dat += "<a href='?src=\ref[src];purchase=soap'>Syndicate Soap</a><br>"
+		else
+			dat +="Syndicate Soap<br>"
 
 		dat += "(10 Influence) "
 		if(points >= 10)
@@ -204,6 +210,10 @@
 			if("spraycan")
 				if(gang.points >= 5)
 					item_type = /obj/item/toy/crayon/spraycan/gang
+					pointcost = 5
+			if("soap")
+				if(gang.points >= 5)
+					item_type = /obj/item/weapon/soap/syndie
 					pointcost = 5
 			if("switchblade")
 				if(gang.points >= 10)


### PR DESCRIPTION
Adds syndiesoap to gangtools, purchasable by all gang types for 5 influence.

[From this suggestion.](https://tgstation13.org/phpBB/viewtopic.php?f=9&t=30&view=unread#p134090)

I'm very open to feedback.

:cl: PKPenguin321
rscadd: Gangsters are now able to purchase syndicate soap from their gangtools for 5 influence.
/:cl:
