### PR TITLE
All people can now use soulstones normally.

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -8,9 +8,9 @@
 	slot_flags = SLOT_BELT
 	origin_tech = "bluespace=4;materials=4"
 	var/imprinted = "empty"
-	var/usability = 0
+	var/usability = 1
 
-/obj/item/device/soulstone/anybody
+/obj/item/device/soulstone/anybody //redundant, but kept for the sake of compatibility and easy reversion.
 	usability = 1
 
 /obj/item/device/soulstone/pickup(mob/living/user)


### PR DESCRIPTION
Fixes #14407

Strictly speaking this shouldn't really change anything, cultist soulstones being cultist only isn't really useful, it's obvious that you can't use it the second you pick it up so you can't use it as a trap or anything.

And if you take a cultist's soulstone and make a construct it's still a cultist, so you can't use it against cultists, and if you do that as a non-cultist you're helping antags as a non antag, which'll get you bwoinked.

Really the only difference is that non-cultist antags could help cultists make constructs, which is a very rare and specific scenario that won't occur during normal gameplay anyway. Anyway if this turns out to be horrible I only changed 1 var so it's super easy and quick to fix.
