### PR TITLE
 Ensures Legional continuality

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/megafauna/legion
-	name = "legion"
+	name = "Legion"
 	health = 800
 	maxHealth = 800
 	icon_state = "legion"
@@ -57,20 +57,35 @@
 				charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()
+	if(health > 0)
+		return
 	if(size > 2)
-		for(var/i in 1 to 2)
-			var/mob/living/simple_animal/hostile/megafauna/legion/L = new(src.loc)
-			L.health = src.maxHealth * 0.6
-			L.maxHealth = L.health
-			L.size = size - 2
-			var/size_multiplier = L.size * 0.08
-			L.resize = size_multiplier
-			L.pixel_y = L.pixel_y * size_multiplier
-			L.pixel_x = L.pixel_x * size_multiplier
+		adjustHealth(-maxHealth) //heal ourself to full in prep for splitting
+		var/mob/living/simple_animal/hostile/megafauna/legion/L = new(src.loc)
 
-			L.update_transform()
+		L.maxHealth = maxHealth * 0.6
+		maxHealth = L.maxHealth
+
+		L.health = L.maxHealth
+		health = L.health
+
+		L.size = size - 2
+		size = L.size
+
+		var/size_multiplier = L.size * 0.08
+		L.resize = size_multiplier
+		resize = L.resize
+
+		L.pixel_y = L.pixel_y * size_multiplier
+		pixel_y = L.pixel_y
+
+		L.pixel_x = L.pixel_x * size_multiplier
+		pixel_x = L.pixel_x
+
+		L.update_transform()
+		update_transform()
+
 		visible_message("<span class='danger'>[src] splits!</span>")
-		qdel(src)
 	else
 		var/last_legion = TRUE
 		for(var/mob/living/simple_animal/hostile/megafauna/legion/other in mob_list)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -76,12 +76,6 @@
 		L.resize = size_multiplier
 		resize = L.resize
 
-		L.pixel_y = L.pixel_y * size_multiplier
-		pixel_y = L.pixel_y
-
-		L.pixel_x = L.pixel_x * size_multiplier
-		pixel_x = L.pixel_x
-
 		L.update_transform()
 		update_transform()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -79,6 +79,8 @@
 		L.update_transform()
 		update_transform()
 
+		L.target = target
+
 		visible_message("<span class='danger'>[src] splits!</span>")
 	else
 		var/last_legion = TRUE


### PR DESCRIPTION
Legion's name is now capitalized, for that 'important boss' feel. Also, so you can more easily find it in the mob list.
The splitting Legion is no longer deleted when splitting, so ghosts remain orbitting it and admin VV menus still work on it after splitting.
You can't wand of death a Legion with remaining splits anymore.
Fixes a bug where Legion's pixel_x/y would be fucked up until it attacked something.
