### PR TITLE
The AI's core no longer fits inside regular closets

### DIFF
--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -50,9 +50,7 @@
 		add_fingerprint(user)
 
 /obj/structure/bed/nest/user_buckle_mob(mob/living/M, mob/living/user)
-	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.stat || M.buckled || istype(user,
-
-/mob/living/silicon/pai) )
+	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.incapacitated() || M.buckled )
 		return
 
 	if(M.getorgan(/obj/item/organ/internal/alien/plasmavessel))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -121,8 +121,11 @@
 	if(contents.len >= storage_capacity)
 		return -1
 
-	var/mob/living/L = AM
-	if(istype(L))
+
+	if(ismob(AM))
+		if(!isliving(AM)) //let's not put ghosts or camera mobs inside closets...
+			return
+		var/mob/living/L = AM
 		if(L.buckled || L.buckled_mob)
 			return
 		if(L.mob_size > MOB_SIZE_TINY) // Tiny mobs are treated as items.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -24,6 +24,7 @@ var/list/ai_list = list()
 	see_in_dark = 8
 	med_hud = DATA_HUD_MEDICAL_BASIC
 	sec_hud = DATA_HUD_SECURITY_BASIC
+	mob_size = MOB_SIZE_LARGE
 	var/list/network = list("SS13")
 	var/obj/machinery/camera/current = null
 	var/list/connected_robots = list()


### PR DESCRIPTION
Fixes #15616
 (but still fits inside bluespace bodybag).

Ghosts and camera mobs no longer get inserted inside closets. Fixes #15612

Fixes an error in alien nest code.
