### PR TITLE
Ghost sword orbits on button click, added URL, POI

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -40,3 +40,8 @@
 #define ANTAG_HUD_SINTOUCHED	18
 #define ANTAG_HUD_SOULLESS		19
 #define ANTAG_HUD_CLOCKWORK		20
+
+// Notification action types
+#define NOTIFY_JUMP "jump"
+#define NOTIFY_ATTACK "attack"
+#define NOTIFY_ORBIT "orbit"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -318,25 +318,28 @@ so as to remain in compliance with the most up-to-date laws."
 	var/mob/dead/observer/G = usr
 	G.reenter_corpse()
 
-/obj/screen/alert/notify_jump
+/obj/screen/alert/notify_action
 	name = "Body created"
 	desc = "A body was created. You can enter it."
 	icon_state = "template"
 	timeout = 300
-	var/atom/jump_target = null
-	var/attack_not_jump = null
+	var/atom/target = null
+	var/action = NOTIFY_JUMP
 
-/obj/screen/alert/notify_jump/Click()
+/obj/screen/alert/notify_action/Click()
 	if(!usr || !usr.client) return
-	if(!jump_target) return
+	if(!target) return
 	var/mob/dead/observer/G = usr
 	if(!istype(G)) return
-	if(attack_not_jump)
-		jump_target.attack_ghost(G)
-	else
-		var/turf/T = get_turf(jump_target)
-		if(T && isturf(T))
-			G.loc = T
+	switch(action)
+		if(NOTIFY_ATTACK)
+			target.attack_ghost(G)
+		if(NOTIFY_JUMP)
+			var/turf/T = get_turf(target)
+			if(T && isturf(T))
+				G.loc = T
+		if(NOTIFY_ORBIT)
+			G.ManualFollow(target)
 
 //OBJECT-BASED
 

--- a/code/game/gamemodes/demon/demoninfo.dm
+++ b/code/game/gamemodes/demon/demoninfo.dm
@@ -268,7 +268,7 @@ var/global/list/lawlorify = list (
 		D.forceMove(get_turf(D))//Fixes dying while jaunted leaving you permajaunted.
 	var/area/A = get_area(owner.current)
 	if(A)
-		notify_ghosts("An arch devil has ascended in \the [A.name]. Reach out to the devil to be given a new shell for your soul.", source = owner.current, attack_not_jump = 1)
+		notify_ghosts("An arch devil has ascended in \the [A.name]. Reach out to the devil to be given a new shell for your soul.", source = owner.current, action=NOTIFY_ATTACK)
 	sleep(50)
 	if(!ticker.mode.devil_ascended)
 		SSshuttle.emergency.request(null, 0.3)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -10,7 +10,7 @@
 
 /obj/item/device/unactivated_swarmer/New()
 	if(!crit_fail)
-		notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src, attack_not_jump = 1)
+		notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK)
 	..()
 
 /obj/item/device/unactivated_swarmer/Topic(href, href_list)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -189,7 +189,7 @@
 			S.faction = faction.Copy()
 			if(player_spiders)
 				S.playable_spider = TRUE
-				notify_ghosts("Spider [S.name] can be controlled", null, enter_link="<a href=?src=\ref[S];activate=1>(Click to play)</a>", source=S, attack_not_jump = 1)
+				notify_ghosts("Spider [S.name] can be controlled", null, enter_link="<a href=?src=\ref[S];activate=1>(Click to play)</a>", source=S, action=NOTIFY_ATTACK)
 			qdel(src)
 
 

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -174,7 +174,7 @@
 
 /obj/machinery/capture_the_flag/proc/TellGhost()
 	if(ctf_enabled)
-		notify_ghosts("[name] has been activated!", enter_link="<a href=?src=\ref[src];join=1>(Click to join the [team] team!)</a> or click on the controller directly!", source = src, attack_not_jump = 0)
+		notify_ghosts("[name] has been activated!", enter_link="<a href=?src=\ref[src];join=1>(Click to join the [team] team!)</a> or click on the controller directly!", source = src, action=NOTIFY_ATTACK)
 
 /obj/machinery/capture_the_flag/Topic(href, href_list)
 	if(href_list["join"])

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -35,7 +35,7 @@ var/global/posibrain_notif_cooldown = 0
 
 /obj/item/device/mmi/posibrain/proc/ping_ghosts(msg)
 	if(!posibrain_notif_cooldown)
-		notify_ghosts("[name] [msg] in [get_area(src)]!", 'sound/effects/ghost2.ogg', enter_link="<a href=?src=\ref[src];activate=1>(Click to enter)</a>", source = src, attack_not_jump = 1)
+		notify_ghosts("[name] [msg] in [get_area(src)]!", 'sound/effects/ghost2.ogg', enter_link="<a href=?src=\ref[src];activate=1>(Click to enter)</a>", source = src, action=NOTIFY_ATTACK)
 		posibrain_notif_cooldown = 1
 		spawn(askDelay) //Global one minute cooldown to avoid spam.
 			posibrain_notif_cooldown = 0

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -20,7 +20,7 @@
 	..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, attack_not_jump = 1)
+		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK)
 
 /obj/item/drone_shell/attack_ghost(mob/user)
 	if(jobban_isbanned(user,"drone"))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -248,6 +248,8 @@
 	poi_list |= src
 
 /obj/item/weapon/melee/ghost_sword/Destroy()
+	for(var/mob/dead/observer/G in spirits)
+		G.invisibility = initial(G.invisibility)
 	spirits.Cut()
 	SSobj.processing -= src
 	poi_list -= src

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -239,13 +239,18 @@
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0
+	var/list/mob/dead/observer/spirits
 
 /obj/item/weapon/melee/ghost_sword/New()
 	..()
+	spirits = list()
 	SSobj.processing += src
+	poi_list |= src
 
 /obj/item/weapon/melee/ghost_sword/Destroy()
+	spirits.Cut()
 	SSobj.processing -= src
+	poi_list -= src
 	. = ..()
 
 /obj/item/weapon/melee/ghost_sword/attack_self(mob/user)
@@ -253,33 +258,50 @@
 		user << "You just recently called out for aid. You don't want to annoy the spirits."
 		return
 	user << "You call out for aid, attempting to summon spirits to your side."
-	notify_ghosts("[user] is raising their [src], calling for your help!", source = user)
+
+	notify_ghosts("[user] is raising their [src], calling for your help!",
+		enter_link="<a href=?src=\ref[src];orbit=1>(Click to help)</a>",
+		source = user, action=NOTIFY_ORBIT)
+
 	summon_cooldown = world.time + 600
+
+/obj/item/weapon/melee/ghost_sword/Topic(href, href_list)
+	if(href_list["orbit"])
+		var/mob/dead/observer/ghost = usr
+		if(istype(ghost))
+			ghost.ManualFollow(src)
 
 /obj/item/weapon/melee/ghost_sword/process()
 	ghost_check()
 
-/obj/item/weapon/melee/ghost_sword/proc/ghost_check(mob/user)
+/obj/item/weapon/melee/ghost_sword/proc/ghost_check()
 	var/ghost_counter = 0
+	var/turf/T = get_turf(src)
+	var/list/contents = T.GetAllContents()
+	var/mob/dead/observer/current_spirits = list()
 	for(var/mob/dead/observer/G in dead_mob_list)
-		if(G.orbiting == user)
+		if(G.orbiting in contents)
 			ghost_counter++
 			G.invisibility = 0
-			spawn(30)
-				if(G.orbiting != user)
-					G.invisibility = initial(G.invisibility)
+			current_spirits |= G
+
+	for(var/mob/dead/observer/G in spirits - current_spirits)
+		G.invisibility = initial(G.invisibility)
+
+	spirits = current_spirits
+
 	return ghost_counter
 
 /obj/item/weapon/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	force = 0
-	var/ghost_counter = ghost_check(user)
+	var/ghost_counter = ghost_check()
 
 	force = Clamp((ghost_counter * 4), 0, 75)
 	user.visible_message("<span class='danger'>[user] strikes with the force of [ghost_counter] vengeful spirits!</span>")
 	..()
 
 /obj/item/weapon/melee/ghost_sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
-	var/ghost_counter = ghost_check(owner)
+	var/ghost_counter = ghost_check()
 	final_block_chance += Clamp((ghost_counter * 5), 0, 75)
 	owner.visible_message("<span class='danger'>[owner] is protected by a ring of [ghost_counter] ghosts!</span>")
 	return ..()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -391,20 +391,20 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 /mob/proc/reagent_check(datum/reagent/R) // utilized in the species code
 	return 1
 
-/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/image/alert_overlay = null, var/attack_not_jump = 0) //Easy notification of ghosts.
+/proc/notify_ghosts(var/message, var/ghost_sound = null, var/enter_link = null, var/atom/source = null, var/image/alert_overlay = null, var/action = NOTIFY_JUMP) //Easy notification of ghosts.
 	for(var/mob/dead/observer/O in player_list)
 		if(O.client)
 			O << "<span class='ghostalert'>[message][(enter_link) ? " [enter_link]" : ""]<span>"
 			if(ghost_sound)
 				O << sound(ghost_sound)
 			if(source)
-				var/obj/screen/alert/notify_jump/A = O.throw_alert("\ref[source]_notify_jump", /obj/screen/alert/notify_jump)
+				var/obj/screen/alert/notify_action/A = O.throw_alert("\ref[source]_notify_action", /obj/screen/alert/notify_action)
 				if(A)
 					if(O.client.prefs && O.client.prefs.UI_style)
 						A.icon = ui_style2icon(O.client.prefs.UI_style)
 					A.desc = message
-					A.attack_not_jump = attack_not_jump
-					A.jump_target = source
+					A.action = action
+					A.target = source
 					if(!alert_overlay)
 						var/old_layer = source.layer
 						source.layer = FLOAT_LAYER

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -32,7 +32,7 @@
 	var/area/A = get_area(src)
 	if(A)
 		var/image/alert_overlay = image('icons/effects/effects.dmi', "ghostalertsie")
-		notify_ghosts("Nar-Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, attack_not_jump = 1)
+		notify_ghosts("Nar-Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, action=NOTIFY_ATTACK)
 
 	narsie_spawn_animation()
 

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -250,7 +250,7 @@
 	..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("An ash walker egg is ready to hatch in \the [A.name].", source = src, attack_not_jump = 1)
+		notify_ghosts("An ash walker egg is ready to hatch in \the [A.name].", source = src, action=NOTIFY_ATTACK)
 
 //Wishgranter Exile
 
@@ -356,7 +356,7 @@
 	..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A golem shell has been completed in \the [A.name].", source = src, attack_not_jump = 1)
+		notify_ghosts("A golem shell has been completed in \the [A.name].", source = src, action=NOTIFY_ATTACK)
 
 /obj/effect/mob_spawn/human/golem/special(mob/living/new_spawn)
 	var/golem_surname = pick(golem_names)


### PR DESCRIPTION
:cl: coiax
rscadd: Spectral sword is now a point of interest for ghosts.
fix: Clicking the spectral sword action now orbits the sword, instead of
just teleporting to its location.
/:cl:

Fixes #17990

Changed the notify_jump alert to notify_action, added three different
notification actions (jump, attack, orbit), modified notify_ghosts and
its callers appropriately.

Spectral sword now just counts the number of orbiting ghosts in the
turf, irregardless of what they're orbiting. Generally this'll be the
summation of orbiters of the mob, and orbiters of the sword.
