### PR TITLE
Add livers and stomachs

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -36,6 +36,8 @@
 	internal_organs += new /obj/item/organ/internal/brain/alien
 	internal_organs += new /obj/item/organ/internal/alien/hivenode
 	internal_organs += new /obj/item/organ/internal/tongue/alien
+	internal_organs += new /obj/item/organ/internal/liver/alien
+	internal_organs += new /obj/item/organ/internal/stomach/alien
 
 	for(var/obj/item/organ/internal/I in internal_organs)
 		I.Insert(src)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -31,3 +31,5 @@
 	var/rotate_on_lying = 1
 
 	var/tinttotal = 0	// Total level of visualy impairing items
+
+	var/drunkenness = 0 //Overall drunkenness - check handle_status_effects() in life.dm for effects

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -31,6 +31,8 @@
 	internal_organs += new /obj/item/organ/internal/lungs
 	internal_organs += new /obj/item/organ/internal/heart
 	internal_organs += new /obj/item/organ/internal/brain
+	internal_organs += new /obj/item/organ/internal/liver
+	internal_organs += new /obj/item/organ/internal/stomach
 
 	//Note: Additional organs are generated/replaced on the dna.species level
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -53,5 +53,3 @@
 	var/name_override //For temporary visible name changes
 
 	var/heart_attack = 0
-
-	var/drunkenness = 0 //Overall drunkenness - check handle_alcohol() in life.dm for effects

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -259,6 +259,9 @@
 		if (getToxLoss() >= 45 && nutrition > 20)
 			lastpuke ++
 			if(lastpuke >= 25) // about 25 second delay I guess
+				if(!getorganslot("stomach"))
+					lastpuke = 0
+					return
 				Stun(5)
 
 				visible_message("<span class='danger'>[src] throws up!</span>", \
@@ -311,75 +314,5 @@
 			losebreath += 2
 		adjustOxyLoss(5)
 		adjustBruteLoss(1)
-
-/*
-Alcohol Poisoning Chart
-Note that all higher effects of alcohol poisoning will inherit effects for smaller amounts (i.e. light poisoning inherts from slight poisoning)
-In addition, severe effects won't always trigger unless the drink is poisonously strong
-All effects don't start immediately, but rather get worse over time; the rate is affected by the imbiber's alcohol tolerance
-
-0: Non-alcoholic
-1-10: Barely classifiable as alcohol - occassional slurring
-11-20: Slight alcohol content - slurring
-21-30: Below average - imbiber begins to look slightly drunk
-31-40: Just below average - no unique effects
-41-50: Average - mild disorientation, imbiber begins to look drunk
-51-60: Just above average - disorientation, vomiting, imbiber begins to look heavily drunk
-61-70: Above average - small chance of blurry vision, imbiber begins to look smashed
-71-80: High alcohol content - blurry vision, imbiber completely shitfaced
-81-90: Extremely high alcohol content - light brain damage, passing out
-91-100: Dangerously toxic - swift death
-*/
-
-/mob/living/carbon/human/handle_status_effects()
-	..()
-	if(drunkenness)
-		if(sleeping)
-			drunkenness = max(drunkenness - 1.5, 0)
-		else
-			drunkenness = max(drunkenness - 0.2, 0)
-
-		if(drunkenness >= 6)
-			if(prob(25))
-				slurring += 2
-			jitteriness = max(jitteriness - 3, 0)
-
-		if(drunkenness >= 11 && slurring < 5)
-			slurring += 1.2
-
-		if(drunkenness >= 41)
-			if(prob(25))
-				confused += 2
-			Dizzy(10)
-
-		if(drunkenness >= 51)
-			if(prob(5))
-				confused += 10
-				vomit()
-			Dizzy(25)
-
-		if(drunkenness >= 61)
-			if(prob(50))
-				blur_eyes(5)
-
-		if(drunkenness >= 71)
-			blur_eyes(5)
-
-		if(drunkenness >= 81)
-			adjustToxLoss(0.2)
-			if(prob(5) && !stat)
-				src << "<span class='warning'>Maybe you should lie down for a bit...</span>"
-
-		if(drunkenness >= 91)
-			adjustBrainLoss(0.4)
-			if(prob(20) && !stat)
-				if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && z == ZLEVEL_STATION) //QoL mainly
-					src << "<span class='warning'>You're so tired... but you can't miss that shuttle...</span>"
-				else
-					src << "<span class='warning'>Just a quick nap...</span>"
-					Sleeping(45)
-
-		if(drunkenness >= 101)
-			adjustToxLoss(4) //Let's be honest you shouldn't be alive by now
 
 #undef HUMAN_MAX_OXYLOSS

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -28,6 +28,8 @@
 	internal_organs += new /obj/item/organ/internal/heart
 	internal_organs += new /obj/item/organ/internal/brain
 	internal_organs += new /obj/item/organ/internal/tongue
+	internal_organs += new /obj/item/organ/internal/liver
+	internal_organs += new /obj/item/organ/internal/stomach
 
 	for(var/obj/item/organ/internal/I in internal_organs)
 		I.Insert(src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -201,7 +201,12 @@
 		return
 
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
-		if( (ishuman(user) && (user.disabilities & FAT) && ismonkey(affecting) ) || ( isalien(user) && iscarbon(affecting) ) )
+		if((isalien(user) || (user.disabilities & FAT)) && iscarbon(affecting))
+			var/obj/item/organ/internal/stomach/S = user.getorganslot("stomach")
+			if(!S)
+				return
+			if(!S.check_devourabilty(affecting))
+				return
 			var/mob/living/carbon/attacker = user
 			user.visible_message("<span class='danger'>[user] is attempting to devour [affecting]!</span>")
 			if(istype(user, /mob/living/carbon/alien/humanoid/hunter))

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -33,10 +33,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 */
 
 /datum/reagent/consumable/ethanol/on_mob_life(mob/living/M)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
-			H.drunkenness = max((H.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(C.drunkenness < volume * boozepwr * ALCOHOL_THRESHOLD_MODIFIER)
+			C.drunkenness = max((C.drunkenness + (sqrt(volume) * boozepwr * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 	return ..() || .
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -766,9 +766,9 @@
 	M.confused = 0
 	M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3*REM, 0, 1)
 	M.adjustToxLoss(-0.2*REM, 0)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.drunkenness = max(H.drunkenness - 10, 0)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.drunkenness = max(C.drunkenness - 10, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -56,6 +56,8 @@
 		return 0
 	var/mob/living/carbon/C = eater
 	var/covered = ""
+	if(!C.getorganslot("stomach"))
+		return 0
 	if(C.is_mouth_covered(head_only = 1))
 		covered = "headgear"
 	else if(C.is_mouth_covered(mask_only = 1))

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -231,8 +231,6 @@
 	priority = 100 //it's an indicator you're dieing, so it's very high priority
 	colour = "red"
 
-
-
 /obj/item/organ/internal/lungs
 	name = "lungs"
 	icon_state = "lungs"
@@ -245,6 +243,70 @@
 	var/obj/S = ..()
 	S.reagents.add_reagent("salbutamol", 5)
 	return S
+
+/obj/item/organ/internal/liver
+	name = "liver"
+	desc = "The big but unassuming northern neighbour of the stomach; the Canada of human viscera."
+	icon_state = "liver"
+	zone = "chest"
+	slot = "liver"
+
+/obj/item/organ/internal/liver/proc/handle_sobering()
+	if(owner.sleeping)
+		owner.drunkenness = max(owner.drunkenness - 1.5, 0)
+	else
+		owner.drunkenness = max(owner.drunkenness - 0.2, 0)
+
+/obj/item/organ/internal/liver/artificial
+	name = "artificial liver"
+	desc = "Pros: It's efficient enough to keep you sober. Cons: It's efficient enough to keep you sober."
+	icon_state = "liver-c"
+
+/obj/item/organ/internal/liver/artificial/handle_sobering()
+	owner.drunkenness = max(owner.drunkenness - 5, 0)
+	..()
+
+/obj/item/organ/internal/liver/alien
+	name = "alien liver"
+	desc = "A highly advanced liver that can break down and neutralize poisons."
+	icon_state = "liver-x"
+
+/obj/item/organ/internal/liver/alien/handle_sobering()
+	owner.drunkenness = 0
+
+/obj/item/organ/internal/stomach
+	name = "stomach"
+	desc = "Despite what some people say, this isn't the quickest way to a man's heart."
+	icon_state = "stomach"
+	zone = "chest"
+	slot = "stomach"
+	var/can_devour = /mob/living/carbon/monkey
+
+/obj/item/organ/internal/stomach/proc/handle_stomach()
+	for(var/mob/living/M in owner.stomach_contents)
+		if(M.loc != owner)
+			owner.stomach_contents.Remove(M)
+			continue
+		if(M.stat == DEAD)
+			M.death(1)
+			owner.stomach_contents.Remove(M)
+			qdel(M)
+			continue
+		if(SSmob.times_fired%3==1)
+			if(!(M.status_flags & GODMODE))
+				M.adjustBruteLoss(5)
+			owner.nutrition += 10
+
+/obj/item/organ/internal/stomach/proc/check_devourabilty(mob/living/carbon/C)
+	if(istype(C, can_devour))
+		return 1
+	return 0
+
+/obj/item/organ/internal/stomach/alien
+	name = "alien stomach"
+	desc = "An unnevingly huge meat sack for holding unnerved meatsacks."
+	icon_state = "stomach-x"
+	can_devour = /mob/living/carbon
 
 /obj/item/organ/internal/tongue
 	name = "tongue"


### PR DESCRIPTION
Without a stomach:
- You can't puke to reduce your toxins
- You can't eat or drink
- You can't devour anything

Without a liver:
- You can't get sober, ever (unless you take antihol)

Xenos get xeno versions of the stomach and liver, the xeno stomach allows for devouring of all carbons and the liver removes any drunkenness (and likewise a xeno with a removed or replaced liver can now get drunk).

Like all xeno organs these will function in humans if transplanted, but humans have to be fat to devour even with the xeno stomach.

Also adds a robotic version of the liver simply because the sprite was there, but doesn't meaningfully implement it.

If anyone has some ideas for more functionality/special mutantrace versions feel free to suggest em.

!!pull has not been tested yet!!
