### PR TITLE
Added: Radiation suit storage holds gieger counter

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -125,7 +125,7 @@
 	permeability_coefficient = 0.50
 	flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/geiger_counter)
 	slowdown = 1.5
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)
 	strip_delay = 60


### PR DESCRIPTION
Added the gieger counter to the suit storage of radiation suits.

Other suits have specific items allowed, makes sense for radiation suits to be the same.

:cl: Coiax
rscadd: Geiger counters can now be stored in the suit storage of radiation suits
/:cl:
