### PR TITLE
Makes mining mobs fireproof

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -5,6 +5,7 @@
 	faction = list("mining")
 	environment_smash = 2
 	minbodytemp = 0
+	maxbodytemp = INFINITY
 	response_help = "pokes"
 	response_disarm = "shoves"
 	response_harm = "strikes"


### PR DESCRIPTION
So they can survive lavaland without me making 8 new subtypes with a single var changed.

Considering they usually live in vacuum and can't be set on fire anyway this has almost 0 impact on game balance.
