### PR TITLE
Slimes can now be put in stasis by CO2

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/emote.dm
+++ b/code/modules/mob/living/simple_animal/slime/emote.dm
@@ -1,5 +1,6 @@
 /mob/living/simple_animal/slime/emote(act)
-
+	if(stat)
+		return
 
 	if (findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)

--- a/code/modules/mob/living/simple_animal/slime/say.dm
+++ b/code/modules/mob/living/simple_animal/slime/say.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/slime/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans)
-	if(speaker != src && !radio_freq)
+	if(speaker != src && !radio_freq && !stat)
 		if (speaker in Friends)
 			speech_buffer = list()
 			speech_buffer += speaker

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -63,6 +63,7 @@
 
 	var/mood = "" // To show its face
 	var/mutator_used = FALSE //So you can't shove a dozen mutators into a single slime
+	var/force_stasis = FALSE
 
 	///////////TIME FOR SUBSPECIES
 
@@ -99,7 +100,7 @@
 	icon_dead = "[icon_text] dead"
 	if(stat != DEAD)
 		icon_state = icon_text
-		if(mood)
+		if(mood && !stat)
 			overlays += image('icons/mob/slimes.dmi', icon_state = "aslime-[mood]")
 	else
 		icon_state = icon_dead
@@ -169,7 +170,11 @@
 			else
 				stat(null, "You can evolve!")
 
-		stat(null,"Power Level: [powerlevel]")
+		if(stat == UNCONSCIOUS)
+			stat(null,"You are knocked out by high levels of CO2!")
+		else
+			stat(null,"Power Level: [powerlevel]")
+
 
 /mob/living/simple_animal/slime/adjustFireLoss(amount)
 	..(-abs(amount)) // Heals them
@@ -286,7 +291,7 @@
 			for(var/datum/surgery/S in surgeries)
 				if(S.next_step(user, src))
 					return 1
-	if(istype(W,/obj/item/stack/sheet/mineral/plasma)) //Let's you feed slimes plasma.
+	if(istype(W,/obj/item/stack/sheet/mineral/plasma) && !stat) //Let's you feed slimes plasma.
 		if (user in Friends)
 			++Friends[user]
 		else
@@ -329,6 +334,8 @@
 	if (src.stat == DEAD)
 		msg += "<span class='deadsay'>It is limp and unresponsive.</span>\n"
 	else
+		if (stat == UNCONSCIOUS) // Slime stasis
+			msg += "<span class='deadsay'>It appears to be alive but unresponsive.</span>\n"
 		if (src.getBruteLoss())
 			msg += "<span class='warning'>"
 			if (src.getBruteLoss() < 40)
@@ -338,7 +345,6 @@
 			msg += "</span>\n"
 
 		switch(powerlevel)
-
 			if(2 to 3)
 				msg += "It is flickering gently with a little electrical activity.\n"
 
@@ -356,8 +362,7 @@
 	return
 
 /mob/living/simple_animal/slime/proc/discipline_slime(mob/user)
-
-	if(stat == DEAD)
+	if(stat)
 		return
 
 	if(prob(80) && !client)


### PR DESCRIPTION
This is a first use for CO2 canisters that doesn't involve mass death.

Slimes in stasis can't move, attack or feed, but stop losing nutrition. It also stops them from regenerating health, reduces their electric charge to 0 and stops the rabid rage. This makes CO2 a good solution both for storing unused slimes (catch them all!) and fighting a lot of slimes at once.

You need to have 5% or more CO2 in atmosphere for it to work. It wouldn't work when slime is hot (100C and hotter), so starting a plasma fire is not a good way to achieve this effect. But grabbing a CO2 canister from gas storage and releasing it at 110 kPa would work.

:cl: CoreOverload
rscadd: You can now put slimes in stasis by exposing them to room temp CO2. Useful for both fighting the slimes and safely storing them.
/:cl:

PSA: always put on a gas mask and connect the internals while working with CO2!
