### PR TITLE
Removes brains dropping from admin caused gibs and c4 suicide

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -48,7 +48,7 @@
 	message_admins("[key_name(user)] suicided with [src.name] at ([x],[y],[z])")
 	sleep(10)
 	explode(get_turf(user))
-	user.gib()
+	user.gib(no_brain = 1)
 
 /obj/item/weapon/c4/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/modules/admin/verbs/bluespacearty.dm
+++ b/code/modules/admin/verbs/bluespacearty.dm
@@ -28,7 +28,7 @@
 	message_admins("[target.name] has been hit by Bluespace Artillery fired by [usr]")
 
 	if(target.health <= 1)
-		target.gib()
+		target.gib(no_brain = 1)
 	else
 		target.adjustBruteLoss(min(99,(target.health - 1)))
 		target.Stun(20)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -583,8 +583,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		src << "Only administrators may use this command."
 		return
 
-	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
-	if(confirm != "Yes")
+	var/confirm = alert(src, "Drop a brain?", "Confirm", "Yes", "No","Cancel")
+	if(confirm == "Cancel")
 		return
 	//Due to the delay here its easy for something to have happened to the mob
 	if(!M)
@@ -596,8 +596,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(istype(M, /mob/dead/observer))
 		gibs(M.loc, M.viruses)
 		return
-
-	M.gib()
+	if(confirm == "Yes")
+		M.gib()
+	else
+		M.gib(no_brain = 1)
 	feedback_add_details("admin_verb","GIB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_gib_self()
@@ -609,7 +611,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if (istype(mob, /mob/dead/observer)) // so they don't spam gibs everywhere
 			return
 		else
-			mob.gib()
+			mob.gib(no_brain = 1)
 
 		log_admin("[key_name(usr)] used gibself.")
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] used gibself.</span>")


### PR DESCRIPTION
gibself dropping brains has been a complaint I've heard from other admins
admin gibbing a mob now brings up a prompt for dropping the brain.
c4 suiciding is going out with a bang, not leaving your brain behind to be borged and cucked.
