### PR TITLE
Fixes Super Obscure Spray Tan Bugs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -311,9 +311,9 @@
 							newcolor += ascii2text(ascii+31)	//letters B to F - translates to lowercase
 						else
 							break
-				N.dna.features["mcolor"] = newcolor
-				N.regenerate_icons()
-			N.update_body()
+				if(ReadHSV(newcolor)[3] >= ReadHSV("#7F7F7F")[3])
+					N.dna.features["mcolor"] = newcolor
+			N.regenerate_icons()
 
 
 
@@ -334,11 +334,9 @@
 			N.skin_tone = "orange"
 			N.hair_style = "Spiky"
 			N.hair_color = "000"
-			N.update_hair()
 		if(MUTCOLORS in N.dna.species.specflags) //Aliens with custom colors simply get turned orange
 			N.dna.features["mcolor"] = "f80"
-			N.regenerate_icons()
-		N.update_body()
+		N.regenerate_icons()
 		if(prob(7))
 			if(N.w_uniform)
 				M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes their arms."))


### PR DESCRIPTION
Spray tan chem was ineffective on humans because they didn't call the proper update_icon to change the base skin layer.
Races with colors could get to fullblack with careful use of spray tanning.

Fixes #14477 
