### PR TITLE
ghosts can watch animals having SEX

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -8,6 +8,7 @@
 	speak_emote = list("barks", "woofs")
 	emote_hear = list("barks!", "woofs!", "yaps.","pants.")
 	emote_see = list("shakes its head.", "chases its tail.","shivers.")
+	faction = ("dog")
 	see_in_dark = 5
 	speak_chance = 1
 	turns_per_move = 10

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -8,7 +8,7 @@
 	speak_emote = list("barks", "woofs")
 	emote_hear = list("barks!", "woofs!", "yaps.","pants.")
 	emote_see = list("shakes its head.", "chases its tail.","shivers.")
-	faction = ("dog")
+	faction = list("dog")
 	see_in_dark = 5
 	speak_chance = 1
 	turns_per_move = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -851,6 +851,7 @@
 	speak_emote = list("warbles", "quavers")
 	emote_hear = list("trills.")
 	emote_see = list("sniffs.", "burps.")
+	faction = list("mining", "ashwalker")
 	density = 0
 	speak_chance = 1
 	turns_per_move = 8

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -28,12 +28,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/M = A
-			var/faction_check = 0
-			for(var/F in faction)
-				if(F in M.faction)
-					faction_check = 1
-					break
-			if(faction_check && attack_same || !faction_check)
+			if(faction_check(M) && attack_same || !faction_check(M))
 				enemies |= M
 		else if(istype(A, /obj/mecha))
 			var/obj/mecha/M = A
@@ -42,12 +37,7 @@
 				enemies |= M.occupant
 
 	for(var/mob/living/simple_animal/hostile/retaliate/H in around)
-		var/retaliate_faction_check = 0
-		for(var/F in faction)
-			if(F in H.faction)
-				retaliate_faction_check = 1
-				break
-		if(retaliate_faction_check && !attack_same && !H.attack_same)
+		if(faction_check(H) && !attack_same && !H.attack_same)
 			H.enemies |= enemies
 	return 0
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -471,16 +471,17 @@
 	var/mob/living/simple_animal/partner
 	var/children = 0
 	for(var/mob/M in view(7, src))
-		if(M.stat != CONSCIOUS) //Check if it's concious FIRSTER.
+		if(M.stat != CONSCIOUS) //Check if it's conscious FIRST.
 			continue
-		else if(istype(M, childtype)) //Check for children FIRST.
+		else if(istype(M, childtype)) //Check for children SECOND.
 			children++
 		else if(istype(M, animal_species))
 			if(M.ckey)
 				continue
 			else if(!istype(M, childtype) && M.gender == MALE) //Better safe than sorry ;_;
 				partner = M
-		else if(istype(M, /mob/living))
+
+		else if(istype(M, /mob/living) && !faction_check(M)) //shyness check. we're not shy in front of things that share a faction with us.
 			alone = 0
 			continue
 	if(alone && partner && children < 3)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -480,7 +480,7 @@
 				continue
 			else if(!istype(M, childtype) && M.gender == MALE) //Better safe than sorry ;_;
 				partner = M
-		else if(istype(M, /mob/))
+		else if(istype(M, /mob/living))
 			alone = 0
 			continue
 	if(alone && partner && children < 3)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -187,6 +187,7 @@
 	icon = 'icons/mob/nest.dmi'
 	icon_state = "ash_walker_nest"
 	icon_living = "ash_walker_nest"
+	faction = list("ashwalker")
 	health = 200
 	maxHealth = 200
 	loot = list(/obj/effect/gibspawner, /obj/item/device/assembly/signaler/anomaly)


### PR DESCRIPTION
People were having trouble breeding gutlunches, I assume it's because nothing can breed in the presence of ghosts and ashwalkers are a ghost role so people tend to observe near them.

actually it just occured to me that ashwalker tendrils are simple_mobs and that's the reason
damnit

well this is still good

EDIT: Mobs now ignore their own faction mobs for the purposes of alone checks.
Gives ash nests and gutlunches the "ashwalker" faction.
Cleaned up a couple loops.
