### PR TITLE
Honker blast now works off the EARBANGPROTECT flag.

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -167,7 +167,7 @@
 	for(var/mob/living/carbon/M in ohearers(6, chassis))
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
+			if(H.ears && (H.ears.flags & EARBANGPROTECT))
 				continue
 		M << "<font color='red' size='7'>HONK</font>"
 		M.sleeping = 0


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/6499.

BEFORE YOU FREAK OUT: Functionally this is virtually unchanged as the only other item currently in the game with EARBANGPROTECT is nuke ops' headsets. However, this makes it more maintainable if some <s>monster</s> coder wants to add new items that stop the honk.

2 points pls
