### PR TITLE
Stunprods can be make with igniters OR wirecutters

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -102,7 +102,7 @@
 		qdel(I)
 		qdel(src)
 
-	else if(istype(I, /obj/item/device/assembly/igniter) && !(I.flags & NODROP))
+	else if((istype(I, /obj/item/device/assembly/igniter) || if(istype(I, /obj/item/weapon/wirecutters)) && !(I.flags & NODROP))
 		var/obj/item/weapon/melee/baton/cattleprod/P = new /obj/item/weapon/melee/baton/cattleprod
 
 		if(!remove_item_from_storage(user))


### PR DESCRIPTION
Seriously why was this even changed in the first place?
