### PR TITLE
Fix for fiery dismemberment

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -35,7 +35,8 @@
 	playsound(T, 'sound/misc/splort.ogg', 50, 1, -1)
 	for(var/obj/item/I in src)
 		if(I == brain)
-			user.visible_message("<span class='warning'>[user] saws [src] open and pulls out a brain!</span>", "<span class='notice'>You saw [src] open and pull out a brain.</span>")
+			if(user)
+				user.visible_message("<span class='warning'>[user] saws [src] open and pulls out a brain!</span>", "<span class='notice'>You saw [src] open and pull out a brain.</span>")
 			if(brainmob)
 				brainmob.container = null
 				brainmob.loc = brain
@@ -159,3 +160,7 @@
 
 	if(standing.len)
 		return standing
+
+/obj/item/bodypart/head/burn()
+	drop_organs()
+	..()


### PR DESCRIPTION
Fixes #17907 

The brainmob wasn't being put in the brain properly because it was just dumping the brain on the floor when it ashed instead of doing drop_organs
