### PR TITLE
Revert "Fixes things applying to the lighting object that shouldn't."

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -77,8 +77,6 @@
 
 #define ismovableatom(A) (istype(A, /atom/movable))
 
-#define isobj(A) istype(A, /obj) //override the byond proc because it returns true on children of /atom/movable that aren't objs
-
 // ASSEMBLY HELPERS
 
 #define isassembly(O) (istype(O, /obj/item/device/assembly))


### PR DESCRIPTION
Reverts tgstation/tgstation#18161

I think this might be causing #18239

No idea why, but color'ed lights isn't as bad as locker lights, better to revert until we can figure something better out.
