### PR TITLE
Ports the /vg/ pooling resetVars by Clusterfack

### DIFF
--- a/code/game/pooling/pool.dm
+++ b/code/game/pooling/pool.dm
@@ -96,15 +96,24 @@ var/global/list/GlobalPool = list()
 
 	diver.ResetVars()
 
+var/list/exclude = list("animate_movement", "contents", "loc", "locs", "parent_type", "vars", "verbs", "type")
+var/list/pooledvariables = list()
+//thanks to clusterfack @ /vg/station for these two procs
+/datum/proc/createVariables()
+	pooledvariables[type] = new/list()
+	var/list/exclude = global.exclude + args
+
+	for(var/key in vars)
+		if(key in exclude)
+			continue
+		pooledvariables[type][key] = initial(vars[key])
 
 /datum/proc/ResetVars()
-	var/list/excluded = list("animate_movement", "contents", "loc", "locs", "parent_type", "vars", "verbs", "type")
+	if(!pooledvariables[type])
+		createVariables(args)
 
-	for(var/V in vars)
-		if(V in excluded)
-			continue
-
-		vars[V] = initial(vars[V])
+	for(var/key in pooledvariables[type])
+		vars[key] = pooledvariables[type][key]
 
 /atom/movable/ResetVars()
 	..()


### PR DESCRIPTION
See #12198 for the rationale, this is much faster than calling initial() every resetVars().

Fixes #12198 
