### PR TITLE
Fixes unpowered windoors being stuck closed

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -327,7 +327,7 @@
 							ae.loc = src.loc
 
 						qdel(src)
-			return
+				return
 
 
 	//If windoor is unpowered, crowbar, fireaxe and armblade can force it.


### PR DESCRIPTION
This return in the deconstruction istype() was badly indented.
