### PR TITLE
Shades cannot suicide inside soulstones

### DIFF
--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -34,6 +34,11 @@
 	deathmessage = "<span class='warning'>[src] lets out a contented sigh as their form unwinds.</span>"
 	..()
 
+/mob/living/simple_animal/shade/canSuicide()
+	if(istype(loc, /obj/item/device/soulstone)) //do not suicide inside the soulstone
+		return 0
+	return ..()
+
 /mob/living/simple_animal/shade/Process_Spacemove(movement_dir = 0)
 	return TRUE //this doesn't make much sense; you'd thing TRUE would mean it'd process spacemove but it means it doesn't
 


### PR DESCRIPTION
This could possibly be more generic, like being unable to suicide if you have the GODMODE flag, but that might be seen as a feature.

Fixes  #17848
