### PR TITLE
Tweaks minimap

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -45,7 +45,7 @@ var/datum/subsystem/minimap/SSminimap
 	// Scale it up to our target size.
 	minimap.Scale(MINIMAP_SIZE, MINIMAP_SIZE)
 
-	var/counter = 1024
+	var/counter = 512
 	// Loop over turfs and generate icons.
 	for(var/T in block(locate(x1, y1, z), locate(x2, y2, z)))
 		generate_tile(T, minimap)
@@ -53,7 +53,7 @@ var/datum/subsystem/minimap/SSminimap
 		//byond bug, this fixes OOM crashes by flattening and reseting the minimap icon holder every so and so tiles
 		counter--
 		if(counter <= 0)
-			counter = 1024
+			counter = 512
 			var/icon/flatten = new /icon()
 			flatten.Insert(minimap, "", SOUTH, 1, 0)
 			del(minimap)

--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -45,15 +45,15 @@ var/datum/subsystem/minimap/SSminimap
 	// Scale it up to our target size.
 	minimap.Scale(MINIMAP_SIZE, MINIMAP_SIZE)
 
-	var/counter = 128
+	var/counter = 1024
 	// Loop over turfs and generate icons.
 	for(var/T in block(locate(x1, y1, z), locate(x2, y2, z)))
 		generate_tile(T, minimap)
 
-		//byond bug, this fixes OOM crashes by flattening and reseting the minimap icon holder every 128 tiles
+		//byond bug, this fixes OOM crashes by flattening and reseting the minimap icon holder every so and so tiles
 		counter--
 		if(counter <= 0)
-			counter = 128
+			counter = 1024
 			var/icon/flatten = new /icon()
 			flatten.Insert(minimap, "", SOUTH, 1, 0)
 			del(minimap)


### PR DESCRIPTION
Now that we know the crashes from minimaps are a case of the clean bot bug, we can re-enable them.

And this should make them faster as well.
