### PR TITLE
Lavaland Mapping Volume 3

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -1,133 +1,1550 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"ac" = (/turf/closed/wall/r_wall,/area/ruin/powered)
-"ad" = (/obj/structure/flora/ausbushes/leafybush,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"ae" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/stack/cable_coil,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"af" = (/obj/structure/table,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"ag" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"ah" = (/obj/machinery/power/smes,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"ai" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"aj" = (/turf/closed/wall/mineral/sandstone{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"ak" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/obj/structure/toilet,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"al" = (/obj/structure/urinal{pixel_y = 32},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"am" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/obj/structure/urinal{pixel_y = 32},/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"an" = (/obj/item/device/flashlight/lantern,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"ao" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"ap" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"aq" = (/obj/structure/flora/ausbushes/sunnybush,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"ar" = (/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"as" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"at" = (/obj/item/weapon/tank/internals/oxygen,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"au" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"av" = (/obj/machinery/door/airlock/hatch,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"aw" = (/obj/machinery/door/airlock/sandstone,/turf/open/floor/wood,/area/ruin/powered)
-"ax" = (/obj/structure/extinguisher_cabinet,/turf/closed/wall/mineral/sandstone{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"ay" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/obj/machinery/door/airlock/hatch,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"az" = (/obj/item/clothing/tie/dope_necklace,/obj/item/weapon/reagent_containers/spray/spraytan,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"aA" = (/turf/open/floor/plating/beach/sand,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"aB" = (/turf/open/floor/plasteel/asteroid/warning{baseturf = /turf/open/floor/plating/beach/sand; dir = 1; icon_state = "asteroidwarning"; tag = "icon-asteroidwarning (NORTH)"},/area/ruin/powered)
-"aC" = (/turf/open/floor/wood,/area/ruin/powered)
-"aD" = (/obj/structure/table,/obj/item/weapon/storage/box/drinkingglasses,/obj/item/weapon/storage/box/drinkingglasses,/obj/item/weapon/reagent_containers/food/drinks/shaker,/obj/item/weapon/storage/box/beakers,/turf/open/floor/wood,/area/ruin/powered)
-"aE" = (/obj/structure/table,/obj/machinery/reagentgrinder,/turf/open/floor/wood,/area/ruin/powered)
-"aF" = (/obj/machinery/vending/boozeomat{emagged = 1},/turf/open/floor/wood,/area/ruin/powered)
-"aG" = (/obj/structure/table,/obj/item/weapon/reagent_containers/glass/rag,/turf/open/floor/wood,/area/ruin/powered)
-"aH" = (/obj/structure/table,/obj/item/weapon/storage/box/donkpockets,/turf/open/floor/wood,/area/ruin/powered)
-"aI" = (/obj/structure/table,/obj/machinery/microwave,/turf/open/floor/wood,/area/ruin/powered)
-"aJ" = (/obj/structure/closet/crate/bin,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/trash/candy,/obj/item/toy/talking/owl,/turf/open/floor/plasteel/asteroid/warning{baseturf = /turf/open/floor/plating/beach/sand; dir = 1; icon_state = "asteroidwarning"; tag = "icon-asteroidwarning (NORTH)"},/area/ruin/powered)
-"aK" = (/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"aL" = (/obj/effect/mob_spawn/human/bartender/alive{name = "beach bum sleeper"},/turf/open/floor/wood,/area/ruin/powered)
-"aM" = (/obj/structure/reagent_dispensers/beerkeg,/turf/open/floor/wood,/area/ruin/powered)
-"aN" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"aO" = (/obj/structure/stacklifter,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"aP" = (/obj/structure/table/wood,/turf/open/floor/wood,/area/ruin/powered)
-"aQ" = (/obj/structure/table/wood,/obj/item/device/flashlight/lamp,/turf/open/floor/wood,/area/ruin/powered)
-"aR" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,/turf/open/floor/wood,/area/ruin/powered)
-"aS" = (/obj/machinery/processor,/turf/open/floor/wood,/area/ruin/powered)
-"aT" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"aU" = (/obj/effect/overlay/palmtree_l,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"aV" = (/obj/effect/mob_spawn/human/beach/alive{flavour_text = "You're, like, totally a dudebro, bruh. Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?"; pocket2 = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/dank; uniform = /obj/item/clothing/under/pants/youngfolksjeans},/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"aW" = (/obj/structure/chair/stool,/turf/open/floor/plasteel/asteroid/warning{baseturf = /turf/open/floor/plating/beach/sand; dir = 1; icon_state = "asteroidwarning"; tag = "icon-asteroidwarning (NORTH)"},/area/ruin/powered)
-"aX" = (/obj/structure/closet/secure_closet/freezer/meat,/turf/open/floor/wood,/area/ruin/powered)
-"aY" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"aZ" = (/obj/effect/overlay/coconut,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"ba" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bb" = (/obj/structure/weightlifter,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bc" = (/turf/open/floor/wood,/obj/machinery/door/airlock/sandstone,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bd" = (/obj/structure/closet/secure_closet/freezer/kitchen,/turf/open/floor/wood,/area/ruin/powered)
-"be" = (/obj/vehicle/scooter/skateboard{dir = 4},/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bf" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bg" = (/obj/structure/sign/barsign,/turf/closed/wall/mineral/sandstone,/area/ruin/powered)
-"bh" = (/turf/closed/wall/mineral/sandstone,/area/ruin/powered)
-"bi" = (/turf/open/floor/plating/beach/sand{density = 1; opacity = 1},/area/ruin/powered)
-"bj" = (/obj/structure/chair/wood/normal{icon_state = "wooden_chair"; dir = 4},/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"bk" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/pastatomato,/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"bl" = (/obj/structure/chair/wood/normal{icon_state = "wooden_chair"; dir = 8},/turf/open/floor/plasteel/asteroid{baseturf = /turf/open/floor/plating/beach/sand},/area/ruin/powered)
-"bm" = (/mob/living/simple_animal/crab,/turf/open/floor/plating/beach/sand{density = 1; opacity = 1},/area/ruin/powered)
-"bn" = (/obj/structure/closet/athletic_mixed,/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bo" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/obj/structure/rack,/obj/item/clothing/shoes/sandal,/obj/item/clothing/shoes/sandal,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bp" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"bq" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/obj/structure/closet/athletic_mixed,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"br" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bs" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bt" = (/obj/machinery/door/airlock/hatch,/obj/structure/fans/tiny,/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bu" = (/turf/open/floor/pod/light{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"bv" = (/turf/open/floor/pod/light{baseturf = /turf/open/floor/plating/lava/smooth},/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bw" = (/obj/machinery/door/airlock/sandstone,/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bx" = (/obj/structure/flora/rock,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"by" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/obj/machinery/door/airlock/sandstone,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bz" = (/mob/living/simple_animal/crab,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bA" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/item/weapon/bikehorn/airhorn,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/firstaid/brute,/turf/open/floor/wood,/area/ruin/powered)
-"bB" = (/obj/structure/window/reinforced{dir = 4; pixel_x = 0},/obj/structure/window/reinforced{dir = 1; layer = 2.9},/obj/structure/chair/stool,/turf/open/floor/wood,/area/ruin/powered)
-"bC" = (/obj/structure/table/wood,/obj/item/weapon/tank/internals/oxygen,/obj/item/weapon/pickaxe,/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bD" = (/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/obj/structure/dresser,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bE" = (/obj/item/weapon/reagent_containers/spray/spraytan,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bF" = (/obj/item/toy/beach_ball,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bG" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/item/device/megaphone,/turf/open/floor/wood,/area/ruin/powered)
-"bH" = (/obj/structure/window/reinforced{dir = 4; pixel_x = 0},/obj/effect/mob_spawn/human/beach/alive{flavour_text = "You're a spunky lifeguard! It's up to you to make sure nobody drowns or gets eaten by sharks and stuff."; has_id = 1; id_access = "Medical Doctor"; id_job = "Lifeguard"; mob_gender = "female"},/turf/open/floor/wood,/area/ruin/powered)
-"bI" = (/obj/structure/dresser,/turf/open/floor/pod/dark{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
-"bJ" = (/obj/structure/chair,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bK" = (/obj/item/weapon/storage/backpack/dufflebag,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bL" = (/turf/open/floor/pod/light{baseturf = /turf/open/floor/plating/lava/smooth; density = 1},/obj/structure/lattice,/turf/open/floor/plasteel/sandeffect,/area/ruin/powered)
-"bM" = (/turf/open/floor/plasteel/stairs/old,/area/ruin/powered)
-"bN" = (/obj/structure/flora/ausbushes/reedbush,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bO" = (/obj/item/weapon/reagent_containers/spray/spraytan,/obj/item/device/camera,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bP" = (/obj/item/weapon/reagent_containers/food/drinks/beer,/turf/open/floor/plating/beach/sand,/area/ruin/powered)
-"bQ" = (/obj/structure/flora/ausbushes/reedbush,/turf/open/floor/plating/beach/coastline_t,/area/ruin/powered)
-"bR" = (/turf/open/floor/plating/beach/coastline_t,/area/ruin/powered)
-"bS" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/plating/beach/coastline_t,/area/ruin/powered)
-"bT" = (/turf/open/floor/plating/beach/coastline_b,/area/ruin/powered)
-"bU" = (/turf/open/floor/plating/beach/water,/area/ruin/powered)
-"bV" = (/obj/structure/flora/ausbushes/stalkybush,/turf/open/floor/plating/beach/water,/area/ruin/powered)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/closed/wall/r_wall{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ac" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered)
+"ad" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"ae" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"af" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ag" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ah" = (
+/obj/machinery/power/smes,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ai" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"aj" = (
+/turf/closed/wall/mineral/sandstone{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"ak" = (
+/obj/structure/toilet,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"al" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"am" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"an" = (
+/obj/item/device/flashlight/lantern,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ao" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"ap" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aq" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"ar" = (
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"as" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"at" = (
+/obj/item/weapon/tank/internals/oxygen,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"au" = (
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"av" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"aw" = (
+/obj/machinery/door/airlock/sandstone,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"ax" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/mineral/sandstone{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"ay" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"az" = (
+/obj/item/clothing/tie/dope_necklace,
+/obj/item/weapon/reagent_containers/spray/spraytan,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aA" = (
+/obj/effect/decal/sandeffect,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aB" = (
+/turf/open/floor/plasteel/asteroid/warning{
+	baseturf = /turf/open/floor/plating/beach/sand;
+	dir = 1;
+	icon_state = "asteroidwarning";
+	tag = "icon-asteroidwarning (NORTH)"
+	},
+/area/ruin/powered)
+"aC" = (
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aD" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/drinkingglasses,
+/obj/item/weapon/storage/box/drinkingglasses,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/weapon/storage/box/beakers,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aE" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aF" = (
+/obj/machinery/vending/boozeomat{
+	emagged = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aG" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/glass/rag,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aH" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aI" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aJ" = (
+/obj/structure/closet/crate/bin,
+/obj/item/weapon/tank/internals/emergency_oxygen,
+/obj/item/trash/candy,
+/obj/item/toy/talking/owl,
+/turf/open/floor/plasteel/asteroid/warning{
+	baseturf = /turf/open/floor/plating/beach/sand;
+	dir = 1;
+	icon_state = "asteroidwarning";
+	tag = "icon-asteroidwarning (NORTH)"
+	},
+/area/ruin/powered)
+"aK" = (
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"aL" = (
+/obj/effect/mob_spawn/human/bartender/alive{
+	name = "beach bum sleeper"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aM" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aN" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"aO" = (
+/obj/structure/stacklifter,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aP" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aQ" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aR" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tequila,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aS" = (
+/obj/machinery/processor,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aT" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"aU" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aV" = (
+/obj/effect/mob_spawn/human/beach/alive{
+	flavour_text = "You're, like, totally a dudebro, bruh. Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?";
+	pocket2 = /obj/item/weapon/reagent_containers/food/snacks/pizzaslice/dank;
+	uniform = /obj/item/clothing/under/pants/youngfolksjeans
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"aW" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/asteroid/warning{
+	baseturf = /turf/open/floor/plating/beach/sand;
+	dir = 1;
+	icon_state = "asteroidwarning";
+	tag = "icon-asteroidwarning (NORTH)"
+	},
+/area/ruin/powered)
+"aX" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"aY" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"aZ" = (
+/obj/effect/overlay/coconut,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"ba" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bb" = (
+/obj/structure/weightlifter,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bc" = (
+/obj/machinery/door/airlock/sandstone,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"bd" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"be" = (
+/obj/vehicle/scooter/skateboard{
+	dir = 4
+	},
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bf" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bg" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/powered)
+"bh" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/powered)
+"bi" = (
+/turf/open/floor/plating/beach/sand{
+	density = 1;
+	opacity = 1
+	},
+/area/ruin/powered)
+"bj" = (
+/obj/structure/chair/wood/normal{
+	icon_state = "wooden_chair";
+	dir = 4
+	},
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"bk" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/pastatomato,
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"bl" = (
+/obj/structure/chair/wood/normal{
+	icon_state = "wooden_chair";
+	dir = 8
+	},
+/turf/open/floor/plasteel/asteroid{
+	baseturf = /turf/open/floor/plating/beach/sand
+	},
+/area/ruin/powered)
+"bm" = (
+/mob/living/simple_animal/crab,
+/turf/open/floor/plating/beach/sand{
+	density = 1;
+	opacity = 1
+	},
+/area/ruin/powered)
+"bn" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bo" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bp" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"bq" = (
+/obj/structure/closet/athletic_mixed,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"br" = (
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bs" = (
+/obj/effect/decal/sandeffect,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bt" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bu" = (
+/turf/open/floor/pod/light{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"bv" = (
+/obj/effect/decal/sandeffect,
+/turf/open/floor/pod/light{
+	baseturf = /turf/open/floor/plating/lava/smooth
+	},
+/area/ruin/powered)
+"bw" = (
+/obj/machinery/door/airlock/sandstone,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bx" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"by" = (
+/obj/machinery/door/airlock/sandstone,
+/obj/effect/decal/sandeffect,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bz" = (
+/mob/living/simple_animal/crab,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bA" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/bikehorn/airhorn,
+/obj/structure/table/wood,
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/brute,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"bB" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"bC" = (
+/obj/structure/table/wood,
+/obj/item/weapon/tank/internals/oxygen,
+/obj/item/weapon/pickaxe,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bD" = (
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/obj/structure/dresser,
+/turf/open/floor/plasteel/sandeffect,
+/area/ruin/powered)
+"bE" = (
+/obj/item/weapon/reagent_containers/spray/spraytan,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bF" = (
+/obj/item/toy/beach_ball,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/item/device/megaphone,
+/turf/open/floor/wood,
+/area/ruin/powered)
+"bH" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/effect/mob_spawn/human/beach/alive{
+	flavour_text = "You're a spunky lifeguard! It's up to you to make sure nobody drowns or gets eaten by sharks and stuff.";
+	has_id = 1;
+	id_access = "Medical Doctor";
+	id_job = "Lifeguard";
+	mob_gender = "female"
+	},
+/turf/open/floor/wood,
+/area/ruin/powered)
+"bI" = (
+/obj/structure/dresser,
+/turf/open/floor/pod/dark{
+	baseturf = /turf/open/floor/plating/asteroid/basalt
+	},
+/area/ruin/powered)
+"bJ" = (
+/obj/structure/chair,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bK" = (
+/obj/item/weapon/storage/backpack/dufflebag,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bL" = (
+/obj/effect/decal/sandeffect{
+	density = 1
+	},
+/obj/effect/decal/fakelattice,
+/turf/open/floor/pod/light{
+	baseturf = /turf/open/floor/plating/lava/smooth;
+	density = 1
+	},
+/area/ruin/powered)
+"bM" = (
+/turf/open/floor/plasteel/stairs/old,
+/area/ruin/powered)
+"bN" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bO" = (
+/obj/item/device/camera,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bP" = (
+/obj/item/weapon/reagent_containers/food/drinks/beer,
+/turf/open/floor/plating/beach/sand,
+/area/ruin/powered)
+"bQ" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/beach/coastline_t,
+/area/ruin/powered)
+"bR" = (
+/turf/open/floor/plating/beach/coastline_t,
+/area/ruin/powered)
+"bS" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/beach/coastline_t,
+/area/ruin/powered)
+"bT" = (
+/turf/open/floor/plating/beach/coastline_b,
+/area/ruin/powered)
+"bU" = (
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered)
+"bV" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/floor/plating/beach/water,
+/area/ruin/powered)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaabababacacacacacacacacacacacacabababaaaaaaaaaaaa
-aaaaaaaaabababadabaeafagahaiajakajalamanaoabapabababaaaaaaaa
-aaaaaaababaqararabasasasasatajauavasasauauabararaqababaaaaaa
-aaaaababadaraparababajawajaxajajajajajajayabaraparapababaaaa
-aaaaabapararazaraAaBajaCaDaEaFaGaHaIajaJaKaAararararadabaaaa
-aaababarararararaAaKajaCaCaLaCaCaCaMajaNaKaAarararararababaa
-aaabaparaOaraOaraAaKajaPaQaPaRajaCaSajaTaKaAaraUaraqarapabaa
-aaabarararaVararaAaKaBaWaWaWaWajaCaXajaYaKaAararaZarararabaa
-baabararbbarbbaraAaKaKaKaKaKaKbcaCbdajaKaKaAarararbearapabbf
-aaabararararararaAaKaKaKaKaKaKajbgbhajaKaKaAararararararabaa
-ababababbibibibiaAaKbjbkblaKaKaBaBaBaBaKaKaAbibmbibiabababab
-acbnbobpararararaAaKaKaKaKaKaKaKaKaKaKaKaKaAararararbpbqboab
-acbrbrbpararaUaraAaAaAaAaAaAaAaAaAaAaAaAaAaAararararbpbrbsab
-btbubvbpaAaraZararararararararararararararararararaAbpbububt
-abbvbvbwaAarararararararbxararararaZarararararararaAbybvbuab
-btbububpaAarararararararararararaUararararararararaAbpbvbvbt
-acbsbrbparbzarararbxarararararararararbAbBararaZararbpbsbrab
-acbCbDbpararararararararararbEararbFarbGbHarararararbpbIbCab
-ababababarbJarbJarbJarbJbKbJarbJarararbLbMarbJararaUabababab
-aaabadapbNarararbOararararararararbzarararbPararararapbNabaa
-baabbQbRbRbSbRbRbRbRbRbRbRbRbRbRbRbRbRbRbRbRbRbRbSbRbRbRabbf
-aaabbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTbTabaa
-aaababbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUababaa
-aaaaabbUbUbUbUbUbUbUbUbUbUbUbUbUbVbUbUbUbUbUbUbUbUbUbUabaaaa
-aaaaababbUbUbUbUbUbVbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUababaaaa
-aaaaaaababbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbVbUbUbUababaaaaaa
-aaaaaaaaabababbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUbUabababaaaaaaaa
-aaaaaaaaaaaaababababababababababababababababababaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ba
+aa
+ab
+ac
+ac
+bt
+ab
+bt
+ac
+ac
+ab
+aa
+ba
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bn
+br
+bu
+bv
+bu
+bs
+bC
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ap
+ar
+ar
+ar
+ab
+bo
+br
+bv
+bv
+bu
+br
+bI
+ab
+ad
+bQ
+bT
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ap
+ar
+ar
+ar
+ar
+ar
+ab
+bp
+bp
+bp
+bw
+bp
+bp
+bp
+ab
+ap
+bR
+bT
+bU
+bU
+ab
+ab
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+ab
+ab
+ad
+ar
+ar
+aO
+ar
+bb
+ar
+ar
+ar
+ar
+aA
+aA
+aA
+ar
+ar
+ar
+bN
+bR
+bT
+bU
+bU
+bU
+ab
+ab
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+ab
+aq
+ar
+ar
+ar
+ar
+aV
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bz
+ar
+bJ
+ar
+bS
+bT
+bU
+bU
+bU
+bU
+ab
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+ab
+ab
+ar
+ap
+az
+ar
+aO
+ar
+bb
+ar
+ar
+ar
+aU
+aZ
+ar
+ar
+ar
+ar
+ar
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+ab
+ab
+ab
+"}
+(8,1,1) = {"
+aa
+ab
+ad
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bJ
+bE
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(9,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+ar
+ar
+ar
+ap
+ar
+ar
+bO
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(10,1,1) = {"
+aa
+ac
+ae
+as
+ab
+aB
+aK
+aK
+aK
+aK
+aK
+aK
+aK
+aA
+ar
+ar
+ap
+bx
+ar
+bJ
+ar
+bR
+bT
+bU
+bU
+bV
+bU
+bU
+ab
+ab
+"}
+(11,1,1) = {"
+aa
+ac
+af
+as
+aj
+aj
+aj
+aj
+aB
+aK
+aK
+bj
+aK
+aA
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(12,1,1) = {"
+aa
+ac
+ag
+as
+aw
+aC
+aC
+aP
+aW
+aK
+aK
+bk
+aK
+aA
+ar
+ar
+ap
+ar
+ar
+bJ
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(13,1,1) = {"
+aa
+ac
+ah
+as
+aj
+aD
+aC
+aQ
+aW
+aK
+aK
+bl
+aK
+aA
+ar
+bx
+ar
+ar
+ar
+bK
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(14,1,1) = {"
+aa
+ac
+ai
+at
+ax
+aE
+aL
+aP
+aW
+aK
+aK
+aK
+aK
+aA
+ar
+ap
+ar
+ar
+ar
+bJ
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(15,1,1) = {"
+aa
+ac
+aj
+aj
+aj
+aF
+aC
+aR
+aW
+aK
+aK
+aK
+aK
+aA
+ar
+ar
+ar
+ar
+bE
+ar
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(16,1,1) = {"
+aa
+ac
+ak
+au
+aj
+aG
+aC
+aj
+aj
+bc
+aj
+aB
+aK
+aA
+ar
+ar
+ar
+ar
+ar
+bJ
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(17,1,1) = {"
+aa
+ac
+aj
+av
+aj
+aH
+aC
+aC
+aC
+aC
+bg
+aB
+aK
+aA
+ar
+ar
+aU
+ar
+ar
+ar
+ar
+bR
+bT
+bU
+bV
+bU
+bU
+bU
+ab
+ab
+"}
+(18,1,1) = {"
+aa
+ac
+al
+as
+aj
+aI
+aM
+aS
+aX
+bd
+bh
+aB
+aK
+aA
+ar
+aZ
+ar
+ar
+bF
+ar
+bz
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(19,1,1) = {"
+aa
+ac
+am
+as
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aB
+aK
+aA
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(20,1,1) = {"
+aa
+ac
+an
+au
+aj
+aJ
+aN
+aT
+aY
+aK
+aK
+aK
+aK
+aA
+ar
+ar
+ar
+bA
+bG
+bL
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(21,1,1) = {"
+aa
+ac
+ao
+au
+ay
+aK
+aK
+aK
+aK
+aK
+aK
+aK
+aK
+aA
+ar
+ar
+ar
+bB
+bH
+bM
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(22,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+ar
+ar
+ar
+ar
+ar
+ar
+bP
+bR
+bT
+bU
+bU
+bU
+bV
+bU
+ab
+ab
+"}
+(23,1,1) = {"
+aa
+ab
+ap
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bJ
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+bU
+ab
+ab
+"}
+(24,1,1) = {"
+aa
+ab
+ab
+ar
+ap
+ar
+ar
+aU
+ar
+ar
+ar
+bz
+ar
+ar
+ar
+ar
+ar
+aZ
+ar
+ar
+ar
+bR
+bT
+bU
+bU
+bU
+bU
+ab
+ab
+ab
+"}
+(25,1,1) = {"
+aa
+aa
+ab
+aq
+ar
+ar
+ar
+ar
+aZ
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+bS
+bT
+bU
+bU
+bU
+bU
+ab
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+ab
+ab
+ap
+ar
+ar
+aq
+ar
+be
+ar
+ar
+ar
+ar
+aA
+aA
+aA
+ar
+ar
+aU
+ar
+bR
+bT
+bU
+bU
+bU
+ab
+ab
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ad
+ar
+ar
+ar
+ar
+ar
+ab
+bp
+bp
+bp
+by
+bp
+bp
+bp
+ab
+ap
+bR
+bT
+bU
+bU
+ab
+ab
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ap
+ar
+ap
+ar
+ab
+bq
+br
+bu
+bv
+bv
+bs
+bI
+ab
+bN
+bR
+bT
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+bo
+bs
+bu
+bu
+bv
+br
+bC
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+bf
+aa
+ab
+ab
+ab
+bt
+ab
+bt
+ab
+ab
+ab
+aa
+bf
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1,68 +1,140 @@
-"a" = (/turf/template_noop,/area/template_noop)
-"b" = (/turf/closed/wall/r_wall,/area/ruin/powered)
-"c" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"d" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"e" = (/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"f" = (/obj/item/weapon/reagent_containers/food/snacks/grown/banana,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"g" = (/turf/closed/mineral,/area/ruin/powered)
-"h" = (/obj/item/weapon/bikehorn,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"i" = (/obj/item/weapon/grown/bananapeel,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"j" = (/turf/closed/mineral/clown,/area/ruin/powered)
-"k" = (/obj/structure/ore_box,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"l" = (/turf/open/floor/plating/asteroid,/area/ruin/powered)
-"m" = (/obj/item/weapon/grown/bananapeel,/turf/open/floor/plating/asteroid,/area/ruin/powered)
-"n" = (/turf/closed/mineral/gibtonite,/area/ruin/powered)
-"o" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"p" = (/obj/machinery/door/airlock/hatch,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1},/area/ruin/powered)
-"q" = (/obj/machinery/door/airlock/clown,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"r" = (/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"s" = (/obj/item/weapon/grown/bananapeel,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"t" = (/turf/closed/wall/mineral/wood,/area/ruin/powered)
-"u" = (/obj/structure/table/wood,/obj/item/weapon/banhammer,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"v" = (/obj/structure/table/wood,/obj/item/clothing/mask/gas/sexyclown,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"w" = (/obj/structure/table/wood,/obj/item/clothing/mask/gas/clown_hat,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"x" = (/obj/structure/bed,/obj/item/weapon/bedsheet/clown,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"y" = (/obj/machinery/door/airlock/clown,/obj/item/weapon/grown/bananapeel,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"z" = (/obj/item/weapon/grown/bananapeel,/mob/living/simple_animal/hostile/retaliate/clown,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"A" = (/obj/structure/table/wood,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"B" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/pie/cream,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"C" = (/obj/structure/table/wood,/obj/item/weapon/sord,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"D" = (/obj/structure/table/wood,/obj/item/weapon/bikehorn/rubberducky,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"E" = (/obj/item/weapon/grenade/clusterbuster/soap,/obj/structure/bed,/obj/item/weapon/bedsheet/clown,/turf/open/floor/mineral/bananium,/area/ruin/powered)
-"F" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"G" = (/obj/structure/table/wood,/obj/item/weapon/restraints/handcuffs/fake,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"H" = (/obj/structure/table/wood,/obj/item/weapon/bikehorn/airhorn,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
-"I" = (/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aa" = (/turf/template_noop,/area/template_noop)
+"ab" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"ac" = (/turf/open/floor/noslip{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ad" = (/mob/living/simple_animal/hostile/retaliate/clown,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"ae" = (/obj/machinery/light,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"af" = (/obj/item/clothing/head/cone,/turf/open/floor/noslip{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ag" = (/obj/item/weapon/paper/crumpled/bloody{info = "Abandon hope, all ye who enter here."},/obj/effect/decal/cleanable/blood/old,/turf/open/floor/noslip{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ah" = (/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ai" = (/obj/machinery/disposal/deliveryChute{desc = "The following is engraved upon the chute: A FATE WORSE THAN DEATH LIES WITHIN"; dir = 1; name = "THE TRIAL OF HONKITUDE"},/obj/structure/disposalpipe/trunk,/turf/open/floor/noslip{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aj" = (/obj/structure/disposalpipe/trunk,/obj/structure/disposaloutlet{dir = 1},/turf/open/floor/noslip{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ak" = (/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/ruin/powered)
+"al" = (/obj/structure/disposalpipe/segment,/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"am" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"an" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ao" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ap" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aq" = (/obj/structure/disposalpipe/trunk,/obj/structure/disposaloutlet{dir = 1},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ar" = (/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"as" = (/obj/structure/disposalpipe/segment,/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"at" = (/obj/structure/disposalpipe/segment,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"au" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"av" = (/obj/structure/disposalpipe/segment,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aw" = (/obj/structure/disposalpipe/sortjunction{dir = 1; icon_state = "pipe-j2s"; sortType = 3},/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ax" = (/obj/structure/disposalpipe/segment,/obj/structure/window/reinforced,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ay" = (/obj/structure/disposalpipe/segment,/obj/effect/decal/cleanable/pie_smudge,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"az" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aA" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aB" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aC" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aD" = (/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aE" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aF" = (/obj/effect/decal/cleanable/cobweb{icon_state = "cobweb2"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aG" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aH" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aI" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aJ" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/obj/item/weapon/bikehorn,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aK" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aL" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/effect/decal/cleanable/pie_smudge,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aM" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/closed/wall/r_wall{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aN" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aO" = (/obj/structure/disposalpipe/segment,/turf/open/floor/plating,/area/ruin/powered)
+"aP" = (/obj/item/weapon/bikehorn,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aQ" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aR" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aS" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/open/floor/plating,/area/ruin/powered)
+"aT" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aU" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aV" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aW" = (/obj/structure/disposalpipe/segment,/obj/item/weapon/bikehorn,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aX" = (/obj/structure/disposalpipe/trunk{dir = 4},/obj/structure/disposaloutlet{dir = 8},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"aY" = (/obj/structure/disposalpipe/segment,/obj/item/weapon/bikehorn,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"aZ" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"ba" = (/obj/effect/decal/cleanable/pie_smudge,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bb" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bc" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bd" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/table,/obj/item/weapon/paper/crumpled/bloody{info = "If you dare not continue down this path of madness, escape can be found through the chute in this room. "},/obj/item/weapon/pen/fourcolor,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"be" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/structure/table,/obj/item/device/flashlight/lamp/bananalamp,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bf" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/obj/effect/decal/cleanable/pie_smudge,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bg" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/weapon/pickaxe,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bh" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bi" = (/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bj" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/light{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bk" = (/obj/structure/disposalpipe/segment,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bl" = (/turf/open/floor/light{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bm" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bn" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bo" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"bp" = (/turf/closed/mineral/clown,/area/ruin/powered)
+"bq" = (/obj/item/weapon/pickaxe,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"br" = (/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bs" = (/obj/structure/disposalpipe/segment{dir = 4; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bt" = (/obj/structure/disposalpipe/segment{dir = 1; icon_state = "pipe-c"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bu" = (/obj/item/weapon/bikehorn,/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bv" = (/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bw" = (/obj/machinery/light{dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"bx" = (/turf/open/chasm/straight_down/lava_land_surface,/area/ruin/powered)
+"by" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bz" = (/obj/machinery/disposal/deliveryChute{dir = 1},/obj/structure/disposalpipe/trunk,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
+"bA" = (/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bB" = (/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bC" = (/obj/structure/disposalpipe/junction{icon_state = "pipe-y"; dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bD" = (/obj/structure/mecha_wreckage/honker,/obj/structure/disposalpipe/segment{dir = 4},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bE" = (/obj/effect/decal/cleanable/oil,/obj/structure/disposalpipe/segment{dir = 2; icon_state = "pipe-c"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bF" = (/obj/effect/decal/cleanable/cobweb{icon_state = "cobweb2"},/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bG" = (/obj/item/weapon/grown/bananapeel{color = "#2F3000"; name = "stealth banana peel"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
+"bH" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bI" = (/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plasteel/darkyellow{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bJ" = (/obj/structure/disposalpipe/segment{dir = 8; icon_state = "pipe-c"},/turf/open/floor/plasteel/darkred{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bK" = (/obj/item/weapon/reagent_containers/food/drinks/trophy/gold_cup,/obj/structure/table/glass,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bL" = (/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bM" = (/obj/machinery/disposal/deliveryChute,/obj/structure/disposalpipe/trunk{dir = 1},/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bN" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bO" = (/obj/structure/statue/bananium/clown,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bP" = (/obj/structure/table/glass,/obj/item/weapon/grown/bananapeel/bluespace,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bQ" = (/obj/structure/table/glass,/obj/item/clothing/shoes/clown_shoes/banana_shoes,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bR" = (/obj/item/weapon/coin/clown,/obj/item/weapon/coin/clown,/obj/item/weapon/coin/clown,/obj/item/weapon/coin/clown,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bS" = (/obj/item/slime_extract/rainbow,/obj/structure/table/glass,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bT" = (/obj/item/weapon/bikehorn/airhorn,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bU" = (/obj/structure/table/glass,/obj/item/weapon/gun/magic/staff/honk,/turf/open/floor/carpet{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered)
+"bV" = (/obj/item/weapon/bikehorn,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bW" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/ruin/powered)
+"bX" = (/obj/effect/mob_spawn/human/corpse/damaged,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bY" = (/obj/machinery/door/airlock/clown,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"bZ" = (/obj/item/weapon/bikehorn,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/bananium{baseturf = /turf/open/floor/plating/lava/smooth; wet = 2},/area/ruin/powered)
+"ca" = (/obj/machinery/light{dir = 1},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/powered)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bccccccccccccccccccccccccccccb
-bcddddddddddddddddddddddddddcb
-bcdefeeeeeeegggggggggggggggdcb
-bcdeeheieefeeggggggggggjgjgdcb
-bcdeeeeeheeeeekkggggjllllmgdcb
-bcdeeeeeieeeeeeeggggglllllgdcb
-bcdeeheeeeheeieeeeggglnjgggdcb
-bcdeheeoeeeeeeeeoellllgggjgdcb
-bcdeeeeeheeieheeeelmllgggggdcb
-bcdeeheeeeeeeeeeeggggggggggdcb
-bcdeeeeeeeheeeeheggggggggggdcb
-bcdeeeeeeeeefeeeegggggeegggdcb
-bcdeeeeheeeeeeheegggggefeeedcb
-pcqrrrsrrreeeeeeeeeeeeeeeeidcb
-bcdeeeeeereeeheeeeeefeeheehdcb
-bcdeeheeerefeeeoeeeeeeeeeeedcb
-bcdeeeeeereeeeehettttteeoeedcb
-bcdefeheereheeeeetuvwteeeeedcb
-bcdeeeeeireeeeeeetrrxteiehedcb
-bcdeheeeerrrrrsrryrrxteeeeedcb
-bcdeeeoeheeeeeeeetxzxteheeedcb
-bcdeieeeeABCDBefetxxEteeefedcb
-bcdeeeheeBAFGHheetttttieeeedcb
-bcdefeeeeeeheeeeeeeeeeeheeedcb
-bcdeeeeeeeeeeeeoeeeeheeeeehdcb
-bcddddddddddddddddddddddddddcb
-bccccccccccccccccccccccccccccb
-bbbbbIbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaaaaaaaaaaaaaaaaaaababacacacababaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaadaeadadafacagacacadadaeadaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaahahahahahahahahaiacajahahahahahahahahahaaaaaaaaaaaa
+aaaaaaaaahahahakakakakakakahalahalahakakakakakakakahahaaaaaaaaaa
+aaaaaaahahakakakamanaoapahakalakalakakahahaqahahakakahahaaaaaaaa
+aaaaahahakakamaparasalatauanavaoawahahahahaxahahahahakahahaaaaaa
+aaaaahakakahayatatatatatararatatazaAaAaBaBaCaDaEaFahakakahaaaaaa
+aaahahakamaGaCaHaIaHaIaJaCaralaKaBaAaAaBaLaMaBaBaBaNahakahahaaaa
+aaahakakaOauaAaAaBaMaAaAaNatatauaBaAaPaBaMaQaBaMaBaCaRakakahaaaa
+aaahakaSaTatamaMaBaAaAanayataraHaMaBaBaAaAaAaPaBaBaNahaUakahaaaa
+aaahakaKaVaWataXaMaMaMaCataYalauaBaBaBaBaMaMaZaMaNatbaaUakahaaaa
+aaahakaoaIataKaMbbbbbbaMaCatayarbcaBaMaMbdbebbaMaCataDaUakahaaaa
+aaahakaKbfaHaMbbbbbbbgbbaMaIatatataDahbhbbbbbibhaMaTaRahakahaaaa
+aaahahakaKaMaMbbbbbjbjbbaMaBaIavaHaNahbkblblbmbnahahahakahahaaaa
+aaboahahakakahbpbqblblbrbsaVaEbtbuaHbvbnblblbrbpahakakahahbwaaaa
+ababbxahahahbyahbpbrbpahalazaBaNatbaahahbpbzbpahbAahahahbxababaa
+abbxbxbxahbBbAbAahbAahahaKaAaNaHbCaMbDbEahalahbAbAbFahbxbxabbxaa
+ababbGbxahbHbBbAahbAbAbAahahaHaVaEbIahaKbvbJbAbAbBbBahbxbGababaa
+ababbxbxahbBbHbBbAbAbAbBahahahalahahbBbBbAahbAbBbBbBahbxbxababaa
+abbxbxahahahbHahbBbBbBbBahbKbLbMbLbKahbBbBbBbBbBbBahahahbxbxabaa
+aaboahahbNbBbBahbBahbBahbObLbPbLbQbLbOahbBbBbBbBbHbBbBahahbwaaaa
+aaahahakbBbHbHbHbHbBahahbRbLbSbTbUbLbRahahbHbHbBbVbBbBakahahaaaa
+aaahakakbWbXbBahbBbBbBbBahbLbLbLbLbLahbXbBbHbHbBbBahbBakakahaaaa
+aaahakbWakbBbBbBbBbHbBbBbBahahbYahahbBbBbHbHbBahbBbBakaRakahaaaa
+aaahakaRakbWbBbBbZbHbBahbBbBahbBbBbBbBbBbBbBbBbBbBbBakbWakahaaaa
+aaahahakakakahbBbHbBbBbBbHbHbHbHbBbBbHbHbBbVahbBahakakakahahaaaa
+aaaaahakakbWakbWbBbBbHbHbZbHbBbBbBbBbHbBbBbBahakakaRakakahaaaaaa
+aaaaahahakakaRakahakakakbBbBbBahbBbBbBakakahakaRbWakakahahaaaaaa
+aaaaaaahahakakakakbWbWaRakakakakakakakbWbWbWaRakakakahahaaaaaaaa
+aaaaaaaaahahahakakakakbWbWbWbWbWbWbWbWaRakakakakahahahaaaaaaaaaa
+aaaaaaaaaacaahahahahakakakakakakakakakakakahahahahcaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaahahahahahahahahahahahahahaaaaaaaaaaaaaaaaaaaa
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -1,141 +1,1465 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"ac" = (/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"ad" = (/obj/structure/flora/ausbushes/brflowers,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"ae" = (/turf/closed/wall/shuttle/smooth{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"af" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ag" = (/turf/open/floor/plasteel/bar{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ah" = (/obj/structure/toilet,/turf/open/floor/plasteel/bar{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ai" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aj" = (/obj/structure/table/wood,/obj/item/device/flashlight/lamp,/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ak" = (/obj/structure/table/wood,/obj/item/device/taperecorder,/obj/item/weapon/pen/blue,/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"al" = (/obj/structure/table/wood,/obj/item/toy/carpplushie,/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"am" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"an" = (/obj/machinery/sleeper{icon_state = "sleeper-open";dir = 4},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ao" = (/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ap" = (/obj/structure/table,/obj/item/weapon/circular_saw,/obj/item/weapon/scalpel{pixel_y = 12},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aq" = (/obj/structure/table,/obj/item/weapon/cautery{pixel_x = 4},/obj/item/weapon/surgicaldrill,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ar" = (/obj/structure/table,/obj/item/weapon/surgical_drapes,/obj/item/weapon/razor,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"as" = (/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"at" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"au" = (/obj/structure/chair/office/dark{dir = 4},/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"av" = (/obj/item/weapon/reagent_containers/glass/rag,/obj/item/weapon/reagent_containers/spray/cleaner,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"aw" = (/obj/structure/bed/roller,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ax" = (/obj/structure/closet/crate/trashcart,/obj/item/weapon/storage/bag/trash,/obj/item/trash/cheesie,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/bodybag,/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"ay" = (/obj/structure/sink{icon_state = "sink";dir = 8;pixel_x = -12;pixel_y = 2},/obj/structure/mirror{pixel_x = -28},/turf/open/floor/plasteel/bar{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"az" = (/obj/structure/noticeboard{dir = 1;pixel_y = -27},/obj/item/weapon/paper{info = "Nothing of interest to report.";name = "Important Notice - Mrs. Henderson"},/turf/open/floor/plasteel/cmo{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aA" = (/obj/structure/closet/secure_closet/medical2,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aB" = (/obj/machinery/computer/operating,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aC" = (/obj/structure/table/optable,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aD" = (/obj/structure/table,/obj/item/weapon/retractor,/obj/item/weapon/hemostat,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aE" = (/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aF" = (/obj/machinery/door/unpowered/shuttle,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aG" = (/obj/structure/extinguisher_cabinet,/turf/closed/wall/shuttle/smooth{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aH" = (/obj/structure/extinguisher_cabinet,/turf/closed/wall/shuttle/smooth/nodiagonal{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aI" = (/turf/closed/wall/shuttle/smooth,/area/ruin/powered)
-"aJ" = (/turf/open/floor/plasteel/grimy{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"aK" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aL" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"aM" = (/obj/effect/mob_spawn/human/doctor/alive{flavour_text = "You were putting in your hours as a vet in the local animal hospital when a massive bluespace translocation shunted you across the galaxy. Can you survive on this desolate wasteland..?";id_job = "Veterinarian"},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"aN" = (/obj/structure/closet/crate/freezer,/obj/item/weapon/reagent_containers/blood/random,/obj/item/weapon/reagent_containers/blood/random,/obj/item/weapon/reagent_containers/blood/random,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"aO" = (/obj/machinery/iv_drip,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"aP" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 0;icon_state = "blue"},/area/ruin/powered)
-"aQ" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "bluecorner"},/area/ruin/powered)
-"aR" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 4;icon_state = "blue"},/area/ruin/powered)
-"aS" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"aT" = (/obj/structure/closet,/obj/effect/decal/cleanable/cobweb,/obj/item/ammo_casing/shotgun/dart,/obj/item/ammo_casing/shotgun/dart,/obj/item/weapon/gun/projectile/revolver/doublebarrel{desc = "For putting critters out to pasture."},/obj/item/ammo_casing/shotgun/buckshot,/obj/item/weapon/storage/box/bodybags,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aU" = (/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aV" = (/obj/structure/closet/secure_closet/medical1,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aW" = (/obj/machinery/vending/wallmed{pixel_y = 28},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aX" = (/obj/item/stack/cable_coil/random,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aY" = (/obj/structure/bodycontainer/morgue,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"aZ" = (/obj/effect/decal/cleanable/ash,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"ba" = (/obj/structure/table/glass,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/storage/backpack/dufflebag/med,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bb" = (/obj/structure/table/reinforced,/obj/item/device/laser_pointer,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bc" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/firstaid/regular,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bd" = (/obj/structure/table/glass,/obj/item/weapon/storage/box/gloves,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"be" = (/obj/effect/decal/cleanable/oil,/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bf" = (/obj/structure/table,/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,/obj/item/weapon/storage/box/matches,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bg" = (/mob/living/simple_animal/cockroach,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bh" = (/obj/structure/table/glass,/obj/item/weapon/storage/firstaid/brute,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bi" = (/obj/item/toy/cattoy,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bj" = (/obj/structure/table/glass,/obj/item/weapon/lazarus_injector,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bk" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bl" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/obj/item/weapon/reagent_containers/food/snacks/cookie{name = "doggie biscuit"},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"bm" = (/obj/structure/chair/comfy/teal{dir = 8},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"bn" = (/obj/structure/bed/dogbed,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bo" = (/obj/item/weapon/reagent_containers/glass/bowl,/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bp" = (/obj/structure/closet/crate/bin,/obj/item/trash/pistachios,/obj/item/weapon/lipstick/random,/obj/item/seeds/apple,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"bq" = (/obj/structure/filingcabinet/chestdrawer/wheeled,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"br" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bs" = (/obj/structure/table/reinforced,/obj/item/weapon/phone,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bt" = (/obj/structure/flora/kirbyplants,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bu" = (/obj/structure/chair/comfy/teal{dir = 8},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 4;icon_state = "blue"},/area/ruin/powered)
-"bv" = (/obj/effect/mob_spawn/mouse{dir = 4;flavour_text = "You're a mousey! You're getting pretty old as mice go, and you haven't been feeling well as of late. Your master loves you a lot so he took you to this place so you can get better! You can't wait to see him again!";mob_name = "Stallman Jr."},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bw" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bx" = (/obj/machinery/door/airlock/medical{name = "Patient Room";req_access_txt = "5"},/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"by" = (/obj/structure/table/reinforced,/obj/item/device/flashlight/lamp,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"bz" = (/obj/structure/table/reinforced,/obj/item/clothing/glasses/regular,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bA" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen/fourcolor,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bB" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/hug,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bC" = (/obj/structure/chair/office/light{dir = 1},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bD" = (/obj/structure/table/glass,/obj/item/weapon/reagent_containers/glass/bottle/cyanide{desc = "A cocktail of chemotherpy drugs intended to treat bladder cancer.";name = "MVAC regimen"},/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bE" = (/obj/structure/closet/crate/critter,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"bF" = (/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 10;icon_state = "blue"},/area/ruin/powered)
-"bG" = (/obj/structure/chair/comfy/teal{dir = 8},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 6;icon_state = "blue"},/area/ruin/powered)
-"bH" = (/obj/structure/table,/obj/item/weapon/tank/internals/oxygen,/obj/item/weapon/tank/internals/oxygen,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 8;icon_state = "blue"},/area/ruin/powered)
-"bI" = (/obj/structure/sign/bluecross_2{name = "animal hospital"},/turf/closed/wall/shuttle/smooth{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bJ" = (/obj/machinery/door/airlock/glass_large,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bK" = (/obj/item/weapon/reagent_containers/glass/bowl,/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bL" = (/obj/vehicle/scooter/skateboard{dir = 4},/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bM" = (/obj/structure/flora/ausbushes/sunnybush,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bN" = (/obj/effect/mob_spawn/cow{dir = 4;flavour_text = "You're a cow. You've lived a pampered life as a prized show heifer, a real blue-ribbon winner. After showing signs of a minor respiratory infection, your master took you to the hospital right away. He'd better come back soon, you're getting quite impatient.";mob_name = "Flossie"},/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bO" = (/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bP" = (/obj/structure/chair/office/light{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bQ" = (/obj/structure/table/glass,/obj/item/clothing/tie/petcollar,/obj/item/weapon/pen/blue,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"bR" = (/obj/structure/table,/obj/machinery/cell_charger,/obj/item/weapon/melee/baton/cattleprod,/obj/item/weapon/stock_parts/cell/high,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 10;icon_state = "blue"},/area/ruin/powered)
-"bS" = (/obj/structure/closet,/obj/item/weapon/defibrillator/loaded,/obj/item/weapon/storage/belt/medical,/obj/item/clothing/glasses/hud/health,/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 6;icon_state = "blue"},/area/ruin/powered)
-"bT" = (/obj/item/weapon/pickaxe,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"bU" = (/obj/effect/decal/remains/human,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"bV" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"bW" = (/turf/open/floor/grass,/area/lavaland/surface/outdoors)
-"cf" = (/obj/machinery/sleeper{icon_state = "sleeper-open";dir = 4},/turf/open/floor/plasteel{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;dir = 1;icon_state = "blue"},/area/ruin/powered)
-"ce" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible{dir = 1},/obj/machinery/portable_atmospherics/pump,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"cd" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/mask/surgical,/obj/item/clothing/suit/apron/surgical,/turf/open/floor/plasteel/white{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/space)
-"cc" = (/obj/machinery/atmospherics/pipe/simple/general/visible,/turf/closed/wall/shuttle/smooth{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/ruin/powered)
-"cb" = (/obj/machinery/atmospherics/components/binary/valve,/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"ca" = (/obj/machinery/atmospherics/components/unary/tank/air{dir = 4},/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bZ" = (/obj/machinery/atmospherics/pipe/simple/general/visible{dir = 10},/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bY" = (/obj/machinery/atmospherics/pipe/manifold/general/visible{dir = 1},/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
-"bX" = (/obj/machinery/atmospherics/pipe/simple/general/visible{dir = 6},/turf/open/floor/grass{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface},/area/lavaland/surface/outdoors)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ac" = (
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"ad" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"ae" = (
+/turf/closed/wall/shuttle/smooth{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"af" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ag" = (
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ah" = (
+/obj/structure/toilet,
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ai" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aj" = (
+/obj/structure/table/wood,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ak" = (
+/obj/structure/table/wood,
+/obj/item/device/taperecorder,
+/obj/item/weapon/pen/blue,
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"al" = (
+/obj/structure/table/wood,
+/obj/item/toy/carpplushie,
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"am" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"an" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper-open";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ao" = (
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ap" = (
+/obj/structure/table,
+/obj/item/weapon/circular_saw,
+/obj/item/weapon/scalpel{
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aq" = (
+/obj/structure/table,
+/obj/item/weapon/cautery{
+	pixel_x = 4
+	},
+/obj/item/weapon/surgicaldrill,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ar" = (
+/obj/structure/table,
+/obj/item/weapon/surgical_drapes,
+/obj/item/weapon/razor,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"as" = (
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"at" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"au" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"av" = (
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aw" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ax" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/trash/cheesie,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/bodybag,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"ay" = (
+/obj/structure/sink{
+	icon_state = "sink";
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/bar{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"az" = (
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -27
+	},
+/obj/item/weapon/paper{
+	info = "Nothing of interest to report.";
+	name = "Important Notice - Mrs. Henderson"
+	},
+/turf/open/floor/plasteel/cmo{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aA" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aB" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aC" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aD" = (
+/obj/structure/table,
+/obj/item/weapon/retractor,
+/obj/item/weapon/hemostat,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aE" = (
+/turf/closed/wall/shuttle/smooth/nodiagonal{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aF" = (
+/obj/machinery/door/unpowered/shuttle,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aG" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/shuttle/smooth{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aH" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/shuttle/smooth/nodiagonal{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aI" = (
+/turf/closed/wall/shuttle/smooth,
+/area/ruin/powered)
+"aJ" = (
+/turf/open/floor/plasteel/grimy{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"aK" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aL" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aM" = (
+/obj/effect/mob_spawn/human/doctor/alive{
+	flavour_text = "You were putting in your hours as a vet in the local animal hospital when a massive bluespace translocation shunted you across the galaxy. Can you survive on this desolate wasteland..?";
+	id_job = "Veterinarian"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aN" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/obj/item/weapon/reagent_containers/blood/random,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aO" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aP" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 0;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aQ" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/ruin/powered)
+"aR" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aS" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"aT" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/ammo_casing/shotgun/dart,
+/obj/item/ammo_casing/shotgun/dart,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel{
+	desc = "For putting critters out to pasture."
+	},
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/item/weapon/storage/box/bodybags,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aU" = (
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aV" = (
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aW" = (
+/obj/machinery/vending/wallmed{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aX" = (
+/obj/item/stack/cable_coil/random,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aY" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"aZ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ba" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/storage/backpack/dufflebag/med,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bb" = (
+/obj/structure/table/reinforced,
+/obj/item/device/laser_pointer,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bc" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bd" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/gloves,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"be" = (
+/obj/effect/decal/cleanable/oil,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bf" = (
+/obj/structure/table,
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,
+/obj/item/weapon/storage/box/matches,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bg" = (
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bh" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/firstaid/brute,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bi" = (
+/obj/item/toy/cattoy,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bj" = (
+/obj/structure/table/glass,
+/obj/item/weapon/lazarus_injector,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bk" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bl" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/cookie{
+	name = "doggie biscuit"
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bm" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bn" = (
+/obj/structure/bed/dogbed,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bo" = (
+/obj/item/weapon/reagent_containers/glass/bowl,
+/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
+/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bp" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/pistachios,
+/obj/item/weapon/lipstick/random,
+/obj/item/seeds/apple,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bq" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"br" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bs" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/phone,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bt" = (
+/obj/structure/flora/kirbyplants,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bu" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bv" = (
+/obj/effect/mob_spawn/mouse{
+	dir = 4;
+	flavour_text = "You're a mousey! You're getting pretty old as mice go, and you haven't been feeling well as of late. Your master loves you a lot so he took you to this place so you can get better! You can't wait to see him again!";
+	mob_name = "Stallman Jr."
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bx" = (
+/obj/machinery/door/airlock/medical{
+	name = "Patient Room";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"by" = (
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bz" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bA" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/fourcolor,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bB" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/hug,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bC" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bD" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/bottle/cyanide{
+	desc = "A cocktail of chemotherpy drugs intended to treat bladder cancer.";
+	name = "MVAC regimen"
+	},
+/obj/item/weapon/reagent_containers/syringe,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bE" = (
+/obj/structure/closet/crate/critter,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bF" = (
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 10;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bG" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 6;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bH" = (
+/obj/structure/table,
+/obj/item/weapon/tank/internals/oxygen,
+/obj/item/weapon/tank/internals/oxygen,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bI" = (
+/obj/structure/sign/bluecross_2{
+	name = "animal hospital"
+	},
+/turf/closed/wall/shuttle/smooth{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bJ" = (
+/obj/machinery/door/airlock/glass_large,
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bK" = (
+/obj/item/weapon/reagent_containers/glass/bowl,
+/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
+/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
+/obj/item/weapon/reagent_containers/food/snacks/grown/wheat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bL" = (
+/obj/vehicle/scooter/skateboard{
+	dir = 4
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"bM" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"bN" = (
+/obj/effect/mob_spawn/cow{
+	dir = 4;
+	flavour_text = "You're a cow. You've lived a pampered life as a prized show heifer, a real blue-ribbon winner. After showing signs of a minor respiratory infection, your master took you to the hospital right away. He'd better come back soon, you're getting quite impatient.";
+	mob_name = "Flossie"
+	},
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"bP" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bQ" = (
+/obj/structure/table/glass,
+/obj/item/clothing/tie/petcollar,
+/obj/item/weapon/pen/blue,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"bR" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weapon/melee/baton/cattleprod,
+/obj/item/weapon/stock_parts/cell/high,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 10;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bS" = (
+/obj/structure/closet,
+/obj/item/weapon/defibrillator/loaded,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 6;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
+"bT" = (
+/obj/item/weapon/pickaxe,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bU" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bV" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"bW" = (
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors)
+"bX" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"bY" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"bZ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"ca" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"cb" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors)
+"cc" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/shuttle/smooth{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"cd" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/surgical,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ce" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"cf" = (
+/obj/machinery/sleeper{
+	icon_state = "sleeper-open";
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface;
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/ruin/powered)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaa
-aaaaaaaaaaaaababababacacabacabababaaaaaaaa
-aaaaaaaaaaaaababacabacacacbXbYbZabababaaaa
-aaaaaaaaaaababacacacacadaccacacbacacababaa
-aaaaaaaaaeaeaeaeaeafafafaeaeaeccaeaeaeaeaa
-aaaaababaeagahaeaiajakalamaecdceapaqaraeaa
-aaaaababaeagagaeasatasauasaeanaoaoaoawaeaa
-aaababaxaeayagaeasasazasasaeaAaoaBaCaDaeaa
-abababacaEaeaFaGaFaeaeaeaFaHaeaFaIaIaIaeaa
-ababaJaJaFaKaKaLaKaMaMaMaKaLcfaKaLaNaOaeaa
-abababacaeaKaKaPaPaKaPaKaPaPaPaKaPaQaRaeaa
-aaababaeaEaFaEaeaeaFaeaFaeaeaEaFaeaSaRaeaa
-ababacaeaTaUaeaVaWaoaeaoaWaVaeaXaeaSaRaeaa
-aaababaeaYaZaebaaobbaebcaobdaebeaeaSaRaeaa
-aaaaaaaebfbgaebhbiaoaeaoaobjaebkaeaSaRaeaa
-aaaaaaaeaEaFaEaGaeaFaeaFaeaeaeaeaEaSaRaeaa
-aaaaaaaaaeaKaLaLaLaKblaKbmaebnboafavaRaeaa
-aaaaaaaaaebpbqbrbsaKbtaKbuaebvbwbxaKaRaeaa
-aaaaaaaaaebybzbAbBaKaKaKbuaebCbDaebEaRaeaa
-aaaaaaaaaebFaPaPaPaKaKaPbGaeaeaeaEbHaRaeaa
-aaaaaaabaeaeafafbIbJaUaeaeaebnbKafaSaRaeaa
-aaaaababacacadbLbMaJaJbMacaebNaobxaKaRaeaa
-aaaaabababacacacacaJaJacbOaebPbQaebRbSaeaa
-aaababbTababacacabaJabacacaeaeaeaeaeaeaeaa
-aaabbUababababacababababababababaaaaaaaaaa
-aaabbVabababababababbWababababaaaaaaaaaaaa
-aaaaababababbWababababababaaaaaaaaaaaaaaaa
-aaaaaaaaababababaaabababaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+aJ
+ab
+ab
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+bU
+bV
+ab
+ab
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ax
+ac
+aJ
+ac
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+bT
+ab
+ab
+ab
+ab
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+aa
+ae
+ae
+ae
+ae
+aE
+aF
+ae
+aE
+aT
+aY
+bf
+aE
+ae
+ae
+ae
+ae
+ae
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+ab
+ae
+ag
+ag
+ay
+ae
+aK
+aK
+aF
+aU
+aZ
+bg
+aF
+aK
+bp
+by
+bF
+ae
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(7,1,1) = {"
+aa
+ab
+ab
+ab
+ae
+ah
+ag
+ag
+aF
+aK
+aK
+aE
+ae
+ae
+ae
+aE
+aL
+bq
+bz
+aP
+af
+ad
+ac
+ac
+ab
+ab
+bW
+bW
+"}
+(8,1,1) = {"
+aa
+ab
+ab
+ac
+ae
+ae
+ae
+ae
+aG
+aL
+aP
+ae
+aV
+ba
+bh
+aG
+aL
+br
+bA
+aP
+af
+bL
+ac
+ac
+ac
+ab
+ab
+ab
+"}
+(9,1,1) = {"
+ab
+ab
+ac
+ac
+ae
+ai
+as
+as
+aF
+aK
+aP
+ae
+aW
+ao
+bi
+ae
+aL
+bs
+bB
+aP
+bI
+bM
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(10,1,1) = {"
+ab
+ab
+ab
+ac
+af
+aj
+at
+as
+ae
+aM
+aK
+aF
+ao
+bb
+ao
+aF
+aK
+aK
+aK
+aK
+bJ
+aJ
+aJ
+aJ
+ab
+ab
+ab
+ab
+"}
+(11,1,1) = {"
+ab
+ac
+ac
+ac
+af
+ak
+as
+az
+ae
+aM
+aP
+ae
+ae
+ae
+ae
+ae
+bl
+bt
+aK
+aK
+aU
+aJ
+aJ
+ab
+ab
+bW
+ab
+ab
+"}
+(12,1,1) = {"
+ab
+ac
+ac
+ad
+af
+al
+au
+as
+ae
+aM
+aK
+aF
+ao
+bc
+ao
+aF
+aK
+aK
+aK
+aP
+ae
+bM
+ac
+ac
+ab
+ab
+ab
+ab
+"}
+(13,1,1) = {"
+ab
+ab
+ac
+ac
+ae
+am
+as
+as
+aF
+aK
+aP
+ae
+aW
+ao
+ao
+ae
+bm
+bu
+bu
+bG
+ae
+ac
+bO
+ac
+ab
+ab
+ab
+ab
+"}
+(14,1,1) = {"
+ab
+ac
+bX
+ca
+ae
+ae
+ae
+ae
+aH
+aL
+aP
+ae
+aV
+bd
+bj
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ab
+ab
+aa
+aa
+"}
+(15,1,1) = {"
+ab
+ab
+bY
+ca
+ae
+cd
+an
+aA
+ae
+aL
+aP
+aE
+ae
+ae
+ae
+ae
+bn
+bv
+bC
+ae
+bn
+bN
+bP
+ae
+ab
+ab
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+ab
+bZ
+cb
+cc
+ce
+ao
+ao
+aF
+aK
+aK
+aF
+aX
+be
+bk
+ae
+bo
+bw
+bD
+ae
+bK
+ao
+bQ
+ae
+ab
+aa
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+ab
+ab
+ac
+ae
+ap
+ao
+aB
+aI
+aL
+aP
+ae
+ae
+ae
+ae
+aE
+af
+bx
+ae
+aE
+af
+bx
+ae
+ae
+aa
+aa
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+ab
+ac
+ae
+aq
+ao
+aC
+aI
+aN
+aQ
+aS
+aS
+aS
+aS
+aS
+av
+aK
+bE
+bH
+aS
+aK
+bR
+ae
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+ab
+ab
+ae
+ar
+aw
+aD
+aI
+aO
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+aR
+bS
+ae
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+aa
+ab
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -23,3 +23,16 @@
 	icon = 'icons/obj/chempuff.dmi'
 	pass_flags = PASSTABLE | PASSGRILLE
 	layer = 5
+
+/obj/effect/decal/sandeffect
+	name = "sandy tile"
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "sandeffect"
+	layer = 2
+
+/obj/effect/decal/fakelattice
+	name = "lattice"
+	desc = "A lightweight support lattice."
+	icon = 'icons/obj/smooth_structures/lattice.dmi'
+	icon_state = "lattice"
+	density = 1


### PR DESCRIPTION
Tweaks:
-Removes an errant sleeper from the animal hospital
-Fixes invisible walls/weirdness with sandeffect turfs (replaces with sand effect decals), adds breath masks.
-Converts both to TGM format.

And the big one: Completely remodels clown ruin. I won't ruin the surprise. Welcome to clown planet.
