### PR TITLE
Service and standard cyborgs get a spraycan; service cyborgs get a cyborg-hand labeler

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -233,3 +233,24 @@
 	if(G)
 		paint_color = G.color_hex
 		update_icon()
+
+/obj/item/toy/crayon/spraycan/borg
+	desc = "A metallic container containing shiny paint."
+	// Use depletion of uses to determine what the energy cost is
+	uses = 100
+
+/obj/item/toy/crayon/spraycan/borg/afterattack(atom/target,mob/user,proximity)
+	..()
+	if(!isrobot(user))
+		return FALSE
+	var/mob/living/silicon/robot/borgy
+
+	var/starting_uses = initial(uses)
+	var/diff = starting_uses - uses
+	if(diff)
+		uses = starting_uses
+		// 25 is our cost per unit of paint, making it cost 25 energy per
+		// normal tag, 50 per window, and 250 per attack
+		var/cost = diff * 25
+
+		borgy.cell.use(cost)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -243,7 +243,7 @@
 	..()
 	if(!isrobot(user))
 		return FALSE
-	var/mob/living/silicon/robot/borgy
+	var/mob/living/silicon/robot/borgy = user
 
 	var/starting_uses = initial(uses)
 	var/diff = starting_uses - uses

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -252,5 +252,7 @@
 		// 25 is our cost per unit of paint, making it cost 25 energy per
 		// normal tag, 50 per window, and 250 per attack
 		var/cost = diff * 25
-
-		borgy.cell.use(cost)
+		// Cyborgs shouldn't be able to use modules without a cell. But if they do
+		// it's free.
+		if(borgy.cell)
+			borgy.cell.use(cost)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -195,15 +195,22 @@
 				if(C.client)
 					C.blur_eyes(3)
 					C.blind_eyes(1)
-					if(C.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
-						C.confused = max(C.confused, 3)
-						C.Weaken(3)
+				if(C.check_eye_prot() <= 0) // no eye protection? ARGH IT BURNS.
+					C.confused = max(C.confused, 3)
+					C.Weaken(3)
 				if(ishuman(C))
 					var/mob/living/carbon/human/H = C
 					H.lip_style = "spray_face"
 					H.lip_color = paint_color
 					H.update_body()
+				// Caution, spray cans contain inflammable substances
+				if(C.reagents)
+					C.reagents.add_reagent("welding_fuel", 5)
+					C.reagents.add_reagent("ethanol", 5)
+					C.reagents.reaction(C, VAPOR, 10)
+
 				uses = max(0,uses-10)
+
 		if(istype(target, /obj/structure/window))
 			if(uses)
 				target.color = paint_color

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -6,7 +6,7 @@ RSF
 /obj/item/weapon/rsf
 	name = "\improper Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	opacity = 0
 	density = 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -260,6 +260,7 @@
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass(src)
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 	modules += new /obj/item/weapon/pen(src)
+	modules += new /obj/item/toy/crayon/spraycan/borg(src)
 	modules += new /obj/item/weapon/razor(src)
 	modules += new /obj/item/device/instrument/violin(src)
 	modules += new /obj/item/device/instrument/guitar(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -130,6 +130,7 @@
 	modules += new /obj/item/weapon/wrench/cyborg(src)
 	modules += new /obj/item/weapon/crowbar/cyborg(src)
 	modules += new /obj/item/device/healthanalyzer(src)
+	modules += new /obj/item/toy/crayon/spraycan/borg(src)
 	emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
 	fix_modules()
 
@@ -261,6 +262,7 @@
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 	modules += new /obj/item/weapon/pen(src)
 	modules += new /obj/item/toy/crayon/spraycan/borg(src)
+	modules += new /obj/item/weapon/hand_labeler/borg(src)
 	modules += new /obj/item/weapon/razor(src)
 	modules += new /obj/item/device/instrument/violin(src)
 	modules += new /obj/item/device/instrument/guitar(src)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -108,7 +108,10 @@
 		// 50 per label. Magical cyborg paper doesn't come cheap.
 		var/cost = diff * 50
 
-		borgy.cell.use(cost)
+		// If the cyborg manages to use a module without a cell, they get the paper
+		// for free.
+		if(borgy.cell)
+			borgy.cell.use(cost)
 
 /obj/item/hand_labeler_refill
 	name = "hand labeler paper roll"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/hand_labeler
 	name = "hand labeler"
+	desc = "A combined label printer and applicator in a portable device, designed to be easy to operate and use."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
@@ -7,6 +8,17 @@
 	var/labels_left = 30
 	var/mode = 0
 
+/obj/item/weapon/hand_labeler/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is pointing \the [src] \
+		at \himself. They're going to label themselves as a suicide!</span>")
+	labels_left = max(labels_left - 1, 0)
+	user.name = "[user.name] (suicide)"
+
+	mode = 1
+	icon_state = "labeler[mode]"
+	label = "suicide"
+
+	return OXYLOSS
 
 /obj/item/weapon/hand_labeler/afterattack(atom/A, mob/user,proximity)
 	if(!proximity) return
@@ -62,6 +74,25 @@
 		qdel(I)
 		labels_left = initial(labels_left)
 		return
+
+/obj/item/weapon/hand_labeler/borg
+	name = "cyborg-hand labeler"
+
+/obj/item/weapon/hand_labeler/borg/afterattack(atom/A, mob/user, proximity)
+	..(A, user, proximity)
+	if(!isrobot(user))
+		return
+
+	var/mob/living/silicon/robot/borgy = user
+
+	var/starting_labels = initial(labels_left)
+	var/diff = starting_labels - labels_left
+	if(diff)
+		labels_left = starting_labels
+		// 50 per label. Magical cyborg paper doesn't come cheap.
+		var/cost = diff * 50
+
+		borgy.cell.use(cost)
 
 /obj/item/hand_labeler_refill
 	name = "hand labeler paper roll"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -12,7 +12,23 @@
 	user.visible_message("<span class='suicide'>[user] is pointing \the [src] \
 		at \himself. They're going to label themselves as a suicide!</span>")
 	labels_left = max(labels_left - 1, 0)
-	user.name = "[user.name] (suicide)"
+
+	var/old_real_name = user.real_name
+	user.real_name += " (suicide)"
+	// no conflicts with their identification card
+	for(var/atom/A in user)
+		if(istype(A, /obj/item/weapon/card/id))
+			var/obj/item/weapon/card/id/their_card = A
+
+			// only renames their card, as opposed to tagging everyone's
+			if(their_card.registered_name != old_real_name)
+				continue
+
+			their_card.registered_name = user.real_name
+			their_card.update_label()
+
+	// NOT EVEN DEATH WILL TAKE AWAY THE STAIN
+	user.mind.name += " (suicide)"
 
 	mode = 1
 	icon_state = "labeler[mode]"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -709,7 +709,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		step_towards(O, get_turf(M))
 	return ..()
 
-/datum/reagent/consumable/ethanol/hearty_punch //Another reference. Heals those in critical condition extremely quickly. If you die with it in your system, it will be removed and you will live!
+// Another reference. Heals those in critical condition extremely quickly.
+/datum/reagent/consumable/ethanol/hearty_punch
 	name = "Hearty Punch"
 	id = "hearty_punch"
 	description = "Brave bull/syndicate bomb/absinthe mixture resulting in an energizing beverage. Mild alcohol content."


### PR DESCRIPTION
:cl: coiax
rscadd: The Service and the Standard cyborg module now have a spraycan built in, for
hijinks and passing on important urban messages. The Service cyborg module also has a cyborg-hand labeler, in case anything needs to be labelled.
rscadd: Centcom Suicide Prevention wishes to remind the station: Please do not kill yourself with a hand labeler.
/:cl:
- Hand labeler suicide added.
- Fixes bug with RSF having incorrect icon file.
