### PR TITLE
Fixes Druggy vision disappearing immediately due to a typo.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1109,7 +1109,7 @@ Sorry Giacom. Please don't be mad :(
 			overlay_fullscreen("high", /obj/screen/fullscreen/high)
 			throw_alert("high", /obj/screen/alert/high)
 	else if(old_druggy)
-		druggy = max(eye_blurry+amount, 0)
+		druggy = max(druggy+amount, 0)
 		if(!druggy)
 			clear_fullscreen("high")
 			clear_alert("high")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1046,7 +1046,7 @@ Sorry Giacom. Please don't be mad :(
 	if(amount>0)
 		if(!old_eye_blurry)
 			overlay_fullscreen("blurry", /obj/screen/fullscreen/blurry)
-	else if(old_eye_blurry)
+	else if(old_eye_blurry && !eye_blurry)
 		clear_fullscreen("blurry")
 
 /mob/proc/set_blurriness(amount)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -495,10 +495,12 @@ Sorry Giacom. Please don't be mad :(
 	radiation = 0
 	nutrition = NUTRITION_LEVEL_FED + 50
 	bodytemperature = 310
-	disabilities = 0
 	set_blindness(0)
 	set_blurriness(0)
 	set_eye_damage(0)
+	cure_nearsighted()
+	cure_blind()
+	disabilities = 0
 	ear_deaf = 0
 	ear_damage = 0
 	hallucination = 0


### PR DESCRIPTION
Fixes #16034

Also fixes eye blurriness effect disappearing right away when it shouldn't.(another typo)

 Fixes admin revujenate not removing the nearsighted/blind screen effect when it cures nearsightedness and blindness. Fixes #16224
