### PR TITLE
Xenobio Additions and Tweaks

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -17,13 +17,25 @@
 	var/rigged = 0		// true if rigged to explode
 	var/minor_fault = 0 //If not 100% reliable, it will build up faults.
 	var/chargerate = 100 //how much power is given every tick in a recharger
+	var/self_recharge = 0 //does it self recharge, over time, or not?
 
 /obj/item/weapon/stock_parts/cell/New()
 	..()
+	SSobj.processing |= src
 	charge = maxcharge
 	ratingdesc = " This one has a power rating of [maxcharge], and you should not swallow it."
 	desc = desc + ratingdesc
 	updateicon()
+
+/obj/item/weapon/stock_parts/cell/Destroy()
+	SSobj.processing.Remove(src)
+	return ..()
+
+/obj/item/weapon/stock_parts/cell/process()
+	if(self_recharge)
+		give(chargerate * 0.25)
+	else
+		return PROCESS_KILL
 
 /obj/item/weapon/stock_parts/cell/proc/updateicon()
 	overlays.Cut()
@@ -250,8 +262,9 @@
 	materials = list(MAT_GLASS=80)
 	rating = 6
 	chargerate = 30000
-	use()
-		return 1
+
+/obj/item/weapon/stock_parts/cell/infinite/use()
+	return 1
 
 /obj/item/weapon/stock_parts/cell/potato
 	name = "potato battery"
@@ -272,6 +285,7 @@
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "yellow slime extract"
 	materials = list()
+	self_recharge = 1 // Infused slime cores self-recharge, over time
 
 /obj/item/weapon/stock_parts/cell/emproof
 	name = "\improper EMP-proof cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -31,6 +31,13 @@
 	SSobj.processing.Remove(src)
 	return ..()
 
+/obj/item/weapon/stock_parts/cell/on_varedit(modified_var)
+	if(modified_var == "self_recharge")
+		if(self_recharge)
+			SSobj.processing |= src
+		else
+			SSobj.processing -= src
+
 /obj/item/weapon/stock_parts/cell/process()
 	if(self_recharge)
 		give(chargerate * 0.25)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -48,7 +48,7 @@
 	id = "slimerezadone"
 	result = "rezadone"
 	required_reagents = list("blood" = 1)
-	result_amount = 10
+	result_amount = 3
 	required_other = 1
 	required_container = /obj/item/slime_extract/green
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -15,6 +15,18 @@
 	S.loc = get_turf(holder.my_atom)
 	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
 
+/datum/chemical_reaction/slimeinaprov
+	name = "Slime epinephrine"
+	id = "m_inaprov"
+	result = "epinephrine"
+	required_reagents = list("water" = 5)
+	result_amount = 3
+	required_other = 1
+	required_container = /obj/item/slime_extract/grey
+
+/datum/chemical_reaction/slimeinaprov/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+
 /datum/chemical_reaction/slimemonkey
 	name = "Slime Monkey"
 	id = "m_monkey"
@@ -41,18 +53,6 @@
 	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-
-/datum/chemical_reaction/slimeclone
-	name = "Slime Rezadone"
-	id = "slimerezadone"
-	result = "rezadone"
-	required_reagents = list("blood" = 1)
-	result_amount = 3
-	required_other = 1
-	required_container = /obj/item/slime_extract/green
-
-/datum/chemical_reaction/slimeclone/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
 
 //Mutated Green
@@ -467,18 +467,6 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility
 	P.loc = get_turf(holder.my_atom)
-
-/datum/chemical_reaction/slimeomnizine
-	name = "Slime omnizine"
-	id = "m_omni"
-	result = "omnizine"
-	required_reagents = list("water" = 5)
-	result_amount = 5
-	required_other = 1
-	required_container = /obj/item/slime_extract/pink
-
-/datum/chemical_reaction/slimeomnizine/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
 
 //Black
 /datum/chemical_reaction/slimemutate2

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -15,18 +15,6 @@
 	S.loc = get_turf(holder.my_atom)
 	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
 
-/datum/chemical_reaction/slimeinaprov
-	name = "Slime epinephrine"
-	id = "m_inaprov"
-	result = "epinephrine"
-	required_reagents = list("water" = 5)
-	result_amount = 3
-	required_other = 1
-	required_container = /obj/item/slime_extract/grey
-
-/datum/chemical_reaction/slimeinaprov/on_reaction(datum/reagents/holder)
-	feedback_add_details("slime_cores_used","[type]")
-
 /datum/chemical_reaction/slimemonkey
 	name = "Slime Monkey"
 	id = "m_monkey"
@@ -53,6 +41,18 @@
 	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+
+/datum/chemical_reaction/slimeclone
+	name = "Slime Rezadone"
+	id = "slimerezadone"
+	result = "rezadone"
+	required_reagents = list("blood" = 1)
+	result_amount = 10
+	required_other = 1
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slimeclone/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
 
 //Mutated Green
@@ -468,6 +468,17 @@
 	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility
 	P.loc = get_turf(holder.my_atom)
 
+/datum/chemical_reaction/slimeomnizine
+	name = "Slime omnizine"
+	id = "m_omni"
+	result = "omnizine"
+	required_reagents = list("water" = 5)
+	result_amount = 5
+	required_other = 1
+	required_container = /obj/item/slime_extract/pink
+
+/datum/chemical_reaction/slimeomnizine/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
 
 //Black
 /datum/chemical_reaction/slimemutate2
@@ -681,3 +692,18 @@
 	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
 	S.loc = get_turf(holder.my_atom)
 	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
+
+/datum/chemical_reaction/slime_transfer
+	name = "Transfer Potion"
+	id = "slimetransfer"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_other = 1
+	required_container = /obj/item/slime_extract/rainbow
+
+/datum/chemical_reaction/slime_transfer/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/transference/P = new /obj/item/slimepotion/transference
+	P.loc = get_turf(holder.my_atom)
+

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -201,6 +201,50 @@
 		being_used = 0
 		..()
 
+/obj/item/slimepotion/transference
+	name = "consciousness transference potion"
+	desc = "A strange slime-based chemical that, when used, allows the user to transfer their consciousness to a lesser being."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle6"
+	origin_tech = "biotech=6"
+	var/prompted = 0
+	var/animal_type = SENTIENCE_ORGANIC
+
+/obj/item/slimepotion/transference/afterattack(mob/living/M, mob/user)
+	if(prompted || !ismob(M))
+		return
+	if(!isanimal(M) || M.ckey) //much like sentience, these will not work on something that is already player controlled
+		user << "<span class='warning'>[M] already has a higher consciousness!</span>"
+		return ..()
+	if(M.stat)
+		user << "<span class='warning'>[M] is dead!</span>"
+		return ..()
+	var/mob/living/simple_animal/SM = M
+	if(SM.sentience_type != animal_type)
+		user << "<span class='warning'>You cannot transfer your consciousness to [SM].</span>" //no controlling machines
+		return ..()
+	if(jobban_isbanned(user, ROLE_ALIEN)) //ideally sentience and trasnference potions should be their own unique role.
+		user << "<span class='warning'>Your mind goes blank as you attempt to use the potion.</span>"
+		return
+
+	prompted = 1
+	if(alert("This will permanently transfer your consciousness to [SM]. Are you sure you want to do this?",,"Yes","No")=="No")
+		prompted = 0
+		return
+
+	user << "<span class='notice'>You drink the potion then place your hands on [SM]...</span>"
+
+
+	user.mind.transfer_to(SM)
+	SM.languages = user.languages
+	SM.faction = user.faction
+	SM.sentience_act() //Same deal here as with sentience
+	user.death()
+	SM << "<span class='notice'>In a quick flash, you feel your consciousness flow into [SM]!</span>"
+	SM << "<span class='warning'>You are now [SM]. Your allegiances, alliances, and role is still the same as it was prior to consciousness transfer!</span>"
+	SM.name = "[SM.name] as [user.real_name]"
+	qdel(src)
+
 /obj/item/slimepotion/steroid
 	name = "slime steroid"
 	desc = "A potent chemical mix that will cause a baby slime to generate more extract."


### PR DESCRIPTION
Just a few additions to Xenobio, to make it slightly more useful to the station and have a more interesting end-game---not to mention making an existing reaction not totally worthless.
- Adds in support for self-recharging cells; they regain 25% of their recharge rate every `process` (this is 75% slower than putting them in a charger)
- Slime cells self-recharge by default
- Added in Slime transference potion; this potion is similar to sentience potions---the difference is, however, is that it puts the _user_ in control of the simple animal instead of pulling from the ghost population. The user is given the notification that they are still of the same allegiance, alliance, and role as they were prior to transference. Can obtain this potion by injecting a rainbow slime core with blood.

:cl: Fox McCloud
add: Slime batteries now self-recharge.
add: Adds transference potion. A potion that allows the user to transfer their consciousness to a simple mob.
add: Adds rainbow slime core reaction that generates a consciousness transference potion when injected with blood.
/:cl:
