### PR TITLE
Removes camokit from nuke op uplink

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -630,8 +630,10 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 
 /datum/uplink_item/stealthy_tools/chameleon
 	name = "Chameleon Kit"
-	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!"
+	desc = "A set of items that contain chameleon technology allowing \
+		you to disguise as pretty much anyone on the station, and more!"
 	item = /obj/item/weapon/storage/box/syndie_kit/chameleon
+	exclude_modes = list(/datum/game_mode/nuclear)
 	cost = 4
 
 /datum/uplink_item/stealthy_tools/syndigaloshes


### PR DESCRIPTION
:cl: coiax
rscdel: Nuclear operatives can no longer purchase chameleon kits.
/:cl:

Another nerf brought to you by @kevinz000 <3

To be clear, I'm somewhat opposed to this change, but I detected a lot of
salt from admins and coders about stealth ops, so I made the PR for it.
