### PR TITLE
Blob spores now put the factory on cooldown when they die

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -89,6 +89,8 @@
 	attacktext = "hits"
 	attack_sound = 'sound/weapons/genhit1.ogg'
 	flying = 1
+	del_on_death = 1
+	deathmessage = "The blob spore explodes into a cloud of gas!"
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/list/human_overlays = list()
 	var/is_zombie = 0
@@ -134,7 +136,6 @@
 	visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
-	..(1)
 	// On death, create a small smoke of harmful gas (s-Acid)
 	var/datum/effect_system/smoke_spread/chem/S = new
 	var/turf/location = get_turf(src)
@@ -151,9 +152,10 @@
 	S.attach(location)
 	S.set_up(reagents, death_cloud_size, location, silent=1)
 	S.start()
+	if(factory)
+		factory.spore_delay = world.time + factory.spore_cooldown //put the factory on cooldown
 
-	ghostize()
-	qdel(src)
+	..()
 
 /mob/living/simple_animal/hostile/blob/blobspore/Destroy()
 	if(factory)

--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -11,6 +11,7 @@
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/naut = null
 	var/max_spores = 3
 	var/spore_delay = 0
+	var/spore_cooldown = 80 //8 seconds between spores and after spore death
 
 
 /obj/effect/blob/factory/scannerreport()
@@ -38,7 +39,7 @@
 	if(spore_delay > world.time)
 		return
 	flick("blob_factory_glow", src)
-	spore_delay = world.time + 100 // 10 seconds
+	spore_delay = world.time + spore_cooldown
 	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
 	if(overmind) //if we don't have an overmind, we don't need to do anything but make a spore
 		BS.overmind = overmind

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1352,6 +1352,7 @@
 #include "code\modules\mob\living\simple_animal\shade.dm"
 #include "code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "code\modules\mob\living\simple_animal\spawner.dm"
+#include "code\modules\mob\living\simple_animal\status_procs.dm"
 #include "code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "code\modules\mob\living\simple_animal\bot\cleanbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\construction.dm"


### PR DESCRIPTION
:cl: Joan
tweak: Blob spores spawn from factories 2 seconds faster, but the factory goes on cooldown when any of its spores die.
/:cl:

This is mostly so that killing a spore doesn't instantly result in the factory spawning another, because that's a pain in the butt and hard to balance anything around.
