### PR TITLE
fixes ancient tier bug where stealth 3 advanced viruses were visible …

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -199,7 +199,7 @@ var/list/advance_cures = 	list(
 
 	if(properties && properties.len)
 		switch(properties["stealth"])
-			if(2 to 3)
+			if(2)
 				visibility_flags = HIDDEN_SCANNER
 			if(3 to INFINITY)
 				visibility_flags = HIDDEN_SCANNER|HIDDEN_PANDEMIC


### PR DESCRIPTION
…on PANDEMIC.

:cl: 
tweak: Custom viruses with stealth values of 3 or above are now invisible on the PANDEMIC and no longer visible on health huds.
/:cl:
