### PR TITLE
Adds mentorhelp

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -84,11 +84,6 @@
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
 
-/client/proc/ahelp(msg, sound, title, ircalert, unique_id, delay)
-	if(say_disabled)        //This is here to try to identify lag problems
-		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
-		return
-
 //handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)
 		src << "<span class='danger'>Error: [title]-PM: You cannot send adminhelps (Muted).</span>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -72,13 +72,17 @@
 /client/verb/mentorhelp(msg as text)
 		set category = "Admin"
 		set name = "Mentorhelp"
-		ahelp(msg, 'sound/machines/twobeep.ogg', "Mentor", ircalert=FALSE, "MH", 0)
+		ahelp(msg, 'sound/machines/twobeep.ogg', "Mentor", FALSE, "MH", 0)
 
 /client/verb/adminhelp(msg as text)
 		set category = "Admin"
 		set name = "Adminhelp"
+		ahelp(msg, 'sound/effects/adminhelp.ogg', "Admin", TRUE, "AH",  1200)
 
-		ahelp(msg, 'sound/effects/adminhelp.ogg', "Admin", ircalert=TRUE, "AH",  1200)
+/client/proc/ahelp(msg, sound, title, ircalert, unique_id, delay)
+	if(say_disabled)        //This is here to try to identify lag problems
+		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
+		return
 
 /client/proc/ahelp(msg, sound, title, ircalert, unique_id, delay)
 	if(say_disabled)        //This is here to try to identify lag problems

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -1,3 +1,4 @@
+
 /proc/keywords_lookup(msg)
 
 	//This is a list of words which are ignored by the parser when comparing message contents for names. MUST BE IN LOWER CASE!
@@ -146,3 +147,46 @@
 	if(config.useircbot)
 		shell("python nudge.py [msg] [msg2]")
 	return
+
+
+
+
+/client/verb/mentorhelp(msg as text)
+	set category = "Admin"
+	set name = "Mentorhelp"
+
+	if(say_disabled)
+		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
+		return
+
+	if(prefs.muted & MUTE_ADMINHELP)
+		src << "<span class='danger'>Error: Admin-PM: You cannot send adminhelps (Muted).</span>"
+		return
+	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
+		return
+
+	if(!msg)
+		return
+	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
+	if(!msg)	return
+	var/original_msg = msg
+
+	msg = keywords_lookup(msg)
+
+	if(!mob)
+		return
+
+	var/ref_mob = "\ref[mob]"
+	var/ref_client = "\ref[src]"
+	msg = "<span class='adminnotice'><b><font color=red>HELP: </font><A HREF='?priv_msg=[ckey];ahelp_reply=1'>[key_name(src)]</A> (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=[ref_mob]'>FLW</A>) (<A HREF='?_src_=holder;traitor=[ref_mob]'>TP</A>) (<A HREF='?_src_=holder;rejectadminhelp=[ref_client]'>REJT</A>):</b> [msg]</span>"
+
+
+
+	for(var/client/X in admins)
+		if(X.prefs.toggles & SOUND_ADMINHELP)
+			X << 'sound/effects/adminhelp.ogg'
+		X << msg
+
+	src << "<span class='adminnotice'>PM to-<b>Mentors</b>: [original_msg]</span>"
+
+

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -160,7 +160,7 @@
 		return
 
 	if(prefs.muted & MUTE_ADMINHELP)
-		src << "<span class='danger'>Error: Admin-PM: You cannot send adminhelps (Muted).</span>"
+		src << "<span class='danger'>Error: Admin-PM: You cannot send mentorhelps (Muted).</span>"
 		return
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
@@ -184,7 +184,7 @@
 
 	for(var/client/X in admins)
 		if(X.prefs.toggles & SOUND_ADMINHELP)
-			X << 'sound/effects/adminhelp.ogg'
+			X << 'sound/machines/twobeep.ogg'
 		X << msg
 
 	src << "<span class='adminnotice'>PM to-<b>Mentors</b>: [original_msg]</span>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -69,56 +69,63 @@
 	src.verbs |= /client/verb/adminhelp
 	adminhelptimerid = 0
 
-/client/verb/adminhelp(msg as text)
-	set category = "Admin"
-	set name = "Adminhelp"
+/client/verb/mentorhelp(msg as text)
+		set category = "Admin"
+		set name = "Mentorhelp"
+		ahelp(msg, 'sound/machines/twobeep.ogg', "Mentor", ircalert=FALSE, "MH", 0)
 
-	if(say_disabled)	//This is here to try to identify lag problems
+/client/verb/adminhelp(msg as text)
+		set category = "Admin"
+		set name = "Adminhelp"
+
+		ahelp(msg, 'sound/effects/adminhelp.ogg', "Admin", ircalert=TRUE, "AH",  1200)
+
+/client/proc/ahelp(msg, sound, title, ircalert, unique_id, delay)
+	if(say_disabled)        //This is here to try to identify lag problems
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
 
-	//handle muting and automuting
+//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)
-		src << "<span class='danger'>Error: Admin-PM: You cannot send adminhelps (Muted).</span>"
+		src << "<span class='danger'>Error: [title]-PM: You cannot send adminhelps (Muted).</span>"
 		return
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
-	//clean the input msg
+//clean the input msg
 	if(!msg)
 		return
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
-	if(!msg)	return
+	if(!msg)        return
 	var/original_msg = msg
 
-	//remove our adminhelp verb temporarily to prevent spamming of admins.
+//remove our adminhelp verb temporarily to prevent spamming of admins.
 	src.verbs -= /client/verb/adminhelp
-	adminhelptimerid = addtimer(src, "giveadminhelpverb", 1200, FALSE) //2 minute cooldown of admin helps
+	adminhelptimerid = addtimer(src, "giveadminhelpverb", delay, FALSE) //2 minute cooldown of admin helps
 
 	msg = keywords_lookup(msg)
 
 	if(!mob)
-		return						//this doesn't happen
+		return                                                //this doesn't happen
 
 	var/ref_mob = "\ref[mob]"
 	var/ref_client = "\ref[src]"
 	msg = "<span class='adminnotice'><b><font color=red>HELP: </font><A HREF='?priv_msg=[ckey];ahelp_reply=1'>[key_name(src)]</A> (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=[ref_mob]'>FLW</A>) (<A HREF='?_src_=holder;traitor=[ref_mob]'>TP</A>) (<A HREF='?_src_=holder;rejectadminhelp=[ref_client]'>REJT</A>):</b> [msg]</span>"
-
-	//send this msg to all admins
-
+//send this msg to all admins
 	for(var/client/X in admins)
 		if(X.prefs.toggles & SOUND_ADMINHELP)
-			X << 'sound/effects/adminhelp.ogg'
+			X << sound
 		X << msg
 
+//show it to the person adminhelping too
+	src << "<span class='adminnotice'>PM to-<b>[title]s</b>: [original_msg]</span>"
 
-	//show it to the person adminhelping too
-	src << "<span class='adminnotice'>PM to-<b>Admins</b>: [original_msg]</span>"
+//send it to irc if nobody is on and tell us how many were on
 
-	//send it to irc if nobody is on and tell us how many were on
-	var/admin_number_present = send2irc_adminless_only(ckey,original_msg)
-	log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
-	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	if(ircalert)
+		var/admin_number_present = send2irc_adminless_only(ckey,original_msg)
+		log_admin("HELP: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins who have +BAN.")
+	feedback_add_details("admin_verb",unique_id)//If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
 /proc/get_admin_counts(requiredflags = R_BAN)
@@ -147,46 +154,3 @@
 	if(config.useircbot)
 		shell("python nudge.py [msg] [msg2]")
 	return
-
-
-
-
-/client/verb/mentorhelp(msg as text)
-	set category = "Admin"
-	set name = "Mentorhelp"
-
-	if(say_disabled)
-		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
-		return
-
-	if(prefs.muted & MUTE_ADMINHELP)
-		src << "<span class='danger'>Error: Admin-PM: You cannot send mentorhelps (Muted).</span>"
-		return
-	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
-		return
-
-	if(!msg)
-		return
-	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
-	if(!msg)	return
-	var/original_msg = msg
-
-	msg = keywords_lookup(msg)
-
-	if(!mob)
-		return
-
-	var/ref_mob = "\ref[mob]"
-	var/ref_client = "\ref[src]"
-	msg = "<span class='adminnotice'><b><font color=red>HELP: </font><A HREF='?priv_msg=[ckey];ahelp_reply=1'>[key_name(src)]</A> (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=[ref_mob]'>FLW</A>) (<A HREF='?_src_=holder;traitor=[ref_mob]'>TP</A>) (<A HREF='?_src_=holder;rejectadminhelp=[ref_client]'>REJT</A>):</b> [msg]</span>"
-
-
-
-	for(var/client/X in admins)
-		if(X.prefs.toggles & SOUND_ADMINHELP)
-			X << 'sound/machines/twobeep.ogg'
-		X << msg
-
-	src << "<span class='adminnotice'>PM to-<b>Mentors</b>: [original_msg]</span>"
-
-


### PR DESCRIPTION
Alright hear me out, this mentorhelp is basically just an adminhelp, however the main reason I wanted to add it was because newer or more casual players might be too afraid to ahelp for a simple question because of how serious ahelp kind of can be considered. I know this was the case for me when I started playing and other people also agree, this is mainly just a psychological addition.

sorry about copy-paste

:cl: 
   rscadd: There is now a mentor-help button under the admin tab to ask questions.
/:cl:
