### PR TITLE
Orbit fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1227,6 +1227,9 @@ B --><-- A
 	transform = shift
 
 	SpinAnimation(rotation_speed, -1, clockwise, rotation_segments)
+	
+	//we stack the orbits up client side, so we can assign this back to normal server side without it breaking the orbit
+	transform = initial_transform
 	while(orbiting && orbiting.loc)
 		var/targetloc = get_turf(orbiting)
 		if(!lockinorbit && loc != lastloc && loc != targetloc)
@@ -1236,7 +1239,6 @@ B --><-- A
 		sleep(0.6)
 	
 	orbiting = null
-	animate(src,transform = initial_transform, time = 2) //2 second delay
 	SpinAnimation(0,0)
 
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1234,7 +1234,8 @@ B --><-- A
 		loc = targetloc
 		lastloc = loc
 		sleep(0.6)
-
+	
+	orbiting = null
 	animate(src,transform = initial_transform, time = 2) //2 second delay
 	SpinAnimation(0,0)
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1207,7 +1207,6 @@ B --><-- A
 
 	if(orbiting)
 		stop_orbit()
-		sleep(2.6+world.tick_lag) //the 2 second delay at the end of the existing orbit() call, plus some lag slack.
 
 	orbiting = A
 	var/matrix/initial_transform = matrix(transform)
@@ -1230,15 +1229,16 @@ B --><-- A
 	
 	//we stack the orbits up client side, so we can assign this back to normal server side without it breaking the orbit
 	transform = initial_transform
-	while(orbiting && orbiting.loc)
-		var/targetloc = get_turf(orbiting)
+	while(orbiting && orbiting == A && A.loc)
+		var/targetloc = get_turf(A)
 		if(!lockinorbit && loc != lastloc && loc != targetloc)
 			break
 		loc = targetloc
 		lastloc = loc
 		sleep(0.6)
 	
-	orbiting = null
+	if (orbiting == A)
+		orbiting = null
 	SpinAnimation(0,0)
 
 


### PR DESCRIPTION
Fixes being able to break your transform from consecutive orbits

Readds PR #12717 (Clear orbiting var on exit), this fixes the following:

Fixes ghost orbit breaking ghost floating

Fixes orbiting ever breaking golem spawning

Fixes orbiting ever preventing that ghost from showing up in pictures taken by ghost cameras

:cl:
fix: Fixes ghost orbit breaking ghost floating
fix: Fixes orbiting ever breaking golem spawning
fix: Fixes orbiting ever preventing that ghost from showing up in pictures taken by ghost cameras
resdel: Fixes being able to break your ghost sprite by multiple quick consecutive orbits (FINAL SOLUTION, PROVE ME WRONG YOU CAN'T)
/:cl:

Fixes #13793
