### PR TITLE
Random fixes

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -396,7 +396,7 @@
 	string(i, list/node)
 
 		if(copytext(token(i), 1, 2) in list("'", "\""))
-			node += token(i)
+			node += copytext(token(i),2,-1)
 
 		else
 			parse_error("Expected string but found '[token(i)]'")

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -221,8 +221,7 @@
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"
 
-/mob/proc/restrained()
+/mob/living/simple_animal/hostile/statue/restrained()
 	. == ..()
 	if(can_be_seen(loc))
 		return 1
-	return .

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -220,3 +220,9 @@
 
 /mob/living/simple_animal/hostile/statue/sentience_act()
 	faction -= "neutral"
+
+/mob/proc/restrained()
+	. == ..()
+	if(can_be_seen(loc))
+		return 1
+	return .


### PR DESCRIPTION
Fixes #5309
Fixes #4943 <- Outer string parentheses are now escaped. Can't think of use case where this wouldn't be preferred solution but let me know if this causes any issues.
