### PR TITLE
Adds the Rotatium chemical [DNM]

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -346,6 +346,7 @@
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,2.5)
+			M.client.dir = 1
 	if(M.health > 20)
 		M.adjustToxLoss(2.5*REM)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -346,7 +346,7 @@
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,2.5)
-			M.client.dir = 1
+			M.client.dir = NORTH
 	if(M.health > 20)
 		M.adjustToxLoss(2.5*REM)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -642,6 +642,37 @@
 		playsound(M, "sparks", 50, 1)
 	..()
 
+/datum/reagent/toxin/rotatium //Rotatium. Fucks up your rotation and is hilarious
+	name = "Rotatium"
+	id = "rotatium"
+	description = "A constantly swirling, oddly colourful fluid. Causes the consumer's sense of direction and hand-eye coordination to become wild."
+	reagent_state = LIQUID
+	color = "#FFFF00" //RGB: 255, 255, 0 Bright ass yellow
+	metabolization_rate = 0.6 * REAGENTS_METABOLISM
+	toxpwr = 0
+	var/rotate_timer = 0
+	var/randrot = 1
+	var/hold = 0
+
+/datum/reagent/toxin/rotatium/on_mob_life(mob/living/M)
+	rotate_timer++
+	if(M.reagents.get_reagent_amount("rotatium") < 2)
+		M.client.dir = 1
+		return
+	if(rotate_timer >= rand(5,30)) //Random rotations are wildly unpredictable and hilarious
+		rotate_timer = 0
+		hold = rand(1,8)
+		switch(hold)
+			if(1 to 2)
+				randrot = 2
+			if(3 to 4)
+				randrot = 4
+			if(5 to 6)
+				randrot = 6
+			if(7 to 8)
+				randrot = 8
+		M.client.dir = randrot
+	..()
 
 //ACID
 

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -647,32 +647,24 @@
 	id = "rotatium"
 	description = "A constantly swirling, oddly colourful fluid. Causes the consumer's sense of direction and hand-eye coordination to become wild."
 	reagent_state = LIQUID
-	color = "#FFFF00" //RGB: 255, 255, 0 Bright ass yellow
+	color = "#FFFF00"
 	metabolization_rate = 0.6 * REAGENTS_METABOLISM
 	toxpwr = 0
 	var/rotate_timer = 0
-	var/randrot = 1
-	var/hold = 0
 
 /datum/reagent/toxin/rotatium/on_mob_life(mob/living/M)
 	rotate_timer++
-	if(M.reagents.get_reagent_amount("rotatium") < 2)
-		M.client.dir = 1
-		return
-	if(rotate_timer >= rand(5,30)) //Random rotations are wildly unpredictable and hilarious
+	if(volume < 2)
+		M.client.dir = NORTH
+	else if(rotate_timer >= rand(5,30))
 		rotate_timer = 0
-		hold = rand(1,8)
-		switch(hold)
-			if(1 to 2)
-				randrot = 2
-			if(3 to 4)
-				randrot = 4
-			if(5 to 6)
-				randrot = 6
-			if(7 to 8)
-				randrot = 8
-		M.client.dir = randrot
+		M.client.dir = pick(NORTH, EAST, SOUTH, WEST)
 	..()
+
+/datum/reagent/toxin/rotatium/on_mob_delete(mob/living/M)
+	M.client.dir = NORTH
+	..()
+
 
 //ACID
 

--- a/code/modules/reagents/Chemistry-Recipes/Toxins.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Toxins.dm
@@ -110,3 +110,11 @@
 	required_reagents = list("formaldehyde" = 1, "sodium" = 1, "chlorine" = 1, "lithium" = 1)
 	result_amount = 4
 	mix_message = "<span class='danger'>The mixture thins and loses all color.</span>"
+
+/datum/chemical_reaction/rotatium
+	name = "Rotatium"
+	id = "Rotatium"
+	result = "rotatium"
+	required_reagents = list("mindbreaker" = 1, "teslium" = 1, "neurotoxin2" = 1)
+	result_amount = 3
+	mix_message = "<span class='danger'>After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.</span>"


### PR DESCRIPTION
Adds Rotatium, a chemical that causes the person who consumes it to
rotate their view, causing distorted shit like the proc would do.

Ported from HippieStation
https://github.com/HippieStationCode/HippieStation13/pull/1275

Thanks to TDcoolguy300

balance/non code feedback concerns that are greater than a thumbs up / down go here please
https://tgstation13.org/phpBB/viewtopic.php?f=10&t=5276

:cl: oranges
experiment: Nanotrasen chemists announced today a new breakthrough in the field of mind altering substances, the new drug is expected to enter fullscale trials on research stations in the near future. Initial trial results have been described as "promising"
rscadd: Ports Rotatium, a drug that causes your view to rotate funkily, from Hippie. The effects of rotatium stop after it's gone under 2 units, or is purged by Calomel, and your view is restored to normal.
/:cl:
