### PR TITLE
Canister breaking open now properly disconnects from possible connect…

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -262,7 +262,6 @@ Class Procs:
 			user << "<span class='warning'>You momentarily forget how to use [src]!</span>"
 			return 1
 	if(!is_interactable())
-		user << "<span class='danger'>\The [src] seems offline.</span>"
 		return 1
 	if(set_machine)
 		user.set_machine(src)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -102,7 +102,7 @@
 #define FULL 16
 #define DANGER 32
 /obj/machinery/portable_atmospherics/canister/update_icon()
-	if(destroyed)
+	if(stat & BROKEN)
 		overlays.Cut()
 		icon_state = "[initial(icon_state)]-1"
 		return
@@ -153,15 +153,17 @@
 		healthcheck()
 
 /obj/machinery/portable_atmospherics/canister/proc/healthcheck()
-	if(destroyed)
+	if(stat & BROKEN)
 		return
 
 	if(health <= 10)
+		disconnect()
+		var/datum/gas_mixture/expelled_gas = air_contents.remove(air_contents.total_moles())
 		var/turf/T = get_turf(src)
-		T.assume_air(air_contents)
+		T.assume_air(expelled_gas)
 		air_update_turf()
 
-		destroyed = TRUE
+		stat |= BROKEN
 		density = 0
 		playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)
 		update_icon()
@@ -173,7 +175,7 @@
 
 /obj/machinery/portable_atmospherics/canister/process_atmos()
 	..()
-	if(destroyed)
+	if(stat & BROKEN)
 		return PROCESS_KILL
 	if(!valve_open)
 		pump.AIR1 = null
@@ -204,13 +206,13 @@
 /obj/machinery/portable_atmospherics/canister/ex_act(severity, target)
 	switch(severity)
 		if(1)
-			if(destroyed || prob(30))
+			if((stat & BROKEN) || prob(30))
 				qdel(src)
 				return
 			else
 				health = 0
 		if(2)
-			if(destroyed)
+			if(stat & BROKEN)
 				qdel(src)
 				return
 			else

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -8,7 +8,6 @@
 	var/obj/item/weapon/tank/holding
 
 	var/volume = 0
-	var/destroyed = 0
 
 	var/maximum_pressure = 90 * ONE_ATMOSPHERE
 
@@ -25,6 +24,7 @@
 /obj/machinery/portable_atmospherics/Destroy()
 	SSair.atmos_machinery -= src
 
+	disconnect()
 	qdel(air_contents)
 	air_contents = null
 
@@ -69,14 +69,14 @@
 	return air_contents
 
 /obj/machinery/portable_atmospherics/attackby(obj/item/weapon/W, mob/user, params)
-	if((istype(W, /obj/item/weapon/tank) && !destroyed))
+	if(istype(W, /obj/item/weapon/tank) && !(stat & BROKEN))
 		var/obj/item/weapon/tank/T = W
 		if(holding || !user.drop_item())
 			return
 		T.loc = src
 		holding = T
 		update_icon()
-	else if(istype(W, /obj/item/weapon/wrench))
+	else if(istype(W, /obj/item/weapon/wrench) && !(stat & BROKEN))
 		if(connected_port)
 			disconnect()
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)


### PR DESCRIPTION
…or port. Canister broken stat now use machinery's (stat & BROKEN) instead of a separate destroyed var.
Fixes #16192
When a canister breaks it now empties its air correctly.
When deleted the canister properly disconnects itself from its connector port.
You can no longer wrench a broken canister onto a connector port.
You can no longer interact (topic window) with a broken canister. (using an analyzer shows the canister is empty)

Removes message in machinery/attack_hand() saying the machine seems offline, it was showing even when the machine is just (stat & BROKEN).
