### PR TITLE
Blobs can no longer eat the supermatter

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -198,7 +198,7 @@
 /atom/proc/ex_act(severity, target)
 	contents_explosion(severity, target)
 
-/atom/proc/blob_act()
+/atom/proc/blob_act(obj/effect/blob/B)
 	return
 
 /atom/proc/fire_act()

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -29,7 +29,7 @@
 		overmind.blob_mobs -= src
 	return ..()
 
-/mob/living/simple_animal/hostile/blob/blob_act()
+/mob/living/simple_animal/hostile/blob/blob_act(obj/effect/blob/B)
 	if(stat != DEAD && health < maxHealth)
 		for(var/i in 1 to 2)
 			var/obj/effect/overlay/temp/heal/H = PoolOrNew(/obj/effect/overlay/temp/heal, get_turf(src)) //hello yes you are being healed

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -140,7 +140,7 @@
 /mob/camera/blob/emote(act,m_type=1,message = null)
 	return
 
-/mob/camera/blob/blob_act()
+/mob/camera/blob/blob_act(obj/effect/blob/B)
 	return
 
 /mob/camera/blob/Stat()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -117,9 +117,9 @@
 
 /obj/effect/blob/proc/ConsumeTile()
 	for(var/atom/A in loc)
-		A.blob_act()
+		A.blob_act(src)
 	if(istype(loc, /turf/closed/wall))
-		loc.blob_act() //don't ask how a wall got on top of the core, just eat it
+		loc.blob_act(src) //don't ask how a wall got on top of the core, just eat it
 
 /obj/effect/blob/proc/blob_attack_animation(atom/A = null, controller) //visually attacks an atom
 	var/obj/effect/overlay/temp/blob/O = PoolOrNew(/obj/effect/overlay/temp/blob, src.loc)
@@ -155,11 +155,11 @@
 	ConsumeTile() //hit the tile we're in, making sure there are no border objects blocking us
 	if(!T.CanPass(src, T, 5)) //is the target turf impassable
 		make_blob = FALSE
-		T.blob_act() //hit the turf if it is
+		T.blob_act(src) //hit the turf if it is
 	for(var/atom/A in T)
 		if(!A.CanPass(src, T, 5)) //is anything in the turf impassable
 			make_blob = FALSE
-		A.blob_act() //also hit everything in the turf
+		A.blob_act(src) //also hit everything in the turf
 
 	if(make_blob) //well, can we?
 		var/obj/effect/blob/B = new /obj/effect/blob/normal(src.loc)
@@ -177,7 +177,7 @@
 			return B
 		else
 			blob_attack_animation(T, controller)
-			T.blob_act() //if we can't move in hit the turf again
+			T.blob_act(src) //if we can't move in hit the turf again
 			qdel(B) //we should never get to this point, since we checked before moving in. destroy the blob so we don't have two blobs on one tile
 			return null
 	else

--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -149,7 +149,7 @@
 		take_damage(damage_amount, P.damage_type, 0)
 
 
-/obj/machinery/dominator/blob_act()
+/obj/machinery/dominator/blob_act(obj/effect/blob/B)
 	take_damage(110, BRUTE, 0)
 
 /obj/machinery/dominator/attack_hand(mob/user)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -396,7 +396,7 @@
 /obj/effect/swarmer/destructible/ex_act()
 	qdel(src)
 
-/obj/effect/swarmer/destructible/blob_act()
+/obj/effect/swarmer/destructible/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 /obj/effect/swarmer/destructible/emp_act()

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -153,7 +153,7 @@
 /mob/living/simple_animal/revenant/ex_act(severity, target)
 	return 1 //Immune to the effects of explosions.
 
-/mob/living/simple_animal/revenant/blob_act()
+/mob/living/simple_animal/revenant/blob_act(obj/effect/blob/B)
 	return //blah blah blobs aren't in tune with the spirit world, or something.
 
 /mob/living/simple_animal/revenant/singularity_act()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -326,7 +326,7 @@ var/bomb_set
 /obj/machinery/nuclearbomb/ex_act(severity, target)
 	return
 
-/obj/machinery/nuclearbomb/blob_act()
+/obj/machinery/nuclearbomb/blob_act(obj/effect/blob/B)
 	if (timing == -1)
 		return
 	else

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -80,12 +80,12 @@
 		open_machine()
 	..(severity)
 
-/obj/machinery/sleeper/blob_act()
+/obj/machinery/sleeper/blob_act(obj/effect/blob/B)
 	if(prob(75))
 		var/turf/T = get_turf(src)
 		for(var/atom/movable/A in src)
 			A.forceMove(T)
-			A.blob_act()
+			A.blob_act(B)
 		qdel(src)
 
 /obj/machinery/sleeper/MouseDrop_T(mob/target, mob/user)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -79,7 +79,7 @@
 		if(2)
 			take_damage(25, BRUTE, 0)
 
-/obj/structure/barricade/blob_act()
+/obj/structure/barricade/blob_act(obj/effect/blob/B)
 	take_damage(25, BRUTE, 0)
 
 /obj/structure/barricade/CanPass(atom/movable/mover, turf/target, height=0)//So bullets will fly over and stuff.

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -179,7 +179,7 @@ obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
 
 
 
-/obj/machinery/door/blob_act()
+/obj/machinery/door/blob_act(obj/effect/blob/B)
 	if(prob(40))
 		qdel(src)
 	return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -187,7 +187,7 @@ Class Procs:
 	updateUsrDialog()
 	update_icon()
 
-/obj/machinery/blob_act()
+/obj/machinery/blob_act(obj/effect/blob/B)
 	if(!density)
 		qdel(src)
 	if(prob(75))

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -53,7 +53,7 @@
 		if(2)
 			take_damage(50, BRUTE, 0)
 
-/obj/machinery/shield/blob_act()
+/obj/machinery/shield/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -111,7 +111,7 @@
 		if(prob(25))
 			malfunction()
 
-/obj/machinery/vending/blob_act()
+/obj/machinery/vending/blob_act(obj/effect/blob/B)
 	malfunction()
 	..()
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -143,7 +143,7 @@
 				check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
 	return
 
-/obj/mecha/blob_act()
+/obj/mecha/blob_act(obj/effect/blob/B)
 	take_damage(30, "brute")
 	return
 

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -110,7 +110,7 @@
 		if(3)
 			take_damage(50, BRUTE, 0)
 
-/obj/structure/alien/blob_act()
+/obj/structure/alien/blob_act(obj/effect/blob/B)
 	take_damage(50, BRUTE, 0)
 
 /obj/structure/alien/resin/hitby(atom/movable/AM)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -208,7 +208,7 @@
 	qdel(src)
 
 
-/obj/structure/foamedmetal/blob_act()
+/obj/structure/foamedmetal/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -134,7 +134,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 		qdel(X)
 	return ..()
 
-/obj/item/blob_act()
+/obj/item/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 /obj/item/ex_act(severity, target)

--- a/code/game/objects/items/weapons/chrono_eraser.dm
+++ b/code/game/objects/items/weapons/chrono_eraser.dm
@@ -259,7 +259,7 @@
 /obj/effect/chrono_field/ex_act()
 	return
 
-/obj/effect/chrono_field/blob_act()
+/obj/effect/chrono_field/blob_act(obj/effect/blob/B)
 	return
 
 

--- a/code/game/objects/items/weapons/holosign_creator.dm
+++ b/code/game/objects/items/weapons/holosign_creator.dm
@@ -88,7 +88,7 @@
 	..()
 	take_damage(I.force * 0.5, I.damtype)
 
-/obj/effect/overlay/holograph/blob_act()
+/obj/effect/overlay/holograph/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 /obj/effect/overlay/holograph/attack_animal(mob/living/simple_animal/M)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -91,7 +91,7 @@
 
 	user << "<span class='notice'>It feels [descriptive].</span>"
 
-/obj/item/weapon/tank/blob_act()
+/obj/item/weapon/tank/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		var/turf/location = src.loc
 		if (!( istype(location, /turf) ))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -15,7 +15,7 @@
 	if(ticker)
 		cameranet.updateVisibility(src)
 
-/obj/structure/blob_act()
+/obj/structure/blob_act(obj/effect/blob/B)
 	if(!density)
 		qdel(src)
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -206,7 +206,7 @@
 		visible_message("<span class='danger'>[user] destroys \the [src].</span>")
 		qdel(src)
 
-/obj/structure/closet/blob_act()
+/obj/structure/closet/blob_act(obj/effect/blob/B)
 	if(prob(75))
 		qdel(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -120,7 +120,7 @@
 	if(user.environment_smash)
 		shatter()
 
-/obj/structure/closet/statue/blob_act()
+/obj/structure/closet/statue/blob_act(obj/effect/blob/B)
 	shatter()
 
 /obj/structure/closet/statue/attacked_by(obj/item/I, mob/living/user)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -48,7 +48,7 @@
 		showpiece.loc = src.loc
 		showpiece = null
 
-/obj/structure/displaycase/blob_act()
+/obj/structure/displaycase/blob_act(obj/effect/blob/B)
 	if (prob(75))
 		new /obj/item/weapon/shard( src.loc )
 		dump()

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -82,7 +82,7 @@
 	take_damage(P.damage, P.damage_type, 0)
 
 
-/obj/structure/fireaxecabinet/blob_act()
+/obj/structure/fireaxecabinet/blob_act(obj/effect/blob/B)
 	if(fireaxe)
 		fireaxe.loc = src.loc
 	qdel(src)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -261,7 +261,7 @@
 		var/atom/movable/mover = caller
 		. = . || mover.checkpass(PASSGRILLE)
 
-/obj/structure/girder/blob_act()
+/obj/structure/girder/blob_act(obj/effect/blob/B)
 	if(prob(40))
 		qdel(src)
 

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -23,7 +23,7 @@
 		else
 			take_damage(rand(5,10), BRUTE, 0)
 
-/obj/structure/grille/blob_act()
+/obj/structure/grille/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 /obj/structure/grille/Bumped(atom/user)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -28,7 +28,7 @@
 	stored = null
 	return ..()
 
-/obj/structure/lattice/blob_act()
+/obj/structure/lattice/blob_act(obj/effect/blob/B)
 	return
 
 /obj/structure/lattice/ex_act(severity, target)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -164,7 +164,7 @@ FLOOR SAFES
 		return ..()
 
 
-obj/structure/safe/blob_act()
+obj/structure/safe/blob_act(obj/effect/blob/B)
 	return
 
 obj/structure/safe/ex_act(severity, target)

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -13,7 +13,7 @@
 /obj/structure/sign/ex_act(severity, target)
 	qdel(src)
 
-/obj/structure/sign/blob_act()
+/obj/structure/sign/blob_act(obj/effect/blob/B)
 	qdel(src)
 	return
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -53,7 +53,7 @@
 		if(3)
 			take_damage(rand(40,80), BRUTE, 0)
 
-/obj/structure/table/blob_act()
+/obj/structure/table/blob_act(obj/effect/blob/B)
 	if(prob(75))
 		qdel(src)
 
@@ -408,7 +408,7 @@
 		if(3)
 			take_damage(rand(5,25), BRUTE, 0)
 
-/obj/structure/rack/blob_act()
+/obj/structure/rack/blob_act(obj/effect/blob/B)
 	if(prob(75))
 		qdel(src)
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -61,7 +61,7 @@
 		if(3)
 			take_damage(rand(25,75), BRUTE, 0)
 
-/obj/structure/window/blob_act()
+/obj/structure/window/blob_act(obj/effect/blob/B)
 	shatter()
 
 /obj/structure/window/narsie_act()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -88,7 +88,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		if(A.level == 3)
 			return 1
 
-/turf/open/floor/blob_act()
+/turf/open/floor/blob_act(obj/effect/blob/B)
 	return
 
 /turf/open/floor/proc/update_icon()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -80,7 +80,7 @@
 		..()
 	return
 
-/turf/closed/wall/blob_act()
+/turf/closed/wall/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		dismantle_wall()
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -203,7 +203,7 @@
 		air_update_turf() // Update the environment if needed.
 	update_icon()
 
-/obj/machinery/portable_atmospherics/canister/blob_act()
+/obj/machinery/portable_atmospherics/canister/blob_act(obj/effect/blob/B)
 	take_damage(100, BRUTE, 0)
 
 /obj/machinery/portable_atmospherics/canister/bullet_act(obj/item/projectile/P)

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -204,6 +204,6 @@
 	emergency_shutdown()
 	..()
 
-/obj/machinery/computer/holodeck/blob_act()
+/obj/machinery/computer/holodeck/blob_act(obj/effect/blob/B)
 	emergency_shutdown()
 	..()

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -38,7 +38,7 @@
 /mob/living/carbon/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return
 
-/mob/living/carbon/brain/blob_act()
+/mob/living/carbon/brain/blob_act(obj/effect/blob/B)
 	return
 
 /mob/living/carbon/brain/UnarmedAttack(atom/A)//Stops runtimes due to attack_animal being the default

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -341,7 +341,7 @@
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
-/mob/living/carbon/blob_act()
+/mob/living/carbon/blob_act(obj/effect/blob/B)
 	if (stat == DEAD)
 		return
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -153,7 +153,7 @@
 
 	..()
 
-/mob/living/carbon/human/blob_act()
+/mob/living/carbon/human/blob_act(obj/effect/blob/B)
 	if(stat == DEAD)
 		return
 	show_message("<span class='userdanger'>The blob attacks you!</span>")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -350,7 +350,7 @@ var/list/ai_list = list()
 	SSshuttle.cancelEvac(src)
 	return
 
-/mob/living/silicon/ai/blob_act()
+/mob/living/silicon/ai/blob_act(obj/effect/blob/B)
 	if (stat != DEAD)
 		adjustBruteLoss(60)
 		updatehealth()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -92,7 +92,7 @@
 		else
 			stat(null, text("Systems nonfunctional"))
 
-/mob/living/silicon/pai/blob_act()
+/mob/living/silicon/pai/blob_act(obj/effect/blob/B)
 	return 0
 
 /mob/living/silicon/pai/restrained()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -353,7 +353,7 @@
 	if(thruster_button)
 		thruster_button.icon_state = "ionpulse[ionpulse_on]"
 
-/mob/living/silicon/robot/blob_act()
+/mob/living/silicon/robot/blob_act(obj/effect/blob/B)
 	if (stat != 2)
 		adjustBruteLoss(60)
 		updatehealth()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -261,7 +261,7 @@
 	..()
 
 
-/mob/living/simple_animal/blob_act()
+/mob/living/simple_animal/blob_act(obj/effect/blob/B)
 	adjustBruteLoss(20)
 	return
 

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -121,7 +121,7 @@ It is possible to destroy the net by the occupant or someone else.
 		if(3)
 			take_damage(rand(10,25), BRUTE, 0)
 
-/obj/effect/energy_net/blob_act()
+/obj/effect/energy_net/blob_act(obj/effect/blob/B)
 	qdel(src)
 
 /obj/effect/energy_net/hitby(atom/movable/AM)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -309,7 +309,7 @@
 					toner = 0
 
 
-/obj/machinery/photocopier/blob_act()
+/obj/machinery/photocopier/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		qdel(src)
 	else

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1095,7 +1095,7 @@
 				if(prob(25))
 					set_broken()
 
-/obj/machinery/power/apc/blob_act()
+/obj/machinery/power/apc/blob_act(obj/effect/blob/B)
 	set_broken()
 
 /obj/machinery/power/apc/disconnect_terminal()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -155,7 +155,7 @@
 					corrupt()
 
 
-/obj/item/weapon/stock_parts/cell/blob_act()
+/obj/item/weapon/stock_parts/cell/blob_act(obj/effect/blob/B)
 	ex_act(1)
 
 /obj/item/weapon/stock_parts/cell/proc/get_electrocute_damage()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -32,7 +32,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	if(severity == 1) // Very sturdy.
 		set_broken()
 
-/obj/machinery/gravity_generator/blob_act()
+/obj/machinery/gravity_generator/blob_act(obj/effect/blob/B)
 	if(prob(20))
 		set_broken()
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -27,7 +27,7 @@
 		return 1
 
 
-/obj/machinery/field/containment/blob_act()
+/obj/machinery/field/containment/blob_act(obj/effect/blob/B)
 	return 0
 
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -138,7 +138,7 @@ field_generator power level display
 	return 0
 
 
-/obj/machinery/field/generator/blob_act()
+/obj/machinery/field/generator/blob_act(obj/effect/blob/B)
 	if(active)
 		return 0
 	else

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -149,7 +149,7 @@
 		master.toggle_power()
 		investigate_log("was moved whilst active; it <font color='red'>powered down</font>.","singulo")
 
-/obj/structure/particle_accelerator/blob_act()
+/obj/structure/particle_accelerator/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		qdel(src)
 

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -320,7 +320,7 @@
 
 	..()
 
-/obj/machinery/particle_accelerator/control_box/blob_act()
+/obj/machinery/particle_accelerator/control_box/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		qdel(src)
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -63,7 +63,7 @@
 /obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
 	return 0
 
-/obj/singularity/blob_act(severity)
+/obj/singularity/blob_act(obj/effect/blob/B)
 	return
 
 /obj/singularity/ex_act(severity, target)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -537,7 +537,7 @@
 			if(3)
 				take_damage(rand(10,20), BRUTE, 0)
 
-/obj/machinery/power/solar_control/blob_act()
+/obj/machinery/power/solar_control/blob_act(obj/effect/blob/B)
 	if (prob(75))
 		set_broken()
 		src.density = 0

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -234,7 +234,7 @@
 			"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 			Consume(B)
 		else
-			if(B.health - 100 > 0)
+			if(B.health > 100)
 				B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and flinches away!</span>",\
 				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 				B.take_damage(100, BURN, src)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -229,19 +229,14 @@
 	if(B && !istype(loc, /turf/open/space)) //does nothing in space
 		playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, 1)
 		damage += B.health * 0.5 //take damage equal to 50% of remaining blob health before it tried to eat us
-		if(!istype(B, /obj/effect/blob/core) && !istype(B, /obj/effect/blob/node))
+		if(B.health > 100)
+			B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and flinches away!</span>",\
+			"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+			B.take_damage(100, BURN, src)
+		else
 			B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and rapidly flashes to ash.</span>",\
 			"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 			Consume(B)
-		else
-			if(B.health > 100)
-				B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and flinches away!</span>",\
-				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
-				B.take_damage(100, BURN, src)
-			else
-				B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and rapidly flashes to ash.</span>",\
-				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
-				Consume(B)
 
 /obj/machinery/power/supermatter_shard/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -225,6 +225,24 @@
 	qdel(src)
 	return(gain)
 
+/obj/machinery/power/supermatter_shard/blob_act(obj/effect/blob/B)
+	if(B && !istype(loc, /turf/open/space)) //does nothing in space
+		playsound(get_turf(src), 'sound/effects/supermatter.ogg', 50, 1)
+		damage += B.health * 0.5 //take damage equal to 50% of remaining blob health before it tried to eat us
+		if(!istype(B, /obj/effect/blob/core) && !istype(B, /obj/effect/blob/node))
+			B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and rapidly flashes to ash.</span>",\
+			"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+			Consume(B)
+		else
+			if(B.health - 100 > 0)
+				B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and flinches away!</span>",\
+				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+				B.take_damage(100, BURN, src)
+			else
+				B.visible_message("<span class='danger'>\The [B] strikes at \the [src] and rapidly flashes to ash.</span>",\
+				"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
+				Consume(B)
+
 /obj/machinery/power/supermatter_shard/attack_paw(mob/user)
 	return attack_hand(user)
 
@@ -293,7 +311,7 @@
 		investigate_log("has consumed [key_name(user)].", "supermatter")
 		user.dust()
 		power += 200
-	else if(isobj(AM) && !istype(AM, /obj/effect))
+	else if(isobj(AM) && (!istype(AM, /obj/effect) || istype(AM, /obj/effect/blob)))
 		investigate_log("has consumed [AM].", "supermatter")
 		qdel(AM)
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -69,7 +69,7 @@
 	if(severity < 3)
 		..()
 
-/obj/machinery/chem_dispenser/blob_act()
+/obj/machinery/chem_dispenser/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		qdel(src)
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -21,7 +21,7 @@
 	if(severity < 3)
 		..()
 
-/obj/machinery/chem_master/blob_act()
+/obj/machinery/chem_master/blob_act(obj/effect/blob/B)
 	if (prob(50))
 		qdel(src)
 

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -416,7 +416,7 @@
 		if(isliving(cause))
 			B.visible_message("<span class='warning'><b>The blob retaliates, lashing out!</b></span>")
 		for(var/atom/A in range(1, B))
-			A.blob_act()
+			A.blob_act(B)
 	return ..()
 
 //does low burn damage and stamina damage and cools targets down

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -23,7 +23,7 @@
 		else
 	return
 
-/obj/structure/reagent_dispensers/blob_act()
+/obj/structure/reagent_dispensers/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		qdel(src)
 
@@ -70,7 +70,7 @@
 		else
 	return
 
-/obj/structure/reagent_dispensers/watertank/blob_act()
+/obj/structure/reagent_dispensers/watertank/blob_act(obj/effect/blob/B)
 	if(prob(50))
 		PoolOrNew(/obj/effect/particle_effect/water, loc)
 		qdel(src)
@@ -98,7 +98,7 @@
 	if(src)
 		qdel(src)
 
-/obj/structure/reagent_dispensers/fueltank/blob_act()
+/obj/structure/reagent_dispensers/fueltank/blob_act(obj/effect/blob/B)
 	boom()
 
 
@@ -169,7 +169,7 @@
 	..()
 	reagents.add_reagent("beer",1000)
 
-/obj/structure/reagent_dispensers/beerkeg/blob_act()
+/obj/structure/reagent_dispensers/beerkeg/blob_act(obj/effect/blob/B)
 	explosion(src.loc,0,3,5,7,10)
 
 

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -54,7 +54,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 		T += M.rating
 	efficiency_coeff = 2 ** (T - 1) //Only 1 manipulator here, you're making runtimes Razharas
 
-/obj/machinery/r_n_d/circuit_imprinter/blob_act()
+/obj/machinery/r_n_d/circuit_imprinter/blob_act(obj/effect/blob/B)
 	if (prob(50))
 		qdel(src)
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -86,7 +86,7 @@
 	..()
 
 
-/obj/machinery/r_n_d/server/blob_act()
+/obj/machinery/r_n_d/server/blob_act(obj/effect/blob/B)
 	griefProtection()
 	..()
 


### PR DESCRIPTION
:cl: Joan
rscadd: Blobs attempting to attack the supermatter will instead be eaten by it.
experiment: This doesn't mean throwing a supermatter shard at the blob is a good idea; blobs attacking it will gradually damage it, eventually resulting in a massive explosion, and it will not consume blobs if on a space turf.
/:cl:

Adds the acting blob as an argument for blob_act(), currently only used for supermatter blob consumption.
