### PR TITLE
Shuttle movement tweaks

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -1,6 +1,7 @@
 /turf/space/transit
 	icon_state = "black"
 	dir = SOUTH
+	baseturf = /turf/space/transit
 
 /turf/space/transit/horizontal
 	dir = WEST

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -349,51 +349,50 @@
 			continue
 		if(T0.type != T0.baseturf) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
 			T0.copyTurf(T1)
-		areaInstance.contents += T1
+			areaInstance.contents += T1
 
-		//copy over air
-		if(istype(T1, /turf/simulated))
-			var/turf/simulated/Ts1 = T1
-			Ts1.copy_air_with_tile(T0)
+			//copy over air
+			if(istype(T1, /turf/simulated))
+				var/turf/simulated/Ts1 = T1
+				Ts1.copy_air_with_tile(T0)
 
-		//move mobile to new location
+			//move mobile to new location
 
 
+			for(var/atom/movable/AM in T0)
+				if (rotation)
+					AM.shuttleRotate(rotation)
 
-		for(var/atom/movable/AM in T0)
-			if (rotation)
-				AM.shuttleRotate(rotation)
+				if (istype(AM,/obj))
+					var/obj/O = AM
+					if(O.invisibility >= 101)
+						continue
+					if(O == T0.lighting_object)
+						continue
+					O.loc = T1
 
-			if (istype(AM,/obj))
-				var/obj/O = AM
-				if(O.invisibility >= 101)
-					continue
-				if(O == T0.lighting_object)
-					continue
-				O.loc = T1
+					//close open doors
+					if(istype(O, /obj/machinery/door))
+						var/obj/machinery/door/Door = O
+						spawn(-1)
+							if(Door)
+								Door.close()
+				else if (istype(AM,/mob))
+					var/mob/M = AM
+					if(!M.move_on_shuttle)
+						continue
+					M.loc = T1
 
-				//close open doors
-				if(istype(O, /obj/machinery/door))
-					var/obj/machinery/door/Door = O
-					spawn(-1)
-						if(Door)
-							Door.close()
-			else if (istype(AM,/mob))
-				var/mob/M = AM
-				if(!M.move_on_shuttle)
-					continue
-				M.loc = T1
-
-				//docking turbulence
-				if(M.client)
-					spawn(0)
-						if(M.buckled)
-							shake_camera(M, 2, 1) // turn it down a bit come on
-						else
-							shake_camera(M, 7, 1)
-				if(istype(M, /mob/living/carbon))
-					if(!M.buckled)
-						M.Weaken(3)
+					//docking turbulence
+					if(M.client)
+						spawn(0)
+							if(M.buckled)
+								shake_camera(M, 2, 1) // turn it down a bit come on
+							else
+								shake_camera(M, 7, 1)
+					if(istype(M, /mob/living/carbon))
+						if(!M.buckled)
+							M.Weaken(3)
 
 
 		if (rotation)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -347,8 +347,8 @@
 		var/turf/T1 = L1[i]
 		if(!T1)
 			continue
-
-		T0.copyTurf(T1)
+		if(T0.type != T0.baseturf) //So if there is a hole in the shuttle we don't drag along the space/asteroid/etc to wherever we are going next
+			T0.copyTurf(T1)
 		areaInstance.contents += T1
 
 		//copy over air


### PR DESCRIPTION
Shuttles now check that the turf they are moving is not the baseturf. If its the baseturf, it wont move/copy that turf.

In simpler terms, if you poke a hole to the shuttle (and make space, which has a baseturf of space) that tile wont "move" with the shuttle/replace what is at the other end.

So if you blow up half the escape shuttle, and fly it to lavaland it wont drag space with it.

More immediately this means the escape shuttle will break to transit space instead of carrying around blocks of still space, making destroyed shuttles extra dangerous to be on.

Objects on said broken spots wont move either

Tested this with the emergency shuttle and unless a mapper did somethinf terrible it should work with all shuttles.

:cl: Kor
rscadd: Shuttles will no longer drag random tiles of space with them. This means you can be thrown out of partially destroyed escape shuttles very easily.
rscadd: The people and objects on destroyed tiles won't be along for the ride when the shuttle moves either. 
/:cl:
