### PR TITLE
Upgraded the jaunter into the wormhole lifebelt

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -1,34 +1,35 @@
 "a" = (/turf/template_noop,/area/template_noop)
-"b" = (/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"c" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"d" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"e" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"f" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"g" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"h" = (/obj/structure/shuttle/engine/heater{icon_state = "heater"; dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered)
-"i" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered)
-"j" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"k" = (/obj/machinery/computer/arcade/battle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"l" = (/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"m" = (/obj/effect/mob_spawn/human/golem/adamantine,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"n" = (/obj/machinery/mineral/equipment_vendor/golem,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"o" = (/obj/item/weapon/resonator,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"p" = (/obj/machinery/mineral/ore_redemption,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"q" = (/obj/structure/statue/gold/rd,/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"r" = (/obj/machinery/computer/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"s" = (/obj/structure/extinguisher_cabinet{pixel_y = 30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"t" = (/obj/structure/table/wood,/obj/item/weapon/bedsheet/rd{desc = "Majestic."; layer = 3; name = "Royal Cape of the Liberator"; pixel_x = 5; pixel_y = 9},/obj/item/weapon/book/manual/research_and_development{name = "Sacred Text of the Liberator"; pixel_x = -4; pixel_y = 3},/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"u" = (/obj/item/weapon/resonator/upgraded,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"v" = (/obj/machinery/autolathe,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"w" = (/obj/structure/table/wood,/obj/machinery/reagentgrinder,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"x" = (/obj/machinery/computer/arcade/orion_trail,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"y" = (/obj/structure/extinguisher_cabinet{pixel_y = -30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"z" = (/obj/structure/table/wood,/obj/item/weapon/surgical_drapes{pixel_x = 15},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"A" = (/obj/item/weapon/storage/firstaid/fire,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"B" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/areaeditor/blueprints{desc = "Use to build new structures in the wastes."; name = "land claim"},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"C" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/weapon/disk/design_disk/golem_shell,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"D" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"E" = (/obj/structure/ore_box,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"b" = (/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"c" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"d" = (/obj/structure/closet/crate,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/device/flashlight/lantern,/obj/item/weapon/card/id/mining,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"e" = (/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"f" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"g" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"h" = (/obj/structure/shuttle/engine/heater{icon_state = "heater"; dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/golem_ship)
+"i" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered/golem_ship)
+"j" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"k" = (/obj/machinery/computer/arcade/battle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"l" = (/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"m" = (/obj/effect/mob_spawn/human/golem/adamantine,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"n" = (/obj/machinery/mineral/equipment_vendor/golem,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"o" = (/obj/item/weapon/resonator,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"p" = (/obj/machinery/mineral/ore_redemption,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"q" = (/obj/structure/statue/gold/rd,/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"r" = (/obj/machinery/computer/shuttle,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"s" = (/obj/machinery/bluespace_beacon,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"t" = (/obj/structure/extinguisher_cabinet{pixel_y = 30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"u" = (/obj/structure/table/wood,/obj/item/weapon/bedsheet/rd{desc = "Majestic."; layer = 3; name = "Royal Cape of the Liberator"; pixel_x = 5; pixel_y = 9},/obj/item/weapon/book/manual/research_and_development{name = "Sacred Text of the Liberator"; pixel_x = -4; pixel_y = 3},/obj/structure/window/reinforced{dir = 4; name = "shrine of the liberator"; pixel_x = 0},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"v" = (/obj/item/weapon/resonator/upgraded,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"w" = (/obj/machinery/autolathe,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"x" = (/obj/structure/table/wood,/obj/machinery/reagentgrinder,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"y" = (/obj/machinery/computer/arcade/orion_trail,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"z" = (/obj/structure/extinguisher_cabinet{pixel_y = -30},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"A" = (/obj/structure/table/wood,/obj/item/weapon/surgical_drapes{pixel_x = 15},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"B" = (/obj/item/weapon/storage/firstaid/fire,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/fire,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"C" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/areaeditor/blueprints{desc = "Use to build new structures in the wastes."; name = "land claim"},/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"D" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/weapon/disk/design_disk/golem_shell,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"E" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"F" = (/obj/structure/ore_box,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaa
@@ -40,14 +41,14 @@ aabbbbjjbbbbjjbbbbbb
 aabkllllmmbllllllnhi
 aabllllloojlllllllhi
 bbbjjbbbbbblllllpbbb
-bqrllllllljlllllljsj
-btlllllllljlllllljlj
-bbbjjbbbbbblllluvbbb
-aabllllloojllllllwhi
-aabxllllmmbyllzABChi
+bqrllllllljlslllljtj
+bulllllllljlllllljlj
+bbbjjbbbbbbllllvwbbb
+aabllllloojllllllxhi
+aabyllllmmbzllABCDhi
 aabbbbjjbbbbjjbbbbbb
-aaaaabfffffffffffDhi
-aaaaabEEEEEEEefffDhi
+aaaaabfffffffffffEhi
+aaaaabFFFFFFFefffEhi
 aaaaabbbbbbbbbbbbbbb
 aaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaa

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -572,3 +572,6 @@ obj/item/proc/item_action_slot_check(slot, mob/user)
 
 /obj/item/proc/is_sharp()
 	return sharpness
+
+/obj/item/proc/chasm_react(mob/user)
+	return FALSE

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -292,7 +292,7 @@
 		new /datum/data/mining_equipment("GAR scanners",		/obj/item/clothing/glasses/meson/gar,					  		   		500),
 		new /datum/data/mining_equipment("Explorer Belt",		/obj/item/weapon/storage/belt/mining,									500),
 		new /datum/data/mining_equipment("Brute First-Aid Kit",	/obj/item/weapon/storage/firstaid/brute,						   		600),
-		new /datum/data/mining_equipment("Jaunter",             /obj/item/device/wormhole_jaunter,                                 		600),
+		new /datum/data/mining_equipment("Wormhole Lifebelt",   /obj/item/device/wormhole_lifebelt,										600),
 		new /datum/data/mining_equipment("Kinetic Accelerator", /obj/item/weapon/gun/energy/kinetic_accelerator,               	   		750),
 		new /datum/data/mining_equipment("Resonator",           /obj/item/weapon/resonator,                                    	   		800),
 		new /datum/data/mining_equipment("Lazarus Injector",    /obj/item/weapon/lazarus_injector,                                		1000),
@@ -479,9 +479,17 @@
 
 /**********************Jaunter**********************/
 
-/obj/item/device/wormhole_jaunter
-	name = "wormhole jaunter"
-	desc = "A single use device harnessing outdated wormhole technology, Nanotrasen has since turned its eyes to blue space for more accurate teleportation. The wormholes it creates are unpleasant to travel through, to say the least.\nThanks to modifications provided by the Free Golems, this jaunter can be worn on the belt to provide protection from chasms."
+/obj/item/device/wormhole_lifebelt
+	name = "wormhole lifebelt"
+	desc = "A single use safety device harnessing outdated wormhole \
+		technology. It bares the hallmarks of the work of the Free Golems, as \
+		Nanotrasen has turned its eyes to bluespace for more accurate \
+		teleportation.\n\
+		It's designed to be worn around the waist, monitoring lifesigns and \
+		acceleration. In the event of a medical emergency, or a fall severe \
+		enough to qualify as fatal, it activates.\n\
+		The wormholes it creates are unpleasant to travel through though, to \
+		say the least."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "Jaunter"
 	item_state = "electronic"
@@ -492,19 +500,63 @@
 	origin_tech = "bluespace=2"
 	slot_flags = SLOT_BELT
 
-/obj/item/device/wormhole_jaunter/attack_self(mob/user)
+	var/obj/item/device/radio/belt_radio
+	var/radio_key = /obj/item/device/encryptionkey/headset_cargo
+	var/radio_channel = "Supply"
+
+	var/ticks_in_crit = 0
+	var/threshold = 2
+
+/obj/item/device/wormhole_lifebelt/New()
+	. = ..()
+	SSobj.processing += src
+
+	belt_radio = new /obj/item/device/radio(src)
+	belt_radio.keyslot = new radio_key
+	belt_radio.subspace_transmission = 1
+	belt_radio.canhear_range = 0
+	belt_radio.recalculateChannels()
+
+
+/obj/item/device/wormhole_lifebelt/Destroy()
+	SSobj.processing -= src
+	qdel(belt_radio)
+	. = ..()
+
+/obj/item/device/wormhole_lifebelt/process()
+	var/mob/living/carbon/human/user
+	if(istype(loc, /mob/living/carbon/human))
+		user = loc
+	else
+		return
+
+	if(user.get_item_by_slot(slot_belt) != src)
+		return
+
+	if(user.InCritical())
+		if(ticks_in_crit == 0)
+			user << "<span class='notice'>You feel [src] growing warm and vibrating.</span>"
+		ticks_in_crit += 1
+		if(ticks_in_crit >= threshold)
+			feedback_add_details("jaunter", "M") // medical activation
+			belt_radio.talk_into(src, "Medical activation for [user] but yeah, go do whatever.", radio_channel)
+			activate(user)
+	else
+		ticks_in_crit = 0
+
+/obj/item/device/wormhole_lifebelt/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user.name] activates the [src.name]!</span>")
 	feedback_add_details("jaunter", "U") // user activated
 	activate(user)
 
-/obj/item/device/wormhole_jaunter/proc/turf_check(mob/user)
+/obj/item/device/wormhole_lifebelt/proc/turf_check(mob/user)
 	var/turf/device_turf = get_turf(user)
 	if(!device_turf||device_turf.z==2||device_turf.z>=7)
 		user << "<span class='notice'>You're having difficulties getting the [src.name] to work.</span>"
 		return FALSE
 	return TRUE
 
-/obj/item/device/wormhole_jaunter/proc/activate(mob/user)
+/obj/item/device/wormhole_lifebelt/proc/activate(mob/user)
 	if(!turf_check(user))
 		return
 
@@ -517,13 +569,14 @@
 		user << "<span class='notice'>The [src.name] found no beacons in the world to anchor a wormhole to.</span>"
 		return
 	var/chosen_beacon = pick(L)
-	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon, lifespan=100)
+	var/obj/effect/portal/wormhole/jaunt_tunnel/J = new(get_turf(src), chosen_beacon, lifespan=100)
 	J.target = chosen_beacon
 	try_move_adjacent(J)
+	visible_message("<span class='warning'>A [J] appears!</span>", "<span class='notice'>You hear sparks.</span>")
 	playsound(src,'sound/effects/sparks4.ogg',50,1)
 	qdel(src)
 
-/obj/item/device/wormhole_jaunter/emp_act(power)
+/obj/item/device/wormhole_lifebelt/emp_act(power)
 	var/triggered = FALSE
 
 	if(usr.get_item_by_slot(slot_belt) == src)
@@ -533,24 +586,29 @@
 			triggered = TRUE
 
 	if(triggered)
-		usr.visible_message("<span class='warning'>The [src] overloads and activates!</span>")
+		usr.visible_message("<span class='warning'>[src] overloads and activates!</span>")
 		feedback_add_details("jaunter","E") // EMP accidental activation
 		activate(usr)
 
-/obj/item/device/wormhole_jaunter/proc/chasm_react(mob/user)
+/obj/item/device/wormhole_lifebelt/chasm_react(mob/user)
 	if(user.get_item_by_slot(slot_belt) == src)
-		user << "Your [src] activates, saving you from the chasm!</span>"
+		. = TRUE
+		user << "[src] activates, saving you from the chasm!</span>"
 		feedback_add_details("jaunter","C") // chasm automatic activation
 		activate(user)
 	else
-		user << "The [src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
+		user << "[src] is not attached to your belt, preventing it from saving you from the chasm. RIP.</span>"
+		. = FALSE
 
 
 /obj/effect/portal/wormhole/jaunt_tunnel
-	name = "jaunt tunnel"
+	name = "lifebelt tunnel"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "bhole3"
-	desc = "A stable hole in the universe made by a wormhole jaunter. Turbulent doesn't even begin to describe how rough passage through one of these is, but at least it will always get you somewhere near a beacon."
+	desc = "A stable hole in the universe made by a wormhole lifebelt. \
+		Turbulent doesn't even begin to describe how rough passage through \
+		one of these is, but at least it will always get you somewhere near a \
+		beacon."
 
 /obj/effect/portal/wormhole/jaunt_tunnel/teleport(atom/movable/M)
 	if(istype(M, /obj/effect))
@@ -558,6 +616,7 @@
 	if(istype(M, /atom/movable))
 		if(do_teleport(M, target, 6))
 			// KERPLUNK
+			M.visible_message("<span class='warning'>[M] appears from nowhere!</span>", null, "<span class='warning'>There is a loud ker-plunk noise!</span>")
 			playsound(M,'sound/weapons/resonator_blast.ogg',50,1)
 			if(iscarbon(M))
 				var/mob/living/carbon/L = M

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -572,14 +572,18 @@
 		var/mob/living/simple_animal/SA = AM
 		if(SA.flying)
 			return
-	if(istype(AM, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = AM
-		if(istype(H.belt, /obj/item/device/wormhole_jaunter))
-			var/obj/item/device/wormhole_jaunter/J = H.belt
-			// To freak out any bystanders
-			visible_message("[H] falls into [src]!")
-			J.chasm_react(H)
-			return
+	if(istype(AM, /mob/living))
+		var/mob/living/M = AM
+		for(var/atom/movable/thing in M)
+			if(!istype(thing, /obj/item))
+				continue
+			var/obj/item/I = thing
+			// Is anything inside you going to save you?
+			var/outcome = I.chasm_react(M)
+			if(outcome)
+				// To freak out any bystanders
+				visible_message("[M] falls into [src]!")
+				return
 	drop(AM)
 
 

--- a/code/modules/ruins/ruin_areas.dm
+++ b/code/modules/ruins/ruin_areas.dm
@@ -17,16 +17,17 @@
 
 
 
+
 //Areas
 
 /area/ruin/unpowered/no_grav/way_home
 	name = "\improper Salvation"
 	icon_state = "away"
 
-
-
 /area/ruin/powered/snow_biodome
 
+/area/ruin/powered/golem_ship
+	name = "Free Golem Ship"
 
 // Ruins of "onehalf" ship
 /area/ruin/onehalf/hallway


### PR DESCRIPTION
:cl: coiax
rscadd: The Free Golems have developed the jaunter into the  wormhole
lifebelt, which automatically teleports the user when they fall in a
chasm or suffer a major medical emergency. Must be worn on the belt to work.
rscadd: "Yeah go do whatever" reads a note on the equipment vendor. Free Golems no longer have any restrictions on what they can purchase.
/:cl:

Wormhole lifebelt has been added to the mining voucher supplies.

Please don't mistake a random teleportation in crit for saving a user's
life, the Supply channel gets a notification, but suit sensors are
required to find them, and there's no guarantee the location picked is
safe (for example, the Toxins Test Site is a valid jaunt destination,
along with in the middle of the slime cages in Xenobiology).

To prevent Free Golems from purchasing lifebelts to get back to the station, a wormhole lifebelt will now target the Free Golem ship, either by beacon or by the gold statue.
