### PR TITLE
Only anchored dense objects block the shelter capsule

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -198,7 +198,7 @@
 				clear = FALSE
 				break
 			for(var/obj/obj in turf)
-				if(obj.density)
+				if(obj.density && obj.anchored)
 					clear = FALSE
 					break
 		if(!clear)


### PR DESCRIPTION
Rather than all dense objects. This means windows or whatever will still block it, but you can still drag your orebox with you.
