### PR TITLE
Beepsky will no longer hunt aliens.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -38,6 +38,9 @@
 	AddAbility(new/obj/effect/proc_holder/alien/nightvisiontoggle(null))
 	..()
 
+/mob/living/carbon/alien/assess_threat() // beepsky won't hunt aliums
+	return -10
+
 /mob/living/carbon/alien/adjustToxLoss(amount)
 	return
 


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/12894. Beepsky can't do shit to aliums in the first place, this is just to fix variable bugs / remove fun.

edit: I guess this removes tactical beepskying on the part of aliums trying to trip people as they run away but if anyone powergames hard enough to do that they deserve to have it taken away
