### PR TITLE
Makes detective scanners fit inside pockets.

### DIFF
--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -6,7 +6,7 @@
 	name = "forensic scanner"
 	desc = "Used to remotely scan objects and biomass for DNA and fingerprints. Can print a report of the findings."
 	icon_state = "forensicnew"
-	w_class = 3
+	w_class = 2
 	item_state = "electronic"
 	flags = CONDUCT | NOBLUDGEON
 	slot_flags = SLOT_BELT


### PR DESCRIPTION
QOL change for detectives, always bothered me that I couldn't fit my scanner in my pocket. Really shouldn't take up as much inventory space as like, a lasgun.
:cl:
tweak: Detective scanners are now smaller.
/:cl:
