### PR TITLE
Why you gotta be so Mean(...)

### DIFF
--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -69,13 +69,15 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 /proc/Lerp(a, b, amount = 0.5)
 	return a + (b - a) * amount
 
-/proc/Mean(...)
-	var/values 	= 0
-	var/sum		= 0
-	for(var/val in args)
-		values++
-		sum += val
-	return sum / values
+//Calculates the sum of a list of numbers.
+/proc/Sum(var/list/data)
+	. = 0
+	for(var/val in data)
+		.+= val
+
+//Calculates the mean of a list of numbers.
+/proc/Mean(var/list/data)
+	. = Sum(data) / (data.len)
 
 
 // Returns the nth root of x.


### PR DESCRIPTION
Remove the sole use of `(...)` syntax, by expecting an ordinary list -- of numbers -- instead.
Implement a Sum to supplement the Mean.
