### PR TITLE
Allows aliens/monkeys to use magic/arm-mounted guns

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -361,3 +361,8 @@ var/list/bloody_footprints_cache = list()
 
 //Just space
 #define SPACE_ICON_STATE	"[((x + y) ^ ~(x * y) + z) % 25]"
+
+//Gun trigger guards
+#define TRIGGER_GUARD_ALLOW_ALL -1
+#define TRIGGER_GUARD_NONE 0
+#define TRIGGER_GUARD_NORMAL 1

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -153,7 +153,7 @@
 /mob/living/carbon/human/can_use_guns(var/obj/item/weapon/gun/G)
 	. = ..()
 
-	if(G.trigger_guard)
+	if(G.trigger_guard == 1)
 		if(src.dna.check_mutation(HULK))
 			src << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 			return 0

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -153,7 +153,7 @@
 /mob/living/carbon/human/can_use_guns(var/obj/item/weapon/gun/G)
 	. = ..()
 
-	if(G.trigger_guard == 1)
+	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
 		if(src.dna.check_mutation(HULK))
 			src << "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>"
 			return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -968,7 +968,7 @@ Sorry Giacom. Please don't be mad :(
 		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
 	return
 /mob/living/proc/can_use_guns(var/obj/item/weapon/gun/G)
-	if (!IsAdvancedToolUser())
+	if (G.trigger_guard != -1 && !IsAdvancedToolUser())
 		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 0
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -968,7 +968,7 @@ Sorry Giacom. Please don't be mad :(
 		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
 	return
 /mob/living/proc/can_use_guns(var/obj/item/weapon/gun/G)
-	if (G.trigger_guard != -1 && !IsAdvancedToolUser())
+	if (G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser())
 		src << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 0
 	return 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -27,7 +27,7 @@
 	var/recoil = 0						//boom boom shake the room
 	var/clumsy_check = 1
 	var/obj/item/ammo_casing/chambered = null
-	var/trigger_guard = 1				//trigger guard on the weapon, hulks can't fire them with their big meaty fingers
+	var/trigger_guard = TRIGGER_GUARD_NORMAL	//trigger guard on the weapon, hulks can't fire them with their big meaty fingers
 	var/sawn_desc = null				//description change if weapon is sawn-off
 	var/sawn_state = SAWN_INTACT
 	var/burst_size = 1					//how large a burst is

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -38,7 +38,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
 	heavy_weapon = 1
 	can_flashlight = 0
-	trigger_guard = 0
+	trigger_guard = TRIGGER_GUARD_NONE
 	ammo_x_offset = 2
 
 /obj/item/weapon/gun/energy/gun/nuclear

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -16,7 +16,7 @@
 	var/no_den_usage
 	origin_tech = null
 	clumsy_check = 0
-	trigger_guard = 0
+	trigger_guard = -1 // Has no trigger at all, uses magic instead
 	pin = /obj/item/device/firing_pin/magic
 
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi' //not really a gun and some toys use these inhands

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -16,7 +16,7 @@
 	var/no_den_usage
 	origin_tech = null
 	clumsy_check = 0
-	trigger_guard = -1 // Has no trigger at all, uses magic instead
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses magic instead
 	pin = /obj/item/device/firing_pin/magic
 
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi' //not really a gun and some toys use these inhands

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -7,6 +7,7 @@
 	force = 5
 	selfcharge = 1
 	can_flashlight = 0
+	trigger_guard = -1 // Has no trigger at all, uses neural signals instead
 
 /obj/item/weapon/gun/energy/gun/advtaser/mounted/dropped()//if somebody manages to drop this somehow...
 	..()
@@ -20,6 +21,7 @@
 	item_state = "armcannonlase"
 	force = 5
 	selfcharge = 1
+	trigger_guard = -1
 
 /obj/item/weapon/gun/energy/laser/mounted/dropped()
 	..()

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -7,7 +7,7 @@
 	force = 5
 	selfcharge = 1
 	can_flashlight = 0
-	trigger_guard = -1 // Has no trigger at all, uses neural signals instead
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
 
 /obj/item/weapon/gun/energy/gun/advtaser/mounted/dropped()//if somebody manages to drop this somehow...
 	..()
@@ -21,7 +21,7 @@
 	item_state = "armcannonlase"
 	force = 5
 	selfcharge = 1
-	trigger_guard = -1
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/weapon/gun/energy/laser/mounted/dropped()
 	..()


### PR DESCRIPTION
I don't think arm cannons (restricted to adminspawn) and magic wands (restricted to wizard mode) should check dexterity.

Aliens would be unable to pick up magic wands on their own anyway due to w_class restriction. 
