### PR TITLE
Alternate completion to Escape Alive objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -300,6 +300,8 @@
 		return 0
 	if(ticker.force_ending) //This one isn't their fault, so lets just assume good faith
 		return 1
+	if(ticker.mode.station_was_nuked) //If they escaped the blast somehow, let them win
+		return 1
 	if(SSshuttle.emergency.mode < SHUTTLE_ENDGAME)
 		return 0
 	var/turf/location = get_turf(owner.current)


### PR DESCRIPTION
If the station was nuked, and you escaped the blast, you count as escaping alive regardless of your location.

@duncathan 

:cl: Kor
rscadd: If the station is destroyed in a nuclear blast, any surviving traitors will complete their "escape alive" objective regardless of their location.
/:cl:
