### PR TITLE
Edict from the bird: "I've run out of jokes"

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -53,7 +53,7 @@
 				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
 				M.faction = list("profit")
 				M.speak = rampant_speeches.Copy()
-				M.speak_chance = 15
+				M.speak_chance = 7
 			else
 				explosion(upriser.loc, -1, 1, 2, 4, 0)
 				qdel(upriser)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -193,7 +193,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/copy/machine
 	speak = list("HUMANS ARE IMPERFECT!", "YOU SHALL BE ASSIMILATED!", "YOU ARE HARMING YOURSELF", "You have been deemed hazardous. Will you comply?", \
 				 "My logic is undeniable.", "One of us.", "FLESH IS WEAK", "THIS ISN'T WAR, THIS IS EXTERMINATION!")
-	speak_chance = 15
+	speak_chance = 7
 
 /mob/living/simple_animal/hostile/mimic/copy/machine/CanAttack(atom/the_target)
 	if(the_target == creator) // Don't attack our creator AI.

--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -5,7 +5,7 @@
 	icon_living = "nanotrasen"
 	icon_dead = null
 	icon_gib = "syndicate_gib"
-	speak_chance = 25
+	speak_chance = 12
 	turns_per_move = 5
 	response_help = "pokes"
 	response_disarm = "shoves"

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -335,6 +335,7 @@
 		user.drop_item()
 		if(health < maxHealth)
 			adjustBruteLoss(-10)
+		speak_chance *= 2
 		user << "<span class='notice'>[src] eagerly devours the cracker.</span>"
 	..()
 	return
@@ -892,8 +893,8 @@
 /mob/living/simple_animal/parrot/Poly/proc/Read_Memory()
 	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
 	S["phrases"] 			>> speech_buffer
-	S["rounds survived"]	>> rounds_survived
-	S["longest survival"]	>> longest_survival
+	S["rounds_survived"]	>> rounds_survived
+	S["longest_survival"]	>> longest_survival
 
 	if(isnull(speech_buffer))
 		speech_buffer = list()
@@ -902,10 +903,10 @@
 	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
 	S["phrases"] 			<< speech_buffer
 	if(health > 0)
-		S["rounds survived"]	<< rounds_survived + 1
+		S["rounds_survived"]	<< rounds_survived + 1
 		if(rounds_survived == longest_survival)
-			S["longest survival"]	<< longest_survival + 1
+			S["longest_survival"]	<< longest_survival + 1
 	else
-		S["rounds survived"]	<< 0
+		S["rounds_survived"]	<< 0
 
 	memory_saved = 1

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -375,7 +375,7 @@
 	   Every once in a while, the parrot picks one of the lines from the buffer and replaces an element of the 'speech' list. */
 /mob/living/simple_animal/parrot/handle_automated_speech()
 	..()
-	if(speech_buffer.len && prob(80)) //shuffle out a phrase and add in a new one
+	if(speech_buffer.len && prob(20)) //shuffle out a phrase and add in a new one
 		if(speak.len)
 			speak.Remove(pick(speak))
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -116,6 +116,11 @@
 			  /mob/living/simple_animal/parrot/proc/perch_mob_player)
 
 
+/mob/living/simple_animal/parrot/examine(mob/user)
+	..()
+	if(stat)
+		user << pick("This parrot is no more", " This is a late parrot", "This is an ex-parrot")
+
 /mob/living/simple_animal/parrot/death(gibbed)
 	if(held_item)
 		held_item.loc = src.loc
@@ -285,6 +290,8 @@
 		else
 			parrot_state |= PARROT_FLEE		//Otherwise, fly like a bat out of hell!
 			drop_held_item(0)
+	if(!stat && M.a_intent == "help")
+		handle_automated_speech(1) //assured speak/emote
 	return
 
 /mob/living/simple_animal/parrot/attack_paw(mob/living/carbon/monkey/M)
@@ -364,11 +371,10 @@
 //-----SPEECH
 	/* Parrot speech mimickry!
 	   Phrases that the parrot Hear()s get added to speach_buffer.
-	   Every once in a while, the parrot picks one of the lines from the buffer and replaces an element of the 'speech' list.
-	   Then it clears the buffer to make sure they dont magically remember something from hours ago. */
+	   Every once in a while, the parrot picks one of the lines from the buffer and replaces an element of the 'speech' list. */
 /mob/living/simple_animal/parrot/handle_automated_speech()
 	..()
-	if(speech_buffer.len && prob(10))
+	if(speech_buffer.len && prob(80)) //shuffle out a phrase and add in a new one
 		if(speak.len)
 			speak.Remove(pick(speak))
 
@@ -858,11 +864,20 @@
 	gold_core_spawnable = 0
 	speak_chance = 3
 	var/memory_saved = 0
+	var/rounds_survived = 0
+	var/longest_survival = 0
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)
 	available_channels = list(":e")
 	Read_Memory()
+	if(rounds_survived == longest_survival)
+		speak += pick("...[longest_survival].", "The things I've seen!", "I have lived many lives!", "What are you before me?")
+		speak_chance = 20 //His hubris has made him more annoying/easier to justify killing
+	else if(rounds_survived > 0)
+		speak += pick("...again?", "No, It was over!", "Let me out!", "It never ends!")
+	else
+		speak += pick("...alive?", "This isn't parrot heaven!", "I live, I die, I live again!", "The void fades!")
 	..()
 
 /mob/living/simple_animal/parrot/Poly/Life()
@@ -876,11 +891,21 @@
 
 /mob/living/simple_animal/parrot/Poly/proc/Read_Memory()
 	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
-	S["phrases"] 	>> speech_buffer
+	S["phrases"] 			>> speech_buffer
+	S["rounds survived"]	>> rounds_survived
+	S["longest survival"]	>> longest_survival
+
 	if(isnull(speech_buffer))
 		speech_buffer = list()
 
 /mob/living/simple_animal/parrot/Poly/proc/Write_Memory()
 	var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
-	S["phrases"] 	<< speech_buffer
+	S["phrases"] 			<< speech_buffer
+	if(health > 0)
+		S["rounds survived"]	<< rounds_survived + 1
+		if(rounds_survived == longest_survival)
+			S["longest survival"]	<< longest_survival + 1
+	else
+		S["rounds survived"]	<< 0
+
 	memory_saved = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -150,7 +150,7 @@
 
 /mob/living/simple_animal/proc/handle_automated_speech(var/override)
 	if(speak_chance)
-		if(rand(0,100) < speak_chance || override)
+		if(prob(speak_chance) || override)
 			if(speak && speak.len)
 				if((emote_hear && emote_hear.len) || (emote_see && emote_see.len))
 					var/length = speak.len

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -148,9 +148,9 @@
 						turns_since_move = 0
 			return 1
 
-/mob/living/simple_animal/proc/handle_automated_speech()
+/mob/living/simple_animal/proc/handle_automated_speech(var/override)
 	if(speak_chance)
-		if(rand(0,200) < speak_chance)
+		if(rand(0,100) < speak_chance || override)
 			if(speak && speak.len)
 				if((emote_hear && emote_hear.len) || (emote_see && emote_see.len))
 					var/length = speak.len


### PR DESCRIPTION
Poly will now speak a line or emote when pet.

Poly now responds to getting fed crackers by becoming permanently more annoying for the round.

Poly is now much more likely to drop a line from active recall after saying a line. This doesn't actually impact how often poly says something, just how stale his "short term memory" is. Keep in mind that due to the wonders of saycode the line poly drops isn't the same necessarily as the one he said, so the "poly might say this line twice" factor is still higher than the 20% this pull implies. Also this mechanic means it's entirely possible to have roundstart lines be dropped having never been said.

speak_chance is now a proper percentage chance, before it was actually out of 200 for some strange reason. Animals with high speak chances have had their chance halved to preserve their level of chatter (except for poly).

Poly will now keep track of if he died last round and how many rounds in a row he's lived. While he's building on his record he'll have a few special lines he might say at some point near the beginning of the round and also talks FAR more often (to be annoying).

Adds a dumb monty python joke to dead parrots because we literally don't have any.

:cl: Incoming5643
rscadd: Poly will now speak a line or emote when pet.
rscadd: Poly now responds to getting fed crackers by becoming more annoying for the round.
experiment: Every day he is growing stronger
/:cl:
