### PR TITLE
New SW Maint Pantry (Box) (like #17283 but more mergable)

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -52505,7 +52505,9 @@
 /area/solar/port)
 "ccY" = (
 /obj/structure/table,
-/obj/item/weapon/storage/fancy/cigarettes,
+/obj/item/weapon/kitchen/rollingpin,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccZ" = (
@@ -53384,9 +53386,11 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "ceV" = (
-/obj/item/clothing/under/rank/vice,
 /obj/structure/closet,
-/obj/item/clothing/shoes/jackboots,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceW" = (
@@ -63979,8 +63983,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAy" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plating,
-/area/maintenance/electrical)
+/area/maintenance/aft)
 "cAz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -63994,39 +63999,38 @@
 	},
 /area/chapel/office)
 "cAA" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"cAB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
-"cAC" = (
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/crew_quarters/kitchen)
-"cAD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "warnplate";
+/obj/machinery/light/small{
 	dir = 1
 	},
-/area/maintenance/disposal)
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"cAB" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"cAC" = (
+/obj/structure/sink/kitchen{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"cAD" = (
+/obj/structure/table,
+/obj/item/weapon/kitchen/knife,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cAE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	step_y = 2
 	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	step_x = 2
 	},
-/area/medical/morgue)
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cAF" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -64049,10 +64053,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads)
 "cAH" = (
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/medical/morgue)
+/obj/machinery/processor,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cAI" = (
 /obj/machinery/conveyor_switch/oneway{
 	convdir = -1;
@@ -64066,8 +64069,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAK" = (
+/obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/asmaint2)
+/area/maintenance/aft)
 "cAL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /mob/living/simple_animal/hostile/lizard{
@@ -83662,10 +83666,10 @@ apQ
 aaf
 bCq
 bCq
-bLv
-bLv
 bCq
-aaf
+bCq
+bCq
+bCq
 cfx
 cfx
 chO
@@ -83918,11 +83922,11 @@ bXv
 bLv
 aaf
 bCq
-bHE
-ccd
+cAy
+cAB
 ccY
-bLv
-aaf
+cAD
+cAH
 cfw
 cgA
 chP
@@ -84175,11 +84179,11 @@ bHE
 bLv
 aaf
 bCq
+cAA
 bHE
 bHE
 ccZ
-bCq
-bCq
+cAK
 cfw
 cgC
 chR
@@ -84433,9 +84437,9 @@ bLv
 bLv
 bCq
 bHE
-bCq
-bCq
-bCq
+cAC
+ccZ
+cAE
 ceV
 cfw
 cgB
@@ -84689,9 +84693,9 @@ bHE
 bYu
 bZk
 bCq
-bHE
+bTz
 bCq
-bSq
+bCq
 bCq
 bCq
 cfw
@@ -84948,7 +84952,7 @@ bZj
 bCq
 bHE
 bCq
-bHE
+bSq
 cdW
 ceW
 bCq

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -63983,7 +63983,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cAy" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cAz" = (
@@ -64011,7 +64011,8 @@
 /area/maintenance/aft)
 "cAC" = (
 /obj/structure/sink/kitchen{
-	dir = 8
+	dir = 8;
+	pixel_x = 11
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -64028,6 +64029,9 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
 	step_x = 2
+	},
+/obj/item/weapon/reagent_containers/food/snacks/mint{
+	pixel_y = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -64025,10 +64025,10 @@
 "cAE" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	step_y = 2
+	pixel_y = 2
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
-	step_x = 2
+	pixel_x = 2
 	},
 /obj/item/weapon/reagent_containers/food/snacks/mint{
 	pixel_y = 9

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -12,6 +12,20 @@
 	new /obj/item/weapon/reagent_containers/food/condiment/rice(src)
 	new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
 
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance
+	name = "maintenance refrigerator"
+	desc = "This refrigerator looks quite dusty, is there anything edible still inside?"
+	req_access = list()
+
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance/New()
+	..()
+	for(var/i = 0, i < 5, i++)
+		new /obj/item/weapon/reagent_containers/food/condiment/milk(src)
+	for(var/i = 0, i < 5, i++)
+		new /obj/item/weapon/reagent_containers/food/condiment/soymilk(src)
+	for(var/i = 0, i < 2, i++)
+		new /obj/item/weapon/storage/fancy/egg_box(src)
+
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
 


### PR DESCRIPTION
> First map change, might need some guidance.
> 
> I hate SW maint. All the side rooms have glass so all those solar engineers and whoever love to come gawk at you, just feels like there's not enough discrete locations like SE/NW/NE maint have.
> 
> So I moved an unremarkable little dead end around and gave us a new pantry!

:cl: Robustin
rscadd: A small pantry has been added to SW maintenance.
/:cl:

![image](https://cloud.githubusercontent.com/assets/609465/15088762/a3669462-13ef-11e6-9912-95eaf9fdf872.png)

Robustin did the work, I'm just the guy with mapmerge set up.

I did one change, the loot spawn in the closet is now a 2maint loot spawn.

Implements #17283 
