### PR TITLE
Fixes simple bots broadcasting department radios

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -105,7 +105,7 @@
 	Radio = new/obj/item/device/radio(src)
 	if(radio_key)
 		Radio.keyslot = new radio_key
-	Radio.canhear_range = 1 // 0 ?
+	Radio.canhear_range = 0 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
 	Radio.recalculateChannels()
 
 	bot_core = new bot_core_type(src)


### PR DESCRIPTION
Started with #13471 but all simple bots (medbots, floorbots, etc.) had this problem.

Tested briefly, beepsky did not broadcast sec chat to nearby mobs, but sec headsets still picked up his text.
