### PR TITLE
Pipes don't transport air across time and space

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -285,13 +285,14 @@ Pipelines + Other Objects -> Pipe network
 		return
 
 	for(DEVICE_TYPE_LOOP)
-		var/obj/machinery/atmospherics/node = NODE_I
-		var/turf/node_turf = get_turf(node)
-		var/turf/self_turf = get_turf(src)
-		if(node_turf.loc != self_turf.loc) //shuttles are area based, so this means the node is not on the shuttle with us
-			node.disconnect(src)
-			NODE_I = null
-		nullifyPipenet(PARENT_I)
-
+		dealWithShuttleStuff(I)
 	atmosinit() //we've moved, so what once was next to us may not be
 	build_network()
+
+/obj/machinery/atmospherics/proc/dealWithShuttleStuff(I)
+	var/obj/machinery/atmospherics/node = NODE_I
+	var/turf/node_turf = get_turf(node)
+	var/turf/self_turf = get_turf(src)
+	if(node_turf.loc != self_turf.loc) //shuttles are area based, so this means the node is not on the shuttle with us
+		node.disconnect(src)
+		NODE_I = null

--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -279,3 +279,19 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/returnPipenets()
 	return list()
 
+/obj/machinery/atmospherics/onShuttleMove()
+	. = ..()
+	if(!.)
+		return
+
+	for(DEVICE_TYPE_LOOP)
+		var/obj/machinery/atmospherics/node = NODE_I
+		var/turf/node_turf = get_turf(node)
+		var/turf/self_turf = get_turf(src)
+		if(node_turf.loc != self_turf.loc) //shuttles are area based, so this means the node is not on the shuttle with us
+			node.disconnect(src)
+			NODE_I = null
+		nullifyPipenet(PARENT_I)
+
+	atmosinit() //we've moved, so what once was next to us may not be
+	build_network()

--- a/code/ATMOSPHERICS/components/components_base.dm
+++ b/code/ATMOSPHERICS/components/components_base.dm
@@ -156,3 +156,7 @@ Helpers
 	. = list()
 	for(DEVICE_TYPE_LOOP)
 		. += returnPipenet(NODE_I)
+
+/obj/machinery/atmospherics/components/dealWithShuttleStuff(I)
+	..()
+	nullifyPipenet(PARENT_I)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -357,42 +357,8 @@
 				Ts1.copy_air_with_tile(T0)
 
 			//move mobile to new location
-
-
 			for(var/atom/movable/AM in T0)
-				if (rotation)
-					AM.shuttleRotate(rotation)
-
-				if (istype(AM,/obj))
-					var/obj/O = AM
-					if(O.invisibility >= 101)
-						continue
-					if(O == T0.lighting_object)
-						continue
-					O.loc = T1
-
-					//close open doors
-					if(istype(O, /obj/machinery/door))
-						var/obj/machinery/door/Door = O
-						spawn(0)
-							if(Door)
-								Door.close()
-				else if (istype(AM,/mob))
-					var/mob/M = AM
-					if(!M.move_on_shuttle)
-						continue
-					M.loc = T1
-
-					//docking turbulence
-					if(M.client)
-						if(M.buckled)
-							shake_camera(M, 2, 1) // turn it down a bit come on
-						else
-							shake_camera(M, 7, 1)
-					if(istype(M, /mob/living/carbon))
-						if(!M.buckled)
-							M.Weaken(3)
-
+				AM.onShuttleMove(T1, rotation)
 
 		if (rotation)
 			T1.shuttleRotate(rotation)
@@ -412,6 +378,46 @@
 
 	loc = S1.loc
 	dir = S1.dir
+
+/atom/movable/proc/onShuttleMove(turf/T1, rotation)
+	if(rotation)
+		shuttleRotate(rotation)
+	loc = T1
+	return 1
+
+/obj/onShuttleMove()
+	if(invisibility >= 101)
+		return 0
+	. = ..()
+
+/atom/movable/light/onShuttleMove()
+	return 0
+
+/obj/machinery/door/onShuttleMove()
+	. = ..()
+	if(!.)
+		return
+	spawn(0)
+		close()
+
+/mob/onShuttleMove()
+	if(!move_on_shuttle)
+		return 0
+	. = ..()
+	if(!.)
+		return
+	if(client)
+		if(buckled)
+			shake_camera(M, 2, 1) // turn it down a bit come on
+		else
+			shake_camera(M, 7, 1)
+
+/mob/living/carbon/onShuttleMove()
+	. = ..()
+	if(!.)
+		return
+	if(buckled)
+		Weaken(3)
 
 /*
 	if(istype(S1, /obj/docking_port/stationary/transit))

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -408,9 +408,9 @@
 		return
 	if(client)
 		if(buckled)
-			shake_camera(M, 2, 1) // turn it down a bit come on
+			shake_camera(src, 2, 1) // turn it down a bit come on
 		else
-			shake_camera(M, 7, 1)
+			shake_camera(src, 7, 1)
 
 /mob/living/carbon/onShuttleMove()
 	. = ..()


### PR DESCRIPTION
Fixes the pipe part of #11183 
Also adds a proc (`atom/movable/proc/onShuttleMove()`) to facilitate fixing of the rest of this issue
I have no idea what's going on in powernets or disposals pipes so I've left those untouched
