### PR TITLE
Adds a way to change vehicles view range

### DIFF
--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -71,7 +71,8 @@
 	if(istype(buckled_mob))
 		buckled_mob.pixel_x = 0
 		buckled_mob.pixel_y = 0
-		buckled_mob.client.view = world.view
+		if(buckled_mob.client)
+			buckled_mob.client.view = world.view
 	. = ..()
 
 
@@ -85,7 +86,8 @@
 	M.loc = get_turf(src)
 	..()
 	handle_vehicle_offsets()
-	user.client.view = view_range
+	if(user.client)
+		user.client.view = view_range
 
 
 //MOVEMENT

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -12,6 +12,7 @@
 	var/next_vehicle_move = 0 //used for move delays
 	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/auto_door_open = TRUE
+	var/view_range = world.view
 
 	//Pixels
 	var/generic_pixel_x = 0 //All dirs show this pixel_x for the driver
@@ -70,6 +71,7 @@
 	if(istype(buckled_mob))
 		buckled_mob.pixel_x = 0
 		buckled_mob.pixel_y = 0
+		buckled_mob.client.view = world.view
 	. = ..()
 
 
@@ -83,6 +85,7 @@
 	M.loc = get_turf(src)
 	..()
 	handle_vehicle_offsets()
+	user.client.view = view_range
 
 
 //MOVEMENT

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -12,7 +12,7 @@
 	var/next_vehicle_move = 0 //used for move delays
 	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/auto_door_open = TRUE
-	var/view_range = world.view
+	var/view_range = 7
 
 	//Pixels
 	var/generic_pixel_x = 0 //All dirs show this pixel_x for the driver


### PR DESCRIPTION
Didn't touch any vehicle so far, so they are at world's default(which is 7). Admins can change the view_range var to change that vehicle's view range.

Suggested by Sweaterkittens
