### PR TITLE
SNPC Expansion v. Traitorous Scum

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -221,12 +221,19 @@
 #define TRAIT_FRIENDLY 64
 #define TRAIT_THIEVING 128
 
-//defines
+//SNPC defines
 #define MAX_RANGE_FIND 32
 #define MIN_RANGE_FIND 16
 #define FUZZY_CHANCE_HIGH 85
 #define FUZZY_CHANCE_LOW 50
 #define CHANCE_TALK 15
+
+#define SNPC_BRUTE 1
+#define SNPC_STEALTH 2
+#define SNPC_MARTYR 3
+#define SNPC_PSYCHO 4
+
+
 #define MAXCOIL 30
 #define RESIZE_DEFAULT_SIZE 1
 

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -64,6 +64,9 @@ var/datum/subsystem/npcpool/SSnpc
 		npcCount++
 
 	if(needsDelegate.len)
+
+		needsDelegate -= pick(needsDelegate) // cheapo way to make sure stuff doesn't pingpong around in the pool forever. delegation runs seperately to each loop so it will work much smoother
+
 		npcCount = 1 //reset the count
 		for(var/mob/living/carbon/human/interactive/check in needsDelegate)
 			if(!check)
@@ -89,6 +92,9 @@ var/datum/subsystem/npcpool/SSnpc
 			npcCount++
 
 	if(needsAssistant.len)
+
+		needsAssistant -= pick(needsAssistant)
+
 		npcCount = 1 //reset the count
 		for(var/mob/living/carbon/human/interactive/check in needsAssistant)
 			if(!check)


### PR DESCRIPTION
- Fixes SNPCs still healing people
- SNPCs now use similar speech handling to Poly, and will mimic phrases in addition to their usual speech
- SNPCs can now be spawned as traitors, and given a special role.
- Greytide SNPCs now wear assistant outfits
- Certain jobs are now restricted to their area (can be toggled with restrictedJob)
- SNPCs start with a minor variation in stats
- Bartender SNPCs should now appropriately serve people
- Chef SNPC workflow redone, they will now prioritise preparing food over making it, and should serve more food to tables
- Third attempt at fixing infighting
- SNPCs should no longer repeatedly stun a target
- Friendly SNPCs now no longer have a combat module, and they are the station's faction
- NPCPool will routinely trim orders from it, reducing the amount of order ping-pong

The four traitor modules are as follows:
SNPC_BRUTE: Tasked with killing a target, and will stalk and murder them.
SNPC_STEALTH: Tasked with finding an item, will hunt it down and steal it, murdering anyone who gets in the way.
SNPC_MARTYR: Tasked with destroying critical station infrastructure, will beeline towards vital station components such as the GravGen or PA, and begin a 60s countdown, if uninterrupted, proceeds to explode with sufficient force to destroy it.
SNPC_PSYCHO: Picks targets at random from it's vision range, generating grenades and throwing them at whatever it chooses.
