### PR TITLE
Ends Flyman Starvation

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -552,7 +552,7 @@
 
 	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
 		if(message)
-			visible_message("<span class='danger'>[src] throws up all over \himself!</span>", \
+			visible_message("<span class='danger'>[src] throws up all over themself!</span>", \
 							"<span class='userdanger'>You throw up all over yourself!</span>")
 		distance = 0
 	else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -550,7 +550,7 @@
 			Weaken(10)
 		return 1
 
-	if(src.is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
+	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
 		if(message)
 			visible_message("<span class='danger'>[src] throws up all over \himself!</span>", \
 							"<span class='userdanger'>You throw up all over yourself!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -541,40 +541,43 @@
 
 	add_abilities_to_panel()
 
-/mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
-	if(src.is_muzzled())
-		if(message)
-			src << "<span class='warning'>The muzzle prevents you from vomiting!</span>"
-		return 0
-	if(stun)
-		Stun(4)
+/mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1, var/toxic = 0)
 	if(nutrition < 100 && !blood)
 		if(message)
 			visible_message("<span class='warning'>[src] dry heaves!</span>", \
 							"<span class='userdanger'>You try to throw up, but there's nothing your stomach!</span>")
 		if(stun)
 			Weaken(10)
+		return 1
+
+	if(src.is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
+		if(message)
+			visible_message("<span class='danger'>[src] throws up all over \himself!</span>", \
+							"<span class='userdanger'>You throw up all over yourself!</span>")
+		distance = 0
 	else
 		if(message)
-			visible_message("<span class='danger'>[src] throws up!</span>", \
-							"<span class='userdanger'>You throw up!</span>")
-		playsound(get_turf(src), 'sound/effects/splat.ogg', 50, 1)
-		var/turf/T = get_turf(src)
-		for(var/i=0 to distance)
-			if(blood)
-				if(T)
-					T.add_blood_floor(src)
-				if(stun)
-					adjustBruteLoss(3)
-			else
-				if(T)
-					T.add_vomit_floor(src)
-				nutrition -= lost_nutrition
-				if(stun)
-					adjustToxLoss(-3)
-			T = get_step(T, dir)
-			if (is_blocked_turf(T))
-				break
+			visible_message("<span class='danger'>[src] throws up!</span>", "<span class='userdanger'>You throw up!</span>")
+
+	if(stun)
+		Stun(4)
+
+	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, 1)
+	var/turf/T = get_turf(src)
+	for(var/i=0 to distance)
+		if(blood)
+			if(T)
+				T.add_blood_floor(src)
+			if(stun)
+				adjustBruteLoss(3)
+		else
+			if(T)
+				T.add_vomit_floor(src, 0)//toxic barf looks different
+			nutrition -= lost_nutrition
+			adjustToxLoss(-3)
+		T = get_step(T, dir)
+		if (is_blocked_turf(T))
+			break
 	return 1
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -253,27 +253,16 @@
 		reagents.metabolize(src, can_overdose=1)
 	dna.species.handle_chemicals_in_body(src)
 
+
 /mob/living/carbon/human/handle_random_events()
-	// Puke if toxloss is too high
+	//Puke if toxloss is too high
 	if(!stat)
-		if (getToxLoss() >= 45 && nutrition > 20)
+		if(getToxLoss() >= 45 && nutrition > 20)
 			lastpuke ++
 			if(lastpuke >= 25) // about 25 second delay I guess
-				Stun(5)
-
-				visible_message("<span class='danger'>[src] throws up!</span>", \
-						"<span class='userdanger'>[src] throws up!</span>")
-				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-
-				var/turf/location = loc
-				if (istype(location, /turf))
-					location.add_vomit_floor(src, 1)
-
-				nutrition -= 20
-				adjustToxLoss(-3)
-
-				// make it so you can only puke so fast
+				vomit(20, 0, 1, 0, 1, 1)
 				lastpuke = 0
+
 
 /mob/living/carbon/human/has_smoke_protection()
 	if(wear_mask)
@@ -288,6 +277,8 @@
 	if(NOBREATH in dna.species.specflags)
 		. = 1
 	return .
+
+
 /mob/living/carbon/human/proc/handle_embedded_objects()
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
@@ -303,6 +294,7 @@
 				visible_message("<span class='danger'>\the [I] falls out of [name]'s [BP.name]!</span>","<span class='userdanger'>\the [I] falls out of your [BP.name]!</span>")
 				if(!has_embedded_objects())
 					clear_alert("embeddedobject")
+
 
 /mob/living/carbon/human/proc/handle_heart()
 	CHECK_DNA_AND_SPECIES(src)

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -397,9 +397,9 @@
 /datum/species/fly/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(istype(chem,/datum/reagent/consumable))
 		var/datum/reagent/consumable/nutri_check = chem
-		if(nutri_check.nutriment_factor >0)
+		if(nutri_check.nutriment_factor > 0)
 			var/turf/pos = get_turf(H)
-			H.vomit()
+			H.vomit(0, 0, 0, 2, 1)
 			playsound(pos, 'sound/effects/splat.ogg', 50, 1)
 			H.visible_message("<span class='danger'>[H] vomits on the floor!</span>", \
 						"<span class='userdanger'>You throw up on the floor!</span>")

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -399,7 +399,7 @@
 		var/datum/reagent/consumable/nutri_check = chem
 		if(nutri_check.nutriment_factor > 0)
 			var/turf/pos = get_turf(H)
-			H.vomit(0, 0, 0, 2, 1)
+			H.vomit(0, 0, 0, 1, 1)
 			playsound(pos, 'sound/effects/splat.ogg', 50, 1)
 			H.visible_message("<span class='danger'>[H] vomits on the floor!</span>", \
 						"<span class='userdanger'>You throw up on the floor!</span>")


### PR DESCRIPTION
FIXES #16693

Kind of a featureish bugfix, but...
Flymen actually DID gain nutriment from slurping barf. Vomit() itself does not add reagents, but add_vomit_floor() called by vomit() does. 
HOWEVER, it was never more than the amount that barfing cost them in the first place. GG.

Flymen also are no longer stunned by eating, which sucked. They also barf 1 tile further.

Also cleans up vomit code a bit in general.
Removes muzzle limitation on vomiting (when did this ever come up?), replaces it with a more expansive mouth/face cover check which gives you a different message and prevents projectile vomiting.
