### PR TITLE
Added logging to slips

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -346,6 +346,7 @@ var/const/NO_SLIP_WHEN_WALKING = 1
 var/const/SLIDE = 2
 var/const/GALOSHES_DONT_HELP = 4
 /mob/living/carbon/slip(s_amount, w_amount, obj/O, lube)
+	add_logs(src,, "slipped",, "on [O ? O.name : "floor"]")
 	return loc.handle_slip(src, s_amount, w_amount, O, lube)
 
 /mob/living/carbon/fall(forced)


### PR DESCRIPTION
Added logging to slips
Fixes https://github.com/tgstation/-tg-station/issues/1040
Apart from bump logging which is impossible without logs spam everything else pointed in this issue is fixed
