### PR TITLE
Gun reskin (Detective) on alt click instead of left click

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -357,12 +357,14 @@
 		azoom.Remove(user)
 
 
-
-/obj/item/weapon/gun/attack_hand(mob/user)
+/obj/item/weapon/gun/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
 	if(unique_reskin && !reskinned && loc == user)
 		reskin_gun(user)
-		return
-	..()
+
 
 /obj/item/weapon/gun/proc/reskin_gun(mob/M)
 	var/choice = input(M,"Warning, you can only reskin your weapon once!","Reskin Gun") in options


### PR DESCRIPTION
> pick up gun
> put on armour
> see badguy
> try to pull gun out
> WHICH SHITTY SKIN DO YOU WANT?

Fixes #8811

I'm tempted to just move this functionality from gun to the detective gun in particular since its literally the only gun that does this and I don't want to waste altclick for all guns on this.

:cl: Kor
rscadd: The detectives revolver reskins on alt click now.
/:cl:
