### PR TITLE
Nar'sie rune can no longer be scribed off station or on shuttles

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -15,7 +15,7 @@ This file contains the arcane tome files.
 
 /obj/item/weapon/tome/examine(mob/user)
 	..()
-	if(iscultist(user) || user.stat == DEAD)
+	if(iscultist(user) || isobserver(user))
 		user << "<span class='cult'>The scriptures of the Geometer. Allows the scribing of runes and access to the knowledge archives of the cult of Nar-Sie.</span>"
 		user << "<span class='cult'>Striking a cult structure will unanchor or reanchor it.</span>"
 		user << "<span class='cult'>Striking another cultist with it will purge holy water from them.</span>"
@@ -214,12 +214,21 @@ This file contains the arcane tome files.
 			else if(!cult_mode.eldergod)
 				user << "<span class='cultlarge'>\"I am already here. There is no need to try to summon me now.\"</span>"
 				return
+			var/area/A = get_area(src)
+			var/locname = initial(A.name)
+			if(loc.z && loc.z != ZLEVEL_STATION)
+				user << "<span class='warning'>The Geometer is not interested \
+					in lesser locations; the station is the prize!</span>"
+				return
+			if(istype(A, /area/shuttle))
+				user << "<span class='warning'>Interference from hyperspace \
+					engines prevents the Geometer from entering our world on \
+					a shuttle.</span>"
+				return
 			var/confirm_final = alert(user, "This is the FINAL step to summon Nar-Sie, it is a long, painful ritual and the crew will be alerted to your presence", "Are you prepared for the final battle?", "My life for Nar-Sie!", "No")
 			if(confirm_final == "No")
 				user << "<span class='cult'>You decide to prepare further before scribing the rune.</span>"
 				return
-			var/area/A = get_area(src)
-			var/locname = initial(A.name)
 			priority_announce("Figments from an eldritch god are being summoned by [user] into [locname] from an unknown dimension. Disrupt the ritual at all costs!","Central Command Higher Dimensionsal Affairs", 'sound/AI/spanomalies.ogg')
 			for(var/B in spiral_range_turfs(1, user, 1))
 				var/turf/T = B

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -457,27 +457,11 @@ var/list/teleport_runes = list()
 
 /obj/effect/rune/narsie/New()
 	. = ..()
-	SSobj.processing += src
 	poi_list |= src
 
 /obj/effect/rune/narsie/Destroy()
-	SSobj.processing -= src
 	poi_list -= src
 	. = ..()
-
-/obj/effect/rune/narsie/process()
-	// Automatically attempt a summoning, once per process
-	var/list/invokers = can_invoke()
-	if(invokers.len >= req_cultists)
-		invoke(invokers)
-	else
-		fail_invoke(message=FALSE)
-	// Automatically disappear if for some reason it's not present on station
-	if(loc.z != ZLEVEL_STATION)
-		visible_message("<span class='cultitalic'>[src] disappears in \
-			disgust. The Geometer is not interested in lesser locations.\
-			</span>")
-		qdel(src)
 
 /obj/effect/rune/narsie/talismanhide() //can't hide this, and you wouldn't want to
 	return
@@ -546,7 +530,7 @@ var/list/teleport_runes = list()
 	if(!potential_sacrifice_mobs.len)
 		user << "<span class='cultitalic'>There are no eligible sacrifices nearby!</span>"
 		log_game("Raise Dead rune failed - no catalyst corpses")
-		fail_invoke()
+		fail_invoke(message = FALSE)
 		return
 	for(var/mob/living/M in T.contents)
 		if(M.stat == DEAD)
@@ -554,7 +538,7 @@ var/list/teleport_runes = list()
 	if(!potential_revive_mobs.len)
 		user << "<span class='cultitalic'>There is no eligible revival target on the rune!</span>"
 		log_game("Raise Dead rune failed - no corpses to revive")
-		fail_invoke()
+		fail_invoke(message = FALSE)
 		return
 	mob_to_sacrifice = input(user, "Choose a corpse to sacrifice.", "Corpse to Sacrifice") as null|anything in potential_sacrifice_mobs
 	if(!src || qdeleted(src) || rune_in_use || !validness_checks(mob_to_sacrifice, user, 1))
@@ -579,11 +563,12 @@ var/list/teleport_runes = list()
 	if(!mob_to_revive || mob_to_revive.stat != DEAD)
 		visible_message("<span class='warning'>The glowing tendril snaps against the rune with a shocking crack.</span>")
 		rune_in_use = 0
-		fail_invoke()
+		fail_invoke(message = FALSE)
 		return
 	mob_to_sacrifice.visible_message("<span class='warning'><b>[mob_to_sacrifice] disintegrates into a pile of bones.</span>")
 	mob_to_sacrifice.dust()
 	mob_to_revive.revive(1, 1) //This does remove disabilities and such, but the rune might actually see some use because of it!
+	mob_to_revive.grab_ghost()
 	mob_to_revive << "<span class='cultlarge'>\"PASNAR SAVRAE YAM'TOTH. Arise.\"</span>"
 	mob_to_revive.visible_message("<span class='warning'>[mob_to_revive] draws in a huge breath, red light shining from their eyes.</span>", \
 								  "<span class='cultlarge'>You awaken suddenly from the void. You're alive!</span>")

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -142,11 +142,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 		animate(src, transform = matrix()*2, alpha = 0, time = 5) //fade out
 		animate(transform = oldtransform, alpha = 255, time = 0)
 
-/obj/effect/rune/proc/fail_invoke(message=TRUE)
+/obj/effect/rune/proc/fail_invoke()
 	//This proc contains the effects of a rune if it is not invoked correctly, through either invalid wording or not enough cultists. By default, it's just a basic fizzle.
-	if(message)
-		visible_message("<span class='warning'>The markings pulse with a \
-			small flash of red light, then fall dark.</span>")
+	visible_message("<span class='warning'>The markings pulse with a \
+		small flash of red light, then fall dark.</span>")
 	spawn(0) //animate is a delay, we want to avoid being delayed
 		animate(src, color = rgb(255, 0, 0), time = 0)
 		animate(src, color = initial(color), time = 5)
@@ -530,7 +529,7 @@ var/list/teleport_runes = list()
 	if(!potential_sacrifice_mobs.len)
 		user << "<span class='cultitalic'>There are no eligible sacrifices nearby!</span>"
 		log_game("Raise Dead rune failed - no catalyst corpses")
-		fail_invoke(message = FALSE)
+		fail_invoke()
 		return
 	for(var/mob/living/M in T.contents)
 		if(M.stat == DEAD)
@@ -538,7 +537,7 @@ var/list/teleport_runes = list()
 	if(!potential_revive_mobs.len)
 		user << "<span class='cultitalic'>There is no eligible revival target on the rune!</span>"
 		log_game("Raise Dead rune failed - no corpses to revive")
-		fail_invoke(message = FALSE)
+		fail_invoke()
 		return
 	mob_to_sacrifice = input(user, "Choose a corpse to sacrifice.", "Corpse to Sacrifice") as null|anything in potential_sacrifice_mobs
 	if(!src || qdeleted(src) || rune_in_use || !validness_checks(mob_to_sacrifice, user, 1))
@@ -563,7 +562,7 @@ var/list/teleport_runes = list()
 	if(!mob_to_revive || mob_to_revive.stat != DEAD)
 		visible_message("<span class='warning'>The glowing tendril snaps against the rune with a shocking crack.</span>")
 		rune_in_use = 0
-		fail_invoke(message = FALSE)
+		fail_invoke()
 		return
 	mob_to_sacrifice.visible_message("<span class='warning'><b>[mob_to_sacrifice] disintegrates into a pile of bones.</span>")
 	mob_to_sacrifice.dust()


### PR DESCRIPTION
:cl: coiax
rscdel: The Nar'sie rune cannot be scribed on shuttles or off Z-level.
rscadd: The Raise Dead rune automatically grabs the ghost of the raised corpse.
/:cl:
- Made can_invoke() not require a user argument (for that auto-invoke)
- Removed unused user argument from fail_invoke, made message display an
  argument (for that auto-invoke)
