### PR TITLE
Fix some NanoUI checks

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -98,7 +98,7 @@ Passive gate is similar to the regular pump except:
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/binary/passive_gate/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "atmos_pump.tmpl", name, 400, 100)
 		ui.open()
@@ -146,12 +146,14 @@ Passive gate is similar to the regular pump except:
 
 
 /obj/machinery/atmospherics/components/binary/passive_gate/attack_hand(mob/user)
-	if(..() || !user) return
+	if(..() || !user)
+		return
 	add_fingerprint(usr)
 	interact(user)
 
 /obj/machinery/atmospherics/components/binary/passive_gate/Topic(href, href_list)
-	if(..()) return
+	if(..())
+		return
 	if(href_list["power"])
 		on = !on
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -106,7 +106,7 @@ Thus, the two variables affect pump operation are set in New():
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/binary/pump/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "atmos_pump.tmpl", name, 400, 100)
 		ui.open()
@@ -153,11 +153,13 @@ Thus, the two variables affect pump operation are set in New():
 
 
 /obj/machinery/atmospherics/components/binary/pump/attack_hand(mob/user)
-	if(..() | !user) return
+	if(..() | !user)
+		return
 	interact(user)
 
 /obj/machinery/atmospherics/components/binary/pump/Topic(href,href_list)
-	if(..()) return
+	if(..())
+		return
 	if(href_list["power"])
 		on = !on
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -95,14 +95,15 @@ Thus, the two variables affect pump operation are set in New():
 	return 1
 
 /obj/machinery/atmospherics/components/binary/volume_pump/interact(mob/user)
-	if(stat & (BROKEN|NOPOWER)) return
+	if(stat & (BROKEN|NOPOWER))
+		return
 	if(!src.allowed(usr))
 		usr << "<span class='danger'>Access denied.</span>"
 		return
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/binary/volume_pump/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "atmos_pump.tmpl", name, 400, 100)
 		ui.open()
@@ -149,11 +150,13 @@ Thus, the two variables affect pump operation are set in New():
 
 
 /obj/machinery/atmospherics/components/binary/volume_pump/attack_hand(mob/user)
-	if(..() | !user) return
+	if(..() | !user)
+		return
 	interact(user)
 
 /obj/machinery/atmospherics/components/binary/volume_pump/Topic(href,href_list)
-	if(..()) return
+	if(..())
+		return
 	if(href_list["power"])
 		on = !on
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -157,18 +157,20 @@ Filter types:
 	return ..()
 
 /obj/machinery/atmospherics/components/trinary/filter/attack_hand(mob/user)
-	if(..() | !user) return
+	if(..() | !user)
+		return
 	interact(user)
 
 /obj/machinery/atmospherics/components/trinary/filter/interact(mob/user)
-	if(stat & (BROKEN|NOPOWER)) return
+	if(stat & (BROKEN|NOPOWER))
+		return
 	if(!src.allowed(usr))
 		usr << "<span class='danger'>Access denied.</span>"
 		return
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/trinary/filter/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "atmos_filter.tmpl", name, 400, 120)
 		ui.open()
@@ -182,7 +184,8 @@ Filter types:
 	return data
 
 /obj/machinery/atmospherics/components/trinary/filter/Topic(href, href_list)
-	if(..()) return
+	if(..())
+		return
 	if(href_list["filterset"])
 		src.filter_type = text2num(href_list["filterset"])
 		var/filtering_name = "nothing"

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -120,18 +120,20 @@
 	return 1
 
 /obj/machinery/atmospherics/components/trinary/mixer/attack_hand(mob/user)
-	if(..() | !user) return
+	if(..() | !user)
+		return
 	interact(user)
 
 /obj/machinery/atmospherics/components/trinary/mixer/interact(mob/user)
-	if(stat & (BROKEN|NOPOWER)) return
+	if(stat & (BROKEN|NOPOWER))
+		return
 	if(!src.allowed(usr))
 		usr << "<span class='danger'>Access denied.</span>"
 		return
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/trinary/mixer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "atmos_mixer.tmpl", name, 400, 145)
 		ui.open()
@@ -146,7 +148,8 @@
 	return data
 
 /obj/machinery/atmospherics/components/trinary/mixer/Topic(href,href_list)
-	if(..()) return
+	if(..())
+		return
 	if(href_list["power"])
 		on = !on
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", "atmos")

--- a/code/ATMOSPHERICS/components/unary_devices/cryo.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cryo.dm
@@ -125,7 +125,7 @@
 	ui_interact(user)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "cryo.tmpl", name, 520, 410, state = notcontained_state)
 		ui.open()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -177,14 +177,15 @@
 /obj/machinery/alarm/interact(mob/user)
 	if (user.has_unlimited_silicon_privilege && src.aidisabled)
 		user << "AI control for this Air Alarm interface has been disabled."
-		user << browse(null, "window=air_alarm")
 		return
 
-	if(panel_open && !istype(user, /mob/living/silicon/ai)) wires.Interact(user)
-	else if (!shorted) ui_interact(user)
+	if(panel_open && !istype(user, /mob/living/silicon/ai))
+		wires.Interact(user)
+	else if (!shorted)
+		ui_interact(user)
 
 /obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "air_alarm.tmpl", name, 480, 625)
 		ui.open()
@@ -383,16 +384,11 @@
 	if (buildstage != 2)
 		return
 
-	usr.set_machine(src)
-
 	if (locked && !usr.has_unlimited_silicon_privilege)
 		return
 
-	if ( (get_dist(src, usr) > 1 ))
-		if (!istype(usr, /mob/living/silicon))
-			usr.unset_machine()
-			usr << browse(null, "window=air_alarm")
-			return
+	if (usr.has_unlimited_silicon_privilege && src.aidisabled)
+		return
 
 	if(href_list["toggleaccess"])
 		if(usr.has_unlimited_silicon_privilege && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
@@ -449,35 +445,23 @@
 				else
 					newval = round(newval,0.01)
 					tlv.vars[varname] = newval
-				spawn(1)
-					src.updateUsrDialog()
 
 	if(href_list["screen"])
 		screen = text2num(href_list["screen"])
-		spawn(1)
-			src.updateUsrDialog()
-
 
 	if(href_list["atmos_alarm"])
 		if (alarm_area.atmosalert(2,src))
 			post_alert(2)
-		spawn(1)
-			src.updateUsrDialog()
 		update_icon()
+
 	if(href_list["atmos_reset"])
 		if (alarm_area.atmosalert(0,src))
 			post_alert(0)
-		spawn(1)
-			src.updateUsrDialog()
 		update_icon()
 
 	if(href_list["mode"])
 		mode = text2num(href_list["mode"])
 		apply_mode()
-		spawn(5)
-			src.updateUsrDialog()
-
-	return
 
 /obj/machinery/alarm/proc/apply_mode()
 	switch(mode)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -264,16 +264,18 @@ update_flag
 	..()
 
 /obj/machinery/portable_atmospherics/canister/attack_hand(mob/user)
-	if (!user) return
+	if (!user)
+		return
 	interact(user)
 
 /obj/machinery/portable_atmospherics/canister/interact(mob/user)
-	if (src.destroyed) return
+	if (src.destroyed)
+		return
 	add_fingerprint(user)
 	ui_interact(user)
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "canister.tmpl", name, 470, 400, state = physical_state)
 		ui.open()
@@ -298,6 +300,8 @@ update_flag
 	return data
 
 /obj/machinery/portable_atmospherics/canister/Topic(href, href_list)
+	if(..())
+		return
 	if(href_list["toggle"])
 		var/logmsg
 		if (valve_open)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -275,7 +275,7 @@ update_flag
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
 	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "canister.tmpl", name, 470, 400)
+		ui = new(user, src, ui_key, "canister.tmpl", name, 470, 400, state = physical_state)
 		ui.open()
 
 /obj/machinery/portable_atmospherics/canister/get_ui_data()

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -111,7 +111,8 @@
 		bomb_assemble(W,user)
 
 /obj/item/weapon/tank/attack_self(mob/user)
-	if (!user) return
+	if (!user)
+		return
 	interact(user)
 
 /obj/item/weapon/tank/interact(mob/user)
@@ -119,7 +120,7 @@
 	ui_interact(user)
 
 /obj/item/weapon/tank/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "tanks.tmpl", name, 525, 175, state = inventory_state)
 		ui.open()
@@ -157,8 +158,8 @@
 	return data
 
 /obj/item/weapon/tank/Topic(href, href_list)
-	if (..()) return
-	if (usr.stat|| usr.restrained()) return
+	if (..())
+		return
 
 	if (href_list["dist_p"])
 		if (href_list["dist_p"] == "custom")

--- a/code/modules/nano/states/base.dm
+++ b/code/modules/nano/states/base.dm
@@ -40,7 +40,7 @@
   *
   * return NANO_state The state of the UI.
  **/
-/mob/proc/shared_nano_interaction()
+/mob/proc/shared_nano_interaction(atom/src_object)
 	if (!client || stat) // Close NanoUIs if mindless or dead/unconcious.
 		return NANO_CLOSE
 	// Update NanoUIs if incapicitated but concious.
@@ -48,12 +48,19 @@
 		return NANO_UPDATE
 	return NANO_INTERACTIVE
 
-/mob/living/silicon/ai/shared_nano_interaction()
+/mob/living/carbon/human/shared_nano_interaction(atom/src_object)
+	// If we have telekinesis and remain close enough, allow interaction.
+	if (dna.check_mutation(TK))
+		if (tkMaxRangeCheck(src, src_object))
+			return NANO_INTERACTIVE
+	return ..()
+
+/mob/living/silicon/ai/shared_nano_interaction(atom/src_object)
 	if (lacks_power()) // Close NanoUIs if the AI is unpowered.
 		return NANO_CLOSE
 	return ..()
 
-/mob/living/silicon/robot/shared_nano_interaction()
+/mob/living/silicon/robot/shared_nano_interaction(atom/src_object)
 	if (cell.charge <= 0) // Close NanoUIs if the Borg is unpowered.
 		return NANO_CLOSE
 	if (lockcharge) // Disable NanoUIs if the Borg is locked.

--- a/code/modules/nano/states/base.dm
+++ b/code/modules/nano/states/base.dm
@@ -44,7 +44,7 @@
 	if (!client || stat) // Close NanoUIs if mindless or dead/unconcious.
 		return NANO_CLOSE
 	// Update NanoUIs if incapicitated but concious.
-	else if (restrained() || incapacitated() || lying || stunned || weakened)
+	else if (incapacitated() || lying)
 		return NANO_UPDATE
 	return NANO_INTERACTIVE
 

--- a/code/modules/nano/states/base.dm
+++ b/code/modules/nano/states/base.dm
@@ -43,7 +43,8 @@
 /mob/proc/shared_nano_interaction()
 	if (!client || stat) // Close NanoUIs if mindless or dead/unconcious.
 		return NANO_CLOSE
-	else if (restrained() || lying || stat || stunned || weakened) // Update NanoUIs if incapicitated but concious.
+	// Update NanoUIs if incapicitated but concious.
+	else if (restrained() || incapacitated() || lying || stunned || weakened)
 		return NANO_UPDATE
 	return NANO_INTERACTIVE
 

--- a/code/modules/nano/states/base.dm
+++ b/code/modules/nano/states/base.dm
@@ -40,7 +40,7 @@
   *
   * return NANO_state The state of the UI.
  **/
-/mob/proc/shared_nano_interaction(atom/src_object)
+/mob/proc/shared_nano_interaction(atom/movable/src_object)
 	if (!client || stat) // Close NanoUIs if mindless or dead/unconcious.
 		return NANO_CLOSE
 	// Update NanoUIs if incapicitated but concious.
@@ -48,19 +48,19 @@
 		return NANO_UPDATE
 	return NANO_INTERACTIVE
 
-/mob/living/carbon/human/shared_nano_interaction(atom/src_object)
+/mob/living/carbon/human/shared_nano_interaction(atom/movable/src_object)
 	// If we have telekinesis and remain close enough, allow interaction.
 	if (dna.check_mutation(TK))
 		if (tkMaxRangeCheck(src, src_object))
 			return NANO_INTERACTIVE
 	return ..()
 
-/mob/living/silicon/ai/shared_nano_interaction(atom/src_object)
+/mob/living/silicon/ai/shared_nano_interaction(atom/movable/src_object)
 	if (lacks_power()) // Close NanoUIs if the AI is unpowered.
 		return NANO_CLOSE
 	return ..()
 
-/mob/living/silicon/robot/shared_nano_interaction(atom/src_object)
+/mob/living/silicon/robot/shared_nano_interaction(atom/movable/src_object)
 	if (cell.charge <= 0) // Close NanoUIs if the Borg is unpowered.
 		return NANO_CLOSE
 	if (lockcharge) // Disable NanoUIs if the Borg is locked.

--- a/code/modules/nano/states/deep_inventory.dm
+++ b/code/modules/nano/states/deep_inventory.dm
@@ -9,4 +9,4 @@
 /datum/topic_state/deep_inventory_state/can_use_topic(atom/movable/src_object, mob/user)
 	if (!user.contains(src_object))
 		return NANO_CLOSE
-	return user.shared_nano_interaction()
+	return user.shared_nano_interaction(src_object)

--- a/code/modules/nano/states/default.dm
+++ b/code/modules/nano/states/default.dm
@@ -29,6 +29,9 @@
 	. = shared_nano_interaction(src_object)
 	if (. > NANO_CLOSE)
 		. = min(., shared_living_nano_distance(src_object)) // Check the distance...
+		// Derp a bit if we have brain loss.
+		if (getBrainLoss() && prob(50))
+			return NANO_DISABLED
 		// If we have telekinesis and remain close enough, allow interaction.
 		if (. == NANO_UPDATE && dna.check_mutation(TK))
 			return NANO_INTERACTIVE

--- a/code/modules/nano/states/default.dm
+++ b/code/modules/nano/states/default.dm
@@ -20,8 +20,7 @@
 /mob/living/default_can_use_topic(atom/movable/src_object)
 	. = shared_nano_interaction(src_object)
 	if (. > NANO_CLOSE)
-		if(loc) // Check if the loc exists.
-			. = min(., loc.contents_nano_distance(src_object, src)) // Check the distance...
+		. = min(., shared_living_nano_distance(src_object)) // Check the distance...
 	if (. == NANO_INTERACTIVE) // Non-human living mobs can only look, not touch.
 		return NANO_UPDATE
 
@@ -32,12 +31,9 @@
 		// Derp a bit if we have brain loss.
 		if (prob(getBrainLoss()))
 			return NANO_DISABLED
-		// If we have telekinesis and remain close enough, allow interaction.
-		if (. == NANO_UPDATE && dna.check_mutation(TK))
-			return NANO_INTERACTIVE
 
 /mob/living/silicon/robot/default_can_use_topic(atom/movable/src_object)
-	. = shared_nano_interaction()
+	. = shared_nano_interaction(src_object)
 	if (. <= NANO_DISABLED)
 		return
 
@@ -47,7 +43,7 @@
 	return NANO_DISABLED // Otherwise they can keep the UI open.
 
 /mob/living/silicon/ai/default_can_use_topic(atom/movable/src_object)
-	. = shared_nano_interaction()
+	. = shared_nano_interaction(src_object)
 	if (. < NANO_INTERACTIVE)
 		return
 

--- a/code/modules/nano/states/default.dm
+++ b/code/modules/nano/states/default.dm
@@ -30,7 +30,7 @@
 	if (. > NANO_CLOSE)
 		. = min(., shared_living_nano_distance(src_object)) // Check the distance...
 		// Derp a bit if we have brain loss.
-		if (getBrainLoss() && prob(50))
+		if (prob(getBrainLoss()))
 			return NANO_DISABLED
 		// If we have telekinesis and remain close enough, allow interaction.
 		if (. == NANO_UPDATE && dna.check_mutation(TK))

--- a/code/modules/nano/states/default.dm
+++ b/code/modules/nano/states/default.dm
@@ -1,7 +1,7 @@
  /**
   * NanoUI State: default_state
   *
-  * Checks a number of things -- mostly phyiscal distance for humans and view for robots.
+  * Checks a number of things -- mostly physical distance for humans and view for robots.
  **/
 
 /var/global/datum/topic_state/default/default_state = new()

--- a/code/modules/nano/states/inventory.dm
+++ b/code/modules/nano/states/inventory.dm
@@ -9,4 +9,4 @@
 /datum/topic_state/inventory_state/can_use_topic(atom/movable/src_object, mob/user)
 	if (!(src_object in user))
 		return NANO_CLOSE
-	return user.shared_nano_interaction()
+	return user.shared_nano_interaction(src_object)

--- a/code/modules/nano/states/self.dm
+++ b/code/modules/nano/states/self.dm
@@ -9,4 +9,4 @@
 /datum/topic_state/self_state/can_use_topic(atom/movable/src_object, mob/user)
 	if (src_object != user)
 		return NANO_CLOSE
-	return user.shared_nano_interaction()
+	return user.shared_nano_interaction(src_object)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -97,11 +97,6 @@
 	var/global/list/status_overlays_lighting
 	var/global/list/status_overlays_environ
 
-/obj/machinery/power/apc/updateDialog()
-	if (stat & (BROKEN|MAINT))
-		return
-	..()
-
 /obj/machinery/power/apc/connect_to_network()
 	//Override because the APC does not directly connect to the network; it goes through a terminal.
 	//The terminal is what the power computer looks for anyway.
@@ -626,12 +621,15 @@
 
 
 /obj/machinery/power/apc/interact(mob/user)
-	if(stat & (BROKEN|MAINT)) return
-	if(wiresexposed && !istype(user, /mob/living/silicon/ai)) wires.Interact(user)
-	else ui_interact(user)
+	if(stat & (BROKEN|MAINT))
+		return
+	if(wiresexposed && !istype(user, /mob/living/silicon/ai))
+		wires.Interact(user)
+	else
+		ui_interact(user)
 
 /obj/machinery/power/apc/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "apc.tmpl", name, 515, 550)
 		ui.open()
@@ -766,8 +764,10 @@
 	return 1
 
 /obj/machinery/power/apc/Topic(href, href_list)
-	if(..()) return
-	if(!can_use(usr, 1)) return
+	if(..())
+		return
+	if(!can_use(usr, 1))
+		return
 
 	if (href_list["lock"])
 		coverlocked = !coverlocked

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -314,16 +314,18 @@
 		terminal.powernet.load += amount
 
 /obj/machinery/power/smes/attack_hand(mob/user)
-	if (!user) return
+	if (!user)
+		return
 	add_fingerprint(user)
 	interact(user)
 
 /obj/machinery/power/smes/interact(mob/user)
-	if (stat & BROKEN) return
+	if (stat & BROKEN)
+		return
 	ui_interact(user)
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "smes.tmpl", name, 500, 400)
 		ui.open()
@@ -349,9 +351,10 @@
 	return data
 
 /obj/machinery/power/smes/Topic(href, href_list)
-	if(..()) return
+	if(..())
+		return
 
-	else if( href_list["input_attempt"] )
+	if( href_list["input_attempt"] )
 		input_attempt = text2num(href_list["input_attempt"])
 		if(!input_attempt)
 			inputting = 0

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -357,16 +357,18 @@
 		overlays += image('icons/obj/computer.dmi', "solcon-o", FLY_LAYER, angle2dir(cdir))
 
 /obj/machinery/power/solar_control/attack_hand(mob/user)
-	if (..() || !user) return
+	if (..() || !user)
+		return
 	add_fingerprint(user)
 	interact(user)
 
 /obj/machinery/power/solar_control/interact(mob/user)
-	if (stat & BROKEN) return
+	if (stat & BROKEN)
+		return
 	ui_interact(user)
 
 /obj/machinery/power/solar_control/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "solar_control.tmpl", name, 490, 395)
 		ui.open()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -61,11 +61,12 @@
 		qdel(src)
 
 /obj/machinery/chem_dispenser/interact(mob/user)
-	if(stat & BROKEN) return
+	if(stat & BROKEN)
+		return
 	ui_interact(user)
 
 /obj/machinery/chem_dispenser/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "chem_dispenser.tmpl", name, 490, 710)
 		ui.open()
@@ -101,7 +102,8 @@
 	return data
 
 /obj/machinery/chem_dispenser/Topic(href, href_list)
-	if(stat & (BROKEN)) return
+	if(..())
+		return
 
 	if(href_list["amount"])
 		amount = round(text2num(href_list["amount"]), 5) // round to nearest 5
@@ -1459,11 +1461,13 @@
 			return 1
 
 /obj/machinery/chem_heater/attack_hand(mob/user)
-	if (!user) return
+	if (!user)
+		return
 	interact(user)
 
 /obj/machinery/chem_heater/Topic(href, href_list)
-	if(..()) return
+	if(..())
+		return
 
 	if(href_list["toggle_on"])
 		on = !on
@@ -1483,11 +1487,12 @@
 	add_fingerprint(usr)
 
 /obj/machinery/chem_heater/interact(mob/user)
-	if(stat & BROKEN) return
+	if(stat & BROKEN)
+		return
 	ui_interact(user)
 
 /obj/machinery/chem_heater/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
-	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "chem_heater.tmpl", name, 350, 270)
 		ui.open()


### PR DESCRIPTION
Canisters require physical access and nothing else.
NanoUI checks Brain Damage by default.
Fixes a NanoUI assignment derp.
Uses two-line ifs in Nano machines.

:cl: neersighted
tweak: NanoUI becomes... difficult to operate with brain damage. Who would have guessed?
tweak: Telekinesis enables you to use NanoUI at a distance.
fix: Canisters require physical proximity to actuate...
fix: NanoUI no longer leaks memory on click.
/:cl:
