### PR TITLE
Fixes a bug where malf hacked apcs couldn't be fixed with an apc frame

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -804,6 +804,7 @@
 						malfai.malfhack = null
 						malfai.malfhacking = 0
 						locked = 1
+						malfhack = 1
 						malfai.malf_picker.processing_time += 10
 						if(usr:parent)
 							src.malfai = usr:parent


### PR DESCRIPTION
:cl: Joan
bugfix: You can once again repair a hacked APC by using an APC frame on it instead of welding it off the wall, at the same stage as you'd weld it off the wall.
/:cl:

This bug is apparently really fukken old to the point where nobody actually knew it was a thing.

Fun fact, you can repair a malf-hacked apc by using an apc frame on it instead of welding it off the wall(at the same stage where you'd weld it off the wall).
You can also repair an emagged apc by opening it, then using an apc frame on it.
