### PR TITLE
MC: tweaks, midnight rollover fix, and some 510 work

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -24,6 +24,9 @@
 	var/last_fire = 0		//last world.time we called fire()
 	var/next_fire = 0		//scheduled world.time for next fire()
 	var/cost = 0			//average time to execute
+#if DM_VERSION >= 510
+	var/tick_usage = 0		//average tick usage
+#endif
 	var/times_fired = 0		//number of times we have called fire()
 
 	// The object used for the clickable stat() button.
@@ -59,9 +62,13 @@
 		dwait = "DWait:[round(wait,0.1)]ds "
 
 	if(can_fire)
-		msg = "[round(cost,0.001)]ds\t[dwait][msg]"
+#if DM_VERSION >= 510
+		msg = "[round(cost,0.01)]ds|[round(tick_usage,1)]%\t[dwait][msg]"
+#else
+		msg = "[round(cost,0.01)]ds\t[dwait][msg]"
+#endif
 	else
-		msg = "OFFLINE"
+		msg = "OFFLINE\t[msg]"
 
 	stat(name, statclick.update(msg))
 
@@ -79,4 +86,4 @@
 /datum/subsystem/on_varedit(edited_var)
 	if (edited_var == "can_fire" && can_fire)
 		next_fire = world.time + wait
-	
+

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -600,7 +600,7 @@ var/next_mob_id = 0
 			else
 				stat("Failsafe Controller:", "ERROR")
 			if(Master)
-				stat("Subsystems:", "[round(Master.subsystem_cost, 0.001)]ds")
+				stat("Subsystems:", "[round(Master.subsystem_cost, 0.01)]ds")
 				stat(null)
 				for(var/datum/subsystem/SS in Master.subsystems)
 					SS.stat_entry()


### PR DESCRIPTION
Fixes the mc getting all fucked up during midnight rollover

Mc now tracks the tick_usage of every subsystem, and will skip running an expensive subsystem if we are too close to overrunning in a tick, waiting until next tick, unless that subsystem is excessively past due (because we kept skipping it).

It now assumes that 20% of a tick should be saved for byond to do it's things, and stops running all subsystems once we get to 80% tick usage.

Dynamic wait will only smooth out wait changes over 8 fires if the new wait is lower than the old wait, before it would smooth out wait increases as well as decreases.

The fps throttle system is now 509 only.

The mc will now run every 1ds, no GCD bullshit, as we want to spread things out more.

Offline subsystems will still show their stat message
