### PR TITLE
Removes tactical ghosts

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -7,6 +7,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	layer = MOB_LAYER + 1
 	stat = DEAD
 	density = 0
+	mouse_opacity = 0
 	canmove = 0
 	anchored = 1	//  don't get pushed around
 	invisibility = INVISIBILITY_OBSERVER


### PR DESCRIPTION
I don't really think it's a problem so you should probably close both this PR and the issue report. I mean its a dumb wizard event who cares about balance

Fixes #14432

Actually this probably causes more problems than it fixes (being unable to see which ghost is which while dead for example)
