### PR TITLE
Fixes ghost image runtime and see_darkness hiding ghosts again.

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -110,11 +110,19 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 	..()
 
 /mob/dead/observer/Destroy()
-	if (ghostimage)
-		ghost_darkness_images -= ghostimage
-		qdel(ghostimage)
-		ghostimage = null
-		updateallghostimages()
+	ghost_images_full -= ghostimage
+	qdel(ghostimage)
+	ghostimage = null
+	
+	ghost_images_default -= ghostimage_default
+	qdel(ghostimage_default)
+	ghostimage_default = null
+	
+	ghost_images_simple -= ghostimage_simple
+	qdel(ghostimage_simple)
+	ghostimage_simple = null
+	
+	updateallghostimages()
 	return ..()
 
 /mob/dead/CanPass(atom/movable/mover, turf/target, height=0)


### PR DESCRIPTION
(also fixes ghost images not garbage collecting.)

fixes #17190
fixes #16842
fixes #16447
fixes #17817
:cl:
fix: fixes see_darkness improperly hiding ghosts in certain cases.
/:cl:
