### PR TITLE
Fixes ninja suit not draining energy after running out of it once

### DIFF
--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -1,28 +1,22 @@
-
-
 /obj/item/clothing/suit/space/space_ninja/proc/ntick(mob/living/carbon/human/U = affecting)
 	set background = BACKGROUND_ENABLED
 
 	//Runs in the background while the suit is initialized.
 	//Requires charge or stealth to process.
-	spawn while(cell.charge || s_active)
-
-		if(s_initialized && !affecting)
+	spawn while(s_initialized)
+		if(!affecting)
 			terminate()//Kills the suit and attached objects.
-		if(!s_initialized)
-			return
 
-		if(cell.charge)
+		else if(cell.charge > 0)
 			if(s_coold)
 				s_coold--//Checks for ability s_cooldown first.
 
-			var/A = s_cost//s_cost is the default energy cost each ntick, usually 5.
+			cell.charge -= s_cost//s_cost is the default energy cost each ntick, usually 5.
 			if(s_active)//If stealth is active.
-				A += s_acost
-			cell.charge-=A
+				cell.charge -= s_acost
 
-		if(cell.charge <= 0)
-			cell.charge=0
+		else
+			cell.charge = 0
 			cancel_stealth()
 
 		sleep(10)//Checks every second.


### PR DESCRIPTION
   :cl:
   bugfix: Ninja drains power properly, no more infinite stealth.
   /:cl:

The problem was that ntick proc would end when the suit ran out of power, and the only place it was called was in suit initialization. Now it runs until the suit is deinitialized.

Fixes #11716

Potentially removes the need for #13520 

I plan to look at ninja code more in future with the intent to refactor and maybe redo the whole thing differently.
