### PR TITLE
Armour Value Changes

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -4,7 +4,7 @@
 	icon_state = "helmet"
 	flags = HEADBANGPROTECT
 	item_state = "helmet"
-	armor = list(melee = 30, bullet = 25, laser = 25,energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 30, laser = 30,energy = 10, bomb = 25, bio = 0, rad = 0)
 	flags_inv = HIDEEARS
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
@@ -31,7 +31,7 @@
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
 	item_state = "helmetalt"
-	armor = list(melee = 15, bullet = 40, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
+	armor = list(melee = 15, bullet = 80, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
 	can_flashlight = 1
 	dog_fashion = null
 
@@ -44,7 +44,7 @@
 	alt_toggle_message = "You push the visor up on"
 	can_toggle = 1
 	flags = HEADBANGPROTECT
-	armor = list(melee = 41, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
+	armor = list(melee = 60, bullet = 10, laser = 10, energy = 10, bomb = 5, bio = 2, rad = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE
 	strip_delay = 80
 	actions_types = list(/datum/action/item_action/toggle)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -95,7 +95,7 @@
 	name = "head of security cap"
 	desc = "The robust standard-issue cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
-	armor = list(melee = 40, bullet = 30, laser = 25, energy = 10, bomb = 25, bio = 10, rad = 0)
+	armor = list(melee = 60, bullet = 50, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
 	strip_delay = 80
 
 /obj/item/clothing/head/HoS/beret
@@ -107,7 +107,7 @@
 	name = "warden's police hat"
 	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."
 	icon_state = "policehelm"
-	armor = list(melee = 30, bullet = 5, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	strip_delay = 60
 
 	dog_fashion = /datum/dog_fashion/head/warden
@@ -116,7 +116,7 @@
 	name = "security beret"
 	desc = "A robust beret with the security insignia emblazoned on it. Uses reinforced fabric to offer sufficent protection."
 	icon_state = "beret_badge"
-	armor = list(melee = 30, bullet = 25, laser = 25,energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 30, laser = 30,energy = 10, bomb = 25, bio = 0, rad = 0)
 	strip_delay = 60
 	dog_fashion = null
 
@@ -129,7 +129,7 @@
 	name = "warden's beret"
 	desc = "A special beret with the Warden's insignia emblazoned on it. For wardens with class."
 	icon_state = "wardenberet"
-	armor = list(melee = 30, bullet = 5, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	strip_delay = 60
 
 /obj/item/clothing/head/beret/sec/navyofficer

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -15,7 +15,7 @@
 	icon_state = "armoralt"
 	item_state = "armoralt"
 	blood_overlay_type = "armor"
-	armor = list(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
 	dog_fashion = /datum/dog_fashion/back
 
 /obj/item/clothing/suit/armor/vest/alt
@@ -29,7 +29,7 @@
 	icon_state = "hos"
 	item_state = "greatcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(melee = 30, bullet = 30, laser = 30, energy = 10, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 50, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION
This PR puts forward several armour defense value changes I wish to propose.

As a forword, nothing in this PR is fixed and all is subject to change. This PR is meant to show case my proposed PR changes, and justification, as well as to facilitate discussion on this issue. My position is clear in that I feel the current armour defense is too little.

I know this will be controversial but I wish to get some good discussion out of this, so leave the shitposts to singulo please. 

Also, this PR currently only touches armour used by station personal, I feel antagonist armour is very strong as is but no one has discussed if antag armour should be changed. 

Overall I feel enough people agree that current armour is too weak to at least allow for a PR of this kind to exsist to generate discussion and see if we make make armour a bit better. My proposals don't boost armour back to the pre-nerf days, but they take them to a nicer middle ground.

Link to relevant forum thread: https://tgstation13.org/phpBB/viewtopic.php?f=10&t=6763

---

Following changes are effected.

**Armour Vest+Helmet**
Old Value: melee = 25, bullet = 15, laser = 25
New Value: melee = 40, bullet = 30, laser = 30 (Vest is 30)

(This affects Security Officers, Detective, The Warden, the HoP and the Bartender)

Reasoning:  The main justification here is the buff to the bullet protection, a direct hit on the chest or head will deal 30% less damage, in cases of weapons like the Revolver this will force the attacker to either aim for the external limbs or to hit the target a third time to crit someone wearing a armour vest. 

Security Officers will take three revolver rounds to crit instead of two. The melee boost also gives reasonable protection to a wearer unless external limbs are being targeted. Laser protection is only a minor boost for consistency

**HoS Jacket + Beret**
Old Value: melee = 30, bullet = 30, laser = 30
New Value: melee = 60, bullet = 50, laser = 50 (50 melee for jacket)

Reasoning: The HoS is meant to represent the best of security, and his old defense values were barely better than a stock armour vest. These new values will mean it'll take some real considerable effort to kill the HoS (or just stun him and strip him).

I feel currently the HoS, considering him being the most targeted and stress inducing job on station, is very squishy against attacks. I believe this buff will go a long way into making the HoS far more durable.

**Bulletproof and Riot Helmet** have both had their values buffed to match the Chest pieces values.
So Bulletproof Helmet from 40 to 80
And Riot Helmet from 41 to 60.
