### PR TITLE
DreamStation: Added drone dispenser to Toxins Launch Room

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -72230,6 +72230,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "cHo" = (


### PR DESCRIPTION
This is the closest that Dreamstation has to a Testing Lab, so we'll put
the drone shell dispenser here.

:cl: coiax
rscadd: Dreamstation now has a drone shell dispenser in the Toxins Launch Room
/:cl:
