### PR TITLE
Scales back grab nerf

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -1,5 +1,5 @@
-#define UPGRADE_COOLDOWN	100
-#define UPGRADE_KILL_TIMER	150
+#define UPGRADE_COOLDOWN	60
+#define UPGRADE_KILL_TIMER	100
 
 /obj/item/weapon/grab
 	name = "grab"
@@ -104,12 +104,13 @@
 	var/breathing_tube = affecting.getorganslot("breathing_tube")
 
 	if(state >= GRAB_NECK)
+		affecting.Stun(2)	//It will hamper your voice, being choked and all.
 		if(isliving(affecting) && !breathing_tube)
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(0.5)
 
 	if(state >= GRAB_KILL)
-		affecting.Weaken(2)	//Should keep you down unless you get help.
+		affecting.Weaken(5)	//Should keep you down unless you get help.
 		if(!breathing_tube)
 			affecting.losebreath = min(affecting.losebreath + 2, 3)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -228,14 +228,14 @@
 
 				if(GRAB_AGGRESSIVE)
 					move_delay = world.time + 10
-					if(!prob(75))
+					if(!prob(50))
 						return 1
 					mob.visible_message("<span class='danger'>[mob] has broken free of [G.assailant]'s grip!</span>")
 					qdel(G)
 
 				if(GRAB_NECK)
 					move_delay = world.time + 10
-					if(!prob(50))
+					if(!prob(15))
 						return 1
 					mob.visible_message("<span class='danger'>[mob] has broken free of [G.assailant]'s headlock!</span>")
 					qdel(G)


### PR DESCRIPTION
Original value -> goof value -> new value
grab upgrade timer:
40 -> 100 (>2x bigger than original) -> 60 (1.5x bigger)
This was already pretty big, and did not need to be more than doubled. At most, it deserved a minor increase, which I've given it.

killgrab timer:
100 -> 150 -> 100 (didn't need to be changed originally)
The killgrab timer is already absurd and made actually choking people out pretty much pointless (it's faster to chokehold and then punch them to death or something). It did not need to be increased.

Readds the stun on neckgrab, but more than halves the duration. You've been neckgrabbed. Now you have more of a chance to break out, but can't immediately just walk out of the grab.

Undoes the weaken nerf on the killgrab. If you have been killgrabbed, you will suffer dire consequences. The person doing this to you has been sitting around and upgraded his grab for probably 10 minutes to even get you this far. Accept your fate.

Aggro grab breakout chance:
25 -> 75 -> 50
IMO because of the spammability of being able to just move to break out of a grab, this is kind of pointless. (Plus the fact that aggro grab doesn't actually restrain you so you can just walk away anyways, so this value doesn't really do much at all except allow you to break out of a grab by walking into a wall.)

Neckgrab breakout chance:
5 -> 50 -> 15
A fifty percent chance per second to break out of a _neckgrab,_ which already takes an eon to get to with the goofnerf. You may as well never go for a grab again at that point. Even with 15% it's probably still not even worth considering, and I'd lower it back to 5 but "muh kneejerk!"
