### PR TITLE
Removes "error" message from roundstart logout report

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -461,8 +461,7 @@
 						continue //Dead mob, ghost abandoned
 				else
 					if(D.can_reenter_corpse)
-						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='boldannounce'>This shouldn't appear.</span>)\n"
-						continue //Lolwhat
+						continue //Adminghost, or cult/wizard ghost
 					else
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<span class='boldannounce'>Ghosted</span>)\n"
 						continue //Ghosted while alive


### PR DESCRIPTION
Ghosting while being able to return to your corpse is a feature in many places (admins, wizards, cultists) and a bug in none (not known currently, anyway).

This message is not needed.

Fixes #14282
