### PR TITLE
Removes RD's firing pins

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -22,4 +22,4 @@
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/weapon/door_remote/research_director(src)
-	new /obj/item/weapon/storage/box/firingpins(src)
+


### PR DESCRIPTION
the entire point of adding firing pins was to limit who could use guns, thats why you don't get the guns in lockboxes anymore

0/10 kor bad idea :sheep: :sheep: :sheep: :sheep: :sheep: :sheep: 
