### PR TITLE
IC OOC detection fixes

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -44,17 +44,9 @@
 	msg = emoji_parse(msg)
 
 	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
-		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") == "Yes")
-			raw_msg = "|~|" + raw_msg
-			ooc(raw_msg)
+		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 			return
-		else
-			return
-
-	if(copytext(msg, 1, 4) == "|~|")
-		raw_msg = copytext(raw_msg, 4)
-		msg		= copytext(msg, 4)
-
+			
 	log_ooc("[mob.name]/[key] : [raw_msg]")
 
 	var/keyname = key

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -48,6 +48,8 @@
 			raw_msg = "|~|" + raw_msg
 			ooc(raw_msg)
 			return
+		else
+			return
 
 	if(copytext(msg, 1, 4) == "|~|")
 		raw_msg = copytext(raw_msg, 4)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -38,19 +38,27 @@
 			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
-			
+
+	var/raw_msg = msg
+
+	msg = emoji_parse(msg)
+
 	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
-		if(alert("Your message \"[msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
+		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") == "Yes")
+			raw_msg = "|~|" + raw_msg
+			ooc(raw_msg)
 			return
 
-	log_ooc("[mob.name]/[key] : [msg]")
+	if(copytext(msg, 1, 4) == "|~|")
+		raw_msg = copytext(raw_msg, 4)
+		msg		= copytext(msg, 4)
+
+	log_ooc("[mob.name]/[key] : [raw_msg]")
 
 	var/keyname = key
 	if(prefs.unlock_content)
 		if(prefs.toggles & MEMBER_PUBLIC)
 			keyname = "<font color='[prefs.ooccolor ? prefs.ooccolor : normal_ooc_colour]'><img style='width:9px;height:9px;' class=icon src=\ref['icons/member_content.dmi'] iconstate=blag>[keyname]</font>"
-
-	msg = emoji_parse(msg)
 
 	for(var/client/C in clients)
 		if(C.prefs.chat_toggles & CHAT_OOC)

--- a/code/modules/emoji/emoji_parse.dm
+++ b/code/modules/emoji/emoji_parse.dm
@@ -10,11 +10,11 @@ var/list/emojis
 	var/search = 0
 	var/emoji = ""
 	while(1)
-		search = findtext(text, "*", pos)
+		search = findtext(text, ":", pos)
 		parsed += copytext(text, pos, search)
 		if(search)
 			pos = search
-			search = findtext(text, "*", pos+1)
+			search = findtext(text, ":", pos+1)
 			if(search)
 				emoji = lowertext(copytext(text, pos+1, search))
 				if(emoji in emojis)

--- a/code/modules/emoji/emoji_parse.dm
+++ b/code/modules/emoji/emoji_parse.dm
@@ -10,11 +10,11 @@ var/list/emojis
 	var/search = 0
 	var/emoji = ""
 	while(1)
-		search = findtext(text, ":", pos)
+		search = findtext(text, "*", pos)
 		parsed += copytext(text, pos, search)
 		if(search)
 			pos = search
-			search = findtext(text, ":", pos+1)
+			search = findtext(text, "*", pos+1)
 			if(search)
 				emoji = lowertext(copytext(text, pos+1, search))
 				if(emoji in emojis)


### PR DESCRIPTION
emoji parsing now happens before IC OOC checks.

Fixes #13349

<s>Changes up how OOC checks to see that you agreed that a message isn't accidental IC.

<s>It now passes a special string, "|~|", in front of your message and runs it through OOC again. The string saves the message from further scrutiny, and is then cut off. A "cool kid" could manually insert the |~| to tell the parser to ignore the IC OOC check, but this is pretty much harmless. 

<s>Fixes #13353
