### PR TITLE
Fixes some bug about alien evolving

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -177,6 +177,12 @@ Des: Removes all infected images from the alien.
 /mob/living/carbon/alien/get_standard_pixel_y_offset(lying = 0)
 	return initial(pixel_y)
 
+/mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
+	src << "<span class='noticealien'>You begin to evolve!</span>"
+	visible_message("<span class='alertalien'>[src] begins to twist and contort!</span>")
+	if(mind)
+		mind.transfer_to(new_xeno)
+	qdel(src)
 
 #undef HEAT_DAMAGE_LEVEL_1
 #undef HEAT_DAMAGE_LEVEL_2

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -26,12 +26,12 @@
 	action_icon_state = "alien_evolve_drone"
 
 /obj/effect/proc_holder/alien/evolve/fire(mob/living/carbon/alien/user)
-	if(!alien_type_present(/mob/living/carbon/alien/humanoid/royal/))
-		user << "<span class='noticealien'>You begin to evolve!</span>"
-		user.visible_message("<span class='alertalien'>[user] begins to twist and contort!</span>")
+	if(!isturf(user.loc))
+		user << "<span class='notice'>You can't evolve here!</span>"
+		return 0
+	if(!alien_type_present(/mob/living/carbon/alien/humanoid/royal))
 		var/mob/living/carbon/alien/humanoid/royal/praetorian/new_xeno = new (user.loc)
-		user.mind.transfer_to(new_xeno)
-		qdel(user)
+		user.alien_evolve(new_xeno)
 		return 1
 	else
 		user << "<span class='notice'>We already have a living royal!</span>"

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -54,7 +54,6 @@
 
 /obj/effect/proc_holder/alien/royal/praetorian/evolve/fire(mob/living/carbon/alien/user)
 	if(!alien_type_present(/mob/living/carbon/alien/humanoid/royal/queen))
-		user.alien_evolve(/mob/living/carbon/alien/humanoid/royal/queen)
 		var/mob/living/carbon/alien/humanoid/royal/queen/new_xeno = new (user.loc)
 		user.alien_evolve(new_xeno)
 		return 1

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -54,11 +54,9 @@
 
 /obj/effect/proc_holder/alien/royal/praetorian/evolve/fire(mob/living/carbon/alien/user)
 	if(!alien_type_present(/mob/living/carbon/alien/humanoid/royal/queen))
-		user << "<span class='noticealien'>You begin to evolve!</span>"
-		user.visible_message("<span class='alertalien'>[user] begins to twist and contort!</span>")
+		user.alien_evolve(/mob/living/carbon/alien/humanoid/royal/queen)
 		var/mob/living/carbon/alien/humanoid/royal/queen/new_xeno = new (user.loc)
-		user.mind.transfer_to(new_xeno)
-		qdel(user)
+		user.alien_evolve(new_xeno)
 		return 1
 	else
 		user << "<span class='notice'>We already have an alive queen.</span>"

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -149,6 +149,15 @@
 /mob/living/carbon/alien/humanoid/get_permeability_protection()
 	return 0.8
 
+/mob/living/carbon/alien/humanoid/alien_evolve(mob/living/carbon/alien/humanoid/new_xeno)
+	drop_l_hand()
+	drop_r_hand()
+	for(var/atom/movable/A in stomach_contents)
+		stomach_contents.Remove(A)
+		new_xeno.stomach_contents.Add(A)
+		A.loc = new_xeno
+	..()
+
 //For alien evolution/promotion procs. Checks for
 proc/alien_type_present(var/alienpath)
 	for(var/mob/living/carbon/alien/humanoid/A in living_mob_list)

--- a/code/modules/mob/living/carbon/alien/larva/powers.dm
+++ b/code/modules/mob/living/carbon/alien/larva/powers.dm
@@ -32,8 +32,6 @@
 		return
 	var/mob/living/carbon/alien/larva/L = user
 
-	if(L.stat != CONSCIOUS)
-		return
 	if(L.handcuffed || L.legcuffed) // Cuffing larvas ? Eh ?
 		user << "<span class='danger'>You cannot evolve when you are cuffed.</span>"
 
@@ -45,6 +43,9 @@
 		L << "<span class='name'>Drones</span> <span class='info'>are the weakest and slowest of the castes, but can grow into the queen if there is none, and are vital to maintaining a hive with their resin secretion abilities.</span>"
 		var/alien_caste = alert(L, "Please choose which alien caste you shall belong to.",,"Hunter","Sentinel","Drone")
 
+		if(user.incapacitated()) //something happened to us while we were choosing.
+			return
+
 		var/mob/living/carbon/alien/humanoid/new_xeno
 		switch(alien_caste)
 			if("Hunter")
@@ -53,8 +54,8 @@
 				new_xeno = new /mob/living/carbon/alien/humanoid/sentinel(L.loc)
 			if("Drone")
 				new_xeno = new /mob/living/carbon/alien/humanoid/drone(L.loc)
-		if(L.mind)	L.mind.transfer_to(new_xeno)
-		qdel(L)
+
+		L.alien_evolve(new_xeno)
 		return 0
 	else
 		user << "<span class='danger'>You are not fully grown.</span>"

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -82,8 +82,6 @@
 	switch(M.a_intent)
 		if("help")
 			help_shake_act(M)
-		if("grab")
-			grabbedby(M)
 		if("harm")
 			M.do_attack_animation(src)
 			if (prob(75))
@@ -107,22 +105,6 @@
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>[M] has attempted to punch [name]!</span>", \
 						"<span class='userdanger'>[M] has attempted to punch [name]!</span>")
-
-		if("disarm")
-			if (!( paralysis ))
-				M.do_attack_animation(src)
-				if (prob(25))
-					Paralyse(2)
-					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					add_logs(M, src, "pushed")
-					visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
-							"<span class='userdanger'>[M] has pushed down [src]!</span>")
-				else
-					if(drop_item())
-						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						visible_message("<span class='danger'>[M] has disarmed [src]!</span>", \
-								"<span class='userdanger'>[M] has disarmed [src]!</span>")
-	return
 
 /mob/living/carbon/monkey/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if(..()) //if harm or disarm intent.


### PR DESCRIPTION
- Adds a visible message when the larva grows into a humanoid (for consistency with other evolutions).
- Removes some duplicated code in alien evolve code (larva-to-humanoid, praetorian and queen now all use the same proc).
- Alien drones can no longer evolve into a praetorian while inside a pipe (praetorian can't ventcrawl) or other containers.
- Removed an unneeded check in larva_evolve/fire().
- Fixes bug where a larva could evolve despite being incapacitated/dead during the selection of the alien caste.
- Remove outdated code in monkey/attack_hand about disarm and grab intent.
- Evolving into a royal alien no longer deletes what you hold in your hands and the content of your stomach.
