### PR TITLE
Make JSON.stringify encode numbers properly

### DIFF
--- a/code/modules/json/json.dm
+++ b/code/modules/json/json.dm
@@ -12,7 +12,7 @@
 /datum/jsonHelper/proc/WriteValue(list/json, value)
 	. = json
 	if(isnum(value))
-		json += value // Consider num2text(value, 20) for maximum accuracy.
+		json += num2text(value, 20)
 	else if(isnull(value))
 		json += "null"
 	else if(istext(value))


### PR DESCRIPTION
JSON doesn't allow scientific/exponential notation with a space...

Fixes #14098
