### PR TITLE
Shadowling Space Fix and Thrall Exploit Fix

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -525,6 +525,10 @@
 					user << "<span class='warning'>[thrallToRevive] must be conscious to become empowered.</span>"
 					revert_cast()
 					return
+				if(thrallToRevive.dna.species.id == "l_shadowling")
+					user << "<span class='warning'>[thrallToRevive] is already empowered.</span>"
+					revert_cast()
+					return
 				var/empowered_thralls = 0
 				for(var/datum/mind/M in ticker.mode.thralls)
 					if(!ishuman(M.current))

--- a/code/game/gamemodes/shadowling/shadowling_items.dm
+++ b/code/game/gamemodes/shadowling/shadowling_items.dm
@@ -23,7 +23,7 @@
 	heat_protection = null //You didn't expect a light-sensitive creature to have heat resistance, did you?
 	max_heat_protection_temperature = null
 	armor = list(melee = 25, bullet = 0, laser = 0, energy = 0, bomb = 25, bio = 100, rad = 100)
-	flags = ABSTRACT | NODROP | THICKMATERIAL
+	flags = ABSTRACT | NODROP | THICKMATERIAL | STOPSPRESSUREDMAGE
 
 
 /obj/item/clothing/shoes/shadowling


### PR DESCRIPTION
Fixes Shadowlings not being spaceproof and a Lesser Shadowling Exploit

They're meant to be 100% spaceproof, but still take damage from starlight--not take damage from pressure and starlight both.

Also fixes https://github.com/tgstation/-tg-station/issues/16337

Fixes being able to repeatedly set a Lesser Shadowling to Lesser Shadowling, thereby granting additional spells, each time.

:cl: Fox McCloud
fix: Fixes Shadowlings not being spaceproof to pressure
fix: Fixes being able to receive multiple spells as a Lesser Shadowling
/:cl:
