### PR TITLE
[s]Computer ID is a string, Thanks byond.

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -5,7 +5,7 @@
 		log_access("Failed Login (invalid data): [key] [address]-[computer_id]")
 		return list("reason"="invalid login data", "desc"="Error: Could not check ban status, Please try again. Error message: Your computer provided invalid or blank information to the server on connection (byond username, IP, and Computer ID.) Provided information for reference: Username:'[key]' IP:'[address]' Computer ID:'[computer_id]'. (If you continue to get this error, please restart byond or contact byond support.)")
 	
-	if (computer_id == 2147483647) //this cid causes stickybans to go haywire 
+	if (text2num(computer_id) == 2147483647) //this cid causes stickybans to go haywire 
 		log_access("Failed Login (invalid cid): [key] [address]-[computer_id]")
 		return list("reason"="invalid login data", "desc"="Error: Could not check ban status, Please try again. Error message: Your computer provided an invalid Computer ID.)")
 	var/admin = 0


### PR DESCRIPTION
I chose text2num() over putting the integer max in quotes since I believe text2num() is nicer than doing a string comparison.

@MrStonedOne 
@Fox-McCloud 

> computer_id var (client)
> Default value: 
> A unique numerical identifier for the player's computer. The value is in text form. 
