### PR TITLE
Refactors Guardian Color Handling

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -32,6 +32,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	butcher_results = list(/obj/item/weapon/ectoplasm = 1)
 	AIStatus = AI_OFF
 	var/reset = 0 //if the summoner has reset the guardian already
+	var/image/guardianoverlay = null
 	var/cooldown = 0
 	var/mob/living/summoner
 	var/range = 10 //how far from the user the spirit can be
@@ -69,24 +70,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	namedatum = pick(possible_names)
 	updatetheme(pickedtheme)
 
-/mob/living/simple_animal/hostile/guardian/proc/updatetheme(theme) //update the guardian's theme to whatever its datum is; proc for adminfuckery
-	name = "[namedatum.prefixname] [namedatum.suffixcolour]"
-	real_name = "[name]"
-	icon_living = "[namedatum.parasiteicon]"
-	icon_state = "[namedatum.parasiteicon]"
-	icon_dead = "[namedatum.parasiteicon]"
-	bubble_icon = "[namedatum.bubbleicon]"
-
-	if (namedatum.stainself)
-		color = namedatum.colour
-
-	//Special case holocarp, because #snowflake code
-	if(theme == "carp")
-		speak_emote = list("gnashes")
-		desc = "A mysterious fish that stands by its charge, ever vigilant."
-
-		attacktext = "bites"
-		attack_sound = 'sound/weapons/bite.ogg'
+/mob/living/simple_animal/hostile/guardian/proc/updatetheme() //update the guardian's theme to whatever its datum is; proc for adminfuckery
+	namedatum.update(src)
 
 
 /mob/living/simple_animal/hostile/guardian/Login() //if we have a mind, set its name to ours when it logs in
@@ -326,6 +311,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 						src << "<span class='holoparasite'><font color=\"[G.namedatum.colour]\"><b>[G.real_name]</b></font> is now online!</span>"
 					if("magic")
 						src << "<span class='holoparasite'><font color=\"[G.namedatum.colour]\"><b>[G.real_name]</b></font> has been summoned!</span>"
+					if("carp")
+						src << "<span class='holoparasite'><font color=\"[G.namedatum.colour]\"><b>[G.real_name]</b></font> has been caught!</span>"
 				guardians -= G
 				if(!guardians.len)
 					verbs -= /mob/living/proc/guardian_reset

--- a/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
@@ -1,21 +1,58 @@
-
+#define GUARDIANCOLOROVERLAY "color overlay" //Used with spritecolor var for guardians to determine what color to apply
+#define GUARDIANCOLORBASE "color base"
+#define GUARDIANCOLORBOTH "color both"
+#define GUARDIANCOLORNONE "color none"
 /datum/guardianname
 	var/prefixname = "Default" //the prefix the guardian uses for its name
 	var/suffixcolour = "Name" //the suffix the guardian uses for its name
-	var/parasiteicon = "techbase" //the icon of the guardian
+	var/parasitebaseicon = "techbase" //the icon of the guardian
+	var/parasiteoverlayicon = "techglowbase"
 	var/bubbleicon = "holo" //the speechbubble icon of the guardian
 	var/theme = "tech" //what the actual theme of the guardian is
 	var/colour = "#C3C3C3" //what color the guardian's name is in chat and what color is used for effects from the guardian
-	var/stainself = 0 //whether to use the color var to literally dye ourself our chosen colour, for lazy spriting
+	var/spritecolor = GUARDIANCOLOROVERLAY //whether to use the color var to literally dye ourself our chosen colour.
+
+/datum/guardianname/proc/update(mob/living/simple_animal/hostile/guardian/G)
+	G.name = "[prefixname] [suffixcolour]"
+	G.real_name = "[G.name]"
+	G.icon_living = "[parasitebaseicon]"
+	G.icon_state = "[parasitebaseicon]"
+	G.icon_dead = "[parasitebaseicon]"
+	G.bubble_icon = "[bubbleicon]"
+
+	G.overlays.Cut()
+	if(parasiteoverlayicon)
+		G.guardianoverlay = image('icons/mob/guardian.dmi',parasiteoverlayicon)
+
+	switch(spritecolor)
+		if(GUARDIANCOLORBASE)
+			G.color = colour
+		if(GUARDIANCOLOROVERLAY)
+			G.guardianoverlay.color = colour
+		if(GUARDIANCOLORBOTH)
+			G.color = colour
+			G.guardianoverlay.color = colour
+
+	if(parasiteoverlayicon)
+		G.overlays += G.guardianoverlay
 
 /datum/guardianname/carp
 	bubbleicon = "guardian"
 	theme = "carp"
-	parasiteicon = "holocarp"
-	stainself = 1
+	parasitebaseicon = "holocarp"
+	parasiteoverlayicon = null
+	spritecolor = GUARDIANCOLORBASE
 
 /datum/guardianname/carp/New()
 	prefixname = pick(carp_names)
+
+/datum/guardianname/carp/update(mob/living/simple_animal/hostile/guardian/G)
+	..()
+	G.speak_emote = list("gnashes")
+	G.desc = "A mysterious fish that stands by its charge, ever vigilant."
+
+	G.attacktext = "bites"
+	G.attack_sound = 'sound/weapons/bite.ogg'
 
 /datum/guardianname/carp/seagreen
 	suffixcolour = "Sea Green"
@@ -44,33 +81,35 @@
 /datum/guardianname/magic
 	bubbleicon = "guardian"
 	theme = "magic"
+	parasiteoverlayicon = null
+	spritecolor = GUARDIANCOLORNONE
 
 /datum/guardianname/magic/New()
 	prefixname = pick("Aries", "Leo", "Sagittarius", "Taurus", "Virgo", "Capricorn", "Gemini", "Libra", "Aquarius", "Cancer", "Scorpio", "Pisces", "Ophiuchus")
 
 /datum/guardianname/magic/red
 	suffixcolour = "Red"
-	parasiteicon = "magicRed"
+	parasitebaseicon = "magicRed"
 	colour = "#E32114"
 
 /datum/guardianname/magic/pink
 	suffixcolour = "Pink"
-	parasiteicon = "magicPink"
+	parasitebaseicon = "magicPink"
 	colour = "#FB5F9B"
 
 /datum/guardianname/magic/orange
 	suffixcolour = "Orange"
-	parasiteicon = "magicOrange"
+	parasitebaseicon = "magicOrange"
 	colour = "#F3CF24"
 
 /datum/guardianname/magic/green
 	suffixcolour = "Green"
-	parasiteicon = "magicGreen"
+	parasitebaseicon = "magicGreen"
 	colour = "#A4E836"
 
 /datum/guardianname/magic/blue
 	suffixcolour = "Blue"
-	parasiteicon = "magicBlue"
+	parasitebaseicon = "magicBlue"
 	colour = "#78C4DB"
 
 /datum/guardianname/tech/New()
@@ -78,60 +117,53 @@
 
 /datum/guardianname/tech/rose
 	suffixcolour = "Rose"
-	parasiteicon = "techRose"
 	colour = "#F62C6B"
 
 /datum/guardianname/tech/peony
 	suffixcolour = "Peony"
-	parasiteicon = "techPeony"
 	colour = "#E54750"
 
 /datum/guardianname/tech/lily
 	suffixcolour = "Lily"
-	parasiteicon = "techLily"
 	colour = "#F6562C"
 
 /datum/guardianname/tech/daisy
 	suffixcolour = "Daisy"
-	parasiteicon = "techDaisy"
 	colour = "#ECCD39"
 
 /datum/guardianname/tech/zinnia
 	suffixcolour = "Zinnia"
-	parasiteicon = "techZinnia"
 	colour = "#89F62C"
 
 /datum/guardianname/tech/ivy
 	suffixcolour = "Ivy"
-	parasiteicon = "techIvy"
 	colour = "#5DF62C"
 
 /datum/guardianname/tech/iris
 	suffixcolour = "Iris"
-	parasiteicon = "techIris"
 	colour = "#2CF6B8"
 
 /datum/guardianname/tech/petunia
 	suffixcolour = "Petunia"
-	parasiteicon = "techPetunia"
 	colour = "#51A9D4"
 
 /datum/guardianname/tech/violet
 	suffixcolour = "Violet"
-	parasiteicon = "techViolet"
 	colour = "#8A347C"
 
 /datum/guardianname/tech/lotus
 	suffixcolour = "Lotus"
-	parasiteicon = "techLotus"
 	colour = "#463546"
 
 /datum/guardianname/tech/lilac
 	suffixcolour = "Lilac"
-	parasiteicon = "techLilac"
 	colour = "#C7A0F6"
 
 /datum/guardianname/tech/orchid
 	suffixcolour = "Orchid"
-	parasiteicon = "techOrchid"
 	colour = "#F62CF5"
+
+#undef GUARDIANCOLOROVERLAY
+#undef GUARDIANCOLORBASE
+#undef GUARDIANCOLORBOTH
+#undef GUARDIANCOLORNONE

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -36,7 +36,7 @@
 		return 0
 	cooldown = world.time + 10
 	if(toggle)
-		overlays.Cut()
+		namedatum.update(src)//Rebuild default overlays
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper)
 		speed = initial(speed)


### PR DESCRIPTION
Makes guardians use an overlay system to allow for more colors to be added easier, added a color flag to determine which part of the sprite gets color.
