### PR TITLE
Undoes Gatling Nerf

### DIFF
--- a/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
+++ b/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
@@ -190,5 +190,5 @@
 	click_cooldown_override = 1
 
 /obj/item/projectile/beam/weak
-	damage = 7
+	damage = 15
 	armour_penetration = 50


### PR DESCRIPTION
I got tricked by balance memes and it sort sucks now.

Originally: 5 round burst, 10 damage a shot

Now merged: 3 round burst, 7 damage a shot (the burst change was to prevent crashes mostly)

Proposed: 3 round burst, 15 damage a shot (So roughly the same damage output as originally)

I'm open to arguing about these numbers. Ideally it'd be the original spam but the server fucking dies if more than one fires at once.
