### PR TITLE
More mining fixes and tweaks.

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -65,25 +65,28 @@
 
 /obj/machinery/mineral/ore_redemption/process()
 	if(!panel_open && powered()) //If the machine is partially disassembled and/or depowered, it should not process minerals
-		var/turf/T = get_turf(get_step(src, input_dir))
-		var/i
+		var/turf/T = get_step(src, input_dir)
+		var/i = 0
 		if(T)
-			if(locate(/obj/item/weapon/ore) in T)
-				for (i = 0; i < ore_pickup_rate; i++)
-					var/obj/item/weapon/ore/O = locate() in T
-					if(O && O.refined_type)
-						process_sheet(O)
-					else
+			for(var/obj/item/weapon/ore/O in T)
+				if (i >= ore_pickup_rate)
+					break
+				else if (!O || !O.refined_type)
+					continue
+				else
+					process_sheet(O)
+					i++
+		else
+			var/obj/structure/ore_box/B = locate() in T
+			if(B)
+				for(var/obj/item/weapon/ore/O in B.contents)
+					if (i >= ore_pickup_rate)
 						break
-			else
-				var/obj/structure/ore_box/B = locate() in T
-				if(B)
-					for (i = 0; i < ore_pickup_rate; i++)
-						var/obj/item/weapon/ore/O = locate() in B.contents
-						if(O)
-							process_sheet(O)
-						else
-							break
+					else if (!O || !O.refined_type)
+						continue
+					else
+						process_sheet(O)
+						i++
 
 /obj/machinery/mineral/ore_redemption/attackby(obj/item/weapon/W, mob/user, params)
 	if (!powered())
@@ -289,11 +292,11 @@
 		new /datum/data/mining_equipment("Kinetic Accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,               	   750),
 		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                    	   800),
 		new /datum/data/mining_equipment("Lazarus Injector",    /obj/item/weapon/lazarus_injector,                                1000),
-		new /datum/data/mining_equipment("Silver Pickaxe",		/obj/item/weapon/pickaxe/silver,				                  1200),
+		new /datum/data/mining_equipment("Silver Pickaxe",		/obj/item/weapon/pickaxe/silver,				                  1000),
 		new /datum/data/mining_equipment("Jetpack",             /obj/item/weapon/tank/jetpack/carbondioxide/mining,               2000),
 		new /datum/data/mining_equipment("Space Cash",    		/obj/item/stack/spacecash/c1000,                    			  2000),
-		new /datum/data/mining_equipment("Super Resonator",     /obj/item/weapon/resonator/upgraded,                              2400),
-		new /datum/data/mining_equipment("Diamond Pickaxe",		/obj/item/weapon/pickaxe/diamond,				                  2500),
+		new /datum/data/mining_equipment("Diamond Pickaxe",		/obj/item/weapon/pickaxe/diamond,				                  2000),
+		new /datum/data/mining_equipment("Super Resonator",     /obj/item/weapon/resonator/upgraded,                              2500),
 		new /datum/data/mining_equipment("Super Accelerator",	/obj/item/weapon/gun/energy/kinetic_accelerator/super,			  3000),
 		new /datum/data/mining_equipment("Point Transfer Card", /obj/item/weapon/card/mining_point_card,               			   500),
 		)
@@ -895,13 +898,13 @@
 
 /obj/item/weapon/hivelordstabilizer
 	name = "hivelord stabilizer"
-	icon_state = "hivestabilizer"
-	item_state = "hivestabilizer"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle19"
 	desc = "Inject a hivelord core with this stabilizer to preserve its healing powers indefinitely."
 	w_class = 1
 	origin_tech = "biotech=1"
 
-/obj/item/weapon/hivelordstabilizer/attack(obj/item/organ/internal/M, mob/user)
+/obj/item/weapon/hivelordstabilizer/afterattack(obj/item/organ/internal/M, mob/user)
 	var/obj/item/organ/internal/hivelord_core/C = M
 	if(!istype(C, /obj/item/organ/internal/hivelord_core))
 		user << "<span class='warning'>The stabilizer only works on hivelord cores.</span>"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -146,6 +146,11 @@
 	var/ore_eaten = 1
 	var/chase_time = 100
 
+/mob/living/simple_animal/hostile/asteroid/goldgrub/New()
+	..()
+	ore_types_eaten += pick(/obj/item/weapon/ore/silver, /obj/item/weapon/ore/gold, /obj/item/weapon/ore/uranium, /obj/item/weapon/ore/diamond)
+	ore_eaten = rand(1,3)
+
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
@@ -172,8 +177,8 @@
 		if(!(O.type in ore_types_eaten))
 			ore_types_eaten += O.type
 		qdel(O)
-	if(ore_eaten > 5)//Limit the scope of the reward you can get, or else things might get silly
-		ore_eaten = 5
+	if(ore_eaten > 10)//Limit the scope of the reward you can get, or else things might get silly
+		ore_eaten = 10
 	visible_message("<span class='notice'>The ore was swallowed whole!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//Begin the chase to kill the goldgrub in time
@@ -275,10 +280,10 @@
 
 /obj/item/organ/internal/hivelord_core/on_life()
 	..()
-
-	owner.adjustBruteLoss(-1)
-	owner.adjustFireLoss(-1)
-	owner.adjustOxyLoss(-2)
+	if(owner)
+		owner.adjustBruteLoss(-1)
+		owner.adjustFireLoss(-1)
+		owner.adjustOxyLoss(-2)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		var/datum/reagent/blood/B = locate() in H.vessel.reagent_list //Grab some blood

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -146,18 +146,16 @@
 	name = "super-kinetic accelerator"
 	desc = "An upgraded, superior version of the proto-kinetic accelerator."
 	icon_state = "kineticgun_u"
-	item_state = "kineticgun_u"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/super)
-	overheat_time = 14
+	overheat_time = 15
 	origin_tech = "combat=3;powerstorage=2"
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/hyper
 	name = "hyper-kinetic accelerator"
 	desc = "An upgraded, even more superior version of the proto-kinetic accelerator."
 	icon_state = "kineticgun_h"
-	item_state = "kineticgun_h"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/hyper)
-	overheat_time = 12
+	overheat_time = 14
 	origin_tech = "combat=4;powerstorage=3"
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()


### PR DESCRIPTION
- Super-kinetic accelerator has inhand. Hivelord stabilizer has a sprite and works. Bluespace crystals no longer jam up the ore processing machine. Fixes https://github.com/tgstation/-tg-station/issues/13278. Fixes https://github.com/tgstation/-tg-station/issues/13259.
- Adds sanity check to hivelord life proc. Fixes https://github.com/tgstation/-tg-station/issues/12681. Or at least it should.
- Tweaks the cost of certain mining items based on playing a couple times and getting a better sense of points on the ground. The tweaks are generally downward.
- Nerfs the cooldown of super/hyper KAs slightly based on feedback that it is ridiculous.
