### PR TITLE
Fixes alien surgery

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -14,7 +14,7 @@
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if(butcher_results && stat == DEAD) //can we butcher it?
+	if(user.a_intent == "harm" && stat == DEAD && butcher_results) //can we butcher it?
 		var/sharpness = I.is_sharp()
 		if(sharpness)
 			user << "<span class='notice'>You begin to butcher [src]...</span>"


### PR DESCRIPTION
Butchering will only happen if you are on harm intent.

Fixes #12311

I'll make a changelog in a minute don't bully me

:cl: Kor
rscadd: Butchering mobs by attacking them with sharp objects will only happen on harm intent. This means it is possible to do surgery on aliens again.
/:cl:
