### PR TITLE
Improve ruins spawn logging

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -83,7 +83,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 					break
 
 			if(valid)
-				world.log << "Ruins marker placed at [T.x][T.y][T.z]"
+				world.log << "Ruins marker placed at ([T.x], [T.y], [T.z])"
 				var/obj/effect/ruin_loader/R = new /obj/effect/ruin_loader(T)
 				R.Load(potentialRuins,template)
 				ruin_number --


### PR DESCRIPTION
seedRuins will now log the x/y/z coordinates of its ruin spawns as a human-readable triplet.
Because `Ruins marker placed at 1761835` isn't that clear.
