### PR TITLE
Adds internals and coffee to sustenance vendor's contraband stock

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -674,7 +674,10 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/tofu = 24,
 					/obj/item/weapon/reagent_containers/food/drinks/ice = 12,
 					/obj/item/weapon/reagent_containers/food/snacks/candy_corn = 6)
-	contraband = list(/obj/item/weapon/kitchen/knife = 6)
+	contraband = list(/obj/item/weapon/kitchen/knife = 6,
+					/obj/item/weapon/reagent_containers/food/drinks/coffee = 12,
+					/obj/item/weapon/tank/internals/emergency_oxygen = 6,
+					/obj/item/clothing/mask/breath = 6)
 
 
 /obj/machinery/vending/cola


### PR DESCRIPTION
An agent who breaks into the prison wing can improve prisoners' spirits by hacking the wires of the sustenance vendor; when the green light is on the machine serves hot drinks and sets of internals. 
Bold prisoners may try using these to improve their chances of surviving an escape through space, though they may still require outside help.
