### PR TITLE
fixes atmos pressure chambers having no pressure

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -6376,10 +6376,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/warningline{
@@ -6658,10 +6655,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/item/clothing/mask/gas{
@@ -6866,10 +6860,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /turf/open/floor/plasteel/warningline{
 	tag = "icon-warningline (WEST)";
@@ -6954,10 +6945,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/airalarm{
@@ -7428,10 +7416,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/warningline{
@@ -7714,10 +7699,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -7783,10 +7765,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/light_switch{
@@ -10662,16 +10641,10 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "avL" = (
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "avM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11304,19 +11277,13 @@
 	frequency = 1441;
 	id_tag = "mix_sensor"
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "awX" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "awY" = (
 /obj/structure/cable/green{
@@ -12132,10 +12099,7 @@
 	id = "mix_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "ayy" = (
 /obj/machinery/camera{
@@ -12145,10 +12109,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "ayz" = (
 /obj/structure/cable/green{
@@ -13961,10 +13922,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -14715,10 +14673,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8";
@@ -15443,10 +15398,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/warningline{
@@ -15966,10 +15918,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	tag = "icon-manifold-b-f (WEST)";
@@ -16209,26 +16158,17 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aGw" = (
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aGx" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aGy" = (
 /obj/structure/rack,
@@ -16937,26 +16877,17 @@
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aHZ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aIa" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aIb" = (
 /obj/structure/girder,
@@ -17808,10 +17739,7 @@
 	id = "tox_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "aJI" = (
 /obj/structure/chair/comfy/brown{
@@ -19156,17 +19084,10 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aME" = (
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aMF" = (
 /turf/open/floor/plating{
@@ -19663,26 +19584,17 @@
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aNM" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aNN" = (
 /obj/structure/cable/green{
@@ -20614,10 +20526,7 @@
 	id = "co2_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "co2=50000"
-	name = "co2 floor";
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "aPn" = (
 /obj/structure/rack,
@@ -22349,8 +22258,8 @@
 /turf/open/floor/plasteel/brown{
 	dir = 9;
 	icon_state = "brown";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aSV" = (
@@ -22358,8 +22267,8 @@
 /turf/open/floor/plasteel/green/side{
 	dir = 5;
 	icon_state = "green";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aSW" = (
@@ -22394,8 +22303,8 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/darkred/side{
 	dir = 5;
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aSZ" = (
@@ -22463,10 +22372,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /area/engine/engineering)
 "aTg" = (
@@ -23286,8 +23192,8 @@
 /turf/open/floor/plasteel/brown{
 	dir = 10;
 	icon_state = "brown";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aUG" = (
@@ -23295,8 +23201,8 @@
 /turf/open/floor/plasteel/green/side{
 	dir = 6;
 	icon_state = "green";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aUH" = (
@@ -23329,8 +23235,8 @@
 /turf/open/floor/plasteel/darkred/side{
 	dir = 6;
 	icon_state = "darkred";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /area/tcommsat/server)
 "aUL" = (
@@ -23419,10 +23325,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /area/engine/engineering)
 "aUS" = (
@@ -24633,10 +24536,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /area/engine/engineering)
 "aWP" = (
@@ -24822,20 +24722,14 @@
 	frequency = 1441;
 	id = "n2_in"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aXh" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aXi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -24849,10 +24743,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aXj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -24860,20 +24751,14 @@
 	frequency = 1441;
 	id = "o2_in"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aXk" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aXl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -24887,10 +24772,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aXm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -24898,20 +24780,14 @@
 	frequency = 1441;
 	id = "air_in"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aXn" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "air_sensor"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aXo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
@@ -24925,10 +24801,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aXp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25604,53 +25477,32 @@
 /turf/open/floor/plasteel/black,
 /area/engine/chiefs_office)
 "aYH" = (
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aYI" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aYJ" = (
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aYK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aYL" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aYM" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aYN" = (
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aYO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26558,24 +26410,15 @@
 /area/hallway/secondary/entry)
 "bax" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "bay" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "baz" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "baA" = (
 /obj/structure/rack{
@@ -28587,8 +28430,8 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 9;
 	icon_state = "yellow";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-yellow (NORTHWEST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-yellow (NORTHWEST)"
 	},
 /area/tcommsat/server)
 "beB" = (
@@ -28596,8 +28439,8 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 5;
 	icon_state = "neutral";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-neutral (NORTHEAST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-neutral (NORTHEAST)"
 	},
 /area/tcommsat/server)
 "beC" = (
@@ -28612,8 +28455,8 @@
 /turf/open/floor/plasteel{
 	dir = 9;
 	icon_state = "whiteblue";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-whiteblue (NORTHWEST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-whiteblue (NORTHWEST)"
 	},
 /area/tcommsat/server)
 "beE" = (
@@ -28621,8 +28464,8 @@
 /turf/open/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-whitehall (WEST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-whitehall (WEST)"
 	},
 /area/tcommsat/server)
 "beF" = (
@@ -28636,10 +28479,7 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8;
 	icon_state = "yellow";
-	
-	
-	tag = "";
-	
+	tag = ""
 	},
 /area/tcommsat/computer)
 "beG" = (
@@ -29456,8 +29296,8 @@
 /turf/open/floor/plasteel/yellow/side{
 	dir = 10;
 	icon_state = "yellow";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-yellow (SOUTHWEST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-yellow (SOUTHWEST)"
 	},
 /area/tcommsat/server)
 "bgi" = (
@@ -29465,8 +29305,8 @@
 /turf/open/floor/plasteel/neutral/side{
 	dir = 6;
 	icon_state = "neutral";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-neutral (SOUTHEAST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-neutral (SOUTHEAST)"
 	},
 /area/tcommsat/server)
 "bgj" = (
@@ -29481,8 +29321,8 @@
 /turf/open/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-whiteblue (SOUTHWEST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-whiteblue (SOUTHWEST)"
 	},
 /area/tcommsat/server)
 "bgl" = (
@@ -29490,8 +29330,8 @@
 /turf/open/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "icon-whitepurple (SOUTHEAST)";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "icon-whitepurple (SOUTHEAST)"
 	},
 /area/tcommsat/server)
 "bgm" = (
@@ -60560,8 +60400,8 @@
 /turf/open/floor/plasteel/brown{
 	dir = 10;
 	icon_state = "brown";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/warningline{
@@ -71624,8 +71464,8 @@
 /turf/open/floor/plasteel/brown{
 	dir = 10;
 	icon_state = "brown";
-	initial_gas_mix = "n2=100;TEMP=80"
-	tag = "SERVER";
+	initial_gas_mix = "n2=100;TEMP=80";
+	tag = "SERVER"
 	},
 /turf/open/floor/plasteel/warningline{
 	tag = "icon-warningline (SOUTHWEST)";

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -10340,25 +10340,16 @@
 	},
 /area/maintenance/incinerator)
 "arI" = (
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "arJ" = (
 /turf/open/floor/engine/n2o,
 /area/atmos)
 "arK" = (
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "arL" = (
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "arM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -10759,17 +10750,11 @@
 /area/atmos)
 "asz" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "asA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "asB" = (
 /obj/structure/grille,
@@ -11323,20 +11308,14 @@
 	id = "waste_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "aty" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "mix_sensor"
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "atz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -11350,10 +11329,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "n2=0.01;o2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "atA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -11392,20 +11368,14 @@
 	id = "tox_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "atE" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "atF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -11419,10 +11389,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "atG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -11431,20 +11398,14 @@
 	id = "waste_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "atH" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "atI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -11458,10 +11419,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "atJ" = (
 /obj/structure/lattice,
@@ -16530,16 +16488,10 @@
 	frequency = 1441;
 	id = "o2_in"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aCz" = (
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aCA" = (
 /obj/machinery/vending/cigarette,
@@ -17181,17 +17133,11 @@
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aDK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aDL" = (
 /obj/structure/lattice/catwalk,
@@ -17855,10 +17801,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "aET" = (
 /obj/structure/disposalpipe/segment,
@@ -19293,16 +19236,10 @@
 	frequency = 1441;
 	id = "n2_in"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aHs" = (
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aHt" = (
 /obj/structure/disposalpipe/segment,
@@ -19901,17 +19838,11 @@
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aIz" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aIA" = (
 /obj/item/weapon/cautery{
@@ -20537,10 +20468,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "aJH" = (
 /obj/structure/disposalpipe/segment,
@@ -21951,16 +21879,10 @@
 	frequency = 1441;
 	id = "air_in"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aMs" = (
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aMt" = (
 /obj/item/weapon/hemostat,
@@ -22668,17 +22590,11 @@
 	frequency = 1441;
 	id_tag = "air_sensor"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aNG" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aNH" = (
 /obj/item/weapon/surgicaldrill,
@@ -23416,10 +23332,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "aPa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,

--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -51208,10 +51208,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bEH" = (
 /turf/open/floor/engine{
@@ -52102,19 +52099,13 @@
 	frequency = 1441;
 	id_tag = "mix_sensor"
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bGj" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bGk" = (
 /obj/machinery/telecomms/processor/preset_one,
@@ -53537,10 +53528,7 @@
 	id = "mix_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bIi" = (
 /obj/machinery/camera{
@@ -53550,10 +53538,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bIj" = (
 /obj/machinery/telecomms/bus/preset_one,
@@ -59142,26 +59127,17 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bRK" = (
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bRL" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bRM" = (
 /obj/machinery/light/small{
@@ -60084,26 +60060,17 @@
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bTk" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bTl" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bTm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60957,10 +60924,7 @@
 	id = "tox_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bUx" = (
 /obj/machinery/camera{
@@ -60970,10 +60934,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bUy" = (
 /obj/structure/table,
@@ -62463,16 +62424,10 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bWV" = (
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bWW" = (
 /obj/structure/window/reinforced,
@@ -63102,27 +63057,17 @@
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bYa" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bYb" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bYc" = (
 /obj/structure/chair/stool,
@@ -64078,10 +64023,7 @@
 	id = "co2_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bZE" = (
 /obj/machinery/camera{
@@ -64091,10 +64033,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "bZF" = (
 /obj/machinery/power/solar_control{
@@ -70739,20 +70678,14 @@
 	frequency = 1441;
 	id = "n2_in"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "cka" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "ckb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -70766,10 +70699,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "ckc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -70777,20 +70707,14 @@
 	frequency = 1441;
 	id = "o2_in"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "ckd" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "cke" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -70804,10 +70728,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "ckf" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -70815,20 +70736,14 @@
 	frequency = 1441;
 	id = "air_in"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "ckg" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "air_sensor"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "ckh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
@@ -70842,10 +70757,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cki" = (
 /obj/structure/window/reinforced{
@@ -71572,17 +71484,11 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/incinerator)
 "clo" = (
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "clp" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "clq" = (
 /obj/machinery/camera{
@@ -71592,23 +71498,14 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "clr" = (
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "cls" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "clt" = (
 /obj/machinery/camera{
@@ -71618,27 +71515,18 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "clu" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clv" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clw" = (
 /obj/machinery/camera{
@@ -71648,10 +71536,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clx" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -72562,30 +72447,18 @@
 /area/maintenance/incinerator)
 "cmS" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "cmT" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "cmU" = (
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cmV" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cmW" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -84862,7 +84735,7 @@
 	dir = 4;
 	icon_state = "warnplate";
 	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
+	initial_gas_mix = "o2=0.01;n2=0.01";
 	temperature = 2.7
 	},
 /area/toxins/test_area)
@@ -100636,10 +100509,8 @@
 	name = "Aft Maintenance"
 	})
 "dfy" = (
-/turf/open/floor/plating,
-/area/maintenance/aft{
-	name = "Aft Maintenance"
-	})
+/turf/open/floor/engine/vacuum,
+/area/atmos)
 "dfz" = (
 /obj/machinery/light{
 	dir = 1
@@ -146356,9 +146227,9 @@ aaf
 aaa
 aaf
 bCV
-bEH
-bEH
-bEH
+dfy
+dfy
+dfy
 bCV
 bLl
 bMS
@@ -146613,7 +146484,7 @@ aaf
 aaf
 aaf
 bCV
-bEH
+dfy
 bGj
 bIi
 bCV

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -45808,10 +45808,7 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Waste Tank"
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bPl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -45825,16 +45822,10 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bPm" = (
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bPn" = (
 /obj/structure/grille,
@@ -46401,19 +46392,13 @@
 	frequency = 1441;
 	id_tag = "mix_sensor"
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bQC" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bQD" = (
 /obj/structure/chair/stool,
@@ -46928,10 +46913,7 @@
 	id = "mix_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "vacuum floor";
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
+/turf/open/floor/engine/vacuum,
 /area/atmos)
 "bRM" = (
 /obj/structure/table,
@@ -50022,10 +50004,7 @@
 	},
 /area/atmos)
 "bXW" = (
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bXX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -50039,20 +50018,14 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bXY" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bXZ" = (
 /obj/structure/closet/crate,
@@ -50459,29 +50432,20 @@
 /area/atmos)
 "bYU" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bYV" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "tox_sensor"
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bYW" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bYX" = (
 /obj/structure/closet/l3closet/virology,
@@ -50852,10 +50816,7 @@
 	id = "tox_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "plasma floor";
-	initial_gas_mix = "plasma=70000"
-	},
+/turf/open/floor/engine/plasma,
 /area/atmos)
 "bZM" = (
 /turf/open/floor/plating{
@@ -51876,10 +51837,7 @@
 	},
 /area/atmos)
 "cbH" = (
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "cbI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -51893,10 +51851,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "cbJ" = (
 /obj/structure/cable{
@@ -52353,29 +52308,20 @@
 /area/atmos)
 "ccB" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "ccC" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "co2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "ccD" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "ccE" = (
 /obj/structure/sign/nosmoking_2{
@@ -52875,10 +52821,7 @@
 	id = "co2_in";
 	pixel_y = 1
 	},
-/turf/open/floor/engine{
-	name = "co2 floor";
-	initial_gas_mix = "co2=50000"
-	},
+/turf/open/floor/engine/co2,
 /area/atmos)
 "cdE" = (
 /obj/structure/cable{
@@ -56357,10 +56300,7 @@
 	frequency = 1441;
 	id_tag = "n2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "ckV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -56368,10 +56308,7 @@
 	frequency = 1441;
 	id = "n2_in"
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "ckW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56385,20 +56322,14 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "ckX" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "o2_sensor"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "ckY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -56406,10 +56337,7 @@
 	frequency = 1441;
 	id = "o2_in"
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "ckZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -56423,20 +56351,14 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "cla" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
 	id_tag = "air_sensor"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -56444,10 +56366,7 @@
 	frequency = 1441;
 	id = "air_in"
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
@@ -56461,10 +56380,7 @@
 	pressure_checks = 2;
 	pump_direction = 0
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cld" = (
 /obj/effect/landmark{
@@ -56851,29 +56767,17 @@
 /area/security/main)
 "clT" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "clU" = (
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "clV" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "clW" = (
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "clX" = (
 /obj/effect/landmark/event_spawn,
@@ -56886,16 +56790,10 @@
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "clZ" = (
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cma" = (
 /obj/machinery/door/window{
@@ -57319,24 +57217,15 @@
 /area/shuttle/syndicate)
 "cmU" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "n2 floor";
-	initial_gas_mix = "n2=100000"
-	},
+/turf/open/floor/engine/n2,
 /area/atmos)
 "cmV" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "o2 floor";
-	initial_gas_mix = "o2=100000"
-	},
+/turf/open/floor/engine/o2,
 /area/atmos)
 "cmW" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cmX" = (
 /obj/item/stack/cable_coil{
@@ -64755,10 +64644,7 @@
 "cBP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/engine{
-	name = "air floor";
-	initial_gas_mix = "n2=10580;o2=2644"
-	},
+/turf/open/floor/engine/air,
 /area/atmos)
 "cBQ" = (
 /obj/structure/cable/yellow{

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -117,18 +117,33 @@
 			if(prob(50))
 				make_plating(1)
 
+//air filled floors; used in atmos pressure chambers
+
 /turf/open/floor/engine/n2o
 	name = "n2o floor"
+	initial_gas_mix = "n2o=6000;TEMP=293.15"
 
-/turf/open/floor/engine/n2o/New()
-	..()
+/turf/open/floor/engine/co2
+	name = "co2 floor"
+	initial_gas_mix = "co2=50000;TEMP=293.15"
 
-	var/datum/gas_mixture/adding = new
-	adding.assert_gas("n2o")
-	adding.gases["n2o"][MOLES] = 6000
-	adding.temperature = T20C
+/turf/open/floor/engine/plasma
+	name = "plasma floor"
+	initial_gas_mix = "plasma=70000;TEMP=293.15"
 
-	assume_air(adding)
+/turf/open/floor/engine/o2
+	name = "o2 floor"
+	initial_gas_mix = "o2=100000;TEMP=293.15"
+
+/turf/open/floor/engine/n2
+	name = "n2 floor"
+	initial_gas_mix = "n2=100000;TEMP=293.15"
+
+/turf/open/floor/engine/air
+	name = "air floor"
+	initial_gas_mix = "o2=2644;n2=10580;TEMP=293.15"
+
+
 
 /turf/open/floor/engine/cult
 	name = "engraved floor"


### PR DESCRIPTION
I made some subtypes of floor/engine for this purpose;they should make mappers' lives easier.
Map merge also seemed to clean up a few of my mistakes with turfs, too, which is nice.

quads get
