### PR TITLE
Mechas can now butcher with their drills

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -86,8 +86,11 @@
 		var/obj/item/organ/limb/affecting = H.get_organ("chest")
 		affecting.take_damage(drill_damage)
 		H.update_damage_overlays(0)
+	else if(target.stat == DEAD && target.butcher_results)
+		target.harvest(chassis) // Butcher the mob with our drill.
 	else
 		target.take_organ_damage(drill_damage)
+
 	if(target)
 		target.Paralyse(10)
 		target.updatehealth()


### PR DESCRIPTION
Drilling mob's corpse with a mech-mounted drill will now butcher it.

This works only if mob is normally butcherable. Humans are not affected.
