### PR TITLE
Fixes the Traitor AI nuclear detonation by restoring the malf cinematic.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -206,7 +206,7 @@ var/datum/subsystem/ticker/ticker
 
 
 //Plus it provides an easy way to make cinematics for other events. Just use this as a template
-/datum/subsystem/ticker/proc/station_explosion_cinematic(station_missed=0, override = null)
+/datum/subsystem/ticker/proc/station_explosion_cinematic(station_missed=0, override = null, corebunker = 0)
 	if( cinematic )	return	//already a cinematic in progress!
 
 	for (var/datum/html_interface/hi in html_interfaces)
@@ -228,6 +228,8 @@ var/datum/subsystem/ticker/ticker
 			if(M.stat != DEAD)
 				var/turf/T = get_turf(M)
 				if(T && T.z==1)
+					if(corebunker && istype(get_area(M), /area/turret_protected/ai))
+						continue
 					M.death(0) //no mercy
 
 	//Now animate the cinematic

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -74,15 +74,10 @@
 	for(var/mob/M in player_list)
 		M << 'sound/machines/Alarm.ogg'
 	sleep(100)
-	for(var/mob/living/L in mob_list)
-		var/turf/T = get_turf(L)
-		if(T.z != z_level)
-			continue
-		if(issilicon(L))
-			continue
-		L << "<span class='danger'><B>The blast wave from the [src] tears you atom from atom!</B></span>"
-		L.dust()
-	world << "<B>The AI cleansed the station of life with the doomsday device!</B>"
+	ticker.mode.explosion_in_progress = 1
+	ticker.station_explosion_cinematic(0,"AI malfunction",1)
+	ticker.mode.explosion_in_progress = 0
+	world << "<B>The self-destruction of [station_name()] killed everyone not in the AI's nuclear bunker!</B>"
 	ticker.force_ending = 1
 
 /datum/AI_Module/large/fireproof_core

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -23,7 +23,7 @@
 	shuttle_caller_list -= src
 	SSshuttle.autoEvac()
 
-	if(nuking)
+	if(nuking && !ticker.mode.explosion_in_progress)
 		set_security_level("red")
 		nuking = 0
 		SSshuttle.emergencyNoEscape = 0


### PR DESCRIPTION
In order to not change the current balance at all, anyone in the AI core is shielded from the blast.
