### PR TITLE
Properly fixes power sinks

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -12,9 +12,9 @@
 	throw_range = 2
 	materials = list(MAT_METAL=750)
 	origin_tech = "powerstorage=3;syndicate=5"
-	var/drain_rate = 600000		// amount of power to drain per tick
+	var/drain_rate = 1200000	// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1e8		// maximum power that can be drained before exploding
+	var/max_power = 1e10		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = 0 // stop spam, only warn the admins once that we are about to boom
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -133,7 +133,7 @@
 						if(A.charging == 2) // If the cell was full
 							A.charging = 1 // It's no longer full
 
-	if(power_drained > max_power * 0.95)
+	if(power_drained > max_power * 0.98)
 		if (!admins_warned)
 			admins_warned = 1
 			message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) is 95% full. Explosion imminent.")

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -12,7 +12,7 @@
 	throw_range = 2
 	materials = list(MAT_METAL=750)
 	origin_tech = "powerstorage=3;syndicate=5"
-	var/drain_rate = 1200000	// amount of power to drain per tick
+	var/drain_rate = 1600000	// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
 	var/max_power = 1e10		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -141,5 +141,5 @@
 
 	if(power_drained >= max_power)
 		SSobj.processing.Remove(src)
-		explosion(src.loc, 3,6,9,12)
+		explosion(src.loc, 4,8,16,32)
 		qdel(src)


### PR DESCRIPTION
Why the fuck would you have this functionality where they can be overloaded if you are gonna raise the numbers so high as to make it useless.

Goofball please.

Fixes #9677

closes #14907

Making its capacity so large such that in no case could it ever overload is fucking stupid.

I also ramped up the explosion to account for the bigger storage, and give a decent incentive to not powergame wiring the engine to grid.

:cl:
fix: Fixes the powersink drawing less power than the smeses put out.
tweak: Made the powersink hold significantly more power before overloading and going boom.
tweak: Buffed the explosion of the power sink when it overloads. You are suggested to think twice about wiring the engine to the grid.
/:cl:
