### PR TITLE
Asteroid fixes

### DIFF
--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -12,7 +12,13 @@
 	var/max = world.maxx-TRANSITIONEDGE
 	var/min = 1+TRANSITIONEDGE
 
-	var/_z = rand(ZLEVEL_SPACEMIN,ZLEVEL_SPACEMAX)	//select a random space zlevel
+	var/list/possible_transtitons = list()
+	var/k = 1
+	for(var/a in map_transition_config)
+		if(map_transition_config[a] == CROSSLINKED) // Only pick z-levels connected to station space
+			possible_transtitons += k
+		k++
+	var/_z = pick(possible_transtitons)
 
 	//now select coordinates for a border turf
 	var/_x

--- a/code/modules/mining/laborcamp/laborminerals.dm
+++ b/code/modules/mining/laborcamp/laborminerals.dm
@@ -1,5 +1,7 @@
 /turf/closed/mineral/random/labormineral
-	mineralSpawnChanceList = list("Uranium" = 1, "Iron" = 100, "Diamond" = 1, "Gold" = 1, "Silver" = 1, "Plasma" = 1/*, "Adamantine" =5, "Cave" = 1 */) //Don't suffocate the prisoners with caves
+	mineralSpawnChanceList = list(
+		/turf/closed/mineral/iron = 100, /turf/closed/mineral/uranium = 1, /turf/closed/mineral/diamond = 1,
+		/turf/closed/mineral/gold = 1, /turf/closed/mineral/silver = 1, /turf/closed/mineral/plasma = 1)
 	icon_state = "rock_labor"
 
 /turf/closed/mineral/random/labormineral/New()

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -13,8 +13,8 @@
 	blocks_air = 1
 	layer = MOB_LAYER + 0.05
 	temperature = TCMB
-	var/environment_type = "basalt"
-	var/turf/open/floor/plating/asteroid/turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface //For basalt vs normal asteroid
+	var/environment_type = "asteroid"
+	var/turf/open/floor/plating/asteroid/turf_type = /turf/open/floor/plating/asteroid/airless
 	var/mineralType = null
 	var/mineralAmt = 3
 	var/spread = 0 //will the seam spread?
@@ -413,7 +413,7 @@
 /**********************Asteroid**************************/
 
 /turf/open/floor/plating/asteroid //floor piece
-	name = "Asteroid"
+	name = "asteroid sand"
 	baseturf = /turf/open/floor/plating/asteroid
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "asteroid"


### PR DESCRIPTION
#16577 is dead, so it's grave robbing time.

Fixes mining labor turfs. Fixes #16469. Transit space random Z level is now picked from `CROSSLINKING` levels. Fixes asteroid turfs spawning lavaland turfs when mined.

inb4 lavaland is future: 
At least one asteroid is still on the map, and there would be more when #16434 will be remade and merged.
