### PR TITLE
Reduces cooldown of the Bluespace Artillery on the space battle away mission

### DIFF
--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -60,4 +60,4 @@
 	for(var/turf/T in get_area_turfs(thearea.type))
 		L+=T
 	var/loc = pick(L)
-	explosion(loc,2,5,11)*
+	explosion(loc,2,5,11)*/

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -1,8 +1,8 @@
 
-#define artillery_reload_time 60
+#define ARTILLERY_RELOAD_TIME 60
 
 /obj/machinery/artillerycontrol
-	var/reload = artillery_reload_time
+	var/reload = ARTILLERY_RELOAD_TIME
 	name = "bluespace artillery control"
 	icon_state = "control_boxp1"
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
@@ -10,7 +10,7 @@
 	anchored = 1
 
 /obj/machinery/artillerycontrol/process()
-	if(src.reload<artillery_reload_time)
+	if(src.reload<ARTILLERY_RELOAD_TIME)
 		src.reload++
 
 /obj/structure/artilleryplaceholder
@@ -26,7 +26,7 @@
 	user.set_machine(src)
 	var/dat = "<B>Bluespace Artillery Control:</B><BR>"
 	dat += "Locked on<BR>"
-	dat += "<B>Charge progress: [reload]/[artillery_reload_time]:</B><BR>"
+	dat += "<B>Charge progress: [reload]/[ARTILLERY_RELOAD_TIME]:</B><BR>"
 	dat += "<A href='byond://?src=\ref[src];fire=1'>Open Fire</A><BR>"
 	dat += "Deployment of weapon authorized by <br>Nanotrasen Naval Command<br><br>Remember, friendly fire is grounds for termination of your contract and life.<HR>"
 	user << browse(dat, "window=scroll")
@@ -40,7 +40,7 @@
 	A = input("Area to jump bombard", "Open Fire", A) in teleportlocs
 	var/area/thearea = teleportlocs[A]
 	if (usr.stat || usr.restrained()) return
-	if(src.reload < artillery_reload_time) return
+	if(src.reload < ARTILLERY_RELOAD_TIME) return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		priority_announce("Bluespace artillery fire detected. Brace for impact.")
 		message_admins("[key_name_admin(usr)] has launched an artillery strike.")

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -1,6 +1,8 @@
 
+#define artillery_reload_time 60
+
 /obj/machinery/artillerycontrol
-	var/reload = 60
+	var/reload = artillery_reload_time
 	name = "bluespace artillery control"
 	icon_state = "control_boxp1"
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
@@ -8,7 +10,7 @@
 	anchored = 1
 
 /obj/machinery/artillerycontrol/process()
-	if(src.reload<60)
+	if(src.reload<artillery_reload_time)
 		src.reload++
 
 /obj/structure/artilleryplaceholder
@@ -24,7 +26,7 @@
 	user.set_machine(src)
 	var/dat = "<B>Bluespace Artillery Control:</B><BR>"
 	dat += "Locked on<BR>"
-	dat += "<B>Charge progress: [reload]/60:</B><BR>"
+	dat += "<B>Charge progress: [reload]/[artillery_reload_time]:</B><BR>"
 	dat += "<A href='byond://?src=\ref[src];fire=1'>Open Fire</A><BR>"
 	dat += "Deployment of weapon authorized by <br>Nanotrasen Naval Command<br><br>Remember, friendly fire is grounds for termination of your contract and life.<HR>"
 	user << browse(dat, "window=scroll")
@@ -38,7 +40,7 @@
 	A = input("Area to jump bombard", "Open Fire", A) in teleportlocs
 	var/area/thearea = teleportlocs[A]
 	if (usr.stat || usr.restrained()) return
-	if(src.reload < 60) return
+	if(src.reload < artillery_reload_time) return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		priority_announce("Bluespace artillery fire detected. Brace for impact.")
 		message_admins("[key_name_admin(usr)] has launched an artillery strike.")

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -60,4 +60,4 @@
 	for(var/turf/T in get_area_turfs(thearea.type))
 		L+=T
 	var/loc = pick(L)
-	explosion(loc,2,5,11)*/
+	explosion(loc,2,5,11)*

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -1,6 +1,6 @@
 
 /obj/machinery/artillerycontrol
-	var/reload = 180
+	var/reload = 60
 	name = "bluespace artillery control"
 	icon_state = "control_boxp1"
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
@@ -8,7 +8,7 @@
 	anchored = 1
 
 /obj/machinery/artillerycontrol/process()
-	if(src.reload<180)
+	if(src.reload<60)
 		src.reload++
 
 /obj/structure/artilleryplaceholder
@@ -24,7 +24,7 @@
 	user.set_machine(src)
 	var/dat = "<B>Bluespace Artillery Control:</B><BR>"
 	dat += "Locked on<BR>"
-	dat += "<B>Charge progress: [reload]/180:</B><BR>"
+	dat += "<B>Charge progress: [reload]/60:</B><BR>"
 	dat += "<A href='byond://?src=\ref[src];fire=1'>Open Fire</A><BR>"
 	dat += "Deployment of weapon authorized by <br>Nanotrasen Naval Command<br><br>Remember, friendly fire is grounds for termination of your contract and life.<HR>"
 	user << browse(dat, "window=scroll")
@@ -38,7 +38,7 @@
 	A = input("Area to jump bombard", "Open Fire", A) in teleportlocs
 	var/area/thearea = teleportlocs[A]
 	if (usr.stat || usr.restrained()) return
-	if(src.reload < 180) return
+	if(src.reload < 60) return
 	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
 		priority_announce("Bluespace artillery fire detected. Brace for impact.")
 		message_admins("[key_name_admin(usr)] has launched an artillery strike.")


### PR DESCRIPTION
180 Byond seconds seems a little too long, considering this is one of the hardest away missions, this reduces it to a third, 60 Byond seconds.

I've never seen a group succeed at this mission before, and the only solo antag that could reasonably do it is a Changeling, and it would take 10-20 minutes at least. Since it is so incredibly difficult, getting essentially 2-3 shots in a 10 minute period seems a little unfair.
