### PR TITLE
Toggle Weapon Refactor

### DIFF
--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -117,7 +117,7 @@ var/global/max_secret_rooms = 6
 		if("speakeasy")
 			theme = "speakeasy"
 			floortypes = list(/turf/simulated/floor/plasteel,/turf/simulated/floor/wood)
-			treasureitems = list(/obj/item/weapon/melee/energy/sword/pirate=1,/obj/item/weapon/gun/projectile/revolver/doublebarrel=1,/obj/item/weapon/storage/backpack/satchel_flat=1,
+			treasureitems = list(/obj/item/weapon/melee/toggle/energy/sword/pirate=1,/obj/item/weapon/gun/projectile/revolver/doublebarrel=1,/obj/item/weapon/storage/backpack/satchel_flat=1,
 			/obj/machinery/reagentgrinder=2, /obj/machinery/computer/security/wooden_tv=4, /obj/machinery/vending/coffee=3)
 			fluffitems = list(/obj/structure/table/wood=2,/obj/structure/reagent_dispensers/beerkeg=1,/obj/item/stack/spacecash/c500=4,
 							  /obj/item/weapon/reagent_containers/food/drinks/shaker=1,/obj/item/weapon/reagent_containers/food/drinks/bottle/wine=3,
@@ -138,7 +138,7 @@ var/global/max_secret_rooms = 6
 			walltypes = list(/turf/simulated/wall/mineral/clown)
 			floortypes= list(/turf/simulated/floor/engine)
 			treasureitems = list(/obj/item/weapon/spellbook=1,/obj/mecha/combat/marauder=1,/obj/machinery/wish_granter=1)
-			fluffitems = list(/obj/item/weapon/melee/energy/axe)*/
+			fluffitems = list(/obj/item/weapon/melee/toggle/energy/axe)*/
 
 	possiblethemes -= theme //once a theme is selected, it's out of the running!
 	var/floor = pick(floortypes)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -190,7 +190,7 @@
 					pointcost = 5
 			if("switchblade")
 				if(gang.points >= 10)
-					item_type = /obj/item/weapon/switchblade
+					item_type = /obj/item/weapon/melee/toggle/switchblade
 					pointcost = 10
 			if("necklace")
 				if(gang.points >=1)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -222,7 +222,7 @@
 	add_fingerprint(user)
 	return
 
-// Copied from /obj/item/weapon/melee/energy/sword/attackby
+// Copied from /obj/item/weapon/melee/toggle/energy/sword/attackby
 /obj/item/toy/sword/attackby(obj/item/weapon/W, mob/living/user, params)
 	..()
 	if(istype(W, /obj/item/toy/sword))

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -155,7 +155,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		lighting_text = "<span class='notice'>After some fiddling, [user] manages to light their [name] with [O].</span>"
 	else if(istype(O, /obj/item/weapon/lighter))
 		lighting_text = "<span class='rose'>With a single flick of their wrist, [user] smoothly lights their [name] with [O]. Damn they're cool.</span>"
-	else if(istype(O, /obj/item/weapon/melee/energy))
+	else if(istype(O, /obj/item/weapon/melee/toggle/energy))
 		lighting_text = "<span class='warning'>[user] swings their [O], barely missing their nose. They light their [name] in the process.</span>"
 	else if(istype(O, /obj/item/device/assembly/igniter))
 		lighting_text = "<span class='notice'>[user] fiddles with [O], and manages to light their [name].</span>"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -1,25 +1,25 @@
-/obj/item/weapon/melee/energy
-	var/active = 0
-	var/force_on = 30 //force when active
-	var/throwforce_on = 20
-	var/icon_state_on = "axe1"
-	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+/obj/item/weapon/melee/toggle/energy
+	force_on = 30 //force when active
+	throwforce_on = 20
+	icon_state_on = "axe1"
+	attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = 2
-	var/w_class_on = 4
+	w_class_on = 4
+	active_hitsound = 'sound/weapons/blade1.ogg'
 	heat = 3500
 
-/obj/item/weapon/melee/energy/suicide_act(mob/user)
+/obj/item/weapon/melee/toggle/energy/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</span>", \
 						"<span class='suicide'>[user] is falling on the [src.name]! It looks like \he's trying to commit suicide.</span>"))
 	return (BRUTELOSS|FIRELOSS)
 
-/obj/item/weapon/melee/energy/rejects_blood()
+/obj/item/weapon/melee/toggle/energy/rejects_blood()
 	return 1
 
-/obj/item/weapon/melee/energy/is_sharp()
+/obj/item/weapon/melee/toggle/energy/is_sharp()
 	return active * sharpness
 
-/obj/item/weapon/melee/energy/axe
+/obj/item/weapon/melee/toggle/energy/axe
 	name = "energy axe"
 	desc = "An energised battle axe."
 	icon_state = "axe0"
@@ -38,11 +38,11 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	attack_verb_on = list()
 
-/obj/item/weapon/melee/energy/axe/suicide_act(mob/user)
+/obj/item/weapon/melee/toggle/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings the [src.name] towards \his head! It looks like \he's trying to commit suicide.</span>")
 	return (BRUTELOSS|FIRELOSS)
 
-/obj/item/weapon/melee/energy/sword
+/obj/item/weapon/melee/toggle/energy/sword
 	name = "energy sword"
 	desc = "May the force be within you."
 	icon_state = "sword0"
@@ -59,55 +59,34 @@
 	block_chance = 50
 	var/hacked = 0
 
-/obj/item/weapon/melee/energy/sword/New()
+/obj/item/weapon/melee/toggle/energy/sword/New()
 	if(item_color == null)
 		item_color = pick("red", "blue", "green", "purple")
 
-/obj/item/weapon/melee/energy/sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+/obj/item/weapon/melee/toggle/energy/sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
 	if(active)
 		return ..()
 	return 0
 
-/obj/item/weapon/melee/energy/attack_self(mob/living/carbon/user)
+/obj/item/weapon/melee/toggle/energy/attack_self(mob/living/carbon/user)
+	..()
 	if(user.disabilities & CLUMSY && prob(50))
 		user << "<span class='warning'>You accidentally cut yourself with [src], like a doofus!</span>"
 		user.take_organ_damage(5,5)
-	active = !active
-	if (active)
-		force = force_on
-		throwforce = throwforce_on
-		hitsound = 'sound/weapons/blade1.ogg'
-		throw_speed = 4
-		if(attack_verb_on.len)
-			attack_verb = attack_verb_on
-		if(!item_color)
-			icon_state = icon_state_on
-		else
-			icon_state = "sword[item_color]"
-		w_class = w_class_on
-		playsound(user, 'sound/weapons/saberon.ogg', 35, 1) //changed it from 50% volume to 35% because deafness
-		user << "<span class='notice'>[src] is now active.</span>"
-	else
-		force = initial(force)
-		throwforce = initial(throwforce)
-		hitsound = initial(hitsound)
-		throw_speed = initial(throw_speed)
-		if(attack_verb_on.len)
-			attack_verb = list()
-		icon_state = initial(icon_state)
-		w_class = initial(w_class)
-		playsound(user, 'sound/weapons/saberoff.ogg', 35, 1)  //changed it from 50% volume to 35% because deafness
+	if(active && item_color)
+		icon_state = "sword[item_color]"
+		item_state = "sword[item_color]"
+	if(!active)
 		user << "<span class='notice'>[src] can now be concealed.</span>"
-	add_fingerprint(user)
-	return
+		playsound(user, 'sound/weapons/saberoff.ogg', 35, 1)
 
-/obj/item/weapon/melee/energy/is_hot()
+/obj/item/weapon/melee/toggle/energy/is_hot()
 	return active * heat
 
-/obj/item/weapon/melee/energy/sword/cyborg
+/obj/item/weapon/melee/toggle/energy/sword/cyborg
 	var/hitcost = 50
 
-/obj/item/weapon/melee/energy/sword/cyborg/attack(mob/M, var/mob/living/silicon/robot/R)
+/obj/item/weapon/melee/toggle/energy/sword/cyborg/attack(mob/M, var/mob/living/silicon/robot/R)
 	if(R.cell)
 		var/obj/item/weapon/stock_parts/cell/C = R.cell
 		if(active && !(C.use(hitcost)))
@@ -117,7 +96,7 @@
 		..()
 	return
 
-/obj/item/weapon/melee/energy/sword/cyborg/saw //Used by medical Syndicate cyborgs
+/obj/item/weapon/melee/toggle/energy/sword/cyborg/saw //Used by medical Syndicate cyborgs
 	name = "energy saw"
 	desc = "For heavy duty cutting. It has a carbon-fiber blade in addition to a toggleable hard-light edge to dramatically increase sharpness."
 	icon_state = "esaw"
@@ -133,31 +112,31 @@
 	w_class = 3
 	sharpness = IS_SHARP
 
-/obj/item/weapon/melee/energy/sword/cyborg/saw/New()
+/obj/item/weapon/melee/toggle/energy/sword/cyborg/saw/New()
 	..()
 	icon_state = "esaw_0"
 	item_color = null
 
-/obj/item/weapon/melee/energy/sword/cyborg/saw/hit_reaction()
+/obj/item/weapon/melee/toggle/energy/sword/cyborg/saw/hit_reaction()
 	return 0
 
-/obj/item/weapon/melee/energy/sword/saber
+/obj/item/weapon/melee/toggle/energy/sword/saber
 
-/obj/item/weapon/melee/energy/sword/saber/blue
+/obj/item/weapon/melee/toggle/energy/sword/saber/blue
 	item_color = "blue"
 
-/obj/item/weapon/melee/energy/sword/saber/purple
+/obj/item/weapon/melee/toggle/energy/sword/saber/purple
 	item_color = "purple"
 
-/obj/item/weapon/melee/energy/sword/saber/green
+/obj/item/weapon/melee/toggle/energy/sword/saber/green
 	item_color = "green"
 
-/obj/item/weapon/melee/energy/sword/saber/red
+/obj/item/weapon/melee/toggle/energy/sword/saber/red
 	item_color = "red"
 
-/obj/item/weapon/melee/energy/sword/saber/attackby(obj/item/weapon/W, mob/living/user, params)
+/obj/item/weapon/melee/toggle/energy/sword/saber/attackby(obj/item/weapon/W, mob/living/user, params)
 	..()
-	if(istype(W, /obj/item/weapon/melee/energy/sword/saber))
+	if(istype(W, /obj/item/weapon/melee/toggle/energy/sword/saber))
 		if(W == src)
 			user << "<span class='notice'>You try to attach the end of the energy sword to... itself. You're not very smart, are you?</span>"
 			if(ishuman(user))
@@ -191,16 +170,16 @@
 		else
 			user << "<span class='warning'>It's already fabulous!</span>"
 
-/obj/item/weapon/melee/energy/sword/pirate
+/obj/item/weapon/melee/toggle/energy/sword/pirate
 	name = "energy cutlass"
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 	icon_state_on = "cutlass1"
 
-/obj/item/weapon/melee/energy/sword/pirate/New()
+/obj/item/weapon/melee/toggle/energy/sword/pirate/New()
 	return
 
-/obj/item/weapon/melee/energy/blade
+/obj/item/weapon/melee/toggle/energy/blade
 	name = "energy blade"
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
@@ -214,13 +193,13 @@
 	var/datum/effect_system/spark_spread/spark_system
 
 //Most of the other special functions are handled in their own files. aka special snowflake code so kewl
-/obj/item/weapon/melee/energy/blade/New()
+/obj/item/weapon/melee/toggle/energy/blade/New()
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-/obj/item/weapon/melee/energy/blade/dropped()
+/obj/item/weapon/melee/toggle/energy/blade/dropped()
 	qdel(src)
 
-/obj/item/weapon/melee/energy/blade/attack_self(mob/user)
+/obj/item/weapon/melee/toggle/energy/blade/attack_self(mob/user)
 	return

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -12,7 +12,7 @@
 			new /obj/item/device/multitool/ai_detect(src)
 			new /obj/item/device/encryptionkey/syndicate(src)
 			new /obj/item/weapon/reagent_containers/syringe/mulligan(src)
-			new /obj/item/weapon/switchblade(src)
+			new /obj/item/weapon/melee/toggle/switchblade(src)
 			return
 
 		if("stealth")
@@ -52,7 +52,7 @@
 			return
 
 		if("murder")
-			new /obj/item/weapon/melee/energy/sword/saber(src)
+			new /obj/item/weapon/melee/toggle/energy/sword/saber(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
 			new /obj/item/weapon/card/emag(src)
 			new /obj/item/clothing/shoes/sneakers/syndigaloshes(src)
@@ -92,8 +92,8 @@
 			new /obj/item/weapon/cartridge/syndicate(src)
 
 		if("darklord")
-			new /obj/item/weapon/melee/energy/sword/saber(src)
-			new /obj/item/weapon/melee/energy/sword/saber(src)
+			new /obj/item/weapon/melee/toggle/energy/sword/saber(src)
+			new /obj/item/weapon/melee/toggle/energy/sword/saber(src)
 			new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
 			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 			new /obj/item/weapon/card/id/syndicate(src)

--- a/code/game/objects/items/weapons/toggle_weapons.dm
+++ b/code/game/objects/items/weapons/toggle_weapons.dm
@@ -1,0 +1,35 @@
+/obj/item/weapon/melee/toggle
+	var/active = FALSE
+	var/force_on = 0
+	var/throwforce_on = 0
+	var/icon_state_on = "null"
+	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/w_class_on = 4
+	var/armour_penetration_on = 0
+	var/activation_sound
+	var/active_hitsound
+
+/obj/item/weapon/melee/toggle/attack_self(mob/living/carbon/user)
+	if(active)
+		active = FALSE
+		force = initial(force)
+		throwforce = initial(throwforce)
+		hitsound = initial(hitsound)
+		attack_verb = list()
+		icon_state = initial(icon_state)
+		item_state = initial(item_state)
+		armour_penetration = initial(armour_penetration)
+		w_class = initial(w_class)
+	else
+		active = TRUE
+		force = force_on
+		throwforce = throwforce_on
+		if(active_hitsound)
+			hitsound = active_hitsound
+		w_class = w_class_on
+		item_state = icon_state_on
+		icon_state = icon_state_on
+		armour_penetration = armour_penetration_on
+		attack_verb = attack_verb_on
+		if(activation_sound)
+			playsound(user, activation_sound, 35, 1)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -143,7 +143,7 @@
 
 
 
-/obj/item/weapon/switchblade
+/obj/item/weapon/melee/toggle/switchblade
 	name = "switchblade"
 	icon_state = "switchblade"
 	desc = "A sharp, concealable, spring-loaded knife."
@@ -157,27 +157,21 @@
 	origin_tech = "materials=1"
 	hitsound = 'sound/weapons/Genhit.ogg'
 	attack_verb = list("stubbed", "poked")
-	var/extended = 0
+	active = FALSE
+	force_on = 20
+	throwforce_on = 23
+	icon_state_on = "switchblade_ext"
+	attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	w_class_on = 3
+	activation_sound = 'sound/weapons/batonextend.ogg'
+	active_hitsound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/weapon/switchblade/attack_self(mob/user)
-	extended = !extended
-	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
-	if(extended)
-		force = 20
-		w_class = 3
-		throwforce = 23
-		icon_state = "switchblade_ext"
-		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-		hitsound = 'sound/weapons/bladeslice.ogg'
-	else
-		force = 3
-		w_class = 2
-		throwforce = 5
-		icon_state = "switchblade"
-		attack_verb = list("stubbed", "poked")
-		hitsound = 'sound/weapons/Genhit.ogg'
+/obj/item/weapon/melee/toggle/switchblade/attack_self(mob/living/carbon/user)
+	..()
+	if(!active)
+		playsound(user, activation_sound, 35, 1) //Switchblades make the same noise either way
 
-/obj/item/weapon/switchblade/suicide_act(mob/user)
+/obj/item/weapon/melee/toggle/switchblade/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is slitting \his own throat with the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	return (BRUTELOSS)
 

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -63,7 +63,7 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/suit/armor/tdome/red(src)
 	for(var/i in 1 to 3)
-		new /obj/item/weapon/melee/energy/sword/saber(src)
+		new /obj/item/weapon/melee/toggle/energy/sword/saber(src)
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/gun/energy/laser(src)
 	for(var/i in 1 to 3)
@@ -72,7 +72,7 @@
 		new /obj/item/weapon/storage/box/flashbangs(src)
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/head/helmet/thunderdome(src)
-	
+
 /obj/structure/closet/thunderdome/tdgreen
 	name = "green-team Thunderdome closet"
 	icon_door = "green"
@@ -82,7 +82,7 @@
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/suit/armor/tdome/green(src)
 	for(var/i in 1 to 3)
-		new /obj/item/weapon/melee/energy/sword/saber(src)
+		new /obj/item/weapon/melee/toggle/energy/sword/saber(src)
 	for(var/i in 1 to 3)
 		new /obj/item/weapon/gun/energy/laser(src)
 	for(var/i in 1 to 3)
@@ -91,7 +91,7 @@
 		new /obj/item/weapon/storage/box/flashbangs(src)
 	for(var/i in 1 to 3)
 		new /obj/item/clothing/head/helmet/thunderdome(src)
-	
+
 /obj/structure/closet/malf/suits
 	desc = "It's a storage unit for operational gear."
 	icon_state = "syndicate"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -140,7 +140,7 @@ obj/item/weapon/paper/crumpled/snowdin/shovel
 				/obj/item/weapon/dnainjector/lasereyesmut = 7,
 				/obj/item/weapon/gun/magic/wand/fireball/inert = 3,
 				/obj/item/weapon/pneumatic_cannon = 15,
-				/obj/item/weapon/melee/energy/sword = 7,
+				/obj/item/weapon/melee/toggle/energy/sword = 7,
 				/obj/item/weapon/spellbook/oneuse/knock = 15,
 				/obj/item/weapon/spellbook/oneuse/summonitem = 20,
 				/obj/item/weapon/spellbook/oneuse/forcewall = 17,

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -177,7 +177,7 @@ BLIND     // can't see anything
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
 	var/can_hold_items = 0//if set to 1, the shoe can hold knives and edaggers
 	var/obj/held_item
-	var/list/valid_held_items = list(/obj/item/weapon/kitchen/knife, /obj/item/weapon/pen, /obj/item/weapon/switchblade)//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
+	var/list/valid_held_items = list(/obj/item/weapon/kitchen/knife, /obj/item/weapon/pen, /obj/item/weapon/melee/toggle/switchblade)//can hold both regular pens and energy daggers. made for your every-day tactical librarians/murderers.
 
 
 /obj/item/clothing/shoes/worn_overlays(var/isinhands = FALSE)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -35,7 +35,7 @@
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/clothing/mask/gas/sechailer=1,\
 		/obj/item/weapon/gun/energy/gun=1)
-	l_pocket = /obj/item/weapon/switchblade
+	l_pocket = /obj/item/weapon/melee/toggle/switchblade
 
 /datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -54,7 +54,7 @@
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/clothing/mask/gas/sechailer/swat=1,\
 		/obj/item/weapon/gun/energy/pulse/pistol/loyalpin=1)
-	l_pocket = /obj/item/weapon/melee/energy/sword/saber
+	l_pocket = /obj/item/weapon/melee/toggle/energy/sword/saber
 
 /datum/outfit/ert/security
 	name = "ERT Security"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -84,7 +84,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	head = /obj/item/clothing/head/bandana
 	glasses = /obj/item/clothing/glasses/eyepatch
-	r_hand = /obj/item/weapon/melee/energy/sword/pirate
+	r_hand = /obj/item/weapon/melee/toggle/energy/sword/pirate
 
 /datum/outfit/pirate/space
 	name = "Space Pirate"
@@ -146,7 +146,7 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	ears = /obj/item/device/radio/headset
 	glasses = /obj/item/clothing/glasses/sunglasses
-	l_pocket = /obj/item/weapon/melee/energy/sword/saber
+	l_pocket = /obj/item/weapon/melee/toggle/energy/sword/saber
 	l_hand = /obj/item/weapon/storage/secure/briefcase
 	id = /obj/item/weapon/card/id/syndicate
 	belt = /obj/item/device/pda/heads
@@ -334,7 +334,7 @@
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	glasses = /obj/item/clothing/glasses/hud/toggle/thermal
 	back = /obj/item/weapon/storage/backpack/security
-	l_pocket = /obj/item/weapon/melee/energy/sword/saber
+	l_pocket = /obj/item/weapon/melee/toggle/energy/sword/saber
 	r_pocket = /obj/item/weapon/shield/energy
 	suit_store = /obj/item/weapon/tank/internals/emergency_oxygen
 	belt = /obj/item/weapon/gun/projectile/revolver/mateba

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -258,7 +258,7 @@
 	w_class = 3
 	action_button_name = "Toggle Helmet"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/toggle/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 
 /obj/item/clothing/suit/space/hardsuit/syndi/New()
@@ -570,7 +570,7 @@
 	item_state = "syndie_hardsuit"
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/toggle/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi
 	slowdown = 0
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -150,7 +150,7 @@ Contains:
 	item_state = "pirate"
 	w_class = 3
 	flags_inv = 0
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals, /obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals, /obj/item/weapon/melee/toggle/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
 	slowdown = 0
 	armor = list(melee = 30, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	strip_delay = 40

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -4,7 +4,7 @@
 /obj/item/clothing/suit/space/eva/plasmaman
 	name = "plasmaman suit"
 	desc = "A special containment suit designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_casing,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_casing,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/toggle/energy/sword,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 0)
 	icon_state = "plasmaman_suit"
 	item_state = "plasmaman_suit"

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -13,7 +13,7 @@
 	item_state = "space_suit_syndicate"
 	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
 	w_class = 3
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
+	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/toggle/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	armor = list(melee = 40, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -36,14 +36,14 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	item_state = "pirate"
-	allowed = list(/obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
+	allowed = list(/obj/item/weapon/melee/toggle/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
 
 /obj/item/clothing/suit/hgpirate
 	name = "pirate captain coat"
 	desc = "Yarr."
 	icon_state = "hgpirate"
 	item_state = "hgpirate"
-	allowed = list(/obj/item/weapon/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
+	allowed = list(/obj/item/weapon/melee/toggle/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/weapon/reagent_containers/food/drinks/bottle/rum)
 
 
 /obj/item/clothing/suit/cyborg_suit

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -460,7 +460,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 	return
 
 var/list/non_fakeattack_weapons = list(/obj/item/weapon/gun/projectile, /obj/item/ammo_box/a357,\
-	/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow, /obj/item/weapon/melee/energy/sword/saber,\
+	/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow, /obj/item/weapon/melee/toggle/energy/sword/saber,\
 	/obj/item/weapon/storage/box/syndicate, /obj/item/weapon/storage/box/emps,\
 	/obj/item/weapon/cartridge/syndicate, /obj/item/clothing/under/chameleon,\
 	/obj/item/clothing/shoes/sneakers/syndigaloshes, /obj/item/weapon/card/id/syndicate,\

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -68,7 +68,7 @@
 
 /obj/item/weapon/grown/log/attackby(obj/item/weapon/W, mob/user, params)
 	..()
-	if(istype(W, /obj/item/weapon/circular_saw) || istype(W, /obj/item/weapon/hatchet) || (istype(W, /obj/item/weapon/twohanded/fireaxe) && W:wielded) || istype(W, /obj/item/weapon/melee/energy) || istype(W, /obj/item/weapon/twohanded/required/chainsaw))
+	if(istype(W, /obj/item/weapon/circular_saw) || istype(W, /obj/item/weapon/hatchet) || (istype(W, /obj/item/weapon/twohanded/fireaxe) && W:wielded) || istype(W, /obj/item/weapon/melee/toggle/energy) || istype(W, /obj/item/weapon/twohanded/required/chainsaw))
 		user.show_message("<span class='notice'>You make [plank_name] out of \the [src]!</span>", 1)
 		var/obj/item/stack/plank = new plank_type(user.loc, 1 + round(potency / 25))
 		var/old_plank_amount = plank.amount

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -130,7 +130,7 @@
 	modules += new /obj/item/weapon/wrench(src)
 	modules += new /obj/item/weapon/crowbar(src)
 	modules += new /obj/item/device/healthanalyzer(src)
-	emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
+	emag = new /obj/item/weapon/melee/toggle/energy/sword/cyborg(src)
 	fix_modules()
 
 
@@ -307,7 +307,7 @@
 
 /obj/item/weapon/robot_module/syndicate/New()
 	..()
-	modules += new /obj/item/weapon/melee/energy/sword/cyborg(src)
+	modules += new /obj/item/weapon/melee/toggle/energy/sword/cyborg(src)
 	modules += new /obj/item/weapon/gun/energy/printer(src)
 	modules += new /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg(src)
 	modules += new /obj/item/weapon/card/emag(src)
@@ -329,7 +329,7 @@
 	modules += new /obj/item/weapon/hemostat(src)
 	modules += new /obj/item/weapon/cautery(src)
 	modules += new /obj/item/weapon/scalpel(src)
-	modules += new /obj/item/weapon/melee/energy/sword/cyborg/saw(src) //Energy saw -- primary weapon
+	modules += new /obj/item/weapon/melee/toggle/energy/sword/cyborg/saw(src) //Energy saw -- primary weapon
 	modules += new /obj/item/roller/robo(src)
 	modules += new /obj/item/weapon/card/emag(src)
 	modules += new /obj/item/weapon/crowbar(src)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -23,7 +23,7 @@
 	unsuitable_atmos_damage = 15
 	speak_emote = list("yarrs")
 	loot = list(/obj/effect/landmark/mobcorpse/pirate,
-			/obj/item/weapon/melee/energy/sword/pirate)
+			/obj/item/weapon/melee/toggle/energy/sword/pirate)
 	del_on_death = 1
 	faction = list("pirate")
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -88,7 +88,7 @@
 	maxHealth = 340
 	health = 340
 	loot = list(/obj/effect/landmark/mobcorpse/syndicatestormtrooper,
-				/obj/item/weapon/melee/energy/sword/saber/red,
+				/obj/item/weapon/melee/toggle/energy/sword/saber/red,
 				/obj/item/weapon/shield/energy)
 
 ///////////////Guns////////////

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -83,8 +83,8 @@
 	..()
 	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/gun/energy/plasmacutter))
 		sawoff(user)
-	if(istype(A, /obj/item/weapon/melee/energy))
-		var/obj/item/weapon/melee/energy/W = A
+	if(istype(A, /obj/item/weapon/melee/toggle/energy))
+		var/obj/item/weapon/melee/toggle/energy/W = A
 		if(W.active)
 			sawoff(user)
 
@@ -189,8 +189,8 @@
 	..()
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
 		chamber_round()
-	if(istype(A, /obj/item/weapon/melee/energy))
-		var/obj/item/weapon/melee/energy/W = A
+	if(istype(A, /obj/item/weapon/melee/toggle/energy))
+		var/obj/item/weapon/melee/toggle/energy/W = A
 		if(W.active)
 			sawoff(user)
 	if(istype(A, /obj/item/weapon/circular_saw) || istype(A, /obj/item/weapon/gun/energy/plasmacutter))

--- a/code/modules/surgery/generic_steps.dm
+++ b/code/modules/surgery/generic_steps.dm
@@ -2,7 +2,7 @@
 //make incision
 /datum/surgery_step/incise
 	name = "make incision"
-	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/melee/energy/sword = 75, /obj/item/weapon/kitchen/knife = 65, /obj/item/weapon/shard = 45)
+	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/melee/toggle/energy/sword = 75, /obj/item/weapon/kitchen/knife = 65, /obj/item/weapon/shard = 45)
 	time = 16
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -77,7 +77,7 @@
 //saw bone
 /datum/surgery_step/saw
 	name = "saw bone"
-	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/toggle/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -124,7 +124,7 @@
 /datum/surgery_step/chainsaw_removal
 	time = 128
 	name = "saw off chainsaw"
-	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/toggle/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 75, /obj/item/weapon/mounted_chainsaw = 65, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/twohanded/required/chainsaw = 50, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 
 /datum/surgery_step/chainsaw_removal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] begins sawing the chainsaw off of [target]'s arms.", "<span class='notice'>You begin removing [target]'s chainsaw...</span>")

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -12,7 +12,7 @@
 //cut fat
 /datum/surgery_step/cut_fat
 	name = "cut excess fat"
-	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/toggle/energy/sword/cyborg/saw = 100, /obj/item/weapon/hatchet = 35, /obj/item/weapon/kitchen/knife/butcher = 25)
 	time = 64
 
 /datum/surgery_step/cut_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/tail_modification.dm
+++ b/code/modules/surgery/tail_modification.dm
@@ -17,7 +17,7 @@
 
 /datum/surgery_step/sever_tail
 	name = "sever tail"
-	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 80, /obj/item/weapon/twohanded/required/chainsaw = 80, /obj/item/weapon/mounted_chainsaw = 80, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 40, /obj/item/weapon/kitchen/knife/butcher = 25)
+	implements = list(/obj/item/weapon/scalpel = 100, /obj/item/weapon/circular_saw = 100, /obj/item/weapon/melee/toggle/energy/sword/cyborg/saw = 100, /obj/item/weapon/melee/arm_blade = 80, /obj/item/weapon/twohanded/required/chainsaw = 80, /obj/item/weapon/mounted_chainsaw = 80, /obj/item/weapon/twohanded/fireaxe = 50, /obj/item/weapon/hatchet = 40, /obj/item/weapon/kitchen/knife/butcher = 25)
 	time = 64
 
 /datum/surgery_step/sever_tail/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -237,7 +237,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			pocketed when inactive. Activating it produces a loud, distinctive noise. One can combine two \
 			energy swords to create a double energy sword, which must be wielded in two hands but is more robust \
 			and deflects all energy projectiles."
-	item = /obj/item/weapon/melee/energy/sword/saber
+	item = /obj/item/weapon/melee/toggle/energy/sword/saber
 	cost = 8
 
 /datum/uplink_item/dangerous/emp
@@ -737,7 +737,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 4
 	surplus = 30
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-	
+
 /datum/uplink_item/stealthy_tools/emplight
 	name = "EMP Flashlight"
 	desc = "A small, self-charging, short-ranged EMP device disguised as a flashlight. \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -618,6 +618,7 @@
 #include "code\game\objects\items\weapons\stunbaton.dm"
 #include "code\game\objects\items\weapons\teleportation.dm"
 #include "code\game\objects\items\weapons\teleprod.dm"
+#include "code\game\objects\items\weapons\toggle_weapons.dm"
 #include "code\game\objects\items\weapons\tools.dm"
 #include "code\game\objects\items\weapons\twohanded.dm"
 #include "code\game\objects\items\weapons\vending_items.dm"


### PR DESCRIPTION
Energy swords and switchblades are now both under the same object path/have unified toggling instead of copypaste.

I plan to move teleshields and eshields as well.

This is mostly so I can add new toggle weapons (like chainsaw swords) without more copypaste though.
