### PR TITLE
Adds alternate behaviours to addtimer, making it even more useful than before.

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -71,25 +71,23 @@ var/datum/subsystem/timer/SStimer
 	event.thingToCall = thingToCall
 	event.procToCall = procToCall
 	event.timeToRun = world.time + wait
-	event.hash = jointext(args, null)
 	if(args.len > 4)
 		event.argList = args.Copy(5)
 
 	// Check for dupes if unique = 1.
 	switch(unique)
 		if(TIMER_DEFAULT)
-			event.hash = jointext(args, null)
+			var/semihash = args.Copy(1,3)
+			event.hash = jointext(semihash, null)
 		if(TIMER_OLDEST) // Uses the first timer that was created.
-			var/semihash = args.Copy()
-			semihash.Cut(3, 5)
+			var/semihash = args.Copy(1,3)
 			event.hash = jointext(semihash, null)
 			if(event.hash in SStimer.unique)
 				qdel(src)
 				return
 			SStimer.unique[event.hash] = event
 		if(TIMER_NEWEST) // Uses the most recently created timer.
-			var/semihash = args.Copy()
-			semihash.Cut(3, 5)
+			var/semihash = args.Copy(1,3)
 			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
@@ -97,8 +95,7 @@ var/datum/subsystem/timer/SStimer
 				qdel(old)
 			SStimer.unique[event.hash] = event
 		if(TIMER_SHORTEST) // Uses the timer that will fire first.
-			var/semihash = args.Copy()
-			semihash.Cut(3, 5)
+			var/semihash = args.Copy(1,3)
 			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
@@ -109,8 +106,7 @@ var/datum/subsystem/timer/SStimer
 				qdel(old)
 			SStimer.unique[event.hash] = event
 		if(TIMER_LONGEST) // Uses the timer that will fire last.
-			var/semihash = args.Copy()
-			semihash.Cut(3, 5)
+			var/semihash = args.Copy(1,3)
 			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -85,8 +85,8 @@ var/datum/subsystem/timer/SStimer
 		if(TIMER_NEWEST) // Uses the most recently created timer.
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
+				SStimer.processing -= old // In case qdel doesnt get to it fast enough to remove it from the processing list.
 				qdel(old)
-			SStimer.processing -= old // In case qdel doesnt get to it fast enough to remove it from the processing list.
 			SStimer.unique[event.hash] = event
 		if(TIMER_SHORTEST) // Uses the timer that will fire first.
 			var/datum/timedevent/old = SStimer.unique[event.hash]
@@ -94,8 +94,8 @@ var/datum/subsystem/timer/SStimer
 				if(old.timeToRun <= event.timeToRun)
 					qdel(src)
 					return
+				SStimer.processing -= old
 				qdel(old)
-			SStimer.processing -= old
 			SStimer.unique[event.hash] = event
 		if(TIMER_LONGEST) // Uses the timer that will fire last.
 			var/datum/timedevent/old = SStimer.unique[event.hash]
@@ -103,8 +103,8 @@ var/datum/subsystem/timer/SStimer
 				if(old.timeToRun >= event.timeToRun)
 					qdel(src)
 					return
+				SStimer.processing -= old
 				qdel(old)
-			SStimer.processing -= old
 			SStimer.unique[event.hash] = event
 
 	// If we are unique (or we're not checking that), add the timer and return the id.

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,9 +1,8 @@
 #define TIMER_DEFAULT 0
-#define TIMER_UNIQUE 1
-#define TIMER_OLDEST 2
-#define TIMER_NEWEST 3
-#define TIMER_SHORTEST 4
-#define TIMER_LONGEST 5
+#define TIMER_OLDEST 1
+#define TIMER_NEWEST 2
+#define TIMER_SHORTEST 3
+#define TIMER_LONGEST 4
 
 var/datum/subsystem/timer/SStimer
 
@@ -78,18 +77,29 @@ var/datum/subsystem/timer/SStimer
 
 	// Check for dupes if unique = 1.
 	switch(unique)
+		if(TIMER_DEFAULT)
+			event.hash = jointext(args, null)
 		if(TIMER_OLDEST) // Uses the first timer that was created.
+			var/semihash = args.Copy()
+			semihash.Cut(3, 5)
+			event.hash = jointext(semihash, null)
 			if(event.hash in SStimer.unique)
 				qdel(src)
 				return
 			SStimer.unique[event.hash] = event
 		if(TIMER_NEWEST) // Uses the most recently created timer.
+			var/semihash = args.Copy()
+			semihash.Cut(3, 5)
+			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
 				SStimer.processing -= old // In case qdel doesnt get to it fast enough to remove it from the processing list.
 				qdel(old)
 			SStimer.unique[event.hash] = event
 		if(TIMER_SHORTEST) // Uses the timer that will fire first.
+			var/semihash = args.Copy()
+			semihash.Cut(3, 5)
+			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
 				if(old.timeToRun <= event.timeToRun)
@@ -99,6 +109,9 @@ var/datum/subsystem/timer/SStimer
 				qdel(old)
 			SStimer.unique[event.hash] = event
 		if(TIMER_LONGEST) // Uses the timer that will fire last.
+			var/semihash = args.Copy()
+			semihash.Cut(3, 5)
+			event.hash = jointext(semihash, null)
 			var/datum/timedevent/old = SStimer.unique[event.hash]
 			if(old)
 				if(old.timeToRun >= event.timeToRun)
@@ -106,6 +119,12 @@ var/datum/subsystem/timer/SStimer
 					return
 				SStimer.processing -= old
 				qdel(old)
+			SStimer.unique[event.hash] = event
+		else
+			event.hash = jointext(args, null)
+			if(event.hash in SStimer.unique)
+				qdel(src)
+				return
 			SStimer.unique[event.hash] = event
 
 	// If we are unique (or we're not checking that), add the timer and return the id.

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,8 +1,9 @@
 #define TIMER_DEFAULT 0
-#define TIMER_OLDEST 1
-#define TIMER_NEWEST 2
-#define TIMER_SHORTEST 3
-#define TIMER_LONGEST 4
+#define TIMER_UNIQUE 1
+#define TIMER_OLDEST 2
+#define TIMER_NEWEST 3
+#define TIMER_SHORTEST 4
+#define TIMER_LONGEST 5
 
 var/datum/subsystem/timer/SStimer
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -53,7 +53,6 @@ var/datum/subsystem/timer/SStimer
 /datum/timedevent/Destroy()
 	SStimer.processing -= src
 	SStimer.hashes -= hash
-	SStimer.unique[hash] = null
 	SStimer.unique -= hash
 	return QDEL_HINT_IWILLGC
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -84,7 +84,7 @@
 			cameranet.removeCamera(src)
 			stat |= EMPED
 			SetLuminosity(0)
-			addtimer(src, "emp_reset", 900, TIMER_LONGEST)
+			addtimer(src, "emp_reset", 900, 1, SSTIMER_WAIT) // this will increase the timer if the camera is emp'd again.
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -79,12 +79,12 @@
 	if(!isEmpProof())
 		if(prob(150/severity))
 			icon_state = "[initial(icon_state)]emp"
-			networkbackup = network
+			networkbackup = network.Copy()
 			network = list()
 			cameranet.removeCamera(src)
 			stat |= EMPED
 			SetLuminosity(0)
-			addtimer(src, "emp_reset", 900, TIMER_NEWEST)
+			addtimer(src, "emp_reset", 900, TIMER_LONGEST)
 			for(var/mob/O in mob_list)
 				if (O.client && O.client.eye == src)
 					O.unset_machine()
@@ -94,7 +94,7 @@
 
 /obj/machinery/camera/proc/emp_reset()
 	triggerCameraAlarm()
-	network = networkbackup
+	network = networkbackup.Copy()
 	icon_state = initial(icon_state)
 	stat &= ~EMPED
 	if(can_use())


### PR DESCRIPTION
Also updates camera.dm to use the timer.

DNM i broke something.

WHAT IS THIS?

this adds more functionality to proc/addtimer, allowing for different behaviours.
to be used in place of spawn(x) for increased code reuseability, quality, and stability.

addtimer(src, "procname", timetowait, unique, BEHAVIOUR)

When using spawn, it can typically be replaced with this.

**old:**

```
stuffity stuff
spawn(5)
        more stuff
        even more stuff
other stuff
```

**new:**

```
stuffity stuff
addtimer(src, "dostuff", 5)
otherstuff

proc/dostuff()
    more stuff
    even more stuff
```

the fourth argument can be set to ANYTHING in order to use the behaviours, which allow you to extend or shorten timers, or alter the arguments of the timer before it finishes. 

BEHAVIOUR argument:

the behaviour arguments are only compatible with the defined behaviours. This is used to control matched unique timers.

**TIMER_DEFAULT** will never overwrite an existing timer. this is the default behaviour.
**TIMER_WAIT** will overwrite timer only. Useful for extending a timer without altering it.
**TIMER_DATA** will overwrite arguments only. Useful for altering without extending it.
**TIMER_FULL** will overwrite arguments and timer. Useful for completely altering it.

_I HAVE NO IDEA HOW TO TEST THIS or IF IT WORKS. was guided by @MrStonedOne  and @RemieRichards_
