### PR TITLE
Fixes the tongueless human mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -22,6 +22,9 @@
 	randomize_human(src)
 	dna.initialize_dna()
 
+	if(dna.species)
+		set_species(dna.species.type)
+
 	//initialise organs
 	organs = newlist(/obj/item/organ/limb/chest, /obj/item/organ/limb/head, /obj/item/organ/limb/l_arm,
 					 /obj/item/organ/limb/r_arm, /obj/item/organ/limb/r_leg, /obj/item/organ/limb/l_leg)


### PR DESCRIPTION
The solution isn't great, but it's the only one I've found that works properly. For those keeping track yes this is a bit redundant in some situations, but just dundant enough for others. Blame the mass of procs that have to fire in a very specific order on the mob, dna, species, and client levels to create a functional spessman for this one.

Fixes #16840 
Fixes #16892

The bug reports are recent but this bug is actually as old as dna.species. It's just it wasn't very noticable at all until the human species datum finally diverged a bit from the human mob.
