### PR TITLE
Hulks now lose hulk on crit

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -137,11 +137,9 @@
 	return visual_indicators[g]
 
 /datum/mutation/human/hulk/on_life(mob/living/carbon/human/owner)
-	if(owner.health < 25)
+	if(owner.health < 0)
 		on_losing(owner)
 		owner << "<span class='danger'>You suddenly feel very weak.</span>"
-		owner.Weaken(3)
-		owner.emote("collapse")
 
 /datum/mutation/human/hulk/on_losing(mob/living/carbon/human/owner)
 	if(..())


### PR DESCRIPTION
Instead of at 25 health. No reason for them to have less health if they don't have stun punches

:cl: Kor
rscadd: Hulks now lose hulk when going into crit, rather than at 25 health.
/:cl:
