### PR TITLE
Abductor Vest Fix

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -98,6 +98,7 @@
 	if(istype(src.loc, /mob/living/carbon/human))
 		if(combat_cooldown != initial(combat_cooldown))
 			src.loc << "<span class='warning'>Combat injection is still recharging.</span>"
+			return
 		var/mob/living/carbon/human/M = src.loc
 		M.adjustStaminaLoss(-75)
 		M.SetParalysis(0)


### PR DESCRIPTION
Fixes a bug where Abductor's vests had no cooldown.

Fixes https://github.com/tgstation/-tg-station/issues/16957

:cl: Fox McCloud
fix: Fixes abductor vests having no cooldown between uses
/:cl:
