### PR TITLE
makes pulling stop if the thing clicked can't be pulled

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -162,10 +162,10 @@ Sorry Giacom. Please don't be mad :(
 	set name = "Pull"
 	set category = "Object"
 
-	if(pulling == AM)
+	if(AM.Adjacent(src))
+		start_pulling(AM)
+	else
 		stop_pulling()
-	else if(AM.Adjacent(src))
-		src.start_pulling(AM)
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view())


### PR DESCRIPTION
This is better then making it a toggle, as people spam click or may think that the pull didn't go thru clicking again, and this causes the pull to stop.

Fixes #13551

:cl:
tweak: control clicking on the thing you are pulling will no longer unpull, instead control clicking on anything too far away to be pulled will unpull. (reminder that the delete key also unpulls)
/:cl:
