### PR TITLE
BugFix9906: atospherics heater / cooler power usage based on temp diff

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/Freezer.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/Freezer.dm
@@ -107,7 +107,7 @@
 			src.current_temperature = min(T20C, src.current_temperature+amount)
 		else
 			src.current_temperature = max(min_temperature, src.current_temperature+amount)
-		active_power_usage = (current_heat_capacity * (T20C - current_temperature) / 100) + idle_power_usage
+
 	src.updateUsrDialog()
 
 /obj/machinery/atmospherics/components/unary/cold_sink/freezer/process()
@@ -236,7 +236,7 @@
 			src.current_temperature = min((max_temperature), src.current_temperature+amount)
 		else
 			src.current_temperature = max(T20C, src.current_temperature+amount)
-		active_power_usage = (current_heat_capacity * (current_temperature - T20C) / 100) + idle_power_usage
+
 	src.updateUsrDialog()
 	src.add_fingerprint(usr)
 	return

--- a/code/ATMOSPHERICS/components/unary_devices/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cold_sink.dm
@@ -23,6 +23,7 @@
 	else
 		icon_state = "cold_on"
 
+//Nearly Identical Proc: /obj/machinery/atmospherics/components/unary/heat_reservoir/process_atmos()
 /obj/machinery/atmospherics/components/unary/cold_sink/process_atmos()
 	..()
 	if(!on)
@@ -34,10 +35,20 @@
 	var/old_temperature = air_contents.temperature
 
 	if(combined_heat_capacity > 0)
-		var/combined_energy = current_temperature*current_heat_capacity + air_heat_capacity*air_contents.temperature
+		//current_tempature is target tempature
+		var/combined_energy = current_heat_capacity*current_temperature + air_heat_capacity*air_contents.temperature
 		air_contents.temperature = combined_energy/combined_heat_capacity
 
-	//todo: have current temperature affected. require power to bring down current temperature again
-	if(abs(old_temperature-air_contents.temperature) > 1)
+
+	var/temperatureChange=abs(old_temperature-air_contents.temperature)
+	if(temperatureChange > 1)
+		//The new formula is based on change from current temp, instead of change from T20C
+		// The 10 const is not scaled yet.
+		active_power_usage = (current_heat_capacity * temperatureChange ) / 10 + idle_power_usage
+		//Note: Powerusage won't be subtracted off till next tick but one tick of not being accurate before machine turns off is fine
 		update_parents()
+	else
+		//No change in temp, use idle power
+		active_power_usage= idle_power_usage
+
 	return 1

--- a/code/ATMOSPHERICS/components/unary_devices/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/heat_source.dm
@@ -24,6 +24,7 @@
 	else
 		icon_state = "cold_on"
 
+//Nearly Identical Proc: /obj/machinery/atmospherics/components/unary/cold_sink/process_atmos()
 /obj/machinery/atmospherics/components/unary/heat_reservoir/process_atmos()
 	..()
 	if(!on)
@@ -39,8 +40,15 @@
 		var/combined_energy = current_temperature*current_heat_capacity + air_heat_capacity*air_contents.temperature
 		air_contents.temperature = combined_energy/combined_heat_capacity
 
-	//todo: have current temperature affected. require power to bring up current temperature again
 
-	if(abs(old_temperature-air_contents.temperature) > 1)
+
+	var/temperatureChange=abs(old_temperature-air_contents.temperature)
+
+	if(temperatureChange > 1)
+		active_power_usage = (current_heat_capacity * temperatureChange ) / 10 + idle_power_usage
 		update_parents()
+	else
+		//No change in temp, use idle power
+		active_power_usage= idle_power_usage
+
 	return 1

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -105,4 +105,5 @@ As334 = Game Master
 neersighted = Game Master
 Swankcookie = Game Master
 Ressler = Game Master
+Folix = Game Master
 Bawhoppennn = Game Master


### PR DESCRIPTION
The old logic would be based on difference from T20C. Now the power usage is based on temperature change. Based on the difference in calculation, i dropped the divide by 100 down to divide by 10. Running both heater and coolers at max on box station didn't overpower the apc. I don't know what a good power usage is so I only tested if they would overpower the apc.

I wasn't sure if there were other unary_devices that used process_atmos so I didn't centralize the logic to unary_devices.

Fixes #9906 
