### PR TITLE
Adds more in depth descriptions of coding policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,10 +99,10 @@ The previous code made compliant:
 	code
 ```
 
-###No overriding byond type safety checks.
+###No overriding type safety checks.
 The use of the : operator to override type safety checks is strongly discouraged. You must cast the variable to the proper type.
 
-Exceptions are only made when used in loops that require the performance boast from being called ***extremely*** often. (Rule of thumb: If you aren't messing with the master controller or it's subsystems, this exception probably doesn't apply)
+Exceptions are only made when used in loops that require the performance boost from being called ***extremely*** often. (Rule of thumb: If you aren't messing with the master controller or it's subsystems, this exception probably doesn't apply)
 
 ###Type paths must began with a /
 eg: `/datum/thing` not `datum/thing`
@@ -127,16 +127,46 @@ You must use tabs to indent your code, NOT SPACES.
 (You may use spaces to align something, but you should tab to the block level first, then add the remaining spaces)
 
 ###No Hacky code
-Hacky code, such as adding specific checks, is highly discouraged and only allowed when there is no other option.
+Hacky code, such as adding specific checks, is highly discouraged and only allowed when there is ***no*** other option. (Protip: 'I couldn't immediately think of a proper way so thus there must be no other option' is not gonna cut it here )
 
 You can avoid hacky code by using object oriented methodologies, such as overriding a function (called procs in DM) or sectioning code into functions and then overriding them as required.
 
 ###No duplicated code.
-Duplicated code is 99% of the time never allowed. 
-
 Copying code from one place to another maybe suitable for small short time projects but /tg/station focuses on the long term and thus discourages this.
 
 Instead you can use object orientation, or simply placing repeated code in a function, to obey this specification easily.
+
+###No magic numbers or strings
+Make these #defines with a name that more clearly states what it's for.
+	
+###Control statements:
+(if,while,for,etc)
+
+* All control statements must not contain code on the same line as the statement (`if (blah) return`)
+* All control statements comparing a variable to a number should use the formula of `thing` `operator` `number`, not the reverse (eg: `if (count <= 10)` not `if (10 >= count)`)
+
+###Use early return.
+Do not enclose a proc in an if block when returning on a condition is more feasible
+This is bad:
+````
+/datum/datum1/proc/proc1()
+	if (thing1)
+		if (!thing2)
+			if (thing3 == 30)
+				do stuff
+````
+This is good:
+````
+/datum/datum1/proc/proc1()
+	if (!thing1)
+		return
+	if (thing2)
+		return
+	if (thing3 != 30)
+		return
+	do stuff
+````
+This prevents nesting levels from getting deeper then they need to be.
 
 ###Develop Secure Code
 
@@ -159,7 +189,22 @@ Instead you can use object orientation, or simply placing repeated code in a fun
 
 * You are expected to help maintain the code that you add, meaning if there is a problem then you are likely to be approached in order to fix any issues, runtimes or bugs.
 
+* Do not divide when you can easily convert it to a multiplication. (ie `4/2` should be done as `4*0.5`)
 
+####Operators and spaces:
+(this is not strictly enforced, but more a guideline for readability's sake)
+
+* Operators that should be separated by spaces
+	* Boolean and logic operators like &&, || <, >, ==, etc (but not !)
+	* Argument separator operators like , (and ; when used in a forloop)
+	* Assignment operators like = or += or the like
+* Operators that should not be separated by spaces
+	* Bitwise operators like & or |
+	* Access operators like . and :
+	* Parentheses ()
+	* logical not !
+
+Math operators like +, -, /, *, etc are up in the air, just choose which version looks more readable.
 
 ##Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ datum
 
 The use of this is not allowed in this project as it makes finding definitions via full text searching next to impossible. The only exception is the variables of an object may be nested to the object, but must not nest further.
 
-The previous code made complaint:
+The previous code made compliant:
 
 ```c++
 /datum/datum1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,29 +42,70 @@ Maintainers can revert your changes if they feel they are not worth maintaining 
 
 As mentioned before, you are expected to follow these specifications in order to make everyone's lives easier, it will also save you and us time, with having to make the changes and us having to tell you what to change. Thank you for reading this section.
 
-* As BYOND's Dream Maker is an object oriented language, code must be object oriented when possible in order to be more flexible when adding content to it. If you are unfamiliar with this concept, it is highly recommended you look it up.
+###Object Oriented code 
+As BYOND's Dream Maker is an object oriented language, code must be object oriented when possible in order to be more flexible when adding content to it. If you are unfamiliar with this concept, it is highly recommended you look it up.
 
-* You must write BYOND code with absolute pathing, like so:
+###All Byond paths must contain the full path.
+(ie: absolute pathing)
 
-```C++
+Byond will allow you nest almost any type keyword into a block, such as:
 
-/obj/item/weapon/baseball_bat
-    name = "baseball bat"
-    desc = "A baseball bat."
-    var/wooden = 1
-
-/obj/item/weapon/baseball_bat/examine()
-    if(wooden)
-        desc = "A wooden baseball bat."
-    else
-        desc = "A metal baseball bat."
-    ..()
-
+```c++
+datum
+	datum1
+		var
+			varname1 = 1
+			varname2
+			static
+				varname3
+				varname4
+		proc
+			proc1()
+				code
+			proc2()
+				code
+		
+		datum2
+			varname1 = 0
+			proc
+				proc3()
+					code
+			proc2()
+				..()
+				code
 ```
 
-* You must not use colons to override safety checks on an object's variable/function, instead of using proper type casting.
+The use of this is not allowed in this project as it makes finding definitions via full text searching next to impossible. The only exception is the variables of an object may be nested to the object, but must not nest further.
 
-* It is rarely allowed to put type paths in a text format, as they is no compile errors if the type path no longer exists. Here is an example:
+The previous code made complaint:
+
+```c++
+/datum/datum1
+		var/varname1
+		var/varname2
+		var/static/varname3
+		var/static/varname4
+
+/datum/datum1/proc/proc1()
+	code
+/datum/datum1/proc/proc2()
+	code
+/datum/datum1/datum2
+	varname1 = 0
+/datum/datum1/datum2/proc/proc3()
+	code
+/datum/datum1/datum2/proc2()
+	..()
+	code
+```
+
+###No overriding byond type safety checks.
+The use of the : operator to override type safety checks is strongly discouraged. You must cast the variable to the proper type.
+
+Exceptions are only made when used in loops that require the performance boast from being called ***extremely*** often. (Rule of thumb: If you aren't messing with the master controller or it's subsystems, this exception probably doesn't apply)
+
+###Do not use text/string based type paths
+It is rarely allowed to put type paths in a text format, as there are no compile errors if the type path no longer exists. Here is an example:
 
 ```C++
 //Good
@@ -74,17 +115,45 @@ var/path_type = /obj/item/weapon/baseball_bat
 var/path_type = "/obj/item/weapon/baseball_bat"
 ```
 
-* You must use tabs to indent your code, NOT SPACES.
+###Tabs not spaces
+You must use tabs to indent your code, NOT SPACES.
 
-* Hacky code, such as adding specific checks, is highly discouraged and only allowed when there is no other option. You can avoid hacky code by using object oriented methodologies, such as overriding a function (called procs in DM) or sectioning code into functions and then overriding them as required.
+(You may use spaces to align something, but you should tab to the block level first, then add the remaining spaces)
 
-* Duplicated code is 99% of the time never allowed. Copying code from one place to another maybe suitable for small short time projects but /tg/station focuses on the long term and thus discourages this. Instead you can use object orientation, or simply placing repeated code in a function, to obey this specification easily.
+###No Hacky code
+Hacky code, such as adding specific checks, is highly discouraged and only allowed when there is no other option.
 
+You can avoid hacky code by using object oriented methodologies, such as overriding a function (called procs in DM) or sectioning code into functions and then overriding them as required.
+
+###No duplicated code.
+Duplicated code is 99% of the time never allowed. 
+
+Copying code from one place to another maybe suitable for small short time projects but /tg/station focuses on the long term and thus discourages this.
+
+Instead you can use object orientation, or simply placing repeated code in a function, to obey this specification easily.
+
+###Develop Secure Code
+
+* Player input must always be escaped safely, we recommend you use stripped_input in all cases where you would use input. Essentially, just always treat input from players as inherently malicious and design with that use case in mind
+
+* Calls to the database must be escaped properly - use sanitizeSQL to escape text based database entries from players or admins, and isnum() for number based database entries from players or admins.
+
+* All calls to topics must be checked for correctness, topic href calls can be easily faked by clients, so you should ensure that the call is valid for the state the item is in. Do not rely on the UI code to provide only valid topic calls
+
+* Information that players could use to metagame (that is to identify the round type and or the antags via information that would not be available to them in character) should be kept as administrator only
+
+* It is recommended as well you do not expose information about the players - even something as simple as the number of people who have readied up at the start of the round can and has been used to try to identify the round type
+
+* Where you have code that can cause large scale modification and *FUN* make sure you start it out locked behind one of the default admin roles - use common sense to determine which role fits the level of damage a function could do
+
+###Other Notes
 * Code should be modular where possible, if you are working on a new class then it is best if you put it in a new file.
 
 * Bloated code may be necessary to add a certain feature, which means there has to be a judgement over whether the feature is worth having or not. You can help make this decision easier by making sure your code is modular.
 
 * You are expected to help maintain the code that you add, meaning if there is a problem then you are likely to be approached in order to fix any issues, runtimes or bugs.
+
+
 
 ##Pull Request Process
 
@@ -99,18 +168,3 @@ There is no strict process when it comes to merging pull requests, pull requests
 * If you are proposing multiple changes, which change many different aspects of the code, you are expected to section them off into different pull requests in order to make it easier to review them and to deny/accept the changes that are deemed acceptable.
 
 * If your pull request is accepted, the code you add is no longer exclusively yours but everyones, everyone is free to work on it but you are also free to object to any changes being made, which will be noted by a Project Lead or Project Manager. It is a shame this has to be explicitly told but there have been cases where this would've saved some trouble.
-
-##Developing Secure Code
-
-* Player input must always be escaped safely, we recommend you use stripped_input in all cases where you would use input. Essentially, just always treat input from players as inherently malicious and design with that use case in mind
-
-* Calls to the database must be escaped properly - use sanitizeSQL to escape database entries from players or admins
-
-* All calls to topics must be checked for correctness, topic href calls can be generated maliciously, so you should ensure that the call is valid for the state the item is in. Do not rely on the UI code to provide only valid topic calls
-
-* Information that players could use to metagame (that is to identify the round type and or the antags via information that would not be available to them in character) should be kept as administrator only
-
-* It is recommended as well you do not expose information about the players - even something as simple as the number of people who have readied up at the start of the round can and has been used to try to identify the round type
-
-* Where you have code that can cause large scale modification and *FUN* make sure you start it out locked behind one of the default admin roles - use common sense to determine which role fits the level of damage a function could do
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,12 @@ The use of the : operator to override type safety checks is strongly discouraged
 
 Exceptions are only made when used in loops that require the performance boast from being called ***extremely*** often. (Rule of thumb: If you aren't messing with the master controller or it's subsystems, this exception probably doesn't apply)
 
+###Type paths must began with a /
+eg: `/datum/thing` not `datum/thing`
+
+###Datum type paths must began with "datum"
+In byond this is optional, but omitting it makes finding definitions harder.
+
 ###Do not use text/string based type paths
 It is rarely allowed to put type paths in a text format, as there are no compile errors if the type path no longer exists. Here is an example:
 


### PR DESCRIPTION
I used h3 rather than bullets for the code policies so that you can link to a particular one.

I moved the secure code section to code policies to ensure it's seen.

I added the rule about starting type paths with `/` and not omitting `datum` in datum type paths. (Because a maintainer(@Aranclanos) asked @Firecage to fix all type paths that didn't have / or datum i'm assuming thats a rule now.)

I expanded on some of them, like pathing type checks, and used terms that somebody not familiar with byond would understand

edit:

Any part of https://github.com/tcl4dm/tcl4dm/blob/master/CONTRIBUTING.md#style-and-code-requirements that i should also bring in? More particularly, https://github.com/tcl4dm/tcl4dm/blob/master/CONTRIBUTING.md#operators-and-spaces and beyond? as everything above that is already in ours
