### PR TITLE
Refactors NOREACT flag; minor cig refactor

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -32,8 +32,6 @@
 #define BLOCK_GAS_SMOKE_EFFECT 8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with THICKMATERIAL)
 #define THICKMATERIAL 8192		//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
 
-#define	NOREACT		16384 		//Reagents dont' react inside this container.
-
 //turf-only flags
 #define NOJAUNT		1
 
@@ -81,3 +79,6 @@
 #define SLIME 16
 #define DRONE 32
 #define SWARMER 64
+
+// Flags for reagents
+#define REAGENT_NOREACT 1

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -264,11 +264,11 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/New()
 	..()
-	flags |= NOREACT
+	create_reagents(max_volume)
+	reagents.set_reacting(FALSE)
 	syringes = new
 	known_reagents = list("epinephrine"="Epinephrine","charcoal"="Charcoal")
 	processed_reagents = new
-	create_reagents(max_volume)
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/detach()
 	SSobj.processing -= src
@@ -280,8 +280,8 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/critfail()
 	..()
-	flags &= ~NOREACT
-	return
+	if(reagents)
+		reagents.set_reacting(TRUE)
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/can_attach(obj/mecha/medical/M)
 	if(..())

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -99,8 +99,8 @@
 
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
-	flags |= NOREACT
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	reagents.set_reacting(FALSE)
 	for(var/obj/item/clothing/mask/cigarette/cig in src)
 		cig.desc = "\An [name] brand [cig.name]."
 	name = "\improper [name] packet"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -183,7 +183,7 @@ BLIND     // can't see anything
 		permeability_coefficient = null
 		flags &= ~visor_flags
 		flags_inv &= ~visor_flags_inv
-		flags_cover &= 0
+		flags_cover = 0
 		if(adjusted_flags)
 			slot_flags = adjusted_flags
 	user.wear_mask_update(src, toggle_off = mask_adjusted)

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -15,12 +15,13 @@
 	var/portion = 10
 	var/selected_drink
 	var/list/stored_food = list()
-	flags = OPENCONTAINER | NOREACT
+	flags = OPENCONTAINER
 	var/obj/item/weapon/reagent_containers/mixer
 
 /obj/machinery/food_cart/New()
 	..()
 	create_reagents(LIQUID_CAPACIY)
+	reagents.set_reacting(FALSE)
 	mixer = new /obj/item/weapon/reagent_containers(src, MIXER_CAPACITY)
 	mixer.name = "Mixer"
 

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -16,8 +16,7 @@
 	var/list/product_types = list()
 	var/dispense_flavour = ICECREAM_VANILLA
 	var/flavour_name = "vanilla"
-	flags = OPENCONTAINER | NOREACT
-	reagents = new()
+	flags = OPENCONTAINER
 
 /obj/machinery/icecream_vat/proc/get_ingredient_list(type)
 	switch(type)
@@ -55,7 +54,8 @@
 	..()
 	while(product_types.len < 6)
 		product_types.Add(5)
-	reagents.my_atom = src
+	create_reagents()
+	reagents.set_reacting(FALSE)
 	reagents.add_reagent("milk", 5)
 	reagents.add_reagent("flour", 5)
 	reagents.add_reagent("sugar", 5)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -12,13 +12,15 @@
 	use_power = 1
 	idle_power_usage = 5
 	active_power_usage = 100
-	flags = NOREACT
 	var/max_n_of_items = 1500
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
 
 /obj/machinery/smartfridge/New()
 	..()
+	create_reagents()
+	reagents.set_reacting(FALSE)
+
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/smartfridge(null)
 	B.apply_default_parts(src)
 
@@ -360,8 +362,11 @@
 /obj/machinery/smartfridge/chemistry
 	name = "smart chemical storage"
 	desc = "A refrigerated storage unit for medicine storage."
-	var/list/spawn_meds = list(/obj/item/weapon/reagent_containers/pill/epinephrine = 12,/obj/item/weapon/reagent_containers/pill/charcoal = 1,
-								/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 1, /obj/item/weapon/reagent_containers/glass/bottle/charcoal = 1)
+	var/list/spawn_meds = list(
+		/obj/item/weapon/reagent_containers/pill/epinephrine = 12,
+		/obj/item/weapon/reagent_containers/pill/charcoal = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/charcoal = 1)
 
 /obj/machinery/smartfridge/chemistry/New()
 	..()
@@ -397,4 +402,10 @@
 /obj/machinery/smartfridge/chemistry/virology
 	name = "smart virus storage"
 	desc = "A refrigerated storage unit for volatile sample storage."
-	spawn_meds = list(/obj/item/weapon/reagent_containers/syringe/antiviral = 4, /obj/item/weapon/reagent_containers/glass/bottle/cold = 1, /obj/item/weapon/reagent_containers/glass/bottle/flu_virion = 1, /obj/item/weapon/reagent_containers/glass/bottle/mutagen = 1, /obj/item/weapon/reagent_containers/glass/bottle/plasma = 1, /obj/item/weapon/reagent_containers/glass/bottle/synaptizine = 1)
+	spawn_meds = list(
+		/obj/item/weapon/reagent_containers/syringe/antiviral = 4,
+		/obj/item/weapon/reagent_containers/glass/bottle/cold = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/flu_virion = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/mutagen = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/plasma = 1,
+		/obj/item/weapon/reagent_containers/glass/bottle/synaptizine = 1)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -290,15 +290,15 @@
 
 
 /datum/plant_gene/trait/noreact
-	// Makes plant NOREACT until squashed.
+	// Makes plant reagents not react until squashed.
 	name = "Separated Chemicals"
 
 /datum/plant_gene/trait/noreact/on_new(obj/item/weapon/reagent_containers/food/snacks/grown/G, newloc)
 	..()
-	G.flags |= NOREACT
+	G.reagents.set_reacting(FALSE)
 
 /datum/plant_gene/trait/noreact/on_squash(obj/item/weapon/reagent_containers/food/snacks/grown/G, atom/target)
-	G.flags &= ~NOREACT
+	G.reagents.set_reacting(TRUE)
 	G.reagents.handle_reactions()
 
 

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -215,9 +215,9 @@
 
 /obj/item/ammo_casing/shotgun/dart/New()
 	..()
-	flags |= NOREACT
 	flags |= OPENCONTAINER
 	create_reagents(30)
+	reagents.set_reacting(FALSE)
 
 /obj/item/ammo_casing/shotgun/dart/attackby()
 	return

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -170,8 +170,8 @@
 
 /obj/item/projectile/bullet/dart/New()
 	..()
-	flags |= NOREACT
 	create_reagents(50)
+	reagents.set_reacting(FALSE)
 
 /obj/item/projectile/bullet/dart/on_hit(atom/target, blocked = 0, hit_zone)
 	if(iscarbon(target))
@@ -188,7 +188,7 @@
 									   "<span class='userdanger'>You were protected against the [name]!</span>")
 
 	..(target, blocked, hit_zone)
-	flags &= ~NOREACT
+	reagents.set_reacting(TRUE)
 	reagents.handle_reactions()
 	return 1
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -174,16 +174,23 @@
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	name = "cryostasis beaker"
-	desc = "A cryostasis beaker that allows for chemical storage without reactions. Can hold up to 50 units."
+	desc = "A cryostasis beaker that allows for chemical storage without \
+		reactions. Can hold up to 50 units."
 	icon_state = "beakernoreact"
 	materials = list(MAT_GLASS=500)
 	volume = 50
 	amount_per_transfer_from_this = 10
-	flags = OPENCONTAINER | NOREACT
+	flags = OPENCONTAINER
+
+/obj/item/weapon/reagent_containers/glass/beaker/noreact/New()
+	..()
+	reagents.set_reacting(FALSE)
 
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	name = "bluespace beaker"
-	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
+	desc = "A bluespace beaker, powered by experimental bluespace technology \
+		and Element Cuban combined with the Compound Pete. Can hold up to \
+		300 units."
 	icon_state = "beakerbluespace"
 	materials = list(MAT_GLASS=5000)
 	volume = 300

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -266,7 +266,10 @@
 	name = "cryo syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	volume = 20
-	flags = NOREACT
+
+/obj/item/weapon/reagent_containers/syringe/noreact/New()
+	. = ..()
+	reagents.set_reacting(FALSE)
 
 /obj/item/weapon/reagent_containers/syringe/piercing
 	name = "piercing syringe"


### PR DESCRIPTION
The reagents datum now has its own flags, which currently includes
REAGENT_NOREACT, which functions in the same way. Shouldn't be touched
directly, use set_reacting(bool) to modify it, as modification also adds
or removes the reagents datum from the SSobj.processing list.

Also refactors cigs a little, adds a Destroy(), uses the open_flame()
proc for the hotspot exposure.
