### PR TITLE
Enables Frankensteins

### DIFF
--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -18,6 +18,7 @@
 	name = "add prosthetic"
 	implements = list(/obj/item/robot_parts = 100, /obj/item/bodypart = 100)
 	time = 32
+	var/organ_rejection_dam = 0
 
 /datum/surgery_step/add_prosthetic/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/tool_body_zone
@@ -27,8 +28,9 @@
 	else if(istype(tool, /obj/item/bodypart))
 		var/obj/item/bodypart/L = tool
 		if(L.status != ORGAN_ROBOTIC)
-			user << "<span class='warning'>You need a robotic limb for this.</span>"
-			return -1 //fail
+			organ_rejection_dam = 10
+			if(target.dna.species.id != L.species_id)
+				organ_rejection_dam = 30
 		tool_body_zone = L.body_zone
 	if(target_zone == tool_body_zone) //so we can't replace a leg with an arm.
 		user.visible_message("[user] begins to replace [target]'s [parse_zone(target_zone)].", "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)]...</span>")
@@ -43,6 +45,10 @@
 		qdel(tool)
 	else
 		L = tool
+		user.drop_item()
 	L.attach_limb(target)
+	if(organ_rejection_dam)
+		target.adjustToxLoss(organ_rejection_dam)
 	user.visible_message("[user] successfully replaces [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>")
 	return 1
+


### PR DESCRIPTION
- Allows you to frankenstein organic limbs onto people, dealing 10 tox damage if the species match
- Allows you to frankenstein organic limbs from OTHER SPECIES onto people, dealing 30 tox damage
- Fixes a bug where `/body_parts` used for surgery would stay in your hands when they're supposed to be in nullspace.

I say "Enabled" and not "Added" as this is clearly part of the system, Phil just hasn't enabled it because it's not 100% finished (I only really noticed species parts like snouts not following their limbs but that's only a minor graphical issue) but I've enabled it anyway as it's p.fun regardless

@phil235 if you want to save this for when it's more functional feel free to close it.

![ART](http://i.imgur.com/75IcTXW.png)
