### PR TITLE
Removes Radio MMI sybtype and adds a toggleable  radio to normal MMIs.

### DIFF
--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -486,7 +486,7 @@
 "jr" = (/obj/structure/table,/obj/item/weapon/firstaid_arm_assembly,/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
 "js" = (/obj/structure/table,/obj/item/device/assembly/flash/handheld,/obj/item/device/assembly/flash/handheld,/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
 "jt" = (/obj/structure/table,/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
-"ju" = (/obj/structure/table,/obj/item/device/mmi/radio_enabled,/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
+"ju" = (/obj/structure/table,/obj/item/device/mmi,/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
 "jv" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/plasteel{icon_state = "vault"},/area/awaymission/centcomAway/hangar)
 "jw" = (/obj/machinery/door/airlock/maintenance_hatch{req_access_txt = "101"},/turf/simulated/floor/plating,/area/awaymission/centcomAway/general)
 "jx" = (/obj/machinery/door/window,/obj/machinery/door/window/northright,/turf/simulated/floor/plasteel{icon_state = "floor"},/area/awaymission/centcomAway/general)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -8,7 +8,7 @@
 	w_class = 3
 	origin_tech = "biotech=3"
 	var/braintype = "Cyborg"
-
+	var/obj/item/device/radio/radio = null //Let's give it a radio.
 	var/syndiemmi = 0 //Whether or not this is a Syndicate MMI
 	var/mob/living/carbon/brain/brainmob = null //The current occupant.
 	var/mob/living/silicon/robot = null //Appears unused.
@@ -31,6 +31,12 @@
 			braintype = "Cyborg"
 	else
 		icon_state = "mmi_empty"
+
+/obj/item/device/mmi/New()
+	..()
+	radio = new(src) //Spawns a radio inside the MMI.
+	radio.broadcasting = 0 //researching radio mmis turned the robofabs into radios because this didnt start as 0.
+
 
 
 /obj/item/device/mmi/attackby(obj/item/O, mob/user, params)
@@ -78,7 +84,8 @@
 
 /obj/item/device/mmi/attack_self(mob/user)
 	if(!brain)
-		user << "<span class='warning'>You upend the MMI, but there's nothing in it!</span>"
+		radio.on = !radio.on
+		user << "<span class='notice'>You toggle the MMI's radio system [radio.on==1 ? "on" : "off"].</span>"
 	else
 		user << "<span class='notice'>You unlock and upend the MMI, spilling the brain onto the floor.</span>"
 
@@ -118,19 +125,8 @@
 	update_icon()
 	return
 
-/obj/item/device/mmi/radio_enabled
-	name = "Radio-enabled Man-Machine Interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity, that nevertheless has become standard-issue on Nanotrasen stations. This one comes with a built-in radio."
-	origin_tech = "biotech=4"
 
-	var/obj/item/device/radio/radio = null //Let's give it a radio.
-
-/obj/item/device/mmi/radio_enabled/New()
-	..()
-	radio = new(src) //Spawns a radio inside the MMI.
-	radio.broadcasting = 0 //researching radio mmis turned the robofabs into radios because this didnt start as 0.
-
-/obj/item/device/mmi/radio_enabled/verb/Toggle_Listening()
+/obj/item/device/mmi/verb/Toggle_Listening()
 	set name = "Toggle Listening"
 	set desc = "Toggle listening channel on or off."
 	set category = "MMI"
@@ -139,6 +135,9 @@
 
 	if(brainmob.stat)
 		brainmob << "<span class='warning'>Can't do that while incapacitated or dead!</span>"
+	if(!radio.on)
+		brainmob << "<span class='warning'>Your radio is disabled!</span>"
+		return
 
 	radio.listening = radio.listening==1 ? 0 : 1
 	brainmob << "<span class='notice'>Radio is [radio.listening==1 ? "now" : "no longer"] receiving broadcast.</span>"
@@ -184,3 +183,7 @@
 	name = "Syndicate Man-Machine Interface"
 	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs created with it, but doesn't fit in Nanotrasen AI cores."
 	syndiemmi = 1
+
+/obj/item/device/mmi/syndie/New()
+	..()
+	radio.on = 0

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -10,8 +10,8 @@
 		..()
 
 /mob/living/carbon/brain/radio(message, message_mode, list/spans)
-	if(message_mode && istype(container, /obj/item/device/mmi/radio_enabled))
-		var/obj/item/device/mmi/radio_enabled/R = container
+	if(message_mode && istype(container, /obj/item/device/mmi))
+		var/obj/item/device/mmi/R = container
 		if(R.radio)
 			R.radio.talk_into(src, message, , spans)
 			return ITALICS | REDUCE_RANGE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -112,7 +112,7 @@
 
 	//MMI stuff. Held togheter by magic. ~Miauw
 	if(!mmi || !mmi.brainmob)
-		mmi = new /obj/item/device/mmi/radio_enabled(src)
+		mmi = new (src)
 		mmi.brain = new /obj/item/organ/internal/brain(mmi)
 		mmi.brain.name = "[real_name]'s brain"
 		mmi.icon_state = "mmi_full"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -112,7 +112,7 @@
 
 	//MMI stuff. Held togheter by magic. ~Miauw
 	if(!mmi || !mmi.brainmob)
-		mmi = new(src)
+		mmi = new /obj/item/device/mmi/radio_enabled(src)
 		mmi.brain = new /obj/item/organ/internal/brain(mmi)
 		mmi.brain.name = "[real_name]'s brain"
 		mmi.icon_state = "mmi_full"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -37,18 +37,6 @@
 	build_path = /obj/item/device/mmi
 	category = list("Misc","Medical Designs")
 
-/datum/design/mmi_radio
-	name = "Radio-enabled Man-Machine Interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. This one comes with a built-in radio."
-	id = "mmi_radio"
-	req_tech = list("programming" = 2, "biotech" = 4)
-	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 1200, MAT_GLASS = 500)
-	construction_time = 75
-	reliability = 74
-	build_path = /obj/item/device/mmi/radio_enabled
-	category = list("Misc","Medical Designs")
-
 /datum/design/posibrain
 	name = "Positronic Brain"
 	desc = "The latest in Artificial Intelligences."


### PR DESCRIPTION
Getting blown as a borg really sucks. Usually you're stuck there forever with your only choice being to ghost and abandon your mmi body because brain code is weird and you cant like suicide or anything.
With a radio, ad least you can call for help or listen to what's going on in the station.

New update:
Regular MMIS now have built in radios! You can manually disable an MMI radio however by using an empty MMI inhand.
