### PR TITLE
Fixes the away mission loader always choosing the same map

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -66,7 +66,7 @@ var/global/list/potentialSpaceRuins = generateMapList(filename = "config/spaceRu
 
 		potentialMaps.Add(t)
 
-		return potentialMaps
+	return potentialMaps
 
 
 /proc/seedRuins(z_level = 1, ruin_number = 0, whitelist = /area/space, list/potentialRuins = potentialSpaceRuins)


### PR DESCRIPTION
Bad indent made it return after the first map was added to the list.
