### PR TITLE
Cult changes: Stunpapers no longer mute

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -76,12 +76,11 @@
 
 
 /datum/game_mode/cult/pre_setup()
+	cult_objectives += "sacrifice"
 	if(prob(50))
 		cult_objectives += "survive"
-		cult_objectives += "sacrifice"
 	else
 		cult_objectives += "eldergod"
-		cult_objectives += "sacrifice"
 
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -56,15 +56,9 @@ It also contains rune words, which are soon to be removed.
 /obj/item/weapon/tome/examine(mob/user)
 	..()
 	if(iscultist(user))
-		user << "The scriptures of the Geometer. Allows the scribing of runes and access of knowledge archives."
+		user << "The scriptures of the Geometer. Allows the scribing of runes and access to the knowledge archives of the cult of Nar-Sie."
 
 /obj/item/weapon/tome/attack(mob/living/M, mob/living/user)
-	if(istype(M,/mob/dead/observer))
-		M.invisibility = 0
-		user.visible_message("<span class='warning'>[user] strikes the air with [src], and a spirit appears!</span>", \
-							 "<span class='danger'>You drag the ghost to your plane of reality!</span>")
-		add_logs(user, M, "smacked", src)
-		return
 	if(!istype(M))
 		return
 	if(!iscultist(user))
@@ -87,20 +81,15 @@ It also contains rune words, which are soon to be removed.
 
 /obj/item/weapon/tome/attack_self(mob/user)
 	if(!iscultist(user))
-		user << "<span class='warning'>[src] seems full of unintelligible shapes, scribbles, and notes. Is this some sort of joke?</span>"
+		user << "<span class='warning'>[src] seems full of unintelligible symbols, scribbles, images, and notes. Is this some sort of joke?</span>"
 		return
 	open_tome(user)
 
 /obj/item/weapon/tome/proc/open_tome(mob/user)
-	var/choice = alert(user,"You open the tome...",,"Commune","Scribe Rune","(More...)")
+	var/choice = alert(user,"You open the tome...",,"Commune","Scribe Rune","Read Tome")
 	switch(choice)
-		if("(More...)")
-			var/choice2 = alert(user,"You open the tome...",,"(Back...)", "Information")
-			switch(choice2)
-				if("(Back...)")
-					return open_tome(user)
-				if("Information")
-					read_tome(user)
+		if("Read Tome")
+			read_tome(user)
 		if("Scribe Rune")
 			scribe_rune(user)
 		if("Commune")
@@ -115,8 +104,7 @@ It also contains rune words, which are soon to be removed.
 	text += "As a member of the cult, your goals are almost or entirely impossible to complete without special aid from the Geometer's plane. The primary method of doing this are <b>runes</b>. These \
 	scribings, drawn in blood, are concentrated nodes of the magic within Nar-Sie's realm and will allow the performance of many tasks to aid you and the rest of the cult in your objectives. Runes \
 	have many different names, and almost all of them are known as Rites. The only rune that is not a Rite is the Ritual of Dimensional Rending, which can only be performed with nine cultists and calls \
-	forth the avatar of the Geometer itself (so long as it consents). A small description of each rune can be found below.<br><br>Do note that sometimes runes can be drawn incorrectly. Runes such as these \
-	will be colorful and written in gibberish. They are malformed, and invoking them serves only to ignite the Geometer's wrath. Be cautious in your scribings.<br><br>A rune's name and effects can be \
+	forth the avatar of the Geometer itself (so long as it consents). A small description of each rune can be found below.<br><br>A rune's name and effects can be \
 	revealed by examining the rune.<br><br><br>"/*In order to write a rune, you must know the combination of words required for the rune. These words are in the tongue of the Geometer and must be written as such. \
 	A rune will always have a specific combination, and the combination for runes may be revealed by perfomring actions such as conversion or sacrifice. Once a rune has been written, any cultists can \
 	examine it to find out its \"grammar\", or the words required to scribe it. To scribe the rune, the words must be entered in lowercase and separated by exactly one space. For instance, to draw a \
@@ -168,10 +156,6 @@ It also contains rune words, which are soon to be removed.
 	text += "<font color='red'><b>Reveal Runes</b></font><br>The Rite of True Sight is the foil of the Rite of Obscurity. It will turn all invisible runes visible once more, in addition to causing \
 	all spirits nearby to become partially corporeal.<br><br>"
 
-	text += "<font color='red'><b>Disguise Runes</b></font><br>Many crew men enjoy drawing runes in crayon that resemble spell circles in order to play pranks on their fellow crewmen. The Rite of \
-	False Truths takes advantage of this very joke. When invoked, all nearby runes will appear dull, precisely resembling those drawn in crayon. They still cannot be cleaned by conventional means, so \
-	anyone trying to clean up the rune may become suspicious as it does not respond.<br><br>"
-
 	text += "<font color='red'><b>Electromagnetic Disruption</b></font><br>Robotic lifeforms have time and time again been the downfall of fledgling cults. The Rite of Disruption may allow you to gain the upper \
 	hand against these pests. By using the rune, a large electromagnetic pulse will be emitted from the rune's location.<br><br>"
 
@@ -184,14 +168,11 @@ It also contains rune words, which are soon to be removed.
 	rune will draw a small amount of life force from the user and make the space above the rune completely dense, rendering it impassable to all but the most complex means. The rune may be invoked again to \
 	undo this effect and allow passage again.<br><br>"
 
-	text += "<font color='red'><b>Deafen</b></font><br>The Rite of the Unheard Whisper is simple. When invoked, it will cause all non-cultists within a radius of seven tiles to become \
-	completely deaf for a large amount of time.<br><br>"
+	text += "<font color='red'><b>Debilitate</b></font><br>The Rite of the Shadowed Mind is simple. When invoked, it will cause all non-cultists that can see the rune to become \
+	completely deaf, blind, and mute for a short amount of time.<br><br>"
 
-	text += "<font color='red'><b>Blind</b></font><br>Much like the Rite of the Unheard Whisper, the Rite of the Unseen Glance serves a single purpose. Any non-cultists who can see \
-	the rune will instantly be blinded for a substantial amount of time.<br><br>"
-
-	text += "<font color='red'><b>Stun</b></font><br>A somewhat empowered version of the Rite of the Unseen Glance, this rune will cause any non-cultists that can see the rune to become \
-	disoriented, disabling them for a short time.<br><br>"
+	text += "<font color='red'><b>Stun</b></font><br>Though the Rite of Blazing Light is weak when invoked normally, using it in conjuction with the Rite of Binding makes it much more useful. \
+	This rune will cause any non-cultists that can see the rune to become disoriented, disabling them for a short time.<br><br>"
 
 	text += "<font color='red'><b>Summon Cultist</b></font><br>The Rite of Joined Souls requires two acolytes to use. When invoked, it will allow the user to summon a single cultist to the rune from \
 	any location. This will deal a moderate amount of damage to all invokers.<br><br>"
@@ -202,13 +183,13 @@ It also contains rune words, which are soon to be removed.
 	text += "<font color='red'><b>Fabricate Shell</b></font><br>The Rite of Fabrication is the main way of creating construct shells. To use it, one must place five sheets of plasteel on top of the rune \
 	and invoke it. The sheets will them be twisted into a construct shell, ready to recieve a soul to occupy it.<br><br>"
 
-	text += "<font color='red'><b>Summon Arnaments</b></font><br>The Rite of Arming will equip the user with invoker's robes, a backpack, a Nar-Sian longsword, and a pair of boots. Any items that cannot \
-	be equipped will instead not be summoned regardless.<br><br>"
+	text += "<font color='red'><b>Summon Armaments</b></font><br>The Rite of Arming will summon armored robes, a backpack, an edritch longsword, and a pair of boots for use against the enemies of Nar-Sie. \
+	If imbued, any items that cannot be equipped will not be summoned.<br><br>"
 
 	text += "<font color='red'><b>Drain Life</b></font><br>The Rite of Leeching will drain the life of any non-cultist above the rune and heal the invoker for the same amount.<br><br>"
 
-	text += "<font color='red'><b>Boil Blood</b></font><br>The Rite of Boiling Blood may be considered one of the most dangerous rites composed by the Nar-Sian cult. When invoked, it will do a \
-	massive amount of damage to all non-cultist viewers, but it will also emit an explosion upon invocation. Use with caution<br><br>"
+	text += "<font color='red'><b>Blood Boil</b></font><br>The Rite of Boiling Blood may be considered one of the most dangerous rites composed by the cult of Nar-Sie. When invoked, it will do a \
+	massive amount of damage to all non-cultist viewers as well as setting them on fire. Use with caution<br><br>"
 
 	text += "<font color='red'><b>Manifest Spirit</b></font><br>If you wish to bring a spirit back from the dead with a wish for vengeance and desire to serve, the Rite of Spectral \
 	Manifestation can do just that. When invoked, any spirits above the rune will be brought to life as a human wearing nothing that seeks only to serve you and the Geometer. However, the spirit's link \
@@ -226,16 +207,22 @@ It also contains rune words, which are soon to be removed.
 	text += "<font color='red'><b>Talisman of Teleportation</b></font><br>The talisman form of the Rite of Translocation will transport the invoker to a randomly chosen rune of the same keyword, then \
 	disappear.<br><br>"
 
-	text += "<font color='red'><b>Talisman of Tome summoning</b></font><br>This talisman functions identically to the rune. It can be used once, then disappears.<br><br>"
+	text += "<font color='red'><b>Talisman of Tome Summoning</b></font><br>This talisman functions nearly identically to the rune. The talisman will attempt to place the tome in your hand \
+	instead of on the ground, though this is the only advantage it has over the rune. It can be used once, then disappears.<br><br>"
 
 	text += "<font color='red'><b>Talismans of Veiling, Revealing, and Disguising</b></font><br>These talismans all function identically to their rune counterparts, but with less range. In addition, \
 	the Talisman of True Sight will not reveal spirits. They will disappear after one use.<br><br>"
 
-	text += "<font color='red'><b>Talisman of Electromagnets</b></font><br>This talisman functions like the Rite of Disruption. It disappears after one use.<br><br>"
+	text += "<font color='red'><b>Talisman of Electromagnetic Pulse</b></font><br>This talisman functions like the Rite of Disruption. It disappears after one use.<br><br>"
 
-	text += "<font color='red'><b>Talisman of Stunning</b></font><br>Without this talisman, the cult would have no way of easily acquiring targets to convert. Commonly called \"stunpapers\", this \
-	talisman functions differently from others. Rather than simply reading the words, the target must be attacked directly with the talisman. The talisman will then knock down the target for a long \
-	duration in addition to rendering them incapable of speech. Robotic lifeforms will suffer the effects of a heavy electromagnetic pulse instead."
+	text += "<font color='red'><b>Talisman of Stunning</b></font><br>Without this talisman and the Talisman of Debilitation, the cult would have no way of easily acquiring targets to convert. Commonly called \"stunpapers\", these \
+	talismans functions differently from others. Rather than simply reading the words, the target must be attacked directly with the talisman. The target will be stunned for a long \
+	duration, though they will not be muted without use of the Talisman of Debilitation.<br><br>"
+
+	text += "<font color='red'><b>Talisman of Debilitation</b></font><br>Without this talisman and the Talisman of Stunning, the cult would have no way of easily acquiring targets to convert. Commonly called \"mutepapers\", these \
+	talismans functions differently from others. Rather than simply reading the words, the target must be attacked directly with the talisman. The target will then be muted, blind, and deaf \
+	for a long duration, though they will not be stunned without use of the Talisman of Stunning."
+
 
 	var/datum/browser/popup = new(user, "tome", "", 800, 600)
 	popup.set_content(text)
@@ -267,14 +254,14 @@ It also contains rune words, which are soon to be removed.
 	if(!rune_to_scribe)
 		return
 	user.visible_message("<span class='warning'>[user] cuts open their arm and begins writing in their own blood!</span>", \
-						 "<span class='danger'>You slice open your arm and begin drawing a sigil of the Geometer.</span>")
+						 "<span class='cultsmall'>You slice open your arm and begin drawing a sigil of the Geometer.</span>")
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.apply_damage(0.1, BRUTE, pick("l_arm", "r_arm"))
 	if(!do_after(user, 50, target = get_turf(user)))
 		return
 	user.visible_message("<span class='warning'>[user] creates a strange circle in their own blood.</span>", \
-						 "<span class='danger'>You finish drawing the arcane markings of the Geometer.</span>")
+						 "<span class='cultsmall'>You finish drawing the arcane markings of the Geometer.</span>")
 	var/obj/effect/rune/R = new rune_to_scribe(get_turf(user))
 	if(chosen_keyword)
 		R.keyword = chosen_keyword

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -158,7 +158,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	color = rgb(rand(0,255), rand(0,255), rand(0,255))
 
 /obj/effect/rune/malformed/invoke(mob/living/user)
-	user << "<span class='warning'><b>You feel your life force draining. The Geometer is displeased.</b></span>"
+	user << "<span class='cultitalic'><b>You feel your life force draining. The Geometer is displeased.</b></span>"
 	user.apply_damage(30, BRUTE)
 	qdel(src)
 
@@ -203,7 +203,7 @@ var/list/teleport_runes = list()
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
 	user.visible_message("<span class='warning'>[user] vanishes in a flash of red light!</span>", \
-						 "<span class='danger'>Your vision blurs, and you suddenly appear somewhere else.</span>")
+						 "<span class='cultsmall'>Your vision blurs, and you suddenly appear somewhere else.</span>")
 	user.forceMove(get_turf(selected_rune))
 
 
@@ -260,7 +260,7 @@ var/list/teleport_other_runes = list()
 	if(target.buckled)
 		target.buckled.unbuckle_mob()
 	target.visible_message("<span class='warning'>[target] vanishes in a flash of red light!</span>", \
-						   "<span class='danger'>Your vision blurs, and you suddenly appear somewhere else.</span>")
+						   "<span class='cultsmall'>Your vision blurs, and you suddenly appear somewhere else.</span>")
 	target.forceMove(get_turf(selected_rune))
 
 
@@ -313,9 +313,9 @@ var/list/teleport_other_runes = list()
 					  			"<span class='userdanger'><i>AAAAAAAAAAAAAA-</i></span>")
 	ticker.mode.add_cultist(new_cultist.mind)
 	new_cultist.mind.special_role = "Cultist"
-	new_cultist << "<span class='purple'><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
+	new_cultist << "<span class='cultsmall'><b><i>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
 	and something evil takes root.</i></b></span>"
-	new_cultist << "<span class='purple'><b><i>Assist your new compatriots in their dark dealings. Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back.\
+	new_cultist << "<span class='cultsmall'><b><i>Assist your new compatriots in their dark dealings. Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back.\
 	</i></b></span>"
 
 
@@ -363,7 +363,7 @@ var/list/teleport_other_runes = list()
 				cultists_nearby++
 				M.say(invocation)
 		if(cultists_nearby < 3)
-			user << "<span class='warning'>You require three acolytes to sacrifice greater targets!</span>"
+			user << "<span class='warning'>[offering] is too greatly linked to the world! You need more acolytes!</span>"
 			fail_invoke()
 			log_game("Sacrifice rune failed - not enough acolytes and target is living")
 			rune_in_use = 0
@@ -380,7 +380,7 @@ var/list/teleport_other_runes = list()
 		if(istype(T, /mob/living/simple_animal/pet/dog/corgi))
 			for(var/mob/living/carbon/C in orange(1,src))
 				if(iscultist(C))
-					C << "<span class='warning'>Even dark gods from another plane have standards, sicko.</span>"
+					C << "<span class='cultitalic'>\"A tasty morsel. And yet,</span> <span class='cult'>NOT WHAT I ASKED FOR! FIND THE ONE I WISH SACRIFICED!\"</span>"
 					if(C.reagents)
 						C.reagents.add_reagent("hell_water", 2)
 		if(T.mind)
@@ -464,7 +464,7 @@ var/list/teleport_other_runes = list()
 			if(iscultist(M))
 				M.say("TOK-LYR RQA-NAP G'OLT-ULOFT!!")
 		world << 'sound/effects/dimensional_rend.ogg'
-		world << "<b><i>Rip... <span class='big'>Rrrip...</span> <span class='reallybig'>RRRRRRRRRR--</span></i></b>"
+		world << "<span class='cultitalic'><b>Rip... <span class='big'>Rrrip...</span> <span class='reallybig'>RRRRRRRRRR--</span></b></span>"
 		sleep(40)
 		new /obj/singularity/narsie/large(get_turf(user)) //Causes Nar-Sie to spawn even if the rune has been removed
 		cult_mode.eldergod = 0
@@ -532,10 +532,11 @@ var/list/teleport_other_runes = list()
 	if(!mob_to_revive || mob_to_revive.stat != DEAD)
 		visible_message("<span class='warning'>The black mist rises and dissipates.</span>")
 		return
+	mob_to_revive.revive() //This does remove disabilities and such, but the rune might actually see some use because of it!
 	mob_to_revive << "<span class='cult'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>"
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from their eyes.</span>", \
-								  "<span class='userdanger'>You awaken suddenly from the void. You're alive!</span>")
-	mob_to_revive.revive() //This does remove disabilities and such, but the rune might actually see some use because of it!
+								  "<span class='cult'>You awaken suddenly from the void. You're alive!</span>")
+
 
 /obj/effect/rune/raise_dead/fail_invoke()
 	for(var/mob/living/M in orange(1,src))
@@ -585,21 +586,6 @@ var/list/teleport_other_runes = list()
 	qdel(src)
 
 
-//Rite of False Truths: Makes runes appear like crayon ones
-/obj/effect/rune/make_runes_fake
-	cultist_name = "Disguise Runes"
-	cultist_desc = "Causes all nearby runes (including itself) to resemble those drawn in crayon."
-	invocation = "By'o isit!"
-	icon_state = "4"
-	color = rgb(0, 150, 0)
-	grammar = "geeri nahlizet jatkaa"
-
-/obj/effect/rune/make_runes_fake/invoke(mob/living/user)
-	visible_message("<span class='warning'>[src] flares brightly, then slowly dulls and appears mundane.</span>")
-	for(var/obj/effect/rune/R in range(3,src))
-		R.desc = "A rune drawn in crayon."
-
-
 //Rite of Disruption: Emits an EMP blast.
 /obj/effect/rune/emp
 	cultist_name = "Electromagnetic Disruption"
@@ -632,17 +618,17 @@ var/list/teleport_other_runes = list()
 /obj/effect/rune/astral/examine(mob/user)
 	..()
 	if(affecting)
-		user << "<span class='warning'>A translucent field encases [user] above the rune!</span>"
+		user << "<span class='cultsmall'>A translucent field encases [user] above the rune!</span>"
 
 /obj/effect/rune/astral/invoke(mob/living/user)
 	if(rune_in_use)
-		user << "<span class='warning'>[src] cannot support more than one body!</span>"
+		user << "<span class='cultsmall'>[src] cannot support more than one body!</span>"
 		fail_invoke()
 		log_game("Astral Communion rune failed - more than one user")
 		return
 	var/turf/T = get_turf(src)
 	if(!user in T.contents)
-		user << "<span class='warning'>You must be standing on top of [src]!</span>"
+		user << "<span class='cultsmall'>You must be standing on top of [src]!</span>"
 		fail_invoke()
 		log_game("Astral Communion rune failed - user not standing on rune")
 		return
@@ -675,14 +661,14 @@ var/list/teleport_other_runes = list()
 			if(prob(10))
 				var/mob/dead/observer/G = user.get_ghost()
 				if(G)
-					G << "<span class='warning'>You feel the link between you and your body weakening... you must hurry!</span>"
+					G << "<span class='cultitalic'>You feel the link between you and your body weakening... you must hurry!</span>"
 		if(user.stat == DEAD)
 			user.color = initial(user.color)
 			rune_in_use = 0
 			affecting = null
 			var/mob/dead/observer/G = user.get_ghost()
 			if(G)
-				G << "<span class='warning'><b>You suddenly feel your physical form pass on. [src]'s exertion has killed you!</b></span>"
+				G << "<span class='cultitalic'><b>You suddenly feel your physical form pass on. [src]'s exertion has killed you!</b></span>"
 			return
 		sleep(10)
 	rune_in_use = 0
@@ -700,56 +686,41 @@ var/list/teleport_other_runes = list()
 /obj/effect/rune/wall/examine(mob/user)
 	..()
 	if(density)
-		user << "<span class='warning'>There is a barely perceptible shimmering of the air above [src].</span>"
+		user << "<span class='cultsmall'>There is a barely perceptible shimmering of the air above [src].</span>"
 
 /obj/effect/rune/wall/invoke(mob/living/user)
 	density = !density
 	user.visible_message("<span class='warning'>[user] places their hands on [src], and [density ? "the air above it begins to shimmer" : "the shimmer above it fades"].</span>", \
-						 "<span class='warning'>You channel your life energy into [src], [density ? "preventing" : "allowing"] passage above it.</span>")
+						 "<span class='cultitalic'>You channel your life energy into [src], [density ? "preventing" : "allowing"] passage above it.</span>")
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.apply_damage(2, BRUTE, pick("l_arm", "r_arm"))
 
 
-//Rite of the Unheard Whisper:  Deafens all non-cultists nearby.
-/obj/effect/rune/deafen
-	cultist_name = "Deafen"
-	cultist_desc = "Causes all non-followers nearby to lose their hearing."
-	invocation = "Sti kaliedir!"
+//Rite of the something whatever:  Briefly blinds, mutes, and deafens nearby noncultists.
+/obj/effect/rune/debilitate
+	cultist_name = "Debilitate"
+	cultist_desc = "Causes all non-followers nearby to become mute, deaf, and blind briefly."
+	invocation = "Sti kali'ezar!"
 	grammar = "geeri jatkaa karazet"
 	color = rgb(0, 255, 0)
 	icon_state = "4"
 
-/obj/effect/rune/deafen/invoke(mob/living/user)
-	visible_message("<span class='warning'>[src] blurs for a moment before fading away.</span>")
-	for(var/mob/living/carbon/C in range(7,src))
-		if(!iscultist(C) && !C.null_rod_check())
-			C << "<span class='warning'>The world around you goes quiet.</span>"
-			C.adjustEarDamage(0,50)
-	qdel(src)
-
-
-//Rite of the Unseen Glance: Blinds all non-cultists nearby.
-/obj/effect/rune/blind
-	cultist_name = "Blind"
-	cultist_desc = "Causes all non-followers nearby to lose their sight."
-	invocation = "Sti kaliesin!"
-	icon_state = "4"
-	color = rgb(0, 0, 255)
-	grammar = "mgar jatkaa karazet"
-
-/obj/effect/rune/blind/invoke(mob/living/user)
-	visible_message("<span class='warning'>[src] emits a blinding red flash!</span>")
+/obj/effect/rune/debilitate/invoke(mob/living/user)
+	visible_message("<span class='warning'>[src] emits a burst of squirming shadows!</span>")
 	for(var/mob/living/carbon/C in viewers(src))
-		if(!iscultist(C) && !C.null_rod_check())
-			C << "<span class='warning'><b>You can't see!</b></span>"
-			C.flash_eyes(1, 1)
-			C.eye_blurry += 50
-			C.eye_blind += 20
+		if(!iscultist(C))
+			if(!C.null_rod_check())
+				C << "<span class='cultsmall'><b>Your senses are covered by writhing shadows!</b></span>"
+				C.silent += 10
+				C.adjustEarDamage(0,35)
+				C.eye_blurry += 30
+				C.eye_blind += 5
+			else
+				C << "<span class='warning'>The null rod absorbs the burst of twisting shadows!</span>"
 	qdel(src)
 
-
-//Rite of Disorientation: Stuns all non-cultists nearby for a brief time
+//Rite of Blazing Light: Stuns all non-cultists nearby for a brief time
 /obj/effect/rune/stun
 	cultist_name = "Stun"
 	cultist_desc = "Stuns all nearby non-followers for a brief time."
@@ -759,13 +730,19 @@ var/list/teleport_other_runes = list()
 	grammar = "certum geeri balaq"
 
 /obj/effect/rune/stun/invoke(mob/living/user)
-	visible_message("<span class='warning'>[src] explodes in a bright flash!</span>")
+	visible_message("<span class='warning'>[src] emits a blinding red flash!</span>")
 	for(var/mob/living/M in viewers(src))
-		if(!iscultist(M) && !M.null_rod_check())
-			M << "<span class='warning'><b>You are disoriented by [src]!</b></span>"
-			M.Weaken(3)
-			M.Stun(3)
-			M.flash_eyes(1,1)
+		if(!M.null_rod_check())
+			if(!iscultist(M))
+				M << "<span class='cultitalic'><b>You are disoriented by [src]!</b></span>"
+				M.Weaken(3)
+				M.Stun(3)
+				M.flash_eyes(1,1)
+			else
+				M << "<span class='cultitalic'>The bright glow of [src] makes you flinch.</span>"
+				M.flash_eyes(1,1)
+		else
+			M << "<span class='warning'>The null rod absorbs the burst of light!</span>"
 	qdel(src)
 
 
@@ -797,7 +774,7 @@ var/list/teleport_other_runes = list()
 	if(cultist_to_summon.buckled)
 		cultist_to_summon.buckled.unbuckle_mob()
 	cultist_to_summon.visible_message("<span class='warning'>[cultist_to_summon] suddenly disappears in a flash of red light!</span>", \
-									  "<span class='warning'><b>Overwhelming vertigo consumes you as you are hurled through the air!</b></span>")
+									  "<span class='cultitalic'><b>Overwhelming vertigo consumes you as you are hurled through the air!</b></span>")
 	visible_message("<span class='warning'>A foggy shape materializes atop [src] and solidifes into [cultist_to_summon]!</span>")
 	for(var/mob/living/carbon/C in orange(1,src))
 		if(iscultist(C))
@@ -886,8 +863,8 @@ var/list/teleport_other_runes = list()
 
 //Rite of Arming: Creates cult robes, a trophy rack, and a cult sword on the rune.
 /obj/effect/rune/armor
-	cultist_name = "Summon Arnaments"
-	cultist_desc = "Equips the user with robes, shoes, a backpack, and a longsword. Items that cannot be equipped will not be summoned."
+	cultist_name = "Summon Armaments"
+	cultist_desc = "Summons armored robes, shoes, a backpack, and a longsword for use against the enemies of Nar-Sie."
 	invocation = "N'ath reth sh'yro eth draggathnor!"
 	icon_state = "4"
 	color = rgb(255, 0, 0)
@@ -895,11 +872,12 @@ var/list/teleport_other_runes = list()
 
 /obj/effect/rune/armor/invoke(mob/living/user)
 	visible_message("<span class='warning'>With the sound of clanging metal, [src] crumbles to dust!</span>")
-	user.equip_to_slot_or_del(new /obj/item/clothing/head/culthood/alt(user), slot_head)
-	user.equip_to_slot_or_del(new /obj/item/clothing/suit/cultrobes/alt(user), slot_wear_suit)
-	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult/alt(user), slot_shoes)
-	user.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
-	user.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
+	var/turf/T = get_turf(src)
+	new /obj/item/clothing/head/culthood/alt(T)
+	new /obj/item/clothing/suit/cultrobes/alt(T)
+	new /obj/item/clothing/shoes/cult/alt(T)
+	new /obj/item/weapon/storage/backpack/cultpack(T)
+	new /obj/item/weapon/melee/cultblade(T)
 	qdel(src)
 
 
@@ -929,7 +907,7 @@ var/list/teleport_other_runes = list()
 	user.adjustBruteLoss(-drained_amount)
 	target << "<span class='warning'>You feel extremely weak.</span>"
 	user.visible_message("<span class='warning'>Blood flows from the rune into [user]!</span>", \
-						 "<span class='danger'>[target]'s blood flows into you, healing your wounds and revitalizing your spirit.</span>")
+						 "<span class='cultsmall'>[target]'s blood flows into you, healing your wounds and revitalizing your spirit.</span>")
 
 
 //Rite of Boiling Blood: Deals extremely high amounts of damage to non-cultists nearby
@@ -947,15 +925,16 @@ var/list/teleport_other_runes = list()
 	for(var/mob/living/carbon/C in viewers(src))
 		if(!iscultist(C))
 			if(C.null_rod_check())
-				C << "<span class='userdanger'>The null rod suddenly burns hotly before returning to normal!</span>"
+				C << "<span class='warning'>The null rod suddenly burns hotly before returning to normal!</span>"
 				continue
-			C << "<span class='userdanger'>Agonizing heat overwhelms you!</span>"
-			C.take_overall_damage(51,51)
+			C << "<span class='cult'>Your blood boils in your veins!</span>"
+			C.adjustFireLoss(75)
+			C.adjust_fire_stacks(1)
+			C.IgniteMob()
 	for(var/mob/living/carbon/M in orange(1,src))
 		if(iscultist(M))
 			M.apply_damage(15, BRUTE, pick("l_arm", "r_arm"))
-			M << "<span class='warning'>[src] saps your strength!</span>"
-	explosion(get_turf(src), -1, 0, 1, 5)
+			M << "<span class='cultitalic'>[src] saps your strength!</span>"
 	qdel(src)
 
 
@@ -970,7 +949,7 @@ var/list/teleport_other_runes = list()
 
 /obj/effect/rune/manifest/invoke(mob/living/user)
 	if(!(user in get_turf(src)))
-		user << "<span class='warning'>You must be standing on [src]!</span>"
+		user << "<span class='cultitalic'>You must be standing on [src]!</span>"
 		fail_invoke()
 		log_game("Manifest rune failed - user not standing on rune")
 		return
@@ -979,7 +958,7 @@ var/list/teleport_other_runes = list()
 		if(O.client)
 			ghosts_on_rune.Add(O)
 	if(!ghosts_on_rune.len)
-		user << "<span class='warning'>There are no spirits near [src]!</span>"
+		user << "<span class='cultitalic'>There are no spirits near [src]!</span>"
 		fail_invoke()
 		log_game("Manifest rune failed - no nearby ghosts")
 		return
@@ -988,10 +967,10 @@ var/list/teleport_other_runes = list()
 	new_human.real_name = ghost_to_spawn.real_name
 	new_human.alpha = 150 //Makes them translucent
 	visible_message("<span class='warning'>A cloud of red mist forms above [src], and from within steps... a man.</span>")
-	user << "<span class='warning'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>"
+	user << "<span class='cultitalic'>Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely...</span>"
 	new_human.key = ghost_to_spawn.key
 	ticker.mode.add_cultist(new_human.mind)
-	new_human << "<span class='purple'><b><i>You are a servant of the Geometer. You have been made semi-corporeal by the cult, and you are to serve them at all costs.</i></b></span>"
+	new_human << "<span class='cultitalic'><b>You are a servant of the Geometer. You have been made semi-corporeal by the cult, and you are to serve them at all costs.</b></span>"
 
 	while(user in get_turf(src))
 		if(user.stat)

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -22,15 +22,16 @@ Rite of Disorientation
 	var/health_cost = 0 //The amount of health taken from the user when invoking the talisman
 
 /obj/item/weapon/paper/talisman/examine(mob/user)
-	..()
 	if(iscultist(user) || user.stat == DEAD)
 		user << "<b>Name:</b> [cultist_name]"
 		user << "<b>Effect:</b> [cultist_desc]"
 		user << "<b>Uses Remaining:</b> [uses]"
+		return
+	..()
 
 /obj/item/weapon/paper/talisman/attack_self(mob/living/user)
 	if(!iscultist(user))
-		user << "<span class='warning'>There are strange, illegible symbols drawn on [src]. Maybe some sort of blueprint?</span>"
+		user << "<span class='danger'>There are indecipherable images scrawled on the paper in what looks to be... <i>blood?</i></span>"
 		return
 	if(invocation)
 		user.whisper(invocation)
@@ -63,7 +64,7 @@ Rite of Disorientation
 	cultist_name = "Supply Talisman"
 	cultist_desc = "A multi-use talisman that can create various objects. Intended to increase the cult's strength early on."
 	invocation = null
-	uses = 3
+	uses = 5
 
 /obj/item/weapon/paper/talisman/supply/invoke(mob/living/user)
 	var/dat = "<B>There are [uses] bloody runes on the parchment.</B><BR>"
@@ -72,12 +73,11 @@ Rite of Disorientation
 	dat += "<A href='?src=\ref[src];rune=newtome'>N'ath reth sh'yro eth d'raggathnor!</A> - Allows you to summon an arcane tome.<BR>"
 	dat += "<A href='?src=\ref[src];rune=teleport'>Sas'so c'arta forbici!</A> - Allows you to move to a Rite of Dislocation with the keyword of \"veri\".<BR>"
 	dat += "<A href='?src=\ref[src];rune=emp'>Ta'gh fara'qha fel d'amar det!</A> - Allows you to destroy technology in a short range.<BR>"
-	dat += "<A href='?src=\ref[src];rune=conceal'>Kla'atu barada nikt'o!</A> - Allows you to conceal nearby runes.<BR>"
-	dat += "<A href='?src=\ref[src];rune=reveal'>Nikt'o barada kla'atu!</A> - Allows you to reveal nearby runes.<BR>"
 	dat += "<A href='?src=\ref[src];rune=runestun'>Fuu ma'jin!</A> - Allows you to stun a person by attacking them with the talisman.<BR>"
+	dat += "<A href='?src=\ref[src];rune=runedebilitate'>Sti kali'ezar!</A> - Allows you to mute and blind a person by attacking them with the talisman.<BR>"
 	dat += "<A href='?src=\ref[src];rune=soulstone'>Kal'om neth!</A> - Summons a soul stone, used to capure the spirits of dead or dying humans.<BR>"
 	dat += "<A href='?src=\ref[src];rune=construct'>Daa'ig osk!</A> - Summons a construct shell for use with captured souls. It is too large to carry on your person.<BR>"
-	var/datum/browser/popup = new(user, "talisman", "", 800, 600)
+	var/datum/browser/popup = new(user, "talisman", "", 350, 450)
 	popup.set_content(dat)
 	popup.open()
 	uses++ //To prevent uses being consumed just by opening it
@@ -99,11 +99,8 @@ Rite of Disorientation
 				if("emp")
 					var/obj/item/weapon/paper/talisman/emp/T = new(usr)
 					usr.put_in_hands(T)
-				if("conceal")
-					var/obj/item/weapon/paper/talisman/hide_runes/T = new(usr)
-					usr.put_in_hands(T)
-				if("reveal")
-					var/obj/item/weapon/paper/talisman/true_sight/T = new(usr)
+				if("runedebilitate")
+					var/obj/item/weapon/paper/talisman/debilitate/T = new(usr)
 					usr.put_in_hands(T)
 				if("runestun")
 					var/obj/item/weapon/paper/talisman/stun/T = new(usr)
@@ -169,7 +166,7 @@ Rite of Disorientation
 	health_cost = 1
 
 /obj/item/weapon/paper/talisman/summon_tome/invoke(mob/living/user)
-	user.visible_message("<span class='warning'>Dust flows from [user]'s hand for a moment.</span>", \
+	user.visible_message("<span class='warning'>[user]'s hand glows red for a moment.</span>", \
 						 "<span class='warning'>You speak the words of the talisman!</span>")
 	var/obj/item/weapon/tome/T = new(get_turf(user))
 	if(user.put_in_hands(T))
@@ -208,23 +205,9 @@ Rite of Disorientation
 		R.invisibility = 0
 
 
-//Rite of False Truths: Same as rune
-/obj/item/weapon/paper/talisman/make_runes_fake
-	cultist_name = "Talisman of Disguising"
-	cultist_desc = "A talisman that will make nearby runes appear fake."
-	invocation = "By'o isit!"
-	health_cost = 3
-
-/obj/item/weapon/paper/talisman/make_runes_fake/invoke(mob/living/user)
-	user.visible_message("<span class='warning'>Dust flows from [user]s hand.</span>", \
-						 "<span class='warning'>You speak the words of the talisman, making nearby runes appear fake.</span>")
-	for(var/obj/effect/rune/R in orange(3,user))
-		R.desc = "A rune drawn in crayon."
-
-
 //Rite of Disruption: Same as rune, halved radius
 /obj/item/weapon/paper/talisman/emp
-	cultist_name = "Talisman of Electromagnets"
+	cultist_name = "Talisman of Electromagnetic Pulse"
 	cultist_desc = "A talisman that will cause a moderately-sized electromagnetic pulse."
 	invocation = "Ta'gh fara'qha fel d'amar det!"
 	health_cost = 5
@@ -232,18 +215,21 @@ Rite of Disorientation
 /obj/item/weapon/paper/talisman/emp/invoke(mob/living/user)
 	user.visible_message("<span class='warning'>[user]'s hand flashes a bright blue!</span>", \
 						 "<span class='warning'>You speak the words of the talisman, emitting an EMP blast.</span>")
-	empulse(src, 4, 8)
+	empulse(src, 3, 7)
 
 
-//Rite of Disorientation: Stuns and mutes a single target for quite some time
+//Rite of Blazing Light: Stuns a single target for quite some time
 /obj/item/weapon/paper/talisman/stun
 	cultist_name = "Talisman of Stunning"
-	cultist_desc = "A talisman that will stun and mute a single target. To use, attack target directly."
+	cultist_desc = "A talisman that will stun a single target. To use, attack target directly."
 	invocation = "Fuu ma'jin!"
-	health_cost = 10 //A lot of health because of how powerful this is
+	health_cost = 5 //A lot of health because of how powerful this is
 
 /obj/item/weapon/paper/talisman/stun/attack_self(mob/living/user)
-	user << "<span class='warning'>To use this talisman, attack the target directly.</span>"
+	if(iscultist(user))
+		user << "<span class='warning'>To use this talisman, attack the target directly.</span>"
+	else
+		user << "<span class='danger'>There are indecipherable images scrawled on the paper in what looks to be... <i>blood?</i></span>"
 	return
 
 /obj/item/weapon/paper/talisman/stun/attack(mob/living/target, mob/living/user)
@@ -253,18 +239,51 @@ Rite of Disorientation
 							 "<span class='warning'>You stun [target] with the talisman!</span>")
 		var/obj/item/weapon/nullrod/N = locate() in target
 		if(N)
-			target.visible_message("<span class='warning'>[target]'s null rod absorbs the talisman's power!</span>", \
+			target.visible_message("<span class='warning'>[target]'s null rod absorbs the talisman's light!</span>", \
 								   "<span class='userdanger'>Your null rod absorbs the blinding light!</span>")
 		else
 			target.Weaken(10)
 			target.Stun(10)
 			target.flash_eyes(1,1)
-			if(issilicon(target))
-				var/mob/living/silicon/S = target
-				S.emp_act(1)
-			if(iscarbon(target))
-				var/mob/living/carbon/C = target
-				C.silent += 10
+		user.drop_item()
+		qdel(src)
+		return
+	..()
+
+//Rite of the Shadowed Mind: Mutes, blinds, and deafens a single target for quite some time.
+/obj/item/weapon/paper/talisman/debilitate
+	cultist_name = "Talisman of Debilitation"
+	cultist_desc = "A talisman that will mute, blind, confuse, and deafen a single human target. To use, attack target directly."
+	invocation = "Sti kali'ezar!"
+	health_cost = 5 //A lot of health because of how powerful this is
+
+/obj/item/weapon/paper/talisman/debilitate/attack_self(mob/living/user)
+	if(iscultist(user))
+		user << "<span class='warning'>To use this talisman, attack the target directly.</span>"
+	else
+		user << "<span class='danger'>There are indecipherable images scrawled on the paper in what looks to be... <i>blood?</i></span>"
+	return
+
+/obj/item/weapon/paper/talisman/debilitate/attack(mob/living/target, mob/living/user)
+	if(iscultist(user))
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
+			user.whisper(invocation)
+			user.visible_message("<span class='warning'>[user] holds up [src], which explodes in a burst of writhing shadows!</span>", \
+								 "<span class='warning'>You debilitate [C] with the talisman!</span>")
+			var/obj/item/weapon/nullrod/N = locate() in C
+			if(N)
+				C.visible_message("<span class='warning'>[C]'s null rod absorbs the talisman's shadows!</span>", \
+								   "<span class='userdanger'>Your null rod absorbs the twisting shadows!</span>")
+			else
+				C.silent += 15
+				C.adjustEarDamage(0,40)
+				C.eye_blurry += 40
+				C.eye_blind += 15
+				C.confused += 10
+		else
+			user << "<span class='cultsmall'>You cannot use this talisman on nonhumans!</span>" //You can technically use it on aliens and monkeys but there's not really a good way to phrase that
+			return
 		user.drop_item()
 		qdel(src)
 		return
@@ -274,7 +293,7 @@ Rite of Disorientation
 //Rite of Arming: Equips cultist armor on the user, where available
 /obj/item/weapon/paper/talisman/armor
 	cultist_name = "Talisman of Arming"
-	cultist_desc = "A talisman that will equip the invoker with cultist equipment where available."
+	cultist_desc = "A talisman that will equip the invoker with cultist equipment if there is a slot to equip it to."
 	invocation = "N'ath reth sh'yro eth draggathnor!"
 	health_cost = 3
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -87,13 +87,13 @@
 	attacktext = "smashes their armored gauntlet into"
 	speed = 3
 	environment_smash = 2
-	attack_sound = 'sound/weapons/punch3.ogg'
+	attack_sound = 'sound/weapons/punch4.ogg'
 	status_flags = 0
 	mob_size = MOB_SIZE_LARGE
 	force_threshold = 11
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall)
 	playstyle_string = "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, \
-						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>"
+						create shield walls, rip apart enemies and walls alike, and even deflect energy weapons.</B>"
 
 /mob/living/simple_animal/construct/armored/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
@@ -131,7 +131,7 @@
 /mob/living/simple_animal/construct/wraith
 	name = "Wraith"
 	real_name = "Wraith"
-	desc = "A wicked bladed shell contraption piloted by a bound spirit"
+	desc = "A wicked bladed shell contraption piloted by a bound spirit."
 	icon_state = "floating"
 	icon_living = "floating"
 	maxHealth = 75
@@ -152,7 +152,7 @@
 /mob/living/simple_animal/construct/builder
 	name = "Artificer"
 	real_name = "Artificer"
-	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies"
+	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies."
 	icon_state = "artificer"
 	icon_living = "artificer"
 	maxHealth = 50
@@ -164,7 +164,6 @@
 	attacktext = "rams"
 	speed = 0
 	environment_smash = 2
-	attack_sound = 'sound/weapons/punch2.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone,
@@ -185,14 +184,16 @@
 	icon_living = "harvester"
 	maxHealth = 60
 	health = 60
-	melee_damage_lower = 1
+	melee_damage_lower = 5
 	melee_damage_upper = 5
-	attacktext = "prods"
+	attacktext = "jabs"
 	speed = 0
-	environment_smash = 1
+	environment_smash = 3
 	see_in_dark = 7
-	attack_sound = 'sound/weapons/tap.ogg'
-	construct_spells = list(/obj/effect/proc_holder/spell/targeted/smoke/disable)
+	attack_sound = 'sound/weapons/punch2.ogg'
+	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
+							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor,
+							/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
 

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -213,7 +213,6 @@
 	description = "Something that shouldn't exist on this plane of existance."
 
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/M)
-	M.adjustBrainLoss(3)
 	if(iscultist(M))
 		M.status_flags |= GOTTAGOFAST
 		M.drowsyness = max(M.drowsyness-5, 0)
@@ -221,6 +220,7 @@
 		M.AdjustStunned(-2)
 		M.AdjustWeakened(-2)
 	else
+		M.adjustBrainLoss(3)
 		M.adjustToxLoss(2)
 		M.adjustFireLoss(2)
 		M.adjustOxyLoss(2)

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -66,6 +66,7 @@ h1.alert, h2.alert		{color: #000000;}
 .green					{color: #03ff39;}
 .shadowling				{color: #3b2769;}
 .cultsmall				{color: #960000;}
+.cultitalic				{color: #960000; font-style: italic;}
 .cult					{color: #960000; font-weight: bold; font-size: 3;}
 .narsie					{color: #960000; font-weight: bold; font-size: 15;}
 .purple					{color: #5e2d79;}


### PR DESCRIPTION
:cl: Joan
tweak: Harvesters can break walls, including rwalls, and produce cult floors and walls.
tweak: Unholy water no longer causes brain damage to cultists.
rscdel: Deafen, Blind, and Disguise Runes removed.
rscadd: Debilitate rune added, which blinds, deafens, and mutes all who can see it for a relatively short time.
tweak: Stun rune flashes cultists who can see it(though it doesn't stun them).
tweak: Summon armor rune now produces the armor on the rune instead of equipping it to you. Talisman functionality is the same, however.
tweak: Blood boil now does 75 burn damage and sets targets on fire, though it no longer blows up the tile it is on.
tweak: The supply talisman now has 5 uses, can no longer produce conceal or reveal talismans, and can produce the new debilitate talisman.
rscdel: Disguise runes talisman removed.
tweak: Stun talismans no longer mute.
tweak: Debilitate talisman added, which mutes, blinds, confuses, and deafens a single target.
tweak: EMP talisman now has a slightly smaller radius than the rune.
experiment: While the removal of stun talismans muting and the new debilitate talisman doesn't majorly effect the ability of the cult to stun and mute you instantly, it does increase the setup time and number of inventory spots required to do so.
/:cl:
HERE WE GO SALT FOR DAYS NO TURNING BACK NOW
