### PR TITLE
Template loading improvements

### DIFF
--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -28,7 +28,7 @@
 
 /datum/map_template/proc/load(turf/T, centered = FALSE)
 	if(centered)
-		T = locate(T.x - width/2 , T.y - height/2 , T.z)
+		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
 	if(!T)
 		return
 	if(T.x+width > world.maxx)
@@ -36,14 +36,14 @@
 	if(T.y+height > world.maxy)
 		return
 
-	maploader.load_map(get_file(), T.x, T.y, T.z)
+	maploader.load_map(get_file(), T.x-1, T.y-1, T.z)
 
 	//initialize things that are normally initialized after map load
 	var/list/obj/machinery/atmospherics/atmos_machines = list()
 	var/list/obj/structure/cable/cables = list()
 	var/list/atom/atoms = list()
 
-	for(var/L in block(T,locate(T.x+width, T.y+height, T.z)))
+	for(var/L in block(T,locate(T.x+width-1, T.y+height-1, T.z)))
 		var/turf/B = L
 		for(var/A in B)
 			atoms += A
@@ -70,10 +70,10 @@
 /datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE)
 	var/turf/placement = T
 	if(centered)
-		var/turf/corner = locate(placement.x - width/2, placement.y - height/2, placement.z)
+		var/turf/corner = locate(placement.x - round(width/2), placement.y - round(height/2), placement.z)
 		if(corner)
 			placement = corner
-	return block(placement, locate(placement.x + width, placement.y + height, placement.z))
+	return block(placement, locate(placement.x+width-1, placement.y+height-1, placement.z))
 
 
 /proc/preloadTemplates(path = "_maps/templates/") //see master controller setup

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -166,12 +166,11 @@
 		//Trigger alarm effect
 		RA.set_fire_alarm_effect()
 		//Lockdown airlocks
-		for(var/obj/machinery/door/airlock/DOOR in RA)
+		for(var/obj/machinery/door/DOOR in RA)
 			spawn(0)
 				DOOR.close()
 				if(DOOR.density)
-					DOOR.locked = 1
-					DOOR.update_icon()
+					DOOR.lock()
 		for (var/obj/machinery/camera/C in RA)
 			cameras += C
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -80,11 +80,17 @@ var/list/airlock_overlays = list()
 		airlock_material = "glass"
 	update_icon()
 
+/obj/machinery/door/airlock/lock()
+	bolt()
+
 /obj/machinery/door/airlock/proc/bolt()
 	if(locked)
 		return
 	locked = 1
 	update_icon()
+
+/obj/machinery/door/airlock/unlock()
+	unbolt()
 
 /obj/machinery/door/airlock/proc/unbolt()
 	if(!locked)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -270,3 +270,9 @@
 
 /obj/machinery/door/storage_contents_dump_act(obj/item/weapon/storage/src_object, mob/user)
 	return 0
+
+/obj/machinery/door/proc/lock()
+	return
+
+/obj/machinery/door/proc/unlock()
+	return

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -13,7 +13,7 @@
 	template = map_templates[map]
 
 	var/list/preview = list()
-	for(var/turf/S in template.get_affected_turfs(T,centered = TRUE))
+	for(var/S in template.get_affected_turfs(T,centered = TRUE))
 		preview += image('icons/turf/overlays.dmi',S,"greenOverlay")
 	usr.client.images += preview
 	if(alert(usr,"Confirm location.","Template Confirm","Yes","No") == "Yes")

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -2,19 +2,23 @@
 	set category = "Debug"
 	set name = "Map template - Place"
 
-	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in map_templates
-	if(!map)
-		return
+
+	var/datum/map_template/template
 
 	var/turf/T = get_turf(mob)
 	if(!T)
 		return
 
-	var/datum/map_template/template
-
 	template = map_templates[map]
-	template.load(T)
-	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has placed a map template ([template.name]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a></span>")
+
+	var/list/preview = list()
+	for(var/turf/S in template.get_affected_turfs(T,centered = TRUE))
+		preview += image('icons/turf/overlays.dmi',S,"greenOverlay")
+	usr.client.images += preview
+	if(alert(usr,"Confirm location.","Template Confirm","Yes","No") == "Yes")
+		template.load(T, centered = TRUE)
+		message_admins("<span class='adminnotice'>[key_name_admin(usr)] has placed a map template ([template.name]) at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a></span>")
+	usr.client.images -= preview
 
 /client/proc/map_template_upload()
 	set category = "Debug"

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -2,13 +2,14 @@
 	set category = "Debug"
 	set name = "Map template - Place"
 
-
 	var/datum/map_template/template
 
 	var/turf/T = get_turf(mob)
 	if(!T)
 		return
-
+	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in map_templates
+	if(!map)
+		return
 	template = map_templates[map]
 
 	var/list/preview = list()

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -174,17 +174,17 @@ var/global/dmm_suite/preloader/_preloader = new
 
 	//first instance the /area and remove it from the members list
 	index = members.len
-	var/atom/instance
-	_preloader.setup(members_attributes[index])//preloader for assigning  set variables on atom creation
+	if(members[index] != /area/template_noop)
+		var/atom/instance
+		_preloader.setup(members_attributes[index])//preloader for assigning  set variables on atom creation
 
-	instance = locate(members[index])
-	var/turf/crds = locate(xcrd,ycrd,zcrd)
-	if(crds)
-		instance.contents.Add(crds)
+		instance = locate(members[index])
+		var/turf/crds = locate(xcrd,ycrd,zcrd)
+		if(crds)
+			instance.contents.Add(crds)
 
-	if(use_preloader && instance)
-		_preloader.load(instance)
-
+		if(use_preloader && instance)
+			_preloader.load(instance)
 	members.Remove(members[index])
 
 	//then instance the /turf and, if multiple tiles are presents, simulates the DMM underlays piling effect
@@ -194,7 +194,9 @@ var/global/dmm_suite/preloader/_preloader = new
 		first_turf_index++
 
 	//instanciate the first /turf
-	var/turf/T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],xcrd,ycrd,zcrd)
+	var/turf/T
+	if(members[first_turf_index] != /turf/template_noop)
+		T = instance_atom(members[first_turf_index],members_attributes[first_turf_index],xcrd,ycrd,zcrd)
 
 	if(T)
 		//if others /turf are presents, simulates the underlays piling effect
@@ -350,3 +352,9 @@ var/global/dmm_suite/preloader/_preloader = new
 	for(var/attribute in attributes)
 		what.vars[attribute] = attributes[attribute]
 	use_preloader = FALSE
+
+/area/template_noop
+	name = "Area Passthrough"
+
+/turf/template_noop
+	name = "Turf Passthrough"


### PR DESCRIPTION
- Adds area preview, makes templates centered on user, fixes some off by one errors.
- Adds noop turf and area, these will preserve whatever was originally on the loaded coordinates.
  If anyone has idea how to make these less intrusive on the loader please let me know, i'm not entirely happy on how it works right now.
- Makes burglar alarms also drop areas shutters/poddoors.
