### PR TITLE
Ghost name QoL changes

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -79,11 +79,12 @@
 	if(ckey)
 		M.ckey = ckey
 		M << "[flavour_text]"
+		var/datum/mind/MM = M.mind
 		if(objectives)
-			var/datum/mind/MM = M.mind
 			for(var/objective in objectives)
 				MM.objectives += new/datum/objective(objective)
 		special(M)
+		MM.name = M.real_name
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -50,6 +50,9 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	//If there's a bug with changing your ghost settings, it's probably related to this.
 	var/ghost_accs = GHOST_ACCS_DEFAULT_OPTION
 	var/ghost_others = GHOST_OTHERS_DEFAULT_OPTION
+	// Used for displaying in ghost chat, without changing the actual name
+	// of the mob
+	var/deadchat_name
 
 /mob/dead/observer/New(mob/body)
 	verbs += /mob/dead/observer/proc/dead_tele
@@ -592,11 +595,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/verb/restore_ghost_apperance()
 	set name = "Restore Ghost Character"
-	set desc = "Sets your ghost name and apperance to the name of your \
+	set desc = "Sets your deadchat name and ghost appearance to your \
 		roundstart character."
 	set category = "Ghost"
 
 	set_ghost_appearance()
+	if(client && client.prefs)
+		deadchat_name = client.prefs.real_name
 
 /mob/dead/observer/proc/set_ghost_appearance()
 	if((!client) || (!client.prefs))
@@ -613,12 +618,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(FACEHAIR in client.prefs.pref_species.specflags)
 		facial_hair_style = client.prefs.facial_hair_style
 		facial_hair_color = brighten_color(client.prefs.facial_hair_color)
-
-	real_name = client.prefs.real_name
-	name = real_name
-
-	if(mind)
-		mind.name = name
 
 	update_icon()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -590,6 +590,38 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		src << "<span class='notice'>Data HUDs enabled.</span>"
 		data_huds_on = 1
 
+/mob/dead/observer/verb/restore_ghost_apperance()
+	set name = "Restore Ghost Character"
+	set desc = "Sets your ghost name and apperance to the name of your \
+		roundstart character."
+	set category = "Ghost"
+
+	set_ghost_appearance()
+
+/mob/dead/observer/proc/set_ghost_appearance()
+	if((!client) || (!client.prefs))
+		return
+
+	if(client.prefs.be_random_name)
+		client.prefs.real_name = random_unique_name(gender)
+	if(client.prefs.be_random_body)
+		client.prefs.random_character(gender)
+
+	if(HAIR in client.prefs.pref_species.specflags)
+		hair_style = client.prefs.hair_style
+		hair_color = brighten_color(client.prefs.hair_color)
+	if(FACEHAIR in client.prefs.pref_species.specflags)
+		facial_hair_style = client.prefs.facial_hair_style
+		facial_hair_color = brighten_color(client.prefs.facial_hair_color)
+
+	real_name = client.prefs.real_name
+	name = real_name
+
+	if(mind)
+		mind.name = name
+
+	update_icon()
+
 /mob/dead/observer/canUseTopic()
 	if(check_rights(R_ADMIN, 0))
 		return 1

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -130,6 +130,9 @@
 			observer.key = key
 			observer.client = client
 			observer.set_ghost_appearance()
+			if(client && client.prefs)
+				observer.real_name = client.prefs.real_name
+			observer.name = observer.real_name
 			observer.update_icon()
 			observer.stopLobbySound()
 			qdel(mind)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -127,19 +127,9 @@
 				observer.loc = O.loc
 			else
 				src << "<span class='notice'>Teleporting failed. You should be able to use ghost verbs to teleport somewhere useful</span>"
-			if(client.prefs.be_random_name)
-				client.prefs.real_name = random_unique_name(gender)
-			if(client.prefs.be_random_body)
-				client.prefs.random_character(gender)
-			if(HAIR in client.prefs.pref_species.specflags)
-				observer.hair_style = client.prefs.hair_style
-				observer.hair_color = observer.brighten_color(client.prefs.hair_color)
-			if(FACEHAIR in client.prefs.pref_species.specflags)
-				observer.facial_hair_style = client.prefs.facial_hair_style
-				observer.facial_hair_color = observer.brighten_color(client.prefs.facial_hair_color)
-			observer.real_name = client.prefs.real_name
-			observer.name = observer.real_name
 			observer.key = key
+			observer.client = client
+			observer.set_ghost_appearance()
 			observer.update_icon()
 			observer.stopLobbySound()
 			qdel(mind)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -32,13 +32,16 @@
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
 		return
 
-	if(mind && mind.name)
-		name = "[mind.name]"
+	var/mob/dead/observer/O = src
+	if(isobserver(src) && O.deadchat_name)
+		name = "[O.deadchat_name]"
 	else
-		name = real_name
-	if(name != real_name)
-		alt_name = " (died as [real_name])"
-
+		if(mind && mind.name)
+			name = "[mind.name]"
+		else
+			name = real_name
+		if(name != real_name)
+			alt_name = " (died as [real_name])"
 
 	var/K
 


### PR DESCRIPTION
:cl: coiax
rscadd: Ghosts now have the "Restore Character Name" verb, which will set
their ghost appearance and dead chat name to their character preferences.
bugfix: Mob spawners now give any generated names to the mind of the
spawned mob, meaning ghosts will have the name they had in life.
bugfix: Fixes interaction with envy's knife and lavaland spawns.
/:cl:

Fixes #17842.
