### PR TITLE
Allow handlewet to queue ticks properly

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -129,6 +129,10 @@
 				overlays -= wet_overlay
 
 /turf/open/proc/HandleWet()
+	if(!wet)
+		//It's possible for this handler to get called after all the wetness is
+		//cleared, so bail out if that is the case
+		return
 	if(!wet_time && wet < TURF_WET_ICE)
 		MakeDry(TURF_WET_ICE)
 	if(wet_time > MAXIMUM_WET_TIME)
@@ -159,5 +163,5 @@
 	if(!wet && wet_time)
 		wet_time = 0
 	if(wet)
-		addtimer(src, "HandleWet", 15, 1)
+		addtimer(src, "HandleWet", 15)
 


### PR DESCRIPTION
hash check is working by obj name, not reference, so most handle_wet doesn't get queued

Fixes #17860
