### PR TITLE
Improvised Shell Rework Attempt 2

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -237,7 +237,8 @@
 	name = "Overload Improvised Shell"
 	result = /obj/item/ammo_casing/shotgun/improvised/overload
 	reqs = list(/obj/item/ammo_casing/shotgun/improvised = 1,
-				/datum/reagent/blackpowder = 5)
+				/datum/reagent/blackpowder = 10,
+				/datum/reagent/toxin/plasma = 20)
 	tools = list(/obj/item/weapon/screwdriver)
 	time = 5
 	category = CAT_AMMO

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -123,23 +123,19 @@
 	icon_state = "improvshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/weak
 	materials = list(MAT_METAL=250)
-	pellets = 5
+	pellets = 10
 	variance = 0.8
 
 
-/obj/item/ammo_casing/shotgun/improvised/overload
+/obj/item/ammo_casing/shotgun/improvised/overload/
 	name = "overloaded improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards. This one has been packed with even more \
 	propellant. It's like playing russian roulette, with a shotgun."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/random
+	projectile_type = /obj/item/projectile/bullet/pellet/overload
 	materials = list(MAT_METAL=250)
-	pellets = 5
+	pellets = 4
 	variance = 1
-
-/obj/item/ammo_casing/shotgun/improvised/overload/New()
-	..()
-	pellets = rand(3, 8)
 
 
 /obj/item/ammo_casing/shotgun/stunslug

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -33,11 +33,30 @@
 	name = "pellet"
 	damage = 15
 
-/obj/item/projectile/bullet/pellet/weak
-	damage = 3
+/obj/item/projectile/bullet/pellet/weak/New()
+	damage = 6
+	range = rand(8)
 
-/obj/item/projectile/bullet/pellet/random/New()
-	damage = rand(10)
+/obj/item/projectile/bullet/pellet/weak/on_range()
+ 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+ 	sparks.set_up(1, 1, src)
+ 	sparks.start()
+ 	..()
+
+/obj/item/projectile/bullet/pellet/overload/New()
+	damage = 3
+	range = rand(10)
+
+/obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
+ 	..()
+ 	explosion(target, 0, 0, 2)
+
+/obj/item/projectile/bullet/pellet/overload/on_range()
+ 	explosion(src, 0, 0, 2)
+ 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
+ 	sparks.set_up(3, 3, src)
+ 	sparks.start()
+ 	..()
 
 /obj/item/projectile/bullet/midbullet
 	damage = 20


### PR DESCRIPTION
Hopefully this follow code standards now. I really feel like I've learned so much on not being a fuck up :)

Anyway, the gist from last time is that improvised shells now have random range and deal more damage. They've still way more gimped than proper buckshot shells. Buckshot will deal 90 point blank, improvised will deal 60 and have much worse range. Also they throw pretty sparks all over the place when you fire them.

Overloaded shells fire four explosive pellets with a good chance of hitting you. They now cost more black powder and now need liquid plasma to make (no, not the stable kind). It isn't strong enough to punch holes in the station but it'll mess up windows and in two shots or so will knock down regular walls. Perfect for B&E/murder if you don't mind getting your ass blown up.

As always, I'm open to all suggestions and criticisms. I nerfed the overloaded shells pellets from 6 to 4 on a suggestion so I _will_ listen.

:cl: Impisi
tweak: Improvised shells now deal more far more damage but are more inaccurate.
tweak: Overloaded shells now require liquid plasma in addition to black powder. Shells now fire explosive pellets that are good at hurting you and everything in front of you.
/:cl:
