### PR TITLE
Fixes AI not recieving malf powers and cyborgs not recieving 0 law

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1089,7 +1089,6 @@
 					if(isAI(current))
 						var/mob/living/silicon/ai/A = current
 						ticker.mode.add_law_zero(A)
-						A.show_laws()
 
 			if("autoobjectives")
 				ticker.mode.forge_traitor_objectives(src)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -600,6 +600,7 @@
 					break
 
 			// Give the power and take away the money.
+			A.view_core() //A BYOND bug requires you to be viewing your core before your verbs update
 			A.verbs += AM.power_type
 			A.current_modules += new AM.type
 			temp = AM.description

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -206,7 +206,6 @@
 	var/law_borg = "Accomplish your AI's objectives at all costs."
 	killer << "<b>Your laws have been changed!</b>"
 	killer.set_zeroth_law(law, law_borg)
-	killer << "New law: 0. [law]"
 	give_codewords(killer)
 	killer.set_syndie_radio()
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
@@ -215,6 +214,7 @@
 	killer.view_core() //A BYOND bug requires you to be viewing your core before your verbs update
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
+	killer.show_laws()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
 	if(traitors.len)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -212,6 +212,7 @@
 	killer << "Your radio has been upgraded! Use :t to speak on an encrypted channel with Syndicate Agents!"
 	killer << "In the top right corner of the screen you will find the Malfunctions tab, where you can purchase various abilities, from upgraded surveillance to station ending doomsday devices."
 	killer << "You are also capable of hacking APCs, which grants you more points to spend on your Malfunction powers. The drawback is that a hacked APC will give you away if spotted by the crew. Hacking an APC takes 60 seconds."
+	killer.view_core() //A BYOND bug requires you to be viewing your core before your verbs update
 	killer.verbs += /mob/living/silicon/ai/proc/choose_modules
 	killer.malf_picker = new /datum/module_picker
 


### PR DESCRIPTION
The fix is hacky, but we have to wait on Lummox for an actual fix (not recieving new verbs if your client perspective is too far away), and I'd rather not leave AI's confused and unable to use their powers in the meantime. @Shadowlight213 figured out the issue

Fixes #14646

Fixes #14620
