### PR TITLE
Fix #17497; moves bardrone from map to drone types

### DIFF
--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -34,7 +34,7 @@
 "aH" = (/obj/machinery/door/airlock/shuttle{name = "Emergency Shuttle Airlock"},/obj/docking_port/mobile/emergency{name = "The Emergency Escape Bar"},/turf/open/floor/plasteel/bar,/area/shuttle/escape)
 "aI" = (/obj/structure/table,/obj/machinery/chem_dispenser/drinks/beer,/turf/open/floor/plasteel/bar,/area/shuttle/escape)
 "aJ" = (/obj/structure/chair,/turf/open/floor/plasteel/bar,/area/shuttle/escape)
-"aK" = (/mob/living/simple_animal/drone/snowflake{desc = "A barkeeping drone, an indestructible robot built to tend bars."; dir = 8; health = 3000; languages = 127; laws = "1. Serve drinks. 2. Talk to patrons. 3. Don't get messed up in their affairs."; maxHealth = 3000; name = "Bardrone"; seeStatic = 0},/turf/open/floor/plasteel/bar,/area/shuttle/escape)
+"aK" = (/mob/living/simple_animal/drone/snowflake/bardrone,/turf/open/floor/plasteel/bar,/area/shuttle/escape)
 "aL" = (/obj/machinery/vending/boozeomat,/turf/open/floor/plasteel/bar,/area/shuttle/escape)
 "aM" = (/obj/structure/table,/turf/open/floor/plasteel/bar,/area/shuttle/escape)
 "aN" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/condiment/saltshaker,/obj/item/weapon/reagent_containers/food/condiment/peppermill{pixel_x = 6; pixel_y = 4},/turf/open/floor/plasteel/bar,/area/shuttle/escape)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -62,13 +62,9 @@
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = 0 //If we have laws to destroy the station
 	var/datum/personal_crafting/handcrafting
-	var/has_number = TRUE
 
 /mob/living/simple_animal/drone/New()
 	..()
-	if(has_number)
-		name = name + " ([rand(100,999)])"
-	real_name = name
 
 	access_card = new /obj/item/weapon/card/id(src)
 	var/datum/job/captain/C = new /datum/job/captain

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -62,10 +62,11 @@
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = 0 //If we have laws to destroy the station
 	var/datum/personal_crafting/handcrafting
+	var/has_number = TRUE
 
 /mob/living/simple_animal/drone/New()
 	..()
-	if(name != initial(name))
+	if(has_number)
 		name = name + " ([rand(100,999)])"
 	real_name = name
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -43,6 +43,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	staticOverlays = list()
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
+	unique_name = TRUE
 	var/staticChoice = "static"
 	var/list/staticChoices = list("static", "blank", "letter", "animal")
 	var/picked = FALSE //Have we picked our visual appearence (+ colour if applicable)
@@ -64,7 +65,7 @@
 	var/datum/personal_crafting/handcrafting
 
 /mob/living/simple_animal/drone/New()
-	..()
+	. = ..()
 
 	access_card = new /obj/item/weapon/card/id(src)
 	var/datum/job/captain/C = new /datum/job/captain

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -54,6 +54,18 @@
 	..()
 	desc += " This drone appears to have a complex holoprojector built on its 'head'."
 
+/mob/living/simple_animal/drone/snowflake/bardrone
+	name = "Bardrone"
+	desc = "A barkeeping drone, an indestructible robot built to tend bars."
+	has_number = FALSE
+	seeStatic = FALSE
+	laws = "1. Serve drinks.\n\
+		2. Talk to patrons.\n\
+		3. Don't get messed up in their affairs."
+	languages = ALL
+	status_flags = GODMODE // Please don't punch the barkeeper
+	unique_name = TRUE
+
 /obj/item/drone_shell/syndrone
 	name = "syndrone shell"
 	desc = "A shell of a syndrone, a modified maintenance drone designed to infiltrate and annihilate."

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -57,14 +57,13 @@
 /mob/living/simple_animal/drone/snowflake/bardrone
 	name = "Bardrone"
 	desc = "A barkeeping drone, an indestructible robot built to tend bars."
-	has_number = FALSE
 	seeStatic = FALSE
 	laws = "1. Serve drinks.\n\
 		2. Talk to patrons.\n\
 		3. Don't get messed up in their affairs."
 	languages = ALL
 	status_flags = GODMODE // Please don't punch the barkeeper
-	unique_name = TRUE
+	unique_name = FALSE // disables the (123) number suffix
 
 /obj/item/drone_shell/syndrone
 	name = "syndrone shell"

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -61,7 +61,7 @@
 
 
 	if(ishuman(user))
-		if(stat == DEAD)
+		if(stat == DEAD || status_flags & GODMODE)
 			..()
 			return
 		if(user.get_active_hand())


### PR DESCRIPTION
Fixes #17497.

Bardrone is now a valid type, rather than map specific.
