### PR TITLE
World "?status" expansion, Topic() rework

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -26,10 +26,10 @@
 #define EMPED		16		// temporary broken by EMP pulse
 
 //shuttle mode defines
-#define SHUTTLE_IDLE 0
-#define SHUTTLE_RECALL 1
-#define SHUTTLE_CALL 2
-#define SHUTTLE_DOCKED 3
-#define SHUTTLE_STRANDED 4
-#define SHUTTLE_ESCAPE 5
-#define SHUTTLE_ENDGAME 6
+#define SHUTTLE_IDLE		0
+#define SHUTTLE_RECALL		1
+#define SHUTTLE_CALL		2
+#define SHUTTLE_DOCKED		3
+#define SHUTTLE_STRANDED	4
+#define SHUTTLE_ESCAPE		5
+#define SHUTTLE_ENDGAME		6

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -32,7 +32,8 @@
 	var/log_attack = 0					// log attack messages
 	var/log_adminchat = 0				// log admin chat messages
 	var/log_pda = 0						// log pda messages
-	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
+	var/log_hrefs = 0					// log all links clicked in-game. Could be used for debugging and tracking down exploits
+	var/log_world_topic = 0				// log all world.Topic() calls
 	var/sql_enabled = 0					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
@@ -281,6 +282,8 @@
 					config.log_pda = 1
 				if("log_hrefs")
 					config.log_hrefs = 1
+				if("log_world_topic")
+					config.log_world_topic = 1
 				if("allow_admin_ooccolor")
 					config.allow_admin_ooccolor = 1
 				if("allow_vote_restart")

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -83,20 +83,9 @@
 			remove_display()
 		if(1)				//emergency shuttle timer
 			if(SSshuttle.emergency.timer)
-				var/line1
-				var/line2 = get_shuttle_timer()
-				switch(SSshuttle.emergency.mode)
-					if(SHUTTLE_RECALL)
-						line1 = "-RCL-"
-					if(SHUTTLE_CALL)
-						line1 = "-ETA-"
-					if(SHUTTLE_DOCKED)
-						line1 = "-ETD-"
-					if(SHUTTLE_ESCAPE)
-						line1 = "-ESC-"
-					if(SHUTTLE_STRANDED)
-						line1 = "-ERR-"
-						line2 = "??:??"
+				var/line1 = "-[SSshuttle.emergency.getModeStr()]-"
+				var/line2 = SSshuttle.emergency.getTimerStr()
+
 				if(length(line2) > CHARS_PER_LINE)
 					line2 = "Error!"
 				update_display(line1, line2)
@@ -133,7 +122,7 @@
 					line2 = "Docked"
 			else
 				line1 = "CARGO"
-				line2 = get_supply_shuttle_timer()
+				line2 = SSshuttle.supply.getTimerStr()
 				if(lentext(line2) > CHARS_PER_LINE)
 					line2 = "Error"
 
@@ -170,18 +159,6 @@
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
-
-/obj/machinery/status_display/proc/get_shuttle_timer()
-	var/timeleft = SSshuttle.emergency.timeLeft()
-	if(timeleft > 0)
-		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
-	return "00:00"
-
-/obj/machinery/status_display/proc/get_supply_shuttle_timer()
-	var/timeleft = SSshuttle.supply.timeLeft()
-	if(timeleft > 0)
-		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
-	return "00:00"
 
 /obj/machinery/status_display/proc/remove_display()
 	if(overlays.len)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -584,21 +584,10 @@ var/next_mob_id = 0
 		if (nextmap && istype(nextmap))
 			stat(null, "Next Map: [nextmap.friendlyname]")
 		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
-		var/ETA
-		switch(SSshuttle.emergency.mode)
-			if(SHUTTLE_RECALL)
-				ETA = "RCL"
-			if(SHUTTLE_CALL)
-				ETA = "ETA"
-			if(SHUTTLE_DOCKED)
-				ETA = "ETD"
-			if(SHUTTLE_ESCAPE)
-				ETA = "ESC"
-			if(SHUTTLE_STRANDED)
-				ETA = "ERR"
+
+		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
-			var/timeleft = SSshuttle.emergency.timeLeft()
-			stat(null, "[ETA]-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+			stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
 
 
 	if(client && client.holder)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -168,10 +168,10 @@
 	var/area/shuttle/areaInstance
 
 	var/timer						//used as a timer (if you want time left to complete move, use timeLeft proc)
-	var/mode = SHUTTLE_IDLE			//current shuttle mode (see global defines)
+	var/mode = SHUTTLE_IDLE			//current shuttle mode (see /__DEFINES/stat.dm)
 	var/callTime = 50				//time spent in transit (deciseconds)
 	var/roundstart_move				//id of port to send shuttle to at roundstart
-	var/travelDir = 0			//direction the shuttle would travel in
+	var/travelDir = 0				//direction the shuttle would travel in
 
 	var/obj/docking_port/stationary/destination
 	var/obj/docking_port/stationary/previous
@@ -518,6 +518,33 @@
 	if(!timer)
 		return round(callTime/divisor, 1)
 	return max( round((timer+callTime-world.time)/divisor,1), 0 )
+
+// returns 3-letter mode string, used by status screens and mob status panel
+/obj/docking_port/mobile/proc/getModeStr()
+	switch(mode)
+		if(SHUTTLE_RECALL)
+			return "RCL"
+		if(SHUTTLE_CALL)
+			return "ETA"
+		if(SHUTTLE_DOCKED)
+			return "ETD"
+		if(SHUTTLE_ESCAPE)
+			return "ESC"
+		if(SHUTTLE_STRANDED)
+			return "ERR"
+	return ""
+
+// returns 5-letter timer string, used by status screens and mob status panel
+/obj/docking_port/mobile/proc/getTimerStr()
+	if(mode == SHUTTLE_STRANDED)
+		return "--:--"
+
+	var/timeleft = timeLeft()
+	if(timeleft > 0)
+		return "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+	else
+		return "00:00"
+
 
 /obj/docking_port/mobile/proc/getStatusText()
 	var/obj/docking_port/stationary/dockedAt = get_docked()

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,6 +1,6 @@
 /world
 	mob = /mob/new_player
-	turf = /turf/space
+	turf = /turf/open/space
 	area = /area/space
 	view = "15x15"
 	cache_lifespan = 7

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,6 +1,6 @@
 /world
 	mob = /mob/new_player
-	turf = /turf/open/space
+	turf = /turf/space
 	area = /area/space
 	view = "15x15"
 	cache_lifespan = 7
@@ -77,7 +77,7 @@ var/last_irc_status = 0
 		diary << "TOPIC: \"[T]\", from:[addr], master:[master], key:[key]"
 
 	var/list/input = params2list(T)
-	var/key_valid = (input["key"] == global.comms_key)
+	var/key_valid = (global.comms_allowed && input["key"] == global.comms_key)
 
 	if("ping" in input)
 		var/x = 1
@@ -120,6 +120,7 @@ var/last_irc_status = 0
 		s["gamestate"] = 1
 		if(ticker)
 			s["gamestate"] = ticker.current_state
+
 		s["map_name"] = map_name ? map_name : "Unknown"
 
 		if(key_valid && ticker && ticker.mode)
@@ -139,14 +140,13 @@ var/last_irc_status = 0
 		return list2params(s)
 
 	else if("announce" in input)
-		if(global.comms_allowed)
-			if(!key_valid)
-				return "Bad Key"
-			else
+		if(!key_valid)
+			return "Bad Key"
+		else
 #define CHAT_PULLR	64 //defined in preferences.dm, but not available here at compilation time
-				for(var/client/C in clients)
-					if(C.prefs && (C.prefs.chat_toggles & CHAT_PULLR))
-						C << "<span class='announce'>PR: [input["announce"]]</span>"
+			for(var/client/C in clients)
+				if(C.prefs && (C.prefs.chat_toggles & CHAT_PULLR))
+					C << "<span class='announce'>PR: [input["announce"]]</span>"
 #undef CHAT_PULLR
 
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
@@ -201,7 +201,7 @@ var/inerror = 0
 	inerror = 1
 	//newline at start is because of the "runtime error" byond prints that can't be timestamped.
 	e.name = "\n\[[time2text(world.timeofday,"hh:mm:ss")]\][e.name]"
-	
+
 	//this is done this way rather then replace text to pave the way for processing the runtime reports more thoroughly
 	//	(and because runtimes end with a newline, and we don't want to basically print an empty time stamp)
 	var/list/split = splittext(e.desc, "\n")
@@ -211,7 +211,7 @@ var/inerror = 0
 	e.desc = jointext(split, "\n")
 	inerror = 0
 	return ..(e)
-	
+
 /world/proc/load_mode()
 	var/list/Lines = file2list("data/mode.txt")
 	if(Lines.len)

--- a/config/config.txt
+++ b/config/config.txt
@@ -65,6 +65,9 @@ LOG_LAW
 ## log all Topic() calls (for use by coders in tracking down Topic issues)
 # LOG_HREFS
 
+## log all world.Topic() calls
+# LOG_WORLD_TOPIC
+
 ## disconnect players who did nothing during 10 minutes
 # KICK_INACTIVE
 


### PR DESCRIPTION
`Topic()` code is tweaked a bit, making it easier to add new key-checking calls, and add parameters to the old ones.

Status checks now returns more parameters:
`"round_duration"` - duration of the round, in seconds.
`"shuttle_mode"` - status of the escape shuttle, see `/__DEFINES/stat.dm`.
`"shuttle_timer"` - shuttle countdown time, in seconds. It returns time even when the shuttle isn't moving, use status above to check if the countdown is actually running.
`"security_level"` - alert code, as string. "green", "blue", "red", "delta".

If you sent "status" with the correct key, it will also output `"real_mode"` - the game mode behind the "secret".

This PR also adds world.Topic() logging option to the config file. Before, Topic() was always logging, taking a lot of space in log if it's used really often.

Unrelated: a helper procs for returning "ETA", "ETD", etc. and shuttle timer string is added to the shuttles. It has replaced repeated code in status screens and mob Stat()
