### PR TITLE
Moves SNPC admin buttons to the debug tab

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -222,7 +222,10 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/toggle_nuke,
 	/client/proc/cmd_display_del_log,
 	/client/proc/toggle_antag_hud,
-	/client/proc/debug_huds
+	/client/proc/debug_huds,
+	/client/proc/customiseSNPC,
+	/client/proc/resetSNPC,
+	/client/proc/toggleSNPC
 	)
 
 /client/proc/add_admin_verbs()

--- a/code/modules/mob/interactive.dm
+++ b/code/modules/mob/interactive.dm
@@ -122,7 +122,7 @@
 /client/proc/resetSNPC(var/mob/A in SSnpc.botPool_l)
 	set name = "Reset SNPC"
 	set desc = "Reset the SNPC"
-	set category = "Admin"
+	set category = "Debug"
 
 	if(!holder)
 		return
@@ -139,7 +139,7 @@
 /client/proc/toggleSNPC(var/mob/A in SSnpc.botPool_l)
 	set name = "Toggle SNPC Proccessing Mode"
 	set desc = "Toggle SNPC Proccessing Mode"
-	set category = "Admin"
+	set category = "Debug"
 
 	if(!holder)
 		return
@@ -156,7 +156,7 @@
 /client/proc/customiseSNPC(var/mob/A in SSnpc.botPool_l)
 	set name = "Customize SNPC"
 	set desc = "Customise the SNPC"
-	set category = "Admin"
+	set category = "Debug"
 
 	if(!holder)
 		return


### PR DESCRIPTION
A number of admins including myself have gotten used to where certain admin buttons in the admin tab were located. The new buttons moving them around was really annoying.
I tried to make it so that the verbs don't appear in the right click menu unless you are right clicking on a SNPC but I couldnt get that to work.
Permissions for the buttons have not changed.
