### PR TITLE
Objective assignments will only target the crew

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -11,5 +11,5 @@ var/global/list/player_list = list()				//all mobs **with clients attached**. Ex
 var/global/list/mob_list = list()					//all mobs, including clientless
 var/global/list/living_mob_list = list()			//all alive mobs, including clientless. Excludes /mob/new_player
 var/global/list/dead_mob_list = list()				//all dead mobs, including clientless. Excludes /mob/new_player
-var/global/list/joined_player_list = list()			//all clients that have joined the game at round-start or as a latejoin.
+var/global/list/joined_player_list = list()			//all minds that have joined the game at round-start or as a latejoin.
 var/global/list/silicon_mobs = list()				//all silicon mobs

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -318,7 +318,7 @@ var/datum/subsystem/ticker/ticker
 /datum/subsystem/ticker/proc/create_characters()
 	for(var/mob/new_player/player in player_list)
 		if(player.ready && player.mind)
-			joined_player_list += player.ckey
+			joined_player_list += player.mind
 			if(player.mind.assigned_role=="AI")
 				player.close_spawn_windows()
 				player.AIize()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -26,7 +26,7 @@
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()
 	for(var/datum/mind/possible_target in ticker.minds)
-		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && is_unique_objective(possible_target))
+		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && is_unique_objective(possible_target) && (possible_target.current.ckey in joined_player_list))
 			possible_targets += possible_target
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -29,7 +29,7 @@
 
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 		if(ready)
-			output += "<p>\[ <b>Ready</b> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]</p>"
+			output += "<p>\[ <bjoined_player_list>Ready</b> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]</p>"
 		else
 			output += "<p>\[ <a href='byond://?src=\ref[src];ready=1'>Ready</a> | <b>Not Ready</b> \]</p>"
 
@@ -317,7 +317,7 @@
 	else
 		character.Robotize()
 
-	joined_player_list += character.ckey
+	joined_player_list += character.mind
 
 	if(config.allow_latejoin_antagonists)
 		switch(SSshuttle.emergency.mode)


### PR DESCRIPTION
When assigning targets for objectives, valid targets will consist only of normal crew members. Not things like wizards, ash walkers, or golems. Only properly jobbed players that joined at roundstart or later as a latejoin will be considered.

This also disallows assigning the vacant as targets, which seems fine to me, as that's just too dang easy.

Fixes #11982
Fixes #11761
Fixes #16736

Maybe others
