### PR TITLE
Tweaks revenant reveal times down slightly

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -24,7 +24,7 @@
 	see_in_dark = 8
 	languages = ALL
 	response_help   = "passes through"
-	response_disarm = "swings at"
+	response_disarm = "swings through"
 	response_harm   = "punches through"
 	unsuitable_atmos_damage = 0
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0) //I don't know how you'd apply those, but revenants no-sell them anyway.

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -89,10 +89,9 @@
 	charge_max = 200
 	range = 5
 	stun = 30
-	reveal = 100
 	cast_amount = 40
 	var/shock_range = 2
-	var/shock_damage = 18
+	var/shock_damage = 20
 	action_icon_state = "overload_lights"
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
@@ -217,7 +216,7 @@
 	desc = "Causes nearby living things to waste away."
 	charge_max = 200
 	range = 3
-	reveal = 60
+	reveal = 50
 	cast_amount = 50
 	unlock_amount = 200
 	action_icon_state = "blight"

--- a/code/modules/mob/living/simple_animal/revenant/revenant_blight.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_blight.dm
@@ -37,7 +37,7 @@
 		stagedamage++
 		affected_mob.adjustToxLoss(stage*3) //should, normally, do about 45 toxin damage.
 		PoolOrNew(/obj/effect/overlay/temp/revenant, affected_mob.loc)
-	if(prob(45))
+	if(!finalstage && prob(45))
 		affected_mob.adjustStaminaLoss(stage*2)
 	..() //So we don't increase a stage before applying the stage damage.
 	switch(stage)


### PR DESCRIPTION
Fixes blight still doing stamina damage at final stage.
:cl: Joan
tweak: Revenant Overload Lights reveal time lowered from 10 seconds to 8 seconds, shock damage increased from 18 to 20.
tweak: Revenant Blight reveal time lowered from 6 seconds to 5 seconds.
/:cl:
