### PR TITLE
Changes event fire rate from 5-15 minutes to 3-10 minutes

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,8 +8,8 @@ var/datum/subsystem/events/SSevent
 	var/list/running = list()	//list of all existing /datum/round_event
 
 	var/scheduled = 0			//The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 3000	//5 minutes lower bound.
-	var/frequency_upper = 9000	//15 minutes upper bound. Basically an event will happen every 5 to 15 minutes.
+	var/frequency_lower = 1800	//3 minutes lower bound.
+	var/frequency_upper = 6000	//10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = 0


### PR DESCRIPTION
Because of the increase in the number of events possible, it seems it would make sense to raise how often events fire
