### PR TITLE
Chair Fixes.

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -211,6 +211,7 @@
 	throwforce = 10
 	throw_range = 3
 	hitsound = 'sound/items/trayhit1.ogg'
+	hit_reaction_chance = 50
 
 	var/origin_type = /obj/structure/chair
 
@@ -221,16 +222,13 @@
 	icon_state = "[origin.icon_state]_toppled"
 	item_state = origin.hold_icon
 	origin_type = origin.type
-	hit_reaction_chance = 50
+
 
 /obj/item/chair/attack_hand(mob/user)
-	if(user.a_intent == "help")
-		user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [src.name].</span>")
-		plant()
-	else
-		..()
+	plant(user)
 
-/obj/item/chair/proc/plant()
+/obj/item/chair/proc/plant(user)
+	user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [name].</span>")
 	var/obj/structure/chair/C = new origin_type(get_turf(loc))
 	C.dir = dir
 	qdel(src)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -227,7 +227,7 @@
 /obj/item/chair/attack_self(mob/user)
 	plant(user)
 
-/obj/item/chair/proc/plant(user)
+/obj/item/chair/proc/plant(mob/user)
 	user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [name].</span>")
 	var/obj/structure/chair/C = new origin_type(get_turf(loc))
 	C.dir = dir

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -228,6 +228,14 @@
 	plant(user)
 
 /obj/item/chair/proc/plant(mob/user)
+	for(var/obj/A in get_turf(loc))
+		if(istype(A,/obj/structure/chair))
+			user << "<span class='danger'>There is already a chair here.</span>"
+			return
+		if(A.density)
+			user << "<span class='danger'>There is already something here.</span>"
+			return
+
 	user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [name].</span>")
 	var/obj/structure/chair/C = new origin_type(get_turf(loc))
 	C.dir = dir

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -224,7 +224,7 @@
 	origin_type = origin.type
 
 
-/obj/item/chair/attack_hand(mob/user)
+/obj/item/chair/attack_self(mob/user)
 	plant(user)
 
 /obj/item/chair/proc/plant(user)


### PR DESCRIPTION
Fixes an issue where you would plant a chair while moving hands.

Sets the block chance on declaration rather then on instantiation.
