### PR TITLE
Alt-clicking abandoned crates no longer makes them explode.

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -175,7 +175,7 @@
 	boom(user)
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
-	if(user.incapacitated() || !Adjacent(user) || !ishuman(user))
+	if(!user.canUseTopic(src))
 		return
 	attack_hand(user)
 

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -175,7 +175,7 @@
 	boom(user)
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
-	if(user.incapacitated() || !Adjacent(user) || !istype(user))
+	if(user.incapacitated() || !Adjacent(user) || !ishuman(user))
 		return
 	attack_hand(user)
 

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -174,6 +174,11 @@
 /obj/structure/closet/crate/secure/loot/attack_animal(mob/user)
 	boom(user)
 
+/obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
+	if(user.incapacitated() || !Adjacent(user) || !istype(user))
+		return
+	attack_hand(user)
+
 /obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W, mob/user)
 	if(locked)
 		if(istype(W, /obj/item/weapon/card/emag))


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/17421.

This feature was too fun to leave in.
