### PR TITLE
Makes blobs emit less light

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -12,6 +12,7 @@
 	var/point_rate = 2
 	var/is_offspring = null
 
+
 /obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
 	blob_cores += src
 	SSobj.processing |= src
@@ -24,7 +25,6 @@
 		is_offspring = 1
 	point_rate = new_rate
 	..(loc, h)
-
 
 /obj/effect/blob/core/adjustcolors(a_color)
 	overlays.Cut()
@@ -51,9 +51,7 @@
 	return
 
 /obj/effect/blob/core/update_icon()
-	if(health <= 0)
-		qdel(src)
-		return
+	..()
 	// update_icon is called when health changes so... call update_health in the overmind
 	if(overmind)
 		overmind.update_health()

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -10,9 +10,6 @@
 	var/max_spores = 3
 	var/spore_delay = 0
 
-/obj/effect/blob/factory/update_icon()
-	if(health <= 0)
-		qdel(src)
 
 /obj/effect/blob/factory/Destroy()
 	for(var/mob/living/simple_animal/hostile/blob/blobspore/spore in spores)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -7,6 +7,7 @@
 	maxhealth = 200
 	point_return = 25
 
+
 /obj/effect/blob/node/New(loc, var/h = 100)
 	blob_nodes += src
 	SSobj.processing |= src
@@ -33,9 +34,3 @@
 	pulseLoop(5)
 	health = min(initial(health), health + 1)
 	color = null
-
-/obj/effect/blob/node/update_icon()
-	if(health <= 0)
-		qdel(src)
-		return
-	return

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -8,9 +8,6 @@
 	point_return = 15
 	var/resource_delay = 0
 
-/obj/effect/blob/resource/update_icon()
-	if(health <= 0)
-		qdel(src)
 
 /obj/effect/blob/resource/PulseAnimation(activate = 0)
 	if(activate)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -9,17 +9,20 @@
 	point_return = 2
 
 
-/obj/effect/blob/shield/update_icon()
-	if(health <= 0)
-		qdel(src)
-		return
-	return
+/obj/effect/blob/shield/New()
+	..()
+	air_update_turf(1)
+
+/obj/effect/blob/shield/Destroy()
+	spawn(1)
+		loc.air_update_turf(1)
+	..()
 
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 
 /obj/effect/blob/shield/CanAtmosPass(turf/T)
-	return 0
+	return gc_destroyed
 
 /obj/effect/blob/shield/BlockSuperconductivity()
 	return 1

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -22,7 +22,7 @@
 	return
 
 /obj/effect/blob/shield/CanAtmosPass(turf/T)
-	return gc_destroyed
+	return 0
 
 /obj/effect/blob/shield/BlockSuperconductivity()
 	return 1

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -14,8 +14,9 @@
 	air_update_turf(1)
 
 /obj/effect/blob/shield/Destroy()
+	var/turf/T = get_turf(src)
 	spawn(1)
-		loc.air_update_turf(1)
+		T.air_update_turf(1)
 	..()
 
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/gamemodes/blob/blobs/storage.dm
+++ b/code/game/gamemodes/blob/blobs/storage.dm
@@ -8,10 +8,11 @@
 	point_return = -1
 	var/point_bonus = 50 //How much the overmind's point cap increases from storage blobs
 
+
 /obj/effect/blob/storage/update_icon()
 	if(health <= 0)
 		overmind.max_blob_points -= point_bonus
-		qdel(src)
+		..()
 
 /obj/effect/blob/storage/PulseAnimation(activate = 0)
 	if(activate)


### PR DESCRIPTION
In addition to the title;
Blobs now consume items and damage mobs on them when pulsed, as one might expect.
Shield blobs now properly block atmos.
Blob update_icon now uses ..() instead of being copypasted on every subtype

This does not fix Pulse() even if I rather want to fix it, mostly because this was something I did on a whim and could do relatively easy with little testing.
