### PR TITLE
Fixes abandoned crates minigame / Also fixes tuberculosis kit

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -247,7 +247,7 @@
 /obj/item/weapon/storage/box/syndie_kit/tuberculosiskit
 	name = "boxed virus kit"
 
-/obj/item/weapon/storage/box/virus_kit/tuberculosiskit/New()
+/obj/item/weapon/storage/box/syndie_kit/tuberculosiskit/New()
 	..()
 	new /obj/item/weapon/reagent_containers/glass/bottle/tuberculosis(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen/tuberculosiscure(src)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -13,8 +13,7 @@
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()
-	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
-
+	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
 	code = ""
 	for(var/i = 0, i < codelen, i++)
 		var/dig = pick(digits)
@@ -169,7 +168,7 @@
 				user << "<span class='notice'>You leave the crate alone.</span>"
 			else
 				user << "<span class='warning'>A red light flashes.</span>"
-				lastattempt = input
+				lastattempt = replacetext(input, 0, "z")
 				attempts--
 				if (attempts == 0)
 					user << "<span class='danger'>The crate's anti-tamper system activates!</span>"


### PR DESCRIPTION
Replaces the user input 0 with "z"(Code side only. Player can still use
0). Wont return 0 as "cows" anymore.

Fixes #12246 

As a side-effect, players can use "z" instead of the number zero and that will also work, I guess.

Now it also fixes Tuberculosis kit being named wrong. I need to learn how to git.
