### PR TITLE
Fixes doubled drone messages

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -23,10 +23,8 @@
 /mob/living/simple_animal/drone/proc/alert_drones(msg, dead_can_hear = 0)
 	for(var/W in mob_list)
 		var/mob/M = W
-		if(istype(M, /mob/living/simple_animal/drone) && M.stat != DEAD)
-			for(var/F in src.faction)
-				if(F in M.faction)
-					M << msg
+		if(istype(M, /mob/living/simple_animal/drone) && M.stat != DEAD && faction_check(M)) //if it's a living drone with matching factions, it gets a message
+			M << msg
 		if(dead_can_hear && (M in dead_mob_list))
 			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -22,8 +22,8 @@
 
 /mob/living/simple_animal/drone/proc/alert_drones(msg, dead_can_hear = 0)
 	for(var/W in mob_list)
-		var/mob/M = W
-		if(istype(M, /mob/living/simple_animal/drone) && M.stat != DEAD && faction_check(M)) //if it's a living drone with matching factions, it gets a message
+		var/mob/living/simple_animal/drone/M = W
+		if(istype(M) && M.stat != DEAD && faction_check(M)) //if it's a living drone with matching factions, it gets a message
 			M << msg
 		if(dead_can_hear && (M in dead_mob_list))
 			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"


### PR DESCRIPTION
Fixes #15332 

Cause; it checked the mobs faction without using the proc, resulting in it sending a message for each matching faction, instead of just if it found a match.
