### PR TITLE
Adds art supplies to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1418,3 +1418,18 @@
 					/obj/item/ammo_box/magazine/toy/pistol,
 					/obj/item/ammo_box/magazine/toy/pistol)
 	crate_name = "foam force crate"
+
+/datum/supply_pack/misc/artsupply
+	name = "Art Supplies"
+	cost = 800
+	contains = list(/obj/structure/easel,
+					/obj/structure/easel,
+					/obj/item/weapon/canvas/nineteenXnineteen,
+					/obj/item/weapon/canvas/nineteenXnineteen,
+					/obj/item/weapon/canvas/twentythreeXnineteen,
+					/obj/item/weapon/canvas/twentythreeXnineteen,
+					/obj/item/weapon/canvas/twentythreeXtwentythree,
+					/obj/item/weapon/canvas/twentythreeXtwentythree,
+					/obj/item/toy/crayon/rainbow,
+					/obj/item/toy/crayon/rainbow)
+	crate_name= "art supply crate"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -114,6 +114,6 @@ coiax = Game Master
 RandomMarine = Game Master
 PKPenguin321 = Game Master
 TechnoAlchemist = Game Master
-
+Aloraydrel = Game Master
 
 


### PR DESCRIPTION
Lets you order art supplies for 800 points which has,
- two easels
- three different canvases with two each
- two rainbow crayons to draw with

Lastly adds me to the admin.txt 

No other way to get  these besides admin spawn so why not add them. I've seen a few people draw some neat stuff with them.
