### PR TITLE
Loyalty Implants removed from cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -313,12 +313,13 @@
 					/obj/item/ammo_box/magazine/wt550m9)
 	crate_name = "auto rifle ammo crate"
 
+/*
 /datum/supply_pack/security/armory/loyalty
 	name = "Loyalty Implants Crate"
 	cost = 40
 	contains = list(/obj/item/weapon/storage/lockbox/loyalty)
 	crate_name = "loyalty implant crate"
-
+*/
 /datum/supply_pack/security/armory/trackingimp
 	name = "Tracking Implants Crate"
 	cost = 20


### PR DESCRIPTION
By which I mean security starts with their 8 implants, and that is it. No more extra from cargo.

I think that the order implants/tase everyone/implant everyone metagame for conversion modes is very boring. Cutting security off cold turkey would also be bad though (or maybe not so much bad as anger inducing), so they still have a few spare to start the round.

I plan to test merge this. Admins are obviously going to have to play along and give security some extra leeway during conversion modes, and crew some extra leeway to kill security if they decide to just murder everyone.

EDIT: Maybe I should do this the other way around and have them be a cargo crate but not something they start with? Or just drop the whole thing, it'll probably just cause tears.
