### PR TITLE
Laser Cannon Changes

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -39,11 +39,6 @@
 	select_name = "anti-vehicle"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
-/obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/item/projectile/bullet/sniper/accelerator/laser
-	select_name = "accelerator"
-	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-
 /obj/item/ammo_casing/energy/laser/pulse
 	projectile_type = /obj/item/projectile/beam/pulse
 	e_cost = 200

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -39,6 +39,11 @@
 	select_name = "anti-vehicle"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
+/obj/item/ammo_casing/energy/laser/accelerator
+	projectile_type = /obj/item/projectile/bullet/sniper/accelerator
+	select_name = "accelerator"
+	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+
 /obj/item/ammo_casing/energy/laser/pulse
 	projectile_type = /obj/item/projectile/beam/pulse
 	e_cost = 200

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -40,7 +40,7 @@
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/item/projectile/bullet/sniper/accelerator
+	projectile_type = /obj/item/projectile/bullet/sniper/accelerator/laser
 	select_name = "accelerator"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -57,6 +57,8 @@
 	desc = "A laser gun equipped with a refraction kit that spreads bolts."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 
+///Laser Cannon
+
 /obj/item/weapon/gun/energy/lasercannon
 	name = "accelerator laser cannon"
 	desc = "An advanced laser cannon that does more damage the farther away the target is."
@@ -70,6 +72,22 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	pin = null
 	ammo_x_offset = 3
+
+/obj/item/ammo_casing/energy/laser/accelerator
+	projectile_type = /obj/item/projectile/beam/laser/accelerator
+	select_name = "accelerator"
+	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+
+/obj/item/projectile/beam/laser/accelerator
+	name = "accelerator laser"
+	icon_state = "scatterlaser"
+	range = 255
+	damage = 6
+
+/obj/item/projectile/beam/laser/accelerator/Range()
+	..()
+	damage += 7
+	transform *= TransformUsingVariable(20 , 100, 1)
 
 /obj/item/weapon/gun/energy/xray
 	name = "xray laser gun"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -58,8 +58,8 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/weapon/gun/energy/lasercannon
-	name = "laser cannon"
-	desc = "With the L.A.S.E.R. cannon, the lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	name = "accelerator laser cannon"
+	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
 	item_state = "laser"
 	w_class = 4
@@ -67,7 +67,7 @@
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	origin_tech = "combat=4;materials=3;powerstorage=3"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/heavy)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	pin = null
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -190,5 +190,5 @@
 		icon_state = "gauss"
 
 /obj/item/projectile/bullet/sniper/accelerator/laser
-	name = "accelerator beam
+	name = "accelerator beam"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -188,3 +188,7 @@
 		breakthings = TRUE
 	else if(damage > 25)
 		icon_state = "gauss"
+
+/obj/item/projectile/bullet/sniper/accelerator/laser
+	name = "accelerator beam
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -173,7 +173,7 @@
 	icon_state = ".50"
 
 /obj/item/projectile/bullet/sniper/accelerator
-	icon_state = "gaussweak"
+	icon_state = "scatterlaser"
 	name = "accelerator round"
 	damage = 5
 	stun = 0
@@ -182,13 +182,12 @@
 
 /obj/item/projectile/bullet/sniper/accelerator/Range()
 	..()
-	damage += 5
-	if(damage > 40)
-		icon_state = "gaussstrong"
+	damage += 7
+	transform *= TransformUsingVariable(1.2 , 100)
+	if(damage > 42)
 		breakthings = TRUE
-	else if(damage > 25)
-		icon_state = "gauss"
 
 /obj/item/projectile/bullet/sniper/accelerator/laser
 	name = "accelerator beam"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	damage_type = BURN

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -155,39 +155,3 @@
 	stun = 0
 	weaken = 0
 	breakthings = FALSE
-
-
-
-//Accelerator ammo
-
-/obj/item/ammo_box/magazine/sniper_rounds/accelerator
-	name = "sniper rounds (accelerator)"
-	desc = "An advanced round which gains more power the farther it flies."
-	ammo_type = /obj/item/ammo_casing/accelerator
-	max_ammo = 5
-
-/obj/item/ammo_casing/accelerator
-	desc = "A .50 caliber accelerator round casing."
-	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/accelerator
-	icon_state = ".50"
-
-/obj/item/projectile/bullet/sniper/accelerator
-	icon_state = "scatterlaser"
-	name = "accelerator round"
-	damage = 5
-	stun = 0
-	weaken = 0
-	breakthings = FALSE
-
-/obj/item/projectile/bullet/sniper/accelerator/Range()
-	..()
-	damage += 7
-	transform *= TransformUsingVariable(1.2 , 100)
-	if(damage > 42)
-		breakthings = TRUE
-
-/obj/item/projectile/bullet/sniper/accelerator/laser
-	name = "accelerator beam"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage_type = BURN

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -54,8 +54,8 @@
 	category = list("Weapons")
 
 /datum/design/lasercannon
-	name = "Laser Cannon"
-	desc = "A heavy duty laser cannon."
+	name = "Accelerator Laser Cannon"
+	desc = "A heavy duty laser cannon. It does more damage the farther away the target is."
 	id = "lasercannon"
 	req_tech = list("combat" = 4, "materials" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -452,12 +452,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/ammo_box/magazine/sniper_rounds/penetrator
 	cost = 5
 
-/datum/uplink_item/ammo/sniper/accelerator
-	name = ".50 Accelerator Magazine"
-	desc = "A 5-round magazine of accelerator ammo designed for use with .50 sniper rifles. \
-			The shot is weak at close range, but gains more power the farther it flies."
-	item = /obj/item/ammo_box/magazine/sniper_rounds/accelerator
-
 /datum/uplink_item/ammo/toydarts
 	name = "Box of Riot Darts"
 	desc = "A box of 40 Donksoft foam riot darts, for reloading any compatible foam dart gun. Don't forget to share!"


### PR DESCRIPTION
Inspired by the "help how do we balance xenos when lasercannons kill them in two shots" discussion.

Laser Cannon is now the Accelerator Laser Cannon. The projectile grows the farther it flies. There is no cap to to this damage, but it starts off very weak.

This should make it a more situational weapon/sidegrade rather than X2 DAMAGE GUN.

For those who want to crunch numbers, its 5 damage to start off and +7 damage per tile.

:cl: Kor
add: The Laser Cannon in RD has been replaced with the Accelerator Laser Cannon. Try it out!
/:cl:
