### PR TITLE
attempts to solve minimaps crashing the server. (again)

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -98,7 +98,7 @@ var/datum/subsystem/minimap/SSminimap
 			flatten.Insert(minimap, "", SOUTH, 1, 0)
 			del(minimap)
 			minimap = flatten
-			sleep -1
+			sleep(-1)
 
 	// Create a new icon and insert the generated minimap, so that BYOND doesn't generate different directions.
 	var/icon/final = new /icon()

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -43,7 +43,7 @@ var/datum/subsystem/minimap/SSminimap
 	// Scale it up to our target size.
 	minimap.Scale(MINIMAP_SIZE, MINIMAP_SIZE)
 	var/list/obj_icons = list() 
-	var/counter = 255
+	var/counter = 128
 	// Loop over turfs and generate icons.
 	for(var/T in block(locate(x1, y1, z), locate(x2, y2, z)))
 		
@@ -88,15 +88,17 @@ var/datum/subsystem/minimap/SSminimap
 			tile_icon.Scale(TILE_SIZE, TILE_SIZE)
 			// Add the tile to the minimap.
 			minimap.Blend(tile_icon, ICON_OVERLAY, ((tile.x - 1) * TILE_SIZE), ((tile.y - 1) * TILE_SIZE))
+			del(tile_icon)
 		
 		//byond bug, this fixes OOM crashes by flattening and reseting the minimap icon holder every 255 tiles
 		counter--
 		if (counter <= 0)
-			counter = 255
+			counter = 128
 			var/icon/flatten = new /icon()
 			flatten.Insert(minimap, "", SOUTH, 1, 0)
 			del(minimap)
 			minimap = flatten
+			sleep -1
 
 	// Create a new icon and insert the generated minimap, so that BYOND doesn't generate different directions.
 	var/icon/final = new /icon()


### PR DESCRIPTION
so lummox knows about this, he thinks it's an icon's internal storage not getting properly freed until the icon itself is freed, but we haven't narrowed it down, other then that Blend() is the cause.
