### PR TITLE
Adds a cryostorage version of the ghost spawner.

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -12,6 +12,8 @@
 	var/instant = FALSE	//fires on New
 	var/flavour_text = "The mapper forgot to set this!"
 	var/faction = null
+	var/permanent = FALSE	//Set to true for infinite mob spawn I guess.
+	var/random = FALSE		//Don't set a name or gender, just go random
 	var/objectives = null
 	var/brute_damage = 0
 	var/oxy_damage = 0
@@ -58,8 +60,9 @@
 
 /obj/effect/mob_spawn/proc/create(ckey)
 	var/mob/living/M = new mob_type(loc) //living mobs only
-	M.real_name = mob_name ? mob_name : M.name
-	M.gender = mob_gender
+	if(!random)
+		M.real_name = mob_name ? mob_name : M.name
+		M.gender = mob_gender
 	if(faction)
 		M.faction = list(faction)
 	if(death)
@@ -77,7 +80,8 @@
 			for(var/objective in objectives)
 				MM.objectives += new/datum/objective(objective)
 		special(M)
-	qdel(src)
+	if(!permanent)
+		qdel(src)
 
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
@@ -450,3 +454,22 @@
 	var/crime = pick("distribution of contraband" , "unauthorized erotic action on duty", "embezzlement", "piloting under the influence", "dereliction of duty", "syndicate collaboration", "mutiny", "multiple homicides", "corporate espionage", "recieving bribes", "malpractice", "worship of prohbited life forms", "possession of profane texts", "murder", "arson", "insulting your manager", "grand theft", "conspiracy", "attempting to unionize", "vandalism", "gross incompetence")
 	new_spawn << "You were convincted of: [crime]."
 
+//For ghost bar.
+/obj/effect/mob_spawn/human/alive/space_bar_patron
+	name = "Bar cryogenics"
+	mob_name = "Bar patron"
+	random = TRUE
+	permanent = TRUE
+	uniform = /obj/item/clothing/under/rank/bartender
+	back = /obj/item/weapon/storage/backpack
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	suit = /obj/item/clothing/suit/armor/vest
+	glasses = /obj/item/clothing/glasses/sunglasses/reagent
+
+
+/obj/effect/mob_spawn/human/alive/space_bar_patron/attack_hand(mob/user)
+	var/despawn = alert("Return to cryosleep? (Warning, Your mob will be deleted!)",,"Yes","No")
+	if(despawn == "No" || !loc || !Adjacent(user))
+		return
+	user.visible_message("<span class='notice'>[user.name] climbs back into cryosleep...</span>")
+	qdel(user)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -15,6 +15,7 @@
 	var/permanent = FALSE	//Set to true for infinite mob spawn I guess.
 	var/random = FALSE		//Don't set a name or gender, just go random
 	var/objectives = null
+	var/uses = 1			//how many times can we spawn from it. set to -1 for infinite.
 	var/brute_damage = 0
 	var/oxy_damage = 0
 	density = 1
@@ -22,6 +23,9 @@
 
 /obj/effect/mob_spawn/attack_ghost(mob/user)
 	if(ticker.current_state != GAME_STATE_PLAYING || !loc)
+		return
+	if(uses == 0)
+		user << "<span class='warning'>This spawner is out of charges!</span>"
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
@@ -80,7 +84,9 @@
 			for(var/objective in objectives)
 				MM.objectives += new/datum/objective(objective)
 		special(M)
-	if(!permanent)
+	if(uses > 0)
+		uses--
+	if(!permanent && (uses == 0))
 		qdel(src)
 
 // Base version - place these on maps/templates.
@@ -460,6 +466,7 @@
 	mob_name = "Bar patron"
 	random = TRUE
 	permanent = TRUE
+	uses = -1
 	uniform = /obj/item/clothing/under/rank/bartender
 	back = /obj/item/weapon/storage/backpack
 	shoes = /obj/item/clothing/shoes/sneakers/black

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -24,7 +24,7 @@
 /obj/effect/mob_spawn/attack_ghost(mob/user)
 	if(ticker.current_state != GAME_STATE_PLAYING || !loc)
 		return
-	if(uses == 0)
+	if(!uses)
 		user << "<span class='warning'>This spawner is out of charges!</span>"
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
@@ -86,7 +86,7 @@
 		special(M)
 	if(uses > 0)
 		uses--
-	if(!permanent && (uses == 0))
+	if(!permanent && !uses)
 		qdel(src)
 
 // Base version - place these on maps/templates.

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -12,7 +12,7 @@
 	var/instant = FALSE	//fires on New
 	var/flavour_text = "The mapper forgot to set this!"
 	var/faction = null
-	var/permanent = FALSE	//Set to true for infinite mob spawn I guess.
+	var/permanent = FALSE	//If true, the spawner will not disappear upon running out of uses.
 	var/random = FALSE		//Don't set a name or gender, just go random
 	var/objectives = null
 	var/uses = 1			//how many times can we spawn from it. set to -1 for infinite.


### PR DESCRIPTION
Has infinite uses and can be "reentered" (mob just deletes) by clicking on it with an empty hand.
Requested by @Bawhoppen for some sort of ghost bar thing.
