### PR TITLE
Makes is_type_in_list() much faster (thanks remie)

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -53,10 +53,16 @@
 
 //Checks for specific types in a list
 /proc/is_type_in_list(atom/A, list/L)
+	if (!L.len)
+		return 0
+	if (!isnum(L[L[1]]))
+		generate_type_list_cache(L)
+	return L[A.type]
+
+/proc/generate_type_list_cache(L)
 	for(var/type in L)
-		if(istype(A, type))
-			return 1
-	return 0
+		for(var/T in typesof(type))
+			L[T] = 1
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected
 /proc/clearlist(list/list)


### PR DESCRIPTION
The gist is that we cache all subtypes of each type in the list, so that we can just check for the exact type in the list.

Core idea is credited to remie

**1.8** million calls, **282.940** old vs **1.627** new (thats not a typo)
Results in about a 175:1 ratio (Old CPU Cost : New CPU Cost), 175x faster, and 2 orders of magnitude faster.

This was tested using live code by making is_type_in_list() randomly switch between calling the old and new, (prob(50)) and making the tesla grow 31 balls, and locking it to the middle above bridge, and just waiting.
