### PR TITLE
Holoparasite balance

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -17,10 +17,10 @@
 
 /mob/living/simple_animal/hostile/guardian/bomb/AttackingTarget()
 	if(..())
-		if(prob(33))
-			if(istype(target, /atom/movable))
-				var/atom/movable/M = target
-				if(!M.anchored && M != summoner)
+		if(prob(40))
+			if(isliving(target))
+				var/mob/living/M = target
+				if(!M.anchored && M != summoner && !hasmatchingsummoner(M))
 					PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(M))
 					do_teleport(M, M, 10)
 					for(var/mob/living/L in range(1, M))
@@ -74,7 +74,7 @@
 	qdel(src)
 
 /obj/item/weapon/guardian_bomb/Bump(atom/A)
-	if(isliving(A) && !spawner.hasmatchingsummoner(A))
+	if(isliving(A) && A != spawner && A != spawner.summoner && !spawner.hasmatchingsummoner(A))
 		detonate(A)
 	else
 		..()
@@ -91,4 +91,4 @@
 /obj/item/weapon/guardian_bomb/examine(mob/user)
 	stored_obj.examine(user)
 	if(get_dist(user,src)<=2)
-		user << "<span class='notice'>Looks odd!</span>"
+		user << "<span class='holoparasite'>It glows with a strange <font color=\"[spawner.namedatum.colour]\">light</font>!</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -36,7 +36,7 @@
 	collision_ignite(AM)
 
 /mob/living/simple_animal/hostile/guardian/fire/proc/collision_ignite(AM as mob|obj)
-	if(istype(AM, /mob/living/))
+	if(isliving(AM))
 		var/mob/living/M = AM
 		if(!hasmatchingsummoner(M) && M != summoner && M.fire_stacks < 7)
 			M.fire_stacks = 7

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -20,7 +20,7 @@
 	playstyle_string = "<span class='holoparasite'>As a <b>ranged</b> type, you have only light damage resistance, but are capable of spraying shards of crystal at incredibly high speed. You can also deploy surveillance snares to monitor enemy movement. Finally, you can switch to scout mode, in which you can't attack, but can move without limit.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Sentinel, an alien master of ranged combat.</span>"
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Ranged combat modules active. Holoparasite swarm online.</span>"
-	see_invisible = SEE_INVISIBLE_MINIMUM
+	see_invisible = SEE_INVISIBLE_LIVING
 	see_in_dark = 8
 	toggle_button_type = /obj/screen/guardian/ToggleMode
 	var/list/snares = list()
@@ -43,7 +43,7 @@
 			melee_damage_lower = 0
 			melee_damage_upper = 0
 			environment_smash = 0
-			alpha = 60
+			alpha = 45
 			range = 255
 			incorporeal_move = 1
 			src << "<span class='danger'><B>You switch to scout mode.</span></B>"
@@ -67,24 +67,24 @@
 		see_invisible = SEE_INVISIBLE_MINIMUM
 
 /mob/living/simple_animal/hostile/guardian/ranged/verb/Snare()
-	set name = "Set Surveillance Trap"
+	set name = "Set Surveillance Snare"
 	set category = "Guardian"
-	set desc = "Set an invisible trap that will alert you when living creatures walk over it. Max of 5"
+	set desc = "Set an invisible snare that will alert you when living creatures walk over it. Max of 5"
 	if(src.snares.len <6)
 		var/turf/snare_loc = get_turf(src.loc)
 		var/obj/item/effect/snare/S = new /obj/item/effect/snare(snare_loc)
 		S.spawner = src
-		S.name = "[get_area(snare_loc)] trap ([rand(1, 1000)])"
+		S.name = "[get_area(snare_loc)] snare ([rand(1, 1000)])"
 		src.snares |= S
-		src << "<span class='danger'><B>Surveillance trap deployed!</span></B>"
+		src << "<span class='danger'><B>Surveillance snare deployed!</span></B>"
 	else
-		src << "<span class='danger'><B>You have too many traps deployed. Delete some first.</span></B>"
+		src << "<span class='danger'><B>You have too many snares deployed. Remove some first.</span></B>"
 
 /mob/living/simple_animal/hostile/guardian/ranged/verb/DisarmSnare()
-	set name = "Remove Surveillance Trap"
+	set name = "Remove Surveillance Snare"
 	set category = "Guardian"
-	set desc = "Disarm unwanted surveillance traps."
-	var/picked_snare = input(src, "Pick which trap to disarm", "Disarm Trap") as null|anything in src.snares
+	set desc = "Disarm unwanted surveillance snares."
+	var/picked_snare = input(src, "Pick which snare to remove", "Remove Snare") as null|anything in src.snares
 	if(picked_snare)
 		src.snares -= picked_snare
 		qdel(picked_snare)
@@ -93,16 +93,13 @@
 /obj/item/effect/snare
 	name = "snare"
 	desc = "You shouldn't be seeing this!"
-	var/mob/living/spawner
-	invisibility = 1
+	var/mob/living/simple_animal/hostile/guardian/spawner
+	invisibility = 101
 
 
 /obj/item/effect/snare/Crossed(AM as mob|obj)
-	if(istype(AM, /mob/living/))
-		var/turf/snare_loc = get_turf(src.loc)
-		if(spawner)
-			spawner << "<span class='danger'><B>[AM] has crossed your surveillance trap at [get_area(snare_loc)].</span></B>"
-			if(istype(spawner, /mob/living/simple_animal/hostile/guardian))
-				var/mob/living/simple_animal/hostile/guardian/G = spawner
-				if(G.summoner)
-					G.summoner << "<span class='danger'><B>[AM] has crossed your surveillance trap at [get_area(snare_loc)].</span></B>"
+	if(isliving(AM) && spawner && spawner.summoner && AM != spawner && !hasmatchingsummoner(AM))
+		spawner.summoner << "<span class='danger'><B>[AM] has crossed surveillance snare, [name].</span></B>"
+		var/list/guardians = spawner.summoner.hasparasites()
+		for(var/para in guardians)
+			para << "<span class='danger'><B>[AM] has crossed surveillance snare, [name].</span></B>"

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -98,7 +98,7 @@
 
 
 /obj/item/effect/snare/Crossed(AM as mob|obj)
-	if(isliving(AM) && spawner && spawner.summoner && AM != spawner && !hasmatchingsummoner(AM))
+	if(isliving(AM) && spawner && spawner.summoner && AM != spawner && !spawner.hasmatchingsummoner(AM))
 		spawner.summoner << "<span class='danger'><B>[AM] has crossed surveillance snare, [name].</span></B>"
 		var/list/guardians = spawner.summoner.hasparasites()
 		for(var/para in guardians)

--- a/code/modules/mob/living/simple_animal/guardian/types/standard.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/standard.dm
@@ -2,6 +2,7 @@
 /mob/living/simple_animal/hostile/guardian/punch
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	next_move_modifier = 0.9 //attacks 20% faster
 	environment_smash = 2
 	playstyle_string = "<span class='holoparasite'>As a <b>standard</b> type you have no special abilities, but have a high damage resistance and a powerful attack capable of smashing through walls.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Assistant, faceless and generic, but never to be underestimated.</span>"
@@ -11,19 +12,18 @@
 /mob/living/simple_animal/hostile/guardian/punch/verb/Battlecry()
 	set name = "Set Battlecry"
 	set category = "Guardian"
-	set desc = "Choose what you shout as you punch"
-	var/input = stripped_input(src,"What do you want your battlecry to be? Max length of 5 characters.", ,"", 6)
+	set desc = "Choose what you shout as you punch people."
+	var/input = stripped_input(src,"What do you want your battlecry to be? Max length of 6 characters.", ,"", 7)
 	if(input)
 		battlecry = input
 
 
 
 /mob/living/simple_animal/hostile/guardian/punch/AttackingTarget()
+	if(isliving(target))
+		src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]!!")
+		playsound(loc, src.attack_sound, 50, 1, 1)
+		playsound(loc, src.attack_sound, 50, 1, 1)
+		playsound(loc, src.attack_sound, 50, 1, 1)
+		playsound(loc, src.attack_sound, 50, 1, 1)
 	..()
-	if(istype(target, /mob/living))
-		src.say("[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]\
-		[src.battlecry][src.battlecry][src.battlecry][src.battlecry][src.battlecry]")
-		playsound(loc, src.attack_sound, 50, 1, 1)
-		playsound(loc, src.attack_sound, 50, 1, 1)
-		playsound(loc, src.attack_sound, 50, 1, 1)
-		playsound(loc, src.attack_sound, 50, 1, 1)

--- a/code/modules/mob/living/simple_animal/guardian/types/standard.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/standard.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/hostile/guardian/punch
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	next_move_modifier = 0.9 //attacks 20% faster
+	next_move_modifier = 0.8 //attacks 20% faster
 	environment_smash = 2
 	playstyle_string = "<span class='holoparasite'>As a <b>standard</b> type you have no special abilities, but have a high damage resistance and a powerful attack capable of smashing through walls.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Assistant, faceless and generic, but never to be underestimated.</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -6,9 +6,9 @@
 	damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 0.7, CLONE = 0.7, STAMINA = 0, OXY = 0.7)
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	playstyle_string = "<span class='holoparasite'>As a <b>support</b> type, you may toggle your basic attacks to a healing mode. In addition, Alt-Clicking on an adjacent mob will warp them to your bluespace beacon after a short delay.</span>"
+	playstyle_string = "<span class='holoparasite'>As a <b>support</b> type, you may toggle your basic attacks to a healing mode. In addition, Alt-Clicking on an adjacent object or mob will warp them to your bluespace beacon after a short delay.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the CMO, a potent force of life... and death.</span>"
-	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Medical modules active. Bluespace modules activated. Holoparasite swarm online.</span>"
+	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Support modules active. Holoparasite swarm online.</span>"
 	toggle_button_type = /obj/screen/guardian/ToggleMode
 	var/turf/simulated/floor/beacon
 	var/beacon_cooldown = 0
@@ -63,7 +63,7 @@
 /mob/living/simple_animal/hostile/guardian/healer/verb/Beacon()
 	set name = "Place Bluespace Beacon"
 	set category = "Guardian"
-	set desc = "Mark a floor as your beacon point, allowing you to warp targets to it. Your beacon will not work in unfavorable atmospheric conditions."
+	set desc = "Mark a floor as your beacon point, allowing you to warp targets to it. Your beacon will not work at extreme distances."
 	if(beacon_cooldown<world.time)
 		var/turf/beacon_loc = get_turf(src.loc)
 		if(istype(beacon_loc, /turf/simulated/floor))
@@ -72,6 +72,9 @@
 			F.name = "bluespace recieving pad"
 			F.desc = "A recieving zone for bluespace teleportations. Building a wall over it should disable it."
 			F.icon_state = "light_on-w"
+			F.luminosity = 1
+			if(namedatum)
+				F.color = namedatum.colour
 			src << "<span class='danger'><B>Beacon placed! You may now warp targets to it, including your user, via Alt+Click. </span></B>"
 			if(beacon)
 				beacon.ChangeTurf(/turf/simulated/floor/plating)
@@ -96,45 +99,17 @@
 	if((A.anchored))
 		src << "<span class='danger'><B>Your target cannot be anchored!</span></B>"
 		return
-	src << "<span class='danger'><B>You begin to warp [A]</span></B>"
 
-	if(src.beacon) //Check that the beacon still exists and is in a safe place. No instant kills.
-
-		if(beacon.air) //does it have air?
-			var/datum/gas_mixture/Z = beacon.air
-			var/list/Z_gases = Z.gases
-			var/trace_gases = FALSE
-			for(var/id in Z_gases)
-				if(id in hardcoded_gases)
-					continue
-				trace_gases = TRUE
-				break
-
-			if((Z_gases["o2"] && Z_gases["o2"][MOLES] >= 16) && !Z_gases["plasma"] && (!Z_gases["co2"] || Z_gases["co2"][MOLES] < 10) && !trace_gases) //does it have nonlethal gas mixtures?
-
-				if((Z.temperature > 270) && (Z.temperature < 360)) //is it not too hot or cold?
-					var/pressure = Z.return_pressure()
-
-					if((pressure > 20) && (pressure < 550)) //does it have safe pressure?
-
-						if(do_mob(src, A, 50)) //now start the channel
-							PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(A))
-							do_teleport(A, beacon, 0)
-							PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))
-						else
-							src << "<span class='danger'><B>You need to hold still!</span></B>"
-
-					else
-						src << "<span class='danger'><B>The beacon detects pressure extremes!</span></B>"
-
-				else
-					src << "<span class='danger'><B>The beacon detects temperature extremes!</span></B>"
-
-			else
-				src << "<span class='danger'><B>The beacon detects dangerous gasses near it!</span></B>"
-
+	var/turf/T = get_turf(A)
+	if(beacon.z != T.z)
+		src << "<span class='danger'><B>You begin to warp [A]</span></B>"
+		do_attack_animation(A)
+		if(do_mob(src, A, 60)) //now start the channel
+			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(T))
+			do_teleport(A, beacon, 0)
+			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))
 		else
-			src << "<span class='danger'><B>The beacon detects no air near it!</span></B>"
+			src << "<span class='danger'><B>You need to hold still!</span></B>"
 
 	else
-		src << "<span class='danger'><B>You need a beacon to warp things!</span></B>"
+		src << "<span class='danger'><B>The beacon is too far away to warp to!</span></B>"

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -107,6 +107,10 @@
 		do_attack_animation(A)
 		if(do_mob(src, A, 60)) //now start the channel
 			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, T)
+			if(isliving(A))
+				var/mob/living/L = A
+				L.flash_eyes()
+			A.visible_message("<span class='danger'>[A] disappears in a flash of light!</span>", "<span class='userdanger'>Your vision is obscured by a flash of light!</span>")
 			do_teleport(A, beacon, 0)
 			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))
 		else

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -102,10 +102,11 @@
 
 	var/turf/T = get_turf(A)
 	if(beacon.z != T.z)
-		src << "<span class='danger'><B>You begin to warp [A]</span></B>"
+		src << "<span class='danger'><B>You begin to warp [A].</span></B>"
+		A.visible_message("<span class='danger'>[A] starts to glow faintly!</span>", "<span class='userdanger'>You start to faintly glow, and you feel strangely weightless!</span>")
 		do_attack_animation(A)
 		if(do_mob(src, A, 60)) //now start the channel
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(T))
+			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, T)
 			do_teleport(A, beacon, 0)
 			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))
 		else


### PR DESCRIPTION
:cl: Joan
tweak: Explosive Holoparasites no longer teleport non-mobs when attacking, but have a higher chance to teleport mobs.
rscdel: Explosive Holoparasite bombs no longer trigger on their summoner or any other parasites their summoner has.
bugfix: Ranged Holoparasites no longer have nightvision active by default. It can still be toggled on.
tweak: Ranged Holoparasite snares no longer alert if the crossing mob is their summoner or one of the parasites their summoner has.
tweak: Ranged Holoparasites are slightly less visible in scout mode.
tweak: Standard Holoparasites attack 20% faster than other parasite types.
rscdel: Support Holoparasite beacons no longer require safe atmospheric conditions, but the warp channel takes slightly longer, and is preceded with a visible message.
/:cl:

Someone asked me to balance holoparasites
I'm not sure this is what they wanted done
But they asked, so this is what they get
