### PR TITLE
Some random TC price rebalances

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -21,6 +21,7 @@
 			new /obj/item/device/rad_laser(src)
 			new /obj/item/device/chameleon(src)
 			new /obj/item/weapon/soap/syndie(src)
+			new /obj/item/clothing/glasses/thermal/syndi(src)
 			return
 
 		if("bond")
@@ -30,6 +31,8 @@
 			new /obj/item/ammo_box/magazine/m10mm(src)
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/weapon/card/id/syndicate(src)
+			new /obj/item/weapon/reagent_containers/syringe/stimulants(src)
+
 			return
 
 		if("screwed")

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -139,7 +139,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
 			with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/pistol
-	cost = 9
+	cost = 5
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"
@@ -790,7 +790,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			for rapid healing, a medical HUD for quick identification of injured personnel, \
 			and other supplies helpful for a field medic."
 	item = /obj/item/weapon/storage/firstaid/tactical
-	cost = 9
+	cost = 4
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
 
 /datum/uplink_item/device_tools/thermal
@@ -839,7 +839,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			during gravitational generator failures. These reverse-engineered knockoffs of Nanotrasen's \
 			'Advanced Magboots' slow you down in simulated-gravity environments much like the standard issue variety."
 	item = /obj/item/clothing/shoes/magboots/syndie
-	cost = 3
+	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/c4
@@ -862,7 +862,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			load on the grid, causing a stationwide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes."
 	item = /obj/item/device/powersink
-	cost = 10
+	cost = 6
 
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Power Beacon"
@@ -901,7 +901,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			of humanoids. It has two settings: intensity, which controls the power of the radiation, \
 			and wavelength, which controls how long the radiation delay is."
 	item = /obj/item/device/rad_laser
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/device_tools/assault_pod
 	name = "Assault Pod Targetting Device"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -139,7 +139,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
 			with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/pistol
-	cost = 5
+	cost = 7
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"


### PR DESCRIPTION
I have changed some of the prices of items to be more reflective of their use
these are typically the unused items so I have made them cheaper to encourage their use

Stechkin down from 9 tc to 5, nobody ever buys it in traitor really, maybe they'll want to get it as a side defense now to whatever else they're doing/
Tactical medkit from 9 to 4, nobody used it, medbeam was way more useful now, hopefully having it at 4 tc will make it so an op who wants to die a little less might buy it on the side.
Syndie magboots from 3 to 2, nobody used them.
This is probably the most controversial, but powersinks from 10 to 6. Powersinks used to be used all the time, but now it seems like they are basically never purchased outside of surplus crates. Maybe someone will try the old powersink technique once again.
Rad laser from 5 to 3. Nobody used it. Could be a cool side stealth thing.

:cl: 
rscadd: Several lesser-used uplink's TC cost have been rebalanced.
tweak: Steckhin down from 9TC to 7TC.
tweak: Tactical medkit down from 9TC to 4TC.
tweak: Syndicate magboots from 3TC to 2TC.
tweak: Powersinks down from 10TC to 6TC.
tweak: Stealth rad-laser down from 5TC to 3TC.
tweak: Bundles have been updated accordingly.
/:cl:
