### PR TITLE
Fixes shuttle holes

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -6673,8 +6673,11 @@
 /turf/open/floor/plating,
 /area/maintenance/auxsolarport)
 "amB" = (
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/escape)
 "amC" = (
 /turf/open/floor/plating,
 /area/maintenance/fpmaint2)
@@ -7075,8 +7078,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/labor)
+/turf/open/floor/plasteel/shuttle{
+	icon_state = "shuttlefloor3"
+	},
+/area/shuttle/escape)
 "anr" = (
 /obj/structure/chair{
 	dir = 8
@@ -62786,14 +62791,6 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency,
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 9;
-	height = 11;
-	id = "emergency_home";
-	name = "emergency evac bay";
-	width = 22
-	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cxo" = (
@@ -62822,11 +62819,11 @@
 	},
 /area/shuttle/escape)
 "cxr" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle{
 	icon_state = "shuttlefloor3"
@@ -115871,11 +115868,11 @@ cxd
 cxe
 cwU
 cwL
-cxk
-cxk
-cxk
-cxk
-cxk
+anq
+anq
+anq
+anq
+anq
 cwL
 cwU
 cxQ
@@ -117153,7 +117150,7 @@ cwL
 cwX
 cwL
 cwL
-cxk
+anq
 cxj
 cwL
 cxq
@@ -117405,8 +117402,8 @@ aaa
 aaa
 crx
 cwG
-cwM
-cwM
+amB
+amB
 cwW
 cxa
 cwL


### PR DESCRIPTION
Looks like part of the Armory and Warden's office are there on the Box map, which the shuttle movement code ignores because it's not part of the shuttle area, which means it arrives on Centcom with holes, which drain the air, etc.

It looks like some models are being wrongly put, @xxalpha might be a merge issue.
