### PR TITLE
Windows now give a message when repaired.

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -205,6 +205,7 @@
 					health = maxhealth
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					update_nearby_icons()
+					user << "<span class='notice'>You repair [src].</span>"
 		else
 			user << "<span class='warning'>[src] is already in good condition!</span>"
 		return


### PR DESCRIPTION
Previously they gave no message, not sure why this was overlooked but now it is not. 
