### PR TITLE
Fixes changeling swap body kicking people to lobby

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -159,6 +159,7 @@
 	user.mind.transfer_to(target)
 	if(ghost && ghost.mind)
 		ghost.mind.transfer_to(user)
+	else
 		user.key = ghost.key
 
 	user.Paralyse(2)


### PR DESCRIPTION
Don't set the ckey after transfer_to(), as tranfer_to() will have nulled that field for the source mob.

Fixes #13107
