### PR TITLE
Reactive Armour is admin only

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -65,12 +65,6 @@
 	difficulty = 3
 	excludefromjob = list("Head of Security", "Warden")
 
-/datum/objective_item/steal/reactive
-	name = "the reactive teleport armor"
-	targetitem = /obj/item/clothing/suit/armor/reactive
-	difficulty = 5
-	excludefromjob = list("Research Director")
-
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization"
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,7 +18,6 @@
 	new /obj/item/device/radio/headset/heads/rd(src)
 	new /obj/item/weapon/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/weapon/door_remote/research_director(src)


### PR DESCRIPTION
Every nerf that gets added to it is just countered by carrying something extra (hand tele to counter spacing, charcoal to counter toxins). I give up trying to balance this. Was meant to be a fun zany toy for the RD, not something for the captain to run around in every round as the best armour in the game. Don't think it's workable without gutting it at this point though, and the code to check for hand teles (or for hand teles to check for reactive) would be ugly snowflake.

Also whoever buffed the hand tele to be 100% accurate with no downsides is a very silly person.
