### PR TITLE
CTF machines produce a handy ghost shortcut

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -112,6 +112,11 @@
 	poi_list.Remove(src)
 	..()
 
+/obj/machinery/capture_the_flag/process()
+	if(ctf_enabled)
+		notify_ghosts(null, null, null, src, null, 1)
+
+
 /obj/machinery/capture_the_flag/red
 	name = "Red CTF Controller"
 	icon_state = "syndbeacon"


### PR DESCRIPTION
Only oddness is that it kind of flickers/jumps a bit as it replaces itself.

> why do it on process?

If I just did it when enabled, people who died after the game started  wouldn't know it was going.
