### PR TITLE
Fixes the recursive qdel dropped loop from ling suits

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -89,8 +89,8 @@
 	var/mob/living/carbon/human/H = user
 	if(istype(H.wear_suit, suit_type) || istype(H.head, helmet_type))
 		H.visible_message("<span class='warning'>[H] casts off their [suit_name_simple]!</span>", "<span class='warning'>We cast off our [suit_name_simple][genetic_damage > 0 ? ", temporarily weakening our genomes." : "."]</span>", "<span class='italics'>You hear the organic matter ripping and tearing!</span>")
-		qdel(H.wear_suit)
-		qdel(H.head)
+		H.unEquip(H.head, TRUE) //The qdel on dropped() takes care of it
+		H.unEquip(H.wear_suit, TRUE)
 		H.update_inv_wear_suit()
 		H.update_inv_head()
 		H.update_hair()


### PR DESCRIPTION
:cl: Kiazusho
bugfix: Changeling organic suit and chitin armor can be toggled off once again.
/:cl:

Fixes #17750 

Thanks @phil235 for pointing out what was causing the loop

Also, kinda weird we didn't have much attention to this bug, it's been open for two weeks and haven't received any other reports, people might be under-using these abilities in favor of other.
