### PR TITLE
Blacklisted areas for ghosts

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -14,10 +14,10 @@
 
 	// Otherwise jump
 	else if(A.loc)
-		loc = get_turf(A)
+		Move(get_turf(A.loc))
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)
-	
+
 	if(client.click_intercept)
 		if(call(client.click_intercept,"InterceptClickOn")(src,params,A))
 			return

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -54,6 +54,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/has_gravity = 0
 	var/safe = 0 				//Is the area teleport-safe: no space / radiation / aggresive mobs / other dangers
 
+	var/blacklisted = 0			//Rejects ghosts
+
 	var/no_air = null
 	var/area/master				// master area used for power calcluations
 	var/list/related			// the other areas of the same type as this

--- a/code/modules/mining/lavaland/lavaland_areas.dm
+++ b/code/modules/mining/lavaland/lavaland_areas.dm
@@ -26,3 +26,4 @@
 
 /area/lavaland/surface/outdoors
 	name = "Lavaland Wastes"
+	blacklisted = 1

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -116,6 +116,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		loc = NewLoc
 		for(var/obj/effect/step_trigger/S in NewLoc)
 			S.Crossed(src)
+		var/area/new_area = get_area(loc)
+		if(new_area.blacklisted)
+			src << "You can't move around here!"
+			loc = pick(latejoin)
 
 		return
 	loc = get_turf(src) //Get out of closets and such as a ghost
@@ -190,10 +194,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!thearea)
 		return
 
+	if(thearea.blacklisted)
+		usr << "This area does not allow ghosts!"
+
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
 		L+=T
-
 	if(!L || !L.len)
 		usr << "No area available."
 


### PR DESCRIPTION
Kicks them out of they try to fly around in the area. They can still orbit mobs in the area, but no free movement.

The only area blacklisted right now is Lavaland Wastes.

It will

A) Help surprises last slightly longer

B) Stop people scouting out where everything is before spawning as an ash walker or something.
