### PR TITLE
Breathing requests a turf activation

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -90,7 +90,7 @@
 
 	if(breath)
 		loc.assume_air(breath)
-		loc.air_update_turf()
+		air_update_turf()
 
 /mob/living/carbon/proc/has_smoke_protection()
 	return 0

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -90,6 +90,7 @@
 
 	if(breath)
 		loc.assume_air(breath)
+		loc.air_update_turf()
 
 /mob/living/carbon/proc/has_smoke_protection()
 	return 0


### PR DESCRIPTION
The idea is to let atmos handle if the turf needs to be activated.

This won't activate a turf unless it's needed, and most won't need this, but a few will, so its nice to have.

Also means admins can spawn 100 humans again without them all dying in five minutes to co2 poisoning because turfs didn't activate
