### PR TITLE
[s] Fixes Antag status showing for Diagnostic HUD mobs.

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -15,7 +15,7 @@
 #define DIAG_MECH_HUD	"11"// Mech health bar
 #define DIAG_BOT_HUD	"12"// Bot HUDs
 //for antag huds. these are used at the /mob level
-#define ANTAG_HUD		"12"
+#define ANTAG_HUD		"13"
 
 //data HUD (medhud, sechud) defines
 //Don't forget to update human/New() if you change these!


### PR DESCRIPTION
ANTAG_HUD and DIAG_BOT_HUD were set to the same define, meaning that mobs showing up on the Diagnostic HUD (notably Traitor and Ratvar Silicons).

Expedited review recommended.

Fixes https://github.com/tgstation/tgstation/issues/17889
