### PR TITLE
Stamina damage can hurt simple mobs.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -28,6 +28,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1500
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0.33, OXY = 1)
 
 	faction = list("carp")
 	flying = 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -48,8 +48,9 @@
 	gold_core_spawnable = 1
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 4
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0.33, OXY = 1)
 	var/playable_spider = FALSE
-    
+
 /mob/living/simple_animal/hostile/poison/giant_spider/Topic(href, href_list)
 	if(href_list["activate"])
 		var/mob/dead/observer/ghost = usr

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -46,6 +46,7 @@
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value
 	var/melee_damage_type = BRUTE //Damage type of a simple mob's melee attack, should it do damage.
 	var/list/damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) // 1 for full damage , 0 for none , -1 for 1:1 heal from that source
+	var/resisttext = "It had no effect."
 	var/attacktext = "attacks"
 	var/attack_sound = null
 	var/friendly = "nuzzles" //If the mob does no damage with it's attack
@@ -304,26 +305,38 @@
 /mob/living/simple_animal/adjustBruteLoss(amount)
 	if(damage_coeff[BRUTE])
 		. = adjustHealth(amount*damage_coeff[BRUTE])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/adjustFireLoss(amount)
 	if(damage_coeff[BURN])
 		. = adjustHealth(amount*damage_coeff[BURN])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/adjustOxyLoss(amount)
 	if(damage_coeff[OXY])
 		. = adjustHealth(amount*damage_coeff[OXY])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/adjustToxLoss(amount)
 	if(damage_coeff[TOX])
 		. = adjustHealth(amount*damage_coeff[TOX])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/adjustCloneLoss(amount)
 	if(damage_coeff[CLONE])
 		. = adjustHealth(amount*damage_coeff[CLONE])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/adjustStaminaLoss(amount)
 	if(damage_coeff[STAMINA])
 		. = adjustHealth(amount*damage_coeff[STAMINA])
+	else
+		visible_message(resisttext)
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M)
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -322,7 +322,8 @@
 		. = adjustHealth(amount*damage_coeff[CLONE])
 
 /mob/living/simple_animal/adjustStaminaLoss(amount)
-	return
+	if(damage_coeff[STAMINA])
+		. = adjustHealth(amount*damage_coeff[STAMINA])
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M)
 	..()


### PR DESCRIPTION
Stamina damage can now do damage to simple_animals. Defaults to a modifier of 0 so simple_animals are immune. Carp and Spiders take 1/3 damage from stamina, which is about 10 damage from a disabler.
:cl: Eaglendia and KazeEspada
add: The cutting edge in self-defense technology, Nanotrasen's disabler beams are thought to operate by causing a psychosomatic effect that catalyzes the buildup of fatigue toxins in target tissue. While most complex organisms are capable of quickly recovering from this sudden stress, organisms with open circulatory systems have less capacity to eliminate high concentrations of these compounds - often, this has life-threatening consequences for the organism in question.
add: Carp and Spiders now take damage from disablers and other source of stamina damage.
/:cl:
