### PR TITLE
Adds laserguns with rechargeable, swappable magazines

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -120,7 +120,7 @@
 				icon_state = "recharger3"
 		if(istype(charging, /obj/item/ammo_box/magazine/recharge))
 			var/obj/item/ammo_box/magazine/recharge/R = charging
-			if(R.stored_ammo.len<R.max_ammo)
+			if(R.stored_ammo.len < R.max_ammo)
 				R.stored_ammo += new R.ammo_type(R)
 				icon_state = "recharger1"
 				use_power(200)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -98,34 +98,31 @@
 	if(stat & (NOPOWER|BROKEN) || !anchored)
 		return
 
+	var/using_power = 0
 	if(charging)
 		if(istype(charging, /obj/item/weapon/gun/energy))
 			var/obj/item/weapon/gun/energy/E = charging
 			if(E.power_supply.charge < E.power_supply.maxcharge)
 				E.power_supply.give(E.power_supply.chargerate * recharge_coeff)
-				icon_state = "recharger1"
 				use_power(250 * recharge_coeff)
-			else
-				icon_state = "recharger2"
-			return
+				using_power = 1
+
+
 		if(istype(charging, /obj/item/weapon/melee/baton))
 			var/obj/item/weapon/melee/baton/B = charging
 			if(B.bcell)
 				if(B.bcell.give(B.bcell.chargerate * recharge_coeff))
-					icon_state = "recharger1"
 					use_power(200 * recharge_coeff)
-				else
-					icon_state = "recharger2"
-			else
-				icon_state = "recharger3"
+					using_power = 1
+
 		if(istype(charging, /obj/item/ammo_box/magazine/recharge))
 			var/obj/item/ammo_box/magazine/recharge/R = charging
 			if(R.stored_ammo.len < R.max_ammo)
 				R.stored_ammo += new R.ammo_type(R)
-				icon_state = "recharger1"
-				use_power(200)
-			else
-				icon_state = "recharger2"
+				use_power(200 * recharge_coeff)
+				using_power = 1
+
+	update_icon(using_power)
 
 /obj/machinery/recharger/power_change()
 	..()
@@ -148,12 +145,17 @@
 	..(severity)
 
 
-/obj/machinery/recharger/update_icon()	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
+/obj/machinery/recharger/update_icon(using_power = 0)	//we have an update_icon() in addition to the stuff in process to make it feel a tiny bit snappier.
 	if(stat & (NOPOWER|BROKEN) || !anchored)
 		icon_state = "rechargeroff"
-	else if(panel_open)
+		return
+	if(panel_open)
 		icon_state = "rechargeropen"
-	else if(charging)
-		icon_state = "recharger1"
-	else
-		icon_state = "recharger0"
+		return
+	if(charging)
+		if(using_power)
+			icon_state = "recharger1"
+		else
+			icon_state = "recharger2"
+		return
+	icon_state = "recharger0"

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -33,7 +33,7 @@
 		return
 	if(istype(user,/mob/living/silicon))
 		return
-	if(istype(G, /obj/item/weapon/gun/energy) || istype(G, /obj/item/weapon/melee/baton))
+	if(istype(G, /obj/item/weapon/gun/energy) || istype(G, /obj/item/weapon/melee/baton) || istype(G, /obj/item/ammo_box/magazine/recharge))
 		if(anchored)
 			if(charging || panel_open)
 				return
@@ -118,6 +118,14 @@
 					icon_state = "recharger2"
 			else
 				icon_state = "recharger3"
+		if(istype(charging, /obj/item/ammo_box/magazine/recharge))
+			var/obj/item/ammo_box/magazine/recharge/R = charging
+			if(R.stored_ammo.len<R.max_ammo)
+				R.stored_ammo += new R.ammo_type(R)
+				icon_state = "recharger1"
+				use_power(200)
+			else
+				icon_state = "recharger2"
 
 /obj/machinery/recharger/power_change()
 	..()

--- a/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
+++ b/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
@@ -18,6 +18,7 @@
  	caliber = "laser"
  	icon_state = "s-casing-live"
  	projectile_type = /obj/item/projectile/beam
+ 	fire_sound = 'sound/weapons/Laser.ogg'
 
 
 /obj/item/ammo_box/magazine/recharge/attack_self() //No popping out the "bullets"

--- a/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
+++ b/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
@@ -1,0 +1,46 @@
+//Energy guns with swappable, rechargable, magazines.
+
+/obj/item/ammo_box/magazine/recharge
+ 	name = "power pack"
+ 	icon_state = "oldrifle-20"
+ 	ammo_type = /obj/item/ammo_casing/caseless/laser
+ 	caliber = "laser"
+ 	max_ammo = 20
+
+/obj/item/ammo_box/magazine/recharge/update_icon()
+	..()
+	icon_state = "oldrifle-[round(ammo_count(),4)]"
+
+
+/obj/item/ammo_casing/caseless/laser
+ 	name = "laser casing"
+ 	desc = "You shouldn't be seeing this."
+ 	caliber = "laser"
+ 	icon_state = "s-casing-live"
+ 	projectile_type = /obj/item/projectile/beam
+
+
+/obj/item/ammo_box/magazine/recharge/attack_self() //No popping out the "bullets"
+ 	return
+
+
+
+/obj/item/weapon/gun/projectile/automatic/laser
+	name = "laser rifle"
+	desc = "Though sometimes mocked for the relatively weak firepower of their energy weapons, the logistic miracle of rechargable ammunition has given Nanotrasen a decisive edge over many a foe."
+	icon_state = "oldrifle"
+	item_state = "arg"
+	mag_type = /obj/item/ammo_box/magazine/recharge
+	fire_delay = 2
+	can_suppress = 0
+	burst_size = 0
+	action_button_name = null
+
+/obj/item/weapon/gun/projectile/automatic/laser/process_chamber(eject_casing = 0, empty_chamber = 1)
+	..()
+
+
+/obj/item/weapon/gun/projectile/automatic/laser/update_icon()
+	..()
+	icon_state = "oldrifle[magazine ? "-[Ceiling(get_ammo(0)/4)*4]" : ""]"
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1480,6 +1480,7 @@
 #include "code\modules\projectiles\guns\projectile\automatic.dm"
 #include "code\modules\projectiles\guns\projectile\launchers.dm"
 #include "code\modules\projectiles\guns\projectile\pistol.dm"
+#include "code\modules\projectiles\guns\projectile\rechargable_magazine.dm"
 #include "code\modules\projectiles\guns\projectile\revolver.dm"
 #include "code\modules\projectiles\guns\projectile\saw.dm"
 #include "code\modules\projectiles\guns\projectile\shotgun.dm"


### PR DESCRIPTION
They use the old autorifle sprites that Ausops made, since they are nice and future looking and shouldn't be unused.

:cl: Kor
rscadd: Add laserguns with swappable, rechargeable magazines. They are adminspawn only.
/:cl:
