### PR TITLE
Blob event can now happen earlier

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -95,12 +95,13 @@
 	playsound(B.loc, 'sound/effects/splat.ogg', 50, 1)
 	blobber.overmind = src
 	blobber.update_icons()
-	blobber.AIStatus = AI_OFF
+	blobber.notransform = 1 //stop the naut from moving around
 	blob_mobs.Add(blobber)
 	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as a [blob_reagent_datum.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50) //players must answer rapidly
 	var/client/C = null
 	if(candidates.len) //if we got at least one candidate, they're a blobbernaut now.
 		C = pick(candidates)
+		blobber.notransform = 0
 		blobber.key = C.key
 		blobber << 'sound/effects/blobattack.ogg'
 		blobber << 'sound/effects/attackblob.ogg'
@@ -109,7 +110,7 @@
 		blobber << "Your overmind's blob reagent is: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
 		blobber << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]"
 	else
-		blobber.AIStatus = AI_ON //otherwise, they reactivate AI and continue
+		blobber.notransform = 0 //otherwise, just let it move
 
 /mob/camera/blob/verb/relocate_core()
 	set category = "Blob"

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,15 +4,14 @@
 	weight = 5
 	max_occurrences = 1
 
-	earliest_start = 48000 // 1 hour 20 minutes
+	earliest_start = 18000 //30 minutes
 
-	gamemode_blacklist = list("blob") // Just in case blob survives that long
+	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
 /datum/round_event/blob
 	announceWhen	= 12
 	endWhen			= 120
 	var/new_rate = 2
-	var/obj/effect/blob/core/Blob
 
 /datum/round_event/blob/New(var/strength)
 	..()
@@ -27,14 +26,4 @@
 	var/turf/T = pick(blobstart)
 	if(!T)
 		return kill()
-	Blob = new /obj/effect/blob/core(T, 200, null, new_rate)
-	for(var/i = 1; i < rand(3, 6), i++)
-		Blob.process()
-
-
-/datum/round_event/blob/tick()
-	if(!Blob)
-		kill()
-		return
-	if(IsMultiple(activeFor, 3))
-		Blob.process()
+	new/obj/effect/blob/core(T, 200, null, new_rate)


### PR DESCRIPTION
The blob random event can now happen as early as 30 minutes(this is the same time+weight as the abductor random event)
Bonus; fixes a bug where blobbernauts spawned from factories would wander in the 5 seconds before they got a client
Other Bonus; removes some unneeded code in the blob event that would cause the blob to process faster than normal gamemode blobs.
