### PR TITLE
Ghosts can now double click on ANY movable thing (ie: not a turf) to orbit it

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -20,7 +20,7 @@
 			return									// seems legit.
 
 	// Things you might plausibly want to follow
-	if((ismob(A) && A != src) || istype(A,/obj/singularity))
+	if(istype(A, /atom/movable))
 		ManualFollow(A)
 
 	// Otherwise jump


### PR DESCRIPTION
:cl:
tweak: Ghosts can now double click on ANY movable thing (ie: not a turf) to orbit it
/:cl:
