### PR TITLE
Ends traitorling + snowflake rules, totally unrelated to #17618

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -43,6 +43,7 @@
 		for(var/j = 0, j < num_changelings, j++)
 			if(!possible_changelings.len) break
 			var/datum/mind/changeling = pick(possible_changelings)
+			antag_candidates -= changeling
 			possible_changelings -= changeling
 			changelings += changeling
 			modePlayer += changelings

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -366,7 +366,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Lightning", "Protector", "Charger", "Assassin")
 	var/random = TRUE
 	var/allowmultiple = 0
-	var/allowling = 0
+	var/allowling = 1
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	var/list/guardians = user.hasparasites()


### PR DESCRIPTION
Because the .001% chance a ling could have forced a traitor to hand over PDA codes via #17618 and get a holoparasite that removes their ability to revive was too risky to justify merging the last PR, even after I worked with Coiax to nerf fleshmend, again. 

I'm done dealing with lings Ahelp'ing because their traitor crate gave them a 14TC unusable piece of junk or having to deal with Ling balance being affected by traitor items, and traitor items affected by ling balance. This also smooths out the "grief lottery" by allowing 1-2 more people to play antag roles when a traitorling would've otherwise happened. Plus its a boon to lowpop rounds where a traitorling might as well be an ascendant shadowling for balance purposes. 
