### PR TITLE
Dice of fate is now reusable

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -185,7 +185,7 @@
 
 
 /obj/item/weapon/dice/d20/fate/proc/effect(var/mob/living/carbon/human/user,roll)
-	if(reusable = 0)
+	if(!reusable)
 		used = 1
 	visible_message("<span class='userdanger'>The die flare briefly.</span>")
 	switch(roll)

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -163,6 +163,7 @@
 	desc = "A die with twenty sides. You can feel unearthly energies radiating from it. Using this might be VERY risky."
 	icon_state = "d20"
 	sides = 20
+	var/reusable = 1
 	var/used = 0
 	var/rigged = -1
 
@@ -184,7 +185,8 @@
 
 
 /obj/item/weapon/dice/d20/fate/proc/effect(var/mob/living/carbon/human/user,roll)
-	used = 1
+	if(reusable = 0)
+		used = 1
 	visible_message("<span class='userdanger'>The die flare briefly.</span>")
 	switch(roll)
 		if(1)


### PR DESCRIPTION
It's a var, so it can be changed as desired. I figured this seemed better, because as-is it's one of the rarest and hardest to get items on any away mission, and it essentially has a 5/20 chance of doing something good to one person.

You still have a 2/20 chance of outright dying every use, and a 5/20 overall chance of being fucked up, so I don't think it's overpowered.

If this is too much of a buff I could always make it have limited uses.
