### PR TITLE
(partially) Revert "atmos dynamic wait tweaks"

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -5,7 +5,8 @@ var/datum/subsystem/air/SSair
 	priority = -1
 	wait = 5
 	dynamic_wait = 1
-	dwait_upper = 50
+	dwait_upper = 300
+	dwait_buffer = 0.5
 	display = 1
 
 	var/cost_turfs = 0

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -5,9 +5,7 @@ var/datum/subsystem/air/SSair
 	priority = -1
 	wait = 5
 	dynamic_wait = 1
-	dwait_upper = 300
-	dwait_buffer = 0
-	dwait_delta = 10
+	dwait_upper = 50
 	display = 1
 
 	var/cost_turfs = 0


### PR DESCRIPTION
Reverts tgstation/-tg-station#13845

The was only needed because of lag that was unprofiled and unmeasured by the mc caused by space wind spawn()ing its step(). this was properly fixed in #14322
