### PR TITLE
Fixes shift clicking action buttons not immediately resetting them.

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -7,6 +7,7 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		moved = 0
+		usr.update_action_buttons() //redraw buttons that are no longer considered "moved"
 		return 1
 	if(usr.next_move >= world.time) // Is this needed ?
 		return


### PR DESCRIPTION
@phil235 broke this when he made updates happen on-demand for action buttons, just a small mistake though.

:cl: 
fix: fixes shift-clicking action buttons not instantly resetting their location. (I'm only making a changelog for this because apparently barely noone even knows you can move the buttons, let alone reset them...)
/:cl: 
