### PR TITLE
Tweaks cult pylons

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -121,7 +121,7 @@
 			T.ChangeTurf(/turf/open/floor/engine/cult)
 			last_corrupt = world.time + corrupt_delay
 		else
-			last_corrupt = world.time + corrupt_delay*0.2
+			last_corrupt = world.time + corrupt_delay*2
 
 /obj/structure/cult/tome
 	name = "archives"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -93,6 +93,8 @@
 	return ..()
 
 /obj/structure/cult/pylon/process()
+	if(!anchored)
+		return
 	if(last_heal <= world.time)
 		last_heal = world.time + heal_delay
 		for(var/mob/living/L in range(5, src))


### PR DESCRIPTION
Pylons now process rapidly and heal more often:

Healing is about the same per second, but is faster on human cultists that have both brute AND burn damage.

The faster processing means the healing might be slightly faster/more per second overall due to checking if it can heal more often, but it's still not a lot of healing at all.

Pylons now generate a list of valid turfs to convert every 5 seconds, which means they'll properly update if turfs get removed/damaged near them but has the downside of possibly converting turfs outside the hideout if it's too close to the entrance.
