### PR TITLE
Fixes the pre-mapped cave pieces to spawn the right tiles

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -330,6 +330,7 @@ var/global/list/rockTurfEdgeCache
 	var/length = 100
 	var/mob_spawn_list = list("Goldgrub" = 1, "Goliath" = 5, "Basilisk" = 4, "Hivelord" = 3)
 	var/sanity = 1
+	turf_type = /turf/simulated/floor/plating/asteroid/airless
 
 /turf/simulated/floor/plating/asteroid/airless/cave/New(loc, var/length, var/go_backwards = 1, var/exclude_dir = -1)
 
@@ -509,6 +510,7 @@ var/global/list/rockTurfEdgeCache
 /turf/simulated/floor/plating/asteroid/airless
 	oxygen = 0.01
 	nitrogen = 0.01
+	turf_type = /turf/simulated/floor/plating/asteroid/airless
 	temperature = TCMB
 
 /turf/simulated/floor/plating/asteroid/basalt


### PR DESCRIPTION
There are two ways cave tiles (which cause tunnel generation) can appear on a map

1) By being spawned randomly from a mineral wall. I fixed these giving aired tiles last commit.

2) By being premapped/peppered around the asteroid. I am fixing these this commit.

I'll try to work out a less dumb system for caves later.
