### PR TITLE
[MAP] Security Mini-Medbay

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2052,7 +2052,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "redcorner";
 	dir = 4
@@ -2518,7 +2518,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aeV" = (
@@ -2936,8 +2936,7 @@
 /obj/structure/table,
 /obj/item/device/electropack,
 /turf/open/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "red"
 	},
 /area/security/prison)
 "afE" = (
@@ -2955,8 +2954,7 @@
 /obj/structure/table,
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plasteel{
-	dir = 2;
-	icon_state = "escape"
+	icon_state = "red"
 	},
 /area/security/prison)
 "afG" = (
@@ -2972,8 +2970,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "red"
 	},
 /area/security/prison)
 "afH" = (
@@ -2985,10 +2982,8 @@
 	},
 /area/security/prison)
 "afI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "red"
 	},
 /area/security/prison)
 "afJ" = (
@@ -2997,8 +2992,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "red"
 	},
 /area/security/prison)
 "afK" = (
@@ -3236,13 +3230,13 @@
 	},
 /area/security/prison)
 "agl" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Insanity Ward";
-	req_access_txt = "2"
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access = null;
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
 /area/security/prison)
 "agm" = (
@@ -3471,46 +3465,14 @@
 	},
 /area/security/main)
 "agH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "warnwhite";
-	dir = 1
-	},
-/area/security/prison)
-"agI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel{
-	icon_state = "warnwhite";
-	dir = 5
-	},
-/area/security/prison)
-"agJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brig)
-"agK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
-"agL" = (
-/obj/structure/table,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/turf/open/floor/plasteel{
-	dir = 9;
-	icon_state = "warnwhite"
-	},
 /area/security/prison)
-"agM" = (
+"agI" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -3520,14 +3482,61 @@
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brig)
-"agN" = (
+/area/security/prison)
+"agJ" = (
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
+	},
+/area/security/prison)
+"agK" = (
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
+"agL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
+"agM" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel{
+	dir = 9;
+	icon_state = "whitered"
+	},
+/area/security/brig)
+"agN" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/device/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
+	name = "Station Intercom (General)";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel{
+	dir = 10;
+	icon_state = "whitered"
 	},
 /area/security/brig)
 "agO" = (
@@ -3763,73 +3772,26 @@
 	},
 /area/security/main)
 "ahm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whitered"
 	},
-/area/security/prison)
+/area/security/brig)
 "ahn" = (
 /turf/closed/wall,
 /area/maintenance/fsmaint)
 "aho" = (
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"ahp" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"ahq" = (
-/obj/machinery/flasher{
-	id = "insaneflash";
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	external_pressure_bound = 101.325;
-	on = 1;
-	pressure_checks = 1
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"ahr" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brig)
-"ahs" = (
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
-"aht" = (
+/area/security/prison)
+"ahp" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -3837,12 +3799,56 @@
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/security/brig)
-"ahu" = (
+/area/security/prison)
+"ahq" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
+	},
+/area/security/prison)
+"ahr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/brig)
+"ahs" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "whitered"
+	},
+/area/security/brig)
+"aht" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/security/brig)
+"ahu" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/bodybags,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/syringe,
+/obj/item/weapon/reagent_containers/glass/bottle/charcoal,
+/obj/item/weapon/reagent_containers/glass/bottle/epinephrine,
+/turf/open/floor/plasteel{
+	dir = 10;
+	icon_state = "whitered"
 	},
 /area/security/brig)
 "ahv" = (
@@ -3965,21 +3971,21 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/window/westleft{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "Infirmary";
+	req_access_txt = "0"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
+	dir = 4;
+	icon_state = "whitered"
 	},
-/area/security/warden)
+/area/security/brig)
 "ahE" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Brig Control";
@@ -4160,12 +4166,8 @@
 /turf/closed/wall,
 /area/security/main)
 "ahP" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8
-	},
 /turf/open/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/security/brig)
 "ahQ" = (
@@ -4224,37 +4226,35 @@
 /turf/open/floor/plating,
 /area/maintenance/fsmaint)
 "ahU" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/machinery/camera{
-	c_tag = "Prison Sanitatium";
-	dir = 4;
-	network = list("SS13","Prison");
-	pixel_x = 0;
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/effect/landmark{
-	name = "revenantspawn"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
-	icon_state = "white"
+	icon_state = "red";
+	dir = 9
 	},
-/area/security/prison)
+/area/security/brig)
 "ahV" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/effect/landmark{
-	name = "revenantspawn"
-	},
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"ahW" = (
 /obj/structure/table,
 /obj/item/weapon/folder/red,
 /obj/item/device/taperecorder{
 	pixel_y = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
+"ahW" = (
+/obj/structure/bodycontainer/morgue,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
@@ -4343,12 +4343,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fsmaint)
 "aid" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "whitered"
 	},
 /area/security/brig)
 "aie" = (
@@ -4384,19 +4382,14 @@
 	},
 /area/security/warden)
 "aih" = (
-/obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
+	icon_state = "red";
+	dir = 5
 	},
-/area/security/warden)
+/area/security/brig)
 "aii" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment{
@@ -4438,9 +4431,14 @@
 	},
 /area/security/main)
 "ail" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/security/brig)
+/obj/machinery/camera{
+	c_tag = "Brig Interrogation";
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "aim" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -4451,14 +4449,9 @@
 	},
 /area/security/main)
 "ain" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access = null;
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whitered"
 	},
 /area/security/brig)
 "aio" = (
@@ -4566,24 +4559,18 @@
 	},
 /area/security/main)
 "aiw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "63"
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Infirmary";
+	req_access_txt = "0"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "whitered"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/main)
+/area/security/brig)
 "aix" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4628,28 +4615,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fsmaint)
 "aiB" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/bottle/morphine,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"aiC" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/syringe,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/security/prison)
-"aiD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/brig)
-"aiE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
 	on = 1;
@@ -4659,13 +4624,38 @@
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
+/area/security/prison)
+"aiC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
+"aiD" = (
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/brig)
-"aiF" = (
+"aiE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel{
 	icon_state = "dark"
+	},
+/area/security/prison)
+"aiF" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/machinery/iv_drip{
+	density = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "whitered"
 	},
 /area/security/brig)
 "aiG" = (
@@ -4777,20 +4767,19 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aiO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Security Office";
-	req_access = null;
-	req_access_txt = "63"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/device/healthanalyzer{
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel{
+	dir = 6;
+	icon_state = "whitered"
+	},
+/area/security/brig)
 "aiP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -4827,10 +4816,16 @@
 /turf/closed/wall/r_wall,
 /area/security/processing)
 "aiW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access = null;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/prison)
 "aiX" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
@@ -4851,7 +4846,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "redcorner";
 	dir = 1
@@ -4864,7 +4858,9 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajb" = (
@@ -5069,6 +5065,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "red";
 	dir = 1
@@ -5107,9 +5104,7 @@
 	},
 /area/security/brig)
 "ajA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	icon_state = "red";
 	dir = 1
@@ -5414,9 +5409,7 @@
 	c_tag = "Brig West";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel{
 	dir = 2;
 	icon_state = "redcorner"
@@ -89603,12 +89596,12 @@ adF
 aef
 aeM
 afz
-acd
 aai
 aai
 aai
 aai
-aiV
+aai
+aai
 ajt
 akc
 akJ
@@ -89862,10 +89855,10 @@ aeO
 afJ
 acd
 agL
-ahp
-ahU
+agK
+agK
 aiB
-aiX
+aai
 ajw
 akf
 aiX
@@ -90115,14 +90108,14 @@ abK
 acY
 adG
 aeh
-aeR
+aeO
 afI
 agl
 agH
-ahm
+agK
+agK
 aho
-aho
-aiW
+acd
 ajv
 ake
 agj
@@ -90373,13 +90366,13 @@ acd
 acd
 aek
 aeU
-afE
-adF
+afI
+acd
 agI
 ahq
 ahV
-aiC
-agj
+aho
+acd
 ajy
 akh
 afK
@@ -90631,12 +90624,12 @@ adF
 aej
 aeQ
 afD
-agj
-agj
-agj
-agj
-agj
-agj
+acd
+agJ
+ahp
+ahp
+aiC
+adF
 ajx
 akg
 agj
@@ -90888,12 +90881,12 @@ adI
 aem
 aeO
 afG
-agj
+acd
 agK
-ahs
-ahs
+agK
+ail
 aiE
-agj
+aiW
 ajA
 akj
 agj
@@ -91146,10 +91139,10 @@ ael
 aeO
 afF
 agj
-agJ
-ahs
-ahs
-aiD
+agj
+agj
+agj
+agj
 agj
 ajz
 aki
@@ -91662,11 +91655,11 @@ afH
 agj
 agN
 aht
-aht
+ain
 aid
-ail
+agj
 aiZ
-ajF
+akk
 akN
 alw
 amg
@@ -91918,10 +91911,10 @@ aeT
 afH
 agj
 ahs
-ahs
+ahr
 ahP
 aiF
-ain
+agj
 aja
 ajG
 akQ
@@ -92174,10 +92167,10 @@ aeq
 aeV
 acd
 agj
-agj
-agj
-agj
-agj
+ahm
+ahD
+aiw
+aiO
 agj
 ajD
 akm
@@ -92432,7 +92425,7 @@ afC
 agk
 agF
 agP
-agP
+ahU
 agP
 agP
 aiz
@@ -92689,7 +92682,7 @@ afB
 agi
 agD
 agO
-agO
+aih
 agO
 agO
 aiy

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2953,6 +2953,7 @@
 "afF" = (
 /obj/structure/table,
 /obj/item/device/assembly/signaler,
+/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel{
 	icon_state = "red"
 	},
@@ -4654,6 +4655,7 @@
 /obj/machinery/iv_drip{
 	density = 0
 	},
+/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel{
 	icon_state = "whitered"
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -3307,16 +3307,13 @@
 	},
 /area/security/warden)
 "ags" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
+	icon_state = "dark"
 	},
-/area/security/warden)
+/area/security/prison)
 "agt" = (
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -3519,15 +3516,6 @@
 /area/security/brig)
 "agN" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
 	frequency = 1459;
@@ -3535,6 +3523,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
+/obj/item/weapon/storage/firstaid/regular,
 /turf/open/floor/plasteel{
 	dir = 10;
 	icon_state = "whitered"
@@ -3776,6 +3765,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
 /turf/open/floor/plasteel{
 	dir = 5;
 	icon_state = "whitered"
@@ -90114,8 +90109,8 @@ aeO
 afI
 agl
 agH
-agK
-agK
+ags
+ags
 aho
 acd
 ajv


### PR DESCRIPTION
Since I'm annoyed by the constant removal of the security medkit I'm instead porting over a variant of Metastation's security medbay.

![screenshot 2016-05-23 13 54 57](https://cloud.githubusercontent.com/assets/6595389/15461521/15fbbac4-20ee-11e6-83da-f6deb3419a16.png)

(The sliding doors are all access)

I would argue this is a minor map change considering how little of the map is changed but I'll accept waiting for the end of the freeze if need be.

This PR was created thanks to discussion in game.

E: Also fixes #17747
