### PR TITLE
Emagging cargo console also unlocks contraband

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -170,6 +170,7 @@
 	build_path = /obj/machinery/computer/cargo
 	origin_tech = "programming=3"
 	var/contraband = 0
+	var/emagged = 0
 /obj/item/weapon/circuitboard/cargo/request
 	name = "circuit board (Supply Request Console)"
 	build_path = /obj/machinery/computer/cargo/request
@@ -241,8 +242,15 @@
 
 /obj/item/weapon/circuitboard/cargo/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/device/multitool))
-		contraband = !contraband
-		user << "<span class='notice'>Receiver spectrum set to [contraband ? "Broad" : "Standard"].</span>"
+		if(!emagged)
+			contraband = !contraband
+			user << "<span class='notice'>Receiver spectrum set to [contraband ? "Broad" : "Standard"].</span>"
+		else
+			user << "<span class='notice'>The spectrum chip is unresponsive.</span>"
+	if(istype(I,/obj/item/weapon/card/emag))
+		contraband = TRUE
+		emagged = TRUE
+		user << "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>"
 
 /obj/item/weapon/circuitboard/rdconsole/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/weapon/screwdriver))

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -248,9 +248,10 @@
 		else
 			user << "<span class='notice'>The spectrum chip is unresponsive.</span>"
 	if(istype(I,/obj/item/weapon/card/emag))
-		contraband = TRUE
-		emagged = TRUE
-		user << "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>"
+		if(!emagged)
+			contraband = TRUE
+			emagged = TRUE
+			user << "<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>"
 
 /obj/item/weapon/circuitboard/rdconsole/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/weapon/screwdriver))

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -24,6 +24,11 @@
 							"<span class='notice'>You adjust [src]'s routing, unlocking special supplies.</span>")
 		emagged = TRUE
 
+		// Emagging also unlocks the Broad-banded supplies
+		var/obj/item/weapon/circuitboard/cargo/board = circuit
+		circuit.contraband = TRUE
+		contraband = TRUE
+
 /obj/machinery/computer/cargo/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 											datum/tgui/master_ui = null, datum/ui_state/state = default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -17,17 +17,20 @@
 	..()
 	var/obj/item/weapon/circuitboard/cargo/board = circuit
 	contraband = board.contraband
+	emagged = board.emagged
 
 /obj/machinery/computer/cargo/emag_act(mob/living/user)
 	if(!emagged)
 		user.visible_message("<span class='warning'>[user] swipes a suspicious card through [src]!",
-							"<span class='notice'>You adjust [src]'s routing, unlocking special supplies.</span>")
-		emagged = TRUE
+		"<span class='notice'>You adjust [src]'s routing and receiver spectrum, unlocking special supplies and contraband.</span>")
 
-		// Emagging also unlocks the Broad-banded supplies
-		var/obj/item/weapon/circuitboard/cargo/board = circuit
-		circuit.contraband = TRUE
+		emagged = TRUE
 		contraband = TRUE
+
+		// This also permamently sets this on the circuit board
+		var/obj/item/weapon/circuitboard/cargo/board = circuit
+		board.contraband = TRUE
+		board.emagged = TRUE
 
 /obj/machinery/computer/cargo/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, \
 											datum/tgui/master_ui = null, datum/ui_state/state = default_state)


### PR DESCRIPTION
Using an emag will also unlock some of the speciality crates that you would
normally have to multitool the cargo circuit board for.

:cl: coiax
rscadd: Emagging the cargo console also unlocks regular contraband, in addition to syndicate gear
/:cl:
