### PR TITLE
Plasmaman jumpsuit now only extinguishes wearer if they are on fire

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -531,7 +531,7 @@
 	if(!istype(H))
 		return
 
-	if(H.fire_stacks)
+	if(H.on_fire)
 		if(extinguishes_left)
 			if(next_extinguish > world.time)
 				return


### PR DESCRIPTION
Fixes #16091

This fixes the bug described in https://github.com/tgstation/-tg-station/issues/16091, but only with the plasmaman jumpsuit. The plasmaman EVA suit code (/code/modules/clothing/spacesuits/plasmamen.dm) hasn't been changed.

The wearer may douse themself in water or welding fuel without their jumpsuit automatically 'extinguishing' them as long as they are not on fire.
