### PR TITLE
Blob Tuning: Revenge of the Buff/Nerf

### DIFF
--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/blob.dmi'
 
 /obj/screen/blob/MouseEntered(location,control,params)
-	openToolTip(usr,src,params,title = name,content = desc)
+	openToolTip(usr,src,params,title = name,content = desc, theme = "blob")
 
 /obj/screen/blob/MouseExited()
 	closeToolTip(usr)
@@ -37,7 +37,7 @@
 	if(isovermind(usr))
 		var/mob/camera/blob/B = usr
 		if(!B.placed)
-			openToolTip(usr,src,params,title = "Place Blob Core",content = "Attempt to place your blob core at this location.")
+			openToolTip(usr,src,params,title = "Place Blob Core",content = "Attempt to place your blob core at this location.", theme = "blob")
 		else
 			..()
 
@@ -97,7 +97,7 @@
 	if(isovermind(usr))
 		var/mob/camera/blob/B = usr
 		if(B.free_chem_rerolls)
-			openToolTip(usr,src,params,title = "Readapt Chemical (FREE)",content = "Randomly rerolls your chemical for free.")
+			openToolTip(usr,src,params,title = "Readapt Chemical (FREE)",content = "Randomly rerolls your chemical for free.", theme = "blob")
 		else
 			..()
 

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -2,6 +2,12 @@
 /obj/screen/blob
 	icon = 'icons/mob/blob.dmi'
 
+/obj/screen/blob/MouseEntered(location,control,params)
+	openToolTip(usr,src,params,title = name,content = desc)
+
+/obj/screen/blob/MouseExited()
+	closeToolTip(usr)
+
 /obj/screen/blob/BlobHelp
 	icon_state = "ui_help"
 	name = "Blob Help"
@@ -27,6 +33,14 @@
 	name = "Jump to Core"
 	desc = "Moves your camera to your blob core."
 
+/obj/screen/blob/JumpToCore/MouseEntered(location,control,params)
+	if(isovermind(usr))
+		var/mob/camera/blob/B = usr
+		if(!B.placed)
+			openToolTip(usr,src,params,title = "Place Blob Core",content = "Attempt to place your blob core at this location.")
+		else
+			..()
+
 /obj/screen/blob/JumpToCore/Click()
 	if(isovermind(usr))
 		var/mob/camera/blob/B = usr
@@ -37,7 +51,7 @@
 /obj/screen/blob/Blobbernaut
 	icon_state = "ui_blobbernaut"
 	name = "Produce Blobbernaut (30)"
-	desc = "Produces a blobbernaut for 30 points."
+	desc = "Produces a strong, smart blobbernaut from a factory blob for 30 points.<br>The factory blob used will become fragile and briefly unable to produce spores."
 
 /obj/screen/blob/Blobbernaut/Click()
 	if(isovermind(usr))
@@ -47,7 +61,7 @@
 /obj/screen/blob/ResourceBlob
 	icon_state = "ui_resource"
 	name = "Produce Resource Blob (40)"
-	desc = "Produces a resource blob for 40 points."
+	desc = "Produces a resource blob for 40 points.<br>Resource blobs will give you points every few seconds."
 
 /obj/screen/blob/ResourceBlob/Click()
 	if(isovermind(usr))
@@ -57,7 +71,7 @@
 /obj/screen/blob/NodeBlob
 	icon_state = "ui_node"
 	name = "Produce Node Blob (60)"
-	desc = "Produces a node blob for 60 points."
+	desc = "Produces a node blob for 60 points.<br>Node blobs will expand and activate nearby resource and factory blobs."
 
 /obj/screen/blob/NodeBlob/Click()
 	if(isovermind(usr))
@@ -67,7 +81,7 @@
 /obj/screen/blob/FactoryBlob
 	icon_state = "ui_factory"
 	name = "Produce Factory Blob (60)"
-	desc = "Produces a resource blob for 60 points."
+	desc = "Produces a factory blob for 60 points.<br>Factory blobs will produce spores every few seconds."
 
 /obj/screen/blob/FactoryBlob/Click()
 	if(isovermind(usr))
@@ -78,6 +92,14 @@
 	icon_state = "ui_chemswap"
 	name = "Readapt Chemical (40)"
 	desc = "Randomly rerolls your chemical for 40 points."
+
+/obj/screen/blob/ReadaptChemical/MouseEntered(location,control,params)
+	if(isovermind(usr))
+		var/mob/camera/blob/B = usr
+		if(B.free_chem_rerolls)
+			openToolTip(usr,src,params,title = "Readapt Chemical (FREE)",content = "Randomly rerolls your chemical for free.")
+		else
+			..()
 
 /obj/screen/blob/ReadaptChemical/Click()
 	if(isovermind(usr))
@@ -110,7 +132,7 @@
 	infodisplay += healths
 
 	using = new /obj/screen/blob/BlobHelp()
-	using.screen_loc = "NORTH:-6,WEST:6"
+	using.screen_loc = "WEST:6,NORTH:-3"
 	static_inventory += using
 
 	using = new /obj/screen/blob/JumpToNode()

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -66,11 +66,8 @@
 	if(overmind)
 		overmind.update_health_hud()
 	Pulse_Area(overmind, 12, 4, 3)
-	for(var/b_dir in alldirs)
-		if(!prob(5))
-			continue
-		var/obj/effect/blob/normal/B = locate() in get_step(src, b_dir)
-		if(B)
+	for(var/obj/effect/blob/normal/B in range(1, src))
+		if(prob(5))
 			B.change_to(/obj/effect/blob/shield, overmind)
 	..()
 

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -8,11 +8,22 @@
 	point_return = 15
 	var/resource_delay = 0
 
+/obj/effect/blob/resource/creation_action()
+	if(overmind)
+		overmind.resource_blobs += src
+
+/obj/effect/blob/resource/Destroy()
+	if(overmind)
+		overmind.resource_blobs -= src
+	return ..()
+
 /obj/effect/blob/resource/Be_Pulsed()
 	. = ..()
 	if(resource_delay > world.time)
 		return
 	flick("blob_resource_glow", src)
-	resource_delay = world.time + 45 // 4 and a half seconds
 	if(overmind)
 		overmind.add_points(1)
+		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
+	else
+		resource_delay = world.time + 40

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -20,6 +20,7 @@
 	var/list/resource_blobs = list()
 	var/ghostimage = null
 	var/free_chem_rerolls = 1 //one free chemical reroll
+	var/nodes_required = 1 //if the blob needs nodes to place resource and factory blobs
 	var/placed = 0
 	var/base_point_rate = 2 //for blob core placement
 	var/manualplace_min_time = 600 //in deciseconds //a minute, to get bearings

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -68,13 +68,15 @@
 	..()
 
 /mob/camera/blob/Destroy()
-	for(var/obj/effect/blob/BL in blobs)
-		if(BL.overmind == src)
-			BL.overmind = null
-			BL.update_icon() //reset anything that was ours
-	for(var/mob/living/simple_animal/hostile/blob/BLO in blob_mobs)
-		BLO.overmind = null
-		BLO.update_icons()
+	for(var/BL in blobs)
+		var/obj/effect/blob/B = BL
+		if(B.overmind == src)
+			B.overmind = null
+			B.update_icon() //reset anything that was ours
+	for(var/BLO in blob_mobs)
+		var/mob/living/simple_animal/hostile/blob/BM = BLO
+		BM.overmind = null
+		BM.update_icons()
 	overminds -= src
 	if(ghostimage)
 		ghost_darkness_images -= ghostimage

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -17,7 +17,9 @@
 	var/last_attack = 0
 	var/datum/reagent/blob/blob_reagent_datum = new/datum/reagent/blob()
 	var/list/blob_mobs = list()
+	var/list/resource_blobs = list()
 	var/ghostimage = null
+	var/free_chem_rerolls = 1 //one free chemical reroll
 	var/placed = 0
 	var/base_point_rate = 2 //for blob core placement
 	var/manualplace_min_time = 600 //in deciseconds //a minute, to get bearings
@@ -65,8 +67,15 @@
 	..()
 
 /mob/camera/blob/Destroy()
+	for(var/obj/effect/blob/BL in blobs)
+		if(BL.overmind == src)
+			BL.overmind = null
+			BL.update_icon() //reset anything that was ours
+	for(var/mob/living/simple_animal/hostile/blob/BLO in blob_mobs)
+		BLO.overmind = null
+		BLO.update_icons()
 	overminds -= src
-	if (ghostimage)
+	if(ghostimage)
 		ghost_darkness_images -= ghostimage
 		qdel(ghostimage)
 		ghostimage = null;
@@ -137,10 +146,12 @@
 		if(blob_core)
 			stat(null, "Core Health: [blob_core.health]")
 		stat(null, "Power Stored: [blob_points]/[max_blob_points]")
+		if(free_chem_rerolls)
+			stat(null, "You have [free_chem_rerolls] Free Chemical Reroll\s Remaining")
 		if(!placed)
-			stat(null, "Time Before Automatic Placement: [max(round((autoplace_max_time - world.time)*0.1, 0.1), 0)]")
 			if(manualplace_min_time)
 				stat(null, "Time Before Manual Placement: [max(round((manualplace_min_time - world.time)*0.1, 0.1), 0)]")
+			stat(null, "Time Before Automatic Placement: [max(round((autoplace_max_time - world.time)*0.1, 0.1), 0)]")
 
 /mob/camera/blob/Move(NewLoc, Dir = 0)
 	if(placed)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -263,8 +263,8 @@
 	var/list/surrounding_turfs = block(locate(T.x - 1, T.y - 1, T.z), locate(T.x + 1, T.y + 1, T.z))
 	if(!surrounding_turfs.len)
 		return
-	for(var/mob/living/simple_animal/hostile/blob/blobspore/BS in living_mob_list)
-		if(BS.overmind == src && isturf(BS.loc) && get_dist(BS, T) <= 35)
+	for(var/mob/living/simple_animal/hostile/blob/blobspore/BS in blob_mobs)
+		if(isturf(BS.loc) && get_dist(BS, T) <= 35)
 			BS.LoseTarget()
 			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
 
@@ -277,9 +277,10 @@
 		return
 	else
 		src << "You broadcast with your minions, <B>[speak_text]</B>"
-	for(var/mob/living/simple_animal/hostile/blob/blob_minion in blob_mobs)
-		if(blob_minion.overmind == src && blob_minion.stat == CONSCIOUS)
-			blob_minion.say(speak_text)
+	for(var/BLO in blob_mobs)
+		var/mob/living/simple_animal/hostile/blob/BM = BLO
+		if(BM.stat == CONSCIOUS)
+			BM.say(speak_text)
 
 /mob/camera/blob/verb/chemical_reroll()
 	set category = "Blob"
@@ -293,12 +294,14 @@
 /mob/camera/blob/proc/set_chemical()
 	var/datum/reagent/blob/BC = pick((subtypesof(/datum/reagent/blob) - blob_reagent_datum.type))
 	blob_reagent_datum = new BC
-	for(var/obj/effect/blob/BL in blobs)
-		BL.update_icon()
-	for(var/mob/living/simple_animal/hostile/blob/BLO in blob_mobs)
-		BLO.update_icons() //If it's getting a new chemical, tell it what it does!
-		BLO << "Your overmind's blob reagent is now: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
-		BLO << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]"
+	for(var/BL in blobs)
+		var/obj/effect/blob/B = BL
+		B.update_icon()
+	for(var/BLO in blob_mobs)
+		var/mob/living/simple_animal/hostile/blob/BM = BLO
+		BM.update_icons() //If it's getting a new chemical, tell it what it does!
+		BM << "Your overmind's blob reagent is now: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
+		BM << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.shortdesc ? "[blob_reagent_datum.shortdesc]" : "[blob_reagent_datum.description]"]"
 	src << "Your reagent is now: <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font>!"
 	src << "The <b><font color=\"[blob_reagent_datum.color]\">[blob_reagent_datum.name]</b></font> reagent [blob_reagent_datum.description]"
 

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -81,7 +81,7 @@
 	if(!istype(B, /obj/effect/blob/normal))
 		src << "<span class='warning'>Unable to use this blob, find a normal one.</span>"
 		return
-	if(needsNode)
+	if(needsNode && nodes_required)
 		if(!(locate(/obj/effect/blob/node) in orange(3, T)) && !(locate(/obj/effect/blob/core) in orange(4, T)))
 			src << "<span class='warning'>You need to place this blob closer to a node or core!</span>"
 			return //handholdotron 2000
@@ -94,6 +94,16 @@
 		return
 	var/obj/effect/blob/N = B.change_to(blobType, src)
 	return N
+
+/mob/camera/blob/verb/toggle_node_req()
+	set category = "Blob"
+	set name = "Toggle Node Requirement"
+	set desc = "Toggle requiring nodes to place resource and factory blobs."
+	nodes_required = !nodes_required
+	if(nodes_required)
+		src << "<span class='warning'>You no longer require a nearby node or core to place factory and resource blobs.</span>"
+	else
+		src << "<span class='warning'>You now require a nearby node or core to place factory and resource blobs.</span>"
 
 /mob/camera/blob/verb/create_shield_power()
 	set category = "Blob"

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -101,9 +101,9 @@
 	set desc = "Toggle requiring nodes to place resource and factory blobs."
 	nodes_required = !nodes_required
 	if(nodes_required)
-		src << "<span class='warning'>You no longer require a nearby node or core to place factory and resource blobs.</span>"
-	else
 		src << "<span class='warning'>You now require a nearby node or core to place factory and resource blobs.</span>"
+	else
+		src << "<span class='warning'>You no longer require a nearby node or core to place factory and resource blobs.</span>"
 
 /mob/camera/blob/verb/create_shield_power()
 	set category = "Blob"

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -8,9 +8,6 @@
 // Power verbs
 
 /mob/camera/blob/proc/place_blob_core(var/point_rate = base_point_rate, var/override = 0)
-	if(!override && world.time <= manualplace_min_time && world.time <= autoplace_max_time)
-		src << "<span class='warning'>It is too early to place your blob core!</span>"
-		return 0
 	if(placed)
 		return 1
 	if(!override)
@@ -40,6 +37,9 @@
 			if(O.density)
 				src << "<span class='warning'>This spot is too dense to place a blob core on!</span>"
 				return 0
+		if(world.time <= manualplace_min_time && world.time <= autoplace_max_time)
+			src << "<span class='warning'>It is too early to place your blob core!</span>"
+			return 0
 	else if(override == 1)
 		var/turf/T = pick(blobstart)
 		loc = T //got overrided? you're somewhere random, motherfucker

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -305,7 +305,7 @@
 	src << "<i>Shield Blobs</i> are strong and expensive blobs which take more damage. In additon, they are fireproof and can block air, use these to protect yourself from station fires."
 	src << "<i>Resource Blobs</i> are blobs which produce more resources for you, build as many of these as possible to consume the station. This type of blob must be placed near node blobs or your core to work."
 	src << "<i>Factory Blobs</i> are blobs that spawn blob spores which will attack nearby enemies. This type of blob must be placed near node blobs or your core to work."
-	src << "<i>Blobbernauts</i> can be produced from factories for a cost, and are hard to kill, powerful, and moderately smart. However, the factory used to create one will become fragile and unable to produce spores as long as the blobbernaut lives."
+	src << "<i>Blobbernauts</i> can be produced from factories for a cost, and are hard to kill, powerful, and moderately smart. The factory used to create one will become fragile and briefly unable to produce spores."
 	src << "<i>Node Blobs</i> are blobs which grow, like the core. Like the core it can activate resource and factory blobs."
 	src << "<b>In addition to the buttons on your HUD, there are a few click shortcuts to speed up expansion and defense.</b>"
 	src << "<b>Shortcuts:</b> Click = Expand Blob <b>|</b> Middle Mouse Click = Rally Spores <b>|</b> Ctrl Click = Create Shield Blob <b>|</b> Alt Click = Remove Blob"

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -237,9 +237,9 @@
 				continue
 			if(L.stat != DEAD)
 				attacksuccess = TRUE
-				var/mob_protection = L.get_permeability_protection()
-				blob_reagent_datum.reaction_mob(L, VAPOR, 25, 1, mob_protection, src)
-				blob_reagent_datum.send_message(L)
+			var/mob_protection = L.get_permeability_protection()
+			blob_reagent_datum.reaction_mob(L, VAPOR, 25, 1, mob_protection, src)
+			blob_reagent_datum.send_message(L)
 		var/obj/effect/blob/B = locate() in T
 		if(B)
 			if(attacksuccess) //if we successfully attacked a turf with a blob on it, don't refund shit

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -99,7 +99,8 @@
 		for(var/obj/effect/blob/B in orange(pulse_range, src))
 			B.Be_Pulsed()
 	if(expand_range)
-		src.expand()
+		if(prob(85))
+			src.expand()
 		for(var/obj/effect/blob/B in orange(expand_range, src))
 			if(prob(max(13 - get_dist(get_turf(src), get_turf(B)) * 4, 1))) //expand falls off with range but is faster near the blob causing the expansion
 				B.expand()

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -434,6 +434,8 @@
 				return damage * 2
 			if(0.25)
 				return damage * 4
+			if(0.1)
+				return damage * 10
 	return damage * 1.25 //a laser will do 25 damage, which will kill any normal blob
 
 /datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause)

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -10,6 +10,8 @@
 	var/message_living = null //extension to first mob sent to only living mobs i.e. silicons have no skin to be burnt
 
 /datum/reagent/blob/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
+	if(M.stat == DEAD)
+		return 0 //the dead don't cause reactions
 	if(istype(M, /mob/living/simple_animal/hostile/blob))
 		return 0 //the blob mobs do not cause effects when hitting themselves or other blob mobs
 	return round(reac_volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any prot below 0.5 means 100% volume.
@@ -102,12 +104,12 @@
 	M.apply_damage(0.6*reac_volume, BRUTE)
 
 /datum/reagent/blob/shifting_fragments/expand_reaction(obj/effect/blob/B, obj/effect/blob/newB, turf/T)
-	if(istype(B, /obj/effect/blob/normal) || istype(B, /obj/effect/blob/shield))
+	if(istype(B, /obj/effect/blob/normal) || (istype(B, /obj/effect/blob/shield) && prob(20)))
 		newB.forceMove(get_turf(B))
 		B.forceMove(T)
 
 /datum/reagent/blob/shifting_fragments/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(cause && prob(40))
+	if(cause && damage > 0 && original_health - damage > 0 && prob(40))
 		var/list/blobstopick = list()
 		for(var/obj/effect/blob/OB in orange(1, B))
 			if((istype(OB, /obj/effect/blob/normal) || istype(OB, /obj/effect/blob/shield)) && OB.overmind && OB.overmind.blob_reagent_datum.id == B.overmind.blob_reagent_datum.id)
@@ -185,7 +187,7 @@
 /datum/reagent/blob/flammable_goo/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	if(cause && damage_type == BURN)
 		for(var/turf/T in range(1, B))
-			if(prob(80))
+			if(!(locate(/obj/effect/blob) in T) && prob(80))
 				PoolOrNew(/obj/effect/hotspot, T)
 		return damage * 1.5
 	return ..()
@@ -432,13 +434,11 @@
 				return damage * 2
 			if(0.25)
 				return damage * 4
-			if(0.1)
-				return damage * 10
 	return damage * 1.25 //a laser will do 25 damage, which will kill any normal blob
 
 /datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause)
 	if(cause)
-		empulse(B.loc, 1, 2) //less than screen range, so you can stand out of range to avoid it
+		empulse(B.loc, 1, 3) //less than screen range, so you can stand out of range to avoid it
 
 //does brute damage, bonus damage for each nearby blob, and spreads damage out
 /datum/reagent/blob/synchronous_mesh

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -39,8 +39,8 @@
 		}
 
 		/* Custom Themes */
-		.blob .wrap {border-color: #009900;}
-		.blob .content {border-color: #66FF00; background-color: #475E13;}
+		.blob .wrap {border-color: #2E2E2E;}
+		.blob .content {color: #82ED00; border-color: #4E4C4A; background-color: #191918;}
 
 		.wraith .wrap {border-color: #492136;}
 		.wraith .content {border-color: #331726; background-color: #471962;}


### PR DESCRIPTION
:cl: Joan
tweak: Resource blobs produce resources for their overmind slightly slower for each resource blob their overmind has.
rscadd: Blob overminds get one free chemical reroll.
rscadd: Blob overminds can no longer place resource and factory blobs out of range of cores and nodes, unless they Toggle Node Requirement off. It is on by default.
rscadd: Blob UI buttons now have tooltips.
tweak: Cores and nodes will expand slightly slower.
tweak: Blob Chemicals no longer trigger effects on dead mobs.
tweak: Shifting Fragments has a lower chance to move shields with normal expansion and will no longer shift blobs to the location of a dying blob.
tweak: Flammable Goo no longer applies fire to tiles with blobs.
tweak: Electromagnetic Web has a slightly higher EMP range.
/:cl:
