### PR TITLE
Change spider ghost alert to an in chat one

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -202,13 +202,8 @@
 			S.poison_type = poison_type
 			S.faction = faction.Copy()
 			if(player_spiders)
-				var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [S.name]?", ROLE_ALIEN, null, ROLE_ALIEN, 50)
-				var/mob/dead/observer/theghost = null
-				if(candidates.len)
-					theghost = pick(candidates)
-					S.key = theghost.key
+				notify_ghosts("Spider [S.name] can be controlled", null, enter_link="<a href=?src=\ref[S];activate=1>(Click to play)</a>", source=S, attack_not_jump = 1)
 			qdel(src)
-
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -62,10 +62,10 @@
 	if(key)//Someone is in it
 		return
 	var/spider_ask = alert("Become a spider?", "Are you australian?", "Yes", "No")
-	if(spider_ask == "No" || gc_destroyed)
+	if(spider_ask == "No" || !src || !qdeleted(src))
 		return
 	if(key)
-		user << "Someone else took this spider"
+		user << "<span class='notice'>Someone else already took this spider.</span>"
 		return
 	key = user.key
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -48,6 +48,26 @@
 	gold_core_spawnable = 1
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 4
+    
+/mob/living/simple_animal/hostile/poison/giant_spider/Topic(href, href_list)
+	if(href_list["activate"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			humanize_spider(ghost)
+
+/mob/living/simple_animal/hostile/poison/giant_spider/attack_ghost(mob/user)
+	humanize_spider(user)
+
+/mob/living/simple_animal/hostile/poison/giant_spider/proc/humanize_spider(mob/user)
+	if(key)//Someone is in it
+		return
+	var/spider_ask = alert("Become a spider?", "Are you australian?", "Yes", "No")
+	if(spider_ask == "No" || gc_destroyed)
+		return
+	if(key)
+		user << "Someone else took this spider"
+		return
+	key = user.key
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -62,7 +62,7 @@
 	if(key)//Someone is in it
 		return
 	var/spider_ask = alert("Become a spider?", "Are you australian?", "Yes", "No")
-	if(spider_ask == "No" || !src || !qdeleted(src))
+	if(spider_ask == "No" || !src || qdeleted(src))
 		return
 	if(key)
 		user << "<span class='notice'>Someone else already took this spider.</span>"


### PR DESCRIPTION
This could actually benefit from a nice subystem to handle it (calling humanize_from_ghost) on the appropriate mob when the user clicks the chatlink or action button

The alerts appear only once per spider

You can click on any uncontrolled spider as a ghost and you will become that spider.

Fixes #14689

Image for scale
![Spiders with alerts and chat links](http://puu.sh/mNCxX/929af441f1.png)
