### PR TITLE
Hostile Animal Projectile Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -5,9 +5,9 @@
 	var/atom/target
 	var/ranged = 0
 	var/rapid = 0
-	var/projectiletype
+	var/projectiletype	//set ONLY it and NULLIFY casingtype var, if we have ONLY projectile
 	var/projectilesound
-	var/casingtype
+	var/casingtype		//set ONLY it and NULLIFY projectiletype, if we have projectile IN CASING
 	var/move_to_delay = 3 //delay for the automated movement.
 	var/list/friends = list()
 	var/list/emote_taunt = list()
@@ -218,46 +218,43 @@
 	LoseTarget()
 	..(gibbed)
 
-/mob/living/simple_animal/hostile/proc/OpenFire(the_target)
+/mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 
-	var/target = the_target
-	visible_message("<span class='danger'><b>[src]</b> [ranged_message] at [target]!</span>")
+	visible_message("<span class='danger'><b>[src]</b> [ranged_message] at [A]!</span>")
 
 	if(rapid)
 		spawn(1)
-			Shoot(target, src.loc, src)
-			if(casingtype)
-				new casingtype(get_turf(src))
+			Shoot(A)
 		spawn(4)
-			Shoot(target, src.loc, src)
-			if(casingtype)
-				new casingtype(get_turf(src))
+			Shoot(A)
 		spawn(6)
-			Shoot(target, src.loc, src)
-			if(casingtype)
-				new casingtype(get_turf(src))
+			Shoot(A)
 	else
-		Shoot(target, src.loc, src)
-		if(casingtype)
-			new casingtype
+		Shoot(A)
 	ranged_cooldown = ranged_cooldown_cap
 	return
 
-/mob/living/simple_animal/hostile/proc/Shoot(target, start, user, bullet = 0)
-	if(target == start)
+/mob/living/simple_animal/hostile/proc/Shoot(atom/targeted_atom)
+	if(targeted_atom == src.loc)
 		return
-
-	var/obj/item/projectile/A = new projectiletype(src.loc)
-	playsound(user, projectilesound, 100, 1)
-	if(!A)	return
-	A.current = target
-	A.firer = src
-	A.yo = target:y - start:y
-	A.xo = target:x - start:x
-	if(AIStatus == AI_OFF)//Don't want mindless mobs to have their movement screwed up firing in space
-		newtonian_move(get_dir(target, user))
-	A.original = target
-	A.fire()
+	var/turf/startloc = get_turf(src)
+	if(casingtype)
+		var/obj/item/ammo_casing/casing = new casingtype
+		playsound(src, projectilesound, 100, 1)
+		casing.fire(targeted_atom, src, zone_override = ran_zone())
+		casing.loc = startloc
+	else if(projectiletype)
+		var/obj/item/projectile/P = new projectiletype(src.loc)
+		playsound(src, projectilesound, 100, 1)
+		P.current = startloc
+		P.starting = startloc
+		P.firer = src
+		P.yo = targeted_atom.y - startloc.y
+		P.xo = targeted_atom.x - startloc.x
+		if(AIStatus == AI_OFF)//Don't want mindless mobs to have their movement screwed up firing in space
+			newtonian_move(get_dir(targeted_atom, src))
+		P.original = targeted_atom
+		P.fire()
 	return
 
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -235,8 +235,6 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 		if(istype(G, /obj/item/weapon/gun/projectile))
 			Pewgun = G
 			var/obj/item/ammo_box/magazine/M = Pewgun.mag_type
-			var/obj/item/ammo_casing/A = initial(M.ammo_type)
-			projectiletype = initial(A.projectile_type)
 			casingtype = initial(M.ammo_type)
 		if(istype(G, /obj/item/weapon/gun/energy))
 			Zapgun = G

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -35,7 +35,6 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/bullet
 	projectilesound = 'sound/weapons/Gunshot.ogg'
 	casingtype = /obj/item/ammo_casing/a357
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -84,7 +84,6 @@
 	icon_living = "syndicateranged"
 	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/Gunshot_smg.ogg'
-	projectiletype = /obj/item/projectile/bullet/midbullet2
 
 	weapon1 = /obj/item/weapon/gun/projectile/automatic/c20r/unrestricted
 


### PR DESCRIPTION
Most of this PR is a copy of #13002 by @bear1ake . (with less commits and additional fixes)
- The ammo casings dropped by hostile ranged mobs are now empty as they should. Fixes #12507
- Fixes hostile ranged mobs's projectile auto-tracking the target. Fixes #13240
- Rework OpenFire() and Shoot() procs of simple_animal/hostile a bit to be less shitty.
