### PR TITLE
Fixes up blob code some

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -7,6 +7,7 @@
 	maxhealth = 400
 	explosion_block = 6
 	point_return = -1
+	atmosblock = 1
 	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
 	var/resource_delay = 0
 	var/point_rate = 2
@@ -50,12 +51,10 @@
 /obj/effect/blob/core/ex_act(severity, target)
 	return
 
-/obj/effect/blob/core/update_icon()
+/obj/effect/blob/core/check_health()
 	..()
-	// update_icon is called when health changes so... call update_health in the overmind
-	if(overmind)
+	if(overmind) //we should have an overmind, but...
 		overmind.update_health()
-	return
 
 /obj/effect/blob/core/RegenHealth()
 	return // Don't regen, we handle it in Life()
@@ -116,4 +115,3 @@
 				B.verbs -= /mob/camera/blob/verb/split_consciousness
 		return 1
 	return 0
-

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -6,6 +6,7 @@
 	health = 200
 	maxhealth = 200
 	point_return = 25
+	atmosblock = 1
 
 
 /obj/effect/blob/node/New(loc, var/h = 100)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -7,27 +7,8 @@
 	maxhealth = 150
 	explosion_block = 3
 	point_return = 2
+	atmosblock = 1
 
-
-/obj/effect/blob/shield/New()
-	..()
-	air_update_turf(1)
-
-/obj/effect/blob/shield/Destroy()
-	var/turf/T = get_turf(src)
-	spawn(1)
-		T.air_update_turf(1)
-	..()
 
 /obj/effect/blob/shield/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
-
-/obj/effect/blob/shield/CanAtmosPass(turf/T)
-	return 0
-
-/obj/effect/blob/shield/BlockSuperconductivity()
-	return 1
-
-/obj/effect/blob/shield/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
-	return 0

--- a/code/game/gamemodes/blob/blobs/storage.dm
+++ b/code/game/gamemodes/blob/blobs/storage.dm
@@ -9,16 +9,16 @@
 	var/point_bonus = 50 //How much the overmind's point cap increases from storage blobs
 
 
-/obj/effect/blob/storage/update_icon()
-	if(health <= 0)
+/obj/effect/blob/storage/creation_action()
+	if(overmind)
+		overmind.max_blob_points += point_bonus
+
+/obj/effect/blob/storage/Destroy()
+	if(overmind)
 		overmind.max_blob_points -= point_bonus
-		..()
+	return ..()
 
 /obj/effect/blob/storage/PulseAnimation(activate = 0)
 	if(activate)
 		..()
 	return
-
-/obj/effect/blob/storage/creation_action()
-	if(overmind)
-		overmind.max_blob_points += point_bonus

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -191,18 +191,16 @@
 	set category = "Blob"
 	set name = "Split consciousness (100) (One use)"
 	set desc = "Expend resources to attempt to produce another sentient overmind"
-	if(!blob_nodes || !blob_nodes.len)
-		src << "<span class='warning'>A node is required to produce another overmind.</span>"
-		return
-	var/obj/effect/blob/node/N = locate(/obj/effect/blob) in blob_nodes
-	if(!N)
-		src << "<span class='warning'>A node is required to produce another overmind.</span>"
+	var/turf/T = get_turf(src)
+	var/obj/effect/blob/node/B = locate(/obj/effect/blob/node) in T
+	if(!B)
+		src << "<span class='warning'>You must be on a blob node!</span>"
 		return
 	if(!can_buy(100))
 		return
 	verbs -= /mob/camera/blob/verb/split_consciousness
-	new /obj/effect/blob/core/ (get_turf(N), 200, null, blob_core.point_rate, "offspring")
-	qdel(N)
+	new/obj/effect/blob/core/(get_turf(B), 200, null, blob_core.point_rate, 1)
+	qdel(B)
 	if(ticker && ticker.mode.name == "blob")
 		var/datum/game_mode/blob/BL = ticker.mode
 		BL.blobwincount += initial(BL.blobwincount) //Increase the victory condition by the set amount


### PR DESCRIPTION
Any blob can block atmos, the core and nodes now do so
Blobs use two different procs for checking health and updating icons instead of one(there's probably a use for this)
The split consciousness verb now requires a node under your selector, instead of checking a global list of nodes and picking the oldest(why?)
Blobs can no longer take non-brute and burn damage types(I would make toxin do bonus damage but the crew can't apply it anyway)
:cl: Joan
tweak: The blob Split Consciousness ability now requires a node under the overmind's selector, instead of picking the oldest living node to spawn a core on.
/:cl:
