### PR TITLE
Removes inconsistences with UMT and tesla

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -47,7 +47,9 @@
 
 
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, override = 0, tesla_shock = 0)
-	shock_damage *= siemens_coeff
+	CHECK_DNA_AND_SPECIES(src)
+
+	shock_damage *= (siemens_coeff * dna.species.siemens_coeff)
 	if(shock_damage<1 && !override)
 		return 0
 	if(reagents.has_reagent("teslium"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -305,13 +305,10 @@
 		siemens_coeff = total_coeff
 	else if(!safety)
 		var/gloves_siemens_coeff = 1
-		var/species_siemens_coeff = 1
 		if(gloves)
 			var/obj/item/clothing/gloves/G = gloves
 			gloves_siemens_coeff = G.siemens_coefficient
-		if(dna && dna.species)
-			species_siemens_coeff = dna.species.siemens_coeff
-		siemens_coeff = gloves_siemens_coeff * species_siemens_coeff
+		siemens_coeff = gloves_siemens_coeff
 	if(heart_attack)
 		if(shock_damage * siemens_coeff >= 1 && prob(25))
 			heart_attack = 0

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -245,6 +245,7 @@
 		callforward.Remove(C)
 	if(callback)
 		callback.Remove(C)
+	C.faction -= "slime"
 	..()
 
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C)
@@ -252,6 +253,7 @@
 	if(ishuman(C))
 		slime_split = new
 		slime_split.Grant(C)
+	C.faction |= "slime"
 
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
 	var/jelly_amount = H.reagents.get_reagent_amount(exotic_blood)
@@ -338,6 +340,23 @@
 	nojumpsuit = 1
 	sexes = 0
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem
+	// To prevent golem subtypes from overwhelming the odds when random species
+	// changes, only the Random Golem type can be chosen
+	blacklisted = TRUE
+	dangerous_existence = TRUE
+
+/datum/species/golem/random
+	name = "Random Golem"
+	blacklisted = FALSE
+	dangerous_existence = FALSE
+
+/datum/species/golem/random/New()
+	. = ..()
+	var/list/golem_types = typesof(/datum/species/golem) - src.type
+	var/datum/species/golem/golem_type = pick(golem_types)
+	name = initial(golem_type.name)
+	id = initial(golem_type.id)
+	meat = initial(golem_type.id)
 
 /datum/species/golem/adamantine
 	name = "Adamantine Golem"
@@ -347,32 +366,22 @@
 /datum/species/golem/plasma
 	name = "Plasma Golem"
 	id = "plasma"
-	dangerous_existence = 1
-	blacklisted = 1
 
 /datum/species/golem/diamond
 	name = "Diamond Golem"
 	id = "diamond"
-	blacklisted = 1
-	dangerous_existence = 1
 
 /datum/species/golem/gold
 	name = "Gold Golem"
 	id = "gold"
-	blacklisted = 1
-	dangerous_existence = 1
 
 /datum/species/golem/silver
 	name = "Silver Golem"
 	id = "silver"
-	blacklisted = 1
-	dangerous_existence = 1
 
 /datum/species/golem/uranium
 	name = "Uranium Golem"
 	id = "uranium"
-	blacklisted = 1
-	dangerous_existence = 1
 
 
 /*

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -389,7 +389,6 @@
 	spawn(30)
 		if(!H || qdeleted(H))
 			return
-		//var/list/blacklisted_species = list(
 		var/list/possible_morphs = list()
 		for(var/type in subtypesof(/datum/species))
 			var/datum/species/S = type
@@ -397,13 +396,9 @@
 				continue
 			possible_morphs += S
 		var/datum/species/mutation = pick(possible_morphs)
-		if(prob(90) && mutation && H.dna.species != /datum/species/golem && H.dna.species != /datum/species/golem/adamantine)
+		if(prob(90) && mutation)
 			H << "<span class='danger'>The pain subsides. You feel... different.</span>"
 			H.set_species(mutation)
-			if(mutation.id == "slime")
-				H.faction |= "slime"
-			else
-				H.faction -= "slime"
 		else
 			H << "<span class='danger'>The pain vanishes suddenly. You feel no different.</span>"
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -10,6 +10,7 @@
 	flags = OPENCONTAINER
 	slot_flags = SLOT_BELT
 	var/ignore_flags = 0
+	var/infinite = FALSE
 
 /obj/item/weapon/reagent_containers/hypospray/attack_paw(mob/user)
 	return attack_hand(user)
@@ -31,8 +32,12 @@
 			var/list/injected = list()
 			for(var/datum/reagent/R in reagents.reagent_list)
 				injected += R.name
+			var/trans = 0
+			if(!infinite)
+				trans = reagents.trans_to(M, amount_per_transfer_from_this)
+			else
+				trans = reagents.copy_to(M, amount_per_transfer_from_this)
 
-			var/trans = reagents.trans_to(M, amount_per_transfer_from_this)
 			user << "<span class='notice'>[trans] unit\s injected.  [reagents.total_volume] unit\s remaining in [src].</span>"
 
 			var/contained = english_list(injected)
@@ -128,3 +133,11 @@
 	volume = 80
 	amount_per_transfer_from_this = 80
 	list_reagents = list("salbutamol" = 10, "coffee" = 20, "leporazine" = 20, "tricordrazine" = 15, "epinephrine" = 10, "omnizine" = 5)
+
+/obj/item/weapon/reagent_containers/hypospray/medipen/species_mutator
+	name = "species mutator medipen"
+	desc = "Embark on a whirlwind tour of racial insensitivity by \
+		literally appropriating other races."
+	volume = 1
+	amount_per_transfer_from_this = 1
+	list_reagents = list("unstablemutationtoxin" = 1)


### PR DESCRIPTION
- Unstable mutation toxin now acts normally on golems, and can turn
  people into golems
- Because there are so many golem subtypes, the only non-blacklisted
  golem type is /datum/species/golem/random which will select a random
  name and ID and meatype from one of the others.
- Moved the check for a species siemens_coeff (electricity resistence)
  down to carbon level, and make it always run. Now golems are immune to
  all electricity; no other modification of siemens_coeff are in existing
  species code.
- Added an "infinite" var to hyposprays (which includes epipens), which
  causes it not to deplete its internal stock if true.
- Adds a species mutator epipen, admin only, used for testing all the
  species stuff. A lot of sprites are broken.

Fixes #17831
:cl: coiax
fix: Free Golem scientists have proved that as beings made out of stone,
golems are immune to all electrical discharges, including the tesla.
/:cl:
