### PR TITLE
Fixes small items covering the entire tile 

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -173,9 +173,15 @@
 		return 1
 
 /obj/proc/burn()
-	for(var/obj/item/Item in contents) //Empty out the contents
-		Item.loc = src.loc
-		Item.fire_act() //Set them on fire, too
+	if(istype(src, /obj/item/weapon/storage))  //Empty out the contents of bags and boxes, to handle the UI/opacity changes
+		var/obj/item/weapon/storage/Box = src
+		for(var/obj/item/Item in Box.contents)
+			Box.remove_from_storage(Item, Box)
+			Item.fire_act()
+	else
+		for(var/obj/item/Item in contents) //Empty out the contents of other things like jumpsuits
+			Item.loc = src.loc
+			Item.fire_act()
 	var/obj/effect/decal/cleanable/ash/A = new(src.loc)
 	A.desc = "Looks like this used to be a [name] some time ago."
 	SSobj.burning -= src

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -278,8 +278,13 @@
 			Human.unEquip(src)
 
 		if(bomb)
-			for(var/obj/item/Item in contents) //Empty out the contents
-				Item.loc = src.loc
+			if(istype(src, /obj/item/weapon/storage)) //Empty out the contents of bags and boxes, to handle the UI/opacity changes
+				var/obj/item/weapon/storage/Box = src
+				for(var/obj/item/Item in Box.contents)
+					Box.remove_from_storage(Item, Box)
+			else
+				for(var/obj/item/Item in contents) //Empty out the contents of other things like jumpsuits
+					Item.loc = src.loc
 			spawn(1) //so the shreds aren't instantly deleted by the explosion
 				var/obj/effect/decal/cleanable/shreds/Shreds = new(loc)
 				Shreds.desc = "The sad remains of what used to be [src.name]."


### PR DESCRIPTION
However this does involve a few lines of copypaste in both procs (which were already basically the same thing) because storage needs to be handled differently.

Unless I can make remove_from_storage an /obj proc I'm not sure how to avoid this though.

@RemieRichards since you helped me with this already and know the code in question

Fixes #13159 

Fixes #13436
