### PR TITLE
Added staff of death and fire(adminspawn only).

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -1,6 +1,14 @@
 /obj/item/weapon/gun/magic/staff/
 	slot_flags = SLOT_BACK
 
+/obj/item/weapon/gun/magic/staff/death
+	name = "staff of death"
+	desc = "An artefact that spits deadly bolts of energy which overwhelm a victim's body with pure energy, slaying them without fail"
+	fire_sound = "sound/magic/WandoDeath.ogg"
+	ammo_type = /obj/item/ammo_casing/magic/death
+	icon_state = "staffofchaos"
+	item_state = "staffofchaos"
+
 /obj/item/weapon/gun/magic/staff/change
 	name = "staff of change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself"

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -9,6 +9,14 @@
 	icon_state = "staffofchaos"
 	item_state = "staffofchaos"
 
+/obj/item/weapon/gun/magic/staff/fireball
+	name = "staff of fireball"
+	desc = "An artefact that shoots scorching balls of fire which explode into destructive flames"
+	fire_sound = "sound/magic/Fireball.ogg"
+	ammo_type = /obj/item/ammo_casing/magic/fireball
+	icon_state = "staffofchaos"
+	item_state = "staffofchaos"
+
 /obj/item/weapon/gun/magic/staff/change
 	name = "staff of change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself"

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -6,14 +6,22 @@
 	desc = "An artefact that spits deadly bolts of energy which overwhelm a victim's body with pure energy, slaying them without fail"
 	fire_sound = "sound/magic/WandoDeath.ogg"
 	ammo_type = /obj/item/ammo_casing/magic/death
-	icon_state = "staffofchaos"
-	item_state = "staffofchaos"
+	icon_state = "scythe0"
+	item_state = "scythe0"
 
 /obj/item/weapon/gun/magic/staff/fireball
 	name = "staff of fireball"
 	desc = "An artefact that shoots scorching balls of fire which explode into destructive flames"
 	fire_sound = "sound/magic/Fireball.ogg"
 	ammo_type = /obj/item/ammo_casing/magic/fireball
+	icon_state = "staffofchaos"
+	item_state = "staffofchaos"
+
+/obj/item/weapon/gun/magic/staff/teleport
+	name = "staff of teleportation"
+	desc = "An artefact that will wrench targets through space and time to move them somewhere else."
+	ammo_type = /obj/item/ammo_casing/magic/teleport
+	fire_sound = "sound/magic/Wand_Teleport.ogg"
 	icon_state = "staffofchaos"
 	item_state = "staffofchaos"
 


### PR DESCRIPTION
These shouldn't appear normally even with summon magic, it's strictly adminspawn only.

It seemed inconsistent that there was a wand of death and fire, but not a staff of death or staff of fire. The staff of death is basically one step below a instagib rifle so it's reserved for admin hijinks, and the fireball staff is pretty strong so it's also admin only

I don't have a sprite for it they both just uses the staff of change sprite.
