### PR TITLE
Tweaks stun/teleprod tablecrafting recipes

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -23,10 +23,6 @@
 	update_icon()
 	return
 
-/obj/item/weapon/melee/baton/CheckParts()
-	bcell = locate(/obj/item/weapon/stock_parts/cell) in contents
-	update_icon()
-
 /obj/item/weapon/melee/baton/loaded/New() //this one starts with a cell pre-installed.
 	..()
 	bcell = new(src)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -63,10 +63,8 @@
 	result = /obj/item/weapon/melee/baton/cattleprod
 	reqs = list(/obj/item/weapon/restraints/handcuffs/cable = 1,
 				/obj/item/stack/rods = 1,
-				/obj/item/device/assembly/igniter = 1,
-				/obj/item/weapon/stock_parts/cell = 1)
+				/obj/item/device/assembly/igniter = 1)
 	time = 40
-	parts = list(/obj/item/weapon/stock_parts/cell = 1)
 	category = CAT_WEAPON
 
 /datum/table_recipe/teleprod
@@ -74,11 +72,9 @@
 	result = /obj/item/weapon/melee/baton/cattleprod/teleprod
 	reqs = list(/obj/item/weapon/restraints/handcuffs/cable = 1,
 				/obj/item/stack/rods = 1,
-				/obj/item/weapon/wirecutters = 1,
-				/obj/item/weapon/stock_parts/cell = 1,
+				/obj/item/device/assembly/igniter = 1,
 				/obj/item/weapon/ore/bluespace_crystal = 1)
 	time = 40
-	parts = list(/obj/item/weapon/stock_parts/cell = 1)
 	category = CAT_WEAPON
 
 /datum/table_recipe/tailclub


### PR DESCRIPTION
Mainly to fix this issue:
Fixes #13229 

Removes the cell requirement from both, now you can craft one without a battery (but have to manually add the battery afterwords)

Also changes the teleprod tablecrafting recipe to be consistent with the stunprod by replacing the wirecutters requirement with an igniter requirement, I need to touch up teleprods soon
