### PR TITLE
Buffs Toolbox.

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -5,8 +5,8 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 	flags = CONDUCT
-	force = 10
-	throwforce = 10
+	force = 15
+	throwforce = 15
 	throw_speed = 2
 	throw_range = 7
 	w_class = 4
@@ -73,8 +73,8 @@
 	item_state = "toolbox_syndi"
 	origin_tech = "combat=1;syndicate=1"
 	silent = 1
-	force = 15
-	throwforce = 18
+	force = 20
+	throwforce = 20
 
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -10,6 +10,7 @@
 	throw_speed = 2
 	throw_range = 7
 	w_class = 4
+	max_combined_w_class = 28
 	materials = list(MAT_METAL = 500)
 	origin_tech = "combat=1"
 	attack_verb = list("robusted")


### PR DESCRIPTION
Toolbox's are buffed to 15 force, putting them in line with cleavers and welder.
Syndie toolboxes are 20. Since they were literally only bought for the tools and then abandoned.

Toolboxes can also now hold double what they can now. But only with small items, such as tools. Previously they were the same size as a box.
Reasons: Due to their massive weight class, carrying them in a pain.
The other weapons at 10 force are all smaller and arguably more useful(most notably the fire extingisher).
They are uncommon.

Weapon comparisons:
Spear-10 force one handed, 18 dual wielded, fits in backslot.
Cleaver-15 force. Fits in belt, chef outfits, and backpack. Rare.
Welder-15 force. Requires fuel, only does burn, fits in pockets!

Extinguisher-10 force. Fits in backpack, useful in space, and extinguishing yourself.
Floor Tiles-10 throwforce, stacks to 50.
