### PR TITLE
Some fixes: mech mining scanner and camera tool interaction

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -142,10 +142,12 @@
 		if(istype(W, /obj/item/weapon/wirecutters)) //enable/disable the camera
 			toggle_cam(user, 1)
 			health = initial(health) //this is a pretty simplistic way to heal the camera, but there's no reason for this to be complex.
+			return
 
 		else if(istype(W, /obj/item/device/multitool)) //change focus
 			setViewRange((view_range == initial(view_range)) ? short_range : initial(view_range))
 			user << "<span class='notice'>You [(view_range == initial(view_range)) ? "restore" : "mess up"] the camera's focus.</span>"
+			return
 
 		else if(istype(W, /obj/item/weapon/weldingtool))
 			if(weld(W, user))
@@ -157,7 +159,7 @@
 				assembly.dir = src.dir
 				assembly = null
 				qdel(src)
-				return
+			return
 
 		else if(istype(W, /obj/item/device/analyzer))
 			if(!isXRay())

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -113,6 +113,7 @@
 	icon_state = "mecha_analyzer"
 	origin_tech = "materials=3;engineering=2"
 	selectable = 0
+	equip_cooldown = 30
 	var/scanning = 0
 
 /obj/item/mecha_parts/mecha_equipment/mining_scanner/New()


### PR DESCRIPTION
Fixes wirecutters on open panel camera attacking it.
Fixes missing equip_cooldown = 30 on mech mining scanner.
Fixes #17376
Fixes  #17304
