### PR TITLE
alt click will no longer show atoms overridden by a client image

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -676,10 +676,16 @@ var/list/slot_equipment_priority = list( \
 			listed_turf = null
 		else
 			statpanel(listed_turf.name, null, listed_turf)
+			var/list/overrides = list()
+			for(var/image/I in client.images)
+				if(I.loc && I.loc.loc == listed_turf && I.override)
+					overrides = I.loc
 			for(var/atom/A in listed_turf)
 				if(!A.mouse_opacity)
 					continue
 				if(A.invisibility > see_invisible)
+					continue
+				if(overrides.len && (A in overrides))
 					continue
 				statpanel(listed_turf.name, null, A)
 


### PR DESCRIPTION
fixes #1951 (ais can see blood runes in alt click)

GETTING THEM OLDIES BEFORE THE FREEZE STARTS SO NOBODY CAN CLAIM THE POINTS!
