### PR TITLE
Holoparasite hosts can now be lings and/or have multiple parasites

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -47,7 +47,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 
 /datum/game_mode/changeling/announce()
 	world << "<b>The current game mode is - Changeling!</b>"
-	world << "<b>There are alien changelings on the station. Do not let the changelings succeed!</b>"
+	world << "<b>There are alien changelings on the station.ch Do not let the changelings succeed!</b>"
 
 /datum/game_mode/changeling/pre_setup()
 
@@ -282,8 +282,8 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/dna_max = 6 //How many extra DNA strands the changeling can store for transformation.
 	var/absorbedcount = 0
 	var/chem_charges = 20
-	var/chem_storage = 75
-	var/chem_recharge_rate = 1
+	var/chem_storage = 50
+	var/chem_recharge_rate = 0.8
 	var/chem_recharge_slowdown = 0
 	var/sting_range = 2
 	var/changelingID = "Changeling"

--- a/code/game/gamemodes/changeling/powers/glands.dm
+++ b/code/game/gamemodes/changeling/powers/glands.dm
@@ -9,5 +9,5 @@
 	..()
 	var/datum/changeling/changeling=user.mind.changeling
 	changeling.chem_storage += 25
-	changeling.chem_recharge_rate *=2
+	changeling.chem_recharge_rate *=1.5
 	return

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -615,12 +615,6 @@
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	for(var/mob/living/simple_animal/hostile/guardian/G in living_mob_list)
-		if (G.summoner == user)
-			user << "You already have a [mob_name]!"
-			return
-	if(user.mind && user.mind.changeling)
-		user << "[ling_failure]"
-		return
 	if(used == TRUE)
 		user << "[used_message]"
 		return


### PR DESCRIPTION
Snowflake rules suck, trading a godly first life at the expense of being able to revive is a completely fair trade for 14TC+Ling status. 

Multiple parasites also aren't even that OP, just makes it harder to miss your lasers when killing the host. 

Edit: Will probably redo all this in another PR, but I'm tweaking Ling chems in this so assuage concerns about ling murderbone. 
