### PR TITLE
Cream pie map edits

### DIFF
--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -33852,7 +33852,14 @@
 /area/crew_quarters/theatre)
 "boC" = (
 /obj/structure/table/wood,
-/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "boD" = (
@@ -78083,6 +78090,10 @@
 /area/hallway/primary/aft{
 	name = "Aft Port Hallway"
 	})
+"cSm" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 
 (1,1,1) = {"
 aaa
@@ -108287,7 +108298,7 @@ biH
 bjZ
 bkT
 bmM
-boC
+cSm
 bqO
 bte
 bmM

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -33996,8 +33996,8 @@
 	},
 /area/crew_quarters/kitchen)
 "bjL" = (
-/obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},
@@ -34014,8 +34014,15 @@
 	},
 /area/crew_quarters/theatre)
 "bjN" = (
-/obj/item/weapon/storage/crayons,
 /obj/structure/table/wood,
+/obj/item/weapon/storage/crayons{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},
@@ -61714,6 +61721,25 @@
 	},
 /turf/closed/indestructible/opshuttle,
 /area/shuttle/syndicate)
+"ckh" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/item/weapon/storage/crayons{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel{
+	icon_state = "redbluefull"
+	},
+/area/space)
 "cki" = (
 /turf/open/space,
 /obj/machinery/porta_turret/syndicate{
@@ -61722,17 +61748,6 @@
 /turf/closed/wall/shuttle{
 	dir = 1;
 	icon_state = "diagonalWall3"
-	},
-/area/shuttle/syndicate)
-"ckh" = (
-/turf/open/space,
-/obj/machinery/porta_turret/syndicate{
-	dir = 4
-	},
-/turf/closed/wall/shuttle{
-	tag = "icon-diagonalWall3 (WEST)";
-	icon_state = "diagonalWall3";
-	dir = 8
 	},
 /area/shuttle/syndicate)
 
@@ -95288,7 +95303,7 @@ bkQ
 bfv
 bvd
 bfv
-bfv
+ckh
 bqH
 bsy
 btK

--- a/_maps/map_files/MetaStation/MetaStation.v41I.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41I.dmm
@@ -50973,7 +50973,15 @@
 	pixel_x = 24
 	},
 /obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /obj/item/weapon/reagent_containers/food/snacks/pie/cream,
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bEj" = (

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -14640,7 +14640,14 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/obj/item/weapon/lipstick/random,
+/obj/item/weapon/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 4
@@ -15937,10 +15944,10 @@
 /turf/closed/wall,
 /area/crew_quarters/theatre)
 "aGw" = (
-/obj/structure/closet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},
@@ -16043,7 +16050,9 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/obj/item/weapon/lipstick/random,
+/obj/item/device/flashlight/lamp/bananalamp{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},
@@ -16645,7 +16654,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aHK" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},
@@ -16797,7 +16806,14 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/item/weapon/storage/crayons,
+/obj/item/weapon/storage/crayons{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/food/snacks/pie/cream{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel{
 	icon_state = "redbluefull"
 	},

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -351,6 +351,10 @@
 	icon_state = "duffle-clown"
 	item_state = "duffle-clown"
 
+/obj/item/weapon/storage/backpack/dufflebag/clown/cream_pie/New()
+	. = ..()
+	for(var/i in 1 to 10)
+		new /obj/item/weapon/reagent_containers/food/snacks/pie/cream(src)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie
 	name = "suspicious looking dufflebag"

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -69,5 +69,4 @@
 
 /obj/structure/closet/secure_closet/freezer/pie/New()
 	..()
-	for(var/i in 1 to 3)
-		new /obj/item/weapon/reagent_containers/food/snacks/pie/cream(src)
+	new /obj/item/weapon/reagent_containers/food/snacks/pie/cream(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -61,3 +61,13 @@
 		new /obj/item/stack/spacecash/c500(src)
 	for(var/i = 0, i < 6, i++)
 		new /obj/item/stack/spacecash/c200(src)
+
+/obj/structure/closet/secure_closet/freezer/cream_pie
+	name = "cream pie closet"
+	desc = "Contains pies filled with cream and/or custard, you sickos."
+	req_access = list(access_theatre)
+
+/obj/structure/closet/secure_closet/freezer/pie/New()
+	..()
+	for(var/i in 1 to 3)
+		new /obj/item/weapon/reagent_containers/food/snacks/pie/cream(src)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -829,6 +829,14 @@
 					/obj/item/pizzabox/vegetable)
 	crate_name = "pizza crate"
 
+/datum/supply_pack/organic/cream_piee
+	name = "High-yield Clown-grade Cream Pie Crate"
+	cost = 6000
+	contains = list(/obj/item/weapon/storage/backpack/dufflebag/clown/cream_pie)
+	crate_name = "party equipment crate"
+	contraband = TRUE
+	access = access_theatre
+
 /datum/supply_pack/organic/monkey
 	name = "Monkey Crate"
 	cost = 2000


### PR DESCRIPTION
:cl: coiax
rscadd: Added the cream pie closet to various maps. Added contraband Cream Pie Crate to Cargo.
/:cl:

Each closet contains one cream pie. At least it's better than the empty lockers the clown had before, and they're lockable. #stealthclownbuffs

![Box](https://cloud.githubusercontent.com/assets/609465/15101053/947d5a46-157d-11e6-868f-341e53394cde.png)
![Metastation](https://cloud.githubusercontent.com/assets/609465/15101058/e335a990-157d-11e6-97e9-962c5e8a0195.png)
![Efficiency](https://cloud.githubusercontent.com/assets/609465/15101063/051bc224-157e-11e6-9418-8ba4b7a62962.png)
![Dream](https://cloud.githubusercontent.com/assets/609465/15101069/358399aa-157e-11e6-8dd9-1565bbb1ded3.png)
