### PR TITLE
is_type_in_list() fixes

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -55,7 +55,7 @@
 /proc/is_type_in_list(atom/A, list/L)
 	if (!L.len)
 		return 0
-	if (!isnum(L[L[1]]))
+	if (!L[L[1]])
 		generate_type_list_cache(L)
 	return L[A.type]
 


### PR DESCRIPTION
`is_type_in_list()` will now detect non-numeric associative values, to avoid unnecessary conversions that would break the list, for example:
Grinding uses a `type = list("results" = amount)` format, with `list()` not being a number it was then converted to `type = 1`, this conversion was unnecessary as a `list()` is still true and all we want in the associative value is a truth value, not specifically a `1`.

fixes #17813 

@MrStonedOne 
