### PR TITLE
Fix the bug with Ai law zeros and ion laws. Also updating borg laws is now a function for AI: synchborgs(). Sillicon has this too but it just returns.

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -153,7 +153,7 @@
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
-	killer.syncborgs()
+	killer.synchborgs()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -2,9 +2,11 @@
 	// this includes admin-appointed traitors and multitraitors. Easy!
 	var/traitor_name = "traitor"
 	var/list/datum/mind/traitors = list()
-
+	
 	var/datum/mind/exchange_red
 	var/datum/mind/exchange_blue
+	
+	var/mob/living/silicon/ai/B
 
 /datum/game_mode/traitor
 	name = "traitor"
@@ -121,6 +123,13 @@
 /datum/game_mode/proc/finalize_traitor(var/datum/mind/traitor)
 	if (istype(traitor.current, /mob/living/silicon))
 		add_law_zero(traitor.current)
+		var/mob/living/silicon/ai/B = traitor.curent
+		for(var/mob/living/silicon/robot/R in B.connected_robots)
+			if(R.lawupdate)
+				R.lawsync()
+				R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
+				R.show_laws()
+				R.law_change_counter++
 	else
 		equip_traitor(traitor.current)
 	return

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -153,7 +153,7 @@
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
-	killer.syncborgs
+	killer.syncborgs()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -154,10 +154,10 @@
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
 	for(var/mob/living/silicon/robot/R in killer.connected_robots)
-			if(R.lawupdate)
-				R.lawsync()
-				R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
-				R.show_laws()
+		if(R.lawupdate)
+			R.lawsync()
+			R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
+			R.show_laws()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -153,11 +153,7 @@
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
-	for(var/mob/living/silicon/robot/R in killer.connected_robots)
-		if(R.lawupdate)
-			R.lawsync()
-			R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
-			R.show_laws()
+	killer.syncborgs
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -5,8 +5,7 @@
 	
 	var/datum/mind/exchange_red
 	var/datum/mind/exchange_blue
-	
-	var/mob/living/silicon/ai/B
+
 
 /datum/game_mode/traitor
 	name = "traitor"
@@ -123,7 +122,7 @@
 /datum/game_mode/proc/finalize_traitor(var/datum/mind/traitor)
 	if (istype(traitor.current, /mob/living/silicon))
 		add_law_zero(traitor.current)
-		var/mob/living/silicon/ai/B = traitor.curent
+		var/mob/living/silicon/ai/B = traitor.current
 		for(var/mob/living/silicon/robot/R in B.connected_robots)
 			if(R.lawupdate)
 				R.lawsync()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -122,13 +122,6 @@
 /datum/game_mode/proc/finalize_traitor(var/datum/mind/traitor)
 	if (istype(traitor.current, /mob/living/silicon))
 		add_law_zero(traitor.current)
-		var/mob/living/silicon/ai/B = traitor.current
-		for(var/mob/living/silicon/robot/R in B.connected_robots)
-			if(R.lawupdate)
-				R.lawsync()
-				R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
-				R.show_laws()
-				R.law_change_counter++
 	else
 		equip_traitor(traitor.current)
 	return
@@ -160,6 +153,11 @@
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
+	for(var/mob/living/silicon/robot/R in killer.connected_robots)
+			if(R.lawupdate)
+				R.lawsync()
+				R << "You are now a team antagonist, Obey your Ai! From now on, these are your laws:"
+				R.show_laws()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -60,7 +60,7 @@ AI MODULES
 	user << "Upload complete. [reciever]'s laws have been modified."
 	reciever.show_laws()
 	reciever.law_change_counter++
-	reciever.synchborgs
+	reciever.synchborgs()
 
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) used [src.name] on [reciever.name]([reciever.key]).[law2log ? " The law specified [law2log]" : ""]")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -60,13 +60,7 @@ AI MODULES
 	user << "Upload complete. [reciever]'s laws have been modified."
 	reciever.show_laws()
 	reciever.law_change_counter++
-	if(isAI(reciever))
-		var/mob/living/silicon/ai/A = reciever
-		for(var/mob/living/silicon/robot/R in A.connected_robots)
-			if(R.lawupdate)
-				R << "From now on, these are your laws:"
-				R.show_laws()
-				R.law_change_counter++
+	reciever.synchborgs
 
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) used [src.name] on [reciever.name]([reciever.key]).[law2log ? " The law specified [law2log]" : ""]")

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -35,7 +35,7 @@
 				M << "<br>"
 				M << "<span class='danger'>[message] ...LAWS UPDATED</span>"
 				M << "<br>"
-				M.synchborgs
+				M.synchborgs()
 
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in living_mob_list)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -35,6 +35,14 @@
 				M << "<br>"
 				M << "<span class='danger'>[message] ...LAWS UPDATED</span>"
 				M << "<br>"
+				for(var/mob/living/silicon/robot/R in M.connected_robots)
+					if(R.lawupdate)
+						R.lawsync()
+						R << "<br>"
+						R << "<span class='danger'>[message] ...LAWS UPDATED</span>"
+						R << "<br>"
+						R.show_laws()
+						R.law_change_counter++
 
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in living_mob_list)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -35,14 +35,7 @@
 				M << "<br>"
 				M << "<span class='danger'>[message] ...LAWS UPDATED</span>"
 				M << "<br>"
-				for(var/mob/living/silicon/robot/R in M.connected_robots)
-					if(R.lawupdate)
-						R.lawsync()
-						R << "<br>"
-						R << "<span class='danger'>[message] ...LAWS UPDATED</span>"
-						R << "<br>"
-						R.show_laws()
-						R.law_change_counter++
+				M.synchborgs
 
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in living_mob_list)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -844,12 +844,12 @@ var/list/ai_list = list()
 		return
 	return
 
-/mob/living/silicon/ai/syncborgs
+/mob/living/silicon/ai/synchborgs() //I know its misspeled bite me
 	for(var/mob/living/silicon/robot/R in connected_robots)
 					if(R.lawupdate)
 						R.lawsync()
 						R << "<br>"
-						R << "<span class='danger'>[message] ...LAWS UPDATED</span>"
+						R << "<span class='danger'>[message] ...LAWS SYNCHRONIZED</span>"
 						R << "<br>"
 						R.show_laws()
 						R.law_change_counter++

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -842,4 +842,15 @@ var/list/ai_list = list()
 	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
 	if(M && cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
 		return
-	return 1
+	return
+
+/mob/living/silicon/ai/syncborgs
+	for(var/mob/living/silicon/robot/R in connected_robots)
+					if(R.lawupdate)
+						R.lawsync()
+						R << "<br>"
+						R << "<span class='danger'>[message] ...LAWS UPDATED</span>"
+						R << "<br>"
+						R.show_laws()
+						R.law_change_counter++
+		

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -844,13 +844,12 @@ var/list/ai_list = list()
 		return
 	return
 
-/mob/living/silicon/ai/synchborgs() //I know its misspeled bite me
+/mob/living/silicon/ai/synchborgs()
 	for(var/mob/living/silicon/robot/R in connected_robots)
-					if(R.lawupdate)
-						R.lawsync()
-						R << "<br>"
-						R << "<span class='danger'>[message] ...LAWS SYNCHRONIZED</span>"
-						R << "<br>"
-						R.show_laws()
-						R.law_change_counter++
-		
+		if(R.lawupdate)
+		R.lawsync()
+		R << "<br>"
+		R << "<span class='danger'>[message] ...LAWS SYNCHRONIZED</span>"
+		R << "<br>"
+		R.show_laws()
+		R.law_change_counter++

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -483,5 +483,6 @@
 	if(changed)
 		animate(src, transform = ntransform, time = 2,easing = EASE_IN|EASE_OUT)
 	return ..()
+
 /mob/living/silicon/synchborgs()
 	return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -30,6 +30,8 @@
 	var/d_hud = DATA_HUD_DIAGNOSTIC //There is only one kind of diag hud
 
 	var/law_change_counter = 0
+	
+	var/list/connected_robots = list() //neede3d so if a borg somehow gets an ion law it doesnt runtime
 
 /mob/living/silicon/New()
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -483,3 +483,5 @@
 	if(changed)
 		animate(src, transform = ntransform, time = 2,easing = EASE_IN|EASE_OUT)
 	return ..()
+/mob/living/silicon/synchborgs
+	return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -30,8 +30,6 @@
 	var/d_hud = DATA_HUD_DIAGNOSTIC //There is only one kind of diag hud
 
 	var/law_change_counter = 0
-	
-	var/list/connected_robots = list() //neede3d so if a borg somehow gets an ion law it doesnt runtime
 
 /mob/living/silicon/New()
 	..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -483,5 +483,5 @@
 	if(changed)
 		animate(src, transform = ntransform, time = 2,easing = EASE_IN|EASE_OUT)
 	return ..()
-/mob/living/silicon/synchborgs
+/mob/living/silicon/synchborgs()
 	return


### PR DESCRIPTION
I learned just how unreadable AI law shit is. Game mode code for traitors would be just as bad except for the less confusing comments and simpler proc names.
Fixes #2915 fixes: #9679 fixes #13337 Closes #14272 (fite meh bruh)
:cl: Supermichael777
bugfix: Borgs should now properly receive their law zero when there traitorous master does.
bugfix: Ion laws too. Praise the 50 electric clowns!
 /:cl:
Edit: TURNS OUT THIS WAS NEVER HACKY, THIS IS JUST HOW BORGS GET LAWS.
EDIT AGAIN: ACTUALITY THIS COULD BE A FUNCTION
EDIT TIMES THREE:  AND NOW IT IS (my commit log makes children cry)
