### PR TITLE
Adds five new bundles to traitors. Removes random bundles.

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -77,5 +77,7 @@
 
 /obj/item/weapon/implanter/weapons_auth
 	name = "implanter (weapons authentication)"
+	
+/obj/item/weapon/implanter/weapons_auth/New()
 	imp = new /obj/item/weapon/implant/weapons_auth()
 	..()

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -74,3 +74,8 @@
 /obj/item/weapon/implanter/emp/New()
 	imp = new /obj/item/weapon/implant/emp(src)
 	..()
+
+/obj/item/weapon/implanter/weapons_auth
+	name = "implanter (weapons authentication)"
+	imp = new /obj/item/weapon/implant/weapons_auth()
+	..()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/storage/box/syndicate/
+/obj/item/weapon/storage/box/syndicate/ //Exclusive to the emagged cargo console
 
 /obj/item/weapon/storage/box/syndicate/New()
 	..()
@@ -90,6 +90,7 @@
 			new /obj/item/device/camera_bug(src)
 			new /obj/item/device/sbeacondrop/powersink(src)
 			new /obj/item/weapon/cartridge/syndicate(src)
+			return
 
 		if("darklord")
 			new /obj/item/weapon/melee/energy/sword/saber(src)
@@ -103,6 +104,61 @@
 	name = "box"
 	desc = "A sleek, sturdy box"
 	icon_state = "box_of_doom"
+
+/*New Uplink Bundles*/
+/obj/item/weapon/storage/box/syndie_kit/darklord/New() //Now you too can play as darth vader
+	..()
+	new /obj/item/weapon/melee/energy/sword/saber/red(src)
+	new /obj/item/weapon/melee/energy/sword/saber/red(src)
+	new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
+	new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
+	new /obj/item/weapon/card/id/syndicate(src)
+	new /obj/item/clothing/mask/chameleon(src)
+
+/obj/item/weapon/storage/box/syndie_kit/sleepingcarp/New() //Space Ninjas aren't just admin only anymore.
+	..()
+	new /obj/item/weapon/storage/box/syndie_kit/throwing_weapons(src)
+	new /obj/item/weapon/sleeping_carp_scroll(src)
+	new /obj/item/weapon/twohanded/bostaff(src)
+	new /obj/item/weapon/card/id/syndicate(src)
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/head/chameleon(src)
+	new /obj/item/clothing/mask/chameleon(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
+
+/obj/item/weapon/storage/box/syndie_kit/awperative/New() //SYNDIES CALL THE SHUTTLE!
+	..()
+	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
+	new /obj/item/weapon/implanter/explosive(src)
+	new /obj/item/weapon/implanter/weapons_auth(src)
+	new /obj/item/weapon/gun/projectile/automatic/c20r(src)
+	new /obj/item/clothing/mask/gas/syndicate(src)
+	new /obj/item/weapon/card/id/syndicate(src)
+	new /obj/item/weapon/c4(src) //Like a cherry on top.
+
+
+/obj/item/weapon/storage/box/syndie_kit/implantbundle/New() //Makes you slippery like a fish. Worse case scenario, just *deathgasp
+	..()
+	new /obj/item/weapon/implanter/freedom(src)
+	//new /obj/item/weapon/implanter/uplink(src)
+	new /obj/item/weapon/implanter/emp(src)
+	new /obj/item/weapon/implanter/adrenalin(src)
+	new /obj/item/weapon/implanter/explosive(src)
+	new /obj/item/weapon/implanter/storage(src)
+
+/obj/item/weapon/storage/box/syndie_kit/awperator/New()
+	..()
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/weapon/gun/projectile/automatic/pistol(src)
+	new /obj/item/weapon/suppressor(src)
+	new /obj/item/weapon/reagent_containers/syringe/mulligan(src)
+	new /obj/item/weapon/card/id/syndicate(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/weapon/storage/secure/briefcase/syndie(src)
+	new /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate(src)
+
+
+
 
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 	name = "boxed freedom implant (with injector)"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -126,6 +126,43 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter
 	cost = 30
 
+//Traitor Bundles
+/datum/uplink_item/traitoroffer
+	category = "Special Offers"
+	surplus = 0
+	include_modes = list(/datum/game_mode/traitor)
+
+/datum/uplink_item/traitoroffer/darklord
+	name = "Dark Lord Bundle"
+	desc = "In a galaxy far far away, these are the weapons of choice that they use. Contains: Two red energy swords, a TK injector, a cool black robe, and voice changing mask."
+	item = /obj/item/weapon/storage/box/syndie_kit/darklord
+	cost = 20
+
+/datum/uplink_item/traitoroffer/sleepingcarp
+	name = "Sleeping Carp Bundle"
+	desc = "Bring honor to your clan with these time honored weapons. Includes: The secrets of the sleeping carp, a box of throwing stars, a bo staff, and a ninja costume."
+	item = /obj/item/weapon/storage/box/syndie_kit/sleepingcarp
+	cost = 20
+
+/datum/uplink_item/traitoroffer/awperative
+	name = "Nuclear Operative Bundle"
+	desc = "Get dat disk! This bundle gears you like an a nuclear operative. Includes: A slick blood red hardsuit, an explosive implant, a C-20r, the implant required to used the C-20r, and, to make it really convincing, some C4."
+	item = /obj/item/weapon/storage/box/syndie_kit/awperative
+	cost = 20
+
+/datum/uplink_item/traitoroffer/implantbundle
+	name = "Implant Bundle"
+	desc = "A handful of syndicate implants to turn yourself into the human of the future! Includes: A freedom implant, an adrenaline implant, an explosive implant, a storage implant, and an EMP impant."
+	item = /obj/item/weapon/storage/box/syndie_kit/implantbundle
+	cost = 20
+
+/datum/uplink_item/traitoroffer/awperator
+	name = "Operator Bundle"
+	desc = "Be quick, be courteous, and plan to kill everyone you meet. This bundle will help you make sure your target is dead as cleanly as possible. Includes: A chamelous jumpsuit, a silenced stechkin, a mulligan syring(when things get bumpy), a briefcase of cash, a body bag, and finally some sweet smokes."
+	item = /obj/item/weapon/storage/box/syndie_kit/awperator
+	cost = 20
+
+
 // Dangerous Items
 /datum/uplink_item/dangerous
 	category = "Conspicuous and Dangerous Weapons"
@@ -1065,7 +1102,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			Can blow the deepest of covers."
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
-
+/*
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"
 	desc = "Syndicate Bundles are specialised groups of items that arrive in a plain box. \
@@ -1074,7 +1111,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-
+*/
 /datum/uplink_item/badass/surplus
 	name = "Syndicate Surplus Crate"
 	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortion of items, \


### PR DESCRIPTION
Removes random bundles because they were always worse then the surplus crate.

Five bundles are now buyable.

**Dark Lord:**
-Two energy swords
-A TK injector
-A chamelon voice changing gas mask
-An agent ID
-Chaplain Robes

**Sleeping Carp**-A bit iffy on the balance of this bundle
-Sleeping Carp Scroll
-Throwing Star Kit(includes the two bolas)
-Bo staff
-Chameleon helmet, jumpsuit, and mask
-Agent Card
-Smoke Grenade

**Nuclear Operative**
-Blood Red Hardsuit
-C-20r
-Weapon Authetication Implant
-Explosive Implant
-Agent Card
-Syndicate Mask
-C4

**Implant Bundle**
-Freedom Implant
-Explosive Implant
-Adrenaline Implant
-EMP Implant
-Storage Implant

**Operator Bundle**
-Chameleon Jumpsuit
-Agent ID
-Stechkin
-Silencer
-Briefcase Full of Dosh
-Body Bag
-Mulligan Syringe
-Syndie Smokes

:cl: KazeEspada
remove:Random Bundles are removed from the traitor uplink
add: Adds five new bundles for 20 TC. Darklord, Operative, Sleeping Carp, Operator, and Implant
/:cl:
