### PR TITLE
Biogenerator can make nutriment

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -143,7 +143,9 @@
 			dat += "10 cream: <A href='?src=\ref[src];create=cream;amount=1'>Make</A><A href='?src=\ref[src];create=cream;amount=5'>x5</A> ([30/efficiency])<BR>"
 			dat += "Milk Carton: <A href='?src=\ref[src];create=cmilk;amount=1'>Make</A><A href='?src=\ref[src];create=cmilk;amount=5'>x5</A> ([100/efficiency])<BR>"
 			dat += "Cream Carton: <A href='?src=\ref[src];create=ccream;amount=1'>Make</A><A href='?src=\ref[src];create=ccream;amount=5'>x5</A> ([300/efficiency])<BR>"
-			dat += "Monkey cube: <A href='?src=\ref[src];create=meat;amount=1'>Make</A><A href='?src=\ref[src];create=meat;amount=5'>x5</A> ([250/efficiency])"
+			dat += "Monkey cube: <A href='?src=\ref[src];create=meat;amount=1'>Make</A><A href='?src=\ref[src];create=meat;amount=5'>x5</A> ([250/efficiency])<BR>"
+			dat += "10 nutriment: <A href='?src=\ref[src];create=nutriment;amount=1'>Make</A><A href='?src=\ref[src];create=nutriment;amount=5'>x5</A> ([100])<BR>"
+			dat += "Nutriment bottle: <A href='?src=\ref[src];create=bnutriment;amount=1'>Make</A><A href='?src=\ref[src];create=bnutriment;amount=5'>x5</A> ([500])"
 			dat += "</div>"
 			dat += "<h3>Botany Chemicals:</h3>"
 			dat += "<div class='statusDisplay'>"
@@ -247,6 +249,13 @@
 		if("meat")
 			if (check_cost(250/efficiency)) return 0
 			else new/obj/item/weapon/reagent_containers/food/snacks/monkeycube(src.loc)
+		if("nutriment")
+			if(check_container_volume(10)) return 0
+			else if (check_cost(100)) return 0
+			else beaker.reagents.add_reagent("nutriment",10)
+		if("bnutriment")
+			if (check_cost(500)) return 0
+			else new/obj/item/weapon/reagent_containers/glass/bottle/nutrient/nutriment(src.loc)
 		if("ez")
 			if (check_cost(10/efficiency)) return 0
 			else new/obj/item/weapon/reagent_containers/glass/bottle/nutrient/ez(src.loc)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -162,6 +162,16 @@
 	..()
 	reagents.add_reagent("robustharvestnutriment", 50)
 
+/obj/item/weapon/reagent_containers/glass/bottle/nutrient/nutriment
+	name = "bottle of nutriment"
+	desc = "Contains nutrients suitable for plants and animals."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle15"
+
+/obj/item/weapon/reagent_containers/glass/bottle/nutrient/nutriment/New()
+	..()
+	reagents.add_reagent("nutriment", 50)
+
 /obj/item/weapon/reagent_containers/glass/bottle/weedkiller
 	name = "bottle of weed killer"
 	icon = 'icons/obj/chemical.dmi'


### PR DESCRIPTION
Nutriment can be produced at a high biomass cost; 100 biomass for 10u nutriment. This is because 1u nutriment is processed into 10u biomass in a biogenerator with no upgrades. The cost of producing nutriment will not decrease with efficiency upgrades.

Nutriment is food, so I placed the buttons within the Food category. Nutriment can also be used as a fertilizer, and it is useful for healing a plant.
Currently gardeners use nutriment by composting growns into their plants, and this is unlikely to change that. Players might find it useful to carry a single bottle for all their character's nutrition needs (though they could carry a plant bag for this). It could also make it a little easier to make moonshine.

It is possible for someone to cycle the nutriment through the biogenerator by putting nutriment in a condiment bottle, adding the nutriment to a grown, then adding that grown to the biogenerator. 

By upgrading the productivity of the biogen you can get more nutriment than you would from grinding up the growns, but you can't get vitamins or other substances in the plant from the biogenerator. 

:cl: Erwgd
rscadd: The biogenerator can produce nutriment.
/:cl:
