### PR TITLE
Reduces min. pop. for NukeOps and Cult

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -59,7 +59,7 @@
 	antag_flag = ROLE_CULTIST
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 35
+	required_players = 30
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 35 // 35 players - 5 players to be the nuke ops = 30 players remaining
+	required_players = 30 // 30 players - 5 players to be the nuke ops = 25 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
@@ -305,7 +305,7 @@
 	belt = /obj/item/weapon/gun/projectile/automatic/pistol
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1)
 
-	var/tc = 30
+	var/tc = 25
 
 /datum/outfit/syndicate/no_crystals
 	tc = 0


### PR DESCRIPTION
As a trialmin I've gained some valuable insight into how active in-game round-start players are a fraction of players connected.

Last 30 days we've had roughly 1,300 rounds, cult makes up 2% of those and nukeops make up 3.5% (25 and 46 rounds respectively).

So I'm bumping the numbers down. Cult successfully summoned Nar-Sie in only 3 rounds, but Nukeops fared better at 43% major victories. So I'm reducing the TC per syndie radio to 25 from 30. This affects the "base" TC availability without screwing with the scaling TC that Nuke Ops get from higher pop or declarations of war. Cult isn't getting any balance changes. 

http://ss13.eu/tgdb/tg/latest_stats.html
