### PR TITLE
Fixes endless division by zero runtimes

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -8,7 +8,7 @@
 
 /turf/open/floor/mech_bay_recharge_floor/airless
 	icon_state = "recharge_floor_asteroid"
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /obj/machinery/mech_bay_recharge_port
 	name = "mech bay power port"

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -116,7 +116,7 @@
 			spam_flag = 0
 
 /turf/open/floor/mineral/bananium/airless
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 //DIAMOND
 

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -383,7 +383,7 @@
 	return
 
 /turf/open/floor/plasteel/cult/airless
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 
 

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -70,7 +70,7 @@
 
 /turf/open/floor/plating/airless
 	icon_state = "plating"
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/engine
 	name = "reinforced floor"
@@ -168,10 +168,10 @@
 /turf/open/floor/engine/vacuum
 	name = "vacuum floor"
 	icon_state = "engine"
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plasteel/airless
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plating/abductor
 	name = "alien floor"
@@ -192,7 +192,7 @@
 	luminosity = 1
 
 /turf/open/floor/plating/lava/airless
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plating/lava/Entered(atom/movable/AM)
 	burn_stuff()
@@ -252,4 +252,4 @@
 	canSmoothWith = list(/turf/closed/wall, /turf/closed/mineral, /turf/open/floor/plating/lava/smooth, /turf/open/floor/plating/lava/smooth/lava_land_surface
 	)
 /turf/open/floor/plating/lava/smooth/airless
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -15,7 +15,9 @@
 
 	//used for mapping and for breathing while in walls (because that's a thing that needs to be accounted for...)
 	//string parsed by /datum/gas/proc/copy_from_turf
-	var/initial_gas_mix = "o2=22;n2=82;TEMP=293.15" //approximation of MOLES_O2STANDARD and MOLES_N2STANDARD pending byond allowing constant expressions to be embedded in constant strings
+	var/initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	//approximation of MOLES_O2STANDARD and MOLES_N2STANDARD pending byond allowing constant expressions to be embedded in constant strings
+	// If someone will place 0 of some gas there, SHIT WILL BREAK. Do not do that.
 
 /turf/open
 	//used for spacewind

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -7,7 +7,7 @@
 	smooth = SMOOTH_MORE|SMOOTH_BORDER
 	canSmoothWith = list (/turf/closed/mineral, /turf/closed/wall)
 	baseturf = /turf/open/floor/plating/asteroid/airless
-	initial_gas_mix = "o2=0;n2=0;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 	opacity = 1
 	density = 1
 	blocks_air = 1
@@ -424,7 +424,7 @@
 	var/sand_type = /obj/item/weapon/ore/glass
 
 /turf/open/floor/plating/asteroid/airless
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 	turf_type = /turf/open/floor/plating/asteroid/airless
 
 /turf/open/floor/plating/asteroid/basalt
@@ -440,7 +440,7 @@
 	baseturf = /turf/open/floor/plating/lava/smooth
 
 /turf/open/floor/plating/asteroid/basalt/airless
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plating/asteroid/snow
 	name = "snow"
@@ -455,7 +455,7 @@
 	sand_type = /obj/item/stack/sheet/mineral/snow
 
 /turf/open/floor/plating/asteroid/snow/airless
-	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7"
+	initial_gas_mix = "TEMP=2.7"
 
 /turf/open/floor/plating/asteroid/snow/temperatre
 	temperature = 255.37


### PR DESCRIPTION
High priority, merge before updating server. Fixes division by zero runtimes caused by #16869. 

The source was `initial_gas_mix = "o2=0;n2=0;TEMP=2.7"` and similar lines. These lines were causing 0 moles gases to be created. Which should never happen, or shit will break, because there are no sanity checks for division by zero. Not sure why, performance reasons maybe?

Also unifies all airless turfs. They are actually airless now.

@duncathan @RandomMarine 
