### PR TITLE
The gravity generator is no longer permanently destroyed by the blob

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -32,6 +32,10 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	if(severity == 1) // Very sturdy.
 		set_broken()
 
+/obj/machinery/gravity_generator/blob_act()
+	if(prob(20))
+		set_broken()
+
 /obj/machinery/gravity_generator/update_icon()
 	..()
 	icon_state = "[get_status()]_[sprite_number]"


### PR DESCRIPTION
Instead, it gets broken, but can still be fixed if you manage to kill the blob.
