### PR TITLE
Make Ctrl-Click unpull work by using the verb

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -224,9 +224,10 @@
 /atom/proc/CtrlClick(mob/user)
 	return
 
-/atom/movable/CtrlClick(mob/user)
-	if(Adjacent(user))
-		user.start_pulling(src)
+/atom/movable/CtrlClick(mob/living/user)
+	var/mob/living/ML = user
+	if(istype(ML))
+		ML.pulled(src)
 
 /*
 	Alt click

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -164,7 +164,6 @@ Sorry Giacom. Please don't be mad :(
 		stop_pulling()
 	else if(AM.Adjacent(src))
 		src.start_pulling(AM)
-	return
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view())


### PR DESCRIPTION
Did not realize this didn't use the verb.

:cl:
tweak: You can now cancel pulling by Ctrl+Clicking anything else
/:cl:
