### PR TITLE
Adds follow links to overmind, revenant, and abductor chat

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -93,8 +93,10 @@
 	var/rendered = "<span class='big'><font color=\"#EE4000\">Blob Telepathy, <b>[name](<font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</font>)</b> [message_a]</font></span>"
 
 	for(var/mob/M in mob_list)
-		if(isovermind(M) || isobserver(M) || istype(M, /mob/living/simple_animal/hostile/blob))
-			M.show_message(rendered, 2)
+		if(isovermind(M) || istype(M, /mob/living/simple_animal/hostile/blob))
+			M << rendered
+		if(isobserver(M))
+			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a>[rendered]"
 
 /mob/camera/blob/emote(act,m_type=1,message = null)
 	return

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -238,11 +238,12 @@
 	if(!message)
 		return
 	log_say("[key_name(src)] : [message]")
+	var/rendered = "<span class='revennotice'><b>[src]</b> says, \"[message]\"</span>"
 	for(var/mob/M in mob_list)
-		if (istype(M, /mob/new_player))
-			continue
-		if(istype(M, /mob/living/simple_animal/revenant) || M.stat == DEAD)
-			M << "<span class='revennotice'><b>[src]</b> says, \"[message]\"" //Can commune with the dead
+		if(istype(M, /mob/living/simple_animal/revenant))
+			M << rendered
+		if(isobserver(M))
+			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a>[rendered]"
 	return
 
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -272,7 +272,7 @@
 		return
 	var/my_message = "<span class='shadowling'><b>\[Shadowling\]</b><i> [user.real_name]</i>: [text]</span>"
 	for(var/mob/M in mob_list)
-		if(is_shadow_or_thrall(M) || (M in dead_mob_list))
+		if(is_shadow_or_thrall(M))
 			M << my_message
 		if(M in dead_mob_list)
 			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a>[my_message]"
@@ -750,9 +750,12 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 	var/text = stripped_input(user, "What do you want to say your masters and fellow thralls?.", "Lesser Commune", "")
 	if(!text)
 		return
+	text = "<span class='shadowling'><b>\[Thrall\]</b><i> [user.real_name]</i>: [text]</span>"
 	for(var/mob/M in mob_list)
-		if(is_shadow_or_thrall(M) || (M in dead_mob_list))
-			M << "<span class='shadowling'><b>\[Thrall\]</b><i> [user.real_name]</i>: [text]</span>"
+		if(is_shadow_or_thrall(M))
+			M << text
+		if(isobserver(M))
+			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a>[text]"
 	log_say("[user.real_name]/[user.key] : [text]")
 
 
@@ -891,8 +894,10 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 	var/text = stripped_input(user, "What do you want to say to fellow thralls and shadowlings?.", "Hive Chat", "")
 	if(!text)
 		return
-	text = "<font size=4>[text]</font>"
+	text = "<font size=4><span class='shadowling'><b>\[Ascendant\]<i> [user.real_name]</i>: [text]</b></span></font>"
 	for(var/mob/M in mob_list)
-		if(is_shadow_or_thrall(M) || (M in dead_mob_list))
-			M << "<span class='shadowling'><b>\[Ascendant\]<i> [user.real_name]</i>: [text]</b></span>" //Bigger text for ascendants.
+		if(is_shadow_or_thrall(M))
+			M << text
+		if(isobserver(M))
+			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a>[text]"
 	log_say("[user.real_name]/[user.key] : [text]")

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -453,16 +453,16 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 /datum/species/abductor/handle_speech(message)
 	//Hacks
 	var/mob/living/carbon/human/user = usr
+	var/rendered = "<i><font color=#800080><b>[user.name]:</b> [message]</font></i>"
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.dna.species.id != "abductor")
 			continue
 		else
 			var/datum/species/abductor/target_spec = H.dna.species
 			if(target_spec.team == team)
-				H << "<i><font color=#800080><b>[user.name]:</b> [message]</font></i>"
-				//return - technically you can add more aliens to a team
+				H << rendered
 	for(var/mob/M in dead_mob_list)
-		M << "<i><font color=#800080><b>[user.name]:</b> [message]</font></i>"
+		M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a>[rendered]"
 	return ""
 
 


### PR DESCRIPTION
Ghosts can follow revenants, blob overminds, and abductors from deadchat links now.
Fixes the doubled shadowling messages and adds the follow link to thrall and ascendant chat too.
Probably doesn't need a changelog, see #14133
