### PR TITLE
[ready]Speed up process_cell() by caching atmos_adjacent_turfs as a list of nearby turfs and not a bitflag so we can avoid doing a bunch of turf lookups 4 times for each turf in atmos

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -124,8 +124,10 @@ var/datum/subsystem/air/SSair
 
 
 /datum/subsystem/air/proc/process_active_turfs()
+	//cache for sanic speed
+	var/fire_count = times_fired
 	for(var/turf/simulated/T in active_turfs)
-		T.process_cell()
+		T.process_cell(fire_count)
 
 
 /datum/subsystem/air/proc/remove_from_active(turf/simulated/T)
@@ -143,12 +145,8 @@ var/datum/subsystem/air/SSair
 		if(blockchanges && T.excited_group)
 			T.excited_group.garbage_collect()
 	else
-		for(var/direction in cardinal)
-			if(!(T.atmos_adjacent_turfs & direction))
-				continue
-			var/turf/simulated/S = get_step(T, direction)
-			if(istype(S))
-				add_to_active(S)
+		for(var/turf/simulated/S in T.atmos_adjacent_turfs)
+			add_to_active(S)
 
 /datum/subsystem/air/proc/process_excited_groups()
 	for(var/datum/excited_group/EG in excited_groups)
@@ -180,11 +178,8 @@ var/datum/subsystem/air/SSair
 
 		T.update_visuals()
 
-		for(var/direction in cardinal)
-			if(!(T.atmos_adjacent_turfs & direction))
-				continue
-
-			var/turf/enemy_tile = get_step(T, direction)
+		for(var/tile in T.atmos_adjacent_turfs)
+			var/turf/enemy_tile = tile
 			var/datum/gas_mixture/enemy_air = enemy_tile.return_air()
 
 			var/is_active = T.air.compare(enemy_air)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -36,11 +36,8 @@
 
 /turf/Destroy()
 	// Adds the adjacent turfs to the current atmos processing
-	for(var/direction in cardinal)
-		if(atmos_adjacent_turfs & direction)
-			var/turf/simulated/T = get_step(src, direction)
-			if(istype(T))
-				SSair.add_to_active(T)
+	for(var/turf/simulated/T in atmos_adjacent_turfs)
+		SSair.add_to_active(T)
 	..()
 	return QDEL_HINT_HARDDEL_NOW
 

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -126,11 +126,8 @@
 		//Possible spread due to radiated heat
 		if(location.air.temperature > FIRE_MINIMUM_TEMPERATURE_TO_SPREAD)
 			var/radiated_temperature = location.air.temperature*FIRE_SPREAD_RADIOSITY_SCALE
-			for(var/direction in cardinal)
-				if(!(location.atmos_adjacent_turfs & direction))
-					continue
-				var/turf/simulated/T = get_step(src, direction)
-				if(istype(T) && T.active_hotspot)
+			for(var/turf/simulated/T in location.atmos_adjacent_turfs)
+				if(T.active_hotspot)
 					T.hotspot_expose(radiated_temperature, CELL_VOLUME/4)
 
 	else

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -62,21 +62,15 @@
 	return 0
 
 /turf/proc/CalculateAdjacentTurfs()
-	atmos_adjacent_turfs_amount = 0
 	for(var/direction in cardinal)
 		var/turf/T = get_step(src, direction)
 		if(!istype(T))
 			continue
 		if(CanAtmosPass(T))
-			atmos_adjacent_turfs_amount += 1
 			atmos_adjacent_turfs |= T
-			if(!(src in T.atmos_adjacent_turfs))
-				T.atmos_adjacent_turfs_amount += 1
 			T.atmos_adjacent_turfs |= src
 		else
 			atmos_adjacent_turfs -= T
-			if(src in T.atmos_adjacent_turfs)
-				T.atmos_adjacent_turfs_amount -= 1
 			T.atmos_adjacent_turfs -= src
 
 //returns a list of adjacent turfs that can share air with this one.

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -67,18 +67,17 @@
 		var/turf/T = get_step(src, direction)
 		if(!istype(T))
 			continue
-		var/counterdir = get_dir(T, src)
 		if(CanAtmosPass(T))
 			atmos_adjacent_turfs_amount += 1
-			atmos_adjacent_turfs |= direction
-			if(!(T.atmos_adjacent_turfs & counterdir))
+			atmos_adjacent_turfs |= T
+			if(!(src in T.atmos_adjacent_turfs))
 				T.atmos_adjacent_turfs_amount += 1
-			T.atmos_adjacent_turfs |= counterdir
+			T.atmos_adjacent_turfs |= src
 		else
-			atmos_adjacent_turfs &= ~direction
-			if(T.atmos_adjacent_turfs & counterdir)
+			atmos_adjacent_turfs -= T
+			if(src in T.atmos_adjacent_turfs)
 				T.atmos_adjacent_turfs_amount -= 1
-			T.atmos_adjacent_turfs &= ~counterdir
+			T.atmos_adjacent_turfs -= src
 
 //returns a list of adjacent turfs that can share air with this one.
 //alldir includes adjacent diagonal tiles that can share
@@ -86,28 +85,20 @@
 /turf/proc/GetAtmosAdjacentTurfs(alldir = 0)
 	if (!istype(src, /turf/simulated))
 		return list()
-
-	var/adjacent_turfs = list()
-
-	var/turf/simulated/curloc = src
-	for (var/direction in cardinal)
-		if(!(curloc.atmos_adjacent_turfs & direction))
-			continue
-
-		var/turf/simulated/S = get_step(curloc, direction)
-		if (istype(S))
-			adjacent_turfs += S
+	
+	var/adjacent_turfs = atmos_adjacent_turfs.Copy()
 	if (!alldir)
-		return adjacent_turfs
+		return adjacent_turfs()
+	var/turf/simulated/curloc = src
 
 	for (var/direction in diagonals)
 		var/matchingDirections = 0
 		var/turf/simulated/S = get_step(curloc, direction)
 
 		for (var/checkDirection in cardinal)
-			if(!(S.atmos_adjacent_turfs & checkDirection))
-				continue
 			var/turf/simulated/checkTurf = get_step(S, checkDirection)
+			if(!(checkTurf in S.atmos_adjacent_turfs))
+				continue
 
 			if (checkTurf in adjacent_turfs)
 				matchingDirections++

--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -88,7 +88,7 @@
 	
 	var/adjacent_turfs = atmos_adjacent_turfs.Copy()
 	if (!alldir)
-		return adjacent_turfs()
+		return adjacent_turfs
 	var/turf/simulated/curloc = src
 
 	for (var/direction in diagonals)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -3,7 +3,7 @@
 /turf
 	var/pressure_difference = 0
 	var/pressure_direction = 0
-	var/atmos_adjacent_turfs = list()
+	var/list/atmos_adjacent_turfs = list()
 	var/atmos_adjacent_turfs_amount = 0
 	var/atmos_supeconductivity = 0
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -4,7 +4,6 @@
 	var/pressure_difference = 0
 	var/pressure_direction = 0
 	var/list/atmos_adjacent_turfs = list()
-	var/atmos_adjacent_turfs_amount = 0
 	var/atmos_supeconductivity = 0
 
 /turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
@@ -124,69 +123,82 @@
 
 
 
-/turf/simulated/proc/process_cell()
+/turf/simulated/proc/process_cell(fire_count)
 
-	if(archived_cycle < SSair.times_fired) //archive self if not already done
+	if(archived_cycle < fire_count) //archive self if not already done
 		archive()
-	current_cycle = SSair.times_fired
 
+	current_cycle = fire_count
 	var/remove = 1 //set by non simulated turfs who are sharing with this turf
 
-	for(var/t in atmos_adjacent_turfs)
+	//cache for sanic speed
+	var/list/adjacent_turfs = atmos_adjacent_turfs
+	var/datum/excited_group/our_excited_group = excited_group
+	var/adjacent_turfs_length = adjacent_turfs.len
+
+	for(var/t in adjacent_turfs)
 		var/turf/enemy_tile = t
 
 		if(istype(enemy_tile,/turf/simulated))
 			var/turf/simulated/enemy_simulated = enemy_tile
 
-			if(current_cycle > enemy_simulated.current_cycle)
+			if(fire_count > enemy_simulated.current_cycle)
 				enemy_simulated.archive()
 
 		/******************* GROUP HANDLING START *****************************************************************/
 
 			if(enemy_simulated.excited)
-				if(excited_group)
-					if(enemy_simulated.excited_group)
-						if(excited_group != enemy_simulated.excited_group)
-							excited_group.merge_groups(enemy_simulated.excited_group) //combine groups
-						share_air(enemy_simulated) //share
+				//cache for sanic speed
+				var/datum/excited_group/enemy_excited_group = enemy_simulated.excited_group
+				if(our_excited_group)
+					if(enemy_excited_group)
+						if(our_excited_group != enemy_excited_group)
+							//combine groups (this also handles updating the excited_group var of all involved turfs)
+							our_excited_group.merge_groups(enemy_excited_group)
+							our_excited_group = excited_group //update our cache
+						share_air(enemy_simulated, fire_count, adjacent_turfs_length) //share
 					else
 						if((recently_active == 1 && enemy_simulated.recently_active == 1) || air.compare(enemy_simulated.air))
-							excited_group.add_turf(enemy_simulated) //add enemy to our group
-							share_air(enemy_simulated) //share
+							our_excited_group.add_turf(enemy_simulated) //add enemy to our group
+							share_air(enemy_simulated, fire_count, adjacent_turfs_length) //share
 				else
-					if(enemy_simulated.excited_group)
+					if(enemy_excited_group)
 						if((recently_active == 1 && enemy_simulated.recently_active == 1) || air.compare(enemy_simulated.air))
-							enemy_simulated.excited_group.add_turf(src) //join self to enemy group
-							share_air(enemy_simulated) //share
+							enemy_excited_group.add_turf(src) //join self to enemy group
+							our_excited_group = excited_group //update our cache
+							share_air(enemy_simulated, fire_count, adjacent_turfs_length) //share
 					else
 						if((recently_active == 1 && enemy_simulated.recently_active == 1) || air.compare(enemy_simulated.air))
 							var/datum/excited_group/EG = new //generate new group
 							EG.add_turf(src)
 							EG.add_turf(enemy_simulated)
-							share_air(enemy_simulated) //share
+							our_excited_group = excited_group //update our cache
+							share_air(enemy_simulated, fire_count, adjacent_turfs_length) //share
 			else
 				if(air.compare(enemy_simulated.air)) //compare if
 					SSair.add_to_active(enemy_simulated) //excite enemy
-					if(excited_group)
+					if(our_excited_group)
 						excited_group.add_turf(enemy_simulated) //add enemy to group
 					else
 						var/datum/excited_group/EG = new //generate new group
 						EG.add_turf(src)
 						EG.add_turf(enemy_simulated)
-					share_air(enemy_simulated) //share
+						our_excited_group = excited_group //update our cache
+					share_air(enemy_simulated, fire_count, adjacent_turfs_length) //share
 
 		/******************* GROUP HANDLING FINISH *********************************************************************/
 
 		else
-			if(air.check_turf(enemy_tile, atmos_adjacent_turfs_amount))
-				var/difference = air.mimic(enemy_tile,atmos_adjacent_turfs_amount)
+
+			if(air.check_turf(enemy_tile, adjacent_turfs_length))
+				var/difference = air.mimic(enemy_tile, adjacent_turfs_length)
 				if(difference)
 					if(difference > 0)
 						consider_pressure_difference(enemy_tile, difference)
 					else
 						enemy_tile.consider_pressure_difference(src, -difference)
 				remove = 0
-				if(excited_group)
+				if(our_excited_group)
 					last_share_check()
 
 	air.react()
@@ -203,7 +215,7 @@
 			if(consider_superconductivity(starting = 1))
 				remove = 0
 
-	if(!excited_group && remove == 1)
+	if(!our_excited_group && remove == 1)
 		SSair.remove_from_active(src)
 
 /turf/simulated/temperature_expose()
@@ -236,10 +248,10 @@
 		if(gas[GAS_META][META_GAS_OVERLAY] && gas[MOLES] > gas[GAS_META][META_GAS_MOLES_VISIBLE])
 			. += gas[GAS_META][META_GAS_OVERLAY]
 
-/turf/simulated/proc/share_air(turf/simulated/T)
-	if(T.current_cycle < current_cycle)
+/turf/simulated/proc/share_air(turf/simulated/T, fire_count, adjacent_turfs_length)
+	if(T.current_cycle < fire_count)
 		var/difference
-		difference = air.share(T.air, atmos_adjacent_turfs_amount)
+		difference = air.share(T.air, adjacent_turfs_length)
 		if(difference)
 			if(difference > 0)
 				consider_pressure_difference(T, difference)
@@ -354,13 +366,14 @@
 	else
 		//Does particate in air exchange so only consider directions not considered during process_cell()
 		for(var/direction in cardinal)
-			if(!(atmos_adjacent_turfs & direction) && !(atmos_supeconductivity & direction))
+			var/turf/T = get_step(src, direction)
+			if(!(T in atmos_adjacent_turfs) && !(atmos_supeconductivity & direction))
 				conductivity_directions += direction
 
 	if(conductivity_directions>0)
 		//Conduct with tiles around me
 		for(var/direction in cardinal)
-			if(conductivity_directions&direction)
+			if(conductivity_directions & direction)
 				var/turf/neighbor = get_step(src,direction)
 
 				if(!neighbor.thermal_conductivity)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -3,7 +3,7 @@
 /turf
 	var/pressure_difference = 0
 	var/pressure_direction = 0
-	var/atmos_adjacent_turfs = 0
+	var/atmos_adjacent_turfs = list()
 	var/atmos_adjacent_turfs_amount = 0
 	var/atmos_supeconductivity = 0
 
@@ -132,11 +132,8 @@
 
 	var/remove = 1 //set by non simulated turfs who are sharing with this turf
 
-	for(var/direction in cardinal)
-		if(!(atmos_adjacent_turfs & direction))
-			continue
-
-		var/turf/enemy_tile = get_step(src, direction)
+	for(var/t in atmos_adjacent_turfs)
+		var/turf/enemy_tile = t
 
 		if(istype(enemy_tile,/turf/simulated))
 			var/turf/simulated/enemy_simulated = enemy_tile

--- a/code/orphaned procs/AStar.dm
+++ b/code/orphaned procs/AStar.dm
@@ -165,17 +165,7 @@ Actual Adjacent procs :
 
 //Returns adjacent turfs in cardinal directions that are reachable via atmos
 /turf/proc/reachableAdjacentAtmosTurfs()
-	var/list/L = new()
-	var/turf/simulated/T
-
-	for(var/dir in cardinal)
-		if(dir & atmos_adjacent_turfs)
-			T = get_step(src,dir)
-			if(!istype(T))
-				continue
-			if(CanAtmosPass(T))
-				L.Add(T)
-	return L
+	return atmos_adjacent_turfs
 
 /turf/proc/LinkBlockedWithAccess(turf/T, caller, ID)
 	var/adir = get_dir(src, T)


### PR DESCRIPTION
todo: 
- [x] Find anything else that treats atmos_adjacent_turfs as a bitflag and switch it over to treating it as a list
- [x] Test

I also cached every var i could in process_cell(), and even pass the cached vars to share_air

I got a ~20% improvement in process_cell's self and a ~30% improvement in turf/share_air()'s self but they only make up a ~5% of the total processing time.

Test case:
### VarEdit by MrStonedOne: /datum/subsystem/air dwait_delta=1
## NOTICE: mrstonedone(Simon Wilson) executed SDQL query:

```
update /obj/machinery/door set locked = 0;
call open() on /obj/machinery/door;
update /obj/machinery/door set locked = 1;
update /obj/machinery/atmospherics/components/unary/vent_pump set internal_pressure_bound = 5066, pressure_checks = 0;
call open() on /obj/machinery/atmospherics/components/binary/valve;
update /obj/machinery/atmospherics/components/binary/pump set on = 1, target_pressure = 5066;
```
