### PR TITLE
SHADOWLING NERF

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -1,6 +1,6 @@
 #define LIGHT_DAM_THRESHOLD 4
-#define LIGHT_HEAL_THRESHOLD 2
-#define LIGHT_DAMAGE_TAKEN 7
+#define LIGHT_HEAL_THRESHOLD 1
+#define LIGHT_DAMAGE_TAKEN 14
 
 /*
 
@@ -46,7 +46,7 @@ Made by Xhuis
 	var/list/datum/mind/shadows = list()
 	var/list/datum/mind/thralls = list()
 	var/list/shadow_objectives = list()
-	var/required_thralls = 15 //How many thralls are needed (hardcoded for now)
+	var/required_thralls = 30 //How many thralls are needed (hardcoded for now)
 	var/shadowling_ascended = 0 //If at least one shadowling has ascended
 	var/shadowling_dead = 0 //is shadowling kill
 	var/objective_explanation
@@ -68,7 +68,7 @@ Made by Xhuis
 	name = "shadowling"
 	config_tag = "shadowling"
 	antag_flag = ROLE_SHADOWLING
-	required_players = 30
+	required_players = 50
 	required_enemies = 2
 	recommended_enemies = 2
 	restricted_jobs = list("AI", "Cyborg")
@@ -271,20 +271,18 @@ Made by Xhuis
 				H << "<span class='userdanger'>The light burns you!</span>" //Message spam to say "GET THE FUCK OUT"
 				H << 'sound/weapons/sear.ogg'
 		else if (light_amount < LIGHT_HEAL_THRESHOLD)
-			H.heal_overall_damage(5,5)
-			H.adjustToxLoss(-5)
-			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
+			H.heal_overall_damage(1,1)
+			H.adjustToxLoss(-3)
+			H.adjustBrainLoss(-5) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
 			H.adjustCloneLoss(-1)
-			H.SetWeakened(0)
-			H.SetStunned(0)
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful
 	name = "Lesser Shadowling"
 	id = "l_shadowling"
 	say_mod = "chitters"
 	specflags = list(NOBREATH,NOBLOOD,RADIMMUNE)
-	burnmod = 1.1
-	heatmod = 1.1
+	burnmod = 1.3
+	heatmod = 1.3
 
 /datum/species/shadow/ling/lesser/spec_life(mob/living/carbon/human/H)
 	if(!H.weakeyes) H.weakeyes = 1
@@ -296,9 +294,9 @@ Made by Xhuis
 		if(light_amount > LIGHT_DAM_THRESHOLD && !H.incorporeal_move)
 			H.take_overall_damage(0, LIGHT_DAMAGE_TAKEN/2)
 		else if (light_amount < LIGHT_HEAL_THRESHOLD)
-			H.heal_overall_damage(2,2)
-			H.adjustToxLoss(-5)
-			H.adjustBrainLoss(-25)
+			H.heal_overall_damage(0.5,0.5)
+			H.adjustToxLoss(-1)
+			H.adjustBrainLoss(-1)
 			H.adjustCloneLoss(-1)
 
 /datum/game_mode/proc/update_shadow_icons_added(datum/mind/shadow_mind)


### PR DESCRIPTION
We checked stat gathering today.

(RATING: 92%) was the shadowling success rate.

No.
:cl: Iamgoofball
rscadd: Shadowlings have gotten serious nerfs, due to having a success rate of 92%.
rscadd: They now need a light level of 1 or lower to heal, down from 2.
rscadd: They now take 7 damage a tick from light, up from 3.5.
rscadd: You now need 30 thralls to win, up from 15
rscadd: The gamemode now needs 50 players, up from 30.
rscadd: Empowered Thralls now take 1.3x more brute/burn, up from 1.1x
rscadd: Empowered Thralls now only heal 0.5 brute/burn, 1 toxin, 1 brain, and 1 clone loss a tick when healing.
rscadd: Hatched Shadowlings now only heal 1 brute/burn, 3 toxin, 5 brain, and 1 clone loss a tick, and are no longer completely immune to stuns.
/:cl:
