### PR TITLE
Mobs only take damage once from a shuttle roadkill

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -549,9 +549,11 @@
 				Door.close()
 
 /obj/docking_port/mobile/proc/roadkill(list/L, dir, x, y)
+	var/list/hurt_mobs = list()
 	for(var/turf/T in L)
 		for(var/atom/movable/AM in T)
-			if(isliving(AM))
+			if(isliving(AM) && (!(AM in hurt_mobs)))
+				hurt_mobs |= AM
 				if(ishuman(AM))
 					var/mob/living/M = AM
 					M.visible_message("<span class='warning'>[M] is hit by \


### PR DESCRIPTION
Fixes #18061.

:cl: coiax
bugfix: You can only be damaged once by a shuttle's arrival. It is still
unpleasant to be in the path of one though; try to avoid it.
/:cl:
