### PR TITLE
Restores the old sound of windowed doors

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -210,7 +210,6 @@
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
 	opacity = 0
 	doortype = /obj/structure/door_assembly/door_assembly_glass
-	doorsound = 'sound/machines/windowdoor.ogg'
 	glass = 1
 
 //////////////////////////////////


### PR DESCRIPTION
Makes the vanilla white windowed doors (the fulltile ones) sound like other doors again as opposed to sounding like windoors (the tile border ones).

I'll take "Things everyone wanted to do but inexplicably didn't" for 400, Alex.
