### PR TITLE
SNPCs v3: Robustaloo

### DIFF
--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -26,21 +26,10 @@ var/datum/subsystem/npcpool/SSnpc
 
 /datum/subsystem/npcpool/proc/cleanNull()
 		//cleanup nulled bots
-	for(var/a in botPool_l)
-		if(!a)
-			botPool_l -= a
-
-	for(var/a in needsDelegate)
-		if(!a)
-			needsDelegate -= a
-
-	for(var/a in canBeUsed)
-		if(!a)
-			canBeUsed -= a
-
-	for(var/a in needsAssistant)
-		if(!a)
-			needsAssistant -= a
+	listclearnulls(botPool_l)
+	listclearnulls(needsDelegate)
+	listclearnulls(canBeUsed)
+	listclearnulls(needsAssistant)
 
 
 /datum/subsystem/npcpool/fire()

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -24,6 +24,25 @@ var/datum/subsystem/npcpool/SSnpc
 	..("T:[botPool_l.len + botPool_l_non.len]|D:[needsDelegate.len]|A:[needsAssistant.len + needsHelp_non.len]|U:[canBeUsed.len + canBeUsed_non.len]")
 
 
+/datum/subsystem/npcpool/proc/cleanNull()
+		//cleanup nulled bots
+	for(var/a in botPool_l)
+		if(!a)
+			botPool_l -= a
+
+	for(var/a in needsDelegate)
+		if(!a)
+			needsDelegate -= a
+
+	for(var/a in canBeUsed)
+		if(!a)
+			canBeUsed -= a
+
+	for(var/a in needsAssistant)
+		if(!a)
+			needsAssistant -= a
+
+
 /datum/subsystem/npcpool/fire()
 	//bot delegation and coordination systems
 	//General checklist/Tasks for delegating a task or coordinating it (for SNPCs)
@@ -34,6 +53,8 @@ var/datum/subsystem/npcpool/SSnpc
 	// 5. Do all assignments: goes through the delegated/coordianted bots and assigns the right variables/tasks to them.
 	var/npcCount = 1
 
+	cleanNull()
+
 	//SNPC handling
 	for(var/mob/living/carbon/human/interactive/check in botPool_l)
 		if(!check)
@@ -43,7 +64,7 @@ var/datum/subsystem/npcpool/SSnpc
 		if(!(locate(check.TARGET) in checkInRange))
 			needsDelegate |= check
 
-		else if(check.isnotfunc(FALSE))
+		else if(check.IsDeadOrIncap(FALSE))
 			needsDelegate |= check
 
 		else if(check.doing & FIGHTING)
@@ -75,6 +96,7 @@ var/datum/subsystem/npcpool/SSnpc
 						needsDelegate -= check
 						canBeUsed -= candidate
 						candidate.eye_color = "red"
+						candidate.update_icons()
 			npcCount++
 
 	if(needsAssistant.len)
@@ -99,4 +121,5 @@ var/datum/subsystem/npcpool/SSnpc
 						needsAssistant -= check
 						canBeUsed -= candidate
 						candidate.eye_color = "yellow"
+						candidate.update_icons()
 			npcCount++

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -178,7 +178,7 @@
 		if("Chief Medical Officer","Medical Doctor","Chemist","Virologist","Geneticist")
 			favoured_types = list(/obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/storage/firstaid, /obj/item/stack/medical, /obj/item/weapon/reagent_containers/syringe)
 		if("Research Director","Scientist","Roboticist")
-			return /area/toxins
+			favoured_types = list(/obj/item/weapon/reagent_containers/glass/beaker, /obj/item/stack, /obj/item/weapon/reagent_containers)
 		if("Head of Security","Warden","Security Officer","Detective")
 			favoured_types = list(/obj/item/clothing, /obj/item/weapon, /obj/item/weapon/restraints)
 		if("Janitor")

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -160,8 +160,9 @@
 		var/obj/item/organ/limb/head/L = locate(/obj/item/organ/limb/head) in organs
 		qdel(L)
 		organs += new /obj/item/organ/limb/robot/head
-	for(var/obj/item/organ/limb/LIMB in organs)
-		LIMB.owner = src
+	for(var/LIMB in organs)
+		var/obj/item/organ/limb/L = LIMB
+		L.owner = src
 	update_icons()
 	update_damage_overlays(0)
 	update_augments()
@@ -551,9 +552,10 @@
 		return pick(/area/hallway,/area/crew_quarters)
 
 /mob/living/carbon/human/interactive/proc/target_filter(target)
+	var/list/filtered_targets = list(/area, /turf, /obj/machinery/door, /atom/movable/light, /obj/structure/cable, /obj/machinery/atmospherics)
 	var/list/L = target
 	for(var/atom/A in target) // added a bunch of "junk" that clogs up the general find procs
-		if(istype(A,/area) || istype(A,/turf) || istype(A,/obj/machinery/door) || istype(A,/atom/movable/light) || istype(A,/obj/structure/cable) || istype(A,/obj/machinery/atmospherics))
+		if(is_type_in_list(A,filtered_targets))
 			L -= A
 	return L
 
@@ -763,7 +765,7 @@
 						if(Adjacent(TARGET))
 							M.attack_hand(src)
 			timeout++
-		else if(timeout >= 10 || M.health <= 1 || !(targetRange(M) > 14))
+		else if(timeout >= 10 || !(targetRange(M) > 14))
 			doing = doing & ~FIGHTING
 			timeout = 0
 			TARGET = null

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -633,13 +633,14 @@
 			M = A
 	if(shouldTryHeal)
 		for(var/mob/living/carbon/C in nearby)
-			if(C.health <= 75)
-				if(get_dist(src,C) <= 2)
-					src.say("Wait, [C], let me heal you!")
-					M.attack(C,src)
-					sleep(25)
-				else
-					tryWalk(get_turf(C))
+			if(istype(C,/mob/living/carbon)) //I haven't the foggiest clue why this is turning up non-carbons but sure here whatever
+				if(C.health <= 75)
+					if(get_dist(src,C) <= 2)
+						src.say("Wait, [C], let me heal you!")
+						M.attack(C,src)
+						sleep(25)
+					else
+						tryWalk(get_turf(C))
 
 /mob/living/carbon/human/interactive/proc/dojanitor(obj)
 	if(istype(main_hand,/obj/item/weapon/mop))

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -719,36 +719,43 @@
 			if(M.health > 1)
 				if(main_hand)
 					if(main_hand.force != 0)
-						if(istype(main_hand,/obj/item/weapon/gun/projectile))
-							var/obj/item/weapon/gun/projectile/P = main_hand
-							if(!P.chambered)
-								P.chamber_round()
-								P.update_icon()
-							else if(P.get_ammo(1) == 0)
-								P.update_icon()
-								blacklistItems += P
-								P.loc = get_turf(src) // drop item works inconsistently
+						if(istype(main_hand,/obj/item/weapon/gun))
+							var/obj/item/weapon/gun/G = main_hand
+							if(G.can_trigger_gun(src))
+								if(istype(main_hand,/obj/item/weapon/gun/projectile))
+									var/obj/item/weapon/gun/projectile/P = main_hand
+									if(!P.chambered)
+										P.chamber_round()
+										P.update_icon()
+									else if(P.get_ammo(1) == 0)
+										P.update_icon()
+										blacklistItems += P
+										P.loc = get_turf(src) // drop item works inconsistently
+										enforce_hands()
+										update_icons()
+									else
+										P.afterattack(TARGET, src)
+								else if(istype(main_hand,/obj/item/weapon/gun/energy))
+									var/obj/item/weapon/gun/energy/P = main_hand
+									if(P.power_supply.charge <= 10) // can shoot seems to bug out for tasers, using this hacky method instead
+										P.update_icon()
+										blacklistItems += P
+										P.loc = get_turf(src) // likewise
+										enforce_hands()
+										update_icons()
+									else
+										P.afterattack(TARGET, src)
+								else
+									if(get_dist(src,TARGET) > 2)
+										if(!walk2derpless(TARGET))
+											timeout++
+									else
+										var/obj/item/weapon/W = main_hand
+										W.attack(TARGET,src)
+							else
+								G.loc = get_turf(src) // drop item works inconsistently
 								enforce_hands()
 								update_icons()
-							else
-								P.afterattack(TARGET, src)
-						else if(istype(main_hand,/obj/item/weapon/gun/energy))
-							var/obj/item/weapon/gun/energy/P = main_hand
-							if(P.power_supply.charge <= 10) // can shoot seems to bug out for tasers, using this hacky method instead
-								P.update_icon()
-								blacklistItems += P
-								P.loc = get_turf(src) // likewise
-								enforce_hands()
-								update_icons()
-							else
-								P.afterattack(TARGET, src)
-						else
-							if(get_dist(src,TARGET) > 2)
-								if(!walk2derpless(TARGET))
-									timeout++
-							else
-								var/obj/item/weapon/W = main_hand
-								W.attack(TARGET,src)
 				else
 					if(targetRange(TARGET) > (istype(main_hand,/obj/item/weapon/gun) ? 6 : 2))
 						tryWalk(TARGET)

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -58,6 +58,7 @@
 	var/graytide = 0
 	var/list/favoured_types = list() // allow a mob to favour a type, and hold onto them
 	var/chattyness = CHANCE_TALK
+	var/targetInterestShift = 10 // how much a good action should "reward" the npc
 	//modules
 	var/list/functions = list("nearbyscan","combat","doorscan","shitcurity","chatter")
 
@@ -165,25 +166,26 @@
 	hand = 0
 
 	//job specific favours
-	if(myjob.title == "Assistant")
-		favoured_types = list(/obj/item/clothing, /obj/item/weapon)
-	if(myjob.title == "Captain" || myjob.title == "Head of Personnel")
-		favoured_types = list(/obj/item/clothing, /obj/item/weapon/stamp/captain,/obj/item/weapon/disk/nuclear)
-	if(myjob.title == "Bartender" || myjob.title == "Chef")
-		favoured_types = list(/obj/item/weapon/reagent_containers/food, /obj/item/weapon/kitchen)
-	if(myjob.title == "Station Engineer" || myjob.title == "Chief Engineer" || myjob.title == "Atmospheric Technician")
-		favoured_types = list(/obj/item/stack, /obj/item/weapon, /obj/item/clothing)
-	if(myjob.title == "Chief Medical Officer" || myjob.title == "Medical Doctor" || myjob.title == "Chemist" || myjob.title == "Virologist" || myjob.title == "Geneticist")
-		favoured_types = list(/obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/storage/firstaid, /obj/item/stack/medical, /obj/item/weapon/reagent_containers/syringe)
-	if(myjob.title == "Research Director" || myjob.title == "Scientist" || myjob.title == "Roboticist")
-		return /area/toxins
-	if(myjob.title == "Head of Security" || myjob.title == "Warden" || myjob.title == "Security Officer" || myjob.title == "Detective")
-		favoured_types = list(/obj/item/clothing, /obj/item/weapon, /obj/item/weapon/restraints)
-	if(myjob.title == "Janitor")
-		favoured_types = list(/obj/item/weapon/mop, /obj/item/weapon/reagent_containers/glass/bucket, /obj/item/weapon/reagent_containers/spray/cleaner, /obj/effect/decal/cleanable)
-		functions += "dojanitor"
-	else
-		favoured_types = list(/obj/item/clothing)
+	switch(myjob.title)
+		if("Assistant")
+			favoured_types = list(/obj/item/clothing, /obj/item/weapon)
+		if("Captain","Head of Personnel")
+			favoured_types = list(/obj/item/clothing, /obj/item/weapon/stamp/captain,/obj/item/weapon/disk/nuclear)
+		if("Bartender","Chef")
+			favoured_types = list(/obj/item/weapon/reagent_containers/food, /obj/item/weapon/kitchen)
+		if("Station Engineer","Chief Engineer","Atmospheric Technician")
+			favoured_types = list(/obj/item/stack, /obj/item/weapon, /obj/item/clothing)
+		if("Chief Medical Officer","Medical Doctor","Chemist","Virologist","Geneticist")
+			favoured_types = list(/obj/item/weapon/reagent_containers/glass/beaker, /obj/item/weapon/storage/firstaid, /obj/item/stack/medical, /obj/item/weapon/reagent_containers/syringe)
+		if("Research Director","Scientist","Roboticist")
+			return /area/toxins
+		if("Head of Security","Warden","Security Officer","Detective")
+			favoured_types = list(/obj/item/clothing, /obj/item/weapon, /obj/item/weapon/restraints)
+		if("Janitor")
+			favoured_types = list(/obj/item/weapon/mop, /obj/item/weapon/reagent_containers/glass/bucket, /obj/item/weapon/reagent_containers/spray/cleaner, /obj/effect/decal/cleanable)
+			functions += "dojanitor"
+		else
+			favoured_types = list(/obj/item/clothing)
 
 
 	if(TRAITS & TRAIT_ROBUST)
@@ -414,7 +416,7 @@
 					STR.attackby(W, src)
 				else
 					STR.attack_hand(src)
-		interest = interest + 10
+		interest += targetInterestShift
 		doing = doing & ~INTERACTING
 		timeout = 0
 		TARGET = null
@@ -659,6 +661,16 @@
 					TARGET = M
 				if(!M)
 					doing = doing & ~FIGHTING
+
+	//no infighting
+	if(retal)
+		if(retal_target)
+			if(retal_target.faction == src.faction)
+				if(prob(FUZZY_CHANCE_HIGH+FUZZY_CHANCE_LOW))	//high chance to forgive
+					retal = 0
+					retal_target = null
+					TARGET = null
+					doing = 0
 
 	//ensure we're using the best object possible
 


### PR DESCRIPTION
Makes a number of changes and tweaks to SNPCs to make them work better in general.
- NPCPool now automatically clears nulls from its list (badminnery, singulo, gibbing etc)
- NPCs now correctly update their eyes when delegating
- NPCs will blacklist items they deem unusable (currently only empty guns)
- Augmentation chance is now singular instead of recursive
- NPCs support favoured types, which they will use above others when equipping, fighting and looting
- Renamed the non-descript "isnotfunc" to "IsDeadOrIncap"
- enforce_hands() now ensures the held items are still held by the npc (no more floaty items and ghostly guns)
- take_to_slot() now supports taking to hands directly
- NPCs will now appropriately dress themselves
- Interest/Timeout rates tweaked to create smoother transitions between states
- NPC choice system moved from prob to switch to create more activity
- NPCs now have a basic pathfinding system that should work (in most cases)
- Shitcurity NPCs now use any restraints, not just handcuffs
- NPCs spawned with the janitor job will now do some basic janitorial duties
- NPCs priorities in terms of weapons and held objects have been completely rebalanced
- NPCs will now appropriately equip, fire and discard guns.
- NPCs using guns will attempt to maintain a range instead of shooting point blank
- NPCs doorscan now uses all directions to improve mobility
- NPCs doorscan places the NPC in the door instead of attempting to path to it.
