### PR TITLE
Makes suit sensors useful (Suit sensor random levels will now favor higher levels)

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -330,7 +330,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/New()
 	if(random_sensor)
-		sensor_mode = pick(0,1,1,2,2,2,3,3,3,3)
+		sensor_mode = pickweight(list(0 = 1, 1 = 2, 2 = 3, 3 = 4))
 	adjusted = 0
 	suit_color = item_color
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -330,7 +330,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/New()
 	if(random_sensor)
-		sensor_mode = pick(0,1,2,3)
+		sensor_mode = pick(0,1,1,2,2,2,3,3,3,3)
 	adjusted = 0
 	suit_color = item_color
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -330,7 +330,8 @@ BLIND     // can't see anything
 
 /obj/item/clothing/under/New()
 	if(random_sensor)
-		sensor_mode = pickweight(list(0 = 1, 1 = 2, 2 = 3, 3 = 4))
+		//make the sensor mode favor higher levels, except coords.
+		sensor_mode = pickweight(list(0 = 1, 1 = 2, 2 = 3, 3 = 2))
 	adjusted = 0
 	suit_color = item_color
 	..()


### PR DESCRIPTION
Old odds: 25% off 25% binary 25% lifesigns 25% coordinates 
New odds: 12.5% off 25% binary 37.5% lifesigns 25% coordinates

The only reason they don't start maxxed out, is to prevent meta. (so and so turned them off, they are hiding something.)

This preserves that without making features that depend on them (ai health hud being the primary motivator for this pr.) useless

:cl:
tweak: Suit sensors will now favor higher levels for starting amount with the exception of the max level, that remains unchanged.
tweak: Old odds: 25% off 25% binary lifesigns 25% full lifesigns 25% coordinates
tweak: New odds: 12.5% off 25% binary lifesigns 37.5% full lifesigns 25% coordinates
/:cl:
