### PR TITLE
Ends the confusing inconsistency of power cable and CONDUCT weapons

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -28,7 +28,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	on_blueprints = TRUE
 	var/datum/powernet/powernet
 	name = "power cable"
-	desc = "A flexible, superconducting cable for heavy-duty power transfer."
+	desc = "A flexible, superconducting insulated cable for heavy-duty power transfer."
 	icon = 'icons/obj/power_cond/power_cond_red.dmi'
 	icon_state = "0-1"
 	var/d1 = 0   // cable direction 1 (see above)
@@ -150,10 +150,6 @@ By design, d1 is the smallest direction and d2 is the highest
 		else
 			user << "<span class='danger'>The cable is not powered.</span>"
 		shock(user, 5, 0.2)
-
-	else
-		if (W.flags & CONDUCT)
-			shock(user, 50, 0.7)
 
 	src.add_fingerprint(user)
 
@@ -469,7 +465,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
 	amount = MAXCOIL
 	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
 	item_color = "red"
-	desc = "A coil of power cable."
+	desc = "A coil of insulated power cable."
 	throwforce = 0
 	w_class = 2
 	throw_speed = 3


### PR DESCRIPTION
No meme lives forever my son. 

This mechanic was horribly unintuitive and didn't enhance the game in any way.

Even IF you get away from the absurdity of getting shocked by insulated power cables on contact, the CONDUCT flag used to determine if you get shocked was horribly inconsistent:
- Lit welder shocks you
- Telescopic baton doesn't
- Metal rod shocks you
- Metal chair doesn't
- Wooden Staff of Doors shocks you
- Chainsaws do not

It's just a bad system all around, if you still want to watch innocent people get shocked to death then just hang around an exposed grille. 
