### PR TITLE
Add infrastructure for safely spawning atoms at roundstart

### DIFF
--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -9,6 +9,7 @@ var/datum/subsystem/objects/SSobj
 	name = "Objects"
 	priority = 12
 
+	var/list/atom_spawners = list()
 	var/list/processing = list()
 	var/list/currentrun = list()
 	var/list/burning = list()
@@ -17,6 +18,7 @@ var/datum/subsystem/objects/SSobj
 	NEW_SS_GLOBAL(SSobj)
 
 /datum/subsystem/objects/Initialize(timeofday, zlevel)
+	trigger_atom_spawners()
 	setupGenetics()
 	for(var/V in world)
 		var/atom/A = V
@@ -26,6 +28,12 @@ var/datum/subsystem/objects/SSobj
 		CHECK_TICK
 	. = ..()
 
+/datum/subsystem/objects/proc/trigger_atom_spawners(zlevel)
+	for(var/V in atom_spawners)
+		var/atom/A = V
+		if (zlevel && A.z != zlevel)
+			continue
+		A.spawn_atom_to_world()
 
 /datum/subsystem/objects/stat_entry()
 	..("P:[processing.len]")
@@ -57,4 +65,5 @@ var/datum/subsystem/objects/SSobj
 /datum/subsystem/objects/proc/setup_template_objects(list/objects)
 	for(var/A in objects)
 		var/atom/B = A
+		B.spawn_atom_to_world()
 		B.initialize()

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -28,10 +28,10 @@ var/datum/subsystem/objects/SSobj
 		CHECK_TICK
 	. = ..()
 
-/datum/subsystem/objects/proc/trigger_atom_spawners(zlevel)
+/datum/subsystem/objects/proc/trigger_atom_spawners(zlevel, ignore_z=FALSE)
 	for(var/V in atom_spawners)
 		var/atom/A = V
-		if (zlevel && A.z != zlevel)
+		if (!ignore_z && (zlevel && A.z != zlevel))
 			continue
 		A.spawn_atom_to_world()
 
@@ -63,7 +63,7 @@ var/datum/subsystem/objects/SSobj
 			SSobj.burning.Remove(burningobj)
 
 /datum/subsystem/objects/proc/setup_template_objects(list/objects)
+	trigger_atom_spawners(0, ignore_z=TRUE)
 	for(var/A in objects)
 		var/atom/B = A
-		B.spawn_atom_to_world()
 		B.initialize()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -358,6 +358,10 @@ var/list/blood_splatter_icons = list()
 	. = ..()
 	sleep(1)
 
+//This is called just before maps and objects are initialized, use it to spawn other mobs/objects
+//effects at world start up without causing runtimes
+/atom/proc/spawn_atom_to_world()
+
 //This will be called after the map and objects are loaded
 /atom/proc/initialize()
 	return

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -27,7 +27,9 @@
 	log_game("[user.ckey] became [mob_name]")
 	create(ckey = user.ckey)
 
-/obj/effect/mob_spawn/initialize()
+/obj/effect/mob_spawn/spawn_atom_to_world()
+	//We no longer need to spawn mobs, deregister ourself
+	SSobj.atom_spawners -= src
 	if(roundstart)
 		create()
 	else
@@ -35,6 +37,8 @@
 
 /obj/effect/mob_spawn/New()
 	..()
+	//Add to the atom spawners register for roundstart atom spawning
+	SSobj.atom_spawners += src
 	if(instant)
 		create()
 	else

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -37,8 +37,10 @@
 
 /obj/effect/mob_spawn/New()
 	..()
-	//Add to the atom spawners register for roundstart atom spawning
-	SSobj.atom_spawners += src
+	if(roundstart)
+		//Add to the atom spawners register for roundstart atom spawning
+		SSobj.atom_spawners += src
+
 	if(instant)
 		create()
 	else


### PR DESCRIPTION
This system is called just before initialize and does not use a world
loop, so it is safe to spawn and create new atoms.

Any atom can inherit this behaviour by overriding the
spawn_atom_to_world proc and spawning atoms in this proc

Make sure you register the atom in question to the list of spawner atoms
by doing SSobj.atom_spawners += src in New(), and then remove when you are done
spawning objects

**Away missions - maploader etc:**

the same proc is called before initialize for all atoms loaded by the maploader, which should ensure that the logic works as expected on loaded maps and data.

Corpse spawners are moved to this system to prevent round start null errors.

Log showing roundstart errors are disappeared when using this system:
https://file.house/uJx1.log
