### PR TITLE
Tweaks atmos: excited groups and ssair

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -30,9 +30,12 @@
 #define TANK_RUPTURE_PRESSURE				(35.*ONE_ATMOSPHERE)	//Tank spills all contents into atmosphere
 #define TANK_FRAGMENT_PRESSURE				(40.*ONE_ATMOSPHERE)	//Boom 3x3 base explosion
 #define TANK_FRAGMENT_SCALE	    			(6.*ONE_ATMOSPHERE)	//+1 for each SCALE kPa aboe threshold
-#define MINIMUM_AIR_RATIO_TO_SUSPEND		0.005	//Minimum ratio of air that must move to/from a tile to suspend group processing
+#define MINIMUM_AIR_RATIO_TO_SUSPEND		0.1		//Ratio of air that must move to/from a tile to reset group processing
+#define MINIMUM_AIR_RATIO_TO_MOVE			0.001	//Minimum ratio of air that must move to/from a tile
 #define MINIMUM_AIR_TO_SUSPEND				(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND)	//Minimum amount of air that has to move before a group processing can be suspended
-#define MINIMUM_MOLES_DELTA_TO_MOVE			(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND) //Either this must be active
+#define MINIMUM_MOLES_DELTA_TO_MOVE			(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_MOVE) //Either this must be active
+#define EXCITED_GROUP_BREAKDOWN_CYCLES		4
+#define EXCITED_GROUP_DISMANTLE_CYCLES		16
 #define MINIMUM_TEMPERATURE_TO_MOVE			(T20C+100)			//or this (or both, obviously)
 #define MINIMUM_TEMPERATURE_RATIO_TO_SUSPEND		0.012
 #define MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND		4		//Minimum temperature difference before group processing is suspended

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -1,3 +1,10 @@
+#define SSAIR_PIPENETS 1
+#define SSAIR_ATMOSMACHINERY 2
+#define SSAIR_ACTIVETURFS 3
+#define SSAIR_EXCITEDGROUPS 4
+#define SSAIR_HIGHPRESSURE 5
+#define SSAIR_HOTSPOTS 6
+#define SSAIR_SUPERCONDUCTIVITY 7
 var/datum/subsystem/air/SSair
 
 /datum/subsystem/air
@@ -19,14 +26,18 @@ var/datum/subsystem/air/SSair
 
 	var/list/excited_groups = list()
 	var/list/active_turfs = list()
-	var/list/currentrun = list()
 	var/list/hotspots = list()
 	var/list/networks = list()
 	var/list/obj/machinery/atmos_machinery = list()
 
+
 	//Special functions lists
 	var/list/turf/active_super_conductivity = list()
 	var/list/turf/open/high_pressure_delta = list()
+
+
+	var/list/currentrun = list()
+	var/currentpart = SSAIR_PIPENETS
 
 
 /datum/subsystem/air/New()
@@ -57,76 +68,140 @@ var/datum/subsystem/air/SSair
 
 #define MC_AVERAGE(average, current) (0.8*(average) + 0.2*(current))
 /datum/subsystem/air/fire(resumed = 0)
-
 	var/timer = world.timeofday
-	//tick paused, that means we already did this bit
-	if (!resumed)
-		process_pipenets()
+
+	if(currentpart == SSAIR_PIPENETS || !resumed)
+		process_pipenets(resumed)
 		cost_pipenets = MC_AVERAGE(cost_pipenets, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_ATMOSMACHINERY
 
+	if(currentpart == SSAIR_ATMOSMACHINERY)
 		timer = world.timeofday
-		process_atmos_machinery()
+		process_atmos_machinery(resumed)
 		cost_atmos_machinery = MC_AVERAGE(cost_atmos_machinery, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_ACTIVETURFS
 
+	if(currentpart == SSAIR_ACTIVETURFS)
 		timer = world.timeofday
+		process_active_turfs(resumed)
+		cost_turfs = MC_AVERAGE(cost_turfs, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_EXCITEDGROUPS
 
-	process_active_turfs(resumed)
-	cost_turfs = MC_AVERAGE(cost_turfs, (world.timeofday - timer))
-	if (paused)
-		return //we paused mid way thru processing turfs due to tick overrun
-	timer = world.timeofday
-	process_excited_groups()
-	cost_groups = MC_AVERAGE(cost_groups, (world.timeofday - timer))
+	if(currentpart == SSAIR_EXCITEDGROUPS)
+		timer = world.timeofday
+		process_excited_groups(resumed)
+		cost_groups = MC_AVERAGE(cost_groups, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_HIGHPRESSURE
 
-	timer = world.timeofday
-	process_high_pressure_delta()
-	cost_highpressure = MC_AVERAGE(cost_highpressure, (world.timeofday - timer))
+	if(currentpart == SSAIR_HIGHPRESSURE)
+		timer = world.timeofday
+		process_high_pressure_delta(resumed)
+		cost_highpressure = MC_AVERAGE(cost_highpressure, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_HOTSPOTS
 
-	timer = world.timeofday
-	process_hotspots()
-	cost_hotspots = MC_AVERAGE(cost_hotspots, (world.timeofday - timer))
+	if(currentpart == SSAIR_HOTSPOTS)
+		timer = world.timeofday
+		process_hotspots(resumed)
+		cost_hotspots = MC_AVERAGE(cost_hotspots, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+		currentpart = SSAIR_SUPERCONDUCTIVITY
 
-	timer = world.timeofday
-	process_super_conductivity()
-	cost_superconductivity = MC_AVERAGE(cost_superconductivity, (world.timeofday - timer))
-
+	if(currentpart == SSAIR_SUPERCONDUCTIVITY)
+		timer = world.timeofday
+		process_super_conductivity(resumed)
+		cost_superconductivity = MC_AVERAGE(cost_superconductivity, (world.timeofday - timer))
+		if(paused)
+			return
+		resumed = 0
+	currentpart = SSAIR_PIPENETS
 
 #undef MC_AVERAGE
 
 
-
-/datum/subsystem/air/proc/process_pipenets()
-	for(var/thing in networks)
+/datum/subsystem/air/proc/process_pipenets(resumed = 0)
+	if (!resumed)
+		src.currentrun = networks.Copy()
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+	while(currentrun.len)
+		var/datum/thing = currentrun[1]
+		currentrun.Cut(1, 2)
 		if(thing)
-			thing:process()
-			continue
-		networks.Remove(thing)
+			thing.process()
+		else
+			networks.Remove(thing)
+		if(MC_TICK_CHECK)
+			return
 
 
-/datum/subsystem/air/proc/process_atmos_machinery()
+/datum/subsystem/air/proc/process_atmos_machinery(resumed = 0)
 	var/seconds = wait * 0.1
-	for(var/obj/machinery/M in atmos_machinery)
-		if(M && (M.process_atmos(seconds) != PROCESS_KILL))
-			continue
-		atmos_machinery.Remove(M)
+	if (!resumed)
+		src.currentrun = atmos_machinery.Copy()
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+	while(currentrun.len)
+		var/obj/machinery/M = currentrun[1]
+		currentrun.Cut(1, 2)
+		if(!M || (M.process_atmos(seconds) == PROCESS_KILL))
+			atmos_machinery.Remove(M)
+		if(MC_TICK_CHECK)
+			return
 
 
-/datum/subsystem/air/proc/process_super_conductivity()
-	for(var/turf/T in active_super_conductivity)
+/datum/subsystem/air/proc/process_super_conductivity(resumed = 0)
+	if (!resumed)
+		src.currentrun = active_super_conductivity.Copy()
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+	while(currentrun.len)
+		var/turf/T = currentrun[1]
+		currentrun.Cut(1, 2)
 		T.super_conduct()
+		if(MC_TICK_CHECK)
+			return
+
+/datum/subsystem/air/proc/process_hotspots(resumed = 0)
+	if (!resumed)
+		src.currentrun = hotspots.Copy()
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+	while(currentrun.len)
+		var/obj/effect/hotspot/H = currentrun[1]
+		currentrun.Cut(1, 2)
+		if (H)
+			H.process()
+		else
+			hotspots -= H
+		if(MC_TICK_CHECK)
+			return
 
 
-/datum/subsystem/air/proc/process_hotspots()
-	for(var/obj/effect/hotspot/H in hotspots)
-		H.process()
-
-
-/datum/subsystem/air/proc/process_high_pressure_delta()
-	for(var/O in high_pressure_delta)
-		var/turf/open/T = O
+/datum/subsystem/air/proc/process_high_pressure_delta(resumed = 0)
+	while (high_pressure_delta.len)
+		var/turf/open/T = high_pressure_delta[1]
+		high_pressure_delta.Cut(1,2)
 		T.high_pressure_movements()
 		T.pressure_difference = 0
-	high_pressure_delta.len = 0
+		if(MC_TICK_CHECK)
+			return
 
 /datum/subsystem/air/proc/process_active_turfs(resumed = 0)
 	//cache for sanic speed
@@ -142,6 +217,24 @@ var/datum/subsystem/air/SSair
 			T.process_cell(fire_count)
 		if (MC_TICK_CHECK)
 			return
+
+/datum/subsystem/air/proc/process_excited_groups(resumed = 0)
+	if (!resumed)
+		src.currentrun = excited_groups.Copy()
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+	while(currentrun.len)
+		var/datum/excited_group/EG = currentrun[1]
+		currentrun.Cut(1, 2)
+		EG.breakdown_cooldown++
+		EG.dismantle_cooldown++
+		if(EG.breakdown_cooldown >= EXCITED_GROUP_BREAKDOWN_CYCLES)
+			EG.self_breakdown()
+		else if(EG.dismantle_cooldown >= EXCITED_GROUP_DISMANTLE_CYCLES)
+			EG.dismantle()
+		if (MC_TICK_CHECK)
+			return
+
 
 /datum/subsystem/air/proc/remove_from_active(turf/open/T)
 	active_turfs -= T
@@ -161,14 +254,6 @@ var/datum/subsystem/air/SSair
 		for(var/turf/S in T.atmos_adjacent_turfs)
 			add_to_active(S)
 
-/datum/subsystem/air/proc/process_excited_groups()
-	for(var/datum/excited_group/EG in excited_groups)
-		EG.breakdown_cooldown ++
-		if(EG.breakdown_cooldown == 10)
-			EG.self_breakdown()
-			return
-		if(EG.breakdown_cooldown > 20)
-			EG.dismantle()
 
 /datum/subsystem/air/proc/setup_allturfs(z_level)
 	var/z_start = 1
@@ -239,3 +324,12 @@ var/datum/subsystem/air/SSair
 		var/obj/machinery/atmospherics/AM = A
 		AM.build_network()
 		CHECK_TICK
+
+
+#undef SSAIR_PIPENETS
+#undef SSAIR_ATMOSMACHINERY
+#undef SSAIR_ACTIVETURFS
+#undef SSAIR_EXCITEDGROUPS
+#undef SSAIR_HIGHPRESSURE
+#undef SSAIR_HOTSPOT
+#undef SSAIR_SUPERCONDUCTIVITY

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -275,7 +275,8 @@ var/datum/subsystem/air/SSair
 			continue
 
 		var/turf/open/T = t
-
+		if(!istype(T))
+			continue
 		T.excited = 0
 		T.update_visuals()
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -215,6 +215,8 @@
 /turf/open/proc/last_share_check()
 	if(air.last_share > MINIMUM_AIR_TO_SUSPEND)
 		excited_group.reset_cooldowns()
+	else if(air.last_share > MINIMUM_MOLES_DELTA_TO_MOVE)
+		excited_group.dismantle_cooldown = 0
 
 /turf/open/proc/high_pressure_movements()
 	for(var/atom/movable/M in src)
@@ -236,6 +238,7 @@
 /datum/excited_group
 	var/list/turf_list = list()
 	var/breakdown_cooldown = 0
+	var/dismantle_cooldown = 0
 
 /datum/excited_group/New()
 	SSair.excited_groups += src
@@ -264,6 +267,7 @@
 
 /datum/excited_group/proc/reset_cooldowns()
 	breakdown_cooldown = 0
+	dismantle_cooldown = 0
 
 /datum/excited_group/proc/self_breakdown()
 	var/datum/gas_mixture/A = new
@@ -282,6 +286,7 @@
 			T_gases[id][MOLES] = A_gases[id][MOLES]/turf_list.len
 
 		T.update_visuals()
+		breakdown_cooldown = 0
 
 /datum/excited_group/proc/dismantle()
 	for(var/t in turf_list)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -271,22 +271,25 @@
 
 /datum/excited_group/proc/self_breakdown()
 	var/datum/gas_mixture/A = new
+
+	//make local for sanic speed
 	var/list/A_gases = A.gases
+	var/list/turf_list = src.turf_list
+	var/turflen = turf_list.len
 
 	for(var/t in turf_list)
 		var/turf/open/T = t
 		A.merge(T.air)
 
+	for(var/id in A_gases)
+		A_gases[id][MOLES] = A_gases[id][MOLES]/turflen
+
 	for(var/t in turf_list)
 		var/turf/open/T = t
-		var/T_gases = T.air.gases
-
-		for(var/id in A_gases)
-			T.air.assert_gas(id)
-			T_gases[id][MOLES] = A_gases[id][MOLES]/turf_list.len
-
+		T.air.copy_from(A)
 		T.update_visuals()
-		breakdown_cooldown = 0
+
+	breakdown_cooldown = 0
 
 /datum/excited_group/proc/dismantle()
 	for(var/t in turf_list)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -531,11 +531,11 @@ var/list/gaslist_cache = null
 		var/gas_moles = cached_gases[id] ? cached_gases[id][datatype] : 0
 		var/sample_moles = sample_gases[id] ? sample_gases[id][datatype] : 0
 		var/delta = abs(gas_moles - sample_moles)/(adjacents+1)
-		if(delta > MINIMUM_AIR_TO_SUSPEND && \
-			delta > gas_moles * MINIMUM_AIR_RATIO_TO_SUSPEND)
+		if(delta > MINIMUM_MOLES_DELTA_TO_MOVE && \
+			delta > gas_moles * MINIMUM_AIR_RATIO_TO_MOVE)
 			return id
 
-	if(total_moles() > MINIMUM_AIR_TO_SUSPEND)
+	if(total_moles() > MINIMUM_MOLES_DELTA_TO_MOVE)
 		var/temp
 		var/sample_temp
 


### PR DESCRIPTION
Excited groups will be **_much**_ more aggressive about averaging out their turfs when air movement within has slowed down.
Excited groups will be less aggressive about sleeping simi-idle turfs to prevent deadlocking
Sleeping thresholds lowered.
SSair will now tick_check all loops, not just active turf processing.

I was gonna do these in two prs, but i have to touch the same code in both, and i didn't want to cuck myself.
