### PR TITLE
Toxin Filter symptom no longer heals absurd amounts of damage

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -35,7 +35,7 @@ Bonus
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
 
-	var/get_damage = rand(8, 14)
+	var/get_damage = rand(2, 5)
 	M.adjustToxLoss(-get_damage)
 	return 1
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -35,7 +35,7 @@ Bonus
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
 
-	var/get_damage = rand(2, 5)
+	var/get_damage = rand(4, 8)
 	M.adjustToxLoss(-get_damage)
 	return 1
 


### PR DESCRIPTION
:cl: Joan
tweak: The Toxin Filter virology symptom now heals 4-8 toxin damage instead of 8-14.
/:cl:

For reference, the damage converter symptom does 1-2 toxin damage whenever it successfully heals, so this was healing between 4 and _14_ times the damage the damage converter symptom could.
This means it'll only heal 2 to 8 times the damage damage converter could do.

With #15963 it'll heal -3 to 8 times the damage damage converter could do(based on number of damaged limbs)
