### PR TITLE
Try to protect the ones we hug

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -35,7 +35,7 @@
 	bloodcrawl = BLOODCRAWL_EAT
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	var/playstyle_string = "<B><font size=3 color='red'>You are a slaughter demon,</font> a terrible creature from another realm. You have a single desire: To kill.  \
-							You may use the \"Blood Crawl\" ability near blood pools to travel through them, appearing and dissaapearing from the station at will. \
+							You may use the \"Blood Crawl\" ability near blood pools to travel through them, appearing and disappearing from the station at will. \
 							Pulling a dead or unconscious mob while you enter a pool will pull them in with you, allowing you to feast and regain your health. \
 							You move quickly upon leaving a pool of blood, but the material world will soon sap your strength and leave you sluggish. </B>"
 
@@ -128,11 +128,26 @@
 
 	icon_state = "bowmon"
 	icon_living = "bowmon"
-	deathmessage = "fades out, as all of its friends are released from its prison of hugs."
+	deathmessage = "fades out, as all of its friends are released from its \
+		prison of hugs."
 	loot = list(/mob/living/simple_animal/pet/cat/kitten{name = "Laughter"})
 
 	// Keep the people we hug!
 	var/list/consumed_mobs = list()
+
+	playstyle_string = "<B><font size=3 color='red'>You are a laughter \
+	demon,</font> a wonderful creature from another realm. You have a single \
+	desire: <span class='clown'>To hug and tickle.</span><BR>\
+	You may use the \"Blood Crawl\" ability near blood pools to travel \
+	through them, appearing and disappearing from the station at will. \
+	Pulling a dead or unconscious mob while you enter a pool will pull \
+	them in with you, allowing you to hug them and regain your health.<BR> \
+	You move quickly upon leaving a pool of blood, but the material world \
+	will soon sap your strength and leave you sluggish.<BR>\
+	What makes you a little sad is that people seem to die when you tickle \
+	them; but don't worry! When you die, everyone you hugged will be \
+	released and fully healed, because in the end it's just a jape, \
+	sibling!</B>"
 
 /mob/living/simple_animal/slaughter/laughter/Destroy()
 	// You know, if there's ANYONE LEFT.
@@ -166,7 +181,7 @@
 		if(M.revive(full_heal = TRUE, admin_revive = TRUE))
 			M.grab_ghost(force = TRUE)
 			playsound(T, feast_sound, 50, 1, -1)
-			M << "<span class='clown'>You leave the [src]'s warm embrace, \
+			M << "<span class='clown'>You leave [src]'s warm embrace, \
 				and feel ready to take on the world.</span>"
 
 /mob/living/simple_animal/slaughter/laughter/bloodcrawl_swallow(var/mob/living/victim)

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -134,8 +134,15 @@
 	// Keep the people we hug!
 	var/list/consumed_mobs = list()
 
-	// HOT. PINK.
-	//color = "#FF69B4"
+/mob/living/simple_animal/slaughter/laughter/Destroy()
+	// You know, if there's ANYONE LEFT.
+	release_friends()
+	. = ..()
+
+/mob/living/simple_animal/slaughter/laughter/ex_act(severity)
+	if(severity == 1)
+		release_friends() // ABANDON SHIP
+	. = ..()
 
 /mob/living/simple_animal/slaughter/laughter/death()
 	release_friends()
@@ -150,9 +157,15 @@
 		return
 
 	for(var/mob/living/M in consumed_mobs)
-		M.loc = get_turf(src)
-		if(M.revive(full_heal = 1))
-			M.grab_ghost(force = FALSE)
+		if(!M)
+			continue
+		var/turf/T = find_safe_turf()
+		if(!T)
+			T = get_turf(src)
+		M.forceMove(T)
+		if(M.revive(full_heal = TRUE, admin_revive = TRUE))
+			M.grab_ghost(force = TRUE)
+			playsound(T, feast_sound, 50, 1, -1)
 			M << "<span class='clown'>You leave the [src]'s warm embrace, \
 				and feel ready to take on the world.</span>"
 

--- a/tools/linux_build.py
+++ b/tools/linux_build.py
@@ -31,7 +31,7 @@ def stage2(map):
         txt = "-M{}".format(map)
     else:
         txt = ''
-    args = "bash dm.sh {} tgstation.dme".format(txt)
+    args = "bash tools/travis/dm.sh {} tgstation.dme".format(txt)
     print(args)
     p = subprocess.Popen(args, shell=True)
     wait(p)


### PR DESCRIPTION
Laughter demons now try REALLY hard to ensure that on their death all of
their friends are released, even using swarmer get_safe_turf() algorithm
to check that they're not going to get mulched up in a blast wave.

:cl: coiax
bugfix: Laughter demons should now always let their friends go when
asked correctly.
/:cl:
