### PR TITLE
Drones no longer receive toxin damage.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -38,6 +38,7 @@
 	languages = DRONE
 	mob_size = MOB_SIZE_SMALL
 	has_unlimited_silicon_privilege = 1
+	ignored_damage_types = list(BRUTE = 0, BURN = 0, TOX = 1, CLONE = 1, STAMINA = 1, OXY = 1) // 0 to receive that damage type, 1 to ignore
 	staticOverlays = list()
 	var/staticChoice = "static"
 	var/list/staticChoices = list("static", "blank", "letter")


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/12594.

I went ahead and blocked the other kinds of damage robots really shouldn't be taking, in case by some freak accident they receive it
