### PR TITLE
Fixes for Merge Tokens

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -28,7 +28,7 @@
 /obj/item/weapon/storage/briefcase/lawyer/New()
 	new /obj/item/weapon/stamp/law(src)
 	..()
-	
+
 /obj/item/weapon/storage/briefcase/sniperbundle
 	name = "briefcase"
 	desc = "It's label reads genuine hardened Captain leather, but suspiciously has no other tags or branding. Smells like L'Air du Temps."
@@ -47,7 +47,7 @@
 
 /obj/item/weapon/storage/briefcase/sniperbundle/New()
 	..()
-	new /obj/item/weapon/gun/projectile/sniper_rifle/syndicate(src)
+	new /obj/item/weapon/gun/projectile/automatic/sniper_rifle/syndicate(src)
 	new /obj/item/clothing/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -282,6 +282,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/armor/heavy
 	name = "heavy armor"
@@ -294,6 +295,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 3
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -301,6 +303,7 @@
 	flags = THICKMATERIAL
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/armor/tdome/red
 	name = "thunderdome suit"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -8,6 +8,7 @@
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
 	fire_delay = 40
+	burst_size = 1
 	origin_tech = "combat=7"
 	can_unsuppress = 1
 	can_suppress = 1
@@ -15,6 +16,7 @@
 	zoomable = TRUE
 	zoom_amt = 7 //Long range, enough to see in front of you, but no tiles behind you.
 	slot_flags = SLOT_BACK
+	actions_types = list()
 
 
 /obj/item/weapon/gun/projectile/automatic/sniper_rifle/update_icon()

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,5 +1,5 @@
 
-/obj/item/weapon/gun/projectile/sniper_rifle
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle
 	name = "sniper rifle"
 	desc = "The kind of gun that will leave you crying for mummy before you even realise your leg's missing"
 	icon_state = "sniper"
@@ -17,14 +17,14 @@
 	slot_flags = SLOT_BACK
 
 
-/obj/item/weapon/gun/projectile/sniper_rifle/update_icon()
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle/update_icon()
 	if(magazine)
 		icon_state = "sniper-mag"
 	else
 		icon_state = "sniper"
 
 
-/obj/item/weapon/gun/projectile/sniper_rifle/syndicate
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face"
 	pin = /obj/item/device/firing_pin/implant/pindicate

--- a/code/modules/spells/spell_types/rightandwrong.dm
+++ b/code/modules/spells/spell_types/rightandwrong.dm
@@ -112,7 +112,7 @@
 				if("goldenrevolver")
 					G = new /obj/item/weapon/gun/projectile/revolver/golden(get_turf(H))
 				if("sniper")
-					G = new /obj/item/weapon/gun/projectile/sniper_rifle(get_turf(H))
+					G = new /obj/item/weapon/gun/projectile/automatic/sniper_rifle(get_turf(H))
 				if("medibeam")
 					G = new /obj/item/weapon/gun/medbeam(get_turf(H))
 				if("scatterbeam")

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -190,7 +190,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/dangerous/sniper
 	name = "Sniper Rifle"
 	desc = "Ranged fury, Syndicate style. guaranteed to cause shock and awe or your TC back!"
-	item = /obj/item/weapon/gun/projectile/sniper_rifle/syndicate
+	item = /obj/item/weapon/gun/projectile/automatic/sniper_rifle/syndicate
 	cost = 16
 	surplus = 25
 	include_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
Fixes #15649 
Given deathsquad armour values for now, unless someone wants it changed. Did the same for the CentComm and thunderdome armours as they were missing values too.

Fixes #16575 
Moved sniper rifles to /projectile/automatic
Not entirely sure WHY this fixes the issue, but fix the issue it does
