### PR TITLE
Adds a DEFAULTPICK() macro, updates an old list helper

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -238,13 +238,7 @@
 	return r
 
 // Returns the key based on the index
-/proc/get_key_by_index(list/L, index)
-	var/i = 1
-	for(var/key in L)
-		if(index == i)
-			return key
-		i++
-	return null
+#define KEYBYINDEX(L, index) ((index <= L:len) && (index > 0) ? L[index] : null)
 
 /proc/count_by_type(list/L, type)
 	var/i = 0
@@ -365,3 +359,6 @@
 	for(var/i = 1 to l.len)
 		if(islist(.[i]))
 			.[i] = .(.[i])
+
+//Picks from the list, with some safeties, and returns the "default" arg if it fails
+#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -238,7 +238,7 @@
 	return r
 
 // Returns the key based on the index
-#define KEYBYINDEX(L, index) ((index <= L:len) && (index > 0) ? L[index] : null)
+#define KEYBYINDEX(L, index) (((index <= L:len) && (index > 0)) ? L[index] : null)
 
 /proc/count_by_type(list/L, type)
 	var/i = 0


### PR DESCRIPTION
- `DEFAULTPICK()` Picks from the list, with some safeties, and returns the "default" arg if it fails - `DEFAULTPICK()` is the generic form of something Lummox suggested to help us with Lazy loading of lists.
- `get_key_by_index()` didn't need to be as slow as it was, and now it isn't, it's also a macro now `KEYBYINDEX()` - I saw this was shit and it annoyed me so I fixed it, it's not used anyway (and doesn't really need to be, since it's essentially safety boilerplate) but I fixed it regardless.

For example, `DEFAULTPICK()` allows us to use the `attack_verb` list without having to worry if it's null:
`visible_message("[user] has [DEFAULTPICK(weapon.attack_verb, "attack")]ed [victim])`
