### PR TITLE
Fixes being able to become huge with genetics

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -280,22 +280,22 @@
 	quality = POSITIVE
 	get_chance = 15
 	lowest_value = 256 * 12
-	text_gain_indication = "<span class='notice'>Everything around you seems to grow..</span>"
-	text_lose_indication = "<span class='notice'>Everything around you seems to shrink..</span>"
 
 /datum/mutation/human/dwarfism/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.resize = 0.8
+	owner.update_transform()
 	owner.pass_flags |= PASSTABLE
-	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>")
+	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.resize = 1.25
+	owner.update_transform()
 	owner.pass_flags &= ~PASSTABLE
-	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>")
+	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
 
 /datum/mutation/human/clumsy
 

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -287,7 +287,7 @@
 	owner.resize = 0.8
 	owner.update_transform()
 	owner.pass_flags |= PASSTABLE
-	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")
+	owner.visible_message("<span class='danger'>[owner] suddenly shrinks!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
 
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
@@ -295,7 +295,7 @@
 	owner.resize = 1.25
 	owner.update_transform()
 	owner.pass_flags &= ~PASSTABLE
-	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to grow..</span>")
+	owner.visible_message("<span class='danger'>[owner] suddenly grows!</span>", "<span class='notice'>Everything around you seems to shrink..</span>")
 
 /datum/mutation/human/clumsy
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1056,3 +1056,5 @@ var/next_mob_id = 0
 			setEarDamage(ear_damage, -1)
 		if("maxHealth")
 			updatehealth()
+		if("resize")
+			update_transform()


### PR DESCRIPTION
 by injecting yourself with dwarfism while having mutadone in you. The resizing now happens instantly and no longer waits for the next life() call.
- Fixes resizing. It was broken because I had removed update_canmove() call in living/life(). Now every part of the code that modifies resize directly calls update_transform().
- Fixes mob seeing two messages when acquiring (or losing) the dwarfism mutation.

Fixes #15346. Fixes #12297.
