### PR TITLE
Replaces sleepers in Syndicate shuttle with Syndcate-colored ones

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -488,9 +488,8 @@
 /turf/closed/mineral/random,
 /area/mine/explored)
 "abg" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
-	 dir = 4
+/obj/machinery/sleeper/syndie{
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{
 	icon_state = "shuttlefloor4"

--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -56,7 +56,7 @@
 "abd" = (/obj/machinery/door/window{dir = 4; name = "Infirmary"; req_access_txt = "150"},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
 "abe" = (/obj/machinery/door/window/westright{name = "Tool Storage"; req_access_txt = "150"},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
 "abf" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/weapon/crowbar/red,/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
-"abg" = (/obj/machinery/sleeper{icon_state = "sleeper-open"; dir = 4},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
+"abg" = (/obj/machinery/sleeper/syndie{dir = 4},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
 "abh" = (/obj/machinery/door/window{base_state = "right"; dir = 4; icon_state = "right"; name = "Infirmary"; req_access_txt = "150"},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
 "abi" = (/obj/machinery/door/window{dir = 8; name = "Tool Storage"; req_access_txt = "150"},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)
 "abj" = (/obj/structure/table,/obj/item/weapon/gun/syringe{pixel_x = 1; pixel_y = 2},/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/shuttle/syndicate)

--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -2971,8 +2971,7 @@
 	},
 /area/shuttle/syndicate)
 "afH" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -2176,8 +2176,7 @@
 	name = "AI Satellite Service"
 	})
 "adT" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{

--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -96487,8 +96487,7 @@
 	},
 /area/shuttle/syndicate)
 "cXV" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -15165,8 +15165,7 @@
 	},
 /area/tcommsat/computer)
 "Gu" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -57122,8 +57122,7 @@
 	},
 /area/engine/engineering)
 "cmM" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper-open";
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle{

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -69,6 +69,8 @@
 /obj/machinery/sleeper/close_machine(mob/user)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
 		..(user)
+		if(occupant && occupant.stat != DEAD)
+			occupant << "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.</b></span>"
 
 /obj/machinery/sleeper/attack_animal(mob/living/simple_animal/M)
 	if(M.environment_smash)


### PR DESCRIPTION
![sleeper](https://cloud.githubusercontent.com/assets/7305553/15069105/66753bfc-1373-11e6-8afe-84a25ad624c3.png)
Also ports one sleeper-related fluff message from Bay.
