### PR TITLE
Removes lag from AStar()

### DIFF
--- a/code/orphaned procs/AStar.dm
+++ b/code/orphaned procs/AStar.dm
@@ -92,7 +92,6 @@ Actual Adjacent procs :
 
 	//then run the main loop
 	while(!open.IsEmpty() && !path)
-	{
 		//get the lower f node on the open list
 		cur = open.Pop() //get the lower f turf in the open list
 		closed.Add(cur.source) //and tell we've processed it
@@ -133,8 +132,8 @@ Actual Adjacent procs :
 					T.PNode.calc_f()
 					T.PNode.nt = cur.nt + 1
 					open.ReSort(T.PNode)//reorder the changed element in the list
+		CHECK_TICK
 
-	}
 
 	//cleaning after us
 	for(var/PathNode/PN in open.L)


### PR DESCRIPTION
On sybil, during a round, lag happened and this was at the top of the profile (no idea if this is the actual cause, but the profile i took on sybil 10 minute before didn't have it at the top), the avg run time was ~2ds per run, meaning each astar call leads to about 4 byond ticks getting lost. I suspect that most calls to AStar are much less and that this was certain extreme edge cases taking a long amount.

Heres to hoping nothing using astar gets mad at a sleep.
