### PR TITLE
Spray bottles now have a "stream" mode toggled by clicking the bottle.

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -15,3 +15,4 @@
 	name = "chemicals"
 	icon = 'icons/obj/chempuff.dmi'
 	pass_flags = PASSTABLE | PASSGRILLE
+	layer = 5


### PR DESCRIPTION
The stream mode launches a chem puff that does not react with objects or turfs on its trajectory, it only reacts with standing mobs in its way, the puff doesn't go through the mob and is immediately deleted after reacting. If no mob is in its way and it reaches its destination tile then it reacts with all the things on the tile.
This mode is the initial mode for the nukeops chemsprayer (but the mode can still be toggled if you want to spray things on many floor tiles). Also the chemsprayer always spray 10 units per use now, and its range in spray mode is reduced to 4 tiles (so player aren't confused by the puff doing nothing when they aim very far and the amount transfered to each tile encountered is very low(in spray mode, the amount transfered to turfs/objects/mobs is divided by range)). Fixes #12382
Fixes the chem puff appearing behind mobs it passes through.
