### PR TITLE
Fixes Abductor event firing up multiple times

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -12,9 +12,10 @@
 
 /datum/round_event/abductor/start()
 	//spawn abductor team
+	processing = 0 //so it won't fire again in next subsystem tick
 	if(!makeAbductorTeam())
 		message_admins("Abductor event failed to find players. Retrying in 30s.")
-		spawn(30)
+		spawn(300)
 			makeAbductorTeam()
 
 /datum/round_event/abductor/proc/makeAbductorTeam()
@@ -55,7 +56,7 @@
 
 		if(ticker.mode.config_tag != "abduction")
 			ticker.mode.abductors |= temp.abductors
-
+		processing = 1 //So it will get gc'd
 		return 1
 	else
 		return 0


### PR DESCRIPTION
Events probably need states instead of this silly counter.
