### PR TITLE
Chasm Fix

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -683,7 +683,7 @@ var/global/list/rockTurfEdgeCache
 
 /turf/simulated/chasm/proc/drop(atom/movable/AM)
 	visible_message("[AM] falls into [src]!")
-	AM.Move(locate(drop_x, drop_y, drop_z))
+	AM.forceMove(locate(drop_x, drop_y, drop_z))
 	AM.visible_message("[AM] falls from above!")
 	if(istype(AM, /mob/living))
 		var/mob/living/L = AM


### PR DESCRIPTION
Now uses forcemove instead of move, so you aren't stuck inexplicably floating above a hole if there is a wall underneath it on the lower Z level.
