### PR TITLE
Adds new ionlaws: This new class of ion laws causes the AI to use wrong names

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -491,7 +491,7 @@
 						if(3) //X is Ying an abstract
 							message = "THE [ionabstract] IS [ionverb] THE [ionadjectiveshalf][ionobjects]"
 		if(40 to 41)// the X is now named Y
-			switch(rand(1,)) //What is being renamed?
+			switch(rand(1,5)) //What is being renamed?
 				if(1)//Areas
 					switch(rand(1,4)//What is the area being renamed to?
 						if(1)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -93,7 +93,7 @@
 
 	var/message = ""
 
-	switch(rand(1,39))
+	switch(rand(1,41))
 		if(1 to 3) //There are # X on the station
 			switch(rand(1,3)) //What is X?
 				if(1) //X is a threat
@@ -490,7 +490,61 @@
 							message = "[ionabstract] IS [ionverb] THE [ionadjectiveshalf][ionthreats]"
 						if(3) //X is Ying an abstract
 							message = "THE [ionabstract] IS [ionverb] THE [ionadjectiveshalf][ionobjects]"
-
+		if(40 to 41)// the X is now named Y
+			switch(rand(1,)) //What is being renamed?
+				if(1)//Areas
+					switch(rand(1,4)//What is the area being renamed to?
+						if(1)
+							message = "[ionarea] IS NOW NAMED [ioncrew1]."
+						if(2)
+							message = "[ionarea] IS NOW NAMED [ionspecies]."
+						if(3)
+							message = "[ionarea] IS NOW NAMED [ionobjects]."
+						if(4)
+							message = "[ionarea] IS NOW NAMED [ionthreats]."
+				if(2)//Crew
+					switch(rand(1,5)//What is the crew being renamed to?
+						if(1)
+							message = "ALL [ioncrew1] ARE NOW NAMED [ionarea]."
+						if(2)
+							message = "ALL [ioncrew1] ARE NOW NAMED [ioncrew2]."
+						if(3)
+							message = "ALL [ioncrew1] ARE NOW NAMED [ionspecies]."
+						if(4)
+							message = "ALL [ioncrew1] ARE NOW NAMED [ionobjects]."
+						if(5)
+							message = "ALL [ioncrew1] ARE NOW NAMED [ionthreats]."
+				if(3)//Races
+					switch(rand(1,4)//What is the race being renamed to?
+						if(1)
+							message = "ALL [ionspecies] ARE NOW NAMED [ionarea]."
+						if(2)
+							message = "ALL [ionspecies] ARE NOW NAMED [ioncrew1]."
+						if(3)
+							message = "ALL [ionspecies] ARE NOW NAMED [ionobjects]."
+						if(4)
+							message = "ALL [ionspecies] ARE NOW NAMED [ionthreats]."
+				if(4)//Objects
+					switch(rand(1,4)//What is the object being renamed to?
+						if(1)
+							message = "ALL [ionobjects] ARE NOW NAMED [ionarea]."
+						if(2)
+							message = "ALL [ionobjects] ARE NOW NAMED [ioncrew1]."
+						if(3)
+							message = "ALL [ionobjects] ARE NOW NAMED [ionspecies]."
+						if(4)
+							message = "ALL [ionobjects] ARE NOW NAMED [ionthreats]."
+				if(5)//Threats
+					switch(rand(1,4)//What is the object being renamed to?
+						if(1)
+							message = "ALL [ionthreats] ARE NOW NAMED [ionarea]."
+						if(2)
+							message = "ALL [ionthreats] ARE NOW NAMED [ioncrew1]."
+						if(3)
+							message = "ALL [ionthreats] ARE NOW NAMED [ionspecies]."
+						if(4)
+							message = "ALL [ionthreats] ARE NOW NAMED [ionobjects]."
+							
 	return message
 
 #undef ION_RANDOM

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -493,7 +493,7 @@
 		if(40 to 41)// the X is now named Y
 			switch(rand(1,5)) //What is being renamed?
 				if(1)//Areas
-					switch(rand(1,4)//What is the area being renamed to?
+					switch(rand(1,4))//What is the area being renamed to?
 						if(1)
 							message = "[ionarea] IS NOW NAMED [ioncrew1]."
 						if(2)
@@ -503,7 +503,7 @@
 						if(4)
 							message = "[ionarea] IS NOW NAMED [ionthreats]."
 				if(2)//Crew
-					switch(rand(1,5)//What is the crew being renamed to?
+					switch(rand(1,5))//What is the crew being renamed to?
 						if(1)
 							message = "ALL [ioncrew1] ARE NOW NAMED [ionarea]."
 						if(2)
@@ -515,7 +515,7 @@
 						if(5)
 							message = "ALL [ioncrew1] ARE NOW NAMED [ionthreats]."
 				if(3)//Races
-					switch(rand(1,4)//What is the race being renamed to?
+					switch(rand(1,4))//What is the race being renamed to?
 						if(1)
 							message = "ALL [ionspecies] ARE NOW NAMED [ionarea]."
 						if(2)
@@ -525,7 +525,7 @@
 						if(4)
 							message = "ALL [ionspecies] ARE NOW NAMED [ionthreats]."
 				if(4)//Objects
-					switch(rand(1,4)//What is the object being renamed to?
+					switch(rand(1,4))//What is the object being renamed to?
 						if(1)
 							message = "ALL [ionobjects] ARE NOW NAMED [ionarea]."
 						if(2)
@@ -535,7 +535,7 @@
 						if(4)
 							message = "ALL [ionobjects] ARE NOW NAMED [ionthreats]."
 				if(5)//Threats
-					switch(rand(1,4)//What is the object being renamed to?
+					switch(rand(1,4))//What is the object being renamed to?
 						if(1)
 							message = "ALL [ionthreats] ARE NOW NAMED [ionarea]."
 						if(2)


### PR DESCRIPTION
A simple change to ion laws.  This simply causes the AI to refer to things by the wrong name, which can wreak havoc on the station, for example, if the AI starts referring to all assistants as "NON HUMAN"
