### PR TITLE
Fixes old species conversion code being incorrect

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -167,7 +167,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				if(13)
 					underwear = "Nude"
 
-	if(!(pref_species in species_list))
+	if(pref_species && !(pref_species.id in roundstart_species))
 		pref_species = new /datum/species/human()
 
 	if(current_version < 13 || !istext(backbag))


### PR DESCRIPTION
Technically not my fault.
The oldcode was wrong on 2 levels, I just only happened to notice 1 level the first time round.
