### PR TITLE
Non-airlock doors check for mobs while closing + extra shit

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -508,7 +508,7 @@ About the new airlock wires panel:
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack())
-				user << "We've lost our connection! Unable to hack airlock."
+				user << "Connection lost! Unable to hack airlock."
 				src.aiHacking=0
 				return
 			user << "Fault confirmed: airlock control wire disabled or cut."
@@ -520,7 +520,7 @@ About the new airlock wires panel:
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack())
-				user << "We've lost our connection! Unable to hack airlock."
+				user << "Connection lost! Unable to hack airlock."
 				src.aiHacking=0
 				return
 			user << "Upload access confirmed. Loading control program into airlock software."
@@ -530,7 +530,7 @@ About the new airlock wires panel:
 				src.aiHacking=0
 				return
 			else if(!src.canAIHack())
-				user << "We've lost our connection! Unable to hack airlock."
+				user << "Connection lost! Unable to hack airlock."
 				src.aiHacking=0
 				return
 			user << "Transfer complete. Forcing airlock to execute program."
@@ -658,7 +658,7 @@ About the new airlock wires panel:
 					else if (src.normalspeed)
 						normalspeed = 0
 					else
-						usr << text("Door timing circurity already accellerated.")
+						usr << text("Door timing circurity already accelerated.")
 
 				if(7)
 					//close door
@@ -1053,9 +1053,7 @@ About the new airlock wires panel:
 	air_update_turf(1)
 	update_freelook_sight()
 	if(safe)
-		if(locate(/mob/living) in get_turf(src))
-			sleep(1)
-			open()
+		CheckForMobs()
 	return 1
 
 /obj/machinery/door/airlock/proc/prison_open()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -658,7 +658,7 @@ About the new airlock wires panel:
 					else if (src.normalspeed)
 						normalspeed = 0
 					else
-						usr << text("Door timing circurity already accelerated.")
+						usr << text("Door timing circuitry already accelerated.")
 
 				if(7)
 					//close door

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -54,6 +54,7 @@ var/list/airlock_overlays = list()
 	var/autoclose = 1
 	var/obj/item/device/doorCharge/charge = null //If applied, causes an explosion upon opening the door
 	var/detonated = 0
+	var/doorsound = 'sound/machines/airlock.ogg'
 
 	var/airlock_material = null //material of inner filling; if its an airlock with glass, this should be set to "glass"
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
@@ -762,7 +763,7 @@ About the new airlock wires panel:
 						normalspeed = 1
 						src.updateUsrDialog()
 					else
-						usr << text("Door timing circurity currently operating normally.")
+						usr << text("Door timing circuitry currently operating normally.")
 
 				if(7)
 					//open door
@@ -978,12 +979,7 @@ About the new airlock wires panel:
 		if(emagged)
 			return 0
 		use_power(50)
-		if(istype(src, /obj/machinery/door/airlock/glass))
-			playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-		if(istype(src, /obj/machinery/door/airlock/clown))
-			playsound(src.loc, 'sound/items/bikehorn.ogg', 30, 1)
-		else
-			playsound(src.loc, 'sound/machines/airlock.ogg', 30, 1)
+		playsound(src.loc, doorsound, 30, 1)
 		if(src.closeOther != null && istype(src.closeOther, /obj/machinery/door/airlock/) && !src.closeOther.density)
 			src.closeOther.close()
 	else
@@ -1032,12 +1028,7 @@ About the new airlock wires panel:
 		if(emagged)
 			return
 		use_power(50)
-		if(istype(src, /obj/machinery/door/airlock/glass))
-			playsound(src.loc, 'sound/machines/windowdoor.ogg', 30, 1)
-		if(istype(src, /obj/machinery/door/airlock/clown))
-			playsound(src.loc, 'sound/items/bikehorn.ogg', 30, 1)
-		else
-			playsound(src.loc, 'sound/machines/airlock.ogg', 30, 1)
+		playsound(src.loc, doorsound, 30, 1)
 	else
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -183,6 +183,7 @@
 	desc = "Honkhonkhonk"
 	icon = 'icons/obj/doors/airlocks/station/bananium.dmi'
 	var/mineral = "bananium"
+	doorsound = 'sound/items/bikehorn.ogg'
 	doortype = /obj/structure/door_assembly/door_assembly_clown
 
 /obj/machinery/door/airlock/sandstone
@@ -209,6 +210,7 @@
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
 	opacity = 0
 	doortype = /obj/structure/door_assembly/door_assembly_glass
+	doorsound = 'sound/machines/windowdoor.ogg'
 	glass = 1
 
 //////////////////////////////////

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -221,6 +221,9 @@
 	update_icon()
 	if(visible && !glass)
 		SetOpacity(1)
+	if(locate(/mob/living) in get_turf(src))
+		sleep(1)
+		open()
 	operating = 0
 	air_update_turf(1)
 	update_freelook_sight()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -79,6 +79,11 @@
 /obj/machinery/door/proc/CanAStarPass(var/obj/item/weapon/card/id/ID)
 	return !density
 
+/obj/machinery/door/proc/CheckForMobs()
+	if(locate(/mob/living) in get_turf(src))
+		sleep(1)
+		open()
+
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)
 		return
@@ -221,9 +226,7 @@
 	update_icon()
 	if(visible && !glass)
 		SetOpacity(1)
-	if(locate(/mob/living) in get_turf(src))
-		sleep(1)
-		open()
+	CheckForMobs()
 	operating = 0
 	air_update_turf(1)
 	update_freelook_sight()


### PR DESCRIPTION
- Non-airlock doors check for mobs while closing. Fixes https://github.com/tgstation/-tg-station/issues/14005. Door/airlock procs are messy, I know. The alternative to yet another proc is copypasta.
- Removed a bunch of fucking terrible istypes from airlock code.
- Minor edits to messages. FULL DISCLOSURE Y'ALL.
