### PR TITLE
Trash code solution to monsters spawning inside ruins

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -78,6 +78,11 @@ var/global/datum/controller/master/Master = new()
 	if(mining_type == "lavaland")
 		seedRuins(5, 5, /area/lavaland/surface/outdoors, lava_ruins_templates)
 		spawn_rivers()
+		for(var/mob/living/simple_animal/L in mob_list)
+			if("mining" in L.faction)
+				var/area/A = get_area(L)
+				if(istype(A, /area/ruin))
+					qdel(L)
 	else
 		make_mining_asteroid_secrets()
 


### PR DESCRIPTION
So the issue is that the maploader does not delete mobs when it plonks stuff down.

This is the only way I can think of doing it and it's ugly and bad
