### PR TITLE
Lava Proofs some mechs.

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -7,6 +7,7 @@
 	deflect_chance = 25
 	damage_absorption = list("brute"=0.5,"fire"=0.7,"bullet"=0.45,"laser"=0.6,"energy"=0.7,"bomb"=0.7)
 	max_temperature = 60000
+	burn_state = LAVA_PROOF
 	infra_luminosity = 3
 	operation_req_access = list(access_cent_specops)
 	wreckage = /obj/structure/mecha_wreckage/marauder

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -61,6 +61,7 @@
 	icon_state = "firefighter"
 	max_temperature = 65000
 	health = 250
+	burn_state = LAVA_PROOF
 	lights_power = 7
 	damage_absorption = list("brute"=0.6,"fire"=0.5,"bullet"=0.7,"laser"=0.7,"energy"=1,"bomb"=0.4)
 	max_equip = 5 // More armor, less tools


### PR DESCRIPTION
The firefighter ripley and the maurader mecha family are now lava proof.

Firefighters now have a better niche as the only mech available to the crew that can cross lava.

The only version of the Maurader available to players is the Mauler, and on average, nuke ops and lava will never come in contact.
