### PR TITLE
Mining Cyborg Hyper-Kenetic Accelerator Upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -194,6 +194,26 @@
 
 	return 1
 
+/obj/item/borg/upgrade/hyperka
+	name = "mining cyborg hyper-kinetic accelerator"
+	desc = "A satchel of holding replacement for mining cyborg's ore satchel module."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/weapon/robot_module/miner
+	origin_tech = "materials=6;powerstorage=4;engineering=4;magnets=4;combat=4"
+
+/obj/item/borg/upgrade/hyperka/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	for(var/obj/item/weapon/gun/energy/kinetic_accelerator/cyborg/H in R.module.modules)
+		qdel(H)
+
+	R.module.modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/hyper/cyborg(R.module)
+	R.module.rebuild()
+
+	return 1
+
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -119,6 +119,10 @@
 	holds_charge = TRUE
 	unique_frequency = TRUE
 
+/obj/item/weapon/gun/energy/kinetic_accelerator/hyper/cyborg
+	holds_charge = TRUE
+	unique_frequency = TRUE
+
 /obj/item/weapon/gun/energy/kinetic_accelerator/New()
 	. = ..()
 	if(!holds_charge)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -648,6 +648,16 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_hyperka
+	name = "Cyborg (Hyper-Kinetic Accelerator)"
+	id = "borg_upgrade_hyperka"
+	req_tech = list("materials" = 7, "powerstorage" = 5, "engineering" = 5, "magnets" = 5, "combat" = 4)
+	build_type = MECHFAB //Reqs same as human Hyper KA
+	materials = list(MAT_METAL = 8000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/borg/upgrade/hyperka
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_syndicate_module
 	name = "Cyborg Upgrade (Illegal Modules)"
 	id = "borg_syndicate_module"


### PR DESCRIPTION
- Mining Cyborgs may now be upgraded with Hyper-Kenetic Accelerators.
- Same cost and requirements as human version.

:cl:
Name: Gun Hog
rscadd: Nanotrasen has approved the Hyper-Kenetic Accelerator upgrade for cyborg mining modules.
/:cl:

I personally feel the tech requirements for a Hyper KA are too high; I think it should be lower for the borg. For now, I will keep them the same.

EDIT: Merge Token: #18355 
