### PR TITLE
Map Template Load Verb + Maploader Improvements

### DIFF
--- a/_maps/templates/small_asteroid_1.dmm
+++ b/_maps/templates/small_asteroid_1.dmm
@@ -1,0 +1,14 @@
+"a" = (/turf/space,/area/space)
+"b" = (/turf/simulated/mineral,/area/space)
+"c" = (/turf/simulated/mineral/random/low_chance,/area/space)
+
+(1,1,1) = {"
+aabbaaa
+abbbcaa
+bbcccca
+cccccbb
+bcccccb
+bccccbb
+bcbcbba
+aabbaaa
+"}

--- a/_maps/templates/small_shuttle_1.dmm
+++ b/_maps/templates/small_shuttle_1.dmm
@@ -1,0 +1,33 @@
+"a" = (/turf/space,/area/space)
+"b" = (/turf/space,/turf/simulated/wall/shuttle{tag = "icon-swall_f6"; icon_state = "swall_f6"},/area/space)
+"c" = (/obj/structure/grille,/obj/structure/window/shuttle,/turf/simulated/floor/plating/airless,/area/space)
+"d" = (/turf/space,/turf/simulated/wall/shuttle{tag = "icon-swall_f10"; icon_state = "swall_f10"},/area/space)
+"e" = (/turf/simulated/wall/shuttle{tag = "icon-swall3"; icon_state = "swall3"},/area/space)
+"f" = (/turf/simulated/floor/plasteel/shuttle,/area/space)
+"g" = (/obj/structure/bed/chair{dir = 1},/turf/simulated/floor/plasteel/shuttle,/area/space)
+"h" = (/turf/simulated/wall/shuttle{tag = "icon-swall13"; icon_state = "swall13"},/area/space)
+"i" = (/turf/simulated/wall/shuttle{tag = "icon-swall8"; icon_state = "swall8"},/area/space)
+"j" = (/obj/machinery/door/unpowered/shuttle,/turf/simulated/floor/plasteel/shuttle,/area/space)
+"k" = (/turf/simulated/wall/shuttle{tag = "icon-swall4"; icon_state = "swall4"},/area/space)
+"l" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor/plasteel/shuttle,/area/space)
+"m" = (/obj/structure/bed/chair{dir = 8},/turf/simulated/floor/plasteel/shuttle,/area/space)
+"n" = (/obj/structure/shuttle/engine/heater,/turf/simulated/floor/plating/airless,/area/space)
+"o" = (/turf/space,/turf/simulated/wall/shuttle{tag = "icon-swall_f5"; icon_state = "swall_f5"},/area/space)
+"p" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_l"},/turf/simulated/floor/plating/airless,/area/space)
+"q" = (/obj/structure/shuttle/engine/propulsion,/turf/simulated/floor/plating/airless,/area/space)
+"r" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_r"},/turf/simulated/floor/plating/airless,/area/space)
+"s" = (/turf/space,/turf/simulated/wall/shuttle{tag = "icon-swall_f9"; icon_state = "swall_f9"},/area/space)
+
+(1,1,1) = {"
+abcccda
+aefgfea
+aefffea
+bhijkhd
+elfffme
+elfffme
+jfffffj
+jfffffj
+efffffe
+ennnnne
+opqqqrs
+"}

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -135,7 +135,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_display_del_log,
 	/client/proc/reset_latejoin_spawns,
 	/client/proc/create_outfits,
-	/client/proc/debug_huds
+	/client/proc/debug_huds,
+	/client/proc/map_template_load
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -136,7 +136,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/reset_latejoin_spawns,
 	/client/proc/create_outfits,
 	/client/proc/debug_huds,
-	/client/proc/map_template_load
+	/client/proc/map_template_load,
+	/client/proc/map_template_upload
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -39,7 +39,7 @@ var/global/list/map_template_uploads = list()
 	var/map = input(usr, "Choose a Map Template to upload to template storage","Upload Map Template") as null|file
 	if(!map)
 		return
-	if(!findtext("[map]",".dmm"))
+	if(copytext("[map]",-4) != ".dmm")
 		usr << "Bad map file: [map]"
 		return
 

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -1,0 +1,18 @@
+
+/client/proc/map_template_load()
+	set category = "Debug"
+	set name = "Load Map Template"
+
+	var/turf/T = get_turf(mob)
+	if(!T)
+		return
+	var/map = input(usr, "Choose a Map Template to load at your CURRENT LOCATION","Load Map Template") as null|anything in flist("_maps/templates/")
+	if(!map)
+		return
+	var/formatted_map = "_maps/templates/[map]"
+	var/mapfile = file(formatted_map)
+	if(isfile(mapfile))
+		maploader.load_map(mapfile, T.x, T.y, T.z)
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has loaded a map template ([map]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a></span>")
+	else
+		usr << "Bad map file"

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -1,18 +1,47 @@
 
 /client/proc/map_template_load()
 	set category = "Debug"
-	set name = "Load Map Template"
+	set name = "Map template - Place"
 
 	var/turf/T = get_turf(mob)
 	if(!T)
 		return
-	var/map = input(usr, "Choose a Map Template to load at your CURRENT LOCATION","Load Map Template") as null|anything in flist("_maps/templates/")
+
+	var/list/filelist = flist("_maps/templates/")
+	filelist |= map_template_uploads
+
+	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in filelist
 	if(!map)
 		return
-	var/formatted_map = "_maps/templates/[map]"
-	var/mapfile = file(formatted_map)
+
+	var/mapfile
+	if(map in map_template_uploads) //in the cache, not the template folder
+		mapfile = map
+	else
+		mapfile = file("_maps/templates/[map]")
+
 	if(isfile(mapfile))
 		maploader.load_map(mapfile, T.x, T.y, T.z)
-		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has loaded a map template ([map]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a></span>")
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has placed a map template ([map]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a></span>")
 	else
-		usr << "Bad map file"
+		usr << "Bad map file: [map]"
+
+
+//A list of map files that have been uploaded by admins
+//It's NOT persistent between rounds
+var/global/list/map_template_uploads = list()
+
+
+/client/proc/map_template_upload()
+	set category = "Debug"
+	set name = "Map Template - Upload"
+
+	var/map = input(usr, "Choose a Map Template to upload to template storage","Upload Map Template") as null|file
+	if(!map)
+		return
+	if(!findtext("[map]",".dmm"))
+		usr << "Bad map file: [map]"
+		return
+
+	map_template_uploads |= file(map)
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has uploaded a map template ([map])</span>")

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -81,7 +81,9 @@ var/global/dmm_suite/preloader/_preloader = null
 
 			//fill the current square using the model map
 			xcrd=0
-			for(var/mpos=1;mpos<=x_depth;mpos+=key_len)
+
+
+			for(var/mpos in 1 to x_depth step key_len)
 				xcrd++
 				var/model_key = copytext(grid_line,mpos,mpos+key_len)
 				parse_grid(grid_models[model_key],xcrd+x_offset,ycrd+y_offset,zcrd+z_offset)
@@ -175,7 +177,9 @@ var/global/dmm_suite/preloader/_preloader = null
 	_preloader = new(members_attributes[index])//preloader for assigning  set variables on atom creation
 
 	instance = locate(members[index])
-	instance.contents.Add(locate(xcrd,ycrd,zcrd))
+	var/turf/crds = locate(xcrd,ycrd,zcrd)
+	if(crds)
+		instance.contents.Add(crds)
 
 	if(_preloader && instance)
 		_preloader.load(instance)
@@ -191,17 +195,18 @@ var/global/dmm_suite/preloader/_preloader = null
 	//instanciate the first /turf
 	var/turf/T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],xcrd,ycrd,zcrd)
 
-	//if others /turf are presents, simulates the underlays piling effect
-	index = first_turf_index + 1
-	while(index <= members.len)
-		turfs_underlays.Insert(1,image(T.icon,null,T.icon_state,T.layer,T.dir))//add the current turf image to the underlays list
-		var/turf/UT = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd)//instance new turf
-		add_underlying_turf(UT,T,turfs_underlays)//simulates the DMM piling effect
-		T = UT
-		index++
+	if(T)
+		//if others /turf are presents, simulates the underlays piling effect
+		index = first_turf_index + 1
+		while(index <= members.len)
+			turfs_underlays.Insert(1,image(T.icon,null,T.icon_state,T.layer,T.dir))//add the current turf image to the underlays list
+			var/turf/UT = instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd)//instance new turf
+			add_underlying_turf(UT,T,turfs_underlays)//simulates the DMM piling effect
+			T = UT
+			index++
 
 	//finally instance all remainings objects/mobs
-	for(index=1,index < first_turf_index,index++)
+	for(index in 1 to first_turf_index-1)
 		instance_atom(members[index],members_attributes[index],xcrd,ycrd,zcrd)
 
 ////////////////
@@ -213,7 +218,9 @@ var/global/dmm_suite/preloader/_preloader = null
 	var/atom/instance
 	_preloader = new(attributes, path)
 
-	instance = new path (locate(x,y,z))//first preloader pass
+	var/turf/T = locate(x,y,z)
+	if(T)
+		instance = new path (T)//first preloader pass
 
 	if(_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 		_preloader.load(instance)

--- a/code/modules/awaymissions/maploader/swapmaps.dm
+++ b/code/modules/awaymissions/maploader/swapmaps.dm
@@ -227,11 +227,11 @@ swapmap
 		S["areas"] << areas
 		for(n in 1 to areas.len) areas[areas[n]]=n
 		var/oldcd=S.cd
-		for(z=z1,z<=z2,++z)
+		for(z in z1 to z2)
 			S.cd="[z-z1+1]"
-			for(y=y1,y<=y2,++y)
+			for(y in y1 to y2)
 				S.cd="[y-y1+1]"
-				for(x=x1,x<=x2,++x)
+				for(x in x1 to x2)
 					S.cd="[x-x1+1]"
 					var/turf/T=locate(x,y,z)
 					S["type"] << T.type
@@ -270,11 +270,11 @@ swapmap
 		locked=1
 		AllocateSwapMap()	// adjust x1,y1,z1 - x2,y2,z2 coords
 		var/oldcd=S.cd
-		for(z=z1,z<=z2,++z)
+		for(z in z1 to z2)
 			S.cd="[z-z1+1]"
-			for(y=y1,y<=y2,++y)
+			for(y in y1 to y2)
 				S.cd="[y-y1+1]"
-				for(x=x1,x<=x2,++x)
+				for(x in x1 to x2)
 					S.cd="[x-x1+1]"
 					var/tp
 					S["type"]>>tp

--- a/code/modules/awaymissions/maploader/writer.dm
+++ b/code/modules/awaymissions/maploader/writer.dm
@@ -49,9 +49,9 @@ dmm_suite{
 		var/list/templates[0]
 		var/template_buffer = {""}
 		var/dmm_text = {""}
-		for(var/pos_z=nw.z;pos_z<=se.z;pos_z++){
-			for(var/pos_y=nw.y;pos_y>=se.y;pos_y--){
-				for(var/pos_x=nw.x;pos_x<=se.x;pos_x++){
+		for(var/pos_z in nw.z to se.z){
+			for(var/pos_y in nw.y to se.y){
+				for(var/pos_x in nw.x to se.x){
 					var/turf/test_turf = locate(pos_x,pos_y,pos_z)
 					var/test_template = make_template(test_turf, flags)
 					var/template_number = templates.Find(test_template)
@@ -67,7 +67,7 @@ dmm_suite{
 			}
 		var/key_length = round/*floor*/(log(letter_digits.len,templates.len-1)+1)
 		var/list/keys[templates.len]
-		for(var/key_pos=1;key_pos<=templates.len;key_pos++){
+		for(var/key_pos in 1 to templates.len){
 			keys[key_pos] = get_model_key(key_pos,key_length)
 			dmm_text += {""[keys[key_pos]]" = ([templates[key_pos]])\n"}
 			}
@@ -163,7 +163,7 @@ dmm_suite{
 		get_model_key(var/which as num, var/key_length as num){
 			var/key = ""
 			var/working_digit = which-1
-			for(var/digit_pos=key_length;digit_pos>=1;digit_pos--){
+			for(var/digit_pos in key_length to 1 step -1){
 				var/place_value = round/*floor*/(working_digit/(letter_digits.len**(digit_pos-1)))
 				working_digit-=place_value*(letter_digits.len**(digit_pos-1))
 				key = "[key][letter_digits[place_value+1]]"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -880,6 +880,7 @@
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\machine_upgrade.dm"
 #include "code\modules\admin\verbs\manipulate_organs.dm"
+#include "code\modules\admin\verbs\map_template_loadverb.dm"
 #include "code\modules\admin\verbs\mapping.dm"
 #include "code\modules\admin\verbs\maprotation.dm"
 #include "code\modules\admin\verbs\massmodvar.dm"


### PR DESCRIPTION
## Map Templates:
- Admins with +DEBUG can now Load map files in the <B>_map/templates</B> folder where they (or their ghost) is standing.
- Admins with +DEBUG can now Upload a map file (smaller than 1MB) to the server for use within that round, it does not persist between rounds.

Includes two examples:
- <B>small_asteroid_1:</B> an asteroid with low chance for minerals
- <B>small_shuttle_1:</B> a small shuttle with some chairs

Example naming scheme: <B>"size_quick-description-or-title_instance-number"</B>
I'd like this naming scheme to be followed, but it's not necessary
(I might swap size and title around, so "asteroid_small" appears at the top)

![example](http://i.imgur.com/wglc0KX.gif)
## Maploader Improvements:
- Maploader `for(X = 1, X<=some_max, X++)` loops replaced with the much faster `for(X in 1 to some_max)` format, removes the 1-2ms delay after loading a maptemplate, woo!
- Maploader no longer assumes that the coordinates it is given exist, this has NOT slowed down the maploader, _AND_ prevents runtimes from loading templates at map edge, go ahead, load half a shuttle off the z level, the game doesn't give a -shit- anymore!
