### PR TITLE
Marginal washing machine improvements

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -18,8 +18,6 @@
 	var/obj/crayon
 
 /obj/machinery/washing_machine/AltClick(mob/user)
-	if(!in_range(src, user))
-		return
 	if(!user.canUseTopic(src))
 		return
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -20,7 +20,7 @@
 /obj/machinery/washing_machine/AltClick(mob/user)
 	if(!in_range(src, user))
 		return
-	if(!user.canUseTopic(user))
+	if(!user.canUseTopic(src))
 		return
 
 	if( state != 4 )

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -14,21 +14,13 @@
 	//6 = blood, open door
 	//7 = blood, closed door
 	//8 = blood, running
-	var/panel = 0
-	//0 = closed
-	//1 = open
-	var/hacked = 1 //Bleh, screw hacking, let's have it hacked by default.
-	//0 = not hacked
-	//1 = hacked
 	var/gibs_ready = 0
 	var/obj/crayon
 
-/obj/machinery/washing_machine/verb/start()
-	set name = "Start Washing"
-	set category = "Object"
-	set src in oview(1)
-
-	if(usr.stat || usr.restrained() || !usr.canmove)
+/obj/machinery/washing_machine/AltClick(mob/user)
+	if(!in_range(src, user))
+		return
+	if(!user.canUseTopic(user))
 		return
 
 	if( state != 4 )
@@ -183,12 +175,9 @@
 
 
 /obj/machinery/washing_machine/update_icon()
-	icon_state = "wm_[state][panel]"
+	icon_state = "wm_[state]0"
 
 /obj/machinery/washing_machine/attackby(obj/item/weapon/W, mob/user, params)
-	/*if(istype(W,/obj/item/weapon/screwdriver))
-		panel = !panel
-		user << "\blue you [panel ? "open" : "close"] the [src]'s maintenance panel"*/
 	if(istype(W,/obj/item/toy/crayon) ||istype(W,/obj/item/weapon/stamp))
 		if( state in list(	1, 3, 6 ) )
 			if(!crayon)
@@ -201,7 +190,7 @@
 		else
 			..()
 	else if(istype(W,/obj/item/weapon/grab))
-		if( (state == 1) && hacked)
+		if(state == 1)
 			var/obj/item/weapon/grab/G = W
 			if(iscorgi(G.affecting))
 				G.affecting.loc = src
@@ -249,9 +238,6 @@
 		if ( istype(W,/obj/item/clothing/head/syndicatefake ) )
 			user << "This item does not fit."
 			return
-//		if ( istype(W,/obj/item/clothing/head/powered ) )
-//			user << "This item does not fit."
-//			return
 		if ( istype(W,/obj/item/clothing/head/helmet ) )
 			user << "This item does not fit."
 			return


### PR DESCRIPTION
Activated by altclick instead of an object verb. Removes unused vars. I didn't want to go any further into this nonsense though.

:cl: Kor
rscadd: Washing machines are activated via alt+click rather than a right click verb.
/:cl:
