### PR TITLE
The Goofball no longer deletes parts of the gateway

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -13,7 +13,8 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/structure/particle_accelerator/power_box,
 										/obj/structure/particle_accelerator/end_cap,
 										/obj/machinery/field/containment,
-										/obj/structure/disposalpipe)
+										/obj/structure/disposalpipe
+										/obj/machinery/gateway)
 
 /obj/singularity/energy_ball
 	name = "energy ball"

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -13,7 +13,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/structure/particle_accelerator/power_box,
 										/obj/structure/particle_accelerator/end_cap,
 										/obj/machinery/field/containment,
-										/obj/structure/disposalpipe
+										/obj/structure/disposalpipe,
 										/obj/machinery/gateway)
 
 /obj/singularity/energy_ball


### PR DESCRIPTION
Fixes #14551

The Goofball won't zap the gateway at all now, which isn't a big deal since the gateway has no EMP reaction anyway.
