### PR TITLE
PDA messages now have a (F) link for ghosts

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -719,7 +719,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	if(!message || !targets.len)
 		return
-	
+
 	if(last_text && world.time < last_text + 5)
 		return
 
@@ -739,17 +739,17 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				show_to_sender(msg)
 			P.show_recieved_message(msg,src)
 			if(!multiple)
-				show_to_ghosts(msg)
+				show_to_ghosts(user,msg)
 				log_pda("[user] (PDA: [src.name]) sent \"[message]\" to [P.name]")
 		else
 			if(!multiple)
 				user << "<span class='notice'>ERROR: Server isn't responding.</span>"
 				return
 	photo = null
-	
+
 	if(multiple)
 		show_to_sender(last_sucessful_msg,1)
-		show_to_ghosts(last_sucessful_msg,1)
+		show_to_ghosts(user,last_sucessful_msg,1)
 		log_pda("[user] (PDA: [src.name]) sent \"[message]\" to Everyone")
 
 /obj/item/device/pda/proc/show_to_sender(datum/data_pda_msg/msg,multiple = 0)
@@ -769,16 +769,16 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		L = get(src, /mob/living/silicon)
 
-	if(L)
+	if(L && L.stat != UNCONSCIOUS)
 		L << "\icon[src] <b>Message from [source.owner] ([source.ownjob]), </b>\"[msg.message]\"[msg.get_photo_ref()] (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[source]'>Reply</a>)"
 
 	overlays.Cut()
 	overlays += image(icon, icon_alert)
 
-/obj/item/device/pda/proc/show_to_ghosts(datum/data_pda_msg/msg,multiple = 0)
+/obj/item/device/pda/proc/show_to_ghosts(mob/living/user, datum/data_pda_msg/msg,multiple = 0)
 	for(var/mob/M in player_list)
 		if(isobserver(M) && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTPDA))
-			M.show_message("<span class='game say'>PDA Message - <span class='name'>[msg.sender]</span> -> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>")
+			M.show_message("<a href=?src=\ref[M];follow=\ref[user]>(F)</a>[msg.sender]<span class='game say'>PDA Message - </span> -> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>")
 
 /obj/item/device/pda/proc/can_send(obj/item/device/pda/P)
 	if(!P || qdeleted(P) || P.toff)
@@ -808,7 +808,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(useTC == 2)
 		return useMS
 	else
-		return null 
+		return null
 
 
 /obj/item/device/pda/proc/send_to_all(mob/living/U = usr)


### PR DESCRIPTION
Mostly so admins can go nuke the person who stole the laywer PDA to send WGW to everyone on station. Fixes #13829

Also fixes seeing PDA messages while in crit. Fixes #14087
