### PR TITLE
>GOOFBALL IN CHARGE OF MATH

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -238,8 +238,6 @@
 		tot_rating += MB.rating
 	tot_rating *= 25000
 	materials.max_amount = tot_rating * 3
-	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		prod_coeff += M.rating - 1
 
 /obj/machinery/autolathe/proc/main_win(mob/user)
 	var/dat = "<div class='statusDisplay'><h3>Autolathe Menu:</h3><br>"

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -58,18 +58,14 @@ Note: Must be placed west/left of and R&D console to function.
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
 	materials.max_amount = T * 75000
-	T = 0
-	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		T += (M.rating/3)
-	efficiency_coeff = max(T, 1)
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
 	var/A = materials.amount(M)
 	if(!A)
 		A = reagents.get_reagent_amount(M)
-		A = A / max(1, (being_built.reagents[M]/efficiency_coeff))
+		A = A / max(1, (being_built.reagents[M]))
 	else
-		A = A / max(1, (being_built.materials[M]/efficiency_coeff))
+		A = A / max(1, (being_built.materials[M]))
 	return A
 
 /obj/machinery/r_n_d/protolathe/attackby(obj/item/O, mob/user, params)


### PR DESCRIPTION
Removes autolathe/protolathe efficiency upgrades. Not even going to try to bother balancing and re-adding them until I can get basic values for each gun settled.

With goofs protolathe/orm upgrades you'd be getting x4 sheets per ore (enough for 4-8 guns per ore) at roundstart, nevermind when you got both to T4.

Realizing that every single machine in the game is gonna need to be looked at is a nightmare

**16-80 ores per mineral vein!**
