### PR TITLE
Detective starts with his bowman on

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -140,7 +140,7 @@ Detective
 	name = "Detective"
 
 	belt = /obj/item/device/pda/detective
-	ears = /obj/item/device/radio/headset/headset_sec
+	ears = /obj/item/device/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/det
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	suit = /obj/item/clothing/suit/det_suit

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -171,6 +171,7 @@
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/weapon/storage/box/evidence(src)
 	new /obj/item/device/radio/headset/headset_sec/alt(src)
+	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/device/detective_scanner(src)
 	new /obj/item/tapeproj/security(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)


### PR DESCRIPTION
The rest of security starts with their bowman on, there is no reason for the detective to have to click extra roundstart for his objectively better headset/to punish players who don't know it spawns 2 tiles away from them.
