### PR TITLE
Shuttle collisions no longer run into limb damage caps on mobs

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -455,7 +455,7 @@
 	for(var/turf/T in L)
 		for(var/atom/movable/AM in T)
 			if(ismob(AM))
-				if(istype(AM, /mob/living/carbon/human))
+				if(ishuman(AM))
 					var/mob/living/M = AM
 					M.Paralyse(10)
 					M.apply_damage(60, BRUTE, "chest")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -455,12 +455,15 @@
 	for(var/turf/T in L)
 		for(var/atom/movable/AM in T)
 			if(ismob(AM))
-				if(istype(AM, /mob/living))
+				if(istype(AM, /mob/living/carbon/human))
 					var/mob/living/M = AM
 					M.Paralyse(10)
-					M.take_organ_damage(80)
+					M.apply_damage(60, BRUTE, "chest")
+					M.apply_damage(60, BRUTE, "head")
 					M.anchored = 0
 				else
+					var/mob/M = AM
+					M.gib()
 					continue
 
 			if(!AM.anchored)


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/14778.

Broken down:
- For human mobs, shuttle collisions now deal 60 damage to the chest and 60 damage to the head. The damage has been increased from 80 to 120 total in this case to account for likely pre-existing brute damage to either limb. Even 120 is really low for being hit by a fucking shuttle IMO, I'd be happy with shuttle gibbing returning, but that is a fair bit more controversial.
- Non-human mobs are gibbed outright.
