### PR TITLE
Adds Light Replacer Refilling With Box of Lights

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -116,14 +116,14 @@
 						break
 
 		if(!found_good_light)
-			user << "<span class='warning'>The [S.name] contains no useable lights!</span>"
+			user << "<span class='warning'>\The [S] contains no useable lights!</span>"
 			return
 
 		if(!replaced_something && src.uses == max_uses)
-			user << "<span class='warning'>The [src.name] is full!</span>"
+			user << "<span class='warning'>\The [src] is full!</span>"
 			return
 
-		user << "<span class='notice'>You fill the [src.name] with lights from the [S.name]. You have [uses] lights remaining.</span>"
+		user << "<span class='notice'>You fill \the [src] with lights from \the [S]. You have [uses] lights remaining.</span>"
 
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -100,15 +100,24 @@
 
 	if(istype(W, /obj/item/weapon/storage/box/lights))
 		var/obj/item/weapon/storage/box/lights/B = W
-		if(!B.contents.len)
-			user << "<span class='warning'>The [B.name] is empty!</span>"
+		var/tmp/useable_lights = 0
+		for(var/obj/item/weapon/light/L in B.contents)
+			if(L.status == 0) // If the light is not broken or burned out
+				useable_lights = 1
+				break
+		if(!useable_lights) // This check necessitates the loop above, as I figure it to be useful to know the box has no useable lights first.
+			user << "<span class='warning'>The [B.name] contains no useable lights!</span>"
 		else if(uses == max_uses)
 			user << "<span class='warning'>The [src.name] is full!</span>"
 		else
 			B.close_all()
-			while(src.uses < max_uses && B.contents.len > 0)
-				B.contents.Cut(1,2)
-				AddUses(1)
+			for(var/obj/item/weapon/light/L in B.contents)
+				if(L.status == 0) // Don't want to allow broken or burnt out lights to be useable
+					if(src.uses < max_uses)
+						qdel(L)
+						AddUses(1)
+					else
+						break
 			user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
 		return
 

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -98,6 +98,20 @@
 			user << "<span class='warning'>You need a working light!</span>"
 			return
 
+		if(istype(W, /obj/item/weapon/storage/box/lights))
+			var/obj/item/weapon/storage/box/lights/B = W
+			if(!B.contents.len)
+				user << "<span class='warning'>The [B.name] is empty!</span>"
+			else if(uses == max_uses)
+				user << "<span class='warning'>The [src.name] is full!</span>"
+			else
+				B.close_all()
+				while(src.uses < max_uses && B.contents.len > 0)
+					B.contents.Cut(1,2)
+					AddUses(1)
+				user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
+			return
+
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)
 		Emag()

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -100,26 +100,30 @@
 
 	if(istype(W, /obj/item/weapon/storage/box/lights))
 		var/obj/item/weapon/storage/box/lights/B = W
-		var/tmp/useable_lights = 0
-		for(var/obj/item/weapon/light/L in B.contents)
-			if(L.status == 0) // If the light is not broken or burned out
-				useable_lights = 1
-				break
-		if(!useable_lights) // This check necessitates the loop above, as I figure it to be useful to know the box has no useable lights first.
-			user << "<span class='warning'>The [B.name] contains no useable lights!</span>"
-		else if(uses == max_uses)
-			user << "<span class='warning'>The [src.name] is full!</span>"
+		var/tmp/replacement_status = 1 // 0-useable lights found, 1-no useable lights, 2-light replacer was full
+
+		if(src.uses == max_uses)
+			if(!B.contents.len) // empty box
+				replacement_status = 1
+			else // I REAALLYYY want 'no useable lights' to be the primary warning
+				replacement_status = 2
 		else
-			B.close_all()
 			for(var/obj/item/weapon/light/L in B.contents)
 				if(L.status == 0) // Don't want to allow broken or burnt out lights to be useable
+					replacement_status = 0
 					if(src.uses < max_uses)
 						qdel(L)
 						AddUses(1)
 					else
 						break
-			user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
-		return
+
+		if(replacement_status == 1)
+			user << "<span class='warning'>The [B.name] contains no useable lights!</span>"
+			return
+		else if(replacement_status == 2)
+			user << "<span class='warning'>The [src.name] is full!</span>"
+			return
+		user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
 
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -98,32 +98,32 @@
 			user << "<span class='warning'>You need a working light!</span>"
 			return
 
-	if(istype(W, /obj/item/weapon/storage/box/lights))
-		var/obj/item/weapon/storage/box/lights/B = W
-		var/tmp/replacement_status = 1 // 0-useable lights found, 1-no useable lights, 2-light replacer was full
+	if(istype(W, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = W
+		var/found_good_light = 0
+		var/replaced_something = 0
 
-		if(src.uses == max_uses)
-			if(!B.contents.len) // empty box
-				replacement_status = 1
-			else // I REAALLYYY want 'no useable lights' to be the primary warning
-				replacement_status = 2
-		else
-			for(var/obj/item/weapon/light/L in B.contents)
-				if(L.status == 0) // Don't want to allow broken or burnt out lights to be useable
-					replacement_status = 0
+		for(var/obj/item/I in S.contents)
+			if(istype(I,/obj/item/weapon/light))
+				var/obj/item/weapon/light/L = I
+				if(L.status == LIGHT_OK)
+					found_good_light = 1
 					if(src.uses < max_uses)
 						qdel(L)
 						AddUses(1)
+						replaced_something = 1
 					else
 						break
 
-		if(replacement_status == 1)
-			user << "<span class='warning'>The [B.name] contains no useable lights!</span>"
+		if(!found_good_light)
+			user << "<span class='warning'>The [S.name] contains no useable lights!</span>"
 			return
-		else if(replacement_status == 2)
+
+		if(!replaced_something && src.uses == max_uses)
 			user << "<span class='warning'>The [src.name] is full!</span>"
 			return
-		user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
+
+		user << "<span class='notice'>You fill the [src.name] with lights from the [S.name]. You have [uses] lights remaining.</span>"
 
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -98,19 +98,19 @@
 			user << "<span class='warning'>You need a working light!</span>"
 			return
 
-		if(istype(W, /obj/item/weapon/storage/box/lights))
-			var/obj/item/weapon/storage/box/lights/B = W
-			if(!B.contents.len)
-				user << "<span class='warning'>The [B.name] is empty!</span>"
-			else if(uses == max_uses)
-				user << "<span class='warning'>The [src.name] is full!</span>"
-			else
-				B.close_all()
-				while(src.uses < max_uses && B.contents.len > 0)
-					B.contents.Cut(1,2)
-					AddUses(1)
-				user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
-			return
+	if(istype(W, /obj/item/weapon/storage/box/lights))
+		var/obj/item/weapon/storage/box/lights/B = W
+		if(!B.contents.len)
+			user << "<span class='warning'>The [B.name] is empty!</span>"
+		else if(uses == max_uses)
+			user << "<span class='warning'>The [src.name] is full!</span>"
+		else
+			B.close_all()
+			while(src.uses < max_uses && B.contents.len > 0)
+				B.contents.Cut(1,2)
+				AddUses(1)
+			user << "<span class='notice'>You fill the [src.name] with lights from the [B.name]. You have [uses] lights remaining.</span>"
+		return
 
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)


### PR DESCRIPTION
Adds the ability to refill a light replacer using a box of lights.

A box of lights specifically must be used, broken or burnt out lights will not be used, and the amount of lights used will only be as many as it takes to fill the replacer to capacity.

:cl:
rscadd: Added the ability to use a box of lights on a light replacer to more quickly refill it to capacity.
/:cl:
