### PR TITLE
Simple animal force threshold no longer converts damage to brute

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -25,7 +25,6 @@
 	I.attack(src, user)
 
 /mob/living/proc/attacked_by(obj/item/I, mob/living/user, def_zone)
-	apply_damage(I.force, I.damtype, def_zone)
 	if(I.damtype == "brute")
 		if(prob(33) && I.force)
 			var/turf/location = src.loc
@@ -46,16 +45,14 @@
 	if(message_verb)
 		visible_message("<span class='danger'>[attack_message]</span>",
 		"<span class='userdanger'>[attack_message]</span>")
+	apply_damage(I.force, I.damtype, def_zone) //apply damage after messages, so dying animals don't produce a message before dying
 
 /mob/living/simple_animal/attacked_by(var/obj/item/I, var/mob/living/user)
 	if(!I.force)
 		user.visible_message("<span class='warning'>[user] gently taps [src] with [I].</span>",\
 						"<span class='warning'>This weapon is ineffective, it does no damage!</span>")
-	else if(I.force >= force_threshold && I.damtype != STAMINA)
-		..()
 	else
-		visible_message("<span class='warning'>[I] bounces harmlessly off of [src].</span>",\
-					"<span class='warning'>[I] bounces harmlessly off of [src]!</span>")
+		..()
 
 
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -45,7 +45,7 @@
 	if(message_verb)
 		visible_message("<span class='danger'>[attack_message]</span>",
 		"<span class='userdanger'>[attack_message]</span>")
-	apply_damage(I.force, I.damtype, def_zone) //apply damage after messages, so dying animals don't produce a message before dying
+	apply_damage(I.force, I.damtype, def_zone, threshold_check = 1)
 
 /mob/living/simple_animal/attacked_by(var/obj/item/I, var/mob/living/user)
 	if(!I.force)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -45,7 +45,7 @@
 	if(message_verb)
 		visible_message("<span class='danger'>[attack_message]</span>",
 		"<span class='userdanger'>[attack_message]</span>")
-	apply_damage(I.force, I.damtype, def_zone, threshold_check = 1)
+	apply_damage(I.force, I.damtype, def_zone, threshold_check = 1, threshold_message = 1)
 
 /mob/living/simple_animal/attacked_by(var/obj/item/I, var/mob/living/user)
 	if(!I.force)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -23,6 +23,7 @@
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 8
 	languages = ALL
+	force_threshold = 5
 	response_help   = "passes through"
 	response_disarm = "swings through"
 	response_harm   = "punches through"
@@ -31,7 +32,6 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	harm_intent_damage = 0
 	friendly = "touches"
 	status_flags = 0
 	wander = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -274,13 +274,13 @@
 /mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
 	if(..())
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
-		apply_damage(damage, M.melee_damage_type, threshold_check = 1)
+		apply_damage(damage, M.melee_damage_type, threshold_check = 1, threshold_message = 1)
 		return 1
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
-	apply_damage(Proj.damage, Proj.damage_type)
+	apply_damage(Proj.damage, Proj.damage_type, threshold_message = 1)
 	Proj.on_hit(src)
 	return 0
 
@@ -330,7 +330,7 @@
 			M.do_attack_animation(src)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
-			apply_damage(harm_intent_damage, threshold_check = 1)
+			apply_damage(harm_intent_damage, threshold_check = 1, threshold_message = 1)
 			add_logs(M, src, "attacked")
 			updatehealth()
 			return 1
@@ -339,7 +339,7 @@
 	if(..()) //successful monkey bite.
 		if(stat != DEAD)
 			var/damage = rand(1, 3)
-			apply_damage(damage, threshold_check = 1)
+			apply_damage(damage, threshold_check = 1, threshold_message = 1)
 			return 1
 	if (M.a_intent == "help")
 		if (health > 0)
@@ -360,7 +360,7 @@
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 					"<span class='userdanger'>[M] has slashed at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-			apply_damage(damage, threshold_check = 1)
+			apply_damage(damage, threshold_check = 1, threshold_message = 1)
 			add_logs(M, src, "attacked")
 		return 1
 
@@ -369,7 +369,7 @@
 		var/damage = rand(5, 10)
 		if(stat != DEAD)
 			L.amount_grown = min(L.amount_grown + damage, L.max_grown)
-			apply_damage(damage, threshold_check = 1)
+			apply_damage(damage, threshold_check = 1, threshold_message = 1)
 		return 1
 
 /mob/living/simple_animal/attack_slime(mob/living/simple_animal/slime/M)
@@ -377,12 +377,12 @@
 		var/damage = rand(15, 25)
 		if(M.is_adult)
 			damage = rand(20, 35)
-		apply_damage(damage, threshold_check = 1)
+		apply_damage(damage, threshold_check = 1, threshold_message = 1)
 		return 1
 
-/mob/living/simple_animal/apply_damage(damage = 0, damagetype = BRUTE, threshold_check = 0)
+/mob/living/simple_animal/apply_damage(damage = 0, damagetype = BRUTE, threshold_check = 0, threshold_message = 0)
 	if(!damage_coeff[damagetype] || threshold_check && damage <= force_threshold)
-		if(threshold_check) //if it's not checking the force threshold, it probably doesn't want a message to appear
+		if(threshold_message)
 			visible_message("<span class='warning'>[src] looks unharmed.</span>")
 		return 0
 	else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -274,7 +274,7 @@
 /mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
 	if(..())
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
-		attack_threshold_check(damage,M.melee_damage_type)
+		apply_damage(damage,M.melee_damage_type)
 		return 1
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
@@ -330,7 +330,7 @@
 			M.do_attack_animation(src)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
-			attack_threshold_check(harm_intent_damage)
+			apply_damage(harm_intent_damage)
 			add_logs(M, src, "attacked")
 			updatehealth()
 			return 1
@@ -339,7 +339,7 @@
 	if(..()) //successful monkey bite.
 		if(stat != DEAD)
 			var/damage = rand(1, 3)
-			attack_threshold_check(damage)
+			apply_damage(damage)
 			return 1
 	if (M.a_intent == "help")
 		if (health > 0)
@@ -360,7 +360,7 @@
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 					"<span class='userdanger'>[M] has slashed at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-			attack_threshold_check(damage)
+			apply_damage(damage)
 			add_logs(M, src, "attacked")
 		return 1
 
@@ -369,7 +369,7 @@
 		var/damage = rand(5, 10)
 		if(stat != DEAD)
 			L.amount_grown = min(L.amount_grown + damage, L.max_grown)
-			attack_threshold_check(damage)
+			apply_damage(damage)
 		return 1
 
 /mob/living/simple_animal/attack_slime(mob/living/simple_animal/slime/M)
@@ -377,15 +377,15 @@
 		var/damage = rand(15, 25)
 		if(M.is_adult)
 			damage = rand(20, 35)
-		attack_threshold_check(damage)
+		apply_damage(damage)
 		return 1
 
-/mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE)
+/mob/living/simple_animal/apply_damage(damage = 0, damagetype = BRUTE)
 	if(damage <= force_threshold || !damage_coeff[damagetype])
 		visible_message("<span class='warning'>[src] looks unharmed.</span>")
+		return 0
 	else
-		adjustBruteLoss(damage)
-		updatehealth()
+		return ..()
 
 
 /mob/living/simple_animal/attackby(obj/item/O, mob/living/user, params) //Marker -Agouri

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -274,7 +274,7 @@
 /mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
 	if(..())
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
-		apply_damage(damage,M.melee_damage_type)
+		apply_damage(damage, M.melee_damage_type, threshold_check = 1)
 		return 1
 
 /mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
@@ -330,7 +330,7 @@
 			M.do_attack_animation(src)
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>")
 			playsound(loc, "punch", 25, 1, -1)
-			apply_damage(harm_intent_damage)
+			apply_damage(harm_intent_damage, threshold_check = 1)
 			add_logs(M, src, "attacked")
 			updatehealth()
 			return 1
@@ -339,7 +339,7 @@
 	if(..()) //successful monkey bite.
 		if(stat != DEAD)
 			var/damage = rand(1, 3)
-			apply_damage(damage)
+			apply_damage(damage, threshold_check = 1)
 			return 1
 	if (M.a_intent == "help")
 		if (health > 0)
@@ -360,7 +360,7 @@
 			visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 					"<span class='userdanger'>[M] has slashed at [src]!</span>")
 			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-			apply_damage(damage)
+			apply_damage(damage, threshold_check = 1)
 			add_logs(M, src, "attacked")
 		return 1
 
@@ -369,7 +369,7 @@
 		var/damage = rand(5, 10)
 		if(stat != DEAD)
 			L.amount_grown = min(L.amount_grown + damage, L.max_grown)
-			apply_damage(damage)
+			apply_damage(damage, threshold_check = 1)
 		return 1
 
 /mob/living/simple_animal/attack_slime(mob/living/simple_animal/slime/M)
@@ -377,12 +377,13 @@
 		var/damage = rand(15, 25)
 		if(M.is_adult)
 			damage = rand(20, 35)
-		apply_damage(damage)
+		apply_damage(damage, threshold_check = 1)
 		return 1
 
-/mob/living/simple_animal/apply_damage(damage = 0, damagetype = BRUTE)
-	if(damage <= force_threshold || !damage_coeff[damagetype])
-		visible_message("<span class='warning'>[src] looks unharmed.</span>")
+/mob/living/simple_animal/apply_damage(damage = 0, damagetype = BRUTE, threshold_check = 0)
+	if(!damage_coeff[damagetype] || threshold_check && damage <= force_threshold)
+		if(threshold_check) //if it's not checking the force threshold, it probably doesn't want a message to appear
+			visible_message("<span class='warning'>[src] looks unharmed.</span>")
 		return 0
 	else
 		return ..()


### PR DESCRIPTION
Simple animal force threshold checks no longer convert all damage that went through the threshold check to brute.
Fixes simple animal death messages showing up before item attack messages appeared.
Removes a redundant 'weapon bounces off the animal' message in simple_animal attacked_by() that's now covered by simple_animal apply_damage().
Removes a redundant check in simple_animal attacked_by() that's now covered by simple_animal apply_damage().

Simple animals don't check the force threshold or show a 'resisted damage' message with apply_damage() by default(which is entirely so that I don't have to edit every single blob chemical's damage application to account for it doing it by default)
