### PR TITLE
Fixes Ministation hydroponics tray supply pack.

### DIFF
--- a/_maps/map_files/MiniStation/supplypacks.dm
+++ b/_maps/map_files/MiniStation/supplypacks.dm
@@ -31,8 +31,12 @@
 	anchored = 0
 
 /datum/supply_packs/organic/hydroponics/hydro_tray
-	name = "Hydroponics Tray"
-	contains = list(/obj/machinery/hydroponics/unattached)
+	name = "Hydroponics Tray Kit"
+	contains = list(/obj/item/weapon/circuitboard/hydroponics,
+                   /obj/item/weapon/stock_parts/matter_bin,
+                   /obj/item/weapon/stock_parts/matter_bin,
+                   /obj/item/weapon/stock_parts/manipulator,
+                   /obj/item/weapon/stock_parts/console_screen)
 	cost = 10
-	containertype = /obj/structure/largecrate
-	containername = "hydroponics tray crate"
+	containertype = /obj/structure/closet/crate/hydroponics
+	containername = "hydroponics kit"

--- a/_maps/map_files/MiniStation/supplypacks.dm
+++ b/_maps/map_files/MiniStation/supplypacks.dm
@@ -27,16 +27,12 @@
 	containername = "carbon dioxide canister crate"
 
 
-/obj/machinery/hydroponics/unattached
+/obj/machinery/hydroponics/constructable/unattached
 	anchored = 0
 
 /datum/supply_packs/organic/hydroponics/hydro_tray
 	name = "Hydroponics Tray Kit"
-	contains = list(/obj/item/weapon/circuitboard/hydroponics,
-                   /obj/item/weapon/stock_parts/matter_bin,
-                   /obj/item/weapon/stock_parts/matter_bin,
-                   /obj/item/weapon/stock_parts/manipulator,
-                   /obj/item/weapon/stock_parts/console_screen)
+	contains = list(/obj/machinery/hydroponics/constructable/unattached)
 	cost = 10
-	containertype = /obj/structure/closet/crate/hydroponics
+	containertype = /obj/structure/largecrate
 	containername = "hydroponics kit"


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/4305. Instead of getting the outdated tray, you get the component parts to build your own (correct) tray.

GIMME THOSE TWO POINTS FAM
