### PR TITLE
Space dust is now stopped by grilles.

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -185,7 +185,7 @@
 /obj/effect/meteor/dust
 	name = "space dust"
 	icon_state = "dust"
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE
 	hits = 1
 	hitpwr = 3
 	meteorsound = 'sound/weapons/throwtap.ogg'


### PR DESCRIPTION
Fixes #13441

This should cause space dust to break only 1 grille and stop, instead of passing through & breaking a unlimited number of them.
