### PR TITLE
Fixes to bot scanning improvements.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -374,13 +374,23 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	var/list/adjacent = T.GetAtmosAdjacentTurfs(1)
+	var/list/adjacent = shuffle(T.GetAtmosAdjacentTurfs(1))
 	for(var/scan in adjacent)//Let's see if there's something right next to us first!
-		var/final_result = checkscan(scan,scan_type,old_target)
-		if(final_result)
-			return final_result
-
+		if(check_bot(scan))	//Is there another bot there? Then let's just skip it
+			continue
+		if(isturf(scan_type))	//If we're lookeing for a turf we can just run the checks directly!
+			var/final_result = checkscan(scan,scan_type,old_target)
+			if(final_result)
+				return final_result
+		else
+			var/turf/turfy = scan
+			for(var/deepscan in turfy.contents)//Check the contents since adjacent is turfs
+				var/final_result = checkscan(deepscan,scan_type,old_target)
+				if(final_result)
+					return final_result
 	for (var/scan in shuffle(view(scan_range, src))-adjacent) //Search for something in range!
+		if(check_bot(scan))
+			continue
 		var/final_result = checkscan(scan,scan_type,old_target)
 		if(final_result)
 			return final_result
@@ -390,11 +400,7 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 		return 0 //If not, keep searching!
 	if( (scan in ignore_list) || (scan == old_target) ) //Filter for blacklisted elements, usually unreachable or previously processed oness
 		return 0
-	var/turf/T = get_turf(scan)
-	if(T)
-		for(var/C in T.contents)
-			if(istype(C,src.type) && (C != src))	//Is there another bot there already? If so, let's skip it so we dont all atack on top of eachother.
-				return 0
+
 	var/scan_result = process_scan(scan) //Some bots may require additional processing when a result is selected.
 	if(scan_result)
 		return scan_result
@@ -402,6 +408,12 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 		return 0 //The current element failed assessment, move on to the next.
 	return
 
+/mob/living/simple_animal/bot/proc/check_bot(targ)
+	var/turf/T = get_turf(targ)
+	if(T)
+		for(var/C in T.contents)
+			if(istype(C,src.type) && (C != src))	//Is there another bot there already? If so, let's skip it so we dont all atack on top of eachother.
+				return 1	//Let's abort if we find a bot so we dont have to keep rechecking
 
 //When the scan finds a target, run bot specific processing to select it for the next step. Empty by default.
 /mob/living/simple_animal/bot/proc/process_scan(scan_target)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -61,6 +61,7 @@
 	var/new_destination		// pending new destination (waiting for beacon response)
 	var/destination			// destination description tag
 	var/next_destination	// the next destination in the patrol route
+	var/shuffle = FALSE		// If we should shuffle our adjacency checking
 
 	var/blockcount = 0		//number of times retried a blocked path
 	var/awaiting_beacon	= 0	// count of pticks awaiting a beacon response
@@ -375,6 +376,9 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 	if(!T)
 		return
 	var/list/adjacent = T.GetAtmosAdjacentTurfs(1)
+	if(shuffle)	//If we were on the same tile as another bot, let's randomize our choices so we dont both go the same way
+		adjacent = shuffle(adjacent)
+		shuffle = FALSE
 	for(var/scan in adjacent)//Let's see if there's something right next to us first!
 		if(check_bot(scan))	//Is there another bot there? Then let's just skip it
 			continue
@@ -389,8 +393,6 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 				if(final_result)
 					return final_result
 	for (var/scan in shuffle(view(scan_range, src))-adjacent) //Search for something in range!
-		if(check_bot(scan))
-			continue
 		var/final_result = checkscan(scan,scan_type,old_target)
 		if(final_result)
 			return final_result
@@ -412,7 +414,7 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 	var/turf/T = get_turf(targ)
 	if(T)
 		for(var/C in T.contents)
-			if(istype(C,src.type) && (C != src))	//Is there another bot there already? If so, let's skip it so we dont all atack on top of eachother.
+			if(istype(C,type) && (C != src))	//Is there another bot there already? If so, let's skip it so we dont all atack on top of eachother.
 				return 1	//Let's abort if we find a bot so we dont have to keep rechecking
 
 //When the scan finds a target, run bot specific processing to select it for the next step. Empty by default.

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -374,7 +374,7 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	var/list/adjacent = shuffle(T.GetAtmosAdjacentTurfs(1))
+	var/list/adjacent = T.GetAtmosAdjacentTurfs(1)
 	for(var/scan in adjacent)//Let's see if there's something right next to us first!
 		if(check_bot(scan))	//Is there another bot there? Then let's just skip it
 			continue

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -140,7 +140,8 @@
 			return
 
 	if(target && loc == target.loc)
-		clean(target)
+		if(!check_bot(target))	//Target is not defined at the parent
+			clean(target)	//Rather than check at every step of the way, let's check before we do an action, so we can rescan before the other bot.
 		path = list()
 		target = null
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -140,8 +140,10 @@
 			return
 
 	if(target && loc == target.loc)
-		if(!check_bot(target))	//Target is not defined at the parent
+		if(!(check_bot(target) && prob(50)))	//Target is not defined at the parent. 50% chance to still try and clean so we dont get stuck on the last blood drop.
 			clean(target)	//Rather than check at every step of the way, let's check before we do an action, so we can rescan before the other bot.
+		else
+			shuffle = TRUE	//Shuffle the list the next time we scan so we dont both go the same way.
 		path = list()
 		target = null
 

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -224,8 +224,6 @@
 				bot_patrol()
 
 	if(target)
-		if(check_bot(target))	//Target is not defined at the parent.
-			return
 		if(path.len == 0)
 			if(!istype(target, /turf/))
 				var/turf/TL = get_turf(target)
@@ -245,9 +243,11 @@
 
 		if(loc == target || loc == target.loc)
 			if(check_bot(target))	//Target is not defined at the parent
-				target = null
-				path = list()
-				return
+				shuffle = TRUE
+				if(prob(50))	//50% chance to still try to repair so we dont end up with 2 floorbots failing to fix the last breach
+					target = null
+					path = list()
+					return
 			if(istype(target, /turf/) && emagged < 2)
 				repair(target)
 			else if(emagged == 2 && istype(target,/turf/open/floor))

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -81,7 +81,7 @@
 		dat += "<A href='?src=\ref[src];operation=eject'>Loaded \[[specialtiles]/[maxtiles]\]</a><BR>"
 	else
 		dat += "None Loaded<BR>"
-	
+
 	dat += "Behaviour controls are [locked ? "locked" : "unlocked"]<BR>"
 	if(!locked || issilicon(user) || IsAdminGhost(user))
 		dat += "Add tiles to new hull plating: <A href='?src=\ref[src];operation=autotile'>[autotile ? "Yes" : "No"]</A><BR>"
@@ -162,7 +162,7 @@
 				if("disable")
 					targetdirection = null
 	update_controls()
-	
+
 /mob/living/simple_animal/bot/floorbot/proc/empty_tiles()
 	var/turf/Tsec = get_turf(src)
 
@@ -204,7 +204,7 @@
 		if(!target && fixfloors) //Repairs damaged floors and tiles.
 			process_type = FIX_TILE
 			target = scan(/turf/open/floor)
-			
+
 		if(!target && replacetiles && specialtiles > 0) //Replace a floor tile with custom tile
 			process_type = REPLACE_TILE //The target must be a tile. The floor must already have a floortile.
 			target = scan(/turf/open/floor)
@@ -224,6 +224,8 @@
 				bot_patrol()
 
 	if(target)
+		if(check_bot(target))	//Target is not defined at the parent.
+			return
 		if(path.len == 0)
 			if(!istype(target, /turf/))
 				var/turf/TL = get_turf(target)
@@ -242,6 +244,10 @@
 			return
 
 		if(loc == target || loc == target.loc)
+			if(check_bot(target))	//Target is not defined at the parent
+				target = null
+				path = list()
+				return
 			if(istype(target, /turf/) && emagged < 2)
 				repair(target)
 			else if(emagged == 2 && istype(target,/turf/open/floor))


### PR DESCRIPTION
Makes the improved bot scanning code actually work for more than floorbots!

Add some more checks to hopefully prevent bot stacking.

:cl: 
fix: Cleanbot and floorbot scanning has greatly improved. they should prioritize areas next to them, as well as resolve themselves stacking on the same tiles.
/:cl:
