### PR TITLE
#Make Xenos Great Again

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -298,8 +298,8 @@
 #define BURSTING 1
 #define GROWING 2
 #define GROWN 3
-#define MIN_GROWTH_TIME 1800	//time it takes to grow a hugger
-#define MAX_GROWTH_TIME 3000
+#define MIN_GROWTH_TIME 1200	//time it takes to grow a hugger
+#define MAX_GROWTH_TIME 2100
 
 /obj/structure/alien/egg
 	name = "egg"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -49,7 +49,7 @@
 
 /mob/living/carbon/alien/adjustFireLoss(amount) // Weak to Fire
 	if(amount > 0)
-		..(amount * 2)
+		..(amount * 1.5)
 	else
 		..(amount)
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -179,7 +179,7 @@ Doesn't work on other aliens/AI.*/
 /obj/effect/proc_holder/alien/neurotoxin
 	name = "Spit Neurotoxin"
 	desc = "Spits neurotoxin at someone, paralyzing them for a short time."
-	plasma_cost = 35
+	plasma_cost = 30
 	action_icon_state = "alien_neurotoxin"
 
 /obj/effect/proc_holder/alien/neurotoxin/fire(mob/living/carbon/alien/user)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -179,7 +179,7 @@ Doesn't work on other aliens/AI.*/
 /obj/effect/proc_holder/alien/neurotoxin
 	name = "Spit Neurotoxin"
 	desc = "Spits neurotoxin at someone, paralyzing them for a short time."
-	plasma_cost = 50
+	plasma_cost = 35
 	action_icon_state = "alien_neurotoxin"
 
 /obj/effect/proc_holder/alien/neurotoxin/fire(mob/living/carbon/alien/user)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -52,12 +52,7 @@
 		src << "<span class='alertalien'>It is unsafe to leap without gravity!</span>"
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
-	if(user.getPlasma() < plasma_cost)
-		if(!silent)
-			user << "<span class='noticealien'>Not enough plasma stored.</span>"
-		return 0
-	else // Added plasma cost for balance
-		user.adjustPlasma(-15)
+	else // Hoping to add plasma cost for balance plz halp
 		leaping = 1
 		update_icons()
 		throw_at(A,MAX_ALIEN_LEAP_DIST,1, spin=0, diagonals_first = 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -18,6 +18,9 @@
 //Hunter verbs
 
 /mob/living/carbon/alien/humanoid/hunter/proc/toggle_leap(message = 1)
+	if(pounce_cooldown)
+		src << "<span class='alertalien'>You are too fatigued to pounce right now!</span>"
+		return
 	leap_on_click = !leap_on_click
 	leap_icon.icon_state = "leap_[leap_on_click ? "on":"off"]"
 	update_icons()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -52,9 +52,12 @@
 		src << "<span class='alertalien'>It is unsafe to leap without gravity!</span>"
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
-
+	if(user.getPlasma() < plasma_cost)
+		if(!silent)
+			user << "<span class='noticealien'>Not enough plasma stored.</span>"
+		return 0
 	else // Added plasma cost for balance
-		plasma_cost = 15
+		user.adjustPlasma(-15)
 		leaping = 1
 		update_icons()
 		throw_at(A,MAX_ALIEN_LEAP_DIST,1, spin=0, diagonals_first = 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -25,7 +25,7 @@
 	leap_icon.icon_state = "leap_[leap_on_click ? "on":"off"]"
 	update_icons()
 	if(message)
-		src << "<span class='noticealien'>You will now [leap_on_click ? "leap at":"slash at"] enemies!</span>"
+		src << "<span class='noticealien'>You will now [leap_on_click ? "metabolize plasma to leap at":"slash at"] enemies!</span>"
 	else
 		return
 
@@ -53,7 +53,8 @@
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
 
-	else //Maybe uses plasma in the future, although that wouldn't make any sense...
+	else // Added plasma cost for balance
+		plasma_cost = 15
 		leaping = 1
 		update_icons()
 		throw_at(A,MAX_ALIEN_LEAP_DIST,1, spin=0, diagonals_first = 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -5,6 +5,7 @@
 	health = 125
 	icon_state = "alienh_s"
 	var/obj/screen/leap_icon = null
+	var/plasma_cost = 0
 
 /mob/living/carbon/alien/humanoid/hunter/New()
 	internal_organs += new /obj/item/organ/internal/alien/plasmavessel/small
@@ -54,6 +55,7 @@
 		return
 	
 	else // Hoping to add plasma cost for balance plz halp
+		plasma_cost = 15
 		leaping = 1
 		update_icons()
 		throw_at(A,MAX_ALIEN_LEAP_DIST,1, spin=0, diagonals_first = 1)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -52,6 +52,7 @@
 		src << "<span class='alertalien'>It is unsafe to leap without gravity!</span>"
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
+	
 	else // Hoping to add plasma cost for balance plz halp
 		leaping = 1
 		update_icons()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/royal/praetorian
 	name = "alien praetorian"
 	caste = "p"
-	maxHealth = 250
-	health = 250
+	maxHealth = 300
+	health = 300
 	icon_state = "alienp"
 
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -9,7 +9,7 @@
 	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
 	var/leap_on_click = 0
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 100
+	var/pounce_cooldown_time = 50
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0
 	var/sneaking = 0 //For sneaky-sneaky mode and appropriate slowdown

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -9,7 +9,7 @@
 	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
 	var/leap_on_click = 0
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 30
+	var/pounce_cooldown_time = 100
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0
 	var/sneaking = 0 //For sneaky-sneaky mode and appropriate slowdown

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -48,7 +48,7 @@
 
 /mob/living/carbon/alien/humanoid/royal/queen/movement_delay()
 	. = ..()
-	. += 5
+	. += 1
 
 
 //Queen verbs

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -51,7 +51,7 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
-	if(stage < 5 && prob(3))
+	if(stage < 5 && prob(4))
 		stage++
 		spawn(0)
 			RefreshInfectionImage()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -2,8 +2,8 @@
 
 //TODO: Make these simple_animals
 
-var/const/MIN_IMPREGNATION_TIME = 100 //time it takes to impregnate someone
-var/const/MAX_IMPREGNATION_TIME = 150
+var/const/MIN_IMPREGNATION_TIME = 60 //time it takes to impregnate someone
+var/const/MAX_IMPREGNATION_TIME = 120
 
 var/const/MIN_ACTIVE_TIME = 200 //time between being dropped and going idle
 var/const/MAX_ACTIVE_TIME = 400

--- a/code/modules/mob/living/carbon/human/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/human/human_attackalien.dm
@@ -30,7 +30,7 @@
 
 		if(M.a_intent == "disarm")
 			var/randn = rand(1, 100)
-			if (randn <= 80)
+			if (randn <= 100)	// Set to 100 to remove disarm/miss chance
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				Weaken(5)
 				add_logs(M, src, "tackled")

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -171,7 +171,7 @@
 /obj/item/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
-	damage = 10
+	damage = 15
 	damage_type = TOX
 	weaken = 3
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -171,9 +171,9 @@
 /obj/item/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
-	damage = 5
+	damage = 10
 	damage_type = TOX
-	weaken = 5
+	weaken = 3
 
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = 0)
 	if(isalien(target))

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -340,10 +340,10 @@
 	name = "Tail Sweep"
 	desc = "Throw back attackers with a sweep of your tail."
 	sound = 'sound/magic/Tail_swing.ogg'
-	charge_max = 150
+	charge_max = 300
 	clothes_req = 0
-	range = 2
-	cooldown_min = 150
+	range = 3
+	cooldown_min = 300
 	invocation_type = "none"
 	animation = "tailsweep"
 	action_icon_state = "tailsweep"
@@ -354,4 +354,19 @@
 		var/mob/living/carbon/C = user
 		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1)
 		C.spin(6,1)
+	for(var/atom/movable/AM in thrownatoms)
+		if(distfromcaster == 0)
+			if(istype(AM, /mob/living))
+				var/mob/living/M = AM
+				M.Weaken(5)
+				M.adjustBruteLoss(20)
+				M << "<span class='userdanger'>You're slammed into the floor by the [user]'s tail!</span>"
+		else
+			if(istype(AM, /mob/living))
+				var/mob/living/M = AM
+				M.Weaken(4)
+				M.adjustBruteLoss(10)
+				M << "<span class='userdanger'>You're thrown back by the [user]'s tail!</span>"
+			AM.throw_at_fast(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
+	
 	..()

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -354,19 +354,36 @@
 		var/mob/living/carbon/C = user
 		playsound(C.loc, 'sound/voice/hiss5.ogg', 80, 1, 1)
 		C.spin(6,1)
+	var/list/thrownatoms = list()
+	var/atom/throwtarget
+	var/distfromcaster
+	playMagSound()
+	for(var/turf/T in targets) //Done this way so things don't get thrown all around hilariously.
+		for(var/atom/movable/AM in T)
+			thrownatoms += AM
+
 	for(var/atom/movable/AM in thrownatoms)
+		if(AM == user || AM.anchored) continue
+
+		var/obj/effect/overlay/targeteffect	= new /obj/effect/overlay{icon='icons/effects/effects.dmi'; icon_state="shieldsparkles"; mouse_opacity=0; density = 0}()
+		targeteffect.icon_state = animation
+		AM.overlays += targeteffect
+		throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(AM, user)))
+		distfromcaster = get_dist(user, AM)
+		spawn(10)
+			AM.overlays -= targeteffect
+			qdel(targeteffect)
 		if(distfromcaster == 0)
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
-				M.Weaken(5)
+				M.Weaken(7)
 				M.adjustBruteLoss(20)
 				M << "<span class='userdanger'>You're slammed into the floor by the [user]'s tail!</span>"
 		else
 			if(istype(AM, /mob/living))
 				var/mob/living/M = AM
-				M.Weaken(4)
+				M.Weaken(5)
 				M.adjustBruteLoss(10)
 				M << "<span class='userdanger'>You're thrown back by the [user]'s tail!</span>"
 			AM.throw_at_fast(throwtarget, ((Clamp((maxthrow - (Clamp(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
-	
 	..()


### PR DESCRIPTION
Took a look at the state of xenos and was ashamed. These guys are treated as game-enders but against a competent crew they're glorified target practice.

Issues: 
- RNG tackle is bad. I hope I don't have to explain why its awful when masked/armored crew have to be held down for like 20 seconds while you strip helm, strip mask, apply facehugger. It's tolerable when facehuggers used to rip off helmets/masks but that's not the case anymore.
- Xeno survivabliity has fallen to science powercreep. Even putting the easier research and ORM+reduced cost memes aside, science has a LOT of toys now and that attracts more players to learn it, which in turn means that its much more common for someone to have RND ready when xenos show up. Laser cannons were the biggest issue I had with this PR. Xenos feel ok against lasers right now but the cannons screw everything up. 40 damage base, with a 2x modifier = lel just killed the queen in 5 shots. Reduced the burn modifier to 1.5x to make xenos a little heartier.
- Sentinels just feel underwhelming. They are nest guards but their only formidable tool is the spit, which had a high cost but you can't aim it. It was like a ghetto taser with a slow recharge. I reduced the cost, bumped down the stun to compensate for them getting full tackles again, and made it hurt just a little more. 
- Queens are a bad joke. Partially due to the xeno survivability issue, but also as a threat itself. The queen should feel like a boss, not a free kill waiting to be gunned down once you've cleared the guards. I decided not to touch her speed, but instead buffed the tail sweep so that it actually offers a reasonable stun with increased range. If a queen is holed up in a room you might actually have to exercise some caution now instead of just "WEW LADS" and sprinting with laser spam. Also makes praetorians more intimidating than just a giant sentinel. Cooldown was doubled to compensate for tail sweep actually being good now.
- Hunters are in a decent spot but this change certainly helps them. To compensate I've increased the leap cooldown and given it a 15 plasma cost. One of the biggest issues with hunters before was that they never used plasma and thus would immediately start regenerating as soon as they were on weeds. Unlike the plasma-spending castes who might have to wait a minute or longer before they've recharged plasma and the healing can begin, hunters were always at 100%. This was frustrating to people because you could pop a few lasers into a hunter, have it run and hide, and less than a minute later its back out terrorizing at full health. Incorporating a plasma cost means that hunters will have a longer recovery time when they are wounded. It also skillful leaping as opposed to the current system of "leap down the hallway and fuck up the first thing you touch". 
- The whole egg/larva/infest/burst/evolve process just takes too much time and RNG right now. Hives losing queens just got even more devastating, don't need a 20 minute downtime for a survivor drone to get a new brood started. These are modest decreases for most stages, but as a total it should shave a couple minutes of waiting around. 

Conclusion: These xenos will end games again, but without being preposterously OP. Las cannons will still ruin xenos, fires will still force them into space, all the fundamental mechanics are there but with enough changes to make them a threat. 
