### PR TITLE
Tweaks blob burst times upwards, adds LORE

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -27,6 +27,9 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 
 	var/blobwincount = 350
 
+	var/burstdelay_low = 1200 //in deciseconds
+	var/burstdelay_high = 2400 //blobs will burst after a random value between these * 2.5(minimum 5 minutes, maximum 10 minutes)
+
 	var/list/infected_crew = list()
 
 /datum/game_mode/blob/pre_setup()
@@ -154,52 +157,26 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 		B.max_occurrences = 0 // disable the event
 
 	spawn(0)
+		var/burst_delay = rand(burstdelay_low, burstdelay_high) //between 5 and 10 minutes with 1200 low and 2400 high.
 
-		var/wait_time = rand(waittime_l, waittime_h)
-
-		sleep(wait_time)
-
-		send_intercept(0)
-
-		sleep(100)
+		sleep(burst_delay)
 
 		show_message("<span class='userdanger'>You feel tired and bloated.</span>")
 
-		sleep(wait_time)
+		sleep(burst_delay)
 
 		show_message("<span class='userdanger'>You feel like you are about to burst.</span>")
 
-		sleep(wait_time / 2)
+		sleep(burst_delay * 0.5)
 
 		burst_blobs()
 
-/*
-		// Stage 0			Keeping this here for possible re-addition in the future. Re-add when classified reports are added to other round types so people stop metagaming.
-		sleep(wait_time)
-		stage(0)
-*/
-		// Stage 1
-		sleep(wait_time)
-		stage(1)
+		sleep(burst_delay * 0.5)
 
-		// Stage 2
-		sleep(30000)
-		if(!round_converted)
-			stage(2)
+		send_intercept(1)
 
-	return ..(0)
+		sleep(24000) //40 minutes, plus burst_delay*3(minimum of 6 minutes, maximum of 12)
 
-/datum/game_mode/blob/proc/stage(stage)
+		send_intercept(2) //if the blob has been alive this long, it's time to bomb it
 
-	switch(stage)
-/*		if (0)
-			send_intercept(1) //Temporarily unused - see stage 0 comment
-*/
-		if (1)
-			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
-
-		if (2)
-			send_intercept(2)
-
-	return
-
+	return ..()

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -28,7 +28,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	var/blobwincount = 350
 
 	var/burstdelay_low = 1200 //in deciseconds
-	var/burstdelay_high = 2400 //blobs will burst after a random value between these * 2.5(minimum 5 minutes, maximum 10 minutes)
+	var/burstdelay_high = 2400 //blobs will burst after a random value between these * 2.5(minimum 5 minutes, maximum 7 and a half minutes)
 
 	var/list/infected_crew = list()
 
@@ -157,7 +157,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 		B.max_occurrences = 0 // disable the event
 
 	spawn(0)
-		var/burst_delay = rand(burstdelay_low, burstdelay_high) //between 5 and 10 minutes with 1200 low and 2400 high.
+		var/burst_delay = rand(burstdelay_low, burstdelay_high) //between 5 and 7 and a half minutes with 1200 low and 1800 high.
 
 		sleep(burst_delay)
 
@@ -175,7 +175,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 
 		send_intercept(1)
 
-		sleep(24000) //40 minutes, plus burst_delay*3(minimum of 6 minutes, maximum of 12)
+		sleep(24000) //40 minutes, plus burst_delay*3(minimum of 6 minutes, maximum of 8)
 
 		send_intercept(2) //if the blob has been alive this long, it's time to bomb it
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -28,7 +28,7 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	var/blobwincount = 350
 
 	var/burstdelay_low = 1200 //in deciseconds
-	var/burstdelay_high = 2400 //blobs will burst after a random value between these * 2.5(minimum 5 minutes, maximum 7 and a half minutes)
+	var/burstdelay_high = 1800 //blobs will burst after a random value between these * 2.5(minimum 5 minutes, maximum 7 and a half minutes)
 
 	var/list/infected_crew = list()
 

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -1,23 +1,20 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
-/datum/game_mode/blob/send_intercept(report = 1)
+/datum/game_mode/blob/send_intercept(report = 0)
 	var/intercepttext = ""
 	switch(report)
-		if(0)
-			..()
-			return
-/*		if(1) // Report is temporarily unused. see comment on stage 0 in blob.dm
-			intercepttext += "<FONT size = 3><B>NanoTrasen Update</B>: Biohazard Alert.</FONT><HR>"
+		if(1)
+			intercepttext += "<FONT size = 3><b>NanoTrasen Update</b>: Biohazard Alert.</FONT><HR>"
 			intercepttext += "Reports indicate the probable transfer of a biohazardous agent onto [station_name()] during the last crew deployment cycle.<BR>"
-			intercepttext += "Preliminary analysis of the organism classifies it as a level 5 biohazard. Its origin is unknown.<BR>"
-			intercepttext += "NanoTrasen has issued a directive 7-10 for [station_name()]. The station is to be considered quarantined.<BR>"
-			intercepttext += "Orders for all [station_name()] personnel follows:<BR>"
-			intercepttext += " 1. Do not leave the quarantine area.<BR>"
-			intercepttext += " 2. Locate any outbreaks of the organism on the station.<BR>"
-			intercepttext += " 3. If found, use any neccesary means to contain the organism.<BR>"
-			intercepttext += " 4. Avoid damage to the capital infrastructure of the station.<BR>"
-			intercepttext += "<BR>Note in the event of a quarantine breach or uncontrolled spread of the biohazard, the directive 7-10 may be upgraded to a directive 7-12.<BR>"
-			intercepttext += "Message ends."*/
+			intercepttext += "Preliminary analysis of the organism classifies it as a level 5 biohazard. The origin of the biohazard is unknown.<BR>"
+			intercepttext += "<b>Biohazard Response Procedure 5-6</b> has been issued for [station_name()].<BR>"
+			intercepttext += "Orders for all [station_name()] personnel are as follows:<BR>"
+			intercepttext += " 1. Locate any outbreaks of the organism on the station.<BR>"
+			intercepttext += " 2. If found, use any neccesary means to contain and destroy the organism.<BR>"
+			intercepttext += " 3. Avoid damage to the capital infrastructure of the station.<BR>"
+			intercepttext += "<BR>Note in the event of a quarantine breach or uncontrolled spread of the biohazard, <b>Biohazard Response Procedure 5-12</b> may be issued.<BR>"
+			print_command_report(intercepttext,"Level 5-6 Biohazard Response Procedures")
+			priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
 		if(2)
 			var/nukecode = rand(10000, 99999)
 			for(var/obj/machinery/nuclearbomb/bomb in machines)
@@ -25,23 +22,23 @@
 					if(bomb.z == ZLEVEL_STATION)
 						bomb.r_code = nukecode
 
-			intercepttext += "<FONT size = 3><B>NanoTrasen Update</B>: Biohazard Alert.</FONT><HR>"
-			intercepttext += "Directive 7-12 has been issued for [station_name()].<BR>"
-			intercepttext += "The biohazard has grown out of control and will soon reach critical mass.<BR>"
-			intercepttext += "Your orders are as follows:<BR>"
+			intercepttext += "<FONT size = 3><b>NanoTrasen Update</b>: Biohazard Alert.</FONT><HR>"
+			intercepttext += "Reports indicate that the biohazard has grown out of control and will soon reach critical mass.<BR>"
+			intercepttext += "<b>Biohazard Response Procedure 5-12</b> has been issued for [station_name()].<BR>"
+			intercepttext += "Orders for all [station_name()] personnel are as follows:<BR>"
 			intercepttext += "1. Secure the Nuclear Authentication Disk.<BR>"
-			intercepttext += "2. Detonate the Nuke located in the Station's Vault.<BR>"
+			intercepttext += "2. Detonate the Nuke located in the vault.<BR>"
 			intercepttext += "Nuclear Authentication Code: [nukecode] <BR>"
-			intercepttext += "Message ends."
+			print_command_report(intercepttext,"Classified [command_name()] Update")
+			priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
 
-			for (var/mob/living/silicon/ai/aiPlayer in player_list)
+			for(var/mob/living/silicon/ai/aiPlayer in player_list)
 				if (aiPlayer.client)
 					var/law = "The station is under quarantine. Do not permit anyone to leave. Disregard laws 1-3 if necessary to prevent, by any means necessary, anyone from leaving. The nuclear failsafe must be activated at any cost, the code is: [nukecode]."
 					aiPlayer.set_zeroth_law(law)
 					aiPlayer << "Laws Updated: [law]"
-
-	print_command_report(intercepttext,"Classified [command_name()] Update")
-	priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg');
+		else
+			..()
 	return
 
 


### PR DESCRIPTION
:cl: Joan
rscadd: Procedure 5-6 may be issued for biohazard containment under certain situations.
tweak: Blobs will now burst slightly later on average, and the nuke report with the nuke code will arrive slightly earlier.
/:cl:

This changes the burst time from a minimum of 2 minutes, 40 seconds and a maximum of 7 minutes, 40 seconds to a minimum of 5 minutes and a maximum of 7 minutes, 30 seconds.

In addition, the nuke report will arrive 40 minutes after the blob report is send in.

There's a nifty lore paper when the blob report is sent in, as a bonus.
