### PR TITLE
Cult scaling tweak

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -89,7 +89,7 @@
 		restricted_jobs += "Assistant"
 
 	//cult scaling goes here
-	recommended_enemies = 3 + round(num_players()/30)
+	recommended_enemies = 3 + round(num_players()/20)
 
 
 	for(var/cultists_number = 1 to recommended_enemies)


### PR DESCRIPTION
For some reason in my oldcult PR I ignored my philosophy of "more players on a team is ALWAYS better". Limit cult to 4-5 members makes the round more vulnerable to RNG player selection not grabbing a competent player who can lead the cult.

Currently the cult is 4 members, 5 when over 60 pop.

Now the cult will be 4, 5-6-7 at 40,60, and 80 pop respectively. 

With the new "loud" nar-sie rune, this should prevent any rush strategies with a higher cult start pop. Keep in mind that cult is weaker than it used to be, stun talismans are nerfed in almost every respect. 
