### PR TITLE
Xenobio slime console now gives error messages upon failure.

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -111,6 +111,8 @@
 			S.loc = remote_eye.loc
 			S.visible_message("[S] warps in!")
 			X.stored_slimes -= S
+	else
+		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
 
 /datum/action/innate/slime_pick_up
 	name = "Pick up Slime"
@@ -133,6 +135,8 @@
 				S.visible_message("[S] vanishes in a flash of light!")
 				S.loc = X
 				X.stored_slimes += S
+	else
+		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
 
 
 /datum/action/innate/feed_slime
@@ -152,6 +156,8 @@
 			food.LAssailant = C
 			X.monkeys --
 			owner << "[X] now has [X.monkeys] monkeys left."
+	else
+		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
 
 
 /datum/action/innate/monkey_recycle
@@ -171,3 +177,5 @@
 				M.visible_message("[M] vanishes as they are reclaimed for recycling!")
 				X.monkeys = round(X.monkeys + 0.2,0.1)
 				qdel(M)
+	else
+		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -112,7 +112,7 @@
 			S.visible_message("[S] warps in!")
 			X.stored_slimes -= S
 	else
-		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
+		owner << "<span class='notice'>Target is not near a camera. Cannot proceed.</span>"
 
 /datum/action/innate/slime_pick_up
 	name = "Pick up Slime"
@@ -136,7 +136,7 @@
 				S.loc = X
 				X.stored_slimes += S
 	else
-		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
+		owner << "<span class='notice'>Target is not near a camera. Cannot proceed.</span>"
 
 
 /datum/action/innate/feed_slime
@@ -157,7 +157,7 @@
 			X.monkeys --
 			owner << "[X] now has [X.monkeys] monkeys left."
 	else
-		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
+		owner << "<span class='notice'>Target is not near a camera. Cannot proceed.</span>"
 
 
 /datum/action/innate/monkey_recycle
@@ -178,4 +178,4 @@
 				X.monkeys = round(X.monkeys + 0.2,0.1)
 				qdel(M)
 	else
-		owner <<"<span class='notice'>Target is not near a camera.  Cannot proceed.</span>"
+		owner << "<span class='notice'>Target is not near a camera. Cannot proceed.</span>"


### PR DESCRIPTION
Before, the Xenobio consoles silently failed when there weren't enough cameras.  Now it explains what the error is.

Fixes #16998
