### PR TITLE
Fixes certain reagent making you sleep/be stunned/blind for just a split second every tick

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -323,7 +323,7 @@
 	metabolization_rate = 0.8
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	M.Stun(1)
+	M.Stun(2)
 	..()
 	return
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -493,9 +493,9 @@
 	M.slurring += 3
 	switch(current_cycle)
 		if(51 to 200)
-			M.AdjustSleeping(1)
+			M.Sleeping(5)
 		if(201 to INFINITY)
-			M.AdjustSleeping(1)
+			M.AdjustSleeping(2)
 			M.adjustToxLoss(2)
 	..()
 	return

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -202,8 +202,8 @@
 		else if ( mouth_covered )	// Reduced effects if partially protected
 			if(prob(5))
 				victim.emote("scream")
-			victim.adjust_blurriness(3)
-			victim.adjust_blindness(1)
+			victim.blur_eyes(3)
+			victim.blind_eyes(2)
 			victim.confused = max(M.confused, 3)
 			victim.damageoverlaytemp = 60
 			victim.Weaken(3)
@@ -216,8 +216,8 @@
 		else // Oh dear :D
 			if(prob(5))
 				victim.emote("scream")
-			victim.adjust_blurriness(5)
-			victim.adjust_blindness(2)
+			victim.blur_eyes(5)
+			victim.blind_eyes(3)
 			victim.confused = max(M.confused, 6)
 			victim.damageoverlaytemp = 75
 			victim.Weaken(5)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -539,7 +539,7 @@
 	if(current_cycle >= 12 && current_cycle < 24)
 		M.drowsyness += 1
 	else if(current_cycle >= 24)
-		M.AdjustSleeping(1)
+		M.Sleeping(2)
 	..()
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -256,9 +256,9 @@
 			M.confused += 2
 			M.drowsyness += 2
 		if(10 to 50)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 		if(51 to INFINITY)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 			M.adjustToxLoss((current_cycle - 50)*REM)
 	..()
 	return
@@ -273,9 +273,9 @@
 /datum/reagent/toxin/beer2/on_mob_life(mob/living/M)
 	switch(current_cycle)
 		if(1 to 50)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 		if(51 to INFINITY)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 			M.adjustToxLoss((current_cycle - 50)*REM)
 	..()
 
@@ -412,7 +412,7 @@
 		M.adjustBrainLoss(1*REM)
 		M.adjustToxLoss(1*REM)
 	if(current_cycle >= 18)
-		M.AdjustSleeping(1)
+		M.Sleeping(2)
 	..()
 
 /datum/reagent/toxin/cyanide
@@ -529,7 +529,7 @@
 
 /datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/M)
 	if(current_cycle >= 10)
-		M.AdjustSleeping(1)
+		M.Sleeping(2)
 	M.adjustStaminaLoss(10*REM)
 	..()
 
@@ -544,7 +544,7 @@
 
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/M)
 	if(current_cycle >= 22)
-		M.AdjustSleeping(1)
+		M.Sleeping(2)
 	..()
 
 /datum/reagent/toxin/amanitin


### PR DESCRIPTION
This was due to a reagent making your sleeping var equal to 1 and immediately making you sleep, then the natural decrease of the sleeping var lowers it back to 0 a bit later in the same life() proc making us wake up immediately. Rinse and repeat every time life() is called. Fixes #15322

This also contain some <b>nerfs</b> (since I couldn't fix the bug without changing reagent effect): metabolizing lots of morphine no longer make you sleep long after all the morphine has left your body. The morphine's sleep effect has an upper ceiling. Same thing for condensed capsaicin's blind and blurry effect, and other reagents.
