### PR TITLE
Mutes Wizard during Ethereal Jaunt

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -102,7 +102,7 @@
 	invocation_type = "none"
 	range = -1
 	include_user = 1
-	jaunt_duration = 50 //in deciseconds
+	duration = 50 //in deciseconds
 	centcom_cancast = 0 //Stop people from getting to centcom
 	action_icon_state = "phaseshift"
 	action_background_icon_state = "bg_demon"

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -31,7 +31,7 @@
 			animation.master = holder
 			target.ExtinguishMob()
 			var/mob/living/carbon/wiz = user
-			wiz.mutate |= MUT_MUTE
+			wiz.mute()
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)
@@ -73,7 +73,11 @@
 	animation.icon_state = "liquify"
 	flick("liquify",animation)
 
-
+/obj/effect/proc_holder/spell/targeted/inflict_handler/mute
+	mutations = list(MUT_MUTATE)
+	duration = 50
+	cooldown_min = 100
+	
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/jaunt_reappear(atom/movable/overlay/animation, mob/living/target)
 	flick("reappear",animation)
 

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -43,12 +43,7 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			mutations = list(MUT_MUTE) // no more invisible point blank fireballs
-			for(var/A in mutations)
-				target.dna.add_mutation(A)
-			sleep(duration)
-			for(var/A in mutations)
-				target.dna.remove_mutation(A)
+			target.silent += 50
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -30,8 +30,6 @@
 			animation.layer = 5
 			animation.master = holder
 			target.ExtinguishMob()
-			var/mob/living/carbon/wiz = user
-			mute(wiz)
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -42,9 +42,9 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			target.mutations |= MUT_MUTATE
+			target.dna.add_mutation (MUT_MUTE)
 			sleep(duration)
-			target.mutations &= ~MUT_MUTATE
+			target.dna.remove_mutation (MUT_MUTE)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -42,9 +42,9 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			target.dna.add_mutation(MUT_MUTE)
+			target.mutations |= MUT_MUTATE
 			sleep(duration)
-			target.dna.remove_mutation(MUT_MUTE)
+			target.mutations &= ~MUT_MUTATE
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -30,6 +30,7 @@
 			animation.layer = 5
 			animation.master = holder
 			target.ExtinguishMob()
+			target.silent(target.silent, 5)
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -42,9 +42,9 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			target.dna.add_mutation (MUT_MUTE)
+			target.dna.add_mutation(MUT_MUTE)
 			sleep(duration)
-			target.dna.remove_mutation (MUT_MUTE)
+			target.dna.remove_mutation(MUT_MUTE)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -31,7 +31,7 @@
 			animation.master = holder
 			target.ExtinguishMob()
 			var/mob/living/carbon/wiz = user
-			wiz.mutations |= MUT_MUTE
+			wiz.mutate |= MUT_MUTE
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -48,7 +48,7 @@
 				target.dna.add_mutation(A)
 			sleep(duration)
 			for(var/A in mutations)
-				target.dna.add_mutation(A)
+				target.dna.remove_mutation(A)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -31,7 +31,7 @@
 			animation.master = holder
 			target.ExtinguishMob()
 			var/mob/living/carbon/wiz = user
-			wiz.mute()
+			mute(wiz)
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)
@@ -74,7 +74,7 @@
 	flick("liquify",animation)
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/mute
-	mutations = list(MUT_MUTATE)
+	wiz.mutations | = MUT_MUTATE
 	duration = 50
 	cooldown_min = 100
 	

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -12,7 +12,7 @@
 	include_user = 1
 	centcom_cancast = 0 //Prevent people from getting to centcom
 	nonabstract_req = 1
-	var/jaunt_duration = 50 //in deciseconds
+	var/duration = 50 //in deciseconds
 	action_icon_state = "jaunt"
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
@@ -30,7 +30,7 @@
 			animation.layer = 5
 			animation.master = holder
 			target.ExtinguishMob()
-			target.silent(target.silent, 5)
+			mutations = list(MUT_MUTE)
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)
@@ -43,7 +43,7 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			sleep(jaunt_duration)
+			sleep(duration)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -44,7 +44,9 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
+			target.mutations |= MUT_MUTATE
 			sleep(duration)
+			target.mutations &= ~MUT_MUTATE
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return
@@ -73,11 +75,7 @@
 	animation.icon_state = "liquify"
 	flick("liquify",animation)
 
-/obj/effect/proc_holder/spell/targeted/inflict_handler/mute
-	wiz.mutations | = MUT_MUTATE
-	duration = 50
-	cooldown_min = 100
-	
+
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/jaunt_reappear(atom/movable/overlay/animation, mob/living/target)
 	flick("reappear",animation)
 

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -43,7 +43,7 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			target.silent += 50
+			target.reagents.add_reagent("mutetoxin", 2)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -14,6 +14,7 @@
 	nonabstract_req = 1
 	var/duration = 50 //in deciseconds
 	action_icon_state = "jaunt"
+	starting_spells = list("/obj/effect/proc_holder/spell/targeted/ethereal_jaunt","/obj/effect/proc_holder/spell/targeted/genetic/mute")
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	playsound(get_turf(user), 'sound/magic/Ethereal_Enter.ogg', 50, 1, -1)
@@ -30,7 +31,6 @@
 			animation.layer = 5
 			animation.master = holder
 			target.ExtinguishMob()
-			mutations = list(MUT_MUTE)
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)
@@ -81,6 +81,11 @@
 	var/datum/effect_system/steam_spread/steam = new /datum/effect_system/steam_spread()
 	steam.set_up(10, 0, mobloc)
 	steam.start()
+
+/obj/effect/proc_holder/spell/targeted/genetic/mute
+	mutations = list(MUT_MUTE)
+	duration = 50
+	cooldown_min = 100
 
 /obj/effect/dummy/spell_jaunt
 	name = "water"

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -14,6 +14,7 @@
 	nonabstract_req = 1
 	var/duration = 50 //in deciseconds
 	action_icon_state = "jaunt"
+	var/list/mutations = list() 
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	playsound(get_turf(user), 'sound/magic/Ethereal_Enter.ogg', 50, 1, -1)
@@ -42,9 +43,12 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
-			target.mutations |= MUT_MUTATE
+			mutations = list(MUT_MUTE) // no more invisible point blank fireballs
+			for(var/A in mutations)
+				target.dna.add_mutation(A)
 			sleep(duration)
-			target.mutations &= ~MUT_MUTATE
+			for(var/A in mutations)
+				target.dna.add_mutation(A)
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -14,7 +14,6 @@
 	nonabstract_req = 1
 	var/duration = 50 //in deciseconds
 	action_icon_state = "jaunt"
-	starting_spells = list("/obj/effect/proc_holder/spell/targeted/ethereal_jaunt","/obj/effect/proc_holder/spell/targeted/genetic/mute")
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets,mob/user = usr) //magnets, so mostly hardcoded
 	playsound(get_turf(user), 'sound/magic/Ethereal_Enter.ogg', 50, 1, -1)
@@ -31,6 +30,8 @@
 			animation.layer = 5
 			animation.master = holder
 			target.ExtinguishMob()
+			var/mob/living/carbon/wiz = user
+			wiz.mutations |= MUT_MUTE
 			if(target.buckled)
 				target.buckled.unbuckle_mob()
 			if(target.pulledby)
@@ -81,11 +82,6 @@
 	var/datum/effect_system/steam_spread/steam = new /datum/effect_system/steam_spread()
 	steam.set_up(10, 0, mobloc)
 	steam.start()
-
-/obj/effect/proc_holder/spell/targeted/genetic/mute
-	mutations = list(MUT_MUTE)
-	duration = 50
-	cooldown_min = 100
 
 /obj/effect/dummy/spell_jaunt
 	name = "water"


### PR DESCRIPTION
5 seconds of mute for 5 seconds of jaunt.

This is to prevent the totally hypothetical situation where a wizard goes around doing driveby fireballs while invisible and undetectable. 

Just one of those things where you're like "there's no way after all these years this was overlooked" and then you're like "yea, yea it was". 
