### PR TITLE
Adds a notification for ghosts for enabling or disabling CTF

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -534,8 +534,9 @@
 			for(var/obj/machinery/capture_the_flag/CTF in machines)
 				ctf_enabled = !CTF.ctf_enabled
 				CTF.ctf_enabled = !CTF.ctf_enabled
+				CTF.TellGhost()
 			message_admins("[key_name_admin(usr)] has [ctf_enabled? "enabled" : "disabled"] CTF!")
-			notify_ghosts("CTF has been [ctf_enabled? "enabled" : "disabled"]!")
+			notify_ghosts("CTF has been [ctf_enabled? "enabled" : "disabled"]!",'sound/effects/ghost2.ogg')
 
 	if(E)
 		E.processing = 0

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -535,6 +535,7 @@
 				ctf_enabled = !CTF.ctf_enabled
 				CTF.ctf_enabled = !CTF.ctf_enabled
 			message_admins("[key_name_admin(usr)] has [ctf_enabled? "enabled" : "disabled"] CTF!")
+			notify_ghosts("CTF has been [ctf_enabled? "enabled" : "disabled"]!")
 
 	if(E)
 		E.processing = 0

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -105,11 +105,13 @@
 	var/control_points_to_win = 180
 	var/list/team_members = list()
 	var/ctf_enabled = FALSE
-	var/ctf_gear = /datum/outfit/ctf
+	var/normal_gear = /datum/outfit/ctf
+	var/current_gear
 	var/instagib_gear = /datum/outfit/ctf/instagib
 
 /obj/machinery/capture_the_flag/New()
 	..()
+	current_gear = normal_gear
 	poi_list |= src
 
 /obj/machinery/capture_the_flag/Destroy()
@@ -120,14 +122,14 @@
 	name = "Red CTF Controller"
 	icon_state = "syndbeacon"
 	team = RED_TEAM
-	ctf_gear = /datum/outfit/ctf/red
+	normal_gear = /datum/outfit/ctf/red
 	instagib_gear = /datum/outfit/ctf/red/instagib
 
 /obj/machinery/capture_the_flag/blue
 	name = "Blue CTF Controller"
 	icon_state = "bluebeacon"
 	team = BLUE_TEAM
-	ctf_gear = /datum/outfit/ctf/blue
+	normal_gear = /datum/outfit/ctf/blue
 	instagib_gear = /datum/outfit/ctf/blue/instagib
 
 /obj/machinery/capture_the_flag/attack_ghost(mob/user)
@@ -170,7 +172,17 @@
 	new_team_member.prefs.copy_to(M)
 	M.key = new_team_member.key
 	M.faction += team
-	M.equipOutfit(ctf_gear)
+	M.equipOutfit(current_gear)
+
+/obj/machinery/capture_the_flag/proc/TellGhost()
+	if(ctf_enabled)
+		notify_ghosts("[name] has been activated!", enter_link="<a href=?src=\ref[src];join=1>(Click to join the [team] team!)</a> or click on the controller directly!", source = src, attack_not_jump = 0)
+
+/obj/machinery/capture_the_flag/Topic(href, href_list)
+	if(href_list["join"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			attack_ghost(ghost)
 
 /obj/machinery/capture_the_flag/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/twohanded/required/ctf))
@@ -211,8 +223,14 @@
 /obj/machinery/capture_the_flag/proc/instagib_mode()
 	for(var/obj/machinery/capture_the_flag/CTF in machines)
 		if(CTF.ctf_enabled == TRUE)
-			CTF.ctf_gear = CTF.instagib_gear
+			CTF.current_gear = CTF.instagib_gear
 			CTF.respawn_cooldown = INSTAGIB_RESPAWN
+
+/obj/machinery/capture_the_flag/proc/normal_mode()
+	for(var/obj/machinery/capture_the_flag/CTF in machines)
+		if(CTF.ctf_enabled == TRUE)
+			CTF.current_gear = CTF.normal_gear
+			CTF.respawn_cooldown = DEFAULT_RESPAWN
 
 /obj/item/weapon/gun/projectile/automatic/pistol/deagle/CTF
 	desc = "This looks like it could really hurt in melee."

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -105,13 +105,11 @@
 	var/control_points_to_win = 180
 	var/list/team_members = list()
 	var/ctf_enabled = FALSE
-	var/normal_gear = /datum/outfit/ctf
-	var/current_gear
+	var/ctf_gear = /datum/outfit/ctf
 	var/instagib_gear = /datum/outfit/ctf/instagib
 
 /obj/machinery/capture_the_flag/New()
 	..()
-	current_gear = normal_gear
 	poi_list |= src
 
 /obj/machinery/capture_the_flag/Destroy()
@@ -122,14 +120,14 @@
 	name = "Red CTF Controller"
 	icon_state = "syndbeacon"
 	team = RED_TEAM
-	normal_gear = /datum/outfit/ctf/red
+	ctf_gear = /datum/outfit/ctf/red
 	instagib_gear = /datum/outfit/ctf/red/instagib
 
 /obj/machinery/capture_the_flag/blue
 	name = "Blue CTF Controller"
 	icon_state = "bluebeacon"
 	team = BLUE_TEAM
-	normal_gear = /datum/outfit/ctf/blue
+	ctf_gear = /datum/outfit/ctf/blue
 	instagib_gear = /datum/outfit/ctf/blue/instagib
 
 /obj/machinery/capture_the_flag/attack_ghost(mob/user)
@@ -172,7 +170,7 @@
 	new_team_member.prefs.copy_to(M)
 	M.key = new_team_member.key
 	M.faction += team
-	M.equipOutfit(current_gear)
+	M.equipOutfit(ctf_gear)
 
 /obj/machinery/capture_the_flag/proc/TellGhost()
 	if(ctf_enabled)
@@ -223,13 +221,13 @@
 /obj/machinery/capture_the_flag/proc/instagib_mode()
 	for(var/obj/machinery/capture_the_flag/CTF in machines)
 		if(CTF.ctf_enabled == TRUE)
-			CTF.current_gear = CTF.instagib_gear
+			CTF.ctf_gear = CTF.instagib_gear
 			CTF.respawn_cooldown = INSTAGIB_RESPAWN
 
 /obj/machinery/capture_the_flag/proc/normal_mode()
 	for(var/obj/machinery/capture_the_flag/CTF in machines)
 		if(CTF.ctf_enabled == TRUE)
-			CTF.current_gear = CTF.normal_gear
+			CTF.ctf_gear = initial(ctf_gear)
 			CTF.respawn_cooldown = DEFAULT_RESPAWN
 
 /obj/item/weapon/gun/projectile/automatic/pistol/deagle/CTF


### PR DESCRIPTION
Jump links were added.
You can click on the alert to jump to the controller, or click a link in chat to directly join the team.

Also added a way to switch back from instagib mode.
Fixes #15603
