### PR TITLE
Blobbernaut chem attacks 2, return of the chem attack

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -144,7 +144,7 @@
 	maxHealth = 240
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	attacktext = "hits"
+	attacktext = "slams"
 	attack_sound = 'sound/effects/blobattack.ogg'
 	speak_emote = list("gurgles")
 	minbodytemp = 0
@@ -153,6 +153,25 @@
 	environment_smash = 3
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = 1
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/AttackingTarget()
+	if(isliving(target))
+		if(overmind)
+			var/mob/living/L = target
+			var/mob_protection = L.get_permeability_protection()
+			overmind.blob_reagent_datum.reaction_mob(L, VAPOR, 17.5, 0, mob_protection)//this will do between 7 and 17 damage(reduced by mob protection), depending on chemical, plus 4 from base brute damage.
+	..()
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/update_icons()
+	..()
+	if(overmind) //if we have an overmind, we're doing chemical reactions instead of pure damage
+		melee_damage_lower = 4
+		melee_damage_upper = 4
+		attacktext = overmind.blob_reagent_datum.blobbernaut_message
+	else
+		melee_damage_lower = initial(melee_damage_lower)
+		melee_damage_upper = initial(melee_damage_upper)
+		attacktext = initial(attacktext)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/death(gibbed)
 	..(gibbed)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -8,22 +8,22 @@
 	explosion_block = 6
 	point_return = -1
 	atmosblock = 1
-	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
+	var/overmind_get_delay = 0 //we don't want to constantly try to find an overmind, this var tracks when we'll try to get an overmind again
 	var/resource_delay = 0
 	var/point_rate = 2
-	var/is_offspring = null
+	var/is_offspring = 0
 
 
 /obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
 	blob_cores += src
 	SSobj.processing |= src
 	update_icon() //so it atleast appears
+	if(offspring)
+		is_offspring = 1
 	if(!overmind)
 		create_overmind(new_overmind)
 	if(overmind)
 		update_icon()
-	if(offspring)
-		is_offspring = 1
 	point_rate = new_rate
 	..(loc, h)
 
@@ -79,7 +79,6 @@
 		var/obj/effect/blob/normal/B = locate() in get_step(src, b_dir)
 		if(B)
 			B.change_to(/obj/effect/blob/shield, overmind)
-	color = null
 	..()
 
 
@@ -87,7 +86,7 @@
 	if(overmind_get_delay > world.time && !override_delay)
 		return
 
-	overmind_get_delay = world.time + 300 // 30 seconds
+	overmind_get_delay = world.time + 150 //if this fails, we'll try again in 15 seconds
 
 	if(overmind)
 		qdel(overmind)
@@ -107,11 +106,9 @@
 		B.key = C.key
 		B.blob_core = src
 		src.overmind = B
-		color = overmind.blob_reagent_datum.color
 		if(B.mind && !B.mind.special_role)
 			B.mind.special_role = "Blob Overmind"
-		spawn(0)
-			if(is_offspring)
-				B.verbs -= /mob/camera/blob/verb/split_consciousness
+		if(is_offspring)
+			B.verbs -= /mob/camera/blob/verb/split_consciousness
 		return 1
 	return 0

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -98,8 +98,8 @@
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
 	if(blobber)
 		qdel(B)
-	blobber.color = blob_reagent_datum.color
 	blobber.overmind = src
+	blobber.update_icons()
 	blob_mobs.Add(blobber)
 
 /mob/camera/blob/verb/relocate_core()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -62,10 +62,10 @@
 	return 0
 
 
-/obj/effect/blob/proc/check_health()
+/obj/effect/blob/proc/check_health(cause)
 	if(health <= 0)
 		if(overmind)
-			overmind.blob_reagent_datum.death_reaction(src)
+			overmind.blob_reagent_datum.death_reaction(src, cause)
 		qdel(src) //we dead now
 		return
 	return
@@ -181,12 +181,12 @@
 /obj/effect/blob/ex_act(severity, target)
 	..()
 	var/damage = 150 - 20 * severity
-	take_damage(damage, BRUTE, "explosion")
+	take_damage(damage, BRUTE)
 
 /obj/effect/blob/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
 	var/damage = Clamp(0.01 * exposed_temperature, 0, 4)
-	take_damage(damage, BURN, "fire")
+	take_damage(damage, BURN)
 
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
 	..()
@@ -232,7 +232,7 @@
 		overmind.blob_reagent_datum.damage_reaction(src, health, damage, damage_type, cause) //pass the blob, its health before damage, the damage being done, the type of damage being done, and the cause.
 	health -= damage
 	update_icon()
-	check_health()
+	check_health(cause)
 
 /obj/effect/blob/proc/change_to(type, controller)
 	if(!ispath(type))

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -2,6 +2,7 @@
 /datum/reagent/blob
 	name = "Unknown"
 	description = "shouldn't exist and you should adminhelp immediately."
+	var/blobbernaut_message = "slams" //blobbernaut attack verb
 	var/message = "The blob strikes you" //message sent to any mob hit by the blob
 	var/message_living = null //extension to first mob sent to only living mobs i.e. silicons have no skin to be burnt
 
@@ -11,7 +12,7 @@
 /datum/reagent/blob/proc/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause) //when the blob takes damage, do this
 	return
 
-/datum/reagent/blob/proc/death_reaction(obj/effect/blob/B) //when a blob dies, do this
+/datum/reagent/blob/proc/death_reaction(obj/effect/blob/B, cause) //when a blob dies, do this
 	return
 
 /datum/reagent/blob/proc/expand_reaction(obj/effect/blob/B, turf/T) //when the blob expands, do this
@@ -23,6 +24,7 @@
 	id = "ripping_tendrils"
 	description = "will do medium brute and stamina damage."
 	color = "#7F0000"
+	blobbernaut_message = "rips"
 	message_living = ", and you feel your skin ripping and tearing off"
 
 /datum/reagent/blob/ripping_tendrils/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
@@ -38,6 +40,7 @@
 	id = "energized_fibers"
 	description = "will do low burn, high stamina damage, and react to stamina damage."
 	color = "#FFDC73"
+	blobbernaut_message = "shocks"
 	message_living = ", and you feel a strong tingling sensation"
 
 /datum/reagent/blob/energized_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
@@ -56,6 +59,7 @@
 	id = "boiling_oil"
 	description = "will cause medium burn damage and set targets on fire."
 	color = "#B68D00"
+	blobbernaut_message = "splashes"
 	message = "The blob splashes you with burning oil"
 	message_living = ", and you feel your skin char and melt"
 
@@ -73,6 +77,8 @@
 	id = "hallucinogenic_nectar"
 	description = "will cause low toxin damage, vivid hallucinations, and inject targets with toxins."
 	color = "#CD7794"
+	blobbernaut_message = "splashes"
+	message = "The blob splashes you with sticky nectar"
 	message_living = ", and you feel really good"
 
 /datum/reagent/blob/hallucinogenic_nectar/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
@@ -109,8 +115,8 @@
 /datum/reagent/blob/lexorin_jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	M.apply_damage(0.4*reac_volume, BRUTE)
-	M.apply_damage(1*reac_volume, OXY)
-	M.losebreath += round(0.3*reac_volume)
+	M.apply_damage(0.6*reac_volume, OXY)
+	M.losebreath += round(0.2*reac_volume)
 
 //does semi-random brute damage and reacts to brute damage
 /datum/reagent/blob/reactive
@@ -118,6 +124,7 @@
 	id = "reactive_gelatin"
 	description = "will do high brute damage and react to brute damage."
 	color = "#FFA500"
+	blobbernaut_message = "pummels"
 	message = "The blob pummels you"
 
 /datum/reagent/blob/reactive/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
@@ -137,6 +144,7 @@
 	id = "cryogenic_liquid"
 	description = "will cause low burn damage, stamina damage, and cause targets to freeze."
 	color = "#8BA6E9"
+	blobbernaut_message = "splashes"
 	message = "The blob splashes you with an icy liquid"
 	message_living = ", and you feel cold and tired"
 
@@ -154,6 +162,7 @@
 	id = "pressurized_slime"
 	description = "will cause low brute damage, oxygen damage, stamina damage, and wet tiles when damaged or killed."
 	color = "#AAAABB"
+	blobbernaut_message = "emits slime at"
 	message = "The blob splashes into you"
 	message_living = ", and you gasp for breath"
 
@@ -171,8 +180,9 @@
 		if(prob(damage))
 			T.MakeSlippery(TURF_WET_WATER)
 
-/datum/reagent/blob/pressurized_slime/death_reaction(obj/effect/blob/B)
-	B.visible_message("<span class='warning'><b>The blob ruptures, spraying the area with liquid!</b></span>")
+/datum/reagent/blob/pressurized_slime/death_reaction(obj/effect/blob/B, cause)
+	if(!isnull(cause))
+		B.visible_message("<span class='warning'><b>The blob ruptures, spraying the area with liquid!</b></span>")
 	for(var/turf/simulated/T in range(1, B))
 		if(prob(90))
 			T.MakeSlippery(TURF_WET_WATER)

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -23,7 +23,7 @@
 	name = "Ripping Tendrils"
 	id = "ripping_tendrils"
 	description = "will do medium brute and stamina damage."
-	color = "#7F0000"
+	color = "#890000"
 	blobbernaut_message = "rips"
 	message_living = ", and you feel your skin ripping and tearing off"
 
@@ -109,7 +109,7 @@
 	name = "Lexorin Jelly"
 	id = "lexorin_jelly"
 	description = "will cause low brute damage, high oxygen damage, and cause targets to be unable to breathe."
-	color = "#00FFC5"
+	color = "#00E5B1"
 	message_living = ", and your lungs feel heavy and weak"
 
 /datum/reagent/blob/lexorin_jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume)


### PR DESCRIPTION
:cl: Joan
tweak: Reduces Lexorin Jelly's oxygen damage significantly.
experiment: Blobbernaut chemical application on attack is back, but much less absurd this time; blobbernauts with an overmind will do 70% of the normal chem damage(plus 4) and attack at a much slower rate than the blob itself can.
wip: As an example, a blobbernaut with the Ripping Tendrils chemical would do 14.5 brute and 10.5 stamina damage per hit.
/:cl:

Lexorin Jelly is slightly darker, Ripping Tendrils is slightly brighter.
Fixes Pressurized Slime giving a message when killed by fire or an explosion.
Fixes core blobs to not need a spawn(0) and a few other fixes.
Lowers core blob overmind get delay to 15 seconds.

Full list of blobbernaut hits to crit/stun, assuming no attempts to escape, armor, or bio protection;
CURRENT/NO OVERMIND: 5 to crit
Ripping Tendrils; 7 to crit, stun at 5
Reactive Gelatin; 5 to 10 to crit, Average of 7(not 7.5)
Energized Fibers; 10 to crit, stun at 5
Boiling Oil; 6 to crit
Sorium; 7 to crit, assuming no nearby walls
Envenomed Filaments; 7 to crit, stun at 5
Lexorin Jelly(AFTER NERF), 4 to crit
Cryogenic Liquid; 9 to crit, stun at 7
Dark Matter; 7 to crit, assuming no nearby objects
Hallucinogenic Nectar; 8 to crit
Pressurized Slime; 7 to crit, stun at 5
