### PR TITLE
Removed objectionable absinthe name, procedurally generates absinthe name instead

### DIFF
--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -236,20 +236,23 @@
 	list_reagents = list("wine" = 100)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
-	name = "COMPANY Extra-Strong Absinthe"
+	name = "Extra-Strong Absinthe"
 	desc = "An strong alcoholic drink brewed and distributed by FULL_COMPANY Inc."
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/New()
 	..()
+	redact()
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/proc/redact()
 	// There was a large fight in the coderbus about a player reference
 	// in absinthe. Ergo, this is why the name generation is now so
 	// complicated. Judge us kindly.
 	var/shortname = pickweight(
 		list("T&T" = 1, "A&A" = 1, "Generic" = 1))
 	var/fullname
-	switch(name)
+	switch(shortname)
 		if("T&T")
 			fullname = "Teal and Tealer"
 		if("A&A")
@@ -264,7 +267,7 @@
 	if(prob(chance))
 		shortname = pick_n_take(removals)
 
-	var/final_fullname = list()
+	var/list/final_fullname = list()
 	for(var/word in splittext(fullname, " "))
 		if(prob(chance))
 			word = pick_n_take(removals)
@@ -273,14 +276,17 @@
 	fullname = jointext(final_fullname, " ")
 
 	// Actually finally setting the new name and desc
-	name = replacetext(name, "COMPANY", shortname)
-	desc = replacetext(desc, "FULL_COMPANY", fullname)
+	name = "[shortname] [initial(name)]"
+	desc = replacetext(initial(desc), "FULL_COMPANY", fullname)
 
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/premium
 	name = "Gwyn's Premium Absinthe"
 	desc = "A potent alcoholic beverage, almost makes you forget the ash in your lungs."
 	icon_state = "absinthepremium"
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/premium/redact()
+	return
 
 //////////////////////////JUICES AND STUFF ///////////////////////
 

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -236,8 +236,8 @@
 	list_reagents = list("wine" = 100)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
-	name = "T&T Extra-Strong Absinthe"
-	desc = "An strong alcoholic drink brewed and distributed by Terb & Tonte Inc."
+	name = "\[REDACTED\] Extra-Strong Absinthe"
+	desc = "An strong alcoholic drink brewed and distributed by \[REDACTED\] & \[REMOVED FOR SECURITY REASONS\] Inc."
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
 

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -251,7 +251,7 @@
 	var/fullname
 	switch(name)
 		if("T&T")
-			fullname = "Terb and Tonte"
+			fullname = "Teal and Tealer"
 		if("A&A")
 			fullname = "Ash and Asher"
 		if("Generic")
@@ -262,12 +262,12 @@
 	var/chance = 50
 
 	if(prob(chance))
-		shortname = pick_and_take(removals)
+		shortname = pick_n_take(removals)
 
 	var/final_fullname = list()
 	for(var/word in splittext(fullname, " "))
 		if(prob(chance))
-			word = pick_and_take(removals)
+			word = pick_n_take(removals)
 		final_fullname += word
 
 	fullname = jointext(final_fullname, " ")

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -236,10 +236,46 @@
 	list_reagents = list("wine" = 100)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
-	name = "\[REDACTED\] Extra-Strong Absinthe"
-	desc = "An strong alcoholic drink brewed and distributed by \[REDACTED\] & \[REMOVED FOR SECURITY REASONS\] Inc."
+	name = "COMPANY Extra-Strong Absinthe"
+	desc = "An strong alcoholic drink brewed and distributed by FULL_COMPANY Inc."
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/New()
+	..()
+	// There was a large fight in the coderbus about a player reference
+	// in absinthe. Ergo, this is why the name generation is now so
+	// complicated. Judge us kindly.
+	var/shortname = pickweight(
+		list("T&T" = 1, "A&A" = 1, "Generic" = 1))
+	var/fullname
+	switch(name)
+		if("T&T")
+			fullname = "Terb and Tonte"
+		if("A&A")
+			fullname = "Ash and Asher"
+		if("Generic")
+			fullname = "Nanotrasen Cheap Imitations"
+	var/removals = list("\[REDACTED\]", "\[EXPLETIVE DELETED\]",
+		"\[EXPUNGED\]", "\[INFORMATION ABOVE YOUR SECURITY CLEARANCE\]",
+		"\[MOVE ALONG CITIZEN\]", "\[NOTHING TO SEE HERE\]")
+	var/chance = 50
+
+	if(prob(chance))
+		shortname = pick_and_take(removals)
+
+	var/final_fullname = list()
+	for(var/word in splittext(fullname, " "))
+		if(prob(chance))
+			word = pick_and_take(removals)
+		final_fullname += word
+
+	fullname = jointext(final_fullname, " ")
+
+	// Actually finally setting the new name and desc
+	name = replacetext(name, "COMPANY", shortname)
+	desc = replacetext(desc, "FULL_COMPANY", fullname)
+
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/premium
 	name = "Gwyn's Premium Absinthe"

--- a/code/modules/food&drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food&drinks/drinks/drinks/bottle.dm
@@ -237,7 +237,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
 	name = "Extra-Strong Absinthe"
-	desc = "An strong alcoholic drink brewed and distributed by FULL_COMPANY Inc."
+	desc = "An strong alcoholic drink brewed and distributed by"
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
 
@@ -276,8 +276,8 @@
 	fullname = jointext(final_fullname, " ")
 
 	// Actually finally setting the new name and desc
-	name = "[shortname] [initial(name)]"
-	desc = replacetext(initial(desc), "FULL_COMPANY", fullname)
+	name = "[shortname] [name]"
+	desc = "[desc] [fullname] Inc."
 
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe/premium


### PR DESCRIPTION
:cl: coiax
rscadd: Centcom Department of [REDACTED] have announced a change of supplier
of [EXPLETIVE DELETED]. As such, for security reasons, the absinthe
[MOVE ALONG CITIZEN] will instead be [NOTHING TO SEE HERE]. We hope that
this will not affect the performance of the [INFORMATION ABOVE YOUR
SECURITY CLEARANCE].
/:cl:

Reasons we're better than #17226.
- It's shit.

Reasons we're better than #17198.
- Q U A L I T Y  M E M E S
