### PR TITLE
Fixes cavity implants getting thrown into the nullspace

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -31,7 +31,7 @@
 			user.visible_message("[user] stuffs [tool] into [target]'s [target_zone]!", "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>")
 			user.drop_item()
 			CH.cavity_item = tool
-			tool.loc = null
+			tool.loc = target
 			return 1
 	else
 		if(IC)


### PR DESCRIPTION
This screwed up implanted bombs, grenades, teleport beacons, traitor objectives and other fun things.
@phil235 
