### PR TITLE
Makes flashbangs no longer effective against blobs

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -12,11 +12,6 @@
 	for(var/mob/living/M in get_hearers_in_view(7, flashbang_turf))
 		bang(get_turf(M), M)
 
-	for(var/obj/effect/blob/B in get_hear(8,flashbang_turf))     		//Blob damage here
-		var/damage = round(40/(get_dist(B,get_turf(src))+1))
-		B.take_damage(damage, BURN)
-	qdel(src)
-
 /obj/item/weapon/grenade/flashbang/proc/bang(turf/T , mob/living/M)
 	M.show_message("<span class='warning'>BANG</span>", 2)
 	playsound(loc, 'sound/weapons/flashbang.ogg', 100, 1)


### PR DESCRIPTION
I have seen time and time again through countless rounds dickwads using flashbangs against blobs for a very minor benefit, while a large amount of unflashprotected crew try to actually fight the blob and then they all get stunned and wrecked by the blob. Its better to just remove any blob damage from flashbangs so fighting blobs is more of an actual team effort.

:cl: 
tweak: Flashbangs no longer affect blobs. Don't throw them.

/:cl:
