### PR TITLE
Adds holocarp purchase for 10TC

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardiannaming.dm
@@ -17,6 +17,30 @@
 /datum/guardianname/carp/New()
 	prefixname = pick(carp_names)
 
+/datum/guardianname/carp/sand
+	suffixcolour = "Sand"
+	colour = "#C2B280"
+
+/datum/guardianname/carp/seashell
+	suffixcolour = "Seashell"
+	colour = "#FFF5EE"
+
+/datum/guardianname/carp/coral
+	suffixcolour = "Coral"
+	colour = "#FF7F50"
+
+/datum/guardianname/carp/salmon
+	suffixcolour = "Salmon"
+	colour = "#FA8072"
+
+/datum/guardianname/carp/sunset
+	suffixcolour = "Sunset"
+	colour = "#FAD6A5"
+
+/datum/guardianname/carp/riptide
+	suffixcolour = "Riptide"
+	colour = "#89D9C8"
+
 /datum/guardianname/carp/seagreen
 	suffixcolour = "Sea Green"
 	colour = "#2E8B57"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -310,6 +310,17 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 	player_minimum = 25
 
+/datum/uplink_item/dangerous/holocarp
+	name = "Holocarp"
+	desc = "Based on recovered artifacts from the cult of Carp'sie, a 'holocarp' functions similarly to a holoparasite, but with three major differences. \
+			First, it is not possible to select what type of spirit you will retrieve from Lake Carp, it seems to be impossible to predict. \
+			Second, it seems possible for a human to sustain more than one 'holocarp' in their body at once, due to their soothing fishlike nature. \
+			Third, it's a fish."
+	item = /obj/item/weapon/guardiancreator/carp
+	cost = 10
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	player_minimum = 25
+
 // Ammunition
 /datum/uplink_item/ammo
 	category = "Ammunition"


### PR DESCRIPTION
:cl: coiax
rscadd: The Syndicate have been supplied with holocarp fishsticks from the cult of Carp'sie. Do not trust any transparent fish that you sea. Ahem, we mean see.
/:cl:

Holocarp are like holoparasites, with some differences.
- You can have more than one in a single person
- You are unable to select the type, it is determined entirely randomly
- They look like holocarp, and have fish names and colours

This PR is complete, technically, but mostly exists for a test merge to evaluate the balance and cost of a 10TC fishstick.
