### PR TITLE
Revenant Bugfixes 

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -10,6 +10,10 @@
 	desc = "A malevolent spirit."
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "revenant_idle"
+	var/icon_idle = "revenant_idle"
+	var/icon_reveal = "revenant_revealed"
+	var/icon_stun = "revenant_stun"
+	var/icon_drain = "revenant_draining"
 	incorporeal_move = 3
 	invisibility = INVISIBILITY_REVENANT
 	health = INFINITY //Revenants don't use health, they use essence instead
@@ -101,7 +105,16 @@
 	update_spooky_icon()
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
-	icon_state = revealed ? "revenant_[notransform ? "[draining ? "draining" : "stun"]" : "revealed"]" : "revenant_idle"
+	if(revealed)
+		if(notransform)
+			if(draining)
+				icon_state = icon_drain
+			else
+				icon_state = icon_stun
+		else
+			icon_state = icon_reveal
+	else
+		icon_state = icon_idle
 
 /mob/living/simple_animal/revenant/ex_act(severity, target)
 	return 1 //Immune to the effects of explosions.
@@ -111,6 +124,9 @@
 
 /mob/living/simple_animal/revenant/singularity_act()
 	return //don't walk into the singularity expecting to find corpses, okay?
+
+/mob/living/simple_animal/revenant/narsie_act()
+	return //most humans will now be either bones or harvesters, but we're still un-alive.
 
 /mob/living/simple_animal/revenant/adjustBruteLoss(amount)
 	if(!revealed)

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -101,16 +101,7 @@
 	update_spooky_icon()
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
-	if(revealed)
-		if(draining)
-			icon_state = "revenant_draining"
-			return
-		if(notransform)
-			icon_state = "revenant_stun"
-			return
-		icon_state = "revenant_revealed"
-		return
-	icon_state = "revenant_idle"
+	icon_state = revealed ? "revenant_[notransform ? "[draining ? "draining" : "stun"]" : "revealed"]" : "revenant_idle"
 
 /mob/living/simple_animal/revenant/ex_act(severity, target)
 	return 1 //Immune to the effects of explosions.
@@ -235,11 +226,11 @@
 
 /mob/living/simple_animal/revenant/New()
 	..()
-	
+
 	ghostimage = image(src.icon,src,src.icon_state)
 	ghost_darkness_images |= ghostimage
 	updateallghostimages()
-	
+
 	spawn(5)
 		if(src.mind)
 			src.mind.remove_all_antag()
@@ -414,7 +405,7 @@
 		user << "<span class='revenwarning'>It is shifting and distorted. It would be wise to destroy this.</span>"
 
 /obj/item/weapon/ectoplasm/revenant/proc/reform()
-	if(inert || !src)
+	if(gc_destroyed || !src || inert)
 		return
 	var/key_of_revenant
 	message_admins("Revenant ectoplasm was left undestroyed for 1 minute and is reforming into a new revenant.")

--- a/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
@@ -18,6 +18,7 @@
 		deadMobs++
 	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
 		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
+		occurrences--
 		return
 	key_of_revenant = null
 	if(!key_of_revenant)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
@@ -18,7 +18,6 @@
 		deadMobs++
 	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
 		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
-		occurrences--
 		return
 	key_of_revenant = null
 	if(!key_of_revenant)


### PR DESCRIPTION
Fixes #11442
At least, it should.

Tweaks the revenant icon update so that admins can edit what icons the revenant uses when revealed, idle, stunned, and draining.
Also fixes nar-sie eating revenants.
