### PR TITLE
One person can now have multiple holoparasites.

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -614,10 +614,6 @@
 	var/random = TRUE
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
-	for(var/mob/living/simple_animal/hostile/guardian/G in living_mob_list)
-		if (G.summoner == user)
-			user << "You already have a [mob_name]!"
-			return
 	if(user.mind && user.mind.changeling)
 		user << "[ling_failure]"
 		return


### PR DESCRIPTION
I figured this would be a fun addition, they all take health from the same person so if you somehow get more than one it's more targets anyway, so probably not too overpowered. Having a dedicated healing holo might get a bit strong though.

And a traitor can't buy more than normally 1 except by pure luck, so if you somehow get more than one  you should be able to use it, it's silly getting another holo injector is completely useless if you already have one.
