### PR TITLE
Spill Oxygen / Obtain Atmosphere

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -772,6 +772,23 @@
 	description = "A secondary amine, mildly corrosive."
 	color = "#604030" // rgb: 96, 64, 48
 
+/datum/reagent/carbondioxide
+	name = "Carbon Dioxide"
+	id = "co2"
+	reagent_state = GAS
+	description = "A gas commonly produced by burning carbon fuels."
+	color = "#B0B0B0" // rgb : 192, 192, 192
+
+/datum/reagent/carbondioxide/reaction_obj(obj/O, reac_volume)
+	if((!O) || (!reac_volume))
+		return 0
+	O.atmos_spawn_air(SPAWN_CO2|SPAWN_20C, reac_volume/5)
+
+/datum/reagent/carbondioxide/reaction_turf(turf/simulated/T, reac_volume)
+	if(istype(T))
+		T.atmos_spawn_air(SPAWN_CO2|SPAWN_20C, reac_volume/5)
+	return
+
 
 
 /////////////////////////Coloured Crayon Powder////////////////////////////

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -403,6 +403,16 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 
+/datum/reagent/oxygen/reaction_obj(obj/O, reac_volume)
+	if((!O) || (!reac_volume))
+		return 0
+	O.atmos_spawn_air(SPAWN_OXYGEN|SPAWN_20C, reac_volume/2)
+
+/datum/reagent/oxygen/reaction_turf(turf/simulated/T, reac_volume)
+	if(istype(T))
+		T.atmos_spawn_air(SPAWN_OXYGEN|SPAWN_20C, reac_volume/2)
+	return
+
 /datum/reagent/copper
 	name = "Copper"
 	id = "copper"
@@ -416,6 +426,16 @@
 	description = "A colorless, odorless, tasteless gas."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
+
+/datum/reagent/nitrogen/reaction_obj(obj/O, reac_volume)
+	if((!O) || (!reac_volume))
+		return 0
+	O.atmos_spawn_air(SPAWN_NITROGEN|SPAWN_20C, reac_volume)
+
+/datum/reagent/nitrogen/reaction_turf(turf/simulated/T, reac_volume)
+	if(istype(T))
+		T.atmos_spawn_air(SPAWN_NITROGEN|SPAWN_20C, reac_volume)
+	return
 
 /datum/reagent/hydrogen
 	name = "Hydrogen"

--- a/code/modules/reagents/Chemistry-Recipes/Others.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Others.dm
@@ -116,6 +116,14 @@
 	new /obj/item/weapon/reagent_containers/food/snacks/meat/slab/meatproduct(location)
 	return
 
+/datum/chemical_reaction/carbondioxide
+	name = "Direct Carbon Oxidation"
+	id = "burningcarbon"
+	result = "co2"
+	required_reagents = list("carbon" = 1, "oxygen" = 2)
+	required_temp = 777 // pure carbon isn't especially reactive.
+	result_amount = 3
+
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////
 
 /datum/chemical_reaction/virus_food


### PR DESCRIPTION
Give oxygen and nitrogen reaction_obj and reaction_turf functions, which produce their respective gases.

:cl:
rscadd: Spilling oxygen or nitrogen will obtain a release of the corresponding atmospheric gas in the effected tile.
rscadd: Carbon Dioxide has been added as a reagent.  Recipe: 2:1 carbon:oxygen, heated to 777K.
rscadd: Spilling CO2 will produce CO2 gas.
/:cl:
