### PR TITLE
Bots patrol/summons tweaks and fixes

### DIFF
--- a/code/__DEFINES/bots.dm
+++ b/code/__DEFINES/bots.dm
@@ -1,6 +1,7 @@
 //Bot defines, placed here so they can be read by other things!
 
 #define BOT_STEP_DELAY 4 //Delay between movemements
+#define BOT_STEP_MAX_RETRIES 5 //Maximum times a bot will retry to step from its position
 
 #define DEFAULT_SCAN_RANGE		7	//default view range for finding targets.
 

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -28,14 +28,16 @@
 	var/turf/T = loc
 	hide(T.intact)
 	if(codes["patrol"])
-		navbeacons += src //Register with the patrol list!
+		if(!navbeacons["[z]"])
+			navbeacons["[z]"] = list()
+		navbeacons["[z]"] += src //Register with the patrol list!
 	if(codes["delivery"])
 		deliverybeacons += src
 		deliverybeacontags += location
 
 /obj/machinery/navbeacon/Destroy()
-	navbeacons &= src //Remove from beacon list, if in one.
-	deliverybeacons &= src
+	navbeacons["[z]"] -= src //Remove from beacon list, if in one.
+	deliverybeacons -= src
 	return ..()
 
 // set the transponder codes assoc list from codes_txt

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -408,7 +408,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		return 0
 	var/step_count = move_speed ? move_speed : base_speed //If a value is passed into move_speed, use that instead of the default speed var.
 
-	if(step_count >= 1 && tries < 4)
+	if(step_count >= 1 && tries < BOT_STEP_MAX_RETRIES)
 		for(var/step_number = 0, step_number < step_count,step_number++)
 			spawn(BOT_STEP_DELAY*step_number)
 				bot_step(dest)
@@ -424,6 +424,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		step_towards(src, path[1])
 		if(get_turf(src) == path[1]) //Successful move
 			path -= path[1]
+			tries = 0
 		else
 			tries++
 			return 0
@@ -503,7 +504,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/proc/start_patrol()
 
-	if(tries >= 4) //Bot is trapped, so stop trying to patrol.
+	if(tries >= BOT_STEP_MAX_RETRIES) //Bot is trapped, so stop trying to patrol.
 		auto_patrol = 0
 		tries = 0
 		speak("Unable to start patrol.")
@@ -548,32 +549,15 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 
 		var/moved = bot_move(patrol_target)//step_towards(src, next)	// attempt to move
-		if(moved)	// successful move
-			blockcount = 0
-
-		else		// failed to move
-			blockcount++
-
-			if(blockcount > 5)	// attempt 5 times before recomputing
-				// find new path excluding blocked turf
-
-				spawn(2)
-					calc_path(next)
-					if(path.len == 0)
-						find_patrol_target() //Start looking for the next nearest beacon
-						tries++
-					else
-						blockcount = 0
-						tries = 0
-
-				return
-
-			return
+		if(!moved) //Couldn't proceed the next step of the path BOT_STEP_MAX_RETRIES times
+			spawn(2)
+				calc_path()
+				if(path.len == 0)
+					find_patrol_target()
+				tries = 0
 
 	else	// no path, so calculate new one
 		mode = BOT_START_PATROL
-
-	return
 
 // finds the nearest beacon to self
 /mob/living/simple_animal/bot/proc/find_patrol_target()
@@ -590,7 +574,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 /mob/living/simple_animal/bot/proc/get_next_patrol_target()
 	// search the beacon list for the next target in the list.
-	for(var/obj/machinery/navbeacon/NB in navbeacons)
+	for(var/obj/machinery/navbeacon/NB in navbeacons["[z]"])
 		if(NB.location == next_destination) //Does the Beacon location text match the destination?
 			destination = new_destination //We now know the name of where we want to go.
 			patrol_target = NB.loc //Get its location and set it as the target.
@@ -598,7 +582,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 			return 1
 
 /mob/living/simple_animal/bot/proc/find_nearest_beacon()
-	for(var/obj/machinery/navbeacon/NB in navbeacons)
+	for(var/obj/machinery/navbeacon/NB in navbeacons["[z]"])
 		var/dist = get_dist(src, NB)
 		if(nearest_beacon) //Loop though the beacon net to find the true closest beacon.
 			//Ignore the beacon if were are located on it.
@@ -665,10 +649,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 		else
 			src << "<span class='warning'>Unidentified control sequence recieved:[command]</span>"
 
-/mob/living/simple_animal/bot/proc/bot_summon()
-		// summoned to PDA
+/mob/living/simple_animal/bot/proc/bot_summon() // summoned to PDA
 	summon_step()
-	return
 
 // calculates a path to the current destination
 // given an optional turf to avoid
@@ -680,7 +662,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	check_bot_access()
 	spawn()
 		path = get_path_to(src, summon_target, /turf/proc/Distance_cardinal, 0, 150, id=access_card, exclude=avoid)
-		if(!path.len || tries >= 5) //Cannot reach target. Give up and announce the issue.
+		if(!path.len) //Cannot reach target. Give up and announce the issue.
 			speak("Summon command failed, destination unreachable.",radio_channel)
 			bot_reset()
 
@@ -700,26 +682,13 @@ Pass a positive integer as an argument to override a bot's default speed.
 			return
 
 		var/moved = bot_move(summon_target, 3)	// Move attempt
-		if(moved)
-			blockcount = 0
-
-		else		// failed to move
-			blockcount++
-
-			if(blockcount > 5)	// attempt 5 times before recomputing
-				// find new path excluding blocked turf
-				spawn(2)
-					calc_summon_path(next)
-					tries++
-					return
-
-				return
+		if(!moved)
+			spawn(2)
+				calc_summon_path()
+				tries = 0
 
 	else	// no path, so calculate new one
 		calc_summon_path()
-
-	return
-
 
 /mob/living/simple_animal/bot/Bump(M as mob|obj) //Leave no door unopened!
 	. = ..()


### PR DESCRIPTION
#### Contents

 _Splitted navbeacons global list in several z_level sublists_.

_Fixes `navbeacons` and `deliverybeacons` global lists being erased on navigation beacon `Destroy()`_ .
Deleting **_any**_ beacon was breaking both patrols and mulebot deliveries.

 _Cleaned bot patrol/summon logic regarding pathing retries :_

 **_For patrol**_ :
- Tries to move the next step along the path, up to `BOT_STEP_MAX_RETRIES` times (default 5)
- If failing, restart the patrol pathing (up to 4 times, legacy behavior)
- If still failing, break out of patrol mode

**_For summoning :**_
- Tries to move the next step along the path, up to `BOT_STEP_MAX_RETRIES` times (default 5)
- If failing try to repath
- If still failing, give up

This fixes bots breaking out of patrol when encountering too much obstacles along their path (usually waiting for 2 doors to open was enough to trigger a repath. Add to that, that the blocking turf was excluded from the repathing and any "bottleneck" door could break the bot out of patrol).

Note that, **_Ofitzer**_ _still_ can't patrol labor camp because it's supposed to reach a nav beacon through plastic flaps, which are impassable for it.
