### PR TITLE
Makes syndicate bombs scarier.

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/syndicatebomb/process()
 	if(active && !defused && (timer > 0)) 	//Tick Tock
-		var/volume = (timer <= 10 ? 40 : 10) // Tick louder when the bomb is closer to being detonated.
+		var/volume = (timer <= 5 ? 50 : 3) // Tick louder when the bomb is closer to being detonated.
 		playsound(loc, beepsound, volume, 0)
 		timer--
 	if(active && !defused && (timer <= 0))	//Boom


### PR DESCRIPTION
Syndicate bombs are now not painfully obvious as soon as they are planted, meaning they will not be discovered unless people are patrolling the maint tunnels where you have planted your dastardly device. The bomb will get LOUD in the last five seconds prior to its detonation for PANIC escapes. 

Or saying goodbye to your loved ones. 

:cl:
Syndicate bombs are now harder to detect
/:cl:
