### PR TITLE
[s] Fixes using telekinesis to unwrap items teleporting them.

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -84,7 +84,7 @@
 	qdel(src)
 
 /obj/item/smallDelivery/attack_self_tk(mob/user)
-	if(istype(loc, /mob))
+	if(ismob(loc))
 		var/mob/M = loc
 		M.unEquip(src)
 		for(var/X in contents)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -83,6 +83,20 @@
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
 	qdel(src)
 
+/obj/item/smallDelivery/attack_self_tk(mob/user)
+	if(istype(loc, /mob))
+		var/mob/M = loc
+		M.unEquip(src)
+		for(var/X in contents)
+			var/atom/movable/AM = X
+			M.put_in_hands(AM)
+	else
+		for(var/X in contents)
+			var/atom/movable/AM = X
+			AM.forceMove(src.loc)
+	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
+	qdel(src)
+
 /obj/item/smallDelivery/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/device/destTagger))
 		var/obj/item/device/destTagger/O = W


### PR DESCRIPTION
Fixes #17606 

Not sure if I need the [s] tag so I'm putting it just in case. I did this before I noticed that @phil235 had assigned himself to it, so I'll just put it up anyway so you can tell me what I did wrong. 98% certain I didn't break every gun on the station this time, but you never know.

:cl:
bugfix: unwrapping an item with telekinesis no longer teleports the item into your hand.
/:cl:
