### PR TITLE
Synthflesh now correctly heals instead of kills

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -287,8 +287,8 @@
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(PATCH, TOUCH))
-			M.adjustBruteLoss(1.25 * reac_volume)
-			M.adjustFireLoss(1.25 * reac_volume)
+			M.adjustBruteLoss(-1.25 * reac_volume)
+			M.adjustFireLoss(-1.25 * reac_volume)
 			if(show_message)
 				M << "<span class='danger'>You feel your burns and bruises healing! It stings like hell!</span>"
 	..()


### PR DESCRIPTION
:cl:
oranges
tweak: Nanotrasen apologies for a recent bad batch of synthflesh that was shipped to the station, any rumours of death or serious injury are false and should be reported to your nearest political officer. At most, only light burns would result.
/:cl:

As funny as that was, it's not the intent, which was instead a slight nerf to synthflesh.

Fixes #13087
