### PR TITLE
Revenants are less of a pain in the ass to kill

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -38,6 +38,9 @@
 	density = 0
 	flying = 1
 	anchored = 1
+	mob_size = MOB_SIZE_TINY
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	speed = 0
 	unique_name = 1
 
 	var/essence = 75 //The resource, and health, of revenants.
@@ -63,6 +66,7 @@
 	if(unreveal_time && world.time >= unreveal_time)
 		unreveal_time = 0
 		revealed = 0
+		incorporeal_move = 3
 		invisibility = INVISIBILITY_REVENANT
 		src << "<span class='revenboldnotice'>You are once more concealed.</span>"
 	if(unstun_time && world.time >= unstun_time)
@@ -82,6 +86,7 @@
 		return
 	revealed = 1
 	invisibility = 0
+	incorporeal_move = 0
 	if(!unreveal_time)
 		src << "<span class='revendanger'>You have been revealed!</span>"
 		unreveal_time = world.time + time
@@ -115,6 +120,12 @@
 			icon_state = icon_reveal
 	else
 		icon_state = icon_idle
+	if(ghostimage)
+		ghostimage.icon_state = src.icon_state
+		updateallghostimages()
+
+/mob/living/simple_animal/revenant/Process_Spacemove(movement_dir = 0)
+	return 1
 
 /mob/living/simple_animal/revenant/ex_act(severity, target)
 	return 1 //Immune to the effects of explosions.

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -89,6 +89,7 @@
 	charge_max = 200
 	range = 5
 	stun = 30
+	reveal = 100
 	cast_amount = 40
 	var/shock_range = 2
 	var/shock_damage = 18
@@ -128,6 +129,7 @@
 	charge_max = 150
 	range = 3
 	stun = 10
+	reveal = 40
 	unlock_amount = 75
 	cast_amount = 30
 	action_icon_state = "defile"
@@ -215,6 +217,7 @@
 	desc = "Causes nearby living things to waste away."
 	charge_max = 200
 	range = 3
+	reveal = 60
 	cast_amount = 50
 	unlock_amount = 200
 	action_icon_state = "blight"

--- a/code/modules/mob/living/simple_animal/revenant/revenant_blight.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_blight.dm
@@ -37,11 +37,11 @@
 		stagedamage++
 		affected_mob.adjustToxLoss(stage*3) //should, normally, do about 45 toxin damage.
 		PoolOrNew(/obj/effect/overlay/temp/revenant, affected_mob.loc)
+	if(prob(45))
+		affected_mob.adjustStaminaLoss(stage*2)
 	..() //So we don't increase a stage before applying the stage damage.
 	switch(stage)
 		if(2)
-			if(prob(45))
-				affected_mob.adjustStaminaLoss(4)
 			if(prob(5))
 				affected_mob.emote("pale")
 		if(3)


### PR DESCRIPTION
:cl: Joan
experiment: Revenants can no longer move through walls and windows while revealed, though they can move through tables, plastic flaps, mobs, and other similarly thin objects.
tweak: Defile now reveals for 4 seconds, from 8.
tweak: Overload lights now reveals for 10 seconds, from 8.
tweak: Blight now reveals for 6 seconds, from 8.
rscadd: Blight has a higher chance of applying stamina damage to the infected.
/:cl:
