### PR TITLE
Fixes tesla southern tendency.

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -212,7 +212,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", icon='icons/effects/effects.dmi', time=5)
 		var/zapdir = get_dir(source, closest_atom)
 		if(zapdir)
-			. = closest_atom
+			. = zapdir
 
 	//per type stuff:
 	if(closest_tesla_coil)


### PR DESCRIPTION
I'm not sure this actually makes the game more fun but it's a bug.

:cl:
rscadd: Chairs and stools can now be picked up and used as weapons by dragging them over your character.
/:cl:
