### PR TITLE
Drone dispensers now start preloaded

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -72250,7 +72250,7 @@
 	icon_state = "tube1";
 	dir = 8
 	},
-/obj/machinery/droneDispenser,
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "cHo" = (

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -8786,7 +8786,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},
-/obj/machinery/droneDispenser,
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plasteel{
 	icon_state = "delivery"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -57672,7 +57672,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/machinery/droneDispenser,
+/obj/machinery/droneDispenser/preloaded,
 /obj/machinery/door/window/southleft,
 /turf/open/floor/carpet,
 /area/assembly/showroom{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -45460,7 +45460,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/droneDispenser,
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plasteel,
 /area/toxins/misc_lab)
 "bOx" = (


### PR DESCRIPTION
~~Coders took our drones away, because they hate fun, and don't know how to ahelp troublesome drones.~~

Drone dispensers starting empty merely adds a rough two minute delay before drones spawn because of the presence of derelict drones that can boot up and go to main station (which has been explicitly allowed through admin judgements in the past).

Without a modification to the derelict map or a change in admin policy, this removal of the preloading is meaningless, and just putting a barrier to drones being on the station. If we want to restrict people playing drones, maybe we should actually change drone policy, rather than try to side channel the issue.
