### PR TITLE
Removes distance check from ai nano ui interaction checks

### DIFF
--- a/code/modules/nano/states/default.dm
+++ b/code/modules/nano/states/default.dm
@@ -46,7 +46,7 @@
 		return
 
 	// The AI can interact with anything it can see nearby, or with cameras.
-	if ((get_dist(src, src_object) <= src.client.view) || ((get_dist(eyeobj, src_object) <= src.client.view) && cameranet.checkTurfVis(get_turf_pixel(src_object))))
+	if ((get_dist(src, src_object) <= src.client.view) || cameranet.checkTurfVis(get_turf_pixel(src_object)))
 		return NANO_INTERACTIVE
 	return NANO_CLOSE
 


### PR DESCRIPTION
This is either all or nothing, 

Right now ais can always use it if its in view of a camera, even if it's not in their view range. 

Everything but new nano ui acts this way.

Having some things act this way and some not just doesn't make sense.

Fixes #13892 
