### PR TITLE
Removes plasmic fusion (temporary until a fix is made)

### DIFF
--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -120,6 +120,7 @@ What are the archived variables for?
 					temperature -= (reaction_rate*20000)/heat_capacity()
 
 					reacting = 1
+/*
 	if(thermal_energy() > PLASMA_BINDING_ENERGY)
 		if(toxins > MINIMUM_HEAT_CAPACITY && carbon_dioxide > MINIMUM_HEAT_CAPACITY)
 			//world << "pre [temperature, [toxins], [carbon_dioxide]
@@ -143,7 +144,7 @@ What are the archived variables for?
 				if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 					temperature = (temperature*old_heat_capacity + reaction_energy)/new_heat_capacity
 				//world << "post [temperature], [toxins], [carbon_dioxide]
-
+	*/
 
 
 	fuel_burnt = 0


### PR DESCRIPTION
I understand that it is a new feature and its gonna be buggy.

However it has been buggy for nearly a month now, and currently does not add very much, if anything, to the game (it doesn't even work as a fuel source, since it kills the turbine).

When we have broken game modes or broken away missions we temporarily disable them until fixed. It's very easy to re-enable, so it shouldn't be a huge drama to turn it off temporarily until people have time to do bugfixes.
