### PR TITLE
[WIP] Exporter Cannon

### DIFF
--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -11,7 +11,7 @@
 /obj/item/device/export_scanner/examine(user)
 	..()
 	if(!cargo_console)
-		user << "<span class='notice'>The [src] is currently not linked to a cargo console.</span>"
+		user << "<span class='notice'>\The [name] is currently not linked to a cargo console.</span>"
 
 /obj/item/device/export_scanner/afterattack(obj/O, mob/user, proximity)
 	if(!istype(O) || !proximity)
@@ -30,6 +30,9 @@
 			user << "<span class='warning'>Falied to connect to exports database!</span>"
 			return
 
+		if(O.anchored) // Can't sell it if it's bolted down to the floor
+			return
+
 		user << "<span class='notice'>Scanned [O].</span>"
 
 		// Before you fix it: yes, checking manifests is a part of intended functionality.
@@ -45,3 +48,4 @@
 				break
 		if(!exported)
 			user << "<span class='notice'>The object is unexportable.</span>"
+		return 1

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -54,6 +54,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 // Checks if the item is fit for export datum.
 /datum/export/proc/applies_to(obj/O, contr = 0, emag = 0)
+	if(qdeleted(O))
+		return FALSE
 	if(contraband && !contr)
 		return FALSE
 	if(emagged && !emag)

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -11,7 +11,7 @@
 /datum/export/gear/sec_armor
 	cost = 100
 	unit_name = "armor vest"
-	export_types = list(/obj/item/clothing/suit/armor/vest)
+	export_types = list(/obj/item/clothing/suit/armor/vest, /obj/item/clothing/suit/armor/vest/alt)
 	include_subtypes = FALSE
 
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -126,7 +126,7 @@
 /datum/export/large/grille/get_cost(obj/O)
 	var/obj/structure/grille/G = O
 	var/cost = ..()
-	if(W.destroyed)
+	if(G.destroyed)
 		cost /= 2
 	return round(cost)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -102,6 +102,41 @@
 	export_types = list(/obj/machinery/power/supermatter_shard)
 
 
+// Construction structures
+/datum/export/large/window
+	cost = 5
+	unit_name = "assembled window"
+	export_types = list(/obj/structure/window)
+
+/datum/export/large/window/get_cost(obj/O)
+	var/obj/structure/window/W = O
+	var/cost = ..()
+	if(W.reinf)
+		cost = 8
+	if(W.fulltile)
+		cost *= 2
+	return cost
+
+
+/datum/export/large/grille
+	cost = 5
+	unit_name = "assembled grille"
+	export_types = list(/obj/structure/grille)
+
+/datum/export/large/grille/get_cost(obj/O)
+	var/obj/structure/grille/G = O
+	var/cost = ..()
+	if(W.destroyed)
+		cost /= 2
+	return round(cost)
+
+
+/datum/export/large/girder
+	cost = 10
+	unit_name = "wall girder"
+	export_types = list(/obj/structure/girder)
+
+
 // Misc
 /datum/export/large/iv
 	cost = 300

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1108,6 +1108,13 @@
 /datum/supply_pack/misc
 	group = "Miscellaneous Supplies"
 
+/datum/supply_pack/misc/exporter
+	name = "X-Porter Cannon"
+	cost = 20000
+	contains = list(/obj/item/weapon/gun/energy/xporter)
+	crate_name = "religious supplies crate" // money is my god, capitalism is my religion
+	contraband = TRUE
+
 /datum/supply_pack/misc/mule
 	name = "MULEbot Crate"
 	cost = 2000

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1111,7 +1111,7 @@
 /datum/supply_pack/misc/exporter
 	name = "X-Porter Cannon"
 	cost = 20000
-	contains = list(/obj/item/weapon/gun/energy/xporter)
+	contains = list(/obj/item/weapon/gun/energy/exporter)
 	crate_name = "religious supplies crate" // money is my god, capitalism is my religion
 	contraband = TRUE
 

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -44,3 +44,15 @@
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	e_cost = 20
+
+
+/obj/item/ammo_casing/energy/export
+	projectile_type = /obj/item/projectile/beam/sell
+	select_name = "sell"
+	e_cost = 200
+
+/obj/item/ammo_casing/energy/export/newshot()
+	..()
+	if(istype(BB, /obj/item/projectile/beam/sell) && istype(loc, /obj/item/weapon/gun/energy/xporter))
+		var/obj/item/projectile/beam/sell/S = BB
+		S.gun = loc

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -53,6 +53,6 @@
 
 /obj/item/ammo_casing/energy/export/newshot()
 	..()
-	if(istype(BB, /obj/item/projectile/beam/sell) && istype(loc, /obj/item/weapon/gun/energy/xporter))
+	if(istype(BB, /obj/item/projectile/beam/sell) && istype(loc, /obj/item/weapon/gun/energy/exporter))
 		var/obj/item/projectile/beam/sell/S = BB
 		S.gun = loc

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -358,3 +358,22 @@
 
 /obj/item/weapon/gun/energy/laser/instakill/emp_act() //implying you could stop the instagib
 	return
+
+
+/obj/item/weapon/gun/energy/xporter
+	name = "x-porter cannon"
+	desc = "An industrial-grade teleporter connected to export scanner. Weapon of a true capitalist."
+	icon_state = "export_cannon"
+	ammo_type = list(/obj/item/ammo_casing/energy/export)
+	selfcharge = 1
+	charge_delay = 1
+	var/emagged = 0
+
+/obj/item/weapon/gun/energy/xporter/can_shoot()
+	return power_supply.charge >= power_supply.maxcharge
+
+/obj/item/weapon/gun/energy/xporter/update_icon()
+	if(can_shoot())
+		icon_state = "export_cannon"
+	else
+		icon_state = "export_cannon_empty"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -360,7 +360,7 @@
 	return
 
 
-/obj/item/weapon/gun/energy/xporter
+/obj/item/weapon/gun/energy/exporter
 	name = "x-porter cannon"
 	desc = "An industrial-grade teleporter connected to export scanner. Weapon of a true capitalist."
 	icon_state = "export_cannon"
@@ -369,10 +369,10 @@
 	charge_delay = 1
 	var/emagged = 0
 
-/obj/item/weapon/gun/energy/xporter/can_shoot()
+/obj/item/weapon/gun/energy/exporter/can_shoot()
 	return power_supply.charge >= power_supply.maxcharge
 
-/obj/item/weapon/gun/energy/xporter/update_icon()
+/obj/item/weapon/gun/energy/exporter/update_icon()
 	if(can_shoot())
 		icon_state = "export_cannon"
 	else

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -245,11 +245,11 @@
 
 /obj/item/projectile/beam/sell
 	name = "export beam"
-	icon_state = "e_netting"
+	icon_state = "xray"
 	damage = 1 // Damage is used to detremine if we are performing an execution
 	nodamage = 1
 	eyeblur = 2
-	var/obj/item/weapon/gun/energy/xporter/gun
+	var/obj/item/weapon/gun/energy/exporter/gun
 	var/obj/docking_port/mobile/supply/supply
 	var/selling = 0
 	var/sell_log = ""
@@ -270,7 +270,18 @@
 				C << "<span class='userdanger'>\The [src] reaches deep inside your body, selling your insides!</span>"
 
 		else if(!istype(gun) || gun.emagged) // Not execution, and overloaded? Sell victim's gear.
-			world << "exporter gear sell"
+			for(var/slot_id in 1 to slots_amt) // Check all the slots
+				var/obj/item/thing = C.get_item_by_slot(slot_id)
+				if(!thing || !can_sell(thing))
+					continue
+
+				if(!C.unEquip(thing))
+					continue
+
+				sell(thing)
+
+			if(sell_log)
+				C << "<span class='userdanger'>\The [src] sells your gear!</span>"
 		else
 			target << "<span class='notice'>\The [src] dissipates harmlessly through your body.</span>"
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -270,14 +270,18 @@
 				C << "<span class='userdanger'>\The [src] reaches deep inside your body, selling your insides!</span>"
 
 		else if(!istype(gun) || gun.emagged) // Not execution, and overloaded? Sell victim's gear.
+			var/list/for_sell = list()
+
 			for(var/slot_id in 1 to slots_amt) // Check all the slots
 				var/obj/item/thing = C.get_item_by_slot(slot_id)
 				if(!thing || !can_sell(thing))
 					continue
+				for_sell += thing
 
+			for(var/i in for_sell)
+				var/obj/item/thing = i
 				if(!C.unEquip(thing))
 					continue
-
 				sell(thing)
 
 			if(sell_log)
@@ -290,6 +294,9 @@
 		var/obj/O = target
 		if(!O.anchored)
 			sell(target)
+
+	if(sell_log)
+		add_logs(firer, target, "sold", src, "SOLD:([sell_log])")
 
 	stop_sell()
 
@@ -342,7 +349,6 @@
 		msg += "Total: [points_change>=0 ? "+" : ""][points_change] credits."
 		firer << "<span class='notice'>[msg]</span>"
 
-	world << sell_log
 	SSshuttle.points += points_change
 	if(istype(gun) && gun.power_supply && points_change-200 > 0)
 		gun.power_supply.use(min(points_change-200, gun.power_supply.charge))


### PR DESCRIPTION
This PR adds x-porter cannon, weapon of a true capitalist, to the cargo. It comes in a 20 000 credits contraband crate.

This cannon sells any object it's fired at. Selling affects the contents, so if you fired it at backpack full of plasma, the backpack would remain on the floor, but plasma inside would be sold.

When emagged, the cannon will try to sell the gear of any mob it hits. Similar to acid mix spray, but less lethal and more profitable. Perfect for dealing with red commie secs attacking your capitalistic heaven.

You can aim the cannon at mouth on "help" intent to perform a suicide/execution, just like with any other gun. Doing so will sell target's internal organs on the black market.

TODO:
- [x] Remove debug messages.
- [x] Add logging.
- [x] Implement emagged gear selling.
- [x] Implement execution organs selling.
- [x] Recharge time dependent on amount of credits recieved from the sale.
- [x] New exports for getting rid of things like unscrewed windows or girders.
- [x] Add the gun to cargo contraband crates.
- [ ] "Money spray" effect on successful sale.
- [ ] TEST EVERYTHING!
