### PR TITLE
Changes default time filter for the changelog to 9 weeks from 4 weeks

### DIFF
--- a/tools/ss13_genchangelog.py
+++ b/tools/ss13_genchangelog.py
@@ -36,7 +36,7 @@ dateformat = "%d %B %Y"
 
 opt = argparse.ArgumentParser()
 opt.add_argument('-d', '--dry-run', dest='dryRun', default=False, action='store_true', help='Only parse changelogs and, if needed, the targetFile. (A .dry_changelog.yml will be output for debugging purposes.)')
-opt.add_argument('-t', '--time-period', dest='timePeriod', default=4, type=int, help='Define how many weeks back the changelog should display')
+opt.add_argument('-t', '--time-period', dest='timePeriod', default=9, type=int, help='Define how many weeks back the changelog should display')
 opt.add_argument('targetFile', help='The HTML changelog we wish to update.')
 opt.add_argument('ymlDir', help='The directory of YAML changelogs we will use.')
 


### PR DESCRIPTION
4 weeks is too small, some users do come back in after some time, and some of those are nerdy enough to want to read thru the whole thing.
