### PR TITLE
Fixes ssair trying to proc unsimulated turfs.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -147,9 +147,9 @@ var/datum/subsystem/air/SSair
 /datum/subsystem/air/proc/remove_from_active(turf/simulated/T)
 	if(istype(T))
 		T.excited = 0
-		active_turfs -= T
 		if(T.excited_group)
 			T.excited_group.garbage_collect()
+	active_turfs -= T
 
 
 /datum/subsystem/air/proc/add_to_active(turf/simulated/T, blockchanges = 1)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -145,11 +145,11 @@ var/datum/subsystem/air/SSair
 
 
 /datum/subsystem/air/proc/remove_from_active(turf/simulated/T)
+	active_turfs -= T
 	if(istype(T))
 		T.excited = 0
 		if(T.excited_group)
 			T.excited_group.garbage_collect()
-	active_turfs -= T
 
 
 /datum/subsystem/air/proc/add_to_active(turf/simulated/T, blockchanges = 1)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -117,13 +117,11 @@
 		sharer.temperature += heat/sharer.heat_capacity
 
 
+/turf/proc/process_cell(fire_count)
+	SSair.remove_from_active(src)
 
 
-
-
-
-
-/turf/simulated/proc/process_cell(fire_count)
+/turf/simulated/process_cell(fire_count)
 
 	if(archived_cycle < fire_count) //archive self if not already done
 		archive()


### PR DESCRIPTION
An active/excited simulated turf would get deleted and converted to space, so this would change the turf in ssair's active_turfs list to a space turf, then it would runtime trying to call process_cell on it. (why byond!)

Before a : and some lack of caring and a type check handled this. I removed this thinking it wasn't needed when i did my lag fix. (My exact thought was "why would an unsimulated turf get in ssair's active turf list, that seems like a bug that shouldn't get hidden" i forgot that deleting a turf just converts it to a space turf and all existing references are updated by byond to point to the new space turf)

this OOP way seems better anyways.
