### PR TITLE
Replaces chaplain smoke spell with recall spell

### DIFF
--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -37312,7 +37312,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/item/weapon/spellbook/oneuse/smoke{
+/obj/item/weapon/spellbook/oneuse/summonitem{
 	name = "mysterious old book of "
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,

--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -90507,7 +90507,7 @@
 /area/chapel/office)
 "cOm" = (
 /obj/structure/table/wood,
-/obj/item/weapon/spellbook/oneuse/smoke{
+/obj/item/weapon/spellbook/oneuse/summonitem{
 	name = "mysterious old book of "
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater{

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -833,6 +833,13 @@
 	user <<"<span class='warning'>[src] suddenly vanishes!</span>"
 	qdel(src)
 
+/obj/item/weapon/spellbook/oneuse/summonitem/chaplain
+	spell = /obj/effect/proc_holder/spell/targeted/summonitem/chaplain
+	spellname = "instant summons"
+	icon_state ="booksummons"
+	desc = "This book is bright and garish, very hard to miss."
+
+
 /obj/item/weapon/spellbook/oneuse/random/New()
 	var/real_type = pick(subtypesof(/obj/item/weapon/spellbook/oneuse))
 	new real_type(loc)

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -12,6 +12,7 @@
 	include_user = 1
 
 	var/obj/marked_item
+	var/allowed_type = /obj/item
 
 	action_icon_state = "summons"
 
@@ -24,6 +25,8 @@
 		if(!marked_item) //linking item to the spell
 			message = "<span class='notice'>"
 			for(var/obj/item in hand_items)
+				if(!(istype(item, allowed_type)
+					continue
 				if(ABSTRACT in item.flags)
 					continue
 				if(NODROP in item.flags)
@@ -114,3 +117,13 @@
 
 		if(message)
 			L << message
+
+/obj/effect/proc_holder/spell/targeted/summonitem/chaplain
+	name = "Recall Holy Weapon"
+	desc = "This spell can be used to instantly recall your holy weapon to your hand.."
+	invocation = "DEUS VULT"
+
+	var/obj/marked_item
+	var/allowed_type = /obj/item/weapon/nullrod
+
+	action_icon_state = "summons"


### PR DESCRIPTION
On Meta and Eff. 

I'm not sure whether this is a nerf or buff (aoe disarm is pretty good!), but it will work nicely with his weapons and not punish chaplains who choose a weapon without NODROP.
