### PR TITLE
Severe bloodloss no longer permanently knocks you out

### DIFF
--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -89,8 +89,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				if(!pale)
 					pale = 1
 					update_body()
-				if(oxyloss < 39)
-					oxyloss += 10
+				if(oxyloss < 50)
+					oxyloss = min(oxyloss+10, 50)
 				if(prob(5))
 					eye_blurry += 6
 					var/word = pick("dizzy","woozy","faint")

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -89,9 +89,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				if(!pale)
 					pale = 1
 					update_body()
-				if(oxyloss < 50)
+				if(oxyloss < 39)
 					oxyloss += 10
-				oxyloss += 1
 				if(prob(5))
 					eye_blurry += 6
 					var/word = pick("dizzy","woozy","faint")


### PR DESCRIPTION
Fixes #14538

Extremely severe bloodloss will still knock you out, and then kill you. This just stops severe bloodloss from permanently knocking you out without killing you, leaving you unable to succumb and forcing you to ghost or sit there for the rest of the round.

This appears to be the originally intended behavior, since it was set to not increase oxyloss unless the victim had less than the knockout limit. However, because it increased oxyloss by 10 the instant it fell below the threshold, you effectively were always above it, permastunning you without ever killing you.
