### PR TITLE
Revert "Fabricator Efficiency Removal"

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -10,6 +10,9 @@
 	active_power_usage = 5000
 	req_access = list(access_robotics)
 	var/time_coeff = 1
+	var/resource_coeff = 1
+	var/time_coeff_tech = 1
+	var/resource_coeff_tech = 1
 	var/list/resources = list(
 								MAT_METAL=0,
 								MAT_GLASS=0,
@@ -63,6 +66,12 @@
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
 	res_max_amount = (187000+(T * 37500))
+
+	//ressources adjustment coefficient (1 -> 0.88 -> 0.75)
+	T = -1
+	for(var/obj/item/weapon/stock_parts/micro_laser/Ma in component_parts)
+		T += Ma.rating
+	resource_coeff = round(initial(resource_coeff) - (initial(resource_coeff)*(T))/8,0.01)
 
 	//building time adjustment coefficient (1 -> 0.8 -> 0.6)
 	T = -1
@@ -234,6 +243,30 @@
 		output += "\[<a href='?src=\ref[src];process_queue=1'>Process queue</a> | <a href='?src=\ref[src];clear_queue=1'>Clear queue</a>\]"
 	return output
 
+/obj/machinery/mecha_part_fabricator/proc/update_tech()
+	if(!files)
+		return
+	var/output
+	for(var/v in files.known_tech)
+		var/datum/tech/T = files.known_tech[v]
+		if(T && T.level > 1)
+			var/diff
+			switch(T.id)
+				if("materials")
+					//one materials level is 1/32, so that max level is 0.75 coefficient
+					diff = round(initial(resource_coeff_tech) - (initial(resource_coeff_tech)*(T.level-1))/32,0.01)
+					if(resource_coeff_tech>diff)
+						resource_coeff_tech = diff
+						output+="Production efficiency increased.<br>"
+				if("programming")
+					//one materials level is 1/40, so that max level is 0.8 coefficient
+					diff = round(initial(time_coeff_tech) - (initial(time_coeff_tech)*(T.level-1))/40,0.1)
+					if(time_coeff_tech>diff)
+						time_coeff_tech = diff
+						output+="Production routines updated.<br>"
+	return output
+
+
 /obj/machinery/mecha_part_fabricator/proc/sync()
 	temp = "Updating local R&D database..."
 	updateUsrDialog()
@@ -251,6 +284,7 @@
 		files.RefreshResearch()
 		temp = "Processed equipment designs.<br>"
 		//check if the tech coefficients have changed
+		temp += update_tech()
 		temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
 
 		updateUsrDialog()
@@ -262,10 +296,10 @@
 	return
 
 /obj/machinery/mecha_part_fabricator/proc/get_resource_cost_w_coeff(datum/design/D, resource, roundto = 1)
-	return round(D.materials[resource], roundto)
+	return round(D.materials[resource]*resource_coeff*resource_coeff_tech, roundto)
 
 /obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(datum/design/D, roundto = 1) //aran
-	return round(initial(D.construction_time)*time_coeff, roundto)
+	return round(initial(D.construction_time)*time_coeff*time_coeff_tech, roundto)
 
 /obj/machinery/mecha_part_fabricator/attack_hand(mob/user)
 	if(!(..()))


### PR DESCRIPTION
Reverts tgstation/-tg-station#16775.

It was merged with something like 100% negative feedback. It makes any good mech almost impossible to build, because all the miners are lavaded before they could bring enough minerals. It's another unnecessary nerf to mech building, which already was nerfed way too hard. Revert it now.
