### PR TITLE
Buffs the fuck out of resonators.

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -590,7 +590,7 @@
 		var/pressure = environment.return_pressure()
 		if(pressure < 50)
 			name = "strong resonance field"
-			resonance_damage = 100
+			resonance_damage = 75
 		else
 			timetoburst = 50
 		spawn(timetoburst)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -542,7 +542,7 @@
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
 	origin_tech = "magnets=3;combat=3"
-	fieldlimit = INFINITY
+	fieldlimit = 8
 
 /obj/item/weapon/resonator/proc/CreateResonance(target, creator)
 	var/turf/T = get_turf(target)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -532,8 +532,8 @@
 	throwforce = 10
 	var/cooldown = 0
 	var/fieldsactive = 0
-	var/burst_time = 50
-	var/fieldlimit = 3
+	var/burst_time = 30
+	var/fieldlimit = 5
 	origin_tech = "magnets=2;combat=2"
 
 /obj/item/weapon/resonator/upgraded
@@ -542,7 +542,7 @@
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
 	origin_tech = "magnets=3;combat=3"
-	fieldlimit = 5
+	fieldlimit = INFINITY
 
 /obj/item/weapon/resonator/proc/CreateResonance(target, creator)
 	var/turf/T = get_turf(target)
@@ -557,9 +557,18 @@
 
 /obj/item/weapon/resonator/attack_self(mob/user)
 	if(burst_time == 50)
+		burst_time = 10
+		user << "<span class='info'>You set the resonator's fields to detonate after 1 second.</span>"
+	elseif(burst_time == 10)
+		burst_time = 20
+		user << "<span class='info'>You set the resonator's fields to detonate after 2 seconds.</span>"
+	elseif(burst_time == 20)
 		burst_time = 30
 		user << "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>"
-	else
+	elseif(burst_time == 30)
+		burst_time = 40
+		user << "<span class='info'>You set the resonator's fields to detonate after 4 seconds.</span>"
+	elseif(burst_time == 40)
 		burst_time = 50
 		user << "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>"
 
@@ -575,7 +584,7 @@
 	icon_state = "shield1"
 	layer = 4.1
 	mouse_opacity = 0
-	var/resonance_damage = 20
+	var/resonance_damage = 50
 
 /obj/effect/resonance/New(loc, var/creator = null, var/timetoburst)
 	var/turf/proj_turf = get_turf(src)
@@ -592,7 +601,7 @@
 		var/pressure = environment.return_pressure()
 		if(pressure < 50)
 			name = "strong resonance field"
-			resonance_damage = 50
+			resonance_damage = 200
 		spawn(timetoburst)
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -526,7 +526,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "resonator"
 	item_state = "resonator"
-	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It can also be activated without a target to create a field at the user's location, to act as a delayed time trap. It's more effective in a vacuum."
+	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It can also be activated without a target to create a field at the user's location, to act as a delayed time trap. It's more effective in a vacuum. Deals extra damage to creatures."
 	w_class = 3
 	force = 8
 	throwforce = 10
@@ -538,7 +538,7 @@
 
 /obj/item/weapon/resonator/upgraded
 	name = "upgraded resonator"
-	desc = "An upgraded version of the resonator that can produce more fields at once."
+	desc = "An upgraded version of the resonator that can produce more fields at once. Deals extra damage to creatures."
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
 	origin_tech = "magnets=3;combat=3"
@@ -568,7 +568,7 @@
 
 /obj/effect/resonance
 	name = "resonance field"
-	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures."
+	desc = "A resonating field that significantly damages anything inside of it when the field eventually ruptures. Deals extra damage to creatures."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "shield1"
 	layer = 4.1
@@ -590,7 +590,7 @@
 		var/pressure = environment.return_pressure()
 		if(pressure < 50)
 			name = "strong resonance field"
-			resonance_damage = 200
+			resonance_damage = 100
 		else
 			timetoburst = 50
 		spawn(timetoburst)
@@ -599,11 +599,17 @@
 				for(var/mob/living/L in src.loc)
 					add_logs(creator, L, "used a resonator field on", "resonator")
 					L << "<span class='danger'>The [src.name] ruptured with you in it!</span>"
-					L.adjustBruteLoss(resonance_damage)
+					if(istype(L, /mob/living/simple_animal))
+						L.adjustBruteLoss(resonance_damage*2)
+					else
+						L.adjustBruteLoss(resonance_damage)
 			else
 				for(var/mob/living/L in src.loc)
 					L << "<span class='danger'>The [src.name] ruptured with you in it!</span>"
-					L.adjustBruteLoss(resonance_damage)
+					if(istype(L, /mob/living/simple_animal))
+						L.adjustBruteLoss(resonance_damage*2)
+					else
+						L.adjustBruteLoss(resonance_damage)
 			qdel(src)
 
 /**********************Facehugger toy**********************/

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -556,21 +556,10 @@
 			fieldsactive--
 
 /obj/item/weapon/resonator/attack_self(mob/user)
-	if(burst_time == 50)
-		burst_time = 10
-		user << "<span class='info'>You set the resonator's fields to detonate after 1 second.</span>"
-	if(burst_time == 10)
+	burst_time += 10
+	if(burst_time > 50)
 		burst_time = 20
-		user << "<span class='info'>You set the resonator's fields to detonate after 2 seconds.</span>"
-	if(burst_time == 20)
-		burst_time = 30
-		user << "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>"
-	if(burst_time == 30)
-		burst_time = 40
-		user << "<span class='info'>You set the resonator's fields to detonate after 4 seconds.</span>"
-	if(burst_time == 40)
-		burst_time = 50
-		user << "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>"
+		user << "<span class='info'>You set the resonator's fields to detonate after [burst_time * 0.1] seconds.</span>"
 
 /obj/item/weapon/resonator/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
@@ -602,6 +591,7 @@
 		if(pressure < 50)
 			name = "strong resonance field"
 			resonance_damage = 200
+		else
 			timetoburst = 50
 		spawn(timetoburst)
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -559,16 +559,16 @@
 	if(burst_time == 50)
 		burst_time = 10
 		user << "<span class='info'>You set the resonator's fields to detonate after 1 second.</span>"
-	elseif(burst_time == 10)
+	if(burst_time == 10)
 		burst_time = 20
 		user << "<span class='info'>You set the resonator's fields to detonate after 2 seconds.</span>"
-	elseif(burst_time == 20)
+	if(burst_time == 20)
 		burst_time = 30
 		user << "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>"
-	elseif(burst_time == 30)
+	if(burst_time == 30)
 		burst_time = 40
 		user << "<span class='info'>You set the resonator's fields to detonate after 4 seconds.</span>"
-	elseif(burst_time == 40)
+	if(burst_time == 40)
 		burst_time = 50
 		user << "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>"
 
@@ -584,7 +584,7 @@
 	icon_state = "shield1"
 	layer = 4.1
 	mouse_opacity = 0
-	var/resonance_damage = 50
+	var/resonance_damage = 35
 
 /obj/effect/resonance/New(loc, var/creator = null, var/timetoburst)
 	var/turf/proj_turf = get_turf(src)
@@ -602,6 +602,7 @@
 		if(pressure < 50)
 			name = "strong resonance field"
 			resonance_damage = 200
+			burst_time = 50
 		spawn(timetoburst)
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -602,7 +602,7 @@
 		if(pressure < 50)
 			name = "strong resonance field"
 			resonance_damage = 200
-			burst_time = 50
+			timetoburst = 50
 		spawn(timetoburst)
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)


### PR DESCRIPTION
They are never, ever used as-is, ever. They're arguably even worse than pickaxes, because a pickaxe can at least hit thing immediately instead of placing a field that only simplemobs would ever run into, and even then usually not.

This turns it into a tradeoff, you lose the ranged capabilities of the Kinetic Accelerator and gain a lot more damage output and mining speed. This means you risk getting hit, or have to try and time your fields so mobs run into them, and the mining speed is only useful for mining multiple tiles nearby at once, you can't mine in a straight line quite as fast.

:cl:
Buffed the Resonator and the Upgraded Resonator.
The Resonator can now place 5 fields, the Upgraded Resonator can place a unlimited number of fields.
Resonators now do 35 damage in a normal atmosphere and 75 in space, 75% and 50% more respectively.
Resonators can now select any field-detonation delay from 1 to 5 seconds.
Resonators now deal double damage to simple_animals.
/:cl:
