### PR TITLE
[S]Fixes traitor borg remnant code

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -59,8 +59,8 @@
 			dat += " Slaved to [R.connected_ai.name] |"
 		else
 			dat += " Independent from AI |"
-		if (istype(user, /mob/living/silicon) || IsAdminGhost(usr))
-			if(((issilicon(user) && is_special_character(user)) || IsAdminGhost(usr)) && !R.emagged)
+		if (istype(user, /mob/living/silicon) || IsAdminGhost(user))
+			if(((issilicon(user) && is_special_character(user)) || IsAdminGhost(user)) && !R.emagged && (user != R || R.syndicate))
 				dat += "<A href='?src=\ref[src];magbot=\ref[R]'>(<font color=blue><i>Hack</i></font>)</A> "
 		dat += "<A href='?src=\ref[src];stopbot=\ref[R]'>(<font color=green><i>[R.canmove ? "Lockdown" : "Release"]</i></font>)</A> "
 		dat += "<A href='?src=\ref[src];killbot=\ref[R]'>(<font color=red><i>Destroy</i></font>)</A>"
@@ -88,8 +88,10 @@
 			if(can_control(usr, R))
 				var/choice = input("Are you certain you wish to detonate [R.name]?") in list("Confirm", "Abort")
 				if(choice == "Confirm" && can_control(usr, R) && !..())
-					if(R.mind && R.mind.special_role && R.emagged)
+					if(R.syndicate && R.emagged)
 						R << "Extreme danger.  Termination codes detected.  Scrambling security codes and automatic AI unlink triggered."
+						if(R.connected_ai)
+							R.connected_ai << "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [R.name]</span><br>"
 						R.ResetSecurityCodes()
 					else
 						message_admins("<span class='notice'>[key_name_admin(usr)] (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) detonated [key_name(R, R.client)](<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>)!</span>")
@@ -119,10 +121,11 @@
 	else if (href_list["magbot"])
 		if((issilicon(usr) && is_special_character(usr)) || IsAdminGhost(usr))
 			var/mob/living/silicon/robot/R = locate(href_list["magbot"])
-			if(istype(R) && !R.emagged && (R.connected_ai == usr || IsAdminGhost(usr)) && !R.scrambledcodes && can_control(usr, R))
+			if(istype(R) && !R.emagged && ((R.syndicate && R == usr)|| R.connected_ai == usr || IsAdminGhost(usr)) && !R.scrambledcodes && can_control(usr, R))
 				log_game("[key_name(usr)] emagged [R.name] using robotic console!")
+				message_admins("[key_name_admin(usr)] emagged cyborg [key_name_admin(R)]. using robotic console!")
 				R.SetEmagged(1)
-				if(R.mind.special_role)
+				if(is_special_character(R))
 					R.verbs += /mob/living/silicon/robot/proc/ResetSecurityCodes
 
 	src.updateUsrDialog()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -623,6 +623,13 @@
 			if((world.time - 100) < emag_cooldown)
 				return
 
+			if(syndicate)
+				user << "<span class='notice'>You emag [src]'s interface.</span>"
+				src << "<span class='danger'>ALERT: Foreign software execution prevented.</span>"
+				log_game("[key_name(user)] attempted to emag cyborg [key_name(src)] was a syndicate cyborg.")
+				emag_cooldown = world.time
+				return
+
 			var/ai_is_antag = 0
 			if(connected_ai && connected_ai.mind)
 				if(connected_ai.mind.special_role)
@@ -636,7 +643,7 @@
 				return
 
 			if(wiresexposed)
-				user << "<span class='warning'>You must close the cover first!</span>"
+				user << "<span class='warning'>You must unexpose the wires first!</span>"
 				return
 			else
 				emag_cooldown = world.time
@@ -972,6 +979,7 @@
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	if(src.connected_ai)
+		connected_ai.connected_robots -= src
 		src.connected_ai = null
 	lawupdate = 0
 	lockcharge = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -626,7 +626,7 @@
 			if(syndicate)
 				user << "<span class='notice'>You emag [src]'s interface.</span>"
 				src << "<span class='danger'>ALERT: Foreign software execution prevented.</span>"
-				log_game("[key_name(user)] attempted to emag cyborg [key_name(src)] was a syndicate cyborg.")
+				log_game("[key_name(user)] attempted to emag cyborg [key_name(src)] but they were a syndicate cyborg.")
 				emag_cooldown = world.time
 				return
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -342,14 +342,13 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 	if(issilicon(M))
 		if(isrobot(M)) //For cyborgs, returns 1 if the cyborg has a law 0 and special_role. Returns 0 if the borg is merely slaved to an AI traitor.
 			var/mob/living/silicon/robot/R = M
-			if(R.emagged || R.syndicate) //Count as antags
-				return 1
-			if(R.mind && R.mind.special_role && R.laws && R.laws.zeroth).
-				if(R.connected_ai)
-					if(is_special_character(R.connected_ai) && R.connected_ai.laws && (R.connected_ai.laws.zeroth_borg == R.laws.zeroth || R.connected_ai.laws.zeroth == R.laws.zeroth))
-						return 0 //AI is the real traitor here, so the borg itself is not a traitor
-					return 1 //Slaved but also a traitor
-				return 1 //Unslaved, traitor
+			if(R.mind && R.mind.special_role)
+				if(R.laws && R.laws.zeroth && R.syndicate).
+					if(R.connected_ai)
+						if(is_special_character(R.connected_ai) && R.connected_ai.laws && (R.connected_ai.laws.zeroth_borg == R.laws.zeroth || R.connected_ai.laws.zeroth == R.laws.zeroth))
+							return 0 //AI is the real traitor here, so the borg itself is not a traitor
+						return 1 //Slaved but also a traitor
+					return 1 //Unslaved, traitor
 		else if(isAI(M))
 			var/mob/living/silicon/ai/A = M
 			if(A.laws && A.laws.zeroth && A.mind && A.mind.special_role)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -343,7 +343,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		if(isrobot(M)) //For cyborgs, returns 1 if the cyborg has a law 0 and special_role. Returns 0 if the borg is merely slaved to an AI traitor.
 			var/mob/living/silicon/robot/R = M
 			if(R.mind && R.mind.special_role)
-				if(R.laws && R.laws.zeroth && R.syndicate).
+				if(R.laws && R.laws.zeroth && R.syndicate)
 					if(R.connected_ai)
 						if(is_special_character(R.connected_ai) && R.connected_ai.laws && (R.connected_ai.laws.zeroth_borg == R.laws.zeroth || R.connected_ai.laws.zeroth == R.laws.zeroth))
 							return 0 //AI is the real traitor here, so the borg itself is not a traitor


### PR DESCRIPTION
Fixes an exploit where emagging a borg with a traitor brain in it, would make it immune to being blown.
Refactors remaining traitor borg code to work if it's readded in the future.

:cl:
tweak: AI will be notified when one of their cyborgs is detonated.
/:cl:
