### PR TITLE
Constructs can now invoke runes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -34,6 +34,7 @@ To draw a rune, use an arcane tome.
 	var/scribe_damage = 0.1 //how much damage you take doing it
 
 	var/allow_excess_invokers = 0 //if we allow excess invokers when being invoked
+	var/construct_invoke = 1 //if constructs can invoke it
 
 	var/req_keyword = 0 //If the rune requires a keyword - go figure amirite
 	var/keyword //The actual keyword for the rune
@@ -76,7 +77,10 @@ To draw a rune, use an arcane tome.
 
 /obj/effect/rune/attack_animal(mob/living/simple_animal/M)
 	if(istype(M, /mob/living/simple_animal/shade) || istype(M, /mob/living/simple_animal/hostile/construct))
-		attack_hand(M)
+		if(construct_invoke || !iscultist(M)) //if you're not a cult construct we want the normal fail message
+			attack_hand(M)
+		else
+			M << "<span class='warning'>You are unable to invoke the rune!</span>"
 
 /obj/effect/rune/proc/talismanhide() //for talisman of revealing/hiding
 	visible_message("<span class='danger'>[src] fades away.</span>")
@@ -635,6 +639,7 @@ var/list/teleport_runes = list()
 	icon_state = "6"
 	color = rgb(126, 23, 23)
 	rune_in_use = 0 //One at a time, please!
+	construct_invoke = 0
 	var/mob/living/affecting = null
 
 /obj/effect/rune/astral/examine(mob/user)
@@ -774,6 +779,7 @@ var/list/teleport_runes = list()
 	icon_state = "4"
 	color = rgb(200, 0, 0)
 	req_cultists = 3
+	construct_invoke = 0
 
 /obj/effect/rune/blood_boil/invoke(var/list/invokers)
 	..()
@@ -801,6 +807,7 @@ var/list/teleport_runes = list()
 	cultist_desc = "manifests a spirit as a servant of the Geometer. The invoker must not move from atop the rune, and will take damage for each summoned spirit."
 	invocation = "Gal'h'rfikk harfrandid mud'gib!" //how the fuck do you pronounce this
 	icon_state = "6"
+	construct_invoke = 0
 	color = rgb(200, 0, 0)
 
 /obj/effect/rune/manifest/New(loc)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -74,6 +74,10 @@ To draw a rune, use an arcane tome.
 	else
 		fail_invoke(user)
 
+/obj/effect/rune/attack_animal(mob/living/simple_animal/M)
+	if(istype(M, /mob/living/simple_animal/shade) || istype(M, /mob/living/simple_animal/hostile/construct))
+		attack_hand(M)
+
 /obj/effect/rune/proc/talismanhide() //for talisman of revealing/hiding
 	visible_message("<span class='danger'>[src] fades away.</span>")
 	invisibility = INVISIBILITY_OBSERVER


### PR DESCRIPTION
:cl: Joan
rscadd: Cultist constructs, and shades, can now invoke runes by clicking them.
rscdel: This does not include Manifest Ghost, Blood Boil, or Astral Journey runes.
/:cl:

I checked, and as it happens, none of the runes assume the user is human.
