### PR TITLE
Stops minimaps generating for away missions

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -19,9 +19,9 @@ var/datum/subsystem/minimap/SSminimap
 /datum/subsystem/minimap/Initialize(timeofday, zlevel)
 	if (zlevel)
 		return ..()
-	for(var/z = 1 to world.maxz)
+	for(var/z = 1 to ZLEVEL_SPACEMAX)
 		generate(z)
-	for (var/z = 1 to world.maxz)
+	for (var/z = 1 to ZLEVEL_SPACEMAX)
 		register_asset("minimap_[z].png", file("[getMinimapFile(z)].png"))
 	..()
 


### PR DESCRIPTION
@neersighted you mentioned wanting to making them only generate for Z1 which I think would be ideal if we have lavaworld (haha never) and space exploration but that seems more  controversial so I'll start with blacklisting away missions.

Fixes  #12348
