### PR TITLE
Removes Accidental IC in OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -14,6 +14,10 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
+	if(copytext(msg, 1, 2) in list(".",";",":"))
+		src << "Your message \"[msg]\" looks like it was meant for in game communication."
+		return
+
 	if(!(prefs.chat_toggles & CHAT_OOC))
 		src << "<span class='danger'>You have OOC muted.</span>"
 		return

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -14,9 +14,9 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
-	if(copytext(msg, 1, 2) in list(".",";",":","#"))
-		src << "Your message \"[msg]\" looks like it was meant for in game communication."
-		return
+	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (lowertext(copytext(msg, 1, 4)) == "say"))
+		if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
+			return
 
 	if(!(prefs.chat_toggles & CHAT_OOC))
 		src << "<span class='danger'>You have OOC muted.</span>"

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -14,7 +14,7 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
-	if(copytext(msg, 1, 2) in list(".",";",":"))
+	if(copytext(msg, 1, 2) in list(".",";",":","#"))
 		src << "Your message \"[msg]\" looks like it was meant for in game communication."
 		return
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -14,10 +14,6 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)	return
 
-	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (lowertext(copytext(msg, 1, 4)) == "say"))
-		if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
-			return
-
 	if(!(prefs.chat_toggles & CHAT_OOC))
 		src << "<span class='danger'>You have OOC muted.</span>"
 		return
@@ -41,6 +37,10 @@
 			src << "<B>Advertising other servers is not allowed.</B>"
 			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
+			return
+			
+	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+		if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 			return
 
 	log_ooc("[mob.name]/[key] : [msg]")


### PR DESCRIPTION
OOC will catch messages that start with "." ";", ":", "#" (the say channel modifiers) or "say" itself.

When you type something that looks like IC in OOC you'll get a pop up that will let you actually say it if that's what you meant to do. It defaults to no so real accidental IC OOC can mash out of the command in case what they said was something like ";help I'm being killed!"

:cl: incoming5643
rscadd: OOC will now take steps to try and prevent accidental IC from people who mistakenly use OOC instead of say. This doesn't catch all mistakes, so please don't test it.
/:cl:
