### PR TITLE
Nuke ops dying but disk not getting rescued changed to neutral victory

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -234,8 +234,8 @@
 		world << "<B>The Research Staff has saved the disc and stopped the [syndicate_name()] Operatives!</B>"
 
 	else if (!disk_rescued && are_operatives_dead())
-		feedback_set_details("round_end_result","loss - evacuation - disk not secured")
-		world << "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>"
+		feedback_set_details("round_end_result","halfwin - evacuation - disk not secured")
+		world << "<FONT size = 3><B>Neutral Victory!</B></FONT>"
 		world << "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name()] Operatives!</B>"
 
 	else if (!disk_rescued &&  crew_evacuated)


### PR DESCRIPTION
Title says it all. I've seen many people wondering situations where the crew just murders all ops but captain gets slipped by a clown when running to the shuttle or something and ops get a minor victory. This changes these situations from syndicate minor victory to neutral victory. 
The "The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name()] Operatives!" text seems to be okay even in this situation so I let it stay.

Disk not getting rescued and at least one op staying alive will still give the ops a minor victory. This makes sense rp-wise as the ops alive can then get the disk and nuke the station later if they wish.
