### PR TITLE
Adds client volume control for admin sounds.

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -7,8 +7,13 @@ var/sound/admin_sound
 	if(!check_rights(R_SOUNDS))
 		return
 
-	admin_sound = sound(S, repeat = 0, wait = 1, channel = SOUND_CHANNEL_ADMIN)
+
+	var/sound/admin_sound = new()
+	admin_sound.file = S
 	admin_sound.priority = 250
+	admin_sound.channel = SOUND_CHANNEL_ADMIN
+	admin_sound.wait = 1
+	admin_sound.repeat = 0
 	admin_sound.status = SOUND_UPDATE|SOUND_STREAM
 
 	log_admin("[key_name(src)] played sound [S]")
@@ -20,7 +25,8 @@ var/sound/admin_sound
 
 	for(var/mob/M in player_list)
 		if(M.client.prefs.toggles & SOUND_MIDI)
-			M << admin_sound
+			var/vol = M.client.prefs.adminmusicvolume
+			M << sound(admin_sound,channel = SOUND_CHANNEL_ADMIN,volume=vol)
 
 	admin_sound.frequency = 1 //Remove this line when the AFD stuff above is gone
 	admin_sound.wait = 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -60,7 +60,7 @@ var/list/preferences_datums = list()
 	var/list/features = list("mcolor" = "FFF", "tail_lizard" = "Smooth", "tail_human" = "None", "snout" = "Round", "horns" = "None", "ears" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None")
 
 	var/list/custom_names = list("clown", "mime", "ai", "cyborg", "religion", "deity")
-
+	var/adminmusicvolume = 50
 		//Mob preview
 	var/icon/preview_icon = null
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -220,6 +220,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["preferred_map"]		>> preferred_map
 	S["ignoring"]			>> ignoring
 	S["ghost_hud"]			>> ghost_hud
+	S["adminmusicvolume"]	>> adminmusicvolume
 	S["inquisitive_ghost"]	>> inquisitive_ghost
 
 	//try to fix any outdated data if necessary
@@ -267,6 +268,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["preferred_map"]		<< preferred_map
 	S["ignoring"]			<< ignoring
 	S["ghost_hud"]			<< ghost_hud
+	S["adminmusicvolume"]	<< adminmusicvolume
 	S["inquisitive_ghost"]	<< inquisitive_ghost
 
 	return 1

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -288,3 +288,12 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	src << "You will now [(prefs.toggles & SOUND_ANNOUNCEMENTS) ? "no longer hear announcements" : "hear announcement sounds"]."
 	prefs.save_preferences()
 	feedback_add_details("admin_verb","TAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+
+/client/verb/set_admin_volume()
+	set name = "Set Admin Music Volume"
+	set category = "Preferences"
+	set desc = "Set the volume you hear admin music at."
+	var/musinput = input("Range of 0 to 100.","Admin Music Volume", prefs.adminmusicvolume) as num
+	prefs.adminmusicvolume = max(0,min(musinput,100))
+	prefs.save_preferences()


### PR DESCRIPTION
Ported from goon, clients now have a preference for admin sounds!
Has a range from 0 to 100.

Note this will only affect future sounds, not currently playing ones.
:cl:
add: Clients now have a volume preference for admin-played sounds.
/:cl:
