### PR TITLE
Drops supply shuttle delay to 1 minute

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -1,7 +1,7 @@
 /obj/docking_port/mobile/supply
 	name = "supply shuttle"
 	id = "supply"
-	callTime = 1200
+	callTime = 600
 
 	dir = 8
 	travelDir = 90


### PR DESCRIPTION
I agree that two minute delay is too much, but 15 seconds from #17215 is way too little. I think 1 minute timer can stand as middle point.
