### PR TITLE
Fix Ei Nath victim not-in-brain-has-no-body bug

### DIFF
--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -55,6 +55,7 @@
 		var/obj/item/organ/internal/brain/B = C_target.getorgan(/obj/item/organ/internal/brain)
 		if(B)
 			B.loc = get_turf(C_target)
+			M.death() //B.transfer_identity requires that the source mob is dead.
 			B.transfer_identity(C_target)
 			C_target.internal_organs -= B
 	var/datum/effect_system/spark_spread/sparks = new


### PR DESCRIPTION
Fixes #15263.

Current downside is that now Ei Nath victims are stuck in their brains -- ergo, aren't in deadchat, OOCing it up. Thus, wizards are OP as roboticists, as we saw recently with the brain mountain that led to this bug being found.

One way to resolve this might be to allow brains to `suicide`.
