### PR TITLE
Adds Uplink Soap Clusterbang for 6TC

### DIFF
--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -120,3 +120,7 @@
 /obj/item/weapon/grenade/clusterbuster/spawner_spesscarp
 	name = "Invasion of the Space Carps"
 	payload = /obj/item/weapon/grenade/spawnergrenade/spesscarp
+
+/obj/item/weapon/grenade/clusterbuster/soap
+	name = "Slipocalypse"
+	payload = /obj/item/weapon/soap/syndie

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -123,4 +123,4 @@
 
 /obj/item/weapon/grenade/clusterbuster/soap
 	name = "Slipocalypse"
-	payload = /obj/item/weapon/soap/syndie
+	payload = /obj/item/weapon/grenade/spawnergrenade/syndiesoap

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -39,3 +39,7 @@
 	spawner_type = /mob/living/simple_animal/hostile/carp
 	deliveryamt = 5
 	origin_tech = "materials=3;magnets=4;syndicate=4"
+
+/obj/item/weapon/grenade/spawnergrenade/syndiesoap
+	name = "Mister Scrubby"
+	spawner_type = /obj/item/weapon/soap/syndie

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -633,6 +633,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/toy/carpplushie/dehy_carp
 	cost = 1
 
+/datum/uplink_item/stealthy_weapons/soap_clusterbang
+	name = "Slipocalypse Clusterbang"
+	desc = "A traditional clusterbang grenade with a payload consisting entirely of Syndicate soap. Useful in any scenario!"
+	item = /obj/item/weapon/grenade/clusterbuster/soap
+	cost = 2
+
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
 	desc = "A small, easily concealable device. It can be applied to an open airlock panel, booby-trapping it. \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -637,7 +637,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Slipocalypse Clusterbang"
 	desc = "A traditional clusterbang grenade with a payload consisting entirely of Syndicate soap. Useful in any scenario!"
 	item = /obj/item/weapon/grenade/clusterbuster/soap
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -637,7 +637,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Slipocalypse Clusterbang"
 	desc = "A traditional clusterbang grenade with a payload consisting entirely of Syndicate soap. Useful in any scenario!"
 	item = /obj/item/weapon/grenade/clusterbuster/soap
-	cost = 4
+	cost = 6
 
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"


### PR DESCRIPTION
Because why not?

Adds a 2tc traitor clusterbang which spawns Syndie soap.
2tc may be a bit cheap, but the delay between the priming of the clusterbang and the spawning of the soap  feels like it mostly makes up for the difference in cost between the soap and clusterbang. Also because throwing 10 soap clusterbangs is hilarious.

But I can very easily increase it to 3, 4, or even 5 tc if needed.

:cl:
rcsadd: Operatives within the Syndicate report rumors of a powerful new weapon - a soap clusterbang.
/:cl:
