### PR TITLE
Makes the mc shit on dynamic wait subsystems a bit less

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -206,7 +206,10 @@ var/global/datum/controller/master/Master = new()
 								if(newwait < oldwait)
 									newwait = MC_AVERAGE(oldwait, newwait)
 								SS.wait = Clamp(newwait, SS.dwait_lower, SS.dwait_upper)
-								SS.next_fire = world.time + SS.wait
+								if(SS.paused)
+									SS.next_fire = world.time //run it next tick if we can, but don't priority queue it, as we are a dynamic wait subsystem
+								else //not paused, it ran all the way thru, normal wait time
+									SS.next_fire = world.time + SS.wait
 							else
 								if(!paused)
 									SS.next_fire += SS.wait


### PR DESCRIPTION
So before, a subsystem with dynamic wait enabled, when paused mid run, would have to wait ss.wait until it could resume its run. Where as normally subsystems in these cases get resumed within 3 byond ticks, in most cases, only 1 byond tick.

This makes it so the subsystem resumes next tick, like normal subsystems, but only after every other subsystem has been checked once to see if they need to run, and ran if that's the case. so basically low priority.

tldr: air should be less lame with respects to spread rate when there isn't much else going on (and even when there is).
