### PR TITLE
Glass tables break more, Metastation HoP hat fix

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -60283,9 +60283,7 @@
 	pixel_y = 0
 	},
 /obj/item/weapon/folder/blue,
-/obj/item/clothing/head/collectable/HoS{
-	desc = "It's your turn to demand excessive paperwork, signatures, stamps, and hire more clowns! Papers, please!";
-	icon_state = "hopcap";
+/obj/item/clothing/head/collectable/HoP{
 	name = "novelty HoP hat"
 	},
 /obj/machinery/light/small{

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -264,23 +264,27 @@
 	canSmoothWith = null
 	health = 50
 
-/obj/structure/table/glass/tablepush(obj/item/I, mob/user)
-	if(..())
-		visible_message("<span class='warning'>[src] breaks!</span>")
-		playsound(src.loc, "shatter", 50, 1)
-		new frame(src.loc)
-		new /obj/item/weapon/shard(src.loc)
-		qdel(src)
+/obj/structure/table/glass/Crossed(atom/movable/AM)
+	. = ..()
+	if(flags & NODECONSTRUCT)
+		return
+	// Don't break if they're just flying past
+	if(AM.throwing)
+		return
 
+	if(istype(AM, /mob/living))
+		var/mob/living/M = AM
+		if(has_gravity(M) && M.mob_size > MOB_SIZE_SMALL)
+			table_shatter(M)
 
-/obj/structure/table/glass/climb_structure(mob/user)
-	if(..())
-		visible_message("<span class='warning'>[src] breaks!</span>")
-		playsound(src.loc, "shatter", 50, 1)
-		new frame(src.loc)
-		new /obj/item/weapon/shard(src.loc)
-		qdel(src)
-		user.Weaken(5)
+/obj/structure/table/glass/proc/table_shatter(mob/M)
+	visible_message("<span class='warning'>[src] breaks!</span>")
+	playsound(src.loc, "shatter", 50, 1)
+	new frame(src.loc)
+	var/obj/item/weapon/shard/S = new(src.loc)
+	S.throw_impact(M)
+	M.Weaken(5)
+	qdel(src)
 
 /*
  * Wooden tables

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1317,6 +1317,7 @@
 					/obj/item/clothing/head/collectable/wizard,
 					/obj/item/clothing/head/collectable/hardhat,
 					/obj/item/clothing/head/collectable/HoS,
+					/obj/item/clothing/head/collectable/HoP,
 					/obj/item/clothing/head/collectable/thunderdome,
 					/obj/item/clothing/head/collectable/swat,
 					/obj/item/clothing/head/collectable/slime,

--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -126,6 +126,12 @@
 	desc = "Now you too can beat prisoners, set silly sentences, and arrest for no reason!"
 	icon_state = "hoscap"
 
+/obj/item/clothing/head/collectable/HoP
+	name = "collectable HoP hat"
+	desc = "It's your turn to demand excessive paperwork, signatures, stamps, and hire more clowns! Papers, please!"
+	icon_state = "hopcap"
+	dog_fashion = /datum/dog_fashion/head/hop
+
 /obj/item/clothing/head/collectable/thunderdome
 	name = "collectable Thunderdome helmet"
 	desc = "Go Red! I mean Green! I mean Red! No Green!"


### PR DESCRIPTION
Fixes #17084.
- Glass tables do not break if they have the NODECONSTRUCT flag
  This is primarily to stop the breaking of glass tables on the holodeck.
- Glass tables break if any living mob crosses them above small size and
  under the effects of gravity.
- This means that if you're standing on a non-glass table and move onto a glass table, it'll break.
- It also solves the Xeno Queen on glass tables issue.
