### PR TITLE
Removes headslug from gold slime pool

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -20,7 +20,7 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = 1 //are you sure about this??
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
With the mind transference potions, now its just too easy to become an invincible murder machine

I think even if you don't like this change you understand why its necessary to remove
