### PR TITLE
A number of nerfs and buffs to stunning spells

### DIFF
--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/targeted/lightning
 	name = "Lightning Bolt"
-	desc = "Throws a lightning bolt at the nearby enemy. Classic."
+	desc = "Charges up and throws a lightning bolt at nearby enemies. Classic."
 	charge_type = "recharge"
 	charge_max	= 300
 	clothes_req = 1
@@ -10,7 +10,6 @@
 	cooldown_min = 30
 	selection_type = "view"
 	random_target = 1
-	var/start_time = 0
 	var/ready = 0
 	var/image/halo = null
 	var/sound/Snd // so far only way i can think of to stop a sound, thank MSO for the idea.
@@ -18,12 +17,8 @@
 	action_icon_state = "lightning"
 
 /obj/effect/proc_holder/spell/targeted/lightning/Click()
-	if(!ready && start_time==0)
-		if(cast_check())
-			StartChargeup()
-	else
-		if(ready && cast_check(skipcharge=1))
-			choose_targets()
+	if(!ready && cast_check())
+		StartChargeup()
 	return 1
 
 /obj/effect/proc_holder/spell/targeted/lightning/proc/StartChargeup(mob/user = usr)
@@ -33,14 +28,14 @@
 	halo = image("icon"='icons/effects/effects.dmi',"icon_state" ="electricity","layer" = EFFECTS_LAYER)
 	user.overlays.Add(halo)
 	playsound(get_turf(usr), Snd, 50, 0)
-	start_time = world.time
 	if(do_mob(user,user,100,uninterruptible=1))
-		if(ready)
-			Discharge()
+		if(ready && cast_check(skipcharge=1))
+			choose_targets()
+		else
+			Reset(user)
 
 /obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 	ready = 0
-	start_time = 0
 	if(halo)
 		user.overlays.Remove(halo)
 
@@ -48,14 +43,6 @@
 	user << "<span class='notice'>No target found in range.</span>"
 	Reset(user)
 	..()
-
-/obj/effect/proc_holder/spell/targeted/lightning/proc/Discharge(mob/user = usr)
-	var/mob/living/M = user
-	//M.electrocute_act(25,"Lightning Bolt")
-	M << "<span class='danger'>You lose control over the spell.</span>"
-	Reset(user)
-	start_recharge()
-
 
 /obj/effect/proc_holder/spell/targeted/lightning/cast(list/targets, mob/user = usr)
 	ready = 0
@@ -70,8 +57,7 @@
 	playsound(get_turf(usr), 'sound/magic/lightningbolt.ogg', 50, 1)
 	user.Beam(target,icon_state="lightning",icon='icons/effects/effects.dmi',time=5)
 
-	var/energy = min(world.time - start_time,100)
-	Bolt(user,target,max(15,energy/2),5,user) //5 bounces for energy/2 burn
+	Bolt(user,target,30,5,user)
 	Reset(user)
 
 /obj/effect/proc_holder/spell/targeted/lightning/proc/Bolt(mob/origin,mob/target,bolt_energy,bounces,mob/user = usr)
@@ -92,4 +78,4 @@
 			return
 		var/mob/living/next = pick(possible_targets)
 		if(next)
-			Bolt(current,next,bolt_energy,bounces-1,user)
+			Bolt(current,next,max((bolt_energy-5),5),bounces-1,user)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -3,12 +3,12 @@
 	desc = "This spell fires several, slow moving, magic projectiles at nearby targets."
 
 	school = "evocation"
-	charge_max = 150
+	charge_max = 200
 	clothes_req = 1
 	invocation = "FORTI GY AMA"
 	invocation_type = "shout"
 	range = 7
-	cooldown_min = 90 //15 deciseconds reduction per rank
+	cooldown_min = 60 //35 deciseconds reduction per rank
 
 	max_targets = 0
 
@@ -159,12 +159,12 @@
 /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	name = "Stop Time"
 	desc = "This spell stops time for everyone except for you, allowing you to move freely while your enemies and even projectiles are frozen."
-	charge_max = 400
+	charge_max = 500
 	clothes_req = 1
 	invocation = "TOKI WO TOMARE"
 	invocation_type = "shout"
 	range = 0
-	cooldown_min = 90
+	cooldown_min = 100
 	summon_amt = 1
 	action_icon_state = "time"
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -525,7 +525,7 @@
 
 
 /obj/effect/timestop/wizard
-	duration = 90
+	duration = 100
 
 
 /obj/item/stack/tile/bluespace


### PR DESCRIPTION
Lightning Bolt:
- You can no longer throw the bolt whenever you want, it will fire itself once it's done charging. Fixes #12849
- Getting hit by a bolt will do a flat 30 burn now, as opposed to scaling with how long you spent charging the spell. Unless you made a habit of charging lightning bolt to near maximum every time you cast it this is a buff.
- Every time the bolt jumps the next shock will do five less burn damage.
- Lightning bolts can still jump back to the same body, so the maximum number of bolts you can be hit by in a single casting is three, and the maximum amount of damage you could take for that is 60 burn.

Magic Missile:
- Cooldown raised to 20 seconds, up from 15
- Cooldown reduction from taking the spell multiple times raised from 1.5 seconds to 3.5 seconds. Rank 5 magic missile now has a cooldown of 6 seconds, down from 9, and is effectively a permastun.

Time Stop:
- Time Stop field now persists for 10 seconds, up from 9
- Cooldown raised to 50 seconds, up from 40
- Cooldown reduction from taking the spell multiple times raised from  7.75 seconds to 10 seconds. Rank 5 time stop now has a cooldown of 10 seconds, up from 9, and is effectively a permastun.

:cl: Incoming5643
experiment: A number of popular stunning spells have undergone balance changes. Note that for the most part the stuns themselves are untouched.
experiment: Lightning Bolt Changes:
rscdel: You can no longer throw the bolt whenever you want, it will fire itself once it's done charging.
rscadd: Getting hit by a bolt will do a flat 30 burn now, as opposed to scaling with how long the wizard spent charging the spell. Unless said wizard made a habit of charging lightning bolt to near maximum every time this is a buff to damage.
rscdel: Every time the bolt jumps the next shock will do five less burn damage.
rscadd:  Lightning bolts can still jump back to the same body, so the maximum number of bolts you can be hit by in a single casting is three, and the maximum amount of damage you could take for that is 60 burn.
experiment: Magic Missile Changes:
rscdel: Cooldown raised to 20 seconds, up from 15
rscadd: Cooldown reduction from taking the spell multiple times raised from 1.5 seconds to 3.5 seconds. Rank 5 magic missile now has a cooldown of 6 seconds, down from 9, and is effectively a permastun.
experiment: Time Stop Changes:
rscadd: Time Stop field now persists for 10 seconds, up from 9
rscdel: Cooldown raised to 50 seconds, up from 40
rscadd: Cooldown reduction from taking the spell multiple times raised from  7.75 seconds to 10 seconds. Rank 5 time stop now has a cooldown of 10 seconds, up from 9, and is effectively a permastun.
/:cl:
