### PR TITLE
Adds on_species_gain proc to human species

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -176,6 +176,7 @@
 	if(mrace && has_dna())
 		dna.species.on_species_loss(src)
 		dna.species = new mrace()
+		dna.species.on_species_gain(src)
 
 /mob/living/carbon/human/set_species(datum/species/mrace, icon_update = 1)
 	..()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -31,7 +31,7 @@
 	var/hair_alpha = 255	// the alpha used by the hair. 255 is completely solid, 0 is transparent.
 	var/use_skintones = 0	// does it use skintones or not? (spoiler alert this is only used by humans)
 	var/need_nutrition = 1  //Does it need to eat food on a regular basis?
-	var/exotic_blood = null	// If your race wants to bleed something other than bog standard blood, change this.
+	var/exotic_blood = ""	// If your race wants to bleed something other than bog standard blood, change this to reagent id.
 	var/meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human //What the species drops on gibbing
 	var/skinned_type = /obj/item/stack/sheet/animalhide/generic
 	var/list/no_equip = list()	// slots the race can't equip stuff to
@@ -119,11 +119,18 @@
 		return 0
 	return 1
 
+/datum/species/proc/on_species_gain(mob/living/carbon/C)
+	// Drop the items the new species can't wear
+	for(var/slot_id in no_equip)
+		var/obj/item/thing = C.get_item_by_slot(slot_id)
+		if(thing)
+			C.unEquip(thing)
+	if(exotic_blood)
+		C.reagents.add_reagent(exotic_blood, 80)
+
 /datum/species/proc/on_species_loss(mob/living/carbon/C)
-	if(C.dna.species)
-		if(C.dna.species.exotic_blood)
-			var/datum/reagent/EB = C.dna.species.exotic_blood
-			C.reagents.del_reagent(initial(EB.id))
+	if(C.dna.species && C.dna.species.exotic_blood)
+		C.reagents.del_reagent(C.dna.species.exotic_blood)
 
 /datum/species/proc/update_base_icon_state(mob/living/carbon/human/H)
 	if(H.disabilities & HUSK)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -40,7 +40,7 @@
 		return 1
 
 //Curiosity killed the cat's wagging tail.
-datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
+/datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	if(H)
 		H.endTailWag()
 
@@ -188,34 +188,30 @@ var/regex/lizard_hiSS = new("S+", "g")
 	eyes = "jelleyes"
 	specflags = list(MUTCOLORS,EYECOLOR,NOBLOOD,VIRUSIMMUNE)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/slime
-	exotic_blood = /datum/reagent/toxin/slimejelly
-	var/recently_changed = 1
+	exotic_blood = "slimejelly"
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H)
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
 		return
-	if(!H.reagents.get_reagent_amount("slimejelly"))
-		if(recently_changed)
-			H.reagents.add_reagent("slimejelly", 80)
-			recently_changed = 0
-		else
-			H.reagents.add_reagent("slimejelly", 5)
-			H.adjustBruteLoss(5)
-			H << "<span class='danger'>You feel empty!</span>"
+	if(!H.reagents.get_reagent_amount(exotic_blood))
+		H.reagents.add_reagent(exotic_blood, 5)
+		H.adjustBruteLoss(5)
+		H << "<span class='danger'>You feel empty!</span>"
 
-	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
-		if(S.volume < 100)
-			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
-				H.reagents.add_reagent("slimejelly", 0.5)
-				H.nutrition -= 2.5
-		if(S.volume < 50)
-			if(prob(5))
-				H << "<span class='danger'>You feel drained!</span>"
-		if(S.volume < 10)
-			H.losebreath++
+	var/jelly_amount = H.reagents.get_reagent_amount(exotic_blood)
+
+	if(jelly_amount < 100)
+		if(H.nutrition >= NUTRITION_LEVEL_STARVING)
+			H.reagents.add_reagent(exotic_blood, 0.5)
+			H.nutrition -= 2.5
+	if(jelly_amount < 50)
+		if(prob(5))
+			H << "<span class='danger'>You feel drained!</span>"
+	if(jelly_amount < 10)
+		H.losebreath++
 
 /datum/species/jelly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	if(chem.id == "slimejelly")
+	if(chem.id == exotic_blood)
 		return 1
 
 /*
@@ -250,19 +246,20 @@ var/regex/lizard_hiSS = new("S+", "g")
 		callback.Remove(C)
 	..()
 
-/datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
-	if(recently_changed)
+/datum/species/jelly/slime/on_species_gain(mob/living/carbon/C)
+	..()
+	if(ishuman(C))
 		slime_split = new
-		slime_split.Grant(H)
+		slime_split.Grant(C)
 
-	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
-		if(S.volume >= 200)
-			if(prob(5))
-				H << "<span class='notice'>You feel very bloated!</span>"
-		if(S.volume < 200)
-			if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
-				H.reagents.add_reagent("slimejelly", 0.5)
-				H.nutrition -= 2.5
+/datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
+	var/jelly_amount = H.reagents.get_reagent_amount(exotic_blood)
+	if(jelly_amount >= 200)
+		if(prob(5))
+			H << "<span class='notice'>You feel very bloated!</span>"
+	else if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		H.reagents.add_reagent(exotic_blood, 0.5)
+		H.nutrition -= 2.5
 
 	..()
 


### PR DESCRIPTION
This proc is called when a mob receives new species.

Originally I added this as a part of April Fools ponies PR, but it's useful for non-meme purposes, such as adding reagent blood. And that's why I PR it. It's totally not because I'm trying to push ponies piece by piece into the master branch.

This makes mobs drop the slots their species can't hold. For now it only happens when you are suddenly transformed from human to golem by admin magicks. But it's always better to have it ready, right?

Also changes reagent blood var to use reagent IDs instead of types, for the sake of consistency with the rest of reagents code.
