### PR TITLE
Blobbernaut damage glow is more visible

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -215,8 +215,8 @@
 			for(var/mob/M in viewers(src))
 				if(M.client)
 					viewing += M.client
-			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.1)
-			I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
+			I.appearance_flags = RESET_COLOR
 			if(overmind)
 				I.color = overmind.blob_reagent_datum.complementary_color
 			flick_overlay(I, viewing, 8)

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -215,7 +215,11 @@
 			for(var/mob/M in viewers(src))
 				if(M.client)
 					viewing += M.client
-			flick_overlay(image('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.1), viewing, 8)
+			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.1)
+			I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+			if(overmind)
+				I.color = overmind.blob_reagent_datum.complementary_color
+			flick_overlay(I, viewing, 8)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/adjustHealth(amount)
 	. = ..()


### PR DESCRIPTION
This makes it more visible on all blob types, instead of being super visible on all the blue-green blob types and nearly invisible on red-purple blob types.
