### PR TITLE
Revert "Station hardsuits no longer have in-built jetpacks"

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -119,6 +119,11 @@
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
 
+
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+	..()
+
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
 	name = "atmospherics hardsuit helmet"


### PR DESCRIPTION
Reverts tgstation/tgstation#18028.

Someone kick @optimumtact in balls for merging this hated, balance meme'd, feature frozen PR and then quickclosing my previous attempt at revert with a reason that can be summed up as "i have maintainer buttons, you don't, now suck my cock".

I don't see a single reason why "remove jetpacks" PR was even made. Apparently some sec player got killed by a hardsuited traitor engineer and started a shitstorm with his "I DED IDED IDEDIDED". Hey guys, don't you understand that "i ded" nerfs are _not_ a good way to do balance?

@KorPhaeron, the only compromise I can think of is removal of atmos hardsuit jetpack only. This cuts amount of hardsuit jetpacks in half without hurting engineers. Anything else is balance memeing.
