### PR TITLE
Adds healy glows to cult pylons and the medbeam gun

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -101,15 +101,16 @@
 		last_shot = world.time
 		for(var/mob/living/L in range(5, src))
 			if(iscultist(L))
-				var/mob/living/carbon/human/H = L
-				if(istype(H))
-					L.adjustBruteLoss(-1, 0)
-					L.adjustFireLoss(-1, 0)
-					L.updatehealth()
-				if(istype(L, /mob/living/simple_animal/hostile/construct))
-					var/mob/living/simple_animal/M = L
-					if(M.health < M.maxHealth)
-						M.adjustHealth(-2)
+				if(L.health != L.maxHealth)
+					PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(L), "#960000"))
+					if(ishuman(L))
+						L.adjustBruteLoss(-1, 0)
+						L.adjustFireLoss(-1, 0)
+						L.updatehealth()
+					if(istype(L, /mob/living/simple_animal/hostile/construct))
+						var/mob/living/simple_animal/M = L
+						if(M.health < M.maxHealth)
+							M.adjustHealth(-2)
 		if(corruption.len)
 			var/turf/T = pick_n_take(corruption)
 			corruption -= T

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -100,14 +100,14 @@
 	if((last_shot + heal_delay) <= world.time)
 		last_shot = world.time
 		for(var/mob/living/L in range(5, src))
-			if(iscultist(L))
+			if(iscultist(L) || istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
 				if(L.health != L.maxHealth)
 					PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(src), "#960000"))
 					if(ishuman(L))
 						L.adjustBruteLoss(-1, 0)
 						L.adjustFireLoss(-1, 0)
 						L.updatehealth()
-					if(istype(L, /mob/living/simple_animal/hostile/construct))
+					if(istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
 						var/mob/living/simple_animal/M = L
 						if(M.health < M.maxHealth)
 							M.adjustHealth(-2)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -102,7 +102,7 @@
 		for(var/mob/living/L in range(5, src))
 			if(iscultist(L))
 				if(L.health != L.maxHealth)
-					PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(L), "#960000"))
+					PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(src), "#960000"))
 					if(ishuman(L))
 						L.adjustBruteLoss(-1, 0)
 						L.adjustFireLoss(-1, 0)

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -43,10 +43,12 @@
 	icon_state = "heal"
 	duration = 15
 
-/obj/effect/overlay/temp/heal/New()
+/obj/effect/overlay/temp/heal/New(loc, colour)
 	..()
 	pixel_x = rand(-12, 12)
 	pixel_y = rand(-9, 0)
+	if(colour)
+		color = colour
 
 /obj/effect/overlay/temp/explosion
 	name = "explosion"

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -103,6 +103,8 @@
 	return
 
 /obj/item/weapon/gun/medbeam/proc/on_beam_tick(var/mob/living/target)
+	if(target.health != target.maxHealth)
+		PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(target), "#80F5FF"))
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
 	return


### PR DESCRIPTION
Just a small 'this healed you' glow, like blobbernauts being healed on the blob.
Pylons produce the glow on themselves instead so cultists don't get instavalided(they're next to a pylon of course they're gonna get valided)
![pylon](http://puu.sh/oMmr0/105b886634.png)
![beam](http://puu.sh/oMmu4/403d04ba69.png)
