### PR TITLE
Blob mobs no longer swap

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -14,6 +14,7 @@
 	minbodytemp = 0
 	maxbodytemp = 360
 	unique_name = 1
+	a_intent = "harm"
 	var/mob/camera/blob/overmind = null
 	var/obj/effect/blob/factory/factory = null
 


### PR DESCRIPTION
Blob mobs no longer swap, instead they push others. This leads to disadvantages for the blob and the crew, but swap combat is no longer a thing anymore.
:cl:
bugfix: Blob Mobs no longer swap with other mobs.
/:cl:
