### PR TITLE
Alien queens now prevent the shuttle from leaving

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -16,6 +16,8 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
+	var/alienNoEscape
+
 
 		//supply shuttle stuff
 	var/obj/docking_port/mobile/supply/supply

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -22,9 +22,13 @@
 	maxHealth = 400
 	health = 400
 	icon_state = "alienq"
+	var/shuttleblocker = FALSE
 
 
 /mob/living/carbon/alien/humanoid/royal/queen/New()
+	if(loc.z == 1)
+		SSshuttle.alienNoEscape = 1 //Fuck no we don't want that shit hijacking the shuttle - Centcom
+		src.shuttleblocker = TRUE
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in living_mob_list)
 		if(Q == src)
@@ -45,6 +49,15 @@
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/repulse/xeno(src))
 	AddAbility(new/obj/effect/proc_holder/alien/royal/queen/promote())
 	..()
+
+/mob/living/carbon/alien/humanoid/royal/queen/death()
+	if(shuttleblocker)
+		SSshuttle.alienNoEscape = 0
+		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
+			SSshuttle.emergency.mode = SHUTTLE_DOCKED
+			SSshuttle.emergency.timer = world.time
+			priority_announce("Hostile organisms eliminated. You have 3 minutes to board the Emergency Shuttle.", null, 'sound/AI/shuttledock.ogg', "Priority")
+	
 
 /mob/living/carbon/alien/humanoid/royal/queen/movement_delay()
 	. = ..()


### PR DESCRIPTION
The moment xenos are spotted, the first response is always to call the shuttle, instead of actually fighting them.

And the whole shtick of xenos is that they don't just murder everyone, they have to capture LIVE hosts if they want to grow in numbers. But hosts take a long time to burst, and even longer to evolve into a fighting alien, often more time than it takes the shuttle to arrive. So once the shuttle is called, the aliens have absolutely no reason to not just murder everyone.

By making the shuttle unable to leave when a queen is alive, I hope to resolve this issue by giving the xenos breathing room if they protect their queen, and preventing the crew from just ignoring the xeno threat until the shuttle arrives.

I still need to figure out how to add some sort of win condition to the xenos incase they, yknow, win, so that the shuttle doesn't stay stuck at the station forever.

:cl:
rscadd: A mature alien queen will now prevent the shuttle from leaving, kill it if you want to leave.
rscadd: Alien queens can attack the shuttle console to force the shuttle to leave.
/:cl:
