### PR TITLE
Assault Pod Fix

### DIFF
--- a/code/controllers/subsystem/shuttles/assault_pod.dm
+++ b/code/controllers/subsystem/shuttles/assault_pod.dm
@@ -33,14 +33,14 @@
 /obj/item/device/assault_pod/attack_self(mob/living/user)
 	var/target_area
 	target_area = input("Area to land", "Select a Landing Zone", target_area) in teleportlocs
+	var/area/picked_area = teleportlocs[target_area]
 	if(!src || qdeleted(src))
 		return
-	var/area/picked_area = teleportlocs[target_area]
 
 	var/turf/T = pick(get_area_turfs(picked_area))
 
 	var/obj/docking_port/stationary/landing_zone = new /obj/docking_port/stationary(T)
-	landing_zone.id = "assault_pod(\ref[src]) "
+	landing_zone.id = "assault_pod[rand(1,1000)]"
 	landing_zone.name = "Landing Zone"
 	landing_zone.dwidth = dwidth
 	landing_zone.dheight = dheight

--- a/code/controllers/subsystem/shuttles/assault_pod.dm
+++ b/code/controllers/subsystem/shuttles/assault_pod.dm
@@ -40,7 +40,7 @@
 	var/turf/T = pick(get_area_turfs(picked_area))
 
 	var/obj/docking_port/stationary/landing_zone = new /obj/docking_port/stationary(T)
-	landing_zone.id = "assault_pod[rand(1,1000)]"
+	landing_zone.id = "assault_pod(\ref[src])"
 	landing_zone.name = "Landing Zone"
 	landing_zone.dwidth = dwidth
 	landing_zone.dheight = dheight


### PR DESCRIPTION
Trying to use \ref throws runtime errors (can't find the shuttle ID) and makes the pod unable to launch.

@tkdrg 

:cl: Kor
rscadd: Clicking the (F) follow link for AI speech will now make you orbit their camera eye.
/:cl:
