### PR TITLE
Gibbing Throws Internal Organs

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -249,11 +249,6 @@
 	A.say("PLASMA FIST!")
 	D.visible_message("<span class='danger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>", \
 								"<span class='userdanger'>[A] has hit [D] with THE PLASMA FIST TECHNIQUE!</span>")
-	var/obj/item/organ/internal/brain/B = D.getorgan(/obj/item/organ/internal/brain)
-	if(B)
-		B.loc = get_turf(D)
-		B.transfer_identity(D)
-		D.internal_organs -= B
 	D.gib()
 	return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -71,9 +71,11 @@
 						stomach_contents.Remove(A)
 					src.gib()
 
-/mob/living/carbon/gib(animation = 1)
+/mob/living/carbon/gib(animation = 1, var/no_brain = 0)
 	death(1)
 	for(var/obj/item/organ/internal/I in internal_organs)
+		if(no_brain && istype(I, /obj/item/organ/internal/brain))
+			continue
 		if(I)
 			I.Remove(src)
 			I.loc = get_turf(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -72,6 +72,13 @@
 					src.gib()
 
 /mob/living/carbon/gib(animation = 1)
+	death(1)
+	for(var/obj/item/organ/internal/I in internal_organs)
+		if(I)
+			I.Remove(src)
+			I.loc = get_turf(src)
+			I.throw_at_fast(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
+
 	for(var/mob/M in src)
 		if(M in stomach_contents)
 			stomach_contents.Remove(M)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,6 +1,7 @@
 /mob/living/gib(animation = 1)
 	var/prev_lying = lying
-	death(1)
+	if(stat != DEAD)
+		death(1)
 
 	if(buckled)
 		buckled.unbuckle_mob() //to update alien nest overlay.

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -50,13 +50,6 @@
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
 	var/mob/M = target
-	if(ishuman(M) || ismonkey(M))
-		var/mob/living/carbon/C_target = M
-		var/obj/item/organ/internal/brain/B = C_target.getorgan(/obj/item/organ/internal/brain)
-		if(B)
-			B.loc = get_turf(C_target)
-			B.transfer_identity(C_target)
-			C_target.internal_organs -= B
 	var/datum/effect_system/spark_spread/sparks = new
 	sparks.set_up(4, 0, M.loc) //no idea what the 0 is
 	sparks.start()

--- a/code/modules/spells/spell_types/inflict_handler.dm
+++ b/code/modules/spells/spell_types/inflict_handler.dm
@@ -26,15 +26,6 @@
 		switch(destroys)
 			if("gib")
 				target.gib()
-			if("gib_brain")
-				if(ishuman(target) || ismonkey(target))
-					var/mob/living/carbon/C_target = target
-					var/obj/item/organ/internal/brain/B = C_target.getorgan(/obj/item/organ/internal/brain)
-					if(B)
-						B.loc = get_turf(C_target)
-						B.transfer_identity(C_target)
-						C_target.internal_organs -= B
-				target.gib()
 			if("disintegrate")
 				target.dust()
 


### PR DESCRIPTION
I'm expecting this to be shot down almost instantaneously because of how it changes things.

Gibbing will now remove and throw internal organs--yes, this includes brains.

While this initially comes off as a huge paradigm shift (and it is, in part), I don't personally think it'll be as big of an impact as some might believe: yes, it makes explosions and a few other things easier to "come back from", but revival is still unlikely in a lot of cases and brains are incredibly easy to dispose of/hide/destroy; likewise, with how explosions pattern, sometimes brains end up destroyed, anyway, because gibs, the brain gets moved to a tile where it's inevitably ex_act()'d on and it's gone, forever, anyway.

Yes, this means that Lichdom wizards can revive from a brain to a new body (there's still the gibber and crematorium); I think suicide bombing an antag and wrecking a huge portion of the station in the proces is a lame+griefy tactic anyway.

:cl: Fox McCloud
rscadd: Gibbing mobs will now throw their internal organs
/:cl:
