### PR TITLE
Blobs should cause significantly less lag

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -8,6 +8,7 @@
 	explosion_block = 6
 	point_return = -1
 	atmosblock = 1
+	health_regen = 0 //we regen in Life() instead
 	var/overmind_get_delay = 0 //we don't want to constantly try to find an overmind, this var tracks when we'll try to get an overmind again
 	var/resource_delay = 0
 	var/point_rate = 2
@@ -34,9 +35,6 @@
 	var/image/C = new('icons/mob/blob.dmi', "blob_core_overlay")
 	overlays += C
 
-/obj/effect/blob/core/PulseAnimation()
-	return
-
 /obj/effect/blob/core/Destroy()
 	blob_cores -= src
 	if(overmind)
@@ -56,9 +54,6 @@
 	if(overmind) //we should have an overmind, but...
 		overmind.update_health()
 
-/obj/effect/blob/core/RegenHealth()
-	return // Don't regen, we handle it in Life()
-
 /obj/effect/blob/core/Life()
 	if(!overmind)
 		create_overmind()
@@ -66,7 +61,7 @@
 		if(resource_delay <= world.time)
 			resource_delay = world.time + 10 // 1 second
 			overmind.add_points(point_rate)
-	health = min(maxhealth, health+health_regen)
+	health = min(maxhealth, health+2)
 	if(overmind)
 		overmind.update_health()
 	Pulse_Area(overmind, 12, 4, 3)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -8,7 +8,8 @@
 	explosion_block = 6
 	point_return = -1
 	atmosblock = 1
-	health_regen = 0 //we regen in Life() instead
+	health_regen = 0 //we regen in Life() instead of when pulsed
+	var/core_regen = 2
 	var/overmind_get_delay = 0 //we don't want to constantly try to find an overmind, this var tracks when we'll try to get an overmind again
 	var/resource_delay = 0
 	var/point_rate = 2
@@ -61,7 +62,7 @@
 		if(resource_delay <= world.time)
 			resource_delay = world.time + 10 // 1 second
 			overmind.add_points(point_rate)
-	health = min(maxhealth, health+2)
+	health = min(maxhealth, health+core_regen)
 	if(overmind)
 		overmind.update_health()
 	Pulse_Area(overmind, 12, 4, 3)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -19,15 +19,15 @@
 	return ..()
 
 /obj/effect/blob/factory/Be_Pulsed()
-	if(..())
-		if(spores.len >= max_spores)
-			return 0
-		if(spore_delay > world.time)
-			return 0
-		flick("factory_glow", src)
-		spore_delay = world.time + 100 // 10 seconds
-		var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
-		if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
-			BS.overmind = overmind
-			BS.update_icons()
-			overmind.blob_mobs.Add(BS)
+	. = ..()
+	if(spores.len >= max_spores)
+		return
+	if(spore_delay > world.time)
+		return
+	flick("factory_glow", src)
+	spore_delay = world.time + 100 // 10 seconds
+	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
+	if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
+		BS.overmind = overmind
+		BS.update_icons()
+		overmind.blob_mobs.Add(BS)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -18,22 +18,16 @@
 	spores = null
 	return ..()
 
-/obj/effect/blob/factory/PulseAnimation(activate = 0)
-	if(activate)
-		..()
-	return
-
-/obj/effect/blob/factory/run_action()
+/obj/effect/blob/factory/Be_Pulsed()
 	if(spores.len >= max_spores)
 		return 0
 	if(spore_delay > world.time)
 		return 0
+	flick("factory_glow", src)
 	spore_delay = world.time + 100 // 10 seconds
-	PulseAnimation(1)
 	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
 	if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
 		BS.overmind = overmind
 		BS.update_icons()
 		overmind.blob_mobs.Add(BS)
-	return 0
-
+	. = ..()

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -19,15 +19,15 @@
 	return ..()
 
 /obj/effect/blob/factory/Be_Pulsed()
-	if(spores.len >= max_spores)
-		return 0
-	if(spore_delay > world.time)
-		return 0
-	flick("factory_glow", src)
-	spore_delay = world.time + 100 // 10 seconds
-	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
-	if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
-		BS.overmind = overmind
-		BS.update_icons()
-		overmind.blob_mobs.Add(BS)
-	. = ..()
+	if(..())
+		if(spores.len >= max_spores)
+			return 0
+		if(spore_delay > world.time)
+			return 0
+		flick("factory_glow", src)
+		spore_delay = world.time + 100 // 10 seconds
+		var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
+		if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
+			BS.overmind = overmind
+			BS.update_icons()
+			overmind.blob_mobs.Add(BS)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -25,9 +25,6 @@
 	var/image/C = new('icons/mob/blob.dmi', "blob_node_overlay")
 	src.overlays += C
 
-/obj/effect/blob/node/PulseAnimation()
-	return
-
 /obj/effect/blob/node/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -9,10 +9,10 @@
 	var/resource_delay = 0
 
 /obj/effect/blob/resource/Be_Pulsed()
-	if(resource_delay > world.time)
-		return 0
-	flick("factory_glow", src)
-	resource_delay = world.time + 45 // 4 and a half seconds
-	if(overmind)
-		overmind.add_points(1)
-	. = ..()
+	if(..())
+		if(resource_delay > world.time)
+			return 0
+		flick("factory_glow", src)
+		resource_delay = world.time + 45 // 4 and a half seconds
+		if(overmind)
+			overmind.add_points(1)

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -8,22 +8,11 @@
 	point_return = 15
 	var/resource_delay = 0
 
-
-/obj/effect/blob/resource/PulseAnimation(activate = 0)
-	if(activate)
-		..()
-	return
-
-/obj/effect/blob/resource/run_action()
-
+/obj/effect/blob/resource/Be_Pulsed()
 	if(resource_delay > world.time)
 		return 0
-
-	PulseAnimation(1)
-
+	flick("factory_glow", src)
 	resource_delay = world.time + 45 // 4 and a half seconds
-
 	if(overmind)
 		overmind.add_points(1)
-	return 0
-
+	. = ..()

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -9,10 +9,10 @@
 	var/resource_delay = 0
 
 /obj/effect/blob/resource/Be_Pulsed()
-	if(..())
-		if(resource_delay > world.time)
-			return 0
-		flick("factory_glow", src)
-		resource_delay = world.time + 45 // 4 and a half seconds
-		if(overmind)
-			overmind.add_points(1)
+	. = ..()
+	if(resource_delay > world.time)
+		return
+	flick("factory_glow", src)
+	resource_delay = world.time + 45 // 4 and a half seconds
+	if(overmind)
+		overmind.add_points(1)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -12,8 +12,7 @@
 	var/health = 30
 	var/maxhealth = 30
 	var/health_regen = 2 //how much health this blob regens when pulsed
-	var/health_timestamp = 0 //we got healed when?
-	var/pulse_timestamp = 0 //we got pulsed when?
+	var/pulse_timestamp = 0 //we got pulsed/healed when?
 	var/brute_resist = 0.5 //multiplies brute damage by this
 	var/fire_resist = 1 //multiplies burn damage by this
 	var/atmosblock = 0 //if the blob blocks atmos and heat spread
@@ -90,7 +89,6 @@
 	src.Be_Pulsed()
 	if(claim_range)
 		for(var/obj/effect/blob/B in ultra_range(claim_range, src, 1))
-			B.update_icon()
 			if(!B.overmind && !istype(B, /obj/effect/blob/core) && prob(30))
 				B.overmind = pulsing_overmind //reclaim unclaimed, non-core blobs.
 				B.update_icon()
@@ -106,10 +104,9 @@
 
 /obj/effect/blob/proc/Be_Pulsed()
 	if(pulse_timestamp <= world.time)
-		PulseAnimation()
 		ConsumeTile()
-		RegenHealth()
-		run_action()
+		health = min(maxhealth, health+health_regen)
+		update_icon()
 		pulse_timestamp = world.time + 10
 		return 1 //we did it, we were pulsed!
 	return 0 //oh no we failed
@@ -117,21 +114,6 @@
 /obj/effect/blob/proc/ConsumeTile()
 	for(var/atom/A in loc)
 		A.blob_act()
-
-/obj/effect/blob/proc/PulseAnimation()
-	flick("[icon_state]_glow", src)
-	return
-
-/obj/effect/blob/proc/RegenHealth() //when pulsed, heal!
-	if(health_timestamp <= world.time)
-		health = min(maxhealth, health+health_regen)
-		update_icon()
-		health_timestamp = world.time + 10 //1 second between heals
-		return 1
-	return 0
-
-/obj/effect/blob/proc/run_action()
-	return 0
 
 
 /obj/effect/blob/proc/expand(turf/T = null, prob = 1, controller = null)


### PR DESCRIPTION
:cl: Joan
rscdel: Blob cores and nodes no longer cause normal pulsed blobs to animate. Factories and resource nodes will still animate.
/:cl:

Fixes #10696
Hopefully wrecks the overall lag from blob pulsing by calling less procs and doing more things with the existing procs.
