### PR TITLE
Improves mecha strafing

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1153,10 +1153,17 @@ var/year_integer = text2num(year) // = 2013???
 	if(!owner || !chassis || chassis.occupant != owner)
 		return
 
-	chassis.strafe = !chassis.strafe
+	chassis.toggle_strafe()
 
-	chassis.occupant_message("Toggled strafing mode [chassis.strafe?"on":"off"].")
-	chassis.log_message("Toggled strafing mode [chassis.strafe?"on":"off"].")
+/obj/mecha/AltClick(mob/living/user)
+	if(user == occupant)
+		toggle_strafe()
+
+/obj/mecha/proc/toggle_strafe()
+	strafe = !strafe
+
+	occupant_message("Toggled strafing mode [strafe?"on":"off"].")
+	log_message("Toggled strafing mode [strafe?"on":"off"].")
 
 //////////////////////////////////////// Specific Ability Actions  ///////////////////////////////////////////////
 //Need to be granted by the mech type, Not default abilities.


### PR DESCRIPTION
You can now toggle strafing by alt+clicking your mech, which should be much easier to control mid combat than trying to use the action button.
