### PR TITLE
Keep pixel offsets when changing sign type

### DIFF
--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -32,7 +32,7 @@
 	if(istype(O, /obj/item/weapon/pen))
 		var/list/sign_types = list("Secure Area", "Biohazard", "High Voltage", "Radiation", "Hard Vacuum Ahead", "Disposal: Leads To Space", "Danger: Fire", "No Smoking", "Medbay", "Science", "Chemistry", \
 		"Hydroponics", "Xenobiology")
-		var/sign_type
+		var/obj/structure/sign/sign_type
 		switch(input(user, "Select a sign type.", "Sign Customization") as null|anything in sign_types)
 			if("Blank")
 				sign_type = /obj/structure/sign/basic
@@ -62,9 +62,20 @@
 				sign_type = /obj/structure/sign/botany
 			if("Xenobiology")
 				sign_type = /obj/structure/sign/xenobio
+
+		//Make sure user is adjacent still
+		if(!Adjacent(user))
+			return
+
 		if(!sign_type)
 			return
-		new sign_type(get_turf(src))
+
+		//It's import to clone the pixel layout information
+		//Otherwise signs revert to being on the turf and
+		//move jarringly
+		var/obj/structure/sign/newsign = new sign_type(get_turf(src))
+		newsign.pixel_x = pixel_x
+		newsign.pixel_y = pixel_y
 		qdel(src)
 
 /obj/item/sign_backing


### PR DESCRIPTION
This stops signs realigning to your turf when you go to change the sign type.

Also slight sanity check for adjacency after user uses pen

Fixes #16118 
Fixes #16117 
Fixes #11988
