### PR TITLE
Enables design transfer to autolathe by disk.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -40,7 +40,8 @@
 							"Security",
 							"Machinery",
 							"Medical",
-							"Misc"
+							"Misc",
+							"Imported"
 							)
 
 /obj/machinery/autolathe/New()
@@ -111,7 +112,19 @@
 			return 1
 	if(stat)
 		return 1
-
+	
+	if(istype(O, /obj/item/weapon/disk/design_disk))
+		user.visible_message("[user] begins to load \the [O] in \the [src]...",
+			"You begin to load a design from \the [O]...",
+			"You hear the chatter of a floppy drive.")
+		busy = 1
+		var/obj/item/weapon/disk/design_disk/D = O
+		if(do_after(user, 14.4, target = src))
+			files.AddDesign2Known(D.blueprint)
+		
+		busy = 0
+		return
+	
 	var/material_amount = materials.get_item_material_amount(O)
 	if(!material_amount)
 		user << "<span class='warning'>This object does not contain sufficient amounts of metal or glass to be accepted by the autolathe.</span>"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -232,6 +232,14 @@ proc/CallMaterialName(ID)
 	else if(href_list["copy_design"]) //Copy design data from the research holder to the design disk.
 		for(var/datum/design/D in files.known_designs)
 			if(href_list["copy_design_ID"] == D.id)
+				var/autolathe_friendly = 1
+				for(var/x in D.materials)
+					if( !(x in list(MAT_METAL, MAT_GLASS)))
+						autolathe_friendly = 0
+						D.category -= "Imported"
+				if(D.build_type & (AUTOLATHE|PROTOLATHE|CRAFTLATHE)) // Specifically excludes circuit imprinter and mechfab
+					D.build_type = autolathe_friendly ? (D.build_type | AUTOLATHE) : D.build_type
+					D.category |= "Imported"
 				d_disk.blueprint = D
 				break
 		screen = 1.4


### PR DESCRIPTION
:cl:
rscadd: New designs can now be added to Autolathes via a design disk. Simply use a disk containing a suitable design on your autolathe.
/:cl:
