### PR TITLE
get_turf_pixel() improvements and matrix helpers

### DIFF
--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -24,3 +24,40 @@
 		animate(transform = matrices[i], time = speed)
 		//doesn't have an object argument because this is "Stacking" with the animate call above
 		//3 billion% intentional
+
+
+//Dumps the matrix data in format a-f
+/matrix/proc/tolist()
+	. = list()
+	. += a
+	. += b
+	. += c
+	. += d
+	. += e
+	. += f
+
+//Dumps the matrix data in a matrix-grid format
+/*
+  a d 0
+  b e 0
+  c f 1
+*/
+/matrix/proc/togrid()
+	. = list()
+	. += a
+	. += d
+	. += 0
+	. += b
+	. += e
+	. += 0
+	. += c
+	. += f
+	. += 1
+
+//The X pixel offset of this matrix
+/matrix/proc/get_x_shift()
+	. = c
+
+//The Y pixel offset of this matrix
+/matrix/proc/get_y_shift()
+	. = f


### PR DESCRIPTION
get_turf_pixel() is now more accurate:
- returns a turf closer to the center in even multiples of world.icon_size (64,128, etc.)
- Handles irregular (non-world.icon_size sized objects) better
- Now handles Matrix X/Y shifts

Adds some matrix helpers:
- `tolist()`: returns the matrix as a list, in a-f format (leaving off the 0,0,1 that 3D Matrices use)
- `togrid()`: returns the matrix as a list, in ad0be0cf1 format (keeping the 0,0,1 that 3D Matrices use)
- `get_x_shift()`: returns the x pixel shift this matrix represents (the f component)
- `get_y_shift()`: returns the y pixel shift this matrix represents (the c component)
