### PR TITLE
Removes restriction against implanting nuke disk

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -611,29 +611,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return assembled
 
-
-/atom/proc/GetTypeInAllContents(typepath)
-	var/list/processing_list = list(src)
-	var/list/processed = list()
-
-	var/atom/found = null
-
-	while(processing_list.len && found==null)
-		var/atom/A = processing_list[1]
-		if(istype(A, typepath))
-			found = A
-
-		processing_list -= A
-
-		for(var/atom/a in A)
-			if(!(a in processed))
-				processing_list |= a
-
-		processed |= A
-
-	return found
-
-
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
 	var/turf/current = get_turf(source)
@@ -944,7 +921,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			final_x = T.x + rough_x
 			final_y = T.y + rough_y
 			final_z = T.z
-		else	
+		else
 			final_x = AM.x + rough_x
 			final_y = AM.y + rough_y
 			final_z = AM.z

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -25,7 +25,7 @@
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tool)
-		if(IC || tool.w_class > 3 || NODROP in tool.flags || tool.GetTypeInAllContents(/obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/organ))
+		if(IC || tool.w_class > 3 || NODROP in tool.flags || istype(tool, /obj/item/organ))
 			user << "<span class='warning'>You can't seem to fit [tool] in [target]'s [target_zone]!</span>"
 			return 0
 		else

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -25,7 +25,7 @@
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tool)
-		if(IC || tool.w_class > 3 || NODROP in tool.flags || tool.GetTypeInAllContents(/obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/organ))
+		if(IC || tool.w_class > 3 || NODROP in tool.flags || tool.GetTypeInAllContents(/obj/item/weapon/disk/nuclear) || istype(tool, /obj/item/organ))
 			user << "<span class='warning'>You can't seem to fit [tool] in [target]'s [target_zone]!</span>"
 			return 0
 		else


### PR DESCRIPTION
A) The code doesn't work

B) Nuke ops have a surgery table on their shuttle, they can just kidnap the clowns body

Removes the GetTypeInAllContents proc that was literally only ever used here and was shitcode according to @tkdrg 

:cl: Kor
rscadd: There are no longer restrictions against implanting the nuclear disk in people.
/:cl:
