### PR TITLE
removes a comment from malf modules 

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -9,7 +9,6 @@
 
 	var/power_type
 
-
 /datum/AI_Module/large/
 	uses = 1
 
@@ -81,7 +80,6 @@
 			var/message = "[timer] SECONDS UNTIL DOOMSDAY DEVICE ACTIVATION!"
 			minor_announce(message, "ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4", 1)
 
-
 /obj/machinery/doomsday_device/proc/detonate(z_level = 1)
 	for(var/mob/M in player_list)
 		M << 'sound/machines/Alarm.ogg'
@@ -97,6 +95,8 @@
 	world << "<B>The AI cleansed the station of life with the doomsday device!</B>"
 	ticker.force_ending = 1
 
+//////END DOOMSDAY DEVICE
+
 /datum/AI_Module/large/fireproof_core
 	module_name = "Core Upgrade"
 	mod_pick_name = "coreup"
@@ -105,11 +105,6 @@
 	one_time = 1
 
 	power_type = /mob/living/silicon/ai/proc/fireproof_core
-
-
-
-//////END DOOMSDAY DEVICE
-
 
 /mob/living/silicon/ai/proc/fireproof_core()
 	set category = "Malfunction"
@@ -254,7 +249,6 @@
 	src << "Virus package compiled. Select a target mech at any time. <b>You must remain on the station at all times. Loss of signal will result in total system lockout.</b>"
 	verbs -= /mob/living/silicon/ai/proc/mech_takeover
 
-
 /datum/AI_Module/large/break_fire_alarms
 	module_name = "Thermal Sensor Override"
 	mod_pick_name = "burnpigs"
@@ -302,8 +296,6 @@
 		AA.emagged = 1
 	src << "<span class='notice'>All air alarm safeties on the station have been overriden. Air alarms may now use the Flood environmental mode."
 	src.verbs -= /mob/living/silicon/ai/proc/break_air_alarms
-
-
 
 /datum/AI_Module/small/overload_machine
 	module_name = "Machine Overload"
@@ -622,7 +614,6 @@
 				temp = AM.description
 	src.use(usr)
 	return
-
 
 /datum/AI_Module/large/eavesdrop
 	module_name = "Enhanced Surveillance"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -15,8 +15,6 @@
 /datum/AI_Module/small/
 	uses = 5
 
-//////DOOMSDAY DEVICE
-
 /datum/AI_Module/large/nuke_station
 	module_name = "Doomsday Device"
 	mod_pick_name = "nukestation"
@@ -94,8 +92,6 @@
 		L.dust()
 	world << "<B>The AI cleansed the station of life with the doomsday device!</B>"
 	ticker.force_ending = 1
-
-//////END DOOMSDAY DEVICE
 
 /datum/AI_Module/large/fireproof_core
 	module_name = "Core Upgrade"


### PR DESCRIPTION
Because the ///end doomsday device thing was below the /datum/AI_Module/large/fireproof_core thing, also removes double blank lines that weren't needed? I don't really feel proud about myself only changing the comment so I removed double blank lines, this is my first real merge pull thing hopefully nothing goes horribly wrong like before.

okay a monkey could have done this but everyone starts somewhere
