### PR TITLE
Health update from reagent metabolization now only happens once. Part 2

### DIFF
--- a/code/game/gamemodes/changeling/powers/adrenaline.dm
+++ b/code/game/gamemodes/changeling/powers/adrenaline.dm
@@ -20,35 +20,3 @@
 	feedback_add_details("changeling_powers","UNS")
 	return 1
 
-/datum/reagent/medicine/changelingAdrenaline
-	name = "Adrenaline"
-	id = "changelingAdrenaline"
-	description = "Reduces stun times. Also deals toxin damage at high amounts."
-	color = "#C8A5DC"
-	overdose_threshold = 30
-
-/datum/reagent/medicine/changelingAdrenaline/on_mob_life(mob/living/M as mob)
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
-	M.adjustStaminaLoss(-1)
-	..()
-	return
-
-/datum/reagent/medicine/changelingAdrenaline/overdose_process(mob/living/M as mob)
-	M.adjustToxLoss(1)
-	..()
-	return
-
-/datum/reagent/medicine/changelingAdrenaline2
-	name = "Adrenaline"
-	id = "changelingAdrenaline2"
-	description = "Drastically increases movement speed."
-	color = "#C8A5DC"
-	metabolization_rate = 1
-
-/datum/reagent/medicine/changelingAdrenaline2/on_mob_life(mob/living/M as mob)
-	M.status_flags |= GOTTAGOREALLYFAST
-	M.adjustToxLoss(2)
-	..()
-	return

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -417,31 +417,6 @@
 		S.start()
 	qdel(B)
 
-datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
-	name = "odd black liquid"
-	id = "blindness_smoke"
-	description = "<::ERROR::> CANNOT ANALYZE REAGENT <::ERROR::>"
-	color = "#000000" //Complete black (RGB: 0, 0, 0)
-	metabolization_rate = 100 //lel
-
-/datum/reagent/shadowling_blindness_smoke/on_mob_life(mob/living/M)
-	if(!M)
-		M = holder.my_atom
-	if(!is_shadow_or_thrall(M))
-		M << "<span class='warning'><b>You breathe in the black smoke, and your eyes burn horribly!</b></span>"
-		M.blind_eyes(5)
-		if(prob(25))
-			M.visible_message("<b>[M]</b> claws at their eyes!")
-			M.Stun(3)
-	else
-		M << "<span class='notice'><b>You breathe in the black smoke, and you feel revitalized!</b></span>"
-		M.heal_organ_damage(2,2)
-		M.adjustOxyLoss(-2)
-		M.adjustToxLoss(-2)
-	..()
-	return
-
-
 /obj/effect/proc_holder/spell/aoe_turf/unearthly_screech //Damages nearby windows, confuses nearby carbons, and outright stuns silly cones
 	name = "Sonic Screech"
 	desc = "Deafens, stuns, and confuses nearby people. Also shatters windows."

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -62,7 +62,7 @@
 		M << "<span class='notice'>[high_message]</span>"
 	M.AdjustParalysis(-1, 0)
 	M.AdjustStunned(-1, 0)
-	M.AdjustWeakened(-1, 0)
+	M.AdjustWeakened(-1, 0, 0)
 	..()
 	. = 1
 
@@ -160,7 +160,7 @@
 		M << "<span class='notice'>[high_message]</span>"
 	M.AdjustParalysis(-2, 0)
 	M.AdjustStunned(-2, 0)
-	M.AdjustWeakened(-2, 0)
+	M.AdjustWeakened(-2, 0, 0)
 	M.adjustStaminaLoss(-2, 0)
 	M.status_flags |= GOTTAGOREALLYFAST
 	M.Jitter(2)
@@ -237,7 +237,7 @@
 		M << "<span class='notice'>[high_message]</span>"
 	M.AdjustParalysis(-3, 0)
 	M.AdjustStunned(-3, 0)
-	M.AdjustWeakened(-3, 0)
+	M.AdjustWeakened(-3, 0, 0)
 	M.adjustStaminaLoss(-5, 0)
 	M.adjustBrainLoss(0.5)
 	M.adjustToxLoss(0.1, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1003,3 +1003,37 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	M.adjustStaminaLoss(2.5*REM, 0)
 	..()
 	. = 1
+
+//used for changeling's adrenaline power
+/datum/reagent/medicine/changelingAdrenaline
+	name = "Adrenaline"
+	id = "changelingAdrenaline"
+	description = "Reduces stun times. Also deals toxin damage at high amounts."
+	color = "#C8A5DC"
+	overdose_threshold = 30
+
+/datum/reagent/medicine/changelingAdrenaline/on_mob_life(mob/living/M as mob)
+	M.AdjustParalysis(-1, 0)
+	M.AdjustStunned(-1, 0)
+	M.AdjustWeakened(-1, 0)
+	M.adjustStaminaLoss(-1, 0)
+	. = 1
+	..()
+
+/datum/reagent/medicine/changelingAdrenaline/overdose_process(mob/living/M as mob)
+	M.adjustToxLoss(1, 0)
+	. = 1
+	..()
+
+/datum/reagent/medicine/changelingAdrenaline2
+	name = "Adrenaline"
+	id = "changelingAdrenaline2"
+	description = "Drastically increases movement speed."
+	color = "#C8A5DC"
+	metabolization_rate = 1
+
+/datum/reagent/medicine/changelingAdrenaline2/on_mob_life(mob/living/M as mob)
+	M.status_flags |= GOTTAGOREALLYFAST
+	M.adjustToxLoss(2, 0)
+	. = 1
+	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -80,7 +80,7 @@
 	M.drowsyness = max(M.drowsyness-5, 0)
 	M.AdjustParalysis(-1, 0)
 	M.AdjustStunned(-1, 0)
-	M.AdjustWeakened(-1, 0)
+	M.AdjustWeakened(-1, 0, 0)
 	if(holder.has_reagent("mindbreaker"))
 		holder.remove_reagent("mindbreaker", 5)
 	M.hallucination = max(0, M.hallucination - 10)
@@ -475,7 +475,7 @@
 	M.status_flags |= GOTTAGOFAST
 	M.AdjustParalysis(-1, 0)
 	M.AdjustStunned(-1, 0)
-	M.AdjustWeakened(-1, 0)
+	M.AdjustWeakened(-1, 0, 0)
 	M.adjustStaminaLoss(-1*REM, 0)
 	..()
 	. = 1
@@ -685,7 +685,7 @@
 	if(prob(20))
 		M.AdjustParalysis(-1, 0)
 		M.AdjustStunned(-1, 0)
-		M.AdjustWeakened(-1, 0)
+		M.AdjustWeakened(-1, 0, 0)
 	..()
 
 /datum/reagent/medicine/epinephrine/overdose_process(mob/living/M)
@@ -786,7 +786,7 @@
 		M.adjustFireLoss(-1*REM, 0)
 	M.AdjustParalysis(-3, 0)
 	M.AdjustStunned(-3, 0)
-	M.AdjustWeakened(-3, 0)
+	M.AdjustWeakened(-3, 0, 0)
 	M.adjustStaminaLoss(-5*REM, 0)
 	..()
 	. = 1
@@ -1015,7 +1015,7 @@ datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 /datum/reagent/medicine/changelingAdrenaline/on_mob_life(mob/living/M as mob)
 	M.AdjustParalysis(-1, 0)
 	M.AdjustStunned(-1, 0)
-	M.AdjustWeakened(-1, 0)
+	M.AdjustWeakened(-1, 0, 0)
 	M.adjustStaminaLoss(-1, 0)
 	. = 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -220,7 +220,7 @@
 		M.drowsyness = max(M.drowsyness-5, 0)
 		M.AdjustParalysis(-2, 0)
 		M.AdjustStunned(-2, 0)
-		M.AdjustWeakened(-2, 0)
+		M.AdjustWeakened(-2, 0, 0)
 	else
 		M.adjustToxLoss(2, 0)
 		M.adjustFireLoss(2, 0)
@@ -369,7 +369,7 @@
 	..()
 	H << "<span class='warning'><b>You crumple in agony as your flesh wildly morphs into new forms!</b></span>"
 	H.visible_message("<b>[H]</b> falls to the ground and screams as their skin bubbles and froths!") //'froths' sounds painful when used with SKIN.
-	H.Weaken(3)
+	H.Weaken(3, 0, 0)
 	spawn(30)
 		if(!H || qdeleted(H))
 			return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1163,3 +1163,27 @@
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
+
+//Reagent used for shadowling blindness smoke spell
+datum/reagent/shadowling_blindness_smoke
+	name = "odd black liquid"
+	id = "blindness_smoke"
+	description = "<::ERROR::> CANNOT ANALYZE REAGENT <::ERROR::>"
+	color = "#000000" //Complete black (RGB: 0, 0, 0)
+	metabolization_rate = 100 //lel
+
+/datum/reagent/shadowling_blindness_smoke/on_mob_life(mob/living/M)
+	if(!is_shadow_or_thrall(M))
+		M << "<span class='warning'><b>You breathe in the black smoke, and your eyes burn horribly!</b></span>"
+		M.blind_eyes(5)
+		if(prob(25))
+			M.visible_message("<b>[M]</b> claws at their eyes!")
+			M.Stun(3, 0)
+			. = 1
+	else
+		M << "<span class='notice'><b>You breathe in the black smoke, and you feel revitalized!</b></span>"
+		M.heal_organ_damage(2,2, 0)
+		M.adjustOxyLoss(-2, 0)
+		M.adjustToxLoss(-2, 0)
+		. = 1
+	return ..() || .


### PR DESCRIPTION
Moved changeling adrenaline and shadowling blindness smoke reagent to the proper reagent files.

Fixes these two reagents calling mob update procs when they shouldn't. I forgot to change these in #15791 , because they were not in any proper reagent files.

Also fixes incorrect arguments given to Weaken() and adjustWeakened() in some cases.
