### PR TITLE
Fixes supermatter explosion being capped

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -76,7 +76,7 @@
 
 /obj/machinery/power/supermatter_shard/proc/explode()
 	investigate_log("has exploded.", "supermatter")
-	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1)
+	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 0)
 	qdel(src)
 	return
 


### PR DESCRIPTION
Supermatter explosion is now properly uncapped, and will blow a 8/16/24 hole in the station when it explodes.
