### PR TITLE
you can no longer put light into a closet.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -162,6 +162,8 @@
 			return
 		if(AM.anchored || AM.buckled_mobs.len || (AM.flags & NODROP))
 			return
+	else
+		return
 
 	AM.forceMove(src)
 	if(AM.pulledby)


### PR DESCRIPTION
Atom movable that are neither /mob nor /obj should not be picked by the closet insertion proc.

Fixes #18239 
Fixes #18229
