### PR TITLE
Not voting no longer counts towards anything.

### DIFF
--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -54,19 +54,6 @@ var/datum/subsystem/vote/SSvote
 		total_votes += votes
 		if(votes > greatest_votes)
 			greatest_votes = votes
-	//default-vote for everyone who didn't vote
-	if(!config.vote_no_default && choices.len)
-		var/non_voters = (clients.len - total_votes)
-		if(non_voters > 0)
-			if(mode == "restart")
-				//choices["Continue Playing"] += non_voters
-				if(choices["Continue Playing"] >= greatest_votes)
-					greatest_votes = choices["Continue Playing"]
-			else if(mode == "gamemode")
-				if(master_mode in choices)
-					//choices[master_mode] += non_voters
-					if(choices[master_mode] >= greatest_votes)
-						greatest_votes = choices[master_mode]
 	//get all options with that many votes and return them in a list
 	. = list()
 	if(greatest_votes)

--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -59,12 +59,12 @@ var/datum/subsystem/vote/SSvote
 		var/non_voters = (clients.len - total_votes)
 		if(non_voters > 0)
 			if(mode == "restart")
-				choices["Continue Playing"] += non_voters
+				//choices["Continue Playing"] += non_voters
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
 			else if(mode == "gamemode")
 				if(master_mode in choices)
-					choices[master_mode] += non_voters
+					//choices[master_mode] += non_voters
 					if(choices[master_mode] >= greatest_votes)
 						greatest_votes = choices[master_mode]
 	//get all options with that many votes and return them in a list


### PR DESCRIPTION
This is a important change for several reasons. As is, AFK people and people in the lobby count towards not restarting/not choosing a gamemode, which is silly.

And, since most people don't bother voting, restart votes almost never succeed.

This changes it so that not voting no longer counts as if you voted for any particular option. People who don't vote simply don't vote.
