### PR TITLE
Makes goliath plates stackable.

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -25,7 +25,7 @@
 
 /obj/mecha/working/ripley/Destroy()
 	for(var/i=1, i <= hides, i++)
-		new /obj/item/stack/sheet/goliath_hide(loc) //If a goliath-plated ripley gets killed, all the plates drop
+		new /obj/item/stack/sheet/animalhide/goliath_hide(loc) //If a goliath-plated ripley gets killed, all the plates drop
 	damage_absorption["brute"] =  initial(damage_absorption["brute"])
 	for(var/atom/movable/A in cargo)
 		A.loc = loc

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -25,7 +25,7 @@
 
 /obj/mecha/working/ripley/Destroy()
 	for(var/i=1, i <= hides, i++)
-		new /obj/item/asteroid/goliath_hide(loc) //If a goliath-plated ripley gets killed, all the plates drop
+		new /obj/item/stack/sheet/goliath_hide(loc) //If a goliath-plated ripley gets killed, all the plates drop
 	damage_absorption["brute"] =  initial(damage_absorption["brute"])
 	for(var/atom/movable/A in cargo)
 		A.loc = loc

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -135,6 +135,20 @@ var/global/list/datum/stack_recipe/xeno_recipes = list ( \
 	icon_state = "sinew"
 	origin_tech = "bio=4"
 
+		/*
+ * Plates
+ 		*/
+
+/obj/item/stack/sheet/animalhide/goliath_hide
+	name = "goliath hide plates"
+	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "goliath_hide"
+	singular_name = "hide plate"
+	flags = NOBLUDGEON
+	w_class = 3
+	layer = 4
+
 
 //Step one - dehairing.
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -267,16 +267,4 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
 	throw_range = 3
 	origin_tech = "materials=2;bio=2"
 
-		/*
- * Plates
- 		*/
 
-/obj/item/stack/sheet/goliath_hide
-	name = "goliath hide plates"
-	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
-	icon = 'icons/obj/mining.dmi'
-	icon_state = "goliath_hide"
-	singular_name = "hide plate"
-	flags = NOBLUDGEON
-	w_class = 3
-	layer = 4

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -266,3 +266,17 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
 	throw_speed = 1
 	throw_range = 3
 	origin_tech = "materials=2;bio=2"
+
+		/*
+ * Plates
+ 		*/
+
+/obj/item/stack/sheet/goliath_hide
+	name = "goliath hide plates"
+	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "goliath_hide"
+	singular_name = "hide plate"
+	flags = NOBLUDGEON
+	w_class = 3
+	layer = 4

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -35,7 +35,7 @@
 /datum/export/goliath_hide
 	cost = 2500
 	unit_name = "goliath hide"
-	export_types = list(/obj/item/asteroid/goliath_hide)
+	export_types = list(/obj/item/stack/sheet/goliath_hide)
 
 // Cat hide. Just in case Runtime is catsploding again.
 /datum/export/stack/skin/cat

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -32,7 +32,7 @@
 	export_types = list(/obj/item/stack/sheet/animalhide/human)
 
 // Goliath hide. Expensive.
-/datum/export/goliath_hide
+/datum/export/stack/skin/goliath_hide
 	cost = 2500
 	unit_name = "goliath hide"
 	export_types = list(/obj/item/stack/sheet/animalhide/goliath_hide)

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -35,7 +35,7 @@
 /datum/export/goliath_hide
 	cost = 2500
 	unit_name = "goliath hide"
-	export_types = list(/obj/item/stack/sheet/goliath_hide)
+	export_types = list(/obj/item/stack/sheet/animalhide/goliath_hide)
 
 // Cat hide. Just in case Runtime is catsploding again.
 /datum/export/stack/skin/cat

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -373,7 +373,7 @@
 /datum/table_recipe/boat
 	name = "goliath hide boat"
 	result = /obj/vehicle/lavaboat
-	reqs = list(/obj/item/asteroid/goliath_hide = 3)
+	reqs = list(/obj/item/stack/sheet/goliath_hide = 3)
 	time = 50
 	category = CAT_MISC
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -373,7 +373,7 @@
 /datum/table_recipe/boat
 	name = "goliath hide boat"
 	result = /obj/vehicle/lavaboat
-	reqs = list(/obj/item/stack/sheet/goliath_hide = 3)
+	reqs = list(/obj/item/stack/sheet/animalhide/goliath_hide = 3)
 	time = 50
 	category = CAT_MISC
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -350,7 +350,7 @@
 	mob_size = MOB_SIZE_LARGE
 	var/pre_attack = 0
 	var/pre_attack_icon = "Goliath_preattack"
-	loot = list(/obj/item/asteroid/goliath_hide{layer = 4.1})
+	loot = list(/obj/item/stack/sheet/goliath_hide{layer = 4.1})
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Life()
 	..()
@@ -438,7 +438,7 @@
 		spawn(50)
 			qdel(src)
 
-/obj/item/asteroid/goliath_hide
+/obj/item/stack/sheet/goliath_hide
 	name = "goliath hide plates"
 	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
 	icon = 'icons/obj/mining.dmi'
@@ -447,7 +447,7 @@
 	w_class = 3
 	layer = 4
 
-/obj/item/asteroid/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/stack/sheet/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
 		if(istype(target, /obj/item/clothing/suit/space/hardsuit/mining) || istype(target, /obj/item/clothing/head/helmet/space/hardsuit/mining) ||  istype(target, /obj/item/clothing/suit/hooded/explorer) || istype(target, /obj/item/clothing/head/explorer))
 			var/obj/item/clothing/C = target
@@ -649,7 +649,7 @@
 	icon_dead = "goliath_dead"
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
-	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/asteroid/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
 	loot = list()
 	stat_attack = 1
 	robust_searching = 1

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -455,7 +455,7 @@
 			if(current_armor.["melee"] < 60)
 				current_armor.["melee"] = min(current_armor.["melee"] + 10, 60)
 				user << "<span class='info'>You strengthen [target], improving its resistance against melee attacks.</span>"
-				qdel(src)
+				use(1)
 			else
 				user << "<span class='warning'>You can't improve [C] any further!</span>"
 				return

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -350,7 +350,7 @@
 	mob_size = MOB_SIZE_LARGE
 	var/pre_attack = 0
 	var/pre_attack_icon = "Goliath_preattack"
-	loot = list(/obj/item/stack/sheet/goliath_hide{layer = 4.1})
+	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide{layer = 4.1})
 
 /mob/living/simple_animal/hostile/asteroid/goliath/Life()
 	..()
@@ -438,7 +438,7 @@
 		spawn(50)
 			qdel(src)
 
-/obj/item/stack/sheet/goliath_hide
+/obj/item/stack/sheet/animalhide/goliath_hide
 	name = "goliath hide plates"
 	desc = "Pieces of a goliath's rocky hide, these might be able to make your suit a bit more durable to attack from the local fauna."
 	icon = 'icons/obj/mining.dmi'
@@ -447,7 +447,7 @@
 	w_class = 3
 	layer = 4
 
-/obj/item/stack/sheet/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/stack/sheet/animalhide/goliath_hide/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
 		if(istype(target, /obj/item/clothing/suit/space/hardsuit/mining) || istype(target, /obj/item/clothing/head/helmet/space/hardsuit/mining) ||  istype(target, /obj/item/clothing/suit/hooded/explorer) || istype(target, /obj/item/clothing/head/explorer))
 			var/obj/item/clothing/C = target
@@ -649,7 +649,7 @@
 	icon_dead = "goliath_dead"
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
-	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/animalhide/goliath_hide = 1, /obj/item/stack/sheet/bone = 2)
 	loot = list()
 	stat_attack = 1
 	robust_searching = 1


### PR DESCRIPTION
With the rapidly increasing popularity of mob drops in crafting recipes, having them not be horrible to carry is pretty essential. 

:cl:
tweak: Goliath plates can now be stacked. 
/:cl:
