### PR TITLE
Shuffles bot scanning

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -327,7 +327,7 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 */
 /mob/living/simple_animal/bot/proc/scan(scan_type, old_target, scan_range = DEFAULT_SCAN_RANGE)
 	var/final_result
-	for (var/scan in view (scan_range, src) ) //Search for something in range!
+	for (var/scan in shuffle(view(scan_range, src))) //Search for something in range!
 		if(!istype(scan, scan_type)) //Check that the thing we found is the type we want!
 			continue //If not, keep searching!
 		if( (scan in ignore_list) || (scan == old_target) ) //Filter for blacklisted elements, usually unreachable or previously processed oness


### PR DESCRIPTION
Tile scanning uses view(), the results always presented with the southwest corner placed first the list, since the for loop returns on finding a valid tile this means that a bot will always head southwest if that is a valid option. 

By shuffling up the turfs in priority we can be fairly sure that different bots working in the same area won't constantly try to fix a problem another bot is already fixing, and that when a bunch of bots are released into an environment with lots of valid tiles they'll usually fan outwards in all directions instead of all heading to the southwest corner to sulk.
