### PR TITLE
Mulebot nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -643,8 +643,8 @@ var/global/mulebot_count = 0
 				add_logs(src, M, "knocked down")
 				visible_message("<span class='danger'>[src] knocks over [M]!</span>")
 				M.stop_pulling()
-				M.Stun(8)
-				M.Weaken(5)
+				M.Stun(4)
+				M.Weaken(2)
 	return ..()
 
 // called from mob/living/carbon/human/Crossed()
@@ -655,7 +655,8 @@ var/global/mulebot_count = 0
 					"<span class='userdanger'>[src] drives over you!<span>")
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-	var/damage = rand(5,15)
+	var/damage = rand(4.1,7.5)
+	// Total damage is between ~25 and 45
 	H.apply_damage(2*damage, BRUTE, "head", run_armor_check("head", "melee"))
 	H.apply_damage(2*damage, BRUTE, "chest", run_armor_check("chest", "melee"))
 	H.apply_damage(0.5*damage, BRUTE, "l_leg", run_armor_check("l_leg", "melee"))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -9,6 +9,7 @@ var/global/mulebot_count = 0
 #define SIGH 0
 #define ANNOYED 1
 #define DELIGHT 2
+#define BLOODRAGE 3
 
 /mob/living/simple_animal/bot/mulebot
 	name = "\improper MULEbot"

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -9,7 +9,6 @@ var/global/mulebot_count = 0
 #define SIGH 0
 #define ANNOYED 1
 #define DELIGHT 2
-#define BLOODRAGE 3
 
 /mob/living/simple_animal/bot/mulebot
 	name = "\improper MULEbot"

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -477,21 +477,7 @@ var/global/mulebot_count = 0
 				if(istype( next, /turf))
 					//world << "at ([x],[y]) moving to ([next.x],[next.y])"
 
-					if(bloodiness)
-						var/obj/effect/decal/cleanable/blood/tracks/B = new(loc)
-						B.blood_DNA |= blood_DNA.Copy()
-						var/newdir = get_dir(next, loc)
-						if(newdir == dir)
-							B.dir = newdir
-						else
-							newdir = newdir | dir
-							if(newdir == 3)
-								newdir = 1
-							else if(newdir == 12)
-								newdir = 4
-							B.dir = newdir
-						bloodiness--
-
+					blood_trail(next)
 
 					var/oldloc = loc
 					var/moved = step_towards(src, next)	// attempt to move
@@ -739,6 +725,22 @@ var/global/mulebot_count = 0
 		unload(get_dir(loc, A))
 	else
 		..()
+
+/mob/living/simple_animal/bot/mulebot/proc/blood_trail(turf/next)
+	if(bloodiness)
+		var/obj/effect/decal/cleanable/blood/tracks/B = new(loc)
+		B.blood_DNA |= blood_DNA.Copy()
+		var/newdir = get_dir(next, loc)
+		if(newdir == dir)
+			B.dir = newdir
+		else
+			newdir = newdir | dir
+			if(newdir == 3)
+				newdir = 1
+			else if(newdir == 12)
+				newdir = 4
+			B.dir = newdir
+		bloodiness--
 
 #undef SIGH
 #undef ANNOYED


### PR DESCRIPTION
MULEBOTS OP.

Actual content in PR will follow.

Definite Tasks:
- [x] reduce mulebot damage to a 3 hit crit, rather than a 2 hit crit
- [ ] mulebots with their safeties disable make safety warning noises when moving
- [ ] mulebots slow down as they run people over, as the gunk in their wheels increases

Potential Ideas (WE WILL PICK A SUBSET OF THESE, THIS PR IS JUST TO GATHER FEEDBACK JEEZ):
- Make mulebot batteries actually matter
- Make mulebots running people over fill their wheels with blood, making them slower as they run over more people
- Lower mulebot damage to an unarmoured 3 hit crit rather than unarmoured 2 hit
- Dodge chance for mulebot run over
- Mulebots use more power/move slower on plating rather than floor tiles
- Mulebots with safeties disabled move slower, or just have loud alarms (bonus points for annoyance so people will shoot it)

Nuclear Option:
- Disable pAI control of mulebots
