### PR TITLE
Makes leap_icon a hunter var instead of mob var

### DIFF
--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -81,9 +81,10 @@
 	action_intent = using
 
 	if(istype(mymob, /mob/living/carbon/alien/humanoid/hunter))
-		mymob.leap_icon = new /obj/screen/alien/leap()
-		mymob.leap_icon.screen_loc = ui_alien_storage_r
-		adding += mymob.leap_icon
+		var/mob/living/carbon/alien/humanoid/hunter/H = mymob
+		H.leap_icon = new /obj/screen/alien/leap()
+		H.leap_icon.screen_loc = ui_alien_storage_r
+		adding += H.leap_icon
 
 	using = new /obj/screen/drop()
 	using.icon = 'icons/mob/screen_alien.dmi'

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,6 +4,7 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "alienh_s"
+	var/obj/screen/leap_icon = null
 
 /mob/living/carbon/alien/humanoid/hunter/New()
 	internal_organs += new /obj/item/organ/internal/alien/plasmavessel/small
@@ -36,7 +37,6 @@
 
 
 //Hunter verbs
-
 
 /mob/living/carbon/alien/humanoid/hunter/proc/toggle_leap(message = 1)
 	leap_on_click = !leap_on_click

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -27,7 +27,6 @@
 	Changing this around would probably require a good look-over the pre-existing code.
 	*/
 	var/obj/screen/zone_sel/zone_sel = null
-	var/obj/screen/leap_icon = null
 	var/obj/screen/healthdoll = null
 
 	var/damageoverlaytemp = 0


### PR DESCRIPTION
Don't think every single mob needs a var for a hunter only screen object.
