### PR TITLE
tiny fixes to my stuff. (Sorry! >~<)

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -332,7 +332,7 @@
 	origin_tech = "combat=4;materials=3"
 	icon_state = "chemcore"
 	var/list/beakers = list()
-	var/max_beakers = 4
+	var/max_beakers = 1
 	var/spread_range = 5
 	var/temp_boost = 50
 	var/time_release = 0
@@ -411,11 +411,15 @@
 
 /obj/item/weapon/bombcore/chemical/CheckParts()
 	// Using different grenade casings, causes the payload to have different properties.
+	var/obj/item/weapon/stock_parts/matter_bin/MB = locate(/obj/item/weapon/stock_parts/matter_bin) in src
+	if(MB)
+		max_beakers += MB.rating	// max beakers = 2-5.
+		qdel(MB)
 	for(var/obj/item/weapon/grenade/chem_grenade/G in src)
 
 		if(istype(G, /obj/item/weapon/grenade/chem_grenade/large))
 			var/obj/item/weapon/grenade/chem_grenade/large/LG = G
-			max_beakers += 1 // Adding two large grenades only allows for a maximum of 6 beakers.
+			max_beakers += 1 // Adding two large grenades only allows for a maximum of 7 beakers.
 			spread_range += 2 // Extra range, reduced density.
 			temp_boost += 50 // maximum of +150K blast using only large beakers. Not enough to self ignite.
 			for(var/obj/item/slime_extract/S in LG.beakers) // And slime cores.
@@ -433,7 +437,7 @@
 			temp_boost += 150 // maximum of +350K blast, which is enough to self ignite. Which means a self igniting bomb can't take advantage of other grenade casing properties. Sorry?
 
 		if(istype(G, /obj/item/weapon/grenade/chem_grenade/adv_release))
-			time_release += 25 // A typical bomb, using basic beakers, will explode over 2-4 seconds. Using two will make the reaction last for less time, but it will be more dangerous overall.
+			time_release += 50 // A typical bomb, using basic beakers, will explode over 2-4 seconds. Using two will make the reaction last for less time, but it will be more dangerous overall.
 
 		for(var/obj/item/weapon/reagent_containers/glass/B in G)
 			if(beakers.len < max_beakers)
@@ -443,6 +447,7 @@
 				B.loc = get_turf(src)
 
 		qdel(G)
+
 
 
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -3,7 +3,7 @@
 #define READY 3
 
 /obj/item/weapon/grenade/chem_grenade
-	name = "grenade"
+	name = "chemical grenade"
 	desc = "A custom made grenade."
 	icon_state = "chemg"
 	item_state = "flashbang"
@@ -129,7 +129,7 @@
 		stage = N
 	if(stage == EMPTY)
 		name = "[initial(name)] casing"
-		desc = "A do it yourself [initial(name)] casing!"
+		desc = "A do it yourself [initial(name)]!"
 		icon_state = initial(icon_state)
 	else if(stage == WIRED)
 		name = "unsecured [initial(name)]"
@@ -240,20 +240,22 @@
 
 /obj/item/weapon/grenade/chem_grenade/adv_release // Intended for weaker, but longer lasting effects. Could have some interesting uses.
 	name = "advanced release grenade"
-	desc = "A custom made advanced release grenade. It is able to be triggered more than once. Can be configured using a multitool."
+	desc = "A custom made advanced release grenade. It is able to be detonated more than once. Can be configured using a multitool."
 	icon_state = "timeg"
 	var/unit_spread = 10 // Amount of units per repeat. Can be altered with a multitool.
 
 /obj/item/weapon/grenade/chem_grenade/adv_release/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/device/multitool))
-		if(unit_spread < 100)
-			unit_spread += 5
-		else
-			unit_spread = 5
+		switch(unit_spread)
+			if(0 to 24)
+				unit_spread += 5
+			if(25 to 99)
+				unit_spread += 25
+			else
+				unit_spread = 5
 		user << "<span class='notice'> You set the time release to [unit_spread] units per detonation.</span>"
 		return
-	else
-		return ..()
+	..()
 
 /obj/item/weapon/grenade/chem_grenade/adv_release/prime()
 	if(stage != READY)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -329,25 +329,25 @@
 	category = CAT_MISC
 
 /datum/table_recipe/chemical_payload
-	name = "Chemical Bomb Core (C4)"
+	name = "chemical payload (C4)"
 	result = /obj/item/weapon/bombcore/chemical
 	reqs = list(
 		/obj/item/weapon/stock_parts/matter_bin/super = 1,
 		/obj/item/weapon/c4 = 1,
 		/obj/item/weapon/grenade/chem_grenade = 2
 	)
-	parts = list(/obj/item/weapon/grenade/chem_grenade = 2)
+	parts = list(/obj/item/weapon/stock_parts/matter_bin = 1, /obj/item/weapon/grenade/chem_grenade = 2)
 	time = 30
 	category = CAT_WEAPON
 
 /datum/table_recipe/chemical_payload2
-	name = "Chemical Bomb Core (gibtonite)"
+	name = "chemical payload (gibtonite)"
 	result = /obj/item/weapon/bombcore/chemical
 	reqs = list(
-		/obj/item/weapon/stock_parts/matter_bin/super = 1,
+		/obj/item/weapon/stock_parts/matter_bin = 1,
 		/obj/item/weapon/twohanded/required/gibtonite = 1,
 		/obj/item/weapon/grenade/chem_grenade = 2
 	)
-	parts = list(/obj/item/weapon/grenade/chem_grenade = 2)
+	parts = list(/obj/item/weapon/stock_parts/matter_bin = 1, /obj/item/weapon/grenade/chem_grenade = 2)
 	time = 50
 	category = CAT_WEAPON

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -69,7 +69,7 @@
 		user.drop_item()
 		qdel(O)
 		return
-
+	..()
 
 /datum/action/innate/camera_off/xenobio/Activate()
 	if(!target || !ishuman(target))


### PR DESCRIPTION
makes xeno computer deconstructible again.

From grenade to chemical grenade. This has no effect but to make it so
that tablecrafting recipes calling for chemgrenades specify that its a
grenade casing it needs, not any grenade/flashbang/etc.

Tweaks syndicatebomb recipe so that any matter bin will do, making it
possible to build without rnd's participation whatsoever.

Using a tier one matter bin makes it effectively LESS useful than a
grenade, however.

:cl: nullbear
fix: xenobio console is deconstructable again.
tweak: syndibomb recipe calls for any matter bin, scaling effectiveness with tier.
/:cl:
