### PR TITLE
[s] Fixes being able to return to your body after another ghost takes control

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -619,7 +619,7 @@ body
 				theghost = pick(candidates)
 				M << "Your mob has been taken over by a ghost!"
 				message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(M)])")
-				M.ghostize()
+				M.ghostize(0)
 				M.key = theghost.key
 			else
 				M << "There were no ghosts willing to take control."

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -525,7 +525,7 @@
 		theghost = pick(candidates)
 		M << "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!"
 		message_admins("[key_name_admin(theghost)] has taken control of ([key_name_admin(M)]) to replace a jobbaned player.")
-		M.ghostize()
+		M.ghostize(0)
 		M.key = theghost.key
 
 /datum/game_mode/proc/remove_antag_for_borging(datum/mind/newborgie)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -168,6 +168,8 @@
 	set name = "Reset Guardian Player (One Use)"
 	set category = "Guardian"
 	set desc = "Re-rolls which ghost will control your Guardian. One use."
+
+	src.verbs -= /mob/living/proc/guardian_reset
 	for(var/mob/living/simple_animal/hostile/guardian/G in mob_list)
 		if(G.summoner == src)
 			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [G.real_name]?", "pAI", null, FALSE, 100)
@@ -177,11 +179,11 @@
 				G << "Your user reset you, and your body was taken over by a ghost. Looks like they weren't happy with your performance."
 				src << "Your guardian has been successfully reset."
 				message_admins("[key_name_admin(new_stand)] has taken control of ([key_name_admin(G)])")
-				G.ghostize()
+				G.ghostize(0)
 				G.key = new_stand.key
-				src.verbs -= /mob/living/proc/guardian_reset
 			else
 				src << "There were no ghosts willing to take control. Looks like you're stuck with your Guardian for now."
+				verbs += /mob/living/proc/guardian_reset
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleLight()
 	if(!luminosity)


### PR DESCRIPTION
For Guardian re-roll, admin offer control, and replacing jobbanned players (this last one is why there is a security tag).

Also fixed being able to spam the guardian reroll button while its in use.

Fixes #13367
