### PR TITLE
Hand Tele now displays its destination.

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -145,9 +145,9 @@ Frequency:
 	for(var/obj/machinery/computer/teleporter/com in machines)
 		if(com.target)
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-				L["[com.id] (Active)"] = com.target
+				L["[get_area(com.target)] (Active)"] = com.target
 			else
-				L["[com.id] (Inactive)"] = com.target
+				L["[get_area(com.target)] (Inactive)"] = com.target
 	var/list/turfs = list(	)
 	for(var/turf/T in ultra_range(10, orange=1))
 		if(T.x>world.maxx-8 || T.x<8)	continue	//putting them at the edge is dumb


### PR DESCRIPTION
The Hand Tele will now display the name of the area in which a tracking beacon is placed.

:cl:
tweak: Nanotrasen has improved the interface for the hand-held teleportation device. It will now provide the user with the name of the destination tracking beacon.
/:cl:

![image](https://cloud.githubusercontent.com/assets/4955510/11258993/b2b3bbae-8e23-11e5-8ef2-76db705c0f27.png)
