### PR TITLE
Fixes roundstart runtimes

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -105,14 +105,14 @@
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand()
-	if(!loc.allow_drop())
+	if(!loc || !loc.allow_drop())
 		return
 	return unEquip(l_hand) //All needed checks are in unEquip
 
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand()
-	if(!loc.allow_drop())
+	if(!loc || !loc.allow_drop())
 		return
 	return unEquip(r_hand)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -371,7 +371,8 @@ var/const/GALOSHES_DONT_HELP = 4
 	return loc.handle_slip(src, s_amount, w_amount, O, lube)
 
 /mob/living/carbon/fall(forced)
-    loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
+	if(loc) // coders who think that mobs always have a loc should be deported to the nullspace
+		loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))


### PR DESCRIPTION
This PR fixes annoying runtimes on roundstart. I couldn't track down the main issue (roundstart corpse landmarks are created in nullspace sometimes, somehow) and it looks like one of those mysterious BYOND bugs. But I added null checks to the mobs, so it wouldn't runtime anymore.
