### PR TITLE
Implements freezie floors and buffs frostoil

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -283,6 +283,7 @@ var/list/bloody_footprints_cache = list()
 #define TURF_WET_WATER	1
 #define TURF_WET_LUBE	2
 #define TURF_WET_ICE	3
+#define TURF_WET_PERMAFROST 4
 
 //Object/Item sharpness
 #define IS_BLUNT			0

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -29,7 +29,7 @@
 
 /obj/item/weapon/grenade/gluon
     desc = "An advanced grenade that releases a harmful stream of gluons inducing radiation in those nearby. These gluon streams will also make victims feel exhausted, and induce shivering. This extreme coldness will also likely wet any nearby floors."
-    name = "gluon grenade"
+    name = "gluon frag grenade"
     icon = 'icons/obj/grenade.dmi'
     icon_state = "bluefrag"
     item_state = "flashbang"
@@ -44,7 +44,8 @@
         for(var/turf/T in view(freeze_range,loc))
                 if(istype(T,/turf/open/floor))
                         var/turf/open/floor/F = T
-                        F.MakeSlippery(TURF_WET_ICE)
+                        F.wet = TURF_WET_PERMAFROST
+                        addtimer(F, "MakeDry", rand(3000, 3100), 0, TURF_WET_PERMAFROST)
                 for(var/mob/living/carbon/L in T)
                         L.adjustStaminaLoss(stamina_damage)
                         L.bodytemperature -= 230

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -44,7 +44,7 @@
         for(var/turf/T in view(freeze_range,loc))
                 if(istype(T,/turf/open/floor))
                         var/turf/open/floor/F = T
-                        F.wet = TURF_WET_PERMAFROST
+                        F.MakeSlippery(TURF_WET_PERMAFROST)
                         addtimer(F, "MakeDry", rand(3000, 3100), 0, TURF_WET_PERMAFROST)
                 for(var/mob/living/carbon/L in T)
                         L.adjustStaminaLoss(stamina_damage)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -44,7 +44,7 @@
         for(var/turf/T in view(freeze_range,loc))
                 if(istype(T,/turf/open/floor))
                         var/turf/open/floor/F = T
-                        F.MakeSlippery(TURF_WET_PERMAFROST)
+                        F.wet = TURF_WET_PERMAFROST
                         addtimer(F, "MakeDry", rand(3000, 3100), 0, TURF_WET_PERMAFROST)
                 for(var/mob/living/carbon/L in T)
                         L.adjustStaminaLoss(stamina_damage)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -44,7 +44,7 @@
         for(var/turf/T in view(freeze_range,loc))
                 if(istype(T,/turf/open/floor))
                         var/turf/open/floor/F = T
-                        F.wet = TURF_WET_ICE
+                        F.MakeSlippery(TURF_WET_ICE)
                 for(var/mob/living/carbon/L in T)
                         L.adjustStaminaLoss(stamina_damage)
                         L.bodytemperature -= 230

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -97,19 +97,36 @@
 			wet_overlay = null
 		var/turf/open/floor/F = src
 		if(istype(F))
-			wet_overlay = image('icons/effects/water.dmi', src, "wet_floor_static")
+			if(wet_setting == TURF_WET_ICE)
+				wet_overlay = image('icons/turf/overlays.dmi', src, "snowfloor")
+			else
+				wet_overlay = image('icons/effects/water.dmi', src, "wet_floor_static")
 		else
 			wet_overlay = image('icons/effects/water.dmi', src, "wet_static")
 		overlays += wet_overlay
 
-	spawn(rand(790, 820)) // Purely so for visual effect
-		if(!istype(src, /turf)) //Because turfs don't get deleted, they change, adapt, transform, evolve and deform. they are one and they are all.
-			return
-		MakeDry(wet_setting)
+	if(wet != TURF_WET_ICE)
+		addtimer(src, "MakeDry", rand(790, 820))
 
 /turf/open/proc/MakeDry(wet_setting = TURF_WET_WATER)
-	if(wet > wet_setting)
+	if(!istype(src, /turf)) //Because turfs don't get deleted, they change, adapt, transform, evolve and deform. they are one and they are all.
+		return
+	if(wet > wet_setting || !wet)
 		return
 	wet = TURF_DRY
 	if(wet_overlay)
 		overlays -= wet_overlay
+
+/turf/open/proc/HandleWet()
+	if(!istype(src, /turf))
+		return
+	if(!wet || wet > TURF_WET_ICE)
+		return
+	if(air.temperature < T0C && wet != TURF_WET_ICE)
+		MakeDry(TURF_WET_ICE)
+		MakeSlippery(TURF_WET_ICE)
+	else if (wet == TURF_WET_ICE)
+		MakeDry(TURF_WET_ICE)
+		MakeSlippery(TURF_WET_WATER)
+	else if (air.temperature > T0C + 40) // Warm rooms will dry up rather quickly.
+		addtimer(src, "MakeDry", 100, 1, TURF_WET_ICE)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -97,7 +97,7 @@
 			wet_overlay = null
 		var/turf/open/floor/F = src
 		if(istype(F))
-			if(wet_setting == TURF_WET_ICE)
+			if(wet_setting >= TURF_WET_ICE)
 				wet_overlay = image('icons/turf/overlays.dmi', src, "snowfloor")
 			else
 				wet_overlay = image('icons/effects/water.dmi', src, "wet_floor_static")

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -97,7 +97,7 @@
 			wet_overlay = null
 		var/turf/open/floor/F = src
 		if(istype(F))
-			if(wet_setting >= TURF_WET_ICE)
+			if(wet_setting == TURF_WET_ICE)
 				wet_overlay = image('icons/turf/overlays.dmi', src, "snowfloor")
 			else
 				wet_overlay = image('icons/effects/water.dmi', src, "wet_floor_static")

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -105,7 +105,7 @@
 			wet_overlay = image('icons/effects/water.dmi', src, "wet_static")
 		overlays += wet_overlay
 
-	if(wet != TURF_WET_ICE)
+	if(wet < TURF_WET_ICE)
 		addtimer(src, "MakeDry", rand(790, 820))
 
 /turf/open/proc/MakeDry(wet_setting = TURF_WET_WATER)
@@ -113,9 +113,12 @@
 		return
 	if(wet > wet_setting || !wet)
 		return
-	wet = TURF_DRY
-	if(wet_overlay)
-		overlays -= wet_overlay
+	if(wet == TURF_WET_PERMAFROST)
+		wet = TURF_WET_ICE
+	else
+		wet = TURF_DRY
+		if(wet_overlay)
+			overlays -= wet_overlay
 
 /turf/open/proc/HandleWet()
 	if(!istype(src, /turf))

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -69,7 +69,7 @@
 	temperature = 180
 	baseturf = /turf/open/floor/plating/ice
 	slowdown = 1
-	wet = TURF_WET_ICE
+	wet = TURF_WET_PERMAFROST
 
 /turf/open/floor/plating/ice/colder
 	temperature = 140

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -105,7 +105,7 @@
 					M.inertia_dir = 0
 			if(TURF_WET_LUBE)
 				M.slip(0, 7, null, (SLIDE|GALOSHES_DONT_HELP))
-			if(TURF_WET_ICE)
+			if(TURF_WET_ICE || TURF_WET_PERMAFROST)
 				M.slip(0, 4, null, (SLIDE|NO_SLIP_WHEN_WALKING))
 
 /turf/proc/is_plasteel_floor()

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -192,6 +192,7 @@
 		if(air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
 			if(consider_superconductivity(starting = 1))
 				remove = 0
+	HandleWet() // if the tile is wet, and cold, make ice. Or if it's wet, and warm, dry it off.
 
 	if(!our_excited_group && remove == 1)
 		SSair.remove_from_active(src)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -119,7 +119,7 @@
 /datum/reagent/consumable/frostoil
 	name = "Frost Oil"
 	id = "frostoil"
-	description = "A special oil that noticably chills the body. Extraced from Icepeppers."
+	description = "A special oil that noticably chills the body. Extracted from Icepeppers and slimes."
 	color = "#8BA6E9" // rgb: 139, 166, 233
 
 /datum/reagent/consumable/frostoil/on_mob_life(mob/living/M)
@@ -152,8 +152,11 @@
 	if(reac_volume >= 5)
 		for(var/mob/living/simple_animal/slime/M in T)
 			M.adjustToxLoss(rand(15,30))
-		//if(istype(T))
-		//	T.atmos_spawn_air(SPAWN_COLD)
+	if(reac_volume >= 1) // Make Freezy Foam and anti-fire grenades!
+		if(istype(T, /turf/open))
+			var/turf/open/OT = T
+			OT.MakeSlippery(TURF_WET_WATER) // Is less effective in high pressure/high heat capacity environments. More effective in low pressure.
+			OT.air.temperature -= MOLES_CELLSTANDARD*100*reac_volume/OT.air.heat_capacity() // reduces environment temperature by 5K per unit.
 
 /datum/reagent/consumable/condensedcapsaicin
 	name = "Condensed Capsaicin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -257,7 +257,7 @@
 /datum/reagent/lube/reaction_turf(turf/open/T, reac_volume)
 	if (!istype(T)) return
 	if(reac_volume >= 1)
-		T.MakeSlippery(2)
+		T.MakeSlippery(TURF_WET_LUBE)
 
 /datum/reagent/spraytan
 	name = "Spray Tan"


### PR DESCRIPTION
:cl: nullbear
rscadd: A reminder for crew to avoid mopping floors in cold rooms, as
the water will freeze and provide a dangerous slipping hazard known as
'ice'. Running on it is not recommended.
rscadd: Frostoil is an effective chemical for rapidly cooling areas
in the event of a fire.
/:cl:

Makes wet floors freeze in cold environments, and evaporate faster in warm
environments.

Makes frostoil cool the atmosphere, and make the floor wet. Typically
resulting in icy floors.

Fixes gluon grenade potentially making floors permanently icy.
