### PR TITLE
Added a new traitor item, clown drones.  

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -14,6 +14,7 @@
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
 	origin_tech = "programming=2;biotech=4"
 	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
+	var/owner = "" //Should only be used on special drone types that belong to someone.
 
 /obj/item/drone_shell/New()
 	..()
@@ -30,7 +31,7 @@
 	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_drone == "No" || gc_destroyed)
 		return
-	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
+	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc), owner)
 	D.key = user.key
 	qdel(src)
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -46,6 +46,15 @@
 	var/obj/item/weapon/implant/weapons_auth/W = new/obj/item/weapon/implant/weapons_auth(src)
 	W.implant(src)
 
+/mob/living/simple_animal/drone/annoying
+	desc = "An annoying drone, an expendable robot built to perform station agitation."
+
+/mob/living/simple_animal/drone/annoying/New(loc, ownerName)
+	laws = \
+	"1. You may not involve yourself in the matters of [ownerName], even if such matters conflict with Law Two or Law Three.\n"+\
+	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
+	"3. Your goals are to annoy, agitate, infuriate, anger, and interfere to the best of your abilities, You must never actively work against these goals."
+
 /obj/item/drone_shell/syndrone
 	name = "syndrone shell"
 	desc = "A shell of a syndrone, a modified maintenance drone designed to infiltrate and annihilate."
@@ -55,3 +64,12 @@
 /obj/item/drone_shell/syndrone/badass
 	name = "badass syndrone shell"
 	drone_type = /mob/living/simple_animal/drone/syndrone/badass
+
+/obj/item/drone_shell/annoyingdrone
+	owner = "George Mellons"
+	desc = "A shell of an annoying drone, an expendable robot built to perform station agitation."
+	drone_type = /mob/living/simple_animal/drone/annoying
+
+/obj/item/drone_shell/annoyingdrone/New(loc, ownerName)
+	..()
+	owner = ownerName

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -50,6 +50,8 @@
 	desc = "An annoying drone, an expendable robot built to perform station agitation."
 
 /mob/living/simple_animal/drone/annoying/New(loc, ownerName)
+	default_hatmask = pick(/obj/item/clothing/mask/gas/clown_hat, /obj/item/clothing/mask/gas/sexyclown)
+	..()
 	laws = \
 	"1. You may not involve yourself in the matters of [ownerName], even if such matters conflict with Law Two or Law Three.\n"+\
 	"2. You may not harm any being, regardless of intent or circumstance.\n"+\

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -51,6 +51,7 @@
 
 /mob/living/simple_animal/drone/annoying/New(loc, ownerName)
 	default_hatmask = pick(/obj/item/clothing/mask/gas/clown_hat, /obj/item/clothing/mask/gas/sexyclown)
+	ventcrawler = 0
 	..()
 	laws = \
 	"1. You may not involve yourself in the matters of [ownerName], even if such matters conflict with Law Two or Law Three.\n"+\

--- a/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/visuals_icons.dm
@@ -78,7 +78,10 @@
 			head.screen_loc = ui_drone_head
 			client.screen += head
 
-		var/image/head_overlay = head.build_worn_icon(state = head.icon_state, default_layer = DRONE_HEAD_LAYER, default_icon_file = 'icons/mob/head.dmi')
+		var/icon_file = 'icons/mob/head.dmi'
+		if(istype(head, /obj/item/clothing/mask/))
+			icon_file = 'icons/mob/mask.dmi'
+		var/image/head_overlay = head.build_worn_icon(state = head.icon_state, default_layer = DRONE_HEAD_LAYER, default_icon_file = icon_file)
 		head_overlay.pixel_y += -15
 
 		drone_overlays[DRONE_HEAD_LAYER]	= head_overlay

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -64,7 +64,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		U.telecrystals -= cost
 		U.spent_telecrystals += cost
 
-	var/atom/A = spawn_item(get_turf(user), U)
+	var/atom/A = spawn_item(get_turf(user), U, user)
 	var/obj/item/weapon/storage/box/B = A
 	if(istype(B) && B.contents.len > 0)
 		for(var/obj/item/I in B)
@@ -1111,6 +1111,17 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 		U.purchase_log += "<big>\icon[I.item]</big>"
 
 	return C
+
+/datum/uplink_item/badass/annoydrone
+	name = "Annoyance drone"
+	desc = "A drone designed to create minor annoyances, and agitate the crew.  Will attempt to not interfere with your work."
+	cost = 1
+	item = /obj/item/drone_shell/annoyingdrone
+
+/datum/uplink_item/badass/annoydrone/spawn_item(turf/loc, obj/item/device/uplink/U, mob/user)
+	if(item)
+		feedback_add_details("traitor_uplink_items_bought", "[item]")
+		return new item(loc, user)
 
 /datum/uplink_item/badass/random
 	name = "Random Item"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1113,9 +1113,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	return C
 
 /datum/uplink_item/badass/annoydrone
-	name = "Annoyance drone"
+	name = "Clown drone"
 	desc = "A drone designed to create minor annoyances, and agitate the crew.  Will attempt to not interfere with your work."
-	cost = 1
+	cost = 2
 	item = /obj/item/drone_shell/annoyingdrone
 
 /datum/uplink_item/badass/annoydrone/spawn_item(turf/loc, obj/item/device/uplink/U, mob/user)


### PR DESCRIPTION
:cl:
rscadd: The syndicate has retrieved new drone technology from the clown planet.  Though these drones have been categorized as merely annoying, this technology has been depoloyed to syndicate agents.
bugfix: Drones wearing a mask now show the mask.
/:cl:

They cost 2tc right now, to encourage their purchase, mostly to allow dead players back in the round.

Lawset is as follows:
1. You may not involve yourself in the matters of [ownerName], even if such matters conflict with Law Two or Law Three.
2. You may not harm any being, regardless of intent or circumstance.
3. Your goals are to annoy, agitate, infuriate, anger, and interfere to the best of your abilities, You must never actively work against these goals.
