### PR TITLE
Remove Cryo eject verb, revert sleeping/knockout removal, give resist a delay

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/cryo.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cryo.dm
@@ -78,7 +78,8 @@
 		return
 	close_machine(target)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/user)	open_machine()
+/obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/user)
+	return
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/container_resist()
 	usr << "<span class='notice'>Release sequence activated. This will take about a minute.</span>"

--- a/code/ATMOSPHERICS/components/unary_devices/cryo.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cryo.dm
@@ -80,8 +80,6 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/user)	open_machine()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/container_resist()
-	if(usr.incapacitated()) // Check that they're able to open the tube.
-		return
 	usr << "<span class='notice'>Release sequence activated. This will take about a minute.</span>"
 	sleep(600)
 	if(!src || !usr || (!occupant && !contents.Find(usr))) // Make sure they didn't disappear.

--- a/code/ATMOSPHERICS/components/unary_devices/cryo.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cryo.dm
@@ -80,28 +80,13 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/user)	open_machine()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/container_resist()
+	if(usr.incapacitated()) // Check that they're able to open the tube.
+		return
+	usr << "<span class='notice'>Release sequence activated. This will take about a minute.</span>"
+	sleep(600)
+	if(!src || !usr || (!occupant && !contents.Find(usr))) // Make sure they didn't disappear.
+		return
 	open_machine()
-	return
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/verb/move_eject()
-	set name = "Eject Cryo Cell"
-	set desc = "Begin the release sequence inside the cryo tube."
-	set category = "Object"
-	set src in oview(1)
-	if(usr == occupant || contents.Find(usr))	//If the user is inside the tube...
-		if(usr.stat == DEAD)	//and he's not dead....
-			return
-		usr << "<span class='notice'>Release sequence activated. This will take about a minute.</span>"
-		sleep(600)
-		if(!src || !usr || (!occupant && !contents.Find(usr)))	//Check if someone's released/replaced/bombed him already
-			return
-		open_machine()
-		add_fingerprint(usr)
-	else
-		if(!istype(usr, /mob/living) || usr.stat)
-			usr << "<span class='warning'>You can't do that!</span>"
-			return
-		open_machine()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/examine(mob/user)
 	..()
@@ -281,8 +266,8 @@
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature) * current_heat_capacity / (current_heat_capacity + air_contents.heat_capacity())
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise //TODO: fix someone else's broken promise - duncathan
 		if(occupant.bodytemperature < T0C)
-//			occupant.sleeping = max(5/efficiency, (1 / occupant.bodytemperature)*2000/efficiency)
-//			occupant.Paralyse(max(5/efficiency, (1 / occupant.bodytemperature)*3000/efficiency))
+			occupant.sleeping = max(5/efficiency, (1 / occupant.bodytemperature)*2000/efficiency)
+			occupant.Paralyse(max(5/efficiency, (1 / occupant.bodytemperature)*3000/efficiency))
 			if(air_contents.oxygen > 2)
 				if(occupant.getOxyLoss()) occupant.adjustOxyLoss(-1)
 			else

--- a/code/ATMOSPHERICS/components/unary_devices/cryo.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cryo.dm
@@ -13,6 +13,7 @@
 	var/current_heat_capacity = 50
 	state_open = 0
 	var/efficiency
+	var/autoEject = 0
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/New()
 	..()
@@ -45,6 +46,7 @@
 		beaker.loc = get_step(loc, SOUTH) //Beaker is carefully fed from the wreckage of the cryotube
 	beaker = null
 	return ..()
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()
 	..()
 	var/datum/gas_mixture/air_contents = AIR1
@@ -57,11 +59,10 @@
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process()
 	..()
-	if(occupant)
-		if(occupant.health >= 100)
-			on = 0
-			open_machine()
-			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+	if(occupant && occupant.health >= 100 && autoEject)
+		on = 0
+		open_machine()
+		playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 	if(!NODE1 || !is_operational())
 		return
 
@@ -110,7 +111,7 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 0)
 	SSnano.try_update_ui(user, src, ui_key, ui, force_open = force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "cryo.tmpl", name, 520, 410, state = notcontained_state)
+		ui = new(user, src, ui_key, "cryo.tmpl", name, 520, 560, state = notcontained_state)
 		ui.open()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/get_ui_data()
@@ -120,6 +121,7 @@
 	var/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? 1 : 0
+	data["autoEject"] = autoEject
 
 	var/occupantData = list()
 	if (!occupant)
@@ -172,6 +174,9 @@
 
 	if(href_list["switchOff"])
 		on = 0
+
+	if(href_list["autoEject"])
+		autoEject = !autoEject
 
 	if(href_list["openCell"])
 		open_machine()

--- a/nano/interfaces/cryo.tmpl
+++ b/nano/interfaces/cryo.tmpl
@@ -116,6 +116,15 @@
 			{{:helper.link('Close', 'locked', {'closeCell' : 1}, data.isOpen ? null : 'disabled')}}
 		</div>
 	</div>
+	<div class="item">
+		<div class="itemLabel">
+			Eject:
+		</div>
+		<div class="itemContent">
+			{{:helper.link('Auto', 'eject', {'autoEject' : 1}, data.autoEject ? 'selected' : null)}}
+			{{:helper.link('Manual', 'pin-s', {'autoEject' : 0}, data.autoEject ? null : 'selected')}}
+		</div>
+	</div>
 </div>
 <h2>Beaker</h2>
 <div class="statusDisplay">


### PR DESCRIPTION
Some shitler removed the sleeping effect

:cl: neersighted
fix: Cryo now knocks you out.
fix: Resisting out of cryo has a delay.
add: Cryo auto-ejection can now be configured.
del: Remove Cryo eject verb (resist out).
/:cl:
