### PR TITLE
Removes extra delay for drawing a narsie summon and halves the damage.

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -247,12 +247,10 @@ This file contains the arcane tome files as well as innate cultist emergency com
 		var/mob/living/carbon/C = user
 		C.apply_damage(0.1, BRUTE, pick("l_arm", "r_arm"))
 		if("Call Forth The Geometer" == entered_rune_name)
-			C.apply_damage(40, BRUTE, pick("l_arm", "r_arm"))
+			C.apply_damage(20, BRUTE, pick("l_arm", "r_arm"))
 			var/area/A = get_area(src)
 			var/locname = initial(A.name)
 			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual before it reaches a critical point.","Central Command Higher Dimensionsal Affairs")
-			if(!do_after(user, 500, target = get_turf(user)))
-				return
 	if(!do_after(user, 50, target = get_turf(user)))
 		return
 	user.visible_message("<span class='warning'>[user] creates a strange circle in their own blood.</span>", \


### PR DESCRIPTION
The extreme delay for drawing the summon was absolutely terrible. You had to stand completely still for ages, looking like you were afk, and if anyone pushed you, you'd have to start all over again. The damage was also applied first, and is ridiculous compared to normal rune damage.

I'm keeping the message as it works both to tell the crew to try and stop you before you manage to get enough cult around the rune, and tells your cult members to go gather around.
