### PR TITLE
Plasmamen fixes

### DIFF
--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -26,7 +26,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 
 			for(var/obj/item/I in H) //drops all items
 				H.unEquip(I)
-
+			H.status_flags |= GODMODE //Can't die while hatching
 			sleep(50)
 			var/turf/simulated/floor/F
 			var/turf/shadowturf = get_turf(user)
@@ -36,7 +36,6 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				qdel(R)
 				new /obj/structure/alien/weeds/node(shadowturf) //Dim lighting in the chrysalis -- removes itself afterwards
 			var/temp_flags = H.status_flags
-			H.status_flags |= GODMODE //Can't die while hatching
 
 			H.visible_message("<span class='warning'>A chrysalis forms around [H], sealing them inside.</span>", \
 							"<span class='shadowling'>You create your chrysalis and begin to contort within.</span>")

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -320,7 +320,6 @@
 			missionobj.explanation_text = mission
 			missionobj.completed = 1
 			Commando.mind.objectives += missionobj
-			Commando.set_species(/datum/species/human)
 
 			//Greet the commando
 			Commando << "<B><font size=3 color=red>You are the [numagents==1?"Deathsquad Officer":"Death Commando"].</font></B>"
@@ -333,7 +332,7 @@
 			Commando << missiondesc
 
 			if(config.enforce_human_authority)
-				Commando.set_species("human")
+				Commando.set_species(/datum/species/human)
 
 			//Logging and cleanup
 			if(numagents == 1)
@@ -411,7 +410,9 @@
 		missionobj.explanation_text = mission
 		missionobj.completed = 1
 		newmob.mind.objectives += missionobj
-		newmob.set_species(/datum/species/human)
+
+		if(config.enforce_human_authority)
+			newmob.set_species(/datum/species/human)
 
 		//Greet the official
 		newmob << "<B><font size=3 color=red>You are a Centcom Official.</font></B>"
@@ -509,7 +510,6 @@
 			missionobj.explanation_text = mission
 			missionobj.completed = 1
 			ERTOperative.mind.objectives += missionobj
-			ERTOperative.set_species(/datum/species/human)
 
 			//Greet the commando
 			ERTOperative << "<B><font size=3 color=red>You are [numagents==1?"the Emergency Response Team Commander":"an Emergency Response Officer"].</font></B>"
@@ -522,7 +522,7 @@
 			ERTOperative << missiondesc
 
 			if(config.enforce_human_authority)
-				ERTOperative.set_species("human")
+				ERTOperative.set_species(/datum/species/human)
 
 			//Logging and cleanup
 			if(numagents == 1)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -320,6 +320,7 @@
 			missionobj.explanation_text = mission
 			missionobj.completed = 1
 			Commando.mind.objectives += missionobj
+			Commando.set_species(/datum/species/human)
 
 			//Greet the commando
 			Commando << "<B><font size=3 color=red>You are the [numagents==1?"Deathsquad Officer":"Death Commando"].</font></B>"
@@ -410,6 +411,7 @@
 		missionobj.explanation_text = mission
 		missionobj.completed = 1
 		newmob.mind.objectives += missionobj
+		newmob.set_species(/datum/species/human)
 
 		//Greet the official
 		newmob << "<B><font size=3 color=red>You are a Centcom Official.</font></B>"
@@ -507,6 +509,7 @@
 			missionobj.explanation_text = mission
 			missionobj.completed = 1
 			ERTOperative.mind.objectives += missionobj
+			ERTOperative.set_species(/datum/species/human)
 
 			//Greet the commando
 			ERTOperative << "<B><font size=3 color=red>You are [numagents==1?"the Emergency Response Team Commander":"an Emergency Response Officer"].</font></B>"


### PR DESCRIPTION
ERT/Deathsquad/Centcomm Official all set themselves to human on spawn. This prevents silliness with plasamen burning up (and letting filthy lizards have jobs that outrank the whole station despite being barred from captain)

Shadowling godmode moved to before the sleep() in the chrysalis sequence, to stop them burning to death during the transformation
