### PR TITLE
Fix error in SStimer arguments

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -62,8 +62,8 @@ var/datum/subsystem/timer/SStimer
 	event.procToCall = procToCall
 	event.timeToRun = world.time + wait
 	event.hash = list2text(args)
-	if (args.len > 3)
-		event.argList = args.Copy(4)
+	if (args.len > 4)
+		event.argList = args.Copy(5)
 
 	// Check for dupes if unique = 1.
 	if(unique)


### PR DESCRIPTION
It still works because... luck? The only thing that uses this is the
Crew Monitor which sends a Z-level as the argument... Which happens to
work because the Z-level is usually 1.
