### PR TITLE
Refactor quick-equip verb

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -102,6 +102,25 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/block_chance = 0
 	var/hit_reaction_chance = 0 //If you want to have something unrelated to blocking/armour piercing etc. Maybe not needed, but trying to think ahead/allow more freedom
 
+	//The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
+	var/list/slot_equipment_priority = list( \
+			slot_back,\
+			slot_wear_id,\
+			slot_w_uniform,\
+			slot_wear_suit,\
+			slot_wear_mask,\
+			slot_head,\
+			slot_shoes,\
+			slot_gloves,\
+			slot_ears,\
+			slot_glasses,\
+			slot_belt,\
+			slot_s_store,\
+			slot_l_store,\
+			slot_r_store,\
+			slot_drone_storage\
+		)
+
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
 		return 0

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -173,3 +173,58 @@
 	//if(hasvar(src,"r_hand")) if(src:r_hand) items += src:r_hand
 
 	return items
+
+
+/obj/item/proc/equip_to_best_slot(var/mob/M)
+	if(src != M.get_active_hand())
+		M << "<span class='warning'>You are not holding anything to equip!</span>"
+		return 0
+
+	if(M.equip_to_appropriate_slot(src))
+		if(M.hand)
+			M.update_inv_l_hand()
+		else
+			M.update_inv_r_hand()
+		return 1
+
+	if(M.s_active && M.s_active.can_be_inserted(src,1))	//if storage active insert there
+		M.s_active.handle_item_insertion(src)
+		return 1
+
+	if(istype(M, /mob/living/simple_animal/drone))
+		var/mob/living/simple_animal/drone/D = M
+		var/obj/item/weapon/storage/T = D.internal_storage
+		if (!T)
+			if (D.equip_to_slot_if_possible(src, slot_drone_storage, 0, 1, 1))
+				return 1
+		else if (istype(T) && T.can_be_inserted(src,1)) //If carrying storage item like toolbox
+			T.handle_item_insertion(src)
+			return 1
+
+	var/obj/item/weapon/storage/S = M.get_inactive_hand()
+	if(istype(S) && S.can_be_inserted(src,1))	//see if we have box in other hand
+		S.handle_item_insertion(src)
+		return 1
+
+	S = M.get_item_by_slot(slot_belt)
+	if(istype(S) && S.can_be_inserted(src,1))		//else we put in belt
+		S.handle_item_insertion(src)
+		return 1
+
+	S = M.get_item_by_slot(slot_back)	//else we put in backpack
+	if(istype(S) && S.can_be_inserted(src,1))
+		S.handle_item_insertion(src)
+		playsound(src.loc, "rustle", 50, 1, -5)
+		return 1
+
+	M << "<span class='warning'>You are unable to equip that!</span>"
+	return 0
+
+
+/mob/verb/quick_equip()
+	set name = "quick-equip"
+	set hidden = 1
+
+	var/obj/item/I = get_active_hand()
+	if (I)
+		I.equip_to_best_slot(src)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -191,16 +191,6 @@
 		M.s_active.handle_item_insertion(src)
 		return 1
 
-	if(istype(M, /mob/living/simple_animal/drone))
-		var/mob/living/simple_animal/drone/D = M
-		var/obj/item/weapon/storage/T = D.internal_storage
-		if (!T)
-			if (D.equip_to_slot_if_possible(src, slot_drone_storage, 0, 1, 1))
-				return 1
-		else if (istype(T) && T.can_be_inserted(src,1)) //If carrying storage item like toolbox
-			T.handle_item_insertion(src)
-			return 1
-
 	var/obj/item/weapon/storage/S = M.get_inactive_hand()
 	if(istype(S) && S.can_be_inserted(src,1))	//see if we have box in other hand
 		S.handle_item_insertion(src)
@@ -210,6 +200,10 @@
 	if(istype(S) && S.can_be_inserted(src,1))		//else we put in belt
 		S.handle_item_insertion(src)
 		return 1
+
+	S = M.get_item_by_slot(slot_drone_storage)	//else we put in whatever is in drone storage
+	if(istype(S) && S.can_be_inserted(src,1))
+		S.handle_item_insertion(src)
 
 	S = M.get_item_by_slot(slot_back)	//else we put in backpack
 	if(istype(S) && S.can_be_inserted(src,1))

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,38 +1,6 @@
 /mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = 0)
 	return dna.species.can_equip(I, slot, disable_warning, src)
 
-/mob/living/carbon/human/verb/quick_equip()
-	set name = "quick-equip"
-	set hidden = 1
-
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		var/obj/item/I = H.get_active_hand()
-		var/obj/item/weapon/storage/S = H.get_inactive_hand()
-		if(!I)
-			H << "<span class='warning'>You are not holding anything to equip!</span>"
-			return
-		if(H.equip_to_appropriate_slot(I))
-			if(hand)
-				update_inv_l_hand()
-			else
-				update_inv_r_hand()
-		else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
-			s_active.handle_item_insertion(I)
-		else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
-			S.handle_item_insertion(I)
-		else
-			S = H.get_item_by_slot(slot_belt)
-			if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))		//else we put in belt
-				S.handle_item_insertion(I)
-			else
-				S = H.get_item_by_slot(slot_back)	//else we put in backpack
-				if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))
-					S.handle_item_insertion(I)
-					playsound(src.loc, "rustle", 50, 1, -5)
-				else
-					H << "<span class='warning'>You are unable to equip that!</span>"
-
 
 /mob/living/carbon/human/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = 1)
 	for(var/slot in slots)

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -113,28 +113,3 @@
 
 /mob/living/simple_animal/drone/stripPanelEquip(obj/item/what, mob/who, where)
 	..(what, who, where, 1)
-
-/mob/living/simple_animal/drone/verb/quick_equip()
-	set name = "quick-equip"
-	set hidden = 1
-	var/obj/item/I = get_active_hand()
-	var/obj/item/weapon/storage/S = get_inactive_hand()
-	var/obj/item/weapon/storage/T = internal_storage
-	if (!I)
-		usr << "<span class='warning'>You are not holding anything to equip!</span>"
-		return
-	if(equip_to_appropriate_slot(I))
-		if(hand)
-			update_inv_l_hand()
-		else
-			update_inv_r_hand()
-	else if(s_active && s_active.can_be_inserted(I,1))	//if storage active insert there
-		s_active.handle_item_insertion(I)
-	else if(istype(S, /obj/item/weapon/storage) && S.can_be_inserted(I,1))	//see if we have box in other hand
-		S.handle_item_insertion(I)
-	else if (istype(T) && T.can_be_inserted(I,1)) // If carrying storage item like toolbox
-		T.handle_item_insertion(I)
-	else if(!internal_storage)
-		equip_to_slot(I, slot_drone_storage)
-	else
-		usr << "<span class='warning'>You are unable to equip that!</span>"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -278,30 +278,12 @@ var/next_mob_id = 0
 /mob/proc/equip_to_slot_or_del(obj/item/W, slot)
 	equip_to_slot_if_possible(W, slot, 1, 1, 0)
 
-//The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot.
-var/list/slot_equipment_priority = list( \
-		slot_back,\
-		slot_wear_id,\
-		slot_w_uniform,\
-		slot_wear_suit,\
-		slot_wear_mask,\
-		slot_head,\
-		slot_shoes,\
-		slot_gloves,\
-		slot_ears,\
-		slot_glasses,\
-		slot_belt,\
-		slot_s_store,\
-		slot_l_store,\
-		slot_r_store\
-	)
-
 //puts the item "W" into an appropriate slot in a human's inventory
 //returns 0 if it cannot, 1 if successful
 /mob/proc/equip_to_appropriate_slot(obj/item/W)
 	if(!istype(W)) return 0
 
-	for(var/slot in slot_equipment_priority)
+	for(var/slot in W.slot_equipment_priority)
 		if(equip_to_slot_if_possible(W, slot, 0, 1, 1)) //qdel_on_fail = 0; disable_warning = 0; redraw_mob = 1
 			return 1
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -282,3 +282,38 @@
 		user << "<span class='userdanger'>[src]'s contents spill all over you!</span>"
 		reagents.reaction(user, TOUCH)
 		reagents.clear_reagents()
+
+/obj/item/weapon/reagent_containers/glass/bucket/equip_to_best_slot(var/mob/M)
+	if(reagents.total_volume)
+		if(src != M.get_active_hand())
+			M << "<span class='warning'>You are not holding anything to equip!</span>"
+			return 0
+
+		if(M.s_active && M.s_active.can_be_inserted(src,1))	 //if storage active insert there
+			M.s_active.handle_item_insertion(src)
+			return 1
+
+		if(istype(M, /mob/living/simple_animal/drone))
+			var/mob/living/simple_animal/drone/D = M
+			var/obj/item/weapon/storage/T = D.internal_storage
+			if (!T)
+				if (D.equip_to_slot_if_possible(src, slot_drone_storage, 0, 1, 1))
+					return 1
+			else if (istype(T) && T.can_be_inserted(src,1)) //If carrying storage item like toolbox
+				T.handle_item_insertion(src)
+				return 1
+
+		var/obj/item/weapon/storage/S = M.get_inactive_hand()
+		if(istype(S) && S.can_be_inserted(src,1))	//see if we have box in other hand
+			S.handle_item_insertion(src)
+			return 1
+
+		S = M.get_item_by_slot(slot_back)	//else we put in backpack
+		if(istype(S) && S.can_be_inserted(src,1))
+			S.handle_item_insertion(src)
+			playsound(src.loc, "rustle", 50, 1, -5)
+			return 1
+
+		M << "<span class='warning'>You are unable to equip that!</span>"
+		return 0
+	else return ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -285,13 +285,9 @@
 
 /obj/item/weapon/reagent_containers/glass/bucket/equip_to_best_slot(var/mob/M)
 	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head
-		var/count = 0
-		for (var/slot in slot_equipment_priority)
-			count++
-			if (slot == slot_head)
-				slot[count] = null
-				break
+		var/index = slot_equipment_priority.Find(slot_head)
+		slot_equipment_priority.Remove(slot_head)
 		. = ..()
-		slot_equipment_priority[count] = slot_head
+		slot_equipment_priority.Insert(index, slot_head)
 		return
 	return ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -284,36 +284,14 @@
 		reagents.clear_reagents()
 
 /obj/item/weapon/reagent_containers/glass/bucket/equip_to_best_slot(var/mob/M)
-	if(reagents.total_volume)
-		if(src != M.get_active_hand())
-			M << "<span class='warning'>You are not holding anything to equip!</span>"
-			return 0
-
-		if(M.s_active && M.s_active.can_be_inserted(src,1))	 //if storage active insert there
-			M.s_active.handle_item_insertion(src)
-			return 1
-
-		if(istype(M, /mob/living/simple_animal/drone))
-			var/mob/living/simple_animal/drone/D = M
-			var/obj/item/weapon/storage/T = D.internal_storage
-			if (!T)
-				if (D.equip_to_slot_if_possible(src, slot_drone_storage, 0, 1, 1))
-					return 1
-			else if (istype(T) && T.can_be_inserted(src,1)) //If carrying storage item like toolbox
-				T.handle_item_insertion(src)
-				return 1
-
-		var/obj/item/weapon/storage/S = M.get_inactive_hand()
-		if(istype(S) && S.can_be_inserted(src,1))	//see if we have box in other hand
-			S.handle_item_insertion(src)
-			return 1
-
-		S = M.get_item_by_slot(slot_back)	//else we put in backpack
-		if(istype(S) && S.can_be_inserted(src,1))
-			S.handle_item_insertion(src)
-			playsound(src.loc, "rustle", 50, 1, -5)
-			return 1
-
-		M << "<span class='warning'>You are unable to equip that!</span>"
-		return 0
-	else return ..()
+	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head
+		var/count = 0
+		for (var/slot in slot_equipment_priority)
+			count++
+			if (slot == slot_head)
+				slot[count] = null
+				break
+		. = ..()
+		slot_equipment_priority[count] = slot_head
+		return
+	return ..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/12856 with the power of OBJECT ORIENTED PROGRAMMING, so the priority and slots can be redefined for any item. For example, make handcuffs go into security belt before the pockets.

Also allows any mob for which get_active_hand() is defined and returns an item to quick-equip it, provided there are valid slots. Drone quick-equip is less snowflakey. Didn't touch HUD, so it's only accessible via the hotkey for everything but humans (was already the case with drones).
