### PR TITLE
Fix how AI turrets assess human perps

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -554,9 +554,6 @@
 	invisibility = 2
 	icon_state = "[base_icon_state][off_state]"
 
-/obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
-	return 10 //AI turrets shoot at everything not in their faction
-
 /obj/machinery/porta_turret/proc/assess_perp(mob/living/carbon/human/perp)
 	var/threatcount = 0	//the integer returned
 
@@ -609,6 +606,8 @@
 
 	return threatcount
 
+/obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
+	return 10 //AI turrets shoot at everything not in their faction
 
 /obj/machinery/porta_turret/proc/in_faction(mob/target)
 	if(!(faction in target.faction))

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -554,6 +554,8 @@
 	invisibility = 2
 	icon_state = "[base_icon_state][off_state]"
 
+/obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
+	return 10 //AI turrets shoot at everything not in their faction
 
 /obj/machinery/porta_turret/proc/assess_perp(mob/living/carbon/human/perp)
 	var/threatcount = 0	//the integer returned


### PR DESCRIPTION
Now it matches how the old logic worked

Probably also takes care of how cpu agressive turrets are at the moment (default assess perp has a tonne of checks)

Partialfix #15467
