### PR TITLE
Call check_shields when attacked by an abductor baton.

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -411,23 +411,23 @@ Congratulations! You are now trained for xenobiology research!"}
 	return 1
 
 /obj/item/weapon/abductor_baton/attack(mob/target, mob/living/user)
-	if (!IsAbductor(user))
+	if(!IsAbductor(user))
 		return
 
-	if (isrobot(target))
+	if(isrobot(target))
 		..()
 		return
 
-	if (!isliving(target))
+	if(!isliving(target))
 		return
 
 	var/mob/living/L = target
 
 	user.do_attack_animation(L)
 
-	if (ishuman(L))
+	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
+		if(H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
 			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
 			return 0
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -425,7 +425,6 @@ Congratulations! You are now trained for xenobiology research!"}
 
 	user.do_attack_animation(L)
 
-	// [tgstation/#14599] Allow reactive teleport armor to kick in when attacked.
 	if (ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -411,20 +411,28 @@ Congratulations! You are now trained for xenobiology research!"}
 	return 1
 
 /obj/item/weapon/abductor_baton/attack(mob/target, mob/living/user)
-	if(!IsAbductor(user))
+	if (!IsAbductor(user))
 		return
 
-	if(isrobot(target))
+	if (isrobot(target))
 		..()
 		return
 
-	if(!isliving(target))
+	if (!isliving(target))
 		return
 
 	var/mob/living/L = target
 
 	user.do_attack_animation(L)
-	switch(mode)
+
+	// [tgstation/#14599] Allow reactive teleport armor to kick in when attacked.
+	if (ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if (H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
+			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
+			return 0
+
+	switch (mode)
 		if(BATON_STUN)
 			StunAttack(L,user)
 		if(BATON_SLEEP)


### PR DESCRIPTION
Fixes #14599.

Tested by setting myself to abductor and spawning an interactive human mob.

Without reactive armor stunning works in both cases.

Before patch: With reactive armor the mob is NOT teleported. However, a regular stun baton does initiate a teleport.

After patch: With reactive armor the mob is now teleported just as with a regular stun baton.

I've taken the assumption that probing a mob with the abductor baton counts as an aggressive action and therefore initiates teleport. From what I could see this would only be a balance issue if the person being probed is a changeling -- they would be able to escape exposure by wearing reactive teleport armor. I don't think this is a problem.

This is also my first patch using Git directly, so please let me know if there are issues with the patch.
