### PR TITLE
Replaces all roundstart TTVs with "safe" versions

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -52826,18 +52826,18 @@
 	},
 /area/toxins/mixing)
 "ccC" = (
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe,
+/obj/item/device/transfer_valve/safe,
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /obj/structure/table/glass,

--- a/_maps/map_files/DreamStation/dreamstation04.dmm
+++ b/_maps/map_files/DreamStation/dreamstation04.dmm
@@ -71138,22 +71138,22 @@
 	},
 /area/toxins/mixing)
 "cFH" = (
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /obj/structure/table/reinforced,

--- a/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
+++ b/_maps/map_files/EfficiencyStation/EfficiencyStation.dmm
@@ -11828,18 +11828,18 @@
 	name = "\improper Toxins Lab"
 	})
 "auu" = (
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve,
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe,
+/obj/item/device/transfer_valve/safe,
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /obj/machinery/requests_console{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -84089,22 +84089,22 @@
 	name = "\improper Toxins Lab"
 	})
 "cEH" = (
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /obj/machinery/requests_console{

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -5591,16 +5591,16 @@
 	on = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /turf/open/floor/plasteel{

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -40089,22 +40089,22 @@
 /turf/open/floor/plasteel/white,
 /area/toxins/mixing)
 "bJW" = (
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = -5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 0
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
-/obj/item/device/transfer_valve{
+/obj/item/device/transfer_valve/safe{
 	pixel_x = 5
 	},
 /obj/machinery/requests_console{

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -789,6 +789,15 @@
 	crate_name = "shield generators crate"
 	crate_type = /obj/structure/closet/crate/secure
 
+/datum/supply_pack/science/transfer_valves
+	name = "Safe Tank Transfer Valves Crate"
+	cost = 1000
+	access = access_tox
+	contains = list(/obj/item/device/transfer_valve/safe,
+					/obj/item/device/transfer_valve/safe)
+	crate_name = "safe tank transfer valves crate"
+	crate_type = /obj/structure/closet/crate/secure
+	dangerous = TRUE // you can still emag them to remove the safeties
 
 /datum/supply_pack/science/transfer_valves
 	name = "Tank Transfer Valves Crate"

--- a/tools/linux_build.py
+++ b/tools/linux_build.py
@@ -31,7 +31,7 @@ def stage2(map):
         txt = "-M{}".format(map)
     else:
         txt = ''
-    args = "bash dm.sh {} tgstation.dme".format(txt)
+    args = "bash tools/travis/dm.sh {} tgstation.dme".format(txt)
     print(args)
     p = subprocess.Popen(args, shell=True)
     wait(p)


### PR DESCRIPTION
:cl: coiax
rscadd: For safety purposes, all Toxin research must now be done with
safe tank transfer valves, which will only function on the Toxins
Testing Site. TTVs with no safeties can be ordered from cargo as before.
Please do not expose the circuitry on safe TTVs to high amounts of
electromagnetic current or illegal technology cards, as this will
violate your warranty.
/:cl:
- All TTVs on the maps are now "safe tank transfer valves" which will not toggle except on the testing site
- These safe versions can have their safeties disabled with an EMP or emag
- Safe TTVs can be ordered from cargo, 1000 points for 2
- Unsafe TTVs remain orderable from cargo, 6000 points for 2 as before
