### PR TITLE
Removed atom movable Del() proc override

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -68,14 +68,6 @@
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
 	return 1
 
-/atom/movable/Del()
-	if(isnull(gc_destroyed) && loc)
-		testing("GC: -- [type] was deleted via del() rather than qdel() --")
-//	else if(isnull(gc_destroyed))
-//		testing("GC: [type] was deleted via GC without qdel()") //Not really a huge issue but from now on, please qdel()
-//	else
-//		testing("GC: [type] was deleted via GC with qdel()")
-	..()
 
 /atom/movable/Destroy()
 	. = ..()


### PR DESCRIPTION
It did nothing, and it's called on gc as well as del(), causing 2 proc call overheads as it gets called and then it calls ..()
