### PR TITLE
TimeStamped runtime logs.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -174,6 +174,26 @@ var/last_irc_status = 0
 			C << link("byond://[config.server]")
 	..(0)
 
+var/inerror = 0
+/world/Error(var/exception/e)
+	//runtime while processing runtimes
+	if (inerror)
+		inerror = 0
+		return ..(e)
+	inerror = 1
+	//newline at start is because of the "runtime error" byond prints that can't be timestamped.
+	e.name = "\n\[[time2text(world.timeofday,"hh:mm:ss")]\][e.name]"
+	
+	//this is done this way rather then replace text to pave the way for processing the runtime reports more thoroughly
+	//	(and because runtimes end with a newline, and we don't want to basically print an empty time stamp)
+	var/list/split = splittext(e.desc, "\n")
+	for (var/i in 1 to split.len)
+		if (split[i] != "")
+			split[i] = "\[[time2text(world.timeofday,"hh:mm:ss")]\][split[i]]"
+	e.desc = jointext(split, "\n")
+	inerror = 0
+	return ..(e)
+	
 /world/proc/load_mode()
 	var/list/Lines = file2list("data/mode.txt")
 	if(Lines.len)


### PR DESCRIPTION
```
runtime error:
[23:55:40]list index out of bounds
[23:55:40]proc name: testpickweight (/mob/verb/testpickweight)
[23:55:40]  source file: client.dm,296
[23:55:40]  usr: (src)
[23:55:40]  src: MrStonedOne (/mob)
[23:55:40]  src.loc: null
[23:55:40]  call stack:
[23:55:40]MrStonedOne (/mob): testpickweight()
runtime error:
[23:55:43]list index out of bounds
[23:55:43]proc name: testpickweight (/mob/verb/testpickweight)
[23:55:43]  source file: client.dm,296
[23:55:43]  usr: (src)
[23:55:43]  src: MrStonedOne (/mob)
[23:55:43]  src.loc: null
[23:55:43]  call stack:
[23:55:43]MrStonedOne (/mob): testpickweight()
```
