### PR TITLE
Jaunters can now be belt-worn to offer chasm protection

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -531,10 +531,10 @@
 
 /obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
-		user << "Your [src] activates, saving you from the chasm!</span>")
+		user << "Your [src] activates, saving you from the chasm!</span>"
 		activate(user)
 	else
-		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")
+		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
 
 
 /obj/effect/portal/wormhole/jaunt_tunnel

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -492,26 +492,10 @@
 
 /obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
 	var/turf/device_turf = get_turf(user)
-	var/status = 0
-	// doesn't work if
-	// - you're in nullspace (HOW?)
-	if(!device_turf)
-		status = 182
-	// - you're on centcom
-	if(device_turf.z == 2)
-		status = 274
-	// - you're on a z level higher than you could normally reach
-	// (we currently have 9 legal z levels, should be a way of determining
-	// that programatically)
-	if(device_turf.z >= 10)
-		status = 1483
-
-	if(status != 0)
-		usr << "<span class='warning'>\icon[src] INVALID LOCATION: ERROR CODE [status]"
-		// turf_check returns 0 if failure, so it's false if broken
-		return 0
-	else
-		return 1
+	if(!device_turf||device_turf.z==2||device_turf.z>=7)
+		user << "<span class='notice'>You're having difficulties getting the [src.name] to work.</span>"
+		return FALSE
+	return TRUE
 
 /obj/item/device/wormhole_jaunter/proc/activate(mob/user)
 	if(!turf_check(user))
@@ -550,7 +534,6 @@
 		user.visible_message("<span class='warning'>[user]'s [src] activates, saving them from the chasm!</span>")
 		activate(user)
 	else
-		// TIME TO TAUNT THEM
 		user.visible_message("<span class='warning'>The [src] is not attached to [user]'s belt, preventing it from saving them from the chasm. RIP.</span>")
 
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -1068,10 +1068,10 @@
 /*********************Hivelord stabilizer****************/
 
 /obj/item/weapon/hivelordstabilizer
-	name = "legion's heart stabilizer"
+	name = "stabilizing serum"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
-	desc = "Inject a legion's heart with this stabilizer to preserve its healing powers indefinitely."
+	desc = "Inject certain types of monster organs with this stabilizer to preserve their healing powers indefinitely."
 	w_class = 1
 	origin_tech = "biotech=1"
 
@@ -1130,7 +1130,7 @@
 		new /datum/data/mining_equipment("Alien Toy",           	/obj/item/clothing/mask/facehugger/toy, 		                   		300),
 		new /datum/data/mining_equipment("Monkey Cube",				/obj/item/weapon/reagent_containers/food/snacks/monkeycube,        		300),
 		new /datum/data/mining_equipment("Toolbelt",				/obj/item/weapon/storage/belt/utility,	    							350),
-		new /datum/data/mining_equipment("Hivelord Stabilizer",		/obj/item/weapon/hivelordstabilizer,		                     		400),
+		new /datum/data/mining_equipment("Stabilizing Serum",		/obj/item/weapon/hivelordstabilizer,		                     		400),
 		new /datum/data/mining_equipment("Shelter Capsule",			/obj/item/weapon/survivalcapsule,			                     		400),
 		new /datum/data/mining_equipment("GAR scanners",			/obj/item/clothing/glasses/meson/gar,					  		   		500),
 		new /datum/data/mining_equipment("Sulphuric Acid",			/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,        		500),

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -291,6 +291,7 @@
 		new /datum/data/mining_equipment("GAR scanners",		/obj/item/clothing/glasses/meson/gar,					  		   		500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",	/obj/item/weapon/storage/firstaid/brute,						   		600),
 		new /datum/data/mining_equipment("Jaunter",             /obj/item/device/wormhole_jaunter,                                 		600),
+		new /datum/data/mining_equipment("Wormhole Lifebuoy",   /obj/item/device/wormhole_jaunter/lifebuoy,							   1000),
 		new /datum/data/mining_equipment("Kinetic Accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,               	   		750),
 		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                    	   		800),
 		new /datum/data/mining_equipment("Lazarus Injector",    /obj/item/weapon/lazarus_injector,                                		1000),
@@ -492,20 +493,43 @@
 		return
 	else
 		user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
-		var/list/L = list()
-		for(var/obj/item/device/radio/beacon/B in world)
-			var/turf/T = get_turf(B)
-			if(T.z == ZLEVEL_STATION)
-				L += B
-		if(!L.len)
-			user << "<span class='notice'>The [src.name] failed to create a wormhole.</span>"
-			return
-		var/chosen_beacon = pick(L)
-		var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon, lifespan=100)
-		J.target = chosen_beacon
-		try_move_adjacent(J)
-		playsound(src,'sound/effects/sparks4.ogg',50,1)
-		qdel(src)
+		activate(user)
+
+/obj/item/device/wormhole_jaunter/proc/activate(mob/user)
+	var/list/L = list()
+	for(var/obj/item/device/radio/beacon/B in world)
+		var/turf/T = get_turf(B)
+		if(T.z == ZLEVEL_STATION)
+			L += B
+	if(!L.len)
+		user << "<span class='notice'>The [src.name] failed to create a wormhole.</span>"
+		return
+	var/chosen_beacon = pick(L)
+	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon, lifespan=100)
+	J.target = chosen_beacon
+	try_move_adjacent(J)
+	playsound(src,'sound/effects/sparks4.ogg',50,1)
+	qdel(src)
+
+
+/obj/item/device/wormhole_jaunter/lifebuoy
+	name = "wormhole lifebuoy"
+	desc = "A single use device using similar technology to the wormhole jaunter. In addition, this belt has velocity and depth sensors that will trigger the device automatically if the user falls into a chasm, saving them from their trip into the darkness. Must be worn around the users waist in order to function in this way."
+	slot_flags = SLOT_BELT
+
+/obj/item/device/wormhole_jaunter/lifebuoy/emp_act(power)
+	var/triggered = FALSE
+	if(power == 1)
+		triggered = TRUE
+	else if(power == 2 && prob(50))
+		triggered = TRUE
+	if(triggered)
+		usr.visible_message("<span class='warning'>The [src] overloads and activates!</span>")
+		activate(usr)
+
+/obj/item/device/wormhole_jaunter/lifebuoy/proc/chasm_protect()
+	usr.visible_message("<span class='warning'>[usr]'s [src] activates, saving them from the chasm!</span>")
+	activate(usr)
 
 /obj/effect/portal/wormhole/jaunt_tunnel
 	name = "jaunt tunnel"
@@ -518,6 +542,7 @@
 		return
 	if(istype(M, /atom/movable))
 		if(do_teleport(M, target, 6))
+			playsound(M,'sound/weapons/resonator_blast.ogg',50,1)
 			if(iscarbon(M))
 				var/mob/living/carbon/L = M
 				L.Weaken(3)
@@ -1019,20 +1044,20 @@
 /*********************Hivelord stabilizer****************/
 
 /obj/item/weapon/hivelordstabilizer
-	name = "hivelord stabilizer"
+	name = "legion's heart stabilizer"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
-	desc = "Inject a hivelord core with this stabilizer to preserve its healing powers indefinitely."
+	desc = "Inject a legion's heart with this stabilizer to preserve its healing powers indefinitely."
 	w_class = 1
 	origin_tech = "biotech=1"
 
 /obj/item/weapon/hivelordstabilizer/afterattack(obj/item/organ/internal/M, mob/user)
 	var/obj/item/organ/internal/hivelord_core/C = M
 	if(!istype(C, /obj/item/organ/internal/hivelord_core))
-		user << "<span class='warning'>The stabilizer only works on hivelord cores.</span>"
+		user << "<span class='warning'>The stabilizer only works on legion's hearts.</span>"
 		return ..()
 	C.preserved = 1
-	user << "<span class='notice'>You inject the hivelord core with the stabilizer. It will no longer go inert.</span>"
+	user << "<span class='notice'>You inject the [M] with the stabilizer. It will no longer go inert.</span>"
 	qdel(src)
 
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -531,10 +531,10 @@
 
 /obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
-		user.visible_message("<span class='warning'>[user]'s [src] activates, saving them from the chasm!</span>")
+		user << "Your [src] activates, saving you from the chasm!</span>")
 		activate(user)
 	else
-		user.visible_message("<span class='warning'>The [src] is not attached to [user]'s belt, preventing it from saving them from the chasm. RIP.</span>")
+		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>")
 
 
 /obj/effect/portal/wormhole/jaunt_tunnel
@@ -1061,7 +1061,7 @@
 /obj/item/weapon/hivelordstabilizer/afterattack(obj/item/organ/internal/M, mob/user)
 	var/obj/item/organ/internal/hivelord_core/C = M
 	if(!istype(C, /obj/item/organ/internal/hivelord_core))
-		user << "<span class='warning'>The stabilizer only works on legion's hearts.</span>"
+		user << "<span class='warning'>The stabilizer only works on certain types of monster organs, generally regenerative in nature.</span>"
 		return ..()
 	C.preserved = 1
 	user << "<span class='notice'>You inject the [M] with the stabilizer. It will no longer go inert.</span>"

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -574,9 +574,14 @@
 			return
 	if(istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		if(istype(H.belt, /obj/item/device/wormhole_jaunter/lifebuoy))
-			var/obj/item/device/wormhole_jaunter/lifebuoy/L = H.belt
-			L.chasm_protect()
+		// If we have more than one type of chasm reacting item, then
+		// should change this to some sort of flag on /obj/item and check
+		// the mob's contents. But for now this will do.
+		if(istype(H.belt, /obj/item/device/wormhole_jaunter))
+			var/obj/item/device/wormhole_jaunter/J = H.belt
+			// This also does the belt check in case it's ever transformed
+			// to be more general.
+			J.chasm_react(H)
 			return
 	drop(AM)
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -574,13 +574,8 @@
 			return
 	if(istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
-		// If we have more than one type of chasm reacting item, then
-		// should change this to some sort of flag on /obj/item and check
-		// the mob's contents. But for now this will do.
 		if(istype(H.belt, /obj/item/device/wormhole_jaunter))
 			var/obj/item/device/wormhole_jaunter/J = H.belt
-			// This also does the belt check in case it's ever transformed
-			// to be more general.
 			J.chasm_react(H)
 			return
 	drop(AM)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -563,11 +563,20 @@
 /turf/open/chasm/Entered(atom/movable/AM)
 	if(istype(AM, /obj/singularity) || istype(AM, /obj/item/projectile))
 		return
+	if(istype(AM, /obj/effect/portal))
+		// Portals aren't affected by gravity. Probably.
+		return
 	// Flies right over the chasm
 	if(istype(AM, /mob/living/simple_animal))
 		// apparently only simple_animals can fly??
 		var/mob/living/simple_animal/SA = AM
 		if(SA.flying)
+			return
+	if(istype(AM, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = AM
+		if(istype(H.belt, /obj/item/device/wormhole_jaunter/lifebuoy))
+			var/obj/item/device/wormhole_jaunter/lifebuoy/L = H.belt
+			L.chasm_protect()
 			return
 	drop(AM)
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -576,6 +576,8 @@
 		var/mob/living/carbon/human/H = AM
 		if(istype(H.belt, /obj/item/device/wormhole_jaunter))
 			var/obj/item/device/wormhole_jaunter/J = H.belt
+			// To freak out any bystanders
+			visible_message("[H] falls into [src]!")
 			J.chasm_react(H)
 			return
 	drop(AM)


### PR DESCRIPTION
:cl: coiax
rscadd: As a sign of friendship between the Free Golems and Centcom,
they have modified Centcom's jaunter to be worn around a user's waist,
which will save them from falling to their death in a chasm.
experiment: The Golems warn that these modifications have created
a risk of accidental activation when exposed to heavy electromagnetic
fields.
tweak: Renamed hivelord stabilizer to stabilizing serum.
/:cl:
