### PR TITLE
Robustin-Sponsored Blobbernaut Nerf PR

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -15,6 +15,7 @@
 	maxbodytemp = 360
 	unique_name = 1
 	var/mob/camera/blob/overmind = null
+	var/obj/effect/blob/factory/factory = null
 
 /mob/living/simple_animal/hostile/blob/update_icons()
 	if(overmind)
@@ -76,7 +77,6 @@
 	attack_sound = 'sound/weapons/genhit1.ogg'
 	flying = 1
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
-	var/obj/effect/blob/factory/factory = null
 	var/list/human_overlays = list()
 	var/is_zombie = 0
 	gold_core_spawnable = 1
@@ -182,7 +182,7 @@
 	health = 200
 	maxHealth = 200
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
-	next_move_modifier = 2 //slow-ass attack speed, 4 times higher than how fast the blob can attack
+	next_move_modifier = 1.5 //slow-ass attack speed, 3 times higher than how fast the blob can attack
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attacktext = "slams"
@@ -204,8 +204,14 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life()
 	if(..())
+		var/damagesources
 		if(!(locate(/obj/effect/blob) in range(2, src)))
-			adjustHealth(maxHealth*0.025) //take 2.5% maxhealth as damage when not near the blob
+			damagesources++
+		if(!factory)
+			damagesources++
+		if(damagesources)
+			for(var/i in 1 to damagesources)
+				adjustHealth(maxHealth*0.025) //take 2.5% maxhealth as damage when not near the blob or if the naut has no factory, 5% if both
 			var/list/viewing = list()
 			for(var/mob/M in viewers(src))
 				if(M.client)
@@ -242,4 +248,7 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/death(gibbed)
 	..(gibbed)
+	if(factory)
+		factory.naut = null //remove this naut from its factory
+		factory.maxhealth = initial(factory.maxhealth)
 	flick("blobbernaut_death", src)

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -192,7 +192,6 @@
 	verb_exclaim = "roars"
 	verb_yell = "bellows"
 	force_threshold = 10
-	speed = 2
 	pressure_resistance = 40
 	mob_size = MOB_SIZE_LARGE
 	see_invisible = SEE_INVISIBLE_MINIMUM
@@ -204,7 +203,7 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life()
 	if(..())
-		var/damagesources
+		var/damagesources = 0
 		if(!(locate(/obj/effect/blob) in range(2, src)))
 			damagesources++
 		if(!factory)

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -182,6 +182,7 @@
 	health = 200
 	maxHealth = 200
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
+	next_move_modifier = 2 //slow-ass attack speed, 4 times higher than how fast the blob can attack
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attacktext = "slams"
@@ -191,6 +192,7 @@
 	verb_exclaim = "roars"
 	verb_yell = "bellows"
 	force_threshold = 10
+	speed = 2
 	pressure_resistance = 40
 	mob_size = MOB_SIZE_LARGE
 	see_invisible = SEE_INVISIBLE_MINIMUM

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -19,6 +19,7 @@
 			spore.factory = null
 	if(naut)
 		naut.factory = null
+		naut << "<span class='userdanger'>Your factory was destroyed! You feel yourself dying!</span>"
 	spores = null
 	return ..()
 

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -8,6 +8,7 @@
 	health_regen = 1
 	point_return = 25
 	var/list/spores = list()
+	var/mob/living/simple_animal/hostile/blob/blobbernaut/naut = null
 	var/max_spores = 3
 	var/spore_delay = 0
 
@@ -16,6 +17,8 @@
 	for(var/mob/living/simple_animal/hostile/blob/blobspore/spore in spores)
 		if(spore.factory == src)
 			spore.factory = null
+	if(naut)
+		naut.factory = null
 	spores = null
 	return ..()
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -86,19 +86,22 @@
 	if(B.naut) //if it already made a blobbernaut, it can't do it again
 		src << "<span class='warning'>This factory blob is already sustaining a blobbernaut.</span>"
 		return
+	if(B.health < B.maxhealth * 0.5)
+		src << "<span class='warning'>This factory blob is too damaged to sustain a blobbernaut.</span>"
+		return
 	if(!can_buy(30))
 		return
-	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
 	B.maxhealth = initial(B.maxhealth) * 0.25 //factories that produced a blobbernaut have much lower health
-	B.health = B.maxhealth
+	B.check_health()
 	B.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
 	B.spore_delay = world.time + 600 //one minute before it can spawn spores again
-	B.naut = blobber
 	playsound(B.loc, 'sound/effects/splat.ogg', 50, 1)
+	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
+	flick("blobbernaut_produce", blobber)
+	B.naut = blobber
 	blobber.factory = B
 	blobber.overmind = src
 	blobber.update_icons()
-	flick("blobbernaut_produce", blobber)
 	blobber.notransform = 1 //stop the naut from moving around
 	blob_mobs.Add(blobber)
 	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as a [blob_reagent_datum.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50) //players must answer rapidly

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -83,16 +83,19 @@
 	if(!B)
 		src << "<span class='warning'>You must be on a factory blob!</span>"
 		return
-	if(B.health <= B.maxhealth*0.8) //if it's at less than 80% of its health, you can't blobbernaut it
-		src << "<span class='warning'>This factory blob is too damaged to produce a blobbernaut.</span>"
+	if(B.naut) //if it already made a blobbernaut, it can't do it again
+		src << "<span class='warning'>This factory blob is already sustaining a blobbernaut.</span>"
 		return
 	if(!can_buy(30))
 		return
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobber = new /mob/living/simple_animal/hostile/blob/blobbernaut(get_turf(B))
-	B.take_damage(B.maxhealth*0.8, CLONE, null, 0) //take a bunch of damage, so you can't produce tons of blobbernauts from a single factory
+	B.maxhealth = initial(B.maxhealth) * 0.25 //factories that produced a blobbernaut have much lower health
+	B.health = B.maxhealth
 	B.visible_message("<span class='warning'><b>The blobbernaut [pick("rips", "tears", "shreds")] its way out of the factory blob!</b></span>")
 	B.spore_delay = world.time + 600 //one minute before it can spawn spores again
+	B.naut = blobber
 	playsound(B.loc, 'sound/effects/splat.ogg', 50, 1)
+	blobber.factory = B
 	blobber.overmind = src
 	blobber.update_icons()
 	flick("blobbernaut_produce", blobber)
@@ -107,7 +110,7 @@
 		blobber << 'sound/effects/blobattack.ogg'
 		blobber << 'sound/effects/attackblob.ogg'
 		blobber << "<b>You are a blobbernaut!</b>"
-		blobber << "You are powerful, hard to kill, and slowly regenerate near nodes and cores, but will slowly die if not near the blob."
+		blobber << "You are powerful, hard to kill, and slowly regenerate near nodes and cores, but will slowly die if not near the blob or if the factory that made you is killed."
 		blobber << "You can communicate with other blobbernauts and overminds via <b>:b</b>"
 		blobber << "Your overmind's blob reagent is: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
 		blobber << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]"
@@ -245,7 +248,7 @@
 	src << "<i>Shield Blobs</i> are strong and expensive blobs which take more damage. In additon, they are fireproof and can block air, use these to protect yourself from station fires."
 	src << "<i>Resource Blobs</i> are blobs which produce more resources for you, build as many of these as possible to consume the station. This type of blob must be placed near node blobs or your core to work."
 	src << "<i>Factory Blobs</i> are blobs that spawn blob spores which will attack nearby enemies. This type of blob must be placed near node blobs or your core to work."
-	src << "<i>Blobbernauts</i> can be produced from factories for a cost, and are hard to kill, powerful, and moderately smart. The factory used to create one will become briefly fragile and unable to produce spores."
+	src << "<i>Blobbernauts</i> can be produced from factories for a cost, and are hard to kill, powerful, and moderately smart. The factory used to create one will become fragile and briefly unable to produce spores."
 	src << "<i>Node Blobs</i> are blobs which grow, like the core. Like the core it can activate resource and factory blobs."
 	src << "<b>In addition to the buttons on your HUD, there are a few click shortcuts to speed up expansion and defense.</b>"
 	src << "<b>Shortcuts:</b> Click = Expand Blob <b>|</b> Middle Mouse Click = Rally Spores <b>|</b> Ctrl Click = Create Shield Blob <b>|</b> Alt Click = Remove Blob"


### PR DESCRIPTION
:cl: Joan
tweak: Blobbernauts now attack much slower.
tweak: Blobbernauts are now maximum one per factory, reduce that factory's health drastically, and die slowly if that factory is destroyed.
experiment: Factories must still have above 50% health to produce blobbernauts.
/:cl:

Blobbernauts have 50% higher click delay, and thus attack three times slower than the blob does.
