### PR TITLE
Adds min_players to swarmer, revenant and slaughter demon spawns

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
@@ -4,6 +4,7 @@
 	weight = 7
 	max_occurrences = 1 //Only once okay fam
 	earliest_start = 18000 //30 minutes
+	min_players = 15
 
 
 /datum/round_event/spawn_swarmer

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -6,6 +6,7 @@
 	weight = 7
 	max_occurrences = 1
 	earliest_start = 6000 //Meant to mix things up early-game.
+	min_players = 5
 
 
 /datum/round_event/revenant

--- a/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughterevent.dm
@@ -1,10 +1,10 @@
-
 /datum/round_event_control/slaughter
 	name = "Spawn Slaughter Demon"
 	typepath = /datum/round_event/slaughter
 	weight = 1 //Very rare
 	max_occurrences = 1
 	earliest_start = 36000 //1 hour
+	min_players = 20
 
 
 


### PR DESCRIPTION
They were not in events folder, and I didn't noticed it in #16471. A friendly message to whoever did it that way: fuck you.
