### PR TITLE
Makes dismemberment more adjustable

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -575,10 +575,16 @@ obj/item/proc/item_action_slot_check(slot, mob/user)
 /obj/item/proc/is_sharp()
 	return sharpness
 
-/obj/item/proc/can_dismember()
-	if((sharpness || damtype == BURN) && w_class >= 3)
-		return 1
-	return 0
+/obj/item/proc/get_dismemberment_chance(obj/item/bodypart/affecting)
+	if(affecting.can_dismember(src))
+		if((sharpness || damtype == BURN) && w_class >= 3)
+			. = force*(w_class-1)
+
+/obj/item/proc/get_dismember_sound()
+	if(damtype == BURN)
+		. = 'sound/weapons/sear.ogg'
+	else
+		. = pick('sound/misc/desceration-01.ogg', 'sound/misc/desceration-02.ogg', 'sound/misc/desceration-03.ogg')
 
 /obj/item/proc/open_flame()
 	var/turf/location = loc

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -390,9 +390,9 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/weapon/twohanded/required/chainsaw/can_dismember()
-	return wielded
-
+/obj/item/weapon/twohanded/required/chainsaw/get_dismemberment_chance()
+	if(wielded)
+		. = ..()
 
 //GREY TIDE
 /obj/item/weapon/twohanded/spear/grey_tide

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1035,20 +1035,10 @@
 		return 0 //item force is zero
 
 	//dismemberment
-	if(affecting.get_damage() >= (affecting.max_damage - I.armour_penetration/2))
-		if(I.can_dismember() && prob(I.force*(I.w_class-1)))
-			if(affecting.dismember(I.damtype))
-				I.add_blood(H)
-				switch(I.damtype)
-					if(BURN)
-						playsound(get_turf(H), 'sound/weapons/sear.ogg', 80, 1)
-					else
-						playsound(get_turf(H), pick('sound/misc/desceration-01.ogg', 'sound/misc/desceration-02.ogg', 'sound/misc/desceration-03.ogg'), 80, 1)
-						affecting.add_blood(H)
-						var/turf/location = H.loc
-						if(istype(location))
-							location.add_blood(H)
-							return
+	if(prob(I.get_dismemberment_chance(affecting)))
+		if(affecting.dismember(I.damtype))
+			I.add_blood(H)
+			playsound(get_turf(H), I.get_dismember_sound(), 80, 1)
 
 	var/bloody = 0
 	if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -1,4 +1,6 @@
 
+/obj/item/bodypart/proc/can_dismember(obj/item/I)
+	. = (get_damage() >= (max_damage - I.armour_penetration/2))
 
 //Dismember a limb
 /obj/item/bodypart/proc/dismember(dam_type = BRUTE)
@@ -15,6 +17,10 @@
 	if(dam_type == BURN)
 		burn()
 		return 1
+	add_blood(owner)
+	var/turf/location = owner.loc
+	if(istype(location))
+		location.add_blood(owner)
 	var/direction = pick(cardinal)
 	var/t_range = rand(2,max(throw_range/2, 2))
 	var/turf/target_turf = get_turf(src)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -17,10 +17,10 @@
 	if(dam_type == BURN)
 		burn()
 		return 1
-	add_blood(owner)
-	var/turf/location = owner.loc
+	add_blood(H)
+	var/turf/location = H.loc
 	if(istype(location))
-		location.add_blood(owner)
+		location.add_blood(H)
 	var/direction = pick(cardinal)
 	var/t_range = rand(2,max(throw_range/2, 2))
 	var/turf/target_turf = get_turf(src)


### PR DESCRIPTION
Makes dismemberment more adjustable
Items now return chance for dismemberment against the bodypart instead of binary state
Bodyparts now decide if they are dismemberable or not by the specific item
Items now decide what sound to play on dismemberment or maybe you want no sound at all for assissin voidblade to teleport behind someone and behead with single motion in complete silence(pshh)
No balance changes done
