### PR TITLE
Reverts ye olde Cult Pop. Scaling Nerf

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -89,7 +89,7 @@
 		restricted_jobs += "Assistant"
 
 	//cult scaling goes here
-	recommended_enemies = 3 + round(num_players()/20)
+	recommended_enemies = 3 + round(num_players()/15)
 
 
 	for(var/cultists_number = 1 to recommended_enemies)


### PR DESCRIPTION
When I brought back oldcult I nerfed pop scaling out of (other people's) concerns of cultists snowballing and drawing nar-sie runes 5 minutes into the game.

I think we've proven that wasn't necessary. It's also exacerbated by the people fishing for lavaland roles, 4 cultists when we start hitting 50+ player station is a problem. We'll see if the cult needs more after this revert, but I've been seeing more cult victories lately and I'm confident they're getting close to a good balance. 
