### PR TITLE
Buffs light replacer and makes it easier to use

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -41,7 +41,7 @@
 /obj/item/device/lightreplacer
 
 	name = "light replacer"
-	desc = "A device to automatically replace lights. Refill with working lightbulbs."
+	desc = "A device to automatically replace lights. Refill with broken or working lightbulbs, or sheets of glass."
 
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer0"
@@ -61,6 +61,11 @@
 	var/decrement = 1
 	var/charge = 1
 
+	// Eating used bulbs gives us bulb shards
+	var/bulb_shards = 0
+	// when we get this many shards, we get a free bulb.
+	var/shards_required = 4
+
 /obj/item/device/lightreplacer/New()
 	uses = max_uses / 2
 	failmsg = "The [name]'s refill light blinks red."
@@ -68,7 +73,7 @@
 
 /obj/item/device/lightreplacer/examine(mob/user)
 	..()
-	user << "It has [uses] light\s remaining."
+	user << status_string()
 
 /obj/item/device/lightreplacer/attackby(obj/item/W, mob/user, params)
 
@@ -79,51 +84,60 @@
 			return
 		else if(G.use(decrement))
 			AddUses(increment)
-			user << "<span class='notice'>You insert a piece of glass into the [src.name]. You have [uses] lights remaining.</span>"
+			user << "<span class='notice'>You insert a piece of glass into the [src.name]. You have [uses] light\s remaining.</span>"
 			return
 		else
 			user << "<span class='warning'>You need one sheet of glass to replace lights!</span>"
 
 	if(istype(W, /obj/item/weapon/light))
+		var/new_bulbs = 0
 		var/obj/item/weapon/light/L = W
 		if(L.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
 				if(!user.unEquip(W))
 					return
 				AddUses(1)
-				user << "<span class='notice'>You insert the [L.name] into the [src.name]. You have [uses] lights remaining.</span>"
 				qdel(L)
-				return
 		else
-			user << "<span class='warning'>You need a working light!</span>"
-			return
+			if(!user.unEquip(W))
+				return
+			new_bulbs += AddShards(1)
+			qdel(L)
+		if(new_bulbs != 0)
+			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
+		user << "<span class='notice'>You insert the [L.name] into the [src.name]. " + status_string() + "</span>"
+		return
 
 	if(istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
-		var/found_good_light = 0
-		var/replaced_something = 0
+		var/found_lightbulbs = FALSE
+		var/replaced_something = TRUE
 
 		for(var/obj/item/I in S.contents)
 			if(istype(I,/obj/item/weapon/light))
 				var/obj/item/weapon/light/L = I
+				found_lightbulbs = TRUE
+				if(src.uses >= max_uses)
+					break
 				if(L.status == LIGHT_OK)
-					found_good_light = 1
-					if(src.uses < max_uses)
-						qdel(L)
-						AddUses(1)
-						replaced_something = 1
-					else
-						break
+					replaced_something = TRUE
+					AddUses(1)
+					qdel(L)
 
-		if(!found_good_light)
-			user << "<span class='warning'>\The [S] contains no useable lights!</span>"
+				else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
+					replaced_something = TRUE
+					AddShards(1)
+					qdel(L)
+
+		if(!found_lightbulbs)
+			user << "<span class='warning'>\The [S] contains no bulbs.</span>"
 			return
 
 		if(!replaced_something && src.uses == max_uses)
 			user << "<span class='warning'>\The [src] is full!</span>"
 			return
 
-		user << "<span class='notice'>You fill \the [src] with lights from \the [S]. You have [uses] lights remaining.</span>"
+		user << "<span class='notice'>You fill \the [src] with lights from \the [S]. " + status_string() + "</span>"
 
 /obj/item/device/lightreplacer/emag_act()
 	if(!emagged)
@@ -138,11 +152,13 @@
 			usr << "You shortcircuit the [src]."
 			return
 	*/
-	usr << "It has [uses] lights remaining."
+	usr << status_string()
 
 /obj/item/device/lightreplacer/update_icon()
 	icon_state = "lightreplacer[emagged]"
 
+/obj/item/device/lightreplacer/proc/status_string()
+	return "It has [uses] light\s remaining (plus [bulb_shards] fragment\s)."
 
 /obj/item/device/lightreplacer/proc/Use(mob/user)
 
@@ -152,7 +168,16 @@
 
 // Negative numbers will subtract
 /obj/item/device/lightreplacer/proc/AddUses(amount = 1)
-	uses = min(max(uses + amount, 0), max_uses)
+	uses = Clamp(uses + amount, 0, max_uses)
+
+/obj/item/device/lightreplacer/proc/AddShards(amount = 1)
+	// Returns number of new bulbs made from the shards
+	bulb_shards += amount
+	var/new_bulbs = round(bulb_shards / shards_required)
+	if(new_bulbs > 0)
+		AddUses(new_bulbs)
+	bulb_shards = bulb_shards % shards_required
+	return new_bulbs
 
 /obj/item/device/lightreplacer/proc/Charge(var/mob/user)
 	charge += 1
@@ -168,14 +193,10 @@
 			U << "<span class='notice'>You replace the [target.fitting] with \the [src].</span>"
 
 			if(target.status != LIGHT_EMPTY)
-
-				var/obj/item/weapon/light/L1 = new target.light_type(target.loc)
-				L1.status = target.status
-				L1.rigged = target.rigged
-				L1.brightness = target.brightness
-				L1.switchcount = target.switchcount
-				target.switchcount = 0
-				L1.update()
+				var/new_bulbs = AddShards(1)
+				if(new_bulbs != 0)
+					U << "<span class='notice'>\The [src] has fabricated a new bulb from the broken bulbs it has stored. It now has [uses] uses.</span>"
+					playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 
 				target.status = LIGHT_EMPTY
 				target.update()
@@ -220,7 +241,25 @@
 	else
 		return 0
 
-/obj/item/device/lightreplacer/cyborg
+/obj/item/device/lightreplacer/afterattack(atom/T, mob/U, proximity)
+	if(!proximity)
+		return
+	if(!isturf(T))
+		return
+
+	var/used = FALSE
+	// making special messages if there's more than one light fitting in
+	// a turf is dumb because it never happens
+	for(var/atom/A in T)
+		if(!CanUse(U))
+			break
+		used = TRUE
+		if(istype(A, /obj/machinery/light))
+			ReplaceLight(A, U)
+
+	if(!used)
+		U << failmsg
+		return
 
 /obj/item/device/lightreplacer/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
 	J.put_in_cart(src, user)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -171,7 +171,6 @@
 	uses = Clamp(uses + amount, 0, max_uses)
 
 /obj/item/device/lightreplacer/proc/AddShards(amount = 1)
-	// Returns number of new bulbs made from the shards
 	bulb_shards += amount
 	var/new_bulbs = round(bulb_shards / shards_required)
 	if(new_bulbs > 0)
@@ -248,8 +247,6 @@
 		return
 
 	var/used = FALSE
-	// making special messages if there's more than one light fitting in
-	// a turf is dumb because it never happens
 	for(var/atom/A in T)
 		if(!CanUse(U))
 			break

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -259,7 +259,6 @@
 
 	if(!used)
 		U << failmsg
-		return
 
 /obj/item/device/lightreplacer/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
 	J.put_in_cart(src, user)


### PR DESCRIPTION
:cl: coiax
rscadd: The Janitor's Union has mandated additional features to station
light replacer devices.
rscadd: The light replacer now can be used on the floor to replace
the bulbs of any lights on that tile.
rscadd: The light replacer now eats replaced bulbs, and after a certain
number of bulb fragments (four) will recycle them into a new bulb.
tweak: The description of the light replacer is now more informative.
/:cl:
