### PR TITLE
Makes using an emag show an attack animation

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -351,7 +351,7 @@ var/list/blood_splatter_icons = list()
 	return
 
 /atom/proc/emag_act()
-	return
+	return -1
 
 /atom/proc/narsie_act()
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1165,15 +1165,15 @@ About the new airlock wires panel:
 	if(!operating && density && hasPower() && !emagged)
 		operating = 1
 		update_icon(AIRLOCK_EMAG, 1)
-		sleep(6)
-		if(qdeleted(src))
-			return
-		operating = 0
-		if(!open())
-			update_icon(AIRLOCK_CLOSED, 1)
-		emagged = 1
-		desc = "<span class='warning'>Its access panel is smoking slightly.</span>"
-		lights = 0
-		locked = 1
-		loseMainPower()
-		loseBackupPower()
+		spawn(6)
+			if(qdeleted(src))
+				return
+			operating = 0
+			if(!open())
+				update_icon(AIRLOCK_CLOSED, 1)
+			emagged = 1
+			desc = "<span class='warning'>Its access panel is smoking slightly.</span>"
+			lights = 0
+			locked = 1
+			loseMainPower()
+			loseBackupPower()

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -70,7 +70,9 @@
 /obj/item/weapon/card/emag/afterattack(atom/target, mob/user, proximity)
 	var/atom/A = target
 	if(!proximity) return
-	A.emag_act(user)
+
+	if(A.emag_act(user) != -1)
+		user.do_attack_animation(A)
 
 /obj/item/weapon/card/id
 	name = "identification card"


### PR DESCRIPTION
Fixes #12565 
@RemieRichards informed me that emags showing an attack animation for air alarms is intentional.
Fixing the inconsistency by making everything else also show the animation.
