### PR TITLE
Fixes inflict_handler spells not doing burn damage in some cases

### DIFF
--- a/code/datums/spells/inflict_handler.dm
+++ b/code/datums/spells/inflict_handler.dm
@@ -40,21 +40,11 @@
 
 		if(!target)
 			continue
-		//damage
-		if(amt_dam_brute > 0)
-			if(amt_dam_fire >= 0)
-				target.take_overall_damage(amt_dam_brute,amt_dam_fire)
-			else if (amt_dam_fire < 0)
-				target.take_overall_damage(amt_dam_brute,0)
-				target.heal_overall_damage(0,amt_dam_fire)
-		else if(amt_dam_brute < 0)
-			if(amt_dam_fire > 0)
-				target.take_overall_damage(0,amt_dam_fire)
-				target.heal_overall_damage(amt_dam_brute,0)
-			else if (amt_dam_fire <= 0)
-				target.heal_overall_damage(amt_dam_brute,amt_dam_fire)
+		//damage/healing
+		target.adjustBruteLoss(amt_dam_brute)
+		target.adjustFireLoss(amt_dam_fire)
 		target.adjustToxLoss(amt_dam_tox)
-		target.oxyloss += amt_dam_oxy
+		target.adjustOxyLoss(amt_dam_oxy)
 		//disabling
 		target.Weaken(amt_weakened)
 		target.Paralyse(amt_paralysis)


### PR DESCRIPTION
Specifically, if brute damage was 0, they wouldn't do burn damage.
Also makes them use the proper procs for inflicting damage.
