### PR TITLE
Lavaland Buterching and Suit Fixes

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -1047,7 +1047,9 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	hooded = 1
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	cold_protection = CHEST|GROIN|LEGS|ARMS
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+	heat_protection = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/explorer
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 20, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals, /obj/item/weapon/resonator, /obj/item/device/mining_scanner, /obj/item/device/t_scanner/adv_mining_scanner, /obj/item/weapon/gun/energy/kinetic_accelerator, /obj/item/weapon/pickaxe)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -645,7 +645,6 @@
 	icon_dead = "goliath_dead"
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
-	loot = list(/obj/item/asteroid/goliath_hide{layer = 4.1})
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/asteroid/goliath_hide = 1)
 	loot = list()
 	stat_attack = 1

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -631,6 +631,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	stat_attack = 1
 	robust_searching = 1
+	loot = list()
 	butcher_results = list(/obj/item/weapon/ore/diamond = 2)
 
 //Goliath

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -447,7 +447,7 @@
 
 /obj/item/asteroid/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
-		if(istype(target, /obj/item/clothing/suit/space/hardsuit/mining) || istype(target, /obj/item/clothing/suit/hooded/explorer))
+		if(istype(target, /obj/item/clothing/suit/space/hardsuit/mining) || istype(target, /obj/item/clothing/head/helmet/space/hardsuit/mining) ||  istype(target, /obj/item/clothing/suit/hooded/explorer) || istype(target, /obj/item/clothing/head/explorer))
 			var/obj/item/clothing/C = target
 			var/list/current_armor = C.armor
 			if(current_armor.["melee"] < 60)
@@ -631,9 +631,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	stat_attack = 1
 	robust_searching = 1
-	loot = list(/obj/item/weapon/ore/diamond{layer = 4.1},
-				/obj/item/weapon/ore/diamond{layer = 4.1})
-
+	butcher_results = list(/obj/item/weapon/ore/diamond = 2)
 
 //Goliath
 
@@ -648,7 +646,8 @@
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
 	loot = list(/obj/item/asteroid/goliath_hide{layer = 4.1})
-	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2)
+	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/asteroid/goliath_hide = 1)
+	loot = list()
 	stat_attack = 1
 	robust_searching = 1
 


### PR DESCRIPTION
Maybe these should be different PRs, but it was in the same file so oh well.

Fix: You can use the goliath plates on your hood/hardsuit helmet again

Fix: The explorer suit properly protects your body from cold/heat now.

Notfix: Goliath plates and Watcher diamonds are inside the mob, you butcher the mob to retrieve the stuff. I did this because muh immersions, but if people think it will just be obnoxious to stand there for a few seconds I guess it can be dropped. This only impacts the lavaland versions of the mobs, asteroid mobs die the same as always.

Legion hearts drop on the ground as usual because it'd be extra work to make the corpse it drops have the heart in it, and it's often important to grab them off the ground mid combat.

:cl:
rscadd: You now need to butcher goliaths and watchers on lavaland to receive their loot. Use the combat knives to do so.
/:cl:
