### PR TITLE
Nerfs lesser summon guns

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -211,7 +211,7 @@
 	name = "Lesser Summon Guns"
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns
 	log_name = "IG"
-	cost = 4
+	cost = 3
 
 /datum/spellbook_entry/barnyard
 	name = "Barnyard Curse"

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -9,6 +9,9 @@
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet
 
+/obj/item/ammo_casing/a762/enchanted
+	projectile_type = /obj/item/projectile/bullet/weakbullet3
+
 /obj/item/ammo_casing/a50
 	desc = "A .50AE bullet casing."
 	caliber = ".50"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -146,6 +146,7 @@
 
 /obj/item/ammo_box/magazine/internal/boltaction/enchanted
 	max_ammo =1
+	ammo_type = /obj/item/ammo_casing/a762/enchanted
 
 
 


### PR DESCRIPTION
It now does 20 damage a shot instead of 35.

At this point it is objectively worse than Mutate, which gives you laser eyes for infinite 20 strength projectiles, and mutate for stun immunity/wall destruction. Mutate also costs less spell points than this.

Closes #15225 

Fixes #15294
