### PR TITLE
Updates Holopad code to use AltClick

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -71,7 +71,10 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	default_deconstruction_crowbar(P)
 
 
-/obj/machinery/hologram/holopad/attack_hand(mob/living/carbon/human/user) //Carn: Hologram requests.
+/obj/machinery/hologram/holopad/AltClick(mob/living/carbon/human/user)
+	interact(user)
+
+/obj/machinery/hologram/holopad/interact(mob/living/carbon/human/user) //Carn: Hologram requests.
 	if(!istype(user))
 		return
 	if(user.stat || stat & (NOPOWER|BROKEN))
@@ -108,7 +111,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	else if(href_list["mainmenu"])
 		temp = ""
 
-	updateUsrDialog()
+	updateDialog()
 	add_fingerprint(usr)
 
 /obj/machinery/hologram/holopad/attack_ai(mob/living/silicon/ai/user)


### PR DESCRIPTION
Kor is lazy.

:cl: Remie + Kor
tweak: Holopads now use AltClick to request the AI
/:cl:
