### PR TITLE
Removes NOSHIELD flag, gives NOSHIELD items armour penetration

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -11,7 +11,7 @@
 #define NODROP			2		// This flag makes it so that an item literally cannot be removed at all, or at least that's how it should be. Only deleted.
 #define NOBLUDGEON		4		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define MASKINTERNALS	8		// mask allows internals
-#define HEAR 			16		// This flag is what recursive_hear_check() uses to determine wether to add an item to the hearer list or not.		// weapon not affected by shield
+#define HEAR 			16		// This flag is what recursive_hear_check() uses to determine wether to add an item to the hearer list or not.
 #define CONDUCT			64		// conducts electricity (metal etc.)
 #define ABSTRACT    	128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
 #define NODECONSTRUCT  	128		// For machines and structures that should not break into parts, eg, holodeck stuff

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -11,8 +11,7 @@
 #define NODROP			2		// This flag makes it so that an item literally cannot be removed at all, or at least that's how it should be. Only deleted.
 #define NOBLUDGEON		4		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define MASKINTERNALS	8		// mask allows internals
-#define HEAR 			16		// This flag is what recursive_hear_check() uses to determine wether to add an item to the hearer list or not.
-#define NOSHIELD		32		// weapon not affected by shield
+#define HEAR 			16		// This flag is what recursive_hear_check() uses to determine wether to add an item to the hearer list or not.		// weapon not affected by shield
 #define CONDUCT			64		// conducts electricity (metal etc.)
 #define ABSTRACT    	128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
 #define NODECONSTRUCT  	128		// For machines and structures that should not break into parts, eg, holodeck stuff

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -198,7 +198,6 @@
 	item_state = "sword0"
 	var/active = 0
 	w_class = 2
-	flags = NOSHIELD
 	attack_verb = list("attacked", "struck", "hit")
 	var/hacked = 0
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -32,7 +32,8 @@
 	throw_range = 5
 	w_class = 3
 	w_class_on = 5
-	flags = CONDUCT | NOSHIELD
+	flags = CONDUCT
+	armour_penetration = 100
 	origin_tech = "combat=3"
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	attack_verb_on = list()
@@ -53,7 +54,7 @@
 	sharpness = IS_SHARP
 	embed_chance = 75
 	embedded_impact_pain_multiplier = 10
-	flags = NOSHIELD
+	armour_penetration = 50
 	origin_tech = "magnets=3;syndicate=4"
 	block_chance = 50
 	var/hacked = 0
@@ -210,7 +211,6 @@
 	throw_speed = 3
 	throw_range = 1
 	w_class = 4//So you can't hide it in your pocket or some such.
-	flags = NOSHIELD
 	var/datum/effect_system/spark_spread/spark_system
 
 //Most of the other special functions are handled in their own files. aka special snowflake code so kewl

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -208,7 +208,7 @@
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
 	hitsound = "swing_hit"
-	flags = NOSHIELD
+	armour_penetration = 75
 	origin_tech = "magnets=3;syndicate=4"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -305,7 +305,7 @@
 	throwforce = 20
 	throw_speed = 4
 	embedded_impact_pain_multiplier = 3
-	flags = NOSHIELD
+	armour_penetration = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	sharpness = IS_SHARP

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -238,7 +238,7 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = 2
-	flags = NOSHIELD
+	armour_penetration = 100
 	attack_verb = list("bludgeoned", "whacked", "disciplined")
 	burn_state = FLAMMABLE
 
@@ -260,7 +260,6 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = 2
-	flags = NOSHIELD
 
 /obj/item/weapon/ectoplasm
 	name = "ectoplasm"

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -20,7 +20,7 @@
 	throwforce = 0
 	w_class = 2.0
 	hitsound = "swing_hit"
-	flags = NOSHIELD
+	armour_penetration = 50
 	var/active = 0
 
 /obj/item/weapon/holo/esword/green

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -103,7 +103,8 @@
 	throw_speed = 2
 	throw_range = 3
 	w_class = 4
-	flags = CONDUCT | NOSHIELD
+	flags = CONDUCT
+	armour_penetration = 20
 	slot_flags = SLOT_BACK
 	origin_tech = "materials=2;combat=2"
 	attack_verb = list("chopped", "sliced", "cut", "reaped")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -72,9 +72,7 @@
 
 /mob/living/carbon/human/proc/check_shields(damage = 0, attack_text = "the attack", atom/movable/AM, attack_type = MELEE_ATTACK, armour_penetration = 0)
 	var/block_chance_modifier = round(damage / -3)
-	if(AM)
-		if(AM.flags & NOSHIELD) //weapon ignores shields altogether
-			return 0
+
 	if(l_hand && !istype(l_hand, /obj/item/clothing))
 		var/final_block_chance = l_hand.block_chance - (Clamp((armour_penetration-l_hand.armour_penetration)/2,0,100)) + block_chance_modifier //So armour piercing blades can still be parried by other blades, for example
 		if(l_hand.hit_reaction(src, attack_text, final_block_chance, damage, attack_type))

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	flags = NOSHIELD
+	armour_penetration = 100
 	flag = "magic"
 
 /obj/item/projectile/magic/death


### PR DESCRIPTION
Don't need two systems to do the same thing and NOSHIELD ignores things it shouldn't (like reactive armour or the clown honking when you attack him)

I tried to keep things mostly the same in the switch other than spears which only have armour pen 10 now instead of magically bypassing all blocks.
