### PR TITLE
Fixes spell action button not being updated correctly

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1111,10 +1111,10 @@
 					ticker.mode.shadows -= src
 					special_role = null
 					current << "<span class='userdanger'>Your powers have been quenched! You are no longer a shadowling!</span>"
-					remove_spell(/obj/effect/proc_holder/spell/self/shadowling_hatch)
-					remove_spell(/obj/effect/proc_holder/spell/self/shadowling_ascend)
-					remove_spell(/obj/effect/proc_holder/spell/targeted/enthrall)
-					remove_spell(/obj/effect/proc_holder/spell/self/shadowling_hivemind)
+					RemoveSpell(/obj/effect/proc_holder/spell/self/shadowling_hatch)
+					RemoveSpell(/obj/effect/proc_holder/spell/self/shadowling_ascend)
+					RemoveSpell(/obj/effect/proc_holder/spell/targeted/enthrall)
+					RemoveSpell(/obj/effect/proc_holder/spell/self/shadowling_hivemind)
 					message_admins("[key_name_admin(usr)] has de-shadowling'ed [current].")
 					log_admin("[key_name(usr)] has de-shadowling'ed [current].")
 				else if(src in ticker.mode.thralls)
@@ -1554,7 +1554,7 @@
 	S.action.Grant(current)
 
 //To remove a specific spell from a mind
-/datum/mind/proc/remove_spell(var/obj/effect/proc_holder/spell/spell)
+/datum/mind/proc/RemoveSpell(var/obj/effect/proc_holder/spell/spell)
 	if(!spell) return
 	for(var/X in spell_list)
 		var/obj/effect/proc_holder/spell/S = X

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1553,6 +1553,15 @@
 	spell_list += S
 	S.action.Grant(current)
 
+//To remove a specific spell from a mind
+/datum/mind/proc/remove_spell(var/obj/effect/proc_holder/spell/spell)
+	if(!spell) return
+	for(var/X in spell_list)
+		var/obj/effect/proc_holder/spell/S = X
+		if(istype(S, spell))
+			qdel(S)
+			spell_list -= S
+
 /datum/mind/proc/transfer_actions(mob/living/new_character)
 	if(current && current.actions)
 		for(var/datum/action/A in current.actions)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -169,8 +169,10 @@
 						"<span class='revendanger'>As \the [W] passes through you, you feel your essence draining away!</span>")
 		adjustBruteLoss(25) //hella effective
 		inhibited = 1
+		update_action_buttons_icon()
 		spawn(30)
 			inhibited = 0
+			update_action_buttons_icon()
 	..()
 
 /mob/living/simple_animal/revenant/adjustHealth(amount)

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -111,7 +111,7 @@
 /obj/item/organ/internal/heart/demon/Remove(mob/living/carbon/M, special = 0)
 	..()
 	if(M.mind)
-		M.mind.remove_spell(/obj/effect/proc_holder/spell/bloodcrawl)
+		M.mind.RemoveSpell(/obj/effect/proc_holder/spell/bloodcrawl)
 
 /obj/item/organ/internal/heart/demon/Stop()
 	return 0 // Always beating.

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -168,7 +168,7 @@ Made by Xhuis
 	thrall_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Dethralled</span>"
 	thrall_mind.special_role = null
 	for(var/obj/effect/proc_holder/spell/S in thrall_mind.spell_list)
-		thrall_mind.remove_spell(S)
+		thrall_mind.RemoveSpell(S)
 	if(kill && ishuman(thrall_mind.current)) //If dethrallization surgery fails, kill the mob as well as dethralling them
 		var/mob/living/carbon/human/H = thrall_mind.current
 		H.visible_message("<span class='warning'>[H] jerks violently and falls still.</span>", \
@@ -192,7 +192,7 @@ Made by Xhuis
 	ling_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Deshadowlinged</span>"
 	ling_mind.special_role = null
 	for(var/obj/effect/proc_holder/spell/S in ling_mind.spell_list)
-		ling_mind.remove_spell(S)
+		ling_mind.RemoveSpell(S)
 	var/mob/living/M = ling_mind.current
 	if(issilicon(M))
 		M.audible_message("<span class='notice'>[M] lets out a short blip.</span>", \

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -382,7 +382,7 @@
 				if(CM in M.mind.spell_list)
 					M.mind.spell_list -= CM
 					qdel(CM)
-				M.mind.remove_spell(/obj/effect/proc_holder/spell/self/shadowling_hatch)
+				M.mind.RemoveSpell(/obj/effect/proc_holder/spell/self/shadowling_hatch)
 				M.mind.AddSpell(new /obj/effect/proc_holder/spell/self/shadowling_ascend(null))
 				if(M == user)
 					M << "<span class='shadowling'><i>You project this power to the rest of the shadowlings.</i></span>"
@@ -581,8 +581,8 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 											   "<span class='shadowling'><b>You feel new power flow into you. You have been gifted by your masters. You now closely resemble them. You are empowered in \
 											    darkness but wither slowly in light. In addition, Lesser Glare and Guise have been upgraded into their true forms.</b></span>")
 				thrallToRevive.set_species(/datum/species/shadow/ling/lesser)
-				thrallToRevive.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
-				thrallToRevive.mind.remove_spell(/obj/effect/proc_holder/spell/self/lesser_shadow_walk)
+				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
+				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/self/lesser_shadow_walk)
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/self/shadow_walk(null))
 			if("Revive")

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -10,7 +10,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 	action_icon_state = "hatch"
 
 /obj/effect/proc_holder/spell/self/shadowling_hatch/cast(list/targets,mob/user = usr)
-	if(user.stat || !ishuman(user) || !user || !is_shadow(user || isinspace(user))) 
+	if(user.stat || !ishuman(user) || !user || !is_shadow(user || isinspace(user)))
 		return
 	var/mob/living/carbon/human/H = user
 	var/hatch_or_no = alert(H,"Are you sure you want to hatch? You cannot undo this!",,"Yes","No")
@@ -88,7 +88,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/night/shadowling(H), slot_glasses)
 			H.set_species(/datum/species/shadow/ling) //can't be a shadowling without being a shadowling
 
-			H.mind.remove_spell(src)
+			H.mind.RemoveSpell(src)
 
 			sleep(10)
 			H << "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>"
@@ -159,7 +159,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				var/mob/A = new /mob/living/simple_animal/ascendant_shadowling(H.loc)
 				for(var/obj/effect/proc_holder/spell/S in H.mind.spell_list)
 					if(S == src) continue
-					H.mind.remove_spell(S)
+					H.mind.RemoveSpell(S)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/annihilate(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/hypnosis(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/shadowling_phase_shift(null))
@@ -175,5 +175,5 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				if(!ticker.mode.shadowling_ascended)
 					SSshuttle.emergency.request(null, 0.3)
 				ticker.mode.shadowling_ascended = 1
-				A.mind.remove_spell(src)
+				A.mind.RemoveSpell(src)
 				qdel(H)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -241,16 +241,10 @@
 /mob/proc/spellremove(mob/M)
 	if(!mind)
 		return
-	for(var/obj/effect/proc_holder/spell/spell_to_remove in src.mind.spell_list)
+	for(var/X in src.mind.spell_list)
+		var/obj/effect/proc_holder/spell/spell_to_remove = X
 		qdel(spell_to_remove)
 		mind.spell_list -= spell_to_remove
-
-/datum/mind/proc/remove_spell(var/obj/effect/proc_holder/spell/spell) //To remove a specific spell from a mind - use AddSpell to add one
-	if(!spell) return
-	for(var/obj/effect/proc_holder/spell/S in spell_list)
-		if(istype(S, spell))
-			qdel(S)
-			spell_list -= S
 
 /*Checks if the wizard can cast spells.
 Made a proc so this is not repeated 14 (or more) times.*/

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -630,7 +630,7 @@
 			if(AI.mind.special_role) //Malf AIs cannot leave mechs. Except through death.
 				user << "<span class='boldannounce'>ACCESS DENIED.</span>"
 				return
-			AI.aiRestorePowerRoutine = 0//So the AI initially has power.
+			AI.ai_restore_power()//So the AI initially has power.
 			AI.control_disabled = 1
 			AI.radio_enabled = 0
 			AI.loc = card
@@ -669,7 +669,7 @@
 
 //Hack and From Card interactions share some code, so leave that here for both to use.
 /obj/mecha/proc/ai_enter_mech(mob/living/silicon/ai/AI, interaction)
-	AI.aiRestorePowerRoutine = 0
+	AI.ai_restore_power()
 	AI.loc = src
 	occupant = AI
 	icon_state = initial(icon_state)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -32,6 +32,9 @@
 	user << "<span class='notice'>You [magpulse ? "enable" : "disable"] the mag-pulse traction system.</span>"
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_gravity(user.mob_has_gravity())
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
 	return flags & NOSLIP

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -804,7 +804,7 @@ var/list/ai_list = list()
 			user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
 			return
 		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
-		aiRestorePowerRoutine = 0//So the AI initially has power.
+		ai_restore_power()//So the AI initially has power.
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		radio_enabled = 0 	//No talking on the built-in radio for you either!
 		loc = card//Throw AI into the card.

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -1,3 +1,8 @@
+#define POWER_RESTORATION_OFF 0
+#define POWER_RESTORATION_START 1
+#define POWER_RESTORATION_SEARCH_APC 2
+#define POWER_RESTORATION_APC_FOUND 3
+
 /mob/living/silicon/ai/Life()
 	if (src.stat == DEAD)
 		return
@@ -29,26 +34,12 @@
 			if(home.powered(EQUIP))
 				home.use_power(1000, EQUIP)
 
-			if(aiRestorePowerRoutine==2)
-				src << "Alert cancelled. Power has been restored without our assistance."
-				aiRestorePowerRoutine = 0
-				set_blindness(0)
-				update_sight()
-				return
-			else if (aiRestorePowerRoutine==3)
-				src << "Alert cancelled. Power has been restored."
-				aiRestorePowerRoutine = 0
-				set_blindness(0)
-				update_sight()
+			if(aiRestorePowerRoutine >= POWER_RESTORATION_SEARCH_APC)
+				ai_restore_power()
 				return
 
 		else if(!aiRestorePowerRoutine)
-			aiRestorePowerRoutine = 1
-			blind_eyes(1)
-			update_sight()
-			src << "You've lost power!"
-			spawn(20)
-				start_RestorePowerRoutine()
+			ai_lose_power()
 
 /mob/living/silicon/ai/proc/lacks_power()
 	var/turf/T = get_turf(src)
@@ -97,10 +88,7 @@
 	var/area/AIarea = get_area(src)
 	if(AIarea && AIarea.master.power_equip)
 		if(!istype(T, /turf/space))
-			src << "Alert cancelled. Power has been restored without our assistance."
-			aiRestorePowerRoutine = 0
-			set_blindness(0)
-			update_sight()
+			ai_restore_power()
 			return
 	src << "Fault confirmed: missing external power. Shutting down main control system to save power."
 	sleep(20)
@@ -109,7 +97,7 @@
 	T = get_turf(src)
 	if (istype(T, /turf/space))
 		src << "Unable to verify! No power connection detected!"
-		aiRestorePowerRoutine = 2
+		aiRestorePowerRoutine = POWER_RESTORATION_SEARCH_APC
 		return
 	src << "Connection verified. Searching for APC in power network."
 	sleep(50)
@@ -131,14 +119,11 @@
 					src << "Unable to locate APC!"
 				else
 					src << "Lost connection with the APC!"
-			aiRestorePowerRoutine = 2
+			aiRestorePowerRoutine = POWER_RESTORATION_SEARCH_APC
 			return
 		if(AIarea.master.power_equip)
 			if (!istype(T, /turf/space))
-				src << "Alert cancelled. Power has been restored without our assistance."
-				aiRestorePowerRoutine = 0
-				set_blindness(0)
-				update_sight()
+				ai_restore_power()
 				return
 		switch(PRP)
 			if (1) src << "APC located. Optimizing route to APC to avoid needless power waste."
@@ -152,8 +137,31 @@
 				apc_override = 1
 				theAPC.ui_interact(src, state = conscious_state)
 				apc_override = 0
-				aiRestorePowerRoutine = 3
+				aiRestorePowerRoutine = POWER_RESTORATION_APC_FOUND
 				src << "Here are your current laws:"
 				show_laws()
 		sleep(50)
 		theAPC = null
+
+/mob/living/silicon/ai/proc/ai_restore_power()
+	if(aiRestorePowerRoutine)
+		if(aiRestorePowerRoutine == POWER_RESTORATION_APC_FOUND)
+			src << "Alert cancelled. Power has been restored."
+		else
+			src << "Alert cancelled. Power has been restored without our assistance."
+		aiRestorePowerRoutine = POWER_RESTORATION_OFF
+		set_blindness(0)
+		update_sight()
+
+/mob/living/silicon/ai/proc/ai_lose_power()
+	aiRestorePowerRoutine = POWER_RESTORATION_START
+	blind_eyes(1)
+	update_sight()
+	src << "You've lost power!"
+	spawn(20)
+		start_RestorePowerRoutine()
+
+#undef POWER_RESTORATION_OFF
+#undef POWER_RESTORATION_START
+#undef POWER_RESTORATION_SEARCH_APC
+#undef POWER_RESTORATION_APC_FOUND

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -251,8 +251,6 @@
 	if(client)
 		stopLobbySound()
 	var/mob/living/silicon/ai/O = new (loc,,,1)//No MMI but safety is in effect.
-	O.invisibility = 0
-	O.aiRestorePowerRoutine = 0
 
 	if(mind)
 		mind.transfer_to(O)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -73,6 +73,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 	var/turf/T = get_turf(user)
 	if(T.z == ZLEVEL_CENTCOM && (!centcom_cancast || ticker.mode.name == "ragin' mages")) //Certain spells are not allowed on the centcom zlevel
+		user << "<span class='notice'>You can't cast this spell here.</span>"
 		return 0
 
 	if(!skipcharge)
@@ -159,6 +160,10 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
+
+/obj/effect/proc_holder/spell/Destroy()
+	qdel(action)
+	return ..()
 
 /obj/effect/proc_holder/spell/Click()
 	if(cast_check())
@@ -384,11 +389,6 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	if(((!user.mind) || !(src in user.mind.spell_list)) && !(src in user.mob_spell_list))
 		return 0
 
-	if(user.z == ZLEVEL_CENTCOM && !centcom_cancast) //Certain spells are not allowed on the centcom zlevel
-		return 0
-	if(user.z == ZLEVEL_CENTCOM && ticker.mode.name == "ragin' mages")
-		return 0
-
 	switch(charge_type)
 		if("recharge")
 			if(charge_counter < charge_max)
@@ -400,21 +400,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	if(user.stat && !stat_allowed)
 		return 0
 
-	if(ishuman(user))
-
-		var/mob/living/carbon/human/H = user
-
-		if((invocation_type == "whisper" || invocation_type == "shout") && H.is_muzzled())
-			return 0
-
-		if(clothes_req) //clothes check
-			if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe) && !istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit/wizard))
-				return 0
-			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
-				return 0
-			if(!istype(H.head, /obj/item/clothing/head/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/hardsuit/wizard))
-				return 0
-	else
+	if(!ishuman(user))
 		if(clothes_req || human_req)
 			return 0
 		if(nonabstract_req && (isbrain(user) || ispAI(user)))

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -24,10 +24,11 @@
 	var/A = null
 
 	if(!randomise_selection)
-		A = input("Area to teleport to", "Teleport", A) in teleportlocs
+		A = input("Area to teleport to", "Teleport", A) as null|anything in teleportlocs
 	else
 		A = pick(teleportlocs)
-
+	if(!A)
+		return
 	var/area/thearea = teleportlocs[A]
 
 	return thearea


### PR DESCRIPTION
 regarding zlevel and clothes requirements. The buttons are now never red in these cases but clicking them give the proper fail message. Adding some special checks when changing z level and when equipping clothes, just for these spell buttons would be too much.
- Fixes blind AI (lack of power) staying blind if transfered to a mech or a card. Fixes #15832
- Fixes magboots action button icon not updating when toggling the boots on.
- Fixes Area teleport spells not having a cancel button when choosing the destination area.
- Fixes spell action button not being removed when the spell is refunded. Fixes #15820
- Fixes revenant spell action button icons not being updated when the revenant is inhibited by a null rod.
- I also moved /datum/mind/proc/remove_spell() into mind.dm so it's next to /datum/mind/proc/AddSpell()
