### PR TITLE
Fixing rudimentary transformation not working properly on ghosts with minds

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -62,7 +62,7 @@
 	src.key = key
 
 
-/datum/mind/proc/transfer_to(mob/new_character)
+/datum/mind/proc/transfer_to(mob/new_character, var/force_key_move = 0)
 	if(current)	// remove ourself from our old body's mind variable
 		current.mind = null
 		SStgui.on_transfer(current, new_character)
@@ -83,7 +83,7 @@
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 
-	if(active)
+	if(active || force_key_move)
 		new_character.key = key		//now transfer the key to link the client to our new body
 
 /datum/mind/proc/store_memory(new_text)

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -51,7 +51,7 @@
 		H.dna.update_dna_identity()
 
 	if(mind && istype(M, /mob/living))
-		mind.transfer_to(M)
+		mind.transfer_to(M, 1) // second argument to force key move to new mob
 	else
 		M.key = key
 


### PR DESCRIPTION
Adds a second argument to mind/proc/transfer_to, allowing the proc to bypass the active check and force the key move to the new mob anyways.

I then added that second argument to the proc call from rudimentary transformation, fixing the bug where being a ghost with a mind would not immediately move you into the body of a new mob with rudimentary transform (as when you become a ghost, mind.active becomes 0).

:cl: Isratosh
bugfix: Fixed rudimentary transform not working properly on ghosts with minds.
/:cl:
