### PR TITLE
Cable restraints and spears can be recycled in autolathe, but not zipties

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -72,6 +72,7 @@
 	desc = "Looks like some cables tied together. Could be used to tie something up."
 	icon_state = "cuff_red"
 	item_state = "coil_red"
+	materials = list(MAT_METAL=150, MAT_GLASS=75)
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 	var/datum/robot_energy_storage/wirestorage = null
@@ -179,6 +180,7 @@
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	icon_state = "cuff_white"
+	materials = list()
 	breakouttime = 450 //Deciseconds = 45s
 	trashtype = /obj/item/weapon/restraints/handcuffs/cable/zipties/used
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -307,6 +307,7 @@
 	throw_speed = 4
 	embedded_impact_pain_multiplier = 3
 	armour_penetration = 10
+	materials = list(MAT_METAL=1150, MAT_GLASS=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 	sharpness = IS_SHARP

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -85,7 +85,7 @@
 	force = 9
 	throwforce = 10
 	w_class = 3
-	materials = list(MAT_METAL=1000)
+	materials = list(MAT_METAL=1150, MAT_GLASS=75)
 	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
 
 /obj/item/weapon/wirerod/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
Cables can be recycled at 10 metal, 5 glass per piece, and I changed some things' material values to reflect this: 
- Cable restraints can now be recycled for 150 metal and 75 glass (15x10 + 15*5 = 225);
- Spears can now be recycled for 1150 metal and 2075 glass ( (15x10 + 1000 from rod), (15*5 + 2000 from shard) );
- Wired rods can be recycled for 1150 metal and 75 glass. You could recycle these before but now we account for the cable restraints used on the rod.

Zipties now have an empty material list instead of inheriting 500 units of metal. This means they can no longer be recycled in an autolathe.
