### PR TITLE
Makes mech don't suck while destroying walls

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,8 @@
 					step(obstacle, dir)
 			else if(istype(obstacle, /mob))
 				step(obstacle, dir)
-
+	if(istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/rack))
+		obstacle.ex_act(2)
 
 
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,8 +551,6 @@
 					step(obstacle, dir)
 			else if(istype(obstacle, /mob))
 				step(obstacle, dir)
-	if(istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/rack))
-		obstacle.ex_act(2)
 
 
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -45,9 +45,17 @@
 
 /obj/structure/table/ex_act(severity, target)
 	..()
-	if(severity == 3)
-		if(prob(25))
-			table_destroy(1)
+	switch(severity)
+		if(1)
+			qdel(src)
+		if(2)
+			if(prob(50)
+				table_destroy(1)
+			else
+				qdel(src)
+		if(3)
+			if(prob(25))
+				table_destroy(1)
 
 /obj/structure/table/blob_act()
 	if(prob(75))
@@ -450,6 +458,10 @@
 	else if(prob(50))
 		rack_destroy()
 		return
+
+/obj/structure/rack/mech_melee_attack(/obj/mecha/M)
+	visible.message("<span class='danger'>[M.name] smashes [src] apart!</span>")
+	rack_destroy(1)
 
 /obj/structure/rack/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0) return 1

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -54,6 +54,11 @@
 		table_destroy(1)
 		return
 
+/obj/structure/table/mech_melee_attack(obj/mecha/M)
+	visible_message("<span class='danger'>[M.name] smashes [src] apart!</span>")
+	playsound(src.loc, 'sound/weapons/punch4.ogg.ogg', 50, 1)
+	table_destroy(1)
+
 /obj/structure/table/attack_alien(mob/living/user)
 	user.do_attack_animation(src)
 	playsound(src.loc, 'sound/weapons/bladeslice.ogg', 50, 1)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -44,7 +44,6 @@
 		smooth_icon_neighbors(src)
 
 /obj/structure/table/ex_act(severity, target)
-	..()
 	switch(severity)
 		if(1)
 			qdel(src)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -49,7 +49,7 @@
 		if(1)
 			qdel(src)
 		if(2)
-			if(prob(50)
+			if(prob(50))
 				table_destroy(1)
 			else
 				qdel(src)
@@ -459,8 +459,8 @@
 		rack_destroy()
 		return
 
-/obj/structure/rack/mech_melee_attack(/obj/mecha/M)
-	visible.message("<span class='danger'>[M.name] smashes [src] apart!</span>")
+/obj/structure/rack/mech_melee_attack(obj/mecha/M)
+	visible_message("<span class='danger'>[M.name] smashes [src] apart!</span>")
 	rack_destroy(1)
 
 /obj/structure/rack/CanPass(atom/movable/mover, turf/target, height=0)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -56,7 +56,7 @@
 
 /obj/structure/table/mech_melee_attack(obj/mecha/M)
 	visible_message("<span class='danger'>[M.name] smashes [src] apart!</span>")
-	playsound(src.loc, 'sound/weapons/punch4.ogg.ogg', 50, 1)
+	playsound(src.loc, 'sound/weapons/punch4.ogg', 50, 1)
 	table_destroy(1)
 
 /obj/structure/table/attack_alien(mob/living/user)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -91,7 +91,7 @@
 	if(M.damtype == "brute")
 		playsound(src, 'sound/weapons/punch4.ogg', 50, 1)
 		visible_message("<span class='danger'>[M.name] has hit [src]!</span>")
-		if(prob(5) && M.force > 20)
+		if(prob(hardness) && M.force > 20)
 			dismantle_wall(1)
 			visible_message("<span class='warning'>[src.name] smashes through the wall!</span>")
 			playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)


### PR DESCRIPTION
Fixes #15128
Also makes them destroy table in one hit. 
They now use the hardness var as a chance of destroying a wall, same chance as a hulk has to destroy. 
:cl: Lzimann
tweak: Combat Mechas now have a increased chance of destroying a wall with punches (40% for walls and 20% for reinforced walls)!
rscadd: Combat mechas can now destroy tables and racks with a punch!
/:cl:
