### PR TITLE
Fixes Monkeys not being able to steer jetpacks.

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -153,3 +153,23 @@
 		turn_off()
 		return
 	..()
+
+
+//Return a jetpack that the mob can use
+//Back worn jetpacks, hardsuit internal packs, and so on.
+//Used in Process_Spacemove() and wherever you want to check for/get a jetpack
+
+/mob/proc/get_jetpack()
+	return
+
+/mob/living/carbon/get_jetpack()
+	var/obj/item/weapon/tank/jetpack/J = back
+	if(istype(J))
+		return J
+
+/mob/living/carbon/human/get_jetpack()
+	var/obj/item/weapon/tank/jetpack/J = ..()
+	if(!istype(J) && istype(wear_suit, /obj/item/clothing/suit/space/hardsuit))
+		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
+		J = C.jetpack
+	return J

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -35,6 +35,18 @@
 		if((src.disabilities & FAT) && src.m_intent == "run" && src.bodytemperature <= 360)
 			src.bodytemperature += 2
 
+
+/mob/living/carbon/Process_Spacemove(movement_dir = 0)
+	if(..())
+		return 1
+	if(!isturf(loc)) // In a mecha? A locker? Who knows!
+		return 0
+
+	var/obj/item/weapon/tank/jetpack/J = get_jetpack()
+	if(istype(J) && J.allow_thrust(0.01, src))
+		return 1
+
+
 /mob/living/carbon/movement_delay()
 	. = ..()
 	if(legcuffed)
@@ -832,3 +844,6 @@ var/const/GALOSHES_DONT_HELP = 4
 		user << "<span class='notice'>You retrieve some of [src]\'s internal organs!</span>"
 
 	..()
+
+
+

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -3,19 +3,6 @@
 	. += ..()
 	. += config.human_delay
 
-/mob/living/carbon/human/Process_Spacemove(movement_dir = 0)
-	if(..())
-		return 1
-	if(!isturf(loc)) // In a mecha? A locker? Who knows!
-		return 0
-
-	// Do we have a jetpack (and is it on)?
-	var/obj/item/weapon/tank/jetpack/J = back
-	if(!istype(J) && istype(wear_suit, /obj/item/clothing/suit/space/hardsuit))
-		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
-		J = C.jetpack
-	if(istype(J) && J.allow_thrust(0.01, src))
-		return 1
 
 /mob/living/carbon/human/slip(s_amount, w_amount, obj/O, lube)
 	if(isobj(shoes) && (shoes.flags&NOSLIP) && !(lube&GALOSHES_DONT_HELP))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -728,8 +728,7 @@ Sorry Giacom. Please don't be mad :(
 		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
 		floating = 1
 	else if(((!on || fixed) && floating))
-		var/final_pixel_y = get_standard_pixel_y_offset(lying)
-		animate(src, pixel_y = final_pixel_y, time = 10)
+		animate(src, pixel_y = get_standard_pixel_y_offset(lying), time = 10)
 		floating = 0
 
 //called when the mob receives a bright flash


### PR DESCRIPTION
- Adds a `get_jetpack()` proc
  - This allows all jetpack logic to be moved to `carbon/Process_Spacemove()`
    - Humans no longer have a `Process_Spacemove()` as all its logic is now in `carbon/Process_Spacemove()`
    - Monkeys can now properly use Jetpacks to fly in space.
