### PR TITLE
Allows disabler beams to deal damage to some simple mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -33,6 +33,7 @@
 	flying = 1
 	pressure_resistance = 200
 	gold_core_spawnable = 1
+	circulatory = 1 // Takes damage from disabler bolts
 
 /mob/living/simple_animal/hostile/carp/Process_Spacemove(movement_dir = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -48,8 +48,9 @@
 	gold_core_spawnable = 1
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 4
+	circulatory = 1
 	var/playable_spider = FALSE
-    
+
 /mob/living/simple_animal/hostile/poison/giant_spider/Topic(href, href_list)
 	if(href_list["activate"])
 		var/mob/dead/observer/ghost = usr

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -24,3 +24,4 @@
 	minbodytemp = 150
 	maxbodytemp = 500
 	gold_core_spawnable = 1
+	circulatory = 1 // Takes damage from disabler bolts

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -54,6 +54,8 @@
 	var/eye_damage = 0//Living, potentially Carbon
 	var/lastpuke = 0
 
+	var/circulatory = 0 // Some simple mobs will receive damage from disabler bolts
+
 	var/name_archive //For admin things like possession
 
 	var/timeofdeath = 0//Living

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -47,11 +47,19 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 36
+	damage = 0
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
+
+/obj/item/projectile/beam/disabler/on_hit(atom/target, blocked = 0)
+	. = ..()
+	var/mob/living/C = target
+	if(iscarbon(C))
+		C.apply_damage(36, STAMINA, null)
+	if (C.circulatory) // Some simple mobs will be unable to recover from disabler beams
+		C.apply_damage(7, BRUTE, "chest")
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"


### PR DESCRIPTION
_The cutting edge in self-defense technology, Nanotrasen's disabler beams are thought to operate by causing a psychosomatic effect that catalyzes the buildup of fatigue toxins in target tissue. While most complex organisms are capable of quickly recovering from this sudden stress, organisms with open circulatory systems have less capacity to eliminate high concentrations of these compounds - often, this has life-threatening consequences for the organism in question._

In my opinion, the only good thing about the recently-reverted taser overhaul was a seriously good thing: affording officers with standard equipment a ranged option against such threats as spiders and space carp. This PR introduces a variable, currently enabled for spiders, space carp, and killer tomatoes, which causes disablers to deal 7 damage on hit.

In hindsight, disablers have a much higher shot capacity than the overhauled taser's light laser function, though. If this seems unbalanced I can make the incoming damage modifiable on a per-mob basis.
