### PR TITLE
Health update from reagent metabolization now only happens once.

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -73,7 +73,6 @@
 		if(JITTER)
 			if(status_flags & CANSTUN)
 				jitteriness = max(jitteriness,(effect * blocked))
-	updatehealth()
 	return 1
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -310,6 +310,7 @@ Sorry Giacom. Please don't be mad :(
 	if(status_flags & GODMODE)
 		return 0
 	brainloss = Clamp(brainloss + amount, 0, maxHealth*2)
+
 /mob/living/proc/setBrainLoss(amount)
 	if(status_flags & GODMODE)
 		return 0
@@ -318,28 +319,30 @@ Sorry Giacom. Please don't be mad :(
 /mob/living/proc/getStaminaLoss()
 	return staminaloss
 
-/mob/living/proc/adjustStaminaLoss(amount)
+/mob/living/proc/adjustStaminaLoss(amount, updating_stamina = 1)
 	return
 
-/mob/living/carbon/adjustStaminaLoss(amount)
+/mob/living/carbon/adjustStaminaLoss(amount, updating_stamina = 1)
 	if(status_flags & GODMODE)
 		return 0
 	staminaloss = Clamp(staminaloss + amount, 0, maxHealth*2)
-	update_stamina()
+	if(updating_stamina)
+		update_stamina()
 
-/mob/living/carbon/alien/adjustStaminaLoss(amount)
+/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_stamina = 1)
 	return
 
-/mob/living/proc/setStaminaLoss(amount)
+/mob/living/proc/setStaminaLoss(amount, updating_stamina = 1)
 	return
 
-/mob/living/carbon/setStaminaLoss(amount)
+/mob/living/carbon/setStaminaLoss(amount, updating_stamina = 1)
 	if(status_flags & GODMODE)
 		return 0
 	staminaloss = amount
-	update_stamina()
+	if(updating_stamina)
+		update_stamina()
 
-/mob/living/carbon/alien/setStaminaLoss(amount)
+/mob/living/carbon/alien/setStaminaLoss(amount, updating_stamina = 1)
 	return
 
 /mob/living/proc/getMaxHealth()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -771,7 +771,8 @@ var/next_mob_id = 0
 /mob/proc/Stun(amount, updating_canmove = 1)
 	if(status_flags & CANSTUN)
 		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
-		update_canmove()
+		if(updating_canmove)
+			update_canmove()
 
 /mob/proc/SetStunned(amount, updating_canmove = 1) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -768,56 +768,64 @@ var/next_mob_id = 0
 /mob/proc/Dizzy(amount)
 	dizziness = max(dizziness,amount,0)
 
-/mob/proc/Stun(amount)
+/mob/proc/Stun(amount, updating_canmove = 1)
 	if(status_flags & CANSTUN)
 		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
 		update_canmove()
 
-/mob/proc/SetStunned(amount) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
+/mob/proc/SetStunned(amount, updating_canmove = 1) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)
 		stunned = max(amount,0)
-		update_canmove()
+		if(updating_canmove)
+			update_canmove()
 
-/mob/proc/AdjustStunned(amount)
+/mob/proc/AdjustStunned(amount, updating_canmove = 1)
 	if(status_flags & CANSTUN)
 		stunned = max(stunned + amount,0)
-		update_canmove()
+		if(updating_canmove)
+			update_canmove()
 
-/mob/proc/Weaken(amount, ignore_canweaken = 0)
+/mob/proc/Weaken(amount, ignore_canweaken = 0, updating_canmove = 1)
 	if((status_flags & CANWEAKEN) || ignore_canweaken)
 		weakened = max(max(weakened,amount),0)
-		update_canmove()	//updates lying, canmove and icons
+		if(updating_canmove)
+			update_canmove()	//updates lying, canmove and icons
 
-/mob/proc/SetWeakened(amount)
+/mob/proc/SetWeakened(amount, updating_canmove = 1)
 	if(status_flags & CANWEAKEN)
 		weakened = max(amount,0)
-		update_canmove()	//updates lying, canmove and icons
+		if(updating_canmove)
+			update_canmove()	//updates lying, canmove and icons
 
-/mob/proc/AdjustWeakened(amount, ignore_canweaken = 0)
+/mob/proc/AdjustWeakened(amount, ignore_canweaken = 0, updating_canmove = 1)
 	if((status_flags & CANWEAKEN) || ignore_canweaken)
 		weakened = max(weakened + amount,0)
-		update_canmove()	//updates lying, canmove and icons
+		if(updating_canmove)
+			update_canmove()	//updates lying, canmove and icons
 
-/mob/proc/Paralyse(amount)
+/mob/proc/Paralyse(amount, updating_stat = 1)
 	if(status_flags & CANPARALYSE)
 		var/old_paralysis = paralysis
 		paralysis = max(max(paralysis,amount),0)
 		if((!old_paralysis && paralysis) || (old_paralysis && !paralysis))
-			update_stat()
+			if(updating_stat)
+				update_stat()
 
-/mob/proc/SetParalysis(amount)
+/mob/proc/SetParalysis(amount, updating_stat = 1)
 	if(status_flags & CANPARALYSE)
 		var/old_paralysis = paralysis
 		paralysis = max(amount,0)
 		if((!old_paralysis && paralysis) || (old_paralysis && !paralysis))
-			update_stat()
+			if(updating_stat)
+				update_stat()
 
-/mob/proc/AdjustParalysis(amount)
+/mob/proc/AdjustParalysis(amount, updating_stat = 1)
 	if(status_flags & CANPARALYSE)
 		var/old_paralysis = paralysis
 		paralysis = max(paralysis + amount,0)
 		if((!old_paralysis && paralysis) || (old_paralysis && !paralysis))
-			update_stat()
+			if(updating_stat)
+				update_stat()
 
 /mob/proc/Sleeping(amount, updating_stat = 1)
 	var/old_sleeping = sleeping
@@ -831,25 +839,29 @@ var/next_mob_id = 0
 		if(updating_stat)
 			update_stat()
 
-/mob/proc/SetSleeping(amount)
+/mob/proc/SetSleeping(amount, updating_stat = 1)
 	var/old_sleeping = sleeping
 	sleeping = max(amount,0)
 	if(!old_sleeping && sleeping)
 		throw_alert("asleep", /obj/screen/alert/asleep)
-		update_stat()
+		if(updating_stat)
+			update_stat()
 	else if(old_sleeping && !sleeping)
 		clear_alert("asleep")
-		update_stat()
+		if(updating_stat)
+			update_stat()
 
-/mob/proc/AdjustSleeping(amount)
+/mob/proc/AdjustSleeping(amount, updating_stat = 1)
 	var/old_sleeping = sleeping
 	sleeping = max(sleeping + amount,0)
 	if(!old_sleeping && sleeping)
 		throw_alert("asleep", /obj/screen/alert/asleep)
-		update_stat()
+		if(updating_stat)
+			update_stat()
 	else if(old_sleeping && !sleeping)
 		clear_alert("asleep")
-		update_stat()
+		if(updating_stat)
+			update_stat()
 
 /mob/proc/Resting(amount)
 	resting = max(max(resting,amount),0)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -233,61 +233,61 @@ var/const/INJECT = 5 //injection
 				return total_transfered
 */
 
-/datum/reagents/proc/metabolize(mob/M, can_overdose = 0)
-	if(M)
-		chem_temp = M.bodytemperature
+/datum/reagents/proc/metabolize(mob/living/carbon/C, can_overdose = 0)
+	if(C)
+		chem_temp = C.bodytemperature
 		handle_reactions()
-
+	var/need_mob_update = 0
 	for(var/reagent in reagent_list)
 		var/datum/reagent/R = reagent
 		if(!R.holder)
 			continue
-		if(!M)
-			M = R.holder.my_atom
-		if(M && R)
-			if(M.reagent_check(R) != 1)
+		if(!C)
+			C = R.holder.my_atom
+		if(C && R)
+			if(C.reagent_check(R) != 1)
 				if(can_overdose)
 					if(R.overdose_threshold)
 						if(R.volume >= R.overdose_threshold && !R.overdosed)
 							R.overdosed = 1
-							R.overdose_start(M)
+							need_mob_update += R.overdose_start(C)
 					if(R.addiction_threshold)
 						if(R.volume >= R.addiction_threshold && !is_type_in_list(R, addiction_list))
 							var/datum/reagent/new_reagent = new R.type()
 							addiction_list.Add(new_reagent)
 					if(R.overdosed)
-						R.overdose_process(M)
+						need_mob_update += R.overdose_process(C)
 					if(is_type_in_list(R,addiction_list))
 						for(var/addiction in addiction_list)
 							var/datum/reagent/A = addiction
 							if(istype(R, A))
 								A.addiction_stage = -15 // you're satisfied for a good while.
-				R.on_mob_life(M)
+				need_mob_update += R.on_mob_life(C)
 
 	if(can_overdose)
 		if(addiction_tick == 6)
 			addiction_tick = 1
 			for(var/addiction in addiction_list)
 				var/datum/reagent/R = addiction
-				if(M && R)
-					if(R.addiction_stage <= 0)
-						R.addiction_stage++
-					if(R.addiction_stage > 0 && R.addiction_stage <= 10)
-						R.addiction_act_stage1(M)
-						R.addiction_stage++
-					if(R.addiction_stage > 10 && R.addiction_stage <= 20)
-						R.addiction_act_stage2(M)
-						R.addiction_stage++
-					if(R.addiction_stage > 20 && R.addiction_stage <= 30)
-						R.addiction_act_stage3(M)
-						R.addiction_stage++
-					if(R.addiction_stage > 30 && R.addiction_stage <= 40)
-						R.addiction_act_stage4(M)
-						R.addiction_stage++
-					if(R.addiction_stage > 40)
-						M << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
-						addiction_list.Remove(R)
+				if(C && R)
+					R.addiction_stage++
+					switch(R.addiction_stage)
+						if(1 to 10)
+							need_mob_update += R.addiction_act_stage1(C)
+						if(10 to 20)
+							need_mob_update += R.addiction_act_stage2(C)
+						if(20 to 30)
+							need_mob_update += R.addiction_act_stage3(C)
+						if(30 to 40)
+							need_mob_update += R.addiction_act_stage4(C)
+						if(40 to INFINITY)
+							C << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
+							addiction_list.Remove(R)
 		addiction_tick++
+	if(C && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
+		C.updatehealth()
+		C.update_canmove()
+		C.update_stamina()
 	update_total()
 
 /datum/reagents/process()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -35,7 +35,7 @@
 		if(volume >= boozepwr*3.8)
 			M.adjustToxLoss(1, 0)
 			. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)
 	if(istype(O,/obj/item/weapon/paper))
@@ -134,7 +134,7 @@
 	if(M.getBruteLoss() && prob(10))
 		M.heal_organ_damage(1,0, 0)
 		. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/consumable/ethanol/threemileisland
 	name = "Three Mile Island Iced Tea"
@@ -604,7 +604,7 @@
 	if( ( istype(M, /mob/living/carbon/human) && M.job in list("Clown") ) || istype(M, /mob/living/carbon/monkey) )
 		M.heal_organ_damage(1,1, 0)
 		. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/consumable/ethanol/silencer
 	name = "Silencer"
@@ -618,7 +618,7 @@
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
 		M.heal_organ_damage(1,1)
 		. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin
 	name = "Drunken Blumpkin"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -33,9 +33,10 @@
 			if(M.confused < drunk_value)
 				M.confused += 3
 		if(volume >= boozepwr*3.8)
-			M.adjustToxLoss(1)
-	..()
-	return
+			M.adjustToxLoss(1, 0)
+			. = 1
+	return ..() | .
+
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)
 	if(istype(O,/obj/item/weapon/paper))
 		var/obj/item/weapon/paper/paperaffected = O
@@ -55,7 +56,7 @@
 		return
 	if(method == TOUCH || method == VAPOR)
 		M.adjust_fire_stacks(reac_volume / 15)
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/beer
 	name = "Beer"
@@ -81,10 +82,10 @@
 /datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	M.Jitter(5)
 	..()
-	return
+	return 1
 
 /datum/reagent/consumable/ethanol/whiskey
 	name = "Whiskey"
@@ -108,7 +109,7 @@
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
 	..()
-	return
+	return 1
 
 /datum/reagent/consumable/ethanol/vodka
 	name = "Vodka"
@@ -119,8 +120,7 @@
 
 /datum/reagent/consumable/ethanol/vodka/on_mob_life(mob/living/M)
 	M.radiation = max(M.radiation-2,0)
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/bilk
 	name = "Bilk"
@@ -132,9 +132,9 @@
 
 /datum/reagent/consumable/ethanol/bilk/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() && prob(10))
-		M.heal_organ_damage(1,0)
-	..()
-	return
+		M.heal_organ_damage(1,0, 0)
+		. = 1
+	return ..() | .
 
 /datum/reagent/consumable/ethanol/threemileisland
 	name = "Three Mile Island Iced Tea"
@@ -145,7 +145,7 @@
 
 /datum/reagent/consumable/ethanol/threemileisland/on_mob_life(mob/living/M)
 	M.set_drugginess(50)
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/gin
 	name = "Gin"
@@ -311,8 +311,7 @@
 /datum/reagent/consumable/ethanol/toxins_special/on_mob_life(var/mob/living/M as mob)
 	if (M.bodytemperature < 330)
 		M.bodytemperature = min(330, M.bodytemperature + (15 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash
 	name = "Beepsky Smash"
@@ -325,7 +324,7 @@
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
 	M.Stun(2)
 	..()
-	return
+	return 1
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"
@@ -399,8 +398,7 @@
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/M)
 	M.set_drugginess(30)
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
@@ -419,8 +417,7 @@
 /datum/reagent/consumable/ethanol/antifreeze/on_mob_life(mob/living/M)
 	if (M.bodytemperature < 330)
 		M.bodytemperature = min(330, M.bodytemperature + (20 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/barefoot
 	name = "Barefoot"
@@ -481,8 +478,7 @@
 /datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/M)
 	if (M.bodytemperature < 360)
 		M.bodytemperature = min(360, M.bodytemperature + (50 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/devilskiss
 	name = "Devils Kiss"
@@ -516,8 +512,7 @@
 /datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/M)
 	if(M.bodytemperature > 270)
 		M.bodytemperature = max(270, M.bodytemperature - (20 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
-	..()
-	return
+	return ..()
 
 /datum/reagent/consumable/ethanol/grog
 	name = "Grog"
@@ -607,9 +602,9 @@
 
 /datum/reagent/consumable/ethanol/bananahonk/on_mob_life(mob/living/M)
 	if( ( istype(M, /mob/living/carbon/human) && M.job in list("Clown") ) || istype(M, /mob/living/carbon/monkey) )
-		M.heal_organ_damage(1,1)
-	..()
-	return
+		M.heal_organ_damage(1,1, 0)
+		. = 1
+	return ..() | .
 
 /datum/reagent/consumable/ethanol/silencer
 	name = "Silencer"
@@ -622,8 +617,8 @@
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/M)
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
 		M.heal_organ_damage(1,1)
-	..()
-	return
+		. = 1
+	return ..() | .
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin
 	name = "Drunken Blumpkin"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -12,9 +12,9 @@
 
 /datum/reagent/consumable/orangejuice/on_mob_life(mob/living/M)
 	if(M.getOxyLoss() && prob(30))
-		M.adjustOxyLoss(-1)
+		M.adjustOxyLoss(-1, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/tomatojuice
 	name = "Tomato Juice"
@@ -24,9 +24,9 @@
 
 /datum/reagent/consumable/tomatojuice/on_mob_life(mob/living/M)
 	if(M.getFireLoss() && prob(20))
-		M.heal_organ_damage(0,1)
+		M.heal_organ_damage(0,1, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/limejuice
 	name = "Lime Juice"
@@ -36,9 +36,9 @@
 
 /datum/reagent/consumable/limejuice/on_mob_life(mob/living/M)
 	if(M.getToxLoss() && prob(20))
-		M.adjustToxLoss(-1*REM)
+		M.adjustToxLoss(-1*REM, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/carrotjuice
 	name = "Carrot juice"
@@ -71,9 +71,9 @@
 	color = "#863353" // rgb: 134, 51, 83
 
 /datum/reagent/consumable/poisonberryjuice/on_mob_life(mob/living/M)
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(1, 0)
+	. = 1
 	..()
-	return
 
 /datum/reagent/consumable/watermelonjuice
 	name = "Watermelon Juice"
@@ -95,7 +95,8 @@
 
 /datum/reagent/consumable/banana/on_mob_life(mob/living/M)
 	if( ( istype(M, /mob/living/carbon/human) && M.job in list("Clown") ) || istype(M, /mob/living/carbon/monkey) )
-		M.heal_organ_damage(1,1)
+		M.heal_organ_damage(1,1, 0)
+		. = 1
 	..()
 
 /datum/reagent/consumable/nothing
@@ -105,7 +106,8 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/M)
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
-		M.heal_organ_damage(1,1)
+		M.heal_organ_damage(1,1, 0)
+		. = 1
 	..()
 
 /datum/reagent/consumable/potato_juice
@@ -129,11 +131,11 @@
 
 /datum/reagent/consumable/milk/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
+		. = 1
 	if(holder.has_reagent("capsaicin"))
 		holder.remove_reagent("capsaicin", 2)
 	..()
-	return
 
 /datum/reagent/consumable/soymilk
 	name = "Soy Milk"
@@ -143,9 +145,9 @@
 
 /datum/reagent/consumable/soymilk/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/cream
 	name = "Cream"
@@ -155,9 +157,9 @@
 
 /datum/reagent/consumable/cream/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/coffee
 	name = "Coffee"
@@ -174,12 +176,13 @@
 /datum/reagent/consumable/coffee/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (25 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	if(holder.has_reagent("frostoil"))
 		holder.remove_reagent("frostoil", 5)
 	..()
+	. = 1
 
 /datum/reagent/consumable/tea
 	name = "Tea"
@@ -192,13 +195,13 @@
 	M.dizziness = max(0,M.dizziness-2)
 	M.drowsyness = max(0,M.drowsyness-1)
 	M.jitteriness = max(0,M.jitteriness-3)
-	M.AdjustSleeping(-1)
+	M.AdjustSleeping(-1, 0)
 	if(M.getToxLoss() && prob(20))
-		M.adjustToxLoss(-1)
+		M.adjustToxLoss(-1, 0)
 	if (M.bodytemperature < 310)  //310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (20 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/icecoffee
 	name = "Iced Coffee"
@@ -210,12 +213,12 @@
 /datum/reagent/consumable/icecoffee/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/icetea
 	name = "Iced Tea"
@@ -227,13 +230,13 @@
 /datum/reagent/consumable/icetea/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-2)
 	M.drowsyness = max(0,M.drowsyness-1)
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	if(M.getToxLoss() && prob(20))
-		M.adjustToxLoss(-1)
+		M.adjustToxLoss(-1, 0)
 	if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/space_cola
 	name = "Cola"
@@ -246,7 +249,6 @@
 	if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
 
 /datum/reagent/consumable/nuka_cola
 	name = "Nuka Cola"
@@ -259,12 +261,12 @@
 	M.set_drugginess(30)
 	M.dizziness +=5
 	M.drowsyness = 0
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	M.status_flags |= GOTTAGOFAST
 	if (M.bodytemperature > 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/spacemountainwind
 	name = "SM Wind"
@@ -274,11 +276,12 @@
 
 /datum/reagent/consumable/spacemountainwind/on_mob_life(mob/living/M)
 	M.drowsyness = max(0,M.drowsyness-7)
-	M.AdjustSleeping(-1)
+	M.AdjustSleeping(-1, 0)
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
 	..()
+	. = 1
 
 /datum/reagent/consumable/dr_gibb
 	name = "Dr. Gibb"
@@ -291,7 +294,6 @@
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
 	..()
-	return
 
 /datum/reagent/consumable/space_up
 	name = "Space-Up"
@@ -303,7 +305,6 @@
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (8 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
 	..()
-	return
 
 /datum/reagent/consumable/lemon_lime
 	name = "Lemon Lime"
@@ -315,7 +316,6 @@
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (8 * TEMPERATURE_DAMAGE_COEFFICIENT)) //310 is the normal bodytemp. 310.055
 	..()
-	return
 
 /datum/reagent/consumable/sodawater
 	name = "Soda Water"
@@ -329,7 +329,6 @@
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
 
 /datum/reagent/consumable/tonic
 	name = "Tonic Water"
@@ -340,11 +339,11 @@
 /datum/reagent/consumable/tonic/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.AdjustSleeping(-2)
+	M.AdjustSleeping(-2, 0)
 	if (M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/ice
 	name = "Ice"
@@ -354,9 +353,8 @@
 	color = "#619494" // rgb: 97, 148, 148
 
 /datum/reagent/consumable/ice/on_mob_life(mob/living/M)
-	M.bodytemperature -= 5 * TEMPERATURE_DAMAGE_COEFFICIENT
+	M.bodytemperature = max( M.bodytemperature - 5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
 	..()
-	return
 
 /datum/reagent/consumable/soy_latte
 	name = "Soy Latte"
@@ -367,14 +365,14 @@
 /datum/reagent/consumable/soy_latte/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.SetSleeping(0)
+	M.SetSleeping(0, 0)
 	if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/cafe_latte
 	name = "Cafe Latte"
@@ -385,14 +383,14 @@
 /datum/reagent/consumable/cafe_latte/on_mob_life(mob/living/M)
 	M.dizziness = max(0,M.dizziness-5)
 	M.drowsyness = max(0,M.drowsyness-3)
-	M.SetSleeping(0)
+	M.SetSleeping(0, 0)
 	if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	M.Jitter(5)
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/doctor_delight
 	name = "The Doctor's Delight"
@@ -401,14 +399,15 @@
 	color = "#FF8CFF" // rgb: 255, 140, 255
 
 /datum/reagent/consumable/doctor_delight/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-0.5)
-	M.adjustFireLoss(-0.5)
-	M.adjustToxLoss(-0.5)
-	M.adjustOxyLoss(-0.5)
+	M.adjustBruteLoss(-0.5, 0)
+	M.adjustFireLoss(-0.5, 0)
+	M.adjustToxLoss(-0.5, 0)
+	M.adjustOxyLoss(-0.5, 0)
 	if(M.nutrition && (M.nutrition - 2 > 0))
 		if(!(M.mind && M.mind.assigned_role == "Medical Doctor")) //Drains the nutrition of the holder. Not medical doctors though, since it's the Doctor's Delight!
 			M.nutrition -= 2
 	..()
+	. = 1
 
 /datum/reagent/consumable/chocolatepudding
 	name = "Chocolate Pudding"
@@ -493,12 +492,13 @@
 	M.slurring += 3
 	switch(current_cycle)
 		if(51 to 200)
-			M.Sleeping(5)
+			M.Sleeping(5, 0)
+			. = 1
 		if(201 to INFINITY)
-			M.AdjustSleeping(2)
-			M.adjustToxLoss(2)
+			M.AdjustSleeping(2, 0)
+			M.adjustToxLoss(2, 0)
+			. = 1
 	..()
-	return
 
 /datum/reagent/consumable/gargle_blaster
 	name = "Pan-Galactic Gargle Blaster"
@@ -519,9 +519,9 @@
 		if(55 to 200)
 			M.set_drugginess(55)
 		if(200 to INFINITY)
-			M.adjustToxLoss(2)
+			M.adjustToxLoss(2, 0)
+			. = 1
 	..()
-	return
 
 /datum/reagent/consumable/neurotoxin
 	name = "Neurotoxin"
@@ -530,7 +530,7 @@
 	color = "#2E2E61" // rgb: 46, 46, 97
 
 /datum/reagent/consumable/neurotoxin/on_mob_life(mob/living/carbon/M)
-	M.weakened = max(M.weakened, 3)
+	M.Weaken(3, 1, 0)
 	M.dizziness +=6
 	switch(current_cycle)
 		if(15 to 45)
@@ -543,9 +543,9 @@
 		if(55 to 200)
 			M.set_drugginess(55)
 		if(200 to INFINITY)
-			M.adjustToxLoss(2)
+			M.adjustToxLoss(2, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/consumable/hippies_delight
 	name = "Hippie's Delight"
@@ -583,6 +583,7 @@
 			if(prob(40))
 				M.emote(pick("twitch","giggle"))
 			if(prob(30))
-				M.adjustToxLoss(2)
+				M.adjustToxLoss(2, 0)
+				. = 1
 	..()
-	return
+

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -42,9 +42,10 @@
 	if(prob(1))
 		var/smoke_message = pick("You feel relaxed.", "You feel calmed.","You feel alert.","You feel rugged.")
 		M << "<span class='notice'>[smoke_message]</span>"
-	M.AdjustStunned(-1)
-	M.adjustStaminaLoss(-0.5*REM)
+	M.AdjustStunned(-1, 0)
+	M.adjustStaminaLoss(-0.5*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/crank
 	name = "Crank"
@@ -59,34 +60,39 @@
 	var/high_message = pick("You feel jittery.", "You feel like you gotta go fast.", "You feel like you need to step it up.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
+	M.AdjustParalysis(-1, 0)
+	M.AdjustStunned(-1, 0)
+	M.AdjustWeakened(-1, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/crank/overdose_process(mob/living/M)
 	M.adjustBrainLoss(2*REM)
-	M.adjustToxLoss(2*REM)
-	M.adjustBruteLoss(2*REM)
+	M.adjustToxLoss(2*REM, 0)
+	M.adjustBruteLoss(2*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/crank/addiction_act_stage1(mob/living/M)
 	M.adjustBrainLoss(5*REM)
 	..()
 
 /datum/reagent/drug/crank/addiction_act_stage2(mob/living/M)
-	M.adjustToxLoss(5*REM)
+	M.adjustToxLoss(5*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/crank/addiction_act_stage3(mob/living/M)
-	M.adjustBruteLoss(5*REM)
+	M.adjustBruteLoss(5*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/crank/addiction_act_stage4(mob/living/M)
 	M.adjustBrainLoss(5*REM)
-	M.adjustToxLoss(5*REM)
-	M.adjustBruteLoss(5*REM)
+	M.adjustToxLoss(5*REM, 0)
+	M.adjustBruteLoss(5*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/drug/krokodil
 	name = "Krokodil"
@@ -103,41 +109,40 @@
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
 	..()
-	return
 
 /datum/reagent/drug/krokodil/overdose_process(mob/living/M)
 	M.adjustBrainLoss(0.25*REM)
-	M.adjustToxLoss(0.25*REM)
+	M.adjustToxLoss(0.25*REM, 0)
 	..()
-	return
-
+	. = 1
 
 /datum/reagent/drug/krokodil/addiction_act_stage1(mob/living/M)
 	M.adjustBrainLoss(2*REM)
-	M.adjustToxLoss(2*REM)
+	M.adjustToxLoss(2*REM, 0)
 	..()
-	return
+	. = 1
+
 /datum/reagent/krokodil/addiction_act_stage2(mob/living/M)
 	if(prob(25))
 		M << "<span class='danger'>Your skin feels loose...</span>"
 	..()
-	return
+
 /datum/reagent/drug/krokodil/addiction_act_stage3(mob/living/M)
 	if(prob(25))
 		M << "<span class='danger'>Your skin starts to peel away...</span>"
-	M.adjustBruteLoss(3*REM)
+	M.adjustBruteLoss(3*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/krokodil/addiction_act_stage4(mob/living/carbon/human/M)
 	if(M.has_dna() && M.dna.species.id != "zombie")
 		M << "<span class='userdanger'>Your skin falls off easily!</span>"
-		M.adjustBruteLoss(50*REM) // holy shit your skin just FELL THE FUCK OFF
+		M.adjustBruteLoss(50*REM, 0) // holy shit your skin just FELL THE FUCK OFF
 		M.set_species(/datum/species/cosmetic_zombie)
 	else
-		M.adjustBruteLoss(5*REM)
+		M.adjustBruteLoss(5*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/methamphetamine
 	name = "Methamphetamine"
@@ -153,17 +158,17 @@
 	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.AdjustParalysis(-2)
-	M.AdjustStunned(-2)
-	M.AdjustWeakened(-2)
-	M.adjustStaminaLoss(-2)
+	M.AdjustParalysis(-2, 0)
+	M.AdjustStunned(-2, 0)
+	M.AdjustWeakened(-2, 0)
+	M.adjustStaminaLoss(-2, 0)
 	M.status_flags |= GOTTAGOREALLYFAST
 	M.Jitter(2)
 	M.adjustBrainLoss(0.25)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/methamphetamine/overdose_process(mob/living/M)
 	if(M.canmove && !istype(M.loc, /atom/movable))
@@ -177,23 +182,23 @@
 		if(I)
 			M.drop_item()
 	..()
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(1, 0)
 	M.adjustBrainLoss(pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
-	return
+	. = 1
 
 /datum/reagent/drug/methamphetamine/addiction_act_stage1(mob/living/M)
 	M.Jitter(5)
 	if(prob(20))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/methamphetamine/addiction_act_stage2(mob/living/M)
 	M.Jitter(10)
 	M.Dizzy(10)
 	if(prob(30))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/methamphetamine/addiction_act_stage3(mob/living/M)
 	if(M.canmove && !istype(M.loc, /atom/movable))
 		for(var/i = 0, i < 4, i++)
@@ -203,18 +208,18 @@
 	if(prob(40))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/methamphetamine/addiction_act_stage4(mob/living/carbon/human/M)
 	if(M.canmove && !istype(M.loc, /atom/movable))
 		for(var/i = 0, i < 8, i++)
 			step(M, pick(cardinal))
 	M.Jitter(20)
 	M.Dizzy(20)
-	M.adjustToxLoss(5)
+	M.adjustToxLoss(5, 0)
 	if(prob(50))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/bath_salts
 	name = "Bath Salts"
@@ -230,18 +235,18 @@
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.AdjustParalysis(-3)
-	M.AdjustStunned(-3)
-	M.AdjustWeakened(-3)
-	M.adjustStaminaLoss(-5)
+	M.AdjustParalysis(-3, 0)
+	M.AdjustStunned(-3, 0)
+	M.AdjustWeakened(-3, 0)
+	M.adjustStaminaLoss(-5, 0)
 	M.adjustBrainLoss(0.5)
-	M.adjustToxLoss(0.1)
+	M.adjustToxLoss(0.1, 0)
 	M.hallucination += 10
 	if(M.canmove && !istype(M.loc, /atom/movable))
 		step(M, pick(cardinal))
 		step(M, pick(cardinal))
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/bath_salts/overdose_process(mob/living/M)
 	M.hallucination += 10
@@ -255,7 +260,6 @@
 		if(I)
 			M.drop_item()
 	..()
-	return
 
 /datum/reagent/drug/bath_salts/addiction_act_stage1(mob/living/M)
 	M.hallucination += 10
@@ -267,7 +271,7 @@
 	if(prob(20))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/bath_salts/addiction_act_stage2(mob/living/M)
 	M.hallucination += 20
 	if(M.canmove && !istype(M.loc, /atom/movable))
@@ -279,7 +283,7 @@
 	if(prob(30))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/bath_salts/addiction_act_stage3(mob/living/M)
 	M.hallucination += 30
 	if(M.canmove && !istype(M.loc, /atom/movable))
@@ -291,7 +295,7 @@
 	if(prob(40))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+
 /datum/reagent/drug/bath_salts/addiction_act_stage4(mob/living/carbon/human/M)
 	M.hallucination += 40
 	if(M.canmove && !istype(M.loc, /atom/movable))
@@ -299,12 +303,12 @@
 			step(M, pick(cardinal))
 	M.Jitter(50)
 	M.Dizzy(50)
-	M.adjustToxLoss(5)
+	M.adjustToxLoss(5, 0)
 	M.adjustBrainLoss(10)
 	if(prob(50))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
+	. = 1
 
 /datum/reagent/drug/aranesp
 	name = "Aranesp"
@@ -317,10 +321,10 @@
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.adjustStaminaLoss(-18)
-	M.adjustToxLoss(0.5)
+	M.adjustStaminaLoss(-18, 0)
+	M.adjustToxLoss(0.5, 0)
 	if(prob(50))
 		M.losebreath++
-		M.adjustOxyLoss(1)
+		M.adjustOxyLoss(1, 0)
 	..()
-	return
+	. = 1

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -27,9 +27,9 @@
 
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/M)
 	if(prob(50))
-		M.heal_organ_damage(1,0)
+		M.heal_organ_damage(1,0, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/consumable/vitamin
 	name = "Vitamin"
@@ -40,11 +40,11 @@
 
 /datum/reagent/consumable/vitamin/on_mob_life(mob/living/M)
 	if(prob(50))
-		M.heal_organ_damage(1,1)
+		M.heal_organ_damage(1,1, 0)
+		. = 1
 	if(M.satiety < 600)
 		M.satiety += 30
 	..()
-	return
 
 /datum/reagent/consumable/sugar
 	name = "Sugar"
@@ -58,11 +58,13 @@
 
 /datum/reagent/consumable/sugar/overdose_start(mob/living/M)
 	M << "<span class='userdanger'>You go into hyperglycaemic shock! Lay off the twinkies!</span>"
-	M.AdjustSleeping(30)
+	M.AdjustSleeping(30, 0)
+	. = 1
 
 /datum/reagent/consumable/sugar/overdose_process(mob/living/M)
-	M.AdjustSleeping(3)
+	M.AdjustSleeping(3, 0)
 	..()
+	. = 1
 
 /datum/reagent/consumable/virus_food
 	name = "Virus Food"
@@ -113,7 +115,6 @@
 			if(isslime(M))
 				M.bodytemperature += rand(20,25)
 	..()
-	return
 
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
@@ -146,7 +147,6 @@
 			if(isslime(M))
 				M.bodytemperature -= rand(20,25)
 	..()
-	return
 
 /datum/reagent/consumable/frostoil/reaction_turf(turf/simulated/T, reac_volume)
 	if(reac_volume >= 5)
@@ -210,7 +210,7 @@
 			victim.drop_item()
 			return
 		else if ( eyes_covered ) // Eye cover is better than mouth cover
-			victim.adjust_blurriness(3)
+			victim.blur_eyes(3)
 			victim.damageoverlaytemp = 30
 			return
 		else // Oh dear :D
@@ -228,7 +228,6 @@
 	if(prob(5))
 		M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>")
 	..()
-	return
 
 /datum/reagent/consumable/sodiumchloride
 	name = "Table Salt"
@@ -302,9 +301,8 @@
 
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/M)
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Security Officer", "Head of Security", "Detective", "Warden"))
-		M.heal_organ_damage(1,1)
-		..()
-		return
+		M.heal_organ_damage(1,1, 0)
+		. = 1
 	..()
 
 /datum/reagent/consumable/cornoil
@@ -351,7 +349,6 @@
 	if (M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (10 * TEMPERATURE_DAMAGE_COEFFICIENT))
 	..()
-	return
 
 /datum/reagent/consumable/hell_ramen
 	name = "Hell Ramen"
@@ -363,7 +360,6 @@
 /datum/reagent/consumable/hell_ramen/on_mob_life(mob/living/M)
 	M.bodytemperature += 10 * TEMPERATURE_DAMAGE_COEFFICIENT
 	..()
-	return
 
 /datum/reagent/consumable/flour
 	name = "Flour"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -34,26 +34,26 @@
 
 /datum/reagent/medicine/adminordrazine/on_mob_life(mob/living/carbon/M)
 	M.reagents.remove_all_type(/datum/reagent/toxin, 5*REM, 0, 1)
-	M.setCloneLoss(0)
-	M.setOxyLoss(0)
+	M.setCloneLoss(0, 0)
+	M.setOxyLoss(0, 0)
 	M.radiation = 0
-	M.heal_organ_damage(5,5)
-	M.adjustToxLoss(-5)
+	M.heal_organ_damage(5,5, 0)
+	M.adjustToxLoss(-5, 0)
 	M.hallucination = 0
 	M.setBrainLoss(0)
 	M.disabilities = 0
 	M.set_blurriness(0)
 	M.set_blindness(0)
-	M.SetWeakened(0)
-	M.SetStunned(0)
-	M.SetParalysis(0)
+	M.SetWeakened(0, 0)
+	M.SetStunned(0, 0)
+	M.SetParalysis(0, 0)
 	M.silent = 0
 	M.dizziness = 0
 	M.drowsyness = 0
 	M.stuttering = 0
 	M.slurring = 0
 	M.confused = 0
-	M.SetSleeping(0)
+	M.SetSleeping(0, 0)
 	M.jitteriness = 0
 	for(var/datum/disease/D in M.viruses)
 		if(D.severity == NONTHREAT)
@@ -63,7 +63,7 @@
 		if(D.stage < 1)
 			D.cure()
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/adminordrazine/nanites
 	name = "Nanites"
@@ -78,16 +78,16 @@
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/M)
 	M.drowsyness = max(M.drowsyness-5, 0)
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
+	M.AdjustParalysis(-1, 0)
+	M.AdjustStunned(-1, 0)
+	M.AdjustWeakened(-1, 0)
 	if(holder.has_reagent("mindbreaker"))
 		holder.remove_reagent("mindbreaker", 5)
 	M.hallucination = max(0, M.hallucination - 10)
 	if(prob(30))
-		M.adjustToxLoss(1)
+		M.adjustToxLoss(1, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/inacusiate
 	name = "Inacusiate"
@@ -98,7 +98,6 @@
 /datum/reagent/medicine/inacusiate/on_mob_life(mob/living/M)
 	M.setEarDamage(0,0)
 	..()
-	return
 
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
@@ -107,27 +106,33 @@
 	color = "#0000C8"
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
-	if(M.stat != DEAD && M.bodytemperature < T0C) // Low temperatures are required to take effect.
-		M.status_flags &= ~DISFIGURED
-		M.adjustCloneLoss(-1)
-		M.adjustOxyLoss(-5)
-		M.adjustBruteLoss(-1)
-		M.adjustFireLoss(-1)
-		M.adjustToxLoss(-1)
-	if(M.stat != DEAD && M.bodytemperature < 225) // At lower temperatures (cryo) the full effect is boosted
-		M.adjustCloneLoss(-1)
-		M.adjustOxyLoss(-2)
-		M.adjustBruteLoss(-2)
-		M.adjustFireLoss(-2)
-		M.adjustToxLoss(-2)
-	if(M.stat != DEAD && M.bodytemperature < 100) // At extreme temperatures (upgraded cryo) the effect is greatly increased.
-		M.adjustCloneLoss(-5)
-		M.adjustOxyLoss(-2)
-		M.adjustBruteLoss(-2)
-		M.adjustFireLoss(-2)
-		M.adjustToxLoss(-2)
+	switch(M.bodytemperature) // Low temperatures are required to take effect.
+		if(0 to 100) // At extreme temperatures (upgraded cryo) the effect is greatly increased.
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-7, 0)
+			M.adjustOxyLoss(-9, 0)
+			M.adjustBruteLoss(-5, 0)
+			M.adjustFireLoss(-5, 0)
+			M.adjustToxLoss(-5, 0)
+			. = 1
+		if(100 to 225) // At lower temperatures (cryo) the full effect is boosted
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-2, 0)
+			M.adjustOxyLoss(-7, 0)
+			M.adjustBruteLoss(-3, 0)
+			M.adjustFireLoss(-3, 0)
+			M.adjustToxLoss(-3, 0)
+			. = 1
+		if(225 to T0C)
+			M.status_flags &= ~DISFIGURED
+			M.adjustCloneLoss(-1, 0)
+			M.adjustOxyLoss(-5, 0)
+			M.adjustBruteLoss(-1, 0)
+			M.adjustFireLoss(-1, 0)
+			M.adjustToxLoss(-1, 0)
+			. = 1
 	..()
-	return
+
 
 /datum/reagent/medicine/rezadone
 	name = "Rezadone"
@@ -139,17 +144,17 @@
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
-	M.heal_organ_damage(1,1)
+	M.heal_organ_damage(1,1, 0)
 	M.status_flags &= ~DISFIGURED
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/rezadone/overdose_process(mob/living/M)
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(1, 0)
 	M.Dizzy(5)
 	M.Jitter(5)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/spaceacillin
 	name = "Spaceacillin"
@@ -180,8 +185,9 @@
 	..()
 
 /datum/reagent/medicine/silver_sulfadiazine/on_mob_life(mob/living/M)
-	M.adjustFireLoss(-2*REM)
+	M.adjustFireLoss(-2*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/medicine/oxandrolone
 	name = "Oxandrolone"
@@ -194,17 +200,17 @@
 
 /datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/M)
 	if(M.getFireLoss() > 50)
-		M.adjustFireLoss(-4*REM) //Twice as effective as silver sulfadiazine for severe burns
+		M.adjustFireLoss(-4*REM, 0) //Twice as effective as silver sulfadiazine for severe burns
 	else
-		M.adjustFireLoss(-0.5*REM) //But only a quarter as effective for more minor ones
+		M.adjustFireLoss(-0.5*REM, 0) //But only a quarter as effective for more minor ones
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/oxandrolone/overdose_process(mob/living/M)
 	if(M.getFireLoss()) //It only makes existing burns worse
-		M.adjustFireLoss(4.5*REM) // it's going to be healing either 4 or 0.5
+		M.adjustFireLoss(4.5*REM, 0) // it's going to be healing either 4 or 0.5
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/styptic_powder
 	name = "Styptic Powder"
@@ -228,8 +234,9 @@
 
 
 /datum/reagent/medicine/styptic_powder/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-2*REM)
+	M.adjustBruteLoss(-2*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/medicine/salglu_solution
 	name = "Saline-Glucose Solution"
@@ -241,8 +248,9 @@
 
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/M)
 	if(prob(33))
-		M.adjustBruteLoss(-0.5*REM)
-		M.adjustFireLoss(-0.5*REM)
+		M.adjustBruteLoss(-0.5*REM, 0)
+		M.adjustFireLoss(-0.5*REM, 0)
+		. = 1
 	..()
 
 /datum/reagent/medicine/salglu_solution/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
@@ -267,9 +275,10 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = 5
-	M.adjustBruteLoss(-0.25*REM)
-	M.adjustFireLoss(-0.25*REM)
+	M.adjustBruteLoss(-0.25*REM, 0)
+	M.adjustFireLoss(-0.25*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
@@ -314,12 +323,12 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/charcoal/on_mob_life(mob/living/M)
-	M.adjustToxLoss(-2*REM)
+	M.adjustToxLoss(-2*REM, 0)
+	. = 1
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,1)
 	..()
-	return
 
 /datum/reagent/medicine/omnizine
 	name = "Omnizine"
@@ -331,20 +340,20 @@
 	overdose_threshold = 30
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/M)
-	M.adjustToxLoss(-0.5*REM)
-	M.adjustOxyLoss(-0.5*REM)
-	M.adjustBruteLoss(-0.5*REM)
-	M.adjustFireLoss(-0.5*REM)
+	M.adjustToxLoss(-0.5*REM, 0)
+	M.adjustOxyLoss(-0.5*REM, 0)
+	M.adjustBruteLoss(-0.5*REM, 0)
+	M.adjustFireLoss(-0.5*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/omnizine/overdose_process(mob/living/M)
-	M.adjustToxLoss(1.5*REM)
-	M.adjustOxyLoss(1.5*REM)
-	M.adjustBruteLoss(1.5*REM)
-	M.adjustFireLoss(1.5*REM)
+	M.adjustToxLoss(1.5*REM, 0)
+	M.adjustOxyLoss(1.5*REM, 0)
+	M.adjustBruteLoss(1.5*REM, 0)
+	M.adjustFireLoss(1.5*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/calomel
 	name = "Calomel"
@@ -359,9 +368,9 @@
 		if(R != src)
 			M.reagents.remove_reagent(R.id,2.5)
 	if(M.health > 20)
-		M.adjustToxLoss(2.5*REM)
+		M.adjustToxLoss(2.5*REM, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/potass_iodide
 	name = "Potassium Iodide"
@@ -374,10 +383,7 @@
 /datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/M)
 	if(M.radiation > 0)
 		M.radiation--
-	if(M.radiation < 0)
-		M.radiation = 0
 	..()
-	return
 
 /datum/reagent/medicine/pen_acid
 	name = "Pentetic Acid"
@@ -390,14 +396,14 @@
 /datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
 	if(M.radiation > 0)
 		M.radiation -= 4
-	M.adjustToxLoss(-2*REM)
+	M.adjustToxLoss(-2*REM, 0)
 	if(M.radiation < 0)
 		M.radiation = 0
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,2)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/sal_acid
 	name = "Salicyclic Acid"
@@ -411,16 +417,17 @@
 
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() > 50)
-		M.adjustBruteLoss(-4*REM) //Twice as effective as styptic powder for severe bruising
+		M.adjustBruteLoss(-4*REM, 0) //Twice as effective as styptic powder for severe bruising
 	else
-		M.adjustBruteLoss(-0.5*REM) //But only a quarter as effective for more minor ones
+		M.adjustBruteLoss(-0.5*REM, 0) //But only a quarter as effective for more minor ones
 	..()
-	return
+	. = 1
+
 /datum/reagent/medicine/sal_acid/overdose_process(mob/living/M)
 	if(M.getBruteLoss()) //It only makes existing bruises worse
-		M.adjustBruteLoss(4.5*REM) // it's going to be healing either 4 or 0.5
+		M.adjustBruteLoss(4.5*REM, 0) // it's going to be healing either 4 or 0.5
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/salbutamol
 	name = "Salbutamol"
@@ -431,11 +438,11 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/salbutamol/on_mob_life(mob/living/M)
-	M.adjustOxyLoss(-3*REM)
+	M.adjustOxyLoss(-3*REM, 0)
 	if(M.losebreath >= 4)
 		M.losebreath -= 2
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
@@ -446,13 +453,13 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
-	M.adjustOxyLoss(-12*REM)
+	M.adjustOxyLoss(-12*REM, 0)
 	M.silent = max(M.silent, 5)
 	if(prob(33))
-		M.adjustBruteLoss(-0.5*REM)
-		M.adjustFireLoss(-0.5*REM)
+		M.adjustBruteLoss(-0.5*REM, 0)
+		M.adjustFireLoss(-0.5*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"
@@ -466,44 +473,47 @@
 
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
 	M.status_flags |= GOTTAGOFAST
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
-	M.adjustStaminaLoss(-1*REM)
+	M.AdjustParalysis(-1, 0)
+	M.AdjustStunned(-1, 0)
+	M.AdjustWeakened(-1, 0)
+	M.adjustStaminaLoss(-1*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M)
 	if(prob(33))
-		M.adjustToxLoss(0.5*REM)
+		M.adjustToxLoss(0.5*REM, 0)
 		M.losebreath++
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/ephedrine/addiction_act_stage1(mob/living/M)
 	if(prob(33))
-		M.adjustToxLoss(2*REM)
+		M.adjustToxLoss(2*REM, 0)
 		M.losebreath += 2
+		. = 1
 	..()
-	return
+
 /datum/reagent/medicine/ephedrine/addiction_act_stage2(mob/living/M)
 	if(prob(33))
-		M.adjustToxLoss(3*REM)
+		M.adjustToxLoss(3*REM, 0)
 		M.losebreath += 3
+		. = 1
 	..()
-	return
+
 /datum/reagent/medicine/ephedrine/addiction_act_stage3(mob/living/M)
 	if(prob(33))
-		M.adjustToxLoss(4*REM)
+		M.adjustToxLoss(4*REM, 0)
 		M.losebreath += 4
+		. = 1
 	..()
-	return
+
 /datum/reagent/medicine/ephedrine/addiction_act_stage4(mob/living/M)
 	if(prob(33))
-		M.adjustToxLoss(5*REM)
+		M.adjustToxLoss(5*REM, 0)
 		M.losebreath += 5
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/diphenhydramine
 	name = "Diphenhydramine"
@@ -519,7 +529,6 @@
 	M.jitteriness -= 1
 	M.reagents.remove_reagent("histamine",3)
 	..()
-	return
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
@@ -531,15 +540,16 @@
 	overdose_threshold = 30
 	addiction_threshold = 25
 
-
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
 	M.status_flags |= IGNORESLOWDOWN
-	if(current_cycle == 11)
-		M << "<span class='warning'>You start to feel tired...</span>" //Warning when the victim is starting to pass out
-	if(current_cycle >= 12 && current_cycle < 24)
-		M.drowsyness += 1
-	else if(current_cycle >= 24)
-		M.Sleeping(2)
+	switch(current_cycle)
+		if(11)
+			M << "<span class='warning'>You start to feel tired...</span>" //Warning when the victim is starting to pass out
+		if(12 to 24)
+			M.drowsyness += 1
+		if(24 to INFINITY)
+			M.Sleeping(2, 0)
+			. = 1
 	..()
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/M)
@@ -565,31 +575,33 @@
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()
-		M.adjustToxLoss(1*REM)
+		M.adjustToxLoss(1*REM, 0)
+		. = 1
 		M.Dizzy(3)
 		M.Jitter(3)
 	..()
-	return
+
 /datum/reagent/medicine/morphine/addiction_act_stage3(mob/living/M)
 	if(prob(33))
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()
-		M.adjustToxLoss(2*REM)
+		M.adjustToxLoss(2*REM, 0)
+		. = 1
 		M.Dizzy(4)
 		M.Jitter(4)
 	..()
-	return
+
 /datum/reagent/medicine/morphine/addiction_act_stage4(mob/living/M)
 	if(prob(33))
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()
-		M.adjustToxLoss(3*REM)
+		M.adjustToxLoss(3*REM, 0)
+		. = 1
 		M.Dizzy(5)
 		M.Jitter(5)
 	..()
-	return
 
 /datum/reagent/medicine/oculine
 	name = "Oculine"
@@ -618,7 +630,6 @@
 	else if(M.eye_damage > 0)
 		M.adjust_eye_damage(-1)
 	..()
-	return
 
 /datum/reagent/medicine/atropine
 	name = "Atropine"
@@ -631,23 +642,23 @@
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/M)
 	if(M.health < 0)
-		M.adjustToxLoss(-2*REM)
-		M.adjustBruteLoss(-2*REM)
-		M.adjustFireLoss(-2*REM)
-		M.adjustOxyLoss(-5*REM)
+		M.adjustToxLoss(-2*REM, 0)
+		M.adjustBruteLoss(-2*REM, 0)
+		M.adjustFireLoss(-2*REM, 0)
+		M.adjustOxyLoss(-5*REM, 0)
+		. = 1
 	M.losebreath = 0
 	if(prob(20))
 		M.Dizzy(5)
 		M.Jitter(5)
 	..()
-	return
 
 /datum/reagent/medicine/atropine/overdose_process(mob/living/M)
-	M.adjustToxLoss(0.5*REM)
+	M.adjustToxLoss(0.5*REM, 0)
+	. = 1
 	M.Dizzy(1)
 	M.Jitter(1)
 	..()
-	return
 
 /datum/reagent/medicine/epinephrine
 	name = "Epinephrine"
@@ -660,31 +671,30 @@
 
 /datum/reagent/medicine/epinephrine/on_mob_life(mob/living/M)
 	if(M.health < 0)
-		M.adjustToxLoss(-0.5*REM)
-		M.adjustBruteLoss(-0.5*REM)
-		M.adjustFireLoss(-0.5*REM)
+		M.adjustToxLoss(-0.5*REM, 0)
+		M.adjustBruteLoss(-0.5*REM, 0)
+		M.adjustFireLoss(-0.5*REM, 0)
 	if(M.oxyloss > 35)
-		M.setOxyLoss(35)
+		M.setOxyLoss(35, 0)
 	if(M.losebreath >= 4)
 		M.losebreath -= 2
 	if(M.losebreath < 0)
 		M.losebreath = 0
-	M.adjustStaminaLoss(-0.5*REM)
+	M.adjustStaminaLoss(-0.5*REM, 0)
+	. = 1
 	if(prob(20))
-		M.AdjustParalysis(-1)
-		M.AdjustStunned(-1)
-		M.AdjustWeakened(-1)
+		M.AdjustParalysis(-1, 0)
+		M.AdjustStunned(-1, 0)
+		M.AdjustWeakened(-1, 0)
 	..()
-	return
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/M)
 	if(prob(33))
-		M.adjustStaminaLoss(2.5*REM)
-		M.adjustToxLoss(1*REM)
+		M.adjustStaminaLoss(2.5*REM, 0)
+		M.adjustToxLoss(1*REM, 0)
 		M.losebreath++
+		. = 1
 	..()
-	return
-
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
@@ -714,13 +724,12 @@
 					M.emote("gasp")
 					add_logs(M, M, "revived", src)
 	..()
-	return
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(0.5*REM)
-	M.adjustFireLoss(0.5*REM)
+	M.adjustBruteLoss(0.5*REM, 0)
+	M.adjustFireLoss(0.5*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"
@@ -731,7 +740,6 @@
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/M)
 	M.adjustBrainLoss(-3*REM)
 	..()
-	return
 
 /datum/reagent/medicine/mutadone
 	name = "Mutadone"
@@ -744,7 +752,6 @@
 	if(M.has_dna())
 		M.dna.remove_all_mutations()
 	..()
-	return
 
 /datum/reagent/medicine/antihol
 	name = "Antihol"
@@ -758,8 +765,9 @@
 	M.slurring = 0
 	M.confused = 0
 	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3*REM, 0, 1)
-	M.adjustToxLoss(-0.2*REM)
+	M.adjustToxLoss(-0.2*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"
@@ -772,23 +780,24 @@
 /datum/reagent/medicine/stimulants/on_mob_life(mob/living/M)
 	M.status_flags |= GOTTAGOFAST
 	if(M.health < 50 && M.health > 0)
-		M.adjustOxyLoss(-1*REM)
-		M.adjustToxLoss(-1*REM)
-		M.adjustBruteLoss(-1*REM)
-		M.adjustFireLoss(-1*REM)
-	M.AdjustParalysis(-3)
-	M.AdjustStunned(-3)
-	M.AdjustWeakened(-3)
-	M.adjustStaminaLoss(-5*REM)
+		M.adjustOxyLoss(-1*REM, 0)
+		M.adjustToxLoss(-1*REM, 0)
+		M.adjustBruteLoss(-1*REM, 0)
+		M.adjustFireLoss(-1*REM, 0)
+	M.AdjustParalysis(-3, 0)
+	M.AdjustStunned(-3, 0)
+	M.AdjustWeakened(-3, 0)
+	M.adjustStaminaLoss(-5*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/medicine/stimulants/overdose_process(mob/living/M)
 	if(prob(33))
-		M.adjustStaminaLoss(2.5*REM)
-		M.adjustToxLoss(1*REM)
+		M.adjustStaminaLoss(2.5*REM, 0)
+		M.adjustToxLoss(1*REM, 0)
 		M.losebreath++
+		. = 1
 	..()
-	return
 
 /datum/reagent/medicine/stimulants/longterm
 	name = "Stimulants"
@@ -800,30 +809,33 @@
 	addiction_threshold = 5
 
 /datum/reagent/medicine/stimulants/longterm/addiction_act_stage1(mob/living/M)
-	M.adjustToxLoss(5*REM)
-	M.adjustStaminaLoss(5*REM)
+	M.adjustToxLoss(5*REM, 0)
+	M.adjustStaminaLoss(5*REM, 0)
 	..()
-	return
+	. = 1
+
 /datum/reagent/medicine/stimulants/longterm/addiction_act_stage2(mob/living/M)
-	M.adjustToxLoss(6*REM)
-	M.adjustStaminaLoss(5*REM)
-	M.Stun(2)
+	M.adjustToxLoss(6*REM, 0)
+	M.adjustStaminaLoss(5*REM, 0)
+	M.Stun(2, 0)
 	..()
-	return
+	. = 1
+
 /datum/reagent/medicine/stimulants/longterm/addiction_act_stage3(mob/living/M)
-	M.adjustToxLoss(7*REM)
-	M.adjustStaminaLoss(5*REM)
+	M.adjustToxLoss(7*REM, 0)
+	M.adjustStaminaLoss(5*REM, 0)
 	M.adjustBrainLoss(1*REM)
-	M.Stun(2)
+	M.Stun(2, 0)
 	..()
-	return
+	. = 1
+
 /datum/reagent/medicine/stimulants/longterm/addiction_act_stage4(mob/living/M)
-	M.adjustToxLoss(8*REM)
-	M.adjustStaminaLoss(5*REM)
+	M.adjustToxLoss(8*REM, 0)
+	M.adjustStaminaLoss(5*REM, 0)
 	M.adjustBrainLoss(2*REM)
-	M.Stun(2)
+	M.Stun(2, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/insulin
 	name = "Insulin"
@@ -835,10 +847,10 @@
 
 /datum/reagent/medicine/insulin/on_mob_life(mob/living/M)
 	if(M.sleeping)
-		M.AdjustSleeping(-1)
+		M.AdjustSleeping(-1, 0)
+		. = 1
 	M.reagents.remove_reagent("sugar", 3)
 	..()
-	return
 
 //Trek Chems, used primarily by medibots. Only heals a specific damage type, but is very efficient.
 datum/reagent/medicine/bicaridine
@@ -850,14 +862,14 @@ datum/reagent/medicine/bicaridine
 	overdose_threshold = 30
 
 datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-2*REM)
+	M.adjustBruteLoss(-2*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
-	M.adjustBruteLoss(4*REM)
+	M.adjustBruteLoss(4*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/dexalin
 	name = "Dexalin"
@@ -868,14 +880,14 @@ datum/reagent/medicine/dexalin
 	overdose_threshold = 30
 
 datum/reagent/medicine/dexalin/on_mob_life(mob/living/M)
-	M.adjustOxyLoss(-2*REM)
+	M.adjustOxyLoss(-2*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
-	M.adjustOxyLoss(4*REM)
+	M.adjustOxyLoss(4*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/kelotane
 	name = "Kelotane"
@@ -886,15 +898,14 @@ datum/reagent/medicine/kelotane
 	overdose_threshold = 30
 
 datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
-	M.adjustFireLoss(-2*REM)
+	M.adjustFireLoss(-2*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
-	M.adjustFireLoss(4*REM)
+	M.adjustFireLoss(4*REM, 0)
 	..()
-	return
-
+	. = 1
 
 datum/reagent/medicine/antitoxin
 	name = "Anti-Toxin"
@@ -905,18 +916,17 @@ datum/reagent/medicine/antitoxin
 	overdose_threshold = 30
 
 datum/reagent/medicine/antitoxin/on_mob_life(mob/living/M)
-	M.adjustToxLoss(-2*REM)
+	M.adjustToxLoss(-2*REM, 0)
 	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
 		if(R != src)
 			M.reagents.remove_reagent(R.id,1)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/antitoxin/overdose_process(mob/living/M)
-	M.adjustToxLoss(4*REM) // End result is 2 toxin loss taken, because it heals 2 and then removes 4.
+	M.adjustToxLoss(4*REM, 0) // End result is 2 toxin loss taken, because it heals 2 and then removes 4.
 	..()
-	return
-
+	. = 1
 
 datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
@@ -929,7 +939,6 @@ datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/M)
 	if(M.losebreath >= 5)
 		M.losebreath -= 5
 	..()
-	return
 
 datum/reagent/medicine/tricordrazine
 	name = "Tricordrazine"
@@ -941,20 +950,20 @@ datum/reagent/medicine/tricordrazine
 
 datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/M)
 	if(prob(80))
-		M.adjustBruteLoss(-1*REM)
-		M.adjustFireLoss(-1*REM)
-		M.adjustOxyLoss(-1*REM)
-		M.adjustToxLoss(-1*REM)
+		M.adjustBruteLoss(-1*REM, 0)
+		M.adjustFireLoss(-1*REM, 0)
+		M.adjustOxyLoss(-1*REM, 0)
+		M.adjustToxLoss(-1*REM, 0)
+		. = 1
 	..()
-	return
 
 datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
-	M.adjustToxLoss(2*REM)
-	M.adjustOxyLoss(2*REM)
-	M.adjustBruteLoss(2*REM)
-	M.adjustFireLoss(2*REM)
+	M.adjustToxLoss(2*REM, 0)
+	M.adjustOxyLoss(2*REM, 0)
+	M.adjustBruteLoss(2*REM, 0)
+	M.adjustFireLoss(2*REM, 0)
 	..()
-	return
+	. = 1
 
 datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
 	name = "Restorative Nanites"
@@ -964,14 +973,14 @@ datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical
 	color = "#555555"
 
 datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(-5*REM) //A ton of healing - this is a 50 telecrystal investment.
-	M.adjustFireLoss(-5*REM)
-	M.adjustOxyLoss(-15)
-	M.adjustToxLoss(-5*REM)
+	M.adjustBruteLoss(-5*REM, 0) //A ton of healing - this is a 50 telecrystal investment.
+	M.adjustFireLoss(-5*REM, 0)
+	M.adjustOxyLoss(-15, 0)
+	M.adjustToxLoss(-5*REM, 0)
 	M.adjustBrainLoss(-15*REM)
-	M.adjustCloneLoss(-3*REM)
+	M.adjustCloneLoss(-3*REM, 0)
 	..()
-	return
+	. = 1
 
 /datum/reagent/medicine/haloperidol
 	name = "Haloperidol"
@@ -991,6 +1000,6 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 		M.hallucination -= 5
 	if(prob(20))
 		M.adjustBrainLoss(1*REM)
-	M.adjustStaminaLoss(2.5*REM)
+	M.adjustStaminaLoss(2.5*REM, 0)
 	..()
-	return
+	. = 1

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -180,11 +180,13 @@
 	data++
 	M.jitteriness = max(M.jitteriness-5,0)
 	if(data >= 30)		// 12 units, 54 seconds @ metabolism 0.4 units & tick rate 1.8 sec
-		if (!M.stuttering) M.stuttering = 1
+		if(!M.stuttering)
+			M.stuttering = 1
 		M.stuttering += 4
 		M.Dizzy(5)
 	if(data >= 75 && prob(33))	// 30 units, 135 seconds
-		if (!M.confused) M.confused = 1
+		if (!M.confused)
+			M.confused = 1
 		M.confused += 3
 		if((is_handofgod_cultist(M) && !is_handofgod_prophet(M)))
 			ticker.mode.remove_hog_follower(M.mind)
@@ -194,7 +196,6 @@
 			M.confused = 0
 			return
 	holder.remove_reagent(src.id, 0.4)	//fixed consumption to prevent balancing going out of whack
-	return
 
 /datum/reagent/water/holywater/reaction_turf(turf/simulated/T, reac_volume)
 	..()
@@ -214,15 +215,16 @@
 	if(iscultist(M))
 		M.status_flags |= GOTTAGOFAST
 		M.drowsyness = max(M.drowsyness-5, 0)
-		M.AdjustParalysis(-2)
-		M.AdjustStunned(-2)
-		M.AdjustWeakened(-2)
+		M.AdjustParalysis(-2, 0)
+		M.AdjustStunned(-2, 0)
+		M.AdjustWeakened(-2, 0)
 	else
-		M.adjustToxLoss(2)
-		M.adjustFireLoss(2)
-		M.adjustOxyLoss(2)
-		M.adjustBruteLoss(2)
+		M.adjustToxLoss(2, 0)
+		M.adjustFireLoss(2, 0)
+		M.adjustOxyLoss(2, 0)
+		M.adjustBruteLoss(2, 0)
 	holder.remove_reagent(src.id, 1)
+	. = 1
 
 /datum/reagent/hellwater			//if someone has this in their system they've really pissed off an eldrich god
 	name = "Hell Water"
@@ -232,8 +234,8 @@
 /datum/reagent/hellwater/on_mob_life(mob/living/M)
 	M.fire_stacks = min(5,M.fire_stacks + 3)
 	M.IgniteMob()			//Only problem with igniting people is currently the commonly availible fire suits make you immune to being on fire
-	M.adjustToxLoss(1)
-	M.adjustFireLoss(1)		//Hence the other damages... ain't I a bastard?
+	M.adjustToxLoss(1, 0)
+	M.adjustFireLoss(1, 0)		//Hence the other damages... ain't I a bastard?
 	M.adjustBrainLoss(5)
 	holder.remove_reagent(src.id, 1)
 
@@ -396,11 +398,10 @@
 	metabolization_rate = INFINITY
 
 /datum/reagent/mulligan/on_mob_life(mob/living/carbon/human/H)
-	..()
 	H << "<span class='warning'><b>You grit your teeth in pain as your body rapidly mutates!</b></span>"
 	H.visible_message("<b>[H]</b> suddenly transforms!")
 	randomize_human(H)
-	return 1
+	..()
 
 /datum/reagent/aslimetoxin
 	name = "Advanced Mutation Toxin"
@@ -430,9 +431,9 @@
 
 /datum/reagent/serotrotium/on_mob_life(mob/living/M)
 	if(ishuman(M))
-		if(prob(7)) M.emote(pick("twitch","drool","moan","gasp"))
+		if(prob(7))
+			M.emote(pick("twitch","drool","moan","gasp"))
 	..()
-	return
 
 /datum/reagent/oxygen
 	name = "Oxygen"
@@ -502,7 +503,6 @@
 		M.emote(pick("twitch","drool","moan"))
 	M.adjustBrainLoss(2)
 	..()
-	return
 
 /datum/reagent/sulfur
 	name = "Sulfur"
@@ -532,9 +532,9 @@
 	color = "#808080" // rgb: 128, 128, 128
 
 /datum/reagent/chlorine/on_mob_life(mob/living/M)
-	M.take_organ_damage(1*REM, 0)
+	M.take_organ_damage(1*REM, 0, 0)
+	. = 1
 	..()
-	return
 
 /datum/reagent/fluorine
 	name = "Fluorine"
@@ -544,9 +544,9 @@
 	color = "#808080" // rgb: 128, 128, 128
 
 /datum/reagent/fluorine/on_mob_life(mob/living/M)
-	M.adjustToxLoss(1*REM)
+	M.adjustToxLoss(1*REM, 0)
+	. = 1
 	..()
-	return
 
 /datum/reagent/sodium
 	name = "Sodium"
@@ -575,7 +575,6 @@
 	if(prob(5))
 		M.emote(pick("twitch","drool","moan"))
 	..()
-	return
 
 /datum/reagent/glycerol
 	name = "Glycerol"
@@ -593,7 +592,6 @@
 /datum/reagent/radium/on_mob_life(mob/living/M)
 	M.apply_effect(2*REM/M.metabolism_efficiency,IRRADIATE,0)
 	..()
-	return
 
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 3)
@@ -678,7 +676,8 @@
 	..()
 
 /datum/reagent/fuel/on_mob_life(mob/living/M)
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(1, 0)
+	. = 1
 	..()
 
 /datum/reagent/space_cleaner
@@ -748,7 +747,6 @@
 		M.confused = 1
 	M.confused = max(M.confused, 20)
 	..()
-	return
 
 /datum/reagent/impedrezene
 	name = "Impedrezene"
@@ -758,11 +756,13 @@
 
 /datum/reagent/impedrezene/on_mob_life(mob/living/M)
 	M.jitteriness = max(M.jitteriness-5,0)
-	if(prob(80)) M.adjustBrainLoss(1*REM)
-	if(prob(50)) M.drowsyness = max(M.drowsyness, 3)
-	if(prob(10)) M.emote("drool")
+	if(prob(80))
+		M.adjustBrainLoss(1*REM)
+	if(prob(50))
+		M.drowsyness = max(M.drowsyness, 3)
+	if(prob(10))
+		M.emote("drool")
 	..()
-	return
 
 /datum/reagent/nanites
 	name = "Nanomachines"
@@ -910,9 +910,9 @@
 
 /datum/reagent/plantnutriment/on_mob_life(mob/living/M)
 	if(prob(tox_prob))
-		M.adjustToxLoss(1*REM)
+		M.adjustToxLoss(1*REM, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/plantnutriment/eznutriment
 	name = "E-Z-Nutrient"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -17,8 +17,9 @@
 		Wall.overlays += image('icons/effects/effects.dmi',"thermite")
 
 /datum/reagent/thermite/on_mob_life(mob/living/M)
-	M.adjustFireLoss(1)
+	M.adjustFireLoss(1, 0)
 	..()
+	. = 1
 
 /datum/reagent/nitroglycerin
 	name = "Nitroglycerin"
@@ -44,8 +45,9 @@
 /datum/reagent/clf3/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(2)
 	var/burndmg = max(0.3*M.fire_stacks, 0.3)
-	M.adjustFireLoss(burndmg)
+	M.adjustFireLoss(burndmg, 0)
 	..()
+	. = 1
 
 /datum/reagent/clf3/reaction_turf(turf/simulated/T, reac_volume)
 	if(istype(T, /turf/simulated/floor/plating))
@@ -136,8 +138,9 @@
 /datum/reagent/phlogiston/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(1)
 	var/burndmg = max(0.3*M.fire_stacks, 0.3)
-	M.adjustFireLoss(burndmg)
+	M.adjustFireLoss(burndmg, 0)
 	..()
+	. = 1
 
 /datum/reagent/napalm
 	name = "Napalm"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -10,9 +10,9 @@
 
 /datum/reagent/toxin/on_mob_life(mob/living/M)
 	if(toxpwr)
-		M.adjustToxLoss(toxpwr*REM)
+		M.adjustToxLoss(toxpwr*REM, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/toxin/amatoxin
 	name = "Amatoxin"
@@ -46,7 +46,7 @@
 /datum/reagent/toxin/mutagen/on_mob_life(mob/living/carbon/M)
 	if(istype(M))
 		M.apply_effect(5,IRRADIATE,0)
-	..()
+	return ..()
 
 /datum/reagent/toxin/plasma
 	name = "Plasma"
@@ -61,8 +61,7 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		C.adjustPlasma(20)
-	..()
-	return
+	return ..()
 
 /datum/reagent/toxin/plasma/reaction_obj(obj/O, reac_volume)
 	if((!O) || (!reac_volume))
@@ -90,15 +89,14 @@
 	toxpwr = 0
 
 /datum/reagent/toxin/lexorin/on_mob_life(mob/living/M)
-	if(M.stat != DEAD)
-		M.adjustOxyLoss(5)
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			C.losebreath += 2
-		if(prob(20))
-			M.emote("gasp")
+	M.adjustOxyLoss(5, 0)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.losebreath += 2
+	if(prob(20))
+		M.emote("gasp")
 	..()
-	return
+	. = 1
 
 /datum/reagent/toxin/slimejelly
 	name = "Slime Jelly"
@@ -110,11 +108,12 @@
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/M)
 	if(prob(10))
 		M << "<span class='danger'>Your insides are burning!</span>"
-		M.adjustToxLoss(rand(20,60)*REM)
+		M.adjustToxLoss(rand(20,60)*REM, 0)
+		. = 1
 	else if(prob(40))
-		M.heal_organ_damage(5*REM,0)
+		M.heal_organ_damage(5*REM,0, 0)
+		. = 1
 	..()
-	return
 
 /datum/reagent/toxin/minttoxin
 	name = "Mint Toxin"
@@ -124,10 +123,9 @@
 	toxpwr = 0
 
 /datum/reagent/toxin/minttoxin/on_mob_life(mob/living/M)
-	if (M.disabilities & FAT)
+	if(M.disabilities & FAT)
 		M.gib()
-	..()
-	return
+	return ..()
 
 /datum/reagent/toxin/carpotoxin
 	name = "Carpotoxin"
@@ -146,12 +144,12 @@
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
 	M.status_flags |= FAKEDEATH
-	M.adjustOxyLoss(0.5*REM)
-	M.Weaken(5)
+	M.adjustOxyLoss(0.5*REM, 0)
+	M.Weaken(5, 0, 0)
 	M.silent = max(M.silent, 5)
 	M.tod = worldtime2text()
 	..()
-	return
+	. = 1
 
 /datum/reagent/toxin/zombiepowder/on_mob_delete(mob/M)
 	M.status_flags &= ~FAKEDEATH
@@ -166,8 +164,7 @@
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/M)
 	M.hallucination += 10
-	..()
-	return
+	return ..()
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
@@ -227,7 +224,7 @@
 	M.damageoverlaytemp = 60
 	M.update_damage_hud()
 	M.blur_eyes(3)
-	..()
+	return ..()
 
 /datum/reagent/toxin/spore_burning
 	name = "Burning Spore Toxin"
@@ -237,9 +234,9 @@
 	toxpwr = 0.5
 
 /datum/reagent/toxin/spore_burning/on_mob_life(mob/living/M)
-	..()
 	M.adjust_fire_stacks(2)
 	M.IgniteMob()
+	return ..()
 
 /datum/reagent/toxin/chloralhydrate
 	name = "Chloral Hydrate"
@@ -256,12 +253,13 @@
 			M.confused += 2
 			M.drowsyness += 2
 		if(10 to 50)
-			M.Sleeping(2)
+			M.Sleeping(2, 0)
+			. = 1
 		if(51 to INFINITY)
-			M.Sleeping(2)
-			M.adjustToxLoss((current_cycle - 50)*REM)
+			M.Sleeping(2, 0)
+			M.adjustToxLoss((current_cycle - 50)*REM, 0)
+			. = 1
 	..()
-	return
 
 /datum/reagent/toxin/beer2	//disguised as normal beer for use by emagged brobots
 	name = "Beer"
@@ -273,11 +271,11 @@
 /datum/reagent/toxin/beer2/on_mob_life(mob/living/M)
 	switch(current_cycle)
 		if(1 to 50)
-			M.Sleeping(2)
+			M.Sleeping(2, 0)
 		if(51 to INFINITY)
-			M.Sleeping(2)
-			M.adjustToxLoss((current_cycle - 50)*REM)
-	..()
+			M.Sleeping(2, 0)
+			M.adjustToxLoss((current_cycle - 50)*REM, 0)
+	return ..()
 
 /datum/reagent/toxin/coffeepowder
 	name = "Coffee Grounds"
@@ -315,9 +313,10 @@
 	toxpwr = 0
 
 /datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/M)
-	M.adjustStaminaLoss(REM * data)
+	M.adjustStaminaLoss(REM * data, 0)
 	data = max(data - 1, 3)
 	..()
+	. = 1
 
 /datum/reagent/toxin/polonium
 	name = "Polonium"
@@ -355,14 +354,16 @@
 			if(4)
 				if(prob(75))
 					M << "You scratch at an itch."
-					M.adjustBruteLoss(2*REM)
+					M.adjustBruteLoss(2*REM, 0)
+					. = 1
 	..()
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/M)
-	M.adjustOxyLoss(2*REM)
-	M.adjustBruteLoss(2*REM)
-	M.adjustToxLoss(2*REM)
+	M.adjustOxyLoss(2*REM, 0)
+	M.adjustBruteLoss(2*REM, 0)
+	M.adjustToxLoss(2*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/toxin/formaldehyde
 	name = "Formaldehyde"
@@ -378,7 +379,7 @@
 		holder.add_reagent("histamine", pick(5,15))
 		holder.remove_reagent("formaldehyde", 1.2)
 	else
-		..()
+		return ..()
 
 /datum/reagent/toxin/venom
 	name = "Venom"
@@ -391,7 +392,8 @@
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/M)
 	toxpwr = 0.2*volume
-	M.adjustBruteLoss((0.3*volume)*REM)
+	M.adjustBruteLoss((0.3*volume)*REM, 0)
+	. = 1
 	if(prob(15))
 		M.reagents.add_reagent("histamine", pick(5,10))
 		M.reagents.remove_reagent("venom", 1.1)
@@ -410,9 +412,11 @@
 /datum/reagent/toxin/neurotoxin2/on_mob_life(mob/living/M)
 	if(M.brainloss + M.toxloss <= 60)
 		M.adjustBrainLoss(1*REM)
-		M.adjustToxLoss(1*REM)
+		M.adjustToxLoss(1*REM, 0)
+		. = 1
 	if(current_cycle >= 18)
-		M.Sleeping(2)
+		M.Sleeping(2, 0)
+		. = 1
 	..()
 
 /datum/reagent/toxin/cyanide
@@ -429,9 +433,9 @@
 		M.losebreath += 1
 	if(prob(8))
 		M << "You feel horrendously weak!"
-		M.Stun(2)
-		M.adjustToxLoss(2*REM)
-	..()
+		M.Stun(2, 0)
+		M.adjustToxLoss(2*REM, 0)
+	return ..()
 
 /datum/reagent/toxin/questionmark // food poisoning
 	name = "Bad Food"
@@ -458,13 +462,16 @@
 /datum/reagent/toxin/itching_powder/on_mob_life(mob/living/M)
 	if(prob(15))
 		M << "You scratch at your head."
-		M.adjustBruteLoss(0.2*REM)
+		M.adjustBruteLoss(0.2*REM, 0)
+		. = 1
 	if(prob(15))
 		M << "You scratch at your leg."
-		M.adjustBruteLoss(0.2*REM)
+		M.adjustBruteLoss(0.2*REM, 0)
+		. = 1
 	if(prob(15))
 		M << "You scratch at your arm."
-		M.adjustBruteLoss(0.2*REM)
+		M.adjustBruteLoss(0.2*REM, 0)
+		. = 1
 	if(prob(3))
 		M.reagents.add_reagent("histamine",rand(1,3))
 		M.reagents.remove_reagent("itching_powder",1.2)
@@ -485,11 +492,13 @@
 		var/picked_option = rand(1,3)
 		switch(picked_option)
 			if(1)
-				M.Stun(3)
-				M.Weaken(3)
+				M.Stun(3, 0)
+				M.Weaken(3, 0, 0)
+				. = 1
 			if(2)
 				M.losebreath += 10
-				M.adjustOxyLoss(rand(5,25))
+				M.adjustOxyLoss(rand(5,25), 0)
+				. = 1
 			if(3)
 				if(istype(M, /mob/living/carbon/human))
 					var/mob/living/carbon/human/H = M
@@ -499,8 +508,9 @@
 							H.visible_message("<span class='userdanger'>[H] clutches at their chest as if their heart stopped!</span>")
 					else
 						H.losebreath += 10
-						H.adjustOxyLoss(rand(5,25))
-	..()
+						H.adjustOxyLoss(rand(5,25), 0)
+						. = 1
+	return ..() | .
 
 /datum/reagent/toxin/pancuronium
 	name = "Pancuronium"
@@ -513,7 +523,8 @@
 
 /datum/reagent/toxin/pancuronium/on_mob_life(mob/living/M)
 	if(current_cycle >= 10)
-		M.Paralyse(1)
+		M.Paralyse(2, 0)
+		. = 1
 	if(prob(20))
 		M.losebreath += 4
 	..()
@@ -529,9 +540,10 @@
 
 /datum/reagent/toxin/sodium_thiopental/on_mob_life(mob/living/M)
 	if(current_cycle >= 10)
-		M.Sleeping(2)
-	M.adjustStaminaLoss(10*REM)
+		M.Sleeping(2, 0)
+	M.adjustStaminaLoss(10*REM, 0)
 	..()
+	. = 1
 
 /datum/reagent/toxin/sulfonal
 	name = "Sulfonal"
@@ -544,8 +556,8 @@
 
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/M)
 	if(current_cycle >= 22)
-		M.Sleeping(2)
-	..()
+		M.Sleeping(2, 0)
+	return ..()
 
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
@@ -571,12 +583,10 @@
 
 /datum/reagent/toxin/lipolicide/on_mob_life(mob/living/M)
 	if(!holder.has_reagent("nutriment"))
-		M.adjustToxLoss(0.5*REM)
-	M.nutrition -= 5 * REAGENTS_METABOLISM
+		M.adjustToxLoss(0.5*REM, 0)
+	M.nutrition = max( M.nutrition - 5 * REAGENTS_METABOLISM, 0)
 	M.overeatduration = 0
-	if(M.nutrition < 0)//Prevent from going into negatives.
-		M.nutrition = 0
-	..()
+	return ..()
 
 /datum/reagent/toxin/coniine
 	name = "Coniine"
@@ -589,7 +599,7 @@
 
 /datum/reagent/toxin/coniine/on_mob_life(mob/living/M)
 	M.losebreath += 5
-	..()
+	return ..()
 
 /datum/reagent/toxin/curare
 	name = "Curare"
@@ -602,8 +612,9 @@
 
 /datum/reagent/toxin/curare/on_mob_life(mob/living/M)
 	if(current_cycle >= 11)
-		M.Weaken(3)
-	M.adjustOxyLoss(1*REM)
+		M.Weaken(3, 0, 0)
+	M.adjustOxyLoss(1*REM, 0)
+	. = 1
 	..()
 
 /datum/reagent/toxin/heparin //Based on a real-life anticoagulant. I'm not a doctor, so this won't be realistic.
@@ -619,8 +630,9 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.blood_max += 2
-		H.adjustBruteLoss(1) //Brute damage increases with the amount they're bleeding
-	..()
+		H.adjustBruteLoss(1, 0) //Brute damage increases with the amount they're bleeding
+		. = 1
+	return ..() | .
 
 /datum/reagent/toxin/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
 	name = "Teslium"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -510,7 +510,7 @@
 						H.losebreath += 10
 						H.adjustOxyLoss(rand(5,25), 0)
 						. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/toxin/pancuronium
 	name = "Pancuronium"
@@ -632,7 +632,7 @@
 		H.blood_max += 2
 		H.adjustBruteLoss(1, 0) //Brute damage increases with the amount they're bleeding
 		. = 1
-	return ..() | .
+	return ..() || .
 
 /datum/reagent/toxin/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
 	name = "Teslium"


### PR DESCRIPTION
When reagents are metabolized, we only call update procs like updatehealth() or update_canmove(), once instead of once for each reagent effect that usually calls an update.

This fixes falling and getting up instantly every tick when you have a reagent weakening you and another healing the weaken effect.

(newer version of #15331)
