### PR TITLE
Refactors Human Explosion Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -141,23 +141,7 @@
 			if (prob(50))
 				Paralyse(10)
 
-	var/update = 0
-	for(var/obj/item/organ/limb/temp in organs)
-		switch(temp.name)
-			if("head")
-				update |= temp.take_damage(b_loss * 0.2, f_loss * 0.2)
-			if("chest")
-				update |= temp.take_damage(b_loss * 0.4, f_loss * 0.4)
-			if("l_arm")
-				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
-			if("r_arm")
-				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
-			if("l_leg")
-				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
-			if("r_leg")
-				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
-	if(update)
-		update_damage_overlays(0)
+	take_overall_damage(b_loss,f_loss)
 
 	..()
 


### PR DESCRIPTION
re-upload of: https://github.com/tgstation/-tg-station/pull/14998
Didn't feel like sussing out what went wrong or fiddling with Git for any more than 5 minutes to resolve the issue when it's faster to just submit a new PR.

Refactors human explosion damage to use take_overall_damage (which applies damage to all valid external organs). Instead of having a snowflaked method of dealing damage.

This also has the added benefit that explosion damage will not decrease, should a limb be hypothetically missing (I know, not supported here...yet).

@tkdrg 
