### PR TITLE
Makes holoparasites vulnerable to EMPs

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -96,6 +96,13 @@
 		if(3)
 			adjustBruteLoss(30)
 
+/mob/living/simple_animal/hostile/guardian/emp_act(severity)
+	if (loc != summoner)
+		adjustBruteLoss(20)
+		if (prob(50))
+			src << "<span class=danger'><B>You are forced to retreat in order to prevent further damage from the EMP.</span></B>"
+			src.Recall(forced = 1)
+
 /mob/living/simple_animal/hostile/guardian/gib()
 	if(summoner)
 		summoner << "<span class='danger'><B>Your [src] was blown up!</span></B>"
@@ -117,8 +124,8 @@
 			spawn(6)
 			icon_state = end_icon
 
-/mob/living/simple_animal/hostile/guardian/proc/Recall()
-	if(cooldown > world.time)
+/mob/living/simple_animal/hostile/guardian/proc/Recall(forced = 0)
+	if(cooldown > world.time && forced == 0)
 		return
 	loc = summoner
 	buckled = null

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -1,3 +1,5 @@
+#define EMP_WEAKEN_FACTOR 1.15
+
 /mob/living/simple_animal/hostile/guardian
 	name = "Guardian Spirit"
 	real_name = "Guardian Spirit"
@@ -98,10 +100,10 @@
 
 /mob/living/simple_animal/hostile/guardian/emp_act(severity)
 	if (loc != summoner)
-		adjustBruteLoss(20)
-		if (prob(50))
-			src << "<span class=danger'><B>You are forced to retreat in order to prevent further damage from the EMP.</span></B>"
-			src.Recall(forced = 1)
+		damage_transfer = damage_transfer * EMP_WEAKEN_FACTOR
+		src << "<span class='danger'><B>The EMP renders you more vulnerable, and forces you to flee to shelter!</B></span>"
+		summoner << "<span class='danger'><B>Your [name] has been EMPed, and forced to retreat! Protect it from further EMPs!</B></span>"
+		Recall(forced = 1)
 
 /mob/living/simple_animal/hostile/guardian/gib()
 	if(summoner)
@@ -813,3 +815,5 @@
 	if(isguardian(usr))
 		var/mob/living/simple_animal/hostile/guardian/G = usr
 		G.ToggleLight()
+
+#undef EMP_WEAKEN_FACTOR


### PR DESCRIPTION
:cl:
tweak: Manufacturing cost concerns have resulted in newly produced holoparasites suffering a significant vulnerability to EMPs. Crews are now recommended to engage with the station's ion rifle.
/:cl:
Alternative solution to nerfing holoparasites, instead of increasing the cost, to give them a significant vulnerability.
Every hit from the ion rifle multiplies the damage_transfer of the stand by a factor of 1.15, and forces it to recall. Forced recalls will not respect the usual cooldown.
