### PR TITLE
Added passflags checking for A*

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -64,6 +64,8 @@
 
 #define isbot(A) (istype(A, /mob/living/simple_animal/bot))
 
+#define ismovableatom(A) (istype(A, /atom/movable))
+
 // ASSEMBLY HELPERS
 
 #define isassembly(O) (istype(O, /obj/item/device/assembly))

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -60,6 +60,11 @@
 		return 1
 	return 0
 
+/obj/effect/blob/CanAStarPass(ID, dir, caller)
+	. = 0
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSBLOB)
 
 /obj/effect/blob/proc/check_health(cause)
 	health = Clamp(health, 0, maxhealth)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -245,7 +245,6 @@
 	else
 		..()
 
-
 /obj/structure/girder/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0)
 		return 1
@@ -256,6 +255,12 @@
 			return prob(girderpasschance)
 		else
 			return 0
+
+/obj/structure/girder/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSGRILLE)
 
 /obj/structure/girder/blob_act()
 	if(prob(40))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -111,6 +111,12 @@
 		else
 			return !density
 
+/obj/structure/grille/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSGRILLE)
+
 /obj/structure/grille/bullet_act(var/obj/item/projectile/Proj)
 	if(!Proj)
 		return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -271,3 +271,9 @@ var/global/list/crematoriums = new/list()
 		return 1
 	else
 		return 0
+
+/obj/structure/tray/m_tray/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSTABLE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -99,6 +99,12 @@
 	else
 		return !density
 
+/obj/structure/table/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSTABLE)
+
 /obj/structure/table/MouseDrop_T(atom/movable/O, mob/user)
 	..()
 	if(ismob(O) && user == O && ishuman(user))
@@ -448,6 +454,12 @@
 		return 1
 	else
 		return 0
+
+/obj/structure/rack/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSTABLE)
 
 /obj/structure/rack/MouseDrop_T(obj/O, mob/user)
 	if ((!( istype(O, /obj/item/weapon) ) || user.get_active_hand() != O))

--- a/code/orphaned procs/AStar.dm
+++ b/code/orphaned procs/AStar.dm
@@ -159,7 +159,7 @@ Actual Adjacent procs :
 		T = get_step(src,dir)
 		if(simulated_only && !istype(T))
 			continue
-		if(!T.density && !LinkBlockedWithAccess(T,ID, caller))
+		if(!T.density && !LinkBlockedWithAccess(T,caller, ID))
 			L.Add(T)
 	return L
 
@@ -177,7 +177,7 @@ Actual Adjacent procs :
 				L.Add(T)
 	return L
 
-/turf/proc/LinkBlockedWithAccess(turf/T, ID, caller)
+/turf/proc/LinkBlockedWithAccess(turf/T, caller, ID)
 	var/adir = get_dir(src, T)
 	var/rdir = get_dir(T, src)
 


### PR DESCRIPTION
Fixes #15028.
I've let the `PASSGLASS` define alone to minimize the code scattering, given it's only used for beams.

Ideally `CanPass()` and `CanAstarPass()` should be fused, but that's another can of worms (`CanPass()` applies to movable atoms, `CanAstarPass()` to datums, `CanPass()` doesn't check ID Access, `CanAStarPass()` does, etc).
