### PR TITLE
Makes the shuttle harder to call

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -108,6 +108,10 @@
 	var/list/midround_antag = list() 	// which roundtypes use the midround antagonist system
 	var/midround_antag_time_check = 60  // How late (in minutes) you want the midround antag system to stay on, setting this to 0 will disable the system
 	var/midround_antag_life_check = 0.7 // A ratio of how many people need to be alive in order for the round not to immediately end in midround antagonist
+	var/shuttle_boredom_check = 60 		// """Optimal""" round length time (in minutes), used as a guide for calling the shuttle in the abscence of any other issue to face
+	var/shuttle_life_check = 0.7		// A ratio of how many people need to be alive in order for the shuttle to not justify that as a reason for coming.
+	var/shuttle_antag_overrun = 0.5		// A ratio of dirty traitors to all living crew. If this is achieved the shuttle can come (most likely in revolution/gang).
+	var/shuttle_infrastructure_check = 0.7 // A ratio of "how blown up / singulo'd the station is", again to gauge shuttle calls.
 	var/shuttle_refuel_delay = 12000
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
@@ -458,6 +462,14 @@
 					config.midround_antag_time_check = text2num(value)
 				if("midround_antag_life_check")
 					config.midround_antag_life_check = text2num(value)
+				if("shuttle_boredom_check")
+					config.shuttle_boredom_check	= text2num(value)
+				if("shuttle_life_check")
+					config.shuttle_life_check 		= text2num(value)
+				if("shuttle_antag_overrun")
+					config.shuttle_antag_overrun 	= text2num(value)
+				if("shuttle_infrastructure_check")
+					config.shuttle_infrastructure_check = text2num(value)
 				if("shuttle_refuel_delay")
 					config.shuttle_refuel_delay     = text2num(value)
 				if("show_game_type_odds")

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -16,6 +16,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
+	var/force_shuttle = 0			//Even in abscence of danger, the shuttle will come.
 
 		//supply shuttle stuff
 	var/obj/docking_port/mobile/supply/supply

--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -39,6 +39,15 @@
 		if(SHUTTLE_IDLE)
 			mode = SHUTTLE_CALL
 			timer = world.time
+			if(!legitimize_call())
+				var/time_to_recall = rand(600,1200)
+				var/old_timer = timer
+				if(!redAlert)
+					time_to_recall *= 2
+				spawn(time_to_recall)
+					if(mode == SHUTTLE_CALL && timer == old_timer && !SSshuttle.force_shuttle)
+						cancel(/area/centcom)
+
 		if(SHUTTLE_CALL)
 			if(world.time < timer)	//this is just failsafe
 				timer = world.time
@@ -51,6 +60,44 @@
 		SSshuttle.emergencyLastCallLoc = null
 
 	priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/AI/shuttlecalled.ogg', "Priority")
+
+/obj/docking_port/mobile/emergency/proc/legitimize_call() //Checks are sorted in rough order of processing cost
+	if(SSshuttle.force_shuttle) //Set manually by certain "Oh shit" events, like narsie.
+		message_admins("Shuttle will arrive due to you know what.")
+		return 1
+
+	if(world.time >= (config.shuttle_boredom_check * 600)) //Extended mercy and/or boring/ineffective antags
+		message_admins("Shuttle will arrive due to long round length.")
+		return 1
+
+	var/list/living_crew_bodies = list()
+	var/list/living_crew_minds	= list()
+	for(var/mob/Player in mob_list)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) &&!isbrain(Player))
+			living_crew_bodies	+= Player
+			living_crew_minds	+= Player.mind
+
+	if(living_crew_bodies.len / joined_player_list.len <= config.shuttle_life_check) //Dead people everywhere
+		message_admins("Shuttle will arrive due to rampant death.")
+		return 1
+
+	var/list/antagonist_crew_minds	= list()
+	for(var/datum/mind/M in living_crew_minds)
+		if(M.special_role)
+			antagonist_crew_minds += M
+
+	if(antagonist_crew_minds.len / living_crew_minds.len >= config.shuttle_antag_overrun) //Station ruled by antags
+		message_admins("Shuttle will arrive due to antagonist infestation.")
+		return 1
+
+	var/datum/station_state/current_state = new /datum/station_state()
+	current_state.count()
+	if((start_state.score(current_state)) < config.shuttle_infrastructure_check) //Station bombed to hell/singulo'd
+		message_admins("Shuttle will arrive due to badly damaged station.")
+		return 1
+
+	message_admins("Shuttle will recall automatically. If you feel the shuttle should come, <A HREF='?_src_=holder;force_shuttle=\ref[usr]'>click here</A>.")
+	return 0
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -59,6 +59,7 @@
 /datum/gang/proc/domination(modifier=1)
 	dom_timer = get_domination_time(src) * modifier
 	set_security_level("delta")
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergencyNoEscape = 1
 
 //////////////////////////////////////////// OUTFITS

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -194,6 +194,7 @@
 
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')
 	set_security_level("delta")
+	SSshuttle.force_shuttle = 1
 
 	for(var/obj/item/weapon/pinpointer/point in world)
 		for(var/datum/mind/AI_mind in ticker.mode.malf_ai)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -16,6 +16,7 @@
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
+	var/syndies_made_contact = 0 //Used for tracking when (if?) the syndicates actually manage to step foot on space station 13
 
 /datum/game_mode/nuclear/announce()
 	world << "<B>The current game mode is - Nuclear Emergency!</B>"
@@ -161,6 +162,14 @@
 		return 1
 	return ..()
 
+/datum/game_mode/nuclear/proc/are_operatives_onsite()
+	for(var/datum/mind/operative_mind in syndicates)
+		if(ismob(operative_mind.current))
+			var/mob/M = operative_mind.current
+			if(!M.stat && isarea(M.loc) && M.loc in the_station_areas)
+				syndies_made_contact = 1
+				SSshuttle.force_shuttle = 1
+
 
 /datum/game_mode/proc/are_operatives_dead()
 	for(var/datum/mind/operative_mind in syndicates)
@@ -173,6 +182,8 @@
 		return replacementmode.check_finished()
 	if(SSshuttle.emergency.mode >= SHUTTLE_ENDGAME || station_was_nuked)
 		return 1
+	if(!syndies_made_contact)
+		are_operatives_onsite()
 	if(are_operatives_dead())
 		if(bomb_set) //snaaaaaaaaaake! It's not over yet!
 			return 0
@@ -227,7 +238,6 @@
 		feedback_set_details("round_end_result","loss - evacuation - disk not secured")
 		world << "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>"
 		world << "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name()] Operatives!</B>"
-
 	else if (!disk_rescued &&  crew_evacuated)
 		feedback_set_details("round_end_result","halfwin - detonation averted")
 		world << "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>"

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -318,6 +318,7 @@ var/bomb_set
 	if(timing)
 		bomb_set = 1
 		set_security_level("delta")
+		SSshuttle.force_shuttle = 1
 	else
 		bomb_set = 0
 		set_security_level(previous_level)

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -168,6 +168,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.loc = A
 				sleep(50)
 				if(!ticker.mode.shadowling_ascended)
+					SSshuttle.force_shuttle = 1
 					SSshuttle.emergency.request(null, 0.3)
 				ticker.mode.shadowling_ascended = 1
 				A.mind.remove_spell(src)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -483,6 +483,7 @@
 	feedback_add_details("wizard_spell_learned",log_name)
 	only_me()
 	new /obj/item/weapon/multisword(get_turf(user)) //Because the proc skips special roles
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergency.request()
 	playsound(get_turf(user),"sound/magic/CastSummon.ogg",50,1)
 	user << "<span class='notice'>You have triggerd a multiverse war!</span>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -288,6 +288,13 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [timer] seconds</span>")
 		href_list["secrets"] = "check_antagonist"
 
+	else if(href_list["force_shuttle"])
+		if(!check_rights(R_ADMIN) || SSshuttle.force_shuttle)	return
+
+		SSshuttle.force_shuttle = 1
+		log_admin("[key_name(usr)] allowed the Emergency Shuttle to come.")
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] allowed the Emergency Shuttle to come.</span>")
+
 	else if(href_list["toggle_continuous"])
 		if(!check_rights(R_ADMIN))	return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -608,6 +608,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm != "Yes") return
 
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergency.request()
 	feedback_add_details("admin_verb","CSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-called the emergency shuttle.")

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -35,6 +35,7 @@
 	narsie_spawn_animation()
 
 	sleep(70)
+	SSshuttle.force_shuttle = 1
 	SSshuttle.emergency.request(null, 0.3) // Cannot recall
 
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -140,6 +140,17 @@ MIDROUND_ANTAG BLOB
 #MIDROUND_ANTAG  RAGINMAGES
 #MIDROUND_ANTAG  MONKEY
 
+##A time in minutes a round must progress before a shuttle call can be successful without anything being very wrong with the station.
+SHUTTLE_BOREDOM_CHECK 60
+
+##A ratio (living crew/all crew) used to determine if mass crewmember death is a valid reason to call the shuttle
+SHUTTLE_LIFE_CHECK 0.7
+
+##A ratio (living antag crew/all living crew) used to determine if mass antags is a valid reason to call the shuttle
+SHUTTLE_ANTAG_OVERRUN 0.5
+
+##A ratio (current station/initial station) used to determine if a badly damaged station is a valid reason to call the shuttle
+SHUTTLE_INFRASTRUCTURE_CHECK 0.7
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
 SHUTTLE_REFUEL_DELAY 12000


### PR DESCRIPTION
I've seen it happen far too often, the station passes the 25 minute mark, the antags are lurking in secret, the round is developing... Then someone demands a law 2 shuttle call for no real reason and everyone's forced to scramble and rush to finish their objectives in time in the name of 40 minute rounds.

Well no more. This adds actual checks to assure that a round has ACTUALLY GONE TO POT before the shuttle can be called.

The shuttle will auto recall if ALL the following are true:
- A certain percentage of players are still alive (Defaults to 70%)
- A certain percentage of players alive aren't antags (Defaults to 50%)
- The station isn't damaged more than a certain rating (Defaults to 70% integrity)
- The round hasn't gone over a certain length of time (Defaults to 1 hour)

Beyond this certain traumatic events will also always allow the shuttle to come at any point afterwards:
- Code Delta AI
- Live Nuke
- Ascendant Shadowling
- Gang Takeover Attempt
- Wizard Multiverse Sword War
- Nar-Nar
- Admin Shuttle Call
- <u>Nuke ops on the station</u> <b>Added 11/24</b>

Beyond this if a shuttle call WOULD recall, the admins will also get a message that allows them to have the shuttle come anyway according to their judgement.

If all this is avoided, the shuttle will autorecall at some random point between two and four minutes after calling (between one and two in code red calls). If the recall is traced, it's labeled as coming from centcom

This makes running from threats a less viable strategy. Stand and fight!

:cl: incoming5643
rscadd: Citing frustrations at the seemingly constant abandonment of 'like new' space stations, centcom has clamped down on flighty shuttle calls made on flimsy pretenses.
/:cl:

---
## Due to the immense size of discussion here's a little reminder of what people can ask to change about this pull
- How long it takes before shuttles always arrive when called
- How many people need to die for the shuttle to come over that
- How many antags (mainly group antags) need to exist in the living population for the shuttle to come over that
- How badly damage the station needs to be fo the shuttle to come over that
- Other trackable metrics of station/crew health to use
- Special situations that always justify shuttle calls
