### PR TITLE
Fix temporary martial arts not working properly when you already had another.

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -66,12 +66,8 @@
 		H.verbs += help_verb
 	if(make_temporary)
 		temporary = 1
-	if(H.martial_art && H.martial_art.temporary)
-		if(temporary)
-			base = H.martial_art.base
-		else
-			H.martial_art.base = src //temporary styles have priority
-			return
+	if(H.martial_art && temporary)
+		base = H.martial_art
 	H.martial_art = src
 
 /datum/martial_art/proc/remove(mob/living/carbon/human/H)


### PR DESCRIPTION
If you had, for example, sleeping carp as your martial art and equipped an item that gave you another martial art(boxing gloves, wrestling belt) you would lose the sleeping carp forever.

This still doesn't work really well with multiple martial arts, for example, having sleeping carp, equipping boxing gloves and a championship belt. So if anyone has a better idea than this, let me know.
