### PR TITLE
Variable viewer always expands assoc lists

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -404,7 +404,7 @@ body
 				html += "<ul>"
 				var/index = 1
 				for (var/entry in L)
-					if(istext(entry))
+					if(L[entry])
 						html += debug_variable(entry, L[entry], level + 1)
 					//html += debug_variable("[index]", L[index], level + 1)
 					else


### PR DESCRIPTION
Quite often types are keys in lists as well as strings. I've checked, it
works fine, seems like a shame to lock it behind my datum antags PR so
here it is seperately.

So it looks like this causes some runtimes, I will see what variables are causing them.

runtime error: 
[14:26:18]bad index
[14:26:18]proc name: debug variable (/client/proc/debug_variable)
[14:26:18]  source file: datumvars.dm,407
[14:26:18]  usr: Braxton Cherry (/mob/living/carbon/human)
[14:26:18]  src: Coiax (/client)
[14:26:18]  usr.loc: the floor (120,94,1) (/turf/open/floor/plasteel)
[14:26:18]  call stack:
[14:26:18]Coiax (/client): debug variable("contents", /list (/list), 0, Braxton Cherry (/mob/living/carbon/human))
[14:26:18]Coiax (/client): View Variables(Braxton Cherry (/mob/living/carbon/human))
runtime error: 
[14:26:18]bad index
[14:26:18]proc name: debug variable (/client/proc/debug_variable)
[14:26:18]  source file: datumvars.dm,407
[14:26:18]  usr: Braxton Cherry (/mob/living/carbon/human)
[14:26:18]  src: Coiax (/client)
[14:26:18]  usr.loc: the floor (120,94,1) (/turf/open/floor/plasteel)
[14:26:18]  call stack:
[14:26:18]Coiax (/client): debug variable("verbs", /list (/list), 0, Braxton Cherry (/mob/living/carbon/human))
[14:26:18]Coiax (/client): View Variables(Braxton Cherry (/mob/living/carbon/human))
runtime error: 
[14:27:04]list index out of bounds
[14:27:04]proc name: debug variable (/client/proc/debug_variable)
[14:27:04]  source file: datumvars.dm,407
[14:27:04]  usr: Braxton Cherry (/mob/living/carbon/human)
[14:27:04]  src: Coiax (/client)
[14:27:04]  usr.loc: the floor (120,94,1) (/turf/open/floor/plasteel)
[14:27:04]  call stack:
[14:27:04]Coiax (/client): debug variable("slot_equipment_priority", /list (/list), 0, the syndicate uplink (/obj/item/device/uplink))
[14:27:04]Coiax (/client): View Variables(the syndicate uplink (/obj/item/device/uplink))
[14:27:04]Coiax (/client): view var Topic("_src_=vars;Vars=[0x20064c5]", /list (/list), null)
[14:27:04]Coiax (/client): Topic("_src_=vars;Vars=[0x20064c5]", /list (/list), null)
runtime error: 
[14:27:04]bad index
[14:27:04]proc name: debug variable (/client/proc/debug_variable)
[14:27:04]  source file: datumvars.dm,407
[14:27:04]  usr: Braxton Cherry (/mob/living/carbon/human)
[14:27:04]  src: Coiax (/client)
[14:27:04]  usr.loc: the floor (120,94,1) (/turf/open/floor/plasteel)
[14:27:04]  call stack:
[14:27:04]Coiax (/client): debug variable("verbs", /list (/list), 0, the syndicate uplink (/obj/item/device/uplink))
[14:27:04]Coiax (/client): View Variables(the syndicate uplink (/obj/item/device/uplink))
[14:27:04]Coiax (/client): view var Topic("_src_=vars;Vars=[0x20064c5]", /list (/list), null)
[14:27:04]Coiax (/client): Topic("_src_=vars;Vars=[0x20064c5]", /list (/list), null)
