### PR TITLE
Removes access restricitons on trinary atmos devices.

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -11,8 +11,6 @@
 
 	name = "gas filter"
 
-	req_access = list(access_atmospherics)
-
 	can_unwrench = 1
 
 	var/on = 0

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -3,9 +3,6 @@
 	density = 0
 
 	name = "gas mixer"
-
-	req_access = list(access_atmospherics)
-
 	can_unwrench = 1
 
 	var/on = 0


### PR DESCRIPTION
They are used in several maps toxins rooms and cant be used. Atmos machinery should be open and locked behind doors, not statically access restricted with no way to remove it.
