### PR TITLE
[s]Fixes cult teleport centcom exploit.

### DIFF
--- a/code/controllers/subsystem/shuttles/supply.dm
+++ b/code/controllers/subsystem/shuttles/supply.dm
@@ -211,6 +211,7 @@
 	var/list/blacklist = list(
 		/mob/living,
 		/obj/effect/blob,
+		/obj/effect/rune,
 		/obj/effect/spider/spiderling,
 		/obj/item/weapon/disk/nuclear,
 		/obj/machinery/nuclearbomb,


### PR DESCRIPTION
This was an edge case anyhow, they would have to do it while the shuttle was in transit to centcom as it would delete everything once it go to centcom.

Fixes #14452
