### PR TITLE
Artificers now make soulstones anybody can use if they aren't made by cultists.

### DIFF
--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -64,7 +64,7 @@
 	action_icon_state = "summonsoulstone"
 	action_background_icon_state = "bg_demon"
 
-	if(iscultist(user) || iswizard(user) || !iscarbon(user))
+	if(iscultist(user) || iswizard(user))
 	summon_type = list(/obj/item/device/soulstone)
 	else
 	summon_type = list(/obj/item/device/soulstone/anybody)

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -64,7 +64,7 @@
 	action_icon_state = "summonsoulstone"
 	action_background_icon_state = "bg_demon"
 
-	if(iscultist(user) || iswizard(user))
+	if(iscultist(usr) || iswizard(usr))
 	summon_type = list(/obj/item/device/soulstone)
 	else
 	summon_type = list(/obj/item/device/soulstone/anybody)

--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -64,7 +64,11 @@
 	action_icon_state = "summonsoulstone"
 	action_background_icon_state = "bg_demon"
 
+	if(iscultist(user) || iswizard(user) || !iscarbon(user))
 	summon_type = list(/obj/item/device/soulstone)
+	else
+	summon_type = list(/obj/item/device/soulstone/anybody)
+	
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone/cult
 	cult_req = 1


### PR DESCRIPTION
Hopefully.

This assumes that:
A: Artificers made by cultists are set as cultist, which seems to be the case but I'm not certain.
B: I didn't fuck up.

Fixes #14407

Additionally, if anyone somehow gets the summon soulstone spell without being a wizard, it'll make soulstones they can use. I can't find any reported issues about that, but If you find one please let me know.
