### PR TITLE
Improve player medbot

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -385,6 +385,11 @@
 	else
 		..()
 
+/mob/living/simple_animal/bot/medbot/examinate(atom/A as mob|obj|turf in view())
+	..()
+	if(!is_blind(src))
+		chemscan(src, A)
+
 /mob/living/simple_animal/bot/medbot/proc/medicate_patient(mob/living/carbon/C)
 	if(!on)
 		return


### PR DESCRIPTION
:cl:
rscadd: Player-controlled medibots can examine a patient to know what chems are in the patient's body.
/:cl:
