### PR TITLE
Employment contracts can once again be copied.

### DIFF
--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -23,7 +23,7 @@
 		qdel(src)
 		return -1
 	target = nOwner.mind
-	update_text(nOwner)
+	update_text()
 
 
 /obj/item/weapon/paper/contract/employment/update_text()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -67,7 +67,7 @@
 					var/copy_as_paper = 1
 					if(istype(copy, /obj/item/weapon/paper/contract/employment))
 						var/obj/item/weapon/paper/contract/employment/E = copy
-						var/obj/item/weapon/paper/contract/employment/C = new /obj/item/weapon/paper/contract/employment (loc, E.target)
+						var/obj/item/weapon/paper/contract/employment/C = new /obj/item/weapon/paper/contract/employment (loc, E.target.current)
 						if(C)
 							copy_as_paper = 0
 					if(copy_as_paper)


### PR DESCRIPTION
Fixes a runtime with copying employment contracts.
