### PR TITLE
Enforce Consistency in Chem Machinery

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -161,7 +161,7 @@
 
 	if(!user.drop_item()) // Can't let go?
 		return
-
+	
 	beaker = B
 	beaker.loc = src
 	user << "<span class='notice'>You add the beaker to the machine.</span>"
@@ -299,10 +299,7 @@
 	if(default_unfasten_wrench(user, I))
 		return
 
-	if (istype(I, /obj/item/weapon/reagent_containers/glass) || \
-		istype(I, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass) || \
-		istype(I, /obj/item/weapon/reagent_containers/food/drinks/shaker))
-
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
 		if (beaker)
 			return 1
 		else

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -49,7 +49,7 @@
 	if(isrobot(user))
 		return
 
-	if(istype(I, /obj/item/weapon/reagent_containers/glass))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
 		if(beaker)
 			user << "<span class='warning'>A beaker is already loaded into the machine!</span>"
 			return

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -7,7 +7,7 @@
 	icon_state = "mixer0"
 	use_power = 1
 	idle_power_usage = 20
-	var/obj/item/weapon/reagent_containers/glass/beaker = null
+	var/obj/item/weapon/reagent_containers/beaker = null
 	var/obj/item/weapon/storage/pill_bottle/bottle = null
 	var/mode = 0
 	var/condi = 0
@@ -36,7 +36,7 @@
 	if(default_unfasten_wrench(user, I))
 		return
 
-	if(istype(I, /obj/item/weapon/reagent_containers/glass))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
 		if(isrobot(user))
 			return
 		if(beaker)
@@ -363,7 +363,7 @@
 			user << "<span class='warning'>You can't use the [src.name] while it's panel is opened!</span>"
 			return 1
 
-	if(istype(B, /obj/item/weapon/reagent_containers/glass))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
 		if(beaker)
 			user << "<span class='warning'>A beaker is already loaded into the machine!</span>"
 			return

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -363,7 +363,7 @@
 			user << "<span class='warning'>You can't use the [src.name] while it's panel is opened!</span>"
 			return 1
 
-	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
+	if(istype(B, /obj/item/weapon/reagent_containers) && (B.flags & OPENCONTAINER))
 		if(beaker)
 			user << "<span class='warning'>A beaker is already loaded into the machine!</span>"
 			return

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -10,7 +10,7 @@
 	idle_power_usage = 20
 	var/temp_html = ""
 	var/wait = null
-	var/obj/item/weapon/reagent_containers/glass/beaker = null
+	var/obj/item/weapon/reagent_containers/beaker = null
 
 /obj/machinery/computer/pandemic/New()
 	..()
@@ -271,7 +271,7 @@
 
 
 /obj/machinery/computer/pandemic/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weapon/reagent_containers/glass))
+	if(istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER))
 		if(stat & (NOPOWER|BROKEN)) return
 		if(beaker)
 			user << "<span class='warning'>A beaker is already loaded into the machine!</span>"

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -105,10 +105,7 @@
 		if(default_unfasten_wrench(user, I))
 				return
 
-		if (istype(I, /obj/item/weapon/reagent_containers/glass) || \
-				istype(I, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass) || \
-				istype(I, /obj/item/weapon/reagent_containers/food/drinks/shaker))
-
+		if (istype(I, /obj/item/weapon/reagent_containers) && (I.flags & OPENCONTAINER) )
 				if (beaker)
 						return 1
 				else


### PR DESCRIPTION
Chem dispensers, heaters, masters/condimasters, the grinder, and the pandemic will now accept any reagent_container with OPENCONTAINER. This generalizes the code.

:cl:
bugfix: Chemistry machinery should now all equally accept beakers, drinking glasses, etc.
/:cl:
fixes #14768 
