### PR TITLE
Stronger Exile Implants

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -56,6 +56,7 @@
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
 	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
 	var/datum/gang/gang_datum //Which gang this mind belongs to, if any
+	var/exiled = 0 //If they are allowed to use the gateway to return from away missions
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1,3 +1,9 @@
+#define NO_RESTRICTION 1
+#define STATION_GATE 2
+#define AWAY_GATE 3
+#define BOTH_GATES 4
+
+
 /*	Note from Carnie:
 		The way datum/mind stuff works has been changed a lot.
 		Minds now represent IC characters rather than following a client around constantly.
@@ -56,7 +62,7 @@
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
 	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
 	var/datum/gang/gang_datum //Which gang this mind belongs to, if any
-	var/exiled = 0 //If they are allowed to use the gateway to return from away missions
+	var/gate_restriction = NO_RESTRICTION //If they are allowed to use the gateway to return from away missions
 
 /datum/mind/New(var/key)
 	src.key = key

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -572,6 +572,7 @@
 		revvie.key = O.key
 		revvie.mind.assigned_role = "revenant"
 		revvie.mind.special_role = "Revenant"
+		revvie.mind.gate_restriction = BOTH_GATES
 		return 1
 	else
 		return

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -25,7 +25,7 @@
 /obj/item/weapon/implant/exile/implant(mob/target)
 	if(..())
 		if(target.mind)
-			target.mind.exiled = TRUE
+			target.mind.gate_restriction = AWAY_GATE
 
 /obj/item/weapon/implantcase/exile
 	name = "implant case - 'Exile'"

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -21,6 +21,12 @@
 	imp = new /obj/item/weapon/implant/exile( src )
 	..()
 
+
+/obj/item/weapon/implant/exile/implant(mob/target)
+	if(..())
+		if(target.mind)
+			target.mind.exiled = TRUE
+
 /obj/item/weapon/implantcase/exile
 	name = "implant case - 'Exile'"
 	desc = "A glass case containing an exile implant."

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -132,9 +132,17 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 //okay, here's the good teleporting stuff
 /obj/machinery/gateway/centerstation/Bumped(atom/movable/M as mob|obj)
-	if(!ready)		return
-	if(!active)		return
-	if(!awaygate)	return
+	if(!ready)
+		return
+	if(!active)
+		return
+	if(!awaygate)
+		return
+	if(istype(M, /mob/living))
+		var/mob/living/L = M
+		if(L.mind && L.mind.gate_restriction == STATION_GATE || L.mind.gate_restriction == BOTH_GATES)
+			L << "The other gate is blocking your entry!"
+			return
 
 	if(awaygate.calibrated)
 		M.loc = get_step(awaygate.loc, SOUTH)
@@ -240,7 +248,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 			if(E.imp_in == L)//Checking that it's actually implanted vs just in their pocket
 				L << "The station gate has detected your exile implant and is blocking your entry."
 				return
-		if(L.mind && L.mind.exiled)
+		if(L.mind && L.mind.gate_restriction == AWAY_GATE || L.mind.gate_restriction == BOTH_GATES)
 			L << "The station gate is blocking your entry!"
 			return
 	M.loc = get_step(stationgate.loc, SOUTH)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -238,10 +238,10 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		var/mob/living/L = M
 		for(var/obj/item/weapon/implant/exile/E in L)//Checking that there is an exile implant in the contents
 			if(E.imp_in == L)//Checking that it's actually implanted vs just in their pocket
-				L << "\black The station gate has detected your exile implant and is blocking your entry."
+				L << "The station gate has detected your exile implant and is blocking your entry."
 				return
 		if(L.mind && L.mind.exiled)
-			L << "\black The station gate is blocking your entry!"
+			L << "The station gate is blocking your entry!"
 			return
 	M.loc = get_step(stationgate.loc, SOUTH)
 	M.dir = SOUTH

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -234,11 +234,15 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 /obj/machinery/gateway/centeraway/Bumped(atom/movable/M as mob|obj)
 	if(!ready)	return
 	if(!active)	return
-	if(istype(M, /mob/living/carbon))
-		for(var/obj/item/weapon/implant/exile/E in M)//Checking that there is an exile implant in the contents
-			if(E.imp_in == M)//Checking that it's actually implanted vs just in their pocket
-				M << "\black The station gate has detected your exile implant and is blocking your entry."
+	if(istype(M, /mob/living))
+		var/mob/living/L = M
+		for(var/obj/item/weapon/implant/exile/E in L)//Checking that there is an exile implant in the contents
+			if(E.imp_in == L)//Checking that it's actually implanted vs just in their pocket
+				L << "\black The station gate has detected your exile implant and is blocking your entry."
 				return
+		if(L.mind && L.mind.exiled)
+			L << "\black The station gate is blocking your entry!"
+			return
 	M.loc = get_step(stationgate.loc, SOUTH)
 	M.dir = SOUTH
 

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -102,7 +102,7 @@
 
 /obj/structure/academy_wizard_spawner/proc/summon_wizard()
 	var/turf/T = src.loc
-	
+
 	var/mob/living/carbon/human/wizbody = new(T)
 	wizbody.equipOutfit(/datum/outfit/wizard/academy)
 	var/obj/item/weapon/implant/exile/Implant = new/obj/item/weapon/implant/exile(wizbody)
@@ -110,21 +110,22 @@
 	wizbody.faction |= "wizard"
 	wizbody.real_name = "Academy Teacher"
 	wizbody.name = "Academy Teacher"
-	
+
 	var/datum/mind/wizmind = new /datum/mind()
 	wizmind.name = "Wizard Defender"
 	wizmind.special_role = "Academy Defender"
 	var/datum/objective/O = new("Protect Wizard Academy from the intruders")
 	wizmind.objectives += O
 	wizmind.transfer_to(wizbody)
+	wizmind.exiled = TRUE
 	ticker.mode.wizards |= wizmind
-	
+
 	wizmind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt)
 	wizmind.AddSpell(new /obj/effect/proc_holder/spell/targeted/projectile/magic_missile)
 	wizmind.AddSpell(new /obj/effect/proc_holder/spell/dumbfire/fireball)
 
 	current_wizard = wizbody
-	
+
 	give_control()
 
 /obj/structure/academy_wizard_spawner/proc/update_status()

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -117,7 +117,7 @@
 	var/datum/objective/O = new("Protect Wizard Academy from the intruders")
 	wizmind.objectives += O
 	wizmind.transfer_to(wizbody)
-	wizmind.exiled = TRUE
+	wizmind.gate_restriction = AWAY_GATE
 	ticker.mode.wizards |= wizmind
 
 	wizmind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_spawn_event.dm
@@ -54,6 +54,7 @@
 	player_mind.transfer_to(revvie)
 	player_mind.assigned_role = "revenant"
 	player_mind.special_role = "Revenant"
+	player_mind.gate_restriction = BOTH_GATES
 	ticker.mode.traitors |= player_mind
 	message_admins("[key_of_revenant] has been made into a revenant by an event.")
 	log_game("[key_of_revenant] was spawned as a revenant by an event.")


### PR DESCRIPTION
They now set a var in your mind as well, meaning even if you mindswap/surgery/transform into a corgi, there is still no going back.

I didn't want to make a new var for minds but this is the only way I could think of that would easily cover every edge case. The var can be set for no gate restriction, away restriction (returning), station restriction (leaving), and both.

Revenants can no longer use the gate either for @Anonus 

Fixes https://github.com/tgstation/-tg-station/issues/13518

For everyone saying "it's shit you can't escape!":

You got caught already by security. The alternative to this is execution. They're already sparing your life and letting you continue to play/be alive, if this option is not 100% effective they will not use it. You already had your chance to escape, and you blew it, and sec gets to do what they want with you now. You can't escape from borging either.

:cl: Kor
rscadd: Once exile implanted, you may never return to the station, even if the implant is removed. As a reminder, people on away missions count as dead for objectives, so this is a 100% effective alternative to execution.
/:cl:
