### PR TITLE
Fix re-enter corpse message in adminghost

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -322,10 +322,9 @@ var/list/admin_verbs_hideable = list(
 	if(istype(mob,/mob/dead/observer))
 		//re-enter
 		var/mob/dead/observer/ghost = mob
-		if (!ghost.can_reenter_corpse)
+		if (ghost.can_reenter_corpse)
 			log_admin("[key_name(usr)] re-entered corpse")
 			message_admins("[key_name_admin(usr)] re-entered corpse")
-		ghost.can_reenter_corpse = 1			//just in-case.
 		ghost.reenter_corpse()
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(istype(mob,/mob/new_player))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -322,10 +322,12 @@ var/list/admin_verbs_hideable = list(
 	if(istype(mob,/mob/dead/observer))
 		//re-enter
 		var/mob/dead/observer/ghost = mob
-		if (ghost.mind && ghost.mind.current)
-			log_admin("[key_name(usr)] re-entered corpse")
-			message_admins("[key_name_admin(usr)] re-entered corpse")
-		ghost.can_reenter_corpse = 1 		//So you can re-enter if you ghost out without aghost
+		if(!ghost.mind || !ghost.mind.current) //won't do anything if there is no body
+		    return
+		if(!ghost.can_reenter_corpse)
+		    log_admin("[key_name(usr)] re-entered corpse")
+		    message_admins("[key_name_admin(usr)] re-entered corpse")
+		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
 		ghost.reenter_corpse()
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(istype(mob,/mob/new_player))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -323,10 +323,10 @@ var/list/admin_verbs_hideable = list(
 		//re-enter
 		var/mob/dead/observer/ghost = mob
 		if(!ghost.mind || !ghost.mind.current) //won't do anything if there is no body
-		    return
+			return
 		if(!ghost.can_reenter_corpse)
-		    log_admin("[key_name(usr)] re-entered corpse")
-		    message_admins("[key_name_admin(usr)] re-entered corpse")
+			log_admin("[key_name(usr)] re-entered corpse")
+			message_admins("[key_name_admin(usr)] re-entered corpse")
 		ghost.can_reenter_corpse = 1 //force re-entering even when otherwise not possible
 		ghost.reenter_corpse()
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -322,9 +322,10 @@ var/list/admin_verbs_hideable = list(
 	if(istype(mob,/mob/dead/observer))
 		//re-enter
 		var/mob/dead/observer/ghost = mob
-		if (ghost.can_reenter_corpse)
+		if (ghost.mind && ghost.mind.current)
 			log_admin("[key_name(usr)] re-entered corpse")
 			message_admins("[key_name_admin(usr)] re-entered corpse")
+		ghost.can_reenter_corpse = 1 		//So you can re-enter if you ghost out without aghost
 		ghost.reenter_corpse()
 		feedback_add_details("admin_verb","P") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	else if(istype(mob,/mob/new_player))


### PR DESCRIPTION
It was only showing when you didn't have a body, should be working as intended now.
