### PR TITLE
Ninja event wont occur naturally (admin only)

### DIFF
--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -13,7 +13,7 @@ Contents:
 /datum/round_event_control/ninja
 	name = "Space Ninja"
 	typepath = /datum/round_event/ninja
-	max_occurrences = 1
+	max_occurrences = 0
 	earliest_start = 30000 // 1 hour
 
 


### PR DESCRIPTION
I lost pls nerf etc

Ninja currently either has infinite or near infinite perfect (no counters, no thermals, etc, as far as I know) invisibility and just clicks everyone to death and the round ends, it's very dull. Ninja needs to be reworked before it shows up on its own.
