### PR TITLE
Removes monster spawning from ruin areas

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -121,6 +121,10 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 	if(!template)
 		world << "<span class='boldannounce'>No ruins found.</span>"
 		return
+	for(var/i in template.get_affected_turfs(get_turf(src), 1))
+		var/turf/T = i
+		for(var/mob/living/simple_animal/monster in T)
+			qdel(monster)
 	template.load(get_turf(src),centered = TRUE)
 	template.loaded++
 	world << "<span class='boldannounce'>Ruins loaded.</span>"


### PR DESCRIPTION
- Specifically, this is a post-template selection, pre-template
  placement deletion. So templates can continue to have simple animals,
  it'll only clash if they overlap.

:cl: coiax
rscdel: Lavaland monsters now give ruins a wide berth.
/:cl:
