### PR TITLE
Removes inhand slowdown from space suits

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -12,6 +12,7 @@
 #define NOBLUDGEON		4		// when an item has this it produces no "X has been hit by Y with Z" message in the default attackby()
 #define MASKINTERNALS	8		// mask allows internals
 #define HEAR 			16		// This flag is what recursive_hear_check() uses to determine wether to add an item to the hearer list or not.
+#define HANDSLOW        32		// If an item has this flag, it will slow you to carry it
 #define CONDUCT			64		// conducts electricity (metal etc.)
 #define ABSTRACT    	128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
 #define NODECONSTRUCT  	128		// For machines and structures that should not break into parts, eg, holodeck stuff

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -18,6 +18,7 @@
 	force = 200
 	armour_penetration = 100
 	anchored = TRUE
+	flags = HANDSLOW
 	var/team = WHITE_TEAM
 	var/reset_cooldown = 0
 	var/obj/effect/landmark/reset

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -884,9 +884,9 @@
 				. += H.shoes.slowdown
 			if(H.back)
 				. += H.back.slowdown
-			if(H.l_hand && H.l_hand.flags & HANDSLOW)
+			if(H.l_hand && (H.l_hand.flags & HANDSLOW))
 				. += H.l_hand.slowdown
-			if(H.r_hand && H.r_hand.flags & HANDSLOW)
+			if(H.r_hand && (H.r_hand.flags & HANDSLOW))
 				. += H.r_hand.slowdown
 
 			if((H.disabilities & FAT))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -884,9 +884,9 @@
 				. += H.shoes.slowdown
 			if(H.back)
 				. += H.back.slowdown
-			if(H.l_hand)
+			if(H.l_hand && H.l_hand.flags & HANDSLOW)
 				. += H.l_hand.slowdown
-			if(H.r_hand)
+			if(H.r_hand && H.r_hand.flags & HANDSLOW)
 				. += H.r_hand.slowdown
 
 			if((H.disabilities & FAT))


### PR DESCRIPTION
Makes inhand slowdown an object flag, so you can give it to whatever weapons you want without impacting space suits and the like

Don't know if this check is too intensive for every time a human steps though

Fixes https://github.com/tgstation/-tg-station/issues/14116
