### PR TITLE
Spares those in critical from the mass mindshuffle event

### DIFF
--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -77,7 +77,7 @@
 	var/list/mobs	 = list()
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
-		if(!H.mind || H.mind in ticker.mode.wizards)	continue //the wizard(s) are spared on this one
+		if(!H.stat || !H.mind || H.mind in ticker.mode.wizards)	continue //the wizard(s) are spared on this one
 		mobs += H
 
 	if(!mobs) return


### PR DESCRIPTION
This was always the intention, but past me made a mistake I know I've made before: He assumed that living_mob_list was a list of !stat mobs, when really it was a list of stat != 2 mobs

Fixes #13372
