### PR TITLE
No more low pop nuclear emergency

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 20 // 20 players - 5 players to be the nuke ops = 15 players remaining
+	required_players = 45 // 45 players - 5 players to be the nuke ops = 40 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE


### PR DESCRIPTION
If/when someone comes up with proper scaling we can change the number back, but until then it's not really very much fun for skeleton crews to be stomped on by something that is arguably as strong as the deathsquad.

http://www.ss13.eu/tgdb/tg/latest_stats.html#mode_nuclear_emergency
