### PR TITLE
Fixes xenobio console breaking with monkey numbers

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -25,7 +25,6 @@
 	var/list/stored_slimes = list()
 	var/max_slimes = 5
 	var/monkeys = 0
-	var/monkeypart = 0 //5 of these make a monkey
 
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
@@ -161,8 +160,5 @@
 		for(var/mob/living/carbon/monkey/M in remote_eye.loc)
 			if(M.stat)
 				M.visible_message("[M] vanishes as they are reclaimed for recycling!")
-				X.monkeypart += 1
+				X.monkeys = round(X.monkeys + 0.2,0.1)
 				qdel(M)
-				if(X.monkeypart >= 5)
-					X.monkeys += 1
-					X.monkeypart = 0

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -142,7 +142,7 @@
 			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(remote_eye.loc)
 			food.LAssailant = C
 			X.monkeys --
-			owner << "[X] now has [X.monkeys + X.monkeypart/5] monkeys left."
+			owner << "[X] now has [X.monkeys] monkeys left."
 
 
 /datum/action/innate/monkey_recycle

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -25,6 +25,7 @@
 	var/list/stored_slimes = list()
 	var/max_slimes = 5
 	var/monkeys = 0
+	var/monkeypart = 0 //5 of these make a monkey
 
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
@@ -142,7 +143,7 @@
 			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(remote_eye.loc)
 			food.LAssailant = C
 			X.monkeys --
-			owner << "[X] now has [X.monkeys] monkeys left."
+			owner << "[X] now has [X.monkeys + X.monkeypart/5] monkeys left."
 
 
 /datum/action/innate/monkey_recycle
@@ -160,5 +161,8 @@
 		for(var/mob/living/carbon/monkey/M in remote_eye.loc)
 			if(M.stat)
 				M.visible_message("[M] vanishes as they are reclaimed for recycling!")
-				X.monkeys += 0.2
+				X.monkeypart += 1
 				qdel(M)
+				if(X.monkeypart = 5)
+					X.monkeys += 1
+					X.monkeypart = 0

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -163,6 +163,6 @@
 				M.visible_message("[M] vanishes as they are reclaimed for recycling!")
 				X.monkeypart += 1
 				qdel(M)
-				if(X.monkeypart = 5)
+				if(X.monkeypart >= 5)
 					X.monkeys += 1
 					X.monkeypart = 0


### PR DESCRIPTION
Making the console add +0.2 causes the console to have for example 0.9999998 monkies after 5 monkies and other weird numbers. This will fix it to get a full monkey properly.

~~Not tested yet. I'll test this soon.~~ Tested to work.
