### PR TITLE
Make zombies 2spooky

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -9,8 +9,8 @@
 	speak_emote = list("groans")
 	emote_see = list("groans")
 	a_intent = "harm"
-	maxHealth = 200
-	health = 200
+	maxHealth = 180
+	health = 180
 	speed = 2
 	harm_intent_damage = 8
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -58,12 +58,12 @@
 		if(do_after(src, 250, target))
 			playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 			qdel(target)
-			var/obj/structure/door_assembly/door = new(target.loc)
+			var/obj/machinery/door/airlock/A = target
+			var/obj/structure/door_assembly/door = new A.doortype(target.loc)
 			door.density = 0
 			door.anchored = 1
 			door.name = "ravaged airlock"
 			door.desc = "An airlock that has been torn apart. Looks like it wont be keeping much out now."
-			return 
 
 /mob/living/simple_animal/hostile/zombie/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -58,6 +58,11 @@
 		if(do_after(src, 250, target))
 			playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 			qdel(target)
+			var/obj/structure/door_assembly/door = new airlock.doortype(target.loc)
+			door.density = 0
+			door.anchored = 1
+			door.name = "ravaged airlock"
+			door.desc = "An airlock that has been torn apart. Looks like it wont be keeping much out now."
 			return 
 
 /mob/living/simple_animal/hostile/zombie/death()

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -58,7 +58,7 @@
 		if(do_after(src, 250, target))
 			playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 			qdel(target)
-			var/obj/structure/door_assembly/door = new airlock.doortype(target.loc)
+			var/obj/structure/door_assembly/door = new(target.loc)
 			door.density = 0
 			door.anchored = 1
 			door.name = "ravaged airlock"

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -9,9 +9,9 @@
 	speak_emote = list("groans")
 	emote_see = list("groans")
 	a_intent = "harm"
-	maxHealth = 100
-	health = 100
-	speed = 1
+	maxHealth = 200
+	health = 200
+	speed = 2
 	harm_intent_damage = 8
 	melee_damage_lower = 20
 	melee_damage_upper = 20
@@ -51,6 +51,14 @@
 			visible_message("<span class='danger'>[src] tears [L] to pieces!</span>")
 			src << "<span class='userdanger'>You feast on [L], restoring your health!</span>"
 			revive(full_heal = 1)
+			
+	if(istype(target, /obj/machinery/door/airlock))
+		user << "<span class='notice'>You start tearing apart the airlock...</span>"
+		playsound(src.loc, 'sound/hallucinations/growl3.ogg', 50, 1)
+		if(do_after(user, 250, target))
+			playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
+			qdel(target)
+			return 
 
 /mob/living/simple_animal/hostile/zombie/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -53,9 +53,9 @@
 			revive(full_heal = 1)
 			
 	if(istype(target, /obj/machinery/door/airlock))
-		user << "<span class='notice'>You start tearing apart the airlock...</span>"
+		src << "<span class='notice'>You start tearing apart the airlock...</span>"
 		playsound(src.loc, 'sound/hallucinations/growl3.ogg', 50, 1)
-		if(do_after(user, 250, target))
+		if(do_after(src, 250, target))
 			playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 			qdel(target)
 			return 

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -77,7 +77,7 @@
 		qdel(src)
 		return
 	src << "<span class='userdanger'>You're down, but not quite out. You'll be back on your feet within a minute or two.</span>"
-	spawn(rand(800,1200))
+	spawn(rand(600,900))
 		if(src)
 			visible_message("<span class='danger'>[src] staggers to their feet!</span>")
 			revive(full_heal = 1)


### PR DESCRIPTION
1) Double HP (now 200, so they actually take a little effort to mow down)
2) Can tear down airlocks in around 25 seconds, making super spooky sounds
3) They are now speed = 2, so you can outrun them. If they catch you, you kinda deserve it. (Rule #1 Cardio)

Zombies have potential but their biggest issue is how they immediately fuck up the round before anyone can really react. They function more like 28 weeks later infected (as fragile as humans but just as fast) than traditional zombies (slow, lumbering, takes a beating, but relentless). SS13 is better suited to the latter than a single zombie player that infects 80% of the station within 2 minutes, followed by 20 minutes where everyone else just hides behind welded doors until the round ends. 

This means zombies start slower but finish stronger. A couple zombies will be target practice, but if they manage to grow their numbers, they become infinitely spookier than a bunch of turbozombies zipping around but unable bypass a single door. 

This should make for overall more interesting rounds, I might reduce the revive timer if I think that this makes zombies too much of a non-threat. 
