### PR TITLE
Hitting a locker or crate with an ID, PDA with ID, or wallet with ID will try to toggle the lock instead of opening it

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -251,7 +251,7 @@
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
 	else if(user.a_intent != "harm" && !(W.flags & NOBLUDGEON))
-		if(!toggle(user))
+		if(W.GetID() || !toggle(user))
 			togglelock(user)
 		return 1
 	else


### PR DESCRIPTION
:cl: Joan
tweak: Hitting a locker or crate with an ID, PDA with ID, or wallet with ID will try to toggle the lock instead of trying to open it.
/:cl:
