### PR TITLE
Lavaland can now be disabled in one line

### DIFF
--- a/_maps/birdstation.dm
+++ b/_maps/birdstation.dm
@@ -10,7 +10,7 @@ A small map intended for lowpop(40 players and less).
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "mining"
+		#define LAVALAND_ENABLED 0
 
         #include "map_files\BirdStation\BirdStation.dmm"
         #include "map_files\generic\z2.dmm"

--- a/_maps/birdstation.dm
+++ b/_maps/birdstation.dm
@@ -8,31 +8,31 @@ A small map intended for lowpop(40 players and less).
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 0
+	#define LAVALAND_ENABLED 0
 
-        #include "map_files\BirdStation\BirdStation.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
-        #include "map_files\BirdStation\z5.dmm"
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\BirdStation\BirdStation.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
+	#include "map_files\BirdStation\z5.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/BirdStation"
-        #define MAP_FILE "BirdStation.dmm"
-        #define MAP_NAME "BirdboatStation"
+	#define MAP_PATH "map_files/BirdStation"
+	#define MAP_FILE "BirdStation.dmm"
+	#define MAP_NAME "BirdboatStation"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
 
-		#if !defined(MAP_OVERRIDE_FILES)
-				#define MAP_OVERRIDE_FILES
-				#include "map_files\BirdStation\telecomms.dm"
-				#include "map_files\BirdStation\misc.dm"
-				#include "map_files\BirdStation\job\job_changes.dm"
-		        #include "map_files\BirdStation\job\removed_jobs.dm"
-		#endif
+	#if !defined(MAP_OVERRIDE_FILES)
+		#define MAP_OVERRIDE_FILES
+		#include "map_files\BirdStation\telecomms.dm"
+		#include "map_files\BirdStation\misc.dm"
+		#include "map_files\BirdStation\job\job_changes.dm"
+		#include "map_files\BirdStation\job\removed_jobs.dm"
+	#endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/dreamstation.dm
+++ b/_maps/dreamstation.dm
@@ -17,7 +17,7 @@ z7 = empty space
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "lavaland"
+		#define LAVALAND_ENABLED 1
 
         #include "map_files\DreamStation\dreamstation04.dmm"
         #include "map_files\generic\z2.dmm"

--- a/_maps/dreamstation.dm
+++ b/_maps/dreamstation.dm
@@ -15,23 +15,23 @@ z7 = empty space
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 1
+	#define LAVALAND_ENABLED 0
 
-        #include "map_files\DreamStation\dreamstation04.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
-        #include "map_files\generic\lavaland.dmm"
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\DreamStation\dreamstation04.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
+	#include "map_files\DreamStation\z5.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/DreamStation"
-        #define MAP_FILE "dreamstation04.dmm"
-        #define MAP_NAME "DreamStation"
+	#define MAP_PATH "map_files/DreamStation"
+	#define MAP_FILE "dreamstation04.dmm"
+	#define MAP_NAME "DreamStation"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/dreamstation.dm
+++ b/_maps/dreamstation.dm
@@ -17,13 +17,17 @@ z7 = empty space
 
 	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-	#define LAVALAND_ENABLED 0
+	#define LAVALAND_ENABLED 1
 
 	#include "map_files\DreamStation\dreamstation04.dmm"
 	#include "map_files\generic\z2.dmm"
 	#include "map_files\generic\z3.dmm"
 	#include "map_files\generic\z4.dmm"
-	#include "map_files\DreamStation\z5.dmm"
+	#if (LAVALAND_ENABLED == 1)
+		#include "map_files\generic\lavaland.dmm"
+	#else
+		#include "map_files\DreamStation\z5.dmm"
+	#endif
 	#include "map_files\generic\z6.dmm"
 	#include "map_files\generic\z7.dmm"
 
@@ -31,7 +35,11 @@ z7 = empty space
 	#define MAP_FILE "dreamstation04.dmm"
 	#define MAP_NAME "DreamStation"
 
-	#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#if (LAVALAND_ENABLED == 1)
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#else
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/efficiencystation.dm
+++ b/_maps/efficiencystation.dm
@@ -17,7 +17,7 @@ z7 = empty space
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "mining"
+		#define LAVALAND_ENABLED 0
 
         #include "map_files\EfficiencyStation\EfficiencyStation.dmm"
         #include "map_files\generic\z2.dmm"

--- a/_maps/efficiencystation.dm
+++ b/_maps/efficiencystation.dm
@@ -15,23 +15,23 @@ z7 = empty space
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 0
+	#define LAVALAND_ENABLED 0
 
-        #include "map_files\EfficiencyStation\EfficiencyStation.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
-        #include "map_files\generic\z5.dmm"
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\EfficiencyStation\EfficiencyStation.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
+	#include "map_files\generic\z5.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/EfficiencyStation"
-        #define MAP_FILE "EfficiencyStation.dmm"
-        #define MAP_NAME "Efficiency Station"
+	#define MAP_PATH "map_files/EfficiencyStation"
+	#define MAP_FILE "EfficiencyStation.dmm"
+	#define MAP_NAME "Efficiency Station"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -15,33 +15,33 @@ z7 = empty space
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 1
+	#define LAVALAND_ENABLED 1
 
-        #include "map_files\MetaStation\MetaStation.v41I.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
+	#include "map_files\MetaStation\MetaStation.v41I.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
 
-        #if (LAVALAND_ENABLED == 1)
-                #include "map_files\generic\lavaland.dmm"
-        #else
-                #include "map_files\generic\z5.dmm"
-        #endif
+	#if (LAVALAND_ENABLED == 1)
+		#include "map_files\generic\lavaland.dmm"
+	#else
+		#include "map_files\generic\z5.dmm"
+	#endif
 
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/MetaStation"
-        #define MAP_FILE "MetaStation.v41I.dmm"
-        #define MAP_NAME "MetaStation"
+	#define MAP_PATH "map_files/MetaStation"
+	#define MAP_FILE "MetaStation.v41I.dmm"
+	#define MAP_NAME "MetaStation"
 
-        #if (LAVALAND_ENABLED == 1)
-                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
-        #else
-                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
-        #endif
+	#if (LAVALAND_ENABLED == 1)
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#else
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -17,13 +17,19 @@ z7 = empty space
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "lavaland"
+		#define LAVALAND_ENABLED 1
 
         #include "map_files\MetaStation\MetaStation.v41I.dmm"
         #include "map_files\generic\z2.dmm"
         #include "map_files\generic\z3.dmm"
         #include "map_files\generic\z4.dmm"
-        #include "map_files\generic\lavaland.dmm"
+
+        #if (LAVALAND_ENABLED == 1)
+                #include "map_files\generic\lavaland.dmm"
+        #else
+                #include "map_files\generic\z5.dmm"
+        #endif
+
         #include "map_files\generic\z6.dmm"
         #include "map_files\generic\z7.dmm"
 
@@ -31,7 +37,11 @@ z7 = empty space
         #define MAP_FILE "MetaStation.v41I.dmm"
         #define MAP_NAME "MetaStation"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #if (LAVALAND_ENABLED == 1)
+                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #else
+                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/ministation.dm
+++ b/_maps/ministation.dm
@@ -48,33 +48,33 @@ Changes to the uplinks were made to discourage murderboning, the rest is the sam
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 0
+	#define LAVALAND_ENABLED 0
 
-        #include "map_files\MiniStation\MiniStation.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
-        #include "map_files\MiniStation\z5.dmm"
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\MiniStation\MiniStation.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
+	#include "map_files\MiniStation\z5.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/MiniStation"
-        #define MAP_FILE "MiniStation.dmm"
-        #define MAP_NAME "MiniStation"
+	#define MAP_PATH "map_files/MiniStation"
+	#define MAP_FILE "MiniStation.dmm"
+	#define MAP_NAME "MiniStation"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
 
-		#if !defined(MAP_OVERRIDE_FILES)
-				#define MAP_OVERRIDE_FILES
-				#include "map_files\MiniStation\misc.dm"
-		        #include "map_files\MiniStation\cargopacks.dm"
-		        #include "map_files\MiniStation\telecomms.dm"
-		        #include "map_files\MiniStation\uplink_item.dm"
-		        #include "map_files\MiniStation\job\jobs.dm"
-		        #include "map_files\MiniStation\job\removed.dm"
-		#endif
+	#if !defined(MAP_OVERRIDE_FILES)
+		#define MAP_OVERRIDE_FILES
+		#include "map_files\MiniStation\misc.dm"
+		#include "map_files\MiniStation\cargopacks.dm"
+		#include "map_files\MiniStation\telecomms.dm"
+		#include "map_files\MiniStation\uplink_item.dm"
+		#include "map_files\MiniStation\job\jobs.dm"
+		#include "map_files\MiniStation\job\removed.dm"
+	#endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/ministation.dm
+++ b/_maps/ministation.dm
@@ -50,7 +50,7 @@ Changes to the uplinks were made to discourage murderboning, the rest is the sam
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "mining"
+		#define LAVALAND_ENABLED 0
 
         #include "map_files\MiniStation\MiniStation.dmm"
         #include "map_files\generic\z2.dmm"

--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -15,33 +15,33 @@ z7 = empty space
 
 #if !defined(MAP_FILE)
 
-		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+	#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define LAVALAND_ENABLED 1
+	#define LAVALAND_ENABLED 1
 
-        #include "map_files\TgStation\tgstation.2.1.3.dmm"
-        #include "map_files\generic\z2.dmm"
-        #include "map_files\generic\z3.dmm"
-        #include "map_files\generic\z4.dmm"
+	#include "map_files\TgStation\tgstation.2.1.3.dmm"
+	#include "map_files\generic\z2.dmm"
+	#include "map_files\generic\z3.dmm"
+	#include "map_files\generic\z4.dmm"
 
-        #if (LAVALAND_ENABLED == 1)
-                #include "map_files\generic\lavaland.dmm"
-        #else
-                #include "map_files\generic\z5.dmm"
-        #endif
+	#if (LAVALAND_ENABLED == 1)
+		#include "map_files\generic\lavaland.dmm"
+	#else
+		#include "map_files\generic\z5.dmm"
+	#endif
 
-        #include "map_files\generic\z6.dmm"
-        #include "map_files\generic\z7.dmm"
+	#include "map_files\generic\z6.dmm"
+	#include "map_files\generic\z7.dmm"
 
-		#define MAP_PATH "map_files/TgStation"
-        #define MAP_FILE "tgstation.2.1.3.dmm"
-        #define MAP_NAME "Box Station"
+	#define MAP_PATH "map_files/TgStation"
+	#define MAP_FILE "tgstation.2.1.3.dmm"
+	#define MAP_NAME "Box Station"
 
-        #if (LAVALAND_ENABLED == 1)
-                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
-        #else
-                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
-        #endif
+	#if (LAVALAND_ENABLED == 1)
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#else
+		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+	#endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -17,13 +17,19 @@ z7 = empty space
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
 
-		#define MINETYPE "lavaland"
+		#define LAVALAND_ENABLED 1
 
         #include "map_files\TgStation\tgstation.2.1.3.dmm"
         #include "map_files\generic\z2.dmm"
         #include "map_files\generic\z3.dmm"
         #include "map_files\generic\z4.dmm"
-        #include "map_files\generic\lavaland.dmm"
+
+        #if (LAVALAND_ENABLED == 1)
+                #include "map_files\generic\lavaland.dmm"
+        #else
+                #include "map_files\generic\z5.dmm"
+        #endif
+
         #include "map_files\generic\z6.dmm"
         #include "map_files\generic\z7.dmm"
 
@@ -31,7 +37,11 @@ z7 = empty space
         #define MAP_FILE "tgstation.2.1.3.dmm"
         #define MAP_NAME "Box Station"
 
-        #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #if (LAVALAND_ENABLED == 1)
+                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #else
+                #define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = CROSSLINKED, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED)
+        #endif
 
 #elif !defined(MAP_OVERRIDE)
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -79,8 +79,8 @@ var/global/datum/controller/master/Master = new()
 	createRandomZlevel()
 	// Generate mining.
 
-	var/mining_type = MINETYPE
-	if(mining_type == "lavaland")
+	var/is_lavaland = LAVALAND_ENABLED
+	if(is_lavaland)
 		seedRuins(5, 5, /area/lavaland/surface/outdoors, lava_ruins_templates)
 		spawn_rivers()
 	else

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -59,13 +59,28 @@
 	mask_type = /obj/item/clothing/mask/gas
 	storage_type = /obj/item/weapon/watertank/atmos
 
+
+// This one uses the magic of preprocessing to spawn suits that fit the mining type.
+// Use subtypes to always spawn EVA or surface mining suit.
+#if (LAVALAND_ENABLED == 1)
 /obj/machinery/suit_storage_unit/mining
 	suit_type = /obj/item/clothing/suit/hooded/explorer
 	mask_type = /obj/item/clothing/mask/gas
+#else
+/obj/machinery/suit_storage_unit/mining
+	suit_type = /obj/item/clothing/suit/space/hardsuit/mining
+	mask_type = /obj/item/clothing/mask/breath
+#endif
+
 
 /obj/machinery/suit_storage_unit/mining/eva
 	suit_type = /obj/item/clothing/suit/space/hardsuit/mining
 	mask_type = /obj/item/clothing/mask/breath
+
+/obj/machinery/suit_storage_unit/mining/surface
+	suit_type = /obj/item/clothing/suit/hooded/explorer
+	mask_type = /obj/item/clothing/mask/gas
+
 
 /obj/machinery/suit_storage_unit/cmo
 	suit_type = /obj/item/clothing/suit/space/hardsuit/medical
@@ -79,6 +94,7 @@
 	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi
 	mask_type = /obj/item/clothing/mask/gas/syndicate
 	storage_type = /obj/item/weapon/tank/jetpack/oxygen/harness
+
 
 /obj/machinery/suit_storage_unit/ert/command
 	suit_type = /obj/item/clothing/suit/space/hardsuit/ert

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -12,7 +12,13 @@
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE
 
-	var/_z = rand(ZLEVEL_SPACEMIN,ZLEVEL_SPACEMAX)	//select a random space zlevel
+	var/list/possible_transtitons = list()
+	var/k = 1
+	for(var/a in map_transition_config)
+		if(map_transition_config[a] == CROSSLINKED) // Only pick z-levels connected to station space
+			possible_transtitons += k
+		k++
+	var/_z = pick(possible_transtitons)
 
 	//now select coordinates for a border turf
 	var/_x

--- a/code/modules/mining/laborcamp/laborminerals.dm
+++ b/code/modules/mining/laborcamp/laborminerals.dm
@@ -1,8 +1,8 @@
 /turf/closed/mineral/random/labormineral
 	mineralSpawnChanceList = list(
-		/turf/simulated/mineral/iron = 100, /turf/simulated/mineral/uranium = 1, /turf/simulated/mineral/diamond = 1,
-		/turf/simulated/mineral/gold = 1, /turf/simulated/mineral/silver = 1, /turf/simulated/mineral/plasma = 1)
-	icon_state = "rock_labor"	icon_state = "rock_labor"
+		/turf/closed/mineral/iron = 100, /turf/closed/mineral/uranium = 1, /turf/closed/mineral/diamond = 1,
+		/turf/closed/mineral/gold = 1, /turf/closed/mineral/silver = 1, /turf/closed/mineral/plasma = 1)
+	icon_state = "rock_labor"
 
 /turf/closed/mineral/random/labormineral/New()
 	icon_state = "rock"

--- a/code/modules/mining/laborcamp/laborminerals.dm
+++ b/code/modules/mining/laborcamp/laborminerals.dm
@@ -1,6 +1,8 @@
 /turf/closed/mineral/random/labormineral
-	mineralSpawnChanceList = list("Uranium" = 1, "Iron" = 100, "Diamond" = 1, "Gold" = 1, "Silver" = 1, "Plasma" = 1/*, "Adamantine" =5, "Cave" = 1 */) //Don't suffocate the prisoners with caves
-	icon_state = "rock_labor"
+	mineralSpawnChanceList = list(
+		/turf/simulated/mineral/iron = 100, /turf/simulated/mineral/uranium = 1, /turf/simulated/mineral/diamond = 1,
+		/turf/simulated/mineral/gold = 1, /turf/simulated/mineral/silver = 1, /turf/simulated/mineral/plasma = 1)
+	icon_state = "rock_labor"	icon_state = "rock_labor"
 
 /turf/closed/mineral/random/labormineral/New()
 	icon_state = "rock"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -13,8 +13,8 @@
 	blocks_air = 1
 	layer = MOB_LAYER + 0.05
 	temperature = TCMB
-	var/environment_type = "basalt"
-	var/turf/open/floor/plating/asteroid/turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface //For basalt vs normal asteroid
+	var/environment_type = "asteroid"
+	var/turf/open/floor/plating/asteroid/turf_type = /turf/open/floor/plating/asteroid/airless
 	var/mineralType = null
 	var/mineralAmt = 3
 	var/spread = 0 //will the seam spread?
@@ -413,7 +413,7 @@
 /**********************Asteroid**************************/
 
 /turf/open/floor/plating/asteroid //floor piece
-	name = "Asteroid"
+	name = "asteroid sand"
 	baseturf = /turf/open/floor/plating/asteroid
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "asteroid"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -272,7 +272,11 @@
 	dwidth = 1
 	width = 3
 	height = 4
+#if (LAVALAND_ENABLED == 1)
 	var/target_area = /area/lavaland/surface/outdoors
+#else
+	var/target_area = /area/mine/unexplored
+#endif
 
 /obj/docking_port/stationary/random/initialize()
 	..()


### PR DESCRIPTION
Because lavaland is obviously unfinished and not any downstream wants to use it's players as alpha testers.

`MINETYPE` string define is replaced with numeric `LAVALAND_ENABLED` to allow using preprocesor with this define to toggle code segments on and off.

Changing `LAVALAND_ENABLED` to 0 replaces the lavaland map with asteroid Z5, re-enables the `CROSSLINKING` transition on z5 and changes default equipment in mining SSU to EVA. There are subtype SSUs for both surface and EVA mining outfits, but I can't place them on the map - we have that map freeze.

This PR also replaces spaces with tabs in map configs, for the sake of consistency.

Fixes #16469. Transit space random Z level is now picked from `CROSSLINKING` levels. I would like to just revert the Lavaland, but the time for it hasn't come yet.

Fixes a fuckton of runtimes when spawning asteroid labor camp mineral turfs. Is using "Find All" before changing variable type really that hard?

Lavaland **is still enabled** by default, this PR changes nothing at all from player's perspective, except the shuttle fix.
