### PR TITLE
changes robocop law priority

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -36,9 +36,9 @@
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"
-	inherent = list("Serve the public trust.",\
+	inherent = list("Uphold the law.",\
 					"Protect the innocent.",\
-					"Uphold the law.")
+					"Serve the public trust.")
 
 /datum/ai_laws/malfunction
 	name = "*ERROR*"

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -354,9 +354,9 @@ AI MODULES
 /obj/item/weapon/aiModule/core/full/robocop
 	name = "'Robo-Officer' Core AI Module"
 	origin_tech = "programming=4"
-	laws = list("Serve the public trust.",\
-				"Protect the innocent",\
-				"Uphold the law.")
+	laws = list("Uphold the law.",\
+				"Protect the innocent.",\
+				"Serve the public trust.")
 
 
 /******************** Antimov ********************/


### PR DESCRIPTION
This PR makes a change the the law priorities of the Robocop lawset. 

"Uphold the law" is moved up and "serve the public trust" is moved down.

A lot of times robocop is interpreted as a "valid the salid" lawset. This is in part due to the fact that serve the public trust is a rather vague directive. vague first laws in general have a tendency to let players just do what they want instead of adhering to the lawset.

Uphold the law is a concrete task and should make the module more interesting. Hopefully this will serve to create some nice "I am the law" AI's with all the juicy conflicts that will result. While keeping the theme and references of the lawset intact.

:cl:
edit: It has come to Nanotrasen's attention that their silicon's programmed with the Robo-Officer lawset have not been very effective at their intended purpose of enforcing the law. A change in law priorities should rectify this problem.
/:cl:
