### PR TITLE
Temporary Revert Of Fusion

### DIFF
--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -121,6 +121,7 @@ What are the archived variables for?
 					temperature -= (reaction_rate*20000)/heat_capacity()
 
 					reacting = 1
+	/*
 	if(thermal_energy() > (PLASMA_BINDING_ENERGY*10))
 		if(toxins > MINIMUM_HEAT_CAPACITY && carbon_dioxide > MINIMUM_HEAT_CAPACITY && (toxins+carbon_dioxide)/total_moles() >= FUSION_PURITY_THRESHOLD)//Fusion wont occur if the level of impurities is too high.
 			//world << "pre [temperature, [toxins], [carbon_dioxide]
@@ -145,7 +146,7 @@ What are the archived variables for?
 					temperature = max(((temperature*old_heat_capacity + reaction_energy)/new_heat_capacity),TCMB)
 					//Prevents whatever mechanism is causing it to hit negative temperatures.
 				//world << "post [temperature], [toxins], [carbon_dioxide]
-
+			*/
 
 
 	fuel_burnt = 0


### PR DESCRIPTION
I understand that it is a new feature and its gonna be buggy. Lord knows I've caused worst bugs, and just as unbalanced features so I really hope you understand I don't mean offense by this @as334 

However it has been buggy for nearly a month now, and currently does not add very much, if anything, to the game (it doesn't even work as a fuel source, since it kills the turbine).

When we have broken game modes or broken away missions we temporarily disable them until fixed. It's very easy to re-enable, so it shouldn't be a huge drama to turn it off temporarily until people have time to do bugfixes. 

Fusion is very nicely contained code, so it's very easy to turn off and back on again when it is ready. We don't lose progress on fusion by doing this, and we make the server more playable in the mean time.

The issue reports will be left open since they're all flaws in atmos code that fusion exposed, and will hopefully be corrected with the atmos rewrite @duncathan is doing
