### PR TITLE
Brain fixes and changes

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -198,6 +198,20 @@
 			R = new /mob/living/silicon/robot/syndicate/medical(T)
 		else
 			R = new /mob/living/silicon/robot/syndicate(T) //Assault borg by default
+
+	var/brainfirstname = pick(first_names_male)
+	if(prob(50))
+		brainfirstname = pick(first_names_female)
+	var/brainopslastname = pick(last_names)
+	if(ticker.mode.nukeops_lastname)  //the brain inside the syndiborg has the same last name as the other ops.
+		brainopslastname = ticker.mode.nukeops_lastname
+	var/brainopsname = "[brainfirstname] [brainopslastname]"
+
+	R.mmi.name = "Man-Machine Interface: [brainopsname]"
+	R.mmi.brain.name = "[brainopsname]'s brain"
+	R.mmi.brainmob.real_name = brainopsname
+	R.mmi.brainmob.name = brainopsname
+
 	R.key = C.key
 	ticker.mode.syndicates += R.mind
 	ticker.mode.update_synd_icons_added(R.mind)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -867,9 +867,9 @@
 			user << "<span class='warning'>\the [mmi_as_oc] is stuck to your hand, you cannot put it in \the [src]!</span>"
 			return
 		var/mob/brainmob = mmi_as_oc.brainmob
-		brainmob.reset_perspective(src)
 		occupant = brainmob
 		brainmob.loc = src //should allow relaymove
+		brainmob.reset_perspective(src)
 		brainmob.canmove = 1
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -187,7 +187,7 @@
 				user << "<span class='warning'>The mmi indicates that their mind is currently inactive; it might change!</span>"
 				return
 
-			if(BM.stat == DEAD)
+			if(BM.stat == DEAD || BM.health <= config.health_threshold_dead)
 				user << "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>"
 				return
 
@@ -210,7 +210,6 @@
 			O.invisibility = 0
 			//Transfer debug settings to new mob
 			O.custom_name = created_name
-			O.updatename("Default")
 			O.locked = panel_locked
 			if(!aisync)
 				lawsync = 0
@@ -237,7 +236,9 @@
 			chest.cell.loc = O
 			chest.cell = null
 			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
-			O.mmi = W
+			if(O.mmi) //we delete the mmi created by robot/New()
+				qdel(O.mmi)
+			O.mmi = W //and give the real mmi to the borg.
 			O.updatename()
 
 			feedback_inc("cyborg_birth",1)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -187,7 +187,7 @@
 				user << "<span class='warning'>The mmi indicates that their mind is currently inactive; it might change!</span>"
 				return
 
-			if(BM.stat == DEAD || BM.health <= config.health_threshold_dead)
+			if(BM.stat == DEAD || (M.brain && M.brain.damaged_brain))
 				user << "<span class='warning'>Sticking a dead brain into the frame would sort of defeat the purpose!</span>"
 				return
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -488,9 +488,12 @@
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return. Further attempts futile.</span>"
 						else if(total_burn >= 180 || total_brute >= 180)
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.</span>"
-						else if(H.get_ghost() || !H.getorgan(/obj/item/organ/internal/brain))
+						else if(H.get_ghost())
 							failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - No activity in patient's brain. Further attempts may be successful.</span>"
-
+						else
+							var/obj/item/organ/internal/brain/BR = H.getorgan(/obj/item/organ/internal/brain)
+							if(!BR || BR.damaged_brain)
+								failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's brain is missing or damaged beyond point of no return. Further attempts futile.</span>"
 
 						if(failed)
 							user.visible_message(failed)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -76,7 +76,6 @@
 						"<span class='userdanger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>")
 		spawn(50)
 			death(0)
-			suiciding = 0
 
 /mob/living/carbon/monkey/verb/suicide()
 	set hidden = 1

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -61,9 +61,9 @@
 		newbrain.brainmob = null
 		brainmob.loc = src
 		brainmob.container = src
-		if(brainmob.health > config.health_threshold_dead)
-			brainmob.stat = CONSCIOUS
-			dead_mob_list -= brainmob //Update dem lists
+		if(!newbrain.damaged_brain) // the brain organ hasn't beaten to death.
+			brainmob.stat = CONSCIOUS //we manually revive the brain mob
+			dead_mob_list -= brainmob
 			living_mob_list += brainmob
 
 		brainmob.reset_perspective()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -63,10 +63,10 @@
 		brainmob.container = src
 		if(brainmob.health > config.health_threshold_dead)
 			brainmob.stat = CONSCIOUS
-			brainmob.reset_perspective()
 			dead_mob_list -= brainmob //Update dem lists
 			living_mob_list += brainmob
 
+		brainmob.reset_perspective()
 		newbrain.loc = src //P-put your brain in it
 		brain = newbrain
 
@@ -95,17 +95,19 @@
 		brainmob.emp_damage = 0
 		brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
 		living_mob_list -= brainmob //Get outta here
+		dead_mob_list += brainmob
 		brain.brainmob = brainmob //Set the brain to use the brainmob
 		brainmob = null //Set mmi brainmob var to null
 
-		brain.loc = usr.loc
+		user.put_in_hands(brain) //puts brain in the user's hand or otherwise drops it on the user's turf
 		brain = null //No more brain in here
 
 		update_icon()
 		name = "Man-Machine Interface"
 
 /obj/item/device/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
-	brainmob = new(src)
+	if(!brainmob)
+		brainmob = new(src)
 	brainmob.name = L.real_name
 	brainmob.real_name = L.real_name
 	if(L.has_dna())
@@ -120,6 +122,9 @@
 		var/obj/item/organ/internal/brain/newbrain = H.getorgan(/obj/item/organ/internal/brain)
 		newbrain.loc = src
 		brain = newbrain
+	else if(!brain)
+		brain = new(src)
+		brain.name = "[L.real_name]'s brain"
 
 	name = "Man-Machine Interface: [brainmob.real_name]"
 	update_icon()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -2,7 +2,7 @@
 
 /mob/living/carbon/brain
 	languages = HUMAN
-	var/obj/item/container = null
+	var/obj/item/device/mmi/container = null
 	var/timeofhostdeath = 0
 	var/emp_damage = 0//Handles a type of MMI damage
 	has_limbs = 0
@@ -21,6 +21,7 @@
 		if(stat!=DEAD)	//If not dead.
 			death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
 		ghostize()		//Ghostize checks for key so nothing else is necessary.
+	container = null
 	return ..()
 
 /mob/living/carbon/brain/update_canmove()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -6,6 +6,15 @@
 	var/timeofhostdeath = 0
 	var/emp_damage = 0//Handles a type of MMI damage
 	has_limbs = 0
+	stat = DEAD //we start dead by default
+
+/mob/living/carbon/brain/New(loc)
+	..()
+	if(isturf(loc)) //not spawned in an MMI or brain organ (most likely adminspawned)
+		var/obj/item/organ/internal/brain/OB = new(loc) //we create a new brain organ for it.
+		src.loc = OB
+		OB.brainmob = src
+
 
 /mob/living/carbon/brain/Destroy()
 	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -11,6 +11,7 @@
 	origin_tech = "biotech=4"
 	attack_verb = list("attacked", "slapped", "whacked")
 	var/mob/living/carbon/brain/brainmob = null
+	var/damaged_brain = 0 //whether the brain organ is damaged.
 
 /obj/item/organ/internal/brain/Insert(mob/living/carbon/M, special = 0)
 	..()
@@ -58,6 +59,7 @@
 	brainmob << "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>"
 
 /obj/item/organ/internal/brain/attackby(obj/item/O, mob/user, params)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(brainmob)
 		O.attack(brainmob, user) //Oh noooeeeee
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -57,6 +57,9 @@
 		L.mind.transfer_to(brainmob)
 	brainmob << "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>"
 
+/obj/item/organ/internal/brain/attackby(obj/item/O, mob/user, params)
+	if(brainmob)
+		O.attack(brainmob, user) //Oh noooeeeee
 
 /obj/item/organ/internal/brain/examine(mob/user)
 	..()

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -3,7 +3,7 @@
 		return
 	stat = DEAD
 
-	if(!gibbed && container && istype(container, /obj/item/device/mmi))//If not gibbed but in a container.
+	if(!gibbed && container)//If not gibbed but in a container.
 		var/obj/item/device/mmi = container
 		mmi.visible_message("<span class='warning'>[src]'s MMI flatlines!</span>", \
 					"<span class='italics'>You hear something flatline.</span>")
@@ -12,7 +12,7 @@
 	return ..()
 
 /mob/living/carbon/brain/gib(animation = 0)
-	if(container && istype(container, /obj/item/device/mmi))
+	if(container)
 		qdel(container)//Gets rid of the MMI if there is one
 	if(loc)
 		if(istype(loc,/obj/item/organ/internal/brain))

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -8,15 +8,19 @@
 /mob/living/carbon/brain/handle_environment(datum/gas_mixture/environment)
 	return
 
-/mob/living/carbon/brain/proc/handle_temperature_damage(body_part, exposed_temperature, exposed_intensity)
-	return
-
 /mob/living/carbon/brain/update_stat()
 	if(status_flags & GODMODE)
 		return
-	if(stat != DEAD)
-		if(health <= config.health_threshold_dead)
+	if(health <= config.health_threshold_dead)
+		if(stat != DEAD)
 			death()
+		var/obj/item/organ/internal/brain/BR
+		if(container && container.brain)
+			BR = container.brain
+		else if(istype(loc, /obj/item/organ/internal/brain))
+			BR = loc
+		if(BR)
+			BR.damaged_brain = 1 //beaten to a pulp
 
 /* //currently unused feature, since brain outside a mmi is always dead.
 /mob/living/carbon/brain/proc/handle_brain_revival_life()

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -3,72 +3,16 @@
 	return
 
 /mob/living/carbon/brain/handle_mutations_and_radiation()
-
-	if (radiation)
-		if (radiation > 100)
-			if(!container)//If it's not in an MMI
-				src << "<span class='danger'>You feel weak.</span>"
-			else//Fluff-wise, since the brain can't detect anything itself, the MMI handles thing like that
-				src << "<span class='danger'>STATUS: CRITICAL AMOUNTS OF RADIATION DETECTED.</span>"
-
-		switch(radiation)
-
-			if(50 to 75)
-				if(prob(5))
-					if(!container)
-						src << "<span class='danger'>You feel weak.</span>"
-					else
-						src << "<span class='danger'>STATUS: DANGEROUS LEVELS OF RADIATION DETECTED.</span>"
-		..()
+	return
 
 /mob/living/carbon/brain/handle_environment(datum/gas_mixture/environment)
-	if(!environment)
-		return
-	var/environment_heat_capacity = environment.heat_capacity()
-	if(istype(get_turf(src), /turf/space))
-		var/turf/heat_turf = get_turf(src)
-		environment_heat_capacity = heat_turf.heat_capacity
-
-	if((environment.temperature > (T0C + 50)) || (environment.temperature < (T0C + 10)))
-		var/transfer_coefficient = 1
-
-		handle_temperature_damage(HEAD, environment.temperature, environment_heat_capacity*transfer_coefficient)
-
-	if(stat==2)
-		bodytemperature += 0.1*(environment.temperature - bodytemperature)*environment_heat_capacity/(environment_heat_capacity + 270000)
-
-	//Account for massive pressure differences
-
-	return //TODO: DEFERRED
+	return
 
 /mob/living/carbon/brain/proc/handle_temperature_damage(body_part, exposed_temperature, exposed_intensity)
-	if(status_flags & GODMODE) return
-
-	if(exposed_temperature > bodytemperature)
-		var/discomfort = min( abs(exposed_temperature - bodytemperature)*(exposed_intensity)/2000000, 1)
-		adjustFireLoss(20*discomfort)
-
-	else
-		var/discomfort = min( abs(exposed_temperature - bodytemperature)*(exposed_intensity)/2000000, 1)
-		adjustFireLoss(5*discomfort)
+	return
 
 /mob/living/carbon/brain/update_stat()
-	if(status_flags & GODMODE)
-		return
-	if(stat != DEAD)
-		if(health <= config.health_threshold_dead || !container)
-			death()
-			return
-		if(emp_damage>15)
-			if(stat == CONSCIOUS)
-				stat = UNCONSCIOUS
-				blind_eyes(1)
-		else
-			if(stat == UNCONSCIOUS)
-				stat = CONSCIOUS
-				set_blindness(0)
-
-
+	return
 
 /* //currently unused feature, since brain outside a mmi is always dead.
 /mob/living/carbon/brain/proc/handle_brain_revival_life()
@@ -79,17 +23,37 @@
 */
 
 /mob/living/carbon/brain/handle_status_effects()
-	if(!container)
-		emp_damage = 0
-		return
 	if(emp_damage)
-		update_stat()
 		emp_damage = max(emp_damage-1, 0)
 
 /mob/living/carbon/brain/handle_disabilities()
 	return
 
-/mob/living/carbon/brain/setEarDamage()
+/mob/living/carbon/brain/setEarDamage() // no ears to damage or heal
+	return
+
+/mob/living/carbon/brain/adjustEarDamage()
+	return
+
+/mob/living/carbon/brain/blind_eyes() // no eyes to damage or heal
+	return
+
+/mob/living/carbon/brain/blur_eyes()
+	return
+
+/mob/living/carbon/brain/adjust_blindness()
+	return
+
+/mob/living/carbon/brain/adjust_blurriness()
+	return
+
+/mob/living/carbon/brain/set_blindness()
+	return
+
+/mob/living/carbon/brain/set_blurriness()
+	return
+
+/mob/living/carbon/brain/become_blind()
 	return
 
 /mob/living/carbon/brain/handle_changeling()

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -12,7 +12,11 @@
 	return
 
 /mob/living/carbon/brain/update_stat()
-	return
+	if(status_flags & GODMODE)
+		return
+	if(stat != DEAD)
+		if(health <= config.health_threshold_dead)
+			death()
 
 /* //currently unused feature, since brain outside a mmi is always dead.
 /mob/living/carbon/brain/proc/handle_brain_revival_life()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -36,7 +36,6 @@
 
 /mob/living/death(gibbed)
 	unset_machine()
-	reset_perspective(null)
 	timeofdeath = world.time
 	tod = worldtime2text()
 	if(mind)
@@ -50,7 +49,8 @@
 	stunned = 0
 	weakened = 0
 	sleeping = 0
-	update_sight()
+	blind_eyes(1)
+	reset_perspective(null)
 	hide_fullscreens()
 	update_damage_hud()
 	update_health_hud()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -120,11 +120,10 @@
 		mmi.brain.name = "[real_name]'s brain"
 		mmi.icon_state = "mmi_full"
 		mmi.name = "Man-Machine Interface: [real_name]"
-		mmi.brainmob = new(src)
+		mmi.brainmob = new(mmi)
 		mmi.brainmob.name = src.real_name
 		mmi.brainmob.real_name = src.real_name
 		mmi.brainmob.container = mmi
-		mmi.contents += mmi.brainmob
 
 	updatename()
 
@@ -140,6 +139,10 @@
 		if(T)
 			mmi.loc = T
 		if(mmi.brainmob)
+			if(mmi.brainmob.stat == DEAD)
+				mmi.brainmob.stat = CONSCIOUS
+				dead_mob_list -= mmi.brainmob
+				living_mob_list += mmi.brainmob
 			mind.transfer_to(mmi.brainmob)
 			mmi.update_icon()
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -995,38 +995,9 @@ var/next_mob_id = 0
 					obj.update_explanation_text()
 	return 1
 
-/mob/living/carbon/fully_replace_character_name(oldname,newname)
-	..()
-	if(dna)
-		dna.real_name = real_name
-
-/mob/living/silicon/ai/fully_replace_character_name(oldname,newname)
-	..()
-	if(oldname != real_name)
-		if(eyeobj)
-			eyeobj.name = "[newname] (AI Eye)"
-
-		// Notify Cyborgs
-		for(var/mob/living/silicon/robot/Slave in connected_robots)
-			Slave.show_laws()
-
-/mob/living/silicon/robot/fully_replace_character_name(oldname,newname)
-	..()
-	if(oldname != real_name)
-		notify_ai(3, oldname, newname)
-	if(camera)
-		camera.c_tag = real_name
-	custom_name = newname
-
 //Updates data_core records with new name , see mob/living/carbon/human
 /mob/proc/replace_records_name(oldname,newname)
 	return
-
-/mob/living/carbon/human/replace_records_name(oldname,newname) // Only humans have records right now, move this up if changed.
-	for(var/list/L in list(data_core.general,data_core.medical,data_core.security,data_core.locked))
-		var/datum/data/record/R = find_record("name", oldname, L)
-		if(R)
-			R.fields["name"] = newname
 
 /mob/proc/replace_identification_name(oldname,newname)
 	var/list/searching = GetAllContents()
@@ -1051,12 +1022,6 @@ var/next_mob_id = 0
 				if(!search_id)
 					break
 				search_pda = 0
-
-/mob/living/silicon/ai/replace_identification_name(oldname,newname)
-	if(aiPDA)
-		aiPDA.owner = newname
-		aiPDA.name = newname + " (" + aiPDA.ownjob + ")"
-
 
 /mob/proc/update_stat()
 	return

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -320,33 +320,41 @@
 	for(var/t in organs)
 		qdel(t)
 
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot( loc )
+	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot( loc )
 
 	// cyborgs produced by Robotize get an automatic power cell
-	O.cell = new(O)
-	O.cell.maxcharge = 7500
-	O.cell.charge = 7500
+	R.cell = new(R)
+	R.cell.maxcharge = 7500
+	R.cell.charge = 7500
 
 
-	O.gender = gender
-	O.invisibility = 0
+	R.gender = gender
+	R.invisibility = 0
 
 
 	if(mind)		//TODO
-		mind.transfer_to(O)
+		mind.transfer_to(R)
 		if(mind.special_role)
-			O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
+			R.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 	else
-		O.key = key
+		R.key = key
 
 	if (config.rename_cyborg)
-		O.rename_self("cyborg")
+		R.rename_self("cyborg")
 
-	O.loc = loc
-	O.job = "Cyborg"
-	O.notify_ai(1)
+	if(R.mmi)
+		R.mmi.name = "Man-Machine Interface: [real_name]"
+		if(R.mmi.brain)
+			R.mmi.brain.name = "[real_name]'s brain"
+		if(R.mmi.brainmob)
+			R.mmi.brainmob.real_name = real_name //the name of the brain inside the cyborg is the robotized human's name.
+			R.mmi.brainmob.name = real_name
 
-	. = O
+	R.loc = loc
+	R.job = "Cyborg"
+	R.notify_ai(1)
+
+	. = R
 	qdel(src)
 
 //human -> alien

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -320,7 +320,7 @@
 	for(var/t in organs)
 		qdel(t)
 
-	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot( loc )
+	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
 	// cyborgs produced by Robotize get an automatic power cell
 	R.cell = new(R)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -164,7 +164,6 @@
 						new_mob.invisibility = 0
 						new_mob.job = "Cyborg"
 						var/mob/living/silicon/robot/Robot = new_mob
-						Robot.mmi = new /obj/item/device/mmi(new_mob)
 						Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
 					else
 						new_mob.languages |= HUMAN


### PR DESCRIPTION
- <b>Brains can no longer be blinded, even when inside a MMI.</b> Because they have no eyes. Also because having to handle blindness when moving brain in and out of MMI (making them DEAD or CONSCIOUS) is a pain. Fixes MMI brain becoming forever blind when blinded by a statue.
- Fixes borg made from staff of change not having a brain organ in their MMI. Fixes #15048
- Removes some duplicated procs in mob.dm (probably due to incorrectly fixed merge conflicts)
- You can now attack brains with a weapon even when not inside a MMI (previously only when in MMI).
- Fixes brain vision not being given mech sight when put inside a mech.
- Removing a brain from its MMI place the brain in your hand instead of on the ground.
- Fixes built cyborgs containing two mmis.
- <b>Damaged brain from mob attacks can't be placed inside a cyborg.</b> (Brains can only be damaged by attacks with a weapon).
- Robotized humans (called Robotize()) , such as roundstart cyborgs, now have an MMI with the human's name (instead of having a brain with a borg name, which was inconsistent with built cyborgs).
- Syndiborgs bought by nukeops now have a brain with the same last name as the ops team.
- Fixes brain being killable when inside cyborgs. Fixes borg dropping a dead mmi brain unable to talk. Brains are now immune to environment damage and radiation. Fixes #15312
- Fixes brain being able to suicide multiple times (if put in and out of an MMI)
- Admins can now directly spawn brain mobs. It automatically puts it inside a brain organ. Mostly useful for testing purposes and badminery.
- Fixes defibbed corpse not getting blind overlay despite being in crit.
- Brain mobs that are beaten to death can still be inserted inside a brainless human corpse but defibbing the corpse cannot work (the brain is too damaged). On the other hand cloning that corpse will still work.
- Deffibing a brainless corpse no longer gives "further attempts may be successful".
- Fixes brain mob's container var not being nullified on Destroy().

:cl: phil235
rscadd: Brains can no longer be blinded.
bugfix: Fixes brain being immortal. They are immune to everything but melee weapon attacks. Brains not inside a MMI can now be attacked just like MMIs. Damaged brain can't be put into a robot, they can still be put inside a brainless humanoid corpse and cloned, but deffibing the corpse always fails (can't revive someone with a brain beaten to a pulp).
/:cl:
