### PR TITLE
Fixes borg charging being ridiculously slow.

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -35,7 +35,7 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		repairs += M.rating - 1
 	for(var/obj/item/weapon/stock_parts/cell/C in component_parts)
-		recharge_speed *= C.maxcharge / 10000
+		recharge_speed *= C.maxcharge / 1000
 
 
 /obj/machinery/recharge_station/process()


### PR DESCRIPTION
I'm calling this a fix, because looking at the code, it seems the 10000 was a typo. Standard cells have a max charge of 1000, and if you change the value to that, then the charge rate comes out to pre change levels.
