### PR TITLE
Add map_name to areas

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -23,10 +23,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mouse_opacity = 0
 	invisibility = INVISIBILITY_LIGHTING
 
-	var/map_name
+	var/map_name // Set in New(); preserves the name set by the map maker, even if renamed by the Blueprints.
 
-	var/valid_territory = 1 //If it's a valid territory for gangs to claim
-	var/blob_allowed = 1 //Does it count for blobs score? By default, all areas count.
+	var/valid_territory = 1 // If it's a valid territory for gangs to claim
+	var/blob_allowed = 1 // Does it count for blobs score? By default, all areas count.
 
 	var/eject = null
 
@@ -38,7 +38,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/lightswitch = 1
 
 	var/requires_power = 1
-	var/always_unpowered = 0	//this gets overriden to 1 for space in area/New()
+	var/always_unpowered = 0	// This gets overriden to 1 for space in area/New().
 
 	var/power_equip = 1
 	var/power_light = 1

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -15,11 +15,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 
 /area
-	var/fire = null
-	var/atmos = 1
-	var/atmosalm = 0
-	var/poweralm = 1
-	var/party = null
 	level = null
 	name = "Space"
 	icon = 'icons/turf/areas.dmi'
@@ -27,12 +22,20 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	layer = 10
 	mouse_opacity = 0
 	invisibility = INVISIBILITY_LIGHTING
-	var/lightswitch = 1
-	var/valid_territory = 1 //If it's a valid territory for gangs to claim
 
+	var/map_name
+
+	var/valid_territory = 1 //If it's a valid territory for gangs to claim
 	var/blob_allowed = 1 //Does it count for blobs score? By default, all areas count.
 
 	var/eject = null
+
+	var/fire = null
+	var/atmos = 1
+	var/atmosalm = 0
+	var/poweralm = 1
+	var/party = null
+	var/lightswitch = 1
 
 	var/requires_power = 1
 	var/always_unpowered = 0	//this gets overriden to 1 for space in area/New()
@@ -53,7 +56,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 	var/no_air = null
 	var/area/master				// master area used for power calcluations
-								// (original area before splitting due to sd_DAL)
 	var/list/related			// the other areas of the same type as this
 //	var/list/lights				// list of all lights on this area
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -30,6 +30,7 @@
 	master = src
 	uid = ++global_uid
 	related = list(src)
+	map_name = name // Save the initial (the name set in the map) name of the area.
 
 	if(requires_power)
 		luminosity = 0

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -42,10 +42,10 @@
 			if(!warned && (gang.dom_timer < 180))
 				warned = 1
 				var/area/domloc = get_area(loc)
-				gang.message_gangtools("Less than 3 minutes remain in hostile takeover. Defend your dominator at [initial(domloc.name)]!")
+				gang.message_gangtools("Less than 3 minutes remain in hostile takeover. Defend your dominator at [domloc.map_name]!")
 				for(var/datum/gang/G in ticker.mode.gangs)
 					if(G != gang)
-						G.message_gangtools("WARNING: [gang.name] Gang takeover imminent. Their dominator at [initial(domloc.name)] must be destroyed!",1,1)
+						G.message_gangtools("WARNING: [gang.name] Gang takeover imminent. Their dominator at [domloc.map_name] must be destroyed!",1,1)
 		else
 			SSmachine.processing -= src
 


### PR DESCRIPTION
Fixes #12713

Admin logs should probably use this, but I don't know where to change the `.name`s.

:cl:
fix: Dominator now shows the correct area name on non-Box maps.
/:cl:
