### PR TITLE
Station blueprints improvements

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -81,6 +81,14 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "blueprints"
 	fluffnotice = "Property of Nanotrasen. For heads of staff only. Store in high-secure storage."
+	var/list/image/showing = list()
+	var/client/viewing
+
+
+/obj/item/areaeditor/blueprints/Destroy()
+	clear_viewer()
+
+	return ..()
 
 
 /obj/item/areaeditor/blueprints/attack_self(mob/user)
@@ -89,6 +97,11 @@
 	if(get_area_type() == AREA_STATION)
 		. += "<p>According to \the [src], you are now in <b>\"[html_encode(A.name)]\"</b>.</p>"
 		. += "<p>You may <a href='?src=\ref[src];edit_area=1'>make an amendment</a> to the drawing.</p>"
+	if(!viewing)
+		. += "<p><a href='?src=\ref[src];view_blueprints=1'>View structural data</a></p>"
+	else
+		. += "<p><a href='?src=\ref[src];refresh=1'>Refresh structural data</a></p>"
+		. += "<p><a href='?src=\ref[src];hide_blueprints=1'>Hide structural data</a></p>"
 	var/datum/browser/popup = new(user, "blueprints", "[src]", 700, 500)
 	popup.set_content(.)
 	popup.open()
@@ -101,7 +114,38 @@
 		if(get_area_type()!=AREA_STATION)
 			return
 		edit_area()
-	updateUsrDialog()
+	if(href_list["view_blueprints"])
+		set_viewer(usr, "<span class='notice'>You flip the blueprints over to view the complex information diagram.</span>")
+	if(href_list["hide_blueprints"])
+		clear_viewer(usr,"<span class='notice'>You flip the blueprints over to view the simple information diagram.</span>")
+	if(href_list["refresh"])
+		clear_viewer(usr)
+		set_viewer(usr)
+
+	attack_self(usr) //this is not the proper way, but neither of the old update procs work! it's too ancient and I'm tired shush.
+
+/obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
+	. = list()
+	for(var/tt in RANGE_TURFS(viewsize, T))
+		var/turf/TT = tt
+		if(TT.blueprint_data)
+			. += TT.blueprint_data
+
+/obj/item/areaeditor/blueprints/proc/set_viewer(mob/user, message = "")
+	if(user && user.client)
+		viewing = user.client
+		showing = get_images(get_turf(user), viewing.view)
+		viewing.images |= showing
+		if(message)
+			user << message
+
+/obj/item/areaeditor/blueprints/proc/clear_viewer(mob/user, message = "")
+	if(viewing)
+		viewing.images -= showing
+		viewing = null
+	showing.Cut()
+	if(message)
+		user << message
 
 
 /obj/item/areaeditor/proc/get_area()

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -133,6 +133,8 @@
 
 /obj/item/areaeditor/blueprints/proc/set_viewer(mob/user, message = "")
 	if(user && user.client)
+		if(viewing)
+			clear_viewer()
 		viewing = user.client
 		showing = get_images(get_turf(user), viewing.view)
 		viewing.images |= showing
@@ -146,6 +148,10 @@
 	showing.Cut()
 	if(message)
 		user << message
+
+/obj/item/areaeditor/blueprints/dropped(mob/user)
+	..()
+	clear_viewer()
 
 
 /obj/item/areaeditor/proc/get_area()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -14,6 +14,19 @@
 	var/burn_world_time //What world time the object will burn up completely
 	var/being_shocked = 0
 
+	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
+	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
+
+/obj/New()
+	..()
+
+	if(on_blueprints && isturf(loc))
+		var/turf/T = loc
+		if(force_blueprints)
+			T.add_blueprints(src)
+		else
+			T.add_blueprints_preround(src)
+
 /obj/Destroy()
 	if(!istype(src, /obj/machinery))
 		SSobj.processing.Remove(src) // TODO: Have a processing bitflag to reduce on unnecessary loops through the processing lists

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -19,6 +19,9 @@
 
 	var/image/obscured	//camerachunks
 
+	var/list/image/blueprint_data //for the station blueprints, images of objects eg: pipes
+
+
 /turf/New()
 	..()
 
@@ -131,11 +134,13 @@
 		return
 	if(path == type)
 		return src
+	var/old_blueprint_data = blueprint_data
 
 	SSair.remove_from_active(src)
 
 	var/turf/W = new path(src)
 	W.AfterChange()
+	W.blueprint_data = old_blueprint_data
 	return W
 
 /turf/proc/AfterChange() //called after a turf has been replaced in ChangeTurf()
@@ -271,3 +276,21 @@
 		var/atom/A = V
 		if(A.level >= affecting_level)
 			A.ex_act(severity, target)
+
+
+/turf/proc/add_blueprints(atom/movable/AM)
+	var/image/I = new
+	I.appearance = AM.appearance
+	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
+	I.loc = src
+	I.dir = AM.dir
+	I.alpha = 128
+
+	if(!blueprint_data)
+		blueprint_data = list()
+	blueprint_data += I
+
+
+/turf/proc/add_blueprints_preround(atom/movable/AM)
+	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
+		add_blueprints(AM)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -14,6 +14,7 @@ Pipelines + Other Objects -> Pipe network
 	idle_power_usage = 0
 	active_power_usage = 0
 	power_channel = ENVIRON
+	on_blueprints = TRUE
 	var/nodealert = 0
 	var/can_unwrench = 0
 	var/initialize_directions = 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -25,6 +25,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable
 	level = 1 //is underfloor
 	anchored =1
+	on_blueprints = TRUE
 	var/datum/powernet/powernet
 	name = "power cable"
 	desc = "A flexible superconducting cable for heavy-duty power transfer"

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -10,6 +10,7 @@
 	name = null
 	icon = 'icons/obj/power.dmi'
 	anchored = 1
+	on_blueprints = TRUE
 	var/datum/powernet/powernet = null
 	use_power = 0
 	idle_power_usage = 0

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -131,7 +131,7 @@
 	desc = "An underfloor disposal pipe."
 	anchored = 1
 	density = 0
-
+	on_blueprints = TRUE
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/atmospherics/pipes/disposal.dmi'
 	anchored = 1
 	density = 1
+	on_blueprints = TRUE
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/mode = 1	// mode -1=screws removed 0=off 1=charging 2=charged
 	var/flush = 0	// true if flush handle is pulled


### PR DESCRIPTION
## Changes:
- Ports the functionality of the /vg/ holomap to the Station Blueprints, you can now see a layout of cables/pipes/atmos/power machinery as it was at roundstart to assist in repairs
- Makes the station blueprints actually redraw their UI (it's a nonstandard way of doing it, but both "proper" ways for this old form of UI actually do diddly squat)

![ce_does_their_job.png](http://i.imgur.com/oK0XWLd.png)

:cl:
add: The Station Blueprints now display the piping/wiring and some of the machinery the station started with, to assist in repairs
/:cl:

<B>Modified port of:</B> https://github.com/d3athrow/vgstation13/pull/9311
