### PR TITLE
Adds ghost visible countdowns for bombs

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -12,6 +12,7 @@
 	var/operating = 0	//0=standby or broken, 1=takeover
 	var/warned = 0	//if this device has set off the warning at <3 minutes yet
 	var/datum/effect_system/spark_spread/spark_system
+	var/obj/effect/countdown/dominator/countdown
 
 /obj/machinery/dominator/tesla_act()
 	qdel(src)
@@ -22,6 +23,7 @@
 	poi_list |= src
 	spark_system = new
 	spark_system.set_up(5, 1, src)
+	countdown = new(src)
 
 /obj/machinery/dominator/examine(mob/user)
 	..()
@@ -121,6 +123,9 @@
 	poi_list.Remove(src)
 	gang = null
 	qdel(spark_system)
+	qdel(countdown)
+	countdown = null
+	SSmachine.processing -= src
 	return ..()
 
 /obj/machinery/dominator/emp_act(severity)
@@ -189,6 +194,10 @@
 		src.name = "[gang.name] Gang [src.name]"
 		operating = 1
 		icon_state = "dominator-[gang.color]"
+
+		countdown.text_color = gang.color_hex
+		countdown.start()
+
 		SetLuminosity(3)
 		SSmachine.processing += src
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -210,6 +210,7 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/process()
 	if (timing > 0)
+		countdown.start()
 		bomb_set = 1 //So long as there is one nuke timing, it means one nuke is armed.
 		timeleft--
 		if (timeleft <= 0)
@@ -220,7 +221,8 @@ var/bomb_set
 		for(var/mob/M in viewers(1, src))
 			if ((M.client && M.machine == src))
 				attack_hand(M)
-	return
+	else
+		countdown.stop()
 
 /obj/machinery/nuclearbomb/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -33,9 +33,11 @@ var/bomb_set
 	var/deconstruction_state = NUKESTATE_INTACT
 	var/image/lights = null
 	var/image/interior = null
+	var/obj/effect/countdown/nuclearbomb/countdown
 
 /obj/machinery/nuclearbomb/New()
 	..()
+	countdown = new(src)
 	nuke_list += src
 	core = new /obj/item/nuke_core(src)
 	SSobj.processing -= core
@@ -45,6 +47,9 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/Destroy()
 	poi_list -= src
+	nuke_list -= src
+	qdel(countdown)
+	countdown = null
 	. = ..()
 
 /obj/machinery/nuclearbomb/selfdestruct

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -31,10 +31,14 @@
 	var/radio_key = /obj/item/device/encryptionkey/headset_med
 	var/radio_channel = "Medical"
 
+	var/obj/effect/countdown/clonepod/countdown
+
 /obj/machinery/clonepod/New()
 	..()
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/clonepod(null)
 	B.apply_default_parts(src)
+
+	countdown = new(src)
 
 	radio = new(src)
 	radio.keyslot = new radio_key
@@ -44,6 +48,9 @@
 
 /obj/machinery/clonepod/Destroy()
 	qdel(radio)
+	radio = null
+	qdel(countdown)
+	countdown = null
 	. = ..()
 
 /obj/machinery/clonepod/RefreshParts()
@@ -114,11 +121,13 @@
 	if (isnull(occupant) || !is_operational())
 		return
 	if ((!isnull(occupant)) && (occupant.stat != DEAD))
-		var/completion = (100 * ((occupant.health + 100) / (heal_level + 100)))
-		user << "Current clone cycle is [round(completion)]% complete."
+		user << "Current clone cycle is [round(get_completion())]% complete."
 	else if(mess)
 		user << "It's filled with blood and vicerea. You swear you can see \
 			it moving..."
+
+/obj/machinery/clonepod/proc/get_completion()
+	. = (100 * ((occupant.health + 100) / (heal_level + 100)))
 
 /obj/machinery/clonepod/attack_ai(mob/user)
 	return examine(user)
@@ -145,6 +154,7 @@
 
 	attempting = TRUE //One at a time!!
 	locked = TRUE
+	countdown.start()
 
 	eject_wait = TRUE
 	spawn(30)
@@ -301,6 +311,7 @@
 /obj/machinery/clonepod/proc/go_out()
 	if (locked)
 		return
+	countdown.stop()
 
 	if (mess) //Clean that mess and dump those gibs!
 		mess = 0
@@ -322,7 +333,7 @@
 	var/turf/T = get_turf(src)
 	occupant.forceMove(T)
 	icon_state = "pod_0"
-	eject_wait = 0 //If it's still set somehow.
+	eject_wait = FALSE //If it's still set somehow.
 	occupant.domutcheck() //Waiting until they're out before possible monkeyizing.
 	occupant = null
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -18,6 +18,7 @@
 	var/beepsound = 'sound/items/timer.ogg'
 	var/delayedbig = FALSE	//delay wire pulsed?
 	var/delayedlittle  = FALSE	//activation wire pulsed?
+	var/obj/effect/countdown/syndicatebomb/countdown
 
 /obj/machinery/syndicatebomb/process()
 	if(active && !defused && (timer > 0)) 	//Tick Tock
@@ -41,6 +42,7 @@
 	if(src.payload)
 		payload = new payload(src)
 	update_icon()
+	countdown = new(src)
 	..()
 
 /obj/machinery/syndicatebomb/Destroy()

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -1,0 +1,55 @@
+/obj/effect/countdown
+	name = "countdown"
+	desc = "We're leaving together\n\
+		But still it's farewell\n\
+		And maybe we'll come back\n\
+		To earth, who can tell?"
+
+	var/last_displayed
+	var/atom/attached_to
+	var/text_color = "#ff0000"
+	invisibility = INVISIBILITY_OBSERVER
+	layer = GHOST_LAYER
+	alpha = 100
+
+/obj/effect/countdown/New(atom/A)
+	. = ..()
+	attach(A)
+
+/obj/effect/countdown/proc/attach(atom/A)
+	attached_to = A
+	loc = get_turf(A)
+	SSfastprocess.processing |= src
+
+/obj/effect/countdown/proc/get_value()
+	// Get the value from our atom
+	return
+
+/obj/effect/countdown/process()
+	if(!attached_to || qdeleted(attached_to))
+		qdel(src)
+	var/new_val = get_value()
+	if(new_val == last_displayed)
+		return
+	last_displayed = new_val
+	if(new_val)
+		var/image/text_image = new(loc = src)
+		text_image.maptext = "<font size=4>[new_val]</font>"
+		text_image.color = text_color
+
+		overlays.Cut()
+		overlays += text_image
+	else
+		overlays.Cut()
+
+/obj/effect/countdown/Destroy()
+	attached_to = null
+	SSfastprocess.processing -= src
+	. = ..()
+
+/obj/effect/countdown/syndicatebomb/get_value()
+	var/obj/machinery/syndicatebomb/S = attached_to
+	if(!istype(S))
+		return
+	else if(S.active)
+		return S.timer

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -8,9 +8,9 @@
 	var/last_displayed
 	var/atom/attached_to
 	var/text_color = "#ff0000"
+	var/text_size = 5
 	invisibility = INVISIBILITY_OBSERVER
 	layer = GHOST_LAYER
-	alpha = 100
 
 /obj/effect/countdown/New(atom/A)
 	. = ..()
@@ -34,7 +34,8 @@
 	last_displayed = new_val
 	if(new_val)
 		var/image/text_image = new(loc = src)
-		text_image.maptext = "<font size=4>[new_val]</font>"
+		//text_image.maptext = "<font size=[text_size]>[new_val]</font>"
+		text_image.maptext = "<font size = 4>[new_val]</font>"
 		text_image.color = text_color
 
 		overlays.Cut()
@@ -47,9 +48,23 @@
 	SSfastprocess.processing -= src
 	. = ..()
 
+/obj/effect/countdown/syndicatebomb
+	name = "syndicate bomb countdown"
+
 /obj/effect/countdown/syndicatebomb/get_value()
 	var/obj/machinery/syndicatebomb/S = attached_to
 	if(!istype(S))
 		return
 	else if(S.active)
 		return S.timer
+
+/obj/effect/countdown/nuclearbomb
+	name = "nuclear bomb countdown"
+	text_color = "#81FF14"
+
+/obj/effect/countdown/nuclearbomb/get_value()
+	var/obj/machinery/nuclearbomb/N = attached_to
+	if(!istype(N))
+		return
+	else if(N.timing)
+		return N.timeleft

--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -84,24 +84,25 @@
 /obj/effect/countdown/clonepod
 	name = "cloning pod countdown"
 	text_color = "#0C479D"
-	text_size = 2
+	text_size = 1
 
 /obj/effect/countdown/clonepod/get_value()
 	var/obj/machinery/clonepod/C = attached_to
 	if(!istype(C))
 		return
-	if(C.occupant)
+	else if(C.occupant)
 		var/completion = round(C.get_completion())
 		return completion
 
 /obj/effect/countdown/dominator
 	name = "dominator countdown"
-	text_size = 2
+	text_size = 1
 	text_color = "#ff00ff" // Overwritten when the dominator starts
 
-/obj/effect/countdown/clonepod/get_value()
+/obj/effect/countdown/dominator/get_value()
 	var/obj/machinery/dominator/D = attached_to
 	if(!istype(D))
 		return
-	if(D.gang && D.gang.dom_timer)
-		return D.gang.dom_timer
+	else if(D.gang && D.gang.dom_timer)
+		var/timer = D.gang.dom_timer
+		return timer

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1022,6 +1022,7 @@
 #include "code\modules\clothing\under\jobs\engineering.dm"
 #include "code\modules\clothing\under\jobs\medsci.dm"
 #include "code\modules\clothing\under\jobs\security.dm"
+#include "code\modules\countdown\countdown.dm"
 #include "code\modules\crafting\craft.dm"
 #include "code\modules\crafting\guncrafting.dm"
 #include "code\modules\crafting\recipes.dm"

--- a/tools/linux_build.py
+++ b/tools/linux_build.py
@@ -31,7 +31,7 @@ def stage2(map):
         txt = "-M{}".format(map)
     else:
         txt = ''
-    args = "bash dm.sh {} tgstation.dme".format(txt)
+    args = "bash tools/travis/dm.sh {} tgstation.dme".format(txt)
     print(args)
     p = subprocess.Popen(args, shell=True)
     wait(p)


### PR DESCRIPTION
:cl: coiax
rscadd: For extra observer drama, ghosts can now visibly see the
countdown of syndicate bombs, nuclear devices, cloning pods,
gang dominators and AI doomsday devices.
/:cl:
- Also updates my build script to take account of the move of dm.sh

![image](https://cloud.githubusercontent.com/assets/609465/15741836/6533b0d4-28b3-11e6-9627-fbf8b8ccbf7a.png)
