### PR TITLE
Fixes hardsuit helmets being destroyed when force unequipped

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -13,7 +13,7 @@
 	var/obj/item/clothing/suit/space/hardsuit/suit
 	item_color = "engineering" //Determines used sprites: hardsuit[on]-[color] and hardsuit[on]-[color]2 (lying down sprite)
 	action_button_name = "Toggle Helmet Light"
-	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 
@@ -38,6 +38,15 @@
 	if(on)
 		user.AddLuminosity(-brightness_on)
 		SetLuminosity(brightness_on)
+	if(suit)
+		suit.RemoveHelmet()
+
+/obj/item/clothing/head/helmet/space/hardsuit/equipped(mob/user, slot)
+	if(slot != slot_head)
+		if(suit)
+			suit.RemoveHelmet()
+		else
+			qdel(src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/proc/display_visor_message(var/msg)
 	var/mob/wearer = loc
@@ -178,7 +187,7 @@
 	on = 0
 	var/obj/item/clothing/suit/space/hardsuit/syndi/linkedsuit = null
 	action_button_name = "Toggle Helmet Mode"
-	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -137,6 +137,8 @@
 			helmet.attack_self(H)
 		H.unEquip(helmet, 1)
 		H.update_inv_wear_suit()
+		H << "<span class='notice'>The helmet on the hardsuit disengages.</span>"
+	playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
 	helmet.loc = src
 
 /obj/item/clothing/suit/space/hardsuit/dropped()
@@ -163,6 +165,4 @@
 				H.update_inv_wear_suit()
 				playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
 	else
-		H << "<span class='notice'>You disengage the helmet on the hardsuit.</span>"
-		playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
 		RemoveHelmet()


### PR DESCRIPTION
It disengages instead. This means you can strip peoples helmets/unequip your own helmet by clicking on the inventory slot as well (though it returns to the suit).

Fixes #13041

Fixes #14413

Fixes #14518 (More or less anyway, they'll still have a disembodied hardsuit helmet equipped, but it will qdel as soon as you try and remove it)
