### PR TITLE
Makes plasmamen incompatible with DNA scanners and makes them stop burning after a while.

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -369,6 +369,9 @@
 	if (find_record("ckey", subject.ckey, records))
 		scantemp = "<font class='average'>Subject already in database.</font>"
 		return
+	if (subject.dna.species.id == "plasmaman")
+		scantemp = "<font class='bad'>Subject genetic structure incompatible. Cloning of this species impossible.</font>"
+		return
 
 	var/datum/data/record/R = new()
 	if(subject.dna.species)

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -85,7 +85,7 @@
 	if(connected && connected.is_operational())
 		if(connected.occupant)	//set occupant_status message
 			viable_occupant = connected.occupant
-			if(viable_occupant.has_dna() && (!(viable_occupant.disabilities & NOCLONE) || (connected.scan_level == 3)))	//occupent is viable for dna modification
+			if(viable_occupant.has_dna() && !(viable_occupant.dna.species.id == "plasmaman") && (!(viable_occupant.disabilities & NOCLONE) || (connected.scan_level == 3)))	//occupent is viable for dna modification
 				occupant_status += "[viable_occupant.name] => "
 				switch(viable_occupant.stat)
 					if(CONSCIOUS)
@@ -528,7 +528,7 @@
 	var/mob/living/carbon/viable_occupant = null
 	if(connected)
 		viable_occupant = connected.occupant
-		if(!istype(viable_occupant) || !viable_occupant.dna || (viable_occupant.disabilities & NOCLONE))
+		if(!istype(viable_occupant) || !viable_occupant.dna || (viable_occupant.disabilities & NOCLONE) || (viable_occupant.dna.species.id == "plasmaman"))
 			viable_occupant = null
 	return viable_occupant
 

--- a/code/modules/food&drinks/food/snacks/meat.dm
+++ b/code/modules/food&drinks/food/snacks/meat.dm
@@ -98,6 +98,14 @@
 	filling_color = "#F0F0F0"
 	slice_path = null  //can't slice a bone into cutlets
 
+/obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/plasma
+	name = "-plasmabone"
+	icon_state = "skeletonmeat"
+	desc = "A bone infused with plasma."
+	filling_color = "#660056"
+	list_reagents = list("nutriment" = 3,"plasma" = 3)
+	slice_path = null  //can't slice a bone into cutlets
+
 /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	name = "-meat (rotten)"
 	icon_state = "lizardmeat" //Close enough.

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -482,7 +482,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	id = "plasmaman"
 	say_mod = "rattles"
 	sexes = 0
-	meat = /obj/item/stack/sheet/mineral/plasma
+	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/plasma
 	specflags = list(NOBLOOD,RADIMMUNE,NOTRANSSTING,VIRUSIMMUNE)
 	safe_oxygen_min = 0 //We don't breath this
 	safe_toxins_min = 16 //We breath THIS!
@@ -511,7 +511,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/datum/gas_mixture/environment = H.loc.return_air()
 
-	if(!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman))
+	if(!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) && (H.stat != DEAD))
 		if(environment)
 			var/total_moles = environment.total_moles()
 			if(total_moles)
@@ -526,6 +526,13 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 			if(istype(P))
 				P.Extinguish(H)
 	H.update_fire()
+
+/datum/species/plasmaman/spec_death(gibbed, mob/living/carbon/human/H)//Single life hard mode species.
+	if(H && !gibbed && !H.mind.changeling)//Note: add plasmamen to restricted species for ling post datum antags. This will have to do for now.
+		for(var/obj/item/W in H)
+			H.unEquip(W)
+		H.visible_message("<span class='warning'>[H]'s body crumbles away!</span>")
+		H.dust()
 
 /datum/species/plasmaman/before_equip_job(datum/job/J, mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/datum/outfit/plasmaman/O = new /datum/outfit/plasmaman

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -511,7 +511,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/datum/gas_mixture/environment = H.loc.return_air()
 
-	if(!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) && (H.stat != DEAD))
+	if((!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman)) && !((H.getBruteLoss() + H.getFireLoss() >= 180) || (world.time - H.timeofdeath > 1200)))
 		if(environment)
 			var/total_moles = environment.total_moles()
 			if(total_moles)
@@ -527,13 +527,6 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 				P.Extinguish(H)
 	H.update_fire()
 
-/datum/species/plasmaman/spec_death(gibbed, mob/living/carbon/human/H)//Single life hard mode species.
-	if(H && !gibbed && !H.mind.changeling)//Note: add plasmamen to restricted species for ling post datum antags. This will have to do for now.
-		for(var/obj/item/W in H)
-			H.unEquip(W)
-		H.visible_message("<span class='warning'>[H]'s body crumbles away!</span>")
-		H.dust()
-
 /datum/species/plasmaman/before_equip_job(datum/job/J, mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/datum/outfit/plasmaman/O = new /datum/outfit/plasmaman
 	H.equipOutfit(O, visualsOnly)
@@ -543,6 +536,8 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 	if(rank in security_positions)
 		return 0
 	if(rank == "Clown" || rank == "Mime")//No funny bussiness
+		return 0
+	if(rank == "Geneticist") //DNA incompatible with technology
 		return 0
 	return ..()
 


### PR DESCRIPTION
Plasmamen now will stop igniting after taking enough damage or being dead long enough.
The DNA and cloning scanner now rejects plasmamen DNA.
Plasmamen are restricted from geneticist roles as they are incompatible with all the machines there.
Fixes a runtime whenputting plasmamen in the gibber.
:cl:
rscdel: Plasmamen are no longer compatible with the DNA or cloning scanners.
rscdel: Plasmamen can no longer be geneticists.
bugfix: Plasmamen now stop igniting while dead after taking enough damage or being dead long enough.
/:cl:
