### PR TITLE
Blobs can now attack mobs on top of blob tiles

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -162,24 +162,31 @@
 /mob/camera/blob/proc/expand_blob(turf/T)
 	if(!can_attack())
 		return
-	var/obj/effect/blob/B = locate() in T
-	if(B)
-		src << "<span class='warning'>There is a blob there!</span>"
-		return
 	var/obj/effect/blob/OB = locate() in circlerange(T, 1)
 	if(!OB)
 		src << "<span class='warning'>There is no blob adjacent to the target tile!</span>"
 		return
-	if(!can_buy(5))
-		return
-	last_attack = world.time
-	OB.expand(T, src)
-	for(var/mob/living/L in T)
-		if("blob" in L.faction) //no friendly fire
-			continue
-		var/mob_protection = L.get_permeability_protection()
-		blob_reagent_datum.reaction_mob(L, VAPOR, 25, 1, mob_protection, src)
-		blob_reagent_datum.send_message(L)
+	if(can_buy(5))
+		var/attacksuccess = FALSE
+		last_attack = world.time
+		for(var/mob/living/L in T)
+			if("blob" in L.faction) //no friendly/dead fire
+				continue
+			if(L.stat != DEAD)
+				attacksuccess = TRUE
+				var/mob_protection = L.get_permeability_protection()
+				blob_reagent_datum.reaction_mob(L, VAPOR, 25, 1, mob_protection, src)
+				blob_reagent_datum.send_message(L)
+		var/obj/effect/blob/B = locate() in T
+		if(B)
+			if(attacksuccess) //if we successfully attacked a turf with a blob on it, don't refund shit
+				B.blob_attack_animation(T, src)
+			else
+				src << "<span class='warning'>There is a blob there!</span>"
+				add_points(5) //otherwise, refund all of the cost
+			return
+		else
+			OB.expand(T, src)
 
 /mob/camera/blob/verb/rally_spores_power()
 	set category = "Blob"


### PR DESCRIPTION
:cl: Joan
rscadd: Blobs can now attack people that end up on top of blob tiles with Left-Click or the Expand/Attack Blob verb.
/:cl:

Fixes #15297
Fuck healing viruses, holy shit.
This is a slight change to the damage application which I'm pretty sure is unavoidable; it'll do chem effects -> blob_act() where it was previously blob_act() -> chem effects, so chems that do things based on mob health(Zombifying Feelers/Adaptive Nexuses) will do it before blob_act()'s damage.
It also no longer applies effects to dead mobs, because uh, >sorium blob
