### PR TITLE
The Bluespace Wormhole Projector now teleports mobs!

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -175,6 +175,8 @@ obj/item/projectile/kinetic/New()
 
 /obj/item/projectile/beam/wormhole/on_hit(atom/target)
 	if(ismob(target))
+		var/turf/portal_destination = pick(orange(6, src))
+		do_teleport(target, portal_destination)
 		return ..()
 	if(!gun)
 		qdel(src)


### PR DESCRIPTION
The ~~Portal Gun~~ Bluespace Wormhole Projector will now teleport mobs hit by the
projectile.
- The teleportation is random, with a maximum range of 6.

Shoot a mob with the ~~portal gun~~ projector to teleport it! This PR is inspired by https://github.com/tgstation/-tg-station/pull/13232

Testing notes: Clowns and other people with CLUMSY disability do not have the ability to teleport themselves by shooting themselves accidentally with the device. This is intended behavior. 
