### PR TITLE
Highlander won't kill people who are in space upon being used

### DIFF
--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -25,6 +25,8 @@
 			H << "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]"
 			obj_count++
 
+		if(H.z != ZLEVEL_STATION || H.isinspace()) //We put them on the arrivals shuttle so they don't straight up die
+			H.loc = pick(latejoin)
 		for (var/obj/item/I in H)
 			if (istype(I, /obj/item/weapon/implant))
 				continue


### PR DESCRIPTION
Warps them to arrivals shuttle before equipping them if they are in space.

Fixes #13410
