### PR TITLE
Neurotoxin and Beepsky Smash Tweaks

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -366,7 +366,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	metabolization_rate = 0.8
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	M.Stun(2, 0)
+	if(current_cycle >= 15)
+		M.Stun(2, 0)
 	return ..()
 
 /datum/reagent/consumable/ethanol/irish_cream

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -534,10 +534,10 @@
 	color = "#2E2E61" // rgb: 46, 46, 97
 
 /datum/reagent/consumable/neurotoxin/on_mob_life(mob/living/carbon/M)
-	M.Weaken(3, 1, 0)
 	M.dizziness +=6
 	switch(current_cycle)
 		if(15 to 45)
+			M.Weaken(3, 1, 0)
 			if(!M.slurring)
 				M.slurring = 1
 			M.slurring += 3


### PR DESCRIPTION
Generally speaking, most chems have moved away from being instantaneous stuns/weakens/paralysis unless they're traitor in origin (this has been the treatment prior to the introduction of Goofchem ala Chloral Hydrate...and has continued under it). 

As such, there's two major standouts that are incredibly easy to mass produce that are very similar to old chloral hydrate, in behavior.  Those two standouts are Neurotoxin and Beepsky Smash.

:cl: Fox McCloud
tweak: Neurotoxin and Beepsky smash no longer instantly stun; there's a delay to them before they kick in
/:cl:
