### PR TITLE
Command headsets being really loud is now a physical toggle

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -158,7 +158,7 @@
 		dat+=text_sec_channel(ch_name, channels[ch_name])
 	dat+= text_wires()
 	if (command)
-		dat+= "<b>High Volume Mode:</b> [use_command ? "<A href='byond://?src=\ref[src];bold=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];bold=1'>Disengaged</A>"]<BR>"
+		dat+= "<b>High Volume Mode:</b> [use_command ? "<A href='byond://?src=\ref[src];bold'>Engaged</A>" : "<A href='byond://?src=\ref[src];bold'>Disengaged</A>"]<BR>"
 	var/datum/browser/popup = new(user, "radio", "[src]")
 	popup.set_content(dat)
 	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
@@ -209,7 +209,7 @@
 			else
 				channels[chan_name] |= FREQ_LISTENING
 	else if (href_list["bold"])
-		use_command = text2num(href_list["bold"])
+		use_command = !use_command
 	if (!( master ))
 		if (istype(loc, /mob))
 			interact(loc)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -40,7 +40,8 @@
 	var/const/FREQ_LISTENING = 1
 		//FREQ_BROADCASTING = 2
 
-	var/command = FALSE //If we are speaking into a command headset, our text is LARGE
+	var/command = FALSE //If we are speaking into a command headset, our text can be BOLD
+	var/use_command = FALSE
 
 /obj/item/device/radio/proc/set_frequency(new_frequency)
 	remove_radio(src, frequency)
@@ -156,8 +157,8 @@
 	for (var/ch_name in channels)
 		dat+=text_sec_channel(ch_name, channels[ch_name])
 	dat+= text_wires()
-	//user << browse(dat, "window=radio")
-	//onclose(user, "radio")
+	if (command)
+		dat+= "<b>High Volume Mode:</b> [use_command ? "<A href='byond://?src=\ref[src];bold=0'>Engaged</A>" : "<A href='byond://?src=\ref[src];bold=1'>Disengaged</A>"]<BR>"
 	var/datum/browser/popup = new(user, "radio", "[src]")
 	popup.set_content(dat)
 	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
@@ -207,6 +208,8 @@
 				channels[chan_name] &= ~FREQ_LISTENING
 			else
 				channels[chan_name] |= FREQ_LISTENING
+	else if (href_list["bold"])
+		use_command = text2num(href_list["bold"])
 	if (!( master ))
 		if (istype(loc, /mob))
 			interact(loc)
@@ -235,7 +238,7 @@
 	if(!M.IsVocal())
 		return
 
-	if(command)
+	if(use_command)
 		spans |= SPAN_COMMAND
 
 	/* Quick introduction:

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -91,7 +91,7 @@ h1.alert, h2.alert		{color: #000000;}
 .papyrus				{font-family: "Papyrus", cursive, sans-serif;}
 .robot					{font-family: "Courier New", cursive, sans-serif;}
 
-.commmand_headset       {font-weight: bold; font-size: 3;}
+.commmand_headset       {font-weight: bold;}
 .big					{font-size: 3;}
 .reallybig				{font-size: 4;}
 .greentext				{color: #00FF00;	font-size: 3;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -91,7 +91,7 @@ h1.alert, h2.alert		{color: #000000;}
 .papyrus				{font-family: "Papyrus", cursive, sans-serif;}
 .robot					{font-family: "Courier New", cursive, sans-serif;}
 
-.commmand_headset       {font-weight: bold;}
+.commmand_headset       {font-weight: bold; font-size: 3;}
 .big					{font-size: 3;}
 .reallybig				{font-size: 4;}
 .greentext				{color: #00FF00;	font-size: 3;}


### PR DESCRIPTION
Command headsets being really loud is now a physical toggle on relevant headsets that starts off.

<s>The span change for this mode is now just bolding, as what matters is that the text looks different, as to stand out in the sea of green. It DOESN'T need to be as big as an attack message.</s> Fine have your memetext

Please stop merging PRs with obvious unresolved issues :heart: 

Fixes #14010
