### PR TITLE
Fixes login runtimes for round start observers

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1694,6 +1694,12 @@
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
 	mind.active = 1		//indicates that the mind is currently synced with a client
 
+/mob/new_player/sync_mind()
+	return
+
+/mob/dead/observer/sync_mind()
+	return
+
 //Initialisation procs
 /mob/proc/mind_initialize()
 	if(mind)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,4 +1,9 @@
 /mob/new_player/Login()
+	if(!mind)
+		mind = new /datum/mind(key)
+		mind.active = 1
+		mind.current = src
+
 	..()
 
 	if(join_motd)
@@ -9,11 +14,6 @@
 
 	if(config.soft_popcap && living_player_count() >= config.soft_popcap)
 		src << "<span class='notice'><b>Server Notice:</b>\n \t [config.soft_popcap_message]</span>"
-
-	if(!mind)
-		mind = new /datum/mind(key)
-		mind.active = 1
-		mind.current = src
 
 	if(length(newplayer_start))
 		loc = pick(newplayer_start)


### PR DESCRIPTION
This is a band-aid fix for the runtimes related to round start observing (as in : i didn't check if there's more than this one with the _sync_mind()_ addition).
Whoever put _sync_mind()_ at the end of base _Login()_ didn't check for possible mindless mobs.
Also, _sync_mind()_ is now double called for _/mob/camera/blob_, _/mob/camera/god_ and _/mob/living_ Logins.

While i were at it, some failsafes for new_player login, matching as close as possible what it were doing before merging with base Login().
