### PR TITLE
Decreases cargo shuttle time to 15 seconds from 1 minutes

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 1200
+	callTime = 150
 
 	dir = 8
 	travelDir = 90


### PR DESCRIPTION
:cl: Iamgoofball
rscadd: Cargo Shuttle time reduced to 15 seconds from 2 minutes.
/:cl:

2 minutes is way too long. Cargo is more fun when the shuttle doesn't have an arbitrary time limit.

> muh balance

Try balancing the actual crates instead of using arbitrary time limits to enforce this.

> muh longer rounds

This is a bullshit argument. The cargo shuttle taking an abnormal amount of time does NOT make the round longer.

> muh blob/rev/gang

It's been INSTANT SHUTTLE TIME for the last 2 weeks. There hasn't been any issue reports about it being too short since, so I'm certain its fine.
