### PR TITLE
Makes the explosion size of BS artillery a configurable variable

### DIFF
--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -1,8 +1,10 @@
 
 #define ARTILLERY_RELOAD_TIME 60
+#define EXPLOSION_SIZE 3
 
 /obj/machinery/artillerycontrol
 	var/reload = ARTILLERY_RELOAD_TIME
+	var/explosionsize = EXPLOSION_SIZE
 	name = "bluespace artillery control"
 	icon_state = "control_boxp1"
 	icon = 'icons/obj/machines/particle_accelerator.dmi'
@@ -48,7 +50,7 @@
 		for(var/turf/T in get_area_turfs(thearea.type))
 			L+=T
 		var/loc = pick(L)
-		explosion(loc,2,5,11)
+		explosion(loc,explosionsize,explosionsize*2,explosionsize*4)
 		reload = 0
 
 /*/mob/proc/openfire()


### PR DESCRIPTION
This also slightly increases the explosion size because the scaling was wrong before, it was 2/5/11 and now it's 3/6/12.
