### PR TITLE
eliminates a hard tell in microlaser desc

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -72,7 +72,7 @@ effective or pretty fucking useless.
 	name = "health analyzer"
 	icon_state = "health"
 	item_state = "analyzer"
-	desc = "A hand-held body scanner able to distinguish vital signs of the subject. A strange microlaser is hooked on to the scanning end."
+	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	throwforce = 3


### PR DESCRIPTION
Micro lasers are underused enough as-is, and you can already find out that they're a traitor item by just using them in your hand. It doesn't need it's description to give it away.
