### PR TITLE
Buffs bluespace artillery explosion

### DIFF
--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -48,7 +48,7 @@
 		for(var/turf/T in get_area_turfs(thearea.type))
 			L+=T
 		var/loc = pick(L)
-		explosion(loc,5,10,20)
+		explosion(loc,3,6,12)
 		reload = 0
 
 /*/mob/proc/openfire()

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -48,7 +48,7 @@
 		for(var/turf/T in get_area_turfs(thearea.type))
 			L+=T
 		var/loc = pick(L)
-		explosion(loc,2,5,11)
+		explosion(loc,5,10,20)
 		reload = 0
 
 /*/mob/proc/openfire()


### PR DESCRIPTION
As is, the damage it causes is miniscule and can easily be repaired before it's cooldown ends. Not to mention it's innate inaccuracy means you can only hit the general area you want to, so targeting a individual or even a stationary object is next to impossible.

This increases the explosion all the way to the bombcap, which should give it a bit more oomph.

Remember, the cooldown is in byond seconds, so it's more like 3-4 minutes not 1.
