### PR TITLE
vote improvements

### DIFF
--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -145,9 +145,19 @@ var/datum/subsystem/vote/SSvote
 
 /datum/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
 	if(!mode)
-		if(started_time != null)
+		if(started_time)
 			var/next_allowed_time = (started_time + config.vote_delay)
-			if(next_allowed_time > world.time)
+			if(mode)
+				usr << "<span class='warning'>There is already a vote in progress! please wait for it to finish.</span>"
+				return 0
+	
+			var/admin = FALSE
+			var/ckey = ckey(initiator_key)
+			if((admin_datums[ckey]) || (ckey in deadmins))
+				admin = TRUE
+			
+			if(next_allowed_time > world.time && !admin)
+				usr << "<span class='warning'>A vote was initiated recently, you must wait roughly [(next_allowed_time-world.time)/10] seconds before a new vote can be started!</span>"
 				return 0
 
 		reset()


### PR DESCRIPTION
- Lets admins skip vote wait (so long as one isn't in progress, voting only allows one question at a time) 
- Gives feedback to people who try to start a vote too soon.
- Prevents and Gives feedback to people who try to start a vote while one is in progress (Not actually possible without spoofing/fuckery but w/e lets be safe)
