### PR TITLE
Fixes vision bug with disposal.

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -105,8 +105,8 @@
 	return ..()
 
 /mob/proc/create_mob_hud()
-	return
-
+	if(client && !hud_used)
+		hud_used = new /datum/hud(src)
 
 //Version denotes which style should be displayed. blank or 0 means "next version"
 /datum/hud/proc/show_hud(version = 0)
@@ -173,6 +173,7 @@
 	persistant_inventory_update()
 	mymob.update_action_buttons()
 	reorganize_alerts()
+	mymob.reload_fullscreen()
 
 
 /datum/hud/human/show_hud(version = 0)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -320,7 +320,7 @@
 /mob/living/simple_animal/revenant/attackby(obj/item/W, mob/living/user, params)
 	if(istype(W, /obj/item/weapon/nullrod))
 		visible_message("<span class='warning'>[src] violently flinches!</span>", \
-						"<span class='revendanger'>As the null rod passes through you, you feel your essence draining away!</span>")
+						"<span class='revendanger'>As \the [W] passes through you, you feel your essence draining away!</span>")
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
 		spawn(30)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -20,6 +20,7 @@
 	maxHealth = INFINITY
 	layer = 5
 	healable = 0
+	sight = SEE_SELF
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 8
 	languages = ALL
@@ -319,7 +320,7 @@
 /mob/living/simple_animal/revenant/attackby(obj/item/W, mob/living/user, params)
 	if(istype(W, /obj/item/weapon/nullrod))
 		visible_message("<span class='warning'>[src] violently flinches!</span>", \
-						"<span class='revendanger'>As \the [W] passes through you, you feel your essence draining away!</span>")
+						"<span class='revendanger'>As the null rod passes through you, you feel your essence draining away!</span>")
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
 		spawn(30)

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -192,7 +192,7 @@
 			return ..()
 
 		// otherwise, do normal expel from turf
-		if(H)
+		else
 			expel(H, T, 0)
 	return ..()
 
@@ -740,7 +740,7 @@
 // expel the contents of the holder object, then delete it
 // called when the holder exits the outlet
 /obj/structure/disposaloutlet/proc/expel(obj/structure/disposalholder/H)
-
+	var/turf/T = get_turf(src)
 	flick("outlet-open", src)
 	if((start_eject + 30) < world.time)
 		start_eject = world.time
@@ -751,11 +751,11 @@
 		sleep(20)
 	if(H)
 		for(var/atom/movable/AM in H)
-			AM.forceMove(src.loc)
+			AM.forceMove(T)
 			AM.pipe_eject(dir)
 			AM.throw_at_fast(target, eject_range, 1)
 
-		H.vent_gas(src.loc)
+		H.vent_gas(T)
 		qdel(H)
 	return
 

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -193,8 +193,9 @@
 
 // eject the contents of the disposal unit
 /obj/machinery/disposal/proc/eject()
+	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in src)
-		AM.loc = src.loc
+		AM.forceMove(T)
 		AM.pipe_eject(0)
 	update()
 
@@ -244,14 +245,14 @@
 // called when holder is expelled from a disposal
 // should usually only occur if the pipe network is modified
 /obj/machinery/disposal/proc/expel(obj/structure/disposalholder/H)
-
+	var/turf/T = get_turf(src)
 	var/turf/target
 	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 	if(H) // Somehow, someone managed to flush a window which broke mid-transit and caused the disposal to go in an infinite loop trying to expel null, hopefully this fixes it
 		for(var/atom/movable/AM in H)
 			target = get_offset_target_turf(src.loc, rand(5)-rand(5), rand(5)-rand(5))
 
-			AM.loc = src.loc
+			AM.forceMove(T)
 			AM.pipe_eject(0)
 			AM.throw_at_fast(target, 5, 1)
 


### PR DESCRIPTION
Fixes revenant not seeing itself and not having his action buttons.
Fixes many mobs having a null hud_used.
Fixes fullscreen overlay disappearing when toggling the hud.
Fixes our vision when being ejected by a delivery chute and when inside a disposal unit that is being destroyed. Fixes the bug mentionned in #15321. Fixes #15305
