### PR TITLE
Makes drakes more hugbox

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -12,6 +12,7 @@
 	icon = 'icons/mob/lavaland/dragon.dmi'
 	faction = list("mining")
 	speak_emote = list("roars")
+	luminosity = 3
 	armour_penetration = 40
 	melee_damage_lower = 40
 	melee_damage_upper = 40
@@ -44,11 +45,11 @@
 		..()
 		if(isliving(target))
 			var/mob/living/L = target
-			if(L.stat)
+			if(L.stat == DEAD)
 				L.gib()
 				visible_message("<span class='danger'>[src] devours [L]!</span>")
 				src << "<span class='userdanger'>You feast on [L], restoring your health!</span>"
-				L.adjustBruteLoss(-L.maxHealth)
+				adjustBruteLoss(-L.maxHealth)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/Process_Spacemove(movement_dir = 0)
 	return 1
@@ -59,7 +60,8 @@
 	name = "fireball"
 	desc = "Get out of the way!"
 	layer = 6
-	dir = SOUTH
+	randomdir = 0
+	duration = 10
 	pixel_z = 500
 
 /obj/effect/overlay/temp/target
@@ -67,8 +69,9 @@
 	icon_state = "sniper_zoom"
 	layer = MOB_LAYER - 0.1
 	luminosity = 2
+	duration = 10
 
-/obj/effect/temp/dragon_swoop
+/obj/effect/overlay/temp/dragon_swoop
 	name = "certain death"
 	desc = "Don't just stand there, move!"
 	icon = 'icons/effects/96x96.dmi'
@@ -77,6 +80,7 @@
 	pixel_x = -32
 	pixel_y = -32
 	color = "#FF0000"
+	duration = 10
 
 /obj/effect/overlay/temp/target/ex_act()
 	return
@@ -169,10 +173,9 @@
 	else
 		tturf = get_turf(src)
 	src.loc = tturf
-	var/obj/effect/temp/dragon_swoop/D = new(tturf)
+	var/obj/effect/overlay/temp/dragon_swoop/D = new(tturf)
 	animate(src, pixel_x = 0, pixel_z = 0, time = 10)
 	sleep(10)
-	qdel(D)
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1)
 	for(var/mob/living/L in range(1,tturf))
 		if(L == src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -173,7 +173,6 @@
 	else
 		tturf = get_turf(src)
 	src.loc = tturf
-	var/obj/effect/overlay/temp/dragon_swoop/D = new(tturf)
 	animate(src, pixel_x = 0, pixel_z = 0, time = 10)
 	sleep(10)
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -1,8 +1,8 @@
 /mob/living/simple_animal/hostile/megafauna/dragon
 	name = "ash drake"
 	desc = "Guardians of the necropolis."
-	health = 2500
-	maxHealth = 2500
+	health = 2000
+	maxHealth = 2000
 	attacktext = "chomps"
 	attack_sound = 'sound/magic/demon_attack1.ogg'
 	icon_state = "dragon"
@@ -62,6 +62,17 @@
 	anchored = 1
 	luminosity = 2
 
+/obj/effect/temp/dragon_swoop
+	mouse_opacity = 0
+	name = "certain death"
+	desc = "Don't just stand there, move!"
+	icon = 'icons/effects/96x96.dmi'
+	icon_state = "rune_large"
+	layer = MOB_LAYER - 0.1
+	anchored = 1
+	pixel_x = -32
+	pixel_y = -32
+	color = "#FF0000"
 /obj/effect/overlay/temp/target/ex_act()
 	return
 
@@ -110,21 +121,21 @@
 		attack_dirs = list(NORTH,WEST,SOUTH,EAST)
 	playsound(get_turf(src),'sound/magic/Fireball.ogg', 200, 1)
 
-	spawn(0)
-		for(var/d in attack_dirs)
+	for(var/d in attack_dirs)
+		spawn(0)
 			var/turf/E = get_edge_target_turf(src, d)
 			var/range = 10
 			for(var/turf/open/J in getline(src,E))
 				if(!range)
 					break
 				range--
-
 				PoolOrNew(/obj/effect/hotspot,J)
 				J.hotspot_expose(700,50,1)
 				for(var/mob/living/L in J)
 					if(L != src)
 						L.adjustFireLoss(20)
 						L << "<span class='danger'>You're hit by the drake's fire breath!</span>"
+				sleep(1)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/swoop_attack(fire_rain = 0)
 	if(stat)
@@ -150,9 +161,11 @@
 	else
 		tturf = get_turf(src)
 	src.loc = tturf
+	var/obj/effect/temp/dragon_swoop/D = new(tturf)
 	animate(src, pixel_x = 0, pixel_z = 0, time = 10)
 	sleep(10)
-	playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1)
+	qdel(D)
+	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1)
 	for(var/mob/living/L in range(1,tturf))
 		if(L == src)
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -173,6 +173,7 @@
 	else
 		tturf = get_turf(src)
 	src.loc = tturf
+	new/obj/effect/overlay/temp/dragon_swoop(tturf)
 	animate(src, pixel_x = 0, pixel_z = 0, time = 10)
 	sleep(10)
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -53,17 +53,14 @@
 	layer = 6
 	dir = SOUTH
 	pixel_z = 500
-	anchored = 1
 
 /obj/effect/overlay/temp/target
 	icon = 'icons/mob/actions.dmi'
 	icon_state = "sniper_zoom"
 	layer = MOB_LAYER - 0.1
-	anchored = 1
 	luminosity = 2
 
 /obj/effect/temp/dragon_swoop
-	mouse_opacity = 0
 	name = "certain death"
 	desc = "Don't just stand there, move!"
 	icon = 'icons/effects/96x96.dmi'
@@ -73,6 +70,7 @@
 	pixel_x = -32
 	pixel_y = -32
 	color = "#FF0000"
+
 /obj/effect/overlay/temp/target/ex_act()
 	return
 
@@ -331,15 +329,11 @@
 
 /obj/structure/closet/crate/necropolis/dragon/New()
 	..()
-	var/loot = rand(1,4)
+	var/loot = rand(1,3)
 	switch(loot)
 		if(1)
-			for(var/i in 1 to 10)
-				new /obj/item/weapon/ore/diamond(src)
-				new /obj/item/weapon/ore/gold(src)
-		if(2)
 			new /obj/item/weapon/melee/ghost_sword(src)
-		if(3)
+		if(2)
 			new /obj/item/weapon/dragons_blood(src)
-		if(4)
+		if(3)
 			new /obj/item/weapon/lava_staff(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -74,7 +74,6 @@
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "rune_large"
 	layer = MOB_LAYER - 0.1
-	anchored = 1
 	pixel_x = -32
 	pixel_y = -32
 	color = "#FF0000"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -3,6 +3,7 @@
 	desc = "Attack the weak point for massive damage."
 	health = 1000
 	maxHealth = 1000
+	a_intent = "harm"
 	sentience_type = SENTIENCE_BOSS
 	environment_smash = 4
 	robust_searching = 1


### PR DESCRIPTION
The fire breathe now spreads instead of being instant

The swoop attack has a big indicator of where it's going to land

Player controlled drakes have more health, can eat bodies to restore health, and can alt+click targets to divebomb them. 

:cl:
rscadd: Drake attacks are now much easier to avoid.
rscadd: Player controlled drakes can now consume bodies to heal, and alt+click targets to divebomb them.
/:cl:
