### PR TITLE
Fixes Gibtonite both defusing AND exploding in rare conditions.

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -212,6 +212,7 @@
 	if(stage == 1 && det_time <= 0 && mineralAmt >= 1)
 		var/turf/bombturf = get_turf(src)
 		mineralAmt = 0
+		stage = 3
 		explosion(bombturf,1,3,5, adminlog = notify_admins)
 
 /turf/closed/mineral/gibtonite/proc/defuse()
@@ -233,6 +234,7 @@
 	if(stage == 1 && mineralAmt >= 1) //Gibtonite deposit goes kaboom
 		var/turf/bombturf = get_turf(src)
 		mineralAmt = 0
+		stage = 3
 		explosion(bombturf,1,2,5, adminlog = 0)
 	if(stage == 2) //Gibtonite deposit is now benign and extractable. Depending on how close you were to it blowing up before defusing, you get better quality ore.
 		var/obj/item/weapon/twohanded/required/gibtonite/G = new /obj/item/weapon/twohanded/required/gibtonite/(src)
@@ -242,6 +244,8 @@
 		if(det_time >= 1 && det_time <= 2)
 			G.quality = 2
 			G.icon_state = "Gibtonite ore 2"
+	if(stage == 3)
+		return
 	ChangeTurf(turf_type, defer_change)
 	AfterChange()
 


### PR DESCRIPTION
(explosion() sleeps, so we have the mark the gibeonite as exploding so that if somebody tries to defuse it during this sleep, it knows better.)
#17951

@coiax @phil235 
