### PR TITLE
The Mulligan (traitor item)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -552,7 +552,8 @@ var/list/uplink_items = list()
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about 5 minutes after injection."
 	item = /obj/item/weapon/reagent_containers/syringe/stimulants
 	cost = 5
-
+	surplus = 90
+	
 /datum/uplink_item/stealthy_tools/mulligan
 	name = "Mulligan"
 	desc = "Screwed up and have security on your tail? This handy syringe will give you a completely new identity and appearance."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -559,6 +559,7 @@ var/list/uplink_items = list()
 	desc = "Screwed up and have security on your tail? This handy syringe will give you a completely new identity and appearance."
 	item = /obj/item/weapon/reagent_containers/syringe/mulligan
 	cost = 4
+	excludefrom = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 
 // DEVICE AND TOOLS
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -552,7 +552,12 @@ var/list/uplink_items = list()
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about 5 minutes after injection."
 	item = /obj/item/weapon/reagent_containers/syringe/stimulants
 	cost = 5
-	surplus = 90
+
+/datum/uplink_item/stealthy_tools/mulligan
+	name = "Mulligan"
+	desc = "Screwed up and have security on your tail? This handy syringe will give you a completely new identity and appearance."
+	item = /obj/item/weapon/reagent_containers/syringe/mulligan
+	cost = 4
 
 // DEVICE AND TOOLS
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -11,6 +11,8 @@
 			new /obj/item/device/camera_bug(src)
 			new /obj/item/device/multitool/ai_detect(src)
 			new /obj/item/device/encryptionkey/syndicate(src)
+			new /obj/item/weapon/reagent_containers/syringe/mulligan(src)
+			new /obj/item/weapon/switchblade
 			return
 
 		if("stealth")

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -12,7 +12,7 @@
 			new /obj/item/device/multitool/ai_detect(src)
 			new /obj/item/device/encryptionkey/syndicate(src)
 			new /obj/item/weapon/reagent_containers/syringe/mulligan(src)
-			new /obj/item/weapon/switchblade
+			new /obj/item/weapon/switchblade(src)
 			return
 
 		if("stealth")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -379,6 +379,20 @@
 		H << "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>"
 	return 1
 
+/datum/reagent/mulligan
+	name = "Mulligan Toxin"
+	id = "mulligan"
+	description = "This toxin will rapidly change the DNA of human beings. Commonly used by Syndicate spies and assassins in need of an emergency ID change."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	metabolization_rate = INFINITY
+
+/datum/reagent/mulligan/on_mob_life(mob/living/carbon/human/H)
+	..()
+	H << "<span class='warning'><b>You grit your teeth in pain as your body rapidly mutates!</b></span>"
+	H.visible_message("<b>[H]</b> suddenly transforms!")
+	randomize_human(H)
+	return 1
+
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
 	id = "amutationtoxin"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -240,3 +240,10 @@
 
 /obj/item/weapon/reagent_containers/syringe/lethal/choral
 	list_reagents = list("chloralhydrate" = 50)
+
+/obj/item/weapon/reagent_containers/syringe/mulligan
+	name = "Mulligan"
+	desc = "A syringe used to completely change the users identity."
+	amount_per_transfer_from_this = 1
+	volume = 1
+	list_reagents = list("mulligan" = 1)


### PR DESCRIPTION
A syringe which completely randomizes your name and appearance.

4tc

:cl: Kor
rscadd:  Traitors can now buy a Mulligan for 4 telecrystals, a syringe that completely randomizes your name and appearance.
rscadd:  The spy bundle now includes a switchblade and Mulligan.
/:cl:
