### PR TITLE
Fixes extra messages while grabbing someone who is buckled.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -187,6 +187,7 @@
 	var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(user, src)
 	if(buckled)
 		user << "<span class='warning'>You cannot grab [src], \he is buckled in!</span>"
+		return 0
 	if(!G)	//the grab will delete itself in New if src is anchored
 		return 0
 	user.put_in_active_hand(G)


### PR DESCRIPTION
If you try to grab the message, you get about three messages, two of which are inaccurate. This should get rid of the other two.
