### PR TITLE
Fixes inability to upgrade gun rechargers

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -67,6 +67,9 @@
 			default_deconstruction_crowbar(G)
 			return
 
+		if(exchange_parts(user, G))
+			return
+
 /obj/machinery/recharger/attack_hand(mob/user)
 	if(issilicon(user))
 		return


### PR DESCRIPTION
:cl:
Name: Gun Hog
bugfix: Nanotrasen has discovered a flaw in the weapon recharging station's design that makes it incompatible with the Rapid Part Exchange Device. This has been corrected.
/:cl:
