### PR TITLE
Gateway/singularity interaction fix

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -240,7 +240,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		return
 	if(!active)	
 		return
-	if(!stationgate || qdeleted(station))	
+	if(!stationgate || qdeleted(stationgate))	
 		return
 	if(istype(M, /mob/living/carbon))
 		for(var/obj/item/weapon/implant/exile/E in M)//Checking that there is an exile implant in the contents

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -132,9 +132,12 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 //okay, here's the good teleporting stuff
 /obj/machinery/gateway/centerstation/Bumped(atom/movable/M as mob|obj)
-	if(!ready)		return
-	if(!active)		return
-	if(!awaygate)	return
+	if(!ready)		
+		return
+	if(!active)		
+		return
+	if(!awaygate || qdeleted(awaygate))	
+		return
 
 	if(awaygate.calibrated)
 		M.loc = get_step(awaygate.loc, SOUTH)
@@ -154,8 +157,6 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		user << "\black The gate is already calibrated, there is no work for you to do here."
 		return
 
-/obj/machinery/gateway/centerstation/Destroy()
-	return QDEL_HINT_HARDDEL_NOW
 
 /////////////////////////////////////Away////////////////////////
 
@@ -235,8 +236,12 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 
 /obj/machinery/gateway/centeraway/Bumped(atom/movable/M as mob|obj)
-	if(!ready)	return
-	if(!active)	return
+	if(!ready)	
+		return
+	if(!active)	
+		return
+	if(!stationgate || qdeleted(station))	
+		return
 	if(istype(M, /mob/living/carbon))
 		for(var/obj/item/weapon/implant/exile/E in M)//Checking that there is an exile implant in the contents
 			if(E.imp_in == M)//Checking that it's actually implanted vs just in their pocket
@@ -255,7 +260,3 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 			user << "<span class='boldnotice'>Recalibration successful!</span>: \black This gate's systems have been fine tuned.  Travel to this gate will now be on target."
 			calibrated = 1
 			return
-
-
-/obj/machinery/gateway/centeraway/Destroy()
-	return QDEL_HINT_HARDDEL_NOW

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -154,6 +154,9 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		user << "\black The gate is already calibrated, there is no work for you to do here."
 		return
 
+/obj/machinery/gateway/centerstation/Destroy()
+	return QDEL_HINT_HARDDEL_NOW
+
 /////////////////////////////////////Away////////////////////////
 
 
@@ -252,3 +255,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 			user << "<span class='boldnotice'>Recalibration successful!</span>: \black This gate's systems have been fine tuned.  Travel to this gate will now be on target."
 			calibrated = 1
 			return
+
+
+/obj/machinery/gateway/centeraway/Destroy()
+	return QDEL_HINT_HARDDEL_NOW


### PR DESCRIPTION
Fixes #13325

> but kor why didn't you put the hard_del in /machinery/gateway and let centerstation/centeraway inherit it?

I am under the impression that we're not supposed to hard delete things if at all possible, and there is no need to hard del the other 8 parts of each gate, just the two center pieces.

If I'm wrong on that count it's an easy fix
