### PR TITLE
Reverts Cleavers stabbing eyes

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -65,6 +65,14 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
 
+/obj/item/weapon/kitchen/knife/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.zone_selected == "eyes")
+		if(user.disabilities & CLUMSY && prob(50))
+			M = user
+		return eyestab(M,user)
+	else
+		return ..()
+
 /obj/item/weapon/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting \his wrists with the [src.name]! It looks like \he's trying to commit suicide.</span>", \
 						"<span class='suicide'>[user] is slitting \his throat with the [src.name]! It looks like \he's trying to commit suicide.</span>", \
@@ -87,6 +95,10 @@
 	throwforce = 10
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = 3
+
+/obj/item/weapon/kitchen/knife/butcher/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.zone_selected == "eyes")
+		return
 
 /obj/item/weapon/kitchen/knife/combat
 	name = "combat knife"

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -65,14 +65,6 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP_ACCURATE
 
-/obj/item/weapon/kitchen/knife/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(user.zone_selected == "eyes")
-		if(user.disabilities & CLUMSY && prob(50))
-			M = user
-		return eyestab(M,user)
-	else
-		return ..()
-
 /obj/item/weapon/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting \his wrists with the [src.name]! It looks like \he's trying to commit suicide.</span>", \
 						"<span class='suicide'>[user] is slitting \his throat with the [src.name]! It looks like \he's trying to commit suicide.</span>", \


### PR DESCRIPTION
partially reverts #16573
:cl: 
tweak: Cleavers can no longer stab or slash at the eyes.
/:cl:

Really isn't needed, and it screws with targeting eyes with a cleaver and butchering with a cleaver too.
