### PR TITLE
Fixes blindness overlay after reviving.

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -85,13 +85,14 @@
 	if (href_list["fix"])
 		src.active = 1
 		while (src.occupier.health < 100)
-			src.occupier.adjustOxyLoss(-1)
-			src.occupier.adjustFireLoss(-1)
-			src.occupier.adjustToxLoss(-1)
-			src.occupier.adjustBruteLoss(-1)
+			src.occupier.adjustOxyLoss(-1, 0)
+			src.occupier.adjustFireLoss(-1, 0)
+			src.occupier.adjustToxLoss(-1, 0)
+			src.occupier.adjustBruteLoss(-1, 0)
 			src.occupier.updatehealth()
 			if (src.occupier.health >= 0 && src.occupier.stat == 2)
-				src.occupier.stat = 0
+				src.occupier.stat = CONSCIOUS
+				src.occupier.adjust_blindness(-1)
 				src.occupier.lying = 0
 				dead_mob_list -= src.occupier
 				living_mob_list += src.occupier

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -367,7 +367,7 @@
 		update_icon()
 
 /obj/structure/closet/get_remote_view_fullscreens(mob/user)
-	if(!(user.sight & (SEEOBJS|SEEMOBS)))
+	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 1)
 
 /obj/structure/closet/emp_act(severity)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -93,7 +93,7 @@
 	update_icon()
 
 /obj/structure/bodycontainer/get_remote_view_fullscreens(mob/user)
-	if(!(user.sight & (SEEOBJS|SEEMOBS)))
+	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 2)
 /*
  * Morgue

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -1,4 +1,15 @@
 
+/mob/living/carbon/brain/Life()
+	set invisibility = 0
+	set background = BACKGROUND_ENABLED
+
+	if (notransform)
+		return
+	if(!loc)
+		return
+	. = ..()
+	handle_emp_damage()
+
 /mob/living/carbon/brain/handle_breathing()
 	return
 
@@ -30,9 +41,15 @@
 				death()
 */
 
-/mob/living/carbon/brain/handle_status_effects()
+/mob/living/carbon/brain/proc/handle_emp_damage()
 	if(emp_damage)
-		emp_damage = max(emp_damage-1, 0)
+		if(stat == DEAD)
+			emp_damage = 0
+		else
+			emp_damage = max(emp_damage-1, 0)
+
+/mob/living/carbon/brain/handle_status_effects()
+	return
 
 /mob/living/carbon/brain/handle_disabilities()
 	return

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -39,7 +39,7 @@ var/global/posibrain_notif_cooldown = 0
 		spawn(askDelay) //Seperate from the global cooldown.
 			notified = 0
 			update_icon()
-			if(brainmob.stat == CONSCIOUS && brainmob.client)
+			if(brainmob.client)
 				visible_message("<span class='notice'>The positronic brain pings, and its lights start flashing. Success!</span>")
 			else
 				visible_message("<span class='notice'>The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?</span>")
@@ -99,6 +99,9 @@ var/global/posibrain_notif_cooldown = 0
 	brainmob << "<b>As a synthetic intelligence, you answer to all crewmembers, as well as the AI.</b>"
 	brainmob << "<b>Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"
 	brainmob.mind.assigned_role = "Positronic Brain"
+	brainmob.stat = CONSCIOUS
+	dead_mob_list -= brainmob
+	living_mob_list += brainmob
 
 	visible_message("<span class='notice'>The positronic brain chimes quietly.</span>")
 	update_icon()
@@ -123,8 +126,6 @@ var/global/posibrain_notif_cooldown = 0
 			if(CONSCIOUS)
 				if(!src.brainmob.client)
 					msg += "It appears to be in stand-by mode.\n" //afk
-			if(UNCONSCIOUS)
-				msg += "<span class='warning'>It doesn't seem to be responsive.</span>\n"
 			if(DEAD)
 				msg += "<span class='deadsay'>It appears to be completely inactive.</span>\n"
 	else
@@ -139,7 +140,6 @@ var/global/posibrain_notif_cooldown = 0
 	brainmob.real_name = brainmob.name
 	brainmob.loc = src
 	brainmob.container = src
-	dead_mob_list -= brainmob
 	ping_ghosts("created")
 	..()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -708,11 +708,11 @@ var/const/GALOSHES_DONT_HELP = 4
 		reagents.addiction_list = list()
 	for(var/datum/disease/D in viruses)
 		D.cure(0)
-	if(stat == DEAD)
-		dead_mob_list -= src
-		living_mob_list += src
 	var/obj/item/organ/internal/brain/BR = getorgan(/obj/item/organ/internal/brain)
 	if(BR) //can't revive if the mob has no brain
+		if(stat == DEAD)
+			dead_mob_list -= src
+			living_mob_list += src
 		stat = CONSCIOUS
 		BR.damaged_brain = 0 //if the brain itself is damaged we heal it
 	set_blindness(0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -690,10 +690,7 @@ var/const/GALOSHES_DONT_HELP = 4
 	radiation = 0
 	nutrition = NUTRITION_LEVEL_FED + 50
 	bodytemperature = 310
-	eye_damage = 0
 	disabilities = 0
-	eye_blind = 0
-	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0
 	hallucination = 0
@@ -714,7 +711,13 @@ var/const/GALOSHES_DONT_HELP = 4
 	if(stat == DEAD)
 		dead_mob_list -= src
 		living_mob_list += src
-	stat = CONSCIOUS
+	var/obj/item/organ/internal/brain/BR = getorgan(/obj/item/organ/internal/brain)
+	if(BR) //can't revive if the mob has no brain
+		stat = CONSCIOUS
+		BR.damaged_brain = 0 //if the brain itself is damaged we heal it
+	set_blindness(0)
+	set_blurriness(0)
+	set_eye_damage(0)
 	if(ishuman(src))
 		var/mob/living/carbon/human/human_mob = src
 		human_mob.restore_blood()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -469,10 +469,7 @@ Sorry Giacom. Please don't be mad :(
 	radiation = 0
 	nutrition = NUTRITION_LEVEL_FED + 50
 	bodytemperature = 310
-	eye_damage = 0
 	disabilities = 0
-	eye_blind = 0
-	eye_blurry = 0
 	ear_deaf = 0
 	ear_damage = 0
 	hallucination = 0
@@ -484,6 +481,9 @@ Sorry Giacom. Please don't be mad :(
 		dead_mob_list -= src
 		living_mob_list += src
 	stat = CONSCIOUS
+	set_blindness(0)
+	set_blurriness(0)
+	set_eye_damage(0)
 	updatehealth()
 	update_fire()
 	regenerate_icons()
@@ -962,7 +962,7 @@ Sorry Giacom. Please don't be mad :(
 			src << "<span class='notice'>You're too exhausted to keep going...</span>"
 			Weaken(5)
 			setStaminaLoss(health - 2)
-		update_health_hud()
+	update_health_hud()
 
 /mob/proc/update_sight()
 	return
@@ -1101,10 +1101,6 @@ Sorry Giacom. Please don't be mad :(
 	else if(old_druggy)
 		clear_fullscreen("high")
 		clear_alert("high")
-
-
-/mob/proc/update_vision_overlays()
-	return
 
 /mob/proc/cure_blind() //when we want to cure the BLIND disability only.
 	return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -890,17 +890,3 @@ var/list/ai_list = list()
 			AT.get_remote_view_fullscreens(src)
 		else
 			clear_fullscreen("remote_view", 0)
-
-
-/mob/living/silicon/ai/update_vision_overlays()
-	if(!client)
-		return
-
-	if(stat == DEAD) //if dead we just remove all vision impairments
-		clear_fullscreens()
-		return
-
-	if(eye_blind)
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-	else
-		clear_fullscreen("blind")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1248,25 +1248,6 @@
 				update_canmove()
 				update_headlamp()
 
-/mob/living/silicon/robot/update_vision_overlays()
-	if(!client)
-		return
-
-	if(stat == DEAD) //if dead we just remove all vision impairments
-		clear_fullscreens()
-		return
-
-	if(eye_blind)
-		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
-	else
-		clear_fullscreen("blind")
-
-	if(client.eye != src)
-		var/atom/A = client.eye
-		A.get_remote_view_fullscreens(src)
-	else
-		clear_fullscreen("remote_view", 0)
-
 /mob/living/silicon/robot/fully_replace_character_name(oldname, newname)
 	..()
 	if(oldname != real_name)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -25,9 +25,15 @@
 	nodamage = 0
 
 /obj/item/projectile/magic/fireball/Range()
-	var/mob/living/L = locate(/mob/living) in (range(src, 1) - firer)
+	var/turf/T1 = get_step(src,turn(dir, -45))
+	var/turf/T2 = get_step(src,turn(dir, 45))
+	var/mob/living/L = locate(/mob/living) in T1 //if there's a mob alive in our front right diagonal, we hit it.
 	if(L && L.stat != DEAD)
 		Bump(L) //Magic Bullet #teachthecontroversy
+		return
+	L = locate(/mob/living) in T2
+	if(L && L.stat != DEAD)
+		Bump(L)
 		return
 	..()
 

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -476,7 +476,7 @@
 	return
 
 /obj/machinery/disposal/bin/get_remote_view_fullscreens(mob/user)
-	if(!(user.sight & (SEEOBJS|SEEMOBS)))
+	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 2)
 
 


### PR DESCRIPTION
- Fixes revive() not properly removing the blind overlay. (fixes staff of healing, fixes #15501)
- Fixes revive() working on brainless carbons, making them die right away. It now only heals the body but doesn't actually make the mob alive again.
- Fixes dead mob put into closet and then revived not seeing the closet vision overlay.
- Fixes brain mob's emp_damage never decreasing when stat == DEAD.
- Fixes posibrain's brainmob starting dead when given to a ghost. Fixes #15514
- Fixes ai fixing not clearing the blind overlay properly. Fixes  #15517
- Fireball projectile no longer explodes on the firer when there's a body on their tile. The fireball's range() code now only checks the two tiles on its front left and front right for mobs to hit.
- Remove some update_vision_overlays() (now unused) that I forgot to remove.
- Using a staff oh healing on a corpse with a damaged brain organ will revive the mob and heal the brain organ.
