### PR TITLE
Refactor the visible_message() proc to be faster in some cases.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -620,15 +620,16 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
 	var/turf/current = get_turf(source)
 	var/turf/target_turf = get_turf(target)
-	var/steps = 0
-
-	while(current != target_turf)
-		if(steps > length) return 0
-		if(current.opacity) return 0
-		for(var/atom/A in current)
-			if(A.opacity) return 0
+	var/steps = 1
+	if(current != target_turf)
 		current = get_step_towards(current, target_turf)
-		steps++
+		while(current != target_turf)
+			if(steps > length) return 0
+			if(current.opacity) return 0
+			for(var/atom/A in current)
+				if(A.opacity) return 0
+			current = get_step_towards(current, target_turf)
+			steps++
 
 	return 1
 

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -59,8 +59,7 @@
 	if(!src.lit)
 		src.lit = 1
 		//src.damtype = "fire"
-		for(var/mob/O in viewers(usr, null))
-			O.show_message(flavor_text, 1)
+		usr.visible_message(flavor_text)
 		SetLuminosity(CANDLE_LUMINOSITY)
 		if(!infinite)
 			SSobj.processing |= src

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -778,7 +778,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/proc/show_to_ghosts(mob/living/user, datum/data_pda_msg/msg,multiple = 0)
 	for(var/mob/M in player_list)
 		if(isobserver(M) && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTPDA))
-			M.show_message("<a href='?src=\ref[M];follow=\ref[user]'>(F)</a><span class='name'> [msg.sender] </span><span class='game say'>PDA Message</span> --> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>")
+			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a><span class='name'> [msg.sender] </span><span class='game say'>PDA Message</span> --> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>"
 
 /obj/item/device/pda/proc/can_send(obj/item/device/pda/P)
 	if(!P || qdeleted(P) || P.toff)
@@ -944,9 +944,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		switch(scanmode)
 
 			if(1)
-				user.visible_message(text("<span class='alert'>[] has analyzed []'s vitals!</span>", user, C))
+				C.visible_message("<span class='alert'>[user] has analyzed [C]'s vitals!</span>")
 				healthscan(user, C, 1)
-				src.add_fingerprint(user)
+				add_fingerprint(user)
 
 			if(2)
 				// Unused

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -543,10 +543,10 @@
 		return
 	b_stat = !( b_stat )
 	if(!istype(src, /obj/item/device/radio/beacon))
-		if (b_stat)
-			user.show_message("<span class='notice'>The radio can now be attached and modified!</span>")
+		if(b_stat)
+			user << "<span class='notice'>The radio can now be attached and modified!</span>"
 		else
-			user.show_message("<span class='notice'>The radio can no longer be modified or attached!</span>")
+			user << "<span class='notice'>The radio can no longer be modified or attached!</span>"
 		updateDialog()
 			//Foreach goto(83)
 		add_fingerprint(user)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -114,7 +114,8 @@ MASS SPECTROMETER
 
 // Used by the PDA medical scanner too
 /proc/healthscan(mob/living/user, mob/living/M, mode = 1)
-
+	if(user.stat || user.eye_blind)
+		return
 	//Damage specifics
 	var/oxy_loss = M.getOxyLoss()
 	var/tox_loss = M.getToxLoss()
@@ -199,8 +200,8 @@ MASS SPECTROMETER
 			if(CI.status == ORGAN_ROBOTIC)
 				implant_detect += "[H.name] is modified with a [CI.name].<br>"
 		if(implant_detect)
-			user.show_message("<span class='notice'>Detected cybernetic modifications:</span>")
-			user.show_message("<span class='notice'>[implant_detect]</span>")
+			user << "<span class='notice'>Detected cybernetic modifications:</span>"
+			user << "<span class='notice'>[implant_detect]</span>"
 
 /proc/chemscan(mob/living/user, mob/living/M)
 	if(ishuman(M))
@@ -250,11 +251,13 @@ MASS SPECTROMETER
 
 /obj/item/device/analyzer/attack_self(mob/user)
 
-	if (user.stat)
+	add_fingerprint(user)
+
+	if (user.stat || user.eye_blind)
 		return
 
 	var/turf/location = user.loc
-	if (!( istype(location, /turf) ))
+	if(!istype(location))
 		return
 
 	var/datum/gas_mixture/environment = location.return_air()
@@ -262,11 +265,11 @@ MASS SPECTROMETER
 	var/pressure = environment.return_pressure()
 	var/total_moles = environment.total_moles()
 
-	user.show_message("<span class='info'><B>Results:</B></span>", 1)
+	user << "<span class='info'><B>Results:</B></span>"
 	if(abs(pressure - ONE_ATMOSPHERE) < 10)
-		user.show_message("<span class='info'>Pressure: [round(pressure,0.1)] kPa</span>", 1)
+		user << "<span class='info'>Pressure: [round(pressure,0.1)] kPa</span>"
 	else
-		user.show_message("<span class='alert'>Pressure: [round(pressure,0.1)] kPa</span>", 1)
+		user << "<span class='alert'>Pressure: [round(pressure,0.1)] kPa</span>"
 	if(total_moles)
 		var/o2_concentration = environment.oxygen/total_moles
 		var/n2_concentration = environment.nitrogen/total_moles
@@ -275,30 +278,28 @@ MASS SPECTROMETER
 
 		var/unknown_concentration =  1-(o2_concentration+n2_concentration+co2_concentration+plasma_concentration)
 		if(abs(n2_concentration - N2STANDARD) < 20)
-			user.show_message("<span class='info'>Nitrogen: [round(n2_concentration*100)] %</span>", 1)
+			user << "<span class='info'>Nitrogen: [round(n2_concentration*100)] %</span>"
 		else
-			user.show_message("<span class='alert'>Nitrogen: [round(n2_concentration*100)] %</span>", 1)
+			user << "<span class='alert'>Nitrogen: [round(n2_concentration*100)] %</span>"
 
 		if(abs(o2_concentration - O2STANDARD) < 2)
-			user.show_message("<span class='info'>Oxygen: [round(o2_concentration*100)] %</span>", 1)
+			user << "<span class='info'>Oxygen: [round(o2_concentration*100)] %</span>"
 		else
-			user.show_message("<span class='alert'>Oxygen: [round(o2_concentration*100)] %</span>", 1)
+			user << "<span class='alert'>Oxygen: [round(o2_concentration*100)] %</span>"
 
 		if(co2_concentration > 0.01)
-			user.show_message("<span class='alert'>CO2: [round(co2_concentration*100)] %</span>", 1)
+			user << "<span class='alert'>CO2: [round(co2_concentration*100)] %</span>"
 		else
-			user.show_message("<span class='info'>CO2: [round(co2_concentration*100)] %</span>", 1)
+			user << "<span class='info'>CO2: [round(co2_concentration*100)] %</span>"
 
 		if(plasma_concentration > 0.01)
-			user.show_message("<span class='info'>Plasma: [round(plasma_concentration*100)] %</span>", 1)
+			user << "<span class='info'>Plasma: [round(plasma_concentration*100)] %</span>"
 
 		if(unknown_concentration > 0.01)
-			user.show_message("<span class='alert'>Unknown: [round(unknown_concentration*100)] %</span>", 1)
+			user << "<span class='alert'>Unknown: [round(unknown_concentration*100)] %</span>"
 
-		user.show_message("<span class='info'>Temperature: [round(environment.temperature-T0C)] &deg;C</span>", 1)
+		user << "<span class='info'>Temperature: [round(environment.temperature-T0C)] &deg;C</span>"
 
-	src.add_fingerprint(user)
-	return
 
 /obj/item/device/mass_spectrometer
 	desc = "A hand-held mass spectrometer which identifies trace chemicals in a blood sample."
@@ -327,7 +328,7 @@ MASS SPECTROMETER
 		icon_state = initial(icon_state)
 
 /obj/item/device/mass_spectrometer/attack_self(mob/user)
-	if (user.stat)
+	if (user.stat || user.eye_blind)
 		return
 	if (crit_fail)
 		user << "<span class='warning'>This device has critically failed and is no longer functional!</span>"
@@ -340,7 +341,7 @@ MASS SPECTROMETER
 		for(var/datum/reagent/R in reagents.reagent_list)
 			if(R.id != "blood")
 				reagents.clear_reagents()
-				user.show_message("<span class='warning'>The sample was contaminated! Please insert another sample.</span>", 1)
+				user << "<span class='warning'>The sample was contaminated! Please insert another sample.</span>"
 				return
 			else
 				blood_traces = params2list(R.data["trace_chem"])
@@ -367,7 +368,7 @@ MASS SPECTROMETER
 		dat += "</i>"
 		user << dat
 		reagents.clear_reagents()
-	return
+
 
 /obj/item/device/mass_spectrometer/adv
 	name = "advanced mass-spectrometer"
@@ -389,32 +390,34 @@ MASS SPECTROMETER
 	materials = list(MAT_METAL=30, MAT_GLASS=20)
 
 /obj/item/device/slime_scanner/attack(mob/living/M, mob/living/user)
+	if(user.stat || user.eye_blind)
+		return
 	if (!isslime(M))
-		user.show_message("<span class='warning'>This device can only scan slimes!</span>", 1)
+		user << "<span class='warning'>This device can only scan slimes!</span>"
 		return
 	var/mob/living/simple_animal/slime/T = M
-	user.show_message("Slime scan results:", 1)
-	user.show_message(text("[T.colour] [] slime", T.is_adult ? "adult" : "baby"), 1)
-	user.show_message(text("Nutrition: [T.nutrition]/[]", T.get_max_nutrition()), 1)
+	user << "Slime scan results:"
+	user << "[T.colour] [T.is_adult ? "adult" : "baby"] slime"
+	user << "Nutrition: [T.nutrition]/[T.get_max_nutrition()]"
 	if (T.nutrition < T.get_starve_nutrition())
-		user.show_message("<span class='warning'>Warning: slime is starving!</span>", 1)
+		user << "<span class='warning'>Warning: slime is starving!</span>"
 	else if (T.nutrition < T.get_hunger_nutrition())
-		user.show_message("<span class='warning'>Warning: slime is hungry</span>", 1)
-	user.show_message("Electric change strength: [T.powerlevel]", 1)
-	user.show_message("Health: [T.health]", 1)
+		user << "<span class='warning'>Warning: slime is hungry</span>"
+	user << "Electric change strength: [T.powerlevel]"
+	user << "Health: [T.health]"
 	if (T.slime_mutation[4] == T.colour)
-		user.show_message("This slime does not evolve any further.", 1)
+		user << "This slime does not evolve any further."
 	else
 		if (T.slime_mutation[3] == T.slime_mutation[4])
 			if (T.slime_mutation[2] == T.slime_mutation[1])
-				user.show_message("Possible mutation: [T.slime_mutation[3]]", 1)
-				user.show_message("Genetic destability: [T.mutation_chance/2] % chance of mutation on splitting", 1)
+				user << "Possible mutation: [T.slime_mutation[3]]"
+				user << "Genetic destability: [T.mutation_chance/2] % chance of mutation on splitting"
 			else
-				user.show_message("Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)", 1)
-				user.show_message("Genetic destability: [T.mutation_chance] % chance of mutation on splitting", 1)
+				user << "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]] (x2)"
+				user << "Genetic destability: [T.mutation_chance] % chance of mutation on splitting"
 		else
-			user.show_message("Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]", 1)
-			user.show_message("Genetic destability: [T.mutation_chance] % chance of mutation on splitting", 1)
+			user << "Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]"
+			user << "Genetic destability: [T.mutation_chance] % chance of mutation on splitting"
 	if (T.cores > 1)
-		user.show_message("Anomalious slime core amount detected", 1)
-	user.show_message("Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]", 1)
+		user << "Anomalious slime core amount detected"
+	user << "Growth progress: [T.amount_grown]/[SLIME_EVOLUTION_THRESHOLD]"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -36,21 +36,21 @@
 		if (istype(W, /obj/item/weapon/screwdriver))
 			if (do_after(user, 20/W.toolspeed, target = src))
 				src.open =! src.open
-				user.show_message(text("<span class='notice'>You [] the service panel.</span>", (src.open ? "open" : "close")))
+				user.show_message("<span class='notice'>You [open ? "open" : "close"] the service panel.</span>", 1)
 			return
 		if ((istype(W, /obj/item/device/multitool)) && (src.open == 1)&& (!src.l_hacking))
-			user.show_message(text("<span class='danger'>Now attempting to reset internal memory, please hold.</span>"), 1)
+			user.show_message("<span class='danger'>Now attempting to reset internal memory, please hold.</span>", 1)
 			src.l_hacking = 1
 			if (do_after(usr, 100/W.toolspeed, target = src))
 				if (prob(40))
 					src.l_setshort = 1
 					src.l_set = 0
-					user.show_message(text("<span class='danger'>Internal memory reset.  Please give it a few seconds to reinitialize.</span>"), 1)
+					user.show_message("<span class='danger'>Internal memory reset.  Please give it a few seconds to reinitialize.</span>", 1)
 					sleep(80)
 					src.l_setshort = 0
 					src.l_hacking = 0
 				else
-					user.show_message(text("<span class='danger'>Unable to reset internal memory.</span>"), 1)
+					user.show_message("<span class='danger'>Unable to reset internal memory.</span>", 1)
 					src.l_hacking = 0
 			else	src.l_hacking = 0
 			return

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -156,7 +156,7 @@ Frequency:
 	if(turfs.len)
 		L["None (Dangerous)"] = pick(turfs)
 	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") in L
-	if ((user.get_active_hand() != src || user.stat || user.restrained()))
+	if (user.get_active_hand() != src || user.incapacitated())
 		return
 	if(active_portals >= 3)
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")
@@ -166,7 +166,6 @@ Frequency:
 	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(src), T, src)
 	try_move_adjacent(P)
 	active_portals++
-	src.add_fingerprint(user)
-	return
+	add_fingerprint(user)
 
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -201,7 +201,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	t+= "Plasma : [env.toxins]\n"
 	t+= "CO2: [env.carbon_dioxide]\n"
 
-	usr.show_message(t, 1)
+	usr << t
 	feedback_add_details("admin_verb","ASL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_robotize(mob/M in mob_list)

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -74,7 +74,7 @@
 	if(!secured)
 		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
 		return 0
-	var/dat = text("<TT><B>Health Sensor</B> <A href='?src=\ref[src];scanning=1'>[scanning?"On":"Off"]</A>")
+	var/dat = "<TT><B>Health Sensor</B> <A href='?src=\ref[src];scanning=1'>[scanning?"On":"Off"]</A>"
 	if(scanning && health_scan)
 		dat += "<BR>Health: [health_scan]"
 	user << browse(dat, "window=hscan")

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -125,8 +125,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/proc/SplashReagents(var/mob/M)
 	if(src.reagents.total_volume)
-		for(var/mob/O in viewers(M, null))
-			O.show_message(text("<span class='danger'>The contents of \the [src] splashes all over [M]!</span>"), 1)
+		M.visible_message("<span class='danger'>The contents of \the [src] splashes all over [M]!</span>")
 		reagents.reaction(M, TOUCH)
 		reagents.clear_reagents()
 	return

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -87,7 +87,7 @@
 	else return ..()
 
 /obj/item/weapon/deck/proc/dealTo(mob/living/target, mob/living/source)
-	if (!src.cards.len)
+	if (!cards.len)
 		source.show_message("There are no cards in the deck.")
 		return
 
@@ -185,10 +185,10 @@
 	. = ..()
 
 	if((!concealed || src.loc == usr) && cards.len)
-		usr.show_message("It contains: ")
+		usr.show_message("It contains: ", 1)
 
 		for (var/datum/playingcard/card in cards)
-			usr.show_message("The [card.name].")
+			usr.show_message("The [card.name].", 1)
 
 /obj/item/weapon/hand/proc/update_conceal()
 	if (src.concealed) src.hi.updateContent("headbar", "You are currently concealing your hand. <a href=\"byond://?src=\ref[hi]&action=toggle_conceal\">Reveal your hand.</a>")

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -90,8 +90,7 @@ Doesn't work on other aliens/AI.*/
 	if(locate(/obj/structure/alien/weeds/node) in get_turf(user))
 		src << "There's already a weed node here."
 		return 0
-	for(var/mob/O in viewers(user, null))
-		O.show_message(text("<span class='alertalien'>[user] has planted some alien weeds!</span>"), 1)
+	user.visible_message("<span class='alertalien'>[user] has planted some alien weeds!</span>")
 	new/obj/structure/alien/weeds/node(user.loc)
 	return 1
 
@@ -241,7 +240,7 @@ Doesn't work on other aliens/AI.*/
 		user << "<span class='danger'>There is already a resin structure there.</span>"
 		return 0
 	var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in structures
-	if(!choice) 
+	if(!choice)
 		return 0
 	if (!cost_check(check_turf,user))
 		return 0

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -260,8 +260,7 @@
 			if(href_list["cable"])
 				var/turf/T = get_turf(src.loc)
 				src.cable = new /obj/item/weapon/pai_cable(T)
-				for (var/mob/M in viewers(T))
-					M.show_message("<span class='warning'>A port on [src] opens to reveal [src.cable], which promptly falls to the floor.</span>", 3, "<span class='italics'>You hear the soft click of something light and hard falling to the ground.</span>", 2)
+				T.visible_message("<span class='warning'>A port on [src] opens to reveal [src.cable], which promptly falls to the floor.</span>", "<span class='italics'>You hear the soft click of something light and hard falling to the ground.</span>")
 	//src.updateUsrDialog()		We only need to account for the single mob this is intended for, and he will *always* be able to call this window
 	src.paiInterface()		 // So we'll just call the update directly rather than doing some default checks
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -84,29 +84,26 @@ var/next_mob_id = 0
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	for(var/P in player_list)
-		var/mob/M = P
-		var/turf/U = get_turf(P)
-		if(!U)
+	for(var/mob/M in get_hearers_in_view(7, src))
+		if(!M.client)
 			continue
-		if(get_dist(T,U)<8 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
-			var/msg = message
-			if(M == src) //the src always see the main message or self message
-				if(self_message)
-					msg = self_message
-			else
-				if(M.see_invisible<invisibility || T != loc) //if src is inside something or invisible to us,
-					if(blind_message) // then people see blind message if there is one, otherwise nothing.
+		var/msg = message
+		if(M == src) //the src always see the main message or self message
+			if(self_message)
+				msg = self_message
+		else
+			if(M.see_invisible<invisibility || T != loc) //if src is inside something or invisible to us,
+				if(blind_message) // then people see blind message if there is one, otherwise nothing.
+					msg = blind_message
+				else
+					continue
+			else if(T.lighting_object)
+				if(T.lighting_object.invisibility <= M.see_invisible && !T.lighting_object.luminosity)
+					if(blind_message) //if the light object is dark and not invisible to us, we see blind_message/nothing
 						msg = blind_message
 					else
 						continue
-				else if(T.lighting_object)
-					if(T.lighting_object.invisibility <= M.see_invisible && !T.lighting_object.luminosity)
-						if(blind_message) //if the light object is dark and not invisible to us, we see blind_message/nothing
-							msg = blind_message
-						else
-							continue
-			M.show_message(msg,1,blind_message,2)
+		M.show_message(msg,1,blind_message,2)
 
 // Show a message to all player mobs who sees this atom
 // Use for objects performing visible actions
@@ -117,25 +114,22 @@ var/next_mob_id = 0
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	for(var/P in player_list)
-		var/mob/M = P
-		var/turf/U = get_turf(P)
-		if(!U)
+	for(var/mob/M in get_hearers_in_view(7, src))
+		if(!M.client)
 			continue
-		if(get_dist(T,U)<8 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
-			var/msg = message
-			if(M.see_invisible<invisibility || T != loc)//if src is inside something or invisible to us,
-				if(blind_message) // then people see blind message if there is one, otherwise nothing.
+		var/msg = message
+		if(M.see_invisible<invisibility || T != loc)//if src is inside something or invisible to us,
+			if(blind_message) // then people see blind message if there is one, otherwise nothing.
+				msg = blind_message
+			else
+				continue
+		else if(T.lighting_object)
+			if(T.lighting_object.invisibility <= M.see_invisible && !T.lighting_object.luminosity) //the light object is dark and not invisible to us
+				if(blind_message)
 					msg = blind_message
 				else
 					continue
-			else if(T.lighting_object)
-				if(T.lighting_object.invisibility <= M.see_invisible && !T.lighting_object.luminosity) //the light object is dark and not invisible to us
-					if(blind_message)
-						msg = blind_message
-					else
-						continue
-			M.show_message(msg,1,blind_message,2)
+		M.show_message(msg,1,blind_message,2)
 
 // Show a message to all mobs in earshot of this one
 // This would be for audible actions by the src mob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@ var/next_mob_id = 0
 		var/turf/U = get_turf(P)
 		if(!U)
 			continue
-		if(get_dist(T,U)<7 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
+		if(get_dist(T,U)<8 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
 			var/msg = message
 			if(M == src) //the src always see the main message or self message
 				if(self_message)
@@ -106,7 +106,7 @@ var/next_mob_id = 0
 							msg = blind_message
 						else
 							continue
-			M.show_message(msg,1,blind_message,0)
+			M.show_message(msg,1,blind_message,2)
 
 // Show a message to all player mobs who sees this atom
 // Use for objects performing visible actions
@@ -122,7 +122,7 @@ var/next_mob_id = 0
 		var/turf/U = get_turf(P)
 		if(!U)
 			continue
-		if(get_dist(T,U)<7 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
+		if(get_dist(T,U)<8 && inLineOfSight(T.x,T.y, U.x,U.y,T.z))
 			var/msg = message
 			if(M.see_invisible<invisibility || T != loc)//if src is inside something or invisible to us,
 				if(blind_message) // then people see blind message if there is one, otherwise nothing.

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -100,10 +100,9 @@
 
 /datum/chemical_reaction/slimecrit/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	spawn(50)
-
 		chemical_mob_spawn(holder, 5, "Gold Slime")
 
 /datum/chemical_reaction/slimecritlesser
@@ -117,10 +116,9 @@
 
 /datum/chemical_reaction/slimecritlesser/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	spawn(50)
-
 		chemical_mob_spawn(holder, 3, "Lesser Gold Slime", "neutral")
 
 /datum/chemical_reaction/slimecritfriendly
@@ -134,10 +132,9 @@
 
 /datum/chemical_reaction/slimecritfriendly/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate adorably !</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
 	spawn(50)
-
 		chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
 
 //Silver
@@ -262,8 +259,8 @@
 
 /datum/chemical_reaction/slimefreeze/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
 	spawn(50)
 		if(holder && holder.my_atom)
 			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -310,8 +307,8 @@
 
 /datum/chemical_reaction/slimefire/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+	var/turf/TU = get_turf(holder.my_atom)
+	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
 	spawn(50)
 		if(holder && holder.my_atom)
 			var/turf/simulated/T = get_turf(holder.my_atom)
@@ -359,8 +356,8 @@
 
 /datum/chemical_reaction/slimeglow/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime begins to emit a soft light. Squeezing it will cause it to grow brightly.</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime begins to emit a soft light. Squeezing it will cause it to grow brightly.</span>")
 	var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
 	F.loc = get_turf(holder.my_atom)
 
@@ -438,8 +435,7 @@
 	feedback_add_details("slime_cores_used","[type]")
 	for(var/mob/living/simple_animal/slime/slime in viewers(get_turf(holder.my_atom), null))
 		slime.rabid = 1
-		for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-			O.show_message(text("<span class='danger'>The [slime] is driven into a frenzy!</span>"), 1)
+		slime.visible_message("<span class='danger'>The [slime] is driven into a frenzy!</span>")
 
 
 /datum/chemical_reaction/slimespeed
@@ -498,8 +494,8 @@
 
 /datum/chemical_reaction/slimeexplosion/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 	spawn(50)
 		if(holder && holder.my_atom)
 			explosion(get_turf(holder.my_atom), 1 ,3, 6)


### PR DESCRIPTION
<s>It uses the player list instead of inspecting all atoms around the source (since visible actions don't need to be picked up by radios and other listening devices and clientless mobs). The proc should now be 2 to 6 times faster. It will only be slower than the current version if there is 400 players in a single room.</s>
The proc will no longer call get_hearers_in_view() (or equivalent) twice when the proc has a blind_message argument. This should make the proc faster in this specific case. The added client check will also make it faster when around many non player mobs.

Also:
- Replacing some "for(var/mob/O in viewers()) show_message()" by "visible_message()". This fixes pAI and mech occupant not getting these messages.
- Replacing some "show_message()" by " << "..." " instead. This removes unnecessary checks and prevents some edge cases like an admin not seeing a debug message because their mob is unconscious or blind.
- Fixes being able to see the results of the health and slime analyzers while blind.
- Removing some unnecessary "text(...)".
