### PR TITLE
Morph Balance

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -73,6 +73,8 @@
 		return 0
 	if(istype(A,/mob/living/simple_animal/hostile/morph))
 		return 0
+	if(istype(A,/obj/effect/decal/cleanable))
+		return 0
 	return 1
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)


### PR DESCRIPTION
Morphs can no longer be a run speed drop of blood that taunts you to try to toolbox it while it merrily hits your big human sprite.
