### PR TITLE
Master Controller lag fixes

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -111,8 +111,9 @@ calculate the longest number of ticks the MC can wait between each cycle without
 							if (SS.dynamic_wait)
 								var/oldwait = SS.wait
 								var/GlobalCostDelta = (SSCostPerSecond-(SS.cost/(SS.wait/10)))-1
-								var/NewWait = MC_AVERAGE(oldwait,(SS.cost-SS.dwait_buffer+GlobalCostDelta)*SS.dwait_delta)
+								var/NewWait = (SS.cost-SS.dwait_buffer+GlobalCostDelta)*SS.dwait_delta
 								NewWait = NewWait*(world.cpu/100+1)
+								NewWait = MC_AVERAGE(oldwait,NewWait)
 								SS.wait = Clamp(NewWait,SS.dwait_lower,SS.dwait_upper)
 								if (oldwait != SS.wait)
 									calculateGCD()

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -101,7 +101,7 @@ calculate the longest number of ticks the MC can wait between each cycle without
 				var/SubSystemRan = 0
 				for(var/datum/subsystem/SS in subsystems)
 					if(SS.can_fire > 0)
-						if(SS.next_fire <= world.time && SS.last_fire+(wait*0.5) <= world.time)
+						if(SS.next_fire <= world.time && SS.last_fire+(SS.wait*0.5) <= world.time)
 							SubSystemRan = 1
 							timer = world.timeofday
 							last_thing_processed = SS.type


### PR DESCRIPTION
When the MC is making up missed subsystem fires from lag, it will now only fire that subsystem at most, half of that subsystem's normal fire rate until missed fires are made up, rather than firing as quick as possible making lag worst.

When a subsystem causes byond to miss a byond tick, it will stop processing subsystems and sleep for two extra byond ticks on top of its normal sleep rate.

When the cpu is above 80%, the MC will also sleep for twice as long between ticks (stacks with the change above)

The sleep between fires of the MC is now capped to a lower bound of two byond ticks or 1ds, whatever is lower.

Dwait now scales with the cpu usage var. 10% cpu adds 10% extra to dwait, 50% cpu adds 50% extra to dwait, etc.

The main reason for these changes is to make the MC more lag friendly in higher tick environments like sybil's new 15fps.
