### PR TITLE
Adds a chance to recover internal organs when butchering monkey or alien

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -812,3 +812,17 @@ var/const/GALOSHES_DONT_HELP = 4
 	. = ..()
 	if(!getorgan(/obj/item/organ/internal/brain))
 		return 0
+
+/mob/living/carbon/harvest(mob/living/user)
+	if(qdeleted(src))
+		return
+	var/organs_amt = 0
+	for(var/obj/item/organ/internal/O in internal_organs)
+		if(prob(50))
+			organs_amt++
+			O.Remove(src)
+			O.loc = get_turf(src)
+	if(organs_amt)
+		user << "<span class='notice'>You retrieve some of [src]\'s internal organs!</span>"
+
+	..()


### PR DESCRIPTION
The chance is 50% for every organ - surgery is always a better option when you want to get the organs intact. However, it adds a way for chief to make brain burgers without asking robotist for unused brains.

This is not as controversial as #15429 - it doesn't work on humans and you had to butcher the corpse instead of just gibbing it.

:cl: CoreOverload
rscadd: There is now a chance to recover some of the internal organs when butchering aliens or monkeys.
/:cl:
