### PR TITLE
HoG fountains now give an omnizine-like reagent instead of Doctor's Delight + Typo Fix

### DIFF
--- a/code/game/gamemodes/handofgod/structures.dm
+++ b/code/game/gamemodes/handofgod/structures.dm
@@ -399,7 +399,7 @@
 		user.reagents.add_reagent("hell_water",20)
 	else
 		user << "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>"
-		user.reagents.add_reagent("omnizine",20)
+		user.reagents.add_reagent("godblood",20)
 	update_icons()
 	spawn(time_between_uses)
 		if(src)

--- a/code/game/gamemodes/handofgod/structures.dm
+++ b/code/game/gamemodes/handofgod/structures.dm
@@ -217,7 +217,7 @@
 
 /obj/structure/divine/nexus
 	name = "nexus"
-	desc = "It anchors a deity to this world. It radiates an unusual aura. Cultists protect this at all costs. It looks well protected from explosion shock."
+	desc = "It anchors a deity to this world. It radiates an unusual aura. Cultists protect this at all costs. It looks well protected from explosive shock."
 	icon_state = "nexus"
 	health = 500
 	maxhealth = 500

--- a/code/game/gamemodes/handofgod/structures.dm
+++ b/code/game/gamemodes/handofgod/structures.dm
@@ -399,7 +399,7 @@
 		user.reagents.add_reagent("hell_water",20)
 	else
 		user << "<span class='notice'>The water feels warm and soothing as you touch it. The fountain immediately dries up shortly afterwards.</span>"
-		user.reagents.add_reagent("doctorsdelight",20)
+		user.reagents.add_reagent("omnizine",20)
 	update_icons()
 	spawn(time_between_uses)
 		if(src)

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -240,6 +240,12 @@
 	M.adjustBrainLoss(5)
 	holder.remove_reagent(src.id, 1)
 
+/datum/reagent/medicine/omnizine/godblood
+	name = "Godblood"
+	id = "godblood"
+	description = "Slowly heals all damage types. Has a rather high overdose threshold. Glows with mysterious power."
+	overdose_threshold = 150
+
 /datum/reagent/lube
 	name = "Space Lube"
 	id = "lube"


### PR DESCRIPTION
Doctors Delight has piss-poor healing properties since goofball nerfed it to death, and also drains your nutrition unless you're a doctor. This makes it not a very good chem for a structure that's designed to heal you. ~~This PR changes the chemical to omnizine. 20u of omnizine wont overdose and will heal a very decent amount with essentially no drawbacks.~~ This PR adds a new chemical called Godblood that is identical to omnizine except that it has an OD threshold of 150, and sets the fountains to dispense that, instead.

Fixes #13066  (hopefully)

Also fixes a typo in the description for the Nexus.

Fixes #13084

@RemieRichards If you intend to add a check for enemy cultists and need to edit this file, feel free to close this PR and include this change in yours so you don't have to deal with merge conflicts.

:cl: PKPenguin321
tweak: Healing Fountains in Hand of God now give cultists a better and more culty healing chemical instead of Doctor's Delight.
/:cl:
