### PR TITLE
[s] Golems target Free Golem ship when jaunting

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -8,6 +8,14 @@
 
 #define ishuman(A) (istype(A, /mob/living/carbon/human))
 
+// Human sub-species
+#define isabductor(A) (is_species(A, /datum/species/abductor))
+#define isgolem(A) (is_species(A, /datum/species/golem))
+#define islizard(A) (is_species(A, /datum/species/lizard))
+#define isplasmaman(A) (is_species(A, /datum/species/plasmaman))
+#define ispodperson(A) (is_species(A, /datum/species/podperson))
+#define isflyperson(A) (is_species(A, /datum/species/fly))
+
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))
 
 #define isbrain(A) (istype(A, /mob/living/carbon/brain))

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -325,21 +325,3 @@ Proc for attack log creation, because really why not
 		var/mob/living/carbon/human/H = A
 		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
-
-/proc/isabductor(A)
-	. = is_species(A, /datum/species/abductor)
-
-/proc/isgolem(A)
-	. = is_species(A, /datum/species/golem)
-
-/proc/islizard(A)
-	. = is_species(A, /datum/species/lizard)
-
-/proc/isplasmaman(A)
-	. = is_species(A, /datum/species/plasmaman)
-
-/proc/ispodperson(A)
-	. = is_species(A, /datum/species/pod)
-
-/proc/isflyperson(A)
-	. = is_species(A, /datum/species/fly)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -319,9 +319,27 @@ Proc for attack log creation, because really why not
 	if(progbar)
 		qdel(progbar)
 
-/proc/isabductor(A)
+/proc/is_species(A, species_datum)
 	. = FALSE
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A
-		if(H.dna && istype(H.dna.species, /datum/species/abductor))
+		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
+
+/proc/isabductor(A)
+	. = is_species(A, /datum/species/abductor)
+
+/proc/isgolem(A)
+	. = is_species(A, /datum/species/golem)
+
+/proc/islizard(A)
+	. = is_species(A, /datum/species/lizard)
+
+/proc/isplasmaman(A)
+	. = is_species(A, /datum/species/plasmaman)
+
+/proc/ispodperson(A)
+	. = is_species(A, /datum/species/pod)
+
+/proc/isflyperson(A)
+	. = is_species(A, /datum/species/fly)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -515,15 +515,31 @@
 		return FALSE
 	return TRUE
 
+/obj/item/device/wormhole_jaunter/proc/get_destinations(mob/user)
+	var/list/destinations = list()
+
+	if(isgolem(user))
+		for(var/obj/item/device/radio/beacon/B in world)
+			var/turf/T = get_turf(B)
+			if(istype(T.loc, /area/ruin/powered/golem_ship))
+				destinations += B
+
+	// In the event golem beacon is destroyed, send to station instead
+	if(destinations.len)
+		return destinations
+
+	for(var/obj/item/device/radio/beacon/B in world)
+		var/turf/T = get_turf(B)
+		if(T.z == ZLEVEL_STATION)
+			destinations += B
+
+	return destinations
+
 /obj/item/device/wormhole_jaunter/proc/activate(mob/user)
 	if(!turf_check(user))
 		return
 
-	var/list/L = list()
-	for(var/obj/item/device/radio/beacon/B in world)
-		var/turf/T = get_turf(B)
-		if(T.z == ZLEVEL_STATION)
-			L += B
+	var/list/L = get_destinations(user)
 	if(!L.len)
 		user << "<span class='notice'>The [src.name] found no beacons in the world to anchor a wormhole to.</span>"
 		return


### PR DESCRIPTION
Not all of my jaunter changes were medical, please be more careful next time @TechnoAlchemisto and @KorPhaeron. Golem jaunter access was removed for a reason, restoring it came specifically at the cost of making them target it.

Since this is a quasi-urgent PR, I haven't done any of the other stuff I'd like to do, because restraint.
