### PR TITLE
Make unsafe Wrenching of Pipes less... bonkers...

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -147,31 +147,33 @@ Pipelines + Other Objects -> Pipe network
 				"<span class='italics'>You hear ratchet.</span>")
 			investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", "atmos")
 
-			//You unwrenched a pipe full of pressure? let's splat you into the wall silly.
+			//You unwrenched a pipe full of pressure? Let's splat you into the wall, silly.
 			if(unsafe_wrenching)
-				unsafe_pressure_release(user,internal_pressure)
+				unsafe_pressure_release(user, internal_pressure)
 			Deconstruct()
 
 	else
 		return ..()
 
 
-//Called when an atmospherics object is unwrenched while having a large pressure difference
-//with it's locs air contents.
-/obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/user,pressures)
+// Throws the user when they unwrench a pipe with a major difference between the internal and environmental pressure.
+/obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/user, pressures = null)
 	if(!user)
 		return
-
 	if(!pressures)
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()
-		pressures = int_air.return_pressure()-env_air.return_pressure()
+		pressures = int_air.return_pressure() - env_air.return_pressure()
 
-	var/fuck_you_dir = get_dir(src,user)
-	var/turf/general_direction = get_edge_target_turf(user,fuck_you_dir)
+	var/fuck_you_dir = get_dir(src, user) // Because fuck you...
+	if(!fuck_you_dir)
+		fuck_you_dir = pick(cardinal)
+	var/turf/target = get_edge_target_turf(user, fuck_you_dir)
+	var/range = pressures/250
+	var/speed = range/5
+
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
-	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed
-	user.throw_at(general_direction,pressures/10,pressures/50)
+	user.throw_at(target, range, speed)
 
 /obj/machinery/atmospherics/Deconstruct()
 	if(can_unwrench)


### PR DESCRIPTION
Fixes #12575

:cl: neersighted
fix: Unwrenching atmos pipes is less... nuts...
fix: You don't get hopelessly spun when standing on a unwrenched pipe... Don't try it, though.
/:cl:
