### PR TITLE
[S] Removes edge cases of traitors seeing own antag hud upon body switch.

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -14,10 +14,10 @@ var/datum/atom_hud/huds = list( \
 	ANTAG_HUD_SHADOW = new/datum/atom_hud/antag(), \
 	ANTAG_HUD_HOG_BLUE = new/datum/atom_hud/antag(),\
 	ANTAG_HUD_HOG_RED = new/datum/atom_hud/antag(),\
-	ANTAG_HUD_TRAITOR = new/datum/atom_hud/antag(),\
-	ANTAG_HUD_NINJA = new/datum/atom_hud/antag(),\
-	ANTAG_HUD_CHANGELING = new/datum/atom_hud/antag(),\
-	ANTAG_HUD_ABDUCTOR = new/datum/atom_hud/antag(),\
+	ANTAG_HUD_TRAITOR = new/datum/atom_hud/antag/hidden(),\
+	ANTAG_HUD_NINJA = new/datum/atom_hud/antag/hidden(),\
+	ANTAG_HUD_CHANGELING = new/datum/atom_hud/antag/hidden(),\
+	ANTAG_HUD_ABDUCTOR = new/datum/atom_hud/antag/hidden(),\
 	)
 
 /datum/atom_hud

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -1,13 +1,15 @@
 /datum/atom_hud/antag
 	hud_icons = list(ANTAG_HUD)
+	var/self_visible = 1
 
-/datum/atom_hud/antag/proc/join_hud(mob/M, var/sees_hud = 1)
+/datum/atom_hud/antag/proc/join_hud(mob/M, var/sees_hud = self_visible)
 	//sees_hud should be set to 0 if the mob does not get to see it's own hud type.
 	if(!istype(M))
 		CRASH("join_hud(): [M] ([M.type]) is not a mob!")
 	if(M.mind.antag_hud) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
 		M.mind.antag_hud.leave_hud(M)
 	add_to_hud(M)
+	self_visible = sees_hud
 	if(sees_hud)
 		add_hud_to(M)
 	M.mind.antag_hud = src
@@ -39,7 +41,7 @@
 	leave_all_huds()
 	ticker.mode.set_antag_hud(current, antag_hud_icon_state)
 	if(newhud)
-		newhud.join_hud(current)
+		newhud.join_hud(current, newhud.self_visible)
 
 /datum/mind/proc/leave_all_huds()
 	for(var/datum/atom_hud/antag/hud in huds)

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -43,7 +43,7 @@
 	leave_all_huds()
 	ticker.mode.set_antag_hud(current, antag_hud_icon_state)
 	if(newhud)
-		newhud.join_hud(current, newhud.self_visible)
+		newhud.join_hud(current)
 
 /datum/mind/proc/leave_all_huds()
 	for(var/datum/atom_hud/antag/hud in huds)

--- a/code/game/gamemodes/antag_hud.dm
+++ b/code/game/gamemodes/antag_hud.dm
@@ -2,15 +2,17 @@
 	hud_icons = list(ANTAG_HUD)
 	var/self_visible = 1
 
-/datum/atom_hud/antag/proc/join_hud(mob/M, var/sees_hud = self_visible)
+/datum/atom_hud/antag/hidden
+	self_visible = 0
+
+/datum/atom_hud/antag/proc/join_hud(mob/M)
 	//sees_hud should be set to 0 if the mob does not get to see it's own hud type.
 	if(!istype(M))
 		CRASH("join_hud(): [M] ([M.type]) is not a mob!")
 	if(M.mind.antag_hud) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
 		M.mind.antag_hud.leave_hud(M)
 	add_to_hud(M)
-	self_visible = sees_hud
-	if(sees_hud)
+	if(self_visible)
 		add_hud_to(M)
 	M.mind.antag_hud = src
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -504,7 +504,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 
 /datum/game_mode/proc/update_changeling_icons_added(datum/mind/changling_mind)
 	var/datum/atom_hud/antag/hud = huds[ANTAG_HUD_CHANGELING]
-	hud.join_hud(changling_mind.current, 0)
+	hud.join_hud(changling_mind.current)
 	set_antag_hud(changling_mind.current, "changling")
 
 /datum/game_mode/proc/update_changeling_icons_removed(datum/mind/changling_mind)

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -344,7 +344,7 @@
 
 /datum/game_mode/proc/update_abductor_icons_added(datum/mind/alien_mind)
 	var/datum/atom_hud/antag/hud = huds[ANTAG_HUD_ABDUCTOR]
-	hud.join_hud(alien_mind.current, 0)
+	hud.join_hud(alien_mind.current)
 	set_antag_hud(alien_mind.current, ((alien_mind in abductors) ? "abductor" : "abductee"))
 
 /datum/game_mode/proc/update_abductor_icons_removed(datum/mind/alien_mind)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -377,7 +377,7 @@
 
 /datum/game_mode/proc/update_traitor_icons_added(datum/mind/traitor_mind)
 	var/datum/atom_hud/antag/traitorhud = huds[ANTAG_HUD_TRAITOR]
-	traitorhud.join_hud(traitor_mind.current, 0)
+	traitorhud.join_hud(traitor_mind.current)
 	set_antag_hud(traitor_mind.current, "traitor")
 
 /datum/game_mode/proc/update_traitor_icons_removed(datum/mind/traitor_mind)

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -215,9 +215,9 @@ Contents:
 	return 1
 
 /datum/game_mode/proc/update_ninja_icons_added(var/mob/living/carbon/human/ninja)
-	var/datum/atom_hud/antag/ninjahud = huds[ANTAG_HUD_TRAITOR]
-	ninjahud.join_hud(ninja, 0)
-	set_antag_hud(ninja, "traitor")
+	var/datum/atom_hud/antag/ninjahud = huds[ANTAG_HUD_NINJA]
+	ninjahud.join_hud(ninja)
+	set_antag_hud(ninja, "ninja")
 
 /datum/game_mode/proc/update_ninja_icons_removed(datum/mind/ninja_mind)
 	var/datum/atom_hud/antag/ninjahud = huds[ANTAG_HUD_NINJA]


### PR DESCRIPTION
Antags should no longer see their own antag hud upon being turned into an AI.

Fixes #15977
Also fixes #16092
