### PR TITLE
Names of loaded ruins maps are saved in world log

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -114,7 +114,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 					break
 
 			if(valid)
-				world.log << "Ruins marker placed at ([T.x], [T.y], [T.z])"
+				world.log << "Ruin \"[template.mappath]\" placed at ([T.x], [T.y], [T.z])"
 				var/obj/effect/ruin_loader/R = new /obj/effect/ruin_loader(T)
 				R.Load(potentialRuins,template)
 				potentialRuins -= template


### PR DESCRIPTION
Makes it easier to debug ruins.
