### PR TITLE
Chemical explosions now ignore the bombcap

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -125,15 +125,15 @@
 
 		// Clamp all values to MAX_EXPLOSION_RANGE
 		if (round(amount/12) > 0)
-			devastation = min (MAX_EX_DEVESTATION_RANGE, devastation + round(amount/12))
+			devastation = round(amount/12)
 
 		if (round(amount/6) > 0)
-			heavy = min (MAX_EX_HEAVY_RANGE, heavy + round(amount/6))
+			heavy = round(amount/6)
 
 		if (round(amount/3) > 0)
-			light = min (MAX_EX_LIGHT_RANGE, light + round(amount/3))
+			light = round(amount/3)
 
 		if (flashing && flashing_factor)
 			flash += (round(amount/4) * flashing_factor)
 
-		explosion(location, devastation, heavy, light, flash)
+		explosion(location, devastation, heavy, light, flash, 1, 1)


### PR DESCRIPTION
We discussed this on the forums a while back but I never made a PR for it.

As it says, chemical explosions, I.E. potassium-water, black powder, and nitroglycerin now ignore the bomb cap.

This doesn't effect most grenades however, most of them are limited to the bombcap or below because of the limited size of beakers. Only bluespace-beaker blackpowder and nitro grenades would be effected.

A optimal blackpowder grenade using bluespace beakers would now be 7,15, 32, instead of 5, 10, 20.

A optimal nitroglycerin grenade using bluespace beakers would now be 15, 32, 65(!!!), instead of 5, 10, 20. Keep in mind this requires probably 20 minutes of corn farming and chemical mixing, significantly harder than just releasing the tesla/singulo.

And of course those both require science to do R&D, which is fairly rare.
