### PR TITLE
Dead cyborgs no longer get binary messages twice

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -17,7 +17,7 @@
 				M << renderedAI
 			else
 				M << rendered
-		if(M in dead_mob_list)
+		if(isobserver(M))
 			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
 
 /mob/living/silicon/binarycheck()


### PR DESCRIPTION
Fixes #15634
