### PR TITLE
Nuclear option to Fix catsplosion once and for all.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -93,8 +93,8 @@
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/Life()
-	if(!cats_deployed && ticker.current_state >= GAME_STATE_SETTING_UP)
-		Deploy_The_Cats()
+	//if(!cats_deployed && ticker.current_state >= GAME_STATE_SETTING_UP)
+	//	Deploy_The_Cats()
 	if(!stat && ticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 	..()


### PR DESCRIPTION
Comments out runtime loading their family
Until the issue of catsplosion is solved, this is the only way.
