### PR TITLE
Replaces Mediborg Acid Spray with Poison Hypospray

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -161,10 +161,6 @@
 
 	fix_modules()
 
-/obj/item/weapon/robot_module/medical/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
-	..()
-
-
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -157,17 +157,12 @@
 
 	add_module(new /obj/item/stack/medical/gauze/cyborg())
 
-	emag = new /obj/item/weapon/reagent_containers/spray(src)
-	emag.reagents.add_reagent("facid", 250)
-	emag.name = "Fluacid spray"
+	emag = new /obj/item/weapon/reagent_containers/borghypo/hacked(src)
 
 	fix_modules()
 
 /obj/item/weapon/robot_module/medical/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
 	..()
-	if(R.emagged && istype(emag, /obj/item/weapon/reagent_containers/spray))
-		emag.reagents.add_reagent("facid", 2 * coeff)
-
 
 
 /obj/item/weapon/robot_module/engineering

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -129,7 +129,7 @@ Borg Hypospray
 
 /obj/item/weapon/reagent_containers/borghypo/hacked
 	icon_state = "borghypo_s"
-	reagent_ids = list ("facid", "mutetoxin", "cyanide", "sodium_thiopental", "heparin", "teslium")
+	reagent_ids = list ("facid", "mutetoxin", "cyanide", "sodium_thiopental", "heparin", "lexorin")
 
 /obj/item/weapon/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -127,6 +127,10 @@ Borg Hypospray
 	if(empty)
 		usr << "<span class='warning'>It is currently empty! Allow some time for the internal syntheszier to produce more.</span>"
 
+/obj/item/weapon/reagent_containers/borghypo/hacked
+	icon_state = "borghypo_s"
+	reagent_ids = list ("facid", "mutetoxin", "cyanide", "sodium_thiopental", "heparin", "teslium")
+
 /obj/item/weapon/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"
 	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and morphine, for offense."


### PR DESCRIPTION
Hopefully did this right.
This should replace the rather weak and mostly useless Acid Spray with a Hypospray with a variety of poisons.
Honestly probobly should switch out some of the poisons, but should be fine for now.

As a note, if anyone knows/can figure out a way to make it possible to add this chems on injection to the standard Hypo, I would be happy to change it so it works that way.

Fixes #12383
