### PR TITLE
Fixes containment fields randomly not linking

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -238,7 +238,8 @@ field_generator power level display
 		setup_field(4)
 	spawn(4)
 		setup_field(8)
-	active = FG_ONLINE
+	spawn(5)
+		active = FG_ONLINE
 
 
 /obj/machinery/field/generator/proc/setup_field(NSEW)


### PR DESCRIPTION
Basically, once `active = FG_ONLINE` runs the field will attempt to draw power on the next process(), if that happens before these spawned lines above it runs, linking up to the next field generator, it will shut down, and the field link never happens.

Fixes #17711
