### PR TITLE
anotha reactive teleport armor nerf

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -127,7 +127,7 @@
 	name = "reactive armor"
 	desc = "Doesn't seem to do much for some reason."
 	var/active = 0
-	var/cd = 0//cooldown specific to reactive armor
+	var/reactivearmor_cooldown = 0//cooldown specific to reactive armor
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
@@ -138,9 +138,6 @@
 
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
-	if(world.time < cd)
-		user << "<span class='notice'>[src] is still cooling down. It can't be reactivated yet.</span>"
-		return
 	src.active = !( src.active )
 	if (src.active)
 		user << "<span class='notice'>[src] is now active.</span>"
@@ -171,6 +168,9 @@
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
+		if(world.time < reactivearmor_cooldown)
+			owner.visible_message("<span class='danger'>The reactive teleport system is still recharging! It fails to teleport [H]!</span>")
+			return
 		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text], shutting itself off in the process!</span>")
 		var/list/turfs = new/list()
 		for(var/turf/T in orange(tele_range, H))
@@ -188,16 +188,13 @@
 			return
 		H.forceMove(picked)
 		H.rad_act(rad_amount)
-		active = 0
-		src.icon_state = "reactiveoff"
-		src.item_state = "reactiveoff"
-		cd = world.time + 100
+		reactivearmor_cooldown = world.time + 100
 		return 1
 	return 0
 
 /obj/item/clothing/suit/armor/reactive/teleport/emp_act(severity)
 	..()
-	cd = world.time + 200
+	reactivearmor_cooldown = world.time + 200
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -184,6 +184,9 @@
 			return
 		H.forceMove(picked)
 		H.rad_act(rad_amount)
+		active = 0
+		src.icon_state = "reactiveoff"
+		src.item_state = "reactiveoff"
 		return 1
 	return 0
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -137,6 +137,9 @@
 
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
+	if(cooldown)
+		user << "<span class='notice'>[src] is still cooling down. It can't be reactivated yet.</span>"
+		return
 	src.active = !( src.active )
 	if (src.active)
 		user << "<span class='notice'>[src] is now active.</span>"
@@ -167,7 +170,7 @@
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
-		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
+		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text], shutting itself off in the process!</span>")
 		var/list/turfs = new/list()
 		for(var/turf/T in orange(tele_range, H))
 			if(T.density)
@@ -187,8 +190,21 @@
 		active = 0
 		src.icon_state = "reactiveoff"
 		src.item_state = "reactiveoff"
+		cooldown++
+		var/cd = cooldown
+		spawn(100)
+			if(cooldown == cd)
+				cooldown = 0
 		return 1
 	return 0
+
+/obj/item/clothing/suit/armor/reactive/teleport/emp_act(severity)
+	cooldown++
+	var/curremp = cooldown
+	..()//shut off
+	spawn(200)
+		if(cooldown == curremp)
+			cooldown = 0
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -127,6 +127,7 @@
 	name = "reactive armor"
 	desc = "Doesn't seem to do much for some reason."
 	var/active = 0
+	var/cd = 0//cooldown specific to reactive armor
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
@@ -137,7 +138,7 @@
 
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
-	if(cooldown)
+	if(world.time < cd)
 		user << "<span class='notice'>[src] is still cooling down. It can't be reactivated yet.</span>"
 		return
 	src.active = !( src.active )
@@ -190,21 +191,13 @@
 		active = 0
 		src.icon_state = "reactiveoff"
 		src.item_state = "reactiveoff"
-		cooldown++
-		var/cd = cooldown
-		spawn(100)
-			if(cooldown == cd)
-				cooldown = 0
+		cd = world.time + 100
 		return 1
 	return 0
 
 /obj/item/clothing/suit/armor/reactive/teleport/emp_act(severity)
-	cooldown++
-	var/curremp = cooldown
-	..()//shut off
-	spawn(200)
-		if(cooldown == curremp)
-			cooldown = 0
+	..()
+	cd = world.time + 200
 
 /obj/item/clothing/suit/armor/reactive/fire
 	name = "reactive incendiary armor"


### PR DESCRIPTION
https://www.youtube.com/watch?v=FSswEzWJdWo

it now has a cooldown between teleports that is also applied when it gets EMPed

:cl: PKPenguin321
tweak: The RD's reactive teleport armor now has a cooldown between teleports. EMPing it will cause it to shut down and have a longer cooldown applied.
/:cl:
