### PR TITLE
Self-Defense Rifles for LowPop Rounds

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -281,11 +281,24 @@
 			intercepttext += i_text.build(A)
 		else
 			intercepttext += i_text.build(A, pick(modePlayer))
-
-	print_command_report(intercepttext,"Centcom Status Summary")
-	priority_announce("Summary downloaded and printed out at all communications consoles.", "Enemy communication intercept. Security Level Elevated.", 'sound/AI/intercept.ogg')
 	if(security_level < SEC_LEVEL_BLUE)
-		set_security_level(SEC_LEVEL_BLUE)
+		var/list/players = num_players()
+		if(players.len < 25)
+			for(var/obj/machinery/computer/shuttle/ferry/request/f in world)
+				for(var/j = 1, j < 7, j++)
+					var weaploc = locate(f.x+j,f.y,f.z)
+					new /obj/item/weapon/gun/projectile/sniper_rifle/emergency(weaploc)
+
+				for(var/k = 1, k < 7, k++)
+					var ammoloc = locate(f.x+k,f.y-1,f.z)
+					new /obj/item/ammo_box/magazine/sniper_rounds/emergency(ammoloc)
+			print_command_report(intercepttext,"Centcom Status Summary")
+			priority_announce("Enemy communication intercepted. Skeleton crew confirmed vulnerable: Deploying surplus weaponry. Security Level Elevated.", 'sound/AI/intercept.ogg')
+		else
+			print_command_report(intercepttext,"Centcom Status Summary")
+			priority_announce("Summary downloaded and printed out at all communications consoles.", "Enemy communication intercepted. Security Level Elevated.", 'sound/AI/intercept.ogg')
+	set_security_level(SEC_LEVEL_BLUE)
+	SSshuttle.toggleShuttle("ferry","ferry_home","ferry_away")
 
 
 /datum/game_mode/proc/get_players_for_role(role)

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -9,6 +9,10 @@
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet
 
+/obj/item/ammo_casing/a762/emergency	
+	projectile_type = /obj/item/projectile/bullet/weakbullet3
+	desc = "A modified 7.62 bullet casing"
+
 /obj/item/ammo_casing/a762/enchanted
 	projectile_type = /obj/item/projectile/bullet/weakbullet3
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,4 +1,3 @@
-
 /obj/item/weapon/gun/projectile/sniper_rifle
 	name = "sniper rifle"
 	desc = "The kind of gun that will leave you crying for mummy before you even realise your leg's missing"
@@ -16,23 +15,17 @@
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	slot_flags = SLOT_BACK
 
-
-/obj/item/weapon/gun/projectile/sniper_rifle/update_icon()
-	if(magazine)
-		icon_state = "sniper-mag"
-	else
-		icon_state = "sniper"
-
-
 /obj/item/weapon/gun/projectile/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face"
 	pin = /obj/item/device/firing_pin/implant/pindicate
 	origin_tech = "combat=8;syndicate=4"
 
-
-
-
+/obj/item/weapon/gun/projectile/sniper_rifle/syndicate/update_icon()
+	if(magazine)
+		icon_state = "sniper-mag"
+	else
+		icon_state = "sniper"
 
 //Normal Boolets
 /obj/item/ammo_box/magazine/sniper_rounds
@@ -188,3 +181,24 @@
 		breakthings = TRUE
 	else if(damage > 25)
 		icon_state = "gauss"
+
+// Savior of Lowpop rounds
+
+/obj/item/weapon/gun/projectile/sniper_rifle/emergency
+	name = "emergency self-defense rifle"
+	desc = "Nanotrasen deploys these cheap mass-produced firearms wherever undermanned stations are at risk"
+	icon_state = "moistnugget"
+	item_state = "moistnugget"
+	mag_type = /obj/item/ammo_box/magazine/sniper_rounds/emergency
+	recoil = 1
+	fire_delay = 30
+	origin_tech = "combat=2"
+	zoomable = FALSE
+
+/obj/item/ammo_box/magazine/sniper_rounds/emergency
+	name = "emergency rifle rounds (.762)"
+	ammo_type = /obj/item/ammo_casing/a762/emergency	
+	caliber = "a762"
+	max_ammo = 8
+	multiload = 1
+	icon_state = "75-8"


### PR DESCRIPTION
20 damage per shot, long delay between shots, 8 bullets per mag with limited spare ammo, fire with an empty free hand or else you will drop it. There is no stun or stamina damage associated with the bullets.

When crew population is under 25, code blue will trigger an extra announcement that surplus weaponry is being sent to help protect the undermanned station in light of the enemy activity detected. The Centcom Shuttle will then immediately dock with the station carrying 6 of these rifles with 1 spare mag each. 

Reasoning? Lowpop is the gutter of SS13 gameplay. Any halfway decent traitor can effortlessly rush the armory and murderbone the entire station. These rifles would at least give murderboners a pause since sustained fire or fire from multiple players would still pose a serious threat. At the same time the drawbacks for these rifles make them of very limited use in to virtually anyone else. These aren't a guarantee for crew safety, but if everyone gets killed, they can at least go down with a fight. 
