### PR TITLE
Cyborgs can no longer activate the object in their active module when incapacitated

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -59,7 +59,7 @@
 		return
 
 	// buckled cannot prevent machine interlinking but stops arm movement
-	if( buckled )
+	if( buckled || incapacitated())
 		return
 
 	if(W == A)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -268,9 +268,9 @@ Made a proc so this is not repeated 14 (or more) times.*/
 	else
 		return 1
 
-
+//returns whether the mob is a wizard (or apprentice)
 /proc/iswizard(mob/living/M)
-	return istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.wizards)
+	return istype(M) && M.mind && ticker && ticker.mode && ((M.mind in ticker.mode.wizards) || (M.mind in ticker.mode.apprentices))
 
 
 /datum/game_mode/proc/update_wiz_icons_added(datum/mind/wiz_mind)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -999,11 +999,12 @@
 	set category = "IC"
 	set src = usr
 
+	if(incapacitated())
+		return
 	var/obj/item/W = get_active_hand()
 	if(W)
 		W.attack_self(src)
 
-	return
 
 /mob/living/silicon/robot/proc/SetLockdown(state = 1)
 	// They stay locked down if their wire is cut.

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -368,7 +368,8 @@
 	diagsensor.add_hud_to(src)
 
 /mob/living/silicon/proc/sensor_mode()
-	set name = "Set Sensor Augmentation"
+	if(incapacitated())
+		return
 	var/sensor_type = input("Please select sensor type.", "Sensor Integration", null) in list("Security", "Medical","Diagnostic","Disable")
 	remove_med_sec_hud()
 	switch(sensor_type)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -380,7 +380,11 @@ var/next_mob_id = 0
 	set category = "Object"
 	set src = usr
 
-	if(istype(loc,/obj/mecha)) return
+	if(istype(loc,/obj/mecha))
+		return
+
+	if(incapacitated())
+		return
 
 	if(hand)
 		var/obj/item/W = l_hand
@@ -392,7 +396,6 @@ var/next_mob_id = 0
 		if (W)
 			W.attack_self(src)
 			update_inv_r_hand()
-	return
 
 /*
 /mob/verb/dump_source()


### PR DESCRIPTION
They also can't change their sensor mode (sechud, etc...) while incapacitated. Fixes #15015

Fixes Wizard apprentice not being able to use soulstones. Fixes #15188
