### PR TITLE
Buffs the staff/wand of door creation

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -143,7 +143,9 @@
 	no_den_usage = 1
 
 /obj/item/weapon/gun/magic/wand/door/zap_self()
-	return
+	user << "<span class='notice'>You feel vaguely more open with your feelings.</span>"
+	charges--
+	..()
 
 /////////////////////////////////////
 //WAND OF FIREBALL

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -142,7 +142,7 @@
 	max_charges = 20 //20, 10, 10, 7
 	no_den_usage = 1
 
-/obj/item/weapon/gun/magic/wand/door/zap_self()
+/obj/item/weapon/gun/magic/wand/door/zap_self(mob/living/user)
 	user << "<span class='notice'>You feel vaguely more open with your feelings.</span>"
 	charges--
 	..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -94,9 +94,7 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	var/list/door_types = list(/obj/structure/mineral_door/wood,/obj/structure/mineral_door/iron,/obj/structure/mineral_door/silver,\
-		/obj/structure/mineral_door/gold,/obj/structure/mineral_door/uranium,/obj/structure/mineral_door/sandstone,/obj/structure/mineral_door/transparent/plasma,\
-		/obj/structure/mineral_door/transparent/diamond)
+	var/list/door_types = list(subtypesof(/obj/structure/mineral_door))
 
 /obj/item/projectile/magic/door/on_hit(atom/target)
 	. = ..()
@@ -105,12 +103,20 @@
 		CreateDoor(target)
 	else if (isturf(T) && T.density)
 		CreateDoor(T)
+	else if(istype(target, /obj/machinery/door))
+		OpenDoor(target)
 
 /obj/item/projectile/magic/door/proc/CreateDoor(turf/T)
 	var/door_type = pick(door_types)
-	new door_type(T)
+	var/obj/structure/mineral_door/D = new door_type(T)
 	T.ChangeTurf(/turf/open/floor/plating)
+	D.open()
 
+/obj/item/projectile/magic/door/proc/OpenDoor(/obj/machinery/door/D)
+	if(istype(D,/obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/A = D
+		A.locked = 0
+	D.open()
 
 /obj/item/projectile/magic/change
 	name = "bolt of change"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -94,7 +94,10 @@
 	damage = 0
 	damage_type = OXY
 	nodamage = 1
-	var/list/door_types = list(subtypesof(/obj/structure/mineral_door))
+	var/list/door_types = list(/obj/structure/mineral_door/wood,/obj/structure/mineral_door/iron,/obj/structure/mineral_door/silver,\
+		/obj/structure/mineral_door/gold,/obj/structure/mineral_door/uranium,/obj/structure/mineral_door/sandstone,/obj/structure/mineral_door/transparent/plasma,\
+		/obj/structure/mineral_door/transparent/diamond)
+
 
 /obj/item/projectile/magic/door/on_hit(atom/target)
 	. = ..()
@@ -112,7 +115,7 @@
 	T.ChangeTurf(/turf/open/floor/plating)
 	D.open()
 
-/obj/item/projectile/magic/door/proc/OpenDoor(/obj/machinery/door/D)
+/obj/item/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
 	if(istype(D,/obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = D
 		A.locked = 0

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -113,7 +113,7 @@
 	var/door_type = pick(door_types)
 	var/obj/structure/mineral_door/D = new door_type(T)
 	T.ChangeTurf(/turf/open/floor/plating)
-	D.open()
+	D.Open()
 
 /obj/item/projectile/magic/door/proc/OpenDoor(var/obj/machinery/door/D)
 	if(istype(D,/obj/machinery/door/airlock))


### PR DESCRIPTION
Doors created start open, they can also be used on airlocks to open them akin to the knock spell.

:cl: Incoming5643
rscadd: The staff/wand of door creation can now also be used to open airlock doors. 
rscadd: Doors spawned by the staff/wand now start open. Keep this in mind the next time you try to turn every wall on the escape shuttle into a door.
/:cl:
