### PR TITLE
Reduce count of meteors

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -21,7 +21,7 @@
 /datum/game_mode/meteor/process()
 	if(nometeors) return
 
-	spawn() spawn_meteors(6, meteors_normal)
+	spawn() spawn_meteors(1, meteors_normal)
 
 
 /datum/game_mode/meteor/declare_completion()


### PR DESCRIPTION
A single meteor spawn will bring the server to it's knees, and there is
zero, I repeat ZERO chance that people are going to fix the causes of
lag when explosions trigger (see powernet/pipenet rebuilds) and atmos
triggering
