### PR TITLE
New autolathe category for kitchen+bar items

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -41,6 +41,7 @@
 							"Machinery",
 							"Medical",
 							"Misc",
+							"Dinnerware",
 							"Imported"
 							)
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -94,6 +94,7 @@
 	flags = CONDUCT
 	force = 15
 	throwforce = 10
+	materials = list(MAT_METAL=18000)
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = 3
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -20,6 +20,7 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
+	materials = list(MAT_METAL=80)
 	flags = CONDUCT
 	origin_tech = "materials=1"
 	attack_verb = list("attacked", "stabbed", "poked")

--- a/code/modules/food&drinks/drinks/drinks.dm
+++ b/code/modules/food&drinks/drinks/drinks.dm
@@ -229,6 +229,7 @@
 	name = "shaker"
 	desc = "A metal shaker to mix drinks in."
 	icon_state = "shaker"
+	materials = list(MAT_METAL=1500)
 	amount_per_transfer_from_this = 10
 	volume = 100
 

--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -535,6 +535,7 @@
 	amount_per_transfer_from_this = 15
 	possible_transfer_amounts = list()
 	volume = 15
+	materials = list(MAT_GLASS=100)
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass/on_reagent_change()
 	if (gulp_size < 15)

--- a/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food&drinks/drinks/drinks/drinkingglass.dm
@@ -6,6 +6,7 @@
 	icon_state = "glass_empty"
 	amount_per_transfer_from_this = 10
 	volume = 50
+	materials = list(MAT_GLASS=500)
 	burn_state = FLAMMABLE
 	burntime = 5
 	spillable = 1

--- a/code/modules/food&drinks/food/customizables.dm
+++ b/code/modules/food&drinks/food/customizables.dm
@@ -300,6 +300,7 @@
 	icon = 'icons/obj/food/soupsalad.dmi'
 	icon_state = "bowl"
 	flags = OPENCONTAINER
+	materials = list()
 	w_class = 3
 
 /obj/item/weapon/reagent_containers/glass/bowl/attackby(obj/item/I,mob/user, params)

--- a/code/modules/food&drinks/food/customizables.dm
+++ b/code/modules/food&drinks/food/customizables.dm
@@ -300,7 +300,7 @@
 	icon = 'icons/obj/food/soupsalad.dmi'
 	icon_state = "bowl"
 	flags = OPENCONTAINER
-	materials = list()
+	materials = list(MAT_GLASS = 500)
 	w_class = 3
 
 /obj/item/weapon/reagent_containers/glass/bowl/attackby(obj/item/I,mob/user, params)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -139,6 +139,7 @@
 			dat += "<A href='?src=\ref[src];activate=1'>Activate</A><A href='?src=\ref[src];detach=1'>Detach Container</A>"
 			dat += "<h3>Food:</h3>"
 			dat += "<div class='statusDisplay'>"
+			dat += "Bowl: <A href='?src=\ref[src];create=bowl;amount=1'>Make</A><A href='?src=\ref[src];create=bowl;amount=5'>x5</A> ([10/efficiency])<BR>"
 			dat += "10 milk: <A href='?src=\ref[src];create=milk;amount=1'>Make</A><A href='?src=\ref[src];create=milk;amount=5'>x5</A> ([20/efficiency])<BR>"
 			dat += "10 cream: <A href='?src=\ref[src];create=cream;amount=1'>Make</A><A href='?src=\ref[src];create=cream;amount=5'>x5</A> ([30/efficiency])<BR>"
 			dat += "Milk carton: <A href='?src=\ref[src];create=cmilk;amount=1'>Make</A><A href='?src=\ref[src];create=cmilk;amount=5'>x5</A> ([100/efficiency])<BR>"
@@ -234,6 +235,10 @@
 
 /obj/machinery/biogenerator/proc/create_product(create)
 	switch(create)
+		if("bowl")
+			if (check_cost(10/efficiency))
+				return 0
+			else new/obj/item/weapon/reagent_containers/glass/bowl(src.loc)
 		if("milk")
 			if(check_container_volume(10))
 				return 0

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -139,7 +139,6 @@
 			dat += "<A href='?src=\ref[src];activate=1'>Activate</A><A href='?src=\ref[src];detach=1'>Detach Container</A>"
 			dat += "<h3>Food:</h3>"
 			dat += "<div class='statusDisplay'>"
-			dat += "Bowl: <A href='?src=\ref[src];create=bowl;amount=1'>Make</A><A href='?src=\ref[src];create=bowl;amount=5'>x5</A> ([10/efficiency])<BR>"
 			dat += "10 milk: <A href='?src=\ref[src];create=milk;amount=1'>Make</A><A href='?src=\ref[src];create=milk;amount=5'>x5</A> ([20/efficiency])<BR>"
 			dat += "10 cream: <A href='?src=\ref[src];create=cream;amount=1'>Make</A><A href='?src=\ref[src];create=cream;amount=5'>x5</A> ([30/efficiency])<BR>"
 			dat += "Milk carton: <A href='?src=\ref[src];create=cmilk;amount=1'>Make</A><A href='?src=\ref[src];create=cmilk;amount=5'>x5</A> ([100/efficiency])<BR>"
@@ -235,10 +234,6 @@
 
 /obj/machinery/biogenerator/proc/create_product(create)
 	switch(create)
-		if("bowl")
-			if (check_cost(10/efficiency))
-				return 0
-			else new/obj/item/weapon/reagent_containers/glass/bowl(src.loc)
 		if("milk")
 			if(check_container_volume(10))
 				return 0

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -624,6 +624,14 @@
 	build_path = /obj/item/ammo_box/c9mm
 	category = list("hacked", "Security")
 
+/datum/design/cleaver
+	name = "Butcher's cleaver"
+	id = "cleaver"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 18000)
+	build_path = /obj/item/weapon/kitchen/knife/butcher
+	category = list("hacked", "Dinnerware")
+
 /datum/design/spraycan
 	name = "Spraycan"
 	id = "spraycan"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -221,7 +221,7 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 12000)
 	build_path = /obj/item/weapon/kitchen/knife
-	category = list("initial","Misc")
+	category = list("initial","Dinnerware")
 
 /datum/design/cultivator
 	name = "Cultivator"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -231,6 +231,14 @@
 	build_path = /obj/item/weapon/kitchen/fork
 	category = list("initial","Dinnerware")
 
+/datum/design/bowl
+	name = "Bowl"
+	id = "bowl"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/glass/bowl
+	category = list("initial","Dinnerware")
+
 /datum/design/drinking_glass
 	name = "Drinking glass"
 	id = "drinking_glass"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -223,6 +223,22 @@
 	build_path = /obj/item/weapon/kitchen/knife
 	category = list("initial","Dinnerware")
 
+/datum/design/fork
+	name = "Fork"
+	id = "fork"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/kitchen/fork
+	category = list("initial","Dinnerware")
+
+/datum/design/drinking_glass
+	name = "Drinking glass"
+	id = "drinking_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass
+	category = list("initial","Dinnerware")
+
 /datum/design/cultivator
 	name = "Cultivator"
 	id = "cultivator"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -239,6 +239,22 @@
 	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass
 	category = list("initial","Dinnerware")
 
+/datum/design/shot_glass
+	name = "Shot glass"
+	id = "shot_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass
+	category = list("initial","Dinnerware")
+
+/datum/design/shaker
+	name = "Shaker"
+	id = "shaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/shaker
+	category = list("initial","Dinnerware")
+
 /datum/design/cultivator
 	name = "Cultivator"
 	id = "cultivator"


### PR DESCRIPTION
The autolathe has a new category, Dinnerware. The kitchen knife has been moved to this category. Forks, bowls, drinking glasses and butcher's cleavers can now be made from this category, cleavers being available if the autolathe is hacked.
Materials for the newly autolatheable items have been defined: 500 glass for a drinking glass or a bowl, same as beakers; 80 metal for a fork; 150 glass for a shot and 1500 metal for a shaker. Materials for a butcher's cleaver have been overrided to be 18000 metal.

This PR will add a way to make more bowls, making bug #16519 less of a problem.

:cl: Erwgd
rscadd: Forks, bowls, drinking glasses, shot glasses and shakers can now be made and recycled in the autolathe! Access the designs in the new 'Dinnerware' category.
tweak: Kitchen knives have been moved to the Dinnerware category of the autolathe.
rscadd: Butcher's cleavers can now be made in a hacked autolathe.
/:cl:
