### PR TITLE
Updates some lavaland ruins and adds new ones.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,6 +1,6 @@
 "a" = (/turf/closed/indestructible/riveted{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "b" = (/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/ruin/unpowered)
-"c" = (/obj/item/weapon/paper{desc = "have not gotten around to finishing my cursed item yet sorry - sloth"; name = "note from sloth"},/turf/open/floor/sepia{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1; slowdown = 10},/area/ruin/unpowered)
+"c" = (/obj/item/weapon/paper/sloth,/turf/open/floor/sepia{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1; slowdown = 10},/area/ruin/unpowered)
 "d" = (/turf/open/floor/sepia{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1; slowdown = 10},/area/ruin/unpowered)
 "e" = (/obj/machinery/door/airlock/wood,/turf/open/floor/sepia{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1; slowdown = 10},/area/ruin/unpowered)
 "f" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/grown/citrus/orange,/turf/open/floor/sepia{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1; slowdown = 10},/area/ruin/unpowered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wrath.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wrath.dmm
@@ -1,0 +1,28 @@
+"a" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/space)
+"b" = (/turf/closed/wall/mineral/uranium,/area/ruin/powered)
+"c" = (/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/ruin/powered)
+"d" = (/obj/effect/mob_spawn/human/corpse/wizard,/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/ruin/powered)
+"e" = (/obj/structure/wrathaltar,/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/ruin/powered)
+"f" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/ruin/powered)
+"g" = (/obj/effect/mob_spawn/human/corpse/damaged,/turf/open/floor/plasteel/shuttle{icon_state = "shuttlefloor4"},/area/ruin/powered)
+"h" = (/obj/machinery/door/airlock/uranium,/turf/open/floor/plasteel/freezer{baseturf = /turf/open/floor/plating/lava/smooth;blocks_air = 1},/area/ruin/powered)
+
+(1,1,1) = {"
+aaaaabbbbaaaaaa
+bbbbbbccbbbabbb
+bccdccceccbbccb
+bccfcgccccccccb
+bbbfccccccccccb
+aabcccccccccccb
+aabbbcccccbbbbb
+aaaabcccccbaaaa
+aaaabbcccbbaaaa
+aaaaabcccbaaaaa
+aaabbbcccbbaaaa
+aaabccccccbaaaa
+aaabccccccbaaaa
+aaabbhbbccbaaaa
+aaaaaaabccbaaaa
+aaaaaaabccbaaaa
+aaaaaaabbbbaaaa
+"}

--- a/code/__DEFINES/sins.dm
+++ b/code/__DEFINES/sins.dm
@@ -1,0 +1,7 @@
+#define ACEDIA 1
+#define GLUTTONY 2
+#define GREED 3
+#define SLOTH 4
+#define WRATH 5
+#define ENVY 6
+#define PRIDE 7

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -126,6 +126,18 @@
 	cost = 0
 	allow_duplicates = FALSE
 
+/datum/map_template/ruin/lavaland/sin/acedia
+	name = "Ruin of Acedia"
+	id = "acedia"
+	description = "This is wrong, but why is that bad?"
+	suffix = "lavaland_surface_acedia.dmm"
+
+/datum/map_template/ruin/lavaland/sin/wrath
+	name = "Ruin of Wrath"
+	id = "wrath"
+	description = "The all consuming flames of anger"
+	suffix = "lavaland_surface_wrath.dmm"
+
 /datum/map_template/ruin/lavaland/ato
 	name = "Automated Trade Outpost"
 	id = "ato"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1040,28 +1040,28 @@
 			dna.remove_mutation(HM.name)
 	..()
 
-/mob/living/carbon/human/proc/influenceSin()
+/mob/living/carbon/human/proc/influenceSin(sintype = rand(1,7))
 	var/datum/objective/sintouched/O
-	switch(rand(1,7))//traditional seven deadly sins... except lust.
-		if(1) // acedia
+	switch(sintype)//traditional seven deadly sins... except lust.
+		if(ACEDIA) // acedia
 			log_game("[src] was influenced by the sin of Acedia.")
 			O = new /datum/objective/sintouched/acedia
-		if(2) // Gluttony
+		if(GLUTTONY) // Gluttony
 			log_game("[src] was influenced by the sin of gluttony.")
 			O = new /datum/objective/sintouched/gluttony
-		if(3) // Greed
+		if(GREED) // Greed
 			log_game("[src] was influenced by the sin of greed.")
 			O = new /datum/objective/sintouched/greed
-		if(4) // sloth
+		if(SLOTH) // sloth
 			log_game("[src] was influenced by the sin of sloth.")
 			O = new /datum/objective/sintouched/sloth
-		if(5) // Wrath
+		if(WRATH) // Wrath
 			log_game("[src] was influenced by the sin of wrath.")
 			O = new /datum/objective/sintouched/wrath
-		if(6) // Envy
+		if(ENVY) // Envy
 			log_game("[src] was influenced by the sin of envy.")
 			O = new /datum/objective/sintouched/envy
-		if(7) // Pride
+		if(PRIDE) // Pride
 			log_game("[src] was influenced by the sin of pride.")
 			O = new /datum/objective/sintouched/pride
 	ticker.mode.sintouched += src.mind

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -443,6 +443,9 @@
 
 /datum/reagent/gluttonytoxin/reaction_mob(mob/M, method=TOUCH, reac_volume)
 	M.ForceContractDisease(new /datum/disease/transformation/morph(0))
+	if(istype(M, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = M
+		H.influenceSin(GLUTTONY)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -83,7 +83,7 @@
 	flavour_text = {"You are a strange, artificial creature. Your creators were a highly advanced and benevolent race, and launched many seed vaults into the stars, hoping to aid fledgling civilizations. You are to tend to the vault and await the arrival of sentient species. You've been waiting quite a while though..."}
 
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
-	var/plant_name = pick("Tomato", "Potato", "Brocolli", "Carrot", "Deathcap", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Bannana", "Moss", "Flower", "Bloom", "Spore", "Root", "Bark", "Glowshroom", "Petal", "Leaf", "Venus", "Sprout","Cocao", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
+	var/plant_name = pick("Tomato", "Potato", "Brocolli", "Carrot", "Deathcap", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Bannana", "Moss", "Flower", "Bloom", "Spore", "Root", "Bark", "Glowshroom", "Petal", "Leaf", "Venus", "Sprout", "Cocao", "Strawberry", "Citrus", "Oak", "Cactus", "Pepper", "Juniper")
 	new_spawn.real_name = plant_name
 
 //Greed
@@ -114,6 +114,9 @@
 	if(prob(win_prob))
 		new /obj/item/weapon/dice/d20/fate/one_use(get_turf(src))
 		if(user)
+			if(istype(user, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = user
+				H.influenceSin(GREED)
 			user << "You hear laughter echoing around you as the machine fades away. In it's place...more gambling."
 			qdel(src)
 	else
@@ -138,8 +141,7 @@
 			return 1
 		else
 			H << "<span class='danger'><B>You're not gluttonous enough to pass this barrier!</B></span>"
-	else
-		return 0
+	return 0
 
 //Pride
 
@@ -154,8 +156,23 @@
 	T.ChangeTurf(/turf/open/chasm/straight_down)
 	var/turf/open/chasm/straight_down/C = T
 	C.drop(user)
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		H.influenceSin(PRIDE)
 
-//Sloth - I'll finish this item later
+//Sloth
+
+/obj/item/weapon/paper/sloth
+	name = "note from sloth"
+	var/used = 0
+	desc = "have not gotten around to finishing my cursed item yet sorry - sloth"
+
+/obj/item/weapon/paper/sloth/examine(mob/user)
+	..()
+	if(!used && istype(user, /mob/living/carbon/human))
+		used = 1
+		var/mob/living/carbon/human/H = user
+		H.influenceSin(PRIDE)
 
 //Envy
 
@@ -178,12 +195,60 @@
 		return
 	if(istype(AM, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = AM
+		H.influenceSin(ENVY) //Yes, have it sintouch the TARGET,
 		if(user.real_name != H.dna.real_name)
 			user.real_name = H.dna.real_name
 			H.dna.transfer_identity(user, transfer_SE=1)
 			user.updateappearance(mutcolor_update=1)
 			user.domutcheck()
 			user << "You assume the face of [H]. Are you satisfied?"
+
+//Wrath
+
+/obj/item/weapon/melee/wrathhand
+	name = "The hand of hatred."
+	force = 0
+	hitsound = 'sound/magic/WandODeath.ogg'
+	icon_state = "disintegrate"
+	item_state = "disintegrate"
+	flags = NODROP
+	unacidable = 1
+
+/obj/item/weapon/melee/wrathhand/afterattack(atom/movable/AM, mob/living/carbon/human/user, proximity)
+	if(AM == user)
+		user << "<span class='warning'>Surely there is someone you hate more than yourself.</span>"
+	else
+		if(istype(AM,/mob/living))
+			var/mob/living/L = AM
+			user << "<span class='warning'>Your hatred is fulfilled.</span>"
+			L.gib()
+			user.gib()
+			qdel(src)
+
+/obj/structure/wrathaltar
+	icon_state = "talismanaltar"
+	density = 1
+	anchored = 1
+	icon = 'icons/obj/cult.dmi'
+	name = "Altar of wrath"
+	desc = "Lay your hand upon the altar and recieve the power to smite your enemies."
+	var/used = 0
+
+/obj/structure/wrathaltar/attack_hand(mob/living/user)
+	if (used)
+		user << "<span class='notice'>\The [src]'s power has already been invoked.</span>"
+	else
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.influenceSin(WRATH)
+			if(H.drop_item())
+				used = 1
+				H.put_in_hands(new /obj/item/weapon/melee/wrathhand())
+
+/obj/structure/cult/examine(mob/user)
+	..()
+	user << "<span class='notice'>\The [src] is [anchored ? "":"not "]secured to the floor.</span>"
+
 
 ///Ash Walkers
 

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -245,11 +245,6 @@
 				used = 1
 				H.put_in_hands(new /obj/item/weapon/melee/wrathhand())
 
-/obj/structure/cult/examine(mob/user)
-	..()
-	user << "<span class='notice'>\The [src] is [anchored ? "":"not "]secured to the floor.</span>"
-
-
 ///Ash Walkers
 
 /mob/living/simple_animal/hostile/spawner/ash_walker

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -206,7 +206,7 @@
 //Wrath
 
 /obj/item/weapon/melee/wrathhand
-	name = "The hand of hatred."
+	name = "The hand of hatred"
 	force = 0
 	hitsound = 'sound/magic/WandODeath.ogg'
 	icon_state = "disintegrate"
@@ -215,6 +215,8 @@
 	unacidable = 1
 
 /obj/item/weapon/melee/wrathhand/afterattack(atom/movable/AM, mob/living/carbon/human/user, proximity)
+	if(!proximity)
+		return
 	if(AM == user)
 		user << "<span class='warning'>Surely there is someone you hate more than yourself.</span>"
 	else
@@ -231,7 +233,7 @@
 	anchored = 1
 	icon = 'icons/obj/cult.dmi'
 	name = "Altar of wrath"
-	desc = "Lay your hand upon the altar and recieve the power to smite your enemies."
+	desc = "Lay your hand upon the altar and receive the power to smite your enemies."
 	var/used = 0
 
 /obj/structure/wrathaltar/attack_hand(mob/living/user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,7 +15,6 @@
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
 #include "_maps\tgstation2.dm"
-#include "_maps\RandomRuins\LavaRuins\lavaland_surface_wrath.dmm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\world.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
 #include "_maps\tgstation2.dm"
+#include "_maps\RandomRuins\LavaRuins\lavaland_surface_wrath.dmm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\world.dm"
@@ -46,6 +47,7 @@
 #include "code\__DEFINES\say.dm"
 #include "code\__DEFINES\shuttles.dm"
 #include "code\__DEFINES\sight.dm"
+#include "code\__DEFINES\sins.dm"
 #include "code\__DEFINES\stat.dm"
 #include "code\__DEFINES\tablecrafting.dm"
 #include "code\__DEFINES\tgui.dm"


### PR DESCRIPTION
Adds lavaland wrath ruin.
Adds lavaland wrath ruin's reward.
Lavaland ruins can now cause sintouching.

I'm still working on adding a ruin for Acedia, but I wanted to run wrath's by the coderbase in the meantime.

Bottom line: wrath has an altar of wrath.  Upon using the altar, you will be equipped with a NODROP hand of wrath, which is a one time use melee weapon that gibs you, AND your target.
