### PR TITLE
Makes the MC avoid triggering the byond bug that causes lag.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -133,9 +133,9 @@ var/global/datum/controller/master/Master = new()
 						//byond will pause most client updates for (about) 1.6 seconds.
 						//(1.6 seconds worth of ticks)
 						//We just stop running subsystems to avoid that.
-						break;
+						break
 					if(SS.can_fire > 0)
-						if(SS.next_fire <= world.time && SS.last_fire + (SS.wait * 0.5) <= world.time) // Check if it's time.
+						if(SS.next_fire <= world.time && SS.last_fire + (SS.wait * 0.75) <= world.time) // Check if it's time.
 							ran_subsystems = 1
 							timer = world.timeofday
 							last_type_processed = SS.type
@@ -151,7 +151,9 @@ var/global/datum/controller/master/Master = new()
 								SS.wait = Clamp(newwait, SS.dwait_lower, SS.dwait_upper)
 								if(oldwait != SS.wait)
 									processing_interval = calculate_gcd()
-							SS.next_fire += SS.wait
+								SS.next_fire = world.time + SS.wait
+							else
+								SS.next_fire += SS.wait
 							++SS.times_fired
 							// If we caused BYOND to miss a tick, stop processing for a bit...
 							if(startingtick < world.time || start_time + 1 < world.timeofday)
@@ -174,14 +176,14 @@ var/global/datum/controller/master/Master = new()
 					extrasleep += world.tick_lag * 2
 				// If we are loading the server too much, sleep a bit extra...
 				if(world.cpu >= 75)
-					extrasleep += (1 + extrasleep + processing_interval) * ((world.cpu-50)/10)
+					extrasleep += (extrasleep + processing_interval) * ((world.cpu-50)/10)
+
 				if(world.cpu >= 100)
-					extrasleep += extrasleep //double it, we are close to triggering a byond bug.
 					if(!old_fps)
 						old_fps = world.fps
 						//byond bug, if we go over 120 fps and world.fps is higher then 10, the bad things that happen are made worst.
 						world.fps = 10
-				else if(old_fps && world.cpu < 75)
+				else if(old_fps && world.cpu < 50)
 					world.fps = old_fps
 					old_fps = null
 


### PR DESCRIPTION
See http://www.byond.com/forum/?post=2021963#comment18164837

Long story short, if world.cpu ever goes over 120%, byond suspends all client updates for world.fps*1.6 amount of ticks (25 ticks in the case of sybil's 16fps)

If the cpu is above 100%, we set world.fps to 10 and reset it back to normal once the cpu gets below 50%

(Higher fps when cpu goes over 120 causes the bug to get worst. I have it scaling around 100 to give us a buffer, and not going back down until it drops below 50 to avoid it jumping around too much.)

The mc will also scale how often it runs with world.cpu, doubling its normal delay between fires for every 10% above 50% if the cpu is above 75%, and doubling everything again if it's above 100%

The mc will not run any subsystems if at any point world.cpu is above 100%, this might come back to bite me, but it's better than byond delaying all client updates for 1.6 to 3 seconds.

This is a bit of a mess, but all of it can removed once the bug is fixed on byond's end.

I've also had to disable it trying to make up missed subsystem ticks on dynamic wait subsystems, as that was coming into play against the high cpu delays with air and lighting, and that didn't make any sense to do.

And it will be a bit less aggressive about making up missed ticks, making them up 25% at a time, rather than 50%
