### PR TITLE
Reduces amount of cockroaches from vent clog

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -43,7 +43,5 @@
 			smoke.start()
 			qdel(R)
 
-			var/cockroaches = prob(33) ? 3 : 0
-			while(cockroaches)
+			if(prob(33))
 				new /mob/living/simple_animal/cockroach(get_turf(vent))
-				cockroaches--


### PR DESCRIPTION
They cause excessive load on mob processing - just think of all the atmos checks they do on every Life tick. They also clutter mob lists, and, by extension, affect mob-related stuff such as hearing checks. And on any server with players, there are a lot of hearing checks.

This is acceptable for something that is more useful or more gameplay meaningful - such as mining mobs or carp. But cockroaches have no purpose, and they spawn in large amounts. That's why I made a PR about reduction of this amount and not about complete removal of cuckroaches.
