### PR TITLE
Added a "plant DNA manipulator" to Botany backroom

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -18068,6 +18068,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/plantgenes,
 /turf/open/floor/plasteel{
 	icon_state = "hydrofloor"
 	},

--- a/_maps/templates/lavaland_surface_seed_vault.dmm
+++ b/_maps/templates/lavaland_surface_seed_vault.dmm
@@ -1,22 +1,22 @@
 "a" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
 "b" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "c" = (/turf/closed/wall/r_wall,/area/ruin/powered)
-"d" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
+"d" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion";dir = 8},/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
 "e" = (/obj/machinery/smartfridge,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "f" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/cultivator,/obj/item/weapon/cultivator,/obj/item/weapon/cultivator,/obj/item/weapon/cultivator,/obj/item/weapon/shovel/spade,/obj/item/weapon/shovel/spade,/obj/item/weapon/shovel/spade,/obj/item/weapon/shovel/spade,/obj/item/weapon/hatchet,/obj/item/weapon/hatchet,/obj/item/weapon/hatchet,/obj/item/weapon/hatchet,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "g" = (/obj/machinery/hydroponics/constructable,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "h" = (/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/seed_vault,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "i" = (/obj/item/weapon/hatchet,/obj/item/weapon/storage/bag/plants,/obj/item/weapon/reagent_containers/glass/bucket,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "j" = (/obj/structure/table/wood,/obj/item/weapon/storage/bag/plants,/obj/item/weapon/storage/bag/plants,/obj/item/weapon/storage/bag/plants,/obj/item/weapon/storage/bag/plants,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"k" = (/obj/structure/table/wood,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"k" = (/obj/structure/table/wood,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/gun/energy/floragun,/obj/item/weapon/storage/box/disks_plantgene,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "l" = (/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"m" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"m" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion";dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "n" = (/obj/effect/mob_spawn/human/seed_vault,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"o" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"o" = (/obj/structure/sink{icon_state = "sink";dir = 8;pixel_x = -12;pixel_y = 2},/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "p" = (/obj/machinery/vending/hydronutrients,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "q" = (/obj/machinery/vending/hydroseeds,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "r" = (/obj/machinery/reagentgrinder{pixel_y = 5},/obj/structure/table/glass,/obj/item/weapon/reagent_containers/glass/beaker/bluespace,/obj/item/weapon/reagent_containers/glass/beaker/bluespace,/obj/item/weapon/reagent_containers/glass/beaker/bluespace,/obj/item/weapon/reagent_containers/glass/beaker/bluespace,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"s" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"s" = (/obj/structure/sink{dir = 4;icon_state = "sink";pixel_x = 11;pixel_y = 0},/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "t" = (/obj/machinery/door/airlock,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "u" = (/obj/machinery/door/airlock/external,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "v" = (/obj/structure/disposalpipe/trunk,/obj/machinery/disposal/bin,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
@@ -28,8 +28,10 @@
 "B" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/reagent_containers/glass/bucket,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "C" = (/obj/item/weapon/storage/toolbox/syndicate,/obj/structure/table/wood,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 "D" = (/obj/structure/disposalpipe/segment,/turf/closed/wall/r_wall,/area/ruin/powered)
-"E" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"E" = (/obj/structure/disposalpipe/segment{dir = 1;icon_state = "pipe-c"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "F" = (/obj/structure/disposalpipe/trunk{dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"H" = (/obj/machinery/chem_master/condimaster,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"G" = (/obj/machinery/plantgenes,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
 
 (1,1,1) = {"
 aabbaaaaaaaaaaaaaaaa
@@ -38,14 +40,14 @@ aaaaaaaaaaaaaaabaaaa
 aaaaaaaaaaaaaaaaabab
 aaaaaaaaaaaaaaaaabbb
 aaaccccccccccccdbbbb
-aaccefghhgigjkccabaa
+aaccefghGgigjkccabaa
 ccccllllllllllcmbbbb
 cnlcolgpeqrllscccbbb
 cnltllllllllglulubbb
 cnltllllllllglulubbb
 cnlcolgvwxyllscccbbb
 cccclllzllllllcmbbbb
-aaccoAgzlglgBCccbbbb
+aaccoAgzlgHgBCccbbbb
 aaaccccDcccccccmbbaa
 aaaaaaaEFbaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -10,3 +10,4 @@
 	new /obj/item/device/radio/headset/headset_srv(src)
 	new /obj/item/weapon/cultivator(src)
 	new /obj/item/weapon/hatchet(src)
+	new /obj/item/weapon/storage/box/disks_plantgene(src)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -446,6 +446,16 @@ datum/design/diagnostic_hud_night
 	build_path = /obj/item/clothing/glasses/science
 	category = list("Equipment")
 
+/datum/design/diskplantgene
+	name = "plant data disk"
+	desc = "A disk for storing plant genetic data."
+	id = "diskplantgene"
+	req_tech = list("programming" = 4, "biotech" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=30, MAT_GLASS=10)
+	build_path = /obj/item/weapon/disk/plantgene
+	category = list("Electronics")
+
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////
 /////////////////////////////////////////

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -472,3 +472,13 @@
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/grounding_rod
 	category = list ("Misc. Machinery")
+
+/datum/design/plantgenes
+	name = "Machine Design (Plant DNA Manipulator Board)"
+	desc = "The circuit board for a grounding rod."
+	id = "plantgenes"
+	req_tech = list("programming" = 4, "biotech" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/plantgenes
+	category = list ("Misc. Machinery")

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -475,7 +475,7 @@
 
 /datum/design/plantgenes
 	name = "Machine Design (Plant DNA Manipulator Board)"
-	desc = "The circuit board for a grounding rod."
+	desc = "The circuit board for a plant DNA manipulator."
 	id = "plantgenes"
 	req_tech = list("programming" = 4, "biotech" = 3)
 	build_type = IMPRINTER


### PR DESCRIPTION
On bobdobbington's request, this map change is made.

:cl: coiax, bobdobbington, Core0verload
rscadd: An experimental plant DNA manipulator, based on machinery recovered from ancient seed vaults, has been installed in the Botany department.
/:cl:

> 7:22:23 PM bobdobbington  so, not too long ago coreoverload did a huge
> overhaul and refactor of how plants work
> 7:22:48 PM bobdobbington  breaking out each interesting mutant trait
> into its own gene
> 7:23:10 PM bobdobbington  so, like, the slipperiness of bananas, the
> fluacid content of deathnettles, things like that
> 7:23:34 PM bobdobbington  The idea was to be able to crossbreed
> different types of plants
> 7:23:52 PM bobdobbington  So you could have like say grass tiles that
> glowed like glowshrooms
> 7:24:19 PM bobdobbington  Or glowshrooms that could slip
> 7:24:36 PM bobdobbington  This is the machine that enables the
> manipulation of those traits, which already exist in the code
