### PR TITLE
Slimes can no longer feed on simple animals that are immune to clone and toxin damage

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -141,7 +141,8 @@
 
 /mob/living/simple_animal/revenant/adjustHealth(amount)
 	if(!revealed)
-		return
+		return 0
+	. = amount
 	essence = max(0, essence-amount)
 	if(essence == 0)
 		src << "<span class='revendanger'>You feel your essence fraying!</span>"

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -213,7 +213,7 @@
 		return
 
 /mob/living/simple_animal/shade/howling_ghost/adjustHealth()
-	return
+	. = 0
 
 /mob/living/simple_animal/shade/howling_ghost/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 1
@@ -273,6 +273,7 @@
 	return
 
 /mob/living/simple_animal/hostile/retaliate/clown/insane/adjustHealth()
+	. = 0
 	if(prob(5))
 		playsound(loc, 'sound/spookoween/insane_low_laugh.ogg', 300, 1)
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -745,7 +745,7 @@
 /mob/living/simple_animal/hostile/mining_drone/adjustHealth()
 	if(search_objects)
 		SetOffenseBehavior()
-	..()
+	. = ..()
 
 /**********************Lazarus Injector**********************/
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -170,7 +170,7 @@
 /mob/living/simple_animal/bot/adjustHealth(amount)
 	if(amount>0 && prob(10))
 		new /obj/effect/decal/cleanable/oil(loc)
-	return ..(amount)
+	. = ..()
 
 /mob/living/simple_animal/bot/updatehealth()
 	..()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -90,6 +90,7 @@
 	summoner.death()
 
 /mob/living/simple_animal/hostile/guardian/adjustHealth(amount) //The spirit is invincible, but passes on damage to the summoner
+	. =  ..()
 	if(summoner)
 		if(loc == summoner)
 			return

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -93,7 +93,7 @@
 	. =  ..()
 	if(summoner)
 		if(loc == summoner)
-			return
+			return 0
 		summoner.adjustBruteLoss(amount)
 		if(amount)
 			summoner << "<span class='danger'><B>Your [name] is under attack! You take damage!</span></B>"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -181,7 +181,7 @@
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/adjustHealth(damage)
-	..(damage)
+	. = ..()
 	if(!ckey && !stat && search_objects < 3 && damage > 0)//Not unconscious, and we don't ignore mobs
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight
 			search_objects = 0

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -72,7 +72,7 @@
 
 /mob/living/simple_animal/hostile/mimic/crate/adjustHealth(damage)
 	trigger()
-	..(damage)
+	. = ..()
 
 /mob/living/simple_animal/hostile/mimic/crate/LoseTarget()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -183,7 +183,7 @@
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/adjustHealth(damage)
 	idle_vision_range = 9
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/hivelord
 	name = "hivelord"
@@ -387,7 +387,7 @@
 /mob/living/simple_animal/hostile/asteroid/goliath/adjustHealth(damage)
 	ranged_cooldown--
 	handle_preattack()
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Aggro()
 	vision_range = aggro_vision_range
@@ -526,8 +526,8 @@
 
 /mob/living/simple_animal/hostile/asteroid/fugu/adjustHealth(var/damage)
 	if(wumbo)
-		return
-	..()
+		return 0
+	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/fugu/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -66,7 +66,7 @@
 		retreat_distance = 5
 		spawn(30)
 			retreat_distance = null
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/mushroom/attack_animal(mob/living/L)
 	if(istype(L, /mob/living/simple_animal/hostile/mushroom) && stat == DEAD)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -52,6 +52,6 @@
 	return 0
 
 /mob/living/simple_animal/hostile/retaliate/adjustHealth(damage)
-	..(damage)
+	. = ..()
 	if(stat == CONSCIOUS)
 		Retaliate()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -286,26 +286,27 @@
 		return 0
 	bruteloss = Clamp(bruteloss + amount, 0, maxHealth)
 	handle_regular_status_updates()
+	return amount
 
 /mob/living/simple_animal/adjustBruteLoss(amount)
 	if(damage_coeff[BRUTE])
-		adjustHealth(amount*damage_coeff[BRUTE])
+		. = adjustHealth(amount*damage_coeff[BRUTE])
 
 /mob/living/simple_animal/adjustFireLoss(amount)
 	if(damage_coeff[BURN])
-		adjustHealth(amount*damage_coeff[BURN])
+		. = adjustHealth(amount*damage_coeff[BURN])
 
 /mob/living/simple_animal/adjustOxyLoss(amount)
 	if(damage_coeff[OXY])
-		adjustHealth(amount*damage_coeff[OXY])
+		. = adjustHealth(amount*damage_coeff[OXY])
 
 /mob/living/simple_animal/adjustToxLoss(amount)
 	if(damage_coeff[TOX])
-		adjustHealth(amount*damage_coeff[TOX])
+		. = adjustHealth(amount*damage_coeff[TOX])
 
 /mob/living/simple_animal/adjustCloneLoss(amount)
 	if(damage_coeff[CLONE])
-		adjustHealth(amount*damage_coeff[CLONE])
+		. = adjustHealth(amount*damage_coeff[CLONE])
 
 /mob/living/simple_animal/adjustStaminaLoss(amount)
 	return

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -193,14 +193,17 @@
 
 	else if(isanimal(M))
 		var/mob/living/simple_animal/SA = M
-		SA.adjustBruteLoss(is_adult ? rand(4, 7) : rand(3, 4))
+
+		var/totaldamage = 0 //total damage done to this unfortunate animal
+		totaldamage += SA.adjustCloneLoss(rand(2,4))
+		totaldamage += SA.adjustToxLoss(rand(1,2))
+
+		if(totaldamage <= 0) //if we did no(or negative!) damage to it, stop
+			Feedstop(0, 0)
+			return
 
 	else
-		src << "<span class='warning'>[pick("This subject is incompatible", \
-		"This subject does not have a life energy", "This subject is empty", \
-		"I am not satisified", "I can not feed from this subject", \
-		"I do not feel nourished", "This subject is not food")]!</span>"
-		Feedstop()
+		Feedstop(0, 0)
 		return
 
 	add_nutrition(rand(7,15))

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -95,8 +95,13 @@
 	else
 		src << "<span class='warning'><i>I have failed to latch onto the subject</i></span>"
 
-/mob/living/simple_animal/slime/proc/Feedstop(silent=0)
+/mob/living/simple_animal/slime/proc/Feedstop(silent=0, living=1)
 	if(buckled)
+		if(!living)
+			src << "<span class='warning'>[pick("This subject is incompatible", \
+			"This subject does not have life energy", "This subject is empty", \
+			"I am not satisified", "I can not feed from this subject", \
+			"I do not feel nourished", "This subject is not food")]!</span>"
 		if(!silent)
 			visible_message("<span class='warning'>[src] has let go of [buckled]!</span>", \
 							"<span class='notice'><i>I stopped feeding.</i></span>")


### PR DESCRIPTION
In other words, bots and revenants can't be eaten by slimes.
Fixes #14750

Simple animal damage procs return the damage done(as one would expect)
