### PR TITLE
Synth Creation Surgery[WIP]

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -121,3 +121,8 @@
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
 	origin_tech = "biotech=7"
+
+/obj/item/organ/internal/brain/synthetic
+	name = "positronic brain core"
+	desc = "An artifical positronic brain, calibrated to serve in an augmented human body."
+	icon_state = "brain-x"

--- a/code/modules/surgery/synth_creation.dm
+++ b/code/modules/surgery/synth_creation.dm
@@ -1,0 +1,57 @@
+/datum/surgery/synth_creation
+//Synth surgery. Use a positronic brain to turn a fully augged, debrained corpse into a funcitonal synth!
+	name = "synth creation"
+	steps = list(/datum/surgery_step/incise, /datum/surgery_step/create_synth)
+	species = list(/mob/living/carbon/human)
+	possible_locs = list("head")
+	requires_organic_bodypart = 0 //We in fact, require the EXACT OPPOSITE.
+
+/datum/surgery/synth_creation/can_start(mob/user, mob/living/carbon/human/target)
+	// Requires a brainless corpse, obviously not already a synth.
+	if(target.getorgan(/obj/item/organ/internal/brain) || target.stat != DEAD || target.dna.species.id == "synth")
+		return 0
+	var/organ_count = 0
+	for(var/obj/item/organ/limb/robot/RR in target.organs) //Humans have six limbs. If all six are augged, it is ready for being a synth!
+		organ_count++
+	if(organ_count < 6) //Not fully augged!
+		return 0
+
+	return 1
+
+/datum/surgery_step/create_synth
+	name = "create synth using positronic brain"
+	implements = list(/obj/item/device/mmi/posibrain = 100)
+	time = 64
+
+
+/datum/surgery_step/create_synth/preop(mob/user, mob/living/carbon/human/target, target_zone, var/obj/item/device/mmi/posibrain/PB, datum/surgery/surgery)
+	if(!PB.brainmob || !PB.brainmob.client) //No player, no synth!
+		user << "<span class='warning'>[PB] must be operational before it can be installed.</span>"
+		return -1
+	if(target.getBruteLoss() || target.getFireLoss()) //Physical damage to the mechanical components of the body would complicate the operation.
+		user << "<span class='warning'>[target] appears to be damaged, and requires repair.</span>"
+		return -1
+
+	user.visible_message("[user] begins inserting [PB] into [target].", "<span class='notice'>You begin the delicate task of reconfiguring and installing the synth's brain...</span>")
+
+/datum/surgery_step/create_synth/success(mob/user, mob/living/carbon/human/target, target_zone, var/obj/item/device/mmi/posibrain/PB, datum/surgery/surgery)
+
+	if(target.key) //Well, a brainless corpse should not have a player in it anyway...
+		target.ghostize()
+
+	if(PB.brainmob.mind)
+		PB.brainmob.mind.transfer_to(target)
+		qdel(PB)
+	else
+		return 0
+
+
+	var/obj/item/organ/internal/brain/synthetic/newbrain = new /obj/item/organ/internal/brain/synthetic(target)
+	newbrain.Insert(target) //Carbons die without a brain!
+	target.revive()
+	target.emote("gasp")
+	var/datum/species/prev_species = target.dna.species
+	target.set_species(/datum/species/synth)
+	var/datum/species/synth/synthspecies = target.dna.species
+	synthspecies.assume_disguise(prev_species, target)
+	return 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1580,6 +1580,7 @@
 #include "code\modules\surgery\remove_embedded_object.dm"
 #include "code\modules\surgery\surgery.dm"
 #include "code\modules\surgery\surgery_step.dm"
+#include "code\modules\surgery\synth_creation.dm"
 #include "code\modules\surgery\tail_modification.dm"
 #include "code\modules\surgery\tools.dm"
 #include "code\modules\surgery\organs\augments_external.dm"


### PR DESCRIPTION
Adds Synth Creation surgery!
<b>This is a work in progress. The code is not complete and contains only the basics to function. Not fully tested or balanced. This PR may be discarded based on feedback.</b>
Surgery steps not defined yet, that will be done later.

To create a Nanotrasen aligned Synth, you must insert a _positronic_ brain into a fully augmented, debrained corpse. The corpse must not have any physical damage, as the procedure is very delicate!

More to come once code is progressed. Please note that the current code is quite raw and not well polished. Expect bugs and mistakes!
