### PR TITLE
Cargo shuttle takes 15 seconds to arrive instead of 0, compromise

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 10
+	callTime = 150
 
 	dir = 8
 	travelDir = 90


### PR DESCRIPTION
CERTAIN RETARDS seem to think that "lol 2 minute cargo is a good thing!!1!"

obviously these certain retards dont play cargo

so to prevent them I'm gonna cock block their PRs to put it back to 2 minutes with this one which is better because 1. its not instant, and 2. it's not super fucking long
