### PR TITLE
Fixes facehugger-related bugs.

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -84,7 +84,7 @@ var/const/MAX_ACTIVE_TIME = 400
 	return 0
 
 /obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM as mob|obj)
-	if(CanHug(AM))
+	if(CanHug(AM) && Adjacent(AM))
 		return Attach(AM)
 	return 0
 
@@ -230,7 +230,7 @@ var/const/MAX_ACTIVE_TIME = 400
 		return 1
 
 	var/mob/living/carbon/C = M
-	if(ishuman(C))
+	if(ishuman(C) && !(slot_wear_mask in C.dna.species.no_equip))
 		var/mob/living/carbon/human/H = C
 		if(H.is_mouth_covered(head_only = 1))
 			return 0


### PR DESCRIPTION
- Facehuggers will no longer hug you through border objects. Fixes https://github.com/tgstation/-tg-station/issues/10501.
- Facehuggers will no longer hug you from a Ripley cargo hold. Fixes https://github.com/tgstation/-tg-station/issues/9020. "BUT BANDIT THAT MEANS RIPLEYS ARE UNSTOPPABLE ALIUM KILLERS!" Yes that's the point why do you think they are called Ripleys? Also, it makes easier the possibility of antag shenanigans like dropping off a facehugger at someone's department via Ripley, or for that matter bringing them to xenobio. Also, git gud.
- Facehuggers will no longer hug golems (and other races that cannot equip masks, currently only golems). Fixes https://github.com/tgstation/-tg-station/issues/12408. "BUT BANDIT THAT MEANS GOLEMS ARE UNSTOPPABLE ALIUM KILLERS!" This is sort of mitigated by golems and aliums both relying on ghost population. Also, git gud.
