### PR TITLE
New malf power (lipreading) + points rebalancing

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -111,7 +111,7 @@
 	module_name = "AI Turret Upgrade"
 	mod_pick_name = "turret"
 	description = "Improves the power and health of all AI turrets. This effect is permanent."
-	cost = 50
+	cost = 30
 	one_time = 1
 
 	power_type = /mob/living/silicon/ai/proc/upgrade_turrets
@@ -298,7 +298,7 @@
 	mod_pick_name = "overload"
 	description = "Overloads an electrical machine, causing a small explosion. 2 uses."
 	uses = 2
-	cost = 15
+	cost = 20
 
 	power_type = /mob/living/silicon/ai/proc/overload_machine
 
@@ -327,7 +327,7 @@
 	mod_pick_name = "override"
 	description = "Overrides a machine's programming, causing it to rise up and attack everyone except other machines. 4 uses."
 	uses = 4
-	cost = 15
+	cost = 30
 
 	power_type = /mob/living/silicon/ai/proc/override_machine
 
@@ -606,3 +606,22 @@
 				temp = AM.description
 	src.use(usr)
 	return
+
+
+/datum/AI_Module/large/eavesdrop
+	module_name = "Enhanced Surveillance"
+	mod_pick_name = "eavesdrop"
+	description = "Via a combination of hidden microphones and lip reading software, you are able to use your cameras to listen in on conversations."
+	cost = 30
+	one_time = 1
+
+	power_type = /mob/living/silicon/ai/proc/surveillance
+
+/mob/living/silicon/ai/proc/surveillance()
+	set category = "Malfunction"
+	set name = "Enhanced Surveillance"
+
+	if(eyeobj)
+		eyeobj.relay_speech = TRUE
+	src << "<span class='notice'>OTA firmware distribution complete! Cameras upgraded: Enhanced surveillance package online.</span>"
+	verbs -= /mob/living/silicon/ai/proc/surveillance

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -145,10 +145,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(speaker && masters.len && !radio_freq)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
 		for(var/mob/living/silicon/ai/master in masters)
 			if(masters[master] && speaker != master)
-				raw_message = master.lang_treat(speaker, message_langs, raw_message, spans)
-				var/name_used = speaker.GetVoice()
-				var/rendered = "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> <span class='message'>[raw_message]</span></span></i>"
-				master.show_message(rendered, 2)
+				master.relay_speech(message, speaker, message_langs, raw_message, radio_freq, spans)
 
 /obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, turf/T = loc)
 	var/obj/effect/overlay/holo_pad_hologram/h = new(T)//Spawn a blank effect at the location.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -843,3 +843,9 @@ var/list/ai_list = list()
 	if(M && cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
 		return
 	return 1
+
+/mob/living/silicon/ai/proc/relay_speech(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
+	raw_message = lang_treat(speaker, message_langs, raw_message, spans)
+	var/name_used = speaker.GetVoice()
+	var/rendered = "<i><span class='game say'>Relayed Speech: <span class='name'>[name_used]</span> <span class='message'>[raw_message]</span></span></i>"
+	show_message(rendered, 2)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -5,7 +5,8 @@
 
 /mob/camera/aiEye
 	name = "Inactive AI Eye"
-
+	
+	invisibility = 100
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
 	var/relay_speech = FALSE

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -5,12 +5,11 @@
 
 /mob/camera/aiEye
 	name = "Inactive AI Eye"
-	
+
 	invisibility = 100
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
 	var/relay_speech = FALSE
-
 
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
@@ -80,7 +79,6 @@
 	if (user.camera_light_on)
 		user.light_cameras()
 
-
 // Return to the Core.
 /mob/living/silicon/ai/proc/view_core()
 
@@ -107,10 +105,6 @@
 	acceleration = !acceleration
 	usr << "Camera acceleration has been toggled [acceleration ? "on" : "off"]."
 
-
 /mob/camera/aiEye/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
 	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
-		raw_message = ai.lang_treat(speaker, message_langs, raw_message, spans)
-		var/name_used = speaker.GetVoice()
-		var/rendered = "<i><span class='game say'>Enhanced Camera: <span class='name'>[name_used]</span> <span class='message'>[raw_message]</span></span></i>"
-		ai.show_message(rendered, 2)
+		ai.relay_speech(message, speaker, message_langs, raw_message, radio_freq, spans)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -8,6 +8,7 @@
 
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
+	var/relay_speech = FALSE
 
 
 // Use this when setting the aiEye's location.
@@ -104,3 +105,11 @@
 		return //won't work if dead
 	acceleration = !acceleration
 	usr << "Camera acceleration has been toggled [acceleration ? "on" : "off"]."
+
+
+/mob/camera/aiEye/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
+	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
+		raw_message = ai.lang_treat(speaker, message_langs, raw_message, spans)
+		var/name_used = speaker.GetVoice()
+		var/rendered = "<i><span class='game say'>Enhanced Camera: <span class='name'>[name_used]</span> <span class='message'>[raw_message]</span></span></i>"
+		ai.show_message(rendered, 2)


### PR DESCRIPTION
New malf power upgrades your camera eye to relay speech of nearby mobs. Costs 30 points. LORE is lipreading+bugged cameras. Merry Christmas @GunHog 

Lowered the cost of the turret upgrade, raised the cost of machine uprising+overload machine (both are very spammable now that you can farm points)

:cl: Kor and GunHog
rscadd: Malfunctioning AIs can now purchase Enhanced Surveillance for 30 points, which allows them to "hear" with their camera eye.
/:cl:
