### PR TITLE
Replaces fake insulated gloves with cheap insulated gloves in maint drop

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -61,7 +61,7 @@
 				/obj/item/bodybag = 1,
 				/obj/item/clothing/glasses/meson = 2,
 				/obj/item/clothing/glasses/sunglasses = 1,
-				/obj/item/clothing/gloves/color/yellow/fake = 1,
+				/obj/item/clothing/gloves/color/fyellow = 1,
 				/obj/item/clothing/head/hardhat = 1,
 				/obj/item/clothing/head/hardhat/red = 1,
 				/obj/item/clothing/head/that{throwforce = 1; throwing = 1} = 1,


### PR DESCRIPTION
No, it's not "i ded", I'm smart enough to examine my gloves before using them. The problem is, with the addition of fake gloves, _everyone_ learned to examine gloves before using them. And my prank with crayon-washed "insulated" gloves no longer works.

With fake gloves removed, greyshirts will start to forget that skill, and the fake gloves pranks will be funny again.

And cheap gloves are more fun that fake ones. Fakes always have shock protection 0, cheaps have varying shock protection, ranging from full protection to 2x shock damage.
