### PR TITLE
Removes command and security from AI radio channels

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -127,4 +127,4 @@
 	channels = list("Centcom" = 1)
 
 /obj/item/device/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
-	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1)
+	channels = list("Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1)


### PR DESCRIPTION
Reduces AI validhunting.
Still lets them help with interdepartmental communication.
:cl: 
rscdel: Removes command and security channels from the AI integrated radio
/:cl: 
