### PR TITLE
Fixes the blob win condition

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -205,7 +205,7 @@
 	qdel(N)
 	if(ticker && ticker.mode.name == "blob")
 		var/datum/game_mode/blob/BL = ticker.mode
-		BL.blobwincount = initial(BL.blobwincount) * 2
+		BL.blobwincount += initial(BL.blobwincount) //Increase the victory condition by the set amount
 
 /mob/camera/blob/verb/blob_broadcast()
 	set category = "Blob"


### PR DESCRIPTION
:cl: ktccd
bugfix: Blobs now require the correct amount of blobs to win that scales depending on number of blobs, instead of a set value of 700.
/:cl:
