### PR TITLE
Gives ghosts a full Security HUD.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -417,9 +417,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(data_hud_seen) //give new huds
 		if(0)
-			show_me_the_hud(DATA_HUD_SECURITY_BASIC)
+			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			src << "<span class='notice'>Security HUD set.</span>"
-		if(DATA_HUD_SECURITY_BASIC)
+		if(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			src << "<span class='notice'>Medical HUD set.</span>"
 		if(DATA_HUD_MEDICAL_ADVANCED)


### PR DESCRIPTION
Ghosts will now use the full Security HUD, instead of the AI version.
This means that:
- Ghosts will now see the target's arrest status.
- Ghosts will also now see if the target has loyalty/tracking/chemical implants.

:cl: Gun Hog
rscadd: Ghost security HUDs now show arrest status and implants.
/:cl:
