### PR TITLE
Coldfix for Xeno saycode

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -348,7 +348,7 @@
 	say_mod = "hiss"
 
 /obj/item/organ/internal/tongue/alien/TongueSpeech(var/message)
-	playsound(get_turf(src), "hiss", 25, 1, 1)
+	playsound(owner, "hiss", 25, 1, 1)
 	return message
 
 /obj/item/organ/internal/appendix


### PR DESCRIPTION
Fixes xeno hissing. the dangerous result of testing sounds while the station started with no atmosphere and also misremembering how playsound worked
