### PR TITLE
Adds summon_backup() to hostile animals

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -221,11 +221,12 @@
 /mob/living/simple_animal/hostile/proc/summon_backup(distance)
 	do_alert_animation(src)
 	playsound(loc, 'sound/machines/chime.ogg', 50, 1, -1)
-	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
-		for (var/element in src.faction)
-			if (element in M.faction)
-				M.Goto(src,M.move_to_delay,M.minimum_distance)
-				continue
+	mob_loop:
+		for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
+			for (var/element in src.faction)
+				if (element in M.faction)
+					M.Goto(src,M.move_to_delay,M.minimum_distance)
+					continue mob_loop
 
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -223,10 +223,9 @@
 	playsound(loc, 'sound/machines/chime.ogg', 50, 1, -1)
 	mob_loop:
 		for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
-			for (var/element in src.faction)
-				if (element in M.faction)
-					M.Goto(src,M.move_to_delay,M.minimum_distance)
-					continue mob_loop
+			var/list/L = M.faction&faction
+			if(L.len)
+				M.Goto(src,M.move_to_delay,M.minimum_distance)
 
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -219,6 +219,7 @@
 	..(gibbed)
 
 /mob/living/simple_animal/hostile/proc/summon_backup(distance)
+	do_alert_animation(src)
 	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
 		for (var/element in src.faction)
 			if (element in M.faction)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -221,11 +221,10 @@
 /mob/living/simple_animal/hostile/proc/summon_backup(distance)
 	do_alert_animation(src)
 	playsound(loc, 'sound/machines/chime.ogg', 50, 1, -1)
-	mob_loop:
-		for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
-			var/list/L = M.faction&faction
-			if(L.len)
-				M.Goto(src,M.move_to_delay,M.minimum_distance)
+	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
+		var/list/L = M.faction&faction
+		if(L.len)
+			M.Goto(src,M.move_to_delay,M.minimum_distance)
 
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -218,6 +218,12 @@
 	LoseTarget()
 	..(gibbed)
 
+/mob/living/simple_animal/hostile/proc/summon_backup(distance)
+	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
+		for (var/element in src.faction)
+			if (element in M.faction)
+				M.Goto(src,M.move_to_delay,M.minimum_distance)
+
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 
 	visible_message("<span class='danger'><b>[src]</b> [ranged_message] at [A]!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -220,10 +220,12 @@
 
 /mob/living/simple_animal/hostile/proc/summon_backup(distance)
 	do_alert_animation(src)
+	playsound(loc, 'sound/machines/chime.ogg', 50, 1, -1)
 	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
 		for (var/element in src.faction)
 			if (element in M.faction)
 				M.Goto(src,M.move_to_delay,M.minimum_distance)
+				continue
 
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -103,7 +103,8 @@
 
 
 /mob/living/simple_animal/hostile/syndicate/civilian
-	minimum_distance = 6
+	minimum_distance = 10
+	retreat_distance = 10
 	environment_smash = 0
 
 /mob/living/simple_animal/hostile/syndicate/civilian/Aggro()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -102,6 +102,15 @@
 	return
 
 
+/mob/living/simple_animal/hostile/syndicate/civilian
+	minimum_distance = 6
+	environment_smash = 0
+
+/mob/living/simple_animal/hostile/syndicate/civilian/Aggro()
+	..()
+	summon_backup(15)
+	say("GUARDS!!")
+
 
 /mob/living/simple_animal/hostile/viscerator
 	name = "viscerator"


### PR DESCRIPTION
Proc to allow simple_animal/hostile to summon any other hostile of the same faction within its line of sight (range is arbitrary)
Adds an example syndicate civilian mob which will summon all nearby syndicate mobs on aggroing
