### PR TITLE
Nerfs the worst effects of alcohol

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -366,12 +366,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			blur_eyes(5)
 
 		if(drunkenness >= 81)
-			adjustToxLoss(0.2)
+			adjustToxLoss(0.1)
 			if(prob(5) && !stat)
 				src << "<span class='warning'>Maybe you should lie down for a bit...</span>"
 
 		if(drunkenness >= 91)
-			adjustBrainLoss(0.4)
 			if(prob(20) && !stat)
 				if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && z == ZLEVEL_STATION) //QoL mainly
 					src << "<span class='warning'>You're so tired... but you can't miss that shuttle...</span>"
@@ -380,6 +379,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 					Sleeping(45)
 
 		if(drunkenness >= 101)
-			adjustToxLoss(4) //Let's be honest you shouldn't be alive by now
+			adjustToxLoss(0.9)
 
 #undef HUMAN_MAX_OXYLOSS


### PR DESCRIPTION
Removes the brainloss

cuts normal tox loss from 0.2 to 0.1.

Cuts the ridiculous 4 tox loss from major drunkenness to 0.9

Total tox loss per tick 1 at drunkest levels
