### PR TITLE
Makes chaplain soulshard its own path

### DIFF
--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -37315,7 +37315,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
 /obj/item/weapon/nullrod,
-/obj/item/device/soulstone/anybody,
+/obj/item/device/soulstone/anybody/chaplain,
 /turf/open/floor/plasteel{
 	icon_state = "grimy"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -90596,7 +90596,7 @@
 	pixel_x = 4
 	},
 /obj/item/organ/heart,
-/obj/item/device/soulstone/anybody,
+/obj/item/device/soulstone/anybody/chaplain,
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -12,6 +12,9 @@
 /obj/item/device/soulstone/anybody
 	usability = 1
 
+/obj/item/device/soulstone/anybody/chaplain
+	name = "mysterious old shard"
+
 /obj/item/device/soulstone/pickup(mob/living/user)
 	..()
 	if(!iscultist(user) && !iswizard(user) && !usability)


### PR DESCRIPTION
- Changes the name to "mysterious old shard"
- No other changes.

This is mostly so if the chaplain soulstone is nerfed later it'll be
already possible to do so without nerfing all other universal
soulstones.
