### PR TITLE
Head Megaphones + Megaphone changes

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -39,12 +39,12 @@
 	if ((src.loc == user && user.stat == 0))
 		if(emagged)
 			if(insults)
-				user.audible_message("<B>[user.GetVoice()]</B> broadcasts, <span class='[voicespan]'>\"[pick(insultmsg)]\"</span>")
+				user.say(pick(insultmsg),"machine", list(voicespan))
 				insults--
 			else
 				user << "<span class='warning'>*BZZZZzzzzzt*</span>"
 		else
-			user.audible_message("<B>[user.GetVoice()]</B> broadcasts, <span class='[voicespan]'>\"[message]\"</span>")
+			user.say(message,"machine", list(voicespan))
 
 		playsound(loc, 'sound/items/megaphone.ogg', 100, 0, 1)
 		spamcheck = world.time + 50

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -15,6 +15,7 @@
 	new /obj/item/device/radio/headset/heads/ce(src)
 	new /obj/item/weapon/storage/toolbox/mechanical(src)
 	new /obj/item/clothing/suit/hazardvest(src)
+	new /obj/item/device/megaphone/command(src)
 	new /obj/item/weapon/storage/box/permits(src)
 	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/weapon/airlock_painter(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -63,6 +63,7 @@
 	new /obj/item/clothing/shoes/sneakers/brown	(src)
 	new /obj/item/weapon/cartridge/cmo(src)
 	new /obj/item/device/radio/headset/heads/cmo(src)
+	new /obj/item/device/megaphone/command(src)
 	new /obj/item/weapon/defibrillator/compact/loaded(src)
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/weapon/storage/belt/medical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,6 +18,7 @@
 	new /obj/item/device/radio/headset/heads/rd(src)
 	new /obj/item/weapon/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/device/megaphone/command(src)
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -58,7 +58,7 @@ var/list/department_radio_keys = list(
 
 var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
-/mob/living/say(message, bubble_type,)
+/mob/living/say(message, bubble_type,var/list/spans = list())
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 
 	if(stat == DEAD)
@@ -92,7 +92,6 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 
 	if(message_mode != MODE_WHISPER) //whisper() calls treat_message(); double process results in "hisspering"
 		message = treat_message(message)
-	var/spans = list()
 	spans += get_spans()
 
 	if(!message)
@@ -219,7 +218,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 							if(1)
 								if(prob(40))
 									M << "<i><font color=#800080>We can faintly sense an outsider trying to communicate through the hivemind...</font></i>"
-				return 1 
+				return 1
 			if(2)
 				var/msg = "<i><font color=#800080><b>[mind.changeling.changelingID]:</b> [message]</font></i>"
 				log_say("[mind.changeling.changelingID]/[src.key] : [message]")
@@ -229,7 +228,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 					else
 						switch(M.lingcheck())
 							if(3)
-								M << msg 
+								M << msg
 							if(2)
 								M << msg
 							if(1)
@@ -289,7 +288,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 			return NOPASS
 	return 0
 
-/mob/living/lingcheck() //1 is ling w/ no hivemind. 2 is ling w/hivemind. 3 is ling victim being linked into hivemind. 
+/mob/living/lingcheck() //1 is ling w/ no hivemind. 2 is ling w/hivemind. 3 is ling victim being linked into hivemind.
 	if(mind && mind.changeling)
 		if(mind.changeling.changeling_speak)
 			return 2


### PR DESCRIPTION
Adds Command Megaphones to the following head of staff lockers:
- Research Director
- Chief Medical Officer
- Chief Engineer

You may now yell over the radio using your megaphone. **Clowns intensify!**

:cl:
Name: Gun Hog
rscadd: The CE, RD, and CMO have been issued megaphones.
/:cl:

The Captain, Head of Security, and Head of Personnel already have one.

Salvaged from https://github.com/tgstation/tgstation/pull/17795 

**EDIT:** Megaphones now use the `say()` proc, and thus respect more properties about the mob.

![screenshot 2016-05-26 17 52 33](https://cloud.githubusercontent.com/assets/4955510/15592801/462f6832-236c-11e6-86e0-bea1248010c2.png)

Fixes https://github.com/tgstation/tgstation/issues/17104
Fixes https://github.com/tgstation/tgstation/issues/15865
Fixes https://github.com/tgstation/tgstation/issues/9850
Fixes https://github.com/tgstation/tgstation/issues/9842
