### PR TITLE
Ore box changes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -121,6 +121,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	new/datum/stack_recipe("wooden buckler", /obj/item/weapon/shield/riot/buckler, 20, time = 40), \
 	new/datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50),\
 	new/datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10),\
+	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 20, time = 50, one_per_turf = 1, on_floor = 1),\
 	)
 
 /obj/item/stack/sheet/mineral/wood

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -121,7 +121,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	new/datum/stack_recipe("wooden buckler", /obj/item/weapon/shield/riot/buckler, 20, time = 40), \
 	new/datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50),\
 	new/datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10),\
-	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 20, time = 50, one_per_turf = 1, on_floor = 1),\
+	new/datum/stack_recipe("ore box", /obj/structure/ore_box, 4, time = 50, one_per_turf = 1, on_floor = 1),\
 	)
 
 /obj/item/stack/sheet/mineral/wood

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -19,7 +19,7 @@
 		S.hide_from(usr)
 		for(var/obj/item/weapon/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
-		user << "<span class='notice'>You empty the satchel into the box.</span>"
+		user << "<span class='notice'>You empty the ore in [S] into the [src].</span>"
 	return
 
 /obj/structure/ore_box/attack_hand(mob/user)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -19,6 +19,17 @@
 		for(var/obj/item/weapon/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
 		user << "<span class='notice'>You empty the ore in [S] into \the [src].</span>"
+	if(istype(W, /obj/item/weapon/crowbar))
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+		var/obj/item/weapon/crowbar/C = W
+		var/time = 50
+		if(do_after(user, time/C.toolspeed, target = src))
+			user.visible_message("[user] pries \the [src] apart.", "<span class='notice'>You pry apart \the [src].</span>", "<span class='italics'>You hear splitting wood.</span>")
+			// If you change the amount of wood returned, remember
+			// to change the construction costs
+			var/obj/item/stack/sheet/mineral/wood/WOOD = new (loc, 4)
+			WOOD.add_fingerprint(user)
+			deconstruct()
 	return
 
 /obj/structure/ore_box/attack_hand(mob/user)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -27,8 +27,8 @@
 			user.visible_message("[user] pries \the [src] apart.", "<span class='notice'>You pry apart \the [src].</span>", "<span class='italics'>You hear splitting wood.</span>")
 			// If you change the amount of wood returned, remember
 			// to change the construction costs
-			var/obj/item/stack/sheet/mineral/wood/WOOD = new (loc, 4)
-			WOOD.add_fingerprint(user)
+			var/obj/item/stack/sheet/mineral/wood/wo = new (loc, 4)
+			wo.add_fingerprint(user)
 			deconstruct()
 	return
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -16,7 +16,6 @@
 		W.loc = src
 	if (istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
-		S.hide_from(usr)
 		for(var/obj/item/weapon/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
 		user << "<span class='notice'>You empty the ore in [S] into the [src].</span>"
@@ -90,6 +89,6 @@
 	src.updateUsrDialog()
 	return
 
-obj/structure/ore_box/ex_act(severity, target)
+/obj/structure/ore_box/ex_act(severity, target)
 	if(prob(100 / severity) && severity < 3)
 		qdel(src) //nothing but ores can get inside unless its a bug and ores just return nothing on ex_act, not point in calling it on them

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -22,6 +22,14 @@
 	return
 
 /obj/structure/ore_box/attack_hand(mob/user)
+	if(Adjacent(user))
+		show_contents(user)
+
+/obj/structure/ore_box/attack_robot(mob/user)
+	if(Adjacent(user))
+		show_contents(user)
+
+/obj/structure/ore_box/proc/show_contents(mob/user)
 	var/amt_gold = 0
 	var/amt_silver = 0
 	var/amt_diamond = 0
@@ -76,15 +84,21 @@
 	user << browse("[dat]", "window=orebox")
 	return
 
+/obj/structure/ore_box/proc/dump_contents()
+	for (var/obj/item/weapon/ore/O in contents)
+		contents -= O
+		O.loc = src.loc
+
 /obj/structure/ore_box/Topic(href, href_list)
 	if(..())
 		return
+	if(!Adjacent(usr))
+		return
+
 	usr.set_machine(src)
 	src.add_fingerprint(usr)
 	if(href_list["removeall"])
-		for (var/obj/item/weapon/ore/O in contents)
-			contents -= O
-			O.loc = src.loc
+		dump_contents()
 		usr << "<span class='notice'>You empty the box.</span>"
 	src.updateUsrDialog()
 	return
@@ -92,3 +106,8 @@
 /obj/structure/ore_box/ex_act(severity, target)
 	if(prob(100 / severity) && severity < 3)
 		qdel(src) //nothing but ores can get inside unless its a bug and ores just return nothing on ex_act, not point in calling it on them
+
+/obj/structure/ore_box/Destroy()
+	dump_contents()
+	return ..()
+

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -18,7 +18,7 @@
 		var/obj/item/weapon/storage/S = W
 		for(var/obj/item/weapon/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
-		user << "<span class='notice'>You empty the ore in [S] into the [src].</span>"
+		user << "<span class='notice'>You empty the ore in [S] into \the [src].</span>"
 	return
 
 /obj/structure/ore_box/attack_hand(mob/user)


### PR DESCRIPTION
- Ore boxes can now be emptied by adjacent cyborgs.
- Ore boxes can now be crafted out of four planks of wood.
- Ore boxes now drop their contents when destroyed.
- Ore boxes now give correct messages when emptying containers into them

:cl: coiax
rscadd: Nanotrasen Cyborgs are now able to empty ore boxes without human assistance
rscadd: Ore boxes are now craftable with 4 planks of wood
tweak: Ore boxes now drop their contents when destroyed, or dismantled with a crowbar
/:cl:
