### PR TITLE
volume pumps respect their transfer rate

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -59,7 +59,7 @@ Thus, the two variables affect pump operation are set in New():
 	if((input_starting_pressure < 0.01) || (output_starting_pressure > 9000))
 		return 1
 
-	var/transfer_ratio = max(1, transfer_rate/air1.volume)
+	var/transfer_ratio = min(1, transfer_rate/air1.volume)
 
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)
 


### PR DESCRIPTION
max() sets a lower bound people, not an upper bound
fixes #14671
