### PR TITLE
[Merge It Now!]Remove side effects from Character Setup

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -19,16 +19,16 @@
 	var/l_hand = null
 	var/list/backpack_contents = list() // In the list(path=count,otherpath=count) format
 
-/datum/outfit/proc/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/proc/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for customization depending on client prefs,species etc
 	return
 
-/datum/outfit/proc/post_equip(mob/living/carbon/human/H)
+/datum/outfit/proc/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for toggling internals, id binding, access etc
 	return
 
-/datum/outfit/proc/equip(mob/living/carbon/human/H)
-	pre_equip(H)
+/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	pre_equip(H, visualsOnly)
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
@@ -70,6 +70,6 @@
 		for(var/i=0,i<number,i++)
 			H.equip_to_slot_or_del(new path(H),slot_in_backpack)
 
-	post_equip(H)
+	post_equip(H, visualsOnly)
 
 	return 1

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -40,11 +40,14 @@ Captain
 	backpack = /obj/item/weapon/storage/backpack/captain
 	satchel = /obj/item/weapon/storage/backpack/satchel_cap
 
-/datum/outfit/job/captain/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/captain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 
 	var/obj/item/clothing/under/U = H.w_uniform
 	U.attachTie(new /obj/item/clothing/tie/medal/gold/captain())
+
+	if(visualsOnly)
+		return
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
@@ -97,7 +100,10 @@ Head of Personnel
 	backpack_contents = list(/obj/item/weapon/storage/box/ids=1,\
 		/obj/item/weapon/melee/classic_baton/telescopic=1)
 
-/datum/outfit/job/hop/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/hop/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
 
 	announce_head(H, list("Supply", "Service"))

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -31,12 +31,20 @@ Clown
 	backpack = /obj/item/weapon/storage/backpack/clown
 	satchel = /obj/item/weapon/storage/backpack/clown
 
-/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/clown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	H.fully_replace_character_name(H.real_name, pick(clown_names))
 
-/datum/outfit/job/clown/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	new /obj/item/weapon/reagent_containers/food/snacks/grown/banana(H.back, 50)
 
 	H.dna.add_mutation(CLOWNMUT)
@@ -76,8 +84,12 @@ Mime
 	backpack = /obj/item/weapon/storage/backpack/mime
 	satchel = /obj/item/weapon/storage/backpack/mime
 
-/datum/outfit/job/mime/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/mime/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall(null))
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak(null))
@@ -144,8 +156,12 @@ Lawyer
 	l_hand = /obj/item/weapon/storage/briefcase
 	l_pocket = /obj/item/device/laser_pointer
 
-/datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/lawyer/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/datum/job/lawyer/J = SSjob.GetJob(H.job)
 	J.lawyers++
 	if(J.lawyers>1)

--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -26,8 +26,11 @@ Chaplain
 	backpack_contents = list(/obj/item/device/camera/spooky = 1)
 
 
-/datum/outfit/job/chaplain/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
 
 	var/obj/item/weapon/storage/book/bible/B = new /obj/item/weapon/storage/book/bible/booze(H)
 	var/new_religion = "Christianity"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -43,8 +43,12 @@ Chief Engineer
 	box = /obj/item/weapon/storage/box/engineer
 	pda_slot = slot_l_store
 
-/datum/outfit/job/ce/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/ce/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	announce_head(H, list("Engineering"))
 
 /*

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -45,17 +45,17 @@
 /datum/job/proc/equip_items(mob/living/carbon/human/H)
 
 //But don't override this
-/datum/job/proc/equip(mob/living/carbon/human/H)
+/datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)
 		return 0
 
 	//Equip the rest of the gear
-	H.dna.species.before_equip_job(src, H)
+	H.dna.species.before_equip_job(src, H, visualsOnly)
 
 	if(outfit)
-		H.equipOutfit(outfit)
+		H.equipOutfit(outfit, visualsOnly)
 
-	H.dna.species.after_equip_job(src, H)
+	H.dna.species.after_equip_job(src, H, visualsOnly)
 
 /datum/job/proc/apply_fingerprints(mob/living/carbon/human/H)
 	if(!istype(H))
@@ -146,7 +146,7 @@
 
 	var/pda_slot = slot_belt
 
-/datum/outfit/job/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(H.backbag == 1) //Backpack
 		back =  backpack
 	else //Satchel
@@ -154,7 +154,10 @@
 
 	backpack_contents[box] = 1
 
-/datum/outfit/job/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/C = H.wear_id
 	if(istype(C))
 		var/datum/job/J = SSjob.GetJob(H.job) // Not sure the best idea

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -39,8 +39,12 @@ Chief Medical Officer
 	backpack = /obj/item/weapon/storage/backpack/medic
 	satchel = /obj/item/weapon/storage/backpack/satchel_med
 
-/datum/outfit/job/cmo/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/cmo/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	announce_head(H, list("Medical")) //tell underlings (medical radio) they have a head
 
 /*

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -40,8 +40,12 @@ Research Director
 	l_pocket = /obj/item/device/laser_pointer
 	backpack_contents = list(/obj/item/weapon/melee/classic_baton/telescopic=1)
 
-/datum/outfit/job/rd/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/rd/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	announce_head(H, list("Science")) //tell underlings (science radio) they have a head
 
 /*

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -50,8 +50,12 @@ Head of Security
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec
 
-/datum/outfit/job/hos/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/hos/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
 	L.implanted = 1
@@ -101,8 +105,12 @@ Warden
 	backpack = /obj/item/weapon/storage/backpack/security
 	satchel = /obj/item/weapon/storage/backpack/satchel_sec
 
-/datum/outfit/job/warden/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/warden/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
 	L.implanted = 1
@@ -145,10 +153,13 @@ Detective
 		/obj/item/weapon/melee/classic_baton/telescopic=1)
 	mask = /obj/item/clothing/mask/cigarette
 
-/datum/outfit/job/detective/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	var/obj/item/clothing/mask/cigarette/cig = H.wear_mask
 	cig.light("")
+
+	if(visualsOnly)
+		return
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
@@ -207,11 +218,13 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	var/destination = null
 	var/spawn_point = null
 
-/datum/outfit/job/security/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/security/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
 	if(sec_departments.len)
 		department = pick(sec_departments)
-		sec_departments -= department
+		if(!visualsOnly)
+			sec_departments -= department
 		switch(department)
 			if("supply")
 				ears = /obj/item/device/radio/headset/headset_sec/alt/department/supply
@@ -238,17 +251,20 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 				spawn_point = locate(/obj/effect/landmark/start/depsec/science) in department_security_spawns
 				tie = /obj/item/clothing/tie/armband/science
 
-/datum/outfit/job/security/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/security/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	var/obj/item/clothing/under/U = H.w_uniform
+	if(tie)
+		U.attachTie(new tie)
+
+	if(visualsOnly)
+		return
 
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
 	L.implanted = 1
 	H.sec_hud_set_implants()
-
-	var/obj/item/clothing/under/U = H.w_uniform
-	if(tie)
-		U.attachTie(new tie)
 
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.access |= dep_access

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -6,7 +6,10 @@
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/device/radio/headset/headset_cent/alt
 
-/datum/outfit/ert/post_equip(mob/living/carbon/human/H)
+/datum/outfit/ert/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 	L.imp_in = H
 	L.implanted = 1
@@ -34,8 +37,12 @@
 		/obj/item/weapon/gun/energy/gun=1)
 	l_pocket = /obj/item/weapon/switchblade
 
-/datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H)
+/datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/captain
 	R.recalculateChannels()
@@ -64,8 +71,12 @@
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/weapon/gun/energy/gun/advtaser=1)
 
-/datum/outfit/ert/security/post_equip(mob/living/carbon/human/H)
+/datum/outfit/ert/security/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/hos
 	R.recalculateChannels()
@@ -95,8 +106,12 @@
 		/obj/item/weapon/gun/energy/gun=1,\
 		/obj/item/weapon/reagent_containers/hypospray/combat=1)
 
-/datum/outfit/ert/medic/post_equip(mob/living/carbon/human/H)
+/datum/outfit/ert/medic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/cmo
 	R.recalculateChannels()
@@ -126,8 +141,12 @@
 		/obj/item/weapon/gun/energy/gun=1,\
 		/obj/item/weapon/rcd/loaded=1)
 
-/datum/outfit/ert/engineer/post_equip(mob/living/carbon/human/H)
+/datum/outfit/ert/engineer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
+
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/radio/R = H.ears
 	R.keyslot = new /obj/item/device/encryptionkey/heads/ce
 	R.recalculateChannels()
@@ -157,7 +176,10 @@
 	l_hand = /obj/item/weapon/clipboard
 	id = /obj/item/weapon/card/id
 
-/datum/outfit/centcom_official/post_equip(mob/living/carbon/human/H)
+/datum/outfit/centcom_official/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/pda/heads/pda = H.r_store
 	pda.owner = H.real_name
 	pda.ownjob = "Centcom Official"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -56,7 +56,10 @@
 	l_pocket = /obj/item/weapon/grenade/chem_grenade/cleaner
 	backpack_contents = list(/obj/item/stack/tile/plasteel=6)
 
-/datum/outfit/tournament/janitor/post_equip(mob/living/carbon/human/H)
+/datum/outfit/tournament/janitor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/reagent_containers/glass/bucket/bucket = H.l_hand
 	bucket.reagents.add_reagent("water",70)
 
@@ -112,7 +115,10 @@
 	id = /obj/item/weapon/card/id
 	r_hand = /obj/item/weapon/twohanded/fireaxe
 
-/datum/outfit/tunnel_clown/post_equip(mob/living/carbon/human/H)
+/datum/outfit/tunnel_clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.access = get_all_accesses()
 	W.assignment = "Tunnel Clown!"
@@ -153,9 +159,12 @@
 	id = /obj/item/weapon/card/id/syndicate
 	belt = /obj/item/device/pda/heads
 
-/datum/outfit/assassin/post_equip(mob/living/carbon/human/H)
+/datum/outfit/assassin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/obj/item/clothing/under/U = H.w_uniform
 	U.attachTie(new /obj/item/clothing/tie/waistcoat(H))
+
+	if(visualsOnly)
+		return
 
 	//Could use a type
 	var/obj/item/weapon/storage/secure/briefcase/sec_briefcase = H.l_hand
@@ -196,7 +205,10 @@
 	back = /obj/item/weapon/storage/backpack/satchel
 	id = /obj/item/weapon/card/id
 
-/datum/outfit/centcom_commander/post_equip(mob/living/carbon/human/H)
+/datum/outfit/centcom_commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
@@ -221,7 +233,10 @@
 	back = /obj/item/weapon/storage/backpack/satchel
 	id = /obj/item/weapon/card/id
 
-/datum/outfit/spec_ops/post_equip(mob/living/carbon/human/H)
+/datum/outfit/spec_ops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
@@ -276,7 +291,10 @@
 
 	id = /obj/item/weapon/card/id
 
-/datum/outfit/soviet/post_equip(mob/living/carbon/human/H)
+/datum/outfit/soviet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
@@ -297,7 +315,10 @@
 	r_hand = /obj/item/weapon/gun/projectile/automatic/tommygun
 	id = /obj/item/weapon/card/id
 
-/datum/outfit/mobster/post_equip(mob/living/carbon/human/H)
+/datum/outfit/mobster/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.assignment = "Assistant"
 	W.registered_name = H.real_name
@@ -336,7 +357,10 @@
 		/obj/item/device/flashlight=1,\
 		/obj/item/weapon/c4=1)
 
-/datum/outfit/death_commando/post_equip(mob/living/carbon/human/H)
+/datum/outfit/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
 	var/obj/item/device/radio/R = H.ears
 	R.set_frequency(CENTCOM_FREQ)
 	R.freqlock = 1

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -289,7 +289,7 @@
 
 	return shredded
 
-/mob/living/carbon/human/proc/equipOutfit(outfit)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))
@@ -301,4 +301,4 @@
 	if(!O)
 		return 0
 
-	return O.equip(src)
+	return O.equip(src, visualsOnly)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -505,9 +505,9 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 				P.Extinguish(H)
 	H.update_fire()
 
-/datum/species/plasmaman/before_equip_job(datum/job/J, mob/living/carbon/human/H)
+/datum/species/plasmaman/before_equip_job(datum/job/J, mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/datum/outfit/plasmaman/O = new /datum/outfit/plasmaman
-	H.equipOutfit(O)
+	H.equipOutfit(O, visualsOnly)
 	return 0
 
 /datum/species/plasmaman/qualifies_for_rank(rank, list/features)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -35,7 +35,6 @@
 
 	// Set up the dummy for its photoshoot
 	var/mob/living/carbon/human/dummy/mannequin = new()
-	mannequin.status_flags |= GODMODE // Why not?
 	copy_to(mannequin)
 
 	// Determine what job is marked as 'High' priority, and dress them up as such.
@@ -60,7 +59,7 @@
 
 	if(previewJob)
 		mannequin.job = previewJob.title
-		previewJob.equip(mannequin)
+		previewJob.equip(mannequin, TRUE)
 
 	preview_icon = icon('icons/effects/effects.dmi', "nothing")
 	preview_icon.Scale(48+32, 16+32)


### PR DESCRIPTION
Antur was right. :sob: 

Adds an argument to the various equip procs.  Setting it to true should disable side effects and other stuff that don't show up in the preview window. (Like implants and ID access.)

Fixes #13218
