### PR TITLE
Swooping drakes are now properly immune to damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -43,6 +43,11 @@
 	qdel(internal)
 	. = ..()
 
+/mob/living/simple_animal/hostile/megafauna/dragon/adjustHealth(amount)
+	if(swooping)
+		return 0
+	return ..()
+
 /mob/living/simple_animal/hostile/megafauna/dragon/AttackingTarget()
 	if(swooping)
 		return
@@ -53,8 +58,7 @@
 			if(L.stat == DEAD)
 				usr.visible_message(
 					"<span class='danger'>[src] devours [L]!</span>",
-					"<span class='userdanger'>You feast on [L], restoring \
-						your health!</span>")
+					"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 				adjustBruteLoss(-L.maxHealth)
 				L.gib()
 
@@ -163,6 +167,7 @@
 		swoop_target = target
 	stop_automated_movement = TRUE
 	swooping = 1
+	density = 0
 	icon_state = "swoop"
 	visible_message("<span class='danger'>[src] swoops up high!</span>")
 	if(prob(50))
@@ -180,7 +185,7 @@
 		tturf = get_turf(swoop_target)
 	else
 		tturf = get_turf(src)
-	src.loc = tturf
+	forceMove(tturf)
 	new/obj/effect/overlay/temp/dragon_swoop(tturf)
 	animate(src, pixel_x = 0, pixel_z = 0, time = 10)
 	sleep(10)


### PR DESCRIPTION
Fixes #17287 
By preventing damage while swooping(also adding a density = 0 that was missing)
Fixes #17891 
By preventing damage while swooping
