### PR TITLE
Actually fixes supermatter explosion to not be capped

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -76,7 +76,7 @@
 
 /obj/machinery/power/supermatter_shard/proc/explode()
 	investigate_log("has exploded.", "supermatter")
-	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 0)
+	explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 1)
 	qdel(src)
 	return
 


### PR DESCRIPTION
:cl: Joan
tweak: Supermatter explosion is no longer capped, and under normal conditions will produce a 8/16/24 explosion when delaminating.
/:cl:
i forgot what to set the arg to between looking at the proc and looking back at supermatter
