### PR TITLE
Fixes var editing clients

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -49,4 +49,5 @@
 	//datum that controls the displaying and hiding of tooltips
 	var/datum/tooltip/tooltips
 
-
+	//Used for var edit flagging, also defined in datums (clients are not a child of datums for some reason)
+	var/var_edited = 0


### PR DESCRIPTION
Clients aren't datums so I'm forced into this slightly scummy situation. If at some point in the future byond makes clients datums this will need to be reverted.

Fixes #17381
