### PR TITLE
Changes Chaos Guardian's attack

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -278,7 +278,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 /obj/effect/hallucination/delusion
 	var/list/image/delusions = list()
 
-/obj/effect/hallucination/delusion/New(loc,mob/living/carbon/T,force_kind = null , duration = 300,skip_nearby = 1)
+/obj/effect/hallucination/delusion/New(loc,mob/living/carbon/T,force_kind = null , duration = 300,skip_nearby = 1, custom_icon = null, custom_icon_file = null)
 	target = T
 	var/image/A = null
 	var/kind = force_kind ? force_kind : pick("clown","corgi","carp","skeleton","demon")
@@ -298,6 +298,8 @@ Gunshots/explosions/opening doors/less rare audio (done)
 				A = image('icons/mob/human.dmi',H,"skeleton_s")
 			if("demon")//Demon
 				A = image('icons/mob/mob.dmi',H,"daemon")
+			if("custom")
+				A = image(custom_icon_file, H, custom_icon)
 		A.override = 1
 		if(target.client)
 			delusions |= A

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -246,7 +246,7 @@
 	if(summoner)
 		summoner.ExtinguishMob()
 		summoner.adjust_fire_stacks(-20)
-
+/*
 /mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
 	if(..())
 		if(prob(45))
@@ -256,6 +256,13 @@
 					PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(M))
 					do_teleport(M, M, 10)
 					PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(M))
+*/
+
+/mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
+	if(..())
+		if(ishuman(target))
+			spawn(0)
+				new /obj/effect/hallucination/delusion(target.loc,target,force_kind="custom",duration=200,skip_nearby=0, custom_icon = src.icon_state, custom_icon_file = src.icon)
 
 /mob/living/simple_animal/hostile/guardian/fire/Crossed(AM as mob|obj)
 	..()


### PR DESCRIPTION
Rather than teleporting the target randomly, it will chaos that target to hallucinate all mobs as looking like the guardian.

Maybe I should save this effect for a Type B of Chaos or something instead, but it's easier to try the idea out here than make a new type
