### PR TITLE
Zombie Tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -85,6 +85,11 @@
 	src << "<span class='userdanger'>You're down, but not quite out. You'll be back on your feet within a minute or two.</span>"
 	spawn(rand(300,400))
 		if(src)
+			if(!src.ckey)
+				for(var/mob/dead/observer/ghost in player_list)
+					if(src.real_name == ghost.real_name)
+						ghost.reenter_corpse()
+						break
 			visible_message("<span class='danger'>[src] staggers to their feet!</span>")
 			revive(full_heal = 1)
 

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -85,11 +85,10 @@
 	src << "<span class='userdanger'>You're down, but not quite out. You'll be back on your feet within a minute or two.</span>"
 	spawn(rand(300,400))
 		if(src)
-			if(!src.ckey)
-				for(var/mob/dead/observer/ghost in player_list)
-					if(src.real_name == ghost.real_name)
-						ghost.reenter_corpse()
-						break
+			for(var/mob/dead/observer/ghost in player_list)
+				if(src.real_name == ghost.real_name)
+					ghost.reenter_corpse()
+					break
 			visible_message("<span class='danger'>[src] staggers to their feet!</span>")
 			revive(full_heal = 1)
 

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -9,8 +9,8 @@
 	speak_emote = list("groans")
 	emote_see = list("groans")
 	a_intent = "harm"
-	maxHealth = 180
-	health = 180
+	maxHealth = 120
+	health = 120
 	speed = 2
 	harm_intent_damage = 8
 	melee_damage_lower = 20
@@ -59,7 +59,7 @@
 			playsound(src.loc, 'sound/hallucinations/growl3.ogg', 50, 1)
 			var/obj/machinery/door/airlock/A = target
 			removingairlock = 1
-			if(do_after(src, 250, 0, A, 1))
+			if(do_after(src, 200, 0, A, 1))
 				playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 				var/obj/structure/door_assembly/door = new A.doortype(get_turf(A))
 				door.density = 0
@@ -83,7 +83,7 @@
 		qdel(src)
 		return
 	src << "<span class='userdanger'>You're down, but not quite out. You'll be back on your feet within a minute or two.</span>"
-	spawn(rand(600,900))
+	spawn(rand(300,400))
 		if(src)
 			visible_message("<span class='danger'>[src] staggers to their feet!</span>")
 			revive(full_heal = 1)


### PR DESCRIPTION
After my last PR #16164 I was largely pleased with how zombies have evolved. Before a single zombie from Xenobio would almost always turn a round on its head since they moved at full speed and had 20-damage hands, within a couple minutes the station would be overrun and fighting back was always pointless.

My PR was designed to make them less snowbally, but I did underestimate how many crew would attempt to melee zombies. A small xenobio outbreak could be contained usually, but anything more and the round would play out like this:

1) The most heavily armed crew (cap, sec) fall back to the brig to either hole up or spend an eternity arming up.

2) The least armed crew rush forth to do melee with the zombies. After being hit a couple times the players would be slowed down to zombie-speed and would usually get finished off and turned. This process repeats itself over and over.

3) Zombies reach critical mass and nobody has enough firepower to stop them. 

This PR reduces Zombie health by 33% (180 -> 120), but cuts their revive time in half. This gives the average spearsistant a decent shot at winning 1v1 with a zombie, but the walking dead will be more relentless than ever if the crew doesn't properly deal with corpses. On that note, zombies that self-res will now pull the ghost back into the zombie.
