### PR TITLE
Re-adds hunger to the game

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -646,7 +646,7 @@
 			H.update_inv_wear_suit()
 
 	// nutrition decrease and satiety
-	if (H.nutrition > 0 && H.stat != DEAD && !H.dna.species.need_nutrition)
+	if (H.nutrition > 0 && H.stat != DEAD && H.dna.species.need_nutrition)
 		var/hunger_rate = HUNGER_FACTOR
 		if(H.satiety > 0)
 			H.satiety--


### PR DESCRIPTION
So in other plasmamen related news, @as334 inadvertently removed hunger from the game by setting the hunger check backwards for species (while leaving plasmamen hungry and unable to eat because of their helmets)

:cl: Kor
rscadd: Hunger was accidentally disabled sometime back in October 2015. We finally noticed and fixed it.
/:cl:
