### PR TITLE
Improves selections for head of staff fashion

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -35,14 +35,14 @@
 	name = "chief engineer's cloak"
 	desc = "Worn by Engitopia, wielders of an unlimited power. It's slightly shielded against radiation."
 	icon_state = "cecloak"
-	allowed = list(/obj/item/weapon/rcd)
+	allowed = list(/obj/item/weapon/rcd, /obj/item/weapon/pipe_dispenser)
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 10)
 
 /obj/item/clothing/suit/cloak/rd
 	name = "research director's cloak."
 	desc = "Worn by Sciencia, thaumaturges and researchers of the universe. It's slightly shielded from contaminants."
 	icon_state = "rdcloak"
-	allowed = list(/obj/item/weapon/hand_tele)
+	allowed = list(/obj/item/weapon/hand_tele, /obj/item/weapon/storage/part_replacer)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 
 /obj/item/clothing/suit/cloak/cap

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -17,6 +17,7 @@
 	name = "head of security's cloak"
 	desc = "Worn by Securistan, ruling the station with an iron fist. It's slightly armored."
 	icon_state = "hoscloak"
+	allowed = list(/obj/item/weapon/gun/energy/gun/hos)
 	armor = list(melee = 30, bullet = 30, laser = 10, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/cloak/qm
@@ -27,24 +28,28 @@
 	name = "chief medical officer's cloak"
 	desc = "Worn by Meditopia, the valiant men and women keeping pestilence at bay. It's slightly shielded from contaminants."
 	icon_state = "cmocloak"
+	allowed = list(/obj/item/weapon/reagent_containers/hypospray/CMO)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 25, rad = 0)
 
 /obj/item/clothing/suit/cloak/ce
 	name = "chief engineer's cloak"
 	desc = "Worn by Engitopia, wielders of an unlimited power. It's slightly shielded against radiation."
 	icon_state = "cecloak"
+	allowed = list(/obj/item/weapon/rcd)
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 10)
 
 /obj/item/clothing/suit/cloak/rd
 	name = "research director's cloak."
 	desc = "Worn by Sciencia, thaumaturges and researchers of the universe. It's slightly shielded from contaminants."
 	icon_state = "rdcloak"
+	allowed = list(/obj/item/weapon/hand_tele)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
 
 /obj/item/clothing/suit/cloak/cap
 	name = "captain's cloak"
 	desc = "Worn by the commander of Space Station 13."
 	icon_state = "capcloak"
+	allowed = list(/obj/item/weapon/gun/energy/laser/captain)
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 10, rad = 10)
 
 /* //wip


### PR DESCRIPTION
When cloaks were back slot items, they allowed wearers the trade-off of additional armor at the cost of carrying capacity. Now, the head of staff cloaks are suit slot items with the signature aesthetic of a given head of staff. While it might be ridiculous to allow these cloaks to hold the same items as armor, or other suits and vests, it seems reasonable that they might be tailored to carry a particular item suitable to each head of staff.

The Captain's cloak can carry the antique laser gun, the Head of Security's cloak can carry their unique energy gun, the CMO's cloak can carry the hypospray, the RD's cloak can carry a hand teleporter or RPED, and the CE's cloak can carry an RCD or RPD.

:cl: Eaglendia
add: Central Command has released a new, more functional run of their most stylish fashion line.
add: Head of Staff cloaks can now hold specific items - the antique laser gun for the Captain, the replica energy gun for the Head of Security, the hypospray for the Chief Medical Officer, the Hand Teleporter or RPED for the Research Director, and the RCD or RPD for the Chief Engineer.
/:cl:
