### PR TITLE
Refines autoimplanter code, gives CMO single use autoimplanter for HUD augment

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,7 @@
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
-	new /obj/item/organ/cyberimp/eyes/hud/medical(src)
+	new /obj/item/device/autoimplanter/cmo(src)
 	new /obj/item/weapon/door_remote/chief_medical_officer(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -1,3 +1,5 @@
+#define INFINITE -1
+
 /obj/item/device/autoimplanter
 	name = "autoimplanter"
 	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. It has a slot to insert implants and a screwdriver slot for removing accidentally added implants."
@@ -5,8 +7,20 @@
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = 2
 	var/obj/item/organ/cyberimp/storedorgan
+	var/uses = INFINITE
+	var/one_use = 0//separate var, as a 2-use device can have 1 use remaining if used once but not be a single-use device
+
+/obj/item/device/autoimplanter/New()
+	..()
+	if(one_use)
+		uses = 1
+	if(storedorgan)
+		storedorgan.loc = src
 
 /obj/item/device/autoimplanter/attack_self(mob/user)//when the object it used...
+	if(!uses)
+		user << "<span class='warning'>[src] has already been used. The tools are dull and won't reactivate.</span>"
+		return
 	if(!storedorgan)
 		user << "<span class='notice'>[src] currently has no implant stored.</span>"
 		return
@@ -14,9 +28,16 @@
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
 	storedorgan = null
+	if(uses != INFINITE)
+		uses --
+	if(!uses)
+		desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/device/autoimplanter/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/organ/cyberimp))
+		if(one_use && !storedorgan)
+			user << "<span class='notice'>[src] doesn't accept implants. It must be a single-use device.</span>"
+			return//prevents removing the intended implant to insert your own
 		if(storedorgan)
 			user << "<span class='notice'>[src] already has an implant stored.</span>"
 			return
@@ -34,3 +55,9 @@
 			user << "<span class='notice'>You remove the [storedorgan] from [src].</span>"
 			playsound(get_turf(user), 'sound/items/Screwdriver.ogg', 50, 1)
 			storedorgan = null
+
+/obj/item/device/autoimplanter/cmo
+	name = "medical HUD autoimplanter"
+	desc = "A single use autoimplanter that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	storedorgan = new/obj/item/organ/cyberimp/eyes/hud/medical()
+	one_use = 1


### PR DESCRIPTION
Autoimplanter code is now more flexible to allow custom autoimplanters that have a limited number of uses. Nuke op implanters still have infinite uses.

The CMO's medical HUD augment in his locker has been replaced with a single-use autoimplanter containing a medical HUD augment.

Adds a one_use var to autoimplanters. If set, the implanter cannot accept new augments. This means that you can still remove the augment from the CMO's implanter, but cannot reinsert it or any other augment.

:cl: PKPenguin321
rscadd: The CMO's medical HUD implant now comes with a one-use autoimplanter for ease of use.
/:cl:

Merge token: https://github.com/tgstation/tgstation/pull/17965 (Yes I've used this PR before, but it fixes 2 issues so it's worth 2 tokens)
