### PR TITLE
Better sleep()s for procs that abuse it

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -198,7 +198,7 @@ Proc for attack log creation, because really why not
 	var/starttime = world.time
 	. = 1
 	while (world.time < endtime)
-		sleep(1)
+		stoplag()
 		if (progress)
 			progbar.update(world.time - starttime)
 		if(!user || !target)
@@ -245,7 +245,7 @@ Proc for attack log creation, because really why not
 	var/starttime = world.time
 	. = 1
 	while (world.time < endtime)
-		sleep(1)
+		stoplag()
 		if (progress)
 			progbar.update(world.time - starttime)
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1070,7 +1070,7 @@ B --><-- A
 			break
 		loc = targetloc
 		lastloc = loc
-		sleep(0.6)
+		stoplag()
 
 	if (orbiting == A) //make sure we haven't started orbiting something else.
 		orbiting = null

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -58,7 +58,7 @@ var/datum/subsystem/minimap/SSminimap
 			flatten.Insert(minimap, "", SOUTH, 1, 0)
 			del(minimap)
 			minimap = flatten
-			sleep(world.tick_lag) //we have to sleep in order to get byond to clear out the proc's garbage bin
+			stoplag() //we have to sleep in order to get byond to clear out the proc's garbage bin
 
 		CHECK_TICK
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -169,7 +169,7 @@
 
 /datum/browser/alert/proc/wait()
 	while (opentime && selectedbutton <= 0 && (!timeout || opentime+timeout >= world.time))
-		sleep (1)
+		stoplag()
 
 /datum/browser/alert/Topic(href,href_list)
 	if (href_list["close"] || !user || !user.client)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -357,6 +357,7 @@ var/list/blood_splatter_icons = list()
 /atom/Stat()
 	. = ..()
 	sleep(1)
+	stoplag()
 
 //This is called just before maps and objects are initialized, use it to spawn other mobs/objects
 //effects at world start up without causing runtimes

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -205,7 +205,7 @@
 	visible_message("<span class='warning'>[src] lets out a waning screech as violet mist swirls around its dissolving body!</span>")
 	icon_state = "revenant_draining"
 	for(var/i = alpha, i > 0, i -= 10)
-		sleep(0.1)
+		stoplag()
 		alpha = i
 	visible_message("<span class='danger'>[src]'s body breaks apart into a fine pile of blue dust.</span>")
 	var/reforming_essence = essence_regen_cap //retain the gained essence capacity

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -25,7 +25,7 @@
 	var/step = alpha / frames
 	for(var/i = 0, i < frames, i++)
 		alpha -= step
-		sleep(world.tick_lag)
+		stoplag()
 
 /obj/effect/particle_effect/smoke/New()
 	..()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -104,7 +104,7 @@ var/global/list/turf/open/space/space_turfs = list() //i hate everything
 				L.pulling.loc = T
 
 		//now we're on the new z_level, proceed the space drifting
-		sleep(0)//Let a diagonal move finish, if necessary
+		stoplag()//Let a diagonal move finish, if necessary
 		A.newtonian_move(A.inertia_dir)
 
 /turf/open/space/proc/Sandbox_Spacemove(atom/movable/A)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -324,6 +324,7 @@ var/next_external_rsc = 0
 		sleep(1)
 	else
 		sleep(5)
+		stoplag()
 
 //send resources to the client. It's here in its own proc so we can move it around easiliy if need be
 /client/proc/send_resources()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1114,7 +1114,7 @@
 				for(var/obj/machinery/light/L in A)
 					L.on = 1
 					L.broken()
-					sleep(1)
+					stoplag()
 
 /obj/machinery/power/apc/proc/shock(mob/user, prb)
 	if(!prob(prb))

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -73,7 +73,7 @@
 		if(!curr && active)
 			last.expel(src, loc, dir)
 
-		sleep(1)
+		stoplag()
 		if(!(count--))
 			active = 0
 	return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -508,7 +508,7 @@
 			if(get_dist(get_turf(M),get_turf(src)) > freezerange) //If they lagged/ran past the timestop somehow, just ignore them
 				unfreeze_mob(M)
 				stopped_atoms -= M
-		sleep(1)
+		stoplag()
 
 	//End
 	for(var/mob/living/M in stopped_atoms)


### PR DESCRIPTION
(Or in other words, if lag is still too bad after we sleep for 1 tick, we sleep again for two ticks, if its still bad, we sleep for 4 ticks, if it's still bad, we say fuck it and keep on trucking with our shit.)

(This pr was made because orbits have issues at 30 or 60 fps, and this also is a nice way to clamp their lag causing potential down)
