### PR TITLE
Apprentice clean up / bugfixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -364,7 +364,7 @@
 		if (ticker.mode.config_tag=="wizard")
 			text = uppertext(text)
 		text = "<i><b>[text]</b></i>: "
-		if (src in ticker.mode.wizards)
+		if ((src in ticker.mode.wizards) || (src in ticker.mode.apprentices))
 			text += "<b>YES</b>|<a href='?src=\ref[src];wizard=clear'>no</a>"
 			text += "<br><a href='?src=\ref[src];wizard=lair'>To lair</a>, <a href='?src=\ref[src];common=undress'>undress</a>, <a href='?src=\ref[src];wizard=dressup'>dress up</a>, <a href='?src=\ref[src];wizard=name'>let choose name</a>."
 			if (objectives.len==0)

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -92,6 +92,15 @@
 	var/wizard_name_first = pick(wizard_first)
 	var/wizard_name_second = pick(wizard_second)
 	var/randomname = "[wizard_name_first] [wizard_name_second]"
+	var/datum/objective/protect/new_objective = new /datum/objective/protect
+	new_objective.owner = M:mind
+	new_objective:target = usr:mind
+	new_objective.explanation_text = "Protect [usr.real_name], the wizard."
+	M.mind.objectives += new_objective
+	ticker.mode.apprentices += M.mind
+	M.mind.special_role = "apprentice"
+	ticker.mode.update_wiz_icons_added(M.mind)
+	M << sound('sound/effects/magic.ogg')
 	var/newname = copytext(sanitize(input(M, "You are the wizard's apprentice. Would you like to change your name to something else?", "Name change", randomname) as null|text),1,MAX_NAME_LEN)
 	if (!newname)
 		newname = randomname
@@ -99,15 +108,6 @@
 	M.real_name = newname
 	M.name = newname
 	M.dna.update_dna_identity()
-	var/datum/objective/protect/new_objective = new /datum/objective/protect
-	new_objective.owner = M:mind
-	new_objective:target = usr:mind
-	new_objective.explanation_text = "Protect [usr.real_name], the wizard."
-	M.mind.objectives += new_objective
-	ticker.mode.traitors += M.mind
-	M.mind.special_role = "apprentice"
-	ticker.mode.update_wiz_icons_added(M.mind)
-	M << sound('sound/effects/magic.ogg')
 
 /obj/item/weapon/antag_spawner/contract/equip_antag(mob/target)
 	target.equip_to_slot_or_del(new /obj/item/device/radio/headset(target), slot_ears)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -1,5 +1,6 @@
 /datum/game_mode
 	var/list/datum/mind/wizards = list()
+	var/list/datum/mind/apprentices = list()
 
 /datum/game_mode/wizard
 	name = "wizard"

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -431,6 +431,18 @@
 					dat += "<tr><td><i>Wizard not found!</i></td></tr>"
 			dat += "</table>"
 
+		if(ticker.mode.apprentices.len > 0)
+			dat += "<br><table cellspacing=5><tr><td><B>Apprentice</B></td><td></td><td></td></tr>"
+			for(var/datum/mind/apprentice in ticker.mode.apprentices)
+				var/mob/M = apprentice.current
+				if(M)
+					dat += "<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(ghost)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
+					dat += "<td><A href='?priv_msg=[M.ckey]'>PM</A></td>"
+					dat += "<td><A HREF='?_src_=holder;traitor=\ref[M]'>Show Objective</A></td></tr>"
+				else
+					dat += "<tr><td><i>Apprentice not found!</i></td></tr>"
+			dat += "</table>"
+
 		if(ticker.mode.cult.len)
 			dat += "<br><table cellspacing=5><tr><td><B>Cultists</B></td><td></td></tr>"
 			for(var/datum/mind/N in ticker.mode.cult)

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -37,7 +37,7 @@
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		if(ruins_spaceworthiness && (H.z != 1 || istype(H.loc, /turf/space)))	continue	//#savetheminers
-		if(ruins_wizard_loadout && H.mind && H.mind in ticker.mode.wizards)		continue
+		if(ruins_wizard_loadout && H.mind && ((H.mind in ticker.mode.wizards) || (H.mind in ticker.mode.apprentices)))		continue
 		if(item_set == "catgirls2015") //Wizard code means never having to say you're sorry
 			H.gender = FEMALE
 		var/list/slots		= list(H.wear_suit, H.shoes, H.head, H.wear_mask, H.r_hand, H.gloves, H.ears) //add new slots as needed to back

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -35,7 +35,7 @@
 		I.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/turf_teleport/blink(null))
 		I.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt(null))
 
-		ticker.mode.traitors += I.mind
+		ticker.mode.apprentices += I.mind
 		I.mind.special_role = "imposter"
 
 		var/datum/objective/protect/protect_objective = new /datum/objective/protect

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -15,7 +15,7 @@
 			continue
 		var/quality = rand(-5,5)
 		if(quality > 0)
-			I.name = "[pick(prefixespositive)] [I.name] of [pick(suffixes)] plus [quality]"
+			I.name = "[pick(prefixespositive)] [I.name] of [pick(suffixes)] +[quality]"
 		else if(quality < 0)
 			I.name = "[pick(prefixesnegative)] [I.name] of [pick(suffixes)] [quality]"
 		else

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -77,7 +77,7 @@
 	var/list/mobs	 = list()
 
 	for(var/mob/living/carbon/human/H in living_mob_list)
-		if(!H.stat || !H.mind || H.mind in ticker.mode.wizards)	continue //the wizard(s) are spared on this one
+		if(!H.stat || !H.mind || (H.mind in ticker.mode.wizards) || (H.mind in ticker.mode.apprentices))	continue //the wizard(s) are spared on this one
 		mobs += H
 
 	if(!mobs) return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -310,6 +310,9 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 			if("wizard")
 				if(M.mind in ticker.mode.wizards)
 					return 2
+			if("apprentice")
+				if(M.mind in ticker.mode.apprentices)
+					return 2
 			if("monkey")
 				if(M.viruses && (locate(/datum/disease/transformation/jungle_fever) in M.viruses))
 					return 2


### PR DESCRIPTION
Formally defines apprentices as a kind of antag instead of as "traitors".

Wizard events that spare the wizard should now properly spare apprentices too. Fixes #13540

Moves renaming as an apprentice to the end of the spawn proc because the input prompt stops various important things (including the sound meant to inform people they got apprentice) from happening until after it's dealt with.

Restores the "+" for positive quality items in RPG loot. The reason this was changed was already fixed, it just was mistakenly never put back.
