### PR TITLE
Plasmaman tank improvements

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -113,7 +113,7 @@
  */
 
 /obj/item/weapon/tank/internals/plasmaman
-	name = "breathing plasma tank"
+	name = "plasma tank"
 	desc = "A tank of plasma gas."
 	icon_state = "plasmaman_tank"
 	item_state = "plasmaman_tank"
@@ -134,7 +134,6 @@
 
 
 /obj/item/weapon/tank/internals/plasmaman/belt
-	desc = "A tank of plasma gas designed to provide breathing gas for plasmamen."
 	icon_state = "plasmaman_tank_belt"
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_BELT

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -113,7 +113,7 @@
  */
 
 /obj/item/weapon/tank/internals/plasmaman
-	name = "plasma tank"
+	name = "plasmaman plasma tank"
 	desc = "A tank of plasma gas."
 	icon_state = "plasmaman_tank"
 	item_state = "plasmaman_tank"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -113,9 +113,12 @@
  */
 
 /obj/item/weapon/tank/internals/plasmaman
+	name = "breathing plasma tank"
+	desc = "A tank of plasma gas."
 	icon_state = "plasmaman_tank"
 	item_state = "plasmaman_tank"
 	force = 10
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 
 /obj/item/weapon/tank/internals/plasmaman/New()
 	..()
@@ -131,6 +134,7 @@
 
 
 /obj/item/weapon/tank/internals/plasmaman/belt
+	desc = "A tank of plasma gas designed to provide breathing gas for plasmamen."
 	icon_state = "plasmaman_tank_belt"
 	item_state = "plasmaman_tank_belt"
 	slot_flags = SLOT_BELT


### PR DESCRIPTION
The following changes will apply to both the back-slot tank and the belt-slot tank:
- The plasmaman tank is no longer named 'tank'; it now has the name 'plasmaman plasma tank';
- The plasmaman tank now has a description: 'A tank of plasma gas.'
- The plasmaman tank has a distribution pressure of TANK_DEFAULT_RELEASE_PRESSURE, same as oxygen tanks.
