### PR TITLE
Fixes directional atmos spread blockers (like small windows/windoors)

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -9,7 +9,7 @@
 		R = 1
 
 	for(var/obj/O in contents+T.contents)
-		var/turf/other = (O in contents ? T : src)
+		var/turf/other = (O.loc == src ? T : src)
 		if(!O.CanAtmosPass(other))
 			R = 1
 			if(O.BlockSuperconductivity()) 	//the direction and open/closed are already checked on CanAtmosPass() so there are no arguments


### PR DESCRIPTION
byond and `in` are lame, and it processes wrong with tinaries. this is better anyways as it avoids a list loop.

This was processing as `(O in (contents ? T : src))` not `((O in contents) ? T : src)`

Fixes #16415 

:cl:
bugfix: Centcom is happy to report that our single sided windows and our windoors should once again create an airtight seal.
/:cl:
