### PR TITLE
Camera alarms now triggered properly

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -58,7 +58,7 @@
 	return ..()
 
 /obj/machinery/camera/Destroy()
-	toggle_cam(null, 0) //kick anyone viewing out
+	toggle_cam(null, 0, 0) //kick anyone viewing out, produce no alarms
 	remove_from_proximity_list(src, 1)
 	if(assembly)
 		qdel(assembly)
@@ -245,11 +245,10 @@
 			health = max(0, health - W.force)
 			user.do_attack_animation(src)
 			if(!health && status)
-				triggerCameraAlarm()
 				toggle_cam(user, 1)
 	return
 
-/obj/machinery/camera/proc/toggle_cam(mob/user, displaymessage = 1)
+/obj/machinery/camera/proc/toggle_cam(mob/user, displaymessage = 1, producealarm = 1)
 	status = !status
 	if(can_use())
 		cameranet.addCamera(src)
@@ -260,10 +259,11 @@
 	var/change_msg = "deactivates"
 	if(!status)
 		icon_state = "[initial(icon_state)]1"
+		if(producealarm)
+			triggerCameraAlarm()
 	else
 		icon_state = initial(icon_state)
 		change_msg = "reactivates"
-		triggerCameraAlarm()
 		spawn(100)
 			if(!qdeleted(src))
 				cancelCameraAlarm()
@@ -377,7 +377,6 @@
 	if(proj.damage_type == BRUTE)
 		health = max(0, health - proj.damage)
 		if(!health && status)
-			triggerCameraAlarm()
 			toggle_cam(null, 1)
 
 /obj/machinery/camera/portable //Cameras which are placed inside of things, such as helmets.


### PR DESCRIPTION
Cutting a camera with wires would not produce an alarm, nor roundstart camera disables would show up on the alarm list.

By moving the triggerCameraAlarm() call inside toggle_cam(), this means that this problem is fixed.

Note that, as before, EMPs do call to triggerCameraAlarm() manually, 90 seconds afterwards, as EMP'd cameras aren't disabled, but in the special EMPED state.

:cl: coiax
tweak: Camera alarms now trigger correctly when the camera is cut, or round-start disabled. EMPs still have delayed alarm time.
/ :cl:
