### PR TITLE
Adds complex math to virology that scales with virus symptom stats.

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -424,4 +424,33 @@ var/list/advance_cures = 	list(
 		src << "<a href='?_src_=vars;Vars=\ref[D]'>[D.name] - [D.holder]</a>"
 */
 
+
+/datum/disease/advance/proc/totalStageSpeed()
+	var/total_stage_speed = 0
+	for(var/i in symptoms)
+		var/datum/symptom/S = i
+		total_stage_speed += S.stage_speed
+	return total_stage_speed
+
+/datum/disease/advance/proc/totalStealth()
+	var/total_stealth = 0
+	for(var/i in symptoms)
+		var/datum/symptom/S = i
+		total_stealth += S.stealth
+	return total_stealth
+
+/datum/disease/advance/proc/totalResistance()
+	var/total_resistance = 0
+	for(var/i in symptoms)
+		var/datum/symptom/S = i
+		total_resistance += S.resistance
+	return total_resistance
+
+/datum/disease/advance/proc/totalTransmittable()
+	var/total_transmittable = 0
+	for(var/i in symptoms)
+		var/datum/symptom/S = i
+		total_transmittable += S.transmittable
+	return total_transmittable
+
 #undef RANDOM_STARTING_LEVEL

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -34,10 +34,20 @@ Bonus
 				M << "<span class='warning'>[pick("You're having difficulty breathing.", "Your breathing becomes heavy.")]</span>"
 			if(3, 4)
 				M << "<span class='warning'><b>[pick("Your windpipe feels like a straw.", "Your breathing becomes tremendously difficult.")]</span>"
-				M.adjustOxyLoss(5)
+				Choke_stage_3_4(M, A)
 				M.emote("gasp")
 			else
 				M << "<span class='userdanger'>[pick("You're choking!", "You can't breathe!")]</span>"
-				M.adjustOxyLoss(20)
+				Choke(M, A)
 				M.emote("gasp")
 	return
+
+/datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(20+A.totalStageSpeed())/2)+(sqrt(16+A.totalStealth())*1)
+	M.adjustOxyLoss(get_damage)
+	return 1
+
+/datum/symptom/choking/proc/Choke(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(20+A.totalStageSpeed())/2)+(sqrt(16+A.totalStealth()*5))
+	M.adjustOxyLoss(get_damage)
+	return 1

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -31,6 +31,11 @@ Bonus
 		var/mob/living/carbon/M = A.affected_mob
 		M << "<span class='warning'>[pick("You feel hot.", "You feel like you're burning.")]</span>"
 		if(M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
-			M.bodytemperature = min(M.bodytemperature + (20 * A.stage), BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
+			Heat(M, A)
 
 	return
+
+/datum/symptom/fever/proc/Heat(mob/living/M, datum/disease/advance/A)
+	var/get_heat = (sqrt(21+A.totalTransmittable()*2))+(sqrt(20+A.totalStageSpeed()*3))
+	M.bodytemperature = min(M.bodytemperature + (get_heat * A.stage), BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
+	return 1

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -33,15 +33,25 @@ Bonus
 			if(3)
 				M << "<span class='warning'>[pick("You feel hot.", "You hear a crackling noise.", "You smell smoke.")]</span>"
 			if(4)
-				M.adjust_fire_stacks(5)
+				Firestacks_stage_4(M, A)
 				M.IgniteMob()
 				M << "<span class='userdanger'>Your skin bursts into flames!</span>"
-				M.adjustFireLoss(5)
 				M.emote("scream")
 			if(5)
-				M.adjust_fire_stacks(10)
+				Firestacks_stage_5(M, A)
 				M.IgniteMob()
 				M << "<span class='userdanger'>Your skin erupts into an inferno!</span>"
-				M.adjustFireLoss(10)
 				M.emote("scream")
 	return
+
+/datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
+	var/get_stacks = (sqrt(20+A.totalStageSpeed()*2))-(sqrt(16+A.totalStealth()))
+	M.adjust_fire_stacks(get_stacks)
+	M.adjustFireLoss(get_stacks/2)
+	return 1
+
+/datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
+	var/get_stacks = (sqrt(20+A.totalStageSpeed()*3))-(sqrt(16+A.totalStealth()))
+	M.adjust_fire_stacks(get_stacks)
+	M.adjustFireLoss(get_stacks)
+	return 1

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -34,5 +34,10 @@ Bonus
 				M << "<span class='warning'>[pick("You feel a sudden pain across your body.", "Drops of blood appear suddenly on your skin.")]</span>"
 			if(4,5)
 				M << "<span class='userdanger'>[pick("You cringe as a violent pain takes over your body.", "It feels like your body is eating itself inside out.", "IT HURTS.")]</span>"
-				M.adjustBruteLoss(5)
+				Flesheat(M, A)
 	return
+
+/datum/symptom/flesh_eating/proc/Flesheat(mob/living/M, datum/disease/advance/A)
+	var/get_damage = ((sqrt(16-A.totalStealth()))*5)
+	M.adjustBruteLoss(get_damage)
+	return 1

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -34,7 +34,7 @@ Bonus
 	return
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
-	var/get_damage = (sqrt(20+A.totalStageSpeed())*(2+rand()))
+	var/get_damage = (sqrt(20+A.totalStageSpeed())*(1+rand()))
 	M.adjustToxLoss(-get_damage)
 	return 1
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -34,8 +34,7 @@ Bonus
 	return
 
 /datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
-
-	var/get_damage = rand(4, 8)
+	var/get_damage = (sqrt(20+A.totalStageSpeed())*(2+rand()))
 	M.adjustToxLoss(-get_damage)
 	return 1
 
@@ -149,7 +148,7 @@ Bonus
 
 /datum/symptom/heal/dna/Heal(mob/living/carbon/M, datum/disease/advance/A)
 
-	var/amt_healed = rand(5, 10)
+	var/amt_healed = (sqrt(20+A.totalStageSpeed()*3))-(sqrt(16+A.totalStealth()*(1+rand())))
 	M.adjustBrainLoss(-amt_healed)
 	//Non-power mutations, excluding race, so the virus does not force monkey -> human transformations.
 	var/list/unclean_mutations = (not_good_mutations|bad_mutations) - mutations_list[RACEMUT]

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -31,6 +31,10 @@ Bonus
 		var/mob/living/carbon/M = A.affected_mob
 		M << "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>"
 		if(M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-			M.bodytemperature = min(M.bodytemperature - (20 * A.stage), BODYTEMP_COLD_DAMAGE_LIMIT + 1)
-
+			Chill(M, A)
 	return
+
+/datum/symptom/shivering/proc/Chill(mob/living/M, datum/disease/advance/A)
+	var/get_cold = (sqrt(16+A.totalStealth()*2))+(sqrt(21+A.totalResistance()*2))
+	M.bodytemperature = min(M.bodytemperature - (get_cold * A.stage), BODYTEMP_COLD_DAMAGE_LIMIT + 1)
+	return 1


### PR DESCRIPTION
Cleaned PR from https://github.com/tgstation/-tg-station/pull/15873

:cl: 
tweak: Choking now deals damage based on virus' Stage speed and virus Stealth.
tweak: Fever heats the body based on Transmittability and Stage speed.
tweak: Spontaneous Combustion now adjusts firestacks based on stage speed minus Stealth.
tweak: Necrotizing Fasciitis now deals damage based on lower Stealth values.
tweak: Toxic Filter now heals based on Stage speed.
tweak: Deoxyribonucleic Acid Restoration now heals brain damage based on Stage speed minus Stealth.
tweak: Shivering now chills based on Stealth and Resistance.
rscadd: Proc for the total stage speed of a virus' symptoms.
rscadd: Proc for the total stealth of a virus' symptoms.
rscadd: Proc for the total resistance of a virus' symptoms.
rscadd: Proc for the total transmittance speed of a virus' symptoms.
/:cl:

Graphs will be up later.
