### PR TITLE
Makes shuttle turf copy use proper helper.

### DIFF
--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -55,7 +55,7 @@
 //won't get an underlay of the destination turf on shuttle move
 /turf/simulated/wall/shuttle/interior/copyTurf(turf/T)
 	if(T.type != type)
-		T = new type(T)
+		T.ChangeTurf(type)
 		if(underlays.len)
 			T.underlays = underlays
 	if(T.icon_state != icon_state)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -625,7 +625,7 @@
 		if(underlays.len)	//we have underlays, which implies some sort of transparency, so we want to a snapshot of the previous turf as an underlay
 			O = new()
 			O.underlays.Add(T)
-		T = new type(T)
+		T.ChangeTurf(type)
 		if(underlays.len)
 			T.underlays = O.underlays
 	if(T.icon_state != icon_state)


### PR DESCRIPTION
Fixes #13213

Not really sure why it wasn't using proper helper before. 
This might make shuttles bit slower but shouldn't have any unusal sideeffects.
Unless i'm missing something that shouldn't be updated there.
