### PR TITLE
Removes the "Cook" spawning uniform for code maintainability reasons.

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -148,13 +148,6 @@ Cook
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/chefhat
 
-/datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H)
-	..()
-	var/datum/job/cook/J = SSjob.GetJob(H.job)
-	J.cooks++
-	if(J.cooks>1)//Cooks
-		suit = /obj/item/clothing/suit/apron/chef
-		head = /obj/item/clothing/head/soft/mime
 
 
 /*


### PR DESCRIPTION
If you want a head chef, make a head chef job role, just like there is a quartermaster.

We have code standards for a reason people.
