### PR TITLE
Ashwalker Den Update

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -11,19 +11,19 @@
 "k" = (/obj/effect/mob_spawn/human/corpse/damaged,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "l" = (/obj/structure/closet/crate/radiation,/obj/item/device/flashlight/lantern,/obj/item/device/flashlight/lantern,/obj/item/device/flashlight/lantern,/obj/item/device/flashlight/flare,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "m" = (/obj/structure/closet/crate/medical,/obj/item/device/malf_upgrade,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"n" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/storage/belt,/obj/item/weapon/scythe,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"n" = (/obj/structure/closet/crate/hydroponics,/obj/item/weapon/storage/belt,/obj/item/weapon/scythe,/obj/item/seeds/glowshroom,/obj/item/seeds/glowshroom,/obj/item/weapon/reagent_containers/glass/bucket,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "o" = (/obj/item/device/flashlight/lantern,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "p" = (/obj/item/device/flashlight/seclite,/obj/item/device/flashlight,/obj/structure/closet/crate,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "q" = (/obj/item/device/flashlight/flare,/obj/item/device/flashlight/seclite,/obj/item/device/flashlight/seclite,/obj/item/device/flashlight,/obj/structure/closet/crate,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "r" = (/turf/closed/wall/mineral/iron{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "s" = (/obj/item/weapon/twohanded/spear,/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "t" = (/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"u" = (/obj/structure/closet/crate,/obj/item/weapon/rcd/loaded,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"v" = (/obj/structure/closet/crate,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/regular,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"u" = (/obj/structure/closet/crate/engineering,/obj/item/weapon/rcd/loaded,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"v" = (/obj/structure/closet/crate/medical,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "w" = (/obj/machinery/the_singularitygen,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"x" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_left"; name = "skeletal minibar"},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"y" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_right"; name = "skeletal minibar"},/obj/item/clothing/head/helmet/roman/legionaire,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"z" = (/obj/item/weapon/shovel,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"x" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi';icon_state = "minibar_left";name = "skeletal minibar"},/obj/item/stack/sheet/cloth/ten,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"y" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi';icon_state = "minibar_right";name = "skeletal minibar"},/obj/item/clothing/head/helmet/roman/legionaire,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"z" = (/obj/item/weapon/shovel,/obj/effect/decal/cleanable/cobweb2,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "A" = (/obj/structure/closet/crate,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/o2,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "B" = (/obj/structure/table_frame,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "C" = (/obj/structure/table/optable,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
@@ -32,12 +32,16 @@
 "F" = (/obj/structure/closet/crate/miningcar,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "G" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "H" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"I" = (/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1},/area/ruin/unpowered)
+"I" = (/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth;blocks_air = 1},/area/ruin/unpowered)
 "J" = (/turf/closed/wall/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/lavaland/surface/outdoors)
-"K" = (/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
+"K" = (/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth;initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
 "L" = (/obj/item/weapon/twohanded/spear,/obj/structure/table,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"M" = (/obj/item/weapon/pickaxe,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
+"M" = (/obj/item/weapon/pickaxe,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth;initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
 "N" = (/obj/structure/ore_box,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"R" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"Q" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"P" = (/obj/machinery/iv_drip,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"O" = (/obj/item/weapon/reagent_containers/glass/bowl,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 
 (1,1,1) = {"
 aabaaaaaaaaabb
@@ -45,13 +49,13 @@ aaaaaaaaaaaabb
 aaaaccccccaaab
 aaaacdefgcaaab
 aaaacehifcaaab
-baaccifffccaaa
+baacciffOccaaa
 baacjfkfflcaaa
 aaacmnfopqcaaa
 aaccrrstrrccaa
 aacuvwffxyzcaa
-aacAfffkffBcaa
-aacCfDffffEcaa
+aacAPffkQfBcaa
+aacCRDffffEcaa
 bFrGfHrIrrrraa
 JKrLLHrKbKMNaa
 JKrrrrrbbbbbaa

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -764,17 +764,17 @@
 	stat_attack = 1
 	gender = NEUTER
 	stop_automated_movement = FALSE
+	stop_automated_movement_when_pulled = TRUE
 	stat_exclusive = TRUE
 	robust_searching = TRUE
 	search_objects = TRUE
 	del_on_death = TRUE
+	loot = list(/obj/effect/decal/cleanable/blood/gibs)
 
 	animal_species = /mob/living/simple_animal/hostile/asteroid/gutlunch
-	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch = 45, /mob/living/simple_animal/hostile/asteroid/gutlunch/female = 55)
+	childtype = list(/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck = 45, /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen = 55)
 
-	loot = list(/obj/effect/decal/cleanable/blood/gibs)
-	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/, /obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/,
-						  /obj/effect/decal/cleanable/blood/gibs/, /obj/effect/decal/cleanable/blood/drip/,/obj/effect/decal/cleanable/trail_holder)
+	wanted_objects = list(/obj/effect/decal/cleanable/xenoblood/xgibs, /obj/effect/decal/cleanable/blood/gibs/)
 	var/obj/item/udder/gutlunch/udder = null
 
 
@@ -793,7 +793,6 @@
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume)
 		overlays += "gl_full"
 	..()
-
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/attackby(obj/item/O, mob/user, params)
 	if(stat == CONSCIOUS && istype(O, /obj/item/weapon/reagent_containers/glass))
@@ -826,10 +825,11 @@
 
 
 //Male gutlunch. They're smaller and more colorful!
-/mob/living/simple_animal/hostile/asteroid/gutlunch/male
+/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck
+	name = "gubbuck"
 	gender = MALE
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/male/New()
+/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck/New()
 	..()
 	color = pick("#E39FBB", "#D97D64", "#CF8C4A")
 	resize = 0.85
@@ -837,16 +837,16 @@
 
 
 //Lady gutlunch. They make the babby.
-/mob/living/simple_animal/hostile/asteroid/gutlunch/female
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen
 	name = "guthen"
 	gender = FEMALE
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/female/Life()
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/Life()
 	..()
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume) //Only breed when we're full.
 		make_babies()
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/female/make_babies()
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/make_babies()
 	if(..())
 		udder.reagents.clear_reagents()
 		regenerate_icons()

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -208,6 +208,8 @@
 				meat_counter += 20
 			else
 				meat_counter ++
+			for(var/obj/item/W in H)
+				H.unEquip(W)
 			H.gib()
 
 /mob/living/simple_animal/hostile/spawner/ash_walker/spawn_mob()


### PR DESCRIPTION
Gutlunch tweaks: Male gutlunches are now called gubbucks. Some var tweaks.
I tested them briefly on the server and they seemed to be TOO good at cleaning up the mess. Ashwalker dens shouldn't be sterile-looking places, and they also tended to obsessively follow blood trails, leading them out of the den. So now they only eat gibs. 

Map changes:
Adds the gutlunches to the ash walker den.
Adds a couple reagent containers to milk them with.
Adds an IV drip (the milk has salglu, use it to replace lost blood)
Adds a couple glowshroom seeds to the botany crate.
Adds a stack of 10 cloth. Use it wisely.
