### PR TITLE
Adds Modular Receivers to the maint loot spawning table

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -119,6 +119,7 @@
 				/obj/item/weapon/wirecutters = 1,
 				/obj/item/weapon/wrench = 4,
 				/obj/item/weapon/relic = 3,
+				/obj/item/weaponcrafting/reciever = 1,
 				"" = 11
 				)
 


### PR DESCRIPTION
These things never see use due to being more expensive and have a higher tech cost than more effective guns. Its as rare as possible so those assistants are going to have to work for it. I can bump it up to two if one per round odds are a bit too rare.

I might adjust the Protolathe availability of these things later. The forum seems to want them placed in the hacked Autolathe but I'm concerned about how easy it would be for cargo to print massive amount of effective shotgun shells. Any suggestions on what to do would be much appreciated.
