### PR TITLE
Removes lagcheck from throw ()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -258,12 +258,7 @@
 			slept = 1
 			next_sleep += speed
 			sleep(1)
-		if(!slept)
-			var/ticks_slept = TICK_CHECK
-			if(ticks_slept)
-				slept = 1
-				next_sleep += speed*(ticks_slept*world.tick_lag) //delay the next normal sleep
-
+		
 		if(slept && hitcheck()) //to catch sneaky things moving on our tile while we slept
 			hit = 1
 			break


### PR DESCRIPTION
fixes #17598 
fixes #16893

This rarely comes into play, and only during mass spamming meteors has these ever actually needed to be lagchecked

Speaking of this, I should make all idle movement use a SubSystem, as the sleeps clog up the sleep queue and make all other sleeps slower.

This would include no grav drifting and throwing.
