### PR TITLE
Adds Wizard-Tracking crate to cargo

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -301,6 +301,6 @@
 	desc = "Tracks wizards with extreme precision; down the exact locker they are hiding in."
 		
 /obj/item/weapon/pinpointer/attack_self()
-	for(var/datum/mind/wizard in ticker.mode.wizards)
-		the_disk = wizard
-	return ..()
+	if(wizard.current)
+		the_disk = wizard.current
+		break

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -295,3 +295,12 @@
 			user << "Nearest operative detected is <i>[nearest_op.real_name].</i>"
 		else
 			user << "No operatives detected within scanning range."
+			
+/obj/item/weapon/pinpointer/wizard
+	name = "wiz pointer"
+	desc = "Tracks wizards with extreme precision; down the exact locker they are hiding in."
+		
+/obj/item/weapon/pinpointer/attack_self()
+	for(var/datum/mind/wizard in ticker.mode.wizards)
+		the_disk = wizard
+	return ..()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -120,10 +120,8 @@
 
 /datum/supply_pack/emergency/wiztrackers
 	name = "Wizard Trackers"
-	cost = 10000
+	cost = 12000
 	contains = list(/obj/item/weapon/pinpointer/wizard,
-					/obj/item/weapon/pinpointer/wizard,
-					/obj/item/weapon/pinpointer/wizard,
 					/obj/item/weapon/pinpointer/wizard,
 					/obj/item/weapon/pinpointer/wizard)
 	crate_name = "wizard tracking crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -118,6 +118,17 @@
 	crate_name = "special ops crate"
 	crate_type = /obj/structure/closet/crate
 
+/datum/supply_pack/emergency/wiztrackers
+	name = "Wizard Trackers"
+	cost = 10000
+	contains = list(/obj/item/weapon/pinpointer/wizard,
+					/obj/item/weapon/pinpointer/wizard,
+					/obj/item/weapon/pinpointer/wizard,
+					/obj/item/weapon/pinpointer/wizard,
+					/obj/item/weapon/pinpointer/wizard)
+	crate_name = "wizard tracking crate"
+	crate_type = /obj/structure/closet/crate/radiation	
+
 /datum/supply_pack/emergency/syndicate
 	name = "NULL_ENTRY"
 	hidden = TRUE


### PR DESCRIPTION
Lich cancer is metastasizing and locker wizards are as common as ever.

For 12,000 cargo points, YOU can help put an end to this nightmare with 3 pinpointers that will track the wizard. 

On an broader note, this will give the crew something tangible to work towards for wizard rounds instead of just sitting and waiting for the wizard to come murder their department. If the wizard wants to prevent it, they can raid cargo, and if the crew wants to prevent that, they can defend cargo. It gives the crew a place where they can finally force a confrontation with the lord of lockers. 
