### PR TITLE
Makes gatling admin only

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -184,16 +184,6 @@
 	build_path = /obj/item/weapon/gun/energy/ionrifle/carbine
 	category = list("Weapons")
 
-/datum/design/gatling
-	name = "Laser Gatling Gun"
-	desc = "A massive weapon with a backpack mounted power source."
-	id = "gatlinggun"
-	req_tech = list("combat" = 6, "materials" = 4, "magnets" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 30000, MAT_SILVER = 4000, MAT_DIAMOND = 6000, MAT_URANIUM = 10000)
-	build_path = /obj/item/weapon/minigunpack
-	category = list("Weapons")
-
 /datum/design/wormhole_projector
 	name = "Bluespace Wormhole Projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."


### PR DESCRIPTION
People are upset about this gun and I don't really have any good plan to balance it at this moment, so I am offering this PR as a temporary thing.

I think it's mostly fine in person vs person combat (2 hands+back, slowdown, doesn't stun, shots are weak) but it absolutely wrecks blob mode, and one gun is probably not as important as a game mode.

Downsides of the gun

-You move slow (doesn't matter vs a blob)

-Its inaccurate (doesn't matter vs a massive stationary target)

-Takes all hands+back (who cares vs blob)

-Does weak damage (it does double vs blob)

I'm not sure how to make it workable vs a blob, other than to say "you should have won before they got gatlings"
