### PR TITLE
Added mass driver computer to chapel, for real this time.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -1636,7 +1636,7 @@
 "aFx" = (/obj/structure/disposalpipe/segment,/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/simulated/floor/plating,/area/maintenance/fsmaint2)
 "aFy" = (/obj/machinery/power/apc{dir = 2; name = "Chapel Office APC"; pixel_x = 0; pixel_y = -24},/obj/structure/cable,/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,/turf/simulated/floor/plating,/area/chapel/office)
 "aFz" = (/turf/simulated/floor/plasteel{icon_state = "dark"},/area/chapel/main)
-"aFA" = (/obj/machinery/button/massdriver{id = "chapelgun"; name = "Chapel Mass Driver"; pixel_x = 25},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/chapel/main)
+"aFA" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/computer/pod/old{icon = 'icons/obj/airlock_machines.dmi'; icon_state = "airlock_control_standby"; id = "chapelgun"; name = "Mass Driver Controller"; pixel_x = 24; pixel_y = 0},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/chapel/main)
 "aFB" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/chapel/main)
 "aFC" = (/obj/structure/chair,/turf/simulated/floor/plasteel/shuttle,/area/shuttle/arrival)
 "aFD" = (/turf/simulated/wall/shuttle{icon_state = "swall1"; dir = 2},/area/shuttle/arrival)


### PR DESCRIPTION
I fixed it. Does exactly what the title describes, removes the mass driver button and adds a computer to the chapel with timed launch capabilities, variable power levels, and manual outer door control.

I tested it, and it works perfectly.

Images:
[Chapel View](http://i.imgur.com/lFVURz7.png)
[Interface](http://i.imgur.com/Z5DaPHA.png)
