### PR TITLE
Named burgers are back!

### DIFF
--- a/code/modules/food&drinks/food/snacks/meat.dm
+++ b/code/modules/food&drinks/food/snacks/meat.dm
@@ -37,15 +37,17 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/initialize_slice(obj/item/weapon/reagent_containers/food/snacks/meat/rawcutlet/plain/human/slice, reagents_per_slice)
 	..()
+	slice.subjectname = subjectname
+	slice.subjectjob = subjectjob
 	if(subjectname)
-		slice.subjectname = subjectname
 		slice.name = "raw [subjectname] cutlet"
 	else if(subjectjob)
-		slice.subjectjob = subjectjob
 		slice.name = "raw [subjectjob] cutlet"
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/S, cooking_efficiency)
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/initialize_cooked_food(obj/item/weapon/reagent_containers/food/snacks/meat/S, cooking_efficiency)
 	..()
+	S.subjectname = subjectname
+	S.subjectjob = subjectjob
 	if(subjectname)
 		S.name = "[subjectname] meatsteak"
 	else if(subjectjob)

--- a/code/modules/food&drinks/food/snacks_burgers.dm
+++ b/code/modules/food&drinks/food/snacks_burgers.dm
@@ -12,11 +12,25 @@
 	bonus_reagents = list("vitamin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/human
-	var/hname = ""
-	var/job = null
+	var/subjectname = ""
+	var/subjectjob = null
 	name = "human burger"
 	desc = "A bloody burger."
 	bonus_reagents = list("vitamin" = 4)
+
+/obj/item/weapon/reagent_containers/food/snacks/burger/human/CheckParts()
+	var/obj/item/weapon/reagent_containers/food/snacks/meat/M = locate(/obj/item/weapon/reagent_containers/food/snacks/meat/steak/plain/human) in contents
+	if(M)
+		subjectname = M.subjectname
+		subjectjob = M.subjectjob
+		if(subjectname)
+			name = "[subjectname] burger"
+		else if(subjectjob)
+			name = "[subjectjob] burger"
+		qdel(M)
+
+	..()
+
 
 /obj/item/weapon/reagent_containers/food/snacks/burger/corgi
 	name = "corgi burger"

--- a/code/modules/food&drinks/kitchen machinery/gibber.dm
+++ b/code/modules/food&drinks/kitchen machinery/gibber.dm
@@ -9,8 +9,6 @@
 	var/operating = 0 //Is it on?
 	var/dirty = 0 // Does it need cleaning?
 	var/gibtime = 40 // Time from starting until meat appears
-	var/typeofmeat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human
-	var/typeofskin = /obj/item/stack/sheet/animalhide/human
 	var/meat_produced = 0
 	var/ignore_clothing = 0
 	use_power = 1
@@ -161,6 +159,7 @@
 	playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
 	src.operating = 1
 	update_icon()
+
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 	var/sourcename = src.occupant.real_name
@@ -171,6 +170,8 @@
 	var/sourcenutriment = src.occupant.nutrition / 15
 	var/sourcetotalreagents = src.occupant.reagents.total_volume
 	var/gibtype = /obj/effect/decal/cleanable/blood/gibs
+	var/typeofmeat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human
+	var/typeofskin = /obj/item/stack/sheet/animalhide/human
 
 	var/obj/item/weapon/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced]
 	var/obj/item/stack/sheet/animalhide/allskin
@@ -183,11 +184,15 @@
 		else
 			typeofmeat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human
 			typeofskin = /obj/item/stack/sheet/animalhide/human
-	else
-		if(iscarbon(occupant))
-			var/mob/living/carbon/C = occupant
-			typeofmeat = C.type_of_meat
-			gibtype = C.gib_type
+	else if(iscarbon(occupant))
+		var/mob/living/carbon/C = occupant
+		typeofmeat = C.type_of_meat
+		gibtype = C.gib_type
+		if(ismonkey(C))
+			typeofskin = /obj/item/stack/sheet/animalhide/monkey
+		else if(isalien(C))
+			typeofskin = /obj/item/stack/sheet/animalhide/xeno
+
 	for (var/i=1 to meat_produced)
 		var/obj/item/weapon/reagent_containers/food/snacks/meat/slab/newmeat = new typeofmeat
 		var/obj/item/stack/sheet/animalhide/newskin = new typeofskin

--- a/code/modules/food&drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food&drinks/recipes/tablecraft/recipes_burger.dm
@@ -10,6 +10,9 @@
 		/obj/item/weapon/reagent_containers/food/snacks/bun = 1,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/steak/plain/human = 1
 	)
+	parts = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meat/steak/plain/human = 1
+	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/burger/human
 	category = CAT_FOOD
 

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -70,6 +70,7 @@
 			qdel(tool)
 			H.update_damage_overlays(0)
 			H.update_augments() //Gives them the Cyber limb overlay
+			H.updatehealth()
 			add_logs(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else
 		user << "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>"

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -37,10 +37,17 @@
 	var/removednutriment = target.nutrition
 	target.nutrition = NUTRITION_LEVEL_WELL_FED
 	removednutriment -= 450 //whatever was removed goes into the meat
-	var/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/newmeat = new
+	var/mob/living/carbon/human/H = target
+	var/typeofmeat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human
+
+	if(H.dna && H.dna.species)
+		typeofmeat = H.dna.species.meat
+
+	var/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/newmeat = new typeofmeat
 	newmeat.name = "fatty meat"
 	newmeat.desc = "Extremely fatty tissue taken from a patient."
+	newmeat.subjectname = H.real_name
+	newmeat.subjectjob = H.job
 	newmeat.reagents.add_reagent ("nutriment", (removednutriment / 15)) //To balance with nutriment_factor of nutriment
-	var/obj/item/meatslab = newmeat
-	meatslab.loc = target.loc
+	newmeat.loc = target.loc
 	return 1


### PR DESCRIPTION
- Human burgers are, once again, named against generous meat donors that made them possible. This means you can finally take a seat, relax and enjoy a "Captain Comdom burger" after a successful revolution. Fixes #12012. 
- Gibber no longer produces human skin while gibbing aliens or monkeys. Fixes #15664.
- Aug. surgery is now updating health correctly. It isn't related to burgers, meat and cooking, but an extra fix wouldn't hurt, right? Fixes  #15706.
- Liposaction surgery now respects species meat types and passes down job and name to created meat.

:cl: CoreOverload
rscadd: Human burgers are, once again, named after the generous meat donors that made them possible.
/:cl:
