### PR TITLE
Added more stat tracking to mining items and engine generation

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -390,6 +390,10 @@
 			else
 				inserted_id.mining_points -= prize.cost
 				new prize.equipment_path(src.loc)
+				feedback_add_details("mining_equipment_bought",
+					"[src.type]|[prize.equipment_path]")
+				// Add src.type to keep track of free golem purchases
+				// seperately.
 	updateUsrDialog()
 	return
 
@@ -428,6 +432,8 @@
 			new /obj/item/weapon/weldingtool/hugetank(src.loc)
 		if("Advanced Scanner")
 			new /obj/item/device/t_scanner/adv_mining_scanner(src.loc)
+
+	feedback_add_details("mining_voucher_redeemed", selection)
 	qdel(voucher)
 
 /obj/machinery/mineral/equipment_vendor/ex_act(severity, target)
@@ -488,6 +494,7 @@
 
 /obj/item/device/wormhole_jaunter/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
+	feedback_add_details("jaunter", "U") // user activated
 	activate(user)
 
 /obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
@@ -527,11 +534,13 @@
 
 	if(triggered)
 		usr.visible_message("<span class='warning'>The [src] overloads and activates!</span>")
+		feedback_add_details("jaunter","E") // EMP accidental activation
 		activate(usr)
 
 /obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
 		user << "Your [src] activates, saving you from the chasm!</span>"
+		feedback_add_details("jaunter","C") // chasm automatic activation
 		activate(user)
 	else
 		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
@@ -885,6 +894,7 @@
 						H.attack_same = 0
 				loaded = 0
 				user.visible_message("<span class='notice'>[user] injects [M] with [src], reviving it.</span>")
+				feedback_add_details("lazarus_injector", "[M.type]")
 				playsound(src,'sound/effects/refill.ogg',50,1)
 				icon_state = "lazarus_empty"
 				return
@@ -1064,6 +1074,7 @@
 		user << "<span class='warning'>The stabilizer only works on certain types of monster organs, generally regenerative in nature.</span>"
 		return ..()
 	C.preserved = 1
+	feedback_add_details("hivelord_core", "[C.type]|stabilizer") // preserved
 	user << "<span class='notice'>You inject the [M] with the stabilizer. It will no longer go inert.</span>"
 	qdel(src)
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -87,6 +87,7 @@
 		user.sight |= SEE_MOBS
 		icon_state = "lantern"
 		wisp.orbit(user, 20)
+		feedback_add_details("wisp_lantern","F") // freed
 
 	else
 		if(wisp.orbiting)
@@ -100,6 +101,7 @@
 			wisp.loc = src
 			user << "You return the wisp to the latern."
 			icon_state = "lantern-blue"
+			feedback_add_details("wisp_lantern","R") // returned
 
 /obj/item/device/wisp_lantern/New()
 	..()
@@ -143,6 +145,7 @@
 
 	PoolOrNew(/obj/effect/particle_effect/smoke, user.loc)
 	user.forceMove(get_turf(linked))
+	feedback_add_details("warp_cube","[src.type]")
 	PoolOrNew(/obj/effect/particle_effect/smoke, user.loc)
 
 /obj/item/device/warp_cube/red
@@ -215,6 +218,7 @@
 
 /obj/item/device/immortality_talisman/attack_self(mob/user)
 	if(cooldown < world.time)
+		feedback_add_details("immortality_talisman","U") // usage
 		cooldown = world.time + 600
 		user.visible_message("<span class='danger'>[user] vanishes from reality, leaving a a hole in their place!</span>")
 		var/obj/effect/immortality_talisman/Z = new(get_turf(src.loc))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -249,8 +249,10 @@
 		if(!owner && !preserved)
 			inert = 1
 			desc = "The remains of a hivelord that have become useless, having been left alone too long after being harvested."
+			feedback_add_details("hivelord_core", "[src.type]|inert")
 		else
 			preserved = 1
+			feedback_add_details("hivelord_core", "[src.type]|implanted")
 
 /obj/item/organ/internal/hivelord_core/on_life()
 	..()
@@ -276,9 +278,11 @@
 				user << "<span class='notice'>[src] are useless on the dead.</span>"
 				return
 			if(H != user)
+				feedback_add_details("hivelord_core","[src.type]|used|other")
 				H.visible_message("[user] forces [H] to apply [src]... they quickly regenerate all injuries!")
 			else
 				user << "<span class='notice'>You start to smear [src] on yourself. It feels and smells disgusting, but you feel amazingly refreshed in mere moments.</span>"
+				feedback_add_details("hivelord_core","[src.type]|used|self")
 			H.revive(full_heal = 1)
 			qdel(src)
 	..()

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -13,6 +13,7 @@
 /obj/machinery/the_singularitygen/process()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
+		feedback_add_details("engine_started","[src.type]")
 		var/obj/singularity/S = new creation_type(T, 50)
 		transfer_fingerprints_to(S)
 		qdel(src)


### PR DESCRIPTION
Statistics for
- Mining voucher redemption
- Mining rewards vendor (keeping track of miners and Free Golems separately)
- Jaunter usage (deliberate, EMP'd or chasmed)
- Hivelord/legion core/heart usage
- Mobs reanimated with laz injectors
- Wisp lantern, mystery cube and immortality talisman usage
- Engine ignition (tesla and sing)
