### PR TITLE
Give wallets merged access of all IDs inside.

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -78,7 +78,7 @@
 /obj/item/weapon/storage/wallet/GetID()
 	return front_id
 
-/obj/item/weapon/storage/wallet/GetAccess(
+/obj/item/weapon/storage/wallet/GetAccess()
 	if(combined_access.len) 
 		return combined_access
 	else

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -46,7 +46,7 @@
 			refreshID()
 			update_icon()
 
-/obj/item/weapon/storage/wallet/refreshID()
+/obj/item/weapon/storage/wallet/proc/refreshID()
 	net_id.access.Cut()
 	for(var/obj/item/weapon/card/id/I in contents)
 		if(!front_id)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -30,35 +30,31 @@
 	slot_flags = SLOT_ID
 
 	var/obj/item/weapon/card/id/front_id = null
-	var/obj/item/weapon/card/id/net_id = null
+	var/list/combined_access = list()
 
 
-/obj/item/weapon/storage/wallet/New()
-	..()
-	net_id = new /obj/item/weapon/card/id(src)
-
-/obj/item/weapon/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/weapon/storage/wallet/remove_from_storage(obj/item/W, atom/new_location)
 	. = ..(W, new_location)
 	if(.)
-		if(W == front_id)
-			front_id = null
 		if(istype(W, /obj/item/weapon/card/id))
+			if(W == front_id)
+				front_id = null
 			refreshID()
 			update_icon()
 
 /obj/item/weapon/storage/wallet/proc/refreshID()
-	net_id.access.Cut()
+	combined_access.Cut()
 	for(var/obj/item/weapon/card/id/I in contents)
 		if(!front_id)
 			front_id = I
-		net_id.access |= I.access // Merge access from any and all cards in wallet
+			update_icon()
+		combined_access |= I.access
 
-/obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
+/obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W, prevent_warning = 0)
 	. = ..(W, prevent_warning)
 	if(.)
 		if(istype(W, /obj/item/weapon/card/id))
 			refreshID()
-			update_icon()
 
 /obj/item/weapon/storage/wallet/update_icon()
 
@@ -80,12 +76,11 @@
 
 
 /obj/item/weapon/storage/wallet/GetID()
-	return front_id // net_id is only a holder for accesses.
+	return front_id
 
-/obj/item/weapon/storage/wallet/GetAccess()
-	var/list/myaccess = net_id.GetAccess() // favor OOP by not using net_id.access directly.
-	if(myaccess.len) // is there any access to be had this way?
-		return myaccess
+/obj/item/weapon/storage/wallet/GetAccess(
+	if(combined_access.len) 
+		return combined_access
 	else
 		return ..()
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -30,20 +30,34 @@
 	slot_flags = SLOT_ID
 
 	var/obj/item/weapon/card/id/front_id = null
+	var/obj/item/weapon/card/id/net_id = null
 
 
-/obj/item/weapon/storage/wallet/remove_from_storage(obj/item/W, atom/new_location)
+/obj/item/weapon/storage/wallet/New()
+	..()
+	net_id = new /obj/item/weapon/card/id(src)
+
+/obj/item/weapon/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
 	. = ..(W, new_location)
 	if(.)
 		if(W == front_id)
 			front_id = null
+		if(istype(W, /obj/item/weapon/card/id))
+			refreshID()
 			update_icon()
 
-/obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W, prevent_warning = 0)
+/obj/item/weapon/storage/wallet/refreshID()
+	net_id.access.Cut()
+	for(var/obj/item/weapon/card/id/I in contents)
+		if(!front_id)
+			front_id = I
+		net_id.access |= I.access // Merge access from any and all cards in wallet
+
+/obj/item/weapon/storage/wallet/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
 	. = ..(W, prevent_warning)
 	if(.)
-		if(!front_id && istype(W, /obj/item/weapon/card/id))
-			front_id = W
+		if(istype(W, /obj/item/weapon/card/id))
+			refreshID()
 			update_icon()
 
 /obj/item/weapon/storage/wallet/update_icon()
@@ -66,12 +80,12 @@
 
 
 /obj/item/weapon/storage/wallet/GetID()
-	return front_id
+	return front_id // net_id is only a holder for accesses.
 
 /obj/item/weapon/storage/wallet/GetAccess()
-	var/obj/item/I = GetID()
-	if(I)
-		return I.GetAccess()
+	var/list/myaccess = net_id.GetAccess() // favor OOP by not using net_id.access directly.
+	if(myaccess.len) // is there any access to be had this way?
+		return myaccess
 	else
 		return ..()
 


### PR DESCRIPTION
There's  a chance that I should make `var/list/net_access = list()` rather than `net_id` but I'm too tired to assure myself.

:cl:
rscadd: Wallets now use the access of all IDs stored inside them.
rscadd: As the accesses of all IDs are merged, two IDs in a wallet may grant access to a door that neither one alone would open.
bugfix: Wallets used to be useless for access if the first ID card put into it was taken out, until another ID card was put back in.  That should not happen anymore.
/:cl:
