### PR TITLE
Refactors all (F) links into using a define

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -30,5 +30,5 @@
 #define REDUCE_RANGE 2
 #define NOPASS 4
 
-// A link given to alice to follow bob
+// A link given to ghost alice to follow bob
 #define FOLLOW_LINK(alice, bob) "<a href=?src\ref[alice];follow=\ref[bob]>(F)</a>"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -29,3 +29,6 @@
 #define ITALICS 1
 #define REDUCE_RANGE 2
 #define NOPASS 4
+
+// A link given to alice to follow bob
+#define FOLLOW_LINK(alice, bob) "<a href=?src\ref[alice];follow=\ref[bob]>(F)</a>"

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -67,7 +67,8 @@
 		if(isovermind(M) || istype(M, /mob/living/simple_animal/hostile/blob))
 			M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [rendered]"
 
 ////////////////
 // BLOB SPORE //

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -135,7 +135,8 @@
 		if(isovermind(M) || istype(M, /mob/living/simple_animal/hostile/blob))
 			M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [rendered]"
 
 /mob/camera/blob/emote(act,m_type=1,message = null)
 	return

--- a/code/game/gamemodes/cult/cult_comms.dm
+++ b/code/game/gamemodes/cult/cult_comms.dm
@@ -37,7 +37,8 @@
 		if(iscultist(M))
 			M << my_message
 		else if(M in dead_mob_list)
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [my_message]"
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] [my_message]"
 
 	log_say("[user.real_name]/[user.key] : [message]")
 

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -334,7 +334,8 @@
 			if(ganger.current && (ganger.current.z <= 2) && (ganger.current.stat == CONSCIOUS))
 				ganger.current << ping
 		for(var/mob/M in dead_mob_list)
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [ping]"
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] [ping]"
 		log_game("[key_name(user)] Messaged [gang.name] Gang: [message].")
 
 

--- a/code/game/gamemodes/handofgod/actions.dm
+++ b/code/game/gamemodes/handofgod/actions.dm
@@ -20,7 +20,8 @@
 	owner << rendered
 	for(var/mob/M in mob_list)
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[owner]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, owner)
+			M << "[link] [rendered]"
 
 /datum/action/innate/godspeak/Destroy()
 	god = null

--- a/code/game/gamemodes/handofgod/god.dm
+++ b/code/game/gamemodes/handofgod/god.dm
@@ -203,7 +203,8 @@
 		if(is_handofgod_god(M) || is_handofgod_myfollowers(M))
 			M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [rendered]"
 
 
 /mob/camera/god/emote(act,m_type = 1 ,msg = null)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -544,10 +544,12 @@
 
 /mob/living/simple_animal/hostile/swarmer/proc/ContactSwarmers()
 	var/message = input(src, "Announce to other swarmers", "Swarmer contact")
+	// TODO get swarmers their own colour rather than just boldtext
 	var/rendered = "<B>Swarm communication - </b> [src] states: [message]"
 	if(message)
 		for(var/mob/M in mob_list)
 			if(isswarmer(M))
 				M << rendered
-			if(M in dead_mob_list)
-				M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			if(isobserver(M))
+				var/link = FOLLOW_LINK(M, src)
+				M << "[link] [rendered]"

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -149,7 +149,8 @@
 		if(istype(M, /mob/living/simple_animal/revenant))
 			M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [rendered]"
 	return
 
 

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -121,10 +121,12 @@
 			for(var/ded in dead_mob_list)
 				if(!isobserver(ded))
 					continue
-				ded << "<a href='?src=\ref[ded];follow=\ref[user]'>(F)</a> \
+				var/follow_rev = FOLLOW_LINK(ded, user)
+				var/follow_whispee = FOLLOW_LINK(ded, M)
+				ded << "[follow_rev] \
 					<span class='name'>[user]</span> \
 					<span class='revenboldnotice'>Revenant Transmit --></span> \
-					<a href='?src=\ref[ded];follow=\ref[M]'>(F)</a> \
+					[follow_whispee] \
 					<span class='name'>[M]</span> \
 					<span class='revennotice'>[msg]</span>"
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -288,8 +288,9 @@
 	for(var/mob/M in mob_list)
 		if(is_shadow_or_thrall(M))
 			M << my_message
-		if(M in dead_mob_list)
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [my_message]"
+		if(isobserver(M))
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] [my_message]"
 
 
 
@@ -750,7 +751,8 @@
 		if(is_shadow_or_thrall(M))
 			M << text
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [text]"
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] [text]"
 	log_say("[user.real_name]/[user.key] : [text]")
 
 
@@ -893,5 +895,6 @@
 		if(is_shadow_or_thrall(M))
 			M << text
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [text]"
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] [text]"
 	log_say("[user.real_name]/[user.key] : [text]")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -619,7 +619,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/proc/show_to_ghosts(mob/living/user, datum/data_pda_msg/msg,multiple = 0)
 	for(var/mob/M in player_list)
 		if(isobserver(M) && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTPDA))
-			M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a><span class='name'> [msg.sender] </span><span class='game say'>PDA Message</span> --> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>"
+			var/link = FOLLOW_LINK(M, user)
+			M << "[link] <span class='name'>[msg.sender] </span><span class='game say'>PDA Message</span> --> <span class='name'>[multiple ? "Everyone" : msg.recipient]</span>: <span class='message'>[msg.message][msg.get_photo_ref()]</span></span>"
 
 /obj/item/device/pda/proc/can_send(obj/item/device/pda/P)
 	if(!P || qdeleted(P) || P.toff)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -29,5 +29,6 @@
 			speaker = S.eyeobj
 		else
 			speaker = V.source
-	src << "<a href=?src=\ref[src];follow=\ref[speaker]>(F)</a> [message]"
+	var/link = FOLLOW_LINK(src, speaker)
+	src << "[link] [message]"
 

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -91,10 +91,12 @@ Doesn't work on other aliens/AI.*/
 		for(var/ded in dead_mob_list)
 			if(!isobserver(ded))
 				continue
-			ded << "<a href='?src=\ref[ded];follow=\ref[user]'>(F)</a> \
+			var/follow_link_user = FOLLOW_LINK(ded, user)
+			var/follow_link_whispee = FOLLOW_LINK(ded, M)
+			ded << "[follow_link_user] \
 				<span class='name'>[user]</span> \
 				<span class='alertalien'>Alien Whisper --> </span> \
-				<a href='?src=\ref[ded];follow=\ref[M]'>(F)</a> \
+				[follow_link_whispee] \
 				<span class='name'>[M]</span> \
 				<span class='noticealien'>[msg]</span>"
 	else

--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -9,7 +9,8 @@
 		if(!S.stat && S.hivecheck())
 			S << rendered
 		if(S in dead_mob_list)
-			S << "<a href='?src=\ref[S];follow=\ref[src]'>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(S, src)
+			S << "[link] [rendered]"
 
 /mob/living/carbon/alien/humanoid/royal/queen/alien_talk(message, shown_name = name)
 	shown_name = "<FONT size = 3>[shown_name]</FONT>"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -208,7 +208,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 				var/msg = "<i><font color=#800040><b>[src.mind]:</b> [message]</font></i>"
 				for(var/mob/M in mob_list)
 					if(M in dead_mob_list)
-						M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
+						var/link = FOLLOW_LINK(M, src)
+						M << "[link] [msg]"
 					else
 						switch(M.lingcheck())
 							if(3)
@@ -224,7 +225,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 				log_say("[mind.changeling.changelingID]/[src.key] : [message]")
 				for(var/mob/M in mob_list)
 					if(M in dead_mob_list)
-						M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
+						var/link = FOLLOW_LINK(M, src)
+						M << "[link] [msg]"
 					else
 						switch(M.lingcheck())
 							if(3)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -18,7 +18,14 @@
 			else
 				M << rendered
 		if(isobserver(M))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [rendered]"
+			var/following = src
+			// If the AI talks on binary chat, we still want to follow
+			// it's camera eye, like if it talked on the radio
+			if(istype(src, /mob/living/silicon/ai))
+				var/mob/living/silicon/ai/ai = M
+				following = ai.eyeobj
+			var/link = FOLLOW_LINK(M, following)
+			M << "[link] [rendered]"
 
 /mob/living/silicon/binarycheck()
 	return 1

--- a/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -26,7 +26,8 @@
 		if(istype(M) && M.stat != DEAD && faction_check(M)) //if it's a living drone with matching factions, it gets a message
 			M << msg
 		if(dead_can_hear && (M in dead_mob_list))
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [msg]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [msg]"
 
 
 /mob/living/simple_animal/drone/proc/drone_chat(msg)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -275,7 +275,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		for(var/para in guardians)
 			para << my_message
 		for(var/M in dead_mob_list)
-			M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [my_message]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [my_message]"
 
 		log_say("[src.real_name]/[src.key] : [input]")
 
@@ -296,7 +297,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		var/mob/living/simple_animal/hostile/guardian/G = para
 		G << "<font color=\"[G.namedatum.colour]\"><b><i>[src]:</i></b></font> [preliminary_message]" //but for guardians, use their color for the source instead
 	for(var/M in dead_mob_list)
-		M << "<a href='?src=\ref[M];follow=\ref[src]'>(F)</a> [my_message]"
+		var/link = FOLLOW_LINK(M, src)
+		M << "[link] [my_message]"
 
 	log_say("[src.real_name]/[src.key] : [text]")
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -62,7 +62,8 @@
 		if(K && M.client && K in M.client.prefs.ignoring)
 			continue
 		if(istype(M, /mob/dead/observer))
-			M << "<a href=?src=\ref[M];follow=\ref[src]>(F)</a> [rendered]"
+			var/link = FOLLOW_LINK(M, src)
+			M << "[link] [rendered]"
 		else
 			M << "[rendered]"
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -1,4 +1,3 @@
-
 /obj/item/organ
 	name = "organ"
 	icon = 'icons/obj/surgery.dmi'
@@ -326,7 +325,8 @@
 				continue
 		H << rendered
 	for(var/mob/M in dead_mob_list)
-		M << "<a href='?src=\ref[M];follow=\ref[user]'>(F)</a> [rendered]"
+		var/link = FOLLOW_LINK(M, user)
+		M << "[link] [rendered]"
 	return ""
 
 /obj/item/organ/tongue/zombie


### PR DESCRIPTION
:cl:  coiax
bugfix: Clicking the (F) link when an AI talks in binary chat will
follow its camera eye, the same as when (F) is clicked for its radio
chat.
/:cl:

FOLLOW_LINK is a define that creates the clickable (F) link, so it
doesn't have to be typed painstakingly out every time we want to give
that link to an observer.
