### PR TITLE
[ready]Makes SSair's initialize() faster.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -258,42 +258,20 @@ var/datum/subsystem/air/SSair
 /datum/subsystem/air/proc/setup_allturfs(z_level)
 	var/z_start = 1
 	var/z_finish = world.maxz
-
+	var/times_fired = ++src.times_fired
 	if(1 <= z_level && z_level <= world.maxz)
 		z_level = round(z_level)
 		z_start = z_level
 		z_finish = z_level
 
-	var/list/turfs_to_init = block(locate(1, 1, z_start), locate(world.maxx, world.maxy, z_finish)) - space_turfs
+	var/list/turfs_to_init = block(locate(1, 1, z_start), locate(world.maxx, world.maxy, z_finish))
+	var/list/active_turfs = src.active_turfs
 
 	for(var/thing in turfs_to_init)
-		var/turf/t = thing
-		t.CalculateAdjacentTurfs()
-		active_turfs -= t
+		var/turf/T = thing
+		active_turfs -= T
+		T.Initalize_Atmos(times_fired)
 
-		if(t.blocks_air)
-			CHECK_TICK
-			continue
-
-		var/turf/open/T = t
-		if(!istype(T))
-			CHECK_TICK
-			continue
-		T.excited = 0
-		T.update_visuals()
-
-		for(var/tile in T.atmos_adjacent_turfs)
-			var/turf/enemy_tile = tile
-			var/datum/gas_mixture/enemy_air = enemy_tile.return_air()
-
-			var/is_active = T.air.compare(enemy_air)
-
-			if(is_active)
-				//testing("Active turf found. Return value of compare(): [is_active]")
-				T.excited = 1
-				active_turfs |= T
-				break
-		CHECK_TICK
 
 	if(active_turfs.len)
 		warning("There are [active_turfs.len] active turfs at roundstart, this is a mapping error caused by a difference of the air between the adjacent turfs. You can see its coordinates using \"Mapping -> Show roundstart AT list\" verb (debug verbs required)")

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -272,10 +272,12 @@ var/datum/subsystem/air/SSair
 		active_turfs -= t
 
 		if(t.blocks_air)
+			CHECK_TICK
 			continue
 
 		var/turf/open/T = t
 		if(!istype(T))
+			CHECK_TICK
 			continue
 		T.excited = 0
 		T.update_visuals()
@@ -301,6 +303,7 @@ var/datum/subsystem/air/SSair
 /datum/subsystem/air/proc/setup_atmos_machinery(z_level)
 	for (var/obj/machinery/atmospherics/AM in atmos_machinery)
 		if (z_level && AM.z != z_level)
+			CHECK_TICK
 			continue
 		AM.atmosinit()
 		CHECK_TICK
@@ -311,6 +314,7 @@ var/datum/subsystem/air/SSair
 /datum/subsystem/air/proc/setup_pipenets(z_level)
 	for (var/obj/machinery/atmospherics/AM in atmos_machinery)
 		if (z_level && AM.z != z_level)
+			CHECK_TICK
 			continue
 		AM.build_network()
 		CHECK_TICK

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -9,6 +9,47 @@
 	var/wet = 0
 	var/image/wet_overlay = null
 
+/turf/open/Initalize_Atmos(times_fired)
+	excited = 0
+	update_visuals()
+	if (blocks_air)
+		return
+	current_cycle = times_fired
+
+	//cache some vars
+	var/datum/gas_mixture/air = src.air
+	var/list/atmos_adjacent_turfs = src.atmos_adjacent_turfs
+
+	for(var/direction in cardinal)
+		var/turf/open/enemy_tile = get_step(src, direction)
+		if(!istype(enemy_tile))
+			atmos_adjacent_turfs -= enemy_tile
+			continue
+		var/datum/gas_mixture/enemy_air = enemy_tile.return_air()
+
+		//only check this turf, if it didn't check us when it was initalized
+		if(enemy_tile.current_cycle < times_fired)
+			if(CanAtmosPass(enemy_tile))
+				atmos_adjacent_turfs |= enemy_tile
+				enemy_tile.atmos_adjacent_turfs |= src
+			else
+				atmos_adjacent_turfs -= enemy_tile
+				enemy_tile.atmos_adjacent_turfs -= src
+				continue
+		else
+			if (!(enemy_tile in atmos_adjacent_turfs))
+				continue
+
+
+		var/is_active = air.compare(enemy_air)
+
+		if(is_active)
+			//testing("Active turf found. Return value of compare(): [is_active]")
+			if(!excited) //make sure we aren't already excited
+				excited = 1
+				SSair.active_turfs |= src
+
+
 /turf/open/handle_fall(mob/faller, forced)
 	faller.lying = pick(90, 270)
 	if(!forced)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -13,20 +13,19 @@
 
 	var/global/datum/gas_mixture/space/space_gas = new
 
-var/global/list/turf/open/space/space_turfs = list() //i hate everything
 
 /turf/open/space/New()
 	update_icon()
 	air = space_gas
-	space_turfs += src
 
 /turf/open/space/Destroy()
 	return QDEL_HINT_LETMELIVE
 
+/turf/open/space/Initalize_Atmos(times_fired)
+	return
+
 /turf/open/space/ChangeTurf(path)
 	. = ..()
-	if(!istype(., /turf/open/space))
-		space_turfs -= src
 
 /turf/open/space/AfterChange()
 	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -30,6 +30,9 @@
 	for(var/atom/movable/AM in src)
 		Entered(AM)
 
+/turf/proc/Initalize_Atmos(times_fired)
+	CalculateAdjacentTurfs()
+
 /turf/Destroy()
 	visibilityChanged()
 	..()


### PR DESCRIPTION
Initialized Air subsystem within 43.7 seconds! <--- control
Initialized Air subsystem within 43.1 seconds! <--- round 1 (don't calculate adjacent turfs to us that just recently calculated with us)
Initialized Air subsystem within 21.2 seconds! <--- round 2 (remove space_turf list)
Initialized Air subsystem within 21.1 seconds! <--- round 3 (test with my window fix)
Initialized Air subsystem within 5.3 seconds! <--- round 4 (if istype(/turf/open/space) continue)
Initialized Air subsystem within 5.7 seconds! <--- round 5 (move entire code to turf.Initalize_Atmos() to remove iftype checks)
