### PR TITLE
Radioactive Teleport Armor

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,6 +18,6 @@
 	new /obj/item/device/radio/headset/heads/rd(src)
 	new /obj/item/weapon/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/suit/armor/reactive(src)
+	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -185,13 +185,6 @@
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
 	desc = "Someone seperated our Research Director from his own head!"
-	var/active = 0
-	icon_state = "reactiveoff"
-	item_state = "reactiveoff"
-	blood_overlay_type = "armor"
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	action_button_name = "Toggle Armor"
-	unacidable = 1
 	hit_reaction_chance = 50
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -123,10 +123,9 @@
 
 
 //Reactive armor
-//When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive
 	name = "reactive armor"
-	desc = "Someone seperated our Research Director from his own head!"
+	desc = "Doesn't seem to do much for some reason."
 	var/active = 0
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
@@ -156,10 +155,10 @@
 	src.item_state = "reactiveoff"
 	..()
 
+//When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
 	desc = "Someone seperated our Research Director from his own head!"
-	hit_reaction_chance = 50
 	var/tele_range = 6
 	var/rad_amount= 15
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -125,7 +125,7 @@
 //Reactive armor
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive
-	name = "reactive teleport armor"
+	name = "reactive armor"
 	desc = "Someone seperated our Research Director from his own head!"
 	var/active = 0
 	icon_state = "reactiveoff"
@@ -156,36 +156,12 @@
 	src.item_state = "reactiveoff"
 	..()
 
-/obj/item/clothing/suit/armor/reactive/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
-	if(!active)
-		return 0
-	if(prob(hit_reaction_chance))
-		var/mob/living/carbon/human/H = owner
-		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
-		var/list/turfs = new/list()
-		for(var/turf/T in orange(6, H))
-			if(T.density)
-				continue
-			if(T.x>world.maxx-6 || T.x<6)
-				continue
-			if(T.y>world.maxy-6 || T.y<6)
-				continue
-			turfs += T
-		if(!turfs.len)
-			turfs += pick(/turf in orange(6, H))
-		var/turf/picked = pick(turfs)
-		if(!isturf(picked))
-			return
-		if(H.buckled)
-			H.buckled.unbuckle_mob()
-		H.forceMove(picked)
-		return 1
-	return 0
-
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
 	desc = "Someone seperated our Research Director from his own head!"
 	hit_reaction_chance = 50
+	var/tele_range = 6
+	var/rad_amount= 15
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
 	if(!active)
@@ -194,23 +170,23 @@
 		var/mob/living/carbon/human/H = owner
 		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
 		var/list/turfs = new/list()
-		for(var/turf/T in orange(6, H))
+		for(var/turf/T in orange(tele_range, H))
 			if(T.density)
 				continue
-			if(T.x>world.maxx-6 || T.x<6)
+			if(T.x>world.maxx-tele_range || T.x<tele_range)
 				continue
-			if(T.y>world.maxy-6 || T.y<6)
+			if(T.y>world.maxy-tele_range || T.y<tele_range)
 				continue
 			turfs += T
 		if(!turfs.len)
-			turfs += pick(/turf in orange(6, H))
+			turfs += pick(/turf in orange(tele_range, H))
 		var/turf/picked = pick(turfs)
 		if(!isturf(picked))
 			return
 		if(H.buckled)
 			H.buckled.unbuckle_mob()
 		H.forceMove(picked)
-		H.rad_act(15)
+		rad_act(rad_amount)
 		return 1
 	return 0
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -182,6 +182,45 @@
 		return 1
 	return 0
 
+/obj/item/clothing/suit/armor/reactive/teleport
+	name = "reactive teleport armor"
+	desc = "Someone seperated our Research Director from his own head!"
+	var/active = 0
+	icon_state = "reactiveoff"
+	item_state = "reactiveoff"
+	blood_overlay_type = "armor"
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+	action_button_name = "Toggle Armor"
+	unacidable = 1
+	hit_reaction_chance = 50
+
+/obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+	if(!active)
+		return 0
+	if(prob(hit_reaction_chance))
+		var/mob/living/carbon/human/H = owner
+		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+		var/list/turfs = new/list()
+		for(var/turf/T in orange(6, H))
+			if(T.density)
+				continue
+			if(T.x>world.maxx-6 || T.x<6)
+				continue
+			if(T.y>world.maxy-6 || T.y<6)
+				continue
+			turfs += T
+		if(!turfs.len)
+			turfs += pick(/turf in orange(6, H))
+		var/turf/picked = pick(turfs)
+		if(!isturf(picked))
+			return
+		if(H.buckled)
+			H.buckled.unbuckle_mob()
+		H.forceMove(picked)
+		H.rad_act(15)
+		return 1
+	return 0
+
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -186,7 +186,7 @@
 		if(H.buckled)
 			H.buckled.unbuckle_mob()
 		H.forceMove(picked)
-		rad_act(rad_amount)
+		H.rad_act(rad_amount)
 		return 1
 	return 0
 


### PR DESCRIPTION
This Pull Request simply adds a new child of reactive armor... a normal reactive teleport armor that calls rad_act on teleport, radiating the teleporter hopefully.

As a note, this is my first PR, my first time semi-seriously coding, and I forgot to get this looked at first, so please feel free to point out stuff I did wrong.

:cl: Boredone
tweak: Due to an experiment gone wrong, the Research Director's Teleport Armor now causes some mild radiation poisoning on teleportation to the wearer.
/:cl:
