### PR TITLE
Fixes Malfpowwer upgrade camera net not giving the AI nightvision

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -522,6 +522,7 @@
 
 	var/upgradedcams = 0
 	see_override = SEE_INVISIBLE_MINIMUM //Night-vision, without which X-ray would be very limited in power.
+	update_sight()
 
 	for(var/obj/machinery/camera/C in cameranet.cameras)
 		if(C.assembly)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -123,13 +123,22 @@
 	user.SetWeakened(0)
 	user.incorporeal_move = 1
 	user.alpha = 0
+	user.ExtinguishMob()
+	var/turf/T = get_turf(user)
+	user.forceMove(T) //to properly move the mob out of a potential container
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
+	if(user.pulledby)
+		user.pulledby.stop_pulling()
+	user.stop_pulling()
+	if(user.buckled_mob)
+		user.unbuckle_mob(force=1)
 	sleep(40) //4 seconds
-	user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The rift's pressure forces you back to corporeality.</span>")
-	user.incorporeal_move = 0
-	user.alpha = 255
-
+	if(!qdeleted(user))
+		user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The rift's pressure forces you back to corporeality.</span>")
+		user.incorporeal_move = 0
+		user.alpha = 255
+		user.forceMove(user.loc)
 
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze //Stuns and freezes nearby people - a bit more effective than a changeling's cryosting
 	name = "Icy Veins"
@@ -726,12 +735,13 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 	active = !active
 	if(active)
 		user << "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>"
-		user.see_in_dark = 8
+		user.dna.species.darksight = 8
 		user.dna.species.invis_sight = SEE_INVISIBLE_MINIMUM
 	else
 		user << "<span class='notice'>You return your vision to normal.</span>"
-		user.see_in_dark = 0
+		user.dna.species.darksight = 0
 		user.dna.species.invis_sight = initial(user.dna.species.invis_sight)
+	user.update_sight()
 
 
 /obj/effect/proc_holder/spell/self/lesser_shadowling_hivemind //Lets a thrall talk with their allies

--- a/code/game/gamemodes/shadowling/shadowling_items.dm
+++ b/code/game/gamemodes/shadowling/shadowling_items.dm
@@ -96,6 +96,7 @@
 	if(H.dna.species.id != "shadowling")
 		user << "<span class='warning'>You aren't sure how to do this...</span>"
 		return
+	H.dna.species.darksight = 0 //so our species' vision in the dark doesn't interfere.
 	var/new_dark_view
 	new_dark_view = (input(user, "Enter the radius of tiles to see with night vision.", "Night Vision", "[new_dark_view]") as num)
 	new_dark_view = Clamp(new_dark_view,min_darkness_view,max_darkness_view)
@@ -105,4 +106,4 @@
 		else
 			user << "<span class='notice'>You shift your night vision capabilities to see [new_dark_view] tiles away.</span>"
 	darkness_view = new_dark_view
-	return
+	user.update_sight()

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -39,6 +39,7 @@
 				target.unbuckle_mob(force=1)
 			jaunt_disappear(animation, target)
 			target.loc = holder
+			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
 			sleep(jaunt_duration)
@@ -52,16 +53,19 @@
 			holder.reappearing = 1
 			playsound(get_turf(user), 'sound/magic/Ethereal_Exit.ogg', 50, 1, -1)
 			sleep(20)
-			jaunt_reappear(animation, target)
+			if(!qdeleted(target))
+				jaunt_reappear(animation, target)
 			sleep(5)
-			if(mobloc.density)
-				for(var/direction in list(1,2,4,8,5,6,9,10))
-					var/turf/T = get_step(mobloc, direction)
-					if(T)
-						if(target.Move(T))
-							break
-			target.canmove = 1
-			target.client.eye = target
+			if(!qdeleted(target))
+				if(mobloc.density)
+					for(var/direction in list(1,2,4,8,5,6,9,10))
+						var/turf/T = get_step(mobloc, direction)
+						if(T)
+							if(target.Move(T))
+								break
+				target.canmove = 1
+				target.reset_perspective()
+				target.update_canmove() //if the caster became unconscious mid-jaunt we must make him fall down.
 			qdel(animation)
 			qdel(holder)
 


### PR DESCRIPTION
- Fixes #15367
- Fixes client eye not being update when using shadow walk or ethereal_jaunt inside a container.
- Fixes thrall vision spell not udating your vision.
- Fixes Shift Nerves shadowling ability not adjusting your night vision range correctly.
- Using shadow walk now extinguishes the shadowling.
