### PR TITLE
KA rebalance; brings back holding a satchel

### DIFF
--- a/code/game/objects/items/devices/modificationkit.dm
+++ b/code/game/objects/items/devices/modificationkit.dm
@@ -1,6 +1,9 @@
 /obj/item/modkit
 	name = "modification kit"
-	desc = "A one-use kit, which enables kinetic accelerators to be fired with only one hand, as well as allowing less dextrous races to use the tool."
+	desc = "A one-use kit, which enables kinetic accelerators to retain their \
+		charge when away from a bioelectric source, renders them immune to \
+		interference with other accelerators, as well as allowing less \
+		dextrous races to use the tool."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "modkit"
 	origin_tech = "programming=2;materials=2;magnets=4"
@@ -12,12 +15,15 @@
 		qdel(src)
 		return
 	if(!istype(C))
-		user << "<span class='warning'>This kit can only modify kinetic accelerators!</span>"
+		user << "<span class='warning'>This kit can only modify kinetic \
+			accelerators!</span>"
 		return ..()
-	user <<"<span class='notice'>You modify the [C], making it less unwieldy.</span>"
-	C.name = "compact [C.name]"
-	C.weapon_weight = WEAPON_LIGHT
+	user <<"<span class='notice'>You modify the [C], adjusting the trigger \
+		guard and internal capacitor.</span>"
+	C.name = "improved [C.name]"
+	C.holds_charge = TRUE
+	C.unique_frequency = TRUE
 	C.trigger_guard = TRIGGER_GUARD_ALLOW_ALL
-	uses --
+	uses--
 	if(!uses)
 		qdel(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -294,7 +294,7 @@
 	modules += new /obj/item/weapon/shovel(src)
 	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	modules += new /obj/item/device/t_scanner/adv_mining_scanner(src)
-	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator(src)
+	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
 	fix_modules()
 
 /obj/item/weapon/robot_module/syndicate

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -89,12 +89,15 @@
 	icon_state = "kineticgun"
 	item_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
-	cell_type = "/obj/item/weapon/stock_parts/cell/emproof"
-	needs_permit = 0 // Aparently these are safe to carry? I'm sure Golliaths would disagree.
+	cell_type = /obj/item/weapon/stock_parts/cell/emproof
+	// Apparently these are safe to carry? I'm sure goliaths would disagree.
+	needs_permit = 0
 	var/overheat_time = 16
 	unique_rename = 1
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_LIGHT
 	origin_tech = "combat=2;powerstorage=1"
+	var/holds_charge = FALSE
+	var/unique_frequency = FALSE // modified by KA modkits
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/super
 	name = "super-kinetic accelerator"
@@ -112,10 +115,53 @@
 	overheat_time = 14
 	origin_tech = "combat=4;powerstorage=3"
 
+/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg
+	holds_charge = TRUE
+	unique_frequency = TRUE
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/New()
+	. = ..()
+	if(!holds_charge)
+		empty()
+
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
-	..()
-	spawn(overheat_time)
-		reload()
+	. = ..()
+	attempt_reload()
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/equipped(mob/user)
+	. = ..()
+	attempt_reload()
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/dropped()
+	. = ..()
+	if(!holds_charge)
+		// Put it on a delay because moving item from slot to hand
+		// calls dropped().
+		spawn(overheat_time)
+			if(!ismob(loc))
+				empty()
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/proc/empty()
+	power_supply.use(500)
+	update_icon()
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/proc/attempt_reload()
+	var/carried = 0
+	if(!unique_frequency)
+		for(var/obj/item/weapon/gun/energy/kinetic_accelerator/K in \
+			loc.GetAllContents())
+
+			carried++
+
+		carried = max(carried, 1)
+	else
+		carried = 1
+
+	spawn(overheat_time * carried)
+		if(can_shoot())
+			return
+		else
+			reload()
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/emp_act(severity)
 	return
@@ -148,6 +194,8 @@
 	weapon_weight = WEAPON_LIGHT
 	unique_rename = 0
 	overheat_time = 20
+	holds_charge = TRUE
+	unique_frequency = TRUE
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow/large
 	name = "energy crossbow"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -204,10 +204,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 
 /datum/uplink_item/dangerous/crossbow
 	name = "Miniature Energy Crossbow"
-	desc = "A short bow mounted across a tiller in miniature. Small enough to fit into a pocket or slip into a bag \
-			unnoticed. It will synthesize and fire bolts tipped with a paralyzing toxin that will \
-			briefly stun targets and cause them to slur as if inebriated. It can produce an infinite amount \
-			of bolts, but must be manually recharged with each shot."
+	desc = "A short bow mounted across a tiller in miniature. Small enough to \
+		fit into a pocket or slip into a bag unnoticed. It will synthesize \
+		and fire bolts tipped with a paralyzing toxin that will briefly stun \
+		targets and cause them to slur as if inebriated. It can produce an \
+		infinite amount of bolts, but takes time to automatically recharge \
+		after each shot."
 	item = /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow
 	cost = 12
 	surplus = 50


### PR DESCRIPTION
Fixes #17203.

:cl: coiax
rscadd: Kinetic accelerators only require one hand to be fired, as before
rscdel: Kinetic accelerators recharge time is multiplied by the number of KAs that person is carrying.
rscdel: Kinetic accelerators lose their charge quickly if not equipped or being held
rscadd: Kinetic accelerator modkits (made at R&D or your local Free Golem
ship) overcome these flaws
/:cl:

Effects on people who just use one kinetic accelerator: _They can now
carry a mining satchel in the off hand again._
Effects on people who want to dual wield them both at once: They can do
this, but they recharge twice as slow, so no increase in DPS.
Effects on people who quasi-dual wielded by swapping them in and out of
the backpack: Now treated the same as dual wielders. Possibly actually
worse because a KA will lose charge in a backpack, but still interfere with
one in the hand.

And as before, modkits mean you can properly dual wield KAs.
Mining cyborgs are unaffected.
