### PR TITLE
Persistence features for Runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -60,6 +60,60 @@
 	icon_dead = "cat_dead"
 	gender = FEMALE
 	gold_core_spawnable = 0
+	var/list/family = list()
+	var/lives = 9
+	var/memory_saved = 0
+
+/mob/living/simple_animal/pet/cat/Runtime/New()
+	Read_Memory()
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/Life()
+	if(!stat && ticker.current_state == GAME_STATE_FINISHED && !memory_saved)
+		Write_Memory()
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/death()
+	if(!memory_saved)
+		Write_Memory(1)
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
+	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
+	S["family"] 			>> family
+	S["lives"]				>> lives
+
+	if(isnull(family))
+		family = list()
+
+	if(isnull(lives))
+		lives = 9
+
+	if(lives <= 0)
+		lives = 10 //Lowers to 9 in Write_Memory
+		Write_Memory(1)
+		qdel(src)
+
+	for(var/cat_type in family)
+		if(family[cat_type] > 0)
+			for(var/i = 0, i < family[cat_type], i++)
+				new cat_type(loc)
+
+/mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
+	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
+	if(dead)
+		S["lives"] 				<< lives - 1
+	family = list()
+	for(var/mob/living/simple_animal/pet/cat/C in mob_list)
+		if(istype(C,type) || C.stat)
+			continue
+		if(C.type in family)
+			family[C.type] += 1
+		else
+			family[C.type] = 1
+	S["family"]				<< family
+	memory_saved = 1
+
 
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -54,7 +54,7 @@
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/pet/cat/Runtime
 	name = "Runtime"
-	desc = "GCAT"
+	desc = "Tends to show up in the strangest of places."
 	icon_state = "cat"
 	icon_living = "cat"
 	icon_dead = "cat_dead"
@@ -65,6 +65,8 @@
 	var/memory_saved = 0
 
 /mob/living/simple_animal/pet/cat/Runtime/New()
+	if(lives > 9)
+		desc += " Looks like a cat with [lives] lives left."
 	Read_Memory()
 	..()
 
@@ -96,7 +98,7 @@
 
 	for(var/cat_type in family)
 		if(family[cat_type] > 0)
-			for(var/i = 0, i < family[cat_type], i++)
+			for(var/i in 1 to family[cat_type])
 				new cat_type(loc)
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
@@ -105,7 +107,7 @@
 		S["lives"] 				<< lives - 1
 	family = list()
 	for(var/mob/living/simple_animal/pet/cat/C in mob_list)
-		if(istype(C,type) || C.stat)
+		if(istype(C,type) || C.stat || !C.butcher_results) //That last one is a work around for hologram cats
 			continue
 		if(C.type in family)
 			family[C.type] += 1

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -54,7 +54,7 @@
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/pet/cat/Runtime
 	name = "Runtime"
-	desc = "Tends to show up in the strangest of places."
+	desc = "GCAT"
 	icon_state = "cat"
 	icon_living = "cat"
 	icon_dead = "cat_dead"
@@ -66,7 +66,7 @@
 
 /mob/living/simple_animal/pet/cat/Runtime/New()
 	if(lives < 9)
-		desc += " Looks like a cat with [lives] lives left."
+		desc += ". Looks like a cat with [lives] lives left."
 	Read_Memory()
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -65,7 +65,7 @@
 	var/memory_saved = 0
 
 /mob/living/simple_animal/pet/cat/Runtime/New()
-	if(lives > 9)
+	if(lives < 9)
 		desc += " Looks like a cat with [lives] lives left."
 	Read_Memory()
 	..()


### PR DESCRIPTION
- Runtime now keeps track of all cats in the world, at the start of the next round any cats that survived the previous one will spawn with Runtime in the CMO's office.
- After 9 deaths Runtime will be mysteriously missing from the next station (but only for that round). This also clears out any family Runtime might have.

---

A note on mechanics: Yes this allows for potentially infinite cats, but in reality this is not a practical problem because:
1. Runtime and Proc can have kittens, and kittens are saved BUT they can only have three. This is true even if they start with three kittens they didn't actually have. It's technically possible to get more kittens by repeatedly removing new kittens from the cat breeding chamber, but that's a lot of work just to catsplosion the CMO next round.
2. The petsplosion wizard event can exacerbate a cat situation, but Runtime won't carry over other versions of herself, and since Runtime is the only female cat in the whole dang game this puts a bottleneck on kittens that should keep things from going nuts. 
3. It only takes one successful nuke round to genocide the cats.
4. :cat2: 
