### PR TITLE
Security Officers start with Krav Maga Gloves

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -40,7 +40,7 @@ Head of Security
 	uniform = /obj/item/clothing/under/rank/head_of_security
 	shoes = /obj/item/clothing/shoes/jackboots
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
-	gloves = /obj/item/clothing/gloves/color/black/hos
+	gloves = /obj/item/clothing/gloves/krav_maga
 	head = /obj/item/clothing/head/HoS/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	suit_store = /obj/item/weapon/gun/energy/gun
@@ -98,7 +98,7 @@ Warden
 	uniform = /obj/item/clothing/under/rank/warden
 	shoes = /obj/item/clothing/shoes/jackboots
 	suit = /obj/item/clothing/suit/armor/vest/warden
-	gloves = /obj/item/clothing/gloves/color/black
+	gloves = /obj/item/clothing/gloves/krav_maga
 	head = /obj/item/clothing/head/warden
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	r_pocket = /obj/item/device/assembly/flash/handheld
@@ -207,7 +207,7 @@ var/list/sec_departments = list("engineering", "supply", "medical", "science")
 	belt = /obj/item/device/pda/security
 	ears = /obj/item/device/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/security
-	gloves = /obj/item/clothing/gloves/color/black
+	gloves = /obj/item/clothing/gloves/krav_maga
 	head = /obj/item/clothing/head/helmet/sec
 	suit = /obj/item/clothing/suit/armor/vest
 	shoes = /obj/item/clothing/shoes/jackboots


### PR DESCRIPTION
Krav Maga was originally designed as the anti-tider. It allows you to kick the shit out of assistants who walk up to your brig, break the windows, and bait you into attempting an arrest so they can kill you and steal all your gear in self defense. It's only really good for this, because it does not match up against ranged weapons at all, having no defense or counter against it. Punching isnt gonna do anything against a flamethrower or a shotgun, but it will stop the assistant with a toolbox.

If you get your gloves stolen as a security officer somehow with this, I'd be really suprised, and that assistant deserves the reward.

Plus, imagine all the cool kung fu combat fights between sleeping carp traitors and krav maga security officers!

:cl: Iamgoofball
rscadd: Security Forces now start with Krav Maga gloves.
/:cl:
