### PR TITLE
Mulebot buckle check improved

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -362,14 +362,12 @@ var/global/mulebot_count = 0
 	update_icon()
 
 /mob/living/simple_animal/bot/mulebot/proc/load_mob(mob/living/M)
-	if(M.buckled)
-		return 0
-	passenger = M
-	load = M
-	can_buckle = 1
-	buckle_mob(M)
-	can_buckle = 0
-	return 1
+	if(buckle_mob(M))
+		passenger = M
+		load = M
+		can_buckle = FALSE
+		return TRUE
+	return FALSE
 
 /mob/living/simple_animal/bot/mulebot/post_buckle_mob(mob/living/M)
 	if(M == buckled_mob) //post buckling

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -362,6 +362,7 @@ var/global/mulebot_count = 0
 	update_icon()
 
 /mob/living/simple_animal/bot/mulebot/proc/load_mob(mob/living/M)
+	can_buckle = TRUE
 	if(buckle_mob(M))
 		passenger = M
 		load = M


### PR DESCRIPTION
It makes sure you are buckled in before actually setting you as the loaded item/passenger
Fixes #14966
