### PR TITLE
Floorbots can replace existing floor tiles with loadable custom tiles

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -112,7 +112,7 @@
 	if(istype(W, /obj/item/stack/tile))
 		if(specialtiles >= maxtiles)
 			return
-		tiletype = W  //This still needs its own path inside the bot
+		tiletype = W.type
 		var/loaded = min(maxtiles-specialtiles, tiletype.amount)
 		tiletype.use(loaded)
 		specialtiles += loaded
@@ -146,8 +146,12 @@
 			anchored = !anchored
 		if("eject")
 			if(specialtiles)
-				tiletype.loc = get_turf(src)
+				if(tiletype == null) //Just to be safe
+					speak("Something went wrong!")
+					return
+				var/obj/item/stack/tile/T = new tiletype(get_turf(src), specialtiles)
 				specialtiles = 0
+				tiletype = null
 
 		if("bridgemode")
 			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")
@@ -363,7 +367,8 @@
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
 	if(specialtiles)
-		tiletype.loc = Tsec
+		var/obj/item/stack/tile/T = new tiletype(Tsec, specialtiles)
+		specialtiles = 0
 		tiletype = null
 
 	if(prob(50))

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -149,7 +149,7 @@
 				if(tiletype == null) //Just to be safe
 					speak("Something went wrong!")
 					return
-				var/obj/item/stack/tile/T = new tiletype(get_turf(src), specialtiles)
+				new tiletype(get_turf(src), specialtiles)
 				specialtiles = 0
 				tiletype = null
 
@@ -366,8 +366,8 @@
 
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
-	if(specialtiles)
-		var/obj/item/stack/tile/T = new tiletype(Tsec, specialtiles)
+	if(specialtiles && tiletype != null)
+		new tiletype(Tsec, specialtiles)
 		specialtiles = 0
 		tiletype = null
 

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -91,17 +91,17 @@
 
 	return dat
 
-	/mob/living/simple_animal/bot/floorbot/attackby(obj/item/W , mob/user, params)
-		if(istype(W, /obj/item/stack/tile/plasteel))
-			user << "<span class='notice'>The floorbot can produce normal tiles itself.</span>"
+/mob/living/simple_animal/bot/floorbot/attackby(obj/item/W , mob/user, params)
+	if(istype(W, /obj/item/stack/tile/plasteel))
+		user << "<span class='notice'>The floorbot can produce normal tiles itself.</span>"
+		return
+	if(specialtiles != 0 && istype(W, /obj/item/stack/tile/))
+		var/obj/item/stack/tile/usedtile = W
+		if(usedtile != tiletype)
+			user << "<span class='warning'>Different custom tiles are already inside the floorbot.</span>"
 			return
-		if(specialtiles != 0 && istype(W, /obj/item/stack/tile/))
-			var/obj/item/stack/tile/usedtile = W
-			if(usedtile != tiletype)
-				user << "<span class='warning'>Different custom tiles are already inside the floorbot.</span>"
-				return
-		if(istype(W, /obj/item/stack/tile/) && specialtiles == 0)
-			tiletype = W
+	if(istype(W, /obj/item/stack/tile/))
+		tiletype = W
 		if(specialtiles >= 100)
 			return
 		var/loaded = min(100-specialtiles, tiletype.amount)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -32,7 +32,7 @@
 	#define FIX_TILE		3
 	#define AUTO_TILE		4
 	#define PLACE_TILE		5
-	#define PLACE_TILE		6
+	#define REPLACE_TILE		6
 	#define TILE_EMAG		7
 
 /mob/living/simple_animal/bot/floorbot/New()
@@ -95,7 +95,7 @@
 		if(istype(W, /obj/item/stack/tile/plasteel))
 			user << "<span class='notice'>The floorbot can produce normal tiles itself.</span>"
 			return
-		if(specialtiles != 0 && istype(W, /obj/item/stack/tile/)
+		if(specialtiles != 0 && istype(W, /obj/item/stack/tile/))
 			var/obj/item/stack/tile/usedtile = W
 			if(usedtile != tiletype)
 				user << "<span class='warning'>Different custom tiles are already inside the floorbot.</span>"
@@ -108,7 +108,7 @@
 		tiletype.use(loaded)
 		specialtiles += loaded
 		if(loaded > 0)
-			user << "<span class='notice'>You load [loaded] tiles into the floorbot. He now contains [specialtiles] tiles.</span>"
+			user << "<span class='notice'>You load [loaded] tiles into the floorbot. It now contains [specialtiles] tiles.</span>"
 		else
 			user << "<span class='warning'>You need at least one floor tile to put into [src]!</span>"
 	else

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -110,10 +110,10 @@
 			user << "<span class='warning'>Different custom tiles are already inside the floorbot.</span>"
 			return
 	if(istype(W, /obj/item/stack/tile))
-		if(specialtiles >= 100)
+		if(specialtiles >= maxtiles)
 			return
 		tiletype = W  //This still needs its own path inside the bot
-		var/loaded = min(100-specialtiles, tiletype.amount)
+		var/loaded = min(maxtiles-specialtiles, tiletype.amount)
 		tiletype.use(loaded)
 		specialtiles += loaded
 		if(loaded > 0)
@@ -144,9 +144,10 @@
 			autotile = !autotile
 		if("anchor")
 			anchored = !anchored
-		if("eject" && specialtiles)
-			tiletype.loc = get_turf(src)
-			specialtiles = 0
+		if("eject")
+			if(specialtiles)
+				tiletype.loc = get_turf(src)
+				specialtiles = 0
 
 		if("bridgemode")
 			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -8,6 +8,9 @@
 	anchored = 0
 	health = 25
 	maxHealth = 25
+	
+	radio_key = /obj/item/device/encryptionkey/headset_eng
+	radio_channel = "Engineering"
 
 	bot_type = FLOOR_BOT
 	model = "Floorbot"
@@ -95,15 +98,15 @@
 	if(istype(W, /obj/item/stack/tile/plasteel))
 		user << "<span class='notice'>The floorbot can produce normal tiles itself.</span>"
 		return
-	if(specialtiles != 0 && istype(W, /obj/item/stack/tile/))
+	if(specialtiles && istype(W, /obj/item/stack/tile))
 		var/obj/item/stack/tile/usedtile = W
-		if(usedtile != tiletype)
+		if(usedtile.type != tiletype.type)
 			user << "<span class='warning'>Different custom tiles are already inside the floorbot.</span>"
 			return
-	if(istype(W, /obj/item/stack/tile/))
-		tiletype = W
+	if(istype(W, /obj/item/stack/tile))
 		if(specialtiles >= 100)
 			return
+		tiletype = W  //This still needs its own path inside the bot
 		var/loaded = min(100-specialtiles, tiletype.amount)
 		tiletype.use(loaded)
 		specialtiles += loaded
@@ -306,11 +309,11 @@
 	else
 		
 		var/turf/open/floor/F = target_turf
-		if(replacetiles && F != tiletype.turf_type)
+		if(replacetiles && F.type != tiletype.turf_type)
 			mode = BOT_REPAIRING
 			visible_message("<span class='notice'>[src] begins replacing the floor tiles.</span>")
 			spawn(50)
-				if(mode == BOT_REPAIRING)
+				if(mode == BOT_REPAIRING && F)
 					F.broken = 0
 					F.burnt = 0
 					F.ChangeTurf(tiletype.turf_type)
@@ -326,7 +329,7 @@
 			mode = BOT_REPAIRING
 			visible_message("<span class='notice'>[src] begins repairing the floor.</span>")
 			spawn(50)
-				if(mode == BOT_REPAIRING)
+				if(mode == BOT_REPAIRING && F)
 					F.broken = 0
 					F.burnt = 0
 					F.ChangeTurf(/turf/open/floor/plasteel)

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -333,7 +333,7 @@
 			mode = BOT_REPAIRING
 			visible_message("<span class='notice'>[src] begins replacing the floor tiles.</span>")
 			spawn(50)
-				if(mode == BOT_REPAIRING && F)
+				if(mode == BOT_REPAIRING && F && specialtiles)
 					F.broken = 0
 					F.burnt = 0
 					F.ChangeTurf(initial(tiletype.turf_type))

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -265,7 +265,7 @@
 				result = F
 		if(REPLACE_TILE)
 			F = scan_target
-			if(istype(F, /turf/open/floor) && !istype(F, /turf/open/floor/plating) //The floor must already have a tile.
+			if(istype(F, /turf/open/floor) && !istype(F, /turf/open/floor/plating)) //The floor must already have a tile.
 				result = F
 		if(FIX_TILE)	//Selects only damaged floors.
 			F = scan_target

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -23,6 +23,7 @@
 	var/replacetiles = 0
 	var/placetiles = 0
 	var/specialtiles = 0
+	var/maxtiles = 100
 	var/obj/item/stack/tile/tiletype
 	var/fixfloors = 0
 	var/autotile = 0
@@ -76,7 +77,12 @@
 	dat += "<TT><B>Floor Repairer Controls v1.1</B></TT><BR><BR>"
 	dat += "Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
-	dat += "Special tiles left: [specialtiles]<BR>"
+	dat += "Special tiles: "
+	if(specialtiles)
+		dat += "<A href='?src=\ref[src];eject=1'>Loaded \[[specialtiles]/[maxtiles]\]</a>"
+	else
+		dat += "None Loaded"
+	
 	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
 	if(!locked || issilicon(user) || IsAdminGhost(user))
 		dat += "Add tiles to new hull plating: <A href='?src=\ref[src];operation=autotile'>[autotile ? "Yes" : "No"]</A><BR>"
@@ -138,6 +144,9 @@
 			autotile = !autotile
 		if("anchor")
 			anchored = !anchored
+		if("eject" && specialtiles)
+			tiletype.loc = get_turf(src)
+			specialtiles = 0
 
 		if("bridgemode")
 			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")
@@ -351,6 +360,10 @@
 	N.contents = list()
 
 	new /obj/item/device/assembly/prox_sensor(Tsec)
+
+	if(specialtiles)
+		tiletype.loc = Tsec
+		tiletype = null
 
 	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)


### PR DESCRIPTION
Ready for merge.

I got this idea after floorbots were made to have unlimited amount of normal tiles. Now they can be loaded with any tile and if the replace option is enabled they will start replacing all floor tiles with the new ones until the floorbot runs out of them.

The code is partly based on the old code which was removed when the loading of normal floor tiles was removed. I've changed many things to work with custom tiles so I have no idea if this will even compile at first. Coders, please check if there's anything I can do to improve the code.

~~To do: add an eject button to eject any tiles currently loaded.~~ This is ready. 
~~This is not tested to work yet.~~

Also cleans up some unused code from floorbot.

:cl: Lati
rscadd: Custom floor tiles can now be added to floorbots. They will start replacing other tiles with these tiles if the option is toggled on.
/:cl:
