### PR TITLE
Removes a bunch of sleep(-1) and spawn(-1) from the code

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -149,7 +149,7 @@ var/global/datum/controller/master/Master = new()
 							// If we caused BYOND to miss a tick, stop processing for a bit...
 							if(startingtick < world.time || start_time + 1 < world.timeofday)
 								break
-							sleep(-1)
+							sleep(0)
 
 				cost = MC_AVERAGE(cost, world.timeofday - start_time)
 				if(ran_subsystems)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -485,5 +485,5 @@ var/datum/subsystem/ticker/ticker
 	//map rotate chance defaults to 75% of the length of the round (in minutes)
 	if (!prob((world.time/600)*config.maprotatechancedelta))
 		return
-	spawn(-1) //compiling a map can lock up the mc for 30 to 60 seconds if we don't spawn
+	spawn(0) //compiling a map can lock up the mc for 30 to 60 seconds if we don't spawn
 		maprotate()

--- a/code/datums/helper_datums/events.dm
+++ b/code/datums/helper_datums/events.dm
@@ -34,7 +34,7 @@
 	//world << "Events in [args[1]] called"
 	var/list/event = listgetindex(events,args[1])
 	if(istype(event))
-		spawn(-1)
+		spawn(0)
 			for(var/datum/event/E in event)
 				if(!E.Fire(arglist(args.Copy(2))))
 					clearEvent(args[1],E)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -82,12 +82,12 @@
 /datum/teleport/proc/playSpecials(atom/location,datum/effect_system/effect,sound)
 	if(location)
 		if(effect)
-			spawn(-1)
+			spawn(0)
 				src = null
 				effect.attach(location)
 				effect.start()
 		if(sound)
-			spawn(-1)
+			spawn(0)
 				src = null
 				playsound(location,sound,60,1)
 	return

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -40,7 +40,7 @@
 
   obj/proc/receive_signal(datum/signal/signal, var/receive_method as num, var/receive_param)
     Handler from received signals. By default does nothing. Define your own for your object.
-    Avoid of sending signals directly from this proc, use spawn(-1). Do not use sleep() here please.
+    Avoid of sending signals directly from this proc, use spawn(0). Do not use sleep() here please.
       parameters:
         signal - see description below. Extract all needed data from the signal before doing sleep(), spawn() or return!
         receive_method - may be TRANSMISSION_WIRE or TRANSMISSION_RADIO.

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -396,7 +396,7 @@
 		add_part_set_to_queue(filter.get("partset_to_queue"))
 		return update_queue_on_page()
 	if(href_list["process_queue"])
-		spawn(-1)
+		spawn(0)
 			if(processing_queue || being_built)
 				return 0
 			processing_queue = 1

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -10,7 +10,7 @@ var/list/admin_ranks = list()								//list of all admin_rank datums
 	name = init_name
 	switch(name)
 		if("Removed",null,"")
-			spawn(-1)
+			spawn(0)
 				qdel(src)
 			throw EXCEPTION("invalid admin-rank name")
 			return

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -16,12 +16,12 @@ var/list/admin_datums = list()
 
 /datum/admins/New(datum/admin_rank/R, ckey)
 	if(!ckey)
-		spawn(-1)
+		spawn(0)
 			del(src)
 		throw EXCEPTION("Admin datum created without a ckey")
 		return
 	if(!istype(R))
-		spawn(-1)
+		spawn(0)
 			del(src)
 		throw EXCEPTION("Admin datum created without a rank")
 		return

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -131,7 +131,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 		if (register_asset)
 			register_asset(file,files[file])
 		send_asset(client,file)
-		sleep(-1) //queuing calls like this too quickly can cause issues in some client versions
+		sleep(0) //queuing calls like this too quickly can cause issues in some client versions
 
 //This proc "registers" an asset, it adds it to the cache for further use, you cannot touch it from this point on or you'll fuck things up.
 //if it's an icon or something be careful, you'll have to copy it before further use.

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -374,7 +374,7 @@
 					//close open doors
 					if(istype(O, /obj/machinery/door))
 						var/obj/machinery/door/Door = O
-						spawn(-1)
+						spawn(0)
 							if(Door)
 								Door.close()
 				else if (istype(AM,/mob))
@@ -443,7 +443,7 @@
 	if(T)
 		var/obj/machinery/door/Door = locate() in T
 		if(Door)
-			spawn(-1)
+			spawn(0)
 				Door.close()
 
 /obj/docking_port/mobile/proc/roadkill(list/L, dir, x, y)


### PR DESCRIPTION
This seems to be causing issues where if the queue was too long, byond would attempt to process through all of it while hanging everything else.

Not sure if this fixes the issue where atmos would hang for 10 seconds after running, but not show that lag up on the cost, but it SHOULD(tm) from my tests.

It seems that lag was in the sleep -1 in mc's process()
