### PR TITLE
Hopefully stops drakes from bugging out

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -157,7 +157,7 @@
 				sleep(1)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/proc/swoop_attack(fire_rain = 0, atom/movable/manual_target)
-	if(stat)
+	if(stat || swooping)
 		return
 	swoop_cooldown = world.time + 200
 	var/swoop_target


### PR DESCRIPTION
For some reason swooping = 0 is often not set properly at the end of their attack, I'm assuming it's getting lost in all the sleeps or trying to swoop twice at once or something. This causes them to sometimes just sit there forever not attacking, and other times become invincible, both of which are pretty awful.
