### PR TITLE
Fixes successive generations of grey tide clones not despawning

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -58,7 +58,7 @@
 			return
 		var/mob/living/simple_animal/hostile/illusion/M = new(loc)
 		M.faction = faction.Copy()
-		M.Copy_Parent(parent_mob, 80, health/2, melee_damage_upper, multiply_chance)
+		M.Copy_Parent(parent_mob, 80, health/2, melee_damage_upper, multiply_chance/2)
 		M.GiveTarget(L)
 
 ///////Actual Types/////////

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -58,7 +58,7 @@
 			return
 		var/mob/living/simple_animal/hostile/illusion/M = new(loc)
 		M.faction = faction.Copy()
-		M.Copy_Parent(parent_mob, life_span, health/2, melee_damage_upper, multiply_chance)
+		M.Copy_Parent(parent_mob, 80, health/2, melee_damage_upper, multiply_chance)
 		M.GiveTarget(L)
 
 ///////Actual Types/////////


### PR DESCRIPTION
:cl: Kor
bugfix: Fixes successive generations of grey tide clones not despawning.
tweak: Using challenge ops now delays shuttle refuel.
/:cl:
