### PR TITLE
changes `spawn() throw_at` to `throw_at_fast set waitfor = 0`

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -334,7 +334,7 @@
 				var/mob/living/M = AM
 				M.Weaken(2)
 				M << "<span class='userdanger'>You're thrown back by [user]!</span>"
-			spawn(0) AM.throw_at(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
+			AM.throw_at_fast(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
 
 
 /obj/effect/proc_holder/spell/aoe_turf/repulse/xeno //i fixed conflicts only to find out that this is in the WIZARD file instead of the xeno file?!

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -165,6 +165,10 @@
 		step(src, AM.dir)
 	..()
 
+/atom/movable/proc/throw_at_fast(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0)
+	set waitfor = 0
+	throw_at(target, range, speed, thrower, spin, diagonals_first)
+
 /atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0)
 	if(!target || !src || (flags & NODROP))	return 0
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -26,8 +26,7 @@
 				audible_message("<span class='notice'>[src] lets out a screech, it doesn't seem to be able to handle the load.</span>")
 				break
 			use_power(500)
-			spawn(0)
-				O.throw_at(target, drive_range * power, power)
+			O.throw_at_fast(target, drive_range * power, power)
 	flick("mass_driver1", src)
 
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -285,8 +285,7 @@
 	log_message("Launched a [O.name] from [name], targeting [target].")
 	projectiles--
 	proj_init(O)
-	spawn(0)
-		O.throw_at(target, missile_range, missile_speed, spin = 0)
+	O.throw_at_fast(target, missile_range, missile_speed, spin = 0)
 	return 1
 
 //used for projectile initilisation (priming flashbang) and additional logging

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -134,12 +134,11 @@
 
 			var/throw_dir = get_dir(epicenter,T)
 			for(var/obj/item/I in T)
-				spawn(0) //Simultaneously not one at a time
-					if(I && !I.anchored)
-						var/throw_range = rand(throw_dist, max_range)
-						var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-						I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
-						I.throw_at(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
+				if(I && !I.anchored)
+					var/throw_range = rand(throw_dist, max_range)
+					var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
+					I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
+					I.throw_at_fast(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
 
 
 		var/took = (world.timeofday-start)/10

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -467,10 +467,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		bloody_hands_mob = null
 
 /obj/item/singularity_pull(S, current_size)
-	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
-		if(current_size >= STAGE_FOUR)
-			throw_at(S,14,3, spin=0)
-		else ..()
+	if(current_size >= STAGE_FOUR)
+		throw_at_fast(S,14,3, spin=0)
+	else ..()
 
 /obj/item/acid_act(acidpwr, acid_volume)
 	. = 1

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -116,12 +116,11 @@
 	add_logs(user, target, "fired at", src)
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
 	for(var/obj/item/ITD in loadedItems) //Item To Discharge
-		spawn(0)
-			loadedItems.Remove(ITD)
-			loadedWeightClass -= ITD.w_class
-			ITD.throw_speed = pressureSetting * 2
-			ITD.loc = get_turf(src)
-			ITD.throw_at(target, pressureSetting * 5, pressureSetting * 2,user)
+		loadedItems.Remove(ITD)
+		loadedWeightClass -= ITD.w_class
+		ITD.throw_speed = pressureSetting * 2
+		ITD.loc = get_turf(src)
+		ITD.throw_at_fast(target, pressureSetting * 5, pressureSetting * 2,user)
 	if(pressureSetting >= 3 && user)
 		user.visible_message("<span class='warning'>[user] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
 		user.Weaken(3)

--- a/code/modules/food&drinks/kitchen machinery/gibber.dm
+++ b/code/modules/food&drinks/kitchen machinery/gibber.dm
@@ -207,7 +207,7 @@
 			var/list/nearby_turfs = orange(3, get_turf(src))
 			var/obj/item/meatslab = allmeat[i]
 			meatslab.loc = src.loc
-			meatslab.throw_at(pick(nearby_turfs),i,3)
+			meatslab.throw_at_fast(pick(nearby_turfs),i,3)
 			for (var/turfs=1 to meat_produced*3)
 				var/turf/gibturf = pick(nearby_turfs)
 				if (!gibturf.density && src in viewers(gibturf))

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -278,9 +278,7 @@
 			for(var/atom/movable/AM in H)
 				AM.loc = T
 				AM.pipe_eject(direction)
-				spawn(1)
-					if(AM)
-						AM.throw_at(target, 10, 1)
+				AM.throw_at_fast(target, 10, 1)
 
 	else	// no specified direction, so throw in random direction
 
@@ -291,9 +289,7 @@
 
 				AM.loc = T
 				AM.pipe_eject(0)
-				spawn(1)
-					if(AM)
-						AM.throw_at(target, 5, 1)
+				AM.throw_at_fast(target, 5, 1)
 	H.vent_gas(T)
 	qdel(H)
 	return
@@ -800,9 +796,7 @@
 		for(var/atom/movable/AM in H)
 			AM.loc = src.loc
 			AM.pipe_eject(dir)
-			spawn(5)
-				if(AM)
-					AM.throw_at(target, eject_range, 1)
+			AM.throw_at_fast(target, eject_range, 1)
 		H.vent_gas(src.loc)
 		qdel(H)
 	return

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -258,9 +258,7 @@
 
 			AM.loc = src.loc
 			AM.pipe_eject(0)
-			spawn(1)
-				if(AM)
-					AM.throw_at(target, 5, 1)
+			AM.throw_at_fast(target, 5, 1)
 
 		H.vent_gas(loc)
 		qdel(H)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -457,10 +457,9 @@
 			visible_message("<span class='danger'>[src]'s crusher goes way too many levels too high, crushing right through space-time!</span>")
 			playsound(src.loc, 'sound/effects/supermatter.ogg', 50, 1, -3)
 			investigate_log("Experimentor has triggered the 'throw things' reaction.", "experimentor")
-			spawn(0)
-				for(var/atom/movable/AM in oview(7,src))
-					if(!AM.anchored)
-						AM.throw_at(src,10,1)
+			for(var/atom/movable/AM in oview(7,src))
+				if(!AM.anchored)
+					AM.throw_at_fast(src,10,1)
 
 		if(prob(EFFECT_PROB_LOW-badThingCoeff))
 			visible_message("<span class='danger'>[src]'s crusher goes one level too high, crushing right into space-time!</span>")
@@ -470,10 +469,9 @@
 			for(var/atom/movable/AM in oview(7,src))
 				if(!AM.anchored)
 					throwAt.Add(AM)
-			spawn(0)
-				for(var/counter = 1, counter < throwAt.len, ++counter)
-					var/atom/movable/cast = throwAt[counter]
-					cast.throw_at(pick(throwAt),10,1)
+			for(var/counter = 1, counter < throwAt.len, ++counter)
+				var/atom/movable/cast = throwAt[counter]
+				cast.throw_at_fast(pick(throwAt),10,1)
 		ejectItem(TRUE)
 	////////////////////////////////////////////////////////////////////////////////////////////////
 	if(exp == FAIL)
@@ -693,8 +691,7 @@
 		R.realProc = realProc
 		R.revealed = TRUE
 		dupes |= R
-		spawn()
-			R.throw_at(pick(oview(7,get_turf(src))),10,1)
+		R.throw_at_fast(pick(oview(7,get_turf(src))),10,1)
 	counter = 0
 	spawn(rand(10,100))
 		for(counter = 1; counter <= dupes.len; counter++)


### PR DESCRIPTION
Set waitfor = 0 has massively less overhead then spawn() but still does basically the same thing.

It causes the first sleep in the stack from that point on to make the set waitfor = 0 proc return . then continue on as if it was spawn()'ed, but it doesn't have to copy over the local vars of the proc so a lot less overhead

http://pastebin.com/kx538RqS
