### PR TITLE
New cargo crates to buy

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -381,6 +381,17 @@
 	for(var/i in 1 to 5)
 		new /obj/item/device/firing_pin(src)
 
+/obj/item/weapon/storage/box/lasertagpins
+	name = "box of laser tag firing pins"
+	desc = "A box full of laser tag firing pins, to allow newly-developed firearms to require wearing brightly coloured plastic armor before being able to be used."
+	icon_state = "id"
+
+/obj/item/weapon/storage/box/lasertagpins/New()
+	..()
+	for(var/i in 1 to 3)
+		new /obj/item/device/firing_pin/tag/red(src)
+		new /obj/item/device/firing_pin/tag/blue(src)
+
 /obj/item/weapon/storage/box/handcuffs
 	name = "box of spare handcuffs"
 	desc = "A box full of handcuffs."

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -11,7 +11,7 @@
 /obj/item/device/export_scanner/examine(user)
 	..()
 	if(!cargo_console)
-		user << "<span class='notice'>You had to link it to supply console for it to work.</span>"
+		user << "<span class='notice'>The [src] is currently not linked to a cargo console.</span>"
 
 /obj/item/device/export_scanner/afterattack(obj/O, mob/user, proximity)
 	if(!istype(O) || !proximity)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -127,16 +127,16 @@
 					/obj/item/weapon/grenade/smokebomb,
 					/obj/item/weapon/pen/sleepy,
 					/obj/item/weapon/grenade/chem_grenade/incendiary)
-	crate_name = "special ops crate"
-	crate_type = /obj/structure/closet/crate
+	crate_name = "emergency crate"
+	crate_type = /obj/structure/closet/crate/internals
 
 /datum/supply_pack/emergency/syndicate
 	name = "NULL_ENTRY"
 	hidden = TRUE
 	cost = 14000
 	contains = list(/obj/item/weapon/storage/box/syndicate)
-	crate_name = "crate"
-	crate_type = /obj/structure/closet/crate
+	crate_name = "emergency crate"
+	crate_type = /obj/structure/closet/crate/internals
 	dangerous = TRUE
 
 //////////////////////////////////////////////////////////////////////////////
@@ -405,7 +405,7 @@
 	contraband = TRUE
 	contains = list(/obj/item/clothing/head/helmet/justice,
 					/obj/item/clothing/mask/gas/sechailer)
-	crate_name = "justice enforcer crate"
+	crate_name = "security clothing crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////
@@ -491,7 +491,7 @@
 
 /datum/supply_pack/engineering/grounding_rods
 	name = "Grounding Rod Crate"
-	cost = 2500
+	cost = 1700
 	contains = list(/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
 					/obj/machinery/power/grounding_rod,
@@ -708,7 +708,7 @@
 
 /datum/supply_pack/medical/defibs
 	name = "Defibrillator Crate"
-	cost = 1500
+	cost = 2500
 	contains = list(/obj/item/weapon/defibrillator/loaded,
 					/obj/item/weapon/defibrillator/loaded,)
 	crate_name = "defibrillator crate"
@@ -919,7 +919,7 @@
 	contraband = TRUE
 	cost = 5000
 	contains = list(/mob/living/simple_animal/butterfly)
-	crate_name = "butterflies crate"
+	crate_name = "entomology samples crate"
 
 /datum/supply_pack/organic/critter/butterfly/generate()
 	. = ..()
@@ -1137,7 +1137,11 @@
 					/obj/item/clothing/suit/bluetag,
 					/obj/item/clothing/suit/bluetag,
 					/obj/item/clothing/head/helmet/redtaghelm,
-					/obj/item/clothing/head/helmet/bluetaghelm)
+					/obj/item/clothing/head/helmet/redtaghelm,
+					/obj/item/clothing/head/helmet/redtaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm,
+					/obj/item/clothing/head/helmet/bluetaghelm,)
 	crate_name = "laser tag crate"
 
 /datum/supply_pack/misc/lasertag/pins
@@ -1145,14 +1149,15 @@
 	cost = 2000
 	contraband = TRUE
 	contains = list(/obj/item/weapon/storage/box/lasertagpins,)
-	crate_name = "laser tag firing pins crate"
+	crate_name = "laser tag crate"
 
 /datum/supply_pack/misc/clownpin
 	name = "Hilarious Firing Pin Crate"
 	cost = 5000
 	contraband = TRUE
 	contains = list(/obj/item/device/firing_pin/clown,)
-	crate_name = "hilarious firing pin crate"
+	// It's /technically/ a toy. For the clown, at least.
+	crate_name = "toy crate"
 
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"
@@ -1173,7 +1178,7 @@
 					/obj/item/weapon/poster/legit,
 					/obj/item/weapon/poster/legit,
 					/obj/item/weapon/poster/legit)
-	crate_name = "Corporate Posters Crate"
+	crate_name = "corporate posters crate"
 
 /datum/supply_pack/misc/paper
 	name = "Bureaucracy Crate"
@@ -1412,4 +1417,4 @@
 					/obj/item/weapon/gun/projectile/automatic/toy/pistol,
 					/obj/item/ammo_box/magazine/toy/pistol,
 					/obj/item/ammo_box/magazine/toy/pistol)
-	crate_name = "foam force pistols crate"
+	crate_name = "foam force crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -114,7 +114,7 @@
 /datum/supply_pack/emergency/metalfoam
 	name = "Metal Foam Grenade Crate"
 	cost = 1000
-	contains = list(/obj/item/weapon/storage/box/metalfoam,)
+	contains = list(/obj/item/weapon/storage/box/metalfoam)
 	crate_name = "metal foam grenade crate"
 
 /datum/supply_pack/emergency/specialops
@@ -466,7 +466,7 @@
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/glasses/meson/engine,
-					/obj/item/clothing/glasses/meson/engine,)
+					/obj/item/clothing/glasses/meson/engine)
 	crate_name = "engineering gear crate"
 
 /datum/supply_pack/engineering/engine/spacesuit
@@ -478,7 +478,7 @@
 					/obj/item/clothing/head/helmet/space,
 					/obj/item/clothing/head/helmet/space,
 					/obj/item/clothing/mask/breath,
-					/obj/item/clothing/mask/breath,)
+					/obj/item/clothing/mask/breath)
 	crate_name = "space suit crate"
 	crate_type = /obj/structure/closet/crate/secure
 
@@ -486,7 +486,7 @@
 	name = "Anti-breach Shield Projector Crate"
 	cost = 2500
 	contains = list(/obj/machinery/shieldgen,
-					/obj/machinery/shieldgen,)
+					/obj/machinery/shieldgen)
 	crate_name = "anti-breach shield projector crate"
 
 /datum/supply_pack/engineering/grounding_rods
@@ -502,7 +502,7 @@
 /datum/supply_pack/engineering/pacman
 	name = "P.A.C.M.A.N Generator Crate"
 	cost = 2500
-	contains = list(/obj/machinery/power/port_gen/pacman,)
+	contains = list(/obj/machinery/power/port_gen/pacman)
 	crate_name = "PACMAN generator crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -710,7 +710,7 @@
 	name = "Defibrillator Crate"
 	cost = 2500
 	contains = list(/obj/item/weapon/defibrillator/loaded,
-					/obj/item/weapon/defibrillator/loaded,)
+					/obj/item/weapon/defibrillator/loaded)
 	crate_name = "defibrillator crate"
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1141,21 +1141,21 @@
 					/obj/item/clothing/head/helmet/redtaghelm,
 					/obj/item/clothing/head/helmet/bluetaghelm,
 					/obj/item/clothing/head/helmet/bluetaghelm,
-					/obj/item/clothing/head/helmet/bluetaghelm,)
+					/obj/item/clothing/head/helmet/bluetaghelm)
 	crate_name = "laser tag crate"
 
 /datum/supply_pack/misc/lasertag/pins
 	name = "Laser Tag Firing Pins Crate"
 	cost = 2000
 	contraband = TRUE
-	contains = list(/obj/item/weapon/storage/box/lasertagpins,)
+	contains = list(/obj/item/weapon/storage/box/lasertagpins)
 	crate_name = "laser tag crate"
 
 /datum/supply_pack/misc/clownpin
 	name = "Hilarious Firing Pin Crate"
 	cost = 5000
 	contraband = TRUE
-	contains = list(/obj/item/device/firing_pin/clown,)
+	contains = list(/obj/item/device/firing_pin/clown)
 	// It's /technically/ a toy. For the clown, at least.
 	crate_name = "toy crate"
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -53,6 +53,12 @@
 	contains = list(/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
+					/obj/item/clothing/mask/breath,
+					/obj/item/weapon/tank/internals/emergency_oxygen,
+					/obj/item/weapon/tank/internals/emergency_oxygen,
+					/obj/item/weapon/tank/internals/emergency_oxygen,
 					/obj/item/weapon/tank/internals/air,
 					/obj/item/weapon/tank/internals/air,
 					/obj/item/weapon/tank/internals/air)
@@ -104,6 +110,12 @@
 					/obj/item/weapon/grenade/chem_grenade/antiweed)
 	crate_name = "weed control crate"
 	crate_type = /obj/structure/closet/crate/secure/hydroponics
+
+/datum/supply_pack/emergency/metalfoam
+	name = "Metal Foam Grenade Crate"
+	cost = 1000
+	contains = list(/obj/item/weapon/storage/box/metalfoam,)
+	crate_name = "metal foam grenade crate"
 
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
@@ -440,7 +452,7 @@
 
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
-	cost = 1000
+	cost = 1300
 	contains = list(/obj/item/weapon/storage/belt/utility,
 					/obj/item/weapon/storage/belt/utility,
 					/obj/item/weapon/storage/belt/utility,
@@ -452,7 +464,9 @@
 					/obj/item/clothing/head/welding,
 					/obj/item/clothing/head/hardhat,
 					/obj/item/clothing/head/hardhat,
-					/obj/item/clothing/head/hardhat)
+					/obj/item/clothing/head/hardhat,
+					/obj/item/clothing/glasses/meson/engine,
+					/obj/item/clothing/glasses/meson/engine,)
 	crate_name = "engineering gear crate"
 
 /datum/supply_pack/engineering/engine/spacesuit
@@ -467,6 +481,30 @@
 					/obj/item/clothing/mask/breath,)
 	crate_name = "space suit crate"
 	crate_type = /obj/structure/closet/crate/secure
+
+/datum/supply_pack/engineering/shieldgen
+	name = "Anti-breach Shield Projector Crate"
+	cost = 2500
+	contains = list(/obj/machinery/shieldgen,
+					/obj/machinery/shieldgen,)
+	crate_name = "anti-breach shield projector crate"
+
+/datum/supply_pack/engineering/grounding_rods
+	name = "Grounding Rod Crate"
+	cost = 2500
+	contains = list(/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod,
+					/obj/machinery/power/grounding_rod)
+	crate_name = "grounding rod crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engineering/pacman
+	name = "P.A.C.M.A.N Generator Crate"
+	cost = 2500
+	contains = list(/obj/machinery/power/port_gen/pacman,)
+	crate_name = "PACMAN generator crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/engineering/solar
 	name = "Solar Panel Crate"
@@ -667,6 +705,13 @@
 	cost = 1000
 	contains = list(/obj/machinery/iv_drip)
 	crate_name = "iv drip crate"
+
+/datum/supply_pack/medical/defibs
+	name = "Defibrillator Crate"
+	cost = 1500
+	contains = list(/obj/item/weapon/defibrillator/loaded,
+					/obj/item/weapon/defibrillator/loaded,)
+	crate_name = "defibrillator crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
@@ -938,7 +983,7 @@
 	crate_name = "exotic seeds crate"
 
 /datum/supply_pack/organic/hydroponics/beekeeping_fullkit
-	name = "Beekeeping Starter Kit"
+	name = "Beekeeping Starter Crate"
 	cost = 1500
 	contains = list(/obj/structure/beebox,
 					/obj/item/honey_frame,
@@ -947,10 +992,10 @@
 					/obj/item/queen_bee/bought,
 					/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit)
-	crate_name = "beekeeping starter kit"
+	crate_name = "beekeeping starter crate"
 
 /datum/supply_pack/organic/hydroponics/beekeeping_suits
-	name = "2 Beekeeper suits"
+	name = "Beekeeper Suit Crate"
 	cost = 1000
 	contains = list(/obj/item/clothing/head/beekeeper_head,
 					/obj/item/clothing/suit/beekeeper_suit,
@@ -1094,6 +1139,20 @@
 					/obj/item/clothing/head/helmet/redtaghelm,
 					/obj/item/clothing/head/helmet/bluetaghelm)
 	crate_name = "laser tag crate"
+
+/datum/supply_pack/misc/lasertag/pins
+	name = "Laser Tag Firing Pins Crate"
+	cost = 2000
+	contraband = TRUE
+	contains = list(/obj/item/weapon/storage/box/lasertagpins,)
+	crate_name = "laser tag firing pins crate"
+
+/datum/supply_pack/misc/clownpin
+	name = "Hilarious Firing Pin Crate"
+	cost = 5000
+	contraband = TRUE
+	contains = list(/obj/item/device/firing_pin/clown,)
+	crate_name = "hilarious firing pin crate"
 
 /datum/supply_pack/misc/religious_supplies
 	name = "Religious Supplies Crate"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 300
+	callTime = 1200
 
 	dir = 8
 	travelDir = 90

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 10
+	callTime = 1200
 
 	dir = 8
 	travelDir = 90

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 1200
+	callTime = 300
 
 	dir = 8
 	travelDir = 90


### PR DESCRIPTION
Also some minor spelling fixes I noticed.

:cl: coiax
tweak: Internals Crate now contains breath masks and small tanks.
rscadd: Metal foam grenade box crate added for 1000 points
rscadd: Added two Engineering Mesons to Engineering Gear Crate
tweak: Engineering Gear now costs 1300
rscadd: Breach Shield Generator Crate added for 2500 points
rscadd: Grounding Rod Crate added for 1700 points
rscadd: PACMAN Generator Crate added for 2500
rscadd: Defibrillator Crate added for 2500
rscadd: Added more helmets to the Laser Tag Crate.
rscadd: Nanotrasen Customs report that some wide band suppliers have
been providing "alternative" firing pins. Nanotrasen reminds all
crewmembers that contraband is contraband.
rscadd: Contraband crates now appear visually similar to legitimate crates.
fix: The cargo shuttle's normal transit time has been restored.
/:cl:

Laser tag firing pins (only allow gun to be fired with laser tag armour
of the appropriate colour) added to contraband.
Special clown firing pin (prank your friends) added to contraband.
