### PR TITLE
Changes Histamine overdose to work differently, adds Mindbreaker overdose.

### DIFF
--- a/code/datums/diseases/chemicaloverdose.dm
+++ b/code/datums/diseases/chemicaloverdose.dm
@@ -1,0 +1,45 @@
+/datum/disease/chemicaloverdose/histamine_od
+	name = "Histamine Overdose"
+	max_stages = 2
+	spread_text = "Special"
+	spread_flags = SPECIAL
+	cure_text = "Diphenhyramine"
+	cures = list("diphenhydramine")
+	agent = "Concentrated Histamine."
+	viable_mobtypes = list(/mob/living/carbon/human,/mob/living/carbon/monkey)
+	desc = "If left untreated severe oxygen deprivation, flesh damage, eye damage, and organ damage will occur."
+	severity = BIOHAZARD
+	disease_flags = CURABLE
+	spread_flags = NON_CONTAGIOUS
+
+/datum/disease/chemicaloverdose/histamine_od/stage_act()
+	..()
+	switch(stage)
+		if(2)
+			affected_mob.adjustOxyLoss(7)
+			affected_mob.adjustBruteLoss(7)
+			affected_mob.adjustToxLoss(7)
+	return
+
+/datum/disease/chemicaloverdose/mindbreaker_od
+	name = "Mindbreaker Overdose"
+	max_stages = 3
+	spread_text = "Special"
+	spread_flags = SPECIAL
+	cure_text = "Synaptizine"
+	cures = list("Synaptizine")
+	agent = "Concentrated Mindbreaker."
+	viable_mobtypes = list(/mob/living/carbon/human,/mob/living/carbon/monkey)
+	desc = "If left untreated, constant hallucinations and loss of brain function will occur."
+	severity = BIOHAZARD
+	disease_flags = CURABLE
+	spread_flags = NON_CONTAGIOUS
+
+/datum/disease/chemicaloverdose/mindbreaker_od/stage_act()
+	..()
+	switch(stage)
+		if(3)
+			if(prob(15))
+				affected_mob.adjustBrainLoss(2)
+				affected_mob.hallucination += 10
+	return

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -161,10 +161,16 @@
 	description = "A powerful hallucinogen. Not a thing to be messed with."
 	color = "#B31008" // rgb: 139, 166, 233
 	toxpwr = 0
+	overdose_threshold = 30
 
 /datum/reagent/toxin/mindbreaker/on_mob_life(mob/living/M)
 	M.hallucination += 10
 	return ..()
+
+/datum/reagent/toxin/mindbreaker/overdose_process(mob/living/M)
+	M.ForceContractDisease(new /datum/disease/chemicaloverdose/mindbreaker_od(0))
+	..()
+	. = 1
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
@@ -359,9 +365,7 @@
 	..()
 
 /datum/reagent/toxin/histamine/overdose_process(mob/living/M)
-	M.adjustOxyLoss(2*REM, 0)
-	M.adjustBruteLoss(2*REM, 0)
-	M.adjustToxLoss(2*REM, 0)
+	M.ForceContractDisease(new /datum/disease/chemicaloverdose/histamine_od(0))
 	..()
 	. = 1
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -166,6 +166,7 @@
 #include "code\datums\diseases\appendicitis.dm"
 #include "code\datums\diseases\beesease.dm"
 #include "code\datums\diseases\brainrot.dm"
+#include "code\datums\diseases\chemicaloverdose.dm"
 #include "code\datums\diseases\cold.dm"
 #include "code\datums\diseases\cold9.dm"
 #include "code\datums\diseases\dna_spread.dm"


### PR DESCRIPTION
This will promote better gameplay mechanics with the designated chemicals, and make these chemicals far more fearsome.

:cl: 
tweak: Removes damage from Histamine Overdose, replaced with a new virus.
rscadd: chemicaloverdose disease.
rscadd: Histamine and Mindbreaker overdose diseases.
tweak: Mindbreaker now has overdose effects.
/:cl:

Timings:
Histamine overdose previous timings: 80 second to kill.
Histamine overdose disease timings: 60+ seconds to activate,  16 seconds to kill.
