### PR TITLE
Reactive tesla armor uses the proper lightning bolt sprites

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -228,7 +228,7 @@
 		for(var/mob/living/M in view(6, owner))
 			if(M == owner)
 				continue
-			owner.Beam(M,icon_state="purple_lightning",icon='icons/effects/effects.dmi',time=5)
+			owner.Beam(M,icon_state="lightning[rand(1, 12)]",icon='icons/effects/effects.dmi',time=5)
 			M.adjustFireLoss(25)
 			playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
 		return 1


### PR DESCRIPTION
As in, the tesla lightning rather than the purple revenant lightning.
