### PR TITLE
Lowers thermals TC cost

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -760,7 +760,7 @@ var/list/uplink_items = list()
 	They allow you to see organisms through walls by capturing the upper portion of the infrared light spectrum, emitted as heat and light by objects. \
 	Hotter objects, such as warm bodies, cybernetic organisms and artificial intelligence cores emit more of this light than cooler objects like walls and airlocks." //THEN WHY CANT THEY SEE PLASMA FIRES????
 	item = /obj/item/clothing/glasses/thermal/syndi
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"


### PR DESCRIPTION
From 6 to 4.
They're not purchased nearly as much as they used to be, and are a strong item for stealth. Hopefully this can encourage sneakier traitoring.

:cl: PKPenguin321
 tweak: The telecrystal price for thermal imaging goggles has been lowered from 6 to 4.
 /:cl:
