### PR TITLE
Adds Firestarter bundle

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -468,3 +468,18 @@
 	for(var/i in 1 to 10)
 		new /obj/item/weapon/c4(src)
 	return
+
+/obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter
+	desc = "A large dufflebag containing New Russian pyro backpack sprayer, a pistol, a pipebomb, fireproof hardsuit, ammo, and other equipment."
+
+/obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter/New()
+	..()
+	new /obj/item/clothing/under/syndicate/soviet(src)
+	new /obj/item/weapon/watertank/operator(src)
+	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)
+	new /obj/item/weapon/gun/projectile/automatic/pistol/APS(src)
+	new /obj/item/ammo_box/magazine/pistolm9mm(src)
+	new /obj/item/ammo_box/magazine/pistolm9mm(src)
+	new /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka/badminka(src)
+	new /obj/item/weapon/reagent_containers/syringe/stimulants(src)
+	new /obj/item/weapon/grenade/syndieminibomb(src)

--- a/code/game/objects/items/weapons/tanks/watertank.dm
+++ b/code/game/objects/items/weapons/tanks/watertank.dm
@@ -442,3 +442,36 @@
 	..()
 	reagents.add_reagent("stimulants_longterm", 300)
 	update_filling()
+
+//Operator backpack spray
+/obj/item/weapon/watertank/operator
+	name = "backpack water tank"
+	desc = "A New Russian backpack spray for systematic cleansing of carbon lifeforms."
+	icon_state = "waterbackpackjani"
+	item_state = "waterbackpackjani"
+	w_class = 3
+	volume = 2000
+	slowdown = 0
+
+/obj/item/weapon/watertank/operator/New()
+	..()
+	reagents.add_reagent("mutagen",350)
+	reagents.add_reagent("napalm",125)
+	reagents.add_reagent("welding_fuel",125)
+	reagents.add_reagent("clf3",300)
+	reagents.add_reagent("cryptobiolin",350)
+	reagents.add_reagent("plasma",250)
+	reagents.add_reagent("condensedcapsaicin",500)
+
+/obj/item/weapon/reagent_containers/spray/mister/operator
+	name = "janitor spray nozzle"
+	desc = "A mister nozzle attached to several extended water tanks. It suspiciously has a compressor in the system and is labelled entirely in New Cyrillic."
+	icon = 'icons/obj/hydroponics/equipment.dmi'
+	icon_state = "misterjani"
+	item_state = "misterjani"
+	w_class = 4
+	amount_per_transfer_from_this = 100
+	possible_transfer_amounts = list(75,100,150)
+
+/obj/item/weapon/watertank/operator/make_noz()
+	return new /obj/item/weapon/reagent_containers/spray/mister/operator(src)

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -29,3 +29,12 @@
 	icon_state = "camogreen"
 	item_state = "g_suit"
 	item_color = "camogreen"
+
+/obj/item/clothing/under/syndicate/soviet
+	name = "Ratnik 5 tracksuit"
+	desc = "Badly translated labels tell you to clean this in Vodka. Great for squatting in."
+	icon_state = "trackpants"
+	item_color = "trackpants"
+	can_adjust = 0
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	burn_state = FIRE_PROOF

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -120,6 +120,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/med/bioterrorbundle
 	cost = 30 // normally 42
 
+/datum/uplink_item/nukeoffer/firestarter
+	name = "Spetsnaz Pyro bundle"
+	desc = "For systematic suppression of carbon lifeforms in close range: Contains a specialist Pyrotechnic equipment, foreign pistol, two magazines, a pipebomb, and a stimulant syringe."
+	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter
+	cost = 30
+
 // Dangerous Items
 /datum/uplink_item/dangerous
 	category = "Conspicuous and Dangerous Weapons"


### PR DESCRIPTION
A specialist, pyro kit from New Russian stockpiles.

This bundle contains appropriate paraphernalia, a pistol and ammo for problems, a fireproof hardsuit, a minibomb, and the star of the show; the backpack chemspray with it's massive 2000u multicylinder chemical storage system, filled to the brim with everything you need to ruin the days of any carbon lifeforms.

https://github.com/tgstation/-tg-station/pull/15576
I messed the resolution of conflicts.

:cl: 
rscadd: Firestarter Bundle, containing APS pistol, 2 magazines, elite hardsuit, Syndicate Pipebomb, stimulants, and the backpack Pyro chemspray.
rscadd: Backpack Chemspray with 2000u capacity.
rscadd: Syndicate Tracksuit.
/:cl:
