### PR TITLE
Fixes #14442

### DIFF
--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -37,7 +37,7 @@ Bonus
 			if(4, 5)
 				M << "<span class='warning'>[pick("Your skin feels itchy.", "You feel light headed.")]</span>"
 				M.dna.remove_mutation_group(possible_mutations)
-				randmut(M, possible_mutations)
+				randmutb(M)
 	return
 
 // Archive their DNA before they were infected.


### PR DESCRIPTION
Hopefully this works. I suspect the logic was wonky feeding the possible mutations to randommut()
Too bad i cant test this.
Either Fixes #14442 or someone didn't know how to manipulate lists. the only other thin would be too generate the list and then -= away the mutation. or that mutations_list[RACEMUT] isn't what someone thought it was.
ACTUALY i think the problem may be that defines arn't actually associated with the mutations
