### PR TITLE
Fixes areas blobs shouldn't win from spreading to.

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -30,7 +30,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/lightswitch = 1
 	var/valid_territory = 1 //If it's a valid territory for gangs to claim
 
-	var/blob_legit = 1 //Does it count for blobs score? By default, all areas count.
+	var/blob_allowed = 1 //Does it count for blobs score? By default, all areas count.
 
 	var/eject = null
 
@@ -99,7 +99,7 @@ var/list/teleportlocs = list()
 	power_environ = 0
 	valid_territory = 0
 	ambientsounds = list('sound/ambience/ambispace.ogg','sound/ambience/title2.ogg',)
-	blob_legit = 0 //Eating up space doesn't count for victory as a blob.
+	blob_allowed = 0 //Eating up space doesn't count for victory as a blob.
 
 /area/space/nearstation
 	icon_state = "space_near"
@@ -167,7 +167,7 @@ var/list/teleportlocs = list()
 	icon_state = "centcom"
 	requires_power = 0
 	has_gravity = 1
-	blob_legit = 0 //Should go without saying, no blobs should take over centcom as a win condition.
+	blob_allowed = 0 //Should go without saying, no blobs should take over centcom as a win condition.
 
 /area/centcom/control
 	name = "Centcom Docks"
@@ -194,7 +194,7 @@ var/list/teleportlocs = list()
 	icon_state = "syndie-ship"
 	requires_power = 0
 	has_gravity = 1
-	blob_legit = 0 //Not... entirely sure this will ever come up... but if the bus makes blobs AND ops, it shouldn't aim for the ops to win.
+	blob_allowed = 0 //Not... entirely sure this will ever come up... but if the bus makes blobs AND ops, it shouldn't aim for the ops to win.
 
 /area/syndicate_mothership/control
 	name = "Syndicate Control Room"
@@ -211,7 +211,7 @@ var/list/teleportlocs = list()
 	icon_state = "asteroid"
 	requires_power = 0
 	has_gravity = 1
-	blob_legit = 0 //Nope, no winning on the asteroid as a blob. Gotta eat the station.
+	blob_allowed = 0 //Nope, no winning on the asteroid as a blob. Gotta eat the station.
 	valid_territory = 0
 
 /area/asteroid/cave
@@ -1018,7 +1018,7 @@ var/list/teleportlocs = list()
 	name = "Ruskie DJ Station"
 	icon_state = "DJ"
 	has_gravity = 1
-	blob_legit = 0 //Nope, no winning on the DJ station as a blob. Gotta eat the main station.
+	blob_allowed = 0 //Nope, no winning on the DJ station as a blob. Gotta eat the main station.
 
 /area/djstation/solars
 	name = "DJ Station Solars"
@@ -1030,7 +1030,7 @@ var/list/teleportlocs = list()
 /area/derelict
 	name = "Derelict Station"
 	icon_state = "storage"
-	blob_legit = 0 //Nope, no winning on the derelict as a blob. Gotta eat the station.
+	blob_allowed = 0 //Nope, no winning on the derelict as a blob. Gotta eat the station.
 
 /area/derelict/hallway/primary
 	name = "Derelict Primary Hallway"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -30,6 +30,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/lightswitch = 1
 	var/valid_territory = 1 //If it's a valid territory for gangs to claim
 
+	var/blob_legit = 1 //Does it count for blobs score? By default, all areas count.
+
 	var/eject = null
 
 	var/requires_power = 1
@@ -210,6 +212,7 @@ var/list/teleportlocs = list()
 	requires_power = 0
 	has_gravity = 1
 	blob_legit = 0 //Nope, no winning on the asteroid as a blob. Gotta eat the station.
+	valid_territory = 0
 
 /area/asteroid/cave
 	name = "Asteroid - Underground"

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -97,6 +97,7 @@ var/list/teleportlocs = list()
 	power_environ = 0
 	valid_territory = 0
 	ambientsounds = list('sound/ambience/ambispace.ogg','sound/ambience/title2.ogg',)
+	blob_legit = 0 //Eating up space doesn't count for victory as a blob.
 
 /area/space/nearstation
 	icon_state = "space_near"
@@ -164,6 +165,7 @@ var/list/teleportlocs = list()
 	icon_state = "centcom"
 	requires_power = 0
 	has_gravity = 1
+	blob_legit = 0 //Should go without saying, no blobs should take over centcom as a win condition.
 
 /area/centcom/control
 	name = "Centcom Docks"
@@ -190,6 +192,7 @@ var/list/teleportlocs = list()
 	icon_state = "syndie-ship"
 	requires_power = 0
 	has_gravity = 1
+	blob_legit = 0 //Not... entirely sure this will ever come up... but if the bus makes blobs AND ops, it shouldn't aim for the ops to win.
 
 /area/syndicate_mothership/control
 	name = "Syndicate Control Room"
@@ -206,6 +209,7 @@ var/list/teleportlocs = list()
 	icon_state = "asteroid"
 	requires_power = 0
 	has_gravity = 1
+	blob_legit = 0 //Nope, no winning on the asteroid as a blob. Gotta eat the station.
 
 /area/asteroid/cave
 	name = "Asteroid - Underground"
@@ -1011,6 +1015,7 @@ var/list/teleportlocs = list()
 	name = "Ruskie DJ Station"
 	icon_state = "DJ"
 	has_gravity = 1
+	blob_legit = 0 //Nope, no winning on the DJ station as a blob. Gotta eat the main station.
 
 /area/djstation/solars
 	name = "DJ Station Solars"
@@ -1022,6 +1027,7 @@ var/list/teleportlocs = list()
 /area/derelict
 	name = "Derelict Station"
 	icon_state = "storage"
+	blob_legit = 0 //Nope, no winning on the derelict as a blob. Gotta eat the station.
 
 /area/derelict/hallway/primary
 	name = "Derelict Primary Hallway"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -23,7 +23,6 @@
 									'sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg',\
 									'sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg',\
 									'sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
-	var/blob_legit = 1 //Does it count for blobs score? By default, all areas count.
 
 /area/New()
 	icon_state = ""

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -23,6 +23,7 @@
 									'sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg',\
 									'sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg',\
 									'sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
+	var/blob_legit = 1 //Does it count for blobs score? By default, all areas count.
 
 /area/New()
 	icon_state = ""

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -1,9 +1,10 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
 //Few global vars to track the blob
-var/list/blobs = list()
+var/list/blobs = list() //complete list of all blobs made.
 var/list/blob_cores = list()
 var/list/blob_nodes = list()
+var/list/blobs_legit = list() //used for win-score calculations, contains only blobs counted for win condition
 
 
 /datum/game_mode/blob

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/blob/check_finished()
 	if(infected_crew.len > burst)//Some blobs have yet to burst
 		return 0
-	if(blobwincount <= blobs.len)//Blob took over
+	if(blobwincount <= blobs_legit.len)//Blob took over
 		return 1
 	if(!blob_cores.len) // blob is dead
 		if(config.continuous["blob"])

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -19,7 +19,7 @@
 /datum/game_mode/blob/declare_completion()
 	if(round_converted) //So badmin blobs later don't step on the dead natural blobs metaphorical toes
 		..()
-	if(blobwincount <= blobs.len)
+	if(blobwincount <= blobs_legit.len)
 		feedback_set_details("round_end_result","win - blob took over")
 		world << "<FONT size = 3><B>The blob has taken over the station!</B></FONT>"
 		world << "<B>The entire station was eaten by the Blob</B>"

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,7 +19,7 @@
 
 
 /obj/effect/blob/New(loc)
-	var/area/Ablob = loc
+	var/area/Ablob = get_area(loc)
 	if (Ablob.blob_legit) //Is the area Legit for blobs?
 		blobs_legit += src
 	blobs += src //Keep track of the blob in the normal list either way
@@ -34,7 +34,7 @@
 	return
 
 /obj/effect/blob/Destroy()
-	var/area/Ablob = loc
+	var/area/Ablob = get_area(loc)
 	if (Ablob.blob_legit) //Only remove for blobs in Legit places, else they didn't add points to begin with.
 		blobs_legit -= src
 	blobs -= src //It's still removed from the normal list

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,7 +19,7 @@
 
 /obj/effect/blob/New(loc)
 	var/area/Ablob = get_area(loc)
-	if (Ablob.blob_allowed) //Is this area allowed for winning as blob?
+	if(Ablob.blob_allowed) //Is this area allowed for winning as blob?
 		blobs_legit += src
 	blobs += src //Keep track of the blob in the normal list either way
 	src.dir = pick(1, 2, 4, 8)
@@ -34,7 +34,7 @@
 
 /obj/effect/blob/Destroy()
 	var/area/Ablob = get_area(loc)
-	if (Ablob.blob_allowed) //Only remove for blobs in areas that counted for the win
+	if(Ablob.blob_allowed) //Only remove for blobs in areas that counted for the win
 		blobs_legit -= src
 	blobs -= src //It's still removed from the normal list
 	playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) //Expand() is no longer broken, no check necessary.
@@ -134,14 +134,14 @@
 	if(istype(T, /turf/space) && prob(65))
 		Blob_spawnable = 0
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) //Let's give some feedback that we DID try to spawn in space, since players are used to it
-	for (var/atom/A in T)
-		if (A.density != 0) // Unless density is 0, don't spawn a blob
+	for(var/atom/A in T)
+		if(A.density) // Unless density is 0, don't spawn a blob
 			Blob_spawnable = 0
 		A.blob_act() //Hit everything
-	if (T.density != 0) //Check for walls and such dense turfs
+	if(T.density) //Check for walls and such dense turfs
 		Blob_spawnable = 0
 		T.blob_act() //Hit the turf
-	if (Blob_spawnable == 1)
+	if(Blob_spawnable)
 		var/obj/effect/blob/B = new /obj/effect/blob/normal(src.loc)
 		B.color = a_color
 		B.density = 1

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -42,8 +42,10 @@
 
 
 /obj/effect/blob/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)	return 1
-	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
+	if(height==0)
+		return 1
+	if(istype(mover) && mover.checkpass(PASSBLOB))
+		return 1
 	return 0
 
 
@@ -97,7 +99,8 @@
 	var/list/dirs = list(1,2,4,8)
 	dirs.Remove(origin_dir)//Dont pulse the guy who pulsed us
 	for(var/i = 1 to 4)
-		if(!dirs.len)	break
+		if(!dirs.len)
+			break
 		var/dirn = pick(dirs)
 		dirs.Remove(dirn)
 		var/turf/T = get_step(src, dirn)
@@ -124,18 +127,18 @@
 			var/dirn = pick(dirs)
 			dirs.Remove(dirn)
 			T = get_step(src, dirn)
-			if(!(locate(/obj/effect/blob) in T))	break
-			else	T = null
-
-	if(!T)	return 0
-	//We can keep the above code in this proc, it probably works fine?
-	//new blob code with less BS:
+			if(!(locate(/obj/effect/blob) in T))
+				break
+			else
+				T = null
+	if(!T)
+		return 0
 	var/Blob_spawnable = 1
 	if(istype(T, /turf/space) && prob(65))
 		Blob_spawnable = 0
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) //Let's give some feedback that we DID try to spawn in space, since players are used to it
 	for(var/atom/A in T)
-		if(A.density) // Unless density is 0, don't spawn a blob
+		if(A.density) //Unless density is 0, don't spawn a blob
 			Blob_spawnable = 0
 		A.blob_act() //Hit everything
 	if(T.density) //Check for walls and such dense turfs

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -19,7 +19,10 @@
 
 
 /obj/effect/blob/New(loc)
-	blobs += src
+	var/area/Ablob = loc
+	if (Ablob.blob_legit) //Is the area Legit for blobs?
+		blobs_legit += src
+	blobs += src //Keep track of the blob in the normal list either way
 	src.dir = pick(1, 2, 4, 8)
 	src.update_icon()
 	..(loc)
@@ -31,7 +34,10 @@
 	return
 
 /obj/effect/blob/Destroy()
-	blobs -= src
+	var/area/Ablob = loc
+	if (Ablob.blob_legit) //Only remove for blobs in Legit places, else they didn't add points to begin with.
+		blobs_legit -= src
+	blobs -= src //It's still removed from the normal list
 	if(isturf(loc)) //Necessary because Expand() is retarded and spawns a blob and then deletes it
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
 	return ..()

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -544,7 +544,7 @@
 		if(istype(ticker.mode, /datum/game_mode/blob))
 			var/datum/game_mode/blob/mode = ticker.mode
 			dat += "<br><table cellspacing=5><tr><td><B>Blob</B></td><td></td><td></td></tr>"
-			dat += "<tr><td><i>Progress: [blobs.len]/[mode.blobwincount]</i></td></tr>"
+			dat += "<tr><td><i>Progress: [blobs_legit.len]/[mode.blobwincount]</i></td></tr>"
 
 			for(var/datum/mind/blob in mode.infected_crew)
 				var/mob/M = blob.current


### PR DESCRIPTION
:cl: ktccd
bugfix: Blob pieces on some areas no longer count for blob mode victory (Such as space or asteroid).
bugfix: Blobcode no longer spawns and destroys blobs uselessly, which fixes other stuff too.
bugfix: Asteroid areas are no longer valid gang territory.
/:cl:
Fixes  #13126
