### PR TITLE
Cyborgs are vulnerable to high temperatures

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -11,6 +11,15 @@
 	if(!stat)
 		use_power()
 
+/mob/living/silicon/robot/handle_environment(datum/gas_mixture/environment)
+	if(!environment)
+		return
+
+	//var/environment_heat_capacity = environment.heat_capacity()
+	var/loc_temp = get_temperature(environment)
+	if(loc_temp > 450)
+		adjustBruteLoss(4)
+
 /mob/living/silicon/robot/proc/clamp_values()
 	SetStunned(min(stunned, 30))
 	SetParalysis(min(paralysis, 30))


### PR DESCRIPTION
Actual damage, temperature threshold, etc, is nowhere near final (and need to be defines, obviously). I have no idea what good values would be. I figured this PR would result in arguing though so I may as well get that underway.

The issue as I see it: Plasma flooding is a 100% nobrainer for the AI, it's very difficult (and sometimes even bannable!) to counter, simultaneously fucks every room on the station, and the AI suffers 0 consequences for doing this 

The solution: Cyborgs are vulnerable to fire. This means an AI has to be careful with where its borgs are and where it is flooding, or it could potentially damage or destroy the cyborgs under its control, or heavily limit their movement.

Cyborgs would of course still be less vulnerable than humans since they cant get trapped in fire, don't catch on fire, and dont suffer slowdown.

Anyway thoughts/feelings etc
