### PR TITLE
Blobs can now expand onto lattices and catwalks

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -9,9 +9,11 @@
 	pass_flags = PASSBLOB
 	faction = list("blob")
 	bubble_icon = "blob"
+	speak_emote = null //so we use verb_yell/verb_say/etc
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 360
+	unique_name = 1
 	var/mob/camera/blob/overmind = null
 
 /mob/living/simple_animal/hostile/blob/update_icons()
@@ -31,6 +33,22 @@
 		return 1
 	return ..()
 
+/mob/living/simple_animal/hostile/blob/handle_inherent_channels(message, message_mode)
+	if(message_mode == MODE_BINARY)
+		blob_chat(message)
+		return ITALICS | REDUCE_RANGE
+	else
+		..()
+
+/mob/living/simple_animal/hostile/blob/proc/blob_chat(msg)
+	var/spanned_message = say_quote(msg, get_spans())
+	var/rendered = "<font color=\"#EE4000\"><b>\[Blob Telepathy\] [real_name]</b> [spanned_message]</font>"
+	for(var/M in mob_list)
+		if(isovermind(M) || istype(M, /mob/living/simple_animal/hostile/blob))
+			M << rendered
+		if(isobserver(M))
+			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+
 ////////////////
 // BLOB SPORE //
 ////////////////
@@ -42,11 +60,15 @@
 	icon_living = "blobpod"
 	health = 40
 	maxHealth = 40
+	verb_say = "psychically pulses"
+	verb_ask = "psychically probes"
+	verb_exclaim = "psychically yells"
+	verb_yell = "psychically screams"
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	attacktext = "hits"
 	attack_sound = 'sound/weapons/genhit1.ogg'
-	speak_emote = list("pulses")
+
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/obj/effect/blob/factory/factory = null
 	var/list/human_overlays = list()
@@ -83,7 +105,6 @@
 	melee_damage_upper += 11
 	death_cloud_size = 0
 	icon = H.icon
-	speak_emote = list("groans")
 	icon_state = "zombie_s"
 	H.hair_style = null
 	H.update_hair()
@@ -158,7 +179,10 @@
 	melee_damage_upper = 20
 	attacktext = "slams"
 	attack_sound = 'sound/effects/blobattack.ogg'
-	speak_emote = list("gurgles")
+	verb_say = "gurgles"
+	verb_ask = "demands"
+	verb_exclaim = "roars"
+	verb_yell = "bellows"
 	force_threshold = 10
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = 1

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -98,7 +98,7 @@
 		if(isovermind(M) || istype(M, /mob/living/simple_animal/hostile/blob))
 			M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a>[rendered]"
+			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
 
 /mob/camera/blob/emote(act,m_type=1,message = null)
 	return

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -105,6 +105,7 @@
 		blobber << 'sound/effects/blobattack.ogg'
 		blobber << 'sound/effects/attackblob.ogg'
 		blobber << "<b>You are a blobbernaut!</b>"
+		blobber << "You can communicate with other blobbernauts and overminds via <b>:b</b>"
 		blobber << "Your overmind's blob reagent is: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
 		blobber << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]"
 	else

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -119,7 +119,20 @@
 /obj/effect/blob/proc/ConsumeTile()
 	for(var/atom/A in loc)
 		A.blob_act()
+	if(istype(loc, /turf/simulated/wall))
+		loc.blob_act() //don't ask how a wall got on top of the core, just eat it
 
+/obj/effect/blob/proc/blob_attack_animation(atom/A = null, controller) //visually attacks an atom
+	var/obj/effect/overlay/temp/blob/O = PoolOrNew(/obj/effect/overlay/temp/blob, src.loc)
+	if(controller)
+		var/mob/camera/blob/BO = controller
+		O.color = BO.blob_reagent_datum.color
+		O.alpha = 200
+	else if(overmind)
+		O.color = overmind.blob_reagent_datum.color
+	if(A)
+		O.do_attack_animation(A) //visually attack the whatever
+	return O //just in case you want to do something to the animation.
 
 /obj/effect/blob/proc/expand(turf/T = null, controller = null)
 	if(!T)
@@ -136,7 +149,7 @@
 		return 0
 	var/make_blob = TRUE //can we make a blob?
 
-	if(istype(T, /turf/space) && prob(65))
+	if(istype(T, /turf/space) && !(locate(/obj/structure/lattice) in T) && prob(80))
 		make_blob = FALSE
 		playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) //Let's give some feedback that we DID try to spawn in space, since players are used to it
 
@@ -149,15 +162,6 @@
 			make_blob = FALSE
 		A.blob_act() //also hit everything in the turf
 
-	var/obj/effect/overlay/temp/blob/O = PoolOrNew(/obj/effect/overlay/temp/blob, src.loc)
-	if(controller)
-		var/mob/camera/blob/BO = controller
-		O.color = BO.blob_reagent_datum.color
-		O.alpha = 200 //if we have a controller, we're direct attack and must be more important
-	else if(overmind)
-		O.color = overmind.blob_reagent_datum.color
-	O.do_attack_animation(T) //visually attack the turf
-
 	if(make_blob) //well, can we?
 		var/obj/effect/blob/B = new /obj/effect/blob/normal(src.loc)
 		if(controller)
@@ -166,7 +170,6 @@
 			B.overmind = overmind
 		B.density = 1
 		if(T.Enter(B,src)) //NOW we can attempt to move into the tile
-			O.alpha = 0 //if we got to this point, we don't need to visually attack
 			B.density = initial(B.density)
 			B.loc = T
 			B.update_icon()
@@ -174,9 +177,12 @@
 				B.overmind.blob_reagent_datum.expand_reaction(src, B, T)
 			return B
 		else
+			blob_attack_animation(T, controller)
 			T.blob_act() //if we can't move in hit the turf again
 			qdel(B) //we should never get to this point, since we checked before moving in. destroy the blob so we don't have two blobs on one tile
 			return null
+	else
+		blob_attack_animation(T, controller) //if we can't, animate that we attacked
 	return null
 
 

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -9,7 +9,7 @@
 	var/message_living = null //extension to first mob sent to only living mobs i.e. silicons have no skin to be burnt
 
 /datum/reagent/blob/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	return round(reac_volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any protbelow 0.5 means 100% volume.
+	return round(reac_volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any prot below 0.5 means 100% volume.
 
 /datum/reagent/blob/proc/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause) //when the blob takes damage, do this
 	return damage

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -9,7 +9,7 @@
 	var/message_living = null //extension to first mob sent to only living mobs i.e. silicons have no skin to be burnt
 
 /datum/reagent/blob/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	return round(reac_volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any prot below 0.5 means 100% volume.
+	return round(reac_volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any protbelow 0.5 means 100% volume.
 
 /datum/reagent/blob/proc/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause) //when the blob takes damage, do this
 	return damage
@@ -354,10 +354,7 @@
 	if(M)
 		for(var/obj/effect/blob/B in range(1, M)) //if the target is completely surrounded, this is 2.4*reac_volume bonus damage, total of 2.5*reac_volume
 			if(M)
-				var/obj/effect/overlay/temp/blob/OV = PoolOrNew(/obj/effect/overlay/temp/blob, B.loc)
-				if(B.overmind)
-					OV.color = B.overmind.blob_reagent_datum.color
-				OV.do_attack_animation(M) //show them they're getting a bad time
+				B.blob_attack_animation(M) //show them they're getting a bad time
 				M.apply_damage(0.3*reac_volume, BRUTE)
 
 /datum/reagent/blob/synchronous_mesh/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
@@ -430,8 +427,8 @@
 	message = "You feel a thrum as the blob strikes you, and everything flies at you"
 
 /datum/reagent/blob/dark_matter/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	reagent_vortex(M, 0, reac_volume)
 	reac_volume = ..()
+	reagent_vortex(M, 0, reac_volume)
 	M.apply_damage(0.4*reac_volume, BRUTE)
 
 //does brute damage and throws or pushes nearby objects away from the target
@@ -443,9 +440,9 @@
 	message = "The blob slams into you and sends you flying"
 
 /datum/reagent/blob/b_sorium/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	reagent_vortex(M, 1, reac_volume)
 	reac_volume = ..()
-	M.apply_damage(0.5*reac_volume, BRUTE)
+	reagent_vortex(M, 1, reac_volume)
+	M.apply_damage(0.4*reac_volume, BRUTE)
 
 /datum/reagent/blob/proc/reagent_vortex(mob/living/M, setting_type, reac_volume)
 	if(M)

--- a/config/tips.txt
+++ b/config/tips.txt
@@ -133,12 +133,13 @@ As an Alien, the facehugger is by far your most powerful weapon because of its a
 As an Alien, you are unable to pick up or use any human items or machinery. Instead, you should focus on sabotaging APCs, computers, cameras and either stowing, spacing, or melting any weapons you find.
 As the Blob, you will spawn from your character from between a minute to 5 minutes after the round starts. Use this time to find a safe and well hidden location and evaluate where you will strike!
 As the Blob, you can do various sabotage before you spawn, such as spacing the armory or disabling R&D.
-As the Blob, keep your core some distance from space, as it is both expensive to expand onto space and easy to be attacked from. Emitter platforms built in space are especially dangerous.
-As the Blob, the split consciousness ability will create a second blob core, from a node, controlled by another player with a different reagent of their own. Coordinate and communicate your attacks and reactions with them!
+As the Blob, keep your core some distance from space, as it is both expensive to expand onto space, easy to be attacked from, and does not count towards your win condition. Emitter platforms built in space are especially dangerous.
 As the Blob, you can randomly repick your reagent type if the crew has adapted and protected themselves against your current one.
 As the Blob, you fight a war of attrition: Take out medbay and fight in chokepoints to prevent continued assaults and coordinated burst damage attacks!
 As the Blob, remember that you can only expand onto tiles from cardinal directions, while the crew can attack you diagonally. Fight in narrow corridors or expand and widen across the width of the hallway to force confrontations where you can hit them!
 As the Blob, don't neglect the creation of factories. These create spores that carry your reagent and can chase crewmembers far further than you. Spores can also be rallied to swarm the crew and cause panic, and can even take over corpses to create much more dangerous blob zombies!
+As the Blob, you can expand by clicking, create strong blobs with ctrl-click, rally spores with middle-click, and remove blobs with alt-click.
+As the Blob, removing strong blobs, resource nodes, factories, and nodes will give you 2, 15, 25, and 25 resources back, respectively.
 As a Revolutionary, you cannot convert a head of staff or someone who has a loyalty implant, such as a security officer or those they implant. Implants can however be surgically removed, and do not carry over with cloning. Take control of medbay to keep control of conversions!
 As a Revolutionary, cargo can be your best friend or your worst nightmare. In the best case scenario you will be able to order a limitless amount of guns and armor, in the worst case scenario security will take control and order a limitless number of loyalty implants to turn your fellow revolutionaries against you.
 As a Revolutionary, your main power comes from how quickly you spread. Convert people as fast as you can and overwhelm the heads of staff before security can arm up.


### PR DESCRIPTION
:cl: Joan
rscadd: Blobbernauts can now speak to overminds and other blobbernauts with :b
rscadd: Blobs can now expand onto lattices and catwalks.
rscdel: Blob expansion on space tiles with no supports is much slower.
tweak: Blob Sorium and Dark Matter now have less range on targets with bio protection.
tweak: Blob Sorium does slightly less damage.
/:cl:

Updates blob tips.
Blobs now consume walls that are on their tile.
Added a space between blob follow link and message.
