### PR TITLE
The gibber produces gibs again.

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/gibber.dm
+++ b/code/modules/food&drinks/kitchen machinery/gibber.dm
@@ -230,7 +230,7 @@
 			skin.throw_at_fast(pick(nearby_turfs),i,3)
 			for (var/turfs=1 to meat_produced*3)
 				var/turf/gibturf = pick(nearby_turfs)
-				if (!gibturf.density && src in viewers(gibturf))
+				if (!gibturf.density && src in view(gibturf))
 					new gibtype(gibturf,i)
 
 		pixel_x = initial(pixel_x) //return to its spot after shaking


### PR DESCRIPTION
Fixes https://github.com/tgstation/-tg-station/issues/17344.

Remember, viewers() is for mobs only
