### PR TITLE
Correct extra hacked-item designs in autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -374,7 +374,7 @@
 	for(var/datum/design/D in files.possible_designs)
 		if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
 			if(hacked)
-				files.known_designs += D
+				files.known_designs |= D
 			else
 				files.known_designs -= D
 


### PR DESCRIPTION
:cl:
bugfix: autolathes have been showing extra copies of the hacked designs, but no more.
/:cl:

Fixes #15142
