### PR TITLE
Fixes holograms drifting in zero gravity

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -151,7 +151,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 				master.show_message(rendered, 2)
 
 /obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, turf/T = loc)
-	var/obj/effect/overlay/h = new(T)//Spawn a blank effect at the location.
+	var/obj/effect/overlay/holo_pad_hologram/h = new(T)//Spawn a blank effect at the location.
 	h.icon = A.holo_icon
 	h.mouse_opacity = 0//So you can't click on it.
 	h.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
@@ -199,9 +199,13 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
 		step_to(masters[user], user.eyeobj) // So it turns.
-		var/obj/effect/overlay/H = masters[user]
+		var/obj/effect/overlay/holo_pad_hologram/H = masters[user]
 		H.loc = get_turf(user.eyeobj)
 		masters[user] = H
+	return 1
+
+
+/obj/effect/overlay/holo_pad_hologram/Process_Spacemove(movement_dir = 0)
 	return 1
 
 /*


### PR DESCRIPTION
I never even see holograms used and this is the kind of bug that barely seems worth the time to fix but people cared enough to report the issue 4 times so ???

Fixes #6109

EDIT: Apparently this was worth sick bonus cheribucks too bad the freeze isn't for another week

:cl: Kor
rscadd: AI holograms no longer drift in zero gravity
/:cl:
