### PR TITLE
Fixed some foam dart bugs

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -289,23 +289,40 @@
 	if (modified)
 		icon_state = "foamdart_empty"
 		desc = "Its nerf or nothing! ... Although, this one doesn't look too safe."
+		if(BB)
+			BB.icon_state = "foamdart_empty"
+	else
+		icon_state = "foamdart"
+		desc = "Its nerf or nothing! Ages 8 and up."
+		if(BB)
+			BB.icon_state = "foamdart_empty"
+
 
 /obj/item/ammo_casing/caseless/foam_dart/attackby(obj/item/A, mob/user, params)
 	..()
+	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
 	if (istype(A, /obj/item/weapon/screwdriver) && !modified)
 		modified = 1
-		BB.damage_type = BRUTE
-		icon_state = "foamdart_empty"
-		desc = "Its nerf or nothing! ... Although, this one doesn't look too safe."
-		user << "<span class='notice'>You pop the safety cap off of [src].</span>"
-	else if ((istype(A, /obj/item/weapon/pen)) && modified && !BB.contents.len)
+		FD.damage_type = BRUTE
+		update_icon()
+	else if ((istype(A, /obj/item/weapon/pen)) && modified && !FD.pen)
 		if(!user.unEquip(A))
 			return
-		A.loc = BB
-		BB.damage = 5
-		BB.nodamage = 0
+		A.loc = FD
+		FD.pen = A
+		FD.damage = 5
+		FD.nodamage = 0
 		user << "<span class='notice'>You insert [A] into [src].</span>"
 	return
+
+/obj/item/ammo_casing/caseless/foam_dart/attack_self(mob/living/user)
+	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	if(FD.pen)
+		FD.damage = initial(FD.damage)
+		FD.nodamage = initial(FD.nodamage)
+		user.put_in_hands(FD.pen)
+		user << "<span class='notice'>You remove [FD.pen] from [src].</span>"
+		FD.pen = null
 
 /obj/item/ammo_casing/caseless/foam_dart/riot
 	name = "riot foam dart"

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -37,6 +37,7 @@
 	var/turf/curloc = user.loc
 	if (!istype(targloc) || !istype(curloc) || !BB)
 		return 0
+	BB.ammo_casing = src
 	if(targloc == curloc)
 		if(target) //if the target is right on our location we go straight to bullet_act()
 			target.bullet_act(BB, BB.def_zone)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -10,6 +10,7 @@
 	pressure_resistance = INFINITY
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
+	var/obj/item/ammo_casing/ammo_casing = null
 	var/suppressed = 0	//Attack message
 	var/yo = null
 	var/xo = null

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -140,3 +140,8 @@
 	..()
 	if(isliving(AM) && AM.density && !checkpass(PASSMOB))
 		Bump(AM, 1)
+
+/obj/item/projectile/Destroy()
+	if(ammo_casing)
+		qdel(ammo_casing)
+	return ..()

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -1,25 +1,18 @@
 /obj/item/projectile/bullet/reusable
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
-	var/obj/item/ammo_casing/caseless/ammo_type = /obj/item/ammo_casing/caseless/
+	var/ammo_type = /obj/item/ammo_casing/caseless/
 
 /obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = 0)
 	. = ..()
-	if (src.contents.len)
-		var/obj/content
-		for(content in src.contents)
-			content.loc = src.loc
-	else
-		new ammo_type(src.loc)
+	handle_drop()
 
 /obj/item/projectile/bullet/reusable/on_range()
-	if (src.contents.len)
-		var/obj/content
-		for(content in src.contents)
-			content.loc = src.loc
-	else
-		new ammo_type(src.loc)
+	handle_drop()
 	..()
+
+/obj/item/projectile/bullet/reusable/proc/handle_drop()
+	new ammo_type(src.loc)
 
 /obj/item/projectile/bullet/reusable/magspear
 	name = "magnetic spear"
@@ -38,6 +31,21 @@
 	icon_state = "foamdart"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	range = 10
+	var/obj/item/weapon/pen/pen = null
+
+/obj/item/projectile/bullet/reusable/foam_dart/handle_drop()
+	var/obj/item/ammo_casing/caseless/foam_dart/newdart = new ammo_type(src.loc)
+	var/obj/item/ammo_casing/caseless/foam_dart/old_dart = ammo_casing
+	newdart.modified = old_dart.modified
+	if(pen)
+		var/obj/item/projectile/bullet/reusable/foam_dart/newdart_FD = newdart.BB
+		newdart_FD.pen = pen
+		pen.loc = newdart_FD
+		pen = null
+	newdart.BB.damage = damage
+	newdart.BB.nodamage = nodamage
+	newdart.BB.damage_type = damage_type
+	newdart.update_icon()
 
 /obj/item/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -53,6 +53,11 @@
 	newdart.BB.damage_type = damage_type
 	newdart.update_icon()
 
+/obj/item/projectile/bullet/reusable/foam_dart/Destroy()
+	if(pen)
+		qdel(pen)
+	return ..()
+
 /obj/item/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"
 	icon_state = "foamdart_riot"

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -2,6 +2,7 @@
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
 	var/ammo_type = /obj/item/ammo_casing/caseless/
+	var/dropped = 0
 
 /obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = 0)
 	. = ..()
@@ -12,7 +13,9 @@
 	..()
 
 /obj/item/projectile/bullet/reusable/proc/handle_drop()
-	new ammo_type(src.loc)
+	if(!dropped)
+		new ammo_type(src.loc)
+		dropped = 1
 
 /obj/item/projectile/bullet/reusable/magspear
 	name = "magnetic spear"
@@ -34,6 +37,9 @@
 	var/obj/item/weapon/pen/pen = null
 
 /obj/item/projectile/bullet/reusable/foam_dart/handle_drop()
+	if(dropped)
+		return
+	dropped = 1
 	var/obj/item/ammo_casing/caseless/foam_dart/newdart = new ammo_type(src.loc)
 	var/obj/item/ammo_casing/caseless/foam_dart/old_dart = ammo_casing
 	newdart.modified = old_dart.modified


### PR DESCRIPTION
Fixes #16975 
Fixes #16084

:cl:
bugfix: Fixed foam darts with the safety cap removed being reset when fired.
rscadd: Added the ability to remove pens from foam darts.
bugfix: Foam darts with pens inside them are no longer destroyed when fired.
bugfix: Foam darts no longer drop two darts when fired at a person on a janicart.
/:cl:
