### PR TITLE
Removes Assistants, Assistants are now only available when no other jobs are

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -329,7 +329,7 @@ var/datum/subsystem/job/SSjob
 	for(var/mob/new_player/player in unassigned)
 		if(PopcapReached())
 			RejectPlayer(player)
-		else if(player.client.prefs.userandomjob)
+		else
 			GiveRandomJob(player)
 
 	Debug("DO, Standard Check end")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN	8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX	13
+#define SAVEFILE_VERSION_MAX	14
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
 	This proc checks if the current directory of the savefile S needs updating
@@ -177,6 +177,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			else
 				backbag = DBACKPACK
 
+	job_civilian_low &= ~ASSISTANT
+
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
@@ -342,7 +344,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["deity_name"]			>> custom_names["deity"]
 
 	//Jobs
-	S["userandomjob"]		>> userandomjob
 	S["job_civilian_high"]	>> job_civilian_high
 	S["job_civilian_med"]	>> job_civilian_med
 	S["job_civilian_low"]	>> job_civilian_low
@@ -394,7 +395,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	features["spines"] 	= sanitize_inlist(features["spines"], spines_list)
 	features["body_markings"] 	= sanitize_inlist(features["body_markings"], body_markings_list)
 
-	userandomjob	= sanitize_integer(userandomjob, 0, 1, initial(userandomjob))
 	job_civilian_high = sanitize_integer(job_civilian_high, 0, 65535, initial(job_civilian_high))
 	job_civilian_med = sanitize_integer(job_civilian_med, 0, 65535, initial(job_civilian_med))
 	job_civilian_low = sanitize_integer(job_civilian_low, 0, 65535, initial(job_civilian_low))
@@ -452,7 +452,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["deity_name"]			<< custom_names["deity"]
 
 	//Jobs
-	S["userandomjob"]		<< userandomjob
 	S["job_civilian_high"]	<< job_civilian_high
 	S["job_civilian_med"]	<< job_civilian_med
 	S["job_civilian_low"]	<< job_civilian_low

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -340,6 +340,8 @@
 	dat += "<div class='jobs'><div class='jobsColumn'>"
 	var/job_count = 0
 	for(var/datum/job/job in SSjob.occupations)
+		if(job.title == "Assistant")
+			continue
 		if(job && IsJobAvailable(job.title))
 			job_count++;
 			if (job_count > round(available_job_count / 2))


### PR DESCRIPTION
Stems the tide once and for all!
Assistants are not a job. They can never be made fun by code, and often this leads to "greytiding". For every one gimmick assistant, there are probably about 4 more assistants who are just going to be shits for the sake of it.

Besides, everyone complaining about wasting job slots doing nothing:
Atmos Techs
Librarian
Lawyers
Cargo Techs
Chaplain
The third scientist
The chef(especially the second chef)
Clown and Mime
The second and third botanist slot.
Engineering after round start(set up the engine and then you are just a glorified assistant).
The third doctor.
Miners is a very chill job.

Also, new players learn NOTHING from being an assistant that they couldn't learn something more useful in another job.
:cl: KazeEspada
remove:Nanotrasen has made some budget cuts and is trying to improve efficiency of their stations, they have removed the ability to sign up as assistant unless all jobs are full.
/:cl:
