### PR TITLE
Adds new atom and new datum options to viewvars

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -77,7 +77,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			var_value = new type()
 
 		if("new datum")
-			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var/type = input("Enter type:","Type") as null|anything in (typesof(/datum)-typesof(/obj,/mob,/area,/turf))
 			var_value = new type()
 
 	if(!var_value) return
@@ -142,7 +142,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			var_value = new type()
 
 		if("new datum")
-			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var/type = input("Enter type:","Type") as null|anything in (typesof(/datum)-typesof(/obj,/mob,/area,/turf))
 			var_value = new type()
 
 	if(!var_value) return
@@ -397,7 +397,7 @@ var/list/VVckey_edit = list("key", "ckey")
 				L[L.Find(variable)] = new_var
 
 		if("new datum")
-			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var/type = input("Enter type:","Type") as null|anything in (typesof(/datum)-typesof(/obj,/mob,/area,/turf))
 			new_var = new type()
 			if(assoc)
 				L[assoc_key] = new_var
@@ -677,7 +677,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			O.vars[variable] = var_new
 
 		if("new datum")
-			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var/type = input("Enter type:","Type") as null|anything in (typesof(/datum)-typesof(/obj,/mob,/area,/turf))
 			var/var_new = new type()
 			if(var_new==null) return
 			O.vars[variable] = var_new

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -33,10 +33,10 @@ var/list/VVckey_edit = list("key", "ckey")
 	var/class = "text"
 	if(src.holder && src.holder.marked_datum)
 		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum", "marked datum ([holder.marked_datum.type])")
 	else
 		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum")
 
 	if(!class)
 		return
@@ -72,6 +72,14 @@ var/list/VVckey_edit = list("key", "ckey")
 		if("marked datum")
 			var_value = holder.marked_datum
 
+		if("new atom")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/obj,/mob,/area,/turf)
+			var_value = new type()
+
+		if("new datum")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var_value = new type()
+
 	if(!var_value) return
 
 	if(istext(var_value))
@@ -90,10 +98,10 @@ var/list/VVckey_edit = list("key", "ckey")
 	var/class = "text"
 	if(src.holder && src.holder.marked_datum)
 		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum","marked datum ([holder.marked_datum.type])")
 	else
 		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum")
 
 	if(!class)
 		return
@@ -128,6 +136,14 @@ var/list/VVckey_edit = list("key", "ckey")
 
 		if("marked datum")
 			var_value = holder.marked_datum
+
+		if("new atom")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/obj,/mob,/area,/turf)
+			var_value = new type()
+
+		if("new datum")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var_value = new type()
 
 	if(!var_value) return
 
@@ -267,10 +283,10 @@ var/list/VVckey_edit = list("key", "ckey")
 	var/class = "text"
 	if(src.holder && src.holder.marked_datum)
 		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])", "DELETE FROM LIST")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum","marked datum ([holder.marked_datum.type])", "DELETE FROM LIST")
 	else
 		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "DELETE FROM LIST")
+			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum", "DELETE FROM LIST")
 
 	if(!class)
 		return
@@ -367,6 +383,22 @@ var/list/VVckey_edit = list("key", "ckey")
 
 		if("marked datum")
 			new_var = holder.marked_datum
+			if(assoc)
+				L[assoc_key] = new_var
+			else
+				L[L.Find(variable)] = new_var
+
+		if("new atom")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/obj,/mob,/area,/turf)
+			new_var = new type()
+			if(assoc)
+				L[assoc_key] = new_var
+			else
+				L[L.Find(variable)] = new_var
+
+		if("new datum")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			new_var = new type()
 			if(assoc)
 				L[assoc_key] = new_var
 			else
@@ -541,10 +573,10 @@ var/list/VVckey_edit = list("key", "ckey")
 
 		if(src.holder && src.holder.marked_datum)
 			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
+				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum", "marked datum ([holder.marked_datum.type])")
 		else
 			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "new atom", "new datum")
 
 		if(!class)
 			return
@@ -637,6 +669,18 @@ var/list/VVckey_edit = list("key", "ckey")
 
 		if("marked datum")
 			O.vars[variable] = holder.marked_datum
+
+		if("new atom")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/obj,/mob,/area,/turf)
+			var/var_new = new type()
+			if(var_new==null) return
+			O.vars[variable] = var_new
+
+		if("new datum")
+			var/type = input("Enter type:","Type") as null|anything in typesof(/datum)
+			var/var_new = new type()
+			if(var_new==null) return
+			O.vars[variable] = var_new
 
 	O.on_varedit(variable)
 	world.log << "### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]"


### PR DESCRIPTION
WARNING: Some forms of this may not work as expected, using new atom on an existing list element is confirmed not to work, but then, the rest of VV is no less reliable, use with caution.

Allows for creating new atoms directly into a list/var, for things like spawning directly into an atom's contents. Not sure how many uses there are for creating datums, but the option exists if wanted.
