### PR TITLE
Weather Immunity Refactor

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -224,7 +224,7 @@
 		else if (istype(thing, /mob/living))
 			. = 1
 			var/mob/living/L = thing
-			if("mining" in L.faction)
+			if("lava" in L.weather_immunities)
 				continue
 			if(L.buckled)
 				if(isobj(L.buckled))
@@ -232,8 +232,8 @@
 					if(O.burn_state == LAVA_PROOF)
 						continue
 				if(isliving(L.buckled)) //Goliath riding
-					var/mob/living/liv = L.buckled
-					if("mining" in liv.faction)
+					var/mob/living/live = L.buckled
+					if("lava" in live.weather_immunities)
 						continue
 
 			L.adjustFireLoss(20)

--- a/code/modules/mining/lavaland/weather.dm
+++ b/code/modules/mining/lavaland/weather.dm
@@ -25,6 +25,7 @@
 	var/overlay_layer = 10 //This is the default area layer, and above everything else. 2 is floors/below walls and mobs.
 	var/purely_aesthetic = FALSE //If we just want gentle rain that doesn't hurt people
 	var/list/impacted_areas = list()
+	var/immunity_type = "storm"
 
 /datum/weather/proc/weather_start_up()
 	for(var/area/N in get_areas(area_type))
@@ -73,9 +74,8 @@
 
 
 /datum/weather/proc/storm_act(mob/living/L)
-	if(prob(30)) //Dont want it spammed very tick
-		L << "You're buffeted by the storm!"
-		L.adjustBruteLoss(1)
+	if(immunity_type in L.weather_immunities)
+		return
 
 /datum/weather/proc/update_areas()
 	for(var/area/N in impacted_areas)

--- a/code/modules/mining/lavaland/weather_types.dm
+++ b/code/modules/mining/lavaland/weather_types.dm
@@ -18,8 +18,11 @@
 	duration_overlay = "lava"
 	overlay_layer = 2 //Covers floors only
 
+	immunity_type = "lava"
+
 
 /datum/weather/floor_is_lava/storm_act(mob/living/L)
+	..()
 	var/turf/F = get_turf(L)
 	for(var/obj/structure/O in F.contents)
 		if(O.level > F.level && !istype(O, /obj/structure/window)) // Something to stand on and it isn't under the floor!
@@ -77,6 +80,8 @@
 	duration_overlay = "ash_storm"
 	overlay_layer = 10
 
+	immunity_type = "ash"
+
 
 /datum/weather/ash_storm/false_alarm //No storm, just light ember fall
 	purely_aesthetic = TRUE
@@ -85,8 +90,7 @@
 	wind_down_message = "The ash fall starts to trail off."
 
 /datum/weather/ash_storm/storm_act(mob/living/L)
-	if("mining" in L.faction)
-		return
+	..()
 	if(istype(L.loc, /obj/mecha))
 		return
 	if(ishuman(L))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -61,3 +61,5 @@
 	var/list/butcher_results = null
 	var/hellbound = 0 //People who've signed infernal contracts are unrevivable.
 
+	var/list/weather_immunities = list()
+

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -11,6 +11,7 @@
 	friendly = "stares down"
 	icon = 'icons/mob/lavaland/dragon.dmi'
 	faction = list("mining")
+	weather_immunities = list("lava","ash")
 	speak_emote = list("roars")
 	luminosity = 3
 	armour_penetration = 40

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -2,6 +2,7 @@
 	vision_range = 2
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	faction = list("mining")
+	weather_immunities = list("lava","ash")
 	environment_smash = 2
 	minbodytemp = 0
 	maxbodytemp = INFINITY
@@ -853,6 +854,7 @@
 	speak_emote = list("warbles", "quavers")
 	emote_hear = list("trills.")
 	emote_see = list("sniffs.", "burps.")
+	weather_immunities = list("lava","ash")
 	faction = list("mining", "ashwalker")
 	density = 0
 	speak_chance = 1
@@ -966,6 +968,7 @@
 	icon_living = "tendril"
 	icon_dead = "tendril"
 	faction = list("mining")
+	weather_immunities = list("lava","ash")
 	health = 250
 	maxHealth = 250
 	max_mobs = 3

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -19,6 +19,7 @@
 	minbodytemp = 0
 	maxbodytemp = 350
 	layer = MOB_LAYER-0.1
+	sentience_type = SENTIENCE_BOSS
 
 
 /mob/living/simple_animal/hostile/spawner/Destroy()


### PR DESCRIPTION
No longer uses mob factions, but checks against a list of their weather communities instead.

It's like faction checks but for weather, featuring MAGIC STRINGS which I'll make defines when I wake up I guess.

Also made it so sentience potions won't work on mob spawners.

Fixes #17646
