### PR TITLE
Fixes pod early launch

### DIFF
--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -150,7 +150,7 @@
 	height = 4
 
 /obj/docking_port/mobile/pod/request()
-	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA && z == ZLEVEL_STATION)
 		return ..()
 	else
 		return
@@ -185,8 +185,25 @@
 /obj/docking_port/stationary/random/initialize()
 	..()
 	var/target_area = /area/mine/unexplored
-	var/turfs = get_area_turfs(target_area)
-	var/T=pick(turfs)
+	var/list/turfs = get_area_turfs(target_area)
+	var/sanity = 0
+	var/valid = 0
+	var/turf/T
+
+	if(!turfs.len)
+		qdel(src)
+
+	while(!valid)
+		valid = 1
+		sanity++
+		if(sanity > 100)
+			qdel(src)
+		T = pick(turfs)
+		if(!T)
+			qdel(src)
+		if(T.z == ZLEVEL_STATION || T.z == ZLEVEL_CENTCOM)
+			valid = 0
+			continue
 	src.loc = T
 
 //Pod suits/pickaxes

--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -179,29 +179,12 @@
 	dwidth = 1
 	width = 3
 	height = 4
+	var/target_area = /area/mine/unexplored
 
 /obj/docking_port/stationary/random/initialize()
 	..()
-	var/target_area = /area/mine/unexplored
 	var/list/turfs = get_area_turfs(target_area)
-	var/sanity = 0
-	var/valid = 0
-	var/turf/T
-
-	if(!turfs.len)
-		qdel(src)
-
-	while(!valid)
-		valid = 1
-		sanity++
-		if(sanity > 100)
-			qdel(src)
-		T = pick(turfs)
-		if(!T)
-			qdel(src)
-		if(T.z == ZLEVEL_STATION || T.z == ZLEVEL_CENTCOM)
-			valid = 0
-			continue
+	var/turf/T = pick(turfs)
 	src.loc = T
 
 //Pod suits/pickaxes

--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -152,8 +152,6 @@
 /obj/docking_port/mobile/pod/request()
 	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA && z == ZLEVEL_STATION)
 		return ..()
-	else
-		return
 
 /obj/docking_port/mobile/pod/New()
 	if(id == "pod")

--- a/code/controllers/subsystem/shuttles/emergency.dm
+++ b/code/controllers/subsystem/shuttles/emergency.dm
@@ -149,6 +149,12 @@
 	width = 3
 	height = 4
 
+/obj/docking_port/mobile/pod/request()
+	if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+		return ..()
+	else
+		return
+
 /obj/docking_port/mobile/pod/New()
 	if(id == "pod")
 		WARNING("[type] id has not been changed from the default. Use the id convention \"pod1\" \"pod2\" etc.")
@@ -156,13 +162,6 @@
 
 /obj/docking_port/mobile/pod/cancel()
 	return
-
-/*
-	findTransitDock()
-		. = SSshuttle.getDock("[id]_transit")
-		if(.)	return .
-		return ..()
-*/
 
 /obj/machinery/computer/shuttle/pod
 	name = "pod control computer"
@@ -175,11 +174,6 @@
 
 /obj/machinery/computer/shuttle/pod/update_icon()
 	return
-
-/obj/machinery/computer/shuttle/pod/emag_act(mob/user as mob)
-	user << "<span class='warning'> Access requirements overridden. The pod may now be launched manually at any time.</span>"
-	admin_controlled = 0
-	icon_state = "dorm_emag"
 
 /obj/docking_port/stationary/random
 	name = "escape pod"


### PR DESCRIPTION
Now it actually can't launch before red/delta

I swear it worked back in August when it was first merged

Fixes #13199

Can't launch it unless its actually still at the station preventing you from hijacking it mid escape.

Fixes #13210

Adds sanity checks to prevent it from launching to centcomm or something if someone makes a mapping error.
