### PR TITLE
Fixes a edgecase bug in computer camera consoles

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -68,8 +68,10 @@
 
 		if(C)
 			if ((get_dist(user, src) > 1 || user.machine != src || user.eye_blind || !( C.can_use() )) && (!istype(user, /mob/living/silicon/ai)))
+				user.unset_machine()
 				if(!C.can_use() && !isAI(user))
 					src.current = null
+
 				return 0
 			else
 				if(isAI(user))


### PR DESCRIPTION
adds a single unset to the user in attack by to fix the issue of when moving away and activating the OK button on the camera console.
Fixes #9869
