### PR TITLE
Removes changelings also being able to be traitors

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -43,6 +43,7 @@
 		for(var/j = 0, j < num_changelings, j++)
 			if(!possible_changelings.len) break
 			var/datum/mind/changeling = pick(possible_changelings)
+			antag_candidates -= changeling
 			possible_changelings -= changeling
 			changelings += changeling
 			modePlayer += changelings

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -367,7 +367,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Lightning", "Protector", "Charger", "Assassin")
 	var/random = TRUE
 	var/allowmultiple = 0
-	var/allowling = 0
+	var/allowling = 1
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	var/list/guardians = user.hasparasites()


### PR DESCRIPTION
:cl: Robustin
rscdel: Lings can no longer be selected as traitors during traitorchan.
tweak: Lings no longer face any unique item restrictions.
/:cl:

I am a fan of #17070, but apparently not everyone is. I have removed
the contentious ability, these are just changes removing traitorling
and allowing ling holoparasites. Let's get this merged so we don't have
to suffer sleeping carp ling any longer.
