### PR TITLE
Disables changelings use of holoparasite injectors

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -381,7 +381,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Lightning", "Protector", "Charger", "Assassin")
 	var/random = TRUE
 	var/allowmultiple = 0
-	var/allowling = 1
+	var/allowling = FALSE
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	var/list/guardians = user.hasparasites()


### PR DESCRIPTION
BabyRage BabyRage

Changelings will be op, because then they'll be able to (after spending
a lot of time and effort obtaining a guardian creation tool, either by
stealing one from a traitor or fucking around on lavaland) make it so
they DUST on death, which is exactly what changelings love, TOTAL
BODYILY DESTRUCTION.
![image](https://cloud.githubusercontent.com/assets/609465/15274189/93b049da-1aa4-11e6-8b77-5082aac4c4b8.png)

However, bringing back traitorling is bad and dumb, so have this
COMPROMISE PR that I don't actually like but it's certainly better than
the #17670 which is just shit.
