### PR TITLE
Adds meth mixing related explosions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -134,6 +134,29 @@
 		PoolOrNew(/obj/effect/hotspot, turf)
 	holder.chem_temp = 1000 // hot as shit
 
+
+/datum/chemical_reaction/reagent_explosion/methsplosion/
+	name = "Meth explosion"
+	id = "methboom1"
+	result = "methboom1"
+	result_amount = 1
+	required_temp = 380 //slightly above the meth mix time.
+	required_reagents = list("methamphetamine" = 1)
+	strengthdiv = 6
+	modifier = 1
+
+/datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
+	var/turf/T = get_turf(holder.my_atom)
+	for(var/turf/turf in range(1,T))
+		PoolOrNew(/obj/effect/hotspot, turf)
+	holder.chem_temp = 1000 // hot as shit
+	..()
+
+/datum/chemical_reaction/reagent_explosion/methsplosion/methboom2
+	required_reagents = list("diethylamine" = 1, "iodine" = 1, "phosphorus" = 1, "hydrogen" = 1) //diethylamine is often left over from mixing the ephedrine.
+	required_temp = 300 //room temperature, chilling it even a little will prevent the explosion
+	result_amount = 4
+
 /datum/chemical_reaction/sorium
 	name = "Sorium"
 	id = "sorium"


### PR DESCRIPTION
:cl:
rscadd: Meth labs can now blow up if you don't purify the ingredients or over-heat the end product.
/:cl:

So, if meth is heated too high, it will blow up,
Or, if you have diethlyamine in the meth mixture.  (diethlaymine is an ingredient for epinephrine, and often left over)
