### PR TITLE
Nerfs golem punch stun chances

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -29,7 +29,7 @@
 /datum/martial_art/proc/basic_hit(mob/living/carbon/human/A,mob/living/carbon/human/D)
 
 	A.do_attack_animation(D)
-	var/damage = rand(0,9) + A.dna.species.punchmod
+	var/damage = rand(A.dna.species.punchdamagelow, A.dna.species.punchdamagehigh)
 
 	var/atk_verb = A.dna.species.attack_verb
 	if(D.lying)
@@ -98,7 +98,7 @@
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
 
-	var/damage = rand(5,8) + A.dna.species.punchmod
+	var/damage = rand(5, 8) + A.dna.species.punchdamagelow
 	if(!damage)
 		playsound(D.loc, A.dna.species.miss_sound, 25, 1, -1)
 		D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -52,7 +52,7 @@
 	var/heatmod = 1		// multiplier for heat damage
 	var/punchdamagelow = 0       //lowest possible punch damage
 	var/punchdamagehigh = 9      //highest possible punch damage
-	var/punchstunthreshold = 9//damage at which punches from this race will stun
+	var/punchstunthreshold = 9//damage at which punches from this race will stun //yes it should be to the attacked race but it's not useful that way even if it's logical
 	var/siemens_coeff = 1 //base electrocution coefficient
 
 	var/invis_sight = SEE_INVISIBLE_LIVING

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -50,7 +50,9 @@
 	var/burnmod = 1		// multiplier for burn damage
 	var/coldmod = 1		// multiplier for cold damage
 	var/heatmod = 1		// multiplier for heat damage
-	var/punchmod = 0	// adds to the punch damage
+	var/punchdamagelow = 0       //lowest possible punch damage
+	var/punchdamagehigh = 9      //highest possible punch damage
+	var/punchstunthreshold = 9//damage at which punches from this race will stun
 	var/siemens_coeff = 1 //base electrocution coefficient
 
 	var/invis_sight = SEE_INVISIBLE_LIVING
@@ -928,7 +930,7 @@
 				if(H.lying)
 					atk_verb = "kick"
 
-				var/damage = rand(0, 9) + M.dna.species.punchmod
+				var/damage = rand(M.dna.species.punchdamagelow, M.dna.species.punchdamagehigh)
 
 				if(!damage)
 					playsound(H.loc, M.dna.species.miss_sound, 25, 1, -1)
@@ -946,7 +948,7 @@
 
 				H.apply_damage(damage, BRUTE, affecting, armor_block)
 				add_logs(M, H, "punched")
-				if((H.stat != DEAD) && damage >= 9)
+				if((H.stat != DEAD) && damage >= M.dna.species.punchstunthreshold)
 					H.visible_message("<span class='danger'>[M] has weakened [H]!</span>", \
 									"<span class='userdanger'>[M] has weakened [H]!</span>")
 					H.apply_effect(4, WEAKEN, armor_block)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -345,6 +345,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	siemens_coeff = 0
 	punchdamagelow = 5
 	punchdamagehigh = 14
+	punchstunthreshold = 11 //about 40% chance to stun
 	blacklisted = 1
 	no_equip = list(slot_wear_mask, slot_wear_suit, slot_gloves, slot_shoes, slot_w_uniform)
 	nojumpsuit = 1
@@ -570,6 +571,7 @@ var/global/list/synth_flesh_disguises = list()
 	armor = 25
 	punchdamagelow = 10
 	punchdamagehigh = 19
+	punchstunthreshold = 14 //about 50% chance to stun
 	disguise_fail_health = 50
 
 

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -343,7 +343,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	speedmod = 3
 	armor = 55
 	siemens_coeff = 0
-	punchmod = 5
+	punchdamagelow = 5
+	punchdamagehigh = 14
 	blacklisted = 1
 	no_equip = list(slot_wear_mask, slot_wear_suit, slot_gloves, slot_shoes, slot_w_uniform)
 	nojumpsuit = 1
@@ -567,7 +568,8 @@ var/global/list/synth_flesh_disguises = list()
 	name = "Military Synth"
 	id = "military_synth"
 	armor = 25
-	punchmod = 10
+	punchdamagelow = 10
+	punchdamagehigh = 19
 	disguise_fail_health = 50
 
 


### PR DESCRIPTION
:cl: Joan
tweak: Golems have about a 40% chance to stun with punches, from about 60%.
tweak: Millitary Synths have about a 50% chance to stun with punches, from literally 100%.
/:cl:

Changes punch stun threshold from a hardcoded value to a species var.

Functionality should be exactly the same as it was before, but easier to mess with(and nerf)
