### PR TITLE
Removes grab from transit tubes [DNM]

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -82,17 +82,6 @@
 
 
 /obj/structure/transit_tube/station/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weapon/grab) && icon_state == "open")
-		var/obj/item/weapon/grab/G = W
-		if(ismob(G.affecting) && G.state >= GRAB_AGGRESSIVE)
-			var/mob/GM = G.affecting
-			for(var/obj/structure/transit_tube_pod/pod in loc)
-				pod.visible_message("<span class='warning'>[user] starts putting [GM] into the [pod]!</span>")
-				if(do_after(user, 15, target = src) && GM && G && G.affecting == GM)
-					GM.Weaken(5)
-					src.Bumped(GM)
-					qdel(G)
-				break
 	if(istype(W, /obj/item/weapon/crowbar))
 		for(var/obj/structure/transit_tube_pod/pod in loc)
 			if(pod.contents)
@@ -149,6 +138,19 @@
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		pod.mix_air()
+
+/obj/structure/transit_tube/station/MouseDrop(mob/living/target)
+	if(!ishuman(usr) || !usr.canUseTopic(src,BE_CLOSE))
+		return
+	if(!istype(target))
+		return
+	if(target.buckled)
+		return
+	for(var/obj/structure/transit_tube_pod/pod in loc)
+		pod.visible_message("<span class='warning'>[usr] starts putting [target] into the [pod]!</span>")
+		if(do_after(usr, 15, target = src) && !target.buckled)
+			target.Weaken(5)
+			src.Bumped(target)
 
 // Tube station directions are simply 90 to either side of
 //  the exit.


### PR DESCRIPTION
Instead you use mousedrop

:cl: Kor
rscadd: Putting mobs in transit tubes now uses clickdrag instead of grab
/:cl:
