### PR TITLE
Rolls back the life mechanic from Runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -61,7 +61,6 @@
 	gender = FEMALE
 	gold_core_spawnable = 0
 	var/list/family = list()
-	var/lives = 9
 	var/memory_saved = 0
 
 /mob/living/simple_animal/pet/cat/Runtime/New()
@@ -81,18 +80,9 @@
 /mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 	S["family"] 			>> family
-	S["lives"]				>> lives
 
 	if(isnull(family))
 		family = list()
-
-	if(isnull(lives))
-		lives = 9
-
-	if(lives <= 0)
-		lives = 10 //Lowers to 9 in Write_Memory
-		Write_Memory(1)
-		qdel(src)
 
 	for(var/cat_type in family)
 		if(family[cat_type] > 0)
@@ -101,8 +91,6 @@
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
-	if(dead)
-		S["lives"] 				<< lives - 1
 	family = list()
 	for(var/mob/living/simple_animal/pet/cat/C in mob_list)
 		if(istype(C,type) || C.stat)


### PR DESCRIPTION
Partial revert of #15714, for some strange reason (probably a savefiles quirk) Runtime's lives weren't properly resetting and was rendered FOREVER DEAD.

Catsplosion feature will remain.
