### PR TITLE
Fixes Seed runtimes

### DIFF
--- a/code/modules/crafting/table.dm
+++ b/code/modules/crafting/table.dm
@@ -272,28 +272,24 @@
 	if(name_text)
 		for(var/A in R.reqs)
 			if(ispath(A, /obj))
-				var/obj/O = new A
-				req_text += " [R.reqs[A]] [O.name]"
-				qdel(O)
-			if(ispath(A, /datum/reagent))
-				var/datum/reagent/RE = new A
-				req_text += " [R.reqs[A]] [RE.name]"
-				qdel(RE)
+				var/obj/O = A
+				req_text += " [R.reqs[A]] [initial(O.name)]"
+			else if(ispath(A, /datum/reagent))
+				var/datum/reagent/RE = A
+				req_text += " [R.reqs[A]] [initial(RE.name)]"
 
 		if(R.chem_catalysts.len)
 			catalist_text += ", Catalysts:"
 			for(var/C in R.chem_catalysts)
 				if(ispath(C, /datum/reagent))
-					var/datum/reagent/RE = new C
-					catalist_text += " [R.chem_catalysts[C]] [RE.name]"
-					qdel(RE)
+					var/datum/reagent/RE = C
+					catalist_text += " [R.chem_catalysts[C]] [initial(RE.name)]"
 
 		if(R.tools.len)
 			tool_text += ", Tools:"
 			for(var/O in R.tools)
 				if(ispath(O, /obj))
-					var/obj/T = new O
-					tool_text += " [R.tools[O]] [T.name]"
-					qdel(T)
+					var/obj/T = O
+					tool_text += " [R.tools[O]] [initial(T.name)]"
 
 		. = "[name_text][req_text][tool_text][catalist_text]<BR>"

--- a/code/modules/food&drinks/kitchen machinery/juicer.dm
+++ b/code/modules/food&drinks/kitchen machinery/juicer.dm
@@ -146,7 +146,7 @@
 			return allowed_items[i]
 
 /obj/machinery/juicer/proc/get_juice_amount(obj/item/weapon/reagent_containers/food/snacks/grown/O)
-	if (!istype(O))
+	if (!istype(O) || !O.seed)
 		return 5
 	else if (O.seed.potency == -1)
 		return 5

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -24,9 +24,6 @@
 		// This is for adminspawn or map-placed growns. They get the default stats of their seed type.
 		seed = new seed()
 		seed.adjust_potency(50-seed.potency)
-	else // Something is terribly wrong
-		qdel(src)
-		return
 
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
@@ -34,12 +31,12 @@
 	if(dried_type == -1)
 		dried_type = src.type
 
-	for(var/datum/plant_gene/trait/T in seed.genes)
-		T.on_new(src, newloc)
-
-	seed.prepare_result(src)
+	if(seed)
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_new(src, newloc)
+		seed.prepare_result(src)
+		transform *= TransformUsingVariable(seed.potency, 100, 0.5) //Makes the resulting produce's sprite larger or smaller based on potency!
 	add_juice()
-	transform *= TransformUsingVariable(seed.potency, 100, 0.5) //Makes the resulting produce's sprite larger or smaller based on potency!
 
 
 
@@ -52,15 +49,17 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/examine(user)
 	..()
-	for(var/datum/plant_gene/trait/T in seed.genes)
-		if(T.examine_line)
-			user << T.examine_line
+	if(seed)
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			if(T.examine_line)
+				user << T.examine_line
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attackby(obj/item/O, mob/user, params)
 	..()
 	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
 		var/msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>.\n"
-		msg += seed.get_analyzer_text()
+		if(seed)
+			msg += seed.get_analyzer_text()
 		msg += "\n- Nutritional value: [reagents.get_reagent_amount("nutriment")]\n"
 		msg += "- Other substances: [reagents.total_volume-reagents.get_reagent_amount("nutriment")]\n"
 		msg += "*---------*</span>"
@@ -70,10 +69,11 @@
 			"capsaicin" = "Capsaicin", "frostoil" = "Frost Oil", "gold" = "Mineral Content", "glycerol" = "Glycerol",
 			"radium" = "Highly Radioactive Material", "uranium" = "Radioactive Material")
 		var/reag_txt = ""
-		for(var/reagent_id in scannable_reagents)
-			if(reagent_id in seed.reagents_add)
-				var/amt = reagents.get_reagent_amount(reagent_id)
-				reag_txt += "\n<span class='info'>- [scannable_reagents[reagent_id]]: [amt*100/reagents.maximum_volume]%</span>"
+		if(seed)
+			for(var/reagent_id in scannable_reagents)
+				if(reagent_id in seed.reagents_add)
+					var/amt = reagents.get_reagent_amount(reagent_id)
+					reag_txt += "\n<span class='info'>- [scannable_reagents[reagent_id]]: [amt*100/reagents.maximum_volume]%</span>"
 
 		if(reag_txt)
 			msg += reag_txt
@@ -85,13 +85,14 @@
 
 // Various gene procs
 /obj/item/weapon/reagent_containers/food/snacks/grown/attack_self(mob/user)
-	if(seed.get_gene(/datum/plant_gene/trait/squash))
+	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		squash(user)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)
-	if(!..() && seed.get_gene(/datum/plant_gene/trait/squash)) //was it caught by a mob?
-		squash(hit_atom)
+	if(!..()) //was it caught by a mob?
+		if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
+			squash(hit_atom)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/proc/squash(atom/target)
 	var/turf/T = get_turf(target)
@@ -110,8 +111,9 @@
 			new trash(T)
 
 	visible_message("<span class='warning'>[src] has been squashed.</span>","<span class='italics'>You hear a smack.</span>")
-	for(var/datum/plant_gene/trait/trait in seed.genes)
-		trait.on_squash(src, target)
+	if(seed)
+		for(var/datum/plant_gene/trait/trait in seed.genes)
+			trait.on_squash(src, target)
 
 	for(var/A in T)
 		reagents.reaction(A)
@@ -120,43 +122,48 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/On_Consume()
 	if(iscarbon(usr))
-		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_consume(src, usr)
+		if(seed)
+			for(var/datum/plant_gene/trait/T in seed.genes)
+				T.on_consume(src, usr)
 	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/Crossed(atom/movable/AM)
-	var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
-	if(S && !ispath(trash, /obj/item/weapon/grown) && iscarbon(AM))
-		var/mob/living/carbon/M = AM
-		var/stun = max(seed.potency * S.rate * 2, 1)
-		var/weaken = max(seed.potency * S.rate, 0.5)
-		if(M.slip(stun, weaken, src))
-			for(var/datum/plant_gene/trait/T in seed.genes)
-				T.on_slip(src, M)
-		return 1
+	if(seed)
+		var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
+		if(S && !ispath(trash, /obj/item/weapon/grown) && iscarbon(AM))
+			var/mob/living/carbon/M = AM
+			var/stun = max(seed.potency * S.rate * 2, 1)
+			var/weaken = max(seed.potency * S.rate, 0.5)
+			if(M.slip(stun, weaken, src))
+				for(var/datum/plant_gene/trait/T in seed.genes)
+					T.on_slip(src, M)
+			return 1
 	..()
 
 
 // Glow gene procs
 /obj/item/weapon/reagent_containers/food/snacks/grown/Destroy()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G && ismob(loc))
-		loc.AddLuminosity(-G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G && ismob(loc))
+			loc.AddLuminosity(-G.get_lum(seed))
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pickup(mob/user)
 	..()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G)
-		SetLuminosity(0)
-		user.AddLuminosity(G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G)
+			SetLuminosity(0)
+			user.AddLuminosity(G.get_lum(seed))
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/dropped(mob/user)
 	..()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G)
-		user.AddLuminosity(-G.get_lum(seed))
-		SetLuminosity(G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G)
+			user.AddLuminosity(-G.get_lum(seed))
+			SetLuminosity(G.get_lum(seed))
 
 
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -36,7 +36,7 @@
 			T.on_new(src, newloc)
 		seed.prepare_result(src)
 		transform *= TransformUsingVariable(seed.potency, 100, 0.5) //Makes the resulting produce's sprite larger or smaller based on potency!
-	add_juice()
+		add_juice()
 
 
 

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -18,27 +18,27 @@
 		// This is for adminspawn or map-placed growns. They get the default stats of their seed type.
 		seed = new seed()
 		seed.adjust_potency(50-seed.potency)
-	else // Something is terribly wrong
-		qdel(src)
-		return
 
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
-	for(var/datum/plant_gene/trait/T in seed.genes)
-		T.on_new(src, newloc)
+	if(seed)
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_new(src, newloc)
 
-	if(istype(src, seed.product)) // no adding reagents if it is just a trash item
-		seed.prepare_result(src)
+		if(istype(src, seed.product)) // no adding reagents if it is just a trash item
+			seed.prepare_result(src)
+		transform *= TransformUsingVariable(seed.potency, 100, 0.5)
+
 	add_juice()
-	transform *= TransformUsingVariable(seed.potency, 100, 0.5)
 
 
 /obj/item/weapon/grown/attackby(obj/item/O, mob/user, params)
 	..()
 	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
 		var/msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>\n"
-		msg += seed.get_analyzer_text()
+		if(seed)
+			msg += seed.get_analyzer_text()
 		msg += "</span>"
 		usr << msg
 		return
@@ -50,35 +50,39 @@
 
 
 /obj/item/weapon/grown/Crossed(atom/movable/AM)
-	var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
-	if(S && iscarbon(AM))
-		var/mob/living/carbon/M = AM
-		var/stun = max(seed.potency * S.rate * 2, 1)
-		var/weaken = max(seed.potency * S.rate, 0.5)
-		if(M.slip(stun, weaken, src))
-			for(var/datum/plant_gene/trait/T in seed.genes)
-				T.on_slip(src, M)
-			return 1
+	if(seed)
+		var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
+		if(S && iscarbon(AM))
+			var/mob/living/carbon/M = AM
+			var/stun = max(seed.potency * S.rate * 2, 1)
+			var/weaken = max(seed.potency * S.rate, 0.5)
+			if(M.slip(stun, weaken, src))
+				for(var/datum/plant_gene/trait/T in seed.genes)
+					T.on_slip(src, M)
+				return 1
 	..()
 
 
 // Glow gene procs
 /obj/item/weapon/grown/Destroy()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G && ismob(loc))
-		loc.AddLuminosity(-G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G && ismob(loc))
+			loc.AddLuminosity(-G.get_lum(seed))
 	return ..()
 
 /obj/item/weapon/grown/pickup(mob/user)
 	..()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G)
-		SetLuminosity(0)
-		user.AddLuminosity(G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G)
+			SetLuminosity(0)
+			user.AddLuminosity(G.get_lum(seed))
 
 /obj/item/weapon/grown/dropped(mob/user)
 	..()
-	var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
-	if(G)
-		user.AddLuminosity(-G.get_lum(seed))
-		SetLuminosity(G.get_lum(seed))
+	if(seed)
+		var/datum/plant_gene/trait/glow/G = seed.get_gene(/datum/plant_gene/trait/glow)
+		if(G)
+			user.AddLuminosity(-G.get_lum(seed))
+			SetLuminosity(G.get_lum(seed))

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -29,8 +29,7 @@
 		if(istype(src, seed.product)) // no adding reagents if it is just a trash item
 			seed.prepare_result(src)
 		transform *= TransformUsingVariable(seed.potency, 100, 0.5)
-
-	add_juice()
+		add_juice()
 
 
 /obj/item/weapon/grown/attackby(obj/item/O, mob/user, params)

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -8,20 +8,22 @@
 
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown/))
 		var/obj/item/weapon/reagent_containers/food/snacks/grown/F = O
-		while(t_amount < t_max)
-			var/obj/item/seeds/t_prod = F.seed.Copy()
-			t_prod.loc = O.loc
-			t_amount++
-		qdel(O)
-		return 1
+		if(F.seed)
+			while(t_amount < t_max)
+				var/obj/item/seeds/t_prod = F.seed.Copy()
+				t_prod.loc = O.loc
+				t_amount++
+			qdel(O)
+			return 1
 
 	else if(istype(O, /obj/item/weapon/grown))
 		var/obj/item/weapon/grown/F = O
-		while(t_amount < t_max)
-			var/obj/item/seeds/t_prod = F.seed.Copy()
-			t_prod.loc = O.loc
-			t_amount++
-		qdel(O)
+		if(F.seed)
+			while(t_amount < t_max)
+				var/obj/item/seeds/t_prod = F.seed.Copy()
+				t_prod.loc = O.loc
+				t_amount++
+			qdel(O)
 		return 1
 
 	/*else if(istype(O, /obj/item/stack/tile/grass))

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -273,7 +273,7 @@
 						return juice_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_grownweapon_amount(obj/item/weapon/grown/O)
-		if (!istype(O))
+		if (!istype(O) || !O.seed)
 				return 5
 		else if (O.seed.potency == -1)
 				return 5
@@ -281,7 +281,7 @@
 				return round(O.seed.potency)
 
 /obj/machinery/reagentgrinder/proc/get_juice_amount(obj/item/weapon/reagent_containers/food/snacks/grown/O)
-		if (!istype(O))
+		if (!istype(O) || !O.seed)
 				return 5
 		else if (O.seed.potency == -1)
 				return 5


### PR DESCRIPTION
Simplifies the build_recipe_text() proc used by tablecrafting to not create and delete an object just to get its name (replaced by the "initial()" trick).

Adds some if(seed) checks to growns code to prevent runtimes for seedless growns. And we remove the auto-delete in grown/New() when seed is null. Oh god it's ugly, but since someone added a single non-abstract grown with null seed (_cough @KazeEspada cough_)  we have no choice...

 @Core0verload

Fixes #16800
