### PR TITLE
Smooth pixel screens shakes!

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -78,7 +78,6 @@
 	var/stunned = 0
 	var/weakened = 0
 	var/losebreath = 0//Carbon
-	var/shakecamera = 0
 	var/a_intent = "help"//Living
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -187,20 +187,26 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /proc/shake_camera(mob/M, duration, strength=1)
-	spawn(0)
-		if(!M || !M.client || M.shakecamera)
-			return
-		var/oldeye=M.client.eye
-		var/x
-		M.shakecamera = 1
-		for(x=0; x<duration, x++)
-			if(M && M.client)
-				M.client.eye = locate(dd_range(1,M.loc.x+rand(-strength,strength),world.maxx),dd_range(1,M.loc.y+rand(-strength,strength),world.maxy),M.loc.z)
-				sleep(1)
-		if(M)
-			M.shakecamera = 0
-			if(M.client)
-				M.client.eye=oldeye
+	set waitfor = 0
+	if(!M || !M.client || M.shakecamera)
+		return
+	M.shakecamera = 1
+	var/client/C = M.client
+	var/oldx = C.pixel_x
+	var/oldy = C.pixel_y
+	var/max = (strength+1)*world.icon_size
+	var/min = 0-((strength+1)*world.icon_size)
+
+	for(var/i=0, i<duration, i++)
+		var/newx = rand(min,max)
+		var/newy = rand(min,max)
+		if (i == 0)
+			animate(C, pixel_x=newx, pixel_y=newy, 1, 1, ELASTIC_EASING)
+		else
+			animate(pixel_x=newx, pixel_y=newy, 1, 1, ELASTIC_EASING)
+		sleep 1
+	animate(C, pixel_x=oldx, pixel_y=oldy, 1, 1, ELASTIC_EASING)
+	M.shakecamera = 0
 
 
 /proc/findname(msg)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -187,26 +187,21 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 
 /proc/shake_camera(mob/M, duration, strength=1)
-	set waitfor = 0
-	if(!M || !M.client || M.shakecamera)
+	if(!M || !M.client || duration <= 0)
 		return
-	M.shakecamera = 1
 	var/client/C = M.client
 	var/oldx = C.pixel_x
 	var/oldy = C.pixel_y
-	var/max = (strength+1)*world.icon_size
-	var/min = 0-((strength+1)*world.icon_size)
+	var/max = strength*world.icon_size
+	var/min = -(strength*world.icon_size)
 
-	for(var/i=0, i<duration, i++)
-		var/newx = rand(min,max)
-		var/newy = rand(min,max)
+	for(var/i in 0 to duration-1)
 		if (i == 0)
-			animate(C, pixel_x=newx, pixel_y=newy, 1, 1, ELASTIC_EASING)
+			animate(C, pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
 		else
-			animate(pixel_x=newx, pixel_y=newy, 1, 1, ELASTIC_EASING)
-		sleep 1
-	animate(C, pixel_x=oldx, pixel_y=oldy, 1, 1, ELASTIC_EASING)
-	M.shakecamera = 0
+			animate(pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
+	animate(pixel_x=oldx, pixel_y=oldy, time=1)
+
 
 
 /proc/findname(msg)


### PR DESCRIPTION
This pr brought to you by 38 plays of "Shake it off"

fixes #4870 

:cl:
fix: screen shakes will no longer allow you to see through walls
tweak: screen shakes will now move with you when moving rather than lag your client behind your mob
tweak: screen shakes are now less laggy in higher tickrates
/:cl:

Demo: both recorded on a server running at 16fps. (the new one looks cooler on higher fps while the old one just looks faster to move while keeping the same time between changes, so it looks odd)
https://tgstation13.org/msoshit/shakeitoff/old.flv
https://tgstation13.org/msoshit/shakeitoff/new.flv
