### PR TITLE
Mutes carbon wizards during jaunt

### DIFF
--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -42,7 +42,11 @@
 			target.reset_perspective(holder)
 			target.notransform=0 //mob is safely inside holder now, no need for protection.
 			jaunt_steam(mobloc)
+
+			mute(target)
 			sleep(jaunt_duration)
+			unmute(target)
+
 			if(target.loc != holder) //mob warped out of the warp
 				qdel(holder)
 				return
@@ -66,6 +70,29 @@
 							if(target.Move(T))
 								break
 				target.canmove = 1
+
+//Silence wizard during jaunt so they cannot spell cast while invisible
+/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/mute(target)
+	if(!istype(target, /mob/living/carbon))
+		return FALSE
+
+	var/mob/living/carbon/mob_to_mute = target
+	if(!mob_to_mute.dna)
+		return FALSE
+	
+	mob_to_mute.dna.add_mutation(MUT_MUTE)
+	return TRUE
+
+/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/unmute(target)
+	if(!istype(target, /mob/living/carbon))
+		return FALSE
+
+	var/mob/living/carbon/mob_to_mute = target
+	if(!mob_to_mute.dna)
+		return FALSE
+	
+	mob_to_mute.dna.remove_mutation(MUT_MUTE)
+	return TRUE
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/jaunt_disappear(atom/movable/overlay/animation, mob/living/target)
 	animation.icon_state = "liquify"


### PR DESCRIPTION
Adds two helper procs for mute/unmute

@Robustin I hope you don't mind me taking over this one - you were missing the fact that jaunt works on /mob/living and dna mutations only exist on mob/living/carbon

Fixes #15960
