### PR TITLE
Penetrator rounds for sniper rifles

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -389,7 +389,11 @@ var/list/uplink_items = list()
 	desc = "A 5-round magazine of haemorrhage ammo designed for use in the syndicate sniper rifle, causes heavy bleeding in the target."
 	item = /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage
 
-
+/datum/uplink_item/ammo/sniper/penetrator
+	name = "Sniper Magazine - Penetrator Rounds"
+	desc = "A 5-round magazine of penetrator ammo designed for use in the syndicate sniper rifle. Can pierce walls and multiple enemies."
+	item = /obj/item/ammo_box/magazine/sniper_rounds/penetrator
+	cost = 5
 
 // STEALTHY WEAPONS
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -132,3 +132,25 @@
 		H.drip(100)
 
 	return ..()
+
+
+//penetrator ammo
+/obj/item/ammo_box/magazine/sniper_rounds/penetrator
+	name = "sniper rounds (penetrator)"
+	desc = "An extremely powerful round capable of passing straight through cover and anyone unfortunate enough to be behind it."
+	ammo_type = /obj/item/ammo_casing/penetrator
+	max_ammo = 5
+
+/obj/item/ammo_casing/penetrator
+	desc = "A .50 caliber penetrator round casing."
+	caliber = ".50"
+	projectile_type = /obj/item/projectile/bullet/sniper/penetrator
+	icon_state = ".50"
+
+/obj/item/projectile/bullet/sniper/penetrator
+	name = "penetrator round"
+	damage = 60
+	forcedodge = 1
+	stun = 0
+	weaken = 0
+	breakthings = FALSE


### PR DESCRIPTION
They do a bit less damage than the normal rounds, and they don't stun, but they can pass through walls/mobs like an xray beam.

@RemieRichards do you have objections this since its your thing

This could serve as an alternate AI kill without having to buy a syndiborg

:cl: Kor
rscadd: Nuke Ops can now purchase penetrator rounds for their sniper rifles.
/:cl:
