### PR TITLE
Xenomorph Royals are now immune to injection.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -12,6 +12,9 @@
 
 	var/alt_inhands_file = 'icons/mob/alienqueen.dmi'
 
+/mob/living/carbon/alien/humanoid/royal/can_inject()
+	return 0
+
 /mob/living/carbon/alien/humanoid/royal/queen
 	name = "alien queen"
 	caste = "q"


### PR DESCRIPTION
Royal Xenomorphs (Praetorian, Queen) can no longer be injected by
syringes or syringe guns.

This PR is created on behalf of @WJohn. Please direct all comments or concerns regarding the feature itself to him.

I will, of course, take all concerns regarding the code itself.

:cl:
Name: Gun Hog
tweak: Nanotrasen has discovered new strains of Xenomorph which resist penetration by known injection devices, including syringes. This seems to only extend to the large 'Royal' strains, designed 'Queen' and 'Praetorian'. Extreme caution is advised should these specimens escape containment.
/:cl:
