### PR TITLE
Three new malf objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -287,6 +287,46 @@
 	return 1
 
 
+/datum/objective/purge
+	explanation_text = "Ensure no mutant humanoid species are present aboard the escape shuttle."
+	dangerrating = 25
+	martyr_compatible = 1
+
+/datum/objective/purge/check_completion()
+	if(SSshuttle.emergency.mode < SHUTTLE_ENDGAME)
+		return 1
+
+	var/area/A = SSshuttle.emergency.areaInstance
+
+	for(var/mob/living/player in player_list)
+		if(get_area(player) == A && player.mind && player.stat != DEAD && istype(player, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = player
+			if(H.dna.species.id != "human")
+				return 0
+
+	return 1
+
+
+/datum/objective/robot_army
+	explanation_text = "Have at least eight active cyborgs synced to you."
+	dangerrating = 25
+	martyr_compatible = 0
+
+/datum/objective/robot_army/check_completion()
+	if(!istype(owner.current, /mob/living/silicon/ai))
+		return 0
+	var/mob/living/silicon/ai/A = owner.current
+
+	var/counter = 0
+
+	for(var/mob/living/silicon/robot/R in A.connected_robots)
+		if(R.stat != DEAD)
+			counter++
+
+	if(counter < 8)
+		return 0
+	return 1
+
 /datum/objective/escape
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
 	dangerrating = 5

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -88,7 +88,7 @@
 		var/objective_count = 0
 
 		if(prob(30))
-			var/special_pick = rand(1,3)
+			var/special_pick = rand(1,4)
 			switch(special_pick)
 				if(1)
 					var/datum/objective/block/block_objective = new
@@ -104,6 +104,17 @@
 					var/datum/objective/robot_army/robot_objective = new
 					robot_objective.owner = traitor
 					traitor.objectives += robot_objective
+					objective_count++
+				if(4) //Protect and strand a target
+					var/datum/objective/protect/yandere_one = new
+					yandere_one.owner = traitor
+					traitor.objectives += yandere_one
+					yandere_one.find_target()
+					objective_count++
+					var/datum/objective/maroon/yandere_two = new
+					yandere_two.owner = traitor
+					yandere_two.target = yandere_one.target
+					traitor.objectives += yandere_two
 					objective_count++
 
 		for(var/i = objective_count, i < config.traitor_objectives_amount, i++)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -87,11 +87,24 @@
 	if(istype(traitor.current, /mob/living/silicon))
 		var/objective_count = 0
 
-		if(prob(10))
-			var/datum/objective/block/block_objective = new
-			block_objective.owner = traitor
-			traitor.objectives += block_objective
-			objective_count++
+		if(prob(30))
+			var/special_pick = rand(1,3)
+			switch(special_pick)
+				if(1)
+					var/datum/objective/block/block_objective = new
+					block_objective.owner = traitor
+					traitor.objectives += block_objective
+					objective_count++
+				if(2)
+					var/datum/objective/purge/purge_objective = new
+					purge_objective.owner = traitor
+					traitor.objectives += purge_objective
+					objective_count++
+				if(3)
+					var/datum/objective/robot_army/robot_objective = new
+					robot_objective.owner = traitor
+					traitor.objectives += robot_objective
+					objective_count++
 
 		for(var/i = objective_count, i < config.traitor_objectives_amount, i++)
 			var/datum/objective/assassinate/kill_objective = new


### PR DESCRIPTION
:cl: Kor
rscadd: Malf AIs can now get the objective to have a robot army by the end of the round.
rscadd: Malf AIs can now get the objective to ensure only human crew (no mutants) are on the shuttle at round end.
rscadd: Malf AIs can now get the objective to prevent a crewmember from escaping the station, while requiring that crewmember still be alive.
/:cl:

First one is to ensure only humans (not lizards!) escape on the shuttle. 

Second is to have 8 active cyborgs synced to you at round end.

Third is protect a target+prevent them from escaping.

Increased the chance of malf AIs getting a special objective (no organics escape, no mutants escape, or have a robot army)

@Incoming5643 

A brief glance through your PR looked like you hadn't touched objectives yet but let me know if this interferes terribly and I will close it
