### PR TITLE
Makes contraband crates great again.

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -166,7 +166,7 @@
 	icon_state = "carp"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
-	name = "\improper Syndicig cigarette packet"
+	name = "cigarette packet"
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndie"
 

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -166,7 +166,7 @@
 	icon_state = "carp"
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
-	name = "cigarette packet"
+	name = "\improper Syndicig cigarette packet"
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndie"
 
@@ -180,6 +180,7 @@
 	name = "\improper Midori Tabako packet"
 	desc = "You can't understand the runes, but the packet smells funny."
 	icon_state = "midori"
+	spawn_type = /obj/item/clothing/mask/cigarette/rollie
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims
 	name ="\improper Shady Jim's Super Slims"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1229,7 +1229,7 @@
 	cost = 30
 	num_contained = 6
 	contains = list(/obj/item/weapon/poster/contraband,
-					/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate,
+					/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims,
 					/obj/item/weapon/storage/fancy/cigarettes/cigpack_midori,
 					/obj/item/seeds/ambrosiadeusseed,
 					/obj/item/clothing/tie/dope_necklace)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -373,6 +373,7 @@
 /datum/supply_pack/security/justiceinbound
 	name = "Standard Justice Enforcer Crate"
 	cost = 80 //justice comes at a price. An expensive, noisy price.
+	contraband = TRUE
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/mask/gas/sechailer)
 	crate_name = "justice enforcer crate"
@@ -1226,10 +1227,12 @@
 	name = "Contraband Crate"
 	contraband = TRUE
 	cost = 30
-	num_contained = 5
+	num_contained = 6
 	contains = list(/obj/item/weapon/poster/contraband,
-					/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
-					/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims)
+					/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate,
+					/obj/item/weapon/storage/fancy/cigarettes/cigpack_midori,
+					/obj/item/seeds/ambrosiadeusseed,
+					/obj/item/clothing/tie/dope_necklace)
 	crate_name = "crate"
 
 /datum/supply_pack/misc/randomised/toys

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -372,7 +372,7 @@
 
 /datum/supply_pack/security/justiceinbound
 	name = "Standard Justice Enforcer Crate"
-	cost = 80 //justice comes at a price. An expensive, noisy price.
+	cost = 60 //justice comes at a price. An expensive, noisy price.
 	contraband = TRUE
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/mask/gas/sechailer)


### PR DESCRIPTION
Contraband options in cargo have lost a bit of their luster, SO:
- Contraband crates now have a chance to contain ambrosia deus seeds and dope necklaces. Bumped the items in a contraband crate up to 6 to account for new types.
- Midori cigarettes now contain rollies. It fits with what midori is and the desc, sorry if I shat on someone's old meme
- Justice enforcer crates are now contraband because GODDAMN THEY SHOULD BE. Lowered the cost from 80 to 60 to compensate.

:cl:
rscadd: CentComm has been informed that cargo is receiving new forms of contraband in crates. Remember, Nanotrasen has a zero-tolerance contraband policy!
/:cl:
