### PR TITLE
Replaces the blob Split Consciousness ability with better blob scaling

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -12,7 +12,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	config_tag = "blob"
 	antag_flag = ROLE_BLOB
 
-	required_players = 30
+	required_players = 25
 	required_enemies = 1
 	recommended_enemies = 1
 
@@ -22,7 +22,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	var/burst = 0
 
 	var/cores_to_spawn = 1
-	var/players_per_core = 30
+	var/players_per_core = 20
 	var/blob_point_rate = 3
 
 	var/blobwincount = 350

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -11,15 +11,12 @@
 	var/overmind_get_delay = 0 //we don't want to constantly try to find an overmind, this var tracks when we'll try to get an overmind again
 	var/resource_delay = 0
 	var/point_rate = 2
-	var/is_offspring = 0
 
 
-/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
+/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2)
 	blob_cores += src
 	SSobj.processing |= src
 	update_icon() //so it atleast appears
-	if(offspring)
-		is_offspring = 1
 	if(!overmind)
 		create_overmind(new_overmind)
 	if(overmind)
@@ -109,7 +106,5 @@
 		update_icon()
 		if(B.mind && !B.mind.special_role)
 			B.mind.special_role = "Blob Overmind"
-		if(is_offspring)
-			B.verbs -= /mob/camera/blob/verb/split_consciousness
 		return 1
 	return 0

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -186,24 +186,6 @@
 			BS.LoseTarget()
 			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
 
-/mob/camera/blob/verb/split_consciousness()
-	set category = "Blob"
-	set name = "Split consciousness (100) (One use)"
-	set desc = "Expend resources to attempt to produce another sentient overmind"
-	var/turf/T = get_turf(src)
-	var/obj/effect/blob/node/B = locate(/obj/effect/blob/node) in T
-	if(!B)
-		src << "<span class='warning'>You must be on a blob node!</span>"
-		return
-	if(!can_buy(100))
-		return
-	verbs -= /mob/camera/blob/verb/split_consciousness
-	new/obj/effect/blob/core/(get_turf(B), 200, null, blob_core.point_rate, 1)
-	qdel(B)
-	if(ticker && ticker.mode.name == "blob")
-		var/datum/game_mode/blob/BL = ticker.mode
-		BL.blobwincount += initial(BL.blobwincount) //Increase the victory condition by the set amount
-
 /mob/camera/blob/verb/blob_broadcast()
 	set category = "Blob"
 	set name = "Blob Broadcast"


### PR DESCRIPTION
:cl: Joan
rscdel: The blob Split Consciousness ability has been removed.
tweak: The blob mode now spawns more roundstart blobs, instead.
/:cl:

This sets the scaling to 1 blob per 20 players, hitting 4 at around 80 people, and decreases the required players of the mode to 25.

If higher scaling is needed, 1 blob per 16 people would produce 5 blobs at 80 people, though it would produce 2 at 34, which could be too high.

For reference, the current scaling is 1 blob per 30 players, but each blob can split to produce a second blob; 1 blob per 15 players would produce a roughly equivalent experience.
