### PR TITLE
Fixes the mc not running paused dwait systems properly

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -163,13 +163,13 @@ var/global/datum/controller/master/Master = new()
 							priority_queue -= SS
 					if(SS.can_fire > 0)
 						if(priorityrunning || ((SS.next_fire <= world.time) && (SS.last_fire + (SS.wait * 0.75) <= world.time || SS.paused)))
-							if(!priorityrunning && (world.tick_usage + SS.tick_usage > TICK_LIMIT_TO_RUN) && (SS.last_fire + (SS.wait*1.25) > world.time))
-								if(!SS.dynamic_wait)
-									priority_queue += SS
-								continue
 							//we can't reset SS.paused after we fire, incase it pauses again, so we cache it and
 							//	send it to SS.fire()
 							var/paused = SS.paused
+							if(!priorityrunning && !paused && (world.tick_usage + SS.tick_usage > TICK_LIMIT_TO_RUN) && (SS.last_fire + (SS.wait*1.25) > world.time))
+								if(!SS.dynamic_wait)
+									priority_queue += SS
+								continue
 							SS.paused = 0
 							ran_subsystems = 1
 							timer = world.timeofday

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -162,7 +162,7 @@ var/global/datum/controller/master/Master = new()
 						else
 							priority_queue -= SS
 					if(SS.can_fire > 0)
-						if(priorityrunning || ((SS.next_fire <= world.time) && (SS.last_fire + (SS.wait * 0.75) <= world.time)))
+						if(priorityrunning || ((SS.next_fire <= world.time) && (SS.last_fire + (SS.wait * 0.75) <= world.time || SS.paused)))
 							if(!priorityrunning && (world.tick_usage + SS.tick_usage > TICK_LIMIT_TO_RUN) && (SS.last_fire + (SS.wait*1.25) > world.time))
 								if(!SS.dynamic_wait)
 									priority_queue += SS
@@ -174,7 +174,8 @@ var/global/datum/controller/master/Master = new()
 							ran_subsystems = 1
 							timer = world.timeofday
 							last_type_processed = SS.type
-							SS.last_fire = world.time
+							if (!paused) //only set this when we aren't resuming
+								SS.last_fire = world.time
 							var/tick_usage = world.tick_usage
 							SS.fire(paused) // Fire the subsystem
 
@@ -198,7 +199,7 @@ var/global/datum/controller/master/Master = new()
 								if(SS.paused)
 									SS.next_fire = world.time //run it next tick if we can, but don't priority queue it, as we are a dynamic wait subsystem
 								else //not paused, it ran all the way thru, normal wait time
-									SS.next_fire = world.time + SS.wait
+									SS.next_fire = SS.last_fire + SS.wait //we use last_fire so that its next fire is based off when it started this fire, not when it finished.
 							else
 								if(!paused)
 									SS.next_fire += SS.wait


### PR DESCRIPTION
Basically, when atmos (or another dwait subsystem) pauses as it runs to the end of a byond tick, its suppose to be ran again next mc tick as long as nothing else needs to run. (non-dwait subsystems run next tick regardless, rather than checking for other subsystems first)

The issue is the mc won't run it again, because it was ran less then 75% of SS.wait ago. (a safety I added to prevent lag compounding from trying to make up missed ticks caused by lag, back in august)

This fixes that, and fixes another issue where if say atmos takes 3ds to process everything, it's next process would be in 5 ds, not 2 ds like it's suppose to be.

@Shadowlight213 
