### PR TITLE
[wip] Turbulence event

### DIFF
--- a/code/modules/events/turbulence.dm
+++ b/code/modules/events/turbulence.dm
@@ -1,0 +1,69 @@
+/datum/round_event_control/turbulence
+	name = "Turbulence"
+	typepath = /datum/round_event/turbulence
+	weight = 5
+
+/datum/round_event/turbulence
+	announceWhen	= 10
+	startWhen		= 30
+	endWhen			= 35
+
+	var/flying_debris = list()
+	var/weight_class_affected = 3
+
+/datum/round_event/turbulence/announce()
+	var/reasons = list(
+		"The Titan-class starliner Whale is passing through a nearby \
+			hyperspace expressway. Please brace for minor turbulence.",
+		"A small coronal ejection has occured on our host star, there may \
+			be some mild gravitational effects. For your safety, please \
+			secure yourself and nearby equipment.",
+		"Centcom are testing a new classified weapon in our star system \
+			shortly. There will be mild gravitation waves produced.")
+	priority_announce(pick(reasons), "Safety Alert")
+
+
+/datum/round_event/turbulence/setup()
+	world.log << "turbulence setup()"
+	for(var/x in block(locate(1,1,1), locate(world.maxx, world.maxy, 1)))
+		var/turf/T = x
+		for(var/obj/item/I in T)
+			if(I.w_class <= weight_class_affected)
+				flying_debris += I
+
+	shuffle(flying_debris)
+
+/datum/round_event/turbulence/start()
+	world.log << "turbulence start()"
+	for(var/x in living_mob_list)
+		var/mob/living/M = x
+
+		var/turf/T = get_turf(M)
+
+		if(!T || T.z != 1)
+			continue
+
+		if(M.client)
+			if(M.buckled)
+				shake_camera(M, 2, 1)
+			else
+				shake_camera(M, 7, 1)
+
+		if(istype(M, /mob/living/carbon))
+			var/mob/living/carbon/C = M
+			if(!C.buckled)
+				C.Weaken(3)
+
+	var/max_range = 5
+	for(var/x in flying_debris)
+		if(!x)
+			continue
+
+		var/obj/item/I = x
+		var/dist = rand(1, max_range)
+		var/dir = pick(alldirs)
+
+		var/turf/throw_at = get_ranged_target_turf(I, dir, dist)
+		// Like explosions, turbulence increases embedding chance
+		I.throw_speed = 4
+		I.throw_at(throw_at, dist, 2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1034,6 +1034,7 @@
 #include "code\modules\events\spacevine.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
+#include "code\modules\events\turbulence.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wormholes.dm"
 #include "code\modules\events\holiday\halloween.dm"


### PR DESCRIPTION
:cl: coiax
rscadd: Due to budget cuts, Nanotrasen have sold some of the space in
your star system to various third parties. Rest assured this will not
affect the security or safety of the station.
/:cl:

Spoiler alert, it will. Adds the turbulence event, a rare event
triggered by a passing heavy cruise ship, weapons testing or solar
coronal ejection.

The effects: everyone's who's not safely buckled will be thrown to the
floor as everything that isn't nailed down below a certain weight will
be lightly tossed around. Did you know that pens can embed if they're
thrown hard enough?
