### PR TITLE
Greately reduces standard holoparasite battlecry spam

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -223,6 +223,8 @@
 /mob/living/simple_animal/hostile/guardian/punch
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	var cry_cooldown = 5
+	var cry_wait = 0
 	damage_transfer = 0.5
 	playstyle_string = "As a standard type you have no special abilities, but have a high damage resistance and a powerful attack capable of smashing through walls."
 	environment_smash = 2
@@ -244,12 +246,14 @@
 /mob/living/simple_animal/hostile/guardian/punch/AttackingTarget()
 	..()
 	if(istype(target, /mob/living))
-		src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]\
-		[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
+		if(src.cry_wait == 0)
+			src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
+			src.cry_wait = (src.cry_cooldown + 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
+		src.cry_wait--
 
 //Healer
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -223,8 +223,8 @@
 /mob/living/simple_animal/hostile/guardian/punch
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	var cry_cooldown = 5
-	var cry_wait = 0
+	var/cry_cooldown = 20
+	var/last_cry = 0
 	damage_transfer = 0.5
 	playstyle_string = "As a standard type you have no special abilities, but have a high damage resistance and a powerful attack capable of smashing through walls."
 	environment_smash = 2
@@ -246,14 +246,14 @@
 /mob/living/simple_animal/hostile/guardian/punch/AttackingTarget()
 	..()
 	if(istype(target, /mob/living))
-		if(src.cry_wait == 0)
-			src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
+		if( last_cry + cry_cooldown < world.time )
+			last_cry = world.time
+			src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry]!!")
 			src.cry_wait = (src.cry_cooldown + 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
 		playsound(loc, src.attack_sound, 50, 1, 1)
-		src.cry_wait--
 
 //Healer
 


### PR DESCRIPTION
number of battlecries per punch reduced to 4
Battlecry will only trigger every 5th punch.
:cl: Shadowlight213
tweak: Standard holoparasite battlecry has been greatly reduced to decrease spam.
/:cl:
