### PR TITLE
Fixes runtime with 16869

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -900,7 +900,7 @@ var/list/WALLITEMS_INVERSE = list(
 		var/list/cached_gases = air_contents.gases
 
 		for(var/id in cached_gases)
-			var/gas_concentration = cached_gases[id][MOLES]/total_moles
+			var/gas_concentration = (!total_moles ? 0 : cached_gases[id][MOLES]/total_moles)
 			if(id in hardcoded_gases || gas_concentration > 0.001) //ensures the four primary gases are always shown.
 				user << "<span class='notice'>[cached_gases[id][GAS_META][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] %</span>"
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -34,7 +34,10 @@
 		var/total_moles = air_sample.total_moles()
 		for(var/gas_id in air_sample.gases)
 			var/gas_name = air_sample.gases[gas_id][GAS_META][META_GAS_NAME]
-			signal.data["gases"][gas_name] = air_sample.gases[gas_id][MOLES] / total_moles * 100
+			if(total_moles)
+				signal.data["gases"][gas_name] = air_sample.gases[gas_id][MOLES] / total_moles * 100
+			else
+				signal.data["gases"][gas_name] = 0
 
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -34,10 +34,7 @@
 		var/total_moles = air_sample.total_moles()
 		for(var/gas_id in air_sample.gases)
 			var/gas_name = air_sample.gases[gas_id][GAS_META][META_GAS_NAME]
-			if(total_moles)
-				signal.data["gases"][gas_name] = air_sample.gases[gas_id][MOLES] / total_moles * 100
-			else
-				signal.data["gases"][gas_name] = 0
+			signal.data["gases"][gas_name] = (!total_moles ? 0 : air_sample.gases[gas_id][MOLES] / total_moles * 100)
 
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -267,7 +267,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 					if (total_moles)
 						for(var/id in env_gases)
-							var/gas_level = env_gases[id][MOLES]/total_moles
+							var/gas_level = (!total_moles ? 0 : env_gases[id][MOLES]/total_moles)
 							if(id in hardcoded_gases || gas_level > 0.001)
 								dat += "[env_gases[id][GAS_META][META_GAS_NAME]]: [round(gas_level*100, 0.01)]%<br>"
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -274,10 +274,10 @@ MASS SPECTROMETER
 		var/list/env_gases = environment.gases
 
 		environment.assert_gases(arglist(hardcoded_gases))
-		var/o2_concentration = env_gases["o2"][MOLES]/total_moles
-		var/n2_concentration = env_gases["n2"][MOLES]/total_moles
-		var/co2_concentration = env_gases["co2"][MOLES]/total_moles
-		var/plasma_concentration = env_gases["plasma"][MOLES]/total_moles
+		var/o2_concentration = (!total_moles ? 0 : env_gases["o2"][MOLES]/total_moles)
+		var/n2_concentration = (!total_moles ? 0 : env_gases["n2"][MOLES]/total_moles)
+		var/co2_concentration = (!total_moles ? 0 : env_gases["co2"][MOLES]/total_moles)
+		var/plasma_concentration = (!total_moles ? 0 : env_gases["plasma"][MOLES]/total_moles)
 		environment.garbage_collect()
 
 		if(abs(n2_concentration - N2STANDARD) < 20)
@@ -303,7 +303,7 @@ MASS SPECTROMETER
 		for(var/id in env_gases)
 			if(id in hardcoded_gases)
 				continue
-			var/gas_concentration = env_gases[id][MOLES]/total_moles
+			var/gas_concentration = (!total_moles ? 0 : env_gases[id][MOLES]/total_moles)
 			user << "<span class='alert'>[env_gases[id][GAS_META][META_GAS_NAME]]: [round(gas_concentration*100, 0.01)] %</span>"
 		user << "<span class='info'>Temperature: [round(environment.temperature-T0C)] &deg;C</span>"
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -192,7 +192,7 @@
 		cur_tlv = TLV[gas_id]
 		data["environment_data"] += list(list(
 								"name" = environment.gases[gas_id][GAS_META][META_GAS_NAME],
-								"value" = environment.gases[gas_id][MOLES] / total_moles * 100,
+								"value" = (!total_moles ? 0 : environment.gases[gas_id][MOLES] / total_moles * 100),
 								"unit" = "%",
 								"danger_level" = cur_tlv.get_danger_level(environment.gases[gas_id][MOLES] * partial_pressure)
 		))

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -14,7 +14,7 @@
 	breath.assert_gases("plasma", "o2")
 
 	//Partial pressure of the toxins in our breath
-	var/Toxins_pp = (breath_gases["plasma"][MOLES]/breath.total_moles())*breath_pressure
+	var/Toxins_pp = (!breath.total_moles() ? 0 : breath_gases["plasma"][MOLES]/breath.total_moles())*breath_pressure
 
 	if(Toxins_pp) // Detect toxins in air
 		adjustPlasma(breath_gases["plasma"][MOLES]*250)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -495,7 +495,7 @@ var/global/image/plasmaman_on_fire = image("icon"='icons/mob/OnFire.dmi', "icon_
 		if(environment)
 			var/total_moles = environment.total_moles()
 			if(total_moles)
-				if(environment.gases["o2"] && (environment.gases["o2"][MOLES] /total_moles) >= 0.01)
+				if(environment.gases["o2"] && (!total_moles ? 0 : environment.gases["o2"][MOLES] /total_moles) >= 0.01)
 					H.adjust_fire_stacks(0.5)
 					if(!H.on_fire && H.fire_stacks > 0)
 						H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -125,9 +125,9 @@
 	var/list/breath_gases = breath.gases
 	breath.assert_gases("o2","plasma","co2","n2o")
 
-	var/O2_partialpressure = (breath_gases["o2"][MOLES]/breath.total_moles())*breath_pressure
-	var/Toxins_partialpressure = (breath_gases["plasma"][MOLES]/breath.total_moles())*breath_pressure
-	var/CO2_partialpressure = (breath_gases["co2"][MOLES]/breath.total_moles())*breath_pressure
+	var/O2_partialpressure = (!breath.total_moles() ? 0 : breath_gases["o2"][MOLES]/breath.total_moles())*breath_pressure
+	var/Toxins_partialpressure = (!breath.total_moles() ? 0 : breath_gases["plasma"][MOLES]/breath.total_moles())*breath_pressure
+	var/CO2_partialpressure = (!breath.total_moles() ? 0 : breath_gases["co2"][MOLES]/breath.total_moles())*breath_pressure
 
 
 	//OXYGEN
@@ -180,7 +180,7 @@
 
 	//NITROUS OXIDE
 	if(breath_gases["n2o"])
-		var/SA_partialpressure = (breath_gases["n2o"][MOLES]/breath.total_moles())*breath_pressure
+		var/SA_partialpressure = (!breath.total_moles() ? 0 : breath_gases["n2o"][MOLES]/breath.total_moles())*breath_pressure
 		if(SA_partialpressure > SA_para_min)
 			Paralyse(3)
 			if(SA_partialpressure > SA_sleep_min)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -535,7 +535,7 @@
 
 		if (total_moles)
 			for(var/id in env_gases)
-				var/gas_level = env_gases[id][MOLES]/total_moles
+				var/gas_level = (!total_moles ? 0 : env_gases[id][MOLES]/total_moles)
 				if(id in hardcoded_gases || gas_level > 0.01)
 					dat += "[env_gases[id][GAS_META][META_GAS_NAME]]: [round(gas_level*100)]%<br>"
 		dat += "Temperature: [round(environment.temperature-T0C)]&deg;C<br>"

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -135,7 +135,7 @@
 	if(stat != DEAD)
 		var/co2_percentage =0
 		if("co2" in environment.gases)
-			co2_percentage = environment.gases["co2"][MOLES] / environment.total_moles()
+			co2_percentage = (!environment.total_moles() ? 0 : environment.gases["co2"][MOLES] / environment.total_moles())
 		var/stasis = (co2_percentage >= 0.05 && bodytemperature < (T0C + 100)) || force_stasis
 
 		if(stat == CONSCIOUS && stasis)


### PR DESCRIPTION
This adds an exception for cases where total_moles would be zero, preventing a division by zero, but still allowing for turfs with 0 moles to function properly without having to hard set it at 0.000001 or something ridiculous.
