### PR TITLE
Fixes window fixing

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -327,7 +327,7 @@
 							ae.loc = src.loc
 
 						qdel(src)
-				return
+			return
 
 
 	//If windoor is unpowered, crowbar, fireaxe and armblade can force it.

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -204,10 +204,11 @@
 				if(do_after(user, 40/I.toolspeed, target = src))
 					health = maxhealth
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+					update_nearby_icons()
 		else
 			user << "<span class='warning'>[src] is already in good condition!</span>"
-			return
-		update_nearby_icons()
+		return
+
 
 	if(!(flags&NODECONSTRUCT))
 		if(istype(I, /obj/item/weapon/screwdriver))


### PR DESCRIPTION
Still more consequences of reordering the window attackby code.  This time certain cases were falling through and triggering normal attacks.

Fixes #13418 
