### PR TITLE
[DNM] Updated MetaStation.v41I.dmm to MetaStation.v41J.dmm

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41J.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41J.dmm
@@ -3422,9 +3422,7 @@
 	name = "\improper Recreation Area"
 	})
 "afB" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
+/obj/structure/easel,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3752,13 +3750,26 @@
 	},
 /area/ai_monitored/security/armory)
 "agf" = (
-/obj/machinery/flasher/portable,
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 0;
 	pixel_y = 24
+	},
+/obj/structure/rack,
+/obj/item/weapon/grenade/barrier{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/weapon/grenade/barrier,
+/obj/item/weapon/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/weapon/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel{
 	icon_state = "vault";
@@ -3767,9 +3778,13 @@
 /area/ai_monitored/security/armory)
 "agg" = (
 /mob/living/simple_animal/bot/secbot{
-	health = 35;
-	name = "Securitron #359";
-	on = 0
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	on = 1;
+	weaponscheck = 1
 	},
 /turf/open/floor/plasteel{
 	icon_state = "vault";
@@ -4263,13 +4278,14 @@
 	},
 /area/ai_monitored/security/armory)
 "agX" = (
-/obj/machinery/flasher/portable,
 /obj/machinery/airalarm{
 	dir = 4;
 	locked = 0;
 	pixel_x = -23;
 	pixel_y = 0
 	},
+/obj/structure/rack,
+/obj/item/weapon/storage/fancy,
 /turf/open/floor/plasteel{
 	icon_state = "vault";
 	dir = 1
@@ -4666,7 +4682,14 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/flasher/portable,
+/obj/structure/rack,
+/obj/item/weapon/storage/box/flashes{
+	pixel_x = 3
+	},
+/obj/item/weapon/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel{
 	icon_state = "vault";
 	dir = 1
@@ -4728,7 +4751,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/weapon/storage/box/teargas,
 /obj/machinery/button/door{
 	id = "armory";
 	name = "Armory Shutters";
@@ -5042,6 +5064,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aio" = (
+/obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aip" = (
@@ -5594,7 +5617,7 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 0
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/auxsolarport)
 "ajp" = (
 /obj/structure/table,
@@ -6455,7 +6478,6 @@
 	},
 /area/security/warden)
 "akI" = (
-/obj/item/weapon/grenade/barrier,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 0
@@ -6465,12 +6487,13 @@
 	dir = 4;
 	network = list("SS13")
 	},
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
 /area/security/warden)
 "akJ" = (
-/obj/item/weapon/grenade/barrier,
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
@@ -9297,7 +9320,7 @@
 	},
 /obj/item/weapon/storage/belt{
 	desc = "Can hold quite a lot of stuff.";
-	name = "mutli-belt"
+	name = "multi-belt"
 	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9379,7 +9402,7 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "apu" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/auxsolarstarboard)
 "apv" = (
 /obj/machinery/power/solar_control{
@@ -9502,12 +9525,8 @@
 	name = "Port Maintenance"
 	})
 "apF" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/turf/closed/wall,
+/area/maintenance/auxsolarport)
 "apG" = (
 /obj/machinery/light_construct/small{
 	dir = 4
@@ -9526,11 +9545,11 @@
 	name = "Port Maintenance"
 	})
 "apI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/fpmaint2{
-	name = "Port Maintenance"
-	})
+/obj/structure/easel,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
 "apJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -10349,11 +10368,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "arf" = (
-/obj/effect/decal/cleanable/blood,
 /obj/structure/chair,
 /obj/item/weapon/restraints/handcuffs,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/soviet,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "arg" = (
@@ -11957,7 +11976,7 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 0
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/auxsolarstarboard)
 "atw" = (
 /turf/closed/wall/r_wall,
@@ -12735,8 +12754,8 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -13452,12 +13471,12 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = -32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plating{
 	icon_state = "warnplate";
-	dir = 4
+	dir = 1
 	},
 /area/maintenance/starboard)
 "avU" = (
@@ -14171,15 +14190,9 @@
 	},
 /area/engine/gravity_generator)
 "awY" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "awZ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -14949,7 +14962,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ayp" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1;
+	desc = "It's a storage unit for emergency breath masks and O2 tanks, and is securely bolted in place.";
+	name = "anchored emergency closet"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ayq" = (
@@ -15611,13 +15628,14 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "azv" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE"
+/obj/structure/lattice,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Fore Arm - Far";
+	dir = 8;
+	network = list("Singulo")
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/turf/open/space,
+/area/space)
 "azw" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -16572,12 +16590,13 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aAQ" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Fore Arm - Far";
-	dir = 8;
-	network = list("Singulo")
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 0
 	},
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "aAR" = (
 /obj/machinery/door/airlock/shuttle{
@@ -17411,6 +17430,7 @@
 	dir = 4;
 	network = list("Singulo")
 	},
+/obj/structure/lattice,
 /turf/open/space,
 /area/space)
 "aCi" = (
@@ -19944,15 +19964,12 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "aGc" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aGd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -20832,13 +20849,13 @@
 	amount = 50
 	},
 /obj/item/stack/sheet/glass{
-	amount = 12
+	amount = 50
 	},
 /obj/item/stack/sheet/glass{
-	amount = 12
+	amount = 50
 	},
 /obj/item/stack/sheet/glass{
-	amount = 12
+	amount = 50
 	},
 /obj/item/weapon/crowbar,
 /obj/item/weapon/grenade/chem_grenade/metalfoam,
@@ -20887,7 +20904,7 @@
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
-/obj/item/weapon/circuitboard/computer/solar_control,
+/obj/item/weapon/circuitboard/solar_control,
 /obj/item/weapon/electronics/tracker,
 /obj/item/weapon/paper/solar,
 /turf/open/floor/plasteel{
@@ -24449,12 +24466,12 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aNP" = (
+/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/airalarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aNQ" = (
@@ -24749,8 +24766,14 @@
 	},
 /area/engine/engineering)
 "aOo" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/lattice,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Aft Arm - Far";
+	dir = 8;
+	network = list("Singulo")
+	},
+/turf/open/space,
+/area/space)
 "aOp" = (
 /turf/open/floor/plating{
 	icon_plating = "warnplate";
@@ -25058,10 +25081,7 @@
 /area/quartermaster/qm)
 "aOT" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -26649,7 +26669,18 @@
 	pixel_y = 0;
 	supply_display = 1
 	},
-/obj/machinery/computer/stockexchange,
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/weapon/cartridge/quartermaster,
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/device/gps{
+	gpstag = "QM0"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aRC" = (
@@ -27565,17 +27596,9 @@
 /area/quartermaster/qm)
 "aSY" = (
 /obj/structure/table,
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/weapon/cartridge/quartermaster,
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = -4;
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
 	pixel_y = 7
-	},
-/obj/item/device/gps{
-	gpstag = "QM0"
 	},
 /turf/open/floor/plasteel{
 	dir = 2;
@@ -29711,11 +29734,7 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aWD" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Aft Arm - Far";
-	dir = 8;
-	network = list("Singulo")
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aWE" = (
@@ -30088,6 +30107,10 @@
 "aXd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	req_access_txt = 1
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel{
 	icon_state = "delivery";
@@ -31654,18 +31677,21 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/powermonitor{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/item/weapon/circuitboard/pandemic{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/computer/stationalert{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/weapon/circuitboard/computer/atmos_alert{
+/obj/item/weapon/circuitboard/rdconsole,
+/obj/item/weapon/circuitboard/rdserver{
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/weapon/circuitboard/destructive_analyzer,
+/obj/item/weapon/circuitboard/protolathe,
+/obj/item/weapon/circuitboard/aifixer,
+/obj/item/weapon/circuitboard/teleporter,
+/obj/item/weapon/circuitboard/circuit_imprinter,
+/obj/item/weapon/circuitboard/mechfab,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31675,14 +31701,12 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/secure_data{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/item/weapon/circuitboard/mining,
+/obj/item/weapon/circuitboard/autolathe{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/item/weapon/circuitboard/computer/security{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/weapon/circuitboard/arcade/battle,
 /obj/machinery/ai_status_display{
 	pixel_x = 0;
 	pixel_y = 31
@@ -31692,20 +31716,15 @@
 	},
 /area/storage/tech)
 "aZI" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/rack,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/receiver,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/broadcaster,
+/obj/item/weapon/circuitboard/message_monitor{
+	pixel_y = -5
 	},
-/obj/item/weapon/circuitboard/computer/cloning{
-	pixel_x = 0
-	},
-/obj/item/weapon/circuitboard/computer/med_data{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/machine/clonescanner,
-/obj/item/weapon/circuitboard/machine/clonepod,
-/obj/item/weapon/circuitboard/computer/scan_consolenew,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -31838,6 +31857,14 @@
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
 "aZS" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/open/floor/plating{
 	dir = 2;
 	icon_state = "warnplate"
@@ -32749,13 +32776,17 @@
 	},
 /area/security/checkpoint/engineering)
 "bbn" = (
-/obj/machinery/door/airlock/external{
-	name = "South Containment Arm Access"
+/obj/machinery/camera/emp_proof{
+	c_tag = "Aft Arm - Near";
+	dir = 4;
+	network = list("Singulo")
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "bbo" = (
 /obj/machinery/space_heater,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -33263,6 +33294,7 @@
 	pixel_x = 0;
 	pixel_y = 30
 	},
+/obj/item/weapon/pen/red,
 /turf/open/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -33271,11 +33303,6 @@
 	name = "\improper Cargo Office"
 	})
 "bbW" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen/red,
 /obj/structure/table/reinforced,
 /obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel{
@@ -33760,11 +33787,11 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/borgupload{
+/obj/item/weapon/circuitboard/borgupload{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/computer/aiupload{
+/obj/item/weapon/circuitboard/aiupload{
 	pixel_x = 2;
 	pixel_y = -2
 	},
@@ -33804,16 +33831,16 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/message_monitor{
-	pixel_y = -5
+/obj/item/weapon/circuitboard/cloning{
+	pixel_x = 0
 	},
-/obj/item/weapon/circuitboard/computer/arcade/battle{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/weapon/circuitboard/med_data{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/item/weapon/circuitboard/computer/arcade/orion_trail{
-	pixel_x = 4
-	},
+/obj/item/weapon/circuitboard/clonescanner,
+/obj/item/weapon/circuitboard/clonepod,
+/obj/item/weapon/circuitboard/scan_consolenew,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33823,10 +33850,13 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/mining,
-/obj/item/weapon/circuitboard/machine/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/weapon/circuitboard/secure_data{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/security{
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -33837,17 +33867,18 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/pandemic{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/weapon/circuitboard/powermonitor{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/item/weapon/circuitboard/computer/rdconsole,
-/obj/item/weapon/circuitboard/machine/rdserver{
+/obj/item/weapon/circuitboard/stationalert{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/atmos_alert{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/weapon/circuitboard/machine/destructive_analyzer,
-/obj/item/weapon/circuitboard/machine/protolathe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -34078,8 +34109,8 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 32
+	pixel_x = 32;
+	pixel_y = -32
 	},
 /turf/open/floor/plating{
 	icon_state = "warnplate";
@@ -34227,9 +34258,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	req_access_txt = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Cargo Office APC";
+	pixel_x = -24;
 	pixel_y = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel{
 	dir = 9;
@@ -34245,6 +34282,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/open/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -34296,13 +34339,17 @@
 	})
 "bdz" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/folder/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
 	dir = 8;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
 /turf/open/floor/plasteel,
 /area/quartermaster/office{
 	name = "\improper Cargo Office"
@@ -34518,15 +34565,15 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/crew{
+/obj/item/weapon/circuitboard/crew{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/computer/card{
+/obj/item/weapon/circuitboard/card{
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/obj/item/weapon/circuitboard/computer/communications{
+/obj/item/weapon/circuitboard/communications{
 	pixel_x = 5;
 	pixel_y = -5
 	},
@@ -34757,11 +34804,8 @@
 	},
 /area/security/checkpoint/engineering)
 "bes" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/security/checkpoint/engineering)
 "bet" = (
 /obj/machinery/light{
 	dir = 8
@@ -35451,11 +35495,11 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/computer/robotics{
+/obj/item/weapon/circuitboard/robotics{
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/weapon/circuitboard/computer/mecha_control{
+/obj/item/weapon/circuitboard/mecha_control{
 	pixel_x = 1;
 	pixel_y = -1
 	},
@@ -37123,7 +37167,6 @@
 	name = "Customs"
 	})
 "bin" = (
-/obj/item/weapon/grenade/barrier,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26;
@@ -37135,6 +37178,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
+/obj/machinery/flasher/portable,
 /turf/open/floor/plasteel{
 	icon_state = "bot"
 	},
@@ -37290,11 +37334,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 2
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -37310,11 +37349,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office{
@@ -38487,18 +38521,9 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/folder/yellow,
+/obj/item/weapon/folder/yellow,
 /obj/item/device/multitool,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = 0
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/computer/stockexchange,
+/obj/item/weapon/pen/red,
 /turf/open/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -39532,23 +39557,12 @@
 	})
 "bmb" = (
 /obj/structure/table,
-/obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
-	pixel_x = -29
-	},
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 0;
+/obj/machinery/computer/stockexchange,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26;
 	pixel_y = 0
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Office APC";
-	pixel_x = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
@@ -39588,6 +39602,13 @@
 /obj/machinery/newscaster{
 	pixel_x = 28;
 	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel{
 	dir = 6;
@@ -40241,7 +40262,7 @@
 /area/engine/break_room)
 "bng" = (
 /obj/structure/sign/pods,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bnh" = (
 /obj/structure/grille,
@@ -44053,8 +44074,6 @@
 /area/hallway/primary/central)
 "btc" = (
 /obj/structure/table,
-/obj/item/weapon/storage/crayons,
-/obj/item/weapon/storage/crayons,
 /obj/machinery/power/apc{
 	cell_type = 2500;
 	dir = 8;
@@ -44066,6 +44085,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "btd" = (
@@ -45597,10 +45621,15 @@
 /area/hallway/primary/central)
 "bvn" = (
 /obj/structure/table,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
+/obj/item/weapon/canvas/twentythreeXtwentythree,
+/obj/item/weapon/canvas/twentythreeXtwentythree,
+/obj/item/weapon/canvas/twentythreeXnineteen,
+/obj/item/weapon/canvas/twentythreeXnineteen,
+/obj/item/weapon/canvas/nineteenXnineteen,
+/obj/item/weapon/canvas/nineteenXnineteen,
+/obj/item/weapon/storage/crayons,
+/obj/item/weapon/storage/crayons,
+/obj/item/weapon/storage/crayons,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "bvo" = (
@@ -45644,6 +45673,12 @@
 /obj/structure/closet/gmcloset,
 /obj/item/weapon/wrench,
 /obj/item/stack/cable_coil/white,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/stack/sheet/metal{
+	amount = 25
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bvt" = (
@@ -49939,7 +49974,10 @@
 /area/crew_quarters/bar)
 "bCu" = (
 /obj/structure/table/wood/poker,
-/obj/effect/spawner/lootdrop/gambling,
+/obj/effect/spawner/lootdrop{
+	loot = list(/obj/item/weapon/gun/projectile/revolver/russian = 5, /obj/item/weapon/storage/box/syndie_kit/throwing_weapons, /obj/item/toy/cards/deck/syndicate = 2);
+	name = "gambling valuables spawner"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bCv" = (
@@ -50677,7 +50715,7 @@
 	dir = 4
 	},
 /turf/open/floor/goonplaque{
-	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of sentient postcards in a realm of darkness. The station model number is MSv41I:151101"
+	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of sentient postcards in a realm of darkness. The station model number is MSv41J:160509"
 	},
 /area/hallway/primary/port)
 "bDM" = (
@@ -54489,12 +54527,12 @@
 	icon_state = "shower";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/light/small,
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -56442,7 +56480,9 @@
 	name = "Port Maintenance"
 	})
 "bNo" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe{
+	req_access_txt = "0"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
@@ -56963,14 +57003,14 @@
 /area/bridge)
 "bOg" = (
 /obj/structure/rack,
-/obj/item/weapon/circuitboard/machine/telecomms/processor,
-/obj/item/weapon/circuitboard/machine/telecomms/processor,
-/obj/item/weapon/circuitboard/machine/telecomms/receiver,
-/obj/item/weapon/circuitboard/machine/telecomms/server,
-/obj/item/weapon/circuitboard/machine/telecomms/server,
-/obj/item/weapon/circuitboard/machine/telecomms/bus,
-/obj/item/weapon/circuitboard/machine/telecomms/bus,
-/obj/item/weapon/circuitboard/machine/telecomms/broadcaster,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/receiver,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/broadcaster,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
@@ -58852,10 +58892,9 @@
 	},
 /area/crew_quarters/kitchen)
 "bRk" = (
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/crew_quarters/kitchen)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bRl" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -59349,7 +59388,6 @@
 	pixel_y = 0
 	},
 /obj/item/clothing/under/suit_jacket/red,
-/obj/item/weapon/book/codex_gigas,
 /turf/open/floor/plasteel{
 	icon_state = "cult";
 	dir = 2
@@ -61602,11 +61640,16 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 0
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/portsolar)
 "bVC" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/portsolar)
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bVD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -65360,6 +65403,10 @@
 /obj/item/weapon/paper_bin{
 	pixel_x = -2;
 	pixel_y = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel{
 	dir = 4;
@@ -69913,7 +69960,11 @@
 	},
 /area/crew_quarters/kitchen)
 "ciS" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1;
+	desc = "It's a storage unit for emergency breath masks and O2 tanks, and is securely bolted in place.";
+	name = "anchored emergency closet"
+	},
 /turf/open/floor/plating{
 	icon_state = "warnplate";
 	dir = 1
@@ -72348,8 +72399,8 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cmL" = (
@@ -73278,8 +73329,6 @@
 	name = "Aft Maintenance"
 	})
 "col" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -73287,6 +73336,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -73441,14 +73492,10 @@
 	name = "Sleepers"
 	})
 "coC" = (
-/obj/structure/grille,
-/obj/structure/window/fulltile{
-	layer = 2.9
-	},
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/medical/sleeper{
-	name = "Sleepers"
-	})
+/area/engine/engineering)
 "coD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet{
@@ -74760,7 +74807,7 @@
 	name = "Aft Maintenance"
 	})
 "cqG" = (
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -76559,9 +76606,9 @@
 	},
 /area/toxins/explab)
 "ctj" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating{
 	icon_state = "warnplate";
 	dir = 4
@@ -76602,8 +76649,8 @@
 	})
 "ctn" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/aft{
 	name = "Aft Maintenance"
@@ -79098,7 +79145,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/computer/teleporter,
+/obj/item/weapon/circuitboard/teleporter,
 /turf/open/floor/plasteel{
 	icon_state = "cafeteria";
 	dir = 5
@@ -81487,7 +81534,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel{
 	dir = 2;
 	icon_state = "warning"
@@ -83886,8 +83933,10 @@
 	},
 /area/medical/morgue)
 "cEt" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/construction)
+/area/engine/engineering)
 "cEu" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -95007,6 +95056,11 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 4;
+	network = list("SS13","RD","Xeno")
+	},
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "cVE" = (
@@ -95103,6 +95157,11 @@
 "cVM" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #2";
+	dir = 8;
+	network = list("SS13","RD","Xeno")
 	},
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
@@ -96287,7 +96346,7 @@
 	},
 /area/shuttle/syndicate)
 "cXz" = (
-/obj/structure/frame/computer,
+/obj/structure/computerframe,
 /turf/open/floor/plasteel/shuttle{
 	icon_state = "shuttlefloor4"
 	},
@@ -97776,8 +97835,8 @@
 	},
 /area/shuttle/abandoned)
 "daw" = (
-/obj/structure/frame/machine,
-/obj/item/weapon/circuitboard/machine/cyborgrecharger,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/weapon/circuitboard/cyborgrecharger,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -97945,7 +98004,7 @@
 	},
 /area/shuttle/abandoned)
 "daO" = (
-/obj/structure/frame/computer,
+/obj/structure/computerframe,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -98041,7 +98100,7 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/structure/frame/machine{
+/obj/machinery/constructable_frame/machine_frame{
 	desc = "A NanoTrasen hypersleep chamber - this one appears broken. There are exposed bolts for easy detachment using a wrench.";
 	dir = 1;
 	icon = 'icons/obj/Cryogenic2.dmi';
@@ -98058,7 +98117,7 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/structure/frame/machine{
+/obj/machinery/constructable_frame/machine_frame{
 	desc = "A NanoTrasen hypersleep chamber - this one appears broken. There are exposed bolts for easy detachment using a wrench.";
 	dir = 1;
 	icon = 'icons/obj/Cryogenic2.dmi';
@@ -98353,7 +98412,7 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/structure/frame/machine{
+/obj/machinery/constructable_frame/machine_frame{
 	desc = "A NanoTrasen hypersleep chamber - this one appears broken. There are exposed bolts for easy detachment using a wrench.";
 	dir = 2;
 	icon = 'icons/obj/Cryogenic2.dmi';
@@ -98370,7 +98429,7 @@
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/obj/structure/frame/machine{
+/obj/machinery/constructable_frame/machine_frame{
 	desc = "A NanoTrasen hypersleep chamber - this one appears broken. There are exposed bolts for easy detachment using a wrench.";
 	dir = 2;
 	icon = 'icons/obj/Cryogenic2.dmi';
@@ -98466,7 +98525,7 @@
 	},
 /area/shuttle/abandoned)
 "dbC" = (
-/obj/structure/frame/computer,
+/obj/structure/computerframe,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -98644,7 +98703,7 @@
 	},
 /area/shuttle/abandoned)
 "dbS" = (
-/obj/structure/frame/machine,
+/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -98655,8 +98714,8 @@
 	},
 /area/shuttle/abandoned)
 "dbT" = (
-/obj/structure/frame/machine,
-/obj/item/weapon/circuitboard/machine/autolathe,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/weapon/circuitboard/autolathe,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -98788,8 +98847,8 @@
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "dcd" = (
-/obj/structure/frame/machine,
-/obj/item/weapon/circuitboard/machine/chem_dispenser,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/weapon/circuitboard/chem_dispenser,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -98799,7 +98858,7 @@
 	},
 /area/shuttle/abandoned)
 "dce" = (
-/obj/structure/frame/machine,
+/obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -100407,13 +100466,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "dfi" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Aft Arm - Near";
-	dir = 4;
-	network = list("Singulo")
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/break_room)
 "dfj" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -100457,14 +100514,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dfo" = (
-/turf/open/floor/wood,
-/area/security/vacantoffice)
+/obj/item/hand_labeler_refill,
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/maintenance/fpmaint2{
+	name = "Port Maintenance"
+	})
 "dfp" = (
-/turf/open/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/structure/easel,
+/turf/open/floor/plating,
+/area/maintenance/aft{
+	name = "Aft Maintenance"
+	})
 "dfq" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva{
@@ -100476,16 +100537,27 @@
 	},
 /area/crew_quarters/kitchen)
 "dfs" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/maintenance/aft{
-	name = "Aft Maintenance"
-	})
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #3";
+	dir = 4;
+	network = list("SS13","RD","Xeno")
+	},
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 "dft" = (
-/turf/open/floor/wood,
-/area/maintenance/aft{
-	name = "Aft Maintenance"
-	})
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #4";
+	dir = 8;
+	network = list("SS13","RD","Xeno")
+	},
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 "dfu" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
@@ -100504,23 +100576,27 @@
 	},
 /area/medical/morgue)
 "dfw" = (
-/turf/open/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/medical/morgue)
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #5";
+	dir = 4;
+	network = list("SS13","RD","Xeno")
+	},
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 "dfx" = (
-/obj/structure/window/reinforced{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/obj/item/clothing/under/burial,
-/turf/open/floor/plating,
-/area/chapel/main)
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #6";
+	dir = 8;
+	network = list("SS13","RD","Xeno")
+	},
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 "dfy" = (
 /turf/open/floor/engine/vacuum,
 /area/atmos)
@@ -113878,10 +113954,10 @@ bRQ
 asj
 alQ
 bVz
-bVC
-bVC
-bVC
-bVC
+bVz
+bVz
+bVz
+bVz
 aaa
 aaf
 aaa
@@ -114905,11 +114981,11 @@ aLU
 bRT
 aLU
 bUA
-bVC
-bVC
-bVC
-bVC
-bVC
+bVz
+bVz
+bVz
+bVz
+bVz
 aaa
 aaf
 aaa
@@ -118505,7 +118581,7 @@ alQ
 bQr
 bQH
 alI
-avZ
+dfo
 bVE
 caW
 ccb
@@ -118954,10 +119030,10 @@ aaf
 aaf
 aaf
 aek
-agG
-agG
-agG
-agG
+apF
+apF
+apF
+apF
 akr
 ahv
 ahv
@@ -119214,7 +119290,7 @@ aek
 agH
 ahx
 air
-agG
+apF
 aks
 alI
 amY
@@ -119982,8 +120058,8 @@ aaf
 aaf
 aaf
 aek
-agG
-agG
+apF
+apF
 agG
 agG
 aiu
@@ -120865,7 +120941,7 @@ cOU
 cRS
 cRS
 cSP
-dfx
+cRS
 cOU
 cUb
 cOU
@@ -129617,7 +129693,7 @@ cTC
 cTC
 cTC
 cVt
-cVD
+dfw
 cVB
 cTC
 cTC
@@ -129870,7 +129946,7 @@ cVD
 cVN
 cVo
 cVt
-cVD
+dfs
 cVN
 cVo
 cVs
@@ -132954,7 +133030,7 @@ cVM
 cVY
 cVo
 cVN
-cVM
+dft
 cVY
 cVo
 cVB
@@ -133215,7 +133291,7 @@ cTC
 cTC
 cTC
 cVB
-cVM
+dfx
 cVY
 cTC
 cTC
@@ -133960,7 +134036,7 @@ cIx
 cJs
 cKt
 chP
-bZQ
+dfp
 cgG
 ciY
 bVE
@@ -138772,7 +138848,7 @@ aMR
 aOg
 apj
 aQW
-asL
+aGc
 aTz
 alw
 avN
@@ -141834,7 +141910,7 @@ aaf
 aaf
 acn
 alx
-apn
+apI
 apk
 apk
 apk
@@ -143147,15 +143223,15 @@ aCf
 ayo
 azn
 aZR
-aZR
-aZR
-aZR
-aZR
-aZR
+bes
+bes
+bes
+bes
+bes
 bjQ
 bly
 bng
-bfV
+bjF
 brj
 bjF
 bjF
@@ -143403,12 +143479,12 @@ aDp
 aVe
 ayo
 aYd
-aZS
-bbn
+ayp
+ayo
 bdd
-bes
-bfV
-bhH
+bdf
+dfi
+bjR
 bjR
 bjR
 bjF
@@ -143663,11 +143739,11 @@ azn
 ayo
 ayo
 aKe
-ayo
-bfV
+bVC
+bjF
 bhI
 bjR
-bjR
+bhH
 bjF
 bsD
 brm
@@ -143901,8 +143977,8 @@ ayq
 azp
 aaf
 aCh
+aaf
 aIK
-aoa
 aDq
 aDq
 aDq
@@ -143912,16 +143988,16 @@ aDq
 aDq
 aDq
 aDq
-dfi
 aIK
-aaa
+aaf
+bbn
 aaf
 aYe
 aZT
 ayo
-aKe
-ayo
-bfV
+bRk
+coC
+bjF
 bhJ
 bjS
 blz
@@ -144156,7 +144232,7 @@ avP
 atw
 ayr
 azq
-aaf
+aoa
 aaf
 aIM
 aLy
@@ -144172,13 +144248,13 @@ aLy
 aLy
 dfk
 aaf
-aaf
+aoa
 azq
 ayr
 ayo
 bde
-ayo
-bnn
+cEt
+brr
 bhK
 cXk
 bhK
@@ -144434,8 +144510,8 @@ aYf
 aZU
 ayo
 aKe
-ayo
-bnn
+aBZ
+brr
 bhK
 cWO
 bhK
@@ -144669,7 +144745,7 @@ apk
 avN
 atw
 ayr
-azq
+awY
 aAO
 aaa
 aIN
@@ -144687,11 +144763,11 @@ dfj
 dfl
 aaa
 aWC
-azq
+awY
 ayr
 ayo
 bdf
-ayo
+aBZ
 aaf
 bhL
 bjV
@@ -144947,8 +145023,8 @@ azq
 ayq
 azu
 ayo
-aKe
-ayo
+bRk
+aBZ
 aaf
 aaa
 cYF
@@ -145205,7 +145281,7 @@ ayr
 ayo
 ayo
 aKe
-ayo
+aBZ
 aaf
 aaf
 aaf
@@ -145436,7 +145512,7 @@ apu
 apu
 apu
 apu
-atw
+alw
 apk
 anU
 atw
@@ -145462,7 +145538,7 @@ aYg
 ayo
 bbo
 aKe
-ayo
+aBZ
 aaf
 aaa
 aaa
@@ -145692,7 +145768,7 @@ aaf
 aaa
 aaa
 aaa
-atw
+alw
 auL
 avD
 atw
@@ -145719,7 +145795,7 @@ ayr
 ayo
 ayo
 bdg
-ayo
+aBZ
 aaf
 aaa
 aaa
@@ -145975,7 +146051,7 @@ azq
 ayt
 aZT
 ayo
-aKe
+bRk
 aDq
 aaf
 aaa
@@ -146206,12 +146282,12 @@ aaa
 aaa
 aaf
 aaa
-atw
+alw
 auN
 avS
 atw
 ayr
-azq
+awY
 aAP
 aaa
 aIN
@@ -146229,11 +146305,11 @@ dfj
 dfl
 aaa
 azq
-azq
+awY
 ayr
 ayo
 bdh
-ayo
+aBZ
 aaf
 aaf
 aaa
@@ -146463,8 +146539,8 @@ aaa
 aaa
 aaf
 aaa
-atw
-atw
+alw
+alw
 atx
 atw
 ayt
@@ -146490,8 +146566,8 @@ aYf
 azu
 ayo
 bdi
-ayo
-ayo
+aBZ
+aBZ
 aaf
 aaa
 aaa
@@ -146721,13 +146797,13 @@ aaa
 acn
 acn
 atx
-anV
 avT
+avS
 atw
 ayu
 azq
 azq
-aaa
+aaf
 aIL
 aoa
 aoa
@@ -146746,7 +146822,7 @@ azq
 azq
 ayu
 ayo
-bdh
+aKg
 aZS
 bdi
 acn
@@ -146977,14 +147053,14 @@ aaf
 aaf
 aaf
 aaf
-atw
-atw
+alw
+alw
 atx
-awY
+atw
 ayu
 ayu
-aAQ
-aoa
+azq
+aaa
 aLw
 aSG
 aSG
@@ -146998,14 +147074,14 @@ aTN
 aSG
 aSG
 dfm
-aoa
+aaf
 aWD
 ayu
 ayu
-aHA
+ayo
 bdi
-ayo
-ayo
+aBZ
+aBZ
 aaf
 aaa
 aaa
@@ -147239,25 +147315,25 @@ aaf
 acn
 atw
 ayo
-azv
 ayo
-azq
-aoa
-aoa
-aaf
-aaf
-aoa
-apy
-aoa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-azq
 ayo
+aaa
 azv
+aIK
+aaf
+aaa
+aaa
+aaf
+aIK
+aaf
+aaa
+aaa
+aaf
+aIK
+aOo
+aaa
+ayo
+ayo
 ayo
 ayo
 acn
@@ -147496,7 +147572,7 @@ aaf
 acn
 aaf
 aaf
-azw
+aaf
 ayo
 ayo
 ayo
@@ -147752,25 +147828,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaf
-aaf
+ayo
 azw
 azw
 azw
-azw
-aGc
-azw
+aHA
 azw
 azw
 azw
+aAQ
 azw
 azw
 azw
-aGc
+aHA
 azw
 azw
 azw
-azw
+ayo
 aaf
 aaa
 aaf
@@ -148271,17 +148347,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 aaf
 aaa
 aaa
 aaf
-aaa
+aaf
 aaa
 aaa
 aaa
 aaf
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -148533,7 +148609,7 @@ aaf
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -149051,7 +149127,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
 aaa
 aaa
 aaa

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -19,7 +19,7 @@ z7 = empty space
 
 		#define MINETYPE "lavaland"
 
-		#include "map_files\MetaStation\MetaStation.v41I.dmm"
+		#include "map_files\MetaStation\MetaStation.v41J.dmm"
 		#include "map_files\generic\z2.dmm"
 		#include "map_files\generic\z3.dmm"
 		#include "map_files\generic\z4.dmm"
@@ -30,7 +30,7 @@ z7 = empty space
 		#include "map_files\generic\z9.dmm"
 
 		#define MAP_PATH "map_files/MetaStation"
-		#define MAP_FILE "MetaStation.v41I.dmm"
+		#define MAP_FILE "MetaStation.v41J.dmm"
 		#define MAP_NAME "MetaStation"
 
 		#define MAP_TRANSITION_CONFIG	list(MAIN_STATION = CROSSLINKED, CENTCOMM = SELFLOOPING, ABANDONED_SATELLITE = CROSSLINKED, DERELICT = CROSSLINKED, MINING = SELFLOOPING, EMPTY_AREA_1 = CROSSLINKED, EMPTY_AREA_2 = CROSSLINKED, EMPTY_AREA_3 = CROSSLINKED, EMPTY_AREA_4 = CROSSLINKED)


### PR DESCRIPTION
EDIT: Oh damn, seems this doesn't compile for now, so DNM. Seems to be a result of some tgm/dmm issues that I talked to Remie about. Will have to redo it as dmm sometime to fix this at the cost of difference spam some other time. Going to leave this here for now so no one tries to modify the map in the meantime.

Updated MetaStation.v41I.dmm to MetaStation.v41J.dmm
Updated metastation.dm
Fixes https://github.com/tgstation/-tg-station/issues/14177
Fixes https://github.com/tgstation/-tg-station/issues/14484
Fixes https://github.com/tgstation/-tg-station/issues/15655
- Added extra grounding rods to the engine area to stop the tesla destroying airlocks and killing people outside, as well as moving some bothersome conductive signs.
- Added missing circuit boards to tech storage to match current box boards - exosuit fabricator, circuit imprinter, teleporter, and AI integrity restorer boards.
- Added some glass and metal to the bar backroom closet to allow for easier modifications
- Added a selection of blank canvas to art storage and some easels to maint.
- Added cameras to each xenobiology containment pen so the slime computers don't bug out so often.
- Added missing indoor window pane in atmos by one of the computers
- Added a custom name to the armory securitron, which now also starts active and will by default detain unknowns and those holding guns without clearance.
- Adjusted layout of the aft arm of the engine area, making it a separate maint tunnel which is part of the engineering escape pod area.
- Adjusted positions of some machines in the cargo office and QM office so the cargo APC and other items can be accessed properly again.
- Anchored the O2 lockers in the engine room airlocks to stop them being dragged out by spacewind every time the airlocks are used.
- Fixed glass sheet stacks in engineering having 12 sheets not 50
- Fixed the mutli-belt typo
- Fixed maint autodrobe incorrectly requiring theatre access
- Moved the portable flashes out into the armory anteroom, adding racks to where they were, which hold extra flashes, tear gas grenades, emergency doughnuts, and a rack of barrier grenades.
- Replaced an empty canister in toxins with a fourth O2 canister
