### PR TITLE
Bot speech bubbles

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -356,6 +356,15 @@
 		Radio.talk_into(src, message, radio_frequency)
 	else
 		say(message)
+
+		//speech bubble
+		var/list/speech_bubble_recipients = list()
+		for(var/mob/M in get_hearers_in_view(7,src))
+			if(M.client)
+				speech_bubble_recipients.Add(M.client)
+		spawn(0)
+			flick_overlay(image('icons/mob/talk.dmi', src, "hR[say_test(message)]",MOB_LAYER+1), speech_bubble_recipients, 30)
+
 	return
 
 	//Generalized behavior code, override where needed!


### PR DESCRIPTION
Adds speech bubbles for bots whenever they speak!

![beepsky](https://cloud.githubusercontent.com/assets/5420151/11346827/3f147fe6-9227-11e5-8cf8-061c66372267.png)
![medbot](https://cloud.githubusercontent.com/assets/5420151/11346830/3faa08a4-9227-11e5-8d08-10ee05c92061.png)

Copied straight out of @AnturK 's mech speech bubbles PR, I have no idea how it actually works so all edge-case testing suggestions will be tested if someone knows any. I just spawned different bots, waited until they said something and it seemed to be working perfectly.
