### PR TITLE
Reinforced floors no longer burn away under extremely high temperatures.

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -78,7 +78,7 @@
 	name = "reinforced floor"
 	icon_state = "engine"
 	thermal_conductivity = 0.025
-	heat_capacity = 99999999999999999999
+	heat_capacity = INFINITY
 	floor_tile = /obj/item/stack/rods
 
 /turf/simulated/floor/engine/break_tile()

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -78,7 +78,7 @@
 	name = "reinforced floor"
 	icon_state = "engine"
 	thermal_conductivity = 0.025
-	heat_capacity = 325000
+	heat_capacity = 99999999999999999999
 	floor_tile = /obj/item/stack/rods
 
 /turf/simulated/floor/engine/break_tile()


### PR DESCRIPTION
Fixes #13620

Technically this bug was only found because of fusion, but it's still a bug. If fusion is readded this will be a frequent problem again.

"Reinforced floor should never break down period, unless it is being wrenched" - tkdrg
