### PR TITLE
Adds cross server adminhelp relaying

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -26,6 +26,9 @@ var/Debug2 = 0
 var/global/comms_key = "default_pwd"
 var/global/comms_allowed = 0 //By default, the server does not allow messages to be sent to it, unless the key is strong enough (this is to prevent misconfigured servers from becoming vulnerable)
 
+//Cross server communications
+var/global/cross_address = "byond://" //This needs to be global as the message sent contains the comms key.
+var/global/cross_allowed = 0 //Don't bother attempting to send if the address wasn't set.
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
 var/MAX_EX_DEVESTATION_RANGE = 3

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -202,6 +202,7 @@
 	var/client_error_version = 0
 	var/client_error_message = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
 
+	var/cross_name = "Other server"
 
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
@@ -359,6 +360,12 @@
 					global.comms_key = value
 					if(value != "default_pwd" && length(value) > 6) //It's the default value or less than 6 characters long, warn badmins
 						global.comms_allowed = 1
+				if("cross_server_address")
+					global.cross_address = value
+					if(value != "byond:\\address:port")
+						global.cross_allowed = 1
+				if("cross_comms_name")
+					cross_name = value
 				if("see_own_notes")
 					config.see_own_notes = 1
 				if("soft_popcap")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -6,6 +6,10 @@ var/global/BSACooldown = 0
 	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
 	admins << msg
 
+/proc/relay_msg_admins(msg)
+	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message\">[msg]</span></span>"
+	admins << msg
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////Panels
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -137,12 +137,26 @@
 	var/list/adm = get_admin_counts(requiredflags)
 	. = adm["present"]
 	if(. <= 0)
+		var/final = ""
 		if(!adm["afk"] && !adm["stealth"] && !adm["noflags"])
-			send2irc(source, "[msg] - No admins online")
+			final = "[msg] - No admins online"
 		else
-			send2irc(source, "[msg] - All admins AFK ([adm["afk"]]/[adm["total"]]), stealthminned ([adm["stealth"]]/[adm["total"]]), or lack[rights2text(requiredflags, " ")] ([adm["noflags"]]/[adm["total"]])")
+			final = "[msg] - All admins AFK ([adm["afk"]]/[adm["total"]]), stealthminned ([adm["stealth"]]/[adm["total"]]), or lack[rights2text(requiredflags, " ")] ([adm["noflags"]]/[adm["total"]])"
+		send2irc(source,final)
+		send2otherserver(source,final)
+
 
 /proc/send2irc(msg,msg2)
 	if(config.useircbot)
 		shell("python nudge.py [msg] [msg2]")
 	return
+
+/proc/send2otherserver(source,msg,type = "Ahelp")
+	if(global.cross_allowed)
+		var/list/message = list()
+		message["message"] = "[source]: [msg]"
+		message["source"] = "([config.cross_name])"
+		message["key"] = global.comms_key
+		message["crossmessage"] = type
+
+		world.Export("[global.cross_address]?[list2params(message)]")

--- a/code/world.dm
+++ b/code/world.dm
@@ -154,7 +154,7 @@ var/last_irc_status = 0
 			return
 		else
 			if(input["crossmessage"] == "Ahelp")
-				message_admins("<span class='adminnotice'><b><font color=red>HELP: </font> [input["source"]] [input["message"]]</b></span>")
+				relay_msg_admins("<span class='adminnotice'><b><font color=red>HELP: </font> [input["source"]] [input["message"]]</b></span>")
 
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if (reason == 1) //special reboot, do none of the normal stuff

--- a/code/world.dm
+++ b/code/world.dm
@@ -149,6 +149,13 @@ var/last_irc_status = 0
 					C << "<span class='announce'>PR: [input["announce"]]</span>"
 #undef CHAT_PULLR
 
+	else if("crossmessage" in input)
+		if(!key_valid)
+			return
+		else
+			if(input["crossmessage"] == "Ahelp")
+				message_admins("<span class='adminnotice'><b><font color=red>HELP: </font> [input["source"]] [input["message"]]</b></span>")
+
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if (reason == 1) //special reboot, do none of the normal stuff
 		if (usr)

--- a/config/config.txt
+++ b/config/config.txt
@@ -168,6 +168,12 @@ TICKLAG 0.9
 ## Communication key for receiving data through world/Topic(), you don't want to give this out
 #COMMS_KEY default_pwd
 
+## World address and port for server recieving cross server messages
+#CROSS_SERVER_ADDRESS byond:\\address:port
+
+## Name that the server calls itself in communications
+#CROSS_COMMS_NAME
+
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
 #SEE_OWN_NOTES
 


### PR DESCRIPTION
Adds basic cross server message relay system. Currently setup to relay adminhelps to the other server in the case of no admins on a server.

Hopefully the system can be expanded to relay other kinds of messages.
Since the comms key is sent along with the message, the destination has to be unable to be changed in order to keep the key secret.
