### PR TITLE
Nerfs botany slippery-everything

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -129,15 +129,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/Crossed(atom/movable/AM)
 	if(seed)
-		var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
-		if(S && !ispath(trash, /obj/item/weapon/grown) && iscarbon(AM))
-			var/mob/living/carbon/M = AM
-			var/stun = max(seed.potency * S.rate * 2, 1)
-			var/weaken = max(seed.potency * S.rate, 0.5)
-			if(M.slip(stun, weaken, src))
-				for(var/datum/plant_gene/trait/T in seed.genes)
-					T.on_slip(src, M)
-			return 1
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_cross(src, AM)
 	..()
 
 

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -50,15 +50,8 @@
 
 /obj/item/weapon/grown/Crossed(atom/movable/AM)
 	if(seed)
-		var/datum/plant_gene/trait/slip/S = seed.get_gene(/datum/plant_gene/trait/slip)
-		if(S && iscarbon(AM))
-			var/mob/living/carbon/M = AM
-			var/stun = max(seed.potency * S.rate * 2, 1)
-			var/weaken = max(seed.potency * S.rate, 0.5)
-			if(M.slip(stun, weaken, src))
-				for(var/datum/plant_gene/trait/T in seed.genes)
-					T.on_slip(src, M)
-				return 1
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_cross(src, AM)
 	..()
 
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -5,7 +5,7 @@
 /obj/item/seeds
 	icon = 'icons/obj/hydroponics/seeds.dmi'
 	icon_state = "seed"				// Unknown plant seed - these shouldn't exist in-game.
-	w_class = 1						// Pocketable.
+	w_class = 1
 	burn_state = FLAMMABLE
 	var/plantname = "Plants"		// Name of plant when planted.
 	var/product						// A type path. The thing that is created when the plant is harvested.
@@ -15,10 +15,10 @@
 	var/icon_dead					// Used to override dead icon (default is "[species]-dead"). You can use one dead icon for multiple closely related plants with it.
 	var/icon_harvest				// Used to override harvest icon (default is "[species]-harvest"). If null, plant will use [icon_grow][growthstages].
 
-	var/lifespan = 25 				// How long before the plant begins to take damage from age.
-	var/endurance = 15 				// Amount of health the plant has.
-	var/maturation = 6 				// Used to determine which sprite to switch to when growing.
-	var/production = 6 				// Changes the amount of time needed for a plant to become harvestable.
+	var/lifespan = 25				// How long before the plant begins to take damage from age.
+	var/endurance = 15				// Amount of health the plant has.
+	var/maturation = 6				// Used to determine which sprite to switch to when growing.
+	var/production = 6				// Changes the amount of time needed for a plant to become harvestable.
 	var/yield = 3					// Amount of growns created per harvest. If is -1, the plant/shroom/weed is never meant to be harvested.
 	var/oneharvest = 0				// If a plant is cleared from the tray after harvesting, e.g. a carrot.
 	var/potency = 10				// The 'power' of a plant. Generally effects the amount of reagent in a plant, also used in other ways.


### PR DESCRIPTION
**Banana peels and blue tomatoes are unaffected by this nerf.**

This PR, combined with #17107, is designed to make 100 potency uberslips on every plant harder to reach. You still can apply silp gene to any plant, but plants that are not intended by nature to be silppery will have slip duration divided by 3. Banana peels and plants that contain space lube are unaffected, they still have full duration slips.

Yes, a clever botanist still can extract lube gene from blue tomatoes, get T4 parts for gene modder and make everything silppery as fuck. But this would require a lot more effort now.

Fixes #17088. 
