### PR TITLE
Fixes qdel() being broken.

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -166,7 +166,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 		return FALSE
 	if(D.gc_destroyed)
 		return TRUE
-	if(SSgarbage && tobequeued && tobequeued.len && D in tobequeued)
+	if(SSgarbage && SSgarbage.tobequeued && SSgarbage.tobequeued.len && D in SSgarbage.tobequeued)
 		return  TRUE
 	return FALSE
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -98,9 +98,8 @@ var/datum/subsystem/garbage_collector/SSgarbage
 		queue.Cut(1, 2)
 
 /datum/subsystem/garbage_collector/proc/QueueForQueuing(datum/A)
- 	if (!istype(A) || !isnull(A.gc_destroyed))
-		return
- 	tobequeued += A
+	if (istype(A) && isnull(A.gc_destroyed))
+ 		tobequeued += A
 
 /datum/subsystem/garbage_collector/proc/Queue(datum/A)
 	if (!istype(A) || !isnull(A.gc_destroyed))

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -166,6 +166,8 @@ var/datum/subsystem/garbage_collector/SSgarbage
 		return FALSE
 	if(D.gc_destroyed)
 		return TRUE
+	if(SSgarbage && tobequeued && tobequeued.len && D in tobequeued)
+		return  TRUE
 	return FALSE
 
 // Default implementation of clean-up code.

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -99,7 +99,7 @@ var/datum/subsystem/garbage_collector/SSgarbage
 
 /datum/subsystem/garbage_collector/proc/QueueForQueuing(datum/A)
 	if (istype(A) && isnull(A.gc_destroyed))
- 		tobequeued += A
+		tobequeued += A
 
 /datum/subsystem/garbage_collector/proc/Queue(datum/A)
 	if (!istype(A) || !isnull(A.gc_destroyed))


### PR DESCRIPTION
Reversing the if wasn't actually needed, it was a space before the tab on the if, making byond think it was indented the same level as the return, (how this didn't trigger an inconsistent indentation error i don't know)

also, fixes #15337 mostly, ~~i'll edit in a proper fix for that in a moment.~~

Oh, and as a side note, This fixes qdel being broken and not deleting anything.
