### PR TITLE
Cleans up turf/get_lumcount

### DIFF
--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -342,17 +342,10 @@
 	lighting_changed = 0
 
 /turf/proc/get_lumcount()
-	var/light_amount
-	if(!src || !istype(src))
-		return
+	. = LIGHTING_CAP
 	var/area/A = src.loc
-	if(!A || !istype(src))
-		return
 	if(IS_DYNAMIC_LIGHTING(A))
 		light_amount = src.lighting_lumcount
-	else
-		light_amount =  LIGHTING_CAP
-	return light_amount
 
 /area
 	var/lighting_use_dynamic = DYNAMIC_LIGHTING_ENABLED	//Turn this flag off to make the area fullbright

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -345,7 +345,7 @@
 	. = LIGHTING_CAP
 	var/area/A = src.loc
 	if(IS_DYNAMIC_LIGHTING(A))
-		light_amount = src.lighting_lumcount
+		. = src.lighting_lumcount
 
 /area
 	var/lighting_use_dynamic = DYNAMIC_LIGHTING_ENABLED	//Turn this flag off to make the area fullbright


### PR DESCRIPTION
I'm going to just declare that any case where a turf's loc isn't an area to be a bug that lighting code shouldn't be hiding
