### PR TITLE
Adds a compile option for enabling hub

### DIFF
--- a/code/hub.dm
+++ b/code/hub.dm
@@ -1,7 +1,11 @@
 /world
 
 	hub = "Exadv1.spacestation13"
+#ifdef PUTONHUB
+	hub_password = "kMZy3U5jJHSiBQjr"
+#else
 	hub_password = "SORRYNOPASSWORD"
+#endif
 	name = "/tg/ Station 13"
 
 /*


### PR DESCRIPTION
This is mainly so i can make the server tools define this, because hub.dm is a live track file, and making it be held between rounds would be too much.
