### PR TITLE
Revert "Severe bloodloss no longer permanently knocks you out"

### DIFF
--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -90,7 +90,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 					pale = 1
 					update_body()
 				if(oxyloss < 50)
-					oxyloss = min(oxyloss+10, 50)
+					oxyloss += 10
+				oxyloss += 1
 				if(prob(5))
 					eye_blurry += 6
 					var/word = pick("dizzy","woozy","faint")


### PR DESCRIPTION
Reverts tgstation/-tg-station#14556

pr had issues:

(2:06:45 PM) tkdrg: the way he did it you can no longer go into crit from bad blood
(2:06:54 PM) tkdrg: unless it's below BLOOD_VOLUME_BAD
(2:06:59 PM) tkdrg: which is not at all intended
(2:07:39 PM) tkdrg: he removed the oxyloss += 1 for some reason
(2:11:11 PM) tkdrg: oxyloss = min(oxyloss+10, 50)
(2:11:17 PM) tkdrg: it will actually heal you from oxy crit
(2:12:03 PM) tkdrg: losing blood is now dexalin+
