### PR TITLE
Updates proc swap stack trace

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1287,3 +1287,7 @@ proc/pick_closest_path(value)
 			return
 	chosen = matches[chosen]
 	return chosen
+
+//gives us the stack trace from CRASH() without ending the current proc.
+/proc/stack_trace(msg)
+	CRASH(msg)

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -28,11 +28,7 @@
 	var/next_dest
 	var/next_dest_loc
 
-/proc/stack_trace(msg)
-	CRASH(msg)
-
 /mob/living/simple_animal/bot/cleanbot/New()
-	stack_trace("Cleanbot is being instantiated")
 	..()
 	get_targets()
 	icon_state = "cleanbot[on]"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -82,7 +82,7 @@
 	if(!real_name)
 		real_name = name
 	if(!loc)
-		stack_trace(Simple animal being instantiated in nullspace)
+		stack_trace("Simple animal being instantiated in nullspace")
 
 /mob/living/simple_animal/Login()
 	if(src && src.client)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -81,6 +81,8 @@
 	verbs -= /mob/verb/observe
 	if(!real_name)
 		real_name = name
+	if(!loc)
+		stack_trace(Simple animal being instantiated in nullspace)
 
 /mob/living/simple_animal/Login()
 	if(src && src.client)


### PR DESCRIPTION
Remember, the point of this is so that we can see what proc has been swapped in case it isn't sound() as it often is. Also puts the trace behind a check for `if(!loc)` so that we only get it if they're being spawned in nullspace.
