### PR TITLE
Localhost and .dmbs opened with dreamseeker always get admin

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -113,6 +113,12 @@ var/next_external_rsc = 0
 	directory[ckey] = src
 
 	//Admin Authorisation
+	var/localhost_addresses = list("127.0.0.1", "::1")
+	if(!address || (address in localhost_addresses))
+		var/datum/admin_rank/localhost_rank = new("!localhost!", 65535)
+		if(localhost_rank)
+			var/datum/admins/localhost_holder = new(localhost_rank, ckey)
+			localhost_holder.associate(src)
 	if(protected_config.autoadmin)
 		if(!admin_datums[ckey])
 			var/datum/admin_rank/autorank
@@ -127,7 +133,7 @@ var/next_external_rsc = 0
 				admin_datums[ckey] = D
 	holder = admin_datums[ckey]
 	if(holder)
-		admins += src
+		admins |= src
 		holder.owner = src
 
 	//preferences datum - also holds some persistant data for the client (because we may as well keep these datums to a minimum)


### PR DESCRIPTION
When you connect you your server using an ipv4 or ipv6 loopback address (127.0.0.1, or ::1), or directly open a .dmb using DreamSeeker (where connecting address is null), you will automatically get full admin permissions. This overrides any permissions you may get with the admins.txt, sql database, or autoadmin configuration, and is applied every time you connect under these conditions even if your admin was removed.

This should make testing a butt load easier, and give hosts absolute power beyond just shutting down the daemon.
