### PR TITLE
Fleshmend: Diminishing returns; Panacea: Better.

### DIFF
--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -20,8 +20,7 @@
 
 /obj/effect/proc_holder/changeling/fleshmend/process()
 	if(recent_uses > 1)
-		recent_uses -= (1 / healing_ticks)
-		recent_uses = max(recent_uses, 1)
+		recent_uses = max(1, recent_uses - (1 / healing_ticks))
 
 //Starts healing you every second for 10 seconds. Can be used whilst unconscious.
 /obj/effect/proc_holder/changeling/fleshmend/sting_action(mob/living/user)
@@ -36,7 +35,7 @@
 			H.remove_all_embedded_objects()
 		// The healing itself - doesn't heal toxin damage (that's anatomic panacea) and
 		// effectiveness decreases with each use in a short timespan
-		for(var/i = 0, i < healing_ticks, i++)
+		for(var/i in 1 to healing_ticks)
 			if(user)
 				var/healpertick = -(total_healing / healing_ticks)
 				user.adjustBruteLoss(healpertick / recent_uses, 0)

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -6,6 +6,9 @@
 	dna_cost = 2
 	req_stat = UNCONSCIOUS
 	var/recent_uses = 1 //The factor of which the healing should be divided by
+	var/healing_ticks = 10
+	 // The ideal total healing amount, divided by healing_ticks to get heal/tick
+	var/total_healing = 100
 
 /obj/effect/proc_holder/changeling/fleshmend/New()
 	..()
@@ -17,7 +20,8 @@
 
 /obj/effect/proc_holder/changeling/fleshmend/process()
 	if(recent_uses > 1)
-		recent_uses--
+		recent_uses -= (1 / healing_ticks)
+		recent_uses = max(recent_uses, 1)
 
 //Starts healing you every second for 10 seconds. Can be used whilst unconscious.
 /obj/effect/proc_holder/changeling/fleshmend/sting_action(mob/living/user)
@@ -30,12 +34,14 @@
 			var/mob/living/carbon/human/H = user
 			H.restore_blood()
 			H.remove_all_embedded_objects()
-
-		for(var/i = 0, i < 10, i++) //The healing itself - doesn't heal toxin damage (that's anatomic panacea) and effectiveness decreases with each use in a short timespan
+		// The healing itself - doesn't heal toxin damage (that's anatomic panacea) and
+		// effectiveness decreases with each use in a short timespan
+		for(var/i = 0, i < healing_ticks, i++)
 			if(user)
-				user.adjustBruteLoss(-10 / recent_uses, 0)
-				user.adjustOxyLoss(-10 / recent_uses, 0)
-				user.adjustFireLoss(-10 / recent_uses, 0)
+				var/healpertick = -(total_healing / healing_ticks)
+				user.adjustBruteLoss(healpertick / recent_uses, 0)
+				user.adjustOxyLoss(healpertick / recent_uses, 0)
+				user.adjustFireLoss(healpertick / recent_uses, 0)
 				user.updatehealth()
 			sleep(10)
 

--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -21,7 +21,7 @@
 	user.reagents.add_reagent("mutadone", 10)
 	user.reagents.add_reagent("pen_acid", 20)
 	user.reagents.add_reagent("antihol", 10)
-	user.reagents.add_reagent("mannitol", 10)
+	user.reagents.add_reagent("mannitol", 75)
 
 	for(var/datum/disease/D in user.viruses)
 		D.cure()

--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -19,9 +19,9 @@
 		egg.loc = get_turf(user)
 
 	user.reagents.add_reagent("mutadone", 10)
-	user.reagents.add_reagent("potass_iodide", 10)
-	user.reagents.add_reagent("charcoal", 20)
+	user.reagents.add_reagent("pen_acid", 20)
 	user.reagents.add_reagent("antihol", 10)
+	user.reagents.add_reagent("mannitol", 10)
 
 	for(var/datum/disease/D in user.viruses)
 		D.cure()

--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -21,7 +21,7 @@
 	user.reagents.add_reagent("mutadone", 10)
 	user.reagents.add_reagent("pen_acid", 20)
 	user.reagents.add_reagent("antihol", 10)
-	user.reagents.add_reagent("mannitol", 75)
+	user.reagents.add_reagent("mannitol", 25)
 
 	for(var/datum/disease/D in user.viruses)
 		D.cure()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -406,7 +406,7 @@
 /datum/reagent/medicine/pen_acid
 	name = "Pentetic Acid"
 	id = "pen_acid"
-	description = "Reduces massive amounts of radiation and toxin damage while purging other chemicals from the body. Has a chance of dealing brute damage."
+	description = "Reduces massive amounts of radiation and toxin damage while purging other chemicals from the body."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM


### PR DESCRIPTION
:cl: coiax, Robustin
tweak: Changeling Fleshmend is much less effective when used repeatedly
in a short time. Changeling Panacea is much more effective at purging
reagents, reducing radiation and now reduces braindamage.
/:cl:

Also fixed a description problem in pentacid which claims it does brute
damage, but it doesn't actually.

Done some rough numbers:
Using fleshmend once, after 10 ticks, you have 66 damage healed (of each type).
Using fleshmend once at t=0, and then again at t=5, you have about 99 damage healed after 15 ticks.
Fleshmend twice at t=0, you have about 79 damage healed at t=10.

In its current form, this is a nerf for even non-stacking fleshmend, but the numbers can be tweaked.
