### PR TITLE
Protolathe efficiency change

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -67,9 +67,9 @@ Note: Must be placed west/left of and R&D console to function.
 	var/A = materials.amount(M)
 	if(!A)
 		A = reagents.get_reagent_amount(M)
-		A = A / max(1, (being_built.reagents[M]/efficiency_coeff))
+		A = A / max(1, (being_built.reagents[M]*efficiency_coeff))
 	else
-		A = A / max(1, (being_built.materials[M]/efficiency_coeff))
+		A = A / max(1, (being_built.materials[M]*efficiency_coeff))
 	return A
 
 /obj/machinery/r_n_d/protolathe/attackby(obj/item/O, mob/user, params)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -58,10 +58,10 @@ Note: Must be placed west/left of and R&D console to function.
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
 	materials.max_amount = T * 75000
-	T = 0
+	T = 1.2  // two manipulators makes this 1
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		T += (M.rating/2)
-	efficiency_coeff = max(T, 1)
+		T -= M.rating*0.1   // this efficiency is 1 0.8 0.6 0.4, not 2 4 6 8
+	efficiency_coeff = max(0.1,min(T, 1))  // just to avoid any 0's
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
 	var/A = materials.amount(M)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -60,7 +60,7 @@ Note: Must be placed west/left of and R&D console to function.
 	materials.max_amount = T * 75000
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		T += (M.rating/3)
+		T += (M.rating/2)
 	efficiency_coeff = max(T, 1)
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -371,7 +371,7 @@ proc/CallMaterialName(ID)
 
 					var/list/efficient_mats = list()
 					for(var/MAT in being_built.materials)
-						efficient_mats[MAT] = being_built.materials[MAT] / coeff
+						efficient_mats[MAT] = being_built.materials[MAT] * coeff
 
 					if(!linked_lathe.materials.has_materials(efficient_mats, amount))
 						src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete prototype.\"</span>")
@@ -379,7 +379,7 @@ proc/CallMaterialName(ID)
 						g2g = 0
 					else
 						for(var/R in being_built.reagents)
-							if(!linked_lathe.reagents.has_reagent(R, being_built.reagents[R]/coeff))
+							if(!linked_lathe.reagents.has_reagent(R, being_built.reagents[R]*coeff))
 								src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough reagents to complete prototype.\"</span>")
 								enough_materials = 0
 								g2g = 0
@@ -387,11 +387,11 @@ proc/CallMaterialName(ID)
 					if(enough_materials)
 						linked_lathe.materials.use_amount(efficient_mats, amount)
 						for(var/R in being_built.reagents)
-							linked_lathe.reagents.remove_reagent(R, being_built.reagents[R]/coeff)
+							linked_lathe.reagents.remove_reagent(R, being_built.reagents[R]*coeff)
 
 					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
 					var/R = being_built.reliability
-					spawn(32*amount/coeff)
+					spawn(32*coeff*amount**0.8) // making more takes less time per item
 						if(g2g) //And if we only fail the material requirements, we still spend time and power
 							var/already_logged = 0
 							for(var/i = 0, i<amount, i++)
@@ -823,18 +823,18 @@ proc/CallMaterialName(ID)
 					t = linked_lathe.check_mat(D, M)
 					temp_material += " | "
 					if (t < 1)
-						temp_material += "<span class='bad'>[D.materials[M]/coeff] [CallMaterialName(M)]</span>"
+						temp_material += "<span class='bad'>[D.materials[M]*coeff] [CallMaterialName(M)]</span>"
 					else
-						temp_material += " [D.materials[M]/coeff] [CallMaterialName(M)]"
+						temp_material += " [D.materials[M]*coeff] [CallMaterialName(M)]"
 					c = min(c,t)
 
 				for(var/R in D.reagents)
 					t = linked_lathe.check_mat(D, R)
 					temp_material += " | "
 					if (t < 1)
-						temp_material += "<span class='bad'>[D.reagents[R]/coeff] [CallMaterialName(R)]</span>"
+						temp_material += "<span class='bad'>[D.reagents[R]*coeff] [CallMaterialName(R)]</span>"
 					else
-						temp_material += " [D.reagents[R]/coeff] [CallMaterialName(R)]"
+						temp_material += " [D.reagents[R]*coeff] [CallMaterialName(R)]"
 					c = min(c,t)
 
 				if (c >= 1)
@@ -865,9 +865,9 @@ proc/CallMaterialName(ID)
 					t = linked_lathe.check_mat(D, M)
 					temp_material += " | "
 					if (t < 1)
-						temp_material += "<span class='bad'>[D.materials[M]/coeff] [CallMaterialName(M)]</span>"
+						temp_material += "<span class='bad'>[D.materials[M]*coeff] [CallMaterialName(M)]</span>"
 					else
-						temp_material += " [D.materials[M]/coeff] [CallMaterialName(M)]"
+						temp_material += " [D.materials[M]*coeff] [CallMaterialName(M)]"
 					c = min(c,t)
 
 				if (c >= 1)


### PR DESCRIPTION
Alternative to #16393
Fixes one nano manipulator upgrade to protolathe not doing anything.

Currently the reductions to original item costs are 25% (nano), 50% (pico) and 62.5% (femto).
This changes the reductions to 20% 40% 60%. A minor nerf but also allows easier change of these values if needed as now the efficiency is a multiplier: 1; 0.8; 0.6; 0.4 and not 2 4 6 8.

Also makes printing multiple items faster. Making 5 items takes as long as 3.6 single items and 10 items as long as about 6 single items. Single item build times are also slightly slower as they work with that same efficiency coeff. Making 5 or 10 items is mostly used when making tens of parts to upgrade the station and this is to make those long wait times a bit shorter.

I hope I did everything correct here. This is mostly to give a more realistic alternative to the massive R&D nerf and just to give an idea of using efficiency coeff as a multiplier which can easily be changed unlike those 2 4 6 8 values. This can later be changed in other machines as well.
That other PR also has the huge nerf of making every sheet give only 1000 units instead of 2000. 1000 is better than 2000 but would require a rebalance of nearly every items' cost. 

(I'm also thinking about making a bigger R&D level update in May/June/July if I get some other science players and coders to give feedback as well. This cost rebalance and making sheets only 1000 could be also changed at that time.)
