### PR TITLE
Revert commit f6d13b9 (blame RR) (fixes fires from crashing clients)

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -209,11 +209,8 @@
 			. = 1
 			if(O.burn_state == FIRE_PROOF)
 				O.burn_state = FLAMMABLE //Even fireproof things burn up in lava
-				O.fire_act()
-				if (O)
-					O.burn_state = FIRE_PROOF
-			else
-				O.fire_act()
+			
+			O.fire_act()
 			
 			
 		else if (istype(thing, /mob/living))


### PR DESCRIPTION
Revert commit f6d13b93 (blame rr)

This crashes the client

(burn code sets burn_state to ON_FIRE) setting it back to FIRE_PROOF kept it from detecting it was already on fire, so it kept re-adding the overlay, once the total number of overlays visible to the client got to 65k, it crashed the client)

Fixes #14411
