### PR TITLE
New, faster tools for engineering cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -127,8 +127,8 @@
 	..()
 	modules += new /obj/item/weapon/melee/baton/loaded(src)
 	modules += new /obj/item/weapon/extinguisher(src)
-	modules += new /obj/item/weapon/wrench(src)
-	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/wrench/cyborg(src)
+	modules += new /obj/item/weapon/crowbar/cyborg(src)
 	modules += new /obj/item/device/healthanalyzer(src)
 	emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
 	fix_modules()
@@ -181,11 +181,11 @@
 	modules += new /obj/item/weapon/pipe_dispenser(src) //What could possibly go wrong?
 	modules += new /obj/item/weapon/extinguisher(src)
 	modules += new /obj/item/weapon/weldingtool/largetank/cyborg(src)
-	modules += new /obj/item/weapon/screwdriver(src)
-	modules += new /obj/item/weapon/wrench(src)
-	modules += new /obj/item/weapon/crowbar(src)
-	modules += new /obj/item/weapon/wirecutters(src)
-	modules += new /obj/item/device/multitool(src)
+	modules += new /obj/item/weapon/screwdriver/cyborg(src)
+	modules += new /obj/item/weapon/wrench/cyborg(src)
+	modules += new /obj/item/weapon/crowbar/cyborg(src)
+	modules += new /obj/item/weapon/wirecutters/cyborg(src)
+	modules += new /obj/item/device/multitool/cyborg(src)
 	modules += new /obj/item/device/t_scanner(src)
 	modules += new /obj/item/device/analyzer(src)
 
@@ -311,7 +311,7 @@
 	modules += new /obj/item/weapon/gun/energy/printer(src)
 	modules += new /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg(src)
 	modules += new /obj/item/weapon/card/emag(src)
-	modules += new /obj/item/weapon/crowbar/red(src)
+	modules += new /obj/item/weapon/crowbar/cyborg(src)
 	modules += new /obj/item/weapon/pinpointer/operative(src)
 	emag = null
 	fix_modules()
@@ -332,7 +332,7 @@
 	modules += new /obj/item/weapon/melee/energy/sword/cyborg/saw(src) //Energy saw -- primary weapon
 	modules += new /obj/item/roller/robo(src)
 	modules += new /obj/item/weapon/card/emag(src)
-	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/crowbar/cyborg(src)
 	modules += new /obj/item/weapon/pinpointer/operative(src)
 	emag = null
 


### PR DESCRIPTION
In PR #15707 I added a set of new tool sprites, designed to be used with cyborgs and in integrated toolset, and tool items for these sprites. All items have `tool_quality = 2`, meaning they do any work two times faster than regular tools. This PR replaces cyborg tools with these buffed items.

Sprites: (welder, wrench, wirecutters, screwdriver, crowbar, multitool)
![tools](https://cloud.githubusercontent.com/assets/13571765/13417467/4acc2c46-df7d-11e5-922e-711c9bb0ad51.png)

2x tool speed for engineering cyborgs isn't a huge buff, they use RCD/RPD for most of the construction tasks anyway. And this buff doesn't affect engineering cyborg self-repair - it has no tool_quality check and speed remains constant.

:cl: CoreOverload
imageadd: Cyborg tools (screwdriver, crowbar, wrench, etc) now have new fancy sprites.
tweak: Said cyborg tools have received a buff and are now two times faster than their non-cyborg counterparts.
/:cl:
