### PR TITLE
Adds Sleeping Carp Scroll to Traitor uplink

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -1,7 +1,7 @@
 //gang.dm
 //Gang War Game Mode
 
-var/list/gang_name_pool = list("Clandestine", "Prima", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel", "Diablo", "Psyke", "Osiron", "Sirius")
+var/list/gang_name_pool = list("Clandestine", "Prima", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel", "Diablo", "Psyke", "Osiron", "Sirius", "Sleeping Carp")
 var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple")
 
 /datum/game_mode

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -1,7 +1,7 @@
 //gang.dm
 //Gang War Game Mode
 
-var/list/gang_name_pool = list("Clandestine", "Prima", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel", "Diablo", "Psyke", "Osiron", "Sirius", "Sleeping Carp")
+var/list/gang_name_pool = list("Clandestine", "Prima", "Zero-G", "Max", "Blasto", "Waffle", "North", "Omni", "Newton", "Cyber", "Donk", "Gene", "Gib", "Tunnel", "Diablo", "Psyke", "Osiron", "Sirius")
 var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple")
 
 /datum/game_mode

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -159,7 +159,7 @@
 		if(!prob(martial_art.deflection_chance))
 			return ..()
 		if(!src.lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it
-			src.visible_message("<span class='danger'>[src] deflects the projectile, there's no way you'll be able to hit them with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+			src.visible_message("<span class='danger'>[src] deflects the projectile; it's not possible to hit them with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			return 0
 	..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -159,7 +159,7 @@
 		if(!prob(martial_art.deflection_chance))
 			return ..()
 		if(!src.lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it
-			src.visible_message("<span class='warning'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+			src.visible_message("<span class='danger'>[src] deflects the projectile, there's no way you'll be able to hit them with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			return 0
 	..()
 

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -548,6 +548,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "Anyone who reads the sleeping carp scroll will learn secrets of the sleeping carp martial arts style."
 	item = /obj/item/weapon/sleeping_carp_scroll
 	cost = 17
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/stealthy_weapons/throwingstars
 	name = "Box of Throwing Stars"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -543,6 +543,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
 
+/datum/uplink_item/stealthy_weapons/Sleepingcarp
+	name = "Sleeping Carp Scroll"
+	desc = "Anyone who reads the sleeping carp scroll will learn secrets of the sleeping carp martial arts style."
+	item = /obj/item/weapon/sleeping_carp_scroll
+	cost = 17
+
 /datum/uplink_item/stealthy_weapons/throwingstars
 	name = "Box of Throwing Stars"
 	desc = "A box of shurikens from ancient Earth martial arts. They are highly effective throwing weapons, \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -543,9 +543,10 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
 
-/datum/uplink_item/stealthy_weapons/Sleepingcarp
-	name = "Sleeping Carp Scroll"
-	desc = "Anyone who reads the sleeping carp scroll will learn secrets of the sleeping carp martial arts style."
+/datum/uplink_item/stealthy_weapons/martialarts
+	name = "Martial Arts Scroll"
+	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
+			deflecting all ranged weapon fire, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/weapon/sleeping_carp_scroll
 	cost = 17
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)


### PR DESCRIPTION
See: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=5886

It's terrible in Gang War. It would be extremely difficult to balance in Gang War. It's much better suited to being a highly specialized traitor item. 

:cl:
add: Sleeping Carp scrolls are now a traitor item.
/:cl:
