### PR TITLE
Makes solo/team antag age limits a config option instead of hard coded

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -188,6 +188,10 @@
 	// The object used for the clickable stat() button.
 	var/obj/effect/statclick/statclick
 
+	var/min_solo_antag_age = 7
+
+	var/min_team_antag_age = 14
+
 
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
@@ -563,6 +567,10 @@
 					MAX_EX_LIGHT_RANGE = BombCap
 					MAX_EX_FLASH_RANGE = BombCap
 					MAX_EX_FLAME_RANGE = BombCap
+				if("min_solo_antag_age")
+					config.min_solo_antag_age = text2num(value)
+				if("min_team_antag_age")
+					config.min_team_antag_age = text2num(value)
 				else
 					diary << "Unknown setting in configuration: '[name]'"
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -20,6 +20,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 15
 	required_enemies = 1
+	enemy_type = SOLO
 	recommended_enemies = 4
 	reroll_friendly = 1
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -36,7 +36,7 @@
 	required_players = 10
 	required_enemies = 2
 	recommended_enemies = 2
-	enemy_minimum_age = 14
+	enemy_type = TEAM
 
 	var/eldergod = 0
 	var/orbs_needed = 3

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -10,6 +10,8 @@
  * 2. Conditions of finishing the round.
  *
  */
+#define SOLO 1
+#define TEAM 2
 
 
 /datum/game_mode
@@ -33,7 +35,7 @@
 	var/round_converted = 0 //0: round not converted, 1: round going to convert, 2: round converted
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/continuous_sanity_checked	//Catches some cases where config options could be used to suggest that modes without antagonists should end when all antagonists die
-	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
+	var/enemy_type = SOLO
 
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
@@ -513,8 +515,11 @@
 		return 0
 	if(!isnum(C.player_age))
 		return 0 //This is only a number if the db connection is established, otherwise it is text: "Requires database", meaning these restrictions cannot be enforced
-	if(!isnum(enemy_minimum_age))
-		return 0
+	var/enemy_minimum_age = 0
+	if(enemy_type == SOLO)
+		enemy_minimum_age = config.min_solo_antag_age
+	if(enemy_type == TEAM)
+		enemy_minimum_age = config.min_team_antag_age
 
 	return max(0, enemy_minimum_age - C.player_age)
 

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -27,7 +27,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 	required_players = 20
 	required_enemies = 2
 	recommended_enemies = 2
-	enemy_minimum_age = 14
+	enemy_type = TEAM
 
 ///////////////////////////
 //Announces the game type//

--- a/code/game/gamemodes/handofgod/_handofgod.dm
+++ b/code/game/gamemodes/handofgod/_handofgod.dm
@@ -27,6 +27,7 @@ var/global/list/global_handofgod_structuretypes = list()
 	required_players = 25
 	required_enemies = 8
 	recommended_enemies = 8
+	enemy_type = TEAM
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -9,7 +9,7 @@
 	required_enemies = 5
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
-	enemy_minimum_age = 14
+	enemy_type = TEAM
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.
 
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -18,7 +18,7 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 3
-	enemy_minimum_age = 14
+	enemy_type = TEAM
 
 	var/finished = 0
 	var/check_counter = 0

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -71,6 +71,7 @@ Made by Xhuis
 	required_players = 30
 	required_enemies = 2
 	recommended_enemies = 2
+	enemy_type = TEAM
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -5,7 +5,7 @@
 	required_enemies = 5
 	recommended_enemies = 8
 	reroll_friendly = 0
-
+	enemy_type = SOLO
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 6 // Six additional traitors
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -16,6 +16,7 @@
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
+	enemy_type = SOLO
 
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -9,7 +9,7 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
-	enemy_minimum_age = 14
+	enemy_type = SOLO
 	round_ends_with_antag_death = 1
 	var/use_huds = 0
 	var/finished = 0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -324,5 +324,8 @@ BOMBCAP 14
 ## LagHell (7,14,28)
 #BOMBCAP 28
 
+## Minimum player age, in days, for playing solo antagonists (traitor, double agent, changeling, etc). Default is 7
+MIN_SOLO_ANTAG_AGE 7
 
-
+## Minimum player age, in days, for playing team antagonists (nuke, rev, gang, cult, etc). Default is 14
+MIN_TEAM_ANTAG_AGE 14


### PR DESCRIPTION
Making players wait an entire week to play traitor is a good way to lose new players. Currently we have no control over the limit though (you can turn the limit off, but not tweak it).

It's also gonna be an issue on basil soon if we put it on the hub and the majority of players are new.

I'm not sure if this is allowed to do during the freeze or not
