### PR TITLE
Fix missing parent calls in portable atmos

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -82,11 +82,11 @@
 
 /obj/machinery/portable_atmospherics/canister/proc/create_gas()
 	if(gas_type)
-		air_contents.assert_gas(gas_type)
+		air_contents.add_gas(gas_type)
 		air_contents.gases[gas_type][MOLES] = (maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 /obj/machinery/portable_atmospherics/canister/air/create_gas()
-	air_contents.assert_gases("o2","n2")
+	air_contents.add_gases("o2","n2")
 	air_contents.gases["o2"][MOLES] = (O2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 	air_contents.gases["n2"][MOLES] = (N2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
@@ -167,6 +167,7 @@
 			holding = null
 
 /obj/machinery/portable_atmospherics/canister/process_atmos()
+	..()
 	if(destroyed)
 		return PROCESS_KILL
 	if(!valve_open)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -25,6 +25,7 @@
 		overlays += "scrubber-connector"
 
 /obj/machinery/portable_atmospherics/scrubber/process_atmos()
+	..()
 	if(!on)
 		return
 
@@ -44,7 +45,7 @@
 
 	filtered.temperature = filtering.temperature
 	for(var/gas in filtering.gases & scrubbing)
-		filtered.assert_gas(gas)
+		filtered.add_gas(gas)
 		filtered.gases[gas][MOLES] = filtering.gases[gas][MOLES] // Shuffle the "bad" gasses to the filtered mixture.
 		filtering.gases[gas][MOLES] = 0
 	filtering.garbage_collect() // Now that the gasses are set to 0, clean up the mixture.


### PR DESCRIPTION
To enable reactions and fix icons not updating when connected
