### PR TITLE
no grav movement now uses !can_pass as well as density

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -328,7 +328,7 @@
 			var/atom/movable/AM = A
 			if(AM == buckled) //Kind of unnecessary but let's just be sure
 				continue
-			if(AM.density)
+			if(!AM.CanPass(src))
 				if(AM.anchored)
 					return 1
 				if(pulling == AM)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -328,7 +328,7 @@
 			var/atom/movable/AM = A
 			if(AM == buckled) //Kind of unnecessary but let's just be sure
 				continue
-			if(!AM.CanPass(src))
+			if(!AM.CanPass(src) || AM.density)
 				if(AM.anchored)
 					return 1
 				if(pulling == AM)


### PR DESCRIPTION
Fixes #4021 no gravity around the blob

:cl:
tweak: Movement in no gravity now allows you to push off of things only dense to some mobs if it is dense to you (such as tables/blob tiles) rather than just objects that are only dense to all mobs.
/:cl:
