### PR TITLE
Fixes retrovirus referring to ryetalyn as a possible cure

### DIFF
--- a/code/datums/diseases/retrovirus.dm
+++ b/code/datums/diseases/retrovirus.dm
@@ -3,7 +3,7 @@
 	max_stages = 4
 	spread_text = "Contact"
 	spread_flags = CONTACT_GENERAL
-	cure_text = "Rest or an injection of ryetalyn"
+	cure_text = "Rest or an injection of mutadone"
 	cure_chance = 6
 	agent = ""
 	viable_mobtypes = list(/mob/living/carbon/human)


### PR DESCRIPTION
Instead, it now refers to mutadone, as it should have.
