### PR TITLE
Lizardconomy

### DIFF
--- a/code/modules/ruins/ashwalkers/ashshack.dm
+++ b/code/modules/ruins/ashwalkers/ashshack.dm
@@ -1,0 +1,1 @@
+// Everyone loves mysterious shopkeepers, amirite?

--- a/code/modules/ruins/ashwalkers/ashshack.dm
+++ b/code/modules/ruins/ashwalkers/ashshack.dm
@@ -1,1 +1,5 @@
 // Everyone loves mysterious shopkeepers, amirite?
+
+/obj/structure/ashshack
+	name = "ash shack"
+	desc = "A ruined looking building made out of rotten wood. Despite its material, it seems very structurally sound."

--- a/code/modules/ruins/ashwalkers/ashwalker.dm
+++ b/code/modules/ruins/ashwalkers/ashwalker.dm
@@ -1,0 +1,55 @@
+/mob/living/simple_animal/hostile/spawner/ash_walker
+	name = "ash walker nest"
+	desc = "A nest built around a necropolis tendril. The eggs seem to grow unnaturally fast..."
+	icon = 'icons/mob/nest.dmi'
+	icon_state = "ash_walker_nest"
+	icon_living = "ash_walker_nest"
+	health = 200
+	maxHealth = 200
+	loot = list(/obj/effect/gibspawner, /obj/item/device/assembly/signaler/anomaly)
+	del_on_death = 1
+	var/meat_counter
+
+/mob/living/simple_animal/hostile/spawner/ash_walker/Life()
+	..()
+	if(!stat)
+		consume()
+		spawn_mob()
+
+/mob/living/simple_animal/hostile/spawner/ash_walker/proc/consume()
+	for(var/mob/living/H in view(src,1)) //Only for corpse right next to/on same tile
+		if(H.stat)
+			visible_message("<span class='warning'>Tendrils reach out from \the [src.name] pulling [H] in! Blood seeps over the eggs as [H] is devoured.</span>")
+			playsound(get_turf(src),'sound/magic/Demon_consume.ogg', 100, 1)
+			meat_counter ++
+			H.gib()
+
+/mob/living/simple_animal/hostile/spawner/ash_walker/spawn_mob()
+	if(meat_counter >= 2)
+		new /obj/effect/mob_spawn/human/ash_walker(get_step(src.loc, SOUTH))
+		visible_message("<span class='danger'>An egg is ready to hatch!</span>")
+		meat_counter -= 2
+
+/obj/effect/mob_spawn/human/ash_walker
+	name = "ash walker egg"
+	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
+	icon_state = "large_egg"
+	mob_species = /datum/species/lizard
+	helmet = /obj/item/clothing/head/helmet/gladiator
+	uniform = /obj/item/clothing/under/gladiator
+	roundstart = FALSE
+	death = FALSE
+	anchored = 0
+	density = 0
+	flavour_text = {"<B>You are an Ash Walker. Your tribe worships <span class='danger'>the necropolis</span>. The wastes are sacred ground, it's monsters a blessed bounty. You have seen lights in the distance though, the arrival of outsiders seeking to destroy the land. Fresh sacrifices.</B>"}
+
+/obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_lizard_name(gender)
+	new_spawn << "Drag corpses to your nest to feed the young, and spawn more Ash Walkers. Bring glory to the tribe!"
+	if(ishuman(new_spawn))
+		var/mob/living/carbon/human/H = new_spawn
+		H.dna.species.specflags |= NOBREATH
+		H.dna.species.specflags |= NOGUNS
+
+
+

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -166,60 +166,7 @@
 
 ///Ash Walkers
 
-/mob/living/simple_animal/hostile/spawner/ash_walker
-	name = "ash walker nest"
-	desc = "A nest built around a necropolis tendril. The eggs seem to grow unnaturally fast..."
-	icon = 'icons/mob/nest.dmi'
-	icon_state = "ash_walker_nest"
-	icon_living = "ash_walker_nest"
-	health = 200
-	maxHealth = 200
-	loot = list(/obj/effect/gibspawner, /obj/item/device/assembly/signaler/anomaly)
-	del_on_death = 1
-	var/meat_counter
-
-/mob/living/simple_animal/hostile/spawner/ash_walker/Life()
-	..()
-	if(!stat)
-		consume()
-		spawn_mob()
-
-/mob/living/simple_animal/hostile/spawner/ash_walker/proc/consume()
-	for(var/mob/living/H in view(src,1)) //Only for corpse right next to/on same tile
-		if(H.stat)
-			visible_message("<span class='warning'>Tendrils reach out from \the [src.name] pulling [H] in! Blood seeps over the eggs as [H] is devoured.</span>")
-			playsound(get_turf(src),'sound/magic/Demon_consume.ogg', 100, 1)
-			meat_counter ++
-			H.gib()
-
-/mob/living/simple_animal/hostile/spawner/ash_walker/spawn_mob()
-	if(meat_counter >= 2)
-		new /obj/effect/mob_spawn/human/ash_walker(get_step(src.loc, SOUTH))
-		visible_message("<span class='danger'>An egg is ready to hatch!</span>")
-		meat_counter -= 2
-
-/obj/effect/mob_spawn/human/ash_walker
-	name = "ash walker egg"
-	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
-	icon_state = "large_egg"
-	mob_species = /datum/species/lizard
-	helmet = /obj/item/clothing/head/helmet/gladiator
-	uniform = /obj/item/clothing/under/gladiator
-	roundstart = FALSE
-	death = FALSE
-	anchored = 0
-	density = 0
-	flavour_text = {"<B>You are an Ash Walker. Your tribe worships <span class='danger'>the necropolis</span>. The wastes are sacred ground, it's monsters a blessed bounty. You have seen lights in the distance though, the arrival of outsiders seeking to destroy the land. Fresh sacrifices.</B>"}
-
-/obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
-	new_spawn.real_name = random_unique_lizard_name(gender)
-	new_spawn << "Drag corpses to your nest to feed the young, and spawn more Ash Walkers. Bring glory to the tribe!"
-	if(ishuman(new_spawn))
-		var/mob/living/carbon/human/H = new_spawn
-		H.dna.species.specflags |= NOBREATH
-		H.dna.species.specflags |= NOGUNS
-
-
+// Moved to ashwalkers/ashwalker.dm
 
 //Wishgranter Exile
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1612,6 +1612,8 @@
 #include "code\modules\research\xenobiology\xenobiology.dm"
 #include "code\modules\ruins\lavaland_ruin_code.dm"
 #include "code\modules\ruins\ruin_areas.dm"
+#include "code\modules\ruins\ashwalkers\ashshack.dm"
+#include "code\modules\ruins\ashwalkers\ashwalker.dm"
 #include "code\modules\security levels\keycard authentication.dm"
 #include "code\modules\security levels\security levels.dm"
 #include "code\modules\shuttle\assault_pod.dm"


### PR DESCRIPTION
FantasticFwoosh says:

> Within the ash walker compound is a vendor, it is essentially just a front door of a steel locker attached to a upright cairn with some beady yellow eyes beaming through a little slit entrance. Its not a machine that draws power but can be dragged away for amusing station usage.
> 
> Inside 'aesthetically speaking' is a merchant who has shop UI to buy specific sets of things for coins. The base would also require a ore redemption machine and a coin presser. (meaning that aside from some small time loot, most of the crates junking it up can be thrown out)
> 
> Basically as a sub-objective of the ash walkers existance, they can go around picking up minerals, returning and processing them (for obvious benefits of having materials to work with, such as crafting bolas & such) and then coin press the end results to pay off the vendor for supplies. Not quite golem'esque R&D but adds depth. Adding unique items to the ash walker vendor may also spice things up, for a virtually unlimited supply of pickaxes, mining bags, spears and other trophies/useful objects.
> 
> Money purses could also be a thing for containing personal lizard wealth. Think lizard game of thrones.
- [ ] make the "ash shack", the mysterious shopkeeper shack where ash lizards can bargain with a mysterious shopkeeper lizard
- [ ] make ash walkers able to get coins, somehow?
- [ ] make wallets able to store, say, up to 20 coins
- [ ] craftable coin hoards, made out of coins, and deconstructable to get the coins back
