### PR TITLE
The Cult Rises...

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -223,7 +223,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	var/rune_to_scribe
 	var/entered_rune_name
 	var/list/possible_runes = list()
-	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed - /obj/effect/rune/basic)
+	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed)
 		var/obj/effect/rune/R = T
 		if(initial(R.cultist_name))
 			possible_runes.Add(initial(R.cultist_name)) //This is to allow the menu to let cultists select runes by name rather than by object path. I don't know a better way to do this

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -109,21 +109,24 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	have many different names, and almost all of them are known as Rites. The only rune that is not a Rite is the Ritual of Dimensional Rending, which can only be performed with nine cultists and calls \
 	forth the avatar of the Geometer herself (so long as she consents).<br><br>A rune's name and effects can be revealed by examining the rune. <br><br><br>"
 
-	text += "<font color='red'><b>Teleport</b></font><br>The Rite of Translocation is a unique rite in that it requires a keyword before the scribing can begin. When invoked, the rune will \
+	text += "<font color='red'><b>Imbue Talisman</b></font><br>The Rite of Talisman Creation is one of the most important. It is the only way to create talismans. A blank sheet of paper must be on top of the rune, with a valid rune nearby. After \
+	invoking it, the paper will be converted into a talisman, and the rune inlaid upon it.<br><br>"
+
+	text += "<font color='red'><b>Teleport</b></font><br>The Rite of Teleportation is a unique rite in that it requires a keyword before the scribing can begin. When invoked, the rune will \
 	search for other Rites of Translocation with the same keyword. Assuming one is found, the user will be instantaneously transported to the location of the other rune. If more than two runes are scribed \
 	with the same keyword, it will choose randomly between all eligible runes and send the invoker to one of them.<br><br>"
 
-	text += "<font color='red'><b>Teleport Other</b></font><br>The Rite of Forced Translocation, like the Rite of Translocation, works by teleporting the person on the rune to one of the \
+//	text += "<font color='red'><b>Teleport Other</b></font><br>The Rite of Forced Translocation, like the Rite of Translocation, works by teleporting the person on the rune to one of the \
 	same keyword. However, this rune will only work on people other than the user, allowing the user to send any living creature somewhere else.<br><br>"
 
-	text += "<font color='red'><b>Summon Tome</b></font><br>The Rite of Knowledge is a simplistic rune. When invoked, it will summon a single arcane tome to the rune's location before vanishing. \
+//	text += "<font color='red'><b>Summon Tome</b></font><br>The Rite of Knowledge is a simplistic rune. When invoked, it will summon a single arcane tome to the rune's location before vanishing. \
 	<br><br>"
 
-	text += "<font color='red'><b>Convert</b></font><br>The Rite of Enlightment is paramount to the success of the cult. It will allow you to convert normal crew members into cultists. \
+	text += "<font color='red'><b>Convert</b></font><br>The Rite of Conversion is paramount to the success of the cult. It will allow you to convert normal crew members into cultists. \
 	To do this, simply place the crew member upon the rune and invoke it. This rune requires two acolytes to use. If the target to be converted is loyalty-implanted or a certain assignment, they will \
 	be unable to be converted. People the Geometer wishes sacrificed will also be ineligible for conversion, and anyone with a shielding presence like the null rod will not be converted.<br><br>"
 
-	text += "<font color='red'><b>Sacrifice</b></font><br>The Rite of Tribute is used to offer sacrifice to the Geometer. Simply place any living creature upon the rune and invoke it (this will not \
+	text += "<font color='red'><b>Sacrifice</b></font><br>The Rite of Sacrifice is used to offer  tribute to the Geometer. Simply place any living creature upon the rune and invoke it (this will not \
 	target cultists!). If this creature has a mind, a soul shard will be created and the creature's soul transported to it. This rune is required if the cult's objectives include the sacrifice of a crew \
 	member.<br><br>"
 
@@ -131,13 +134,13 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	the rune and the offering body adjacent to it. When the rune is invoked, the body to be sacrificed will turn to dust, the life force flowing into the revival target. Assuming the target is not moved \
 	within a few seconds, they will be brought back to life, healed of all ailments.<br><br>"
 
-	text += "<font color='red'><b>Veil Runes</b></font><br>The Rite of Obscurity is a rite that will cause all nearby runes to become invisible. The runes will still be considered by other rites \
+//	text += "<font color='red'><b>Veil Runes</b></font><br>The Rite of Obscurity is a rite that will cause all nearby runes to become invisible. The runes will still be considered by other rites \
 	(such as the Rite of Translocation) but will be unusuable directly.(such as the Rite of Translocation) but will be unusuable directly. Use the same rite once more to reveal these runes once more.<br><br>"
 
-	text += "<font color='red'><b>Reveal Runes</b></font><br>The Rite of True Sight is the foil of the Rite of Obscurity. It will turn all invisible runes visible once more, in addition to causing \
+//	text += "<font color='red'><b>Reveal Runes</b></font><br>The Rite of True Sight is the foil of the Rite of Obscurity. It will turn all invisible runes visible once more, in addition to causing \
 	all spirits nearby to become visible.<br><br>"
 
-	text += "<font color='red'><b>Disguise Runes</b></font><br>Many crewmen enjoy drawing runes in crayon that resemble spell circles in order to play pranks on their fellow crewmen. The Rite of \
+//	text += "<font color='red'><b>Disguise Runes</b></font><br>Many crewmen enjoy drawing runes in crayon that resemble spell circles in order to play pranks on their fellow crewmen. The Rite of \
 	False Truths takes advantage of this very joke. When invoked, all nearby runes will appear dull, precisely resembling those drawn in crayon. They still cannot be cleaned by conventional means, so \
 	anyone trying to clean up the rune may become suspicious as it does not respond.<br><br>"
 
@@ -153,30 +156,27 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	rune will draw a small amount of life force from the user and make the space above the rune completely dense, rendering it impassable to all but the most complex means. The rune may be invoked again to \
 	undo this effect and allow passage again.<br><br>"
 
-	text += "<font color='red'><b>Debilitate</b></font><br>The Rite of the Shadowed Mind is simple. When invoked, it will cause all non-cultists that can see its rune to become deaf, blind and mute for a \
+//	text += "<font color='red'><b>Debilitate</b></font><br>The Rite of the Shadowed Mind is simple. When invoked, it will cause all non-cultists that can see its rune to become deaf, blind and mute for a \
 	considerable amount of time.<br><br>"
 
-	text += "<font color='red'><b>Stun</b></font><br>Though the Rite of Blazing Light is weak when invoked normally, using it in conjuction with the Rite of Binding makes it much more powerful. \
+//	text += "<font color='red'><b>Stun</b></font><br>Though the Rite of Blazing Light is weak when invoked normally, using it in conjuction with the Rite of Binding makes it much more powerful. \
 	This rune will cause any non-cultists that can see the rune to become disoriented, disabling them for a short time.<br><br>"
 
 	text += "<font color='red'><b>Summon Cultist</b></font><br>The Rite of Joined Souls requires two acolytes to use. When invoked, it will allow the user to summon a single cultist to the rune from \
 	any location. This will deal a moderate amount of damage to all invokers.<br><br>"
 
-	text += "<font color='red'><b>Imbue Talisman</b></font><br>The Rite of Binding is the only way to create talismans. A blank sheet of paper must be on top of the rune, with a valid rune nearby. After \
-	invoking it, the paper will be converted into a talisman, and the rune inlaid upon it.<br><br>"
-
 	text += "<font color='red'><b>Fabricate Shell</b></font><br>The Rite of Fabrication is the main way of creating construct shells. To use it, one must place five sheets of plasteel on top of the rune \
 	and invoke it. The sheets will them be twisted into a construct shell, ready to recieve a soul to occupy it.<br><br>"
 
-	text += "<font color='red'><b>Summon Armaments</b></font><br>The Rite of Arming will equip the user with armored robes, a backpack, an eldrich longsword, and a pair of boots. Any items that cannot \
+//	text += "<font color='red'><b>Summon Armaments</b></font><br>The Rite of Arming will equip the user with armored robes, a backpack, an eldrich longsword, and a pair of boots. Any items that cannot \
 	be equipped will not be summoned.<br><br>"
 
-	text += "<font color='red'><b>Drain Life</b></font><br>The Rite of Leeching will drain the life of any non-cultist above the rune and heal the invoker for the same amount.<br><br>"
+//	text += "<font color='red'><b>Drain Life</b></font><br>The Rite of Leeching will drain the life of any non-cultist above the rune and heal the invoker for the same amount.<br><br>"
 
 	text += "<font color='red'><b>Blood Boil</b></font><br>The Rite of Boiling Blood may be considered one of the most dangerous rites composed by the cult of Nar-Sie. When invoked, it will do a \
 	massive amount of damage to all non-cultist viewers, but it will also emit an explosion upon invocation. Use with caution<br><br>"
 
-	text += "<font color='red'><b>Time Stop</b></font><br>The Rite of Dimensional Corruption is a versatile rite that can be very strong when protecting our cult from the enemies of the Geometer. \
+//	text += "<font color='red'><b>Time Stop</b></font><br>The Rite of Dimensional Corruption is a versatile rite that can be very strong when protecting our cult from the enemies of the Geometer. \
 	As it is invoked, it will rend and reshape reality around itself, stopping time for all those who don't follow the teachings of the Geometer. However, it requires more than one ritual soul as a \
 	catalyst, and its power is bound to overflow and hurt its casters.<br><br>"
 
@@ -185,7 +185,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	to reality is fragile - you must remain on top of the rune, and you will slowly take damage. Upon stepping off the rune, the spirits will dissipate, dropping their items to the ground. You may manifest \
 	multiple spirits with one rune, but you will rapidly take damage in doing so.<br><br>"
 
-	text += "<font color='red'><b><i>Call Forth The Geometer</i></b></font><br>There is only one way to summon the avatar of Nar-Sie, and that is the Ritual of Dimensional Rending. This ritual, in \
+	text += "<font color='red'><b><i>Summon Nar-Sie</i></b></font><br>There is only one way to summon the avatar of Nar-Sie, and that is the Ritual of Dimensional Rending. This ritual, in \
 	comparison to other runes, is very large, requiring a 3x3 space of empty tiles to create. To invoke the rune, nine cultists must stand on the rune, so that all of them are within its circle. Then, \
 	simply invoke it. A brief tearing will be heard as the barrier between dimensions is torn open, and the avatar will come forth.<br><br><br>"
 
@@ -207,6 +207,9 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	text += "<font color='red'><b>Talisman of Stunning</b></font><br>Without this talisman, the cult would have no way of easily acquiring targets to convert. Commonly called \"stunpapers\", this \
 	talisman functions differently from others. Rather than simply reading the words, the target must be attacked directly with the talisman. The talisman will then knock down the target for a long \
 	duration in addition to inhibiting their speech. Robotic lifeforms will suffer the effects of a heavy electromagnetic pulse instead."
+
+	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Rite of Arming will equip the user with armored robes, a backpack, an eldrich longsword, and a pair of boots. Any items that cannot \
+	be equipped will not be summoned.<br><br>"
 
 	var/datum/browser/popup = new(user, "tome", "", 800, 600)
 	popup.set_content(text)
@@ -246,7 +249,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.apply_damage(0.1, BRUTE, pick("l_arm", "r_arm"))
-		if("Call Forth The Geometer" == entered_rune_name)
+		if("Summon Nar-Sie" == entered_rune_name)
 			C.apply_damage(40, BRUTE, pick("l_arm", "r_arm"))
 			var/area/A = get_area(src)
 			var/locname = initial(A.name)

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -211,6 +211,8 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Rite of Arming will equip the user with armored robes, a backpack, an eldrich longsword, and a pair of boots. Any items that cannot \
 	be equipped will not be summoned.<br><br>"
 
+	text += "<font color='red'><b>Talisman of Horrors</b></font><br>The Rite of Horror will breaks your victim's mind with visions of the endtimes.<br><br>"
+	
 	var/datum/browser/popup = new(user, "tome", "", 800, 600)
 	popup.set_content(text)
 	popup.open()
@@ -221,7 +223,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	var/rune_to_scribe
 	var/entered_rune_name
 	var/list/possible_runes = list()
-	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed - /obj/effect/rune/malformed)
+	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed - /obj/effect/rune/basic)
 		var/obj/effect/rune/R = T
 		if(initial(R.cultist_name))
 			possible_runes.Add(initial(R.cultist_name)) //This is to allow the menu to let cultists select runes by name rather than by object path. I don't know a better way to do this

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -255,7 +255,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 			C.apply_damage(40, BRUTE, pick("l_arm", "r_arm"))
 			var/area/A = get_area(src)
 			var/locname = initial(A.name)
-			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual before it reaches a critical point.","Central Command Higher Dimensionsal Affairs")
+			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
 			if(!do_after(user, 500, target = get_turf(user)))
 				return
 	if(!do_after(user, 50, target = get_turf(user)))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -221,7 +221,7 @@ This file contains the arcane tome files as well as innate cultist emergency com
 	var/rune_to_scribe
 	var/entered_rune_name
 	var/list/possible_runes = list()
-	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed)
+	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed - /obj/effect/rune/malformed)
 		var/obj/effect/rune/R = T
 		if(initial(R.cultist_name))
 			possible_runes.Add(initial(R.cultist_name)) //This is to allow the menu to let cultists select runes by name rather than by object path. I don't know a better way to do this

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -270,13 +270,12 @@ var/list/teleport_other_runes = list()
 	invocation = "N'ath reth sh'yro eth d'raggathnor!"
 	icon_state = "5"
 	color = rgb(0, 0, 255)
-*/
 
 /obj/effect/rune/summon_tome/invoke(mob/living/user)
 	visible_message("<span class='warning'>A frayed tome materializes on the surface of [src], which dissolves into nothing.</span>")
 	new /obj/item/weapon/tome(get_turf(src))
 	qdel(src)
-
+*/
 
 //Rite of Enlightenment: Converts a normal crewmember to the cult. Faster for every cultist nearby.
 /obj/effect/rune/convert
@@ -887,7 +886,7 @@ var/list/teleport_other_runes = list()
 				log_game("Construct Shell rune failed - not enough plasteel sheets")
 				return
 
-
+/*
 //Rite of Arming: Creates cult robes, a trophy rack, and a cult sword on the rune.
 /obj/effect/rune/armor
 	cultist_name = "Summon Armaments"
@@ -904,7 +903,7 @@ var/list/teleport_other_runes = list()
 	user.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
 	user.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 	qdel(src)
-
+*/
 
 /*Rite of Leeching: Deals brute damage to the target and heals the same amount to the invoker.
 /obj/effect/rune/leeching

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -200,7 +200,7 @@ var/list/teleport_runes = list()
 						 "<span class='cult'>Your vision blurs, and you suddenly appear somewhere else.</span>")
 	user.forceMove(get_turf(selected_rune))
 
-
+/*
 var/list/teleport_other_runes = list()
 //Rite of Forced Translocation: Warps the target to a random teleport rune with the same keyword.
 /obj/effect/rune/teleport_other
@@ -270,7 +270,7 @@ var/list/teleport_other_runes = list()
 	invocation = "N'ath reth sh'yro eth d'raggathnor!"
 	icon_state = "5"
 	color = rgb(0, 0, 255)
-
+*/
 
 /obj/effect/rune/summon_tome/invoke(mob/living/user)
 	visible_message("<span class='warning'>A frayed tome materializes on the surface of [src], which dissolves into nothing.</span>")
@@ -310,6 +310,7 @@ var/list/teleport_other_runes = list()
 	new_cultist.visible_message("<span class='warning'>[new_cultist] writhes in pain as the markings below them glow a bloody red!</span>", \
 					  			"<span class='cultlarge'><i>AAAAAAAAAAAAAA-</i></span>")
 	ticker.mode.add_cultist(new_cultist.mind)
+	new /obj/item/weapon/tome(get_turf(src))
 	new_cultist.mind.special_role = "Cultist"
 	new_cultist << "<span class='cultitalic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
 	and something evil takes root.</b></span>"
@@ -416,7 +417,7 @@ var/list/teleport_other_runes = list()
 
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar-Sie upon the station.
 /obj/effect/rune/narsie
-	cultist_name = "Call Forth The Geometer"
+	cultist_name = "Summon Nar-Sie"
 	cultist_desc = "Tears apart dimensional barriers, calling forth the avatar of the Geometer."
 	invocation = null
 	req_cultists = 9
@@ -573,7 +574,7 @@ var/list/teleport_other_runes = list()
 		if(M.stat == DEAD)
 			M.visible_message("<span class='warning'>[M] twitches.</span>")
 
-
+/*
 //Rite of Obscurity: Turns all runes within a 3-tile radius invisible or reveals them again.
 /obj/effect/rune/hide_runes
 	cultist_name = "Veil Runes"
@@ -619,7 +620,7 @@ var/list/teleport_other_runes = list()
 	invocation = "By'o isit!"
 	icon_state = "4"
 	color = rgb(0, 150, 0)
-
+*/
 /obj/effect/rune/make_runes_fake/invoke(mob/living/user)
 	visible_message("<span class='warning'>[src] flares brightly, then slowly dulls and appears mundane.</span>")
 	for(var/obj/effect/rune/R in range(3,src))
@@ -732,7 +733,7 @@ var/list/teleport_other_runes = list()
 		var/mob/living/carbon/C = user
 		C.apply_damage(2, BRUTE, pick("l_arm", "r_arm"))
 
-
+/*
 //Rite of the Shadowed Mind:  Deafens, blinds and mutes all non-cultists nearby.
 /obj/effect/rune/deafen
 	cultist_name = "Debilitate"
@@ -770,6 +771,7 @@ var/list/teleport_other_runes = list()
 			M.Stun(3)
 			M.flash_eyes(1,1)
 	qdel(src)
+*/
 //Rite of Joined Souls: Summons a single cultist.
 /obj/effect/rune/summon
 	cultist_name = "Summon Cultist"
@@ -813,7 +815,7 @@ var/list/teleport_other_runes = list()
 
 //Rite of Binding: Turns a nearby rune and a paper on top of the rune to a talisman, if both are valid.
 /obj/effect/rune/imbue
-	cultist_name = "Bind Talisman"
+	cultist_name = "Create Talisman"
 	cultist_desc = "Transforms papers and valid runes into talismans."
 	invocation = null //no talisman made, no invocation.
 	icon_state = "3"
@@ -823,6 +825,7 @@ var/list/teleport_other_runes = list()
 	var/turf/T = get_turf(src)
 	var/list/papers_on_rune = list()
 	var/entered_talisman_name
+	var/obj/item/weapon/paper/talisman/talisman_type
 	var/list/possible_talismans = list()
 	for(var/obj/item/weapon/paper/P in T)
 		if(!P.info)
@@ -834,12 +837,18 @@ var/list/teleport_other_runes = list()
 		return
 	var/obj/item/weapon/paper/paper_to_imbue = pick(papers_on_rune)
 	for(var/I in subtypesof(/obj/item/weapon/paper/talisman) - /obj/item/weapon/paper/talisman/malformed - /obj/item/weapon/paper/talisman/supply)
-		possible_talismans.Add(I) //This is to allow the menu to let cultists select talismans by name
+		var/obj/item/weapon/paper/talisman/J = I
+		if(initial(J.cultist_name))
+			possible_talismans.Add(initial(J.cultist_name)) //This is to allow the menu to let cultists select talismans by name
 	entered_talisman_name = input(user, "Choose a talisman to imbue.", "Talisman Choices") as null|anything in possible_talismans
 	if(!Adjacent(user) || !src || qdeleted(src) || user.incapacitated())
 		return
-	var/talisman_type = entered_talisman_name
+	for(var/I in typesof(/obj/item/weapon/paper/talisman))
+		var/obj/effect/rune/J = I
+		if(initial(J.cultist_name) == entered_talisman_name)
+			talisman_type = J
 	user.say("H'drak v'loso, mir'kanas verbot!")
+	visible_message("<span class='warning'>Dark power begins to channel into the paper!.</span>")
 	if(!do_after(user, 150, target = get_turf(user)))
 		return
 	var/obj/item/weapon/paper/talisman/TA = new talisman_type(get_turf(src))
@@ -847,17 +856,12 @@ var/list/teleport_other_runes = list()
 		var/the_keyword = stripped_input(usr, "Please enter a keyword for the talisman.", "Enter Keyword", "")
 		var/obj/item/weapon/paper/talisman/teleport/TELE = TA
 		TELE.keyword = the_keyword
-	else
-		user << "<span class='cultitalic'>You have failed the ritual!</span>"
-		fail_invoke()
-		log_game("Talisman Imbue rune failed - chosen rune invalid")
-		return
 	visible_message("<span class='warning'>[src] crumbles to dust, and bloody images form themselves on [paper_to_imbue].</span>")
 	qdel(paper_to_imbue)
 	qdel(src)
 //Rite of Fabrication: Creates a construct shell out of 5 metal sheets.
 /obj/effect/rune/construct_shell
-	cultist_name = "Fabricate Shell"
+	cultist_name = "Summon Construct Shell"
 	cultist_desc = "Turns five plasteel sheets into an empty construct shell, suitable for containing a soul shard."
 	invocation = null //see below; doesn't say the invocation unless there's enough sheets.
 	icon_state = "5"
@@ -902,7 +906,7 @@ var/list/teleport_other_runes = list()
 	qdel(src)
 
 
-//Rite of Leeching: Deals brute damage to the target and heals the same amount to the invoker.
+/*Rite of Leeching: Deals brute damage to the target and heals the same amount to the invoker.
 /obj/effect/rune/leeching
 	cultist_name = "Drain Life"
 	cultist_desc = "Drains the life of the target on the rune, restoring it to the user."
@@ -930,7 +934,7 @@ var/list/teleport_other_runes = list()
 	target << "<span class='cultitalic'>You feel extremely weak.</span>"
 	user.visible_message("<span class='warning'>Blood flows from the rune into [user]!</span>", \
 						 "<span class='cult'>[target]'s blood flows into you, healing your wounds and revitalizing your spirit.</span>")
-
+*/
 
 //Rite of Boiling Blood: Deals extremely high amounts of damage to non-cultists nearby
 /obj/effect/rune/blood_boil
@@ -1004,7 +1008,7 @@ var/list/teleport_other_runes = list()
 		for(var/obj/I in new_human)
 			new_human.unEquip(I)
 		new_human.dust()
-
+/*
 //Rite of Dimensional Corruption: Stops time around the rune for all non-cultists.
 /obj/effect/rune/timestop
 	cultist_name = "Time Stop"
@@ -1041,3 +1045,4 @@ var/list/teleport_other_runes = list()
 		if(iscultist(M) || M.null_rod_check())
 			immune |= M
 	..()
+*/

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -261,15 +261,15 @@ Rite of Disorientation
 			target.visible_message("<span class='warning'>[target]'s holy weapon absorbs the talisman's light!</span>", \
 								   "<span class='userdanger'>Your holy weapon absorbs the blinding light!</span>")
 		else
-			target.Weaken(9)
-			target.Stun(9)
+			target.Weaken(10)
+			target.Stun(10)
 			target.flash_eyes(1,1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = target
 				S.emp_act(1)
 			if(iscarbon(target))
 				var/mob/living/carbon/C = target
-				C.silent += 4
+				C.silent += 5
 				C.stuttering += 15
 				C.cultslurring += 15
 				C.Jitter(15)

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -294,9 +294,11 @@ Rite of Disorientation
 	user.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
 	user.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 
-/obj/item/weapon/paper/talisman/stun/attack(mob/living/target, mob/living/user)
+/obj/item/weapon/paper/talisman/horror/attack(mob/living/target, mob/living/user)
 	if(iscultist(user))
 		user.visible_message("<span class='cultitalic'>You disturb [target] with visons of the end!</span>")
 		if(iscarbon(target))
-				var/mob/living/carbon/H = target
-				H.reagents.add_reagent("mindbreaker", 30)
+			var/mob/living/carbon/H = target
+			H.reagents.add_reagent("mindbreaker", 30)
+		qdel(src)
+		return

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -160,7 +160,7 @@ Rite of Disorientation
 	if(iscultist(user) && keyword)
 		user << "<b>Keyword:</b> [keyword]"
 
-//Rite of Knowledge: Same as rune, but has two uses
+//Rite of Knowledge: Has two uses
 /obj/item/weapon/paper/talisman/summon_tome
 	cultist_name = "Talisman of Tome Summoning"
 	cultist_desc = "A one-use talisman that will call an untranslated tome from the archives of the Geometer."
@@ -211,7 +211,7 @@ Rite of Disorientation
 	cultist_name = "Talisman of Disguising"
 	cultist_desc = "A talisman that will make nearby runes appear fake."
 	invocation = "By'o nar'nar!"
-	health_cost = 3
+	health_cost = 0
 
 /obj/item/weapon/paper/talisman/make_runes_fake/invoke(mob/living/user)
 	user.visible_message("<span class='warning'>Dust flows from [user]s hand.</span>", \
@@ -236,14 +236,21 @@ Rite of Disorientation
 	cultist_name = "Talisman of Stunning"
 	cultist_desc = "A talisman that will stun and inhibit speech on a single target. To use, attack target directly."
 	invocation = "Fuu ma'jin!"
-	health_cost = 15
+	health_cost = 12
 
 //Rite of Arming: Equips cultist armor on the user, where available
 /obj/item/weapon/paper/talisman/armor
 	cultist_name = "Talisman of Arming"
 	cultist_desc = "A talisman that will equip the invoker with cultist equipment if there is a slot to equip it to."
 	invocation = "N'ath reth sh'yro eth draggathnor!"
-	health_cost = 3
+	health_cost = 0
+
+//Rite of Horrors: Breaks the mind of the victim with nightmarish hallucinations
+/obj/item/weapon/paper/talisman/horror
+	cultist_name = "Talisman of Horrors"
+	cultist_desc = "A talisman that will break the mind of the victim with nightmarish hallucinations."
+	invocation = "Na' Md'lo 'Nab!"
+	health_cost = 0
 
 /obj/item/weapon/paper/talisman/stun/attack_self(mob/living/user)
 	if(iscultist(user))
@@ -286,3 +293,10 @@ Rite of Disorientation
 	user.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult/alt(user), slot_shoes)
 	user.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
 	user.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
+
+/obj/item/weapon/paper/talisman/stun/attack(mob/living/target, mob/living/user)
+	if(iscultist(user))
+		user.visible_message("<span class='cultitalic'>You disturb [target] with visons of the end!</span>")
+		if(iscarbon(target))
+				var/mob/living/carbon/H = target
+				H.reagents.add_reagent("mindbreaker", 30)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -127,7 +127,7 @@
 		if(rand(1,2)==2)
 			if(lowertext(newletter)=="o")
 				newletter="u"
-			if(lowertext(newletter)=="s")
+			if(lowertext(newletter)=="t")
 				newletter="ch"
 			if(lowertext(newletter)=="a")
 				newletter="ah"
@@ -135,15 +135,15 @@
 				newletter="oo"
 			if(lowertext(newletter)=="c")
 				newletter=" NAR "
-			if(lowertext(newletter)=="t")
+			if(lowertext(newletter)=="s")
 				newletter=" SIE "
 		if(rand(1,4)==4)
 			if(newletter==" ")
-				newletter=" GLORY "
+				newletter=" no hope... "
 			if(newletter=="H")
-				newletter=" HAIL "
+				newletter=" IT COMES... "
 
-		switch(rand(1,10))
+		switch(rand(1,15))
 			if(1)
 				newletter="'"
 			if(2)
@@ -152,6 +152,8 @@
 				newletter="fth"
 			if(4)
 				newletter="nglu"
+			if(5)
+				newletter="glor"
 		newphrase+="[newletter]";counter-=1
 	return newphrase
 


### PR DESCRIPTION
...to the lowest common denominator. 

This PR is focused on SIMPLIFYING the current cult system. I carved out nearly half the runes and put a few in as talismans. The /\* runes */ I took out did not serve any practical purpose or play a unique role in how cult is played. Many of the niche runes like "hide" and "armor" are now exclusively talismans. 

The biggest change is that the imbue rune is now "create talisman". This was the single great barrier to players becoming effective cultists. Most cultists could not figure out how to create new talismans and therefore were virtually useless in expanding the cult. Now the process will simply bring up a menu asking which talisman you wish to create, and after a 15 second invocation channel the rune disappears and you get your talisman. 

One other notable addition is a "Horror Talisman", it has a relatively stealthy application and will give your victim a hefty dose of mindbreaker. Fits the theme of the cult and allows them to subtly undermine security or command staff. 

There are countless other tweaks and improvements, cultslur is slightly less potent, but other aspects of the stun talisman are slightly improved (still nerfed from the original oldcult variables). This will give the victim a small chance to get details about their location to the crew while slur'ing. Many rune and talisman names have been changed to their most intuitive form. 

If anyone doubts the necessity of this PR, please go open a tome and hit scribe rune, ask yourself how any new cultists is going to manage a list of indecipherable runes with a list that you have to actively scroll through with a small novel attached trying to explain the purpose of each. 
