### PR TITLE
Fixes hugging message

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -119,11 +119,11 @@
 	if(health >= 0)
 
 		if(lying)
-			M.visible_message("<span class='notice'>[M] shakes [src] trying to get \him up!</span>", \
-							"<span class='notice'>You shake [src] trying to get \him up!</span>")
+			M.visible_message("<span class='notice'>[M] shakes [src] trying to get them up!</span>", \
+							"<span class='notice'>You shake [src] trying to get them up!</span>")
 		else
-			M.visible_message("<span class='notice'>[M] hugs [src] to make \him feel better!</span>", \
-						"<span class='notice'>You hug [src] to make \him feel better!</span>")
+			M.visible_message("<span class='notice'>[M] hugs [src] to make them feel better!</span>", \
+						"<span class='notice'>You hug [src] to make them feel better!</span>")
 		AdjustSleeping(-5)
 		AdjustParalysis(-3)
 		AdjustStunned(-3)


### PR DESCRIPTION
Message when hugging someone now uses the gender neutral term "them". This fixes being able to tell someone's gender even when they wear clothes hiding their identity. Fixes #16597

The alternative is to add a whole bunch of checks (same as in human/examine), checks which would only be needed for humans whereas help_shake_act() is a carbon proc, blablablah too lazy, not worth the hassle...
