### PR TITLE
Long actions (like resisting out of handcuffs) will no longer count space drifting as moving.

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -147,6 +147,10 @@ Proc for attack log creation, because really why not
 	if(!user || !target)
 		return 0
 	var/user_loc = user.loc
+	
+	var/drifting = 0
+	if(!user.Process_Spacemove(0) && user.inertia_dir)
+		drifting = 1 
 
 	var/target_loc = target.loc
 
@@ -167,7 +171,12 @@ Proc for attack log creation, because really why not
 			break
 		if(uninterruptible)
 			continue
-		if(user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying )
+		
+		if(drifting && !user.inertia_dir)
+				drifting = 0
+				user_loc = user.loc
+		
+		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying )
 			. = 0
 			break
 	if (progress)
@@ -182,7 +191,11 @@ Proc for attack log creation, because really why not
 		Tloc = target.loc
 
 	var/atom/Uloc = user.loc
-
+	
+	var/drifting = 0
+	if(!user.Process_Spacemove(0) && user.inertia_dir)
+		drifting = 1 
+		
 	var/holding = user.get_active_hand()
 
 	var/holdingnull = 1 //User's hand started out empty, check for an empty hand
@@ -200,8 +213,12 @@ Proc for attack log creation, because really why not
 		sleep(1)
 		if (progress)
 			progbar.update(world.time - starttime)
-
-		if(!user || user.stat || user.weakened || user.stunned  || user.loc != Uloc)
+		
+		if(drifting && !user.inertia_dir)
+				drifting = 0
+				Uloc = user.loc
+				
+		if(!user || user.stat || user.weakened || user.stunned  || (!drifting && user.loc != Uloc)
 			. = 0
 			break
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -218,7 +218,7 @@ Proc for attack log creation, because really why not
 				drifting = 0
 				Uloc = user.loc
 				
-		if(!user || user.stat || user.weakened || user.stunned  || (!drifting && user.loc != Uloc)
+		if(!user || user.stat || user.weakened || user.stunned  || (!drifting && user.loc != Uloc))
 			. = 0
 			break
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -173,8 +173,8 @@ Proc for attack log creation, because really why not
 			continue
 		
 		if(drifting && !user.inertia_dir)
-				drifting = 0
-				user_loc = user.loc
+			drifting = 0
+			user_loc = user.loc
 		
 		if((!drifting && user.loc != user_loc) || target.loc != target_loc || user.get_active_hand() != holding || user.incapacitated() || user.lying )
 			. = 0
@@ -215,8 +215,8 @@ Proc for attack log creation, because really why not
 			progbar.update(world.time - starttime)
 		
 		if(drifting && !user.inertia_dir)
-				drifting = 0
-				Uloc = user.loc
+			drifting = 0
+			Uloc = user.loc
 				
 		if(!user || user.stat || user.weakened || user.stunned  || (!drifting && user.loc != Uloc))
 			. = 0


### PR DESCRIPTION
So I was looking into atom/movable/Move() being high up on the profile when I stumbled upon inertia_dir and had ideas.

Everything is SUPPOSE to set this to 0 when they stop space moving. I'm just gonna trust that to be the case (it is in base atom/movable/newtonian_move.

I don't want to keep calling Process_Spacemove in the loop because that feels dirty.
fixes #10235
:cl:
tweak: Long actions (like resisting out of handcuffs) will no longer count space/nograv drifting as the user moving.
tweak: This does not apply to the target of a long action if that target isn't you. Pulling something while space drifting and working on it intentionally won't work.
/:cl:
