### PR TITLE
Revert "Properly reverts timed injectors"

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -352,42 +352,40 @@
 				num = Clamp(num, 1, NUMBER_OF_BUFFERS)
 				var/list/buffer_slot = buffer[num]
 				if(istype(buffer_slot))
-					var/obj/item/weapon/dnainjector/I
+					var/obj/item/weapon/dnainjector/timed/I
 					switch(href_list["text"])
 						if("se")
 							if(buffer_slot["SE"])
-								I = new /obj/item/weapon/dnainjector(loc)
+								I = new /obj/item/weapon/dnainjector/timed(loc)
 								for(var/datum/mutation/human/HM in good_mutations + bad_mutations + not_good_mutations)
 									if(HM.check_block_string(buffer_slot["SE"]))
 										I.add_mutations.Add(HM)
 									else
 										I.remove_mutations.Add(HM)
-/*
 								var/time_coeff
 								for(var/datum/mutation/human/HM in I.add_mutations)
 									if(!time_coeff)
 										time_coeff = HM.time_coeff
 										continue
 									time_coeff = min(time_coeff,HM.time_coeff)
-*/
 								if(connected)
-									//I.duration = I.duration * time_coeff * connected.damage_coeff //this is for timed injectors; the code is being left in case someone wants to add timed injectors to the console again
+									I.duration = I.duration * time_coeff * connected.damage_coeff
 									I.damage_coeff  = connected.damage_coeff
 						if("ui")
 							if(buffer_slot["UI"])
-								I = new /obj/item/weapon/dnainjector(loc)
+								I = new /obj/item/weapon/dnainjector/timed(loc)
 								I.fields = list("UI"=buffer_slot["UI"])
 								if(connected)
 									I.damage_coeff = connected.damage_coeff
 						if("ue")
 							if(buffer_slot["name"] && buffer_slot["UE"] && buffer_slot["blood_type"])
-								I = new /obj/item/weapon/dnainjector(loc)
+								I = new /obj/item/weapon/dnainjector/timed(loc)
 								I.fields = list("name"=buffer_slot["name"], "UE"=buffer_slot["UE"], "blood_type"=buffer_slot["blood_type"])
 								if(connected)
 									I.damage_coeff  = connected.damage_coeff
 						if("mixed")
 							if(buffer_slot["UI"] && buffer_slot["name"] && buffer_slot["UE"] && buffer_slot["blood_type"])
-								I = new /obj/item/weapon/dnainjector(loc)
+								I = new /obj/item/weapon/dnainjector/timed(loc)
 								I.fields = list("UI"=buffer_slot["UI"],"name"=buffer_slot["name"], "UE"=buffer_slot["UE"], "blood_type"=buffer_slot["blood_type"])
 								if(connected)
 									I.damage_coeff = connected.damage_coeff


### PR DESCRIPTION
Reverts tgstation/-tg-station#12977

This broke injectors (giving powers from them a 100% manifestation chance)

And there was miscommunication as to what this actually did, so the outlash from it was wrong.

Fixes #13144

:cl:
rscadd: Re-adds 100% chance timed injectors, as it was removed over a misunderstanding.
bugfix: Fixes bug with injectors having a 100% power chance despite not being timed
/:cl:
