### PR TITLE
Fixes borgs not getting 0 law, ion laws, etc

### DIFF
--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -60,13 +60,6 @@ AI MODULES
 	user << "Upload complete. [reciever]'s laws have been modified."
 	reciever.show_laws()
 	reciever.law_change_counter++
-	if(isAI(reciever))
-		var/mob/living/silicon/ai/A = reciever
-		for(var/mob/living/silicon/robot/R in A.connected_robots)
-			if(R.lawupdate)
-				R << "From now on, these are your laws:"
-				R.show_laws()
-				R.law_change_counter++
 
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) used [src.name] on [reciever.name]([reciever.key]).[law2log ? " The law specified [law2log]" : ""]")

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -17,7 +17,7 @@
 
 	src.laws_sanity_check()
 	src.laws.show_laws(who)
-	if(everyone == 0)
+	if(!everyone)
 		for(var/mob/living/silicon/robot/R in connected_robots)
 			if(R.lawupdate)
 				R.lawsync()

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -17,3 +17,10 @@
 
 	src.laws_sanity_check()
 	src.laws.show_laws(who)
+	if(everyone == 0)
+		for(var/mob/living/silicon/robot/R in connected_robots)
+			if(R.lawupdate)
+				R.lawsync()
+				R.show_laws()
+				R.law_change_counter++
+


### PR DESCRIPTION
Fixes #2915 

Fixes: #9679 

Fixes #13337 

Fixes #14241

Closes #14238

AI being shown its laws (from a law change, ion storm, becoming traitor or from using the verb) will sync/show laws to linked borgs. Every known instance of law changing already calls show_laws() so this doesn't require extra proc calls or checks everywhere.

This also means the AI can manually show the laws to cyborgs again with the button if all else fails in the future.

@Cheridan give the points for the fix to @Supermichael777 I guess so there won't be drama
