### PR TITLE
Adds two Fun verbs for admins (and one boring one)

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -96,6 +96,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/admin_change_sec_level,
 	/client/proc/toggle_nuke,
 	/client/proc/mass_zombie_infection,
+	/client/proc/mass_zombie_cure,
 	/client/proc/polymorph_all
 	)
 var/list/admin_verbs_spawn = list(

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -94,7 +94,9 @@ var/list/admin_verbs_fun = list(
 	/client/proc/forceEvent,
 	/client/proc/bluespace_artillery,
 	/client/proc/admin_change_sec_level,
-	/client/proc/toggle_nuke
+	/client/proc/toggle_nuke,
+	/client/proc/mass_zombie_infection,
+	/client/proc/polymorph_all
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1013,6 +1013,24 @@ var/list/datum/outfit/custom_outfits = list() //Admin created outfits
 	log_admin("[key_name(usr)] added a latent zombie infection to all humans.")
 	feedback_add_details("admin_verb","MZI")
 
+/client/proc/mass_zombie_cure()
+	set category = "Fun"
+	set name = "Mass Zombie Cure"
+	set desc = "Removes the zombie infection from all humans, returning them to normal."
+	if(!holder)
+		return
+
+	var/confirm = alert(src, "Please confirm you want to cure all zombies?", "Confirm Zombie Cure", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	for(var/obj/item/organ/body_egg/zombie_infection/I in zombie_infection_list)
+		qdel(I)
+
+	message_admins("[key_name_admin(usr)] cured all zombies.")
+	log_admin("[key_name(usr)] cured all zombies.")
+	feedback_add_details("admin_verb","MZC")
+
 /client/proc/polymorph_all()
 	set category = "Fun"
 	set name = "Polymorph All"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -992,3 +992,63 @@ var/list/datum/outfit/custom_outfits = list() //Admin created outfits
 
 	for(var/obj/machinery/shuttle_manipulator/M in machines)
 		M.ui_interact(usr)
+
+/client/proc/mass_zombie_infection()
+	set category = "Fun"
+	set name = "Mass Zombie Infection"
+	set desc = "Infects all humans with a latent organ that will zombify \
+		them on death."
+
+	if(!holder)
+		return
+
+	var/confirm = alert(src, "Please confirm you want to add latent zombie organs in all humans?", "Confirm Zombies", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	for(var/mob/living/carbon/human/H in mob_list)
+		new /obj/item/organ/body_egg/zombie_infection(H)
+
+	message_admins("[key_name_admin(usr)] added a latent zombie infection to all humans.")
+	log_admin("[key_name(usr)] added a latent zombie infection to all humans.")
+	feedback_add_details("admin_verb","MZI")
+
+/client/proc/polymorph_all()
+	set category = "Fun"
+	set name = "Polymorph All"
+	set desc = "Applies the effects of the bolt of change to every single mob."
+
+	if(!holder)
+		return
+
+	var/confirm = alert(src, "Please confirm you want polymorph all mobs?", "Confirm Polymorph", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	var/keep_name = alert(src, "Do you want mobs to retain their names?", "Keep The Names?", "Yes", "No")
+
+	var/list/mobs = shuffle(living_mob_list.Copy()) // might change while iterating
+	var/who_did_it = key_name_admin(usr)
+	spawn(5) // let other things clear this tick
+		for(var/mob/living/M in mobs)
+			CHECK_TICK
+
+			if(!M || !M.name || !M.real_name)
+				continue
+
+			M.audible_message("<span class='italics'>...wabbajack...wabbajack...</span>")
+			playsound(M.loc, 'sound/magic/Staff_Change.ogg', 50, 1, -1)
+			var/name = M.name
+			var/real_name = M.real_name
+
+			var/mob/living/new_mob = wabbajack(M)
+			if(keep_name == "Yes" && new_mob)
+				new_mob.name = name
+				new_mob.real_name = real_name
+
+
+		message_admins("Mass polymorph started by [who_did_it] is complete.")
+
+	message_admins("[key_name_admin(usr)] started polymorphed all living mobs.")
+	log_admin("[key_name(usr)] polymorphed all living mobs.")
+	feedback_add_details("admin_verb","MASSWABBAJACK")


### PR DESCRIPTION
- Mass Zombie Infection - gives all humans a zombie infection organ to
  all humans, which will make them reanimate on death.
- Mass Zombie Cure - this removes all zombie organs, turning any humans that changed species to zombie back to their old self. Does not reanimate dead zombies, they'll just be dead humans instead.
- Polymorph All - This applies a bolt of change to all living mobs.
  Slightly laggy.
