### PR TITLE
Changes the napalm recipe to not conflict with hooch.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -372,7 +372,7 @@
 	name = "Napalm"
 	id = "napalm"
 	result = "napalm"
-	required_reagents = list("sugar" = 1, "welding_fuel" = 1, "ethanol" = 1 )
+	required_reagents = list("oil" = 1, "welding_fuel" = 1, "ethanol" = 1 )
 	result_amount = 3
 
 


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/16498.

Old recipe: Sugar + ethanol + welding fuel
New recipe: Oil + ethanol + welding fuel

This both no longer conflicts with hooch and is more accurate to how napalm is made IRL (Fight Club is wrong, the editor changed it, the actual recipe is styrofoam + gasoline, and this is the closest you can get in spess chemistry)
