### PR TITLE
Adds the Warranty Void Clause to Bug Report Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,6 @@
+## **Warranty Void Clause:** 
+## If you are an administrator, and you are reporting a bug that occured AFTER you used varedit/admin buttons to alter an object out of normal operating conditions, please verify that you can re-create the bug without the varedit usage/admin buttons before reporting the issue.
+
 ### What is the problem?
 
 ### Why is it a problem, or what should have happened?


### PR DESCRIPTION
if you varedit the nuke to explode and then it explodes when the clown hits it with his bike horn, please dont make an issue request
