### PR TITLE
Fixes lag on new player login

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -15,11 +15,6 @@
 	if(config.soft_popcap && living_player_count() >= config.soft_popcap)
 		src << "<span class='notice'><b>Server Notice:</b>\n \t [config.soft_popcap_message]</span>"
 
-	if(length(newplayer_start))
-		loc = pick(newplayer_start)
-	else
-		loc = locate(1,1,1)
-
 	sight |= SEE_TURFS
 
 /*

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -18,6 +18,11 @@
 	tag = "mob_[next_mob_id++]"
 	mob_list += src
 
+	if(length(newplayer_start))
+		loc = pick(newplayer_start)
+	else
+		loc = locate(1,1,1)
+
 /mob/new_player/proc/new_player_panel()
 
 	var/output = "<center><p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"


### PR DESCRIPTION
Base `Login()` failed to put location-less mob on the map.

Fixes #14753.
