### PR TITLE
Restricts certain uplink items from appearing in low pop

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1082,6 +1082,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			but you never know. Contents are sorted to always be worth 50 TC."
 	item = /obj/structure/closet/crate
 	cost = 20
+	player_minimum = 30
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/badass/surplus/spawn_item(turf/loc, obj/item/device/uplink/U)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -24,6 +24,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 					continue
 				if(gamemode && (gamemode in I.exclude_modes))
 					continue
+			if(I.player_minimum && I.player_minimum > joined_player_list.len)
+				continue
+
 			if(!filtered_uplink_items[category])
 				filtered_uplink_items[category] = list()
 			filtered_uplink_items[category][item] = I
@@ -46,6 +49,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	var/surplus = 100 // Chance of being included in the surplus crate.
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
+	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
@@ -304,6 +308,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/guardian
 	cost = 12
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	player_minimum = 25
 
 // Ammunition
 /datum/uplink_item/ammo
@@ -634,6 +639,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/clothing/shoes/chameleon
 	cost = 2
 	exclude_modes = list(/datum/game_mode/nuclear)
+	player_minimum = 25
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	name = "Stealthy No-Slip Chameleon Shoes"
@@ -954,6 +960,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			cocktail which has a mild healing effect along with removing all stuns and increasing movement speed."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	cost = 8
+	player_minimum = 25
 
 /datum/uplink_item/implants/storage
 	name = "Storage Implant"


### PR DESCRIPTION
:cl: Kor
rscadd: Adrenals, no slips, surplus crates and SUHTANDOS now have minimum population requirements before they can be purchased.
/:cl:

Adrenals, no slips, and suhtandos will not appear if the crew is smaller than 25 players.

Surplus crate requires 30 players.

> but kor why these items?

Because they all greatly increase a traitors survivability/stun resistance, which is fine with a full crew, but bad when there is only a single officer or ragtag collection of vigilantes trying to stop the bad guy.

This won't fix the problem entirely, but it will mean that the clown PDA will be enough to stop the rampage, no matter how many guns the guy stole from the armory.
