### PR TITLE
Rebalances blobbernaut creation

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -167,7 +167,8 @@
 			var/mob/living/L = target
 			var/mob_protection = L.get_permeability_protection()
 			overmind.blob_reagent_datum.reaction_mob(L, VAPOR, 17.5, 0, mob_protection)//this will do between 7 and 17 damage(reduced by mob protection), depending on chemical, plus 4 from base brute damage.
-	..()
+	if(target)
+		..()
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/update_icons()
 	..()

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -44,7 +44,6 @@
 				return
 	if(!can_buy(price))
 		return
-	B.color = blob_reagent_datum.color
 	var/obj/effect/blob/N = B.change_to(blobType, src)
 	return N
 
@@ -66,13 +65,13 @@
 /mob/camera/blob/verb/create_node()
 	set category = "Blob"
 	set name = "Create Node Blob (60)"
-	set desc = "Create a Node."
+	set desc = "Create a node, which will power nearby factory and resource blobs."
 	createSpecial(60, /obj/effect/blob/node, 5)
 
 /mob/camera/blob/verb/create_factory()
 	set category = "Blob"
 	set name = "Create Factory Blob (60)"
-	set desc = "Create a Spore producing blob."
+	set desc = "Create a spore tower that will spawn spores to harass your enemies."
 	createSpecial(60, /obj/effect/blob/factory, 7)
 
 /mob/camera/blob/verb/create_storage()
@@ -93,14 +92,24 @@
 	if(!istype(B, /obj/effect/blob/factory))
 		src << "<span class='warning'>Unable to use this blob, find a factory blob.</span>"
 		return
+	if(B.health < B.maxhealth*0.6) //if it's at less than 60% of its health, you can't blobbernaut it
+		src << "<span class='warning'>This factory blob is too damaged to produce a blobbernaut.</span>"
+		return
 	if(!can_buy(20))
 		return
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut (get_turf(B))
-	if(blobber)
-		qdel(B)
+	var/obj/effect/blob/factory/F = B
+	F.take_damage(F.maxhealth*0.6, CLONE, null, 0) //take a bunch of damage, so you can't produce tons of blobbernauts from a single factory
+	F.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
+	F.spore_delay = world.time + 600 //one minute before it can spawn spores again
 	blobber.overmind = src
 	blobber.update_icons()
 	blob_mobs.Add(blobber)
+	var/list/candidates = get_candidates(ROLE_BLOB, ALIEN_AFK_BRACKET)
+	var/client/C = null
+	if(candidates.len) //if we got a candidate, they're a blobbernaut now.
+		C = pick(candidates)
+		blobber.key = C.key
 
 /mob/camera/blob/verb/relocate_core()
 	set category = "Blob"

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -110,6 +110,10 @@
 	if(candidates.len) //if we got a candidate, they're a blobbernaut now.
 		C = pick(candidates)
 		blobber.key = C.key
+		blobber << 'sound/effects/blobattack.ogg'
+		blobber << "<b>You are a blobbernaut!</b>"
+		blobber << "Your overmind's blob reagent is: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
+		blobber << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.description]"
 
 /mob/camera/blob/verb/relocate_core()
 	set category = "Blob"

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -206,6 +206,8 @@
 	take_damage(W.force, W.damtype, user)
 
 /obj/effect/blob/attack_animal(mob/living/simple_animal/M)
+	if("blob" in M.faction) //sorry, but you can't kill the blob as a blobbernaut
+		return
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
 	playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1)
@@ -223,7 +225,7 @@
 	take_damage(damage, BRUTE, M)
 	return
 
-/obj/effect/blob/proc/take_damage(damage, damage_type, cause = null)
+/obj/effect/blob/proc/take_damage(damage, damage_type, cause = null, overmind_reagent_trigger = 1)
 	switch(damage_type) //blobs only take brute and burn damage
 		if(BRUTE)
 			damage = max(damage * brute_resist, 0)
@@ -233,7 +235,7 @@
 
 		else
 			damage = 0
-	if(overmind)
+	if(overmind && overmind_reagent_trigger)
 		damage = overmind.blob_reagent_datum.damage_reaction(src, health, damage, damage_type, cause) //pass the blob, its health before damage, the damage being done, the type of damage being done, and the cause.
 	health -= damage
 	update_icon()

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -123,9 +123,8 @@
 
 /datum/reagent/blob/boiling_oil/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	if(M)
-		M.adjust_fire_stacks(round(reac_volume/12))
-		M.IgniteMob()
+	M.adjust_fire_stacks(round(reac_volume/12))
+	M.IgniteMob()
 	if(M)
 		M.apply_damage(0.6*reac_volume, BURN)
 	if(iscarbon(M))
@@ -143,13 +142,12 @@
 
 /datum/reagent/blob/hallucinogenic_nectar/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
+	M.hallucination += 0.6*reac_volume
+	M.druggy += 0.6*reac_volume
+	if(M.reagents)
+		M.reagents.add_reagent("spore", 0.2*reac_volume)
 	if(M)
 		M.apply_damage(0.4*reac_volume, TOX)
-	if(M)
-		M.hallucination += 0.6*reac_volume
-		M.druggy += 0.6*reac_volume
-		if(M.reagents)
-			M.reagents.add_reagent("spore", 0.2*reac_volume)
 
 //toxin, stamina, and some bonus spore toxin
 /datum/reagent/blob/envenomed_filaments
@@ -161,12 +159,12 @@
 
 /datum/reagent/blob/envenomed_filaments/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
+	if(M.reagents)
+		M.reagents.add_reagent("spore", 0.2*reac_volume)
 	if(M)
 		M.apply_damage(0.6*reac_volume, TOX)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
-	if(M && M.reagents)
-		M.reagents.add_reagent("spore", 0.2*reac_volume)
 
 //does tons of oxygen damage and a little brute
 /datum/reagent/blob/lexorin_jelly
@@ -178,12 +176,11 @@
 
 /datum/reagent/blob/lexorin_jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
+	M.losebreath += round(0.2*reac_volume)
 	if(M)
 		M.apply_damage(0.4*reac_volume, BRUTE)
 	if(M)
 		M.apply_damage(0.6*reac_volume, OXY)
-	if(M)
-		M.losebreath += round(0.2*reac_volume)
 
 //does semi-random brute damage and reacts to brute damage
 /datum/reagent/blob/reactive
@@ -219,13 +216,13 @@
 
 /datum/reagent/blob/cryogenic_liquid/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
+	if(M.reagents)
+		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
+		M.reagents.add_reagent("ice", 0.4*reac_volume)
 	if(M)
 		M.apply_damage(0.4*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
-	if(M && M.reagents)
-		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
-		M.reagents.add_reagent("ice", 0.4*reac_volume)
 
 //does brute damage, bonus damage for each nearby blob, and spreads damage out
 /datum/reagent/blob/synchronous_mesh
@@ -270,16 +267,15 @@
 
 /datum/reagent/blob/pressurized_slime/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
+	var/turf/simulated/T = get_turf(M)
+	if(istype(T, /turf/simulated))
+		T.MakeSlippery(TURF_WET_WATER)
 	if(M)
 		M.apply_damage(0.4*reac_volume, BRUTE)
 	if(M)
 		M.apply_damage(0.4*reac_volume, OXY)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
-	if(M)
-		var/turf/simulated/T = get_turf(M)
-		if(istype(T, /turf/simulated))
-			T.MakeSlippery(TURF_WET_WATER)
 
 /datum/reagent/blob/pressurized_slime/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	for(var/turf/simulated/T in range(1, B))

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -29,8 +29,10 @@
 
 /datum/reagent/blob/ripping_tendrils/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
-	M.adjustStaminaLoss(0.6*reac_volume)
+	if(M)
+		M.apply_damage(0.6*reac_volume, BRUTE)
+	if(M)
+		M.adjustStaminaLoss(0.6*reac_volume)
 	if(iscarbon(M))
 		M.emote("scream")
 
@@ -44,7 +46,8 @@
 
 /datum/reagent/blob/sporing_pods/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, TOX)
+	if(M)
+		M.apply_damage(0.4*reac_volume, TOX)
 
 /datum/reagent/blob/sporing_pods/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(!isnull(cause) && damage < 20 && original_health - damage <= 0 && prob(50)) //if the cause isn't fire or a bomb, the damage is less than 20, we're going to die from that damage, 50% chance of a shitty spore.
@@ -71,7 +74,8 @@
 
 /datum/reagent/blob/replicating_foam/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.6*reac_volume, BRUTE)
 
 /datum/reagent/blob/replicating_foam/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(damage > 0 && original_health - damage > 0 && prob(100 - damage))
@@ -96,8 +100,10 @@
 
 /datum/reagent/blob/energized_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BURN)
-	M.adjustStaminaLoss(0.8*reac_volume)
+	if(M)
+		M.apply_damage(0.4*reac_volume, BURN)
+	if(M)
+		M.adjustStaminaLoss(0.8*reac_volume)
 
 /datum/reagent/blob/energized_fibers/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(damage_type == STAMINA)
@@ -117,9 +123,11 @@
 
 /datum/reagent/blob/boiling_oil/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.adjust_fire_stacks(round(reac_volume/12))
-	M.apply_damage(0.6*reac_volume, BURN)
-	M.IgniteMob()
+	if(M)
+		M.adjust_fire_stacks(round(reac_volume/12))
+		M.IgniteMob()
+	if(M)
+		M.apply_damage(0.6*reac_volume, BURN)
 	if(iscarbon(M))
 		M.emote("scream")
 
@@ -135,11 +143,13 @@
 
 /datum/reagent/blob/hallucinogenic_nectar/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, TOX)
-	M.hallucination += 0.6*reac_volume
-	M.druggy += 0.6*reac_volume
-	if(M.reagents)
-		M.reagents.add_reagent("spore", 0.2*reac_volume)
+	if(M)
+		M.apply_damage(0.4*reac_volume, TOX)
+	if(M)
+		M.hallucination += 0.6*reac_volume
+		M.druggy += 0.6*reac_volume
+		if(M.reagents)
+			M.reagents.add_reagent("spore", 0.2*reac_volume)
 
 //toxin, stamina, and some bonus spore toxin
 /datum/reagent/blob/envenomed_filaments
@@ -151,9 +161,11 @@
 
 /datum/reagent/blob/envenomed_filaments/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, TOX)
-	M.adjustStaminaLoss(0.4*reac_volume)
-	if(M.reagents)
+	if(M)
+		M.apply_damage(0.6*reac_volume, TOX)
+	if(M)
+		M.adjustStaminaLoss(0.4*reac_volume)
+	if(M && M.reagents)
 		M.reagents.add_reagent("spore", 0.2*reac_volume)
 
 //does tons of oxygen damage and a little brute
@@ -166,9 +178,12 @@
 
 /datum/reagent/blob/lexorin_jelly/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BRUTE)
-	M.apply_damage(0.6*reac_volume, OXY)
-	M.losebreath += round(0.2*reac_volume)
+	if(M)
+		M.apply_damage(0.4*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.6*reac_volume, OXY)
+	if(M)
+		M.losebreath += round(0.2*reac_volume)
 
 //does semi-random brute damage and reacts to brute damage
 /datum/reagent/blob/reactive
@@ -182,7 +197,8 @@
 /datum/reagent/blob/reactive/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	var/damage = rand(10, 25)/25
-	M.apply_damage(damage*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(damage*reac_volume, BRUTE)
 
 /datum/reagent/blob/reactive/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(damage && damage_type == BRUTE && original_health - damage > 0 && isliving(cause)) //is there any damage, is it brute, will we be alive, and is the cause a mob?
@@ -203,9 +219,11 @@
 
 /datum/reagent/blob/cryogenic_liquid/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BURN)
-	M.adjustStaminaLoss(0.4*reac_volume)
-	if(M.reagents)
+	if(M)
+		M.apply_damage(0.4*reac_volume, BURN)
+	if(M)
+		M.adjustStaminaLoss(0.4*reac_volume)
+	if(M && M.reagents)
 		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
 		M.reagents.add_reagent("ice", 0.4*reac_volume)
 
@@ -220,13 +238,14 @@
 
 /datum/reagent/blob/synchronous_mesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BRUTE)
-	for(var/obj/effect/blob/B in range(1, M)) //if the target is completely surrounded, this is 0.8*reac_volume bonus damage, total of 1.2*reac_volume
-		M.apply_damage(0.1*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.4*reac_volume, BRUTE)
+	if(M)
+		for(var/obj/effect/blob/B in range(1, M)) //if the target is completely surrounded, this is 0.8*reac_volume bonus damage, total of 1.2*reac_volume
+			if(M)
+				M.apply_damage(0.1*reac_volume, BRUTE)
 
 /datum/reagent/blob/synchronous_mesh/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(istype(cause, /obj/effect/blob)) //if a blob is doing it, that means we're splitting the damage, so don't modify it.
-		return ..()
 	if(!isnull(cause)) //the cause isn't fire or bombs, so split the damage
 		var/damagesplit = 0.8 //maximum split is 7.2, reducing the damage each blob takes to 14% but doing that damage to 9 blobs
 		for(var/obj/effect/blob/C in orange(1, B))
@@ -234,7 +253,7 @@
 				damagesplit += 0.8
 		for(var/obj/effect/blob/C in orange(1, B))
 			if(C.overmind && C.overmind.blob_reagent_datum == B.overmind.blob_reagent_datum && !istype(C, /obj/effect/blob/core)) //only hurt blobs that have the same overmind chemical and aren't cores
-				C.take_damage(damage/damagesplit, CLONE, B)
+				C.take_damage(damage/damagesplit, CLONE, B, 0)
 		return damage/damagesplit
 	else
 		return damage*1.25
@@ -251,12 +270,16 @@
 
 /datum/reagent/blob/pressurized_slime/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BRUTE)
-	M.apply_damage(0.4*reac_volume, OXY)
-	M.adjustStaminaLoss(0.4*reac_volume)
-	var/turf/simulated/T = get_turf(M)
-	if(istype(T, /turf/simulated))
-		T.MakeSlippery(TURF_WET_WATER)
+	if(M)
+		M.apply_damage(0.4*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.4*reac_volume, OXY)
+	if(M)
+		M.adjustStaminaLoss(0.4*reac_volume)
+	if(M)
+		var/turf/simulated/T = get_turf(M)
+		if(istype(T, /turf/simulated))
+			T.MakeSlippery(TURF_WET_WATER)
 
 /datum/reagent/blob/pressurized_slime/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	for(var/turf/simulated/T in range(1, B))
@@ -282,7 +305,8 @@
 /datum/reagent/blob/dark_matter/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reagent_vortex(M, 0, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.6*reac_volume, BRUTE)
 
 //does brute damage and throws or pushes nearby objects away from the target
 /datum/reagent/blob/b_sorium
@@ -295,36 +319,38 @@
 /datum/reagent/blob/b_sorium/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reagent_vortex(M, 1, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
+	if(M)
+		M.apply_damage(0.6*reac_volume, BRUTE)
 
 /datum/reagent/blob/proc/reagent_vortex(mob/living/M, setting_type, reac_volume)
-	var/turf/pull = get_turf(M)
-	var/range_power = Clamp(round(reac_volume/5, 1), 1, 5)
-	for(var/atom/movable/X in range(range_power,pull))
-		if(istype(X, /obj/effect))
-			continue
-		if(!X.anchored)
-			var/distance = get_dist(X, pull)
-			var/moving_power = max(range_power - distance, 1)
-			spawn(0)
-				if(moving_power > 2) //if the vortex is powerful and we're close, we get thrown
-					if(setting_type)
-						var/atom/throw_target = get_edge_target_turf(X, get_dir(X, get_step_away(X, pull)))
-						var/throw_range = 5 - distance
-						X.throw_at(throw_target, throw_range, 1)
+	if(M)
+		var/turf/pull = get_turf(M)
+		var/range_power = Clamp(round(reac_volume/5, 1), 1, 5)
+		for(var/atom/movable/X in range(range_power,pull))
+			if(istype(X, /obj/effect))
+				continue
+			if(!X.anchored)
+				var/distance = get_dist(X, pull)
+				var/moving_power = max(range_power - distance, 1)
+				spawn(0)
+					if(moving_power > 2) //if the vortex is powerful and we're close, we get thrown
+						if(setting_type)
+							var/atom/throw_target = get_edge_target_turf(X, get_dir(X, get_step_away(X, pull)))
+							var/throw_range = 5 - distance
+							X.throw_at(throw_target, throw_range, 1)
+						else
+							X.throw_at(pull, distance, 1)
 					else
-						X.throw_at(pull, distance, 1)
-				else
-					if(setting_type)
-						for(var/i = 0, i < moving_power, i++)
-							sleep(2)
-							if(!step_away(X, pull))
-								break
-					else
-						for(var/i = 0, i < moving_power, i++)
-							sleep(2)
-							if(!step_towards(X, pull))
-								break
+						if(setting_type)
+							for(var/i = 0, i < moving_power, i++)
+								sleep(2)
+								if(!step_away(X, pull))
+									break
+						else
+							for(var/i = 0, i < moving_power, i++)
+								sleep(2)
+								if(!step_towards(X, pull))
+									break
 
 
 /datum/reagent/blob/proc/send_message(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -338,12 +338,12 @@
 							X.throw_at(pull, distance, 1)
 					else
 						if(setting_type)
-							for(var/i = 0, i < moving_power, i++)
+							for(var/i in 0 to moving_power-1)
 								sleep(2)
 								if(!step_away(X, pull))
 									break
 						else
-							for(var/i = 0, i < moving_power, i++)
+							for(var/i in 0 to moving_power-1)
 								sleep(2)
 								if(!step_towards(X, pull))
 									break


### PR DESCRIPTION
:cl: Joan
rscadd: Overmind-created blobbernauts are now player-controlled if possible.
tweak: Creating a blobbernaut no longer destroys the factory, instead doing heavy damage to it and preventing it from spawning spores for one minute.
tweak: You cannot spawn blobbernauts from overly damaged factories.
/:cl:

Also fixes some runtimes when killing mice.
