### PR TITLE
Blue space shelters can no longer be triggered directly on a shuttle.

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -180,8 +180,12 @@
 	w_class = 1
 	var/used = FALSE
 
-/obj/item/weapon/survivalcapsule/attack_self()
+/obj/item/weapon/survivalcapsule/attack_self(mob/living/user)
 	if(used == FALSE)
+		var/turf/T = get_turf(src)
+		if(istype(T.loc,/area/shuttle))
+			user << "<span class='notice'>You realize you're an idiot for trying to detonate this on a shuttle."
+			return
 		src.loc.visible_message("The [src] begins to shake. Stand back!")
 		used = TRUE
 		sleep(50)


### PR DESCRIPTION
Bluespace Shelters can no longer be triggered directly on a shuttle. However, if you are seeking to sabotage a shuttle, you can still throw it into the shuttle.

Fixes #13842
