### PR TITLE
Local Bird Transcends Round Based Universe

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -372,7 +372,6 @@
 			speak.Remove(pick(speak))
 
 		speak.Add(pick(speech_buffer))
-		clearlist(speech_buffer)
 
 
 /mob/living/simple_animal/parrot/handle_automated_movement()
@@ -856,8 +855,31 @@
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
 	gold_core_spawnable = 0
+	speak_chance = 3
+	var/memory_saved = 0
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)
 	available_channels = list(":e")
+	Read_Memory()
 	..()
+
+/mob/living/simple_animal/parrot/Poly/Life()
+	if(ticker.current_state == GAME_STATE_FINISHED && !memory_saved)
+		Write_Memory()
+	..()
+
+/mob/living/simple_animal/parrot/Poly/death(gibbed)
+	Write_Memory()
+	..(gibbed)
+
+/mob/living/simple_animal/parrot/Poly/proc/Read_Memory()
+	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
+	S["phrases"] 	>> speech_buffer
+	if(isnull(speech_buffer))
+		speech_buffer = list()
+
+/mob/living/simple_animal/parrot/Poly/proc/Write_Memory()
+	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
+	S["phrases"] 	<< speech_buffer
+	memory_saved = 1


### PR DESCRIPTION
Gives Poly a rudimentary savefile (not committed, will be generated at data/npc_saves/Poly.sav) that allows him to retain his learned phrases between rounds.

Poly can keep up to 20 unique phrases (plus his defaults) at a time. If poly learns a 21st phrase (and eventually this would be any learned phrase) it will randomly remove one of the other 20. The default phrases can't be unlearned this way.

Poly unloads his memories when killed or as the game ends.

This mechanic is unique to Poly, normal parrots won't share his phrase list. He's also been made a little chattier than other parrots to flaunt this ability.

Yes this is a feature. I coded this as a way to mitigate datum antag burnout. Merge after the freeze ends.
