### PR TITLE
check_shields() refactor

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -539,8 +539,8 @@
 			return ..()
 	return ..()
 
-/obj/item/weapon/twohanded/bostaff/IsShield()
-	if(wielded)
+/obj/item/weapon/twohanded/bostaff/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(wielded && prob(final_block_chance))
+		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 		return 1
-	else
-		return 0
+	return 0

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -482,6 +482,7 @@
 	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "bostaff0"
+	block_chance = 50
 
 /obj/item/weapon/twohanded/bostaff/update_icon()
 	icon_state = "bostaff[wielded]"
@@ -540,7 +541,6 @@
 	return ..()
 
 /obj/item/weapon/twohanded/bostaff/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(wielded && prob(final_block_chance))
-		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		return 1
+	if(wielded)
+		return ..()
 	return 0

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -286,12 +286,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "tactical armor crate"
 
 /datum/supply_packs/security/armory/laserarmor
-	name = "Ablative Armor Crate"
+	name = "Reflector Vest Crate"
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof)		// Only two vests to keep costs down for balance
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/plasma
-	containername = "ablative armor crate"
+	containername = "reflector vest crate"
 
 /////// Weapons: Specialist
 

--- a/code/game/gamemodes/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/abduction/abduction_gear.dm
@@ -79,7 +79,7 @@
 
 /obj/item/clothing/suit/armor/abductor/vest/hit_reaction()
 	DeactivateStealth()
-	return 1
+	return 0
 
 /obj/item/clothing/suit/armor/abductor/vest/IsReflect()
 	DeactivateStealth()

--- a/code/game/gamemodes/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/abduction/abduction_gear.dm
@@ -77,9 +77,10 @@
 		M.regenerate_icons()
 	return
 
-/obj/item/clothing/suit/armor/abductor/vest/IsShield()
+/obj/item/clothing/suit/armor/abductor/vest/hit_reaction()
 	DeactivateStealth()
-	return 0
+	return 1
+
 /obj/item/clothing/suit/armor/abductor/vest/IsReflect()
 	DeactivateStealth()
 	return 0

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -227,6 +227,7 @@
 	flags = ABSTRACT | NODROP
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "ling_shield"
+	block_chance = 50
 
 	var/remaining_uses //Set by the changeling ability.
 
@@ -245,10 +246,10 @@
 			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms his shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
 			H.unEquip(src, 1)
 		qdel(src)
-		return 1
+		return 0
 	else
 		remaining_uses--
-		return 0
+		return ..()
 
 
 /***************************************\

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -238,17 +238,17 @@
 /obj/item/clothing/head/helmet/space/changeling/dropped()
 	qdel(src)
 
-/obj/item/weapon/shield/changeling/IsShield()
+/obj/item/weapon/shield/changeling/hit_reaction()
 	if(remaining_uses < 1)
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc
 			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms his shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
 			H.unEquip(src, 1)
 		qdel(src)
-		return 0
+		return 1
 	else
 		remaining_uses--
-		return 1
+		return 0
 
 
 /***************************************\

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -59,8 +59,8 @@
 	difficulty = 5
 	excludefromjob = list("Captain")
 
-/datum/objective_item/steal/ablative
-	name = "an ablative armor vest"
+/datum/objective_item/steal/reflector
+	name = "a reflector vest"
 	targetitem = /obj/item/clothing/suit/armor/laserproof
 	difficulty = 3
 	excludefromjob = list("Head of Security", "Warden")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -99,12 +99,14 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/sharpness = IS_BLUNT
 	var/toolspeed = 1
 
+	var/block_chance = 0
+	var/hit_reaction_chance = 0
+
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
 		return 0
 	else
 		return 1
-
 
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
@@ -315,6 +317,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency
 
+/obj/item/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack", final_block_chance = 0)
+	return 0
+
 /obj/item/proc/talk_into(mob/M, input, channel, spans)
 	return
 
@@ -371,9 +376,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 //Checks before we get to here are: mob is alive, mob is not restrained, paralyzed, asleep, resting, laying, item is on the mob.
 /obj/item/proc/ui_action_click()
 	attack_self(usr)
-
-/obj/item/proc/IsShield()
-	return 0
 
 /obj/item/proc/IsReflect(var/def_zone) //This proc determines if and at what% an object will reflect energy projectiles if it's in l_hand,r_hand or wear_suit
 	return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -318,7 +318,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency
 
 /obj/item/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack", final_block_chance = 0)
-	if(prob(final_block_chance)
+	if(prob(final_block_chance))
 		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
 		return 1
 	return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -100,7 +100,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/toolspeed = 1
 
 	var/block_chance = 0
-	var/hit_reaction_chance = 0
+	var/hit_reaction_chance = 0 //If you want to have something unrelated to blocking/armour piercing etc. Maybe not needed, but trying to think ahead/allow more freedom
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
@@ -318,6 +318,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 // afterattack() and attack() prototypes moved to _onclick/item_attack.dm for consistency
 
 /obj/item/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack", final_block_chance = 0)
+	if(prob(final_block_chance)
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+		return 1
 	return 0
 
 /obj/item/proc/talk_into(mob/M, input, channel, spans)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -288,7 +288,7 @@
 	origin_tech = null
 	attack_verb = list("attacked", "struck", "hit")
 
-/obj/item/weapon/twohanded/dualsaber/toy/IsShield()
+/obj/item/weapon/twohanded/dualsaber/toy/hit_reaction()
 	return 0
 
 /obj/item/weapon/twohanded/dualsaber/toy/IsReflect()//Stops Toy Dualsabers from reflecting energy projectiles

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -63,9 +63,8 @@
 		item_color = pick("red", "blue", "green", "purple")
 
 /obj/item/weapon/melee/energy/sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(active && prob(final_block_chance))
-		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
-		return 1
+	if(active)
+		return ..()
 	return 0
 
 /obj/item/weapon/melee/energy/attack_self(mob/living/carbon/user)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -55,14 +55,16 @@
 	embedded_impact_pain_multiplier = 10
 	flags = NOSHIELD
 	origin_tech = "magnets=3;syndicate=4"
+	block_chance = 50
 	var/hacked = 0
 
 /obj/item/weapon/melee/energy/sword/New()
 	if(item_color == null)
 		item_color = pick("red", "blue", "green", "purple")
 
-/obj/item/weapon/melee/energy/sword/IsShield()
-	if(active)
+/obj/item/weapon/melee/energy/sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(active && prob(final_block_chance))
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
 		return 1
 	return 0
 
@@ -136,7 +138,7 @@
 	icon_state = "esaw_0"
 	item_color = null
 
-/obj/item/weapon/melee/energy/sword/cyborg/saw/IsShield()
+/obj/item/weapon/melee/energy/sword/cyborg/saw/hit_reaction()
 	return 0
 
 /obj/item/weapon/melee/energy/sword/saber

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/shield
 	name = "shield"
+	block_chance = 50
 
 /obj/item/weapon/shield/riot
 	name = "riot shield"
@@ -17,8 +18,11 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
-/obj/item/weapon/shield/riot/IsShield()
-	return 1
+/obj/item/weapon/shield/riot/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(final_block_chance)
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+		return 1
+	return 0
 
 /obj/item/weapon/shield/riot/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/melee/baton))
@@ -49,8 +53,11 @@
 	attack_verb = list("shoved", "bashed")
 	var/active = 0
 
-/obj/item/weapon/shield/energy/IsShield()
-	return (active)
+/obj/item/weapon/shield/energy/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(active && prob(final_block_chance))
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+		return 1
+	return 0
 
 /obj/item/weapon/shield/energy/IsReflect()
 	return (active)
@@ -91,8 +98,11 @@
 	w_class = 3
 	var/active = 0
 
-/obj/item/weapon/shield/riot/tele/IsShield()
-	return (active)
+/obj/item/weapon/shield/riot/tele/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(active && final_block_chance)
+		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
+		return 1
+	return 0
 
 /obj/item/weapon/shield/riot/tele/attack_self(mob/living/user)
 	active = !active

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -18,11 +18,6 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
-/obj/item/weapon/shield/riot/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(final_block_chance)
-		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
-		return 1
-	return 0
 
 /obj/item/weapon/shield/riot/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/melee/baton))
@@ -54,9 +49,8 @@
 	var/active = 0
 
 /obj/item/weapon/shield/energy/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(active && prob(final_block_chance))
-		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
-		return 1
+	if(active)
+		return ..()
 	return 0
 
 /obj/item/weapon/shield/energy/IsReflect()
@@ -99,9 +93,8 @@
 	var/active = 0
 
 /obj/item/weapon/shield/riot/tele/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(active && final_block_chance)
-		owner.visible_message("<span class='danger'>[owner] blocks [attack_text] with [src]!</span>")
-		return 1
+	if(active)
+		return ..()
 	return 0
 
 /obj/item/weapon/shield/riot/tele/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -115,13 +115,13 @@
 /obj/item/weapon/twohanded/offhand/wield()
 	qdel(src)
 
-/obj/item/weapon/twohanded/offhand/IsShield()//if the actual twohanded weapon is a shield, we count as a shield too!
+/obj/item/weapon/twohanded/offhand/hit_reaction()//if the actual twohanded weapon is a shield, we count as a shield too!
 	var/mob/user = loc
-	if(!istype(user)) return 0
+	if(!istype(user)) return 1
 	var/obj/item/I = user.get_active_hand()
 	if(I == src) I = user.get_inactive_hand()
-	if(!I) return 0
-	return I.IsShield()
+	if(!I) return 1
+	return I.hit_reaction()
 
 ///////////Two hand required objects///////////////
 //This is for objects that require two hands to even pick up
@@ -211,6 +211,7 @@
 	origin_tech = "magnets=3;syndicate=4"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	block_chance = 50
 	var/hacked = 0
 
 /obj/item/weapon/twohanded/dualsaber/New()
@@ -242,11 +243,11 @@
 	else
 		user.adjustStaminaLoss(25)
 
-/obj/item/weapon/twohanded/dualsaber/IsShield()
-	if(wielded)
+/obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(wielded && final_block_chance)
+		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 		return 1
-	else
-		return 0
+	return 0
 
 /obj/item/weapon/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up
 	if(wielded)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -117,11 +117,15 @@
 
 /obj/item/weapon/twohanded/offhand/hit_reaction()//if the actual twohanded weapon is a shield, we count as a shield too!
 	var/mob/user = loc
-	if(!istype(user)) return 1
+	if(!istype(user))
+		return 0
 	var/obj/item/I = user.get_active_hand()
-	if(I == src) I = user.get_inactive_hand()
-	if(!I) return 1
-	return I.hit_reaction()
+	if(I == src)
+		I = user.get_inactive_hand()
+	if(!I)
+		return 0
+	return
+		I.hit_reaction()
 
 ///////////Two hand required objects///////////////
 //This is for objects that require two hands to even pick up
@@ -244,9 +248,8 @@
 		user.adjustStaminaLoss(25)
 
 /obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(wielded && final_block_chance)
-		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		return 1
+	if(wielded)
+		return ..()
 	return 0
 
 /obj/item/weapon/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -124,8 +124,7 @@
 		I = user.get_inactive_hand()
 	if(!I)
 		return 0
-	return
-		I.hit_reaction()
+	return I.hit_reaction()
 
 ///////////Two hand required objects///////////////
 //This is for objects that require two hands to even pick up

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -64,12 +64,7 @@
 	throwforce = 10
 	w_class = 3
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-
-/obj/item/weapon/claymore/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(prob(final_block_chance))
-		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		return 1
-	return 0
+	block_chance = 50
 
 /obj/item/weapon/claymore/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is falling on the [src.name]! It looks like \he's trying to commit suicide.</span>")
@@ -87,6 +82,7 @@
 	w_class = 3
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	block_chance = 50
 
 /obj/item/weapon/katana/cursed
 	slot_flags = null
@@ -94,12 +90,6 @@
 /obj/item/weapon/katana/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</span>")
 	return(BRUTELOSS)
-
-/obj/item/weapon/katana/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(prob(final_block_chance))
-		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		return 1
-	return 0
 
 /obj/item/weapon/wirerod
 	name = "wired rod"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -65,8 +65,11 @@
 	w_class = 3
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
-/obj/item/weapon/claymore/IsShield()
-	return 1
+/obj/item/weapon/claymore/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(prob(final_block_chance))
+		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
+		return 1
+	return 0
 
 /obj/item/weapon/claymore/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is falling on the [src.name]! It looks like \he's trying to commit suicide.</span>")
@@ -92,8 +95,11 @@
 	user.visible_message("<span class='suicide'>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</span>")
 	return(BRUTELOSS)
 
-/obj/item/weapon/katana/IsShield()
+/obj/item/weapon/katana/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(prob(final_block_chance))
+		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 		return 1
+	return 0
 
 /obj/item/weapon/wirerod
 	name = "wired rod"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -220,7 +220,8 @@ BLIND     // can't see anything
 		if(blood_DNA)
 			. += image("icon"='icons/effects/blood.dmi', "icon_state"="[blood_overlay_type]blood")
 
-
+/obj/item/clothing/suit/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack")
+	return
 
 //Spacesuit
 //Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -220,9 +220,6 @@ BLIND     // can't see anything
 		if(blood_DNA)
 			. += image("icon"='icons/effects/blood.dmi', "icon_state"="[blood_overlay_type]blood")
 
-/obj/item/clothing/suit/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack")
-	return
-
 //Spacesuit
 //Note: Everything in modules/clothing/spacesuits should have the entire suit grouped together.
 //      Meaning the the suit is defined directly after the corrisponding helmet. Just like below!

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -161,7 +161,7 @@
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
-		visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
 		var/list/turfs = new/list()
 		for(var/turf/T in orange(6, H))
 			if(T.density) continue
@@ -184,7 +184,7 @@
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, attack_text)
 	if(prob(hit_reaction_chance))
-		visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
+		owner.visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
 		for(var/mob/living/carbon/C in range(6, owner))
 			if(C != owner)
 				C.fire_stacks += 8

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -164,14 +164,18 @@
 		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
 		var/list/turfs = new/list()
 		for(var/turf/T in orange(6, H))
-			if(T.density) continue
-			if(T.x>world.maxx-6 || T.x<6)	continue
-			if(T.y>world.maxy-6 || T.y<6)	continue
+			if(T.density)
+				continue
+			if(T.x>world.maxx-6 || T.x<6)
+				continue
+			if(T.y>world.maxy-6 || T.y<6)
+				continue
 			turfs += T
 		if(!turfs.len)
 			turfs += pick(/turf in orange(6, src))
 			var/turf/picked = pick(turfs)
-			if(!isturf(picked)) return
+			if(!isturf(picked))
+				return
 			if(H.buckled)
 				H.buckled.unbuckle_mob()
 			H.forceMove(picked)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -159,6 +159,35 @@
 	src.item_state = "reactiveoff"
 	..()
 
+/obj/item/clothing/suit/armor/reactive/hit_reaction(owner, attack_text)
+	var/mob/living/carbon/human/H = owner
+	visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+	var/list/turfs = new/list()
+	for(var/turf/T in orange(6, H))
+		if(T.density) continue
+		if(T.x>world.maxx-6 || T.x<6)	continue
+		if(T.y>world.maxy-6 || T.y<6)	continue
+		turfs += T
+	if(!turfs.len)
+		turfs += pick(/turf in orange(6, src))
+		var/turf/picked = pick(turfs)
+		if(!isturf(picked)) return
+		if(H.buckled)
+			H.buckled.unbuckle_mob()
+		H.forceMove(picked)
+
+
+/obj/item/clothing/suit/armor/reactive/fire
+	name = "reactive incendiary armor"
+
+
+/obj/item/clothing/suit/armor/reactive/fire/hit_reaction(owner, attack_text)
+	visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
+	for(var/mob/living/carbon/C in orange(6, owner))
+		if(C != owner)
+			C.fire_stacks += 8
+			C.IgniteMob()
+
 
 //All of the armor below is mostly unused
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -182,13 +182,16 @@
 	name = "reactive incendiary armor"
 
 
-/obj/item/clothing/suit/armor/reactive/fire/hit_reaction(owner, attack_text)
-	visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
-	for(var/mob/living/carbon/C in orange(6, owner))
-		if(C != owner)
-			C.fire_stacks += 8
-			C.IgniteMob()
-
+/obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, attack_text)
+	if(prob(hit_reaction_chance))
+		visible_message("<span class='danger'>The [src] blocks the [attack_text], sending out jets of flame!</span>")
+		for(var/mob/living/carbon/C in range(6, owner))
+			if(C != owner)
+				C.fire_stacks += 8
+				C.IgniteMob()
+		owner.fire_stacks = -20
+		return 1
+	return 0
 
 //All of the armor below is mostly unused
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -134,11 +134,8 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	action_button_name = "Toggle Armor"
 	unacidable = 1
+	hit_reaction_chance = 50
 
-/obj/item/clothing/suit/armor/reactive/IsShield()
-	if(active)
-		return 1
-	return 0
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	src.active = !( src.active )
@@ -159,23 +156,27 @@
 	src.item_state = "reactiveoff"
 	..()
 
-/obj/item/clothing/suit/armor/reactive/hit_reaction(owner, attack_text)
-	var/mob/living/carbon/human/H = owner
-	visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
-	var/list/turfs = new/list()
-	for(var/turf/T in orange(6, H))
-		if(T.density) continue
-		if(T.x>world.maxx-6 || T.x<6)	continue
-		if(T.y>world.maxy-6 || T.y<6)	continue
-		turfs += T
-	if(!turfs.len)
-		turfs += pick(/turf in orange(6, src))
-		var/turf/picked = pick(turfs)
-		if(!isturf(picked)) return
-		if(H.buckled)
-			H.buckled.unbuckle_mob()
-		H.forceMove(picked)
-
+/obj/item/clothing/suit/armor/reactive/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(!active)
+		return 0
+	if(prob(hit_reaction_chance))
+		var/mob/living/carbon/human/H = owner
+		visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+		var/list/turfs = new/list()
+		for(var/turf/T in orange(6, H))
+			if(T.density) continue
+			if(T.x>world.maxx-6 || T.x<6)	continue
+			if(T.y>world.maxy-6 || T.y<6)	continue
+			turfs += T
+		if(!turfs.len)
+			turfs += pick(/turf in orange(6, src))
+			var/turf/picked = pick(turfs)
+			if(!isturf(picked)) return
+			if(H.buckled)
+				H.buckled.unbuckle_mob()
+			H.forceMove(picked)
+		return 1
+	return 0
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -59,6 +59,9 @@
 	fitted = FEMALE_UNIFORM_TOP
 	can_adjust = 0
 
+/obj/item/clothing/under/rank/clown/hit_reaction()
+	playsound(loc, 'sound/items/bikehorn.ogg', 50, 1, -1)
+	return 0
 
 /obj/item/clothing/under/rank/head_of_personnel
 	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -31,8 +31,9 @@
 	New()
 		item_color = "red"
 
-/obj/item/weapon/holo/esword/IsShield()
-	if(active)
+/obj/item/weapon/holo/esword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(active && prob(final_block_chance))
+		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
 		return 1
 	return 0
 

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -32,9 +32,8 @@
 		item_color = "red"
 
 /obj/item/weapon/holo/esword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(active && prob(final_block_chance))
-		visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-		return 1
+	if(active)
+		return ..()
 	return 0
 
 /obj/item/weapon/holo/esword/attack(target as mob, mob/user as mob)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -87,20 +87,20 @@ emp_act
 		if(AM.flags & NOSHIELD) //weapon ignores shields altogether
 			return 0
 	if(l_hand)
-		block_chance_modifier += l_hand.block_chance - (Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100)) //So armour piercing blades can still be parried by other blades, for example
-		if(l_hand.hit_reaction(src, attack_text, block_chance_modifier))
+		var/final_block_chance = l_hand.block_chance - (Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100)) + block_chance_modifier //So armour piercing blades can still be parried by other blades, for example
+		if(l_hand.hit_reaction(src, attack_text, final_block_chance))
 			return 1
 	if(r_hand)
-		block_chance_modifier += r_hand.block_chance - (Clamp((armour_penetration-r_hand.armour_penetration)/2,0,100))
-		if(r_hand.hit_reaction(src, attack_text, block_chance_modifier))
+		var/final_block_chance = r_hand.block_chance - (Clamp((armour_penetration-r_hand.armour_penetration)/2,0,100)) + block_chance_modifier //Need to reset the var so it doesn't carry over modifications between attempts
+		if(r_hand.hit_reaction(src, attack_text, final_block_chance))
 			return 1
 	if(wear_suit)
-		block_chance_modifier += wear_suit.block_chance - (Clamp((armour_penetration-wear_suit.armour_penetration)/2,0,100))
-		if(wear_suit.hit_reaction(src, attack_text, block_chance_modifier))
+		var/final_block_chance = wear_suit.block_chance - (Clamp((armour_penetration-wear_suit.armour_penetration)/2,0,100)) + block_chance_modifier
+		if(wear_suit.hit_reaction(src, attack_text, final_block_chance))
 			return 1
 	if(w_uniform)
-		block_chance_modifier += w_uniform.block_chance - (Clamp((armour_penetration-w_uniform.armour_penetration)/2,0,100))
-		if(w_uniform.hit_reaction(src, attack_text, block_chance_modifier))
+		var/final_block_chance = w_uniform.block_chance - (Clamp((armour_penetration-w_uniform.armour_penetration)/2,0,100)) + block_chance_modifier
+		if(w_uniform.hit_reaction(src, attack_text, final_block_chance))
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -86,11 +86,11 @@ emp_act
 	if(AM)
 		if(AM.flags & NOSHIELD) //weapon ignores shields altogether
 			return 0
-	if(l_hand)
+	if(l_hand && !istype(l_hand, /obj/item/clothing))
 		var/final_block_chance = l_hand.block_chance - (Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100)) + block_chance_modifier //So armour piercing blades can still be parried by other blades, for example
 		if(l_hand.hit_reaction(src, attack_text, final_block_chance))
 			return 1
-	if(r_hand)
+	if(r_hand && !istype(r_hand, /obj/item/clothing))
 		var/final_block_chance = r_hand.block_chance - (Clamp((armour_penetration-r_hand.armour_penetration)/2,0,100)) + block_chance_modifier //Need to reset the var so it doesn't carry over modifications between attempts
 		if(r_hand.hit_reaction(src, attack_text, final_block_chance))
 			return 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -103,20 +103,9 @@ emp_act
 		return 1
 	if(wear_suit)
 		if(wear_suit.IsShield() && (prob(50)))
-			visible_message("<span class='danger'>The reactive teleport system flings [src] clear of [attack_text]!</span>", \
-							"<span class='userdanger'>The reactive teleport system flings [src] clear of [attack_text]!</span>")
-			var/list/turfs = new/list()
-			for(var/turf/T in orange(6, src))
-				if(T.density) continue
-				if(T.x>world.maxx-6 || T.x<6)	continue
-				if(T.y>world.maxy-6 || T.y<6)	continue
-				turfs += T
-			if(!turfs.len) turfs += pick(/turf in orange(6, src))
-			var/turf/picked = pick(turfs)
-			if(!isturf(picked)) return
-			if(buckled)
-				buckled.unbuckle_mob()
-			forceMove(picked)
+			if(istype(wear_suit, /obj/item/clothing/suit))
+				var/obj/item/clothing/suit/S = wear_suit
+				S.hit_reaction(src, attack_text)
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -82,30 +82,25 @@ emp_act
 //End Here
 
 /mob/living/carbon/human/proc/check_shields(damage = 0, attack_text = "the attack", atom/movable/AM, thrown_proj = 0, armour_penetration = 0)
-	var/block_chance = 50 + 30*thrown_proj - round(damage / 3) //thrown things are easier to block
+	var/block_chance_modifier = 30*thrown_proj - round(damage / 3) //thrown things are easier to block
 	if(AM)
 		if(AM.flags & NOSHIELD) //weapon ignores shields altogether
 			return 0
-	var/blocker
 	if(l_hand)
-		if(l_hand.IsShield())
-			block_chance -= Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100) //So armour piercing blades can still be parried by other blades, for example
-			if(prob(block_chance))
-				blocker = l_hand
+		block_chance_modifier += l_hand.block_chance - (Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100)) //So armour piercing blades can still be parried by other blades, for example
+		if(l_hand.hit_reaction(src, attack_text, block_chance_modifier))
+			return 1
 	if(r_hand)
-		if(r_hand.IsShield())
-			block_chance -= Clamp((armour_penetration-r_hand.armour_penetration)/2,0,100)
-			if(prob(block_chance))
-				blocker = r_hand
-	if(blocker)
-		visible_message("<span class='danger'>[src] blocks [attack_text] with [blocker]!</span>", \
-						"<span class='userdanger'>[src] blocks [attack_text] with [blocker]!</span>")
-		return 1
+		block_chance_modifier += r_hand.block_chance - (Clamp((armour_penetration-r_hand.armour_penetration)/2,0,100))
+		if(r_hand.hit_reaction(src, attack_text, block_chance_modifier))
+			return 1
 	if(wear_suit)
-		if(wear_suit.IsShield() && (prob(50)))
-			if(istype(wear_suit, /obj/item/clothing/suit))
-				var/obj/item/clothing/suit/S = wear_suit
-				S.hit_reaction(src, attack_text)
+		block_chance_modifier += wear_suit.block_chance - (Clamp((armour_penetration-wear_suit.armour_penetration)/2,0,100))
+		if(wear_suit.hit_reaction(src, attack_text, block_chance_modifier))
+			return 1
+	if(w_uniform)
+		block_chance_modifier += w_uniform.block_chance - (Clamp((armour_penetration-w_uniform.armour_penetration)/2,0,100))
+		if(w_uniform.hit_reaction(src, attack_text, block_chance_modifier))
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1005,8 +1005,8 @@
 	// Allows you to put in item-specific reactions based on species
 	if(user != H)
 		user.do_attack_animation(H)
-	if(user != H && H.check_shields(I.force, "the [I.name]", I, 0, I.armour_penetration))
-		return 0
+		if(H.check_shields(I.force, "the [I.name]", I, 0, I.armour_penetration))
+			return 0
 
 	if(I.attack_verb && I.attack_verb.len)
 		H.visible_message("<span class='danger'>[user] has [pick(I.attack_verb)] [H] in the [hit_area] with [I]!</span>", \

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1005,7 +1005,7 @@
 	// Allows you to put in item-specific reactions based on species
 	if(user != H)
 		user.do_attack_animation(H)
-	if(H.check_shields(I.force, "the [I.name]", I, 0, I.armour_penetration))
+	if(user != H && H.check_shields(I.force, "the [I.name]", I, 0, I.armour_penetration))
 		return 0
 
 	if(I.attack_verb && I.attack_verb.len)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -884,7 +884,7 @@
 /datum/species/proc/spec_attack_hand(mob/living/carbon/human/M, mob/living/carbon/human/H)
 	if(!istype(M)) //sanity check for drones.
 		return
-	if((M != H) && H.check_shields(0, M.name))
+	if((M != H) && M.a_intent != "help" && H.check_shields(0, M.name))
 		add_logs(M, H, "attempted to touch")
 		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>")
 		return 0


### PR DESCRIPTION
Replaces isshield() with hit_reaction(), allowing objects to have custom effects/messages/block chances when checked for blocking. They can also do things entirely unrelated to actually blocking the hit, such as spewing fire everywhere, triggering an explosion, etc. 

Adds vars so you can set the block_chance and react chance of an item.

check_shields() now checks, in order: Left Hand, Right Hand, Exosuit (all exosuits can now have a reaction, rather than just the teleport armour), Jumpsuit 

You can't trigger your own shields anymore.

Fixes #12981

Renames the ablative vest (energy armour) to reflector vest, because it has nothing at all to do with ablative shielding (which will now be possible with hit_reaction, such as having an armour vest that loses ablative plates as it gets hit).

As examples for the new system:

-The clown jumpsuit honks when the owner gets hit

-There is a subtype of reactive armour that sets everyone nearby on fire instead of warping the RD away

:cl: Kor
rscadd: The blocking system has been completely overhauled. Any held item, exosuit, or jumpsuit can now have a chance to block, or a custom on hit effect. Different shields can now have different block chances.
rscadd: The clowns jumpsuit now honks when you beat the owner.
rscadd: There is a new (admin only for now) suit of reactive armour that ignites attackers instead of warping you.
rscadd: Shields will no longer block hugs. Give peace a chance.
/:cl:
