### PR TITLE
Adds lungs internal organ

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -28,6 +28,7 @@
 	for(var/obj/item/organ/limb/O in organs)
 		O.owner = src
 	internal_organs += new /obj/item/organ/internal/appendix
+	internal_organs += new /obj/item/organ/internal/lungs
 	internal_organs += new /obj/item/organ/internal/heart
 	internal_organs += new /obj/item/organ/internal/brain
 
@@ -945,6 +946,9 @@
 				hud_used.healthdoll.icon_state = "healthdoll_DEAD"
 
 /mob/living/carbon/human/fully_heal(admin_revive = 0)
+	if(!getorganslot("lungs"))
+		var/obj/item/organ/internal/lungs/L = new()
+		L.Insert(src)
 	restore_blood()
 	remove_all_embedded_objects()
 	..()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -48,6 +48,8 @@
 	return real_name
 
 /mob/living/carbon/human/IsVocal()
+	if(!getorganslot("lungs"))
+		return 0
 	if(mind)
 		return !mind.miming
 	return 1

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1078,8 +1078,12 @@
 	if((H.status_flags & GODMODE))
 		return
 
-	if(!breath || (breath.total_moles() == 0))
-		if(H.reagents.has_reagent("epinephrine"))
+	var/lungs = H.getorganslot("lungs")
+	if(!lungs)
+		H.adjustOxyLoss(1)
+
+	if(!breath || (breath.total_moles() == 0) || !lungs)
+		if(H.reagents.has_reagent("epinephrine") && lungs)
 			return
 		if(H.health >= config.health_threshold_crit)
 			if(NOBREATH in specflags)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1079,8 +1079,6 @@
 		return
 
 	var/lungs = H.getorganslot("lungs")
-	if(!lungs)
-		H.adjustOxyLoss(1)
 
 	if(!breath || (breath.total_moles() == 0) || !lungs)
 		if(H.reagents.has_reagent("epinephrine") && lungs)
@@ -1089,6 +1087,8 @@
 			if(NOBREATH in specflags)
 				return 1
 			H.adjustOxyLoss(HUMAN_MAX_OXYLOSS)
+			if(!lungs)
+				H.adjustOxyLoss(1)
 			H.failed_last_breath = 1
 		else
 			H.adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -100,9 +100,13 @@
 	if((status_flags & GODMODE))
 		return
 
+	var/lungs = getorganslot("lungs")
+	if(!lungs)
+		adjustOxyLoss(2)
+
 	//CRIT
-	if(!breath || (breath.total_moles() == 0))
-		if(reagents.has_reagent("epinephrine"))
+	if(!breath || (breath.total_moles() == 0) || !lungs)
+		if(reagents.has_reagent("epinephrine") && lungs)
 			return
 		adjustOxyLoss(1)
 		failed_last_breath = 1

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -24,6 +24,7 @@
 		initialize()
 
 	internal_organs += new /obj/item/organ/internal/appendix
+	internal_organs += new /obj/item/organ/internal/lungs
 	internal_organs += new /obj/item/organ/internal/heart
 	internal_organs += new /obj/item/organ/internal/brain
 
@@ -300,3 +301,14 @@
 		var/obj/item/clothing/mask/MFP = src.wear_mask
 		number += MFP.flash_protect
 	return number
+
+/mob/living/carbon/monkey/fully_heal(admin_revive = 0)
+	if(!getorganslot("lungs"))
+		var/obj/item/organ/internal/lungs/L = new()
+		L.Insert(src)
+	..()
+
+/mob/living/carbon/monkey/IsVocal()
+	if(!getorganslot("lungs"))
+		return 0
+	return 1

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -188,6 +188,19 @@
 			H.adjustOxyLoss(-cursed_heart.heal_oxy)
 
 
+/obj/item/organ/internal/lungs
+	name = "lungs"
+	icon_state = "lungs"
+	zone = "chest"
+	slot = "lungs"
+	gender = PLURAL
+	w_class = 3
+
+/obj/item/organ/internal/lungs/prepare_eat()
+	var/obj/S = ..()
+	S.reagents.add_reagent("salbutamol", 5)
+	return S
+
 
 /obj/item/organ/internal/appendix
 	name = "appendix"


### PR DESCRIPTION
Lungs are added to humans and monkeys. They go into the chest and work like the rest of organs. When removed, they cause constant oxyloss and muteness.

"Revive" restores lungs in mobs that had their lungs removed.

I didn't added lungs to aliens because, AFAIK, they don't have any lungs and rely on some sort of completely non-human breathing process involving the tubes on their backs. I don't have a sprite for this, and adding it as organ would require adding on-mob organ icon system - i just don't want to mess with human's icon update without a really good reason.

:cl: CoreOverload
rscadd: A new organ - lungs. When removed, it will give you breathing and speaking troubles. 
/:cl:
