### PR TITLE
Syndicate bomb delay wire changed to one time use

### DIFF
--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -16,6 +16,7 @@
 
 /datum/wires/syndicatebomb/on_pulse(wire)
 	var/obj/machinery/syndicatebomb/B = holder
+	var/delayed = 0
 	switch(wire)
 		if(WIRE_BOOM)
 			if(B.active)
@@ -24,9 +25,13 @@
 		if(WIRE_UNBOLT)
 			holder.visible_message("<span class='notice'>\icon[B] The bolts spin in place for a moment.</span>")
 		if(WIRE_DELAY)
-			holder.visible_message("<span class='notice'>\icon[B] The bomb chirps.</span>")
-			playsound(B, 'sound/machines/chime.ogg', 30, 1)
-			B.timer += 10
+			if(delayed)
+				holder.visible_message("<span class='notice'>\icon[B] The bomb has already been delayed.</span>")
+			else
+				holder.visible_message("<span class='notice'>\icon[B] The bomb chirps.</span>")
+				playsound(B, 'sound/machines/chime.ogg', 30, 1)
+				B.timer += 30
+				delayed = 1
 		if(WIRE_PROCEED)
 			holder.visible_message("<span class='danger'>\icon[B] The bomb buzzes ominously!</span>")
 			playsound(B, 'sound/machines/buzz-sigh.ogg', 30, 1)

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -25,13 +25,13 @@
 		if(WIRE_UNBOLT)
 			holder.visible_message("<span class='notice'>\icon[B] The bolts spin in place for a moment.</span>")
 		if(WIRE_DELAY)
-			if(delayed)
+			if(B.delayedbig)
 				holder.visible_message("<span class='notice'>\icon[B] The bomb has already been delayed.</span>")
 			else
 				holder.visible_message("<span class='notice'>\icon[B] The bomb chirps.</span>")
 				playsound(B, 'sound/machines/chime.ogg', 30, 1)
 				B.timer += 30
-				delayed = 1
+				B.delayedbig = TRUE
 		if(WIRE_PROCEED)
 			holder.visible_message("<span class='danger'>\icon[B] The bomb buzzes ominously!</span>")
 			playsound(B, 'sound/machines/buzz-sigh.ogg', 30, 1)
@@ -47,9 +47,12 @@
 				playsound(B, 'sound/machines/click.ogg', 30, 1)
 				B.active = TRUE
 				B.update_icon()
+			if(B.delayedlittle)
+				holder.visible_message("<span class='notice'>\icon[B] Nothing happens.</span>")
 			else
 				holder.visible_message("<span class='notice'>\icon[B] The bomb seems to hesitate for a moment.</span>")
-				B.timer += 5
+				B.timer += 10
+				B.delayedlittle = TRUE
 
 /datum/wires/syndicatebomb/on_cut(wire, mend)
 	var/obj/machinery/syndicatebomb/B = holder

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -46,7 +46,7 @@
 				playsound(B, 'sound/machines/click.ogg', 30, 1)
 				B.active = TRUE
 				B.update_icon()
-			if(B.delayedlittle)
+			else if(B.delayedlittle)
 				holder.visible_message("<span class='notice'>\icon[B] Nothing happens.</span>")
 			else
 				holder.visible_message("<span class='notice'>\icon[B] The bomb seems to hesitate for a moment.</span>")

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -16,7 +16,6 @@
 
 /datum/wires/syndicatebomb/on_pulse(wire)
 	var/obj/machinery/syndicatebomb/B = holder
-	var/delayed = 0
 	switch(wire)
 		if(WIRE_BOOM)
 			if(B.active)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -15,6 +15,8 @@
 	var/defused = FALSE		//is the bomb capable of exploding?
 	var/obj/item/weapon/bombcore/payload = /obj/item/weapon/bombcore
 	var/beepsound = 'sound/items/timer.ogg'
+	var/delayedbig = FALSE	//delay wire pulsed?
+	var/delayedlittle  = FALSE	//activation wire pulsed?
 
 /obj/machinery/syndicatebomb/process()
 	if(active && !defused && (timer > 0)) 	//Tick Tock
@@ -216,6 +218,8 @@
 			holder.wires.shuffle_wires()
 		holder.defused = 0
 		holder.open_panel = 0
+		holder.delayedbig = FALSE
+		holder.delayedlittle = FALSE
 		holder.update_icon()
 		holder.updateDialog()
 


### PR DESCRIPTION
Pulsing is only possible once now and the time gained from it is changed from 10 seconds to 30 seconds.
 ~~Fixes  #16774~~ nevermind, it's apparently not related directly to this

~~I hope that variable thing works correctly. I'm not sure if it can be added to this wire file like that or to the bomb file as a bomb variable.~~ Fixed

:cl: Lati
tweak: Syndicate bomb can be only delayed once by pulsing the delay wire. Time gained from this is changed from 10 seconds to 30 seconds.
/:cl:
