### PR TITLE
Wizard events will no longer fire unless actually summoned by a wizard

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -27,8 +27,6 @@ var/datum/subsystem/events/SSevent
 		var/datum/round_event_control/E = new type()
 		if(!E.typepath)
 			continue				//don't want this one! leave it for the garbage collector
-		if(E.wizardevent && !wizardmode)
-			E.weight = 0
 		control += E				//add it to the list of all events (controls)
 	reschedule()
 	getHoliday()
@@ -199,10 +197,6 @@ var/datum/subsystem/events/SSevent
 
 /datum/subsystem/events/proc/toggleWizardmode()
 	wizardmode = !wizardmode
-	for(var/datum/round_event_control/E in SSevent.control)
-		E.weight = initial(E.weight)
-		if((E.wizardevent && !wizardmode) || (!E.wizardevent && wizardmode))
-			E.weight = 0
 	message_admins("Summon Events has been [wizardmode ? "enabled, events will occur every [SSevent.frequency_lower / 600] to [SSevent.frequency_upper / 600] minutes" : "disabled"]!")
 	log_game("Summon Events was [wizardmode ? "enabled" : "disabled"]!")
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -6,6 +6,7 @@
 	var/weight = 10				//The weight this event has in the random-selection process.
 								//Higher weights are more likely to be picked.
 								//10 is the default weight. 20 is twice more likely; 5 is half as likely as this default.
+								//0 here does NOT disable the event, it just makes it extremely unlikely
 
 	var/earliest_start = 12000	//The earliest world.time that an event can start (round-duration in deciseconds) default: 20 mins
 	var/min_players = 0			//The minimum amount of alive, non-AFK human players on server required to start the event.
@@ -39,6 +40,8 @@
 	if(occurrences >= max_occurrences)
 		return FALSE
 	if(earliest_start >= world.time)
+		return FALSE
+	if(wizardevent != SSevent.wizardmode)
 		return FALSE
 	if(players_amt < min_players)
 		return FALSE


### PR DESCRIPTION
`weight = 0` was not enough to stop the events from firing. I replaced it with a check in `canSpawnEvent`.

Sadly, this PR isn't fixing random events selection being dark magic itself.
