### PR TITLE
Bot fixes

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -11,7 +11,6 @@
 #define MODE_INTERCOM "intercom"
 #define MODE_BINARY "binary"
 #define MODE_WHISPER "whisper"
-#define MODE_SECURE_HEADSET "secure headset"
 #define MODE_DEPARTMENT "department"
 #define MODE_ALIEN "alientalk"
 #define MODE_HOLOPAD "holopad"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -81,11 +81,6 @@
 				ears.talk_into(src, message, , spans)
 			return ITALICS | REDUCE_RANGE
 
-		if(MODE_SECURE_HEADSET)
-			if (ears)
-				ears.talk_into(src, message, 1, spans)
-			return ITALICS | REDUCE_RANGE
-
 		if(MODE_DEPARTMENT)
 			if (ears)
 				ears.talk_into(src, message, message_mode, spans)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -149,6 +149,7 @@
 		locked = 0
 		emagged = 1
 		user << "<span class='notice'>You bypass [src]'s controls.</span>"
+		return
 	if(!locked && open) //Bot panel is unlocked by ID or emag, and the panel is screwed open. Ready for emagging.
 		emagged = 2
 		remote_disabled = 1 //Manually emagging the bot locks out the AI built in panel.
@@ -156,6 +157,7 @@
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		src << "<span class='userdanger'>(#$*#$^^( OVERRIDE DETECTED</span>"
+		return
 	else //Bot is unlocked, but the maint panel has not been opened with a screwdriver yet.
 		user << "<span class='warning'>You need to open maintenance panel first!</span>"
 
@@ -182,7 +184,7 @@
 /mob/living/simple_animal/bot/handle_automated_action() //Master process which handles code common across most bots.
 	set background = BACKGROUND_ENABLED
 
-	if(!on || ckey)
+	if(!on || client)
 		return
 
 	switch(mode) //High-priority overrides are processed first. Bots can do nothing else while under direct command.
@@ -580,7 +582,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 /mob/living/simple_animal/bot/proc/bot_control(command, mob/user, turf/user_turf, list/user_access = list())
 	if(!on || emagged == 2 || remote_disabled) //Emagged bots do not respect anyone's authority! Bots with their remote controls off cannot get commands.
 		return 1 //ACCESS DENIED
-	if(ckey)
+	if(client)
 		bot_control_message(command,user,user_turf,user_access)
 	// process control input
 	switch(command)
@@ -778,3 +780,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 /mob/living/simple_animal/bot/Login()
 	. = ..()
 	access_card.access += player_access
+
+/mob/living/simple_animal/bot/Logout()
+	. = ..()
+	bot_reset()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -125,6 +125,12 @@
 
 	bot_core = new bot_core_type(src)
 
+/mob/living/simple_animal/bot/update_canmove()
+	. = ..()
+	if(!on)
+		. = 0
+	canmove = .
+
 /mob/living/simple_animal/bot/Destroy()
 	qdel(Radio)
 	qdel(access_card)
@@ -149,6 +155,7 @@
 		locked = 1 //Access denied forever!
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
+		src << "<span class='userdanger'>(#$*#$^^( OVERRIDE DETECTED</span>"
 	else //Bot is unlocked, but the maint panel has not been opened with a screwdriver yet.
 		user << "<span class='warning'>You need to open maintenance panel first!</span>"
 
@@ -293,6 +300,24 @@
 /mob/living/simple_animal/bot/get_spans()
 	return ..() | SPAN_ROBOT
 
+/mob/living/simple_animal/bot/radio(message, message_mode, list/spans)
+	. = ..()
+	if(. != 0)
+		return .
+
+	switch(message_mode)
+		if(MODE_HEADSET)
+			Radio.talk_into(src, message, , spans)
+			return REDUCE_RANGE
+
+		if(MODE_DEPARTMENT)
+			Radio.talk_into(src, message, message_mode, spans)
+			return REDUCE_RANGE
+
+	if(message_mode in radiochannels)
+		Radio.talk_into(src, message, message_mode, spans)
+		return REDUCE_RANGE
+	return 0
 
 //Generalized behavior code, override where needed!
 
@@ -426,7 +451,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 	access_card.access = prev_access
 	tries = 0
 	mode = BOT_IDLE
-
 
 
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -508,6 +508,8 @@ Auto Patrol[]"},
 	lasercolor = "r"
 
 /mob/living/simple_animal/bot/ed209/UnarmedAttack(atom/A)
+	if(!on)
+		return
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
 		if(!C.stunned || arrest_type)
@@ -518,6 +520,8 @@ Auto Patrol[]"},
 		..()
 
 /mob/living/simple_animal/bot/ed209/RangedAttack(atom/A)
+	if(!on)
+		return
 	if(ismob(A))
 		shootAt(A)
 	else
@@ -539,7 +543,7 @@ Auto Patrol[]"},
 		C.Weaken(5)
 		C.stuttering = 5
 		C.Stun(5)
-
+	add_logs(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -447,6 +447,9 @@
 		bot_reset()
 		return
 	else
+		if(!emagged && check_overdose(patient,reagent_id,injection_amount))
+			soft_reset()
+			return
 		C.visible_message("<span class='danger'>[src] is trying to inject [patient]!</span>", \
 			"<span class='userdanger'>[src] is trying to inject you!</span>")
 
@@ -469,6 +472,13 @@
 
 	reagent_id = null
 	return
+
+/mob/living/simple_animal/bot/medbot/proc/check_overdose(mob/living/carbon/patient,reagent_id,injection_amount)
+	var/datum/reagent/R  = chemical_reagents_list[reagent_id]
+	var/current_volume = patient.reagents.get_reagent_amount(reagent_id)
+	if(current_volume + injection_amount > R.overdose_threshold)
+		return 1
+	return 0
 
 /mob/living/simple_animal/bot/medbot/bullet_act(obj/item/projectile/Proj)
 	if(Proj.flag == "taser")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -795,6 +795,11 @@ mob/living/simple_animal/bot/mulebot/bot_reset()
 	else
 		return null
 
+/mob/living/simple_animal/bot/mulebot/resist()
+	..()
+	if(load)
+		unload()
+
 #undef SIGH
 #undef ANNOYED
 #undef DELIGHT

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -46,7 +46,6 @@
 	..()
 	icon_state = "secbot[on]"
 	spawn(3)
-
 		var/datum/job/detective/J = new/datum/job/detective
 		access_card.access += J.get_access()
 		prev_access = access_card.access
@@ -162,6 +161,8 @@ Auto Patrol: []"},
 
 
 /mob/living/simple_animal/bot/secbot/UnarmedAttack(atom/A)
+	if(!on)
+		return
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
 		if(!C.stunned || arrest_type)
@@ -201,7 +202,7 @@ Auto Patrol: []"},
 		C.Weaken(5)
 		C.stuttering = 5
 		C.Stun(5)
-
+	add_logs(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -154,11 +154,6 @@
 				ears.talk_into(src, message, , spans)
 			return ITALICS | REDUCE_RANGE
 
-		if(MODE_SECURE_HEADSET)
-			if (ears)
-				ears.talk_into(src, message, 1, spans)
-			return ITALICS | REDUCE_RANGE
-
 		if(MODE_DEPARTMENT)
 			if (ears)
 				ears.talk_into(src, message, message_mode, spans)


### PR DESCRIPTION
Fixes Player bots moving while deactivated
Fixes Player bot radios
Removes unused HEADSET_SECURE radio mode
Adds secbot/ed209 stuns to attack log
Allows player mulebots to drop the cargo by resisting
