### PR TITLE
[ready]Ghost popup re-work

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -389,22 +389,19 @@
 				continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg' //Alerting them to their consideration
-			switch(alert(G,Question,"Please answer in [poll_time/10] seconds!","Yes","No"))
-				if("Yes")
+			switch(askuser(G,Question,"Please answer in [poll_time/10] seconds!","Yes","No", StealFocus=0, Timeout=poll_time))
+				if(1)
 					G << "<span class='notice'>Choice registered: Yes.</span>"
-					if((world.time-time_passed)>poll_time)//If more than 30 game seconds passed.
+					if((world.time-time_passed)>poll_time)
 						G << "<span class='danger'>Sorry, you were too late for the consideration!</span>"
 						G << 'sound/machines/buzz-sigh.ogg'
-						return
-					candidates += G
-				if("No")
+					else
+						candidates += G
+				if(2)
 					G << "<span class='danger'>Choice registered: No.</span>"
-					return
-				else
-					return
 	sleep(poll_time)
 
-	//Check all our candidates, to make sure they didn't log off during the 30 second wait period.
+	//Check all our candidates, to make sure they didn't log off during the wait period.
 	for(var/mob/dead/observer/G in candidates)
 		if(!G.key || !G.client)
 			candidates.Remove(G)

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -201,7 +201,7 @@ var/datum/subsystem/pai/SSpai
 		if(!C)	return
 		asked.Add(C.key)
 		asked[C.key] = world.time
-		var/response = alert(C, "Someone is requesting a pAI personality. Would you like to play as a personal AI?", "pAI Request", "Yes", "No", "Never for this round")
+		var/response = tgalert(C, "Someone is requesting a pAI personality. Would you like to play as a personal AI?", "pAI Request", "Yes", "No", "Never for this round", StealFocus=0, Timeout=askDelay)
 		if(!C)	return		//handle logouts that happen whilst the alert is waiting for a response.
 		if(response == "Yes")
 			recruitWindow(C.mob)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -5,7 +5,7 @@
 	var/width = 0
 	var/height = 0
 	var/atom/ref = null
-	var/window_options = "focus=0;can_close=1;can_minimize=1;can_maximize=0;can_resize=1;titlebar=1;" // window option is set using window_id
+	var/window_options = "can_close=1;can_minimize=1;can_maximize=0;can_resize=1;titlebar=1;" // window option is set using window_id
 	var/stylesheets[0]
 	var/scripts[0]
 	var/title_image
@@ -100,10 +100,106 @@
 		window_size = "size=[width]x[height];"
 	user << browse(get_content(), "window=[window_id];[window_size][window_options]")
 	if (use_onclose)
-		onclose(user, window_id, ref)
+		spawn(0)
+			//winexists sleeps, so we don't need to.
+			for (var/i = 0, !winexists(user, window_id) && i < 3, i++)
+				onclose(user, window_id, ref)
+
 
 /datum/browser/proc/close()
 	user << browse(null, "window=[window_id]")
+
+/datum/browser/alert
+	var/selectedbutton = 0
+	var/opentime = 0
+	var/timeout
+	var/stealfocus
+
+/datum/browser/alert/New(User,Message,Title,Button1="Ok",Button2,Button3,StealFocus = 1,Timeout=6000)
+	if (!User)
+		return
+	var/output =  {"<center><b>[Message]</b></center><br />
+		<a style="font-size:large;float:left" href="?src=\ref[src];button=1">[Button1]</a>"}
+
+	if (Button2)
+		output += {"<a style="font-size:large;float:right" href="?src=\ref[src];button=2">[Button2]</a>"}
+
+	if (Button3)
+		EXCEPTION("button 3 is not impimented yet")
+
+
+	..(User, ckey("[User]-[Message]-[Title]-[world.time]-[rand(1,10000)]"), Title, 350, 150, src)
+	set_content(output)
+	stealfocus = StealFocus
+	if (!StealFocus)
+		window_options += "focus=false;"
+	timeout = Timeout
+
+/datum/browser/alert/open()
+	set waitfor = 0
+	opentime = world.time
+
+	if (stealfocus)
+		. = ..(use_onclose = 1)
+	else
+		var/focusedwindow = winget(user, null, "focus")
+		. = ..(use_onclose = 1)
+
+		//waits for the window to show up client side before attempting to un-focus it
+		//winexists sleeps until it gets a reply from the client, so we don't need to bother sleeping
+		for (var/i = 0, user && !winexists(user, window_id) && i < 10, i++)
+			if (focusedwindow)
+				winset(user, focusedwindow, "focus=true")
+			else
+				winset(user, "mapwindow", "focus=true")
+	if (timeout)
+		spawn(timeout)
+			close()
+
+/datum/browser/alert/close()
+	.=..()
+	opentime = 0
+
+/datum/browser/alert/proc/wait()
+	while (opentime && selectedbutton <= 0 && (!timeout || opentime+timeout >= world.time))
+		sleep (1)
+
+/datum/browser/alert/Topic(href,href_list)
+	if (href_list["close"] || !user || !user.client)
+		opentime = 0
+		return
+	if (href_list["button"])
+		var/button = text2num(href_list["button"])
+		if (button <= 3 && button >= 1)
+			selectedbutton = button
+	opentime = 0
+	close()
+
+
+/proc/askuser(var/mob/User,Message, Title, Button1="Ok", Button2, Button3, StealFocus = 1, Timeout = 6000)
+	if (!istype(User))
+		if (istype(User, /client/))
+			var/client/C = User
+			User = C.mob
+		else
+			return
+	var/datum/browser/alert/A = new(User, Message, Title, Button1, Button2, Button3, StealFocus, Timeout)
+	A.open()
+	A.wait()
+	if (A.selectedbutton)
+		return A.selectedbutton
+
+//designed as a drop in replacement for alert(); functions the same. (outside of needing User specified)
+/proc/tgalert(var/mob/User, Message, Title, Button1="Ok", Button2, Button3, StealFocus = 1, Timeout = 6000)
+	if (!User)
+		User = usr
+	switch(askuser(User, Message, Title, Button1, Button2, Button3, StealFocus, Timeout))
+		if (1)
+			return Button1
+		if (2)
+			return Button2
+		if (3)
+			return Button3
 
 // This will allow you to show an icon in the browse window
 // This is added to mob so that it can be used without a reference to the browser object

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -102,10 +102,10 @@
 	if (use_onclose)
 		spawn(0)
 			//winexists sleeps, so we don't need to.
-		for (var/i in 1 to 10)
-			if (user && winexists(user, window_id))
-				onclose(user, window_id, ref)
-				break
+			for (var/i in 1 to 10)
+				if (user && winexists(user, window_id))
+					onclose(user, window_id, ref)
+					break
 
 
 /datum/browser/proc/close()
@@ -129,7 +129,7 @@
 		output += {"<a style="font-size:large;[( Button3 ? "" : "float:right" )]" href="?src=\ref[src];button=2">[Button2]</a>"}
 
 	if (Button3)
-		output += {"<a style="font-size:large;float:right" href="?src=\ref[src];button=1">[Button1]</a>"}
+		output += {"<a style="font-size:large;float:right" href="?src=\ref[src];button=3">[Button3]</a>"}
 
 	output += {"</div>"}
 

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -238,27 +238,11 @@
 
 
 /obj/item/device/soulstone/proc/getCultGhost(obj/item/device/soulstone/C, mob/living/carbon/human/T, mob/U)
-	var/list/candidates = get_candidates(ROLE_CULTIST)
 
-	shuffle(candidates)
-
-	var/time_passed = world.time
-	var/list/consenting_candidates = list()
-
-	for(var/candidate in candidates)
-
-		spawn(0)
-			switch(alert(candidate, "Would you like to play as a Shade? Please choose quickly!","Confirmation","Yes","No"))
-				if("Yes")
-					if((world.time-time_passed)>=50 || !src)
-						return
-					consenting_candidates += candidate
-
-	sleep(50)
+	var/list/consenting_candidates = pollCandidates("Would you like to play as a Shade?", be_special_flag = ROLE_CULTIST, poll_time = 100)
 
 	if(!T) //target mob got soulstoned or gibbed during sleep(50)
 		return 0
-	listclearnulls(consenting_candidates) //some candidates might have left during sleep(50)
 
 	if(consenting_candidates.len)
 		var/client/ghost = null


### PR DESCRIPTION
Part 1, the main frame work.

This replaces alert with askuser, a version that uses sleeps and browse() and hacks.

It will auto close after the timeout, and in 95% of the cases, not steal focus.

It's styled using common.css, so midnight theme and shit.

~~Not finished, but I want to pr this before i work on de-fucking do_after~~

Seems to be ready. No noticeable bugs or runtimes.
:cl:
experimental: GHOST POPUP RE-WORK
fix: Ghost popups will no longer steal focus
fix: Ghost popups will no longer submit on key press (regardless of focus) unless you tab to a button first
tweak: Ghost popups will close themselves after the time out has ended
rscadd: Ghost popups are now themed.
/:cl:
