### PR TITLE
Fix a bug with stuffing people into lockers.

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -273,3 +273,48 @@ Proc for attack log creation, because really why not
 				break
 	if (progress)
 		qdel(progbar)
+
+/proc/do_after_mob(mob/user, var/list/targets, time = 30, uninterruptible = 0, progress = 1)
+	if(!user || !targets)
+		return 0
+	if(!islist(targets))
+		targets = list(targets)
+	var/user_loc = user.loc
+
+	var/drifting = 0
+	if(!user.Process_Spacemove(0) && user.inertia_dir)
+		drifting = 1
+
+	var/list/originalloc = list()
+	for(var/atom/target in targets)
+		originalloc[target] = target.loc
+
+	var/holding = user.get_active_hand()
+	var/datum/progressbar/progbar
+	if(progress)
+		progbar = new(user, time, targets[1])
+
+	var/endtime = world.time + time
+	var/starttime = world.time
+	. = 1
+	mainloop:
+		while(world.time < endtime)
+			sleep(1)
+			if(progress)
+				progbar.update(world.time - starttime)
+			if(!user || !targets)
+				. = 0
+				break
+			if(uninterruptible)
+				continue
+
+			if(drifting && !user.inertia_dir)
+				drifting = 0
+				user_loc = user.loc
+
+			for(var/atom/target in targets)
+				if((!drifting && user_loc != user.loc) || originalloc[target] != target.loc || user.get_active_hand() != holding || user.incapacitated() || user.lying )
+					. = 0
+					break mainloop
+	if(progbar)
+		qdel(progbar)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -250,11 +250,12 @@
 	if(user == O)
 		return
 
+	var/lockerloc = loc
 	add_fingerprint(user)
 	user.visible_message("<span class='warning'>[user] tries to stuff [O] into [src].</span>", \
 				 	 	"<span class='warning'>You try to stuff [O] into [src].</span>", \
 				 	 	"<span class='italics'>You hear clanging.</span>")
-	if(do_after(user, 40, target = src))
+	if(do_mob(user, O, 40) && loc == lockerloc)
 		user.visible_message("<span class='notice'>[user] stuffs [O] into [src].</span>", \
 						 	 "<span class='notice'>You stuff [O] into [src].</span>", \
 						 	 "<span class='italics'>You hear a loud metal bang.</span>")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -250,19 +250,20 @@
 	if(user == O)
 		return
 
-	var/lockerloc = loc
+
+	var/list/targets = list(O, src)
 	add_fingerprint(user)
 	user.visible_message("<span class='warning'>[user] tries to stuff [O] into [src].</span>", \
 				 	 	"<span class='warning'>You try to stuff [O] into [src].</span>", \
 				 	 	"<span class='italics'>You hear clanging.</span>")
-	if(do_mob(user, O, 40) && loc == lockerloc)
+	if(do_after_mob(user, targets, 40))
 		user.visible_message("<span class='notice'>[user] stuffs [O] into [src].</span>", \
 						 	 "<span class='notice'>You stuff [O] into [src].</span>", \
 						 	 "<span class='italics'>You hear a loud metal bang.</span>")
 		var/mob/living/L = O
 		if(istype(L) && !issilicon(L))
 			L.Weaken(2)
-		step_towards(O, loc)
+		O.loc = src.loc
 		close()
 	return 1
 


### PR DESCRIPTION
Fixes #16520

Now if the person being stuffed moves, or the locker itself, the action will stop and not try to stuff the person anyway.

Adds a new proc, do_after_mob, which allows multiple targets, so now the progress bar will stop if the closet or target mob moves.

Special thanks to @MrStonedOne on this.
