### PR TITLE
Armor fixes (Reactive Teleport Armor and reflector vest name)

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -100,7 +100,7 @@
 	put_on_delay = 50
 
 /obj/item/clothing/suit/armor/laserproof
-	name = "ablative armor vest"
+	name = "reflector vest"
 	desc = "A vest that excels in protecting the wearer against energy projectiles, as well as occasionally reflecting them."
 	icon_state = "armor_reflec"
 	item_state = "armor_reflec"
@@ -172,13 +172,13 @@
 				continue
 			turfs += T
 		if(!turfs.len)
-			turfs += pick(/turf in orange(6, src))
-			var/turf/picked = pick(turfs)
-			if(!isturf(picked))
-				return
-			if(H.buckled)
-				H.buckled.unbuckle_mob()
-			H.forceMove(picked)
+			turfs += pick(/turf in orange(6, H))
+		var/turf/picked = pick(turfs)
+		if(!isturf(picked))
+			return
+		if(H.buckled)
+			H.buckled.unbuckle_mob()
+		H.forceMove(picked)
 		return 1
 	return 0
 


### PR DESCRIPTION
Ironically the source of the entire refactor is the thing that doesn't work. Messed up the indentation trying to sort out those awful same line returns.

Also renames ablative to reflector vest because I renamed it literally everywhere else but the actual item.
