### PR TITLE
Fixes jobban cache not updating on jobbans and unbans

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -973,6 +973,8 @@
 						log_admin("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins] minutes")
 						feedback_inc("ban_job_tmp",1)
 						DB_ban_record(BANTYPE_JOB_TEMP, M, mins, reason, job)
+						if(M.client)
+							jobban_buildcache(M.client)
 						feedback_add_details("ban_job_tmp","- [job]")
 						if(!msg)
 							msg = job
@@ -994,6 +996,8 @@
 							log_admin("[key_name(usr)] perma-banned [key_name(M)] from [job]")
 							feedback_inc("ban_job",1)
 							DB_ban_record(BANTYPE_JOB_PERMA, M, -1, reason, job)
+							if(M.client)
+								jobban_buildcache(M.client)
 							feedback_add_details("ban_job","- [job]")
 							if(!msg)
 								msg = job
@@ -1022,6 +1026,8 @@
 						ban_unban_log_save("[key_name(usr)] unjobbanned [key_name(M)] from [job]")
 						log_admin("[key_name(usr)] unbanned [key_name(M)] from [job]")
 						DB_ban_unban(M.ckey, BANTYPE_ANY_JOB, job)
+						if(M.client)
+							jobban_buildcache(M.client)
 						feedback_inc("ban_job_unban",1)
 						feedback_add_details("ban_job_unban","- [job]")
 						if(!msg)


### PR DESCRIPTION
Currently, the cache would only rebuild when it did not exist. 
This meant that not only did jobbans not take into effect the same round, but also prevented same round jobban unbanning as well as the possibility of duplicate jobbans which error out the unbanning system.
