### PR TITLE
You can now blow open secure storage containers 

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -69,10 +69,16 @@
 /obj/item/weapon/c4/afterattack(atom/movable/AM, mob/user, flag)
 	if (!flag)
 		return
-	if (ismob(AM) || istype(AM, /obj/item/weapon/storage/))
+	if (ismob(AM))
 		return
 	if(loc == AM)
 		return
+	if((istype(AM, /obj/item/weapon/storage/)) && (!istype(AM, /obj/item/weapon/storage/secure))) //secure storage is a special case handled below.
+		return
+	if(istype(AM,/obj/item/weapon/storage/secure))
+		var/obj/item/weapon/storage/secure/S = AM
+		if(!S.locked)
+			return
 
 	user << "<span class='notice'>You start planting the bomb...</span>"
 

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -73,11 +73,11 @@
 		return
 	if(loc == AM)
 		return
-	if((istype(AM, /obj/item/weapon/storage/)) && (!istype(AM, /obj/item/weapon/storage/secure))) //secure storage is a special case handled below.
+	if((istype(AM, /obj/item/weapon/storage/)) && !((istype(AM, /obj/item/weapon/storage/secure)) || (istype(AM, /obj/item/weapon/storage/lockbox)))) //If its storage but not secure storage OR a lockbox, then place it inside.
 		return
-	if(istype(AM,/obj/item/weapon/storage/secure))
+	if((istype(AM,/obj/item/weapon/storage/secure)) || (istype(AM, /obj/item/weapon/storage/lockbox)))
 		var/obj/item/weapon/storage/secure/S = AM
-		if(!S.locked)
+		if(!S.locked) //Literal hacks, this works for lockboxes despite incorrect type casting, because they both share the locked var. But if its unlocked, place it inside, otherwise PLANTING C4!
 			return
 
 	user << "<span class='notice'>You start planting the bomb...</span>"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -470,8 +470,8 @@
 
 
 /obj/item/weapon/storage/Destroy()
-	for(var/obj/O in contents)
-		O.mouse_opacity = initial(O.mouse_opacity)
+	var/turf = get_turf(src)
+	empty_object_contents(0, turf)
 
 	close_all()
 	qdel(boxes)


### PR DESCRIPTION
You can now blow open secure storage containers such as digital safes, locked briefcases, etc. using C4.

All storage items now drop their contents on deletion.

:cl: KazeEspada
C4 will now blow open locked containers.
/:cl:
