### PR TITLE
Cache pip dependencies in travis [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 
 
 cache:
+  pip: true
   directories:
     - tgui/node_modules
     - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}


### PR DESCRIPTION
Never mind, apparently this don't do shit if the default install is overridden, so we'll have to cache manually.
