### PR TITLE
Cameras can now be upgraded to x-ray cameras with micro lasers, using a RPED/BRPED

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -48,6 +48,15 @@
 		if(C != src && C.c_tag == src.c_tag && tempnetwork.len)
 			world.log << "[src.c_tag] [src.x] [src.y] [src.z] conflicts with [C.c_tag] [C.x] [C.y] [C.z]"
 	*/
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/camera(null)
+	component_parts += new /obj/item/weapon/stock_parts/micro_laser(null)
+	RefreshParts()
+
+/obj/machinery/camera/RefreshParts()
+	for(var/obj/item/weapon/stock_parts/micro_laser/L in component_parts)
+		if(L.rating >= 2)
+			upgradeXRay()
 
 /obj/machinery/camera/initialize()
 	if(z == 1 && prob(3) && !start_active)
@@ -137,6 +146,9 @@
 /obj/machinery/camera/attackby(obj/W, mob/living/user, params)
 	var/msg = "<span class='notice'>You attach [W] into the assembly's inner circuits.</span>"
 	var/msg2 = "<span class='notice'>[src] already has that upgrade!</span>"
+
+	if(exchange_parts(user, W))
+		return
 
 	// DECONSTRUCTION
 	if(istype(W, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -791,3 +791,11 @@ obj/item/weapon/circuitboard/rdserver
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/matter_bin = 3)
+
+/obj/item/weapon/circuitboard/camera //requires a circuit board to be upgradable, this should be unobtainable
+	name = "Camera Electronics"
+	build_path = /obj/machinery/camera
+	board_type = "machine"
+	origin_tech = "programming=1;engineering=2"
+	req_components = list(
+							/obj/item/weapon/stock_parts/micro_laser = 1)


### PR DESCRIPTION
See title.

Also adds the potential to add more upgrades using parts, although the other two current upgrades (emp resistance and motion sensing) wouldn't really make sense/would be abusable. EMP resistance is normally given by a sheet of plasma(which doesn't fit in a RPED) and none of the machine parts giving it would make sense. Prox sensing would be abusable because someone could upgrade every camera on the station with it and spam the AI with "MOTION ALARM IN: CENTRAL PRIMARY HALLWAY" alerts.

And for once, I tested it.

Note: this adds a "Camera Electronics" board because part upgrading doesn't work without a board. It's unobtainable and cannot be used to actually make a camera, camera construction is unchanged.
