### PR TITLE
Nerfs blobbernaut creation, tweaks blob reagents

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -5,6 +5,7 @@
 	desc = "A thick spire of tendrils."
 	health = 200
 	maxhealth = 200
+	health_regen = 1
 	point_return = 25
 	var/list/spores = list()
 	var/max_spores = 3

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -157,8 +157,8 @@
 
 /obj/screen/blob/Blobbernaut
 	icon_state = "ui_blobbernaut"
-	name = "Produce Blobbernaut (20)"
-	desc = "Produces a blobbernaut for 20 points."
+	name = "Produce Blobbernaut (30)"
+	desc = "Produces a blobbernaut for 30 points."
 
 /obj/screen/blob/Blobbernaut/Click()
 	if(isovermind(usr))

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -76,20 +76,20 @@
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
-	set name = "Create Blobbernaut (20)"
+	set name = "Create Blobbernaut (30)"
 	set desc = "Create a powerful blobbernaut which is mildly smart and will attack enemies."
 	var/turf/T = get_turf(src)
 	var/obj/effect/blob/factory/B = locate(/obj/effect/blob/factory) in T
 	if(!B)
 		src << "<span class='warning'>You must be on a factory blob!</span>"
 		return
-	if(B.health < B.maxhealth*0.6) //if it's at less than 60% of its health, you can't blobbernaut it
+	if(B.health < B.maxhealth*0.8) //if it's at less than 60% of its health, you can't blobbernaut it
 		src << "<span class='warning'>This factory blob is too damaged to produce a blobbernaut.</span>"
 		return
 	if(!can_buy(20))
 		return
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
-	B.take_damage(B.maxhealth*0.6, CLONE, null, 0) //take a bunch of damage, so you can't produce tons of blobbernauts from a single factory
+	B.take_damage(B.maxhealth*0.8, CLONE, null, 0) //take a bunch of damage, so you can't produce tons of blobbernauts from a single factory
 	B.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
 	B.spore_delay = world.time + 600 //one minute before it can spawn spores again
 	blobber.overmind = src

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -31,9 +31,9 @@
 /datum/reagent/blob/ripping_tendrils/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.6*reac_volume, BRUTE)
+		M.apply_damage(0.7*reac_volume, BRUTE)
 	if(M)
-		M.adjustStaminaLoss(0.6*reac_volume)
+		M.adjustStaminaLoss(0.5*reac_volume)
 	if(iscarbon(M))
 		M.emote("scream")
 
@@ -241,11 +241,11 @@
 /datum/reagent/blob/synchronous_mesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.2*reac_volume, BRUTE)
+		M.apply_damage(0.1*reac_volume, BRUTE)
 	if(M)
 		for(var/obj/effect/blob/B in range(1, M)) //if the target is completely surrounded, this is 0.8*reac_volume bonus damage, total of 1.2*reac_volume
 			if(M)
-				M.apply_damage(0.2*reac_volume, BRUTE)
+				M.apply_damage(0.3*reac_volume, BRUTE)
 
 /datum/reagent/blob/synchronous_mesh/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(!isnull(cause)) //the cause isn't fire or bombs, so split the damage

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -49,7 +49,7 @@
 /datum/reagent/blob/sporing_pods/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.4*reac_volume, TOX)
+		M.apply_damage(0.5*reac_volume, TOX)
 
 /datum/reagent/blob/sporing_pods/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(!isnull(cause) && damage < 20 && original_health - damage <= 0 && prob(50)) //if the cause isn't fire or a bomb, the damage is less than 20, we're going to die from that damage, 50% chance of a shitty spore.
@@ -81,7 +81,7 @@
 		M.apply_damage(0.6*reac_volume, BRUTE)
 
 /datum/reagent/blob/replicating_foam/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(damage > 0 && original_health - damage > 0 && prob(100 - damage))
+	if(damage > 0 && original_health - damage > 0)
 		var/obj/effect/blob/newB = B.expand()
 		if(newB)
 			newB.health = original_health - damage
@@ -105,7 +105,7 @@
 /datum/reagent/blob/energized_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.4*reac_volume, BURN)
+		M.apply_damage(0.5*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.8*reac_volume)
 
@@ -146,12 +146,12 @@
 
 /datum/reagent/blob/hallucinogenic_nectar/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
-	M.hallucination += 0.6*reac_volume
-	M.druggy += 0.6*reac_volume
+	M.hallucination += 0.8*reac_volume
+	M.druggy += 0.8*reac_volume
 	if(M.reagents)
 		M.reagents.add_reagent("spore", 0.2*reac_volume)
 	if(M)
-		M.apply_damage(0.4*reac_volume, TOX)
+		M.apply_damage(0.6*reac_volume, TOX)
 
 //toxin, stamina, and some bonus spore toxin
 /datum/reagent/blob/envenomed_filaments
@@ -182,7 +182,7 @@
 	reac_volume = ..()
 	M.losebreath += round(0.2*reac_volume)
 	if(M)
-		M.apply_damage(0.4*reac_volume, BRUTE)
+		M.apply_damage(0.2*reac_volume, BRUTE)
 	if(M)
 		M.apply_damage(0.6*reac_volume, OXY)
 
@@ -224,7 +224,7 @@
 		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
 		M.reagents.add_reagent("ice", 0.4*reac_volume)
 	if(M)
-		M.apply_damage(0.4*reac_volume, BURN)
+		M.apply_damage(0.6*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
 
@@ -241,11 +241,11 @@
 /datum/reagent/blob/synchronous_mesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.4*reac_volume, BRUTE)
+		M.apply_damage(0.2*reac_volume, BRUTE)
 	if(M)
 		for(var/obj/effect/blob/B in range(1, M)) //if the target is completely surrounded, this is 0.8*reac_volume bonus damage, total of 1.2*reac_volume
 			if(M)
-				M.apply_damage(0.1*reac_volume, BRUTE)
+				M.apply_damage(0.2*reac_volume, BRUTE)
 
 /datum/reagent/blob/synchronous_mesh/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(!isnull(cause)) //the cause isn't fire or bombs, so split the damage
@@ -274,7 +274,7 @@
 /datum/reagent/blob/pressurized_slime/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	reac_volume = ..()
 	var/turf/simulated/T = get_turf(M)
-	if(istype(T, /turf/simulated))
+	if(istype(T, /turf/simulated) && prob(reac_volume))
 		T.MakeSlippery(TURF_WET_WATER)
 	if(M)
 		M.apply_damage(0.4*reac_volume, BRUTE)
@@ -293,7 +293,7 @@
 	if(!isnull(cause))
 		B.visible_message("<span class='warning'><b>The blob ruptures, spraying the area with liquid!</b></span>")
 	for(var/turf/simulated/T in range(1, B))
-		if(prob(90))
+		if(prob(50))
 			T.MakeSlippery(TURF_WET_WATER)
 
 //does brute damage and throws or pulls nearby objects at the target
@@ -308,7 +308,7 @@
 	reagent_vortex(M, 0, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.6*reac_volume, BRUTE)
+		M.apply_damage(0.4*reac_volume, BRUTE)
 
 //does brute damage and throws or pushes nearby objects away from the target
 /datum/reagent/blob/b_sorium
@@ -322,7 +322,7 @@
 	reagent_vortex(M, 1, reac_volume)
 	reac_volume = ..()
 	if(M)
-		M.apply_damage(0.6*reac_volume, BRUTE)
+		M.apply_damage(0.5*reac_volume, BRUTE)
 
 /datum/reagent/blob/proc/reagent_vortex(mob/living/M, setting_type, reac_volume)
 	if(M)


### PR DESCRIPTION
:cl: Joan
wip: Blobbernaut creation costs 30 points, and does much more damage to the factory.
rscdel: Blob factories regenerate at half normal rate.
tweak: Blob reagents tweaked;
rscadd: Ripping Tendrils does slightly more brute damage, but less stamina damage.
rscdel: Lexorin Jelly does less brute damage.
rscadd: Energized Fibers does slightly more burn damage.
rscadd: Sporing Pods does slightly more toxin damage.
rscadd: Replicating Foam will try to replicate when hit more often.
rscadd: Hallucinogenic Nectar does slightly more toxin damage and causes hallucinations for longer.
rscadd: Cryogenic Liquid does more burn damage.
experiment: Synchronous Mesh does slightly less damage with one blob but massive damage with more than one nearby blob.
rscdel: Dark Matter does less brute damage.
rscdel: Sorium does slightly less brute damage.
rscdel: Pressurized Slime has a lower chance to emit water when killed and when attacking targets.
/:cl:

The blobbernaut nerfs are all to creation:
Creating a blobbernaut costs 50% more resources.
The factory used takes 33% more damage, 80% of its maximum health.
Factories regenerate at half the rate they did before, meaning there's a longer delay between them being able to be used for blobbernauts.
