### PR TITLE
Humanless stations are now possible (not by default calm down)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -115,7 +115,6 @@
 	var/show_game_type_odds = 0			//if set this allows players to see the odds of each roundtype on the get revision screen
 	var/mutant_races = 0				//players can choose their mutant race before joining the game
 	var/list/roundstart_races = list()	//races you can play as from the get go. If left undefined the game's roundstart var for species is used
-	var/cleared_default_races = 0		//used for sanity in clearing the old default list, not actually a config option
 	var/mutant_humans = 0				//players can pick mutant bodyparts for humans before joining the game
 
 	var/no_summon_guns		//No
@@ -536,12 +535,10 @@
 				if("join_with_mutant_race")
 					config.mutant_races				= 1
 				if("roundstart_races")
-					if(!cleared_default_races)
-						roundstart_species = list()
-						cleared_default_races = 1
 					var/race_id = lowertext(value)
 					for(var/species_id in species_list)
 						if(species_id == race_id)
+							roundstart_races += species_list[species_id]
 							roundstart_species[species_id] = species_list[species_id]
 				if("join_with_mutant_humans")
 					config.mutant_humans			= 1

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -226,7 +226,8 @@
 /mob/living/carbon/proc/create_dna()
 	dna = new /datum/dna(src)
 	if(!dna.species)
-		dna.species = new /datum/species/human()
+		var/rando_race = pick(config.roundstart_races)
+		dna.species = new rando_race()
 
 //proc used to update the mob's appearance after its dna UI has been changed
 /mob/living/carbon/proc/updateappearance(icon_update=1, mutcolor_update=0, mutations_overlay_update=0)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -374,7 +374,8 @@
 	if(subject.dna.species)
 		R.fields["mrace"] = subject.dna.species.type
 	else
-		R.fields["mrace"] = /datum/species/human
+		var/datum/species/rando_race = pick(config.roundstart_races)
+		R.fields["mrace"] = rando_race.type
 	R.fields["ckey"] = subject.ckey
 	R.fields["name"] = subject.real_name
 	R.fields["id"] = copytext(md5(subject.real_name), 2, 6)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -168,7 +168,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 					underwear = "Nude"
 
 	if(pref_species && !(pref_species.id in roundstart_species))
-		pref_species = new /datum/species/human()
+		var/rando_race = pick(config.roundstart_races)
+		pref_species = new rando_race()
 
 	if(current_version < 13 || !istext(backbag))
 		switch(backbag)
@@ -299,7 +300,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		var/newtype = roundstart_species[species_id]
 		pref_species = new newtype()
 	else
-		pref_species = new /datum/species/human()
+		var/rando_race = pick(config.roundstart_races)
+		pref_species = new rando_race()
 
 	if(!S["features["mcolor"]"] || S["features["mcolor"]"] == "#000")
 		S["features["mcolor"]"]	<< "#FFF"

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -6,7 +6,6 @@
 	name = "Human"
 	id = "human"
 	default_color = "FFFFFF"
-	roundstart = 1
 	specflags = list(EYECOLOR,HAIR,FACEHAIR,LIPS)
 	mutant_bodyparts = list("tail_human", "ears")
 	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None")
@@ -55,7 +54,6 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	id = "lizard"
 	say_mod = "hisses"
 	default_color = "00FF00"
-	roundstart = 1
 	specflags = list(MUTCOLORS,EYECOLOR,LIPS)
 	mutant_bodyparts = list("tail_lizard", "snout", "spines", "horns", "frills", "body_markings")
 	default_features = list("mcolor" = "0F0", "tail" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None")

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -15,7 +15,8 @@
 	facial_hair_color = hair_color
 	eye_color = random_eye_color()
 	if(!pref_species)
-		pref_species = new /datum/species/human()
+		var/rando_race = pick(config.roundstart_races)
+		pref_species = new rando_race()
 	backbag = 1
 	features = random_features()
 	age = rand(AGE_MIN,AGE_MAX)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -261,9 +261,9 @@ JOIN_WITH_MUTANT_RACE
 
 ## Roundstart Races
 ##-------------------------------------------------------------------------------------------
-## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on
+## Uncommenting races will allow them to be choosen at roundstart while join_with_muntant_race is on. You'll need at least one.
 
-## Disabling humans is possible but a bit buggy. Some code relies on the notion that white people exist in space.
+## You probably want humans on your space station, but technically speaking you can turn them off without any ill effect
 ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
@@ -277,13 +277,22 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES golem
 #ROUNDSTART_RACES adamantine
+#ROUNDSTART_RACES plasma
+#ROUNDSTART_RACES diamond
+#ROUNDSTART_RACES gold
+#ROUNDSTART_RACES silver
+#ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
+#ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton
 #ROUNDSTART_RACES zombie
 #ROUNDSTART_RACES slime
 #ROUNDSTART_RACES pod
+#ROUNDSTART_RACES military_synth
+#ROUNDSTART_RACES agent
+
 ##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game


### PR DESCRIPTION
Removes the human biases from preferences code. You can now run stations with only mutant races if you want.

Caveat: All humanized monkeys will still be humans, I tried to fix this but thanks to what seems to be a race condition in DNA doing so made roughly 50% of all humans (mob/living/carbon/humans) drop dead at the first life tick. This also means any humans you spawn from the game panel will be human (which is something most people want from my experience).

Updates the race list in game_options.txt. Our servers don't auto update config files, so this is just for anyone who makes a server going forward.

This code was destined for a meme pull, but this part of it is actually theoretically useful on its own in a way that isn't a meme.
