### PR TITLE
Scale down dynamic wait on atmos now that the lag bug is fixed

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -6,8 +6,8 @@ var/datum/subsystem/air/SSair
 	wait = 5
 	dynamic_wait = 1
 	dwait_upper = 300
-	dwait_buffer = 0
-	dwait_delta = 10
+	dwait_buffer = 1
+	dwait_delta = 7
 	display = 1
 
 	var/cost_turfs = 0


### PR DESCRIPTION
This was only driven so far up because of the byond lag that 510 fixed.

We can bring it back down now.
