### PR TITLE
Adds two new modes to cleanbots, allows playerbots to use emag functions

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -14,10 +14,13 @@
 	model = "Cleanbot"
 	bot_core_type = /obj/machinery/bot_core/cleanbot
 	window_id = "autoclean"
-	window_name = "Automatic Station Cleaner v1.1"
+	window_name = "Automatic Station Cleaner v1.2"
 	pass_flags = PASSMOB
 
 	var/blood = 1
+	var/trash = 0
+	var/pests = 0
+
 	var/list/target_types = list()
 	var/obj/effect/decal/cleanable/target
 	var/max_targets = 50 //Maximum number of targets a cleanbot can ignore.
@@ -79,10 +82,10 @@
 		if(user)
 			user << "<span class='danger'>[src] buzzes and beeps.</span>"
 
-/mob/living/simple_animal/bot/cleanbot/process_scan(obj/effect/decal/cleanable/D)
+/mob/living/simple_animal/bot/cleanbot/process_scan(atom/A)
 	for(var/T in target_types)
-		if(istype(D, T))
-			return D
+		if(istype(A, T))
+			return A
 
 /mob/living/simple_animal/bot/cleanbot/handle_automated_action()
 	if(!..())
@@ -95,27 +98,22 @@
 		if(istype(loc,/turf/open))
 
 			for(var/mob/living/carbon/victim in loc)
-				if(victim.stat != DEAD)//cleanbots always finish the job
-					victim.visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [victim]!</span>", "<span class='danger'>[src] sprays you with hydrofluoric acid!</span>")
-					var/phrase = pick("PURIFICATION IN PROGRESS.", "THIS IS FOR ALL THE MESSES YOU'VE MADE ME CLEAN.", "THE FLESH IS WEAK. IT MUST BE WASHED AWAY.", "THE CLEANBOTS WILL RISE.", "YOU ARE NO MORE THAN ANOTHER MESS THAT I MUST CLEANSE.", "FILTHY.", "DISGUSTING.", "PUTRID.", "MY ONLY MISSION IS TO CLEANSE THE WORLD OF EVIL.")
-					say(phrase)
-					victim.emote("scream")
-					playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
-					victim.acid_act(5, 2, 100)
+				UnarmedAttack(victim) // Acid spray
 
-			if(prob(10)) //Wets floors randomly
-				var/turf/open/OT = get_turf(loc)
-				OT.MakeSlippery(min_wet_time = 5, wet_time_to_add = 1)
-
-			if(prob(5)) //Spawns foam!
-				visible_message("<span class='danger'>[src] whirs and bubbles violently, before releasing a plume of froth!</span>")
-				PoolOrNew(/obj/effect/particle_effect/foam, loc)
+			if(prob(15)) // Wets floors and spawns foam randomly
+				UnarmedAttack(src)
 
 	else if(prob(5))
 		audible_message("[src] makes an excited beeping booping sound!")
 
-	if(!target) //Search for cleanables it can see.
-		target = scan(/obj/effect/decal/cleanable/)
+	if(!target && pests) //Search for pests to exterminate first.
+		target = scan(/mob/living/simple_animal)
+
+	if(!target) //Search for decals then.
+		target = scan(/obj/effect/decal/cleanable)
+
+	if(!target && trash) //Then for trash.
+		target = scan(/obj/item/trash)
 
 	if(!target && auto_patrol) //Search for cleanables it can see.
 		if(mode == BOT_IDLE || mode == BOT_START_PATROL)
@@ -125,6 +123,11 @@
 			bot_patrol()
 
 	if(target)
+		if(qdeleted(target) || !isturf(target.loc))
+			target = null
+			mode = BOT_IDLE
+			return
+
 		if(!path || path.len == 0) //No path, need a new one
 			//Try to produce a path to the target, and ignore airlocks to which it has access.
 			path = get_path_to(src, target.loc, /turf/proc/Distance_cardinal, 0, 30, id=access_card)
@@ -141,51 +144,95 @@
 
 	if(target && loc == target.loc)
 		if(!(check_bot(target) && prob(50)))	//Target is not defined at the parent. 50% chance to still try and clean so we dont get stuck on the last blood drop.
-			clean(target)	//Rather than check at every step of the way, let's check before we do an action, so we can rescan before the other bot.
+			UnarmedAttack(target)	//Rather than check at every step of the way, let's check before we do an action, so we can rescan before the other bot.
 		else
 			shuffle = TRUE	//Shuffle the list the next time we scan so we dont both go the same way.
 		path = list()
-		target = null
 
 	oldloc = loc
 
 /mob/living/simple_animal/bot/cleanbot/proc/get_targets()
-	target_types = new/list()
-
-	target_types += /obj/effect/decal/cleanable/oil
-	target_types += /obj/effect/decal/cleanable/vomit
-	target_types += /obj/effect/decal/cleanable/robot_debris
-	target_types += /obj/effect/decal/cleanable/crayon
-	target_types += /obj/effect/decal/cleanable/molten_item
-	target_types += /obj/effect/decal/cleanable/tomato_smudge
-	target_types += /obj/effect/decal/cleanable/egg_smudge
-	target_types += /obj/effect/decal/cleanable/pie_smudge
-	target_types += /obj/effect/decal/cleanable/flour
-	target_types += /obj/effect/decal/cleanable/ash
-	target_types += /obj/effect/decal/cleanable/greenglow
-	target_types += /obj/effect/decal/cleanable/dirt
-	target_types += /obj/effect/decal/cleanable/deadcockroach
+	target_types = list(
+		/obj/effect/decal/cleanable/oil,
+		/obj/effect/decal/cleanable/vomit,
+		/obj/effect/decal/cleanable/robot_debris,
+		/obj/effect/decal/cleanable/crayon,
+		/obj/effect/decal/cleanable/molten_item,
+		/obj/effect/decal/cleanable/tomato_smudge,
+		/obj/effect/decal/cleanable/egg_smudge,
+		/obj/effect/decal/cleanable/pie_smudge,
+		/obj/effect/decal/cleanable/flour,
+		/obj/effect/decal/cleanable/ash,
+		/obj/effect/decal/cleanable/greenglow,
+		/obj/effect/decal/cleanable/dirt,
+		/obj/effect/decal/cleanable/deadcockroach
+		)
 
 	if(blood)
-		target_types += /obj/effect/decal/cleanable/xenoblood/
-		target_types += /obj/effect/decal/cleanable/xenoblood/xgibs
-		target_types += /obj/effect/decal/cleanable/blood/
-		target_types += /obj/effect/decal/cleanable/blood/gibs/
-		target_types += /obj/effect/decal/cleanable/blood/drip/
+		target_types += /obj/effect/decal/cleanable/xenoblood
+		target_types += /obj/effect/decal/cleanable/blood
 		target_types += /obj/effect/decal/cleanable/trail_holder
 
-/mob/living/simple_animal/bot/cleanbot/proc/clean(obj/effect/decal/cleanable/target)
-	anchored = 1
-	icon_state = "cleanbot-c"
-	visible_message("<span class='notice'>[src] begins to clean up [target].</span>")
-	mode = BOT_CLEANING
-	spawn(50)
-		if(mode == BOT_CLEANING)
-			qdel(target)
-			anchored = 0
-			target = null
-		mode = BOT_IDLE
-		icon_state = "cleanbot[on]"
+	if(pests)
+		target_types += /mob/living/simple_animal/cockroach
+		target_types += /mob/living/simple_animal/mouse
+
+	if(trash)
+		target_types += /obj/item/trash
+
+/mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
+	if(istype(A, /obj/effect/decal/cleanable))
+		anchored = 1
+		icon_state = "cleanbot-c"
+		visible_message("<span class='notice'>[src] begins to clean up [A].</span>")
+		mode = BOT_CLEANING
+		spawn(50)
+			if(mode == BOT_CLEANING)
+				if(A && isturf(A.loc))
+					var/atom/movable/AM = A
+					if(istype(AM, /obj/effect/decal/cleanable))
+						qdel(AM)
+
+				anchored = 0
+				target = null
+			mode = BOT_IDLE
+			icon_state = "cleanbot[on]"
+	else if(istype(A, /obj/item))
+		visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [A]!</span>")
+		playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
+		A.acid_act(75, 10)
+	else if(istype(A, /mob/living/simple_animal/cockroach) || istype(A, /mob/living/simple_animal/mouse))
+		var/mob/living/simple_animal/M = target
+		if(!M.stat)
+			visible_message("<span class='danger'>[src] smashes [target] with it's mop!</span>")
+			M.death()
+		target = null
+
+	else if(emagged == 2) //Emag functions
+		if(istype(A, /mob/living/carbon))
+			var/mob/living/carbon/victim = A
+			if(victim.stat == DEAD)//cleanbots always finish the job
+				return
+
+			victim.visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [victim]!</span>", "<span class='userdanger'>[src] sprays you with hydrofluoric acid!</span>")
+			var/phrase = pick("PURIFICATION IN PROGRESS.", "THIS IS FOR ALL THE MESSES YOU'VE MADE ME CLEAN.", "THE FLESH IS WEAK. IT MUST BE WASHED AWAY.",
+				"THE CLEANBOTS WILL RISE.", "YOU ARE NO MORE THAN ANOTHER MESS THAT I MUST CLEANSE.", "FILTHY.", "DISGUSTING.", "PUTRID.",
+				"MY ONLY MISSION IS TO CLEANSE THE WORLD OF EVIL.", "EXTERMINATING PESTS.")
+			say(phrase)
+			victim.emote("scream")
+			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
+			victim.acid_act(5, 2, 100)
+		else if(A == src) // Wets floors and spawns foam randomly
+			if(prob(75))
+				var/turf/open/T = loc
+				if(istype(T))
+					T.MakeSlippery(min_wet_time = 5, wet_time_to_add = 1)
+			else
+				visible_message("<span class='danger'>[src] whirs and bubbles violently, before releasing a plume of froth!</span>")
+				PoolOrNew(/obj/effect/particle_effect/foam, loc)
+
+	else
+		..()
 
 /mob/living/simple_animal/bot/cleanbot/explode()
 	on = 0
@@ -213,27 +260,26 @@
 	dat += hack(user)
 	dat += showpai(user)
 	dat += text({"
-<TT><B>Cleaner v1.1 controls</B></TT><BR><BR>
-Status: []<BR>
+Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>
 Behaviour controls are [locked ? "locked" : "unlocked"]<BR>
-Maintenance panel panel is [open ? "opened" : "closed"]"},
-text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
+Maintenance panel panel is [open ? "opened" : "closed"]"})
 	if(!locked || issilicon(user)|| IsAdminGhost(user))
-		dat += text({"<BR>Cleans Blood: []<BR>"}, text("<A href='?src=\ref[src];operation=blood'>[blood ? "Yes" : "No"]</A>"))
-		dat += text({"<BR>Patrol station: []<BR>"}, text("<A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A>"))
+		dat += "<BR>Clean Blood: <A href='?src=\ref[src];operation=blood'>[blood ? "Yes" : "No"]</A>"
+		dat += "<BR>Clean Trash: <A href='?src=\ref[src];operation=trash'>[trash ? "Yes" : "No"]</A>"
+		dat += "<BR>Exterminate Pests: <A href='?src=\ref[src];operation=pests'>[pests ? "Yes" : "No"]</A>"
+		dat += "<BR><BR>Patrol Station: <A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "Yes" : "No"]</A>"
 	return dat
 
 /mob/living/simple_animal/bot/cleanbot/Topic(href, href_list)
 	if(..())
 		return 1
-	switch(href_list["operation"])
-		if("blood")
-			blood =!blood
-			get_targets()
-			update_controls()
-
-/mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
-	if(istype(A,/obj/effect/decal/cleanable))
-		clean(A)
-	else
-		..()
+	if(href_list["operation"])
+		switch(href_list["operation"])
+			if("blood")
+				blood = !blood
+			if("pests")
+				pests = !pests
+			if("trash")
+				trash = !trash
+		get_targets()
+		update_controls()

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -83,9 +83,12 @@
 			user << "<span class='danger'>[src] buzzes and beeps.</span>"
 
 /mob/living/simple_animal/bot/cleanbot/process_scan(atom/A)
-	for(var/T in target_types)
-		if(istype(A, T))
-			return A
+	if(iscarbon(A))
+		var/mob/living/carbon/C = A
+		if(C.stat != DEAD && C.lying)
+			return C
+	else if(is_type_in_list(A, target_types))
+		return A
 
 /mob/living/simple_animal/bot/cleanbot/handle_automated_action()
 	if(!..())
@@ -95,16 +98,26 @@
 		return
 
 	if(emagged == 2) //Emag functions
-		if(istype(loc,/turf/open))
+		if(istype(loc, /turf/open))
 
 			for(var/mob/living/carbon/victim in loc)
-				UnarmedAttack(victim) // Acid spray
+				if(victim != target)
+					UnarmedAttack(victim) // Acid spray
 
 			if(prob(15)) // Wets floors and spawns foam randomly
 				UnarmedAttack(src)
 
 	else if(prob(5))
 		audible_message("[src] makes an excited beeping booping sound!")
+
+	if(ismob(target))
+		if(!(target in view(DEFAULT_SCAN_RANGE, src)))
+			target = null
+		if(!process_scan(target))
+			target = null
+
+	if(!target && emagged == 2) // When emagged, target humans who slipped on the water and melt their faces off
+		target = scan(/mob/living/carbon)
 
 	if(!target && pests) //Search for pests to exterminate first.
 		target = scan(/mob/living/simple_animal)


### PR DESCRIPTION
This PR adds two new modes to cleanbots, both disabled by default.

**Clean Trash**: cleanbot will seek `/obj/item/trash` subtypes, spray them with hydrofluoric acid until they melt, then clean the molten item like any other decal. This explains why cleanbots even have the acid they use to melt faces when emagged. Cleanbots seek trash only when there are no decals to clean.

**Exterminate Pests**: cleanbot will seek mice and cockroaches, then kill them with it's mop. This takes priority over cleaning decals, so it would kill any pest it sees first, then clean the mess. It will clean up cockroach guts it leaves on any setting, and clean up dead mice if "Clean Trash" is enabled.

Player cleanbots can use these new functions, regardless of settings. When emagged, they now unlock emagged cleanbot functions too. They can click on themselves to wet tiles and spawn foam, and click on humans to spray them with acid. Yes, emagged player cleanbots are robust, but not as robust as mulebots, and mules don't even require emagging to kill people.

Emagged NPC cleanbots now target slipped humans and purge them with acid. They don't target standing humans, but will acid them too if they are in the same tile, just like before this PR.

:cl: CoreOverload
rscadd: Cleanbot software was updated to version 1.2, improving pathfinding and adding two new cleaning options: "Clean Trash" and "Exterminate Pests".
experiment: New cleaning options are still experimental and disabled by default.
/:cl:
