### PR TITLE
Adds Changeling Injector

### DIFF
--- a/code/game/gamemodes/changeling/changeling_injector.dm
+++ b/code/game/gamemodes/changeling/changeling_injector.dm
@@ -1,0 +1,26 @@
+/obj/item/weapon/changeling_injector
+	name = "Mutagenic Changeling Injector"
+	desc = "An injection-device that contains mutagenic cells sampled from a changeling."
+	icon = 'icons/obj/syringe.dmi'
+	icon_state = "combat_hypo"
+	item_state = "hypo"
+	var/injected = 0
+	origin_tech = "biotech=6;syndicate=6"
+
+/obj/item/weapon/changeling_injector/attack_self(mob/living/user)
+	if(!ishuman(user))
+		user << "<span class='warning'>The [src] flashes a red warning light. The injector is incompatible with your biological form.</span>"
+		return
+	if(injected)
+		user << "<span class='warning'>The [src]'s cell samples have already been injected.</span>"
+		return
+	var/list/parasites = user.hasparasites()
+	if(parasites.len) //thought you were clever and could cheese the system, eh? Think again.
+		user << "<span class='warning'>The [src]'s flashes a red warning light. You body contains incompatible foreign parasites.</span>"
+		return
+	if(user.mind && user.mind.changeling)
+		user << "<span class='warning'>The cells in the [src] recoil back into the injector.</span>" //can't be a changeling if you're a changeling.
+		return
+	user << "<span class='notice'>You inject the [src].</span>"
+	user.make_changeling()
+	injected = 1

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -310,6 +310,15 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 	player_minimum = 25
 
+/datum/uplink_item/dangerous/changeling
+	name = "Mutagenic Changeling Injector"
+	desc = "A specialized injector that contains sampled cells from a changeling organism. Can be used to induce the user to become a changeling."
+	item = /obj/item/weapon/changeling_injector
+	cost = 20
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
+	player_minimum = 15
+
 // Ammunition
 /datum/uplink_item/ammo
 	category = "Ammunition"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -269,6 +269,7 @@
 #include "code\game\gamemodes\blob\blobs\resource.dm"
 #include "code\game\gamemodes\blob\blobs\shield.dm"
 #include "code\game\gamemodes\changeling\changeling.dm"
+#include "code\game\gamemodes\changeling\changeling_injector.dm"
 #include "code\game\gamemodes\changeling\changeling_power.dm"
 #include "code\game\gamemodes\changeling\evolution_menu.dm"
 #include "code\game\gamemodes\changeling\traitor_chan.dm"


### PR DESCRIPTION
Xenobiologists can create armies of station-aligned (or at least aligned to them) changelings---they can also turn themselves into changelings.

Why not allow traitors, if they sacrifice every single one of their telecrystals, make themselves into a changeling?

Implements a changeling injector. It turns the users into a changeling,  provided a few conditions are met:
- User doesn't have a parasite
- User Isn't a changeling already
- User is Human

Can purchase it on the uplink for 20 telecrystals; not available in surplus crates or to nuke-ops or gangs. Requires 15 or more players before it can be purchased.

:cl: Fox McCloud
add: Adds in a changeling injector; turns the user into a changeling.
add: Adds the changeling injector to the uplink for 20 telecrystals
/:cl:
