### PR TITLE
Adds stat tracking to cargo

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -70,8 +70,12 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 // Adds item's cost and amount to the current export cycle.
 // get_cost, get_amount and applies_to do not neccesary mean a successful sale.
 /datum/export/proc/sell_object(obj/O, contr = 0, emag = 0)
-	total_cost += get_cost(O)
-	total_amount += get_amount(O)
+	var/cost = get_cost(O)
+	var/amount = get_amount(O)
+	total_cost += cost
+	total_amount += amount
+	feedback_add_details("export_sold_amount","[O.type]|[amount]")
+	feedback_add_details("export_sold_cost","[O.type]|[cost]")
 
 // Total printout for the cargo console.
 // Called before the end of current export cycle.

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -92,6 +92,8 @@
 		SSshuttle.orderhistory += SO
 
 		SO.generate(pick_n_take(empty_turfs))
+		feedback_add_details("cargo_imports",
+			"[SO.pack.type]|[SO.pack.name]|[SO.pack.cost]")
 		investigate_log("Order #[SO.id] ([SO.pack.name], placed by [key_name(SO.orderer_ckey)]) has shipped.", "cargo")
 		if(SO.pack.dangerous)
 			message_admins("\A [SO.pack.name] ordered by [key_name_admin(SO.orderer_ckey)] has shipped.")


### PR DESCRIPTION
Amazed we don't track cargo import/exports already.
- "export_sold_amount", "object.type|numbersold"
- "export_sold_cost", "object.type|totalcreditsgained"
- "cargo_imports", "pack.type|pack.name|pack.cost" (called for each
  crate that is bought)
