### PR TITLE
Fixes glowcaps being planted as glowshrooms

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1172,6 +1172,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 	desc = "<I>Mycena Bregprox</I>: This species of mushroom glows in the dark."
 	icon_state = "glowshroom"
 	filling_color = "#00FA9A"
+	var/effect_path = /obj/effect/glowshroom
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/New(var/loc, var/new_potency = 10)
 	..()
@@ -1197,7 +1198,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
 	if(istype(user.loc,/turf/space))
 		return
-	var/obj/effect/glowshroom/planted = new /obj/effect/glowshroom(user.loc)
+	var/obj/effect/glowshroom/planted = new effect_path(user.loc)
 	planted.delay = planted.delay - production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	planted.endurance = endurance
 	planted.yield = yield
@@ -1224,6 +1225,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 	desc = "<I>Mycena Ruthenia</I>: This species of mushroom glows in the dark, but aren't bioluminescent. They're warm to the touch..."
 	icon_state = "glowcap"
 	filling_color = "#00FA9A"
+	effect_path = /obj/effect/glowshroom/glowcap
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap/On_Consume()
 	if(!reagents.total_volume)


### PR DESCRIPTION
An oversight meant that while planted glowcaps worked fine, they'd never be created.

Wouldn't be a incoming feature pull without a bugfix patch a few days later :cry: 
