### PR TITLE
Made the emagged Orion's Trail reward stronger

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1089,7 +1089,7 @@
 	playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 25, 1)
 	sleep(3.6)
 	src.visible_message("<span class='userdanger'>[src] explodes!</span>")
-	explosion(src.loc, 1,2,4, flame_range = 3)
+	explosion(src.loc, 2,4,8, flame_range = 16)
 	qdel(src)
 
 


### PR DESCRIPTION
Emagged Orion's Trail is way harder than Outbomb Cuban Pete, and it broadcasts the fact that it's about to explode to everyone nearby, so it deserves to be stronger.
