### PR TITLE
Seperates combat knives from SWAT crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -256,13 +256,21 @@
 					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
 					/obj/item/clothing/suit/space/swat,
-					/obj/item/weapon/kitchen/knife/combat,
-					/obj/item/weapon/kitchen/knife/combat,
 					/obj/item/clothing/mask/gas/sechailer/swat,
 					/obj/item/clothing/mask/gas/sechailer/swat,
 					/obj/item/weapon/storage/belt/military/assault,
-					/obj/item/weapon/storage/belt/military/assault)
+					/obj/item/weapon/storage/belt/military/assault,
+					/obj/item/clothing/gloves/combat,
+					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
+
+/datum/supply_pack/security/armory/swat
+	name = "Combat knives crate"
+	cost = 30
+	contains = list(/obj/item/weapon/kitchen/knife/combat,
+					/obj/item/weapon/kitchen/knife/combat,
+					/obj/item/weapon/kitchen/knife/combat)
+	crate_name = "combat knife crate"
 
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -266,7 +266,7 @@
 
 /datum/supply_pack/security/armory/swat
 	name = "Combat knives crate"
-	cost = 30
+	cost = 3000
 	contains = list(/obj/item/weapon/kitchen/knife/combat,
 					/obj/item/weapon/kitchen/knife/combat,
 					/obj/item/weapon/kitchen/knife/combat)


### PR DESCRIPTION
:cl: 
rscdel: SWAT crates no longer contain combat knives.
rscadd: SWAT crates now contain combat gloves.
rscadd: Combat knives now can be ordered in their own crate.
/:cl:
