### PR TITLE
Fixes jetpack implant speed boost inconsistency.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -3,10 +3,6 @@
 	if(legcuffed)
 		. += legcuffed.slowdown
 
-	var/obj/item/organ/internal/cyberimp/chest/thrusters/J = getorganslot("thrusters")
-	if(istype(J) && J.on)
-		. -= 2
-
 
 var/const/NO_SLIP_WHEN_WALKING = 1
 var/const/SLIDE = 2

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -795,6 +795,11 @@
 
 			if(istype(J) && J.allow_thrust(0.01, H))
 				. -= 2
+			else
+				var/obj/item/organ/internal/cyberimp/chest/thrusters/T = H.getorganslot("thrusters")
+				if(istype(T) && T.allow_thrust(0.01, H))
+					. -= 2
+
 		else
 			var/health_deficiency = (100 - H.health + H.staminaloss)
 			if(health_deficiency >= 40)


### PR DESCRIPTION
Unlike other jetpacks, the implant gave a speed boost at all times, regardless of if it could actually be active or not.
This pr brings it in line with other jetpacks by only providing a speed boost in no gravity as well as requiring there to be fuel.
