### PR TITLE
Generalises simple animal loot drops and removes copypasta

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1033,7 +1033,9 @@
 	name = "Spaceport Security"
 	desc = "The Premier security forces for all spaceports found along the Orion Trail."
 	faction = list("orion")
-	corpse = /obj/effect/landmark/mobcorpse/orionsecurity
+	loot = list(/obj/effect/landmark/mobcorpse/orionsecurity,
+				/obj/item/weapon/gun/projectile/automatic/c20r/unrestricted,
+				/obj/item/weapon/shield/energy)
 
 /obj/effect/landmark/mobcorpse/orionsecurity
 	name = "Spaceport Security"

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -20,16 +20,12 @@
 	ventcrawler = 2
 	gold_core_spawnable = 2
 	var/squish_chance = 50
+	loot = list(/obj/effect/decal/cleanable/deadcockroach)
+	del_on_death = 1
 
 /mob/living/simple_animal/cockroach/death(gibbed)
 	if(ticker.cinematic) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
-	if(!ckey || gibbed)// stupid staff of change fucking everything up.
-		..(1)
-		new /obj/effect/decal/cleanable/deadcockroach(src.loc)
-		qdel(src)
-		return
-	else
 		..()
 
 /mob/living/simple_animal/cockroach/Crossed(var/atom/movable/AM)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -26,6 +26,7 @@
 	//Spaceborn beings don't get hurt by space
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/poison/bees/Process_Spacemove(movement_dir = 0)
 	return 1
@@ -33,12 +34,6 @@
 /mob/living/simple_animal/hostile/poison/bees/New()
 	..()
 	update_bees()
-
-/mob/living/simple_animal/hostile/poison/bees/death(gibbed)
-	..(1)
-	ghostize()
-	qdel(src)
-	return
 
 /mob/living/simple_animal/hostile/poison/bees/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -47,12 +47,7 @@
 	icon_living = "holocarp"
 	maxbodytemp = INFINITY
 	gold_core_spawnable = 0
-
-/mob/living/simple_animal/hostile/carp/holocarp/death()
-	..(1)
-	ghostize()
-	qdel(src)
-	return
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/carp/megacarp
 	icon = 'icons/mob/alienqueen.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -23,9 +23,4 @@
 	flying = 1
 
 	faction = list("spooky")
-
-
-/mob/living/simple_animal/hostile/carp/eyeball/death()
-	..(1)
-	ghostize()
-	qdel(src)
+	del_on_death = 1

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -23,6 +23,12 @@
 	minbodytemp = 0
 	speak_emote = list("states")
 	gold_core_spawnable = 1
+	del_on_death = 1
+	loot = (/obj/effect/decal/cleanable/robot_debris)
+
+/mob/living/simple_animal/hostile/hivebot/New()
+	..()
+	deathmessage = "[src] blows apart!"
 
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "hivebot"
@@ -44,12 +50,7 @@
 	ranged = 1
 
 /mob/living/simple_animal/hostile/hivebot/death(gibbed)
-	..(1)
-	visible_message("<span class='warning'>[src] blows apart!</span>")
-	new /obj/effect/decal/cleanable/robot_debris(src.loc)
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	ghostize()
-	qdel(src)
-	return
+	..(1)

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -16,6 +16,7 @@
 	var/life_span = INFINITY //how long until they despawn
 	var/mob/living/parent_mob
 	var/multiply_chance = 0 //if we multiply on hit
+	del_on_death = 1
 
 
 /mob/living/simple_animal/hostile/illusion/Life()
@@ -35,11 +36,9 @@
 	faction -= "neutral"
 
 
-/mob/living/simple_animal/hostile/illusion/death()
+/mob/living/simple_animal/hostile/illusion/New()
 	..()
-	visible_message("<span class='warning'>[src] vanishes in a puff of smoke! It was a fake!</span>")
-	qdel(src)
-
+	deathmessage = "[src] vanishes into thin air! It was a fake!"
 
 /mob/living/simple_animal/hostile/illusion/examine(mob/user)
 	if(parent_mob)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -27,12 +27,7 @@
 	faction = list("mimic")
 	move_to_delay = 9
 	gold_core_spawnable = 1
-
-/mob/living/simple_animal/hostile/mimic/death()
-	..(1)
-	visible_message("[src] stops moving!")
-	ghostize()
-	qdel(src)
+	del_on_death = 1
 
 // Aggro when you try to open them. Will also pickup loot when spawns and drop it when dies.
 /mob/living/simple_animal/hostile/mimic/crate

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -77,8 +77,8 @@
 	aggro_vision_range = 9
 	idle_vision_range = 2
 	turns_per_move = 5
-	loot = list(/obj/item/weapon/ore/diamond,
-				/obj/item/weapon/ore/diamond)
+	loot = list(/obj/item/weapon/ore/diamond{layer = 4.1},
+				/obj/item/weapon/ore/diamond{layer = 4.1})
 
 /obj/item/projectile/temp/basilisk
 	name = "freezing blast"
@@ -349,7 +349,7 @@
 	anchored = 1 //Stays anchored until death as to be unpullable
 	mob_size = MOB_SIZE_LARGE
 	var/pre_attack = 0
-	loot = list(/obj/item/asteroid/goliath_hide)
+	loot = list(/obj/item/asteroid/goliath_hide{layer = 4.1})
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Life()
 	..()
@@ -511,7 +511,7 @@
 	environment_smash = 0
 	var/wumbo = 0
 	var/inflate_cooldown = 0
-	loot = list(/obj/item/asteroid/fugu_gland)
+	loot = list(/obj/item/asteroid/fugu_gland{layer = 4.1})
 
 /mob/living/simple_animal/hostile/asteroid/fugu/Life()
 	if(!wumbo)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -77,6 +77,8 @@
 	aggro_vision_range = 9
 	idle_vision_range = 2
 	turns_per_move = 5
+	loot = list(/obj/item/weapon/ore/diamond,
+				/obj/item/weapon/ore/diamond)
 
 /obj/item/projectile/temp/basilisk
 	name = "freezing blast"
@@ -103,14 +105,6 @@
 			adjustBruteLoss(140)
 		if(3)
 			adjustBruteLoss(110)
-
-/mob/living/simple_animal/hostile/asteroid/basilisk/death(gibbed)
-	var/counter
-	for(counter=0, counter<2, counter++)
-		var/obj/item/weapon/ore/diamond/D = new /obj/item/weapon/ore/diamond(src.loc)
-		D.layer = 4.1
-	..(gibbed)
-
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub
 	name = "goldgrub"
@@ -141,29 +135,28 @@
 	wanted_objects = list(/obj/item/weapon/ore/diamond, /obj/item/weapon/ore/gold, /obj/item/weapon/ore/silver,
 						  /obj/item/weapon/ore/uranium)
 
-	var/list/ore_types_eaten = list()
 	var/alerted = 0
-	var/ore_eaten = 1
 	var/chase_time = 100
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/New()
 	..()
-	ore_types_eaten += pick(/obj/item/weapon/ore/silver, /obj/item/weapon/ore/gold, /obj/item/weapon/ore/uranium, /obj/item/weapon/ore/diamond)
-	ore_eaten = rand(1,3)
+	deathmessage = "[src] spits up the contents of its stomach before dying!"
+	var/i = rand(1,3)
+	while(i)
+		loot += pick(/obj/item/weapon/ore/silver, /obj/item/weapon/ore/gold, /obj/item/weapon/ore/uranium, /obj/item/weapon/ore/diamond)
+		i--
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/GiveTarget(new_target)
 	target = new_target
 	if(target != null)
-		if(istype(target, /obj/item/weapon/ore))
+		if(istype(target, /obj/item/weapon/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [src.name] looks at [target.name] with hungry eyes.</span>")
-
 		else if(isliving(target))
 			Aggro()
 			visible_message("<span class='danger'>The [src.name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10
 			minimum_distance = 10
 			Burrow()
-
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/AttackingTarget()
 	if(istype(target, /obj/item/weapon/ore))
@@ -173,12 +166,9 @@
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/EatOre(atom/targeted_ore)
 	for(var/obj/item/weapon/ore/O in targeted_ore.loc)
-		ore_eaten++
-		if(!(O.type in ore_types_eaten))
-			ore_types_eaten += O.type
-		qdel(O)
-	if(ore_eaten > 10)//Limit the scope of the reward you can get, or else things might get silly
-		ore_eaten = 10
+		if(loot.len < 10)
+			loot += O.type
+			qdel(O)
 	visible_message("<span class='notice'>The ore was swallowed whole!</span>")
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Burrow()//Begin the chase to kill the goldgrub in time
@@ -189,26 +179,9 @@
 			visible_message("<span class='danger'>The [src.name] buries into the ground, vanishing from sight!</span>")
 			qdel(src)
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/proc/Reward()
-	if(!ore_eaten || ore_types_eaten.len == 0)
-		return
-	visible_message("<span class='danger'>[src] spits up the contents of its stomach before dying!</span>")
-	var/counter
-	for(var/R in ore_types_eaten)
-		for(counter=0, counter < ore_eaten, counter++)
-			new R(src.loc)
-	ore_types_eaten.Cut()
-	ore_eaten = 0
-
-
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)
 	visible_message("<span class='danger'>The [P.name] was repelled by [src.name]'s girth!</span>")
 	return
-
-/mob/living/simple_animal/hostile/asteroid/goldgrub/death(gibbed)
-	alerted = 0
-	Reward()
-	..(gibbed)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/adjustBruteLoss(damage)
 	idle_vision_range = 9
@@ -245,6 +218,7 @@
 	retreat_distance = 3
 	minimum_distance = 3
 	pass_flags = PASSTABLE
+	loot = list(/obj/item/organ/internal/hivelord_core)
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/OpenFire(the_target)
 	var/mob/living/simple_animal/hostile/asteroid/hivelordbrood/A = new /mob/living/simple_animal/hostile/asteroid/hivelordbrood(src.loc)
@@ -257,7 +231,6 @@
 	OpenFire()
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/death(gibbed)
-	new /obj/item/organ/internal/hivelord_core(src.loc)
 	mouse_opacity = 1
 	..(gibbed)
 
@@ -337,14 +310,12 @@
 	throw_message = "falls right through the strange body of the"
 	environment_smash = 0
 	pass_flags = PASSTABLE
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/New()
 	..()
 	spawn(100)
 		qdel(src)
-
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/death()
-	qdel(src)
 
 /mob/living/simple_animal/hostile/asteroid/goliath
 	name = "goliath"
@@ -378,6 +349,7 @@
 	anchored = 1 //Stays anchored until death as to be unpullable
 	mob_size = MOB_SIZE_LARGE
 	var/pre_attack = 0
+	loot = list(/obj/item/asteroid/goliath_hide)
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Life()
 	..()
@@ -461,11 +433,6 @@
 		spawn(50)
 			qdel(src)
 
-/mob/living/simple_animal/hostile/asteroid/goliath/death(gibbed)
-	var/obj/item/asteroid/goliath_hide/G = new /obj/item/asteroid/goliath_hide(src.loc)
-	G.layer = 4.1
-	..(gibbed)
-
 /obj/item/asteroid/goliath_hide
 	name = "goliath hide plates"
 	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
@@ -544,6 +511,7 @@
 	environment_smash = 0
 	var/wumbo = 0
 	var/inflate_cooldown = 0
+	loot = list(/obj/item/asteroid/fugu_gland)
 
 /mob/living/simple_animal/hostile/asteroid/fugu/Life()
 	if(!wumbo)
@@ -610,8 +578,6 @@
 
 /mob/living/simple_animal/hostile/asteroid/fugu/death(gibbed)
 	Deflate()
-	var/obj/item/asteroid/fugu_gland/F = new /obj/item/asteroid/fugu_gland(src.loc)
-	F.layer = 4.1
 	..(gibbed)
 
 /obj/item/asteroid/fugu_gland

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -58,6 +58,7 @@
 	cap_dead.color = cap_color
 	UpdateMushroomCap()
 	health = maxHealth
+	deathmessage = "[src] fainted."
 	..()
 
 /mob/living/simple_animal/hostile/mushroom/adjustBruteLoss(damage)//Possibility to flee from a fight just to make it more visually interesting
@@ -90,8 +91,6 @@
 	UpdateMushroomCap()
 
 /mob/living/simple_animal/hostile/mushroom/death(gibbed)
-	if(!gibbed)
-		visible_message("[src] fainted.")
 	..(gibbed)
 	UpdateMushroomCap()
 

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -22,9 +22,9 @@
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
 	speak_emote = list("yarrs")
-	var/corpse = /obj/effect/landmark/mobcorpse/pirate
-	var/weapon1 = /obj/item/weapon/melee/energy/sword/pirate
-
+	loot = list(/obj/effect/landmark/mobcorpse/pirate,
+			/obj/item/weapon/melee/energy/sword/pirate)
+	del_on_death = 1
 	faction = list("pirate")
 
 /mob/living/simple_animal/hostile/pirate/ranged
@@ -38,17 +38,5 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	projectiletype = /obj/item/projectile/beam
-	corpse = /obj/effect/landmark/mobcorpse/pirate/ranged
-	weapon1 = /obj/item/weapon/gun/energy/laser
-
-
-/mob/living/simple_animal/hostile/pirate/death()
-	..(1)
-	visible_message("[src] stops moving.")
-	if(corpse)
-		new corpse (src.loc)
-	if(weapon1)
-		new weapon1 (src.loc)
-	ghostize()
-	qdel(src)
-	return
+	loot = list(/obj/effect/landmark/mobcorpse/pirate/ranged,
+			/obj/item/weapon/gun/energy/laser)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -23,8 +23,8 @@
 	attacktext = "attacks"
 	attack_sound = 'sound/items/bikehorn.ogg'
 	environment_smash = 0
-
-	var/corpse = /obj/effect/landmark/mobcorpse/clown
+	del_on_death = 1
+	loot = list(/obj/effect/landmark/mobcorpse/clown)
 
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 270
@@ -36,10 +36,3 @@
 		adjustBruteLoss(10)
 	else if(bodytemperature > maxbodytemp)
 		adjustBruteLoss(15)
-
-/mob/living/simple_animal/hostile/retaliate/clown/death(gibbed)
-	..(gibbed)
-	if(corpse)
-		new corpse (src.loc)
-	qdel(src)
-	return

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -19,19 +19,20 @@
 	attacktext = "punches"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	a_intent = "harm"
-	var/corpse = /obj/effect/landmark/mobcorpse/russian
-	var/weapon1 = /obj/item/weapon/kitchen/knife
+	loot = list(/obj/effect/landmark/mobcorpse/russian,
+				/obj/item/weapon/kitchen/knife)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
 	faction = list("russian")
 	status_flags = CANPUSH
+	del_on_death = 1
 
 
 /mob/living/simple_animal/hostile/russian/ranged
 	icon_state = "russianranged"
 	icon_living = "russianranged"
-	corpse = /obj/effect/landmark/mobcorpse/russian/ranged
-	weapon1 = /obj/item/weapon/gun/projectile/revolver/mateba
+	loot = list(/obj/effect/landmark/mobcorpse/russian/ranged,
+				/obj/item/weapon/gun/projectile/revolver/mateba)
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
@@ -39,18 +40,9 @@
 	casingtype = /obj/item/ammo_casing/a357
 
 /mob/living/simple_animal/hostile/russian/ranged/New()
-	if(prob(50) && ispath(weapon1,/obj/item/weapon/gun/projectile/revolver/mateba)) //to preserve varedits
-		weapon1 = /obj/item/weapon/gun/projectile/shotgun/boltaction
+	var/obj/item/weapon/gun/projectile/revolver/mateba/M
+	if(prob(50) && is_type_in_list(M, loot)) //to preserve varedits
+		loot = list(/obj/effect/landmark/mobcorpse/russian/ranged,
+					/obj/item/weapon/gun/projectile/shotgun/boltaction)
 		casingtype = /obj/item/ammo_casing/a762
 	..()
-
-/mob/living/simple_animal/hostile/russian/death(gibbed)
-	..(1)
-	visible_message("[src] stops moving.")
-	if(corpse)
-		new corpse (src.loc)
-	if(weapon1)
-		new weapon1 (src.loc)
-	ghostize()
-	qdel(src)
-	return

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -30,20 +30,9 @@
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 8
 	layer = MOB_LAYER - 0.1
-	var/remains = /obj/effect/decal/remains/human
-	var/loot
-	var/deathmessage = "The skeleton collaspes into a pile of bones!"
-
-
-/mob/living/simple_animal/hostile/skeleton/death(gibbed)
-	..(gibbed)
-	if(remains)
-		new remains (src.loc)
-	if(loot)
-		new loot (src.loc)
-	visible_message("<span class='danger'>[deathmessage]</span>")
-	qdel(src)
-	return
+	deathmessage = "The skeleton collaspes into a pile of bones!"
+	del_on_death = 1
+	loot = list(/obj/effect/decal/remains/human)
 
 /mob/living/simple_animal/hostile/skeleton/eskimo
 	name = "undead eskimo"
@@ -58,7 +47,8 @@
 	melee_damage_lower = 17
 	melee_damage_upper = 20
 	deathmessage = "The skeleton collaspes into a pile of bones, its gear falling to the floor!"
-	loot = list(/obj/item/weapon/twohanded/spear,
+	loot = list(/obj/effect/decal/remains/human,
+				/obj/item/weapon/twohanded/spear,
 				/obj/item/clothing/shoes/winterboots,
 				/obj/item/clothing/suit/hooded/wintercoat)
 
@@ -75,14 +65,16 @@
 	speed = 2
 	gold_core_spawnable = 0
 	speak_chance = 1
-	speak = list("THE GODS WILL IT!","DUES VULT!","REMOVE KABAB!")
+	speak = list("THE GODS WILL IT!","DEUS VULT!","REMOVE KABAB!")
 	force_threshold = 10 //trying to simulate actually having armor
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	deathmessage = "The templar knight collaspes into a pile of bones, its gear clanging as it hits the ground!"
-	loot = list(/obj/item/clothing/suit/armor/riot/knight/templar,
+	loot = list(/obj/effect/decal/remains/human,
+				/obj/item/clothing/suit/armor/riot/knight/templar,
 				/obj/item/clothing/head/helmet/knight/templar,
 				/obj/item/weapon/claymore/hog{name = "holy sword"})
+
 /mob/living/simple_animal/hostile/skeleton/templar/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
@@ -100,4 +92,4 @@
 	maxHealth = 75
 	health = 75
 	color = rgb(114,228,250)
-	remains = /obj/effect/decal/remains/human{color = rgb(114,228,250)}
+	loot = list(/obj/effect/decal/remains/human{color = rgb(114,228,250)})

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -21,24 +21,12 @@
 	attacktext = "punches"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	a_intent = "harm"
-	var/corpse = /obj/effect/landmark/mobcorpse/syndicatesoldier
-	var/weapon1
-	var/weapon2
+	loot = list(/obj/effect/landmark/mobcorpse/syndicatesoldier)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 15
 	faction = list("syndicate")
 	status_flags = CANPUSH
-
-/mob/living/simple_animal/hostile/syndicate/death(gibbed)
-	..(gibbed)
-	if(corpse)
-		new corpse (src.loc)
-	if(weapon1)
-		new weapon1 (src.loc)
-	if(weapon2)
-		new weapon2 (src.loc)
-	qdel(src)
-	return
+	del_on_death = 1
 
 ///////////////Sword and shield////////////
 
@@ -47,8 +35,9 @@
 	melee_damage_upper = 30
 	icon_state = "syndicatemelee"
 	icon_living = "syndicatemelee"
-	weapon1 = /obj/item/weapon/melee/energy/sword/saber/red
-	weapon2 = /obj/item/weapon/shield/energy
+	loot = list(/obj/effect/landmark/mobcorpse/syndicatesoldier,
+				/obj/item/weapon/melee/energy/sword/saber/red,
+				/obj/item/weapon/shield/energy)
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	armour_penetration = 28
@@ -72,7 +61,9 @@
 	icon_state = "syndicatemeleespace"
 	icon_living = "syndicatemeleespace"
 	name = "Syndicate Commando"
-	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
+	loot = list(/obj/effect/landmark/mobcorpse/syndicatecommando,
+				/obj/item/weapon/melee/energy/sword/saber/red,
+				/obj/item/weapon/shield/energy)
 	speed = 1
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/Process_Spacemove(movement_dir = 0)
@@ -87,8 +78,9 @@
 	icon_living = "syndicateranged"
 	casingtype = /obj/item/ammo_casing/c45nostamina
 	projectilesound = 'sound/weapons/Gunshot_smg.ogg'
-
-	weapon1 = /obj/item/weapon/gun/projectile/automatic/c20r/unrestricted
+	loot = list(/obj/effect/landmark/mobcorpse/syndicatesoldier,
+				/obj/item/weapon/gun/projectile/automatic/c20r/unrestricted,
+				/obj/item/weapon/shield/energy)
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space
 	icon_state = "syndicaterangedpsace"
@@ -96,8 +88,10 @@
 	name = "Syndicate Commando"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	corpse = /obj/effect/landmark/mobcorpse/syndicatecommando
 	speed = 1
+	loot = list(/obj/effect/landmark/mobcorpse/syndicatecommando,
+				/obj/item/weapon/gun/projectile/automatic/c20r/unrestricted,
+				/obj/item/weapon/shield/energy)
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/Process_Spacemove(movement_dir = 0)
 	return
@@ -133,9 +127,8 @@
 	flying = 1
 	speak_emote = list("states")
 	gold_core_spawnable = 1
+	del_on_death = 1
 
-/mob/living/simple_animal/hostile/viscerator/death(gibbed)
-	..(gibbed)
-	visible_message("<span class='danger'><b>[src]</b> is smashed into pieces!</span>")
-	qdel(src)
-	return
+/mob/living/simple_animal/hostile/viscerator/New()
+	..()
+	deathmessage = "<b>[src]</b> is smashed into pieces!"

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -33,8 +33,9 @@
 	maxbodytemp = 1200
 
 	faction = list("hostile")
-	var/drop_type = /obj/item/stack/sheet/mineral/wood
+	loot = list(/obj/item/stack/sheet/mineral/wood)
 	gold_core_spawnable = 1
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/tree/Life()
 	..()
@@ -57,12 +58,9 @@
 			C.visible_message("<span class='danger'>\The [src] knocks down \the [C]!</span>", \
 					"<span class='userdanger'>\The [src] knocks you down!</span>")
 
-/mob/living/simple_animal/hostile/tree/death(gibbed)
-	..(1)
-	visible_message("<span class='danger'>[src] is hacked into pieces!</span>")
-	new drop_type(loc)
-	ghostize()
-	qdel(src)
+/mob/living/simple_animal/hostile/tree/New()
+	..()
+	deathmessage = "[src] is hacked into pieces!"
 
 /mob/living/simple_animal/hostile/tree/festivus
 	name = "festivus pole"
@@ -71,6 +69,5 @@
 	icon_living = "festivus_pole"
 	icon_dead = "festivus_pole"
 	icon_gib = "festivus_pole"
-	drop_type = /obj/item/stack/rods
+	loot = list(/obj/item/stack/rods)
 	speak_emote = list("polls")
-

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -65,7 +65,7 @@
 	var/grasp_chance = 20
 	var/grasp_pull_chance = 85
 	var/grasp_range = 4
-
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/venus_human_trap/handle_automated_action()
 	if(..())
@@ -107,8 +107,3 @@
 	if(.)
 		if(the_target in grasping)
 			return 0
-
-
-
-/mob/living/simple_animal/hostile/venus_human_trap/death()
-	qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -25,6 +25,9 @@
 
 	retreat_distance = 3 //out of fireball range
 	minimum_distance = 3
+	del_on_death = 1
+	loot = list(/obj/effect/landmark/mobcorpse/wizard,
+				/obj/item/weapon/staff)
 
 	var/obj/effect/proc_holder/spell/dumbfire/fireball/fireball = null
 	var/obj/effect/proc_holder/spell/targeted/turf_teleport/blink/blink = null
@@ -53,13 +56,6 @@
 	blink.player_lock = 0
 	blink.outer_tele_radius = 3
 	AddSpell(blink)
-
-/mob/living/simple_animal/hostile/wizard/death(gibbed)
-	..(gibbed)
-	new /obj/effect/landmark/mobcorpse/wizard(src.loc)
-	new /obj/item/weapon/staff(src.loc)
-	qdel(src)
-	return
 
 /mob/living/simple_animal/hostile/wizard/handle_automated_action()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -114,7 +114,7 @@
 	spawn_text = "emerges from"
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	faction = list("zombie")
-
+	del_on_death = 1
 
 /mob/living/simple_animal/hostile/spawner/zombie/lesser
 	name = "lesser corpse pit"
@@ -124,9 +124,9 @@
 	health = 200
 	maxHealth = 200
 
-/mob/living/simple_animal/hostile/spawner/zombie/death()
-	visible_message("<span class='danger'>[src] collapes, stopping the flow of zombies!</span>")
-	qdel(src)
+/mob/living/simple_animal/hostile/spawner/zombie/New()
+	..()
+	deathmessage = "[src] collapes, stopping the flow of zombies!"
 
 
 /obj/item/weapon/shovel/cursed
@@ -157,7 +157,7 @@
 	AIStatus = AI_OFF
 	stop_automated_movement = 1
 	density = 0
-	
+
 /mob/living/simple_animal/hostile/zombie/holder/New()
 	..()
 	spawn(rand(800,1200))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -69,6 +69,10 @@
 
 	var/sentience_type = SENTIENCE_ORGANIC // Sentience type, for slime potions
 
+	var/list/loot = list() //list of things spawned at mob's loc when it dies
+	var/del_on_death = 0 //causes mob to be deleted on death, useful for mobs that spawn lootable corpses
+	var/deathmessage = ""
+
 /mob/living/simple_animal/New()
 	..()
 	verbs -= /mob/verb/observe
@@ -390,15 +394,24 @@
 		return 1
 
 /mob/living/simple_animal/death(gibbed)
-	health = 0
-	icon_state = icon_dead
-	stat = DEAD
-	density = 0
 	if(nest)
 		nest.spawned_mobs -= src
 		nest = null
-	if(!gibbed)
+	if(loot.len)
+		for(var/i in loot)
+			new i(loc)
+	if(deathmessage && !gibbed)
+		visible_message("<span class='danger'>[deathmessage]</span>")
+	else if(!del_on_death)
 		visible_message("<span class='danger'>\the [src] stops moving...</span>")
+	if(del_on_death)
+		ghostize()
+		qdel(src)
+	else
+		health = 0
+		icon_state = icon_dead
+		stat = DEAD
+		density = 0
 	..()
 
 /mob/living/simple_animal/ex_act(severity, target)


### PR DESCRIPTION
Makes simple animals handle dropping items on death with a list; All items in loot list are spawned at animal's loc during death().
Animals that delete themselves and make messages when dying are handled by vars.
Reworks goldgrub procs to eliminate additional list containing ores.
Removes some copypasta.

This also allows for any simple animal to be easily varedited to contain loot or get removed on death.
