### PR TITLE
Pun Pun persistence is now configurable

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -420,3 +420,8 @@ var/global/list/ghost_others_options = list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 #define MAP_MAXX 4
 #define MAP_MAXY 5
 #define MAP_MAXZ 6
+
+// Pun Pun persistence
+#define PUNPUN_PERSISTENCE_DISABLED 0
+#define PUNPUN_PERSISTENCE_ENABLED 1
+#define PUNPUN_PERSISTENCE_ENABLED_SANS_FACEHUGGER 2

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -140,6 +140,8 @@
 	var/ooc_during_round = 0
 	var/emojis = 0
 
+	var/punpun_persistence = 1
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -583,6 +585,8 @@
 					config.no_summon_magic			= 1
 				if("no_summon_events")
 					config.no_summon_events			= 1
+				if("punpun_persistence")
+					config.punpun_persistence		= text2num(value)
 				if("reactionary_explosions")
 					config.reactionary_explosions	= 1
 				if("bombcap")

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -118,8 +118,6 @@ var/const/MAX_ACTIVE_TIME = 400
 		return 0
 	if(M.getorgan(/obj/item/organ/internal/body_egg/alien_embryo))
 		return 0
-	if(loc == M)
-		return 0
 	if(stat != CONSCIOUS)
 		return 0
 	if(!sterile) M.take_organ_damage(strength,0) //done here so that even borgs and humans in helmets take damage

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -14,7 +14,8 @@
 	if(relic_hat)
 		equip_to_slot_or_del(new relic_hat, slot_head)
 	if(relic_mask)
-		if(config.punpun_persistence == 2)
+		if(config.punpun_persistence == \
+			PUNPUN_PERSISTENCE_ENABLED_SANS_FACEHUGGER)
 			// SAFETY MODE ENABLED, CALMLY STEP AWAY FROM THE FACEHUGGER
 			if(ispath(relic_mask, /obj/item/clothing/mask/facehugger))
 				relic_mask = /obj/item/clothing/mask/facehugger/toy
@@ -42,7 +43,7 @@
 	..()
 
 /mob/living/carbon/monkey/punpun/proc/Read_Memory()
-	if(!config.punpun_persistence)
+	if(config.punpun_persistence == PUNPUN_PERSISTENCE_DISABLED)
 		return
 	var/savefile/S = new /savefile("data/npc_saves/Punpun.sav")
 	S["ancestor_name"] 		>> ancestor_name
@@ -51,7 +52,7 @@
 	S["relic_mask"]			>> relic_mask
 
 /mob/living/carbon/monkey/punpun/proc/Write_Memory(dead, gibbed)
-	if(!config.punpun_persistence)
+	if(config.punpun_persistence == PUNPUN_PERSISTENCE_DISABLED)
 		return
 	var/savefile/S = new /savefile("data/npc_saves/Punpun.sav")
 	if(gibbed)

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -14,6 +14,10 @@
 	if(relic_hat)
 		equip_to_slot_or_del(new relic_hat, slot_head)
 	if(relic_mask)
+		if(config.punpun_persistence == 2)
+			// SAFETY MODE ENABLED, CALMLY STEP AWAY FROM THE FACEHUGGER
+			if(ispath(relic_mask, /obj/item/clothing/mask/facehugger))
+				relic_mask = /obj/item/clothing/mask/facehugger/toy
 		equip_to_slot_or_del(new relic_mask, slot_wear_mask)
 	if(ancestor_name)
 		name = ancestor_name
@@ -38,6 +42,8 @@
 	..()
 
 /mob/living/carbon/monkey/punpun/proc/Read_Memory()
+	if(!config.punpun_persistence)
+		return
 	var/savefile/S = new /savefile("data/npc_saves/Punpun.sav")
 	S["ancestor_name"] 		>> ancestor_name
 	S["ancestor_chain"]		>> ancestor_chain
@@ -45,6 +51,8 @@
 	S["relic_mask"]			>> relic_mask
 
 /mob/living/carbon/monkey/punpun/proc/Write_Memory(dead, gibbed)
+	if(!config.punpun_persistence)
+		return
 	var/savefile/S = new /savefile("data/npc_saves/Punpun.sav")
 	if(gibbed)
 		S["ancestor_name"] 		<< null

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -329,6 +329,15 @@ MIDROUND_ANTAG_LIFE_CHECK 0.7
 #NO_SUMMON_MAGIC
 #NO_SUMMON_EVENTS
 
+
+##Pun Pun Persistence
+# This allows Pun Pun, the bartender's monkey, to keep its hat and/or mask from round
+# to round, along with changing its successors name if it died last round.
+# 0 to disable
+# 1 to enable
+# 2 to enable, but turns facehuggers passed into next round into toy facehuggers
+PUNPUN_PERSISTENCE 1
+
 ##Comment for "normal" explosions, which ignore obstacles
 ##Uncomment for explosions that react to doors and walls
 REACTIONARY_EXPLOSIONS
@@ -345,6 +354,3 @@ REACTIONARY_EXPLOSIONS
 BOMBCAP 20
 ## LagHell (7, 14, 28)
 #BOMBCAP 28
-
-
-


### PR DESCRIPTION
- Fixes a bug where a facehugger placed directly onto someone mask slot wouldn't infect them.
- PUNPUN_PERSISTENCE config option added, with options for no persistence, persistence, and persistence BUT NO LIVE FACEHUGGERS KTHX.
  With no config option set, it defaults to persistence.
