### PR TITLE
Wishgranter malus nerf.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -163,6 +163,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	name = "???"
 	id = "shadow"
 	darksight = 8
+	invis_sight = SEE_INVISIBLE_MINIMUM
 	sexes = 0
 	ignored_by = list(/mob/living/simple_animal/hostile/faithless)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/shadow


### PR DESCRIPTION
Shadowpeople (???) born of the Wish-granter can now properly see in the dark as (presumably) intended.

:cl:
bugfix: The Wishgranter now displays its faith in humans with curbed enthusiasm.
/:cl:
