### PR TITLE
[s] Fixes C4 not being able to be screwdrivered(kinda).

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -500,14 +500,14 @@
 	..()
 	contents = list()
 	for(var/i in 1 to 10)
-		new /obj/item/weapon/grenade/plastic/c4(src)
+		new /obj/item/weapon/c4(src)
 	return
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/x4/New()
 	..()
 	contents = list()
 	for(var/i in 1 to 3)
-		new /obj/item/weapon/grenade/plastic/x4(src)
+		new /obj/item/weapon/c4(src)
 
 /obj/item/weapon/storage/backpack/dufflebag/syndie/firestarter
 	desc = "A large dufflebag containing New Russian pyro backpack sprayer, a pistol, a pipebomb, fireproof hardsuit, ammo, and other equipment."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -48,7 +48,7 @@
 			new /obj/item/weapon/gun/projectile/revolver(src)
 			new /obj/item/ammo_box/a357(src)
 			new /obj/item/weapon/card/emag(src)
-			new /obj/item/weapon/grenade/plastic/c4(src)
+			new /obj/item/weapon/c4(src)
 			new /obj/item/clothing/gloves/color/latex/nitrile(src)
 			new /obj/item/clothing/mask/gas/clown_hat(src)
 			new /obj/item/clothing/under/suit_jacket/really_black(src)
@@ -86,8 +86,8 @@
 			return
 
 		if("sabotage")
-			new /obj/item/weapon/grenade/plastic/c4 (src)
-			new /obj/item/weapon/grenade/plastic/c4 (src)
+			new /obj/item/weapon/c4 (src)
+			new /obj/item/weapon/c4 (src)
 			new /obj/item/device/doorCharge(src)
 			new /obj/item/device/doorCharge(src)
 			new /obj/item/device/camera_bug(src)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -849,7 +849,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "C-4 is plastic explosive of the common variety Composition C. You can use it to breach walls, sabotage equipment, or connect \
 			an assembly to it in order to alter the way it detonates. It has a modifiable timer with a \
 			minimum setting of 10 seconds."
-	item = /obj/item/weapon/grenade/plastic/c4
+	item = /obj/item/weapon/c4
 	cost = 1
 
 /datum/uplink_item/device_tools/c4bag


### PR DESCRIPTION
Basically whoever changed the path for c4 to a grenade path bungled it, luckily the regular path for it is still in the game, so I switched out what was in the uplinks from the grenade path to the old path. So now you'll be able to rig up c4 with signalers like you used to.

This will also _fix_ the issue with the grenade path c4s not showing up after being placed on walls.

Tested and it works. 
