### PR TITLE
Makes the syndieborg cost similar to mechs [DNM AI NERF TRAIN HAS NOT YET LEFT]

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -249,7 +249,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Cyborg"
 	desc = "A cyborg designed and programmed for systematic extermination of non-Syndicate personnel."
 	item = /obj/item/weapon/antag_spawner/borg_tele
-	cost = 50
+	cost = 80
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 


### PR DESCRIPTION
:cl: oranges
tweak: Nanotrasen announced today that a tactical strike team had eliminated a manufacturing base where the smuggling ring and criminal organisation known as the Syndicate had been constructing illegal hacked borgs for use. Security procedures were increased across the sector, although Nanotrasen spokespeople were quick to play down the likelihood of reprisal attacks.
tweak: syndicate borgs are now increased in cost to 90tc
/:cl:
Fixes #13623 

They are now priced at 90 points, the same a gygax
