### PR TITLE
Fixes species selection not saving properly between rounds

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -33,7 +33,7 @@
 			continue
 		var/datum/species/S = new spath()
 		if(S.roundstart)
-			roundstart_species[S.name] = S.type
+			roundstart_species[S.id] = S.type
 		species_list[S.id] = S.type
 
 	//Surgeries

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -235,10 +235,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		return 0
 
 	//Species
-	var/species_name
-	S["species"]			>> species_name
-	if(config.mutant_races && species_name && (species_name in roundstart_species))
-		var/newtype = roundstart_species[species_name]
+	var/species_id
+	S["species"]			>> species_id
+	if(config.mutant_races && species_id && (species_id in roundstart_species))
+		var/newtype = roundstart_species[species_id]
 		pref_species = new newtype()
 	else
 		pref_species = new /datum/species/human()
@@ -375,7 +375,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["undershirt"]			<< undershirt
 	S["socks"]				<< socks
 	S["backbag"]			<< backbag
-	S["species"]			<< pref_species.name
+	S["species"]			<< pref_species.id
 	S["feature_mcolor"]					<< features["mcolor"]
 	S["feature_lizard_tail"]			<< features["tail_lizard"]
 	S["feature_human_tail"]				<< features["tail_human"]


### PR DESCRIPTION
Species selection wasn't saving properly. Why? Because species_list used id as a reference, but roundstart_species used name for some insane reason.

THESE AREN'T THE SAME THING.

Both lists now use id, and savefiles will properly look for/save said ids.

:cl: Incoming5643
bugfix: Setting your species to something other than human (if available) once again saves properly. Note that if you join a round where your species setting is no longer valid it will be reset to human.
/:cl:
