### PR TITLE
Revenants' overload lights ability now breaks the lights.

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -121,6 +121,7 @@
 							z.set_up(4, 0, M)
 							z.start()
 							playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
+						L.broken()
 
 //Defile: Corrupts nearby stuff, unblesses floor tiles.
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile


### PR DESCRIPTION
Really this seems like an oversight more than anything -- all other powers that overload lights (changelings' shrieks, malf AIs' blackouts) break them.
