### PR TITLE
Cyborg Blueprints

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -337,3 +337,14 @@
 				found += U
 		found |= F
 	return found
+
+
+
+//Blueprint Subtypes
+
+/obj/item/areaeditor/blueprints/cyborg
+	name = "station schematics"
+	desc = "A digital copy of the station blueprints stored in your memory."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "blueprints"
+	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -179,6 +179,7 @@
 	modules += new /obj/item/device/multitool/cyborg(src)
 	modules += new /obj/item/device/t_scanner(src)
 	modules += new /obj/item/device/analyzer(src)
+	modules += new /obj/item/areaeditor/blueprints/cyborg(src)
 
 	add_module(new /obj/item/stack/sheet/metal/cyborg())
 	add_module(new /obj/item/stack/sheet/glass/cyborg())


### PR DESCRIPTION
So engineering cyborgs can do fun blueprint related things like name all the main halls DICKS

:cl: Kor
rscadd: Engineering cyborgs now have internal blueprints.
/:cl:
