### PR TITLE
New virology chems. Makes virus food actually useful. Adds uranium to virology uses.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1118,60 +1118,30 @@
 
 // Virology virus food chems.
 
-/datum/reagent/mutagenvirusfood
+/datum/reagent/toxin/mutagen/mutagenvirusfood
 	name = "mutagenic agar"
 	id = "mutagenvirusfood"
 	description = "mutates blood"
-	reagent_state = LIQUID
 	color = "#A3C00F" // rgb: 163,192,15
 
-/datum/reagent/mutagenvirusfood/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
-	if(!..())
-		return
-	if(!M.has_dna())
-		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
-	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
-		randmuti(M)
-		if(prob(90))
-			randmutb(M)
-		else
-			randmutg(M)
-		M.updateappearance()
-		M.domutcheck()
-	..()
+/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar
+	name = "sucrose agar"
+	id = "sugarvirusfood"
+	color = "#41B0C0" // rgb: 65,176,192
 
-/datum/reagent/synaptizinevirusfood
+/datum/reagent/medicine/synaptizine/synaptizinevirusfood
 	name = "virus rations"
 	id = "synaptizinevirusfood"
 	description = "mutates blood"
-	reagent_state = LIQUID
 	color = "#D18AA5" // rgb: 209,138,165
 
-/datum/reagent/synaptizinevirusfood/on_mob_life(mob/living/M)
-	M.drowsyness = max(M.drowsyness-3, 0)
-	M.AdjustWeakened(-1)
-	if(holder.has_reagent("mindbreaker"))
-		holder.remove_reagent("mindbreaker", 5)
-	M.hallucination = max(0, M.hallucination - 5)
-	return
-
-/datum/reagent/plasmavirusfood
+/datum/reagent/toxin/plasma/plasmavirusfood
 	name = "virus plasma"
 	id = "plasmavirusfood"
 	description = "mutates blood"
-	reagent_state = LIQUID
 	color = "#A69DA9" // rgb: 166,157,169
 
-/datum/reagent/weakplasmavirusfood
+/datum/reagent/toxin/plasma/plasmavirusfood/weak
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
-	description = "mutates blood"
-	reagent_state = LIQUID
 	color = "#CEC3C6" // rgb: 206,195,198
-
-/datum/reagent/sugarvirusfood
-	name = "sucrose agar"
-	id = "sugarvirusfood"
-	description = "mutates blood"
-	reagent_state = LIQUID
-	color = "#41B0C0" // rgb: 65,176,192

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1115,3 +1115,63 @@
 		var/t_loc = get_turf(O)
 		qdel(O)
 		new /obj/item/clothing/shoes/galoshes/dry(t_loc)
+
+// Virology virus food chems.
+
+/datum/reagent/mutagenvirusfood
+	name = "mutagenic agar"
+	id = "mutagenvirusfood"
+	description = "mutates blood"
+	reagent_state = LIQUID
+	color = "#A3C00F" // rgb: 163,192,15
+
+/datum/reagent/mutagenvirusfood/reaction_mob(mob/living/carbon/M, method=TOUCH, reac_volume)
+	if(!..())
+		return
+	if(!M.has_dna())
+		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
+	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method==PATCH || method==INJECT)
+		randmuti(M)
+		if(prob(90))
+			randmutb(M)
+		else
+			randmutg(M)
+		M.updateappearance()
+		M.domutcheck()
+	..()
+
+/datum/reagent/synaptizinevirusfood
+	name = "virus rations"
+	id = "synaptizinevirusfood"
+	description = "mutates blood"
+	reagent_state = LIQUID
+	color = "#D18AA5" // rgb: 209,138,165
+
+/datum/reagent/synaptizinevirusfood/on_mob_life(mob/living/M)
+	M.drowsyness = max(M.drowsyness-3, 0)
+	M.AdjustWeakened(-1)
+	if(holder.has_reagent("mindbreaker"))
+		holder.remove_reagent("mindbreaker", 5)
+	M.hallucination = max(0, M.hallucination - 5)
+	return
+
+/datum/reagent/plasmavirusfood
+	name = "virus plasma"
+	id = "plasmavirusfood"
+	description = "mutates blood"
+	reagent_state = LIQUID
+	color = "#A69DA9" // rgb: 166,157,169
+
+/datum/reagent/weakplasmavirusfood
+	name = "weakened virus plasma"
+	id = "weakplasmavirusfood"
+	description = "mutates blood"
+	reagent_state = LIQUID
+	color = "#CEC3C6" // rgb: 206,195,198
+
+/datum/reagent/sugarvirusfood
+	name = "sucrose agar"
+	id = "sugarvirusfood"
+	description = "mutates blood"
+	reagent_state = LIQUID
+	color = "#41B0C0" // rgb: 65,176,192

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -133,41 +133,41 @@
 	required_reagents = list("water" = 5, "milk" = 5)
 	result_amount = 15
 
-/datum/chemical_reaction/virus_food_mutation
+/datum/chemical_reaction/virus_food_mutagen
 	name = "mutagenic agar"
 	id = "mutagenvirusfood"
 	result = "mutagenvirusfood"
-	required_reagents = list("mutagen" = 1)
-	required_catalysts = list("virusfood" = 1)
+	required_reagents = list("mutagen" = 1, "virusfood" = 1)
 
-/datum/chemical_reaction/virus_food_mutation/synaptizine
+/datum/chemical_reaction/virus_food_synaptizine
 	name = "virus rations"
 	id = "synaptizinevirusfood"
 	result = "synaptizinevirusfood"
-	required_reagents = list("synaptizine" = 1)
+	required_reagents = list("synaptizine" = 1, "virusfood" = 1)
 
-/datum/chemical_reaction/virus_food_mutation/plasma
+/datum/chemical_reaction/virus_food_plasma
 	name = "virus plasma"
 	id = "plasmavirusfood"
 	result = "plasmavirusfood"
-	required_reagents = list("plasma" = 1)
+	required_reagents = list("plasma" = 1, "virusfood" = 1)
 
-/datum/chemical_reaction/virus_food_mutation/plasma/synaptizine
+/datum/chemical_reaction/virus_food_plasma_synaptizine
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
 	result = "weakplasmavirusfood"
-	required_catalysts = list("plasmavirusfood" = 1)
-	required_reagents = list("synaptizine" = 1)
+	required_reagents = list("synaptizine" = 1, "plasmavirusfood" = 1)
 
-/datum/chemical_reaction/virus_food_mutation/sugar
+/datum/chemical_reaction/virus_food_mutagen_sugar
 	name = "sucrose agar"
 	id = "sugarvirusfood"
 	result = "sugarvirusfood"
-	required_catalysts = list("mutagenvirusfood" = 1)
-	required_reagents = list("sugar" = 1)
+	required_reagents = list("sugar" = 1, "mutagenvirusfood" = 1)
 
-/datum/chemical_reaction/virus_food_mutation/sugar/salineglucose
-	required_reagents = list("salglu_solution" = 1)
+/datum/chemical_reaction/virus_food_mutagen_salineglucose
+	name = "sucrose agar"
+	id = "salineglucosevirusfood"
+	result = "sugarvirusfood"
+	required_reagents = list("salglu_solution" = 1, "mutagenvirusfood" = 1)
 
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -133,6 +133,42 @@
 	required_reagents = list("water" = 5, "milk" = 5)
 	result_amount = 15
 
+/datum/chemical_reaction/virus_food_mutation
+	name = "mutagenic agar"
+	id = "mutagenvirusfood"
+	result = "mutagenvirusfood"
+	required_reagents = list("mutagen" = 1)
+	required_catalysts = list("virusfood" = 1)
+
+/datum/chemical_reaction/virus_food_mutation/synaptizine
+	name = "virus rations"
+	id = "synaptizinevirusfood"
+	result = "synaptizinevirusfood"
+	required_reagents = list("synaptizine" = 1)
+
+/datum/chemical_reaction/virus_food_mutation/plasma
+	name = "virus plasma"
+	id = "plasmavirusfood"
+	result = "plasmavirusfood"
+	required_reagents = list("plasma" = 1)
+
+/datum/chemical_reaction/virus_food_mutation/plasma/synaptizine
+	name = "weakened virus plasma"
+	id = "weakplasmavirusfood"
+	result = "weakplasmavirusfood"
+	required_catalysts = list("plasmavirusfood" = 1)
+	required_reagents = list("synaptizine" = 1)
+
+/datum/chemical_reaction/virus_food_mutation/sugar
+	name = "sucrose agar"
+	id = "sugarvirusfood"
+	result = "sugarvirusfood"
+	required_catalysts = list("mutagenvirusfood" = 1)
+	required_reagents = list("sugar" = 1)
+
+/datum/chemical_reaction/virus_food_mutation/sugar/salineglucose
+	required_reagents = list("salglu_solution" = 1)
+
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"
 	id = "mixvirus"
@@ -163,17 +199,57 @@
 
 	name = "Mix Virus 3"
 	id = "mixvirus3"
-	required_reagents = list("toxin" = 1)
-	level_min = 3
-	level_max = 5
+	required_reagents = list("plasma" = 1)
+	level_min = 4
+	level_max = 6
 
 /datum/chemical_reaction/mix_virus/mix_virus_4
 
 	name = "Mix Virus 4"
 	id = "mixvirus4"
-	required_reagents = list("plasma" = 1)
+	required_reagents = list("uranium" = 1)
 	level_min = 5
 	level_max = 6
+
+/datum/chemical_reaction/mix_virus/mix_virus_5
+
+	name = "Mix Virus 5"
+	id = "mixvirus5"
+	required_reagents = list("mutagenvirusfood" = 1)
+	level_min = 3
+	level_max = 3
+
+/datum/chemical_reaction/mix_virus/mix_virus_6
+
+	name = "Mix Virus 6"
+	id = "mixvirus6"
+	required_reagents = list("sugarvirusfood" = 1)
+	level_min = 4
+	level_max = 4
+
+/datum/chemical_reaction/mix_virus/mix_virus_7
+
+	name = "Mix Virus 7"
+	id = "mixvirus7"
+	required_reagents = list("weakplasmavirusfood" = 1)
+	level_min = 5
+	level_max = 5
+
+/datum/chemical_reaction/mix_virus/mix_virus_8
+
+	name = "Mix Virus 8"
+	id = "mixvirus8"
+	required_reagents = list("plasmavirusfood" = 1)
+	level_min = 6
+	level_max = 6
+
+/datum/chemical_reaction/mix_virus/mix_virus_9
+
+	name = "Mix Virus 9"
+	id = "mixvirus9"
+	required_reagents = list("synaptizinevirusfood" = 1)
+	level_min = 1
+	level_max = 1
 
 /datum/chemical_reaction/mix_virus/rem_virus
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -138,36 +138,42 @@
 	id = "mutagenvirusfood"
 	result = "mutagenvirusfood"
 	required_reagents = list("mutagen" = 1, "virusfood" = 1)
+	result_amount = 1
 
 /datum/chemical_reaction/virus_food_synaptizine
 	name = "virus rations"
 	id = "synaptizinevirusfood"
 	result = "synaptizinevirusfood"
 	required_reagents = list("synaptizine" = 1, "virusfood" = 1)
+	result_amount = 1
 
 /datum/chemical_reaction/virus_food_plasma
 	name = "virus plasma"
 	id = "plasmavirusfood"
 	result = "plasmavirusfood"
 	required_reagents = list("plasma" = 1, "virusfood" = 1)
+	result_amount = 1
 
 /datum/chemical_reaction/virus_food_plasma_synaptizine
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
 	result = "weakplasmavirusfood"
 	required_reagents = list("synaptizine" = 1, "plasmavirusfood" = 1)
+	result_amount = 2
 
 /datum/chemical_reaction/virus_food_mutagen_sugar
 	name = "sucrose agar"
 	id = "sugarvirusfood"
 	result = "sugarvirusfood"
 	required_reagents = list("sugar" = 1, "mutagenvirusfood" = 1)
+	result_amount = 2
 
 /datum/chemical_reaction/virus_food_mutagen_salineglucose
 	name = "sucrose agar"
 	id = "salineglucosevirusfood"
 	result = "sugarvirusfood"
 	required_reagents = list("salglu_solution" = 1, "mutagenvirusfood" = 1)
+	result_amount = 2
 
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -163,8 +163,16 @@
 
 	name = "Mix Virus 3"
 	id = "mixvirus3"
+	required_reagents = list("toxin" = 1)
+	level_min = 3
+	level_max = 5
+
+/datum/chemical_reaction/mix_virus/mix_virus_4
+
+	name = "Mix Virus 4"
+	id = "mixvirus4"
 	required_reagents = list("plasma" = 1)
-	level_min = 4
+	level_min = 5
 	level_max = 6
 
 /datum/chemical_reaction/mix_virus/rem_virus


### PR DESCRIPTION
:cl: 
rscadd: Adds Uranium to Virus reaction. Will create a random symptom between 5 and 6 when mixed with blood.
rscadd: Adds Virus rations, which creates a level 1 symptom when mixed with blood.
rscadd: Adds Mutagenic agar, which creates a level 3 symptom.
rscadd: Adds Sucrose agar which creates a level 4 symptom.
rscadd: Adds Weak virus plasma, which creates a level 5 symptom.
rscadd: Adds Virus plasma, which creates a level 6 symptom.
rscadd: Adds Virus food and Mutagen reaction, creating Mutagenic agar.
rscadd: Adds Virus food and Synaptizine reaction, creating Virus rations.
rscadd: Adds Virus food and Plasma reaction, creating Virus plasma.
rscadd: Adds Synaptizine and Virus plasma reaction, creating weakened virus plasma.
rscadd: Adds Sugar and Mutagenic agar reaction, creating sucrose agar.
rscadd: Adds Saline glucose solution and Mutagenic agar reaction, creating sucrose agar.
rscadd: Adds Viral self-adaptation symptom, which boosts stealth and resistance, but lowers stage speed.
rscadd: Adds Viral evolutionary acceleration, which bosts stage speed and transmittability, but lowers stealth and resistance.
/:cl:

These changes make virology less RNG intensive.
Virus food + mutagen = Mutagenic agar.
Virus food + synaptizine = virus rations.
Virus food + plasma = virus plasma.
Synaptizine + Virus plasma = weakened virus plasma
Sugar OR saline glucose solution + mutagenic agar = sucrose agar

Uranium = level 5 or 6 symptom
Mutagenic agar = level 3 symptom
Sucrose agar = level 4 symptom
Weak virus plasma = level 5 symptom
Plasma virus = level 6 symptom
Virus rations = level 1 symptom

Old stuff, ignore below:
_Toxin now creates a symptom between 3-5 and Plasma now creates a symptom between 5-6.

This should make virology less RNG by allowing you to get the more exclusive levels 5 and 6 viruses easier using plasma._
