### PR TITLE
Anomalies now appear on the POI list.

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -13,6 +13,8 @@
 	var/obj/item/device/assembly/signaler/anomaly/aSignal = null
 
 /obj/effect/anomaly/New()
+	..()
+	poi_list |= src
 	SetLuminosity(initial(luminosity))
 	aSignal = new(src)
 	aSignal.code = rand(1,100)
@@ -21,6 +23,9 @@
 	if(IsMultiple(aSignal.frequency, 2))//signaller frequencies are always uneven!
 		aSignal.frequency++
 
+/obj/effect/anomaly/Destroy()
+	poi_list.Remove(src)
+	return ..()
 
 /obj/effect/anomaly/proc/anomalyEffect()
 	if(prob(movechance))


### PR DESCRIPTION
:cl: Joan
rscadd: Anomalies, such as pyroclastic and vortex anomalies, now appear at the bottom of the ghost orbit and observe menus.
/:cl:
