### PR TITLE
Gun stabilizer/recoil compensator

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -789,6 +789,13 @@ var/list/uplink_items = list()
 	cost = 15
 	gamemodes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/device_tools/recoil_compensator
+	name = "recoil compensator (Gun Upgrade)"
+	desc = "A miniaturized gravity generator, capable of reducing the weight of a gun as well as reducing recoil."
+	item = /obj/item/device/recoil_compensator
+	cost = 10
+	gamemodes = list(/datum/game_mode/nuclear)
+
 
 // IMPLANTS
 

--- a/code/modules/projectiles/gun_upgrades.dm
+++ b/code/modules/projectiles/gun_upgrades.dm
@@ -1,0 +1,19 @@
+/obj/item/device/recoil_compensator
+	name = "anti-grav stabilizer"
+	desc = "A miniaturized gravity generator, capable of reducing the weight of a gun as well as reducing recoil."
+	icon = 'icons/obj/stock_parts.dmi'
+	icon_state = "quadratic_capacitor"
+
+/obj/item/device/recoil_compensator/afterattack(obj/item/weapon/gun/G, mob/user)
+	..()
+	if(!istype(G))
+		user << "<span class='warning'>\The [src] can only be used on guns!</span>"
+		return
+	if(G.heavy_weapon == 0 && G.recoil == 0)
+		user << "<span class='warning'>The gun can't be improved any further!</span>"
+		return..()
+	user <<"<span class='notice'>You carefully install \the [src]. \The [G] is now light as a feather.</span>"
+	G.heavy_weapon = 0
+	G.recoil = 0
+	G.name = "stabilized [G.name]"
+	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1457,6 +1457,7 @@
 #include "code\modules\projectiles\ammunition.dm"
 #include "code\modules\projectiles\firing.dm"
 #include "code\modules\projectiles\gun.dm"
+#include "code\modules\projectiles\gun_upgrades.dm"
 #include "code\modules\projectiles\pins.dm"
 #include "code\modules\projectiles\projectile.dm"
 #include "code\modules\projectiles\ammunition\ammo_casings.dm"


### PR DESCRIPTION
Used to upgrade guns. Removes their heavy_weapon and recoil, allowing you to fire them one handed.

10tc in the ops uplink

:cl: Kor
rscadd: A gun stabilizer has been added to the nuke ops uplink. Attaching it to a will remove any recoil snd let you fire the gun one handed
/:cl:
