### PR TITLE
Adds a 1 second delay to initializing the MC.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -54,7 +54,7 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 
 	data_core = new /datum/datacore()
 
-	spawn(-1)
+	spawn(10)
 		Master.Setup()
 
 	process_teleport_locs()			//Sets up the wizard teleport locations


### PR DESCRIPTION
This is so clients can actually connect from world.reboot before the mc starts hogging the cpu, and mainly so i can actually see how long the minimap subsystem is taking to initialize without having to play "race against the mc"
