### PR TITLE
Wall mounted flashes are now buildable

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -172,7 +172,7 @@
 
 /obj/item/wallframe/flasher/examine(mob/user)
 	..()
-	user << "<span class='notice'>It's channel ID is '[id]'.</span>"
+	user << "<span class='notice'>Its channel ID is '[id]'.</span>"
 
 /obj/item/wallframe/flasher/after_attach(var/obj/O)
 	..()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -22,9 +22,14 @@
 	base_state = "pflash"
 	density = 1
 
-/obj/machinery/flasher/New()
+/obj/machinery/flasher/New(loc, ndir = 0, built = 0)
 	..() // ..() is EXTREMELY IMPORTANT, never forget to add it
-	bulb = new /obj/item/device/assembly/flash/handheld(src)
+	if(built)
+		dir = ndir
+		pixel_x = (dir & 3)? 0 : (dir == 4 ? -28 : 28)
+		pixel_y = (dir & 3)? (dir ==1 ? -28 : 28) : 0
+	else
+		bulb = new /obj/item/device/assembly/flash/handheld(src)
 
 /obj/machinery/flasher/Move()
 	remove_from_proximity_list(src, range)
@@ -63,6 +68,21 @@
 			power_change()
 		else
 			user << "<span class='warning'>A flashbulb is already installed in [src]!</span>"
+
+	else if (istype(W, /obj/item/weapon/wrench))
+		if(!bulb)
+			user << "<span class='notice'>You start unsecuring the flasher frame...</span>"
+			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+			if(do_after(user, 40/W.toolspeed, target = src))
+				user << "<span class='notice'>You unsecure the flasher frame.</span>"
+				var/obj/item/wallframe/flasher/F = new(get_turf(src))
+				transfer_fingerprints_to(F)
+				F.id = id
+				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				qdel(src)
+		else
+			user << "<span class='warning'>Remove a flashbulb from [src] first!</span>"
+
 	add_fingerprint(user)
 
 //Let the AI trigger them directly.
@@ -73,7 +93,6 @@
 		return
 
 /obj/machinery/flasher/proc/flash()
-
 	if (!powered() || !bulb)
 		return
 
@@ -141,3 +160,21 @@
 
 	else
 		..()
+
+
+/obj/item/wallframe/flasher
+	name = "mounted flash frame"
+	desc = "Used for building wall-mounted flashers."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "mflash_frame"
+	result_path = /obj/machinery/flasher
+	var/id = null
+
+/obj/item/wallframe/flasher/examine(mob/user)
+	..()
+	user << "<span class='notice'>It's channel ID is '[id]'.</span>"
+
+/obj/item/wallframe/flasher/after_attach(var/obj/O)
+	..()
+	var/obj/machinery/flasher/F = O
+	F.id = id

--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -39,10 +39,12 @@
 			ndir = turn(ndir, 180)
 
 		var/obj/O = new result_path(get_turf(usr), ndir, 1)
-		transfer_fingerprints_to(O)
+		after_attach(O)
 
 	qdel(src)
 
+/obj/item/wallframe/proc/after_attach(var/obj/O)
+	transfer_fingerprints_to(O)
 
 /obj/item/wallframe/attackby(obj/item/weapon/W, mob/user, params)
 	..()
@@ -51,7 +53,6 @@
 		var/turf/T = get_step(get_turf(user), user.dir)
 		if(istype(T, /turf/simulated/wall))
 			T.attackby(src, user, params)
-
 
 	var/metal_amt = round(materials[MAT_METAL]/MINERAL_MATERIAL_AMOUNT)
 	var/glass_amt = round(materials[MAT_GLASS]/MINERAL_MATERIAL_AMOUNT)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -177,6 +177,24 @@
 	for(var/i in 1 to 6)
 		new /obj/item/device/assembly/flash/handheld(src)
 
+/obj/item/weapon/storage/box/wall_flash
+	name = "wall-mounted flash kit"
+	desc = "This box contains everything neccesary to build a wall-mounted flash. <B>WARNING: Flashes can cause serious eye damage, protective eyewear is required.</B>"
+	icon_state = "flashbang"
+
+/obj/item/weapon/storage/box/wall_flash/New()
+	..()
+	var/id = rand(1000, 9999)
+
+	new /obj/item/wallframe/button(src)
+	new /obj/item/weapon/electronics/airlock(src)
+	var/obj/item/device/assembly/control/flasher/remote = new(src)
+	remote.id = id
+	var/obj/item/wallframe/flasher/frame = new(src)
+	frame.id = id
+	new /obj/item/device/assembly/flash/handheld(src)
+
+
 /obj/item/weapon/storage/box/teargas
 	name = "box of tear gas grenades (WARNING)"
 	desc = "<B>WARNING: These devices are extremely dangerous and can cause blindness and skin irritation.</B>"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -193,6 +193,7 @@
 	var/obj/item/wallframe/flasher/frame = new(src)
 	frame.id = id
 	new /obj/item/device/assembly/flash/handheld(src)
+	new /obj/item/weapon/screwdriver(src)
 
 
 /obj/item/weapon/storage/box/teargas

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -10,7 +10,7 @@
 /obj/item/device/assembly/control/examine(mob/user)
 	..()
 	if(id)
-		user << "It's channel ID is '[id]'."
+		user << "<span class='notice'>Its channel ID is '[id]'.</span>"
 
 
 /obj/item/device/assembly/control/activate()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -169,6 +169,15 @@
 					/obj/item/weapon/melee/baton/loaded)
 	crate_name = "stun baton crate"
 
+/datum/supply_pack/security/wall_flash
+	name = "Wall-Mounted Flash Crate"
+	cost = 10
+	contains = list(/obj/item/weapon/storage/box/wall_flash,
+					/obj/item/weapon/storage/box/wall_flash,
+					/obj/item/weapon/storage/box/wall_flash,
+					/obj/item/weapon/storage/box/wall_flash)
+	crate_name = "wall-mounted flash crate"
+
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	cost = 15


### PR DESCRIPTION
Wall mounted flashes are now buildable and deconstructable. Using a wrench on a wall mounted flash (with flashbulb removed) will deconstruct it, producing a mounted flash frame. Frame keeps flasher ID and can be attached to any wall.

New crate is added to cargo. It contains 4 wall mounted flash kit boxes. Each box contains: flash, mounted  flash frame, flash controller assembly, button frame and airlock control board (used by button for access control). It costs 10 points, crate is locked to sec.

:cl: CoreOverload
rscadd: You can now construct and deconstruct wall mounted flashes by using a wrench on empty wall flash. A crate with four linked "flash frame - flash controller" pairs is added to cargo.
/:cl:
