### PR TITLE
[s] Makes winning a pulse rifle little more noticable

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,7 +51,7 @@
 
 /obj/machinery/computer/arcade/proc/prizevend()
 	if(prob(0.0001)) //1 in a million
-		new /obj/item/weapon/gun/energy/pulse(src)
+		new /obj/item/weapon/gun/energy/pulse/prize(src)
 
 	if(!contents.len)
 		var/prizeselect = pickweight(prizes)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -13,6 +13,26 @@
 /obj/item/weapon/gun/energy/pulse/emp_act(severity)
 	return
 
+/obj/item/weapon/gun/energy/pulse/prize
+	pin = /obj/item/device/firing_pin
+
+/obj/item/weapon/gun/energy/pulse/prize/New()
+	. = ..()
+	poi_list |= src
+	var/msg = "A pulse rifle prize has been created at ([x],[y],[z] - (\
+	<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>\
+	JMP</a>)"
+
+	message_admins(msg)
+	log_game(msg)
+
+	notify_ghosts("Someone won a pulse rifle as a prize!", source = src,
+		action = NOTIFY_ORBIT)
+
+/obj/item/weapon/gun/energy/pulse/prize/Destroy()
+	poi_list -= src
+	. = ..()
+
 /obj/item/weapon/gun/energy/pulse/loyalpin
 	pin = /obj/item/device/firing_pin/implant/loyalty
 


### PR DESCRIPTION
When someone wins a pulse rifle via arcade games, everyone dead
and all admins are notified. Also it comes with a firing pin now.
