### PR TITLE
Blobbernauts and blob spores can now move near blob tiles in no gravity

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -40,6 +40,11 @@
 		return 1
 	return ..()
 
+/mob/living/simple_animal/hostile/blob/Process_Spacemove(movement_dir = 0)
+	for(var/obj/effect/blob/B in range(1, src))
+		return 1
+	return ..()
+
 /mob/living/simple_animal/hostile/blob/handle_inherent_channels(message, message_mode)
 	if(message_mode == MODE_BINARY)
 		blob_chat(message)


### PR DESCRIPTION
:cl: Joan
bugfix: Blobbernauts and blob spores can now move near blob tiles in no gravity.
/:cl:
