### PR TITLE
Moves random slaughter demon spawning waaaaay back

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/slaughter
 	weight = 1 //Very rare
 	max_occurrences = 1
-	earliest_start = 6000 //Let a couple people die first
+	earliest_start = 36000 //1 hour
 
 
 


### PR DESCRIPTION
The earliest a slaughter demon could spawn in a round sans wizard is now one hour, up from 10 minutes(!!!!!)

Just because something's rare doesn't mean you can have it appear nearly instantly. Slaughter Demons are way too powerful to potentially reach the station 10 minutes in.
