### PR TITLE
Allows chainsaws to be used as a ghetto version of the generic sawing step

### DIFF
--- a/code/modules/surgery/generic_steps.dm
+++ b/code/modules/surgery/generic_steps.dm
@@ -74,7 +74,7 @@
 //saw bone
 /datum/surgery_step/saw
 	name = "saw bone"
-	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
Basically, it allows you to use a chainsaw during surgery whenever the surgery calls for a saw. Useful mostly for organ manipulation surgeries. They have the same success chance as fireaxes, unless they're mounted chainsaws, in which case they have a slightly better chance.

:cl: PKPenguin321
rscadd: Chainsaws (both arm-mounted and not arm-mounted) can now be used in surgeries as a ghetto sawing tool. Arm-mounted chainsaws are a teeny bit more precise than regular ol' everyday chainsaws.
/:cl:
