### PR TITLE
fixes flashes being stupid on emp.

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -132,9 +132,9 @@
 
 
 /obj/item/device/assembly/flash/emp_act(severity)
-	if(!try_use_flash())
+	if(!try_use_flash() || !loc)
 		return 0
-	for(var/mob/living/carbon/M in viewers(3, null))
+	for(var/mob/living/carbon/M in viewers(3, loc))
 		flash_carbon(M, null, 10, 0)
 	burn_out()
 	..()


### PR DESCRIPTION
now, if i understand this code right, the old code would flash in the viewers(3) of **_FUCKING USR**_ on emp, meaning the person to trigger the emp, not the person holding the flash.

The documents say that if the second arg is null, **_it defaults to usr.**_

I have it doing loc because this way it flashes from inside a pocket, but not a backpack or other container.

Fixes #6055

:cl:
fix: flashes that were emp'ed were incorrectly flashing people in range of the emper, not in range of the flash.
tweak: flashes in a mob's inventory that are emp'ed will only aoe stun if it is not inside of a container like a backpack/box
/:cl:
