### PR TITLE
Disables minimum account age for TRAITORS and TRAITORS ONLY

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -15,6 +15,7 @@
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
+	enemy_minimum_age = 0
 
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.


### PR DESCRIPTION
Traitor is the basic gamemode for new players. It doesn't matter if they're bad or good, there's 7 other traitors if they fuck it up.

I can understand locks on cult, nuke ops, etc., but on traitor? This is a great learning experience for new players. They can kill shit and not get in trouble.
