### PR TITLE
Fixes Plasmameme and breathed gases no longer go to turfs.

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -88,8 +88,8 @@
 
 	check_breath(breath)
 
-	if(breath)
-		loc.assume_air(breath)
+	/*if(breath)
+		loc.assume_air(breath)*/
 
 /mob/living/carbon/proc/has_smoke_protection()
 	return 0


### PR DESCRIPTION
Alright. So this isn't an actual PR, since it does the fix all wrong. But I really wanted to point out how shit breathing code is.

Let's start with the fact that check_breath() does all the breathing, and yet its not stored into any var.
If check_breath() does all the breathing, and doesn't return anything useful. Then what's it outputting to the turf?
The answer is.... it's outputing whatever you breathed in. And if this is from internals, its dumping internals directly to the turf.
Hence why plasma memes dump their internals to turf.

Even better. Check_breath returns a 1. But... like I said, nothing is expecting it to give anything. So whats it doing with the 1?
