### PR TITLE
Separates Traitor EMP Flashlights from the EMP Kit, reduces TC prices

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -199,7 +199,6 @@
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/implanter/emp(src)
-	new /obj/item/device/flashlight/emp(src)
 	return
 
 /obj/item/weapon/storage/box/syndie_kit/chemical

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -241,11 +241,11 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 8
 
 /datum/uplink_item/dangerous/emp
-	name = "EMP Kit"
-	desc = "A box that contains two EMP grenades, an EMP implant and a short ranged recharging device disguised \
-			as a flashlight. Useful to disrupt communication and silicon lifeforms."
+	name = "EMP Grenades and Implanter Kit"
+	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \
+			security's energy weapons, and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
-	cost = 1
+	cost = 2
 
 /datum/uplink_item/dangerous/syndicate_minibomb
 	name = "Syndicate Minibomb"
@@ -737,6 +737,13 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 4
 	surplus = 30
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	
+/datum/uplink_item/stealthy_tools/emplight
+	name = "EMP Flashlight"
+	desc = "A small, self-charging, short-ranged EMP device disguised as a flashlight. \
+		Useful for disrupting headsets, cameras, and borgs during stealth operations."
+	cost = 2
+	surplus = 30
 
 // Devices and Tools
 /datum/uplink_item/device_tools

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -245,7 +245,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A box that contains two EMP grenades, an EMP implant and a short ranged recharging device disguised \
 			as a flashlight. Useful to disrupt communication and silicon lifeforms."
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
-	cost = 5
+	cost = 1
 
 /datum/uplink_item/dangerous/syndicate_minibomb
 	name = "Syndicate Minibomb"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -878,6 +878,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/c4
 	cost = 1
 
+/datum/uplink_item/device_tools/c4bag
+	name = "Bag of C-4 explosives"
+	desc = "Because sometimes quantity is quality. Contains 10 C-4 plastic explosives."
+	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/c4
+	cost = 9 //10% discount!
+
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to a power grid and activated, this large device places excessive \


### PR DESCRIPTION
This PR removes EMP flashlights from the traitor EMP kit and readds them as a unique and separate item, and changes the price of kits and the flashlight to 2 TCs.

In basically any argument against silicons/cameras, EMPs are brought up as a hard counter, when people fail to realize that it's a whole quarter of your TCs and they're considering it to be basically mandatory. If it's so mandatory, it shouldn't cost so much.

The EMP kit also has too much utility in one purchase to validate a price reduction, so it's functionality has now been spread out to two items.

~~**This PR is entirely experimental and mainly to gather feedback. I don't fully expect it to be merged. Feel free to call me a fucking retard, or, if you're an intelligent person, give actual feedback and thoughts on the issue.**~~ Feedback has mostly been gotten and now I have an idea I'm happy with.

:cl: PKPenguin321
tweak: Traitor EMP kits have had their cost reduced from 5 to 2, and no longer contain the EMP flashlight.
rcsadd: EMP flashlights can now be bought separately for 2 TCs.
/:cl:
