### PR TITLE
Hopefully resolves Runtime catastrophe

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -81,10 +81,11 @@
 	gender = FEMALE
 	gold_core_spawnable = 0
 	var/list/family = list()
+	var/cats_deployed = 0
 	var/memory_saved = 0
 
 /mob/living/simple_animal/pet/cat/Runtime/New()
-	if(prob(30))
+	if(prob(5))
 		icon_state = "original"
 		icon_living = "original"
 		icon_dead = "original_dead"
@@ -92,6 +93,8 @@
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/Life()
+	if(!cats_deployed && ticker.current_state >= GAME_STATE_SETTING_UP)
+		Deploy_The_Cats()
 	if(!stat && ticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 	..()
@@ -108,11 +111,6 @@
 	if(isnull(family))
 		family = list()
 
-	for(var/cat_type in family)
-		if(family[cat_type] > 0)
-			for(var/i in 1 to family[cat_type])
-				new cat_type(loc)
-
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
 	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 	family = list()
@@ -126,6 +124,12 @@
 	S["family"]				<< family
 	memory_saved = 1
 
+/mob/living/simple_animal/pet/cat/Runtime/proc/Deploy_The_Cats()
+	for(var/cat_type in family)
+		if(family[cat_type] > 0)
+			for(var/i in 1 to min(family[cat_type],100)) //Limits to about 500 cats, you wouldn't think this would be needed (BUT IT IS)
+				new cat_type(loc)
+	cats_deployed = 1
 
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"


### PR DESCRIPTION
Runtime's extended family doesn't spawn until the round is just about to start.

In theory this should close out the window during which Runtime would furiously breed with any other cat she can see on her tile.

In addition this lowers the chance of Not!Espeon Runtime to 5% per round. I asked Kor if I could do this and he was/is fine with it. 

Also added a 100 cat cap on each type of spawned cat. HOPEFULLY IT'S NEVER NEEDED.

Fixes #16272
:cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2: :cat2:
