### PR TITLE
Spawnable hostile constructs, for away missions and adminfuckery

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1797,7 +1797,7 @@
 	mind.assigned_role = "Shade"
 	mind.special_role = "Shade"
 
-/mob/living/simple_animal/construct/mind_initialize()
+/mob/living/simple_animal/hostile/construct/mind_initialize()
 	..()
 	mind.assigned_role = "[initial(name)]"
 	mind.special_role = "Cultist"

--- a/code/datums/spells/shapeshift.dm
+++ b/code/datums/spells/shapeshift.dm
@@ -31,7 +31,7 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	caster.loc = shape
 	caster.status_flags |= GODMODE
-	
+
 	current_shapes |= shape
 	current_casters |= caster
 	clothes_req = 0
@@ -54,7 +54,7 @@
 	human_req = initial(human_req)
 	current_casters.Remove(caster)
 	current_shapes.Remove(shape)
-	
+
 	shape.mind.transfer_to(caster)
 	qdel(shape) //Gib it maybe ?
 
@@ -65,7 +65,7 @@
 	var/list/possible_shapes = list(/mob/living/simple_animal/pet/dog/corgi,\
 		/mob/living/simple_animal/hostile/poison/giant_spider/hunter,\
 		/mob/living/simple_animal/hostile/carp/megacarp,\
-		/mob/living/simple_animal/construct/armored)
+		/mob/living/simple_animal/hostile/construct/armored)
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/wild/New()
 	..()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -183,6 +183,7 @@
 	if(!(cult_mind in cult) && is_convertable_to_cult(cult_mind))
 		cult_mind.current.Paralyse(5)
 		cult += cult_mind
+		cult_mind.current.faction |= "cult"
 		cult_mind.current.cult_add_comm()
 		update_cult_icons_added(cult_mind)
 		cult_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Has been converted to the cult!</span>"
@@ -200,6 +201,7 @@
 /datum/game_mode/proc/remove_cultist(datum/mind/cult_mind, show_message = 1)
 	if(cult_mind in cult)
 		cult -= cult_mind
+		cult_mind.current.faction -= "cult"
 		cult_mind.current.verbs -= /mob/living/proc/cult_innate_comm
 		cult_mind.current.Paralyse(5)
 		cult_mind.current << "<span class='userdanger'>An unfamiliar white light flashes through your mind, cleansing the taint of the Dark One and all your memories as its servant.</span>"

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -106,7 +106,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			if(iscultist(L))
 				var/mob/living/carbon/human/H = L
 				if(!istype(H))
-					if(istype(L, /mob/living/simple_animal/construct))
+					if(istype(L, /mob/living/simple_animal/hostile/construct))
 						if(invocation)
 							L.say(invocation)
 						cultists_in_range++

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -171,13 +171,13 @@
 					return
 				switch(construct_class)
 					if("Juggernaut")
-						makeNewConstruct(/mob/living/simple_animal/construct/armored, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/armored, A, user)
 
 					if("Wraith")
-						makeNewConstruct(/mob/living/simple_animal/construct/wraith, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith, A, user)
 
 					if("Artificer")
-						makeNewConstruct(/mob/living/simple_animal/construct/builder, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/builder, A, user)
 
 				qdel(T)
 				qdel(src)
@@ -186,8 +186,8 @@
 	return
 
 
-/proc/makeNewConstruct(mob/living/simple_animal/construct/ctype, mob/target, mob/stoner = null, cultoverride = 0, loc_override = null)
-	var/mob/living/simple_animal/construct/newstruct = new ctype((loc_override) ? (loc_override) : (get_turf(target)))
+/proc/makeNewConstruct(mob/living/simple_animal/hostile/construct/ctype, mob/target, mob/stoner = null, cultoverride = 0, loc_override = null)
+	var/mob/living/simple_animal/hostile/construct/newstruct = new ctype((loc_override) ? (loc_override) : (get_turf(target)))
 	newstruct.faction |= "\ref[stoner]"
 	newstruct.key = target.key
 	if(stoner && iscultist(stoner) || cultoverride)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -171,13 +171,13 @@
 					return
 				switch(construct_class)
 					if("Juggernaut")
-						makeNewConstruct(/mob/living/simple_animal/hostile/construct/armored, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/armored, A, user, 0, T.loc)
 
 					if("Wraith")
-						makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith, A, user, 0, T.loc)
 
 					if("Artificer")
-						makeNewConstruct(/mob/living/simple_animal/hostile/construct/builder, A, user)
+						makeNewConstruct(/mob/living/simple_animal/hostile/construct/builder, A, user, 0, T.loc)
 
 				qdel(T)
 				qdel(src)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -400,9 +400,9 @@
 			if("coffee")			M.change_mob_type( /mob/living/simple_animal/crab/Coffee , null, null, delmob )
 			if("parrot")			M.change_mob_type( /mob/living/simple_animal/parrot , null, null, delmob )
 			if("polyparrot")		M.change_mob_type( /mob/living/simple_animal/parrot/Poly , null, null, delmob )
-			if("constructarmored")	M.change_mob_type( /mob/living/simple_animal/construct/armored , null, null, delmob )
-			if("constructbuilder")	M.change_mob_type( /mob/living/simple_animal/construct/builder , null, null, delmob )
-			if("constructwraith")	M.change_mob_type( /mob/living/simple_animal/construct/wraith , null, null, delmob )
+			if("constructarmored")	M.change_mob_type( /mob/living/simple_animal/hostile/construct/armored , null, null, delmob )
+			if("constructbuilder")	M.change_mob_type( /mob/living/simple_animal/hostile/construct/builder , null, null, delmob )
+			if("constructwraith")	M.change_mob_type( /mob/living/simple_animal/hostile/construct/wraith , null, null, delmob )
 			if("shade")				M.change_mob_type( /mob/living/simple_animal/shade , null, null, delmob )
 
 

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -163,7 +163,7 @@ var/sc_safecode5 = "[rand(0,9)]"
 	desc = "Your body becomes weak and your feel your mind slipping away as you try to comprehend what you know can't be possible."
 	move_self = 0 //Contianed narsie does not move!
 	grav_pull = 0 //Contained narsie does not pull stuff in!
-	var/uneatable = list(/turf/space, /obj/effect/overlay, /mob/living/simple_animal/construct)
+	var/uneatable = list(/turf/space, /obj/effect/overlay, /mob/living/simple_animal/hostile/construct)
 //Override this to prevent no adminlog runtimes and admin warnings about a singularity without containment
 /obj/singularity/narsie/sc_Narsie/admin_investigate_setup()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -766,7 +766,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/narsie_act()
 	if(client)
-		makeNewConstruct(/mob/living/simple_animal/construct/harvester, src, null, 0)
+		makeNewConstruct(/mob/living/simple_animal/hostile/construct/harvester, src, null, 0)
 	spawn_dust()
 	gib()
 	return

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -247,7 +247,7 @@
 	environment_smash = 3
 	attack_sound = 'sound/weapons/tap.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
-							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor.
+							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor,
 							/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -21,10 +21,11 @@
 	healable = 0
 	faction = list("cult")
 	flying = 1
+	pressure_resistance = 200
 	unique_name = 1
 	AIStatus = AI_OFF //normal constructs don't have AI
 	var/list/construct_spells = list()
-	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist.</b>"
+	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist, and you should probably adminhelp this.</b>"
 
 
 /mob/living/simple_animal/hostile/construct/New()
@@ -60,10 +61,10 @@
 			if(src != M)
 				Beam(M,icon_state="sendbeam",icon='icons/effects/effects.dmi',time=4)
 				M.visible_message("<span class='danger'>[M] repairs some of \the <b>[src]'s</b> dents.</span>", \
-						   "<span class='cult'>You repair some of <b>[src]'s</b> dents, leaving <b>[src]</b> at [health]/[maxHealth] health.</span>")
+						   "<span class='cult'>You repair some of <b>[src]'s</b> dents, leaving <b>[src]</b> at <b>[health]/[maxHealth]</b> health.</span>")
 			else
 				M.visible_message("<span class='danger'>[M] repairs some of its own dents.</span>", \
-						   "<span class='cult'>You repair some of your own dents, leaving you at [M.health]/[M.maxHealth] health.</span>")
+						   "<span class='cult'>You repair some of your own dents, leaving you at <b>[M.health]/[M.maxHealth]</b> health.</span>")
 		else
 			if(src != M)
 				M << "<span class='cult'>You cannot repair <b>[src]'s</b> dents, as it has none!</span>"
@@ -89,7 +90,7 @@
 	icon_living = "behemoth"
 	maxHealth = 250
 	health = 250
-	response_harm   = "harmlessly punches"
+	response_harm = "harmlessly punches"
 	harm_intent_damage = 0
 	melee_damage_lower = 30
 	melee_damage_upper = 30
@@ -243,11 +244,14 @@
 	melee_damage_upper = 5
 	retreat_distance = 2 //AI harvesters will move in and out of combat, like wraiths, but shittier
 	attacktext = "prods"
+	environment_smash = 3
 	attack_sound = 'sound/weapons/tap.ogg'
-	construct_spells = list(/obj/effect/proc_holder/spell/targeted/smoke/disable)
+	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
+							/obj/effect/proc_holder/spell/aoe_turf/conjure/floor.
+							/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
 
 /mob/living/simple_animal/hostile/construct/harvester/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON
-
+	environment_smash = 1 //only token destruction, don't smash the cult wall NO STOP

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -188,9 +188,9 @@
 						and shells to place those soulstones into.</b>"
 
 /mob/living/simple_animal/hostile/construct/builder/Found(atom/A) //what have we found here?
-	if(isliving(A))
-		var/mob/living/L = A
-		if(istype(L, /mob/living/simple_animal/hostile/construct) && L.health < L.maxHealth) //is this a hurt construct? let's go heal it if it is
+	if(istype(A, /mob/living/simple_animal/hostile/construct)) //is it a construct?
+		var/mob/living/simple_animal/hostile/construct/C = A
+		if(C.health < C.maxHealth) //is it hurt? let's go heal it if it is
 			return 1
 		else
 			return 0
@@ -205,7 +205,7 @@
 
 /mob/living/simple_animal/hostile/construct/builder/MoveToTarget(var/list/possible_targets)
 	..()
-	if(target && isliving(target))
+	if(isliving(target))
 		var/mob/living/L = target
 		if(istype(L, /mob/living/simple_animal/hostile/construct) && L.health >= L.maxHealth) //is this target an unhurt construct? stop trying to heal it
 			LoseTarget()
@@ -216,7 +216,7 @@
 
 /mob/living/simple_animal/hostile/construct/builder/Aggro()
 	..()
-	if(target && istype(target, /mob/living/simple_animal/hostile/construct)) //oh the target is a construct no need to flee
+	if(istype(target, /mob/living/simple_animal/hostile/construct)) //oh the target is a construct no need to flee
 		retreat_distance = null
 		minimum_distance = 1
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -221,10 +221,13 @@
 /mob/living/simple_animal/hostile/proc/summon_backup(distance)
 	do_alert_animation(src)
 	playsound(loc, 'sound/machines/chime.ogg', 50, 1, -1)
-	for (var/mob/living/simple_animal/hostile/M in oview(distance, src))
+	for(var/mob/living/simple_animal/hostile/M in oview(distance, src))
 		var/list/L = M.faction&faction
 		if(L.len)
-			M.Goto(src,M.move_to_delay,M.minimum_distance)
+			if(M.AIStatus == AI_OFF)
+				return
+			else
+				M.Goto(src,M.move_to_delay,M.minimum_distance)
 
 /mob/living/simple_animal/hostile/proc/OpenFire(atom/A)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -182,7 +182,7 @@
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(damage)
 	..(damage)
-	if(damage > 0 && !ckey && !stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
+	if(!ckey && !stat && search_objects < 3 && damage > 0)//Not unconscious, and we don't ignore mobs
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			search_objects = 0
 			target = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -182,7 +182,7 @@
 
 /mob/living/simple_animal/hostile/adjustBruteLoss(damage)
 	..(damage)
-	if(!ckey && !stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
+	if(damage > 0 && !ckey && !stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			search_objects = 0
 			target = null

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -536,7 +536,7 @@
 	if(!MP)
 		return 0	//Sanity, this should never happen.
 
-	if(ispath(MP, /mob/living/simple_animal/construct))
+	if(ispath(MP, /mob/living/simple_animal/hostile/construct))
 		return 0 //Verbs do not appear for players.
 
 //Good mobs!

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -39,7 +39,7 @@
 
 
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
-	makeNewConstruct(/mob/living/simple_animal/construct/harvester, user, null, 0, loc_override = src.loc)
+	makeNewConstruct(/mob/living/simple_animal/hostile/construct/harvester, user, null, 0, loc_override = src.loc)
 	PoolOrNew(/obj/effect/particle_effect/smoke/sleeping, src.loc)
 
 


### PR DESCRIPTION
Adds spawnable npc constructs that will attack targets without the cult faction.
NPC artificers will flee from targets they can't kill in two hits and will also attempt to heal nearby constructs if those constructs are damaged.
Cultists gain and lose the cult faction properly.

Constructs have pressure resistance because flying spooky.
Normal harvesters can break walls and have the cult wall and floor summoning spells.

This should cause no issues with normal constructs, as constructs default to AI_OFF and thus not attacking, moving, or otherwise interacting automatically.
