### PR TITLE
Hopefully fixes the sloth ruin atmos runtime.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -270,6 +270,8 @@ var/datum/subsystem/air/SSair
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
 		active_turfs -= T
+		if (T.blocks_air)
+			return
 		T.Initalize_Atmos(times_fired)
 
 

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -7,8 +7,7 @@
 /turf/open/Initalize_Atmos(times_fired)
 	excited = 0
 	update_visuals()
-	if (blocks_air)
-		return
+
 	current_cycle = times_fired
 
 	//cache some vars


### PR DESCRIPTION
Fixes #17079
From looking at older code, it looks like the blocks_air check is supposed to happen before update_visuals.
