### PR TITLE
Reverts most of goof's grab nerf

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -673,12 +673,12 @@ Sorry Giacom. Please don't be mad :(
 				qdel(G)
 			else
 				if(G.state == GRAB_AGGRESSIVE)
-					if(prob(75))
+					if(prob(25))
 						visible_message("<span class='danger'>[src] has broken free of [G.assailant]'s grip!</span>")
 						qdel(G)
 				else
 					if(G.state == GRAB_NECK)
-						if(prob(50))
+						if(prob(5))
 							visible_message("<span class='danger'>[src] has broken free of [G.assailant]'s headlock!</span>")
 							qdel(G)
 		if(resisting)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -1,4 +1,4 @@
-#define UPGRADE_COOLDOWN	60
+#define UPGRADE_COOLDOWN	40
 #define UPGRADE_KILL_TIMER	100
 
 /obj/item/weapon/grab
@@ -104,10 +104,10 @@
 	var/breathing_tube = affecting.getorganslot("breathing_tube")
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(2)	//It will hamper your voice, being choked and all.
+		affecting.Stun(5)	//It will hamper your voice, being choked and all.
 		if(isliving(affecting) && !breathing_tube)
 			var/mob/living/L = affecting
-			L.adjustOxyLoss(0.5)
+			L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
 		affecting.Weaken(5)	//Should keep you down unless you get help.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -228,14 +228,14 @@
 
 				if(GRAB_AGGRESSIVE)
 					move_delay = world.time + 10
-					if(!prob(50))
+					if(!prob(25))
 						return 1
 					mob.visible_message("<span class='danger'>[mob] has broken free of [G.assailant]'s grip!</span>")
 					qdel(G)
 
 				if(GRAB_NECK)
 					move_delay = world.time + 10
-					if(!prob(15))
+					if(!prob(5))
 						return 1
 					mob.visible_message("<span class='danger'>[mob] has broken free of [G.assailant]'s headlock!</span>")
 					qdel(G)


### PR DESCRIPTION
See: https://github.com/tgstation/-tg-station/pull/16421

https://tgstation13.org/phpBB/viewtopic.php?f=10&t=6307&start=50#p166940

I left the tweaked if() check and tweaked span classes alone. The values are all reverted, however.

It's been a little over a week since goof's shitty nerf, so don't go full "NEE JURK CLOSAN!" on me please

>inb4 "grabs are on their way out anyways"
can i readd quickchoking then? it'll be out soon anyways :^)

:cl: PKPenguin321
tweak: Goofball's grab nerf has been reverted.
/:cl:
