### PR TITLE
Ends traitorling + Ling improvements

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -52,6 +52,7 @@
 
 	var/datum/faction/faction 			//associated faction
 	var/datum/changeling/changeling		//changeling holder
+	var/datum/linglink			//linked hivemind victims, just a flag to let them speak in hivemind
 
 	var/miming = 0 // Mime's vow of silence
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -290,6 +290,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/changelingID = "Changeling"
 	var/geneticdamage = 0
 	var/isabsorbing = 0
+	var/islinking = 0
 	var/geneticpoints = 10
 	var/purchasedpowers = list()
 	var/mimicing = ""

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -28,7 +28,7 @@
 		user << "<span class='warning'>We must be tightly grabbing a creature in our active hand to link with them!</span>"
 		return
 	if(G.state <= GRAB_NECK)
-		user << "<span class='warning'>We must have a tighter grip to absorb this creature!</span>"
+		user << "<span class='warning'>We must have a tighter grip to link with this creature!</span>"
 		return
 
 	var/mob/living/carbon/target = G.affecting
@@ -49,11 +49,12 @@
 				user << "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>")
 				target << "<span class='userdanger'>You experience a stabbing sensation and your ears begin to ring...</span>"
 			if(3)
-        user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")
+				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")
 				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
 				var/datum/mind/linglink = target.mind
 				linglinkID = target.name
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
+				target.reagents.add_reagent("salbutamol", 40) // So they don't choke to death while you interrogate them
 				sleep(1800)
 				
 		feedback_add_details("changeling_powers","A[stage]")

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -52,7 +52,6 @@
 				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")
 				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
 				var/datum/mind/linglink = target.mind
-				linglinkID = target.name
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
 				target.reagents.add_reagent("salbutamol", 40) // So they don't choke to death while you interrogate them
 				sleep(1800)

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -64,5 +64,5 @@
 
 	changeling.islinking = 0
 	target.mind.linglink = 0
-	user << "<span class='notice'>You cannot sustain the connection any longer, your victim fades from the hivemind</span>")
+	user << "<span class='notice'>You cannot sustain the connection any longer, your victim fades from the hivemind</span>"
 	target << "<span class='userdanger'>The link cannot be sustained any long, your connection to the hivemind has faded!</span>"

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -49,7 +49,7 @@
 				user << "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>"
 				target << "<span class='userdanger'>You experience a stabbing sensation and your ears begin to ring...</span>"
 			if(3)
-				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")
+				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>"
 				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
 				var/datum/mind/linglink = target.mind
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -46,7 +46,7 @@
 			if(1)
 				user << "<span class='notice'>This creature is compatible. We must hold still...</span>"
 			if(2)
-				user << "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>")
+				user << "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>"
 				target << "<span class='userdanger'>You experience a stabbing sensation and your ears begin to ring...</span>"
 			if(3)
 				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -14,11 +14,14 @@
 	if(changeling.islinking)
 		user << "<span class='warning'>We have already formed a link with the victim!</span>"
 		return
-  if(!target.mind)
-    user << "<span class='warning'>The victim has no mind to link to!</span>"
+	if(!target.mind)
+		user << "<span class='warning'>The victim has no mind to link to!</span>"
+		return
+	if(target.stat == DEAD)
+		user << "<span class='warning'>The victim is dead, you cannot link to a dead mind!</span>"
 		return
 	if(target.mind.changeling)
-	  user << "<span class='warning'>The victim is already a part of the hivemind!</span>"
+		user << "<span class='warning'>The victim is already a part of the hivemind!</span>"
 		return	
 	var/obj/item/weapon/grab/G = user.get_active_hand()
 	if(!istype(G))

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -9,8 +9,9 @@
 /obj/effect/proc_holder/changeling/linglink/can_sting(mob/living/carbon/user)
 	if(!..())
 		return
-
 	var/datum/changeling/changeling = user.mind.changeling
+	var/obj/item/weapon/grab/G = user.get_active_hand()
+	var/mob/living/carbon/target = G.affecting
 	if(changeling.islinking)
 		user << "<span class='warning'>We have already formed a link with the victim!</span>"
 		return
@@ -23,18 +24,13 @@
 	if(target.mind.changeling)
 		user << "<span class='warning'>The victim is already a part of the hivemind!</span>"
 		return	
-	var/obj/item/weapon/grab/G = user.get_active_hand()
 	if(!istype(G))
 		user << "<span class='warning'>We must be tightly grabbing a creature in our active hand to link with them!</span>"
 		return
 	if(G.state <= GRAB_NECK)
 		user << "<span class='warning'>We must have a tighter grip to link with this creature!</span>"
 		return
-
-	var/mob/living/carbon/target = G.affecting
 	return changeling.can_absorb_dna(user,target)
-
-
 
 /obj/effect/proc_holder/changeling/linglink/sting_action(mob/user)
 	var/datum/changeling/changeling = user.mind.changeling
@@ -55,10 +51,9 @@
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
 				target.reagents.add_reagent("salbutamol", 40) // So they don't choke to death while you interrogate them
 				sleep(1800)
-				
 		feedback_add_details("changeling_powers","A[stage]")
 		if(!do_mob(user, target, 20))
-			user << "<span class='warning'>Our link with the [target] has ended!</span>"
+			user << "<span class='warning'>Our link with [target] has ended!</span>"
 			changeling.islinking = 0
 			return
 

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -47,7 +47,7 @@
 			if(3)
 				user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>"
 				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
-				var/datum/mind/linglink = target.mind
+				target.mind.linglink = 1
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
 				target.reagents.add_reagent("salbutamol", 40) // So they don't choke to death while you interrogate them
 				sleep(1800)

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -27,7 +27,7 @@
 	if(!istype(G))
 		user << "<span class='warning'>We must be tightly grabbing a creature in our active hand to link with them!</span>"
 		return
-	if(G.state <= GRAB_NECK)
+	if(G.state <= GRAB_AGGRESSIVE)
 		user << "<span class='warning'>We must have a tighter grip to link with this creature!</span>"
 		return
 	return changeling.can_absorb_dna(user,target)
@@ -49,8 +49,9 @@
 				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
 				target.mind.linglink = 1
 				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
-				target.reagents.add_reagent("salbutamol", 40) // So they don't choke to death while you interrogate them
-				sleep(1800)
+				target.reagents.add_reagent("epinephrine", 1) // So they don't choke to death while you interrogate them
+				target.reagents.add_reagent("salbutamol", 30) 
+				sleep(2200)
 		feedback_add_details("changeling_powers","A[stage]")
 		if(!do_mob(user, target, 20))
 			user << "<span class='warning'>Our link with [target] has ended!</span>"

--- a/code/game/gamemodes/changeling/powers/linglink.dm
+++ b/code/game/gamemodes/changeling/powers/linglink.dm
@@ -1,0 +1,65 @@
+/obj/effect/proc_holder/changeling/linglink
+	name = "Hivemind Link"
+	desc = "Link your victim's mind into the hivemind for personal interrogation"
+	chemical_cost = 0
+	dna_cost = 0
+	req_human = 1
+	max_genetic_damage = 100
+
+/obj/effect/proc_holder/changeling/linglink/can_sting(mob/living/carbon/user)
+	if(!..())
+		return
+
+	var/datum/changeling/changeling = user.mind.changeling
+	if(changeling.islinking)
+		user << "<span class='warning'>We have already formed a link with the victim!</span>"
+		return
+  if(!target.mind)
+    user << "<span class='warning'>The victim has no mind to link to!</span>"
+		return
+	if(target.mind.changeling)
+	  user << "<span class='warning'>The victim is already a part of the hivemind!</span>"
+		return	
+	var/obj/item/weapon/grab/G = user.get_active_hand()
+	if(!istype(G))
+		user << "<span class='warning'>We must be tightly grabbing a creature in our active hand to link with them!</span>"
+		return
+	if(G.state <= GRAB_NECK)
+		user << "<span class='warning'>We must have a tighter grip to absorb this creature!</span>"
+		return
+
+	var/mob/living/carbon/target = G.affecting
+	return changeling.can_absorb_dna(user,target)
+
+
+
+/obj/effect/proc_holder/changeling/linglink/sting_action(mob/user)
+	var/datum/changeling/changeling = user.mind.changeling
+	var/obj/item/weapon/grab/G = user.get_active_hand()
+	var/mob/living/carbon/human/target = G.affecting
+	changeling.islinking = 1
+	for(var/stage = 1, stage<=3, stage++)
+		switch(stage)
+			if(1)
+				user << "<span class='notice'>This creature is compatible. We must hold still...</span>"
+			if(2)
+				user << "<span class='notice'>We stealthily stab [target] with a minor proboscis...</span>")
+				target << "<span class='userdanger'>You experience a stabbing sensation and your ears begin to ring...</span>"
+			if(3)
+        user << "<span class='notice'>You mold the [target]'s mind like clay, they can now speak in the hivemind!</span>")
+				target << "<span class='userdanger'>A migraine throbs behind your eyes, you hear yourself screaming - but your mouth has not opened!</span>"
+				var/datum/mind/linglink = target.mind
+				linglinkID = target.name
+				target << "<font color=#800040><span class='boldannounce'>You can now communicate in the changeling hivemind, say \":g message\" to communicate!</span>"
+				sleep(1800)
+				
+		feedback_add_details("changeling_powers","A[stage]")
+		if(!do_mob(user, target, 20))
+			user << "<span class='warning'>Our link with the [target] has ended!</span>"
+			changeling.islinking = 0
+			return
+
+	changeling.islinking = 0
+	target.mind.linglink = 0
+	user << "<span class='notice'>You cannot sustain the connection any longer, your victim fades from the hivemind</span>")
+	target << "<span class='userdanger'>The link cannot be sustained any long, your connection to the hivemind has faded!</span>"

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -43,6 +43,7 @@
 		for(var/j = 0, j < num_changelings, j++)
 			if(!possible_changelings.len) break
 			var/datum/mind/changeling = pick(possible_changelings)
+			antag_candidates -= changeling
 			possible_changelings -= changeling
 			changelings += changeling
 			modePlayer += changelings

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -206,7 +206,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 	if(message_mode == MODE_CHANGELING)
 		switch(lingcheck())
 			if(3)
-				var/msg = "<i><font color=#800040><b>[mind.linglink.linglinkID]:</b> [message]</font></i>"
+				var/msg = "<i><font color=#800040><b>[src.mind]:</b> [message]</font></i>"
 				for(var/mob/M in mob_list)
 					if(M in dead_mob_list)
 						M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -39,21 +39,21 @@ var/list/department_radio_keys = list(
 
 	  //kinda localization -- rastaf0
 	  //same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
-	  ":ê" = "right hand",	"#ê" = "right hand",	".ê" = "right hand",
-	  ":ä" = "left hand",	"#ä" = "left hand",		".ä" = "left hand",
-	  ":ø" = "intercom",	"#ø" = "intercom",		".ø" = "intercom",
-	  ":ð" = "department",	"#ð" = "department",	".ð" = "department",
-	  ":ñ" = "Command",		"#ñ" = "Command",		".ñ" = "Command",
-	  ":ò" = "Science",		"#ò" = "Science",		".ò" = "Science",
-	  ":ü" = "Medical",		"#ü" = "Medical",		".ü" = "Medical",
-	  ":ó" = "Engineering",	"#ó" = "Engineering",	".ó" = "Engineering",
-	  ":û" = "Security",	"#û" = "Security",		".û" = "Security",
-	  ":ö" = "whisper",		"#ö" = "whisper",		".ö" = "whisper",
-	  ":è" = "binary",		"#è" = "binary",		".è" = "binary",
-	  ":ô" = "alientalk",	"#ô" = "alientalk",		".ô" = "alientalk",
-	  ":å" = "Syndicate",	"#å" = "Syndicate",		".å" = "Syndicate",
-	  ":é" = "Supply",		"#é" = "Supply",		".é" = "Supply",
-	  ":ï" = "changeling",	"#ï" = "changeling",	".ï" = "changeling"
+	  ":Ãª" = "right hand",	"#Ãª" = "right hand",	".Ãª" = "right hand",
+	  ":Ã¤" = "left hand",	"#Ã¤" = "left hand",		".Ã¤" = "left hand",
+	  ":Ã¸" = "intercom",	"#Ã¸" = "intercom",		".Ã¸" = "intercom",
+	  ":Ã°" = "department",	"#Ã°" = "department",	".Ã°" = "department",
+	  ":Ã±" = "Command",		"#Ã±" = "Command",		".Ã±" = "Command",
+	  ":Ã²" = "Science",		"#Ã²" = "Science",		".Ã²" = "Science",
+	  ":Ã¼" = "Medical",		"#Ã¼" = "Medical",		".Ã¼" = "Medical",
+	  ":Ã³" = "Engineering",	"#Ã³" = "Engineering",	".Ã³" = "Engineering",
+	  ":Ã»" = "Security",	"#Ã»" = "Security",		".Ã»" = "Security",
+	  ":Ã¶" = "whisper",		"#Ã¶" = "whisper",		".Ã¶" = "whisper",
+	  ":Ã¨" = "binary",		"#Ã¨" = "binary",		".Ã¨" = "binary",
+	  ":Ã´" = "alientalk",	"#Ã´" = "alientalk",		".Ã´" = "alientalk",
+	  ":Ã¥" = "Syndicate",	"#Ã¥" = "Syndicate",		".Ã¥" = "Syndicate",
+	  ":Ã©" = "Supply",		"#Ã©" = "Supply",		".Ã©" = "Supply",
+	  ":Ã¯" = "changeling",	"#Ã¯" = "changeling",	".Ã¯" = "changeling"
 )
 
 var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
@@ -205,6 +205,21 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 /mob/living/proc/handle_inherent_channels(message, message_mode)
 	if(message_mode == MODE_CHANGELING)
 		switch(lingcheck())
+			if(3)
+				var/msg = "<i><font color=#800040><b>[mind.linglink.linglinkID]:</b> [message]</font></i>"
+				for(var/mob/M in mob_list)
+					if(M in dead_mob_list)
+						M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
+					else
+						switch(M.lingcheck())
+							if(3)
+								M << msg
+							if(2)
+								M << msg
+							if(1)
+								if(prob(40))
+									M << "<i><font color=#800080>We can faintly sense an outsider trying to communicate through the hivemind...</font></i>"
+				return 1
 			if(2)
 				var/msg = "<i><font color=#800080><b>[mind.changeling.changelingID]:</b> [message]</font></i>"
 				log_say("[mind.changeling.changelingID]/[src.key] : [message]")
@@ -213,6 +228,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 						M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
 					else
 						switch(M.lingcheck())
+							if(3)
+								M << msg
 							if(2)
 								M << msg
 							if(1)
@@ -272,11 +289,13 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 			return NOPASS
 	return 0
 
-/mob/living/lingcheck() //Returns 1 if they are a changeling. Returns 2 if they are a changeling that can communicate through the hivemind
+/mob/living/lingcheck() //1 is ling w/ no hivemind. 2 is ling w/hivemind. 3 is ling victim being linked into hivemind. 
 	if(mind && mind.changeling)
 		if(mind.changeling.changeling_speak)
 			return 2
 		return 1
+	if(mind && mind.linglink)
+		return 3
 	return 0
 
 /mob/living/say_quote(input, list/spans)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -349,7 +349,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Lightning", "Protector", "Charger", "Assassin")
 	var/random = TRUE
 	var/allowmultiple = 0
-	var/allowling = 0
+	var/allowling = 1
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	var/list/guardians = user.hasparasites()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -285,6 +285,7 @@
 #include "code\game\gamemodes\changeling\powers\hivemind.dm"
 #include "code\game\gamemodes\changeling\powers\humanform.dm"
 #include "code\game\gamemodes\changeling\powers\lesserform.dm"
+#include "code\game\gamemodes\changeling\powers\linglink.dm"
 #include "code\game\gamemodes\changeling\powers\mimic_voice.dm"
 #include "code\game\gamemodes\changeling\powers\mutations.dm"
 #include "code\game\gamemodes\changeling\powers\panacea.dm"


### PR DESCRIPTION
1) Traitorling is ruled out during Traitorchan mode. It's too frustrating trying to make lings into a consistent antag when they're under constant assault from snowflake rules and every balance change has to incorporate the absurd discussion of "well what if they're a traitorling...". I'm not wild about this change, but it's necessary to make real progress. 

2) Lings can now use holoparasite injectors. 

3) Lings can now interrogate their victims with a new default ability, "Hivemind Link". Following a tight (kill) grip, lings can now bring people into the ling hivemind for the purpose of interrogation. Whether you just want to taunt the victim or have them barter valuable intel for their lives, this ability will allow you to 'silently' and somewhat stealthily communicate with conscious or unsconscious people. 

Not only is it a neat idea, I created it to compensate for the divide between traitors/lings that this PR will create. While lings won't be starting with traitor gear anymore, they can use this ability to coerce traitors for PDA codes or demand their cooperation in return for sparing their life. 

:cl: Robustin
add: Lings have a new default ability, Hivemind Link. This lets you bring a neck-grabbed victim into hivemind communications after short period of time. You can talk to victims in crit or muted and perhaps persuade them to help you or 'fess up a PDA code. The link will stabilize crit victims to ensure they do not die during the link. 
add: Lings no longer face any unique item restrictions. 
remove: Lings can no longer roll traitor during traitorchan.
/:cl:
