### PR TITLE
Gives the HoS a pinpointer

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -77,8 +77,8 @@
 	new /obj/item/weapon/shield/riot/tele(src)
 	new /obj/item/weapon/storage/belt/security/full(src)
 	new /obj/item/weapon/gun/energy/gun/hos(src)
-	new /obj/item/weapon/door_remote/head_of_security(src)
 	new /obj/item/device/flashlight/seclite(src)
+	new /obj/item/weapon/pinpointer(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "\proper warden's locker"
@@ -101,6 +101,7 @@
 	new /obj/item/weapon/storage/belt/security/full(src)
 	new /obj/item/device/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/color/black/krav_maga/sec(src)
+	new /obj/item/weapon/door_remote/head_of_security(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"


### PR DESCRIPTION
Malf and Nuke both basically require the pinpointer, don't think it's very good to only have one on station.

Especially when the same guy who has the disk spawns with the pinpointer.

Hopefully this will lead to some fun last minute battles as the nuke is armed instead of "where the hell did the captain go? Guess we should go to mining"

Also gives the door remote to the warden since he's the one sitting on his ass in the brig all day.

:cl:
rscadd: The HoS now has a pinpointer, the Warden now has his door remote.
/:cl:
