### PR TITLE
Alt-clicking a fire extinguisher cabinet opens/closes it.

### DIFF
--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -52,6 +52,7 @@
 	else
 		opened = !opened
 	update_icon()
+
 /obj/structure/extinguisher_cabinet/attack_tk(mob/user)
 	if(has_extinguisher)
 		has_extinguisher.loc = loc
@@ -66,6 +67,9 @@
 	attack_hand(user)
 	return
 
+/obj/structure/extinguisher_cabinet/AltClick(mob/user)
+	opened = !opened
+	update_icon()
 
 /obj/structure/extinguisher_cabinet/update_icon()
 	if(!opened)


### PR DESCRIPTION
it has bugged me for literally ages that there is no way to re-close a fire extinguisher cabinet with an extinguisher in it

:cl:
rscadd: Alt-clicking a fire extinguisher cabinet opens and closes it. That is all.
/:cl:
