### PR TITLE
Uplink refund refactor/fixes cyborg spawners not appearing in nuke purchase log

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -63,6 +63,7 @@ var/list/uplink_items = list()
 	var/list/gamemodes = list() // Empty list means it is in all the gamemodes. Otherwise place the gamemode name here.
 	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
 	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
+	var/refundable = FALSE
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
@@ -332,12 +333,7 @@ var/list/uplink_items = list()
 	cost = 25
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
-
-/datum/uplink_item/dangerous/reinforcement/spawn_item()
-	var/obj/item/weapon/antag_spawner/nuke_ops/T = ..()
-	if(istype(T))
-		T.TC_cost = cost
-
+	refundable = TRUE
 
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
@@ -1049,7 +1045,7 @@ var/list/uplink_items = list()
 		buyable_items += temp_uplink_list[category]
 	var/list/bought_items = list()
 	U.uses -= cost
-	U.used_TC = 20
+	U.used_TC += 20
 	var/remaining_TC = 50
 
 	var/datum/uplink_item/I

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -134,7 +134,6 @@
 	desc = "A single-use teleporter designed to quickly reinforce operatives in the field."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "locator"
-	var/TC_cost = 0
 	var/borg_to_spawn
 	var/list/possible_types = list("Assault", "Medical")
 
@@ -163,6 +162,7 @@
 		var/datum/effect_system/spark_spread/S = new /datum/effect_system/spark_spread
 		S.set_up(4, 1, src)
 		S.start()
+		qdel(src)
 	else
 		user << "<span class='warning'>Unable to connect to Syndicate command. Please wait and try again later or use the teleporter on your uplink to get your points refunded.</span>"
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -175,14 +175,14 @@ var/list/world_uplinks = list()
 	return 0
 //Refund proc for the borg teleporter (later I'll make a general refund proc if there is demand for it)
 /obj/item/device/radio/uplink/attackby(obj/item/weapon/W, mob/user, params)
-	if(istype(W, /obj/item/weapon/antag_spawner/nuke_ops))
-		var/obj/item/weapon/antag_spawner/nuke_ops/S = W
-		if(!S.used)
-			hidden_uplink.uses += S.TC_cost
-			qdel(S)
-			user << "<span class='notice'>Teleporter refunded.</span>"
-		else
-			user << "<span class='warning'>This teleporter is already used!</span>"
+	if(istype(W))
+		for(var/datum/uplink_item/D in subtypesof(/datum/uplink_item))
+			if(D.item == W.type && D.refundable)
+				hidden_uplink.uses += D.cost
+				hidden_uplink.used_TC -= D.cost
+				user << "<span class='notice'>[W] refunded.</span>"
+				qdel(W)
+				return
 
 // PRESET UPLINKS
 // A collection of preset uplinks.

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -176,10 +176,11 @@ var/list/world_uplinks = list()
 //Refund proc for the borg teleporter (later I'll make a general refund proc if there is demand for it)
 /obj/item/device/radio/uplink/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W))
-		for(var/datum/uplink_item/D in subtypesof(/datum/uplink_item))
-			if(D.item == W.type && D.refundable)
-				hidden_uplink.uses += D.cost
-				hidden_uplink.used_TC -= D.cost
+		for(var/path in subtypesof(/datum/uplink_item))
+			var/datum/uplink_item/D = path
+			if(initial(D.item) == W.type && initial(D.refundable))
+				hidden_uplink.uses += (D.cost)
+				hidden_uplink.used_TC -= initial(D.cost)
 				user << "<span class='notice'>[W] refunded.</span>"
 				qdel(W)
 				return


### PR DESCRIPTION
Instead of a snowflake check for cyborg spawners, the uplink now checks vs the uplink datum to see if the item is refundable, and then refunds that cost.

This also fixes syndiborgs not appearing in the purchase log round end. Fixes #3977

Also fixes surplus crates fucking up the TC spent count, which was not a reported bug.
