### PR TITLE
Make changelog build commits not trigger a travis build

### DIFF
--- a/tools/github_webhook_processor.php
+++ b/tools/github_webhook_processor.php
@@ -262,7 +262,7 @@ function checkchangelog($payload, $merge = false) {
 	}
 	$content = array (
 		'branch' 	=> $payload['pull_request']['base']['ref'],
-		'message' 	=> 'Automatic changelog generation for PR #'.$payload['pull_request']['number'].'[ci skip]',
+		'message' 	=> 'Automatic changelog generation for PR #'.$payload['pull_request']['number'].' [ci skip]',
 		'content' 	=> base64_encode($file)
 	);
 	$scontext = array('http' => array(

--- a/tools/github_webhook_processor.php
+++ b/tools/github_webhook_processor.php
@@ -262,7 +262,7 @@ function checkchangelog($payload, $merge = false) {
 	}
 	$content = array (
 		'branch' 	=> $payload['pull_request']['base']['ref'],
-		'message' 	=> 'Automatic changelog generation for PR #'.$payload['pull_request']['number'],
+		'message' 	=> 'Automatic changelog generation for PR #'.$payload['pull_request']['number'].'[ci skip]',
 		'content' 	=> base64_encode($file)
 	);
 	$scontext = array('http' => array(

--- a/tools/tgstation-server/Update Server.bat
+++ b/tools/tgstation-server/Update Server.bat
@@ -41,7 +41,7 @@ if defined PUSHCHANGELOGTOGIT (
 		echo pushing compiled changelog to server
 		git add -u html/changelog.html
 		git add -u html/changelogs
-		git commit -m "Automatic changelog compile"
+		git commit -m "Automatic changelog compile, [ci skip]"
 		if %ERRORLEVEL% == 0 (
 			git push
 		)


### PR DESCRIPTION
There is no reason to build tests on these as they are automated
and not often checked, plus, they do not modify code and the
changelog yaml should already be verified when it was merged

[ci skip]
