### PR TITLE
Doomsday and Self-Destruct now change ALL the blue circuit tiles!

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -8,6 +8,7 @@ var/global/list/navbeacons = list()					//list of all bot nagivation beacons, us
 var/global/list/deliverybeacons = list()			//list of all MULEbot delivery beacons.
 var/global/list/deliverybeacontags = list()			//list of all tags associated with delivery beacons.
 var/global/list/nuke_list = list()
+var/global/list/nuke_tiles = list()					//list of all turfs that turn to animated red grids when a nuke is triggered
 
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 var/global/list/chemical_reagents_list				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -33,7 +33,7 @@
 
 	for(var/N in nuke_tiles)
 		var/turf/T = N
-		T.icon_state = "rcircuitanim" //Causes blue tiles on the map the AI to change to flashing red
+		T.icon_state = "rcircuitanim" //This causes all blue "circuit" tiles on the map to change to animated red icon state.
 
 	src << "<span class='notice'>Nuclear device armed.</span>"
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -31,8 +31,9 @@
 	set category = "Malfunction"
 	set name = "Doomsday Device"
 
-	for(var/turf/simulated/floor/bluegrid/T in orange(5, src))
-		T.icon_state = "rcircuitanim" //Causes blue tiles near the AI to change to flashing red
+	for(var/N in nuke_tiles)
+		var/turf/T = N
+		T.icon_state = "rcircuitanim" //Causes blue tiles on the map the AI to change to flashing red
 
 	src << "<span class='notice'>Nuclear device armed.</span>"
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", 'sound/AI/aimalf.ogg')

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -391,13 +391,18 @@ This is here to make the tiles around the station mininuke change when it's arme
 
 /obj/machinery/nuclearbomb/selfdestruct/proc/SetTurfs()
 	if(loc == initial(loc))
-		for(var/turf/simulated/floor/bluegrid/T in orange(src, 1))
+		for(var/N in nuke_tiles)
+			var/turf/T = N
 			T.icon_state = (timing ? "rcircuitanim" : "bcircuit")
 
 /obj/machinery/nuclearbomb/selfdestruct/set_anchor()
 	return
 
 /obj/machinery/nuclearbomb/selfdestruct/set_active()
+	..()
+	SetTurfs()
+
+/obj/machinery/nuclearbomb/selfdestruct/set_safety()
 	..()
 	SetTurfs()
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -392,8 +392,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/machinery/nuclearbomb/selfdestruct/proc/SetTurfs()
 	if(loc == initial(loc))
 		for(var/N in nuke_tiles)
-			var/turf/T = N
-			T.icon_state = (timing ? "rcircuitanim" : initial(T.icon_state))
+			var/turf/simulated/floor/T = N
+			T.icon_state = (timing ? "rcircuitanim" : T.icon_regular_floor)
 
 /obj/machinery/nuclearbomb/selfdestruct/set_anchor()
 	return

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -393,7 +393,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	if(loc == initial(loc))
 		for(var/N in nuke_tiles)
 			var/turf/T = N
-			T.icon_state = (timing ? "rcircuitanim" : "bcircuit")
+			T.icon_state = (timing ? "rcircuitanim" : initial(T.icon_state))
 
 /obj/machinery/nuclearbomb/selfdestruct/set_anchor()
 	return

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -13,6 +13,14 @@
 	icon_state = "bcircuit"
 	floor_tile = /obj/item/stack/tile/plasteel
 
+/turf/simulated/floor/bluegrid/New()
+	..()
+	nuke_tiles += src
+
+/turf/simulated/floor/bluegrid/Destroy()
+	nuke_tiles -= src
+	return ..()
+
 /turf/simulated/floor/greengrid
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "gcircuit"


### PR DESCRIPTION
- AI's Doomsday Device and Stations' self-destruct now turn **all** blue
  circuit tiles to animated red when activated.
- Fixed a bug where cancelling the self-destruct via the "Safety" button
  did not change the tiles back to normal.
