### PR TITLE
Removes ei nath from spellbook

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -104,11 +104,6 @@
 	log_name = "MM"
 	category = "Defensive"
 
-/datum/spellbook_entry/disintegrate
-	name = "Disintegrate"
-	spell_type = /obj/effect/proc_holder/spell/targeted/touch/disintegrate
-	log_name = "DG"
-
 /datum/spellbook_entry/disabletech
 	name = "Disable Tech"
 	spell_type = /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech


### PR DESCRIPTION
Everyone agrees its the most hated spell and OP,
theres little to no counters to it, and it just isn't fair for wiz rounds

:cl: 
add: Wizard's federation now no longer stocks disintegrate in their standard spellbooks.
/:cl:
