### PR TITLE
Mechs rememeber removed cell's charge level and adjust inserted one's accordingly

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -36,6 +36,7 @@
 	var/list/facing_modifiers = list(FRONT_ARMOUR = 1.5, SIDE_ARMOUR = 1, BACK_ARMOUR = 0.5)
 	var/obj/item/weapon/stock_parts/cell/cell
 	var/state = 0
+	var/cell_power_remaining = 1 // 0 - no power, 1 - 100% power in cell. Starts as 1 so putting any cell into empty mech doesn't deplete charge from it
 	var/list/log = new
 	var/last_message = 0
 	var/add_req_access = 1
@@ -415,7 +416,7 @@
 	if(src == target)
 		return
 	var/dir_to_target = get_dir(src,target)
-	if(dir_to_target && !(dir_to_target & src.dir))//wrong direction
+	if(dir_to_target && !(dir_to_target & dir))//wrong direction
 		return
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		target = safepick(view(3,target))
@@ -471,13 +472,13 @@
 /obj/mecha/relaymove(mob/user,direction)
 	if(!direction)
 		return
-	if(user != src.occupant) //While not "realistic", this piece is player friendly.
+	if(user != occupant) //While not "realistic", this piece is player friendly.
 		user.forceMove(get_turf(src))
 		user << "<span class='notice'>You climb out from [src].</span>"
 		return 0
 	if(connected_port)
 		if(world.time - last_message > 20)
-			src.occupant_message("<span class='warning'>Unable to move while connected to the air system port!</span>")
+			occupant_message("<span class='warning'>Unable to move while connected to the air system port!</span>")
 			last_message = world.time
 		return 0
 	if(state)
@@ -506,7 +507,7 @@
 	var/move_result = 0
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		move_result = mechsteprand()
-	else if(src.dir!=direction && !strafe)
+	else if(dir != direction && !strafe)
 		move_result = mechturn(direction)
 	else
 		move_result = mechstep(direction)
@@ -526,10 +527,10 @@
 	return 1
 
 /obj/mecha/proc/mechstep(direction)
-	var/current_dir = src.dir
+	var/current_dir = dir
 	var/result = step(src,direction)
 	if(strafe)
-		src.dir = current_dir
+		dir = current_dir
 	if(result && stepsound)
 		playsound(src,stepsound,40,1)
 	return result
@@ -585,7 +586,7 @@
 			if(int_dam_flag)
 				setInternalDamage(int_dam_flag)
 	if(prob(5))
-		if(ignore_threshold || src.health*100/initial(src.health)<src.internal_damage_threshold)
+		if(ignore_threshold || health*100/initial(health)<internal_damage_threshold)
 			var/obj/item/mecha_parts/mecha_equipment/ME = safepick(equipment)
 			if(ME)
 				qdel(ME)
@@ -755,7 +756,7 @@
 		return 0
 
 	//Make sure are close enough for a valid connection
-	if(new_port.loc != src.loc)
+	if(new_port.loc != loc)
 		return 0
 
 	//Perform the connection
@@ -773,7 +774,7 @@
 
 	connected_port.connected_device = null
 	connected_port = null
-	src.log_message("Disconnected from gas port.")
+	log_message("Disconnected from gas port.")
 	return 1
 
 /obj/mecha/portableConnectorReturnAir()
@@ -810,13 +811,13 @@
 		user << "<span class='warning'>You can't enter the exosuit with other creatures attached to you!</span>"
 		return
 
-	visible_message("[user] starts to climb into [src.name].")
+	visible_message("[user] starts to climb into [name].")
 
 	if(do_after(user, 40, target = src))
 		if(health <= 0)
-			user << "<span class='warning'>You cannot get in the [src.name], it has been destroyed!</span>"
+			user << "<span class='warning'>You cannot get in the [name], it has been destroyed!</span>"
 		else if(occupant)
-			user << "<span class='danger'>[src.occupant] was faster! Try better next time, loser.</span>"
+			user << "<span class='danger'>[occupant] was faster! Try better next time, loser.</span>"
 		else if(user.buckled)
 			user << "<span class='warning'>You can't enter the exosuit while buckled.</span>"
 		else if(user.buckled_mobs.len)
@@ -858,7 +859,7 @@
 		user << "<span class='warning'>Access denied. [name] is secured with a DNA lock.</span>"
 		return 0
 
-	visible_message("<span class='notice'>[user] starts to insert an MMI into [src.name].</span>")
+	visible_message("<span class='notice'>[user] starts to insert an MMI into [name].</span>")
 
 	if(do_after(user, 40, target = src))
 		if(!occupant)
@@ -968,8 +969,8 @@
 
 /obj/mecha/proc/occupant_message(message as text)
 	if(message)
-		if(src.occupant && src.occupant.client)
-			src.occupant << "\icon[src] [message]"
+		if(occupant && occupant.client)
+			occupant << "\icon[src] [message]"
 	return
 
 /obj/mecha/proc/log_message(message as text,red=null)
@@ -978,7 +979,7 @@
 	return log.len
 
 /obj/mecha/proc/log_append_to_last(message as text,red=null)
-	var/list/last_entry = src.log[src.log.len]
+	var/list/last_entry = log[log.len]
 	last_entry["message"] += "<br>[red?"<font color='red'>":null][message][red?"</font>":null]"
 	return
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -7,11 +7,11 @@
 	var/facing_modifier = 1
 
 	if(adir)
-		facing_modifier = get_armour_facing(src.dir,adir)
+		facing_modifier = get_armour_facing(dir,adir)
 
 	if(prob(deflect_chance * booster_deflection_modifier * facing_modifier))
 		visible_message("<span class='danger'>[src]'s armour deflects the attack!</span>")
-		src.log_append_to_last("Armor saved.")
+		log_append_to_last("Armor saved.")
 		return
 	if(amount)
 		var/damage = absorbDamage(amount,type)
@@ -29,8 +29,8 @@
 
 
 /obj/mecha/proc/update_health()
-	if(src.health > 0)
-		src.spark_system.start()
+	if(health > 0)
+		spark_system.start()
 	else
 		qdel(src)
 
@@ -38,31 +38,31 @@
 	..(user, 1)
 	take_damage(15, "brute", user.dir)
 	check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
-	user.visible_message("<span class='danger'>[user] hits [src.name]. The metal creaks and bends.</span>")
+	user.visible_message("<span class='danger'>[user] hits [name]. The metal creaks and bends.</span>")
 
 /obj/mecha/attack_hand(mob/living/user as mob)
 	user.changeNext_move(CLICK_CD_MELEE) // Ugh. Ideally we shouldn't be setting cooldowns outside of click code.
 	user.do_attack_animation(src)
-	src.log_message("Attack by hand/paw. Attacker - [user].",1)
-	user.visible_message("<span class='danger'>[user] hits [src.name]. Nothing happens</span>","<span class='danger'>You hit [src.name] with no visible effect.</span>")
-	src.log_append_to_last("Armor saved.")
+	log_message("Attack by hand/paw. Attacker - [user].",1)
+	user.visible_message("<span class='danger'>[user] hits [name]. Nothing happens</span>","<span class='danger'>You hit [name] with no visible effect.</span>")
+	log_append_to_last("Armor saved.")
 	return
 
 /obj/mecha/attack_paw(mob/user as mob)
-	return src.attack_hand(user)
+	return attack_hand(user)
 
 
 /obj/mecha/attack_alien(mob/living/user as mob)
-	src.log_message("Attack by alien. Attacker - [user].",1)
+	log_message("Attack by alien. Attacker - [user].",1)
 	user.changeNext_move(CLICK_CD_MELEE) //Now stompy alien killer mechs are actually scary to aliens!
 	user.do_attack_animation(src)
 	take_damage(15, "brute", user.dir)
 	check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
-	playsound(src.loc, 'sound/weapons/slash.ogg', 50, 1, -1)
-	visible_message("<span class='danger'>The [user] slashes at [src.name]'s armor!</span>")
+	playsound(loc, 'sound/weapons/slash.ogg', 50, 1, -1)
+	visible_message("<span class='danger'>The [user] slashes at [name]'s armor!</span>")
 
 /obj/mecha/attack_animal(mob/living/simple_animal/user as mob)
-	src.log_message("Attack by simple animal. Attacker - [user].",1)
+	log_message("Attack by simple animal. Attacker - [user].",1)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(user.melee_damage_upper == 0)
 		user.emote("[user.friendly] [src]")
@@ -99,7 +99,7 @@
 	if(istype(A, /obj))
 		var/obj/O = A
 		if(O.throwforce)
-			visible_message("<span class='danger'>[src.name] is hit by [A].</span>")
+			visible_message("<span class='danger'>[name] is hit by [A].</span>")
 			take_damage(O.throwforce, "brute", 0, deflection, dam_coeff)
 			check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 	return
@@ -117,13 +117,13 @@
 
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		take_damage(Proj.damage*dam_coeff,Proj.flag, Proj.dir, deflection, dam_coeff)
-		visible_message("<span class='danger'>[src.name] is hit by [Proj].</span>")
+		visible_message("<span class='danger'>[name] is hit by [Proj].</span>")
 		check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT))
 	Proj.on_hit(src)
 
 /obj/mecha/ex_act(severity, target)
-	src.log_message("Affected by explosion of severity: [severity].",1)
-	if(prob(src.deflect_chance))
+	log_message("Affected by explosion of severity: [severity].",1)
+	if(prob(deflect_chance))
 		severity++
 		log_append_to_last("Armor saved, changing severity to [severity].")
 	switch(severity)
@@ -133,13 +133,13 @@
 			if (prob(30))
 				qdel(src)
 			else
-				take_damage(initial(src.health)/2)
+				take_damage(initial(health)/2)
 				check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
 		if(3)
 			if (prob(5))
 				qdel(src)
 			else
-				take_damage(initial(src.health)/5)
+				take_damage(initial(health)/5)
 				check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
 	return
 
@@ -151,12 +151,12 @@
 	if(get_charge())
 		use_power((cell.charge/3)/(severity*2))
 		take_damage(30 / severity,"energy")
-	src.log_message("EMP detected",1)
+	log_message("EMP detected",1)
 	check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
 	return
 
 /obj/mecha/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature>src.max_temperature)
+	if(exposed_temperature>max_temperature)
 		log_message("Exposed to dangerous temperature.",1)
 		take_damage(5,"fire")
 		check_for_internal_damage(list(MECHA_INT_FIRE, MECHA_INT_TEMP_CONTROL))
@@ -227,28 +227,29 @@
 		if(internal_damage & MECHA_INT_TEMP_CONTROL)
 			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
 			user << "<span class='notice'>You repair the damaged temperature controller.</span>"
-		else if(state==3 && src.cell)
-			src.cell.forceMove(src.loc)
-			src.cell = null
+		else if(state==3 && cell)
+			cell_power_remaining = max(0.1, cell.charge/cell.maxcharge) //10% charge or whatever is remaining in the current cell
+			cell.forceMove(loc)
+			cell = null
 			state = 4
 			user << "<span class='notice'>You unscrew and pry out the powercell.</span>"
-			src.log_message("Powercell removed")
-		else if(state==4 && src.cell)
+			log_message("Powercell removed")
+		else if(state==4 && cell)
 			state=3
 			user << "<span class='notice'>You screw the cell in place.</span>"
 		return
 
 	else if(istype(W, /obj/item/weapon/stock_parts/cell))
 		if(state==4)
-			if(!src.cell)
+			if(!cell)
 				if(!user.drop_item())
 					return
 				var/obj/item/weapon/stock_parts/cell/C = W
 				user << "<span class='notice'>You install the powercell.</span>"
 				C.forceMove(src)
-				C.use(C.charge * 0.8)
-				src.cell = C
-				src.log_message("Powercell installed")
+				C.use(max(0, C.charge - C.maxcharge*cell_power_remaining)) //Set inserted cell's power to saved percentage if that's higher
+				cell = C
+				log_message("Powercell installed")
 			else
 				user << "<span class='notice'>There's already a powercell installed.</span>"
 		return
@@ -256,19 +257,19 @@
 	else if(istype(W, /obj/item/weapon/weldingtool) && user.a_intent != "harm")
 		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/weapon/weldingtool/WT = W
-		if(src.health<initial(src.health))
+		if(health<initial(health))
 			if (WT.remove_fuel(0,user))
 				if (internal_damage & MECHA_INT_TANK_BREACH)
 					clearInternalDamage(MECHA_INT_TANK_BREACH)
 					user << "<span class='notice'>You repair the damaged gas tank.</span>"
 				else
-					user.visible_message("<span class='notice'>[user] repairs some damage to [src.name].</span>")
-					src.health += min(10, initial(src.health)-src.health)
+					user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>")
+					health += min(10, initial(health)-health)
 			else
 				user << "<span class='warning'>The welder must be on for this task!</span>"
 				return 1
 		else
-			user << "<span class='warning'>The [src.name] is at full integrity!</span>"
+			user << "<span class='warning'>The [name] is at full integrity!</span>"
 		return 1
 
 	else if(istype(W, /obj/item/mecha_parts/mecha_tracking))


### PR DESCRIPTION
As suggested to be added by @Bawhoppen 

This allows you to upgrade the mech's cell without it being drained.

When a power cell is removed from the mech, it remembers the cell's remaining power percentage and when a new one is inserted, it adjusts it's charge level to that percentage, if it is higher (if inserted cells charge percent < removed cell's -> no change).

It never decreases the power cells level below 10% (in case you remove empty cell).

Also removes the (what I believe to be) unnecessary `src` everywhere.

:cl: X-TheDark
rscadd: Mech battery replacement improved. The inserted battery's charge will be set to the same percentage of the removed one's (or 10%, if removed one's was less).
/:cl:
