### PR TITLE
Adds two traitor virus symptoms to TC uplink

### DIFF
--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -57,3 +57,19 @@
 		name = "Reality Destruction"
 		symptoms = list(new/datum/symptom/sensory_destruction)
 	..(process, D, copy)
+
+// Fournier's gangrenous necrosis
+
+/datum/disease/advance/traitor_flesh_eating/New(var/process = 1, var/datum/disease/advance/D, var/copy = 0)
+	if(!D)
+		name = "Fournier's gangrenous necrosis"
+		symptoms = list(new/datum/symptom/traitor_flesh_eating)
+	..(process, D, copy)
+
+// Nuclei Apoptosis
+
+/datum/disease/advance/traitorheal/New(var/process = 1, var/datum/disease/advance/D, var/copy = 0)
+	if(!D)
+		name = "Nuclei Apoptosis"
+		symptoms = list(new/datum/symptom/traitorheal)
+	..(process, D, copy)

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -41,3 +41,58 @@ Bonus
 	var/get_damage = ((sqrt(16-A.totalStealth()))*5)
 	M.adjustBruteLoss(get_damage)
 	return 1
+
+/*
+//////////////////////////////////////
+
+Fournier's gangrenous necrosis (flesh eating disease with gangrene. Do not google.)
+
+	Very noticable.
+	Lowers resistance.
+	No changes to stage speed.
+	Decreases transmittablity.
+	Fatal.
+
+Bonus
+	Deals brute damage over time.
+
+Special traitor bonus
+	Deals damage at earlier stages.
+	Deals 4/5 Brute damage, and 1/5 Clone damage.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/traitor_flesh_eating
+
+	name = "Fournier's gangrenous necrosis" //don't google this
+	stealth = -2
+	resistance = -2
+	stage_speed = 0
+	transmittable = -2
+	level = 9
+	severity = 5
+
+/datum/symptom/traitor_flesh_eating/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(3,4)
+				M << "<span class='warning'>[pick("You feel a violent pain tear into your nerves.", "Drops of blood appear suddenly on your rotting skin")]</span>"
+				FournierGangrene_stage_3_4(M, A)
+			if(5)
+				M << "<span class='userdanger'>[pick("You violently tear and deform your body!", "Your flesh painfully loosens and sags!", "IT HURTS SO MUCH.!")]</span>"
+				FournierGangrene(M, A)
+	return
+
+/datum/symptom/traitor_flesh_eating/proc/FournierGangrene_stage_3_4(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(16-A.totalStealth()))
+	M.adjustBruteLoss(get_damage*3)
+	return 1
+
+/datum/symptom/traitor_flesh_eating/proc/FournierGangrene(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(16-A.totalStealth()))
+	M.adjustBruteLoss(get_damage*4)
+	M.adjustCloneLoss(get_damage)
+	return 1

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -41,6 +41,58 @@ Bonus
 /*
 //////////////////////////////////////
 
+Traitor healing
+
+	Little bit hidden.
+	Lowers resistance.
+	Decreases stage speed.
+	Decreases transmittablity temrendously.
+
+Bonus
+	Heals toxins in the affected mob's blood stream.
+
+Special traitor bonus
+	Heals a very small amount of Brute and Burn damage at stage 5
+	Uses SQRT 26 instead of SQRT 20
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/traitorheal
+
+	name = "Nuclei Apoptosis"
+	stealth = 1
+	resistance = -2
+	stage_speed = -2
+	transmittable = -4
+	level = 9
+
+/datum/symptom/traitorheal/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB * 10))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(3,4)
+				Stage_3_4_heal(M, A)
+			if(5)
+				Stage_5_heal(M, A)
+	return
+
+/datum/symptom/traitorheal/proc/Stage_3_4_heal(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(26+A.totalStageSpeed())*(1+rand()))
+	M.adjustToxLoss(-get_damage)
+	return 1
+
+/datum/symptom/traitorheal/proc/Stage_5_heal(mob/living/M, datum/disease/advance/A)
+	var/get_damage = (sqrt(26+A.totalStageSpeed())*(1+rand()))
+	M.adjustToxLoss(-get_damage)
+	M.adjustBruteLoss(-get_damage/5)
+	M.adjustFireLoss(-get_damage/5)
+	return 1
+
+/*
+//////////////////////////////////////
+
 Metabolism
 
 	Little bit hidden.

--- a/code/datums/diseases/placeholder_symptom.dm
+++ b/code/datums/diseases/placeholder_symptom.dm
@@ -1,0 +1,33 @@
+/datum/disease/do_not_spawn_fournier/
+	name = "Fournier's gangrenous necrosis"
+	max_stages = 1
+	spread_text = "Varies"
+	spread_flags = SPECIAL
+	cure_text = "Varies"
+	agent = "Fournier gangrenous blood serums"
+	viable_mobtypes = list(/mob/living/carbon/human)
+	spread_flags = NON_CONTAGIOUS
+	desc = "A rare, deadlier variety of Necrotizing Fasciitis. This variety rots away and deforms the victim. It's origin is unknown, and it's use is banned by Nanotrasen research."
+	severity = DANGEROUS
+
+/datum/disease/do_not_spawn_fournier/stage_act()
+	..()
+	affected_mob << "<span class='danger'>If you read this message, please contact an admin or a coder.</span>"
+	cure()
+
+/datum/disease/do_not_spawn_traitorheal/
+	name = "Nuclei Apoptosis"
+	max_stages = 1
+	spread_text = "Varies"
+	spread_flags = SPECIAL
+	cure_text = "Varies"
+	agent = "Nuclei Apoptosis infected blood"
+	viable_mobtypes = list(/mob/living/carbon/human)
+	spread_flags = NON_CONTAGIOUS
+	desc = "An extremely unstable virus symptom which causes spontaneous Apoptosis - healing injuries, and purging toxins from the system. It's origin is unknown, and it's use is banned by Nanotrasen research."
+	severity = DANGEROUS
+
+/datum/disease/do_not_spawn_traitorheal/stage_act()
+	..()
+	affected_mob << "<span class='danger'>If you read this message, please contact an admin or a coder.</span>"
+	cure()

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -309,3 +309,15 @@
 	desc = "A small bottle containing Bio Virus Antidote Kit."
 	icon_state = "bottle5"
 	list_reagents = list("atropine" = 5, "epinephrine" = 5, "salbutamol" = 10, "spaceacillin" = 10)
+
+/obj/item/weapon/reagent_containers/glass/bottle/traitor_flesh_eating
+	name = "Fournier's necrosis culture bottle"
+	desc = "A small bottle. Contains Fournier's gangrenous necrosis in synthblood medium."
+	icon_state = "bottle3"
+	spawned_disease = /datum/symptom/traitor_flesh_eating
+
+/obj/item/weapon/reagent_containers/glass/bottle/traitorheal
+	name = "Nuclei Apoptosis culture bottle"
+	desc = "A small bottle. Contains Nuclei Apoptosis in synthblood medium."
+	icon_state = "bottle3"
+	spawned_disease = /datum/symptom/traitorheal

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -567,6 +567,20 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 6
 	surplus = 50
 
+/datum/uplink_item/stealthy_weapons/traitor_flesh_eating_bottle
+	name = "Fournier's necrosis bottle"
+	desc = "One bottle containing a highly deadly, but easy to detect virus symptom which eats away at the flesh and deforms the victim."
+	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor_flesh_eating
+	cost = 16
+	exclude_modes = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
+
+/datum/uplink_item/stealthy_weapons/traitorheal_bottle
+	name = "Nuclei Apoptosis bottle"
+	desc = "One bottle containing a useful, but easy to detect virus symptom which causes constant apoptosis, healing the victim."
+	item = /obj/item/weapon/reagent_containers/glass/bottle/traitorheal
+	cost = 12
+	exclude_modes = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
+
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -175,6 +175,7 @@
 #include "code\datums\diseases\gbs.dm"
 #include "code\datums\diseases\magnitis.dm"
 #include "code\datums\diseases\pierrot_throat.dm"
+#include "code\datums\diseases\placeholder_symptom.dm"
 #include "code\datums\diseases\retrovirus.dm"
 #include "code\datums\diseases\rhumba_beat.dm"
 #include "code\datums\diseases\transformation.dm"


### PR DESCRIPTION
:cl: 
rscadd: Adds Fournier's gangrenous necrosis virus logs.
rscadd: Adds Nuclei Apoptosis symptom and virus logs.
rscadd: Adds above viruses to Uplink for 16 and 12 TC.
/:cl:
Fournier's gangrenous necrosis is a deadlier Necrotizing Fasciitis which deals 4/5 damage in brute and 1/5 damage in Cloneloss. It also has better stats compared to Necrotizing Fasciitis. 16 TC.

Nuclei Apoptosis is a better Toxic filter which heals a bonus 1/5 in brute damage and burn damage, along with toxic filter. It also uses SQRT26 instead of SQRT20, giving it 6 bonus points to scale with, healing more, and features better stats thank Toxic Filter. 12 TC.

You cannot obtain this outside of admins or the uplink.
Buying a bottle and infecting people with any of these alone is a huge waste of TC because it will be cured by salt, and anyone with medhud will see it.
