### PR TITLE
R&D machinery refactor

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -38,8 +38,18 @@
 		species_list[S.id] = S.type
 
 	//Surgeries
-	for(var/path in (subtypesof(/datum/surgery)))
+	for(var/path in subtypesof(/datum/surgery))
 		surgeries_list += new path()
+
+	//Materials
+	for(var/path in subtypesof(/datum/material))
+		var/datum/material/D = new path()
+		materials_list[D.id] = D
+
+	//Techs
+	for(var/path in subtypesof(/datum/tech))
+		var/datum/tech/D = new path()
+		tech_list[D.id] = D
 
 	init_subtypes(/datum/crafting_recipe, crafting_recipes)
 

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -13,6 +13,8 @@ var/global/list/nuke_tiles = list()					//list of all turfs that turn to animate
 
 var/global/list/chemical_reactions_list				//list of all /datum/chemical_reaction datums. Used during chemical reactions
 var/global/list/chemical_reagents_list				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
+var/global/list/materials_list = list()				//list of all /datum/material datums indexed by material id.
+var/global/list/tech_list = list()					//list of all /datum/tech datums indexed by id.
 var/global/list/surgeries_list = list()				//list of all surgeries by name, associated with their path.
 var/global/list/crafting_recipes = list()				//list of all table craft recipes
 var/global/list/rcd_list = list()					//list of Rapid Construction Devices.

--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -22,33 +22,26 @@
 	owner = O
 	max_amount = max(0, max_amt)
 
-	if(mat_list[MAT_METAL])
-		materials[MAT_METAL] = new /datum/material/metal()
-	if(mat_list[MAT_GLASS])
-		materials[MAT_GLASS] = new /datum/material/glass()
-	if(mat_list[MAT_SILVER])
-		materials[MAT_SILVER] = new /datum/material/silver()
-	if(mat_list[MAT_GOLD])
-		materials[MAT_GOLD] = new /datum/material/gold()
-	if(mat_list[MAT_DIAMOND])
-		materials[MAT_DIAMOND] = new /datum/material/diamond()
-	if(mat_list[MAT_URANIUM])
-		materials[MAT_URANIUM] = new /datum/material/uranium()
-	if(mat_list[MAT_PLASMA])
-		materials[MAT_PLASMA] = new /datum/material/plasma()
-	if(mat_list[MAT_BANANIUM])
-		materials[MAT_BANANIUM] = new /datum/material/bananium()
+	var/list/possible_mats = list()
+	for(var/mat_type in subtypesof(/datum/material))
+		var/datum/material/MT = mat_type
+		possible_mats[initial(MT.id)] = mat_type
+
+	for(var/id in mat_list)
+		if(possible_mats[id])
+			var/mat_path = possible_mats[id]
+			materials[id] = new mat_path()
 
 /datum/material_container/Destroy()
 	owner = null
 	return ..()
 
 //For inserting an amount of material
-/datum/material_container/proc/insert_amount(amt, material_type = null)
+/datum/material_container/proc/insert_amount(amt, id = null)
 	if(amt > 0 && has_space(amt))
 		var/total_amount_saved = total_amount
-		if(material_type)
-			var/datum/material/M = materials[material_type]
+		if(id)
+			var/datum/material/M = materials[id]
 			if(M)
 				M.amount += amt
 				total_amount += amt
@@ -120,8 +113,8 @@
 	return total_amount_save - total_amount
 
 
-/datum/material_container/proc/use_amount_type(amt, material_type)
-	var/datum/material/M = materials[material_type]
+/datum/material_container/proc/use_amount_type(amt, id)
+	var/datum/material/M = materials[id]
 	if(M)
 		if(M.amount >= amt)
 			M.amount -= amt
@@ -129,9 +122,9 @@
 			return amt
 	return 0
 
-/datum/material_container/proc/can_use_amount(amt, material_type, list/mats)
-	if(amt && material_type)
-		var/datum/material/M = materials[material_type]
+/datum/material_container/proc/can_use_amount(amt, id, list/mats)
+	if(amt && id)
+		var/datum/material/M = materials[id]
 		if(M && M.amount >= amt)
 			return TRUE
 	else if(istype(mats))
@@ -153,23 +146,23 @@
 		while(sheet_amt > MAX_STACK_SIZE)
 			new M.sheet_type(get_turf(owner), MAX_STACK_SIZE)
 			count += MAX_STACK_SIZE
-			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.material_type)
+			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.id)
 			sheet_amt -= MAX_STACK_SIZE
 
 		if(round(M.amount / MINERAL_MATERIAL_AMOUNT))
 			new M.sheet_type(get_turf(owner), sheet_amt)
 			count += sheet_amt
-			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.material_type)
+			use_amount_type(sheet_amt * MINERAL_MATERIAL_AMOUNT, M.id)
 		return count
 	return 0
 
-/datum/material_container/proc/retrieve_sheets(sheet_amt, material_type)
-	if(materials[material_type])
-		return retrieve(sheet_amt, materials[material_type])
+/datum/material_container/proc/retrieve_sheets(sheet_amt, id)
+	if(materials[id])
+		return retrieve(sheet_amt, materials[id])
 	return 0
 
-/datum/material_container/proc/retrieve_amount(amt, material_type)
-	return retrieve_sheets(amount2sheet(amt),material_type)
+/datum/material_container/proc/retrieve_amount(amt, id)
+	return retrieve_sheets(amount2sheet(amt), id)
 
 /datum/material_container/proc/retrieve_all()
 	var/result = 0
@@ -203,8 +196,8 @@
 		return sheet_amt * MINERAL_MATERIAL_AMOUNT
 	return 0
 
-/datum/material_container/proc/amount(material_type)
-	var/datum/material/M = materials[material_type]
+/datum/material_container/proc/amount(id)
+	var/datum/material/M = materials[id]
 	return M ? M.amount : 0
 
 //returns the amount of material relevant to this container;
@@ -221,45 +214,45 @@
 /datum/material
 	var/name
 	var/amount = 0
-	var/material_type = null
+	var/id = null
 	var/sheet_type = null
 
 /datum/material/metal
 	name = "Metal"
-	material_type = MAT_METAL
+	id = MAT_METAL
 	sheet_type = /obj/item/stack/sheet/metal
 
 /datum/material/glass
 	name = "Glass"
-	material_type = MAT_GLASS
+	id = MAT_GLASS
 	sheet_type = /obj/item/stack/sheet/glass
 
 /datum/material/silver
 	name = "Silver"
-	material_type = MAT_SILVER
+	id = MAT_SILVER
 	sheet_type = /obj/item/stack/sheet/mineral/silver
 
 /datum/material/gold
 	name = "Gold"
-	material_type = MAT_GOLD
+	id = MAT_GOLD
 	sheet_type = /obj/item/stack/sheet/mineral/gold
 
 /datum/material/diamond
 	name = "Diamond"
-	material_type = MAT_DIAMOND
+	id = MAT_DIAMOND
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 
 /datum/material/uranium
 	name = "Uranium"
-	material_type = MAT_URANIUM
+	id = MAT_URANIUM
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 
 /datum/material/plasma
 	name = "Solid Plasma"
-	material_type = MAT_PLASMA
+	id = MAT_PLASMA
 	sheet_type = /obj/item/stack/sheet/mineral/plasma
 
 /datum/material/bananium
 	name = "Bananium"
-	material_type = MAT_BANANIUM
+	id = MAT_BANANIUM
 	sheet_type = /obj/item/stack/sheet/mineral/bananium

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -47,7 +47,7 @@
 
 /obj/machinery/autolathe/New()
 	..()
-	materials = new /datum/material_container(src, list(MAT_METAL=1, MAT_GLASS=1))
+	materials = new /datum/material_container(src, list(MAT_METAL, MAT_GLASS))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/autolathe(null)
 	B.apply_default_parts(src)
 
@@ -255,9 +255,7 @@
 
 /obj/machinery/autolathe/proc/main_win(mob/user)
 	var/dat = "<div class='statusDisplay'><h3>Autolathe Menu:</h3><br>"
-	dat += "<b>Total amount:</b> [materials.total_amount] / [materials.max_amount] cm<sup>3</sup><br>"
-	dat += "<b>Metal amount:</b> [materials.amount(MAT_METAL)] cm<sup>3</sup><br>"
-	dat += "<b>Glass amount:</b> [materials.amount(MAT_GLASS)] cm<sup>3</sup><br>"
+	dat += materials_printout()
 
 	dat += "<form name='search' action='?src=\ref[src]'>\
 	<input type='hidden' name='src' value='\ref[src]'>\
@@ -284,9 +282,7 @@
 /obj/machinery/autolathe/proc/category_win(mob/user,selected_category)
 	var/dat = "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
 	dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><br>"
-	dat += "<b>Total amount:</b> [materials.total_amount] / [materials.max_amount] cm<sup>3</sup><br>"
-	dat += "<b>Metal amount:</b> [materials.amount(MAT_METAL)] cm<sup>3</sup><br>"
-	dat += "<b>Glass amount:</b> [materials.amount(MAT_GLASS)] cm<sup>3</sup><br>"
+	dat += materials_printout()
 
 	for(var/v in files.known_designs)
 		var/datum/design/D = files.known_designs[v]
@@ -315,9 +311,7 @@
 /obj/machinery/autolathe/proc/search_win(mob/user)
 	var/dat = "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
 	dat += "<div class='statusDisplay'><h3>Search results:</h3><br>"
-	dat += "<b>Total amount:</b> [materials.total_amount] / [materials.max_amount] cm<sup>3</sup><br>"
-	dat += "<b>Metal amount:</b> [materials.amount(MAT_METAL)] cm<sup>3</sup><br>"
-	dat += "<b>Glass amount:</b> [materials.amount(MAT_GLASS)] cm<sup>3</sup><br>"
+	dat += materials_printout()
 
 	for(var/v in matching_designs)
 		var/datum/design/D = v
@@ -338,6 +332,13 @@
 		dat += "[get_design_cost(D)]<br>"
 
 	dat += "</div>"
+	return dat
+
+/obj/machinery/autolathe/proc/materials_printout()
+	var/dat = "<b>Total amount:</b> [materials.total_amount] / [materials.max_amount] cm<sup>3</sup><br>"
+	for(var/mat_id in materials.materials)
+		var/datum/material/M = materials.materials[mat_id]
+		dat += "<b>[M.name] amount:</b> [M.amount] cm<sup>3</sup><br>"
 	return dat
 
 /obj/machinery/autolathe/proc/can_build(datum/design/D)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -244,7 +244,7 @@
 	return
 
 /obj/machinery/autolathe/RefreshParts()
-	var/T =1.2
+	var/T = 0
 	for(var/obj/item/weapon/stock_parts/matter_bin/MB in component_parts)
 		T += MB.rating*75000
 	materials.max_amount = T

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -55,7 +55,7 @@
 /obj/machinery/droneDispenser/New()
 	..()
 	health = max_health
-	materials = new(src, list(MAT_METAL=1, MAT_GLASS=1),
+	materials = new(src, list(MAT_METAL, MAT_GLASS),
 		MINERAL_MATERIAL_AMOUNT*MAX_STACK_SIZE*2)
 
 	using_materials = list(MAT_METAL=metal_cost, MAT_GLASS=glass_cost)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -96,6 +96,7 @@ Class Procs:
 /obj/machinery
 	name = "machinery"
 	icon = 'icons/obj/stationobjs.dmi'
+	verb_say = "beeps"
 	verb_yell = "blares"
 	pressure_resistance = 10
 	var/stat = 0

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -20,7 +20,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 /obj/machinery/recycler/New()
 	..()
-	materials = new /datum/material_container(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_PLASMA=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_URANIUM=1, MAT_BANANIUM=1))
+	materials = new /datum/material_container(src, list(MAT_METAL, MAT_GLASS, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_URANIUM, MAT_BANANIUM))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/recycler(null)
 	B.apply_default_parts(src)
 	update_icon()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -12,17 +12,6 @@
 	var/time_coeff = 1
 	var/component_coeff = 1
 	var/datum/material_container/materials
-/*	var/list/resources = list(
-								MAT_METAL=0,
-								MAT_GLASS=0,
-								MAT_BANANIUM=0,
-								MAT_DIAMOND=0,
-								MAT_GOLD=0,
-								MAT_PLASMA=0,
-								MAT_SILVER=0,
-								MAT_URANIUM=0
-								)
-	var/res_max_amount = 200000*/
 	var/datum/research/files
 	var/sync = 0
 	var/part_set

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -11,7 +11,8 @@
 	req_access = list(access_robotics)
 	var/time_coeff = 1
 	var/component_coeff = 1
-	var/list/resources = list(
+	var/datum/material_container/materials
+/*	var/list/resources = list(
 								MAT_METAL=0,
 								MAT_GLASS=0,
 								MAT_BANANIUM=0,
@@ -21,9 +22,8 @@
 								MAT_SILVER=0,
 								MAT_URANIUM=0
 								)
-	var/res_max_amount = 200000
+	var/res_max_amount = 200000*/
 	var/datum/research/files
-	var/id
 	var/sync = 0
 	var/part_set
 	var/datum/design/being_built
@@ -47,9 +47,10 @@
 
 /obj/machinery/mecha_part_fabricator/New()
 	..()
+	files = new /datum/research(src) //Setup the research data holder.
+	materials = new(src, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/mechfab(null)
 	B.apply_default_parts(src)
-	files = new /datum/research(src) //Setup the research data holder.
 
 /obj/item/weapon/circuitboard/machine/mechfab
 	name = "circuit board (Exosuit Fabricator)"
@@ -64,10 +65,10 @@
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
 
-	//maximum stocking amount (max 412000)
+	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-	res_max_amount = (187000+(T * 37500))
+	materials.max_amount = (200000 + (T*50000))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15
@@ -93,24 +94,20 @@
 			return 0
 	return 1
 
-/obj/machinery/mecha_part_fabricator/proc/emag()
-	switch(emagged)
-		if(0)
-			emagged = 0.5
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB error \[Code 0x00F1\]\"")
-			sleep(10)
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"Attempting auto-repair\"")
-			sleep(15)
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
-			sleep(30)
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
-			req_access = null
-			emagged = 1
-		if(0.5)
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")
-		if(1)
-			visible_message("\icon[src] <b>\The [src]</b> beeps: \"No records in User DB\"")
-	return
+/obj/machinery/mecha_part_fabricator/emag_act()
+	if(emagged)
+		return
+
+	emagged = 0.5
+	say("DB error \[Code 0x00F1\]")
+	sleep(10)
+	say("Attempting auto-repair...")
+	sleep(15)
+	say("User DB corrupted \[Code 0x00FA\]. Truncating data structure...")
+	sleep(30)
+	say("User DB truncated. Please contact your Nanotrasen system operator for future assistance.")
+	req_access = null
+	emagged = 1
 
 /obj/machinery/mecha_part_fabricator/proc/output_parts_list(set_name)
 	var/output = ""
@@ -119,8 +116,10 @@
 		if(D.build_type & MECHFAB)
 			if(!(set_name in D.category))
 				continue
-			var/resources_available = check_resources(D)
-			output += "<div class='part'>[output_part_info(D)]<br>\[[resources_available?"<a href='?src=\ref[src];part=[D.id]'>Build</a> | ":null]<a href='?src=\ref[src];add_to_queue=[D.id]'>Add to queue</a>\]\[<a href='?src=\ref[src];part_desc=[D.id]'>?</a>\]</div>"
+			output += "<div class='part'>[output_part_info(D)]<br>\["
+			if(check_resources(D))
+				output += "<a href='?src=\ref[src];part=[D.id]'>Build</a> | "
+			output += "<a href='?src=\ref[src];add_to_queue=[D.id]'>Add to queue</a>\]\[<a href='?src=\ref[src];part_desc=[D.id]'>?</a>\]</div>"
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/output_part_info(datum/design/D)
@@ -131,39 +130,42 @@
 	var/i = 0
 	var/output
 	for(var/c in D.materials)
-		if(c in resources)
-			output += "[i?" | ":null][get_resource_cost_w_coeff(D,c)] [material2name(c)]"
-			i++
+		output += "[i?" | ":null][get_resource_cost_w_coeff(D, c)] [material2name(c)]"
+		i++
 	return output
 
 /obj/machinery/mecha_part_fabricator/proc/output_available_resources()
 	var/output
-	for(var/resource in resources)
-		var/amount = min(res_max_amount, resources[resource])
-		output += "<span class=\"res_name\">[material2name(resource)]: </span>[amount] cm&sup3;"
-		if(amount>0)
-			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=\ref[src];remove_mat=1;material=[resource]'>1</a>\] | \[<a href='?src=\ref[src];remove_mat=10;material=[resource]'>10</a>\] | \[<a href='?src=\ref[src];remove_mat=[resources[resource] / MINERAL_MATERIAL_AMOUNT];material=[resource]'>All</a>\]</span>"
+	for(var/mat_id in materials.materials)
+		var/datum/material/M = materials.materials[mat_id]
+		output += "<span class=\"res_name\">[M.name]: </span>[M.amount] cm&sup3;"
+		if(M.amount >= MINERAL_MATERIAL_AMOUNT)
+			output += "<span style='font-size:80%;'>- Remove \[<a href='?src=\ref[src];remove_mat=1;material=[mat_id]'>1</a>\]"
+			if(M.amount >= (MINERAL_MATERIAL_AMOUNT * 10))
+				output += " | \[<a href='?src=\ref[src];remove_mat=10;material=[mat_id]'>10</a>\]"
+			output += " | \[<a href='?src=\ref[src];remove_mat=50;material=[mat_id]'>All</a>\]</span>"
 		output += "<br/>"
 	return output
 
-/obj/machinery/mecha_part_fabricator/proc/remove_resources(datum/design/D)
-	for(var/resource in D.materials)
-		if(resource in resources)
-			resources[resource] -= get_resource_cost_w_coeff(D,resource)
+/obj/machinery/mecha_part_fabricator/proc/get_resources_w_coeff(datum/design/D)
+	var/list/resources = list()
+	for(var/R in D.materials)
+		resources[R] = get_resource_cost_w_coeff(D, R)
+	return resources
 
 /obj/machinery/mecha_part_fabricator/proc/check_resources(datum/design/D)
-	for(var/R in D.materials)
-		if(R in resources)
-			if(resources[R] < get_resource_cost_w_coeff(D, R))
-				return 0
-		else
-			return 0
-	return 1
+	if(D.reagents.len) // No reagents storage - no reagent designs.
+		return 0
+	if(materials.has_materials(get_resources_w_coeff(D)))
+		return 1
+	return 0
 
 /obj/machinery/mecha_part_fabricator/proc/build_part(datum/design/D)
 	being_built = D
 	desc = "It's building \a [initial(D.name)]."
-	remove_resources(D)
+	var/list/res_coef = get_resources_w_coeff(D)
+
+	materials.use_amount(res_coef)
 	overlays += "fab-active"
 	use_power = 2
 	updateUsrDialog()
@@ -174,9 +176,8 @@
 
 	var/location = get_step(src,(dir))
 	var/obj/item/I = new D.build_path(location)
-	I.materials[MAT_METAL] = get_resource_cost_w_coeff(D,MAT_METAL)
-	I.materials[MAT_GLASS] = get_resource_cost_w_coeff(D,MAT_GLASS)
-	visible_message("\icon[src] <b>\The [src]</b> beeps, \"\The [I] is complete.\"")
+	I.materials = res_coef
+	say("\The [I] is complete.")
 	being_built = null
 
 	updateUsrDialog()
@@ -220,14 +221,14 @@
 		if(stat&(NOPOWER|BROKEN))
 			return 0
 		if(!check_resources(D))
-			visible_message("\icon[src] <b>\The [src]</b> beeps, \"Not enough resources. Queue processing stopped.\"")
+			say("Not enough resources. Queue processing stopped.")
 			temp = {"<span class='alert'>Not enough resources to build next part.</span><br>
 						<a href='?src=\ref[src];process_queue=1'>Try again</a> | <a href='?src=\ref[src];clear_temp=1'>Return</a><a>"}
 			return 0
 		remove_from_queue(1)
 		build_part(D)
 		D = listgetindex(queue, 1)
-	visible_message("\icon[src] <b>\The [src]</b> beeps, \"Queue processing finished successfully.\"")
+	say("Queue processing finished successfully.")
 
 /obj/machinery/mecha_part_fabricator/proc/list_queue()
 	var/output = "<b>Queue contains:</b>"
@@ -239,7 +240,11 @@
 		for(var/datum/design/D in queue)
 			i++
 			var/obj/part = D.build_path
-			output += "<li[!check_resources(D)?" style='color: #f00;'":null]>[initial(part.name)] - [i>1?"<a href='?src=\ref[src];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] [i<queue.len?"<a href='?src=\ref[src];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] <a href='?src=\ref[src];remove_from_queue=[i]'>Remove</a></li>"
+			output += "<li[!check_resources(D)?" style='color: #f00;'":null]>"
+			output += initial(part.name) + " - "
+			output += "[i>1?"<a href='?src=\ref[src];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] "
+			output += "[i<queue.len?"<a href='?src=\ref[src];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] "
+			output += "<a href='?src=\ref[src];remove_from_queue=[i]'>Remove</a></li>"
 
 		output += "</ol>"
 		output += "\[<a href='?src=\ref[src];process_queue=1'>Process queue</a> | <a href='?src=\ref[src];clear_queue=1'>Clear queue</a>\]"
@@ -265,7 +270,7 @@
 		temp += "<a href='?src=\ref[src];clear_temp=1'>Return</a>"
 
 		updateUsrDialog()
-		visible_message("\icon[src] <b>\The [src]</b> beeps, \"Successfully synchronized with R&D server.\"")
+		say("Successfully synchronized with R&D server.")
 		return
 
 	temp = "Unable to connect to local R&D Database.<br>Please check your connections and try again.<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
@@ -289,7 +294,7 @@
 	user.set_machine(src)
 	var/turf/exit = get_step(src,(dir))
 	if(exit.density)
-		visible_message("\icon[src] <b>\The [src]</b> beeps, \"Error! Part outlet is obstructed.\"")
+		say("Error! Part outlet is obstructed.")
 		return
 	if(temp)
 		left_part = temp
@@ -303,7 +308,7 @@
 				left_part = output_available_resources()+"<hr>"
 				left_part += "<a href='?src=\ref[src];sync=1'>Sync with R&D servers</a><hr>"
 				for(var/part_set in part_sets)
-					left_part += "<a href='?src=\ref[src];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=\ref[src];partset_to_queue=[part_set]'>Add all parts to queue\]<br>"
+					left_part += "<a href='?src=\ref[src];part_set=[part_set]'>[part_set]</a> - \[<a href='?src=\ref[src];partset_to_queue=[part_set]'>Add all parts to queue<br>\]"
 			if("parts")
 				left_part += output_parts_list(part_set)
 				left_part += "<hr><a href='?src=\ref[src];screen=main'>Return</a>"
@@ -416,124 +421,57 @@
 					break
 
 	if(href_list["remove_mat"] && href_list["material"])
-		var/amount = text2num(href_list["remove_mat"])
-		var/material = href_list["material"]
-		if(amount < 0 || amount > resources[material]) //href protection
-			return
-
-		var/removed = remove_material(material,amount)
-		if(removed == -1)
-			temp = "Not enough [material2name(material)] to produce a sheet."
-		else
-			temp = "Ejected [removed] of [material2name(material)]"
-		temp += "<br><a href='?src=\ref[src];clear_temp=1'>Return</a>"
+		materials.retrieve_sheets(text2num(href_list["remove_mat"]), href_list["material"])
 
 	updateUsrDialog()
 	return
 
-/obj/machinery/mecha_part_fabricator/proc/remove_material(mat_string, amount)
-	if(resources[mat_string] < MINERAL_MATERIAL_AMOUNT) //not enough mineral for a sheet
-		return -1
-	var/type
-	switch(mat_string)
-		if(MAT_METAL)
-			type = /obj/item/stack/sheet/metal
-		if(MAT_GLASS)
-			type = /obj/item/stack/sheet/glass
-		if(MAT_GOLD)
-			type = /obj/item/stack/sheet/mineral/gold
-		if(MAT_SILVER)
-			type = /obj/item/stack/sheet/mineral/silver
-		if(MAT_DIAMOND)
-			type = /obj/item/stack/sheet/mineral/diamond
-		if(MAT_PLASMA)
-			type = /obj/item/stack/sheet/mineral/plasma
-		if(MAT_URANIUM)
-			type = /obj/item/stack/sheet/mineral/uranium
-		if(MAT_BANANIUM)
-			type = /obj/item/stack/sheet/mineral/bananium
-		else
-			return 0
-	var/result = 0
-
-	while(amount > 50)
-		new type(get_turf(src),50)
-		amount -= 50
-		result += 50
-		resources[mat_string] -= 50 * MINERAL_MATERIAL_AMOUNT
-
-	var/total_amount = round(resources[mat_string]/MINERAL_MATERIAL_AMOUNT)
-	if(total_amount)//if there's still enough material for sheets
-		var/obj/item/stack/sheet/res = new type(get_turf(src),min(amount,total_amount))
-		resources[mat_string] -= res.amount*MINERAL_MATERIAL_AMOUNT
-		result += res.amount
-
-	return result
-
 /obj/machinery/mecha_part_fabricator/deconstruction()
-	for(var/material in resources)
-		remove_material(material, resources[material]/MINERAL_MATERIAL_AMOUNT)
+	materials.retrieve_all()
+	..()
 
-/obj/machinery/mecha_part_fabricator/attackby(obj/W, mob/user, params)
+/obj/machinery/mecha_part_fabricator/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "fab-o", "fab-idle", W))
-		return
+		return 1
 
 	if(exchange_parts(user, W))
-		return
+		return 1
 
 	if(default_deconstruction_crowbar(W))
 		return 1
 
-	if(istype(W, /obj/item/stack))
+	if(istype(W, /obj/item/stack/sheet))
 		if(panel_open)
-			user << "<span class='warning'>You can't load \the [name] while it's opened!</span>"
+			user << "<span class='warning'>You can't load [src] while it's opened!</span>"
 			return 1
-		var/material
-		switch(W.type)
-			if(/obj/item/stack/sheet/mineral/gold)
-				material = MAT_GOLD
-			if(/obj/item/stack/sheet/mineral/silver)
-				material = MAT_SILVER
-			if(/obj/item/stack/sheet/mineral/diamond)
-				material = MAT_DIAMOND
-			if(/obj/item/stack/sheet/mineral/plasma)
-				material = MAT_PLASMA
-			if(/obj/item/stack/sheet/metal)
-				material = MAT_METAL
-			if(/obj/item/stack/sheet/glass)
-				material = MAT_GLASS
-			if(/obj/item/stack/sheet/mineral/bananium)
-				material = MAT_BANANIUM
-			if(/obj/item/stack/sheet/mineral/uranium)
-				material = MAT_URANIUM
-			else
-				return ..()
-
 		if(being_built)
 			user << "<span class='warning'>\The [src] is currently processing! Please wait until completion.</span>"
-			return
-		if(res_max_amount - resources[material] < MINERAL_MATERIAL_AMOUNT) //overstuffing the fabricator
-			user << "<span class='warning'>\The [src] [material2name(material)] storage is full!</span>"
-			return
-		var/obj/item/stack/sheet/stack = W
-		var/sname = "[stack.name]"
-		if(resources[material] < res_max_amount)
-			overlays += "fab-load-[material2name(material)]"//loading animation is now an overlay based on material type. No more spontaneous conversion of all ores to metal. -vey
+			return 1
 
-			var/transfer_amount = min(stack.amount, round((res_max_amount - resources[material])/MINERAL_MATERIAL_AMOUNT,1))
-			resources[material] += transfer_amount * MINERAL_MATERIAL_AMOUNT
-			stack.use(transfer_amount)
-			user << "<span class='notice'>You insert [transfer_amount] [sname] sheet\s into \the [src].</span>"
-			sleep(10)
-			updateUsrDialog()
-			overlays -= "fab-load-[material2name(material)]" //No matter what the overlay shall still be deleted
-		else
-			user << "<span class='warning'>\The [src] cannot hold any more [sname] sheet\s!</span>"
+		var/material_amount = materials.get_item_material_amount(W)
+		if(!material_amount)
+			user << "<span class='warning'>This object does not contain sufficient amounts of materials to be accepted by [src].</span>"
+			return 1
+		if(!materials.has_space(material_amount))
+			user << "<span class='warning'>\The [src] is full. Please remove some materials from [src] in order to insert more.</span>"
+			return 1
+		if(!user.unEquip(W))
+			user << "<span class='warning'>\The [W] is stuck to you and cannot be placed into [src].</span>"
+			return 1
+
+		var/inserted = materials.insert_item(W)
+		if(inserted)
+			user << "<span class='notice'>You insert [inserted] sheet\s into [src].</span>"
+			if(W && W.materials.len)
+				var/mat_overlay = "fab-load-[material2name(W.materials[1])]"
+				overlays += mat_overlay
+				sleep(10)
+				overlays -= mat_overlay //No matter what the overlay shall still be deleted
+
+		updateUsrDialog()
+
 	else
 		return ..()
 
 /obj/machinery/mecha_part_fabricator/proc/material2name(ID)
 	return copytext(ID,2)
-
-/obj/machinery/mecha_part_fabricator/emag_act()
-	emag()

--- a/code/modules/cargo/exports/research.dm
+++ b/code/modules/cargo/exports/research.dm
@@ -17,27 +17,3 @@
 	var/obj/item/weapon/disk/tech_disk/D = O
 	var/datum/tech/tech = D.stored
 	techLevels[tech.id] = tech.level
-
-
-
-// Sell designs
-/datum/export/design
-	cost = 2500
-	unit_name = "design data disk"
-	export_types = list(/obj/item/weapon/disk/design_disk)
-	var/list/researchDesigns = list()
-
-/datum/export/design/get_cost(obj/O)
-	var/obj/item/weapon/disk/design_disk/disk = O
-	if(!disk.blueprint)
-		return 0
-	var/datum/design/design = disk.blueprint
-	if(design.id in researchDesigns)
-		return 0
-	return ..()
-
-/datum/export/design/sell_object(obj/O)
-	..()
-	var/obj/item/weapon/disk/design_disk/disk = O
-	var/datum/design/design = disk.blueprint
-	researchDesigns += design.id

--- a/code/modules/clothing/shoes/bananashoes.dm
+++ b/code/modules/clothing/shoes/bananashoes.dm
@@ -10,7 +10,7 @@
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/New()
 	..()
-	bananium = new/datum/material_container(src,list(MAT_BANANIUM=1),200000)
+	bananium = new/datum/material_container(src,list(MAT_BANANIUM),200000)
 
 /obj/item/clothing/shoes/clown_shoes/banana_shoes/step_action()
 	if(on)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -10,12 +10,8 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	icon_state = "circuit_imprinter"
 	flags = OPENCONTAINER
 
-	var/g_amount = 0
-	var/gold_amount = 0
-	var/diamond_amount = 0
-	var/max_material_amount = 75000
+	var/datum/material_container/materials
 	var/efficiency_coeff
-	reagents = new(0)
 
 	var/list/categories = list(
 								"AI Modules",
@@ -32,9 +28,14 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 
 /obj/machinery/r_n_d/circuit_imprinter/New()
 	..()
+	materials = new(src, list(MAT_GLASS, MAT_GOLD, MAT_DIAMOND))
+	create_reagents(0)
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/circuit_imprinter(null)
 	B.apply_default_parts(src)
-	reagents.my_atom = src
+
+/obj/machinery/r_n_d/circuit_imprinter/Destroy()
+	qdel(materials)
+	return ..()
 
 /obj/item/weapon/circuitboard/machine/circuit_imprinter
 	name = "circuit board (Circuit Imprinter)"
@@ -52,7 +53,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 		G.reagents.trans_to(src, G.reagents.total_volume)
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-	max_material_amount = T * 75000
+	materials.max_amount = T * 75000
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += M.rating
@@ -62,36 +63,22 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	if (prob(50))
 		qdel(src)
 
+/obj/machinery/r_n_d/circuit_imprinter/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
+	var/list/all_materials = being_built.reagents + being_built.materials
 
-/obj/machinery/r_n_d/circuit_imprinter/proc/check_mat(datum/design/being_built, M)
-	switch(M)
-		if(MAT_GLASS)
-			return (g_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
-		if(MAT_GOLD)
-			return (gold_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
-		if(MAT_DIAMOND)
-			return (diamond_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
-		else
-			return (reagents.has_reagent(M, (being_built.materials[M]/efficiency_coeff)) != 0)
+	var/A = materials.amount(M)
+	if(!A)
+		A = reagents.get_reagent_amount(M)
 
+	return round(A / max(1, (all_materials[M]/efficiency_coeff)))
 
-/obj/machinery/r_n_d/circuit_imprinter/proc/TotalMaterials()
-	return g_amount + gold_amount + diamond_amount
-
-//we drop the minerals in the machine onto the ground when deconstructed.
+//we eject the materials upon deconstruction.
 /obj/machinery/r_n_d/circuit_imprinter/deconstruction()
 	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
 		reagents.trans_to(G, G.reagents.maximum_volume)
-	if(g_amount >= MINERAL_MATERIAL_AMOUNT)
-		var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src.loc)
-		G.amount = round(g_amount / MINERAL_MATERIAL_AMOUNT)
-	if(gold_amount >= MINERAL_MATERIAL_AMOUNT)
-		var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold(src.loc)
-		G.amount = round(gold_amount / MINERAL_MATERIAL_AMOUNT)
-	if(diamond_amount >= MINERAL_MATERIAL_AMOUNT)
-		var/obj/item/stack/sheet/mineral/diamond/G = new /obj/item/stack/sheet/mineral/diamond(src.loc)
-		G.amount = round(diamond_amount / MINERAL_MATERIAL_AMOUNT)
+	materials.retrieve_all()
 	..()
+
 
 /obj/machinery/r_n_d/circuit_imprinter/disconnect_console()
 	linked_console.linked_imprinter = null
@@ -99,35 +86,32 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 
 /obj/machinery/r_n_d/circuit_imprinter/Insert_Item(obj/item/O, mob/user)
 
-	if (istype(O, /obj/item/stack/sheet/glass) || istype(O, /obj/item/stack/sheet/mineral/gold) || istype(O, /obj/item/stack/sheet/mineral/diamond))
+	if(istype(O,/obj/item/stack/sheet))
 		. = 1
 		if(!is_insertion_ready(user))
 			return
+		var/sheet_material = materials.get_item_material_amount(O)
+		if(!sheet_material)
+			return
+
+		if(!materials.has_space(sheet_material))
+			user << "<span class='warning'>The [src.name]'s material bin is full! Please remove material before adding more.</span>"
+			return 1
+
 		var/obj/item/stack/sheet/stack = O
-		if ((TotalMaterials() + stack.perunit) > max_material_amount)
-			user << "<span class='warning'>The [name] is full! Please remove glass from the protolathe in order to insert more.</span>"
+		var/amount = round(input("How many sheets do you want to add?") as num)//No decimals
+		if(!in_range(src, stack) || !user.Adjacent(src))
 			return
-
-		var/amount = round(input("How many sheets do you want to add?") as num)
-		if(amount <= 0 || stack.amount <= 0)
-			return
-		if(amount > stack.amount)
-			amount = min(stack.amount, round((max_material_amount-TotalMaterials())/stack.perunit))
-
-		busy = 1
-		use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount/10)))
-		user << "<span class='notice'>You add [amount] sheets to the [src.name].</span>"
-		if(istype(stack, /obj/item/stack/sheet/glass))
-			g_amount += amount * MINERAL_MATERIAL_AMOUNT
-		else if(istype(stack, /obj/item/stack/sheet/mineral/gold))
-			gold_amount += amount * MINERAL_MATERIAL_AMOUNT
-		else if(istype(stack, /obj/item/stack/sheet/mineral/diamond))
-			diamond_amount += amount * MINERAL_MATERIAL_AMOUNT
-		stack.use(amount)
-		busy = 0
-		src.updateUsrDialog()
+		var/amount_inserted = materials.insert_stack(O,amount)
+		if(!amount_inserted)
+			return 1
+		else
+			use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount_inserted/10)))
+			user << "<span class='notice'>You add [amount_inserted] sheets to the [src.name].</span>"
+		updateUsrDialog()
 
 	else if(user.a_intent != "harm")
 		user << "<span class='warning'>You cannot insert this item into the [name]!</span>"
+		return 1
 	else
 		return 0

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -2,154 +2,139 @@
 //////////AI Module Disks//////////
 ///////////////////////////////////
 
-/datum/design/aicore
+/datum/design/board/aicore
 	name = "AI Design (AI Core)"
 	desc = "Allows for the construction of circuit boards used to build new AI cores."
 	id = "aicore"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/aicore
 	category = list("AI Modules")
 
 
-/datum/design/safeguard_module
+/datum/design/board/safeguard_module
 	name = "Module Design (Safeguard)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "safeguard_module"
 	req_tech = list("programming" = 3, "materials" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/safeguard
 	category = list("AI Modules")
 
-/datum/design/onehuman_module
+/datum/design/board/onehuman_module
 	name = "Module Design (OneHuman)"
 	desc = "Allows for the construction of a OneHuman AI Module."
 	id = "onehuman_module"
 	req_tech = list("programming" = 6, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/zeroth/oneHuman
 	category = list("AI Modules")
 
-/datum/design/protectstation_module
+/datum/design/board/protectstation_module
 	name = "Module Design (ProtectStation)"
 	desc = "Allows for the construction of a ProtectStation AI Module."
 	id = "protectstation_module"
 	req_tech = list("programming" = 5, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/protectStation
 	category = list("AI Modules")
 
-/datum/design/quarantine_module
+/datum/design/board/quarantine_module
 	name = "Module Design (Quarantine)"
 	desc = "Allows for the construction of a Quarantine AI Module."
 	id = "quarantine_module"
 	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/quarantine
 	category = list("AI Modules")
 
 
-/datum/design/oxygen_module
+/datum/design/board/oxygen_module
 	name = "Module Design (OxygenIsToxicToHumans)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "oxygen_module"
 	req_tech = list("programming" = 4, "biotech" = 2, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/oxygen
 	category = list("AI Modules")
 
-/datum/design/freeform_module
+/datum/design/board/freeform_module
 	name = "Module Design (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Module."
 	id = "freeform_module"
 	req_tech = list("programming" = 5, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/freeform
 	category = list("AI Modules")
 
-/datum/design/reset_module
+/datum/design/board/reset_module
 	name = "Module Design (Reset)"
 	desc = "Allows for the construction of a Reset AI Module."
 	id = "reset_module"
 	req_tech = list("programming" = 4, "materials" = 6)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/reset
 	category = list("AI Modules")
 
-/datum/design/purge_module
+/datum/design/board/purge_module
 	name = "Module Design (Purge)"
 	desc = "Allows for the construction of a Purge AI Module."
 	id = "purge_module"
 	req_tech = list("programming" = 5, "materials" = 6)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/reset/purge
 	category = list("AI Modules")
 
-/datum/design/freeformcore_module
+/datum/design/board/freeformcore_module
 	name = "AI Core Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Core Module."
 	id = "freeformcore_module"
 	req_tech = list("programming" = 6, "materials" = 6)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/freeformcore
 	category = list("AI Modules")
 
-/datum/design/asimov
+/datum/design/board/asimov
 	name = "Core Module Design (Asimov)"
 	desc = "Allows for the construction of a Asimov AI Core Module."
 	id = "asimov_module"
 	req_tech = list("programming" = 3, "materials" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/asimov
 	category = list("AI Modules")
 
-/datum/design/paladin_module
+/datum/design/board/paladin_module
 	name = "Core Module Design (P.A.L.A.D.I.N.)"
 	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Module."
 	id = "paladin_module"
 	req_tech = list("programming" = 5, "materials" = 5)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/paladin
 	category = list("AI Modules")
 
-/datum/design/tyrant_module
+/datum/design/board/tyrant_module
 	name = "Core Module Design (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
 	req_tech = list("programming" = 5, "syndicate" = 2, "materials" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/tyrant
 	category = list("AI Modules")
 
-/datum/design/corporate_module
+/datum/design/board/corporate_module
 	name = "Core Module Design (Corporate)"
 	desc = "Allows for the construction of a Corporate AI Core Module."
 	id = "corporate_module"
 	req_tech = list("programming" = 5, "materials" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/corp
 	category = list("AI Modules")
 
-/datum/design/custom_module
+/datum/design/board/custom_module
 	name = "Core Module Design (Custom)"
 	desc = "Allows for the construction of a Custom AI Core Module."
 	id = "custom_module"
 	req_tech = list("programming" = 5, "materials" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
+	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/custom
 	category = list("AI Modules")

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -1,311 +1,253 @@
 ///////////////////Computer Boards///////////////////////////////////
 
-/datum/design/seccamera
+/datum/design/board
+	name = "Computer Design (Battle Arcade Machine)"
+	desc = "Allows for the construction of circuit boards used to build a new arcade machine."
+	id = "arcade_battle"
+	req_tech = list("programming" = 1)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	reagents = list("sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/computer/arcade/battle
+	category = list("Computer Boards")
+
+/datum/design/board/orion_trail
+	name = "Computer Design (Orion Trail Arcade Machine)"
+	desc = "Allows for the construction of circuit boards used to build a new Orion Trail machine."
+	id = "arcade_orion"
+	req_tech = list("programming" = 1)
+	build_path = /obj/item/weapon/circuitboard/computer/arcade/orion_trail
+	category = list("Computer Boards")
+
+
+/datum/design/board/seccamera
 	name = "Computer Design (Security)"
 	desc = "Allows for the construction of circuit boards used to build security camera computers."
 	id = "seccamera"
 	req_tech = list("programming" = 2, "combat" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/security
 	category = list("Computer Boards")
 
-/datum/design/aiupload
+/datum/design/board/aiupload
 	name = "Computer Design (AI Upload)"
 	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
 	id = "aiupload"
 	req_tech = list("programming" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/aiupload
 	category = list("Computer Boards")
 
-/datum/design/borgupload
+/datum/design/board/borgupload
 	name = "Computer Design (Cyborg Upload)"
 	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
 	id = "borgupload"
 	req_tech = list("programming" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/borgupload
 	category = list("Computer Boards")
 
-/datum/design/med_data
+/datum/design/board/med_data
 	name = "Computer Design (Medical Records)"
 	desc = "Allows for the construction of circuit boards used to build a medical records console."
 	id = "med_data"
 	req_tech = list("programming" = 2, "biotech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/med_data
 	category = list("Computer Boards")
 
-/datum/design/operating
+/datum/design/board/operating
 	name = "Computer Design (Operating Computer)"
 	desc = "Allows for the construction of circuit boards used to build an operating computer console."
 	id = "operating"
 	req_tech = list("programming" = 2, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/operating
 	category = list("Computer Boards")
 
-/datum/design/pandemic
+/datum/design/board/pandemic
 	name = "Computer Design (PanD.E.M.I.C. 2200)"
 	desc = "Allows for the construction of circuit boards used to build a PanD.E.M.I.C. 2200 console."
 	id = "pandemic"
 	req_tech = list("programming" = 3, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/pandemic
 	category = list("Computer Boards")
 
-/datum/design/scan_console
+/datum/design/board/scan_console
 	name = "Computer Design (DNA Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new DNA scanning console."
 	id = "scan_console"
 	req_tech = list("programming" = 2, "biotech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/scan_consolenew
 	category = list("Computer Boards")
 
-/datum/design/comconsole
+/datum/design/board/comconsole
 	name = "Computer Design (Communications)"
 	desc = "Allows for the construction of circuit boards used to build a communications console."
 	id = "comconsole"
 	req_tech = list("programming" = 3, "magnets" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/communications
 	category = list("Computer Boards")
 
-/datum/design/idcardconsole
+/datum/design/board/idcardconsole
 	name = "Computer Design (ID Console)"
 	desc = "Allows for the construction of circuit boards used to build an ID computer."
 	id = "idcardconsole"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/card
 	category = list("Computer Boards")
 
-/datum/design/crewconsole
+/datum/design/board/crewconsole
 	name = "Computer Design (Crew monitoring computer)"
 	desc = "Allows for the construction of circuit boards used to build a Crew monitoring computer."
 	id = "crewconsole"
 	req_tech = list("programming" = 3, "magnets" = 2, "biotech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/crew
 	category = list("Computer Boards")
 
-/datum/design/secdata
+/datum/design/board/secdata
 	name = "Computer Design (Security Records Console)"
 	desc = "Allows for the construction of circuit boards used to build a security records console."
 	id = "secdata"
 	req_tech = list("programming" = 2, "combat" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/secure_data
 	category = list("Computer Boards")
 
-/datum/design/atmosalerts
+/datum/design/board/atmosalerts
 	name = "Computer Design (Atmosphere Alert)"
 	desc = "Allows for the construction of circuit boards used to build an atmosphere alert console."
 	id = "atmosalerts"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/atmos_alert
 	category = list("Computer Boards")
 
-/datum/design/atmos_control
+/datum/design/board/atmos_control
 	name = "Computer Design (Atmospheric Monitor)"
 	desc = "Allows for the construction of circuit boards used to build an Atmospheric Monitor."
 	id = "atmos_control"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/atmos_control
 	category = list("Computer Boards")
 
-/datum/design/robocontrol
+/datum/design/board/robocontrol
 	name = "Computer Design (Robotics Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a Robotics Control console."
 	id = "robocontrol"
 	req_tech = list("programming" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/robotics
 	category = list("Computer Boards")
 
-/datum/design/arcadebattle
-	name = "Computer Design (Battle Arcade Machine)"
-	desc = "Allows for the construction of circuit boards used to build a new arcade machine."
-	id = "arcademachine"
-	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
-	build_path = /obj/item/weapon/circuitboard/computer/arcade/battle
-	category = list("Computer Boards")
-
-/datum/design/orion_trail
-	name = "Computer Design (Orion Trail Arcade Machine)"
-	desc = "Allows for the construction of circuit boards used to build a new Orion Trail machine."
-	id = "arcademachine"
-	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
-	build_path = /obj/item/weapon/circuitboard/computer/arcade/orion_trail
-	category = list("Computer Boards")
-
-/datum/design/slot_machine
+/datum/design/board/slot_machine
 	name = "Computer Design (Slot Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new slot machine."
 	id = "slotmachine"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/slot_machine
 	category = list("Computer Boards")
 
-/datum/design/powermonitor
+/datum/design/board/powermonitor
 	name = "Computer Design (Power Monitor)"
 	desc = "Allows for the construction of circuit boards used to build a new power monitor."
 	id = "powermonitor"
 	req_tech = list("programming" = 2, "powerstorage" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/powermonitor
 	category = list("Computer Boards")
 
-/datum/design/solarcontrol
+/datum/design/board/solarcontrol
 	name = "Computer Design (Solar Control)"
 	desc = "Allows for the construction of circuit boards used to build a solar control console."
 	id = "solarcontrol"
 	req_tech = list("programming" = 2, "powerstorage" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/solar_control
 	category = list("Computer Boards")
 
-/datum/design/prisonmanage
+/datum/design/board/prisonmanage
 	name = "Computer Design (Prisoner Management Console)"
 	desc = "Allows for the construction of circuit boards used to build a prisoner management console."
 	id = "prisonmanage"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/prisoner
 	category = list("Computer Boards")
 
-/datum/design/mechacontrol
+/datum/design/board/mechacontrol
 	name = "Computer Design (Exosuit Control Console)"
 	desc = "Allows for the construction of circuit boards used to build an exosuit control console."
 	id = "mechacontrol"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/mecha_control
 	category = list("Computer Boards")
 
-/datum/design/mechapower
+/datum/design/board/mechapower
 	name = "Computer Design (Mech Bay Power Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a mech bay power control console."
 	id = "mechapower"
 	req_tech = list("programming" = 3, "powerstorage" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/mech_bay_power_console
 	category = list("Computer Boards")
 
-/datum/design/rdconsole
+/datum/design/board/rdconsole
 	name = "Computer Design (R&D Console)"
 	desc = "Allows for the construction of circuit boards used to build a new R&D console."
 	id = "rdconsole"
 	req_tech = list("programming" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/rdconsole
 	category = list("Computer Boards")
 
-/datum/design/cargo
+/datum/design/board/cargo
 	name = "Computer Design (Supply Console)"
 	desc = "Allows for the construction of circuit boards used to build a Supply Console."
 	id = "cargo"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/cargo
 	category = list("Computer Boards")
 
-/datum/design/cargorequest
+/datum/design/board/cargorequest
 	name = "Computer Design (Supply Request Console)"
 	desc = "Allows for the construction of circuit boards used to build a Supply Request Console."
 	id = "cargorequest"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/cargo/request
 	category = list("Computer Boards")
 
-/datum/design/mining
+/datum/design/board/mining
 	name = "Computer Design (Outpost Status Display)"
 	desc = "Allows for the construction of circuit boards used to build an outpost status display console."
 	id = "mining"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/mining
 	category = list("Computer Boards")
 
-/datum/design/comm_monitor
+/datum/design/board/comm_monitor
 	name = "Computer Design (Telecommunications Monitoring Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunications monitor."
 	id = "comm_monitor"
 	req_tech = list("programming" = 3, "magnets" = 3, "bluespace" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/comm_monitor
 	category = list("Computer Boards")
 
-/datum/design/comm_server
+/datum/design/board/comm_server
 	name = "Computer Design (Telecommunications Server Monitoring Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunication server browser and monitor."
 	id = "comm_server"
 	req_tech = list("programming" = 3, "magnets" = 3, "bluespace" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/comm_server
 	category = list("Computer Boards")
 
-/datum/design/message_monitor
+/datum/design/board/message_monitor
 	name = "Computer Design (Messaging Monitor Console)"
 	desc = "Allows for the construction of circuit boards used to build a messaging monitor console."
 	id = "message_monitor"
 	req_tech = list("programming" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/message_monitor
 	category = list("Computer Boards")
 
-/datum/design/aifixer
+/datum/design/board/aifixer
 	name = "Computer Design (AI Integrity Restorer)"
 	desc = "Allows for the construction of circuit boards used to build an AI Integrity Restorer."
 	id = "aifixer"
 	req_tech = list("programming" = 4, "magnets" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/aifixer
 	category = list("Computer Boards")
 
-/datum/design/libraryconsole
+/datum/design/board/libraryconsole
 	name = "Computer Design (Library Console)"
 	desc = "Allows for the construction of circuit boards used to build a new library console."
 	id = "libraryconsole"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/libraryconsole
 	category = list("Computer Boards")

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -2,482 +2,387 @@
 //////////////MISC Boards///////////////
 ////////////////////////////////////////
 
-/datum/design/smes
+/datum/design/board/smes
 	name = "Machine Design (SMES Board)"
 	desc = "The circuit board for a SMES."
 	id = "smes"
 	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/smes
 	category = list ("Engineering Machinery")
 
-/datum/design/announcement_system
+/datum/design/board/announcement_system
 	name = "Machine Design (Automated Announcement System Board)"
 	desc = "The circuit board for an automated announcement system."
 	id = "automated_announcement"
 	req_tech = list("programming" = 3, "bluespace" = 3, "magnets" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/announcement_system
 	category = list("Subspace Telecomms")
 
-/datum/design/turbine_computer
+/datum/design/board/turbine_computer
 	name = "Computer Design (Power Turbine Console Board)"
 	desc = "The circuit board for a power turbine console."
 	id = "power_turbine_console"
 	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/turbine_computer
 	category = list ("Engineering Machinery")
 
-/datum/design/emitter
+/datum/design/board/emitter
 	name = "Machine Design (Emitter Board)"
 	desc = "The circuit board for an emitter."
 	id = "emitter"
 	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/emitter
 	category = list ("Engineering Machinery")
 
-/datum/design/power_compressor
+/datum/design/board/power_compressor
 	name = "Machine Design (Power Compressor Board)"
 	desc = "The circuit board for a power compressor."
 	id = "power_compressor"
 	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/power_compressor
 	category = list ("Engineering Machinery")
 
-/datum/design/power_turbine
+/datum/design/board/power_turbine
 	name = "Machine Design (Power Turbine Board)"
 	desc = "The circuit board for a power turbine."
 	id = "power_turbine"
 	req_tech = list("programming" = 4, "powerstorage" = 4, "engineering" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/power_turbine
 	category = list ("Engineering Machinery")
 
-/datum/design/thermomachine
+/datum/design/board/thermomachine
 	name = "Machine Design (Freezer/Heater Board)"
 	desc = "The circuit board for a freezer/heater."
 	id = "thermomachine"
 	req_tech = list("programming" = 3, "plasmatech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/thermomachine
 	category = list ("Engineering Machinery")
 
-/datum/design/space_heater
+/datum/design/board/space_heater
 	name = "Machine Design (Space Heater Board)"
 	desc = "The circuit board for a space heater."
 	id = "space_heater"
 	req_tech = list("programming" = 2, "engineering" = 2, "plasmatech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/space_heater
 	category = list ("Engineering Machinery")
 
-/datum/design/teleport_station
+/datum/design/board/teleport_station
 	name = "Machine Design (Teleportation Station Board)"
 	desc = "The circuit board for a teleportation station."
 	id = "tele_station"
 	req_tech = list("programming" = 5, "bluespace" = 4, "engineering" = 4, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/teleporter_station
 	category = list ("Teleportation Machinery")
 
-/datum/design/teleport_hub
+/datum/design/board/teleport_hub
 	name = "Machine Design (Teleportation Hub Board)"
 	desc = "The circuit board for a teleportation hub."
 	id = "tele_hub"
 	req_tech = list("programming" = 3, "bluespace" = 5, "materials" = 4, "engineering" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/teleporter_hub
 	category = list ("Teleportation Machinery")
 
-/datum/design/telepad
+/datum/design/board/telepad
 	name = "Machine Design (Telepad Board)"
 	desc = "The circuit board for a telescience telepad."
 	id = "telepad"
 	req_tech = list("programming" = 4, "bluespace" = 5, "plasmatech" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telesci_pad
 	category = list ("Teleportation Machinery")
 
-/datum/design/teleconsole
+/datum/design/board/teleconsole
 	name = "Computer Design (Teleporter Console)"
 	desc = "Allows for the construction of circuit boards used to build a teleporter control console."
 	id = "teleconsole"
 	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/teleporter
 	category = list("Teleportation Machinery")
 
-/datum/design/telesci_console
+/datum/design/board/telesci_console
 	name = "Computer Design (Telepad Control Console Board)"
 	desc = "Allows for the construction of circuit boards used to build a telescience console."
 	id = "telesci_console"
 	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/telesci_console
 	category = list("Teleportation Machinery")
 
-/datum/design/sleeper
+/datum/design/board/sleeper
 	name = "Machine Design (Sleeper Board)"
 	desc = "The circuit board for a sleeper."
 	id = "sleeper"
 	req_tech = list("programming" = 3, "biotech" = 2, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/sleeper
 	category = list ("Medical Machinery")
 
-/datum/design/cryotube
+/datum/design/board/cryotube
 	name = "Machine Design (Cryotube Board)"
 	desc = "The circuit board for a cryotube."
 	id = "cryotube"
 	req_tech = list("programming" = 5, "biotech" = 3, "engineering" = 4, "plasmatech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/cryo_tube
 	category = list ("Medical Machinery")
 
-/datum/design/chem_dispenser
+/datum/design/board/chem_dispenser
 	name = "Machine Design (Portable Chem Dispenser Board)"
 	desc = "The circuit board for a portable chem dispenser."
 	id = "chem_dispenser"
 	req_tech = list("programming" = 5, "biotech" = 3, "materials" = 4, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_dispenser
 	category = list ("Medical Machinery")
 
-/datum/design/chem_master
+/datum/design/board/chem_master
 	name = "Machine Design (Chem Master Board)"
-	desc = "The circuit board for a Chem Master 2999."
+	desc = "The circuit board for a Chem Master 3000."
 	id = "chem_master"
 	req_tech = list("biotech" = 3, "materials" = 3, "programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_master
 	category = list ("Medical Machinery")
 
-/datum/design/chem_heater
+/datum/design/board/chem_heater
 	name = "Machine Design (Chemical Heater Board)"
 	desc = "The circuit board for a chemical heater."
 	id = "chem_heater"
 	req_tech = list("engineering" = 2, "biotech" = 2, "programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_heater
 	category = list ("Medical Machinery")
 
-/datum/design/clonecontrol
+/datum/design/board/clonecontrol
 	name = "Computer Design (Cloning Machine Console)"
 	desc = "Allows for the construction of circuit boards used to build a new Cloning Machine console."
 	id = "clonecontrol"
 	req_tech = list("programming" = 4, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/cloning
 	category = list("Medical Machinery")
 
-/datum/design/clonepod
+/datum/design/board/clonepod
 	name = "Machine Design (Clone Pod)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Pod."
 	id = "clonepod"
 	req_tech = list("programming" = 4, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/clonepod
 	category = list("Medical Machinery")
 
-/datum/design/clonescanner
+/datum/design/board/clonescanner
 	name = "Machine Design (Cloning Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Scanner."
 	id = "clonescanner"
 	req_tech = list("programming" = 4, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/clonescanner
 	category = list("Medical Machinery")
 
-/datum/design/biogenerator
+/datum/design/board/biogenerator
 	name = "Machine Design (Biogenerator Board)"
 	desc = "The circuit board for a biogenerator."
 	id = "biogenerator"
 	req_tech = list("programming" = 2, "biotech" = 3, "materials" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/biogenerator
 	category = list ("Hydroponics Machinery")
 
-/datum/design/hydroponics
+/datum/design/board/hydroponics
 	name = "Machine Design (Hydroponics Tray Board)"
 	desc = "The circuit board for a hydroponics tray."
 	id = "hydro_tray"
 	req_tech = list("biotech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/hydroponics
 	category = list ("Hydroponics Machinery")
 
-/datum/design/destructive_analyzer
+/datum/design/board/destructive_analyzer
 	name = "Machine Design (Destructive Analyzer Board)"
 	desc = "The circuit board for a destructive analyzer."
 	id = "destructive_analyzer"
 	req_tech = list("programming" = 2, "magnets" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/destructive_analyzer
 	category = list("Research Machinery")
 
-/datum/design/experimentor
+/datum/design/board/experimentor
 	name = "Machine Design (E.X.P.E.R.I-MENTOR Board)"
 	desc = "The circuit board for an E.X.P.E.R.I-MENTOR."
 	id = "experimentor"
 	req_tech = list("programming" = 2, "magnets" = 2, "engineering" = 2, "bluespace" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/experimentor
 	category = list("Research Machinery")
 
-/datum/design/protolathe
+/datum/design/board/protolathe
 	name = "Machine Design (Protolathe Board)"
 	desc = "The circuit board for a protolathe."
 	id = "protolathe"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/protolathe
 	category = list("Research Machinery")
 
-/datum/design/circuit_imprinter
+/datum/design/board/circuit_imprinter
 	name = "Machine Design (Circuit Imprinter Board)"
 	desc = "The circuit board for a circuit imprinter."
 	id = "circuit_imprinter"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/circuit_imprinter
 	category = list("Research Machinery")
 
-/datum/design/rdservercontrol
+/datum/design/board/rdservercontrol
 	name = "Computer Design (R&D Server Control Console Board)"
 	desc = "The circuit board for an R&D Server Control Console."
 	id = "rdservercontrol"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/rdservercontrol
 	category = list("Research Machinery")
 
-/datum/design/rdserver
+/datum/design/board/rdserver
 	name = "Machine Design (R&D Server Board)"
 	desc = "The circuit board for an R&D Server."
 	id = "rdserver"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/rdserver
 	category = list("Research Machinery")
 
-/datum/design/mechfab
+/datum/design/board/mechfab
 	name = "Machine Design (Exosuit Fabricator Board)"
 	desc = "The circuit board for an Exosuit Fabricator."
 	id = "mechfab"
 	req_tech = list("programming" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/mechfab
 	category = list("Research Machinery")
 
-/datum/design/cyborgrecharger
+/datum/design/board/cyborgrecharger
 	name = "Machine Design (Cyborg Recharger Board)"
 	desc = "The circuit board for a Cyborg Recharger."
 	id = "cyborgrecharger"
 	req_tech = list("powerstorage" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/cyborgrecharger
 	category = list("Research Machinery")
 
-/datum/design/mech_recharger
+/datum/design/board/mech_recharger
 	name = "Machine Design (Mechbay Recharger Board)"
 	desc = "The circuit board for a Mechbay Recharger."
 	id = "mech_recharger"
 	req_tech = list("programming" = 3, "powerstorage" = 4, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/mech_recharger
 	category = list("Research Machinery")
 
-/datum/design/microwave
+/datum/design/board/microwave
 	name = "Machine Design (Microwave Board)"
 	desc = "The circuit board for a microwave."
 	id = "microwave"
 	req_tech = list("programming" = 2, "magnets" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/microwave
 	category = list ("Misc. Machinery")
 
-/datum/design/gibber
+/datum/design/board/gibber
 	name = "Machine Design (Gibber Board)"
 	desc = "The circuit board for a gibber."
 	id = "gibber"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/gibber
 	category = list ("Misc. Machinery")
 
-/datum/design/smartfridge
+/datum/design/board/smartfridge
 	name = "Machine Design (Smartfridge Board)"
 	desc = "The circuit board for a smartfridge."
 	id = "smartfridge"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/smartfridge
 	category = list ("Misc. Machinery")
 
-/datum/design/monkey_recycler
+/datum/design/board/monkey_recycler
 	name = "Machine Design (Monkey Recycler Board)"
 	desc = "The circuit board for a monkey recycler."
 	id = "smartfridge"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/monkey_recycler
 	category = list ("Misc. Machinery")
 
-/datum/design/seed_extractor
+/datum/design/board/seed_extractor
 	name = "Machine Design (Seed Extractor Board)"
 	desc = "The circuit board for a seed extractor."
 	id = "seed_extractor"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/seed_extractor
 	category = list ("Misc. Machinery")
 
-/datum/design/processor
+/datum/design/board/processor
 	name = "Machine Design (Processor Board)"
 	desc = "The circuit board for a processor."
 	id = "processor"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/processor
 	category = list ("Misc. Machinery")
 
-/datum/design/recycler
+/datum/design/board/recycler
 	name = "Machine Design (Recycler Board)"
 	desc = "The circuit board for a recycler."
 	id = "recycler"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/recycler
 	category = list ("Misc. Machinery")
 
-/datum/design/holopad
+/datum/design/board/holopad
 	name = "Machine Design (AI Holopad Board)"
 	desc = "The circuit board for a holopad."
 	id = "holopad"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/holopad
 	category = list ("Misc. Machinery")
 
-/datum/design/autolathe
+/datum/design/board/autolathe
 	name = "Machine Design (Autolathe Board)"
 	desc = "The circuit board for an autolathe."
 	id = "autolathe"
 	req_tech = list("programming" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/autolathe
 	category = list ("Misc. Machinery")
 
-/datum/design/recharger
+/datum/design/board/recharger
 	name = "Machine Design (Weapon Recharger Board)"
 	desc = "The circuit board for a Weapon Recharger."
 	id = "recharger"
 	req_tech = list("powerstorage" = 4, "engineering" = 3, "materials" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/circuitboard/machine/recharger
 	category = list("Misc. Machinery")
 
-/datum/design/vendor
+/datum/design/board/vendor
 	name = "Machine Design (Vendor Board)"
 	desc = "The circuit board for a Vendor."
 	id = "vendor"
 	req_tech = list("programming" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/vendor
 	category = list ("Misc. Machinery")
 
-/datum/design/ore_redemption
+/datum/design/board/ore_redemption
 	name = "Machine Design (Ore Redemption Board)"
 	desc = "The circuit board for an Ore Redemption machine."
 	id = "ore_redemption"
 	req_tech = list("programming" = 2, "engineering" = 2, "plasmatech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/ore_redemption
 	category = list ("Misc. Machinery")
 
-/datum/design/mining_equipment_vendor
+/datum/design/board/mining_equipment_vendor
 	name = "Machine Design (Mining Rewards Vender Board)"
 	desc = "The circuit board for a Mining Rewards Vender."
 	id = "mining_equipment_vendor"
 	req_tech = list("engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/mining_equipment_vendor
 	category = list ("Misc. Machinery")
 
-/datum/design/tesla_coil
+/datum/design/board/tesla_coil
 	name = "Machine Design (Tesla Coil Board)"
 	desc = "The circuit board for a tesla coil."
 	id = "tesla_coil"
 	req_tech = list("programming" = 3, "powerstorage" = 3, "magnets" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/tesla_coil
 	category = list ("Misc. Machinery")
 
-/datum/design/grounding_rod
+/datum/design/board/grounding_rod
 	name = "Machine Design (Grounding Rod Board)"
 	desc = "The circuit board for a grounding rod."
 	id = "grounding_rod"
 	req_tech = list("programming" = 3, "powerstorage" = 3, "magnets" = 3, "plasmatech" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/grounding_rod
 	category = list ("Misc. Machinery")
 
-/datum/design/plantgenes
+/datum/design/board/plantgenes
 	name = "Machine Design (Plant DNA Manipulator Board)"
 	desc = "The circuit board for a plant DNA manipulator."
 	id = "plantgenes"
 	req_tech = list("programming" = 4, "biotech" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/plantgenes
 	category = list ("Misc. Machinery")

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -2,163 +2,136 @@
 //////////Mecha Module Disks///////
 ///////////////////////////////////
 
-/datum/design/ripley_main
+/datum/design/board/ripley_main
 	name = "APLU \"Ripley\" Central Control module"
 	desc = "Allows for the construction of a \"Ripley\" Central Control module."
 	id = "ripley_main"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
 	category = list("Exosuit Modules")
 
-/datum/design/ripley_peri
+/datum/design/board/ripley_peri
 	name = "APLU \"Ripley\" Peripherals Control module"
 	desc = "Allows for the construction of a  \"Ripley\" Peripheral Control module."
 	id = "ripley_peri"
 	req_tech = list("programming" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/odysseus_main
+
+/datum/design/board/odysseus_main
 	name = "\"Odysseus\" Central Control module"
 	desc = "Allows for the construction of a \"Odysseus\" Central Control module."
 	id = "odysseus_main"
 	req_tech = list("programming" = 3,"biotech" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/main
 	category = list("Exosuit Modules")
 
-/datum/design/odysseus_peri
+/datum/design/board/odysseus_peri
 	name = "\"Odysseus\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Odysseus\" Peripheral Control module."
 	id = "odysseus_peri"
 	req_tech = list("programming" = 3,"biotech" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/gygax_main
+
+/datum/design/board/gygax_main
 	name = "\"Gygax\" Central Control module"
 	desc = "Allows for the construction of a \"Gygax\" Central Control module."
 	id = "gygax_main"
 	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/main
 	category = list("Exosuit Modules")
 
-/datum/design/gygax_peri
+/datum/design/board/gygax_peri
 	name = "\"Gygax\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Gygax\" Peripheral Control module."
 	id = "gygax_peri"
 	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/gygax_targ
+/datum/design/board/gygax_targ
 	name = "\"Gygax\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Gygax\" Weapons & Targeting Control module."
 	id = "gygax_targ"
 	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/targeting
 	category = list("Exosuit Modules")
 
-/datum/design/durand_main
+
+/datum/design/board/durand_main
 	name = "\"Durand\" Central Control module"
 	desc = "Allows for the construction of a \"Durand\" Central Control module."
 	id = "durand_main"
 	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
 	category = list("Exosuit Modules")
 
-/datum/design/durand_peri
+/datum/design/board/durand_peri
 	name = "\"Durand\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Durand\" Peripheral Control module."
 	id = "durand_peri"
 	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/durand_targ
+/datum/design/board/durand_targ
 	name = "\"Durand\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Durand\" Weapons & Targeting Control module."
 	id = "durand_targ"
 	req_tech = list("programming" = 5, "combat" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
 	category = list("Exosuit Modules")
 
-/datum/design/honker_main
+
+/datum/design/board/honker_main
 	name = "\"H.O.N.K\" Central Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Central Control module."
 	id = "honker_main"
 	req_tech = list("programming" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/main
 	category = list("Exosuit Modules")
 
-/datum/design/honker_peri
+/datum/design/board/honker_peri
 	name = "\"H.O.N.K\" Peripherals Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Peripheral Control module."
 	id = "honker_peri"
 	req_tech = list("programming" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/honker_targ
+/datum/design/board/honker_targ
 	name = "\"H.O.N.K\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Weapons & Targeting Control module."
 	id = "honker_targ"
 	req_tech = list("programming" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/targeting
 	category = list("Exosuit Modules")
 
-/datum/design/phazon_main
+
+/datum/design/board/phazon_main
 	name = "\"Phazon\" Central Control module"
 	desc = "Allows for the construction of a \"Phazon\" Central Control module."
 	id = "phazon_main"
 	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/main
 	category = list("Exosuit Modules")
 
-/datum/design/phazon_peri
+/datum/design/board/phazon_peri
 	name = "\"Phazon\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Phazon\" Peripheral Control module."
 	id = "phazon_peri"
 	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/peripherals
 	category = list("Exosuit Modules")
 
-/datum/design/phazon_targ
+/datum/design/board/phazon_targ
 	name = "\"Phazon\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Phazon\" Weapons & Targeting Control module."
 	id = "phazon_targ"
 	req_tech = list("programming" = 6, "magnets" = 5, "plasmatech" = 5)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/targeting
 	category = list("Exosuit Modules")
 

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -68,32 +68,24 @@
 	build_path = /obj/item/device/lightreplacer
 	category = list("Power Designs")
 
-/datum/design/pacman
+/datum/design/board/pacman
 	name = "Machine Design (PACMAN-type Generator Board)"
 	desc = "The circuit board that for a PACMAN-type portable generator."
 	id = "pacman"
 	req_tech = list("programming" = 2, "plasmatech" = 3, "powerstorage" = 3, "engineering" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/pacman
 	category = list("Engineering Machinery")
 
-/datum/design/superpacman
+/datum/design/board/pacman/super
 	name = "Machine Design (SUPERPACMAN-type Generator Board)"
 	desc = "The circuit board that for a SUPERPACMAN-type portable generator."
 	id = "superpacman"
 	req_tech = list("programming" = 3, "powerstorage" = 4, "engineering" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/pacman/super
-	category = list("Engineering Machinery")
 
-/datum/design/mrspacman
+/datum/design/board/pacman/mrs
 	name = "Machine Design (MRSPACMAN-type Generator Board)"
 	desc = "The circuit board that for a MRSPACMAN-type portable generator."
 	id = "mrspacman"
 	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 5, "plasmatech" = 4)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/pacman/mrs
-	category = list("Engineering Machinery")

--- a/code/modules/research/designs/telecomms_designs.dm
+++ b/code/modules/research/designs/telecomms_designs.dm
@@ -2,72 +2,58 @@
 /////Subspace Telecomms////////////
 ///////////////////////////////////
 
-/datum/design/subspace_receiver
+/datum/design/board/subspace_receiver
 	name = "Machine Design (Subspace Receiver)"
 	desc = "Allows for the construction of Subspace Receiver equipment."
 	id = "s-receiver"
 	req_tech = list("programming" = 2, "engineering" = 2, "bluespace" = 1)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/receiver
 	category = list("Subspace Telecomms")
 
-/datum/design/telecomms_bus
+/datum/design/board/telecomms_bus
 	name = "Machine Design (Bus Mainframe)"
 	desc = "Allows for the construction of Telecommunications Bus Mainframes."
 	id = "s-bus"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/bus
 	category = list("Subspace Telecomms")
 
-/datum/design/telecomms_hub
+/datum/design/board/telecomms_hub
 	name = "Machine Design (Hub Mainframe)"
 	desc = "Allows for the construction of Telecommunications Hub Mainframes."
 	id = "s-hub"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/hub
 	category = list("Subspace Telecomms")
 
-/datum/design/telecomms_relay
+/datum/design/board/telecomms_relay
 	name = "Machine Design (Relay Mainframe)"
 	desc = "Allows for the construction of Telecommunications Relay Mainframes."
 	id = "s-relay"
 	req_tech = list("programming" = 2, "engineering" = 2, "bluespace" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/relay
 	category = list("Subspace Telecomms")
 
-/datum/design/telecomms_processor
+/datum/design/board/telecomms_processor
 	name = "Machine Design (Processor Unit)"
 	desc = "Allows for the construction of Telecommunications Processor equipment."
 	id = "s-processor"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/processor
 	category = list("Subspace Telecomms")
 
-/datum/design/telecomms_server
+/datum/design/board/telecomms_server
 	name = "Machine Design (Server Mainframe)"
 	desc = "Allows for the construction of Telecommunications Servers."
 	id = "s-server"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/server
 	category = list("Subspace Telecomms")
 
-/datum/design/subspace_broadcaster
+/datum/design/board/subspace_broadcaster
 	name = "Machine Design (Subspace Broadcaster)"
 	desc = "Allows for the construction of Subspace Broadcasting equipment."
 	id = "s-broadcaster"
 	req_tech = list("programming" = 2, "engineering" = 2)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/broadcaster
 	category = list("Subspace Telecomms")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -200,7 +200,7 @@
 //WT550 Mags
 
 /datum/design/mag_oldsmg
-	name = "WT-550 Auto Gun Magazine (4.6×30mm)"
+	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
 	desc = "A 20 round magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg"
 	req_tech = list("combat" = 1, "materials" = 1)
@@ -210,21 +210,21 @@
 	category = list("Ammo")
 
 /datum/design/mag_oldsmg/ap_mag
-	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6×30mm AP)"
+	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ap"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
 
 /datum/design/mag_oldsmg/ic_mag
-	name = "WT-550 Auto Gun Incendiary Magazine (4.6×30mm IC)"
+	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ic"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_GLASS = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
 
 /datum/design/mag_oldsmg/tx_mag
-	name = "WT-550 Auto Gun Uranium Magazine (4.6×30mm TX)"
+	name = "WT-550 Auto Gun Uranium Magazine (4.6x30mm TX)"
 	desc = "A 20 round uranium tipped magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_tx"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_URANIUM = 2000)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -29,16 +29,13 @@ Note: Must be placed west/left of and R&D console to function.
 								"Firing Pins"
 								)
 
-	reagents = new()
-
 
 /obj/machinery/r_n_d/protolathe/New()
 	..()
-	materials = new(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_PLASMA=1, MAT_URANIUM=1, MAT_BANANIUM=1))
+	create_reagents(0)
+	materials = new(src, list(MAT_METAL, MAT_GLASS, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_PLASMA, MAT_URANIUM, MAT_BANANIUM))
 	var/obj/item/weapon/circuitboard/machine/B = new /obj/item/weapon/circuitboard/machine/protolathe(null)
 	B.apply_default_parts(src)
-
-	reagents.my_atom = src
 
 /obj/item/weapon/circuitboard/machine/protolathe
 	name = "circuit board (Protolathe)"
@@ -66,13 +63,13 @@ Note: Must be placed west/left of and R&D console to function.
 	efficiency_coeff = min(max(0, T), 1)
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, M)	// now returns how many times the item can be built with the material
+	var/list/all_materials = being_built.reagents + being_built.materials
+
 	var/A = materials.amount(M)
 	if(!A)
 		A = reagents.get_reagent_amount(M)
-		A = A / max(1, (being_built.reagents[M]))
-	else
-		A = A / max(1, (being_built.materials[M]))
-	return A
+
+	return round(A / max(1, (all_materials[M]*efficiency_coeff)))
 
 //we eject the materials upon deconstruction.
 /obj/machinery/r_n_d/protolathe/deconstruction()
@@ -88,11 +85,15 @@ Note: Must be placed west/left of and R&D console to function.
 
 /obj/machinery/r_n_d/protolathe/Insert_Item(obj/item/O, mob/user)
 
-	if(istype(O,/obj/item/stack/sheet))
+	if(istype(O, /obj/item/stack/sheet))
 		. = 1
-		if(!is_insertion_ready(user) || busy)
+		if(!is_insertion_ready(user))
 			return
-		if(!materials.has_space( materials.get_item_material_amount(O) ))
+		var/sheet_material = materials.get_item_material_amount(O)
+		if(!sheet_material)
+			return
+
+		if(!materials.has_space(sheet_material))
 			user << "<span class='warning'>The [src.name]'s material bin is full! Please remove material before adding more.</span>"
 			return 1
 
@@ -116,5 +117,6 @@ Note: Must be placed west/left of and R&D console to function.
 
 	else if(user.a_intent != "harm")
 		user << "<span class='warning'>You cannot insert this item into the [name]!</span>"
+		return 1
 	else
 		return 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -45,6 +45,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/screen = 1.0	//Which screen is currently showing.
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
+	var/first_use = 1	//If first_use = 1, it will try to auto-connect with nearby devices
 
 	req_access = list(access_tox)	//Data and setting manipulation requires scientist access.
 
@@ -53,37 +54,20 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 
 /proc/CallTechName(ID) //A simple helper proc to find the name of a tech with a given ID.
-	for(var/T in subtypesof(/datum/tech))
-		var/datum/tech/tt = T
-		if(initial(tt.id) == ID)
-			return initial(tt.name)
+	if(tech_list[ID])
+		var/datum/tech/tech = tech_list[ID]
+		return tech.name
+	return "ERROR: Report This"
 
-proc/CallMaterialName(ID)
-	if (copytext(ID, 1, 2) == "$")
-		var/return_name = copytext(ID, 2)
-		switch(return_name)
-			if("metal")
-				return_name = "Metal"
-			if("glass")
-				return_name = "Glass"
-			if("gold")
-				return_name = "Gold"
-			if("silver")
-				return_name = "Silver"
-			if("plasma")
-				return_name = "Solid Plasma"
-			if("uranium")
-				return_name = "Uranium"
-			if("diamond")
-				return_name = "Diamond"
-			if("clown")
-				return_name = "Bananium"
-		return return_name
-	else
-		for(var/R in subtypesof(/datum/reagent))
-			var/datum/reagent/rr = R
-			if(initial(rr.id) == ID)
-				return initial(rr.name)
+/proc/CallMaterialName(ID)
+	if (copytext(ID, 1, 2) == "$" && materials_list[ID])
+		var/datum/material/material = materials_list[ID]
+		return material.name
+
+	else if(chemical_reagents_list[ID])
+		var/datum/reagent/reagent = chemical_reagents_list[ID]
+		return reagent.name
+	return "ERROR: Report This"
 
 /obj/machinery/computer/rdconsole/proc/SyncRDevices() //Makes sure it is properly sync'ed up with the devices attached to it (if any).
 	for(var/obj/machinery/r_n_d/D in oview(3,src))
@@ -101,7 +85,7 @@ proc/CallMaterialName(ID)
 			if(linked_imprinter == null)
 				linked_imprinter = D
 				D.linked_console = src
-	return
+	first_use = 0
 
 //Have it automatically push research to the centcom server so wild griffins can't fuck up R&D's work --NEO
 /obj/machinery/computer/rdconsole/proc/griefProtection()
@@ -123,9 +107,6 @@ proc/CallMaterialName(ID)
 		for(var/obj/machinery/r_n_d/server/centcom/S in machines)
 			S.initialize()
 			break
-
-/obj/machinery/computer/rdconsole/initialize()
-	SyncRDevices()
 
 /*	Instead of calling this every tick, it is only being called when needed
 /obj/machinery/computer/rdconsole/process()
@@ -231,10 +212,15 @@ proc/CallMaterialName(ID)
 		var/datum/design/D = files.known_designs[href_list["copy_design_ID"]]
 		if(D)
 			var/autolathe_friendly = 1
-			for(var/x in D.materials)
-				if( !(x in list(MAT_METAL, MAT_GLASS)))
-					autolathe_friendly = 0
-					D.category -= "Imported"
+			if(D.reagents.len)
+				autolathe_friendly = 0
+				D.category -= "Imported"
+			else
+				for(var/x in D.materials)
+					if( !(x in list(MAT_METAL, MAT_GLASS)))
+						autolathe_friendly = 0
+						D.category -= "Imported"
+
 			if(D.build_type & (AUTOLATHE|PROTOLATHE|CRAFTLATHE)) // Specifically excludes circuit imprinter and mechfab
 				D.build_type = autolathe_friendly ? (D.build_type | AUTOLATHE) : D.build_type
 				D.category |= "Imported"
@@ -253,60 +239,59 @@ proc/CallMaterialName(ID)
 				screen = 1.0
 
 	else if(href_list["deconstruct"]) //Deconstruct the item in the destructive analyzer and update the research holder.
-		if(linked_destroy)
-			if(linked_destroy.busy)
-				usr << "<span class='danger'>The destructive analyzer is busy at the moment.</span>"
-				return
-			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
-			var/cancontinue = FALSE
-			for(var/T in temp_tech)
-				if(files.IsTechHigher(T, temp_tech[T]))
-					cancontinue = TRUE
-					break
-			if(!cancontinue)
-				var/choice = input("This item does not raise tech levels. Proceed destroying loaded item anyway?") in list("Proceed", "Cancel")
-				if(choice == "Cancel" || !linked_destroy) return
-			linked_destroy.busy = 1
-			screen = 0.1
+		if(!linked_destroy || linked_destroy.busy || !linked_destroy.loaded_item)
 			updateUsrDialog()
-			flick("d_analyzer_process", linked_destroy)
-			spawn(24)
-				if(linked_destroy)
-					linked_destroy.busy = 0
-					if(!linked_destroy.loaded_item)
-						usr <<"<span class='danger'>The destructive analyzer appears to be empty.</span>"
-						screen = 1.0
-						return
+			return
 
-					for(var/T in temp_tech)
-						var/datum/tech/KT = files.known_tech[T] //For stat logging of high levels
-						if(files.IsTechHigher(T, temp_tech[T]) && KT.level >= 5) //For stat logging of high levels
-							feedback_add_details("high_research_level","[KT][KT.level + 1]") //+1 to show the level which we're about to get
-						files.UpdateTech(T, temp_tech[T])
+		var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
+		var/cancontinue = FALSE
+		for(var/T in temp_tech)
+			if(files.IsTechHigher(T, temp_tech[T]))
+				cancontinue = TRUE
+				break
+		if(!cancontinue)
+			var/choice = input("This item does not raise tech levels. Proceed destroying loaded item anyway?") in list("Proceed", "Cancel")
+			if(choice == "Cancel" || !linked_destroy || !linked_destroy.loaded_item) return
+		linked_destroy.busy = 1
+		screen = 0.1
+		updateUsrDialog()
+		flick("d_analyzer_process", linked_destroy)
+		spawn(24)
+			if(linked_destroy)
+				linked_destroy.busy = 0
+				if(!linked_destroy.loaded_item)
+					screen = 1.0
+					return
 
-					if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
-						for(var/material in linked_destroy.loaded_item.materials)
-							linked_lathe.materials.insert_amount(min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (linked_destroy.loaded_item.materials[material]*(linked_destroy.decon_mod/10))), material)
-						feedback_add_details("item_deconstructed","[linked_destroy.loaded_item.type]")
-					linked_destroy.loaded_item = null
-					for(var/obj/I in linked_destroy.contents)
-						for(var/mob/M in I.contents)
-							M.death()
-						if(istype(I,/obj/item/stack/sheet))//Only deconsturcts one sheet at a time instead of the entire stack
-							var/obj/item/stack/sheet/S = I
-							if(S.amount > 1)
-								S.amount--
-								linked_destroy.loaded_item = S
-							else
-								qdel(S)
-								linked_destroy.icon_state = "d_analyzer"
+				for(var/T in temp_tech)
+					var/datum/tech/KT = files.known_tech[T] //For stat logging of high levels
+					if(files.IsTechHigher(T, temp_tech[T]) && KT.level >= 5) //For stat logging of high levels
+						feedback_add_details("high_research_level","[KT][KT.level + 1]") //+1 to show the level which we're about to get
+					files.UpdateTech(T, temp_tech[T])
+
+				if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
+					for(var/material in linked_destroy.loaded_item.materials)
+						linked_lathe.materials.insert_amount(min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (linked_destroy.loaded_item.materials[material]*(linked_destroy.decon_mod/10))), material)
+					feedback_add_details("item_deconstructed","[linked_destroy.loaded_item.type]")
+				linked_destroy.loaded_item = null
+				for(var/obj/I in linked_destroy.contents)
+					for(var/mob/M in I.contents)
+						M.death()
+					if(istype(I,/obj/item/stack/sheet))//Only deconsturcts one sheet at a time instead of the entire stack
+						var/obj/item/stack/sheet/S = I
+						if(S.amount > 1)
+							S.amount--
+							linked_destroy.loaded_item = S
 						else
-							if(!(I in linked_destroy.component_parts))
-								qdel(I)
-								linked_destroy.icon_state = "d_analyzer"
-				screen = 1.0
-				use_power(250)
-				updateUsrDialog()
+							qdel(S)
+							linked_destroy.icon_state = "d_analyzer"
+					else
+						if(!(I in linked_destroy.component_parts))
+							qdel(I)
+							linked_destroy.icon_state = "d_analyzer"
+			screen = 1.0
+			use_power(250)
+			updateUsrDialog()
 
 	else if(href_list["lock"]) //Lock the console from use by anyone without tox access.
 		if(src.allowed(usr))
@@ -353,183 +338,166 @@ proc/CallMaterialName(ID)
 		sync = !sync
 
 	else if(href_list["build"]) //Causes the Protolathe to build something.
-		if(linked_lathe)
-			if(linked_lathe.busy)
-				usr << "<span class='danger'>Protolathe is busy at the moment.</span>"
-				return
-			var/coeff = linked_lathe.efficiency_coeff
-			var/g2g = 1
-			var/datum/design/being_built = files.known_designs[href_list["build"]]
-			if(being_built)
-				var/power = 2000
-				var/amount=text2num(href_list["amount"])
-				var/old_screen = screen
-				amount = max(1, min(10, amount))
-				for(var/M in being_built.materials)
-					power += round(being_built.materials[M] * amount / 5)
-				power = max(2000, power)
-				screen = 0.3
-				var/key = usr.key	//so we don't lose the info during the spawn delay
-				if (!(being_built.build_type & PROTOLATHE))
+		var/datum/design/being_built = files.known_designs[href_list["build"]]
+		var/amount = text2num(href_list["amount"])
+
+		if(!linked_lathe || !being_built || !amount)
+			updateUsrDialog()
+			return
+
+		if(linked_lathe.busy)
+			usr << "<span class='danger'>Protolathe is busy at the moment.</span>"
+			return
+
+		var/coeff = linked_lathe.efficiency_coeff
+		var/power = 1000
+		var/old_screen = screen
+
+		amount = max(1, min(10, amount))
+		for(var/M in being_built.materials)
+			power += round(being_built.materials[M] * amount / 5)
+		power = max(3000, power)
+		screen = 0.3
+		var/key = usr.key	//so we don't lose the info during the spawn delay
+		if (!(being_built.build_type & PROTOLATHE))
+			message_admins("Protolathe exploit attempted by [key_name(usr, usr.client)]!")
+			updateUsrDialog()
+			return
+
+		var/g2g = 1
+		var/enough_materials = 1
+		linked_lathe.busy = 1
+		flick("protolathe_n",linked_lathe)
+		use_power(power)
+
+		var/list/efficient_mats = list()
+		for(var/MAT in being_built.materials)
+			efficient_mats[MAT] = being_built.materials[MAT]*coeff
+
+		if(!linked_lathe.materials.has_materials(efficient_mats, amount))
+			linked_lathe.say("Not enough materials to complete prototype.")
+			enough_materials = 0
+			g2g = 0
+		else
+			for(var/R in being_built.reagents)
+				if(!linked_lathe.reagents.has_reagent(R, being_built.reagents[R]*coeff))
+					linked_lathe.say("Not enough reagents to complete prototype.")
+					enough_materials = 0
 					g2g = 0
-					message_admins("Protolathe exploit attempted by [key_name(usr, usr.client)]!")
 
-				if (g2g) //If input is incorrect, nothing happens
-					var/enough_materials = 1
-					linked_lathe.busy = 1
-					flick("protolathe_n",linked_lathe)
-					use_power(power)
+		if(enough_materials)
+			linked_lathe.materials.use_amount(efficient_mats, amount)
+			for(var/R in being_built.reagents)
+				linked_lathe.reagents.remove_reagent(R, being_built.reagents[R]*coeff)
 
-					var/list/efficient_mats = list()
-					for(var/MAT in being_built.materials)
-						efficient_mats[MAT] = being_built.materials[MAT]*coeff
-
-					if(!linked_lathe.materials.has_materials(efficient_mats, amount))
-						src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete prototype.\"</span>")
-						enough_materials = 0
-						g2g = 0
-					else
-						for(var/R in being_built.reagents)
-							if(!linked_lathe.reagents.has_reagent(R, being_built.reagents[R])*coeff)
-								src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough reagents to complete prototype.\"</span>")
-								enough_materials = 0
-								g2g = 0
-
-					if(enough_materials)
-						linked_lathe.materials.use_amount(efficient_mats, amount)
-						for(var/R in being_built.reagents)
-							linked_lathe.reagents.remove_reagent(R, being_built.reagents[R]*coeff)
-
-					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
-					spawn(32*coeff*amount**0.8)
-						if(linked_lathe)
-							if(g2g) //And if we only fail the material requirements, we still spend time and power
-								var/already_logged = 0
-								for(var/i = 0, i<amount, i++)
-									var/obj/item/new_item = new P(src)
-									if( new_item.type == /obj/item/weapon/storage/backpack/holding )
-										new_item.investigate_log("built by [key]","singulo")
-									if(!istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches
-										new_item.materials = efficient_mats.Copy()
-									new_item.loc = linked_lathe.loc
-									if(!already_logged)
-										feedback_add_details("item_printed","[new_item.type]|[amount]")
-										already_logged = 1
-							screen = old_screen
-							linked_lathe.busy = 0
-						else
-							src.visible_message("<span class='notice'>The [src.name] beeps, \"Something went wrong, production halted!\"</span>")
-							screen = 1.0
-						updateUsrDialog()
+		var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
+		spawn(32*coeff*amount**0.8)
+			if(linked_lathe)
+				if(g2g) //And if we only fail the material requirements, we still spend time and power
+					var/already_logged = 0
+					for(var/i = 0, i<amount, i++)
+						var/obj/item/new_item = new P(src)
+						if( new_item.type == /obj/item/weapon/storage/backpack/holding )
+							new_item.investigate_log("built by [key]","singulo")
+						if(!istype(new_item, /obj/item/stack/sheet)) // To avoid materials dupe glitches
+							new_item.materials = efficient_mats.Copy()
+						new_item.loc = linked_lathe.loc
+						if(!already_logged)
+							feedback_add_details("item_printed","[new_item.type]|[amount]")
+							already_logged = 1
+				screen = old_screen
+				linked_lathe.busy = 0
+			else
+				say("Protolathe connection failed. Production halted.")
+				screen = 1.0
+			updateUsrDialog()
 
 	else if(href_list["imprint"]) //Causes the Circuit Imprinter to build something.
+		var/datum/design/being_built = files.known_designs[href_list["imprint"]]
+
+		if(!linked_imprinter || !being_built)
+			updateUsrDialog()
+			return
+
+		if(linked_imprinter.busy)
+			usr << "<span class='danger'>Circuit Imprinter is busy at the moment.</span>"
+			updateUsrDialog()
+			return
+
 		var/coeff = linked_imprinter.efficiency_coeff
+
+		var/power = 1000
+		var/old_screen = screen
+		for(var/M in being_built.materials)
+			power += round(being_built.materials[M] / 5)
+		power = max(4000, power)
+		screen = 0.4
+		if (!(being_built.build_type & IMPRINTER))
+			message_admins("Circuit imprinter exploit attempted by [key_name(usr, usr.client)]!")
+			updateUsrDialog()
+			return
+
 		var/g2g = 1
-		if(linked_imprinter)
-			if(linked_imprinter.busy)
-				usr << "<span class='danger'>Circuit Imprinter is busy at the moment.</span>"
-				return
-			var/datum/design/being_built = files.known_designs[href_list["imprint"]]
-			if(being_built)
-				var/power = 2000
-				var/old_screen = screen
-				for(var/M in being_built.materials)
-					power += round(being_built.materials[M] / 5)
-				power = max(2000, power)
-				screen = 0.4
-				if (!(being_built.build_type & IMPRINTER))
+		var/enough_materials = 1
+		linked_imprinter.busy = 1
+		flick("circuit_imprinter_ani", linked_imprinter)
+		use_power(power)
+
+		var/list/efficient_mats = list()
+		for(var/MAT in being_built.materials)
+			efficient_mats[MAT] = being_built.materials[MAT]/coeff
+
+		if(!linked_imprinter.materials.has_materials(efficient_mats))
+			linked_imprinter.say("Not enough materials to complete prototype.")
+			enough_materials = 0
+			g2g = 0
+		else
+			for(var/R in being_built.reagents)
+				if(!linked_imprinter.reagents.has_reagent(R, being_built.reagents[R]/coeff))
+					linked_imprinter.say("Not enough reagents to complete prototype.")
+					enough_materials = 0
 					g2g = 0
-					message_admins("Circuit imprinter exploit attempted by [key_name(usr, usr.client)]!")
 
-				if (g2g) //Again, if input is wrong, do nothing
-					linked_imprinter.busy = 1
-					flick("circuit_imprinter_ani",linked_imprinter)
-					use_power(power)
+		if(enough_materials)
+			linked_imprinter.materials.use_amount(efficient_mats)
+			for(var/R in being_built.reagents)
+				linked_imprinter.reagents.remove_reagent(R, being_built.reagents[R]/coeff)
 
-					for(var/M in being_built.materials)
-						if(!linked_imprinter.check_mat(being_built, M))
-							src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete prototype.\"</span>")
-							g2g = 0
-							break
-						switch(M)
-							if(MAT_GLASS)
-								linked_imprinter.g_amount = max(0, (linked_imprinter.g_amount-being_built.materials[M]/coeff))
-							if(MAT_GOLD)
-								linked_imprinter.gold_amount = max(0, (linked_imprinter.gold_amount-being_built.materials[M]/coeff))
-							if(MAT_DIAMOND)
-								linked_imprinter.diamond_amount = max(0, (linked_imprinter.diamond_amount-being_built.materials[M]/coeff))
-							else
-								linked_imprinter.reagents.remove_reagent(M, being_built.materials[M]/coeff)
+		var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
+		spawn(16)
+			if(linked_imprinter)
+				if(g2g)
+					var/obj/item/new_item = new P(src)
+					new_item.loc = linked_imprinter.loc
+					new_item.materials = efficient_mats.Copy()
+					feedback_add_details("circuit_printed","[new_item.type]")
+				screen = old_screen
+				linked_imprinter.busy = 0
+			else
+				say("Circuit Imprinter connection failed. Production halted.")
+				screen = 1.0
+			updateUsrDialog()
 
-					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
-					spawn(16)
-						if(linked_imprinter)
-							if(g2g)
-								var/obj/item/new_item = new P(src)
-								new_item.loc = linked_imprinter.loc
-								feedback_add_details("circuit_printed","[new_item.type]")
-							screen = old_screen
-							linked_imprinter.busy = 0
-						else
-							src.visible_message("<span class='notice'>The [src.name] beeps, \"Something went wrong, production halted!\"</span>")
-							screen = 1.0
-						updateUsrDialog()
-
-	else if(href_list["disposeI"] && linked_imprinter)  //Causes the circuit imprinter to dispose of a single reagent (all of it)
-		linked_imprinter.reagents.del_reagent(href_list["disposeI"])
-
-	else if(href_list["disposeallI"] && linked_imprinter) //Causes the circuit imprinter to dispose of all it's reagents.
-		linked_imprinter.reagents.clear_reagents()
-
+	//Protolathe Materials
 	else if(href_list["disposeP"] && linked_lathe)  //Causes the protolathe to dispose of a single reagent (all of it)
 		linked_lathe.reagents.del_reagent(href_list["disposeP"])
 
 	else if(href_list["disposeallP"] && linked_lathe) //Causes the protolathe to dispose of all it's reagents.
 		linked_lathe.reagents.clear_reagents()
 
-	else if(href_list["lathe_ejectsheet"] && linked_lathe) //Causes the protolathe to eject a sheet of material
-		var/desired_num_sheets = text2num(href_list["lathe_ejectsheet_amt"])
-		var/MAT
-		switch(href_list["lathe_ejectsheet"])
-			if("metal")
-				MAT = MAT_METAL
-			if("glass")
-				MAT = MAT_GLASS
-			if("gold")
-				MAT = MAT_GOLD
-			if("silver")
-				MAT = MAT_SILVER
-			if("plasma")
-				MAT = MAT_PLASMA
-			if("uranium")
-				MAT = MAT_URANIUM
-			if("diamond")
-				MAT = MAT_DIAMOND
-			if("clown")
-				MAT = MAT_BANANIUM
-		linked_lathe.materials.retrieve_sheets(desired_num_sheets, MAT)
+	else if(href_list["ejectsheet"] && linked_lathe) //Causes the protolathe to eject a sheet of material
+		linked_lathe.materials.retrieve_sheets(text2num(href_list["eject_amt"]), href_list["ejectsheet"])
 
-	else if(href_list["imprinter_ejectsheet"] && linked_imprinter) //Causes the protolathe to eject a sheet of material
-		var/desired_num_sheets = text2num(href_list["imprinter_ejectsheet_amt"])
-		var/res_amount, type
-		switch(href_list["imprinter_ejectsheet"])
-			if("glass")
-				type = /obj/item/stack/sheet/glass
-				res_amount = "g_amount"
-			if("gold")
-				type = /obj/item/stack/sheet/mineral/gold
-				res_amount = "gold_amount"
-			if("diamond")
-				type = /obj/item/stack/sheet/mineral/diamond
-				res_amount = "diamond_amount"
-		if(ispath(type) && hasvar(linked_imprinter, res_amount))
-			var/obj/item/stack/sheet/sheet = new type(linked_imprinter.loc)
-			var/available_num_sheets = round(linked_imprinter.vars[res_amount]/sheet.perunit)
-			if(available_num_sheets>0)
-				sheet.amount = min(available_num_sheets, desired_num_sheets)
-				linked_imprinter.vars[res_amount] = max(0, (linked_imprinter.vars[res_amount]-sheet.amount * sheet.perunit))
-			else
-				qdel(sheet)
+	//Circuit Imprinter Materials
+	else if(href_list["disposeI"] && linked_imprinter)  //Causes the circuit imprinter to dispose of a single reagent (all of it)
+		linked_imprinter.reagents.del_reagent(href_list["disposeI"])
+
+	else if(href_list["disposeallI"] && linked_imprinter) //Causes the circuit imprinter to dispose of all it's reagents.
+		linked_imprinter.reagents.clear_reagents()
+
+	else if(href_list["imprinter_ejectsheet"] && linked_imprinter) //Causes the imprinter to eject a sheet of material
+		linked_imprinter.materials.retrieve_sheets(text2num(href_list["eject_amt"]), href_list["imprinter_ejectsheet"])
+
 
 	else if(href_list["find_device"]) //The R&D console looks for devices nearby to link up with.
 		screen = 0.0
@@ -591,6 +559,10 @@ proc/CallMaterialName(ID)
 
 /obj/machinery/computer/rdconsole/interact(mob/user)
 	user.set_machine(src)
+
+	if(first_use)
+		SyncRDevices()
+
 	var/dat = ""
 	files.RefreshResearch()
 	switch(screen) //A quick check to make sure you get the right screen when a device is disconnected.
@@ -705,13 +677,13 @@ proc/CallMaterialName(ID)
 				if(b_type)
 					dat += "Lathe Types:<BR>"
 					if(b_type & IMPRINTER) dat += "Circuit Imprinter<BR>"
-					if(b_type & PROTOLATHE) dat += "Proto-lathe<BR>"
-					if(b_type & AUTOLATHE) dat += "Auto-lathe<BR>"
-					if(b_type & MECHFAB) dat += "Mech Fabricator<BR>"
+					if(b_type & PROTOLATHE) dat += "Protolathe<BR>"
+					if(b_type & AUTOLATHE) dat += "Autolathe<BR>"
+					if(b_type & MECHFAB) dat += "Exosuit Fabricator<BR>"
 				dat += "Required Materials:<BR>"
-				for(var/M in d_disk.blueprint.materials)
-					if(copytext(M, 1, 2) == "$") dat += "* [copytext(M, 2)] x [d_disk.blueprint.materials[M]]<BR>"
-					else dat += "* [M] x [d_disk.blueprint.materials[M]]<BR>"
+				var/all_mats = d_disk.blueprint.materials + d_disk.blueprint.reagents
+				for(var/M in all_mats)
+					dat += "* [CallMaterialName(M)] x [all_mats[M]]<BR>"
 				dat += "</div>Operations: "
 				dat += "<A href='?src=\ref[src];updt_design=1'>Upload to Database</A>"
 				dat += "<A href='?src=\ref[src];clear_design=1'>Clear Disk</A>"
@@ -779,11 +751,10 @@ proc/CallMaterialName(ID)
 			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 			for(var/T in temp_tech)
 				dat += "* [CallTechName(T)] [temp_tech[T]]"
-				for(var/v in files.known_tech)
-					var/datum/tech/F = files.known_tech[v]
-					if(F.name == CallTechName(T))
-						dat += " (Current: [F.level])"
-						break
+				var/datum/tech/F = files.known_tech[T]
+				if(F)
+					dat += " (Current: [F.level])"
+
 				dat += "<BR>"
 			dat += "</div>Options: "
 			dat += "<A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A>"
@@ -831,22 +802,15 @@ proc/CallMaterialName(ID)
 				var/temp_material
 				var/c = 50
 				var/t
-				for(var/M in D.materials)
+
+				var/all_materials = D.materials + D.reagents
+				for(var/M in all_materials)
 					t = linked_lathe.check_mat(D, M)
 					temp_material += " | "
 					if (t < 1)
-						temp_material += "<span class='bad'>[D.materials[M]*coeff] [CallMaterialName(M)]</span>"
+						temp_material += "<span class='bad'>[all_materials[M]*coeff] [CallMaterialName(M)]</span>"
 					else
-						temp_material += " [D.materials[M]*coeff] [CallMaterialName(M)]"
-					c = min(c,t)
-
-				for(var/R in D.reagents)
-					t = linked_lathe.check_mat(D, R)
-					temp_material += " | "
-					if (t < 1)
-						temp_material += "<span class='bad'>[D.reagents[R]*coeff] [CallMaterialName(R)]</span>"
-					else
-						temp_material += " [D.reagents[R]*coeff] [CallMaterialName(R)]"
+						temp_material += " [all_materials[M]*coeff] [CallMaterialName(M)]"
 					c = min(c,t)
 
 				if (c >= 1)
@@ -898,61 +862,16 @@ proc/CallMaterialName(ID)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A><div class='statusDisplay'>"
 			dat += "<h3>Material Storage:</h3><BR><HR>"
-			//Metal
-			var/m_amount = linked_lathe.materials.amount(MAT_METAL)
-			dat += "* [m_amount] of Metal: "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=5'>5x</A> "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Glass
-			var/g_amount = linked_lathe.materials.amount(MAT_GLASS)
-			dat += "* [g_amount] of Glass: "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=5'>5x</A> "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Gold
-			var/gold_amount = linked_lathe.materials.amount(MAT_GOLD)
-			dat += "* [gold_amount] of Gold: "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=5'>5x</A> "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Silver
-			var/silver_amount = linked_lathe.materials.amount(MAT_SILVER)
-			dat += "* [silver_amount] of Silver: "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=5'>5x</A> "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Plasma
-			var/plasma_amount = linked_lathe.materials.amount(MAT_PLASMA)
-			dat += "* [plasma_amount] of Solid Plasma: "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=5'>5x</A> "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasmalathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Uranium
-			var/uranium_amount = linked_lathe.materials.amount(MAT_URANIUM)
-			dat += "* [uranium_amount] of Uranium: "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=5'>5x</A> "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Diamond
-			var/diamond_amount = linked_lathe.materials.amount(MAT_DIAMOND)
-			dat += "* [diamond_amount] of Diamond: "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=5'>5x</A> "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Bananium
-			var/bananium_amount = linked_lathe.materials.amount(MAT_BANANIUM)
-			dat += "* [bananium_amount] of Bananium: "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=5'>5x</A> "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=50'>All</A>"
+			if(!linked_lathe)
+				dat += "ERROR: Protolathe connection failed."
+			else
+				for(var/mat_id in linked_lathe.materials.materials)
+					var/datum/material/M = linked_lathe.materials.materials[mat_id]
+					dat += "* [M.amount] of [M.name]: "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];ejectsheet=[M.id];eject_amt=1'>Eject</A> "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];ejectsheet=[M.id];eject_amt=5'>5x</A> "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];ejectsheet=[M.id];eject_amt=50'>All</A>"
+					dat += "<BR>"
 			dat += "</div>"
 
 		if(3.3)
@@ -974,7 +893,7 @@ proc/CallMaterialName(ID)
 			dat += "<A href='?src=\ref[src];menu=4.3'>Material Storage</A>"
 			dat += "<A href='?src=\ref[src];menu=4.2'>Chemical Storage</A><div class='statusDisplay'>"
 			dat += "<h3>Circuit Imprinter Menu:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
+			dat += "Material Amount: [linked_imprinter.materials.total_amount]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
 
 			dat += "<form name='search' action='?src=\ref[src]'>\
@@ -991,7 +910,7 @@ proc/CallMaterialName(ID)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"
 			dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
+			dat += "Material Amount: [linked_imprinter.materials.total_amount]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
 
 			var/coeff = linked_imprinter.efficiency_coeff
@@ -1001,13 +920,16 @@ proc/CallMaterialName(ID)
 					continue
 				var/temp_materials
 				var/check_materials = 1
-				for(var/M in D.materials)
+
+				var/all_materials = D.materials + D.reagents
+
+				for(var/M in all_materials)
 					temp_materials += " | "
 					if (!linked_imprinter.check_mat(D, M))
 						check_materials = 0
-						temp_materials += " <span class='bad'>[D.materials[M]/coeff] [CallMaterialName(M)]</span>"
+						temp_materials += " <span class='bad'>[all_materials[M]/coeff] [CallMaterialName(M)]</span>"
 					else
-						temp_materials += " [D.materials[M]/coeff] [CallMaterialName(M)]"
+						temp_materials += " [all_materials[M]/coeff] [CallMaterialName(M)]"
 				if (check_materials)
 					dat += "<A href='?src=\ref[src];imprint=[D.id]'>[D.name]</A>[temp_materials]<BR>"
 				else
@@ -1018,7 +940,7 @@ proc/CallMaterialName(ID)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"
 			dat += "<div class='statusDisplay'><h3>Search results:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
+			dat += "Material Amount: [linked_imprinter.materials.total_amount]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
 
 			var/coeff = linked_imprinter.efficiency_coeff
@@ -1038,9 +960,9 @@ proc/CallMaterialName(ID)
 					dat += "<span class='linkOff'>[D.name]</span>[temp_materials]<BR>"
 			dat += "</div>"
 
-		if(4.2)
+		if(4.2) //Circuit Imprinter Material Storage Sub-menu
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.1'>Imprinter Menu</A>"
+			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"
 			dat += "<A href='?src=\ref[src];disposeallI=1'>Disposal All Chemicals in Storage</A><div class='statusDisplay'>"
 			dat += "<h3>Chemical Storage:</h3><BR><HR>"
 			for(var/datum/reagent/R in linked_imprinter.reagents.reagent_list)
@@ -1051,23 +973,16 @@ proc/CallMaterialName(ID)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A><div class='statusDisplay'>"
 			dat += "<h3>Material Storage:</h3><BR><HR>"
-			//Glass
-			dat += "* [linked_imprinter.g_amount]  glass: "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Gold
-			dat += "* [linked_imprinter.gold_amount] gold: "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Diamond
-			dat += "* [linked_imprinter.diamond_amount] diamond: "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=50'>All</A>"
+			if(!linked_imprinter)
+				dat += "ERROR: Protolathe connection failed."
+			else
+				for(var/mat_id in linked_imprinter.materials.materials)
+					var/datum/material/M = linked_imprinter.materials.materials[mat_id]
+					dat += "* [M.amount] of [M.name]: "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=[M.id];eject_amt=1'>Eject</A> "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=[M.id];eject_amt=5'>5x</A> "
+					if(M.amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=[M.id];eject_amt=50'>All</A>"
+					dat += "<BR>"
 			dat += "</div>"
 
 	var/datum/browser/popup = new(user, "rndconsole", name, 460, 550)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -81,9 +81,14 @@
 		return
 	if (disabled)
 		return
-	if (!linked_console)
-		user << "<span class='warning'>The [name] must be linked to an R&D console first!</span>"
-		return
+	if (!linked_console) // Try to auto-connect to new RnD consoles nearby.
+		for(var/obj/machinery/computer/rdconsole/console in oview(3, src))
+			if(console.first_use)
+				console.SyncRDevices()
+
+		if(!linked_console)
+			user << "<span class='warning'>The [name] must be linked to an R&D console first!</span>"
+			return
 	if (busy)
 		user << "<span class='warning'>The [src.name] is busy right now.</span>"
 		return

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -172,12 +172,12 @@ research holder datum.
 
 /datum/tech/engineering
 	name = "Engineering Research"
-	desc = "Development of new and improved engineering parts and."
+	desc = "Development of new and improved engineering parts and tools."
 	id = "engineering"
 
 /datum/tech/plasmatech
 	name = "Plasma Research"
-	desc = "Research into the mysterious substance colloqually known as 'plasma'."
+	desc = "Research into the mysterious substance colloqually known as \"plasma\"."
 	id = "plasmatech"
 	rare = 3
 
@@ -187,8 +187,8 @@ research holder datum.
 	id = "powerstorage"
 
 /datum/tech/bluespace
-	name = "'Blue-space' Research"
-	desc = "Research into the sub-reality known as 'blue-space'"
+	name = "\"Blue-space\" Research"
+	desc = "Research into the sub-reality known as \"blue-space\"."
 	id = "bluespace"
 	rare = 2
 
@@ -218,6 +218,9 @@ research holder datum.
 	id = "syndicate"
 	rare = 4
 
+
+//Secret Technologies (hidden by default, require rare items to reveal)
+
 /datum/tech/abductor
 	name = "Alien Technologies Research"
 	desc = "The study of technologies used by the advanced alien race known as Abductors."
@@ -225,13 +228,14 @@ research holder datum.
 	rare = 5
 	level = 0
 
-/*
 /datum/tech/arcane
 	name = "Arcane Research"
-	desc = "Research into the occult and arcane field for use in practical science"
+	desc = "When sufficiently analyzed, any magic becomes indistinguishable from technology."
 	id = "arcane"
-	level = 0 //It didn't become "secret" as advertised.
+	rare = 5
+	level = 0
 
+/*
 //Branch Techs
 /datum/tech/explosives
 	name = "Explosives Research"


### PR DESCRIPTION
This PR contains a refactor for R&D machines, mostly touching interaction of RnD machines and material containers. Not to be confused with shitty RnD rebalances.

Player visible changes:
- **R&D now autolinks** when the console is used for a first time. Attempting to load RnD machines would force autolink too, but only if console was never used before. It doesn't make up for all the annoyance added to RnD by @LatD, but at least it makes RnD suck a tiny bit less.
- Designs export is removed from cargo. It was dependent on reliability mechanics. With reliability removed it was broken as fuck.

Under the hood:
- Circuit imprinter and exosuit fabricator now have proper material containers instead of hacky stuff they were using.
- R&D machines now use proper `say()` instead of emulating it with `visible_message()`.
- Material container var `mat_type` renamed to `id`, for the sake of consistency with everything else.
- Material containers are a bit more intuitive and flexible in their setup. Adding new materials is easier.
- Reagents are separated from materials in board designs.
- Board designs now respect OOP. You don't have to set "1000 glass, 20 acid, imprinter" for any generic board.
- Some typos in design/tech names and descs are fixed.
- RnD code is now less shitty and more DRY overall.
