### PR TITLE
Raises Nuke Min Requirement

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 30 // 30 players - 5 players to be the nuke ops = 25 players remaining
+	required_players = 38
 	required_enemies = 5
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE


### PR DESCRIPTION
Please stop forcing nuke on low pop it objectively does not work.

http://www.ss13.eu/tgdb/tg/latest_stats.html#mode_nuclear_emergency

87% winrate below 40 players

If you want more nuke go fix the balance instead of running the mode at the wrong time.
