### PR TITLE
Revenants can no longer leave through the gateway

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -132,9 +132,18 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 //okay, here's the good teleporting stuff
 /obj/machinery/gateway/centerstation/Bumped(atom/movable/M as mob|obj)
-	if(!ready)		return
-	if(!active)		return
-	if(!awaygate)	return
+	if(!ready)
+		return
+	if(!active)
+		return
+	if(!awaygate)
+		return
+
+	if(isliving(M))
+		var/mob/living/L = M
+		if(!L.gateway_leave) //sorry, but you aren't getting out this way.
+			L << "<span class='warning'>The portal flickers as you attempt to move through it, preventing you from leaving this place.</span>"
+			return
 
 	if(awaygate.calibrated)
 		M.loc = get_step(awaygate.loc, SOUTH)
@@ -151,7 +160,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 /obj/machinery/gateway/centerstation/attackby(obj/item/device/W, mob/user, params)
 	if(istype(W,/obj/item/device/multitool))
-		user << "\black The gate is already calibrated, there is no work for you to do here."
+		user << "<span class='notice'>The gate is already calibrated, there is no work for you to do here.</span>"
 		return
 
 /////////////////////////////////////Away////////////////////////
@@ -200,8 +209,10 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 
 /obj/machinery/gateway/centeraway/proc/toggleon(mob/user)
-	if(!ready)			return
-	if(linked.len != 8)	return
+	if(!ready)
+		return
+	if(linked.len != 8)
+		return
 	if(!stationgate)
 		user << "<span class='notice'>Error: No destination found.</span>"
 		return

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -54,3 +54,5 @@
 	var/unique_name = 0 //if a mob's name should be appended with an id when created e.g. Mob (666)
 
 	var/list/butcher_results = null
+
+	var/gateway_leave = 1 //if a mob can leave the station through the gateway, allowed by default

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -42,6 +42,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	speed = 0
 	unique_name = 1
+	gateway_leave = 0
 
 	var/essence = 75 //The resource, and health, of revenants.
 	var/essence_regen_cap = 75 //The regeneration cap of essence (go figure); regenerates every Life() tick up to this amount.


### PR DESCRIPTION
You KNOW why.

Uses a var so that it's relatively easy to prevent other mobs from leaving the station.
