### PR TITLE
Fixes mop wetness stacks

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -31,7 +31,7 @@ obj/item/weapon/mop/proc/clean(turf/A)
 		if(istype(A, /turf/closed))
 			var/turf/closed/C = A
 			C.thermite = 0
-	reagents.reaction(A, TOUCH, 1)	//1 used 1 applied.
+	reagents.reaction(A, TOUCH, 5)	//Needed for proper floor wetting.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
 
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -23,7 +23,7 @@
 
 
 obj/item/weapon/mop/proc/clean(turf/A)
-	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1))
+	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1) || reagents.has_reagent("cleaner", 1))
 		A.clean_blood()
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
@@ -31,7 +31,7 @@ obj/item/weapon/mop/proc/clean(turf/A)
 		if(istype(A, /turf/closed))
 			var/turf/closed/C = A
 			C.thermite = 0
-	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
+	reagents.reaction(A, TOUCH, 1)	//1 used 1 applied.
 	reagents.remove_any(1)			//reaction() doesn't use up the reagents
 
 


### PR DESCRIPTION
Mops currently apply ten times as much liquid as they use and because wetness and lube and the such now stacks this means when you apply something with a mop it takes ten times as long to dry as it would otherwise.

After some testing applying five units seems like the minimum, although this still means you essentially duplicate liquid, but removing this would mostly just make buckets no longer useful for anything but loading the janicart.
