### PR TITLE
Buffs the EMP kit

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -54,7 +54,7 @@
 	desc = "Triggers an EMP."
 	icon_state = "emp"
 	origin_tech = "materials=2;biotech=3;magnets=4;syndicate=4"
-	uses = 2
+	uses = 3
 
 /obj/item/weapon/implant/emp/activate()
 	uses--

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -198,6 +198,9 @@
 	..()
 	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
 	new /obj/item/weapon/implanter/emp(src)
 
 /obj/item/weapon/storage/box/syndie_kit/chemical


### PR DESCRIPTION
By request of OOC, as feedback after my last EMP changes. Numbers in this PR are open to feedback and change.

EMP implant now has 3 uses, up from 2
EMP kit now has 5 EMP grenades, up from 2

:cl: PKPenguin321
tweak: The EMP kit has been buffed. It now contains five EMP grenades, up from two.
tweak: The EMP implant found in the EMP kit has been buffed. It now has three uses, up from two.
/:cl:
