### PR TITLE
Bags of holding create a tear in reality instead of a normal singulo

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -78,8 +78,7 @@
 		investigate_log("has become a singularity. Caused by [user.key]","singulo")
 		user << "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>"
 		qdel(W)
-		var/obj/singularity/singulo = new /obj/singularity (get_turf(src))
-		singulo.energy = 300 //should make it a bit bigger~
+		var/obj/singularity/wizard/singulo = new /obj/singularity/wizard (get_turf(src))
 		message_admins("[key_name_admin(user)] detonated a bag of holding")
 		log_game("[key_name(user)] detonated a bag of holding")
 		qdel(src)


### PR DESCRIPTION
Veil render is dead again and I'd rather not see the sprite go unused. I realize this is completely subjective though so I won't argue this if someone closes it.

This is also technically a nerf to the boh bomb since this singulo doesnt irradiate people or grow any larger.
