### PR TITLE
Ghost DataHUD toggle now shows all HUDs at once

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -970,13 +970,13 @@ var/list/datum/outfit/custom_outfits = list() //Admin created outfits
 
 	if(!holder) return
 
-	var/datum/atom_hud/A = huds[DATA_HUD_SECURITY_ADVANCED]
+	var/datum/atom_hud/A = huds[ANTAG_HUD_TRAITOR]
 	var/adding_hud = (usr in A.hudusers) ? 0 : 1
 
 	for(var/datum/atom_hud/H in huds)
-		if(istype(H, /datum/atom_hud/antag) || istype(H, /datum/atom_hud/data/human/security/advanced))
+		if(istype(H, /datum/atom_hud/antag))
 			(adding_hud) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
-	
+
 	for(var/datum/gang/G in ticker.mode.gangs)
 		var/datum/atom_hud/antag/H = G.ganghud
 		(adding_hud) ? H.add_hud_to(usr) : H.remove_hud_from(usr)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -31,7 +31,8 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/seedarkness = 1
 	var/ghost_hud_enabled = 1 //did this ghost disable the on-screen HUD?
-	var/data_hud_seen = 0 //this should one of the defines in __DEFINES/hud.dm
+	var/data_huds_on = 0 //Are data HUDs currently enabled?
+	var/list/datahuds = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC) //list of data HUDs shown to ghosts.
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 
 	//These variables store hair data if the ghost originates from a species with head and/or facial hair.
@@ -565,33 +566,29 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/mind_initialize()
 	return
 
-/mob/dead/observer/proc/show_me_the_hud(hud_index)
-	var/datum/atom_hud/H = huds[hud_index]
-	H.add_hud_to(src)
-	data_hud_seen = hud_index
+/mob/dead/observer/proc/show_data_huds()
+	for(var/hudtype in datahuds)
+		var/datum/atom_hud/H = huds[hudtype]
+		H.add_hud_to(src)
 
-/mob/dead/observer/verb/toggle_ghost_med_sec_diag_hud()
+/mob/dead/observer/proc/remove_data_huds()
+	for(var/hudtype in datahuds)
+		var/datum/atom_hud/H = huds[hudtype]
+		H.remove_hud_from(src)
+
+/mob/dead/observer/verb/toggle_data_huds()
 	set name = "Toggle Sec/Med/Diag HUD"
 	set desc = "Toggles whether you see medical/security/diagnostic HUDs"
 	set category = "Ghost"
 
-	if(data_hud_seen) //remove old huds
-		var/datum/atom_hud/H = huds[data_hud_seen]
-		H.remove_hud_from(src)
-
-	switch(data_hud_seen) //give new huds
-		if(0)
-			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
-			src << "<span class='notice'>Security HUD set.</span>"
-		if(DATA_HUD_SECURITY_ADVANCED)
-			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
-			src << "<span class='notice'>Medical HUD set.</span>"
-		if(DATA_HUD_MEDICAL_ADVANCED)
-			show_me_the_hud(DATA_HUD_DIAGNOSTIC)
-			src << "<span class='notice'>Diagnostic HUD set.</span>"
-		if(DATA_HUD_DIAGNOSTIC)
-			data_hud_seen = 0
-			src << "<span class='notice'>HUDs disabled.</span>"
+	if(data_huds_on) //remove old huds
+		remove_data_huds()
+		src << "<span class='notice'>Data HUDs disabled.</span>"
+		data_huds_on = 0
+	else
+		show_data_huds()
+		src << "<span class='notice'>Data HUDs enabled.</span>"
+		data_huds_on = 1
 
 /mob/dead/observer/canUseTopic()
 	if(check_rights(R_ADMIN, 0))


### PR DESCRIPTION
Ghost Data HUD toggle switched to show all HUDs at once!

DataHUDs were redesigned such that they no longer conflict, therefore it is entirely safe to use them all.

:cl: Name: Gun Hog
tweak: Security/Medical/Diagnostic HUD toggle for ghosts now combines all three HUD types into one!
rscdel: Security HUD removed from Antag HUD due to conflicts with the ghost toggle.
/:cl:

![screenshot 2016-04-16 15 21 50](https://cloud.githubusercontent.com/assets/4955510/14583508/61463e5e-03e9-11e6-99f0-46a3d155c156.png)
