### PR TITLE
Fixes facehugger related equipping issue

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -122,8 +122,6 @@ var/const/MAX_ACTIVE_TIME = 400
 		return 0
 	if(M.getorgan(/obj/item/organ/body_egg/alien_embryo))
 		return 0
-	if(loc == M)
-		return 0
 	if(stat != CONSCIOUS)
 		return 0
 	if(!sterile) M.take_organ_damage(strength,0) //done here so that even borgs and humans in helmets take damage


### PR DESCRIPTION
If the facehugger is directly equipped to the mask slot (or Pun Pun
spawned and equipped) it will not infect or do anything.

This fixes that.
