### PR TITLE
Fixes a buckling attempt runtime

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -23,7 +23,7 @@
 
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
-	if(user_buckle_mob(M, user))
+	if(istype(M) && user_buckle_mob(M, user))
 		return 1
 
 


### PR DESCRIPTION
It was happening when anything but mobs was mousedropped.
