### PR TITLE
Adds three new syringes

### DIFF
--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -24,10 +24,7 @@
 
 	if(!S) return
 
-	if(istype(S, /obj/item/weapon/reagent_containers/syringe/piercing))
-		chambered.BB = new /obj/item/projectile/bullet/dart/syringe/piercing(src)
-	else
-		chambered.BB = new /obj/item/projectile/bullet/dart/syringe(src)
+	chambered.BB = new S.projectile_type (src)
 
 	S.reagents.trans_to(chambered.BB, S.reagents.total_volume)
 	chambered.BB.name = S.name

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -24,7 +24,11 @@
 
 	if(!S) return
 
-	chambered.BB = new /obj/item/projectile/bullet/dart/syringe(src)
+	if(istype(S, /obj/item/weapon/reagent_containers/syringe/piercing))
+		chambered.BB = new /obj/item/projectile/bullet/dart/syringe/piercing(src)
+	else
+		chambered.BB = new /obj/item/projectile/bullet/dart/syringe(src)
+
 	S.reagents.trans_to(chambered.BB, S.reagents.total_volume)
 	chambered.BB.name = S.name
 	syringes.Remove(S)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -124,7 +124,7 @@
 	damage = 10
 	weaken = 4
 	stun = 4
-	
+
 /obj/item/projectile/bullet/honker
 	damage = 0
 	weaken = 5
@@ -135,7 +135,7 @@
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "banana"
 	range = 200
-	
+
 /obj/item/projectile/bullet/honker/New()
 	..()
 	SpinAnimation()
@@ -166,6 +166,7 @@
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
+	var/piercing = 0
 
 /obj/item/projectile/bullet/dart/New()
 	..()
@@ -176,7 +177,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100) // not completely blocked
-			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject(null,0,hit_zone,piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 				reagents.reaction(M, INJECT)
 				reagents.trans_to(M, reagents.total_volume)
@@ -202,6 +203,10 @@
 	name = "syringe"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "syringeproj"
+
+//Piercing Syringe
+/obj/item/projectile/bullet/dart/syringe/piercing
+	piercing = 1
 
 /obj/item/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -254,3 +254,15 @@
 	amount_per_transfer_from_this = 1
 	volume = 1
 	list_reagents = list("gluttonytoxin" = 1)
+
+/obj/item/weapon/reagent_containers/syringe/bluespace
+	name = "Bluespace Syringe"
+	desc = "An advanced syringe that can hold 60 units of chemicals"
+	amount_per_transfer_from_this = 20
+	volume = 60
+
+/obj/item/weapon/reagent_containers/syringe/noreact
+	name = "Cryo Syringe"
+	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
+	volume = 20
+	flags = NOREACT

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -256,18 +256,18 @@
 	list_reagents = list("gluttonytoxin" = 1)
 
 /obj/item/weapon/reagent_containers/syringe/bluespace
-	name = "Bluespace Syringe"
+	name = "bluespace syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"
 	amount_per_transfer_from_this = 20
 	volume = 60
 
 /obj/item/weapon/reagent_containers/syringe/noreact
-	name = "Cryo Syringe"
+	name = "cryo syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	volume = 20
 	flags = NOREACT
 
 /obj/item/weapon/reagent_containers/syringe/piercing
-	name = "Piercing Syringe"
+	name = "piercing syringe"
 	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
 	volume = 10

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -12,6 +12,7 @@
 	volume = 15
 	var/mode = SYRINGE_DRAW
 	var/busy = 0		// needed for delayed drawing of blood
+	var/projectile_type = /obj/item/projectile/bullet/dart/syringe
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
 
 /obj/item/weapon/reagent_containers/syringe/New()
@@ -271,3 +272,4 @@
 	name = "piercing syringe"
 	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
 	volume = 10
+	projectile_type = /obj/item/projectile/bullet/dart/syringe/piercing

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -181,7 +181,7 @@
 
 
 /obj/item/weapon/reagent_containers/syringe/update_icon()
-	var/rounded_vol = Clamp(round(reagents.total_volume,5), 0, 15)
+	var/rounded_vol = Clamp(round((reagents.total_volume / volume * 15),5), 0, 15)
 	overlays.Cut()
 	if(ismob(loc))
 		var/injoverlay
@@ -266,3 +266,8 @@
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	volume = 20
 	flags = NOREACT
+
+/obj/item/weapon/reagent_containers/syringe/piercing
+	name = "Piercing Syringe"
+	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
+	volume = 10

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -88,9 +88,9 @@
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"
 	id = "bluespacesyringe"
-	req_tech = list("bluespace" = 1, "materials" = 2)
+	req_tech = list("bluespace" = 2, "materials" = 2, "combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_PLASMA = 1000, MAT_DIAMOND = 500)
+	materials = list(MAT_GLASS = 4000, MAT_PLASMA = 4000, MAT_DIAMOND = 2500)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/syringe/bluespace
 	category = list("Medical Designs", "Bluespace Designs")
@@ -99,9 +99,9 @@
 	name = "Cryo Syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	id = "noreactsyringe"
-	req_tech = list("materials" = 2)
+	req_tech = list("materials" = 2, "combat" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GOLD = 200)
+	materials = list(MAT_GLASS = 4000, MAT_GOLD = 1000)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/syringe/noreact
 	category = list("Medical Designs")
@@ -110,9 +110,9 @@
 	name = "Piercing Syringe"
 	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
 	id = "piercesyringe"
-	req_tech = list("materials" = 3)
+	req_tech = list("materials" = 3, "combat" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_DIAMOND = 200)
+	materials = list(MAT_GLASS = 4000, MAT_DIAMOND = 1500)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/syringe/piercing
 	category = list("Medical Designs")

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -88,9 +88,9 @@
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"
 	id = "bluespacesyringe"
-	req_tech = list("bluespace" = 2, "materials" = 2, "combat" = 2)
+	req_tech = list("bluespace" = 3, "materials" = 4, "combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 4000, MAT_PLASMA = 4000, MAT_DIAMOND = 2500)
+	materials = list(MAT_GLASS = 4000, MAT_PLASMA = 2000, MAT_DIAMOND = 2000)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/syringe/bluespace
 	category = list("Medical Designs", "Bluespace Designs")
@@ -99,7 +99,7 @@
 	name = "Cryo Syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	id = "noreactsyringe"
-	req_tech = list("materials" = 2, "combat" = 1)
+	req_tech = list("materials" = 2, "combat" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 4000, MAT_GOLD = 1000)
 	reliability = 76
@@ -110,7 +110,7 @@
 	name = "Piercing Syringe"
 	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
 	id = "piercesyringe"
-	req_tech = list("materials" = 3, "combat" = 1)
+	req_tech = list("materials" = 3, "combat" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 4000, MAT_DIAMOND = 1500)
 	reliability = 76

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -71,7 +71,7 @@
 	materials = list(MAT_METAL = 3000, MAT_PLASMA = 3000, MAT_DIAMOND = 500)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
-	category = list("Misc","Medical Designs")
+	category = list("Medical Designs", "Bluespace Designs")
 
 /datum/design/noreactbeaker
 	name = "Cryostasis Beaker"
@@ -82,6 +82,39 @@
 	materials = list(MAT_METAL = 3000)
 	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
+	category = list("Medical Designs")
+
+/datum/design/bluespacesyringe
+	name = "Bluespace Syringe"
+	desc = "An advanced syringe that can hold 60 units of chemicals"
+	id = "bluespacesyringe"
+	req_tech = list("bluespace" = 1, "materials" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 500, MAT_PLASMA = 1000, MAT_DIAMOND = 500)
+	reliability = 76
+	build_path = /obj/item/weapon/reagent_containers/syringe/bluespace
+	category = list("Medical Designs", "Bluespace Designs")
+
+/datum/design/noreactsyringe
+	name = "Cryo Syringe"
+	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
+	id = "noreactsyringe"
+	req_tech = list("materials" = 2)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GOLD = 200)
+	reliability = 76
+	build_path = /obj/item/weapon/reagent_containers/syringe/noreact
+	category = list("Medical Designs")
+
+/datum/design/piercesyringe
+	name = "Piercing Syringe"
+	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
+	id = "piercesyringe"
+	req_tech = list("materials" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 500, MAT_DIAMOND = 200)
+	reliability = 76
+	build_path = /obj/item/weapon/reagent_containers/syringe/piercing
 	category = list("Medical Designs")
 
 /datum/design/bluespacebodybag


### PR DESCRIPTION
Hey guys, first PR, let me know if I'm doing something horrible

This PR adds three new syringes to the protolathe with the intention to buff a little the syringe guns and make them used more often
- Bluespace syringe, holds up to 60 units and requires 4000 glass, 2000 plasma and 2000 diamond. Tech needed: bluespace 3, materials 4, combat 2.
- Cryo syringe, holds 20 units and prevents reaction inside the syringe, useful for knocking someone down briefly with water and potassium or igniting people with napalm + phlogiston. Requires 4000 glass and 1000 Gold. Tech needed: materials 2, combat 2.
- Piercing syringe, a syringe for piercing armored targets, however it only holds 10 units, made with 4000 glass and 1500 diamond. Tech needed: materials 3, combat 3.

I'm open to suggestion on number tweaking so let me know what you think.
Also, I'm using default syringe sprites for all, would be really nice if someone could make new sprites for them

:cl: Kiazusho
rscadd: Added three new advanced syringes to R&D
/:cl:
