### PR TITLE
Explosive dismemberment fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -150,7 +150,7 @@
 
 	take_overall_damage(b_loss,f_loss)
 	//attempt to dismember bodyparts
-	if(severity >= 2 || !bomb_armor)
+	if(severity <= 2 || !bomb_armor)
 		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X


### PR DESCRIPTION
Fixes a bug that was causing light explosions to take off limbs despite having bomb armour.

There's still a 70% chance of losing at least one limb from a severity 2 explosion though, and 50% at light explosions (without armor) so the numbers might need tweaking on top of this bugfix
