### PR TITLE
Secret documents can now be copied.

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -1,6 +1,6 @@
 /obj/item/documents
 	name = "secret documents"
-	desc = "\"Top Secret\" documents printed on special copy-protected paper."
+	desc = "\"Top Secret\" documents."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "docs_generic"
 	item_state = "paper"
@@ -12,18 +12,33 @@
 	pressure_resistance = 1
 
 /obj/item/documents/nanotrasen
-	desc = "\"Top Secret\" Nanotrasen documents printed on special copy-protected paper. It is filled with complex diagrams and lists of names, dates and coordinates."
+	desc = "\"Top Secret\" Nanotrasen documents, filled with complex diagrams and lists of names, dates and coordinates."
 	icon_state = "docs_verified"
 
 /obj/item/documents/syndicate
-	desc = "\"Top Secret\" documents printed on special copy-protected paper. It details sensitive Syndicate operational intelligence."
+	desc = "\"Top Secret\" documents detailing sensitive Syndicate operational intelligence."
 
 /obj/item/documents/syndicate/red
-	name = "'Red' secret documents"
-	desc = "\"Top Secret\" documents printed on special copy-protected paper. It details sensitive Syndicate operational intelligence. These documents are marked \"Red\"."
+	name = "red secret documents"
+	desc = "\"Top Secret\" documents detailing sensitive Syndicate operational intelligence. These documents are verified with a red wax seal."
 	icon_state = "docs_red"
 
 /obj/item/documents/syndicate/blue
-	name = "'Blue' secret documents"
-	desc = "\"Top Secret\" documents printed on special copy-protected paper. It details sensitive Syndicate operational intelligence. These documents are marked \"Blue\"."
+	name = "blue secret documents"
+	desc = "\"Top Secret\" documents detailing sensitive Syndicate operational intelligence. These documents are verified with a blue wax seal."
 	icon_state = "docs_blue"
+
+/obj/item/documents/photocopy
+	desc = "A copy of some top-secret documents. Nobody will notice they aren't the originals... right?"
+	var/forgedseal = 0
+
+/obj/item/documents/photocopy/attackby(obj/item/O, mob/user, params)
+	if(istype(O, /obj/item/toy/crayon/red) || istype(O, /obj/item/toy/crayon/blue))
+		if (forgedseal)
+			user << "<span class='warning'>You have already forged a seal on [src]!</span>"
+		else
+			var/obj/item/toy/crayon/C = O
+			name = "[C.colourName] secret documents"
+			icon_state = "docs_[C.colourName]"
+			user << "<span class='notice'>You forge the official seal with a [C.colourName] crayon. No one will notice... right?</span>"
+			update_icon()

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -40,5 +40,6 @@
 			var/obj/item/toy/crayon/C = O
 			name = "[C.colourName] secret documents"
 			icon_state = "docs_[C.colourName]"
+			forgedseal = 1
 			user << "<span class='notice'>You forge the official seal with a [C.colourName] crayon. No one will notice... right?</span>"
 			update_icon()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -119,7 +119,7 @@
 					break
 		else if(doccopy)
 			for(var/i = 0, i < copies, i++)
-				if(toner > 0 && !busy && doccopy)
+				if(toner > 5 && !busy && doccopy)
 					new /obj/item/documents/photocopy(src)
 					toner-= 6 // the sprite shows 6 papers, yes I checked
 					busy = 1

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -20,6 +20,7 @@
 	power_channel = EQUIP
 	var/obj/item/weapon/paper/copy = null	//what's in the copier!
 	var/obj/item/weapon/photo/photocopy = null
+	var/obj/item/documents/doccopy = null
 	var/copies = 1	//how many copies to print!
 	var/toner = 40 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
@@ -37,7 +38,7 @@
 	user.set_machine(src)
 
 	var/dat = "Photocopier<BR><BR>"
-	if(copy || photocopy || (ass && (ass.loc == src.loc)))
+	if(copy || photocopy || doccopy || (ass && (ass.loc == src.loc)))
 		dat += "<a href='byond://?src=\ref[src];remove=1'>Remove Paper</a><BR>"
 		if(toner)
 			dat += "<a href='byond://?src=\ref[src];copy=1'>Copy</a><BR>"
@@ -116,6 +117,17 @@
 					busy = 0
 				else
 					break
+		else if(doccopy)
+			for(var/i = 0, i < copies, i++)
+				if(toner > 0 && !busy && doccopy)
+					new /obj/item/documents/photocopy(src)
+					toner-= 6 // the sprite shows 6 papers, yes I checked
+					busy = 1
+					sleep(15)
+					busy = 0
+				else
+					break
+			updateUsrDialog()
 		else if(ass) //ASS COPY. By Miauw
 			for(var/i = 0, i < copies, i++)
 				var/icon/temp_img
@@ -220,16 +232,19 @@
 			greytoggle = "Greyscale"
 		updateUsrDialog()
 
+/obj/machinery/photocopier/proc/do_insertion(obj/item/O, mob/user)
+		O.loc = src
+		user << "<span class='notice'>You insert [O] into [src].</span>"
+		flick("photocopier1", src)
+		updateUsrDialog()
+
 /obj/machinery/photocopier/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/paper))
 		if(copier_empty())
 			if(!user.drop_item())
 				return
 			copy = O
-			O.loc = src
-			user << "<span class='notice'>You insert [O] into [src].</span>"
-			flick("photocopier1", src)
-			updateUsrDialog()
+			do_insertion(O)
 		else
 			user << "<span class='warning'>There is already something in [src]!</span>"
 
@@ -238,10 +253,16 @@
 			if(!user.drop_item())
 				return
 			photocopy = O
-			O.loc = src
-			user << "<span class='notice'>You insert [O] into [src].</span>"
-			flick("photocopier1", src)
-			updateUsrDialog()
+			do_insertion(O)
+		else
+			user << "<span class='warning'>There is already something in [src]!</span>"
+
+	else if(istype(O, /obj/item/documents))
+		if(copier_empty())
+			if(!user.drop_item())
+				return
+			doccopy = O
+			do_insertion(O)
 		else
 			user << "<span class='warning'>There is already something in [src]!</span>"
 


### PR DESCRIPTION
- Secret documents can be copied in a photocopier. It uses 6 toner, one per document sheet.
- For the steal any documents objective, any copy will give you greentext.
- For the steal red/blue documents objective, a photocopy will not be accepted, as these original documents come with a seal. Clever traitors can take advantage of this by forging the seal with a red/blue crayon, resulting in documents that look normal unless closely examined.
- Cleaned up photocopier code slightly.

:cl:
rscadd: Due to budget cuts, Nanotrasen is no longer utilizing copy-protected paper for its classified documents. Fortunately, our world-class security team has always prevented any thefts or photocopies from being made!
rscadd: Secret documents can be photocopied. If you have an objective to steal any set of documents, a photocopy will be accepted. If you must steal red or blue documents, a photocopy will NOT be accepted. Enterprising traitors can forge the red/blue seal with a crayon to take advantage of this.
/:cl:
