### PR TITLE
Gives deadchat the (f) follow link.

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -43,13 +43,17 @@
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>"
 
 	for(var/mob/M in player_list)
-		if(istype(M, /mob/new_player))
+		var/adminoverride = 0
+		if(M.client || M.client.holder || (M.client.prefs.chat_toggles & CHAT_DEAD))
+			adminoverride = 1
+		if(istype(M, /mob/new_player) && !adminoverride)
 			continue
-		if(M.client && M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD)) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
-			M << rendered	//Admins can hear deadchat, if they choose to, no matter if they're blind/deaf or not.
-		else if(M.stat == DEAD)
-			//M.show_message(rendered, 2) //Takes into account blindness and such. //preserved so you can look at it and cry at the stupidity of oldcoders. whoever coded this should be punched into the sun
-			M << rendered
+		if(M.stat != DEAD && !adminoverride)
+			continue
+		if(istype(M, /mob/dead/observer))
+			M << "<a href=?src=\ref[src];follow=\ref[speaker]>(F)</a> [rendered]"
+		else
+			M << "[rendered]"
 
 /mob/proc/emote(var/act)
 	return

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -51,7 +51,7 @@
 		if(M.stat != DEAD && !adminoverride)
 			continue
 		if(istype(M, /mob/dead/observer))
-			M << "<a href=?src=\ref[src];follow=\ref[speaker]>(F)</a> [rendered]"
+			M << "<a href=?src=\ref[M];follow=\ref[src]>(F)</a> [rendered]"
 		else
 			M << "[rendered]"
 


### PR DESCRIPTION
I realllllllllly want to make this use M.Hear() rather then a istype check but it has a lot of args i don't understand how to implement.

If you think it's worth it to fake a say call to Hear(), I'll take suggestions on how to implement that.

(remember: all mob types have a potential to hear dead chat, as admins can always hear it, so we'd have to take into account all mob's overrides to Hear())

Side note: fixes admins not hearing deadchat while in lobby when enabled.
