### PR TITLE
The blob can now be shocked by the tesla

### DIFF
--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -5,6 +5,7 @@
 	desc = "A solid wall of slightly twitching tendrils."
 	health = 150
 	maxhealth = 150
+	brute_resist = 0.1
 	explosion_block = 3
 	point_return = 2
 	atmosblock = 1

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -132,7 +132,7 @@
 		O.do_attack_animation(A) //visually attack the whatever
 	return O //just in case you want to do something to the animation.
 
-/obj/effect/blob/proc/expand(turf/T = null, controller = null)
+/obj/effect/blob/proc/expand(turf/T = null, controller = null, expand_reaction = 1)
 	if(!T)
 		var/list/dirs = list(1,2,4,8)
 		for(var/i = 1 to 4)
@@ -171,7 +171,7 @@
 			B.density = initial(B.density)
 			B.loc = T
 			B.update_icon()
-			if(B.overmind)
+			if(B.overmind && expand_reaction)
 				B.overmind.blob_reagent_datum.expand_reaction(src, B, T)
 			return B
 		else
@@ -193,6 +193,19 @@
 	..()
 	var/damage = Clamp(0.01 * exposed_temperature, 0, 4)
 	take_damage(damage, BURN)
+
+/obj/effect/blob/tesla_act(power)
+	..()
+	if(overmind)
+		if(overmind.blob_reagent_datum.tesla_reaction(src, power))
+			take_damage(power/400, BURN)
+	else
+		take_damage(power/400, BURN)
+
+/obj/effect/blob/extinguish()
+	..()
+	if(overmind)
+		overmind.blob_reagent_datum.extinguish_reaction(src)
 
 /obj/effect/blob/bullet_act(var/obj/item/projectile/Proj)
 	..()

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -148,6 +148,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	var/mob/living/closest_mob
 	var/obj/machinery/closest_machine
 	var/obj/structure/closest_structure
+	var/obj/effect/blob/closest_blob
 
 	for(var/A in oview(source, zap_range))
 		if(istype(A, /obj/machinery/power/tesla_coil))
@@ -197,6 +198,17 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		else if(closest_mob)
 			continue
 
+		else if(istype(A, /obj/effect/blob))
+			var/obj/effect/blob/B = A
+			var/dist = get_dist(source, A)
+			if((dist < closest_dist || !closest_tesla_coil) && !B.being_shocked)
+				closest_blob = B
+				closest_atom = A
+				closest_dist = dist
+
+		else if(closest_mob)
+			continue
+
 		else if(istype(A, /obj/structure))
 			var/obj/structure/S = A
 			var/dist = get_dist(source, A)
@@ -204,7 +216,6 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 				closest_structure = S
 				closest_atom = A
 				closest_dist = dist
-
 
 	//Alright, we've done our loop, now lets see if was anything interesting in range
 	if(closest_atom)
@@ -233,6 +244,9 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 	else if(closest_machine)
 		closest_machine.tesla_act(power)
+
+	else if(closest_blob)
+		closest_blob.tesla_act(power)
 
 	else if(closest_structure)
 		closest_structure.tesla_act(power)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -206,7 +206,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 				closest_atom = A
 				closest_dist = dist
 
-		else if(closest_mob)
+		else if(closest_blob)
 			continue
 
 		else if(istype(A, /obj/structure))

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -23,40 +23,11 @@
 /datum/reagent/blob/proc/expand_reaction(obj/effect/blob/B, obj/effect/blob/newB, turf/T) //when the blob expands, do this
 	return
 
-//does brute and a little stamina damage
-/datum/reagent/blob/ripping_tendrils
-	name = "Ripping Tendrils"
-	id = "ripping_tendrils"
-	description = "will do medium brute and stamina damage."
-	color = "#991010"
-	complementary_color = "#109999"
-	blobbernaut_message = "rips"
-	message_living = ", and you feel your skin ripping and tearing off"
+/datum/reagent/blob/proc/tesla_reaction(obj/effect/blob/B, power) //when the blob is hit by a tesla bolt, do this
+	return 1 //return 0 to ignore damage
 
-/datum/reagent/blob/ripping_tendrils/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	reac_volume = ..()
-	M.apply_damage(0.7*reac_volume, BRUTE)
-	if(M)
-		M.adjustStaminaLoss(0.5*reac_volume)
-	if(iscarbon(M))
-		M.emote("scream")
-
-//does brute and drains blood from humans
-/datum/reagent/blob/draining_spikes
-	name = "Draining Spikes"
-	id = "draining_spikes"
-	description = "will do medium brute damage and drain blood."
-	color = "#AF4150"
-	complementary_color = "#41AFA0"
-	blobbernaut_message = "drains"
-	message_living = ", and you feel lightheaded"
-
-/datum/reagent/blob/draining_spikes/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
-	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
-	if(ishuman(M) && M.stat != DEAD)
-		var/mob/living/carbon/human/H = M
-		H.drip(reac_volume) //will kill at 18 hits(no bio protection) and cause bad effects before that
+/datum/reagent/blob/proc/extinguish_reaction(obj/effect/blob/B) //when the blob is hit with water, do this
+	return
 
 //does low toxin damage, but creates fragile spores when expanding or killed by weak attacks
 /datum/reagent/blob/sporing_pods
@@ -70,10 +41,10 @@
 
 /datum/reagent/blob/sporing_pods/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	M.apply_damage(0.5*reac_volume, TOX)
+	M.apply_damage(0.2*reac_volume, TOX)
 
 /datum/reagent/blob/sporing_pods/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(!isnull(cause) && damage <= 20 && original_health - damage <= 0 && prob(50)) //if the cause isn't fire or a bomb, the damage is less than 21, we're going to die from that damage, 50% chance of a shitty spore.
+	if(!isnull(cause) && damage <= 20 && original_health - damage <= 0 && prob(30)) //if the cause isn't fire or a bomb, the damage is less than 21, we're going to die from that damage, 30% chance of a shitty spore.
 		B.visible_message("<span class='warning'><b>A spore floats free of the blob!</b></span>")
 		var/mob/living/simple_animal/hostile/blob/blobspore/weak/BS = new/mob/living/simple_animal/hostile/blob/blobspore/weak(B.loc)
 		BS.overmind = B.overmind
@@ -92,7 +63,7 @@
 /datum/reagent/blob/replicating_foam
 	name = "Replicating Foam"
 	id = "replicating_foam"
-	description = "will do medium brute damage and replicate when damaged."
+	description = "will do medium brute damage and replicate when damaged, but takes increased brute damage."
 	shortdesc = "will do medium brute damage."
 	color = "#7B5A57"
 	complementary_color = "#57787B"
@@ -102,13 +73,16 @@
 	M.apply_damage(0.6*reac_volume, BRUTE)
 
 /datum/reagent/blob/replicating_foam/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(damage > 0 && original_health - damage > 0 && prob(60))
-		var/obj/effect/blob/newB = B.expand()
+	var/effectivedamage = damage
+	if(damage_type == BRUTE)
+		effectivedamage = damage * 2
+	if(effectivedamage > 0 && original_health - effectivedamage > 0 && prob(60))
+		var/obj/effect/blob/newB = B.expand(null, null, 0)
 		if(newB)
-			newB.health = original_health - damage
+			newB.health = original_health - effectivedamage
 			newB.check_health(cause)
 			newB.update_icon()
-	return ..()
+	return effectivedamage
 
 /datum/reagent/blob/replicating_foam/expand_reaction(obj/effect/blob/B, obj/effect/blob/newB, turf/T)
 	if(prob(40))
@@ -145,11 +119,11 @@
 			B.forceMove(T) //swap the blobs
 	return ..()
 
-//does low burn and a lot of stamina damage, reacts to stamina damage
+//does low burn and a lot of stamina damage, immune to tesla bolts
 /datum/reagent/blob/energized_fibers
 	name = "Energized Fibers"
 	id = "energized_fibers"
-	description = "will do low burn and high stamina damage, and react to stamina damage."
+	description = "will do low burn and high stamina damage and conduct electricity."
 	shortdesc = "will do low burn and high stamina damage."
 	color = "#EFD65A"
 	complementary_color = "#5A73EF"
@@ -158,21 +132,19 @@
 
 /datum/reagent/blob/energized_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	M.apply_damage(0.5*reac_volume, BURN)
+	M.apply_damage(0.4*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.8*reac_volume)
 
-/datum/reagent/blob/energized_fibers/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(damage_type == STAMINA)
-		B.visible_message("<span class='warning'><b>The blob abruptly regenerates!</b></span>")
-		B.health = B.maxhealth //stop disabling the blob!
-	return ..()
+/datum/reagent/blob/energized_fibers/tesla_reaction(obj/effect/blob/B, power)
+	return 0
 
-//sets you on fire, does burn damage
+//sets you on fire, does burn damage, weak to water
 /datum/reagent/blob/boiling_oil
 	name = "Boiling Oil"
 	id = "boiling_oil"
-	description = "will do medium burn damage and set targets on fire."
+	description = "will do medium burn damage and set targets on fire, but is weak to water."
+	shortdesc = "will do medium burn damage and set targets on fire."
 	color = "#B68D00"
 	complementary_color = "#0029B6"
 	blobbernaut_message = "splashes"
@@ -184,9 +156,12 @@
 	M.adjust_fire_stacks(round(reac_volume/12))
 	M.IgniteMob()
 	if(M)
-		M.apply_damage(0.6*reac_volume, BURN)
+		M.apply_damage(0.4*reac_volume, BURN)
 	if(iscarbon(M))
 		M.emote("scream")
+
+/datum/reagent/blob/boiling_oil/extinguish_reaction(obj/effect/blob/B)
+	B.take_damage(rand(2, 3), BURN)
 
 //does burn and toxin damage, explodes into flame when hit with burn damage
 /datum/reagent/blob/flammable_goo
@@ -211,7 +186,7 @@
 		for(var/turf/T in range(1, B))
 			if(prob(80))
 				PoolOrNew(/obj/effect/hotspot, T)
-		return damage * 1.3
+		return damage * 1.5
 	return ..()
 
 //does toxin damage, targets think they're not hurt at all
@@ -227,7 +202,7 @@
 	reac_volume = ..()
 	if(M.reagents)
 		M.reagents.add_reagent("regenerative_materia", 0.2*reac_volume)
-	M.apply_damage(0.6*reac_volume, TOX)
+	M.apply_damage(0.5*reac_volume, TOX)
 
 /datum/reagent/blob/regenerative_materia/on_mob_life(mob/living/M)
 	M.adjustToxLoss(1*REM)
@@ -260,7 +235,7 @@
 
 	if(M.reagents)
 		M.reagents.add_reagent("spore", 0.2*reac_volume)
-	M.apply_damage(0.6*reac_volume, TOX)
+	M.apply_damage(0.5*reac_volume, TOX)
 
 //kills sleeping targets and turns them into blob zombies
 /datum/reagent/blob/zombifying_feelers
@@ -273,7 +248,6 @@
 
 /datum/reagent/blob/zombifying_feelers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, TOX)
 	if(O && ishuman(M) && M.stat == UNCONSCIOUS)
 		M.death() //sleeping in a fight? bad plan.
 		var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore/weak(get_turf(M))
@@ -281,6 +255,8 @@
 		BS.update_icons()
 		O.blob_mobs.Add(BS)
 		BS.Zombify(M)
+	if(M)
+		M.apply_damage(0.6*reac_volume, TOX)
 
 //toxin, stamina, and some bonus spore toxin
 /datum/reagent/blob/envenomed_filaments
@@ -295,7 +271,7 @@
 	reac_volume = ..()
 	if(M.reagents)
 		M.reagents.add_reagent("spore", 0.2*reac_volume)
-	M.apply_damage(0.6*reac_volume, TOX)
+	M.apply_damage(0.4*reac_volume, TOX)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
 
@@ -312,12 +288,12 @@
 /datum/reagent/blob/poisonous_strands/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
 	if(M.reagents)
-		M.reagents.add_reagent("poisonous_strands", 0.12*reac_volume)
+		M.reagents.add_reagent("poisonous_strands", 0.16*reac_volume)
 
 /datum/reagent/blob/poisonous_strands/on_mob_life(mob/living/M)
-	M.adjustBruteLoss(1.5*REM)
-	M.adjustFireLoss(1.5*REM)
-	M.adjustToxLoss(1.5*REM)
+	M.adjustBruteLoss(1*REM)
+	M.adjustFireLoss(1*REM)
+	M.adjustToxLoss(1*REM)
 	..()
 
 //does oxygen damage, randomly pushes or pulls targets
@@ -368,26 +344,29 @@
 	if(reac_volume >= 10) //if it's not a spore cloud, bad time incoming
 		var/obj/effect/overlay/temp/explosion/E = PoolOrNew(/obj/effect/overlay/temp/explosion, get_turf(M))
 		E.alpha = 150
-		for(var/mob/living/L in range(M, 1))
+		for(var/mob/living/L in orange(M, 1))
 			if("blob" in L.faction) //no friendly fire
 				continue
 			L.apply_damage(0.6*reac_volume, BRUTE)
 		if(M)
-			M.apply_damage(0.1*reac_volume, BRUTE)
+			M.apply_damage(0.6*reac_volume, BRUTE)
 	else
 		M.apply_damage(0.8*reac_volume, BRUTE)
 
 /datum/reagent/blob/explosive_lattice/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(isnull(cause) && damage_type == BRUTE)
-		return 0 //no-sell the explosion we do not take damage
+	if(isnull(cause)
+		if(damage_type == BRUTE)
+			return 0 //no-sell the explosion we do not take damage
+		if(damage_type == BURN)
+			return damage * 1.5 //take more from fire, tesla, and flashbangs
 	return ..()
 
 //does semi-random brute damage and reacts to brute damage
 /datum/reagent/blob/reactive_gelatin
 	name = "Reactive Gelatin"
 	id = "reactive_gelatin"
-	description = "will do high brute damage and react to brute damage."
-	shortdesc = "will do high brute damage."
+	description = "will do random brute damage and react to brute damage."
+	shortdesc = "will do random brute damage."
 	color = "#FFA500"
 	complementary_color = "#005AFF"
 	blobbernaut_message = "pummels"
@@ -395,7 +374,7 @@
 
 /datum/reagent/blob/reactive_gelatin/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	var/damage = rand(10, 30)/25
+	var/damage = rand(0, 30)/25
 	M.apply_damage(damage*reac_volume, BRUTE)
 
 /datum/reagent/blob/reactive_gelatin/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
@@ -422,7 +401,7 @@
 	if(M.reagents)
 		M.reagents.add_reagent("frostoil", 0.4*reac_volume)
 		M.reagents.add_reagent("ice", 0.4*reac_volume)
-	M.apply_damage(0.6*reac_volume, BURN)
+	M.apply_damage(0.4*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.4*reac_volume)
 
@@ -430,7 +409,7 @@
 /datum/reagent/blob/electromagnetic_web
 	name = "Electromagnetic Web"
 	id = "electromagnetic_web"
-	description = "will do low burn damage and EMP targets, but is somewhat fragile."
+	description = "will do low burn damage and EMP targets, but is very fragile."
 	shortdesc = "will do low burn damage and EMP targets."
 	color = "#83ECEC"
 	complementary_color = "#EC8383"
@@ -440,17 +419,25 @@
 
 /datum/reagent/blob/electromagnetic_web/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	if(prob(reac_volume))
+	if(prob(reac_volume*2))
 		M.emp_act(2)
 	if(M)
 		M.apply_damage(0.6*reac_volume, BURN)
 
 /datum/reagent/blob/electromagnetic_web/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	return damage * 1.2 //a laser will do 24 damage, which will kill any recently-made normal blob
+	if(damage_type == BRUTE) //take full brute
+		switch(B.brute_resist)
+			if(0.5)
+				return damage * 2
+			if(0.25)
+				return damage * 4
+			if(0.1)
+				return damage * 10
+	return damage * 1.25 //a laser will do 25 damage, which will kill any normal blob
 
 /datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause)
 	if(cause)
-		empulse(B.loc, 2, 3) //less than screen range, so you can stand out of range to avoid it
+		empulse(B.loc, 1, 2) //less than screen range, so you can stand out of range to avoid it
 
 //does brute damage, bonus damage for each nearby blob, and spreads damage out
 /datum/reagent/blob/synchronous_mesh
@@ -509,13 +496,14 @@
 
 /datum/reagent/blob/adaptive_nexuses/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	M.apply_damage(0.6*reac_volume, BRUTE)
 	if(O && ishuman(M) && M.stat == UNCONSCIOUS)
 		PoolOrNew(/obj/effect/overlay/temp/revenant, get_turf(M))
 		var/points = rand(5, 10)
 		O.add_points(points)
 		O << "<span class='notice'>Gained [points] resources from the death of [M].</span>"
 		M.death()
+	if(M)
+		M.apply_damage(0.6*reac_volume, BRUTE)
 
 //does low brute damage, oxygen damage, and stamina damage and wets tiles when damaged
 /datum/reagent/blob/pressurized_slime
@@ -534,7 +522,7 @@
 	var/turf/simulated/T = get_turf(M)
 	if(istype(T, /turf/simulated) && prob(reac_volume))
 		T.MakeSlippery(TURF_WET_WATER)
-	M.apply_damage(0.4*reac_volume, BRUTE)
+	M.apply_damage(0.2*reac_volume, BRUTE)
 	if(M)
 		M.apply_damage(0.4*reac_volume, OXY)
 	if(M)

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -354,7 +354,7 @@
 		M.apply_damage(0.8*reac_volume, BRUTE)
 
 /datum/reagent/blob/explosive_lattice/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(isnull(cause)
+	if(isnull(cause))
 		if(damage_type == BRUTE)
 			return 0 //no-sell the explosion we do not take damage
 		if(damage_type == BURN)


### PR DESCRIPTION
:cl: Joan
rscadd: The blob can now be shocked by the tesla.
tweak: Strong blobs are now much more resistant to brute damage.
wip: Tweaks blob reagents;
rscdel: Removes Ripping Tendrils.
rscdel: Removes Draining Spikes.
tweak: Cryogenic Liquid does less burn damage.
tweak: Pressurized Slime does less brute damage.
tweak: Reactive Gelatin now has a lower minimum damage.
tweak: Poisonous Strands applies its damage over a longer period of time.
tweak: Sporing Pods now does much less damage, and is less likely to produce spores when killed.
tweak: Regenerative Materia, Hallucinogenic Nectar, and Envenomed Filaments do less toxin damage.
rscadd: Energized Fibers no longer heals when hit with stamina damage, and is instead immune to the tesla.
rscadd: Boiling Oil now takes damage from extinguisher blasts. Boiling Oil blobbernauts, however, do not.
tweak: Replicating Foam now takes increased brute damage and when expanding from damage, will not expand again.
tweak: Flammable Goo takes 50% increased burn damage, from 30%.
tweak: Explosive Lattice now takes much higher damage from fire, flashbangs, and the tesla.
experiment: Electromagnetic Web takes full brute damage, lasers will now one-hit normal blobs, and the death EMP is smaller.
/:cl:

@LanCartwright 
