### PR TITLE
Add the lore prefix for changelogs

### DIFF
--- a/html/changelog.css
+++ b/html/changelog.css
@@ -20,6 +20,7 @@ a img {border:none;}
 .imagedel {background-image:url(image-minus.png)}
 .spellcheck {background-image:url(spell-check.png)}
 .experiment {background-image:url(burn-exclamation.png)}
+.lore {background-image:url(tick-circle.png)}
 .sansserif {font-family:Tahoma,sans-serif;font-size:12px;}
 .commit {margin-bottom:20px;font-size:100%;font-weight:normal;}
 .changes {list-style:none;margin:5px 0;padding:0 0 0 25px;font-size:0.8em;}

--- a/tools/ss13_genchangelog.py
+++ b/tools/ss13_genchangelog.py
@@ -55,7 +55,8 @@ validPrefixes = [
     'imagedel',
     'spellcheck',
     'experiment',
-    'tgs'
+    'tgs',
+    'lore',
 ]
 
 def dictToTuples(inp):


### PR DESCRIPTION
If someone has a small scroll sprite that fits with the rest of the changelog icons that would be

EGGXCELLENT
