### PR TITLE
callproc now outputs the contents of returned lists instead of /list

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -92,8 +92,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
 		message_admins("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
 		returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-
-	usr << "<font color='blue'>[procname] returned: [returnval ? returnval : "null"]</font>"
+	. = get_callproc_returnval(returnval)
+	if(.)
+		usr << .
 	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/callproc_datum(A as null|area|mob|obj|turf)
@@ -122,7 +123,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	feedback_add_details("admin_verb","DPC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	var/returnval = call(A,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-	usr << "<span class='notice'>[procname] returned: [returnval ? returnval : "null"]</span>"
+	. = get_callproc_returnval(returnval)
+	if(.)
+		usr << .
 
 
 
@@ -181,6 +184,23 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if("Marked datum")
 				lst += holder.marked_datum
 	return lst
+
+
+/client/proc/get_callproc_returnval(returnval)
+	. = ""
+	if(islist(returnval))
+		var/list/returnedlist = returnval
+		. = "<font color='blue'>"
+		if(returnedlist.len)
+			. += "[procname] returned a list:"
+			for(var/elem in returnedlist)
+				. += "[elem]"
+		else
+			. = "[procname] returned an empty list"
+		. += "</font>"
+
+	else
+		. = "<font color='blue'>[procname] returned: [returnval ? returnval : "null"]</font>"
 
 
 /client/proc/Cell()

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -196,12 +196,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if(istext(assoc_check) && (returnedlist[assoc_check] != null))
 				. += "[procname] returned an associative list:"
 				for(var/key in returnedlist)
-					. += "[key] = [returnedlist[key]]\n"
+					. += "\n[key] = [returnedlist[key]]"
 				
 			else
 				. += "[procname] returned a list:"
 				for(var/elem in returnedlist)
-					. += "[elem]\n"
+					. += "\n[elem]"
 		else
 			. = "[procname] returned an empty list"
 		. += "</font>"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -192,9 +192,16 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		var/list/returnedlist = returnval
 		. = "<font color='blue'>"
 		if(returnedlist.len)
-			. += "[procname] returned a list:"
-			for(var/elem in returnedlist)
-				. += "[elem]"
+			var/assoc_check = returnedlist[1]
+			if(istext(assoc_check) && (returnedlist[assoc_check] != null))
+				. += "[procname] returned an associative list:"
+				for(var/key in returnedlist)
+					. += "[key] = [returnedlist[key]]"
+				
+			else
+				. += "[procname] returned a list:"
+				for(var/elem in returnedlist)
+					. += "[elem]"
 		else
 			. = "[procname] returned an empty list"
 		. += "</font>"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -196,12 +196,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if(istext(assoc_check) && (returnedlist[assoc_check] != null))
 				. += "[procname] returned an associative list:"
 				for(var/key in returnedlist)
-					. += "[key] = [returnedlist[key]]"
+					. += "[key] = [returnedlist[key]]\n"
 				
 			else
 				. += "[procname] returned a list:"
 				for(var/elem in returnedlist)
-					. += "[elem]"
+					. += "[elem]\n"
 		else
 			. = "[procname] returned an empty list"
 		. += "</font>"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -92,7 +92,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		log_admin("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
 		message_admins("[key_name(src)] called [procname]() with [lst.len ? "the arguments [list2params(lst)]":"no arguments"].")
 		returnval = call(procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-	. = get_callproc_returnval(returnval)
+	. = get_callproc_returnval(returnval, procname)
 	if(.)
 		usr << .
 	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -123,7 +123,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	feedback_add_details("admin_verb","DPC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	var/returnval = call(A,procname)(arglist(lst)) // Pass the lst as an argument list to the proc
-	. = get_callproc_returnval(returnval)
+	. = get_callproc_returnval(returnval,procname)
 	if(.)
 		usr << .
 
@@ -186,7 +186,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	return lst
 
 
-/client/proc/get_callproc_returnval(returnval)
+/client/proc/get_callproc_returnval(returnval,procname)
 	. = ""
 	if(islist(returnval))
 		var/list/returnedlist = returnval


### PR DESCRIPTION
While it's useful to know when a `/list` has been returned, it's infinitely more useful to see that list's contents

it can also spot associative lists, in which case it prints `"[key] = [value]"`
