### PR TITLE
Alt clicking on doors sends the AI a request link to open it

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1153,6 +1153,6 @@ var/list/airlock_overlays = list()
 	for(var/mob/living/silicon/ai/AI in living_mob_list)
 		if(!AI.client)
 			continue
-		AI << "<span class='info'>[user] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>"
+		AI << "<span class='info'>[user.name] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>"
 	request_cooldown = world.time + 100
 	user << "<span class='info'>Request sent.</span>"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -65,6 +65,8 @@ var/list/airlock_overlays = list()
 	var/image/old_weld_overlay
 	var/image/old_sparks_overlay
 
+	var/request_cooldown = 0 //To prevent spamming requests for the AI to open
+
 	explosion_block = 1
 
 /obj/machinery/door/airlock/New()
@@ -1129,3 +1131,28 @@ var/list/airlock_overlays = list()
 		locked = 1
 		loseMainPower()
 		loseBackupPower()
+
+
+/obj/machinery/door/airlock/AltClick(mob/living/user)
+	if(!istype(user))
+		user << "<span class='info'>Nice try, ghosts.</span>"
+		return
+
+	if (!user.canUseTopic(src))
+		user << "<span class='info'>You can't do this right now!</span>"
+		return
+
+	if(stat & (NOPOWER|BROKEN) || emagged)
+		user << "<span class='info'>The door isn't working!</span>"
+		return
+
+	if(request_cooldown > world.time)
+		user << "<span class='info'>The airlocks spam filter is blocking your request. Please wait at least 10 seconds between requests.</span>"
+		return
+
+	for(var/mob/living/silicon/ai/AI in living_mob_list)
+		if(!AI.client)
+			continue
+		AI << "<span class='info'>[user] is requesting you to open [src]<a href='?src=\ref[AI];remotedoor=\ref[src]'>(Open)</a></span>"
+	request_cooldown = world.time + 100
+	user << "<span class='info'>Request sent.</span>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -418,6 +418,17 @@ var/list/ai_list = list()
 				H.attack_ai(src) //may as well recycle
 			else
 				src << "<span class='notice'>Unable to locate the holopad.</span>"
+		return
+
+	if(href_list["remotedoor"])
+		var/obj/machinery/door/airlock/A = locate(href_list["remotedoor"])
+		if(stat == CONSCIOUS)
+			if(A && near_camera(A))
+				A.AIShiftClick(src)
+				src << "<span class='notice'>[A] opened.</span>"
+			else
+				src << "<span class='notice'>Unable to locate airlock. It may be out of camera range.</span>"
+
 	if(href_list["track"])
 		var/string = href_list["track"]
 		trackable_mobs()


### PR DESCRIPTION
:cl: Kor
rscadd: Alt+clicking on an airlock will now send a request to the AI to open it. The door must be on camera for this to work.
/:cl:

Alt+click on a door will send the AI a notice with the doors name, and the name (not real name, so disguises will work here) of the person requesting the door. Clicking the link will open the door.

There is a 10 second cooldown on each door to stop request spam.

The door must be near cameras, or the AI can not open it.

Reasoning: AI DOOR followed by using your camera to track them is awful with the artificial lag we added to finding them, but I don't want to buff the AI by removing that entirely when its responding to HUNT DOWN THIS CRIMINAL.

I dont even like the AI very much but AI DOOR is not a very interesting or important part of gameplay, it should be streamlined.
