### PR TITLE
Fixes monkey cube Dupe Glitch

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -440,6 +440,18 @@
 		user << "<span class='notice'>You wet [O] in [src].</span>"
 		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 
+	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
+		var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = O
+		if(M.wrapped)
+			user << "<span class='notice'>You need to unwrap [src] first!</span>"
+			return
+		else
+			user << "<span class='notice'>You place [src] under a stream of water...</span>"
+			user.drop_item()
+			M.loc = get_turf(src)
+			M.Expand()
+			return
+
 	var/obj/item/I = O
 	if(!I || !istype(I))
 		return
@@ -455,7 +467,6 @@
 	O.clean_blood()
 	user.visible_message("<span class='notice'>[user] washes [I] using [src].</span>", \
 						"<span class='notice'>You wash [I] using [src].</span>")
-
 
 /obj/structure/sink/kitchen
 	name = "kitchen sink"

--- a/code/modules/food&drinks/food/snacks_meat.dm
+++ b/code/modules/food&drinks/food/snacks_meat.dm
@@ -133,25 +133,6 @@
 	list_reagents = list("nutriment" = 2)
 	filling_color = "#CD853F"
 
-/obj/item/weapon/reagent_containers/food/snacks/monkeycube/afterattack(obj/O, mob/user,proximity)
-	if(!proximity) return
-	if(istype(O,/obj/structure/sink))
-		if (wrapped)
-			user << "<span class='notice'>You need to unwrap [src] first!</span>"
-			return
-		else
-			user << "<span class='notice'>You place [src] under a stream of water...</span>"
-			user.drop_item()
-			loc = get_turf(O)
-			return Expand()
-	if(istype(O, /obj/machinery/computer/camera_advanced/xenobio))
-		var/obj/machinery/computer/camera_advanced/xenobio/X = O
-		X.monkeys++
-		user << "<span class='notice'>You feed [src] to the [X]. It now has [X.monkeys] monkey cubes stored.</span>"
-		qdel(src)
-		return
-	..()
-
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/attack_self(mob/user)
 	if(wrapped)
 		Unwrap(user)

--- a/code/modules/food&drinks/kitchen machinery/monkeyrecycler.dm
+++ b/code/modules/food&drinks/kitchen machinery/monkeyrecycler.dm
@@ -58,28 +58,39 @@
 		var/grabbed = G.affecting
 		if(ismonkey(grabbed))
 			var/mob/living/carbon/monkey/target = grabbed
-			if(target.stat == 0)
-				user << "<span class='warning'>The monkey is struggling far too much to put it in the recycler.</span>"
-				return
-			if(target.buckled || target.buckled_mobs.len)
-				user << "<span class='warning'>The monkey is attached to something.</span>"
-				return
-			if(!user.drop_item())
-				return
-			qdel(target)
-			user << "<span class='notice'>You stuff the monkey into the machine.</span>"
-			playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
-			var/offset = prob(50) ? -2 : 2
-			animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
-			use_power(500)
-			grinded++
-			sleep(50)
-			pixel_x = initial(pixel_x) //return to its spot after shaking
-			user << "<span class='notice'>The machine now has [grinded] monkey\s worth of material stored.</span>"
-
+			stuff_monkey_in(target, user)
+			user.drop_item()
+			return
 		else
 			user << "<span class='danger'>The machine only accepts monkeys!</span>"
 	return
+
+/obj/machinery/monkey_recycler/MouseDrop_T(mob/living/target, mob/living/user)
+	if(!istype(target))
+		return
+	if(ismonkey(target))
+		stuff_monkey_in(target, user)
+
+/obj/machinery/monkey_recycler/proc/stuff_monkey_in(mob/living/carbon/monkey/target, mob/living/user)
+	if(!istype(target))
+		return
+	if(target.stat == 0)
+		user << "<span class='warning'>The monkey is struggling far too much to put it in the recycler.</span>"
+		return
+	if(target.buckled || target.buckled_mobs.len)
+		user << "<span class='warning'>The monkey is attached to something.</span>"
+		return
+	qdel(target)
+	user << "<span class='notice'>You stuff the monkey into the machine.</span>"
+	playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
+	use_power(500)
+	grinded++
+	sleep(50)
+	pixel_x = initial(pixel_x) //return to its spot after shaking
+	user << "<span class='notice'>The machine now has [grinded] monkey\s worth of material stored.</span>"
+
 
 /obj/machinery/monkey_recycler/attack_hand(mob/user)
 	if (src.stat != 0) //NOPOWER etc

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -306,7 +306,7 @@
 		update()
 		return
 
-	if(!user.drop_item())
+	if(!user.drop_item() || I.flags & ABSTRACT) // Dunno why this wasn't here before?
 		return
 
 	I.loc = src

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -62,6 +62,15 @@
 		return
 	return ..()
 
+/obj/machinery/computer/camera_advanced/xenobio/attackby(obj/item/O, mob/user, params)
+	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/monkeycube))
+		monkeys++
+		user << "<span class='notice'>You feed [O] to the [src]. It now has [monkeys] monkey cubes stored.</span>"
+		user.drop_item()
+		qdel(O)
+		return
+
+
 /datum/action/innate/camera_off/xenobio/Activate()
 	if(!target || !ishuman(target))
 		return


### PR DESCRIPTION
fixes https://github.com/tgstation/-tg-station/issues/14667

Adds some consistency, allowing monkeys to be drag dropped onto the
monkey recycler, like they are with the disposals chutes.

Prevents grabs from being placed in disposals, as they were being
before.
