### PR TITLE
[RPG Loot Intensifies]

### DIFF
--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -56,6 +56,7 @@
 		return
 	target.force 		+= 1
 	target.throwforce	+= 1
-	target.armor		+= 1
+	for(var/armor_value in target.armor)
+		armor_value	+= 1
 	user << "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>"
 	qdel(src)

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -9,11 +9,13 @@
 	var/list/prefixespositive 	= list("greater", "major", "blessed", "superior", "enpowered", "honed", "true", "glorious", "robust")
 	var/list/prefixesnegative 	= list("lesser", "minor", "blighted", "inferior", "enfeebled", "rusted", "unsteady", "tragic", "gimped")
 	var/list/suffixes			= list("orc slaying", "elf slaying", "corgi slaying", "strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma", "the forest", "the hills", "the plains", "the sea", "the sun", "the moon", "the void", "the world", "the fool", "many secrets", "many tales", "many colors", "rending", "sundering", "the night", "the day")
-
+	var/upgrade_scroll_chance	= 0
 	for(var/obj/item/I in world)
 		if(istype(I,/obj/item/organ/))
 			continue
-		var/quality = rand(-5,5)
+		var/quality = pick(1;15, 2;14, 2;13, 2;12, 3;11, 3;10, 3;9, 4;8, 4;7, 4;6, 5;5, 5;4, 5;3, 6;2, 6;1, 6;0)
+		if(prob(50))
+			quality = -quality
 		if(quality > 0)
 			I.name = "[pick(prefixespositive)] [I.name] of [pick(suffixes)] +[quality]"
 		else if(quality < 0)
@@ -21,7 +23,38 @@
 		else
 			I.name = "[I.name] of [pick(suffixes)]"
 
-		I.force 		+= quality
-		I.force			= max(0,I.force)
-		I.throwforce 	+= quality
-		I.throwforce	= max(0,I.throwforce)
+		I.force 		= max(0,I.force + quality)
+		I.throwforce	= max(0,I.throwforce + quality)
+		I.armor			+= quality
+
+		if(istype(I,/obj/item/weapon/storage))
+			var/obj/item/weapon/storage/S = I
+			if(prob(upgrade_scroll_chance) && S.contents.len < S.storage_slots)
+				var/obj/item/upgradescroll/scroll = new
+				S.handle_item_insertion(scroll,1)
+				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)
+			upgrade_scroll_chance += 25
+
+/obj/item/upgradescroll
+	name = "Item Fortification Scroll"
+	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". Apparently there's a risk of losing the item if it's already \"too good\". <i>This all feels so arbitrary...</i>"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "scroll"
+	w_class = 1
+
+/obj/item/upgradescroll/afterattack(obj/item/target, mob/user , proximity)
+	if(!proximity || !istype(target))
+		return
+	var/quality = target.force - initial(target.force)
+	if(quality > 9 && prob((quality - 9)*10))
+		user << "<span class='danger'>[target] catches fire!</span>"
+		if(target.burn_state == -1)
+			target.burn_state = 0
+		target.fire_act()
+		qdel(src)
+		return
+	target.force 		+= 1
+	target.throwforce	+= 1
+	target.armor		+= 1
+	user << "<span class='notice'>[target] glows blue and seems vaguely \"better\"!</span>"
+	qdel(src)

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -25,7 +25,8 @@
 
 		I.force 		= max(0,I.force + quality)
 		I.throwforce	= max(0,I.throwforce + quality)
-		I.armor			+= quality
+		for(var/armor_value in I.armor)
+			armor_value	+= quality
 
 		if(istype(I,/obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = I


### PR DESCRIPTION
The much beloved rpgloot wizard event has been intensified. Modifiers on items can now range between -15 and +15, though items will follow a normal distribution centered around 0.

Additionally items armor values are now also affected by this event, and can add (or remove) up to 15 percent damage from all (defend-able) sources.

Additionally a special new gimmick has been added, new "item fortification scrolls" will be thrown randomly into all containers with room to hold them (read: this mostly means things like backpacks). Using these scrolls on items allows you to rank them up one level (this doesn't change their name though, trust me it's too much to do for a silly event).

BEWARE however that using these scrolls on items with very high modifiers (+10 or more) has a chance of failing and setting fire to the item. The highest possible modifier you can achieve with these scrolls is +19, though again the grand majority of items will burn well before this point.

---

Odds
"Between -5 and +5": ~55%
"10% or higher": ~12%
"-10% or lower": ~12%

(-)15 = ~0.8%
(-)14, (-)13, (-)12 = ~1.6%
(-)11, (-)10, (-)9 = ~2.5%
(-)8, (-)7, (-)6= ~3.3%
(-)5, (-)4, (-)3= ~4.1%
(-)2, (-)1, 0= ~4.9%

---

:cl: Incoming5643
rscadd: The summon events... event "RPG loot" now allows for items to have bonuses of up to +15!
rscadd: The "RPG loot" event now also improves the damage reduction of armor!
rscadd: <s>Check out the item mall for new item fortification scrolls!</s>
/:cl:
