### PR TITLE
Adds a priority system for client.color effects

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -36,3 +36,6 @@ var/cmp_field = "name"
 	if(a.display == b.display)
 		return sorttext(b.name, a.name)
 	return a.display - b.display
+
+/proc/cmp_clientcolour_priority(datum/client_colour/A, datum/client_colour/B)
+	return B.priority - A.priority

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -1,0 +1,72 @@
+
+/*
+	Client Colour Priority System By RemieRichards
+	A System that gives finer control over which client.colour value to display on screen
+	so that the "highest priority" one is always displayed as opposed to the default of
+	"whichever was set last is displayed"
+*/
+
+
+
+/*
+	Define subtypes of this datum
+*/
+/datum/client_colour
+	var/colour = "" //Any client.color-valid value
+	var/priority = 1 //Since only one client.color can be rendered on screen, we take the one with the highest priority value:
+	//eg: "Bloody screen" > "goggles colour" as the former is much more important
+
+
+/mob
+	var/list/client_colours = list()
+
+
+
+/*
+	Adds an instance of colour_type to the mob's client_colours list
+	colour_type - a typepath (subtyped from /datum/client_colour)
+*/
+/mob/proc/add_client_colour(colour_type)
+	if(!ispath(/datum/client_colour))
+		return
+
+	var/datum/client_colour/CC = new colour_type()
+	client_colours |= CC
+	sortTim(client_colours, /proc/cmp_clientcolour_priority)
+	update_client_colour()
+
+
+/*
+	Removes an instance of colour_type from the mob's client_colours list
+	colour_type - a typepath (subtyped from /datum/client_colour)
+*/
+/mob/proc/remove_client_colour(colour_type)
+	if(!ispath(/datum/client_colour))
+		return
+
+	for(var/cc in client_colours)
+		var/datum/client_colour/CC = cc
+		if(CC.type == colour_type)
+			client_colours -= CC
+			qdel(CC)
+			break
+	update_client_colour()
+
+
+/*
+	Resets the mob's client.color to null, and then sets it to the highest priority
+	client_colour datum, if one exists
+*/
+/mob/proc/update_client_colour()
+	if(!client)
+		return
+	client.color = ""
+	if(!client_colours.len)
+		return
+	var/datum/client_colour/CC = client_colours[1]
+	if(CC)
+		client.color = CC.colour
+
+
+
+

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -70,3 +70,5 @@
 			var/datum/alternate_appearance/AA = viewing_alternate_appearances[aakey]
 			if(AA)
 				AA.display_to(list(src))
+
+	update_client_colour()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -7,6 +7,9 @@
 		spellremove(src)
 	for(var/infection in viruses)
 		qdel(infection)
+	for(var/cc in client_colours)
+		qdel(cc)
+	client_colours = null
 	ghostize()
 	return ..()
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -165,6 +165,7 @@
 	origin_tech = "biotech=5"
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
 	var/last_pump = 0
+	var/add_colour = TRUE //So we're not constantly recreating colour datums
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
 	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
@@ -188,8 +189,9 @@
 			var/mob/living/carbon/human/H = owner
 			H.vessel.remove_reagent("blood",blood_loss)
 			H << "<span class = 'userdanger'>You have to keep pumping your blood!</span>"
-			if(H.client)
-				H.client.color = "red" //bloody screen so real
+			if(add_colour)
+				H.add_client_colour(/datum/client_colour/cursed_heart_blood) //bloody screen so real
+				add_colour = FALSE
 		else
 			last_pump = world.time //lets be extra fair *sigh*
 
@@ -218,12 +220,17 @@
 		var/mob/living/carbon/human/H = owner
 		if(istype(H))
 			H.vessel.add_reagent("blood",(cursed_heart.blood_loss*0.5))//gain half the blood back from a failure
-			if(owner.client)
-				owner.client.color = ""
-
+			H.remove_client_colour(/datum/client_colour/cursed_heart_blood)
+			cursed_heart.add_colour = TRUE
 			H.adjustBruteLoss(-cursed_heart.heal_brute)
 			H.adjustFireLoss(-cursed_heart.heal_burn)
 			H.adjustOxyLoss(-cursed_heart.heal_oxy)
+
+
+/datum/client_colour/cursed_heart_blood
+	priority = 100 //it's an indicator you're dieing, so it's very high priority
+	colour = "red"
+
 
 
 /obj/item/organ/internal/lungs

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -914,6 +914,7 @@
 #include "code\modules\client\asset_cache.dm"
 #include "code\modules\client\client defines.dm"
 #include "code\modules\client\client procs.dm"
+#include "code\modules\client\client_colour.dm"
 #include "code\modules\client\message.dm"
 #include "code\modules\client\preferences.dm"
 #include "code\modules\client\preferences_savefile.dm"


### PR DESCRIPTION
## Main:

Added a priority system for `client.color` effects, this allows us greater control over which `client.color` is displayed on screen, as opposed to Byond's default of "whichever was set in the var last" which isn't very useful for us.

simply define subtypes of `/datum/client_colour` with the `colour` and `priority` values changed, the higher `priority` is the more important that colour is treated as and the higher chance it'll be the one drawn on screen.
## Misc:
- Updated cursed hearts to use this system.

This is what I meant about not liking how @KorPhaeron did things in the backend NOT a lewd comment guys jeez.
