### PR TITLE
Revert "You can now blow open secure storage containers "

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -69,16 +69,10 @@
 /obj/item/weapon/c4/afterattack(atom/movable/AM, mob/user, flag)
 	if (!flag)
 		return
-	if (ismob(AM))
+	if (ismob(AM) || istype(AM, /obj/item/weapon/storage/))
 		return
 	if(loc == AM)
 		return
-	if((istype(AM, /obj/item/weapon/storage/)) && !((istype(AM, /obj/item/weapon/storage/secure)) || (istype(AM, /obj/item/weapon/storage/lockbox)))) //If its storage but not secure storage OR a lockbox, then place it inside.
-		return
-	if((istype(AM,/obj/item/weapon/storage/secure)) || (istype(AM, /obj/item/weapon/storage/lockbox)))
-		var/obj/item/weapon/storage/secure/S = AM
-		if(!S.locked) //Literal hacks, this works for lockboxes despite incorrect type casting, because they both share the locked var. But if its unlocked, place it inside, otherwise PLANTING C4!
-			return
 
 	user << "<span class='notice'>You start planting the bomb...</span>"
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -469,8 +469,8 @@
 
 
 /obj/item/weapon/storage/Destroy()
-	var/turf = get_turf(src)
-	empty_object_contents(0, turf)
+	for(var/obj/O in contents)
+		O.mouse_opacity = initial(O.mouse_opacity)
 
 	close_all()
 	qdel(boxes)


### PR DESCRIPTION
This has caused all kinds of problems and exploits such as using the supply shuttle to run over crates, putting lockers in the crematorium, dunking crates in lava, trying to delete mobs as an admin and having their shit spill everywhere, etc.

It's been 2 months and these exploits have not been addressed for marginal gain (C4ing safes, which are supposed to be C4 proof anyway)
