### PR TITLE
Adds the ability to store knives/pens/edaggers in certain shoes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -210,36 +210,18 @@ BLIND     // can't see anything
 		if(!user.drop_item())
 			return
 		I.loc = src
-		user << "<span class='notice'>You discreetly slip [I] into [src]. Click and drag [src] to yourself to remove it.</span>"
+		user << "<span class='notice'>You discreetly slip [I] into [src]. Alt-click [src] to remove it.</span>"
 		held_knife = I
 
-/obj/item/clothing/shoes/MouseDrop(atom/over_object)
-	..()
-	if(!can_hold_knives)
+/obj/item/clothing/shoes/AltClick(mob/user)
+	if(user.incapacitated() || !held_knife || !can_hold_knives)
 		return
-	var/mob/M = usr
-	if(M.restrained() || M.stat || !Adjacent(M) || !held_knife)
-		return
-	if(over_object == M)
-		M.put_in_hands(held_knife)
-		usr.visible_message("<span class='warning'>[usr] draws [held_knife] from \his shoes!</span>", "<span class='notice'>You withdraw [held_knife] from [src].</span>")
-		held_knife = null
-	else if(istype(over_object, /obj/screen))
-		switch(over_object.name)
-			if("r_hand")
-				if(!remove_item_from_storage(M))
-					M.unEquip(held_knife)
-				M.put_in_r_hand(held_knife)
-				usr.visible_message("<span class='warning'>[usr] draws [held_knife] from their boots!</span>", "<span class='notice'>You withdraw [held_knife] from [src].</span>")
-				held_knife = null
-			if("l_hand")
-				if(!remove_item_from_storage(M))
-					M.unEquip(held_knife)
-				M.put_in_l_hand(held_knife)
-				usr.visible_message("<span class='warning'>[usr] draws [held_knife] from their boots!</span>", "<span class='notice'>You withdraw [held_knife] from [src].</span>")
-				held_knife = null
-	add_fingerprint(M)
-
+	if(!user.put_in_hands(held_knife))
+		user << "<span class='notice'>You fumble for [held_knife] and it falls on the floor.</span>"
+		return 1
+	user.visible_message("<span class='warning'>[user] draws [held_knife] from their shoes!</span>", "<span class='notice'>You withdraw [held_knife] from [src].</span>")
+	held_knife = null
+	add_fingerprint(user)
 
 /obj/item/proc/negates_gravity()
 	return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -206,7 +206,7 @@ BLIND     // can't see anything
 	if(held_knife)
 		user << "<span class='notice'>There's already something in [src].</span>"
 		return
-	if(istype(I, /obj/item/weapon/kitchen/knife) || istype(I, /obj/item/weapon/pen))//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
+	if(istype(I, /obj/item/weapon/kitchen/knife) || istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/weapon/switchblade))//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
 		if(!user.drop_item())
 			return
 		I.loc = src

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -175,8 +175,9 @@ BLIND     // can't see anything
 	slowdown = SHOES_SLOWDOWN
 	var/blood_state = BLOOD_STATE_NOT_BLOODY
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
-	var/can_hold_knives = 0//if set to 1, the shoe can hold knives and edaggers
-	var/obj/item/weapon/held_knife
+	var/can_hold_items = 0//if set to 1, the shoe can hold knives and edaggers
+	var/obj/held_item
+	var/list/valid_held_items = list(/obj/item/weapon/kitchen/knife, /obj/item/weapon/pen, /obj/item/weapon/switchblade)//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
 
 
 /obj/item/clothing/shoes/worn_overlays(var/isinhands = FALSE)
@@ -202,27 +203,30 @@ BLIND     // can't see anything
 
 /obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
 	..()
-	if(!can_hold_knives)
+	if(!can_hold_items)
 		return
-	if(held_knife)
+	if(held_item)
 		user << "<span class='notice'>There's already something in [src].</span>"
 		return
-	if(istype(I, /obj/item/weapon/kitchen/knife) || istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/weapon/switchblade))//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
+	if(is_type_in_list(I, valid_held_items))//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
+		if(I.w_class > 2)//if the object is too big (like if it's a cleaver or an extended edagger) it wont fit
+			user << "<span class='notice'>[I] is currently too big to fit into [src]. </span>"
+			return
 		if(!user.drop_item())
 			return
 		I.loc = src
-		held_knife = I
+		held_item = I
 		user << "<span class='notice'>You discreetly slip [I] into [src]. Alt-click [src] to remove it.</span>"
 
 /obj/item/clothing/shoes/AltClick(mob/user)
-	if(user.incapacitated() || !held_knife || !can_hold_knives)
+	if(user.incapacitated() || !held_item || !can_hold_items)
 		return
-	if(!user.put_in_hands(held_knife))
-		user << "<span class='notice'>You fumble for [held_knife] and it falls on the floor.</span>"
+	if(!user.put_in_hands(held_item))
+		user << "<span class='notice'>You fumble for [held_item] and it falls on the floor.</span>"
 		return 1
-		held_knife = null
-	user.visible_message("<span class='warning'>[user] draws [held_knife] from their shoes!</span>", "<span class='notice'>You draw [held_knife] from [src].</span>")
-	held_knife = null
+		held_item = null
+	user.visible_message("<span class='warning'>[user] draws [held_item] from their shoes!</span>", "<span class='notice'>You draw [held_item] from [src].</span>")
+	held_item = null
 
 /obj/item/proc/negates_gravity()
 	return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -210,8 +210,8 @@ BLIND     // can't see anything
 		if(!user.drop_item())
 			return
 		I.loc = src
-		user << "<span class='notice'>You discreetly slip [I] into [src]. Alt-click [src] to remove it.</span>"
 		held_knife = I
+		user << "<span class='notice'>You discreetly slip [I] into [src]. Alt-click [src] to remove it.</span>"
 
 /obj/item/clothing/shoes/AltClick(mob/user)
 	if(user.incapacitated() || !held_knife || !can_hold_knives)
@@ -219,9 +219,8 @@ BLIND     // can't see anything
 	if(!user.put_in_hands(held_knife))
 		user << "<span class='notice'>You fumble for [held_knife] and it falls on the floor.</span>"
 		return 1
-	user.visible_message("<span class='warning'>[user] draws [held_knife] from their shoes!</span>", "<span class='notice'>You withdraw [held_knife] from [src].</span>")
+	user.visible_message("<span class='warning'>[user] draws [held_knife] from their shoes!</span>", "<span class='notice'>You draw [held_knife] from [src].</span>")
 	held_knife = null
-	add_fingerprint(user)
 
 /obj/item/proc/negates_gravity()
 	return 0

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -201,6 +201,7 @@ BLIND     // can't see anything
 		M.update_inv_shoes()
 
 /obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
+	..()
 	if(!can_hold_knives)
 		return
 	if(held_knife)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -219,6 +219,7 @@ BLIND     // can't see anything
 	if(!user.put_in_hands(held_knife))
 		user << "<span class='notice'>You fumble for [held_knife] and it falls on the floor.</span>"
 		return 1
+		held_knife = null
 	user.visible_message("<span class='warning'>[user] draws [held_knife] from their shoes!</span>", "<span class='notice'>You draw [held_knife] from [src].</span>")
 	held_knife = null
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -16,7 +16,7 @@
 	flags = NOSLIP
 	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
-	can_hold_knives = 1//syndicate-brand shoes come with syndicate-brand knife departments
+	can_hold_knives = 1
 
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"
@@ -110,7 +110,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	can_hold_knives = 1//for handling those ice-bear attacks
+	can_hold_knives = 1
 
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
@@ -119,7 +119,7 @@
 	item_state = "jackboots"
 	strip_delay = 40
 	put_on_delay = 40
-	can_hold_knives = 1//for when that wire is too tough for regular wirecutters
+	can_hold_knives = 1
 
 /obj/item/clothing/shoes/cult
 	name = "nar-sian invoker boots"
@@ -160,4 +160,4 @@
 	desc = "A pair of costume boots fashioned after bird talons."
 	icon_state = "griffinboots"
 	item_state = "griffinboots"
-	can_hold_knives = 1//the griffin's secret trump card, unknown to even the owl: a knife in his shoe
+	can_hold_knives = 1

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -16,6 +16,7 @@
 	flags = NOSLIP
 	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
+	can_hold_knives = 1//syndicate-brand shoes come with syndicate-brand knife departments
 
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"
@@ -30,6 +31,7 @@
 	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
 	strip_delay = 70
 	burn_state = FIRE_PROOF
+	can_hold_knives = 1
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT boots"
@@ -97,6 +99,7 @@
 	strip_delay = 50
 	put_on_delay = 50
 	burn_state = FIRE_PROOF
+	can_hold_knives = 1
 
 /obj/item/clothing/shoes/winterboots
 	name = "winter boots"
@@ -107,6 +110,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	can_hold_knives = 1//for handling those ice-bear attacks
 
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
@@ -115,6 +119,7 @@
 	item_state = "jackboots"
 	strip_delay = 40
 	put_on_delay = 40
+	can_hold_knives = 1//for when that wire is too tough for regular wirecutters
 
 /obj/item/clothing/shoes/cult
 	name = "nar-sian invoker boots"
@@ -155,3 +160,4 @@
 	desc = "A pair of costume boots fashioned after bird talons."
 	icon_state = "griffinboots"
 	item_state = "griffinboots"
+	can_hold_knives = 1//the griffin's secret trump card, unknown to even the owl: a knife in his shoe

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -16,7 +16,7 @@
 	flags = NOSLIP
 	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
-	can_hold_knives = 1
+	can_hold_items = 1
 
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"
@@ -31,7 +31,7 @@
 	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
 	strip_delay = 70
 	burn_state = FIRE_PROOF
-	can_hold_knives = 1
+	can_hold_items = 1
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT boots"
@@ -82,6 +82,8 @@
 	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
 	var/footstep = 1	//used for squeeks whilst walking
+	can_hold_items = 1
+	valid_held_items = list(/obj/item/weapon/bikehorn)
 
 /obj/item/clothing/shoes/clown_shoes/step_action()
 	if(footstep > 1)
@@ -99,7 +101,7 @@
 	strip_delay = 50
 	put_on_delay = 50
 	burn_state = FIRE_PROOF
-	can_hold_knives = 1
+	can_hold_items = 1
 
 /obj/item/clothing/shoes/winterboots
 	name = "winter boots"
@@ -110,7 +112,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-	can_hold_knives = 1
+	can_hold_items = 1
 
 /obj/item/clothing/shoes/workboots
 	name = "work boots"
@@ -160,4 +162,4 @@
 	desc = "A pair of costume boots fashioned after bird talons."
 	icon_state = "griffinboots"
 	item_state = "griffinboots"
-	can_hold_knives = 1
+	can_hold_items = 1

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -121,7 +121,7 @@
 	item_state = "jackboots"
 	strip_delay = 40
 	put_on_delay = 40
-	can_hold_knives = 1
+	can_hold_items = 1
 
 /obj/item/clothing/shoes/cult
 	name = "nar-sian invoker boots"


### PR DESCRIPTION
Stored by clicking the shoe with said items, and removed by click-dragging the shoe with the item to yourself/an empty hand slot.
Placing an item into the shoe shows a message to only the user. Taking an item out, however, warns everybody in the vicinity.

:cl: PKPenguin321
rscadd: You can now store knives, pens, switchblades, and energy daggers in certain types of shoes (such as jackboots, workboots, winter boots, combat boots, or no-slips).
rscadd: Horns can now be stored in clown shoes. Honk.
/:cl:
