### PR TITLE
Adds a basketball item

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1181,6 +1181,15 @@
 	user.drop_item()
 	src.throw_at(target, throw_range, throw_speed)
 
+
+
+/obj/item/toy/beach_ball/basketball
+	name = "basketball"
+	desc = "Here's your chance, do your dance at the Space Jam."
+	icon = 'icons/obj/basketball.dmi'
+	icon_state = "basketball"
+	item_state = "basketball"
+
 /*
  * Xenomorph action figure
  */


### PR DESCRIPTION
Because every single basketball in the game is actually a map edited beach ball, and it makes it a pain to spawn for players when they pray for one.
