### PR TITLE
SNPC Expansion v2: EA Edition

### DIFF
--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -31,7 +31,8 @@
 /mob/living/carbon/human/interactive
 	name = "interactive station member"
 	var/doing = 0
-	var/interest = 100
+	var/interest = 10
+	var/maxInterest = 10
 	var/timeout = 0
 	var/inactivity_period = 0
 	var/TARGET = null
@@ -42,7 +43,7 @@
 	var/mob/retal_target = null
 	var/update_hands = 0
 	var/list/blacklistItems = list() // items we should be ignoring
-	var/maxStepsTick = 3
+	var/maxStepsTick = 6 // step as many times as we can per frame
 	//Job and mind data
 	var/obj/item/weapon/card/id/MYID
 	var/obj/item/device/pda/MYPDA
@@ -61,9 +62,9 @@
 	var/graytide = 0
 	var/list/favoured_types = list() // allow a mob to favour a type, and hold onto them
 	var/chattyness = CHANCE_TALK
-	var/targetInterestShift = 10 // how much a good action should "reward" the npc
+	var/targetInterestShift = 5 // how much a good action should "reward" the npc
 	//modules
-	var/list/functions = list("nearbyscan","combat","doorscan","shitcurity","chatter","healpeople")
+	var/list/functions = list("nearbyscan","combat","shitcurity","chatter","healpeople")
 
 //botPool funcs
 /mob/living/carbon/human/interactive/proc/takeDelegate(mob/living/carbon/human/interactive/from,doReset=TRUE)
@@ -78,7 +79,7 @@
 	//
 	timeout = 0
 	inactivity_period = 0
-	interest = 100
+	interest = maxInterest
 	//
 	update_icons()
 	if(doReset)
@@ -118,14 +119,41 @@
 		retal_target = potentialAssault
 	..()
 
-/mob/living/carbon/human/interactive/New()
-	..()
-	random()
+/mob/living/carbon/human/interactive/verb/customiseSNPC()
+	set name = "Customize SNPC"
+	set desc = "Customise the SNPC"
+	set category = "Admin"
+
+	set src in view()
+
+	var/cjob = input("Choose Job") as null|anything in SSjob.occupations.Copy()
+
+	if(cjob)
+		myjob = cjob
+		job = myjob.title
+		for(var/obj/item/W in src)
+			src.unEquip(W, 1)
+			qdel(W)
+		myjob.equip(src)
+		myjob.apply_fingerprints(src)
+		doSetup()
+
+	var/doTele = input("Place the SNPC in their department?") as null|anything in list("Yes","No")
+	if(doTele)
+		if(doTele == "Yes")
+			src.loc = pick(get_area_turfs(job2area(myjob)))
+
+/mob/living/carbon/human/interactive/proc/doSetup()
+	Path_ID = new /obj/item/weapon/card/id(src)
+
+	var/datum/job/captain/C = new/datum/job/captain
+	Path_ID.access = C.get_access()
+
 	MYID = new(src)
 	MYID.name = "[src.real_name]'s ID Card ([myjob.title])"
 	MYID.assignment = "[myjob.title]"
 	MYID.registered_name = src.real_name
-	MYID.access = myjob.access
+	MYID.access = Path_ID.access // Automatons have strange powers... strange indeed
 	equip_to_slot_or_del(MYID, slot_wear_id)
 	MYPDA = new(src)
 	MYPDA.owner = real_name
@@ -168,12 +196,7 @@
 	update_augments()
 
 	hand = 0
-
-	Path_ID = new /obj/item/weapon/card/id(src)
-
-	var/datum/job/captain/C = new/datum/job/captain
-	Path_ID.access = C.get_access()
-
+	functions = list("nearbyscan","combat","shitcurity","chatter","healpeople") // stop customize adding multiple copies of a function
 	//job specific favours
 	switch(myjob.title)
 		if("Assistant")
@@ -182,6 +205,7 @@
 			favoured_types = list(/obj/item/clothing, /obj/item/weapon/stamp/captain,/obj/item/weapon/disk/nuclear)
 		if("Bartender","Chef")
 			favoured_types = list(/obj/item/weapon/reagent_containers/food, /obj/item/weapon/kitchen)
+			functions += "souschef"
 		if("Station Engineer","Chief Engineer","Atmospheric Technician")
 			favoured_types = list(/obj/item/stack, /obj/item/weapon, /obj/item/clothing)
 		if("Chief Medical Officer","Medical Doctor","Chemist","Virologist","Geneticist")
@@ -193,6 +217,12 @@
 		if("Janitor")
 			favoured_types = list(/obj/item/weapon/mop, /obj/item/weapon/reagent_containers/glass/bucket, /obj/item/weapon/reagent_containers/spray/cleaner, /obj/effect/decal/cleanable)
 			functions += "dojanitor"
+		if("Clown")
+			favoured_types = list(/obj/item/weapon/soap, /obj/item/weapon/reagent_containers/food/snacks/grown/banana,/obj/item/weapon/grown/bananapeel)
+			functions += "clowning"
+		if("Botanist")
+			favoured_types = list(/obj/machinery/hydroponics,  /obj/item/weapon/reagent_containers, /obj/item/weapon)
+			functions += "botany"
 		else
 			favoured_types = list(/obj/item/clothing)
 
@@ -217,17 +247,54 @@
 	if(TRAITS & TRAIT_THIEVING)
 		slyness = 75
 
+/mob/living/carbon/human/interactive/New()
+	..()
+
+	src.set_species(/datum/species/synth)
+	var/datum/species/synth/mSyn = dna.species
+	mSyn.assume_disguise(new/datum/species/human,src)
+
+	random()
+
+	doSetup()
+
 	SSnpc.insertBot(src)
 
 
+/mob/living/carbon/human/interactive/proc/retalTarget(var/target)
+	var/mob/living/carbon/human/M = target
+	if(target)
+		if(health > 0)
+			if(M.a_intent == "help")
+				chatter()
+			if(M.a_intent == "harm")
+				retal = 1
+				retal_target = target
+
+//Retaliation clauses
+
+/mob/living/carbon/human/interactive/hitby(atom/movable/AM, skipcatch, hitpush, blocked)
+	..(AM,skipcatch,hitpush,blocked)
+	var/mob/living/carbon/C = locate(/mob/living/carbon) in view(MIN_RANGE_FIND,src)
+	if(C)
+		retalTarget(C)
+
+/mob/living/carbon/human/interactive/bullet_act(obj/item/projectile/P, def_zone)
+	..(P,def_zone)
+	retalTarget(P.firer)
+
 /mob/living/carbon/human/interactive/attack_hand(mob/living/carbon/human/M)
-	..()
-	if (health > 0)
-		if(M.a_intent == "help")
-			chatter()
-		if(M.a_intent == "harm")
-			retal = 1
-			retal_target = M
+	..(M)
+	retalTarget(M)
+
+/mob/living/carbon/human/interactive/show_inv(mob/user)
+	..(user)
+	retalTarget(user)
+
+/mob/living/carbon/human/interactive/can_inject(mob/user, error_msg, target_zone, var/penetrate_thick = 0)
+	..(user,error_msg,target_zone,penetrate_thick)
+	retalTarget(user)
+
 
 //THESE EXIST FOR DEBUGGING OF THE DOING/INTEREST SYSTEM EASILY
 /mob/living/carbon/human/interactive/proc/doing2string(doin)
@@ -295,6 +362,7 @@
 	var/obj/item/T = other_hand
 	main_hand = other_hand
 	other_hand = T
+	update_hands = 1
 
 /mob/living/carbon/human/interactive/proc/take_to_slot(obj/item/G, var/hands=0)
 	var/list/slots = list ("left pocket" = slot_l_store,"right pocket" = slot_r_store,"left hand" = slot_l_hand,"right hand" = slot_r_hand)
@@ -325,8 +393,6 @@
 	if(IsDeadOrIncap())
 		walk(src,0)
 		return
-	if(a_intent != "disarm")
-		a_intent = "disarm"
 	//---------------------------
 	//---- interest flow control
 	if(interest < 0 || inactivity_period < 0)
@@ -334,13 +400,36 @@
 			interest = 0
 		if(inactivity_period < 0)
 			inactivity_period = 0
-	if(interest > 100)
-		interest = 100
+	if(interest > maxInterest)
+		interest = maxInterest
 	//---------------------------
 	//VIEW FUNCTIONS
 
-	if(!l_hand || !r_hand)
-		update_hands = 1
+	//doorscan is now integrated into life and runs before all other procs
+	spawn(0)
+		for(var/dir in alldirs)
+			var/turf/T = get_step(src,dir)
+			if(T)
+				for(var/obj/machinery/door/D in T.contents)
+					if(!istype(D,/obj/machinery/door/poddoor) && D.density)
+						spawn(0)
+							if(istype(D,/obj/machinery/door/airlock))
+								var/obj/machinery/door/airlock/AL = D
+								AL.p_open = 1
+								AL.update_icon()
+								AL.shock(src,5)
+								sleep(5)
+								AL.unbolt()
+								if(!AL.wires.is_cut(WIRE_BOLTS))
+									AL.wires.cut(WIRE_BOLTS)
+								if(!AL.wires.is_cut(WIRE_POWER1))
+									AL.wires.cut(WIRE_POWER1)
+								if(!AL.wires.is_cut(WIRE_POWER2))
+									AL.wires.cut(WIRE_POWER2)
+								sleep(5)
+								AL.p_open = 0
+								AL.update_icon()
+							D.open()
 
 	if(update_hands)
 		if(l_hand || r_hand)
@@ -364,6 +453,10 @@
 				G.assailant.attack_hand(src)
 				inactivity_period = 10
 
+	if(buckled)
+		resist()
+		inactivity_period = 10
+
 	//proc functions
 	for(var/Proc in functions)
 		if(!IsDeadOrIncap())
@@ -376,61 +469,68 @@
 		if(TARGET in blacklistItems)
 			TARGET = null
 
-	if((TARGET && (TARGET in view(1))))
-		if((TARGET in view(1,src)))//this is a bit redundant but it saves two if blocks
-			doing |= INTERACTING
-			//--------DOORS
-			if(istype(TARGET, /obj/machinery/door))
-				var/obj/machinery/door/D = TARGET
-				if(D.check_access(MYID) && !istype(D,/obj/machinery/door/poddoor))
-					D.open()
-					sleep(15)
-					var/turf/T = get_step(get_step(D.loc,dir),dir) //recursion yo
-					tryWalk(T)
-			//THIEVING SKILLS
-			if(prob(slyness))
-				if(!TARGET in blacklistItems)
-					//---------TOOLS
-					if(istype(TARGET, /obj/item/weapon))
-						var/obj/item/weapon/W = TARGET
-						if(W.force >= best_force || prob((FUZZY_CHANCE_LOW+FUZZY_CHANCE_HIGH)/2))
-							if(!l_hand || !r_hand)
-								take_to_slot(W)
-							else
-								insert_into_backpack()
-					//---------FASHION
-					if(istype(TARGET,/obj/item/clothing))
-						var/obj/item/clothing/C = TARGET
-						drop_item()
-						spawn(5)
-							take_to_slot(C,1)
-							if(!equip_to_appropriate_slot(C))
-								var/obj/item/I = get_item_by_slot(C)
-								unEquip(I)
-								spawn(5)
-									equip_to_appropriate_slot(C)
-						update_hands = 1
-						if(MYPDA in src.loc || MYID in src.loc)
-							if(MYPDA in src.loc)
-								equip_to_appropriate_slot(MYPDA)
-							if(MYID in src.loc)
-								equip_to_appropriate_slot(MYID)
-			//THIEVING SKILLS END
-			//-------------TOUCH ME
-			if(istype(TARGET,/obj/structure))
-				var/obj/structure/STR = TARGET
-				if(main_hand)
-					var/obj/item/weapon/W = main_hand
-					STR.attackby(W, src)
+
+	if((TARGET && Adjacent(TARGET)))
+		doing |= INTERACTING
+		//--------DOORS
+		if(istype(TARGET, /obj/machinery/door))
+			var/obj/machinery/door/D = TARGET
+			if(D.check_access(MYID) && !istype(D,/obj/machinery/door/poddoor))
+				D.open()
+				sleep(15)
+				var/turf/T = get_step(get_step(D.loc,dir),dir) //recursion yo
+				tryWalk(T)
+		//THIEVING SKILLS
+		if(!TARGET in blacklistItems)
+			insert_into_backpack() // dump random item into backpack to make space
+			//---------ITEMS
+			if(istype(TARGET, /obj/item))
+				if(istype(TARGET, /obj/item/weapon))
+					var/obj/item/weapon/W = TARGET
+					if(W.force >= best_force || prob((FUZZY_CHANCE_LOW+FUZZY_CHANCE_HIGH)/2))
+						if(!l_hand || !r_hand)
+							put_in_hands(W)
+						else
+							insert_into_backpack()
 				else
-					STR.attack_hand(src)
+					if(!l_hand || !r_hand)
+						put_in_hands(TARGET)
+					else
+						insert_into_backpack()
+			//---------FASHION
+			if(istype(TARGET,/obj/item/clothing))
+				var/obj/item/clothing/C = TARGET
+				drop_item()
+				spawn(5)
+					take_to_slot(C,1)
+					if(!equip_to_appropriate_slot(C))
+						var/obj/item/I = get_item_by_slot(C)
+						unEquip(I)
+						spawn(5)
+							equip_to_appropriate_slot(C)
+				update_hands = 1
+				if(MYPDA in src.loc || MYID in src.loc)
+					if(MYPDA in src.loc)
+						equip_to_appropriate_slot(MYPDA)
+					if(MYID in src.loc)
+						equip_to_appropriate_slot(MYID)
+		//THIEVING SKILLS END
+		//-------------TOUCH ME
+		if(istype(TARGET,/obj/structure))
+			var/obj/structure/STR = TARGET
+			if(main_hand)
+				var/obj/item/weapon/W = main_hand
+				STR.attackby(W, src)
+			else
+				STR.attack_hand(src)
 		interest += targetInterestShift
 		doing = doing & ~INTERACTING
 		timeout = 0
 		TARGET = null
 	else
-		tryWalk(TARGET)
-		timeout++
+		if(TARGET)
+			tryWalk(TARGET)
+			timeout++
 
 	if(doing == 0)
 		interest--
@@ -455,14 +555,14 @@
 		else
 			var/choice = rand(1,50)
 			switch(choice)
-				if(1 to 10)
+				if(1 to 30)
 					//chance to chase an item
 					TARGET = locate(/obj/item) in favouredObjIn(oview(MIN_RANGE_FIND,src))
-				if(11 to 21)
+				if(31 to 40)
 					TARGET = safepick(get_area_turfs(job2area(myjob)))
-				if(22 to 41)
+				if(41 to 45)
 					TARGET = pick(target_filter(favouredObjIn(urange(MAX_RANGE_FIND,src,1))))
-				if(42 to 50)
+				if(46 to 50)
 					TARGET = pick(target_filter(oview(MIN_RANGE_FIND,src)))
 		tryWalk(TARGET)
 	LAST_TARGET = TARGET
@@ -479,7 +579,8 @@
 
 /mob/living/carbon/human/interactive/proc/callfunction(Proc)
 	set waitfor = 0
-	call(src,Proc)(src)
+	spawn(0)
+		call(src,Proc)(src)
 
 /mob/living/carbon/human/interactive/proc/tryWalk(turf/TARGET)
 	if(!IsDeadOrIncap())
@@ -526,9 +627,10 @@
 		if(myPath.len > 0)
 			doing = doing & ~TRAVEL
 			for(var/i = 0; i < maxStepsTick; ++i)
-				if(myPath.len >= 1)
-					walk_to(src,myPath[1],0,5)
-					myPath -= myPath[1]
+				if(!IsDeadOrIncap())
+					if(myPath.len >= 1)
+						walk_to(src,myPath[1],0,5)
+						myPath -= myPath[1]
 			return 1
 	return 0
 
@@ -539,7 +641,7 @@
 	if(T.title == "Captain" || T.title == "Head of Personnel")
 		return /area/bridge
 	if(T.title == "Bartender" || T.title == "Chef")
-		return /area/crew_quarters
+		return pick(/area/crew_quarters/kitchen,/area/crew_quarters/bar)
 	if(T.title == "Station Engineer" || T.title == "Chief Engineer" || T.title == "Atmospheric Technician")
 		return /area/engine
 	if(T.title == "Chief Medical Officer" || T.title == "Medical Doctor" || T.title == "Chemist" || T.title == "Virologist" || T.title == "Geneticist")
@@ -548,6 +650,8 @@
 		return /area/toxins
 	if(T.title == "Head of Security" || T.title == "Warden" || T.title == "Security Officer" || T.title == "Detective")
 		return /area/security
+	if(T.title == "Botanist")
+		return /area/hydroponics
 	else
 		return pick(/area/hallway,/area/crew_quarters)
 
@@ -609,25 +713,151 @@
 					toSay += "[curse_words] "
 				src.say("Hey [nouns_generic], why dont you go [toSay], you [nouns_insult]!")
 
-/mob/living/carbon/human/interactive/proc/shitcurity(obj)
-	if(retal && TARGET)
-		for(var/obj/item/I in src.contents)
-			if(istype(I,/obj/item/weapon/restraints))
-				take_to_slot(I)
-				I.attack(TARGET,src)
-				sleep(25)
 
-/mob/living/carbon/human/interactive/proc/healpeople(obj)
-	var/shouldTryHeal = 0
-	var/obj/item/stack/medical/M
-
+/mob/living/carbon/human/interactive/proc/getAllContents()
 	var/list/allContents = list()
-
 	for(var/atom/A in contents)
 		allContents += A
 		if(A.contents.len > 0)
 			for(var/atom/B in A)
 				allContents += B
+	return allContents
+
+/mob/living/carbon/human/interactive/proc/enforceHome()
+	if(!(get_turf(src) in get_area_turfs(job2area(myjob))))
+		tryWalk(pick(get_area_turfs(job2area(myjob))))
+
+/mob/living/carbon/human/interactive/proc/npcDrop(var/obj/item/A,var/blacklist = 0)
+	if(blacklist)
+		blacklistItems += A
+	A.loc = get_turf(src) // drop item works inconsistently
+	enforce_hands()
+	update_icons()
+
+/mob/living/carbon/human/interactive/proc/botany(obj)
+	var/list/allContents = getAllContents()
+	enforceHome()
+
+	var/obj/item/weapon/reagent_containers/glass/beaker/bluespace/internalBeaker = locate(/obj/item/weapon/reagent_containers/glass/beaker/bluespace) in allContents
+	var/obj/item/weapon/storage/bag/plants/internalBag = locate(/obj/item/weapon/storage/bag/plants) in allContents
+
+	if(!internalBag)
+		internalBag = new/obj/item/weapon/storage/bag/plants(src)
+	if(!internalBeaker)
+		internalBeaker = new/obj/item/weapon/reagent_containers/glass/beaker/bluespace(src)
+		internalBeaker.name = "Grow-U-All Super Spray"
+
+	if(internalBeaker && internalBag)
+		var/obj/machinery/hydroponics/HP
+
+		//consider the appropriate target
+		var/list/considered = list()
+
+		for(var/obj/machinery/hydroponics/tester in view(12,src))
+			considered[tester] = 1
+
+			if(!tester.planted)
+				considered[tester] += 50
+			if(tester.weedlevel > 0)
+				considered[tester] += 5
+			if(tester.pestlevel > 0)
+				considered[tester] += 5
+			if(tester.nutrilevel <  tester.maxnutri)
+				considered[tester] += 15
+			if(tester.waterlevel < tester.maxwater)
+				considered[tester] += 15
+			if(tester.harvest || tester.dead)
+				considered[tester] += 100
+			considered[tester] = max(1,considered[tester] - get_dist(src,tester))
+
+		var/index = 0
+		for(var/A in considered)
+			++index
+			if(considered[A] > considered[HP] || !HP)
+				HP = considered[index]
+
+		if(HP)
+			TARGET = HP
+			if(!Adjacent(HP))
+				tryWalk(get_turf(HP))
+			else
+				if(HP.harvest || HP.dead)
+					HP.attack_hand(src)
+				else if(!HP.planted)
+					var/seedType = pick(typesof(/obj/item/seeds) - /obj/item/seeds)
+					var/obj/item/seeds/SEED = new seedType(src)
+					customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")] towards [TARGET], producing a [SEED]!")
+					HP.attackby(SEED,src)
+				else
+					var/change = 0
+					if(HP.weedlevel > 0)
+						change = 1
+						if(!internalBeaker.reagents.has_reagent("weedkiller", 10))
+							internalBeaker.reagents.add_reagent("weedkiller",10)
+					if(HP.pestlevel > 0)
+						change = 1
+						if(!internalBeaker.reagents.has_reagent("pestkiller", 10))
+							internalBeaker.reagents.add_reagent("pestkiller",10)
+					if(HP.nutrilevel <  HP.maxnutri)
+						change = 1
+						if(!internalBeaker.reagents.has_reagent("eznutriment", 15))
+							internalBeaker.reagents.add_reagent("eznutriment",15)
+						if(!internalBeaker.reagents.has_reagent("diethylamine", 15))
+							internalBeaker.reagents.add_reagent("diethylamine",15)
+					if(HP.waterlevel < HP.maxwater)
+						change = 1
+						if(!internalBeaker.reagents.has_reagent("holywater", 50))
+							internalBeaker.reagents.add_reagent("holywater",50)
+					if(change)
+						HP.attackby(internalBeaker,src)
+
+	var/obj/item/weapon/reagent_containers/food/snacks/grown/GF = locate(/obj/item/weapon/reagent_containers/food/snacks/grown) in view(12,src)
+	if(GF)
+		if(!Adjacent(GF))
+			tryWalk(get_turf(GF))
+		else
+			GF.attackby(internalBag,src)
+
+	if(internalBag.contents.len > 0)
+		var/obj/machinery/smartfridge/SF = locate(/obj/machinery/smartfridge) in range(MAX_RANGE_FIND,src)
+		if(!Adjacent(SF))
+			tryWalk(get_turf(SF))
+		else
+			customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")], upending the [internalBag]'s contents all over [TARGET]!")
+			//smartfridges call updateUsrDialog when you call attackby, so we're going to have to cheese-magic-space this
+			for(var/obj/toLoad in internalBag.contents)
+				if(contents.len >= SF.max_n_of_items)
+					break
+				if(SF.accept_check(toLoad))
+					SF.load(toLoad)
+
+/mob/living/carbon/human/interactive/proc/shitcurity(obj)
+	var/list/allContents = getAllContents()
+
+	if(retal && TARGET)
+		for(var/obj/item/I in allContents)
+			if(istype(I,/obj/item/weapon/restraints))
+				I.attack(TARGET,src) // go go bluespace restraint launcher!
+				sleep(25)
+
+/mob/living/carbon/human/interactive/proc/clowning(obj)
+	var/list/allContents = getAllContents()
+
+	for(var/A in allContents)
+		if(istype(A,/obj/item/weapon/soap))
+			npcDrop(A)
+		if(istype(A,/obj/item/weapon/reagent_containers/food/snacks/grown/banana))
+			var/obj/item/weapon/reagent_containers/food/snacks/B = A
+			B.attack(src, src)
+		if(istype(A,/obj/item/weapon/grown/bananapeel))
+			npcDrop(A)
+
+
+/mob/living/carbon/human/interactive/proc/healpeople(obj)
+	var/shouldTryHeal = 0
+	var/obj/item/stack/medical/M
+
+	var/list/allContents = getAllContents()
 
 	for(var/A in allContents)
 		if(istype(A,/obj/item/stack/medical))
@@ -658,12 +888,85 @@
 			else
 				tryWalk(TARGET)
 
+/mob/living/carbon/human/interactive/proc/customEmote(var/text)
+	for(var/mob/living/carbon/M in view(src))
+		M.show_message("<span class='notice'>[text]</span>", 2)
+
+// START COOKING MODULE
+/mob/living/carbon/human/interactive/proc/cookingwithmagic(var/obj/item/weapon/reagent_containers/food/snacks/target)
+	if(Adjacent(target))
+		customEmote("[src] [pick("gibbers","drools","slobbers","claps wildly","spits")] towards [target], and with a bang, it's instantly cooked!")
+		var/obj/item/weapon/reagent_containers/food/snacks/S = new target.cooked_type (get_turf(src))
+		target.initialize_cooked_food(S, 100)
+		playsound(get_turf(src), 'sound/weapons/flashbang.ogg', 50, 1)
+	else
+		tryWalk(target)
+
+/mob/living/carbon/human/interactive/proc/souschef(obj)
+	var/list/allContents = getAllContents()
+
+	enforceHome()
+
+	//Bluespace in some inbuilt tools
+	var/obj/item/weapon/kitchen/rollingpin/RP = locate(/obj/item/weapon/kitchen/rollingpin) in allContents
+	if(!RP)
+		new/obj/item/weapon/kitchen/rollingpin(src)
+
+	var/obj/item/weapon/kitchen/knife/KK = locate(/obj/item/weapon/kitchen/knife) in allContents
+	if(!KK)
+		new/obj/item/weapon/kitchen/knife(src)
+
+	if(RP && KK) // Ready to cook!
+		//Process dough into various states
+		var/obj/item/weapon/reagent_containers/food/snacks/dough/D = locate(/obj/item/weapon/reagent_containers/food/snacks/dough) in range(MAX_RANGE_FIND,src)
+		if(D)
+			var/choice = pick(1,2)
+			if(choice == 1)
+				tryWalk(get_turf(D))
+				sleep(get_dist(src,D))
+				D.attackby(RP,src)
+			else
+				cookingwithmagic(D)
+		var/obj/item/weapon/reagent_containers/food/snacks/flatdough/FD = locate(/obj/item/weapon/reagent_containers/food/snacks/flatdough) in range(MAX_RANGE_FIND,src)
+		if(FD)
+			var/choice = pick(1,2)
+			if(choice == 1)
+				tryWalk(get_turf(D))
+				sleep(get_dist(src,D))
+				FD.attackby(KK,src)
+			else
+				cookingwithmagic(FD)
+		var/obj/item/weapon/reagent_containers/food/snacks/cakebatter/CB = locate(/obj/item/weapon/reagent_containers/food/snacks/cakebatter) in range(MAX_RANGE_FIND,src)
+		if(CB)
+			var/choice = pick(1,2)
+			if(choice == 1)
+				tryWalk(get_turf(D))
+				sleep(get_dist(src,D))
+				CB.attackby(RP,src)
+			else
+				cookingwithmagic(CB)
+		var/obj/item/weapon/reagent_containers/food/snacks/piedough/PD = locate(/obj/item/weapon/reagent_containers/food/snacks/piedough) in range(MAX_RANGE_FIND,src)
+		if(PD)
+			var/choice = pick(1,2)
+			if(choice == 1)
+				tryWalk(get_turf(D))
+				sleep(get_dist(src,D))
+				PD.attackby(KK,src)
+			else
+				cookingwithmagic(PD)
+		//Cook various regular foods into processed versions
+		var/obj/item/weapon/reagent_containers/food/snacks/toCook = locate(/obj/item/weapon/reagent_containers/food/snacks) in range(MAX_RANGE_FIND,src)
+		if(toCook)
+			if(toCook.cooked_type)
+				cookingwithmagic(toCook)
+// END COOKING MODULE
+
 /mob/living/carbon/human/interactive/proc/combat(obj)
 	set background = 1
 	enforce_hands()
 	if(canmove)
 		if(prob(attitude) && (graytide || (TRAITS & TRAIT_MEAN)) || retal)
-			interest = interest + 10
+			interest += targetInterestShift
 			a_intent = "harm"
 			zone_selected = pick("chest","r_leg","l_leg","r_arm","l_arm","head")
 			doing |= FIGHTING
@@ -671,8 +974,6 @@
 				TARGET = retal_target
 			else
 				var/mob/living/M = locate(/mob/living) in oview(7,src)
-				if(istype(M,/mob/living/carbon/human/interactive/greytide))
-					return
 				if(M != src)
 					TARGET = M
 				if(!M)
@@ -682,17 +983,17 @@
 	if(retal)
 		if(retal_target)
 			if(retal_target.faction == src.faction)
-				if(prob(FUZZY_CHANCE_HIGH+FUZZY_CHANCE_LOW))	//high chance to forgive
-					retal = 0
-					retal_target = null
-					TARGET = null
-					doing = 0
+				retal = 0
+				retal_target = null
+				TARGET = null
+				doing = 0
 
 	//ensure we're using the best object possible
 
 	var/obj/item/weapon/best
 	var/foundFav = 0
-	for(var/test in src.contents)
+	var/list/allContents = getAllContents()
+	for(var/test in allContents)
 		for(var/a in favoured_types)
 			if(ispath(test,a) && !(doing & FIGHTING)) // if we're not in combat and we find our favourite things, use them (for people like janitor and doctors)
 				best = test
@@ -715,10 +1016,28 @@
 	if(best)
 		take_to_slot(best,1)
 
-	if((TARGET && (doing & FIGHTING)) || graytide) // this is a redundancy check
+	if((TARGET && (doing & FIGHTING))) // this is a redundancy check
 		var/mob/living/M = TARGET
 		if(istype(M,/mob/living))
 			if(M.health > 1)
+				//THROWING OBJECTS
+				for(var/A in allContents)
+					if(prob(robustness))
+						if(istype(A,/obj/item/weapon))
+							var/obj/item/weapon/W = A
+							if(W.throwforce > 0)
+								npcDrop(W,1)
+								throw_item(TARGET)
+						if(istype(A,/obj/item/weapon/grenade)) // Allahu ackbar! ALLAHU ACKBARR!!
+							var/obj/item/weapon/grenade/G = A
+							G.attack_self(src)
+							if(prob(smartness))
+								npcDrop(G,1)
+								sleep(15)
+								throw_item(TARGET)
+
+				if(!main_hand && other_hand)
+					swap_hands()
 				if(main_hand)
 					if(main_hand.force != 0)
 						if(istype(main_hand,/obj/item/weapon/gun))
@@ -731,24 +1050,18 @@
 										P.update_icon()
 									else if(P.get_ammo(1) == 0)
 										P.update_icon()
-										blacklistItems += P
-										P.loc = get_turf(src) // drop item works inconsistently
-										enforce_hands()
-										update_icons()
+										npcDrop(P,1)
 									else
 										P.afterattack(TARGET, src)
 								else if(istype(main_hand,/obj/item/weapon/gun/energy))
 									var/obj/item/weapon/gun/energy/P = main_hand
 									if(P.power_supply.charge <= 10) // can shoot seems to bug out for tasers, using this hacky method instead
 										P.update_icon()
-										blacklistItems += P
-										P.loc = get_turf(src) // likewise
-										enforce_hands()
-										update_icons()
+										npcDrop(P,1)
 									else
 										P.afterattack(TARGET, src)
 								else
-									if(get_dist(src,TARGET) > 2)
+									if(get_dist(src,TARGET) > 6)
 										if(!walk2derpless(TARGET))
 											timeout++
 									else
@@ -759,10 +1072,11 @@
 								enforce_hands()
 								update_icons()
 				else
-					if(targetRange(TARGET) > (istype(main_hand,/obj/item/weapon/gun) ? 6 : 2))
+					if(targetRange(TARGET) > 2)
 						tryWalk(TARGET)
 					else
 						if(Adjacent(TARGET))
+							a_intent = pick("disarm","harm")
 							M.attack_hand(src)
 			timeout++
 		else if(timeout >= 10 || !(targetRange(M) > 14))
@@ -774,16 +1088,6 @@
 		else
 			timeout++
 
-/mob/living/carbon/human/interactive/proc/doorscan(obj)
-	for(var/dir in alldirs)
-		var/turf/T = get_step(src,dir)
-		if(T)
-			for(var/obj/machinery/door/D in T.contents)
-				if(D.check_access(MYID) && !istype(D,/obj/machinery/door/poddoor) && D.density)
-					spawn(0)
-						D.open()
-						sleep(5)
-						walk_to(src,T,0,5)
 
 /mob/living/carbon/human/interactive/proc/nearbyscan(obj)
 	nearby = list()
@@ -809,6 +1113,8 @@
 	TRAITS |= TRAIT_MEAN
 	TRAITS |= TRAIT_THIEVING
 	TRAITS |= TRAIT_DUMB
+	maxInterest = 5 // really short attention span
+	targetInterestShift = 2 // likewise
 	faction = list("bot_grey")
 	graytide = 1
 	..()


### PR DESCRIPTION
- Interest values and modifiers tweaked to create a smoother and more active AI
- maxStepsTick raised to 6, to smooth out movement
- doorScan has been integrated into the main AI, and performs before all other functions
- SNPCs have been given all-access, but must "hack" their way through doors, with a small chance to electrocute themselves
- Verb added to customise an SNPC and optionally send it to it's department
- Clown SNPCs will now slip people.
- Chef and Bartended SNPCs now process and cook basic foods.
- Botanist SNPCs will now grow, tend and harvest plants, and deliver them to a smartfridge.
- SNPCs are now the Synth race
- SNPCs now recognise a number of offensive actions, such as injecting, throwing, being shot and people attempting to steal from them
- SNPCs will now atetmpt to unbuckle themselves
- General Backpack and Item handling improved
- SNPCs now correctly recognise and take regular items
- Rebalanced the AI to favour their favourite items and department more
- callFunction now spawns off modules, running them simultaneously
- Botanist,Chefs and Bartenders now attempt to stay near their respective areas
- SNPCs now recognise recursive content (items in boxes in bags etc)
- SNPCs now have emotes attached to certain actions to faciliate their bluespace magic (so players do not get confused)
- Greytide SNPC getting stalled has been fixed
- SNPCs can now recognise and throw items that have are throwable, and will use them in combat.
- SNPCs can now recognise and use grenades, and will (according to their traits) prime and throw them, or suicide bomb a target
- SNPC ranges for combat rebalanced
- SNPCs now switch between disarm and harm in melee combat.
