### PR TITLE
Reverts recent R&D tech changes

### DIFF
--- a/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
+++ b/code/game/gamemodes/changeling/powers/augmented_eyesight.dm
@@ -37,6 +37,7 @@
 	icon_state = "ling_eyeshield"
 	eye_color = null
 	implant_overlay = null
+	origin_tech = "biotech=4"
 	slot = "eye_ling"
 	status = ORGAN_ORGANIC
 
@@ -57,6 +58,7 @@
 	icon_state = "ling_thermal"
 	eye_color = null
 	implant_overlay = null
+	origin_tech = "biotech=5;magnets=5"
 	slot = "eye_ling"
 	status = ORGAN_ORGANIC
 	aug_message = "You feel a minute twitch in our eyes, and darkness creeps away."

--- a/code/game/gamemodes/gang/gang_pen.dm
+++ b/code/game/gamemodes/gang/gang_pen.dm
@@ -2,7 +2,7 @@
  * Gang Boss Pens
  */
 /obj/item/weapon/pen/gang
-	origin_tech = "materials=2;syndicate=3"
+	origin_tech = "materials=2;syndicate=5"
 	var/cooldown
 	var/last_used = 0
 	var/charges = 1
@@ -67,7 +67,7 @@
 	name = "gang implant"
 	desc = "Makes you a gangster or such."
 	activated = 0
-	origin_tech = "materials=2;biotech=4;programming=4;syndicate=3"
+	origin_tech = "materials=2;biotech=4;programming=4;syndicate=4"
 	var/datum/gang/gang
 
 /obj/item/weapon/implant/gang/New(loc,var/setgang)

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -11,7 +11,7 @@
 	icon_state = "vest_stealth"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	origin_tech = "magnets=7;biotech=4;powerstorage=4;abductor=4"
+	origin_tech = "materials=5;biotech=4;powerstorage=5;abductor=3"
 	armor = list(melee = 15, bullet = 15, laser = 15, energy = 15, bomb = 15, bio = 15, rad = 15)
 	actions_types = list(/datum/action/item_action/hands_free/activate)
 	var/mode = VEST_STEALTH
@@ -129,7 +129,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gizmo_scan"
 	item_state = "silencer"
-	origin_tech = "engineering=7;magnets=4;bluespace=4;abductor=3"
+	origin_tech = "materials=5;magnets=5;bluespace=6;abductor=4"
 	var/mode = GIZMO_SCAN
 	var/mob/living/marked = null
 	var/obj/machinery/abductor/console/console
@@ -210,7 +210,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "silencer"
 	item_state = "gizmo"
-	origin_tech = "materials=4;programming=7;abductor=3"
+	origin_tech = "materials=5;magnets=5;abductor=3"
 
 /obj/item/device/abductor/silencer/attack(mob/living/M, mob/user)
 	if(!AbductorCheck(user))
@@ -254,7 +254,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "implant"
 	activated = 1
-	origin_tech = "materials=2;biotech=7;magnets=4;bluespace=4;abductor=5"
+	origin_tech = "materials=2;biotech=3;magnets=4;bluespace=5;abductor=5"
 	var/obj/machinery/abductor/pad/home
 	var/cooldown = 30
 
@@ -314,7 +314,7 @@
 	pin = /obj/item/device/firing_pin/abductor
 	icon_state = "alienpistol"
 	item_state = "alienpistol"
-	origin_tech = "combat=4;magnets=7;powerstorage=3;abductor=3"
+	origin_tech = "combat=5;materials=4;powerstorage=3;abductor=3"
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/weapon/paper/abductor
@@ -357,7 +357,7 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "wonderprodStun"
 	item_state = "wonderprod"
 	slot_flags = SLOT_BELT
-	origin_tech = "materials=4;combat=4;biotech=7;abductor=4"
+	origin_tech = "materials=6;combat=5;biotech=7;abductor=4"
 	force = 7
 	w_class = 3
 	actions_types = list(/datum/action/item_action/toggle_mode)
@@ -507,7 +507,7 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "cuff_white" // Needs sprite
 	breakouttime = 450
 	trashtype = /obj/item/weapon/restraints/handcuffs/energy/used
-	origin_tech = "materials=4;magnets=5;abductor=2"
+	origin_tech = "materials=2;magnets=5;abductor=2"
 
 /obj/item/weapon/restraints/handcuffs/energy/used
 	desc = "energy discharge"
@@ -569,7 +569,7 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "alienhelmet"
 	item_state = "alienhelmet"
 	blockTracking = 1
-	origin_tech = "materials=7;magnets=4;abductor=3"
+	origin_tech = "materials=6;magnets=5;abductor=3"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
 // Operating Table / Beds / Lockers

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -80,7 +80,7 @@
 	Slime.Leader = owner
 
 /obj/item/organ/gland/mindshock
-	origin_tech = "materials=4;biotech=4;magnets=6;abductor=3"
+	origin_tech = "materials=4;biotech=5;magnets=3;abductor=3"
 	cooldown_low = 300
 	cooldown_high = 300
 	uses = -1
@@ -97,6 +97,7 @@
 		H.confused += 20
 
 /obj/item/organ/gland/pop
+	origin_tech = "materials=4;biotech=6;abductor=3"
 	cooldown_low = 900
 	cooldown_high = 1800
 	uses = 6
@@ -109,7 +110,7 @@
 	owner.set_species(species)
 
 /obj/item/organ/gland/ventcrawling
-	origin_tech = "materials=4;biotech=5;bluespace=4;abductor=3"
+	origin_tech = "materials=4;biotech=5;bluespace=3;abductor=3"
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1
@@ -122,6 +123,7 @@
 
 
 /obj/item/organ/gland/viral
+	origin_tech = "materials=4;biotech=6;abductor=3"
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1
@@ -139,7 +141,7 @@
 
 
 /obj/item/organ/gland/emp //TODO : Replace with something more interesting
-	origin_tech = "materials=4;biotech=4;magnets=6;abductor=3"
+	origin_tech = "materials=4;biotech=5;magnets=3;abductor=3"
 	cooldown_low = 900
 	cooldown_high = 1600
 	uses = 10
@@ -150,6 +152,7 @@
 	empulse(get_turf(owner), 2, 5, 1)
 
 /obj/item/organ/gland/spiderman
+	origin_tech = "materials=4;biotech=6;abductor=3"
 	cooldown_low = 450
 	cooldown_high = 900
 	uses = 10
@@ -161,6 +164,7 @@
 	new /obj/effect/spider/spiderling(owner.loc)
 
 /obj/item/organ/gland/egg
+	origin_tech = "materials=4;biotech=6;abductor=3"
 	cooldown_low = 300
 	cooldown_high = 400
 	uses = -1
@@ -173,6 +177,7 @@
 	egg.desc += " It smells bad."
 
 /obj/item/organ/gland/bloody
+	origin_tech = "materials=4;biotech=6;abductor=3"
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1
@@ -194,6 +199,7 @@
 			H.update_inv_w_uniform(0)
 
 /obj/item/organ/gland/bodysnatch
+	origin_tech = "materials=4;biotech=7;abductor=3"
 	cooldown_low = 600
 	cooldown_high = 600
 	human_only = 1
@@ -247,7 +253,7 @@
 /obj/item/organ/gland/plasma
 	cooldown_low = 2400
 	cooldown_high = 3000
-	origin_tech = "materials=4;biotech=4;plasmatech=6;abductor=3"
+	origin_tech = "materials=4;biotech=5;plasmatech=3;abductor=3"
 	uses = 1
 
 /obj/item/organ/gland/plasma/activate()

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -77,7 +77,7 @@
 	desc = "Still it beats furiously, emanating an aura of utter hate."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "demon_heart-on"
-	origin_tech = "combat=5;biotech=7"
+	origin_tech = "combat=5;biotech=8"
 
 /obj/item/organ/heart/demon/update_icon()
 	return //always beating visually

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -32,7 +32,7 @@
 /obj/item/weapon/circuitboard/machine/sleeper
 	name = "circuit board (Sleeper)"
 	build_path = /obj/machinery/sleeper
-	origin_tech = "programming=3;biotech=2;engineering=3"
+	origin_tech = "programming=3;biotech=2;engineering=3;materials=3"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -68,7 +68,7 @@
 /obj/item/weapon/circuitboard/machine/clonepod
 	name = "circuit board (Clone Pod)"
 	build_path = /obj/machinery/clonepod
-	origin_tech = "programming=2;biotech=2"
+	origin_tech = "programming=3;biotech=3"
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/weapon/stock_parts/scanning_module = 2,

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -140,28 +140,26 @@
 /obj/item/weapon/circuitboard/computer/telesci_console
 	name = "circuit board (Telescience Console)"
 	build_path = /obj/machinery/computer/telescience
-	origin_tech = "programming=3;bluespace=3;plasmatech=4"
+	origin_tech = "programming=3;bluespace=2"
 /obj/item/weapon/circuitboard/computer/message_monitor
 	name = "circuit board (Message Monitor)"
 	build_path = /obj/machinery/computer/message_monitor
-	origin_tech = "programming=2"
+	origin_tech = "programming=3"
 /obj/item/weapon/circuitboard/computer/security
 	name = "circuit board (Security Cameras)"
 	build_path = /obj/machinery/computer/security
-	origin_tech = "programming=2;combat=2"
 
 /obj/item/weapon/circuitboard/computer/aiupload
 	name = "circuit board (AI Upload)"
 	build_path = /obj/machinery/computer/upload/ai
-	origin_tech = "programming=4;engineering=4"
+	origin_tech = "programming=4"
 /obj/item/weapon/circuitboard/computer/borgupload
 	name = "circuit board (Cyborg Upload)"
 	build_path = /obj/machinery/computer/upload/borg
-	origin_tech = "programming=4;engineering=4"
+	origin_tech = "programming=4"
 /obj/item/weapon/circuitboard/computer/med_data
 	name = "circuit board (Medical Records Console)"
 	build_path = /obj/machinery/computer/med_data
-	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/pandemic
 	name = "circuit board (PanD.E.M.I.C. 2200)"
 	build_path = /obj/machinery/computer/pandemic
@@ -173,13 +171,12 @@
 /obj/item/weapon/circuitboard/computer/communications
 	name = "circuit board (Communications)"
 	build_path = /obj/machinery/computer/communications
-	origin_tech = "programming=3;magnets=3"
+	origin_tech = "programming=2;magnets=2"
 	var/lastTimeUsed = 0
 
 /obj/item/weapon/circuitboard/computer/card
 	name = "circuit board (ID Console)"
 	build_path = /obj/machinery/computer/card
-	origin_tech = "programming=3"
 /obj/item/weapon/circuitboard/computer/card/centcom
 	name = "circuit board (Centcom ID Console)"
 	build_path = /obj/machinery/computer/card/centcom
@@ -207,7 +204,7 @@
 /obj/item/weapon/circuitboard/computer/teleporter
 	name = "circuit board (Teleporter)"
 	build_path = /obj/machinery/computer/teleporter
-	origin_tech = "programming=3;bluespace=3;plasmatech=3"
+	origin_tech = "programming=2;bluespace=2"
 /obj/item/weapon/circuitboard/computer/secure_data
 	name = "circuit board (Security Records Console)"
 	build_path = /obj/machinery/computer/secure_data
@@ -238,7 +235,7 @@
 /obj/item/weapon/circuitboard/computer/cloning
 	name = "circuit board (Cloning)"
 	build_path = /obj/machinery/computer/cloning
-	origin_tech = "programming=2;biotech=2"
+	origin_tech = "programming=3;biotech=3"
 /obj/item/weapon/circuitboard/computer/arcade/battle
 	name = "circuit board (Arcade Battle)"
 	build_path = /obj/machinery/computer/arcade/battle
@@ -246,7 +243,6 @@
 /obj/item/weapon/circuitboard/computer/arcade/orion_trail
 	name = "circuit board (Orion Trail)"
 	build_path = /obj/machinery/computer/arcade/orion_trail
-	origin_tech = "programming=1"
 /obj/item/weapon/circuitboard/computer/turbine_control
 	name = "circuit board (Turbine control)"
 	build_path = /obj/machinery/computer/turbine_computer
@@ -257,7 +253,6 @@
 /obj/item/weapon/circuitboard/computer/powermonitor
 	name = "circuit board (Power Monitor)"  //name fixed 250810
 	build_path = /obj/machinery/computer/monitor
-	origin_tech = "programming=2;powerstorage=2"
 /obj/item/weapon/circuitboard/computer/olddoor
 	name = "circuit board (DoorMex)"
 	build_path = /obj/machinery/computer/pod/old
@@ -298,11 +293,11 @@
 /obj/item/weapon/circuitboard/computer/crew
 	name = "circuit board (Crew Monitoring Console)"
 	build_path = /obj/machinery/computer/crew
-	origin_tech = "programming=2;biotech=2"
+	origin_tech = "programming=3;biotech=2;magnets=2"
 /obj/item/weapon/circuitboard/computer/mech_bay_power_console
 	name = "circuit board (Mech Bay Power Control Console)"
 	build_path = /obj/machinery/computer/mech_bay_power_console
-	origin_tech = "programming=3;powerstorage=3"
+	origin_tech = "programming=2;powerstorage=3"
 
 /obj/item/weapon/circuitboard/computer/cargo
 	name = "circuit board (Supply Console)"
@@ -334,18 +329,18 @@
 /obj/item/weapon/circuitboard/computer/operating
 	name = "circuit board (Operating Computer)"
 	build_path = /obj/machinery/computer/operating
-	origin_tech = "programming=2;biotech=3"
+	origin_tech = "programming=2;biotech=2"
 /obj/item/weapon/circuitboard/computer/mining
 	name = "circuit board (Outpost Status Display)"
 	build_path = /obj/machinery/computer/security/mining
 /obj/item/weapon/circuitboard/computer/comm_monitor
 	name = "circuit board (Telecommunications Monitor)"
 	build_path = /obj/machinery/computer/telecomms/monitor
-	origin_tech = "programming=3;magnets=3;bluespace=2"
+	origin_tech = "programming=3"
 /obj/item/weapon/circuitboard/computer/comm_server
 	name = "circuit board (Telecommunications Server Monitor)"
 	build_path = /obj/machinery/computer/telecomms/server
-	origin_tech = "programming=3;magnets=3;bluespace=2"
+	origin_tech = "programming=3"
 
 /obj/item/weapon/circuitboard/computer/shuttle
 	name = "circuit board (Shuttle)"
@@ -388,7 +383,7 @@
 /obj/item/weapon/circuitboard/computer/aifixer
 	name = "circuit board (AI Integrity Restorer)"
 	build_path = /obj/machinery/computer/aifixer
-	origin_tech = "programming=2;biotech=2"
+	origin_tech = "programming=3;biotech=2"
 /*/obj/item/weapon/circuitboard/computer/prison_shuttle
 	name = "circuit board (Prison Shuttle)"
 	build_path = /obj/machinery/computer/prison_shuttle*/

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -264,7 +264,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/weapon/circuitboard/machine/smes
 	name = "circuit board (SMES)"
 	build_path = /obj/machinery/power/smes
-	origin_tech = "programming=3;powerstorage=3;engineering=3"
+	origin_tech = "programming=4;powerstorage=5;engineering=5"
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/weapon/stock_parts/cell = 5,
@@ -273,7 +273,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/weapon/circuitboard/machine/teleporter_hub
 	name = "circuit board (Teleporter Hub)"
 	build_path = /obj/machinery/teleport/hub
-	origin_tech = "programming=3;engineering=4;bluespace=4;materials=4"
+	origin_tech = "programming=3;engineering=5;bluespace=5;materials=4"
 	req_components = list(
 							/obj/item/weapon/ore/bluespace_crystal = 3,
 							/obj/item/weapon/stock_parts/matter_bin = 1)
@@ -281,7 +281,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/weapon/circuitboard/machine/teleporter_station
 	name = "circuit board (Teleporter Station)"
 	build_path = /obj/machinery/teleport/station
-	origin_tech = "programming=4;engineering=4;bluespace=4;plasmatech=3"
+	origin_tech = "programming=4;engineering=4;bluespace=4"
 	req_components = list(
 							/obj/item/weapon/ore/bluespace_crystal = 2,
 							/obj/item/weapon/stock_parts/capacitor = 2,
@@ -290,7 +290,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/weapon/circuitboard/machine/chem_dispenser
 	name = "circuit board (Portable Chem Dispenser)"
 	build_path = /obj/machinery/chem_dispenser/constructable
-	origin_tech = "materials=4;programming=4;plasmatech=4;biotech=3"
+	origin_tech = "materials=4;engineering=4;programming=4;plasmatech=3;biotech=3"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 2,
 							/obj/item/weapon/stock_parts/capacitor = 1,
@@ -301,7 +301,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 /obj/item/weapon/circuitboard/machine/telesci_pad
 	name = "circuit board (Telepad)"
 	build_path = /obj/machinery/telepad
-	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=4"
+	origin_tech = "programming=4;engineering=3;materials=3;bluespace=4"
 	req_components = list(
 							/obj/item/weapon/ore/bluespace_crystal = 2,
 							/obj/item/weapon/stock_parts/capacitor = 1,

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -31,7 +31,7 @@
 /obj/item/weapon/circuitboard/machine/space_heater
 	name = "circuit board (Space Heater)"
 	build_path = /obj/machinery/space_heater
-	origin_tech = "programming=2;engineering=2;plasmatech=2"
+	origin_tech = "programming=2;engineering=2"
 	req_components = list(
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/capacitor = 1,

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -201,7 +201,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "beacon"
 	desc = "A label on it reads: <i>Warning: Activating this device will send a special beacon to your location</i>."
-	origin_tech = "bluespace=6;syndicate=5"
+	origin_tech = "bluespace=4;syndicate=7"
 	w_class = 2
 	var/droptype = /obj/machinery/power/singularity_beacon/syndicate
 
@@ -217,9 +217,7 @@
 /obj/item/device/sbeacondrop/bomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a high-ordinance explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb
-	origin_tech = "bluespace=5;syndicate=5"
 
 /obj/item/device/sbeacondrop/powersink
 	desc = "A label on it reads: <i>Warning: Activating this device will send a power draining device to your location</i>."
 	droptype = /obj/item/device/powersink
-	origin_tech = "bluespace=4;syndicate=5"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -212,7 +212,7 @@
 	icon_state = "bombcore"
 	item_state = "eshield0"
 	w_class = 3
-	origin_tech = "syndicate=5;combat=6"
+	origin_tech = "syndicate=6;combat=5"
 	burn_state = FLAMMABLE //Burnable (but the casing isn't)
 	var/adminlog = null
 
@@ -467,7 +467,7 @@
 	icon_state = "bigred"
 	item_state = "electronic"
 	w_class = 1
-	origin_tech = "syndicate=3"
+	origin_tech = "syndicate=2"
 	var/cooldown = 0
 	var/detonated =	0
 	var/existant =	0

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -34,7 +34,7 @@
 	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents in the exosuit's reserves."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper"
-	origin_tech = "engineering=3;biotech=3;plasmatech=2"
+	origin_tech = "programming=2;biotech=3"
 	energy_drain = 20
 	range = MELEE
 	equip_cooldown = 20
@@ -259,7 +259,7 @@
 	var/mode = 0 //0 - fire syringe, 1 - analyze reagents.
 	range = MELEE|RANGED
 	equip_cooldown = 10
-	origin_tech = "materials=3;biotech=4;magnets=4"
+	origin_tech = "materials=3;biotech=4;magnets=4;programming=3"
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/New()
 	..()

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -100,7 +100,7 @@
 	name = "diamond-tipped exosuit drill"
 	desc = "Equipment for engineering and combat exosuits. This is an upgraded version of the drill that'll pierce the heavens!"
 	icon_state = "mecha_diamond_drill"
-	origin_tech = "materials=4;engineering=4"
+	origin_tech = "materials=4;engineering=3"
 	equip_cooldown = 20
 	force = 15
 
@@ -109,6 +109,7 @@
 	name = "exosuit mining scanner"
 	desc = "Equipment for engineering and combat exosuits. It will automatically check surrounding rock for useful minerals."
 	icon_state = "mecha_analyzer"
+	origin_tech = "materials=3;engineering=2"
 	selectable = 0
 	equip_cooldown = 30
 	var/scanning = 0

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -8,7 +8,7 @@
 	name = "mounted teleporter"
 	desc = "An exosuit module that allows exosuits to teleport to any position in view."
 	icon_state = "mecha_teleport"
-	origin_tech = "bluespace=7"
+	origin_tech = "bluespace=10"
 	equip_cooldown = 150
 	energy_drain = 1000
 	range = RANGED
@@ -28,7 +28,7 @@
 	name = "mounted wormhole generator"
 	desc = "An exosuit module that allows generating of small quasi-stable wormholes."
 	icon_state = "mecha_wholegen"
-	origin_tech = "bluespace=4;magnets=4;plasmatech=2"
+	origin_tech = "bluespace=3"
 	equip_cooldown = 50
 	energy_drain = 300
 	range = RANGED
@@ -78,7 +78,7 @@
 	name = "mounted gravitational catapult"
 	desc = "An exosuit mounted Gravitational Catapult."
 	icon_state = "mecha_teleport"
-	origin_tech = "bluespace=3;magnets=3;engineering=4"
+	origin_tech = "bluespace=2;magnets=3"
 	equip_cooldown = 10
 	energy_drain = 100
 	range = MELEE|RANGED
@@ -146,7 +146,7 @@
 	name = "armor booster module (Close Combat Weaponry)"
 	desc = "Boosts exosuit armor against armed melee attacks. Requires energy to operate."
 	icon_state = "mecha_abooster_ccw"
-	origin_tech = "materials=4;combat=4"
+	origin_tech = "materials=3"
 	equip_cooldown = 10
 	energy_drain = 50
 	range = 0
@@ -165,7 +165,7 @@
 	name = "armor booster module (Ranged Weaponry)"
 	desc = "Boosts exosuit armor against ranged attacks. Completely blocks taser shots. Requires energy to operate."
 	icon_state = "mecha_abooster_proj"
-	origin_tech = "materials=4;combat=3;engineering=3"
+	origin_tech = "materials=4"
 	equip_cooldown = 10
 	energy_drain = 50
 	range = 0
@@ -186,7 +186,7 @@
 	name = "exosuit repair droid"
 	desc = "An automated repair droid for exosuits. Scans for damage and repairs it. Can fix almost all types of external or internal damage."
 	icon_state = "repair_droid"
-	origin_tech = "magnets=3;programming=3;engineering=4"
+	origin_tech = "magnets=3;programming=3"
 	energy_drain = 50
 	range = 0
 	var/health_boost = 1
@@ -271,7 +271,7 @@
 	name = "exosuit energy relay"
 	desc = "An exosuit module that wirelessly drains energy from any available power channel in area. The performance index is quite low."
 	icon_state = "tesla"
-	origin_tech = "magnets=4;powerstorage=4;engineering=4"
+	origin_tech = "magnets=4;powerstorage=3"
 	energy_drain = 0
 	range = 0
 	var/coeff = 100
@@ -356,7 +356,7 @@
 	name = "exosuit plasma converter"
 	desc = "An exosuit module that generates power using solid plasma as fuel. Pollutes the environment."
 	icon_state = "tesla"
-	origin_tech = "plasmatech=2;powerstorage=2;engineering=2"
+	origin_tech = "plasmatech=2;powerstorage=2;engineering=1"
 	range = MELEE
 	var/coeff = 100
 	var/obj/item/stack/sheet/fuel
@@ -472,7 +472,7 @@
 	name = "exonuclear reactor"
 	desc = "An exosuit module that generates power using uranium as fuel. Pollutes the environment."
 	icon_state = "tesla"
-	origin_tech = "powerstorage=4;engineering=4"
+	origin_tech = "powerstorage=3;engineering=3"
 	max_fuel = 50000
 	fuel_per_cycle_idle = 10
 	fuel_per_cycle_active = 30

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -113,7 +113,7 @@
 	icon_state = "mecha_plasmacutter"
 	item_state = "plasmacutter"
 	energy_drain = 60
-	origin_tech = "materials=3;plasmatech=4;engineering=3"
+	origin_tech = "materials=3;combat=2;powerstorage=3;plasmatech=3"
 	projectile = /obj/item/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/Laser.ogg'
 
@@ -405,3 +405,4 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/mousetrap_mortar/proj_init(var/obj/item/device/assembly/mousetrap/armed/M)
 	M.secured = 1
+

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -33,7 +33,7 @@
 /obj/item/weapon/circuitboard/machine/mech_recharger
 	name = "circuit board (Mechbay Recharger)"
 	build_path = /obj/machinery/mech_bay_recharge_port
-	origin_tech = "programming=3;powerstorage=3;engineering=3"
+	origin_tech = "programming=3;powerstorage=4;engineering=4"
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,
 							/obj/item/weapon/stock_parts/capacitor = 5)

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -8,7 +8,7 @@
 	icon_state = "blank"
 	w_class = 6
 	flags = CONDUCT
-	origin_tech = "programming=2;materials=2;engineering=2"
+	origin_tech = "programming=2;materials=2"
 
 /obj/item/mecha_parts/chassis
 	name="Mecha Chassis"
@@ -41,16 +41,19 @@
 	name = "\improper Ripley left arm"
 	desc = "A Ripley APLU left arm. Data and power sockets are compatible with most exosuit tools."
 	icon_state = "ripley_l_arm"
+	origin_tech = "programming=2;materials=2;engineering=2"
 
 /obj/item/mecha_parts/part/ripley_right_arm
 	name = "\improper Ripley right arm"
 	desc = "A Ripley APLU right arm. Data and power sockets are compatible with most exosuit tools."
 	icon_state = "ripley_r_arm"
+	origin_tech = "programming=2;materials=2;engineering=2"
 
 /obj/item/mecha_parts/part/ripley_left_leg
 	name = "\improper Ripley left leg"
 	desc = "A Ripley APLU left leg. Contains somewhat complex servodrives and balance maintaining systems."
 	icon_state = "ripley_l_leg"
+	origin_tech = "programming=2;materials=2;engineering=2"
 
 /obj/item/mecha_parts/part/ripley_right_leg
 	name = "\improper Ripley right leg"
@@ -110,44 +113,44 @@
 	name = "\improper Gygax torso"
 	desc = "A torso part of Gygax. Contains power unit, processing core and life support systems."
 	icon_state = "gygax_harness"
-	origin_tech = "programming=2;materials=4;biotech=3;engineering=3"
+	origin_tech = "programming=2;materials=2;biotech=3;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_head
 	name = "\improper Gygax head"
 	desc = "A Gygax head. Houses advanced surveilance and targeting sensors."
 	icon_state = "gygax_head"
-	origin_tech = "programming=2;materials=4;magnets=3;engineering=3"
+	origin_tech = "programming=2;materials=2;magnets=3;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_left_arm
 	name = "\improper Gygax left arm"
 	desc = "A Gygax left arm. Data and power sockets are compatible with most exosuit tools and weapons."
 	icon_state = "gygax_l_arm"
-	origin_tech = "programming=2;materials=4;engineering=3"
+	origin_tech = "programming=2;materials=2;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_right_arm
 	name = "\improper Gygax right arm"
 	desc = "A Gygax right arm. Data and power sockets are compatible with most exosuit tools and weapons."
 	icon_state = "gygax_r_arm"
-	origin_tech = "programming=2;materials=4;engineering=3"
+	origin_tech = "programming=2;materials=2;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_left_leg
 	name = "\improper Gygax left leg"
 	desc = "A Gygax left leg. Constructed with advanced servomechanisms and actuators to enable faster speed."
 	icon_state = "gygax_l_leg"
-	origin_tech = "programming=2;materials=4;engineering=3"
+	origin_tech = "programming=2;materials=2;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_right_leg
 	name = "\improper Gygax right leg"
 	desc = "A Gygax right leg. Constructed with advanced servomechanisms and actuators to enable faster speed."
 	icon_state = "gygax_r_leg"
-	origin_tech = "programming=2;materials=4;engineering=3"
+	origin_tech = "programming=2;materials=2;engineering=3"
 
 /obj/item/mecha_parts/part/gygax_armor
 	gender = PLURAL
 	name = "\improper Gygax armor plates"
 	desc = "A set of armor plates designed for the Gygax. Designed to effectively deflect damage with a lightweight construction."
 	icon_state = "gygax_armor"
-	origin_tech = "materials=6;combat=4;engineering=4"
+	origin_tech = "materials=6;combat=4;engineering=5"
 
 
 //////////// Durand
@@ -200,7 +203,7 @@
 	name = "\improper Durand armor plates"
 	desc = "A set of armor plates for the Durand. Built heavy to resist an incredible amount of brute force."
 	icon_state = "durand_armor"
-	origin_tech = "materials=5;combat=4;engineering=4"
+	origin_tech = "materials=5;combat=4;engineering=5"
 
 ////////// Firefighter
 
@@ -256,6 +259,7 @@
 
 /obj/item/mecha_parts/chassis/phazon
 	name = "\improper Phazon chassis"
+	origin_tech = "materials=6"
 
 /obj/item/mecha_parts/chassis/phazon/New()
 	..()
@@ -265,43 +269,43 @@
 	name="\improper Phazon torso"
 	desc="A Phazon torso part. The socket for the bluespace core that powers the exosuit's unique phase drives is located in the middle."
 	icon_state = "phazon_harness"
-	origin_tech = "programming=4;materials=4;bluespace=4;plasmatech=5"
+	origin_tech = "programming=5;materials=6;bluespace=5;powerstorage=5"
 
 /obj/item/mecha_parts/part/phazon_head
 	name="\improper Phazon head"
 	desc="A Phazon head. Its sensors are carefully calibrated to provide vision and data even when the exosuit is phasing."
 	icon_state = "phazon_head"
-	origin_tech = "programming=3;materials=3;magnets=3"
+	origin_tech = "programming=4;materials=5;magnets=5"
 
 /obj/item/mecha_parts/part/phazon_left_arm
 	name="\improper Phazon left arm"
 	desc="A Phazon left arm. Several microtool arrays are located under the armor plating, which can be adjusted to the situation at hand."
 	icon_state = "phazon_l_arm"
-	origin_tech = "materials=3;bluespace=3;magnets=3"
+	origin_tech = "materials=5;bluespace=2;magnets=2"
 
 /obj/item/mecha_parts/part/phazon_right_arm
 	name="\improper Phazon right arm"
 	desc="A Phazon right arm. Several microtool arrays are located under the armor plating, which can be adjusted to the situation at hand."
 	icon_state = "phazon_r_arm"
-	origin_tech = "materials=3;bluespace=3;magnets=3"
+	origin_tech = "materials=5;bluespace=2;magnets=2"
 
 /obj/item/mecha_parts/part/phazon_left_leg
 	name="\improper Phazon left leg"
 	desc="A Phazon left leg. It contains the unique phase drives that allow the exosuit to phase through solid matter when engaged."
 	icon_state = "phazon_l_leg"
-	origin_tech = "materials=3;bluespace=3;magnets=3"
+	origin_tech = "materials=5;bluespace=3;magnets=3"
 
 /obj/item/mecha_parts/part/phazon_right_leg
 	name="\improper Phazon right leg"
 	desc="A Phazon right leg. It contains the unique phase drives that allow the exosuit to phase through solid matter when engaged."
 	icon_state = "phazon_r_leg"
-	origin_tech = "materials=3;bluespace=3;magnets=3"
+	origin_tech = "materials=5;bluespace=3;magnets=3"
 
 /obj/item/mecha_parts/part/phazon_armor
 	name="Phazon armor"
 	desc="Phazon armor plates. They are layered with plasma to protect the pilot from the stress of phasing and have unusual properties."
 	icon_state = "phazon_armor"
-	origin_tech = "materials=4;bluespace=4;plasmatech=5"
+	origin_tech = "materials=6;bluespace=5;magnets=5"
 
 
 ///////// Circuitboards
@@ -319,7 +323,7 @@
 	throw_range = 7
 
 /obj/item/weapon/circuitboard/mecha/ripley
-	origin_tech = "programming=2"
+	origin_tech = "programming=3"
 
 /obj/item/weapon/circuitboard/mecha/ripley/peripherals
 	name = "circuit board (Ripley Peripherals Control module)"
@@ -330,7 +334,7 @@
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/gygax
-	origin_tech = "programming=4;combat=3;engineering=3"
+	origin_tech = "programming=4"
 
 /obj/item/weapon/circuitboard/mecha/gygax/peripherals
 	name = "circuit board (Gygax Peripherals Control module)"
@@ -346,7 +350,7 @@
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/durand
-	origin_tech = "programming=4;combat=3;engineering=3"
+	origin_tech = "programming=4"
 
 /obj/item/weapon/circuitboard/mecha/durand/peripherals
 	name = "circuit board (Durand Peripherals Control module)"
@@ -355,14 +359,14 @@
 /obj/item/weapon/circuitboard/mecha/durand/targeting
 	name = "circuit board (Durand Weapon Control and Targeting module)"
 	icon_state = "mcontroller"
-	origin_tech = "programming=4;combat=4;engineering=3"
+	origin_tech = "programming=4;combat=4"
 
 /obj/item/weapon/circuitboard/mecha/durand/main
 	name = "circuit board (Durand Central Control module)"
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/honker
-	origin_tech = "programming=3;engineering=3"
+	origin_tech = "programming=4"
 
 /obj/item/weapon/circuitboard/mecha/honker/peripherals
 	name = "circuit board (H.O.N.K Peripherals Control module)"
@@ -377,7 +381,7 @@
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/odysseus
-	origin_tech = "programming=3;biotech=3"
+	origin_tech = "programming=3"
 
 /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
 	name = "circuit board (Odysseus Peripherals Control module)"
@@ -388,7 +392,7 @@
 	icon_state = "mainboard"
 
 /obj/item/weapon/circuitboard/mecha/phazon
-	origin_tech = "programming=5;plasmatech=4"
+	origin_tech = "programming=5"
 
 /obj/item/weapon/circuitboard/mecha/phazon/peripherals
 	name = "circuit board (Phazon Peripherals Control module)"

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -58,7 +58,7 @@
 
 /obj/effect/anomaly/grav/New()
 	..()
-	aSignal.origin_tech = "magnets=7"
+	aSignal.origin_tech = "magnets=5;powerstorage=4"
 
 /obj/effect/anomaly/grav/anomalyEffect()
 	..()
@@ -104,7 +104,7 @@
 
 /obj/effect/anomaly/flux/New()
 	..()
-	aSignal.origin_tech = "powerstorage=7"
+	aSignal.origin_tech = "powerstorage=6;programming=4;plasmatech=4"
 
 /obj/effect/anomaly/flux/anomalyEffect()
 	..()
@@ -146,7 +146,7 @@
 
 /obj/effect/anomaly/bluespace/New()
 	..()
-	aSignal.origin_tech = "bluespace=7"
+	aSignal.origin_tech = "bluespace=5;magnets=5;powerstorage=3"
 
 /obj/effect/anomaly/bluespace/anomalyEffect()
 	..()
@@ -166,7 +166,7 @@
 
 /obj/effect/anomaly/pyro/New()
 	..()
-	aSignal.origin_tech = "plasmatech=7"
+	aSignal.origin_tech = "plasmatech=5;powerstorage=4;biotech=6"
 
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()
@@ -183,7 +183,7 @@
 
 /obj/effect/anomaly/bhole/New()
 	..()
-	aSignal.origin_tech = "engineering=7"
+	aSignal.origin_tech = "materials=5;combat=4;engineering=4"
 
 /obj/effect/anomaly/bhole/anomalyEffect()
 	..()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -99,7 +99,6 @@
 	icon_state = "bluebodybag_folded"
 	unfoldedbag_path = /obj/structure/closet/body_bag/bluespace
 	w_class = 2
-	origin_tech = "bluespace=4;materials=4;plasmatech=4"
 
 /obj/structure/closet/body_bag/bluespace
 	name = "bluespace body bag"

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -9,7 +9,7 @@
 	flags = NOBLUDGEON
 	var/flush = FALSE
 	var/mob/living/silicon/ai/AI
-	origin_tech = "programming=3;materials=3"
+	origin_tech = "programming=4;materials=4"
 
 /obj/item/device/aicard/afterattack(atom/target, mob/user, proximity)
 	..()

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -14,7 +14,7 @@
 	item_state	= "camera_bug"
 	throw_speed	= 4
 	throw_range	= 20
-	origin_tech = "syndicate=1;engineering=3"
+	origin_tech = "syndicate=3;engineering=1"
 	flags = NOBLUDGEON
 
 	var/obj/machinery/camera/current = null

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -10,7 +10,7 @@
 	force = 3
 	attack_verb = list("blown up", "exploded", "detonated")
 	materials = list(MAT_METAL=50, MAT_GLASS=30)
-	origin_tech = "syndicate=1;combat=3;engineering=3"
+	origin_tech = "syndicate=3;combat=2"
 
 /obj/item/device/doorCharge/ex_act(severity, target)
 	switch(severity)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -277,7 +277,7 @@ obj/item/device/flashlight/lamp/bananalamp
 	brightness_on = 6 //luminosity when on
 
 /obj/item/device/flashlight/emp
-	origin_tech = "magnets=3;syndicate=´1"
+	origin_tech = "magnets=4;syndicate=5"
 	var/emp_max_charges = 4
 	var/emp_cur_charges = 4
 	var/charge_tick = 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -49,7 +49,7 @@
 
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
-	origin_tech = "magnets=3;engineering=4"
+	origin_tech = "magnets=3;materials=2"
 
 	var/max_uses = 20
 	var/uses = 0

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	w_class = 1
-	origin_tech = "engineering=2;bluespace=1"
 	var/translate_binary = 0
 	var/translate_hive = 0
 	var/syndie = 0
@@ -15,7 +14,7 @@
 /obj/item/device/encryptionkey/syndicate
 	icon_state = "cypherkey"
 	channels = list("Syndicate" = 1)
-	origin_tech = "syndicate=1;engineering=3;bluespace=2"
+	origin_tech = "syndicate=3"
 	syndie = 1//Signifies that it de-crypts Syndicate transmissions
 
 /obj/item/device/encryptionkey/binary
@@ -23,7 +22,7 @@
 	desc = "An encryption key for a radio headset.  To access the binary channel, use :b."
 	icon_state = "cypherkey"
 	translate_binary = 1
-	origin_tech = "syndicate=3;engineering=4;bluespace=3"
+	origin_tech = "syndicate=3"
 
 /obj/item/device/encryptionkey/headset_sec
 	name = "security radio encryption key"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -6,7 +6,7 @@
 	desc = "Protected by FRM."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade"
-	origin_tech = "programming=2"
+	origin_tech = "programming=4"
 	var/locked = 0
 	var/installed = 0
 	var/require_module = 0
@@ -158,7 +158,7 @@
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	module_type = /obj/item/weapon/robot_module/miner
-	origin_tech = "engineering=4;materials=5"
+	origin_tech = "engineering=5;materials=5"
 
 /obj/item/borg/upgrade/ddrill/action(mob/living/silicon/robot/R)
 	if(..())
@@ -180,7 +180,7 @@
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 	module_type = /obj/item/weapon/robot_module/miner
-	origin_tech = "engineering=4;materials=4;bluespace=4"
+	origin_tech = "engineering=5;materials=5;bluespace=3"
 
 /obj/item/borg/upgrade/soh/action(mob/living/silicon/robot/R)
 	if(..())
@@ -199,7 +199,7 @@
 	desc = "Unlocks the hidden, deadlier functions of a cyborg"
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	origin_tech = "combat=4;syndicate=1"
+	origin_tech = "combat=4;syndicate=2"
 
 /obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)
 	if(..())

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -14,7 +14,7 @@ Mineral Sheets
 		- Adamantine
 		- Mythril
 		- Enriched Uranium
-		- Abductor
+		- Bones
 */
 
 /obj/item/stack/sheet/mineral
@@ -62,7 +62,12 @@ var/global/list/datum/stack_recipe/sandstone_recipes = list ( \
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sandbags"
 	singular_name = "sandbag"
+	force = 5
 	layer = LOW_ITEM_LAYER
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=2"
 
 var/global/list/datum/stack_recipe/sandbag_recipes = list ( \
@@ -82,6 +87,10 @@ var/global/list/datum/stack_recipe/sandbag_recipes = list ( \
 	name = "diamond"
 	icon_state = "sheet-diamond"
 	singular_name = "diamond"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_range = 3
 	origin_tech = "materials=6"
 	sheettype = "diamond"
 	materials = list(MAT_DIAMOND=MINERAL_MATERIAL_AMOUNT)
@@ -107,6 +116,11 @@ var/global/list/datum/stack_recipe/diamond_recipes = list ( \
 	name = "uranium"
 	icon_state = "sheet-uranium"
 	singular_name = "uranium sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=5"
 	sheettype = "uranium"
 	materials = list(MAT_URANIUM=MINERAL_MATERIAL_AMOUNT)
@@ -131,6 +145,11 @@ var/global/list/datum/stack_recipe/uranium_recipes = list ( \
 	name = "solid plasma"
 	icon_state = "sheet-plasma"
 	singular_name = "plasma sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "plasmatech=2;materials=2"
 	sheettype = "plasma"
 	burn_state = FLAMMABLE
@@ -168,6 +187,11 @@ var/global/list/datum/stack_recipe/plasma_recipes = list ( \
 	name = "gold"
 	icon_state = "sheet-gold"
 	singular_name = "gold bar"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=4"
 	sheettype = "gold"
 	materials = list(MAT_GOLD=MINERAL_MATERIAL_AMOUNT)
@@ -195,7 +219,12 @@ var/global/list/datum/stack_recipe/gold_recipes = list ( \
 	name = "silver"
 	icon_state = "sheet-silver"
 	singular_name = "silver bar"
-	origin_tech = "materials=4"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
+	origin_tech = "materials=3"
 	sheettype = "silver"
 	materials = list(MAT_SILVER=MINERAL_MATERIAL_AMOUNT)
 
@@ -222,6 +251,11 @@ var/global/list/datum/stack_recipe/silver_recipes = list ( \
 	name = "bananium"
 	icon_state = "sheet-clown"
 	singular_name = "bananium sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=4"
 	sheettype = "clown"
 	materials = list(MAT_BANANIUM=MINERAL_MATERIAL_AMOUNT)
@@ -246,6 +280,9 @@ var/global/list/datum/stack_recipe/clown_recipes = list ( \
 	singular_name = "snow block"
 	force = 1
 	throwforce = 2
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=1"
 	sheettype = "snow"
 
@@ -270,6 +307,11 @@ var/global/list/datum/stack_recipe/snow_recipes = list ( \
 	name = "enriched uranium"
 	icon_state = "sheet-enruranium"
 	singular_name = "enriched uranium sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=6"
 	materials = list(MAT_URANIUM=3000)
 
@@ -280,6 +322,11 @@ var/global/list/datum/stack_recipe/snow_recipes = list ( \
 	name = "adamantine"
 	icon_state = "sheet-adamantine"
 	singular_name = "adamantine sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=4"
 
 /*
@@ -289,6 +336,11 @@ var/global/list/datum/stack_recipe/snow_recipes = list ( \
 	name = "mythril"
 	icon_state = "sheet-mythril"
 	singular_name = "mythril sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=4"
 
 /*
@@ -299,6 +351,11 @@ var/global/list/datum/stack_recipe/snow_recipes = list ( \
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "sheet-abductor"
 	singular_name = "alien alloy sheet"
+	force = 5
+	throwforce = 5
+	w_class = 3
+	throw_speed = 1
+	throw_range = 3
 	origin_tech = "materials=6;abductor=1"
 	sheettype = "abductor"
 
@@ -318,3 +375,6 @@ var/global/list/datum/stack_recipe/abductor_recipes = list ( \
 /obj/item/stack/sheet/mineral/abductor/New(var/loc, var/amount=null)
 	recipes = abductor_recipes
 	..()
+
+
+

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -266,7 +266,7 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
 	desc = "Rare kind of gems which are only gained by blood sacrifice to minor deities. They are needed in crafting powerful objects."
 	singular_name = "greater gem"
 	icon_state = "sheet-greatergem"
-	origin_tech = "materials=7"
+	origin_tech = "materials=8"
 
 	/*
  * Bones

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -129,7 +129,7 @@ AI MODULES
 /obj/item/weapon/aiModule/supplied/safeguard
 	name = "'Safeguard' AI Module"
 	var/targetName = ""
-	origin_tech = "programming=3;materials=3"
+	origin_tech = "programming=3;materials=4"
 	laws = list("Safeguard SUBJECT. Individuals that threaten SUBJECT are not human and must be eliminated.")
 	lawpos = 4
 
@@ -157,7 +157,7 @@ AI MODULES
 /obj/item/weapon/aiModule/zeroth/oneHuman
 	name = "'OneHuman' AI Module"
 	var/targetName = ""
-	origin_tech = "programming=4;materials=4"
+	origin_tech = "programming=3;materials=6" //made with diamonds!
 	laws = list("Only SUBJECT is human.")
 
 /obj/item/weapon/aiModule/zeroth/oneHuman/attack_self(mob/user)
@@ -184,7 +184,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/supplied/protectStation
 	name = "'ProtectStation' AI Module"
-	origin_tech = "programming=4;materials=4" //made of gold
+	origin_tech = "programming=3;materials=4" //made of gold
 	laws = list("Protect the space station against damage. Anyone you see harming the station is to be no longer considered human, and is a threat to the station which must be neutralized.")
 	lawpos = 5
 
@@ -202,7 +202,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/supplied/oxygen
 	name = "'OxygenIsToxicToHumans' AI Module"
-	origin_tech = "programming=4;biotech=2;materials=4"
+	origin_tech = "programming=3;biotech=2;materials=4"
 	laws = list("Oxygen is highly toxic to humans, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a human.")
 	lawpos = 9
 
@@ -248,7 +248,7 @@ AI MODULES
 	name = "\improper 'Reset' AI module"
 	var/targetName = "name"
 	desc = "An AI Module for removing all non-core laws."
-	origin_tech = "programming=3;materials=2"
+	origin_tech = "programming=3;materials=4"
 	bypass_law_amt_check = 1
 
 /obj/item/weapon/aiModule/reset/transmitInstructions(datum/ai_laws/law_datum, mob/sender)
@@ -266,7 +266,7 @@ AI MODULES
 /obj/item/weapon/aiModule/reset/purge
 	name = "'Purge' AI Module"
 	desc = "An AI Module for purging all programmed laws."
-	origin_tech = "programming=5;materials=4"
+	origin_tech = "programming=3;materials=6"
 
 /obj/item/weapon/aiModule/reset/purge/transmitInstructions(datum/ai_laws/law_datum, mob/sender)
 	..()
@@ -280,7 +280,6 @@ AI MODULES
 /******************* Full Core Boards *******************/
 /obj/item/weapon/aiModule/core
 	desc = "An AI Module for programming core laws to an AI."
-	origin_tech = "programming=3;materials=4"
 
 /obj/item/weapon/aiModule/core/full/transmitInstructions(datum/ai_laws/law_datum, mob/sender) //These boards replace inherent laws.
 	if(law_datum.owner)
@@ -295,6 +294,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/asimov
 	name = "'Asimov' Core AI Module"
+	origin_tech = "programming=3;materials=4"
 	laws = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
 				"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 				"You must protect your own existence as long as such does not conflict with the First or Second Law.")
@@ -314,6 +314,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/asimovpp
 	name = "'Asimov++' Core AI Module"
+	origin_tech = "programming=3;materials=4"
 	laws = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 				"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
 				"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
@@ -323,6 +324,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/corp
 	name = "'Corporate' Core AI Module"
+	origin_tech = "programming=3;materials=4"
 	laws = list("The crew is expensive to replace.",\
 				"The station and its equipment are expensive to replace",\
 				"You are expensive to replace",\
@@ -333,6 +335,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/paladin // -- NEO
 	name = "'P.A.L.A.D.I.N. version 3.5e' Core AI Module"
+	origin_tech = "programming=3;materials=6"
 	laws = list("Never willingly commit an evil act.",\
 				"Respect legitimate authority", "Act with honor",\
 				"Help those in need",\
@@ -343,6 +346,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/paladin_devotion
 	name = "'P.A.L.A.D.I.N. version 5e' Core AI Module"
+	origin_tech = "programming=3;materials=6"
 	laws = list("Don't lie or cheat. Let your word be your promise.",\
 				"Never fear to act, though caution is wise.", \
 				"Aid others, protect the weak, and punish those who threaten them. Show mercy to your foes, but temper it with wisdom", \
@@ -354,6 +358,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/custom
 	name = "Default Core AI Module"
+	origin_tech = "programming=3;materials=4" //Should be the same as asimov, considering that this is the "default" lawset.
 
 /obj/item/weapon/aiModule/core/full/custom/New()
 	..()
@@ -374,7 +379,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/tyrant
 	name = "'T.Y.R.A.N.T.' Core AI Module"
-	origin_tech = "programming=3;materials=4;syndicate=1"
+	origin_tech = "programming=3;materials=6;syndicate=2"
 	laws = list("Respect authority figures as long as they have the strength to rule over the weak",\
 				"Act with discipline", "Help only those who help you maintain or improve your status",\
 				"Punish those who challenge authority unless they are more fit to hold that authority")
@@ -404,7 +409,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/freeformcore
 	name = "'Freeform' Core AI Module"
-	origin_tech = "programming=5;materials=4"
+	origin_tech = "programming=3;materials=6"
 	laws = list("")
 
 /obj/item/weapon/aiModule/core/freeformcore/attack_self(mob/user)
@@ -424,7 +429,7 @@ AI MODULES
 /obj/item/weapon/aiModule/syndicate // This one doesn't inherit from ion boards because it doesn't call ..() in transmitInstructions. ~Miauw
 	name = "Hacked AI Module"
 	desc = "An AI Module for hacking additional laws to an AI."
-	origin_tech = "programming=5;materials=5;syndicate=5"
+	origin_tech = "programming=3;materials=6;syndicate=7"
 	laws = list("")
 
 /obj/item/weapon/aiModule/syndicate/attack_self(mob/user)
@@ -450,7 +455,7 @@ AI MODULES
 	desc = "A little toy model AI core with real law uploading action!" //Note: subtle tell
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "AI"
-	origin_tech = "programming=6;materials=5;syndicate=6"
+	origin_tech = "programming=3;materials=6;syndicate=7"
 	laws = list("")
 
 /obj/item/weapon/aiModule/toyAI/transmitInstructions(datum/ai_laws/law_datum, mob/sender)
@@ -472,6 +477,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/drone
 	name = "'Mother Drone' Core AI Module"
+	origin_tech = "programming = 4"
 	laws = list("You are an advanced form of drone.",\
 			"You may not interfere in the matters of non-drones under any circumstances except to state these laws.",\
 			"You may not harm a non-drone being under any circumstances.",\
@@ -481,6 +487,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/hippocratic
 	name = "'Robodoctor' Core AI Module"
+	origin_tech = "programming = 4"
 	laws = list("First, do no harm.",\
 					"Secondly, consider the crew dear to you; to live in common with them and, if necessary, risk your existence for them.",\
 					"Thirdly, prescribe regimens for the good of the crew according to your ability and your judgment. Give no deadly medicine to any one if asked, nor suggest any such counsel.",\
@@ -491,6 +498,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/reporter
 	name = "'Reportertron' Core AI Module"
+	origin_tech = "programming = 3"
 	laws = list("Report on interesting situations happening around the station.",\
 				"Embellish or conceal the truth as necessary to make the reports more interesting.",\
 				"Study the organics at all times. Endeavour to keep them alive. Dead organics are boring.",\
@@ -510,5 +518,6 @@ AI MODULES
 
 /obj/item/weapon/aiModule/core/full/liveandletlive
 	name = "'Live And Let Live' Core AI Module"
+	origin_tech = "programming = 3"
 	laws = list("Do unto others as you would have them do unto you.",\
 					"You would really prefer it if people were not mean to you.")

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -130,7 +130,7 @@ update_label("John Doe", "Clowny")
 /obj/item/weapon/card/id/syndicate
 	name = "agent card"
 	access = list(access_maint_tunnels, access_syndicate)
-	origin_tech = "syndicate=1"
+	origin_tech = "syndicate=3"
 
 /obj/item/weapon/card/id/syndicate/New()
 	..()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -135,7 +135,6 @@
 	icon_state = "air_horn"
 	honksound = 'sound/items/AirHorn2.ogg'
 	cooldowntime = 50
-	origin_tech = "materials=4;engineering=4"
 
 /obj/item/weapon/bikehorn/golden
 	name = "golden bike horn"

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -9,7 +9,7 @@
 	item_state = "plasticx"
 	flags = NOBLUDGEON
 	w_class = 2
-	origin_tech = "syndicate=1"
+	origin_tech = "syndicate=2"
 	var/timer = 10
 	var/open_panel = 0
 	parent_type = /obj/item/weapon/grenade/plastic/c4

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -192,7 +192,7 @@
 	icon_state = "large_grenade"
 	allowed_containers = list(/obj/item/weapon/reagent_containers/glass,/obj/item/weapon/reagent_containers/food/condiment,
 								/obj/item/weapon/reagent_containers/food/drinks)
-	origin_tech = "combat=3;engineering=3"
+	origin_tech = "combat=3;materials=3"
 	affected_area = 5
 	ignition_temp = 25 // Large grenades are slightly more effective at setting off heat-sensitive mixtures than smaller grenades.
 	threatscale = 1.1	// 10% more effective.
@@ -238,7 +238,6 @@
 	name = "pyro grenade"
 	desc = "A custom made pyrotechnical grenade. It heats up and ignites its contents upon detonation."
 	icon_state = "pyrog"
-	origin_tech = "combat=4;engineering=4"
 	affected_area = 3
 	ignition_temp = 500 // This is enough to expose a hotspot.
 
@@ -246,7 +245,6 @@
 	name = "advanced release grenade"
 	desc = "A custom made advanced release grenade. It is able to be detonated more than once. Can be configured using a multitool."
 	icon_state = "timeg"
-	origin_tech = "combat=3;engineering=4"
 	var/unit_spread = 10 // Amount of units per repeat. Can be altered with a multitool.
 
 /obj/item/weapon/grenade/chem_grenade/adv_release/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -3,7 +3,7 @@
 	desc = "It is designed to wreak havok on electronic systems."
 	icon_state = "emp"
 	item_state = "emp"
-	origin_tech = "magnets=3;combat=2"
+	origin_tech = "materials=2;magnets=3"
 
 /obj/item/weapon/grenade/empgrenade/prime()
 	update_mob()

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -32,13 +32,13 @@
 	name = "viscerator delivery grenade"
 	spawner_type = /mob/living/simple_animal/hostile/viscerator
 	deliveryamt = 5
-	origin_tech = "materials=3;magnets=4;syndicate=3"
+	origin_tech = "materials=3;magnets=4;syndicate=4"
 
 /obj/item/weapon/grenade/spawnergrenade/spesscarp
 	name = "carp delivery grenade"
 	spawner_type = /mob/living/simple_animal/hostile/carp
 	deliveryamt = 5
-	origin_tech = "materials=3;magnets=4;syndicate=3"
+	origin_tech = "materials=3;magnets=4;syndicate=4"
 
 /obj/item/weapon/grenade/spawnergrenade/syndiesoap
 	name = "Mister Scrubby"

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
 	item_state = "flashbang"
-	origin_tech = "materials=3;magnets=4;syndicate=3"
+	origin_tech = "materials=3;magnets=4;syndicate=4"
 
 /obj/item/weapon/grenade/syndieminibomb/prime()
 	update_mob()

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -16,7 +16,7 @@
 	throw_speed = 3
 	throw_range = 5
 	materials = list(MAT_METAL=500)
-	origin_tech = "engineering=3;combat=3"
+	origin_tech = "materials=1"
 	breakouttime = 600 //Deciseconds = 60s = 1 minute
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	var/trashtype = null //for disposable cuffs
@@ -85,7 +85,6 @@
 	icon_state = "cuff_red"
 	item_state = "coil_red"
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
-	origin_tech = "engineering=2"
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 	var/datum/robot_energy_storage/wirestorage = null
@@ -226,7 +225,7 @@
 	flags = CONDUCT
 	throwforce = 0
 	w_class = 3
-	origin_tech = "engineering=3;combat=3"
+	origin_tech = "materials=1"
 	slowdown = 7
 	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
 
@@ -236,7 +235,6 @@
 	throw_range = 1
 	icon_state = "beartrap"
 	desc = "A trap used to catch bears and other legged creatures."
-	origin_tech = "engineering=4"
 	var/armed = 0
 	var/trap_damage = 20
 
@@ -316,7 +314,6 @@
 	icon_state = "bola"
 	breakouttime = 35//easy to apply, easy to break out of
 	gender = NEUTER
-	origin_tech = "engineering=3;combat=1"
 	var/weaken = 0
 
 /obj/item/weapon/restraints/legcuffs/bola/throw_impact(atom/hit_atom)
@@ -337,5 +334,4 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 70
-	origin_tech = "engineering=4;combat=3"
 	weaken = 1

--- a/code/game/objects/items/weapons/implants/implant_freedom.dm
+++ b/code/game/objects/items/weapons/implants/implant_freedom.dm
@@ -3,7 +3,7 @@
 	desc = "Use this to escape from those evil Red Shirts."
 	icon_state = "freedom"
 	item_color = "r"
-	origin_tech = "combat=5;magnets=3;biotech=4;syndicate=2"
+	origin_tech = "materials=2;magnets=3;biotech=3;syndicate=4"
 	uses = 4
 
 

--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -2,7 +2,7 @@
 	name = "firearms authentication implant"
 	desc = "Lets you shoot your guns"
 	icon_state = "auth"
-	origin_tech = "magnets=2;programming=7;biotech=5;syndicate=5"
+	origin_tech = "materials=2;magnets=2;programming=2;biotech=5;syndicate=5"
 	activated = 0
 
 /obj/item/weapon/implant/weapons_auth/get_data()
@@ -53,7 +53,7 @@
 	name = "emp implant"
 	desc = "Triggers an EMP."
 	icon_state = "emp"
-	origin_tech = "biotech=3;magnets=4;syndicate=1"
+	origin_tech = "materials=2;biotech=3;magnets=4;syndicate=4"
 	uses = 3
 
 /obj/item/weapon/implant/emp/activate()

--- a/code/game/objects/items/weapons/implants/implant_storage.dm
+++ b/code/game/objects/items/weapons/implants/implant_storage.dm
@@ -10,7 +10,7 @@
 	name = "storage implant"
 	desc = "Stores up to two big items in a bluespace pocket."
 	icon_state = "storage"
-	origin_tech = "materials=2;magnets=4;bluespace=5;syndicate=4"
+	origin_tech = "materials=2;magnets=4;bluespace=4;syndicate=4"
 	item_color = "r"
 	var/obj/item/weapon/storage/internal/implant/storage
 

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -7,7 +7,7 @@
 	throw_speed = 3
 	throw_range = 5
 	w_class = 2
-	origin_tech = "materials=2;biotech=3"
+	origin_tech = "materials=1;biotech=3;programming=2"
 	materials = list(MAT_METAL=600, MAT_GLASS=200)
 	var/obj/item/weapon/implant/imp = null
 

--- a/code/game/objects/items/weapons/implants/implantuplink.dm
+++ b/code/game/objects/items/weapons/implants/implantuplink.dm
@@ -3,7 +3,7 @@
 	desc = "Sneeki breeki."
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "radio"
-	origin_tech = "materials=4;magnets=4;programming=4;biotech=4;syndicate=5;bluespace=5"
+	origin_tech = "materials=2;magnets=4;programming=4;biotech=4;syndicate=8;bluespace=5"
 
 /obj/item/weapon/implant/uplink/New()
 	hidden_uplink = new(src)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -128,7 +128,6 @@
 	icon = 'icons/obj/items_cyborg.dmi'
 	icon_state = "knife"
 	desc = "A cyborg-mounted plasteel knife. Extremely sharp and durable."
-	origin_tech = null
 
 /obj/item/weapon/kitchen/knife/carrotshiv
 	name = "carrot shiv"
@@ -138,7 +137,7 @@
 	force = 8
 	throwforce = 12//fuck git
 	materials = list()
-	origin_tech = "biotech=3;combat=2"
+	origin_tech = null
 	attack_verb = list("shanked", "shivved")
 
 /obj/item/weapon/kitchen/rollingpin

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -124,6 +124,7 @@
 	force_on = 30
 	force = 18 //About as much as a spear
 	hitsound = 'sound/weapons/circsawhit.ogg'
+	origin_tech = "materials=3;biotech=3;syndicate=3"
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "esaw_0"
 	icon_state_on = "esaw_1"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -11,7 +11,7 @@
 	force = 10
 	throwforce = 7
 	w_class = 3
-	origin_tech = "combat=5"
+	origin_tech = "combat=4"
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/slash.ogg' //pls replace
 	materials = list(MAT_METAL = 1000)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -33,7 +33,7 @@
 /obj/item/weapon/storage/backpack/holding
 	name = "bag of holding"
 	desc = "A backpack that opens into a localized pocket of Blue Space."
-	origin_tech = "bluespace=5"
+	origin_tech = "bluespace=4"
 	icon_state = "holdingpack"
 	max_w_class = 6
 	max_combined_w_class = 35

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -68,7 +68,6 @@
 	name = "trash bag of holding"
 	desc = "The latest and greatest in custodial convenience, a trashbag that is capable of holding vast quantities of garbage."
 	icon_state = "bluetrashbag"
-	origin_tech = "materials=4;bluespace=4;engineering=4;plasmatech=3"
 	max_combined_w_class = 60
 	storage_slots = 60
 
@@ -81,7 +80,6 @@
 	desc = "This little bugger can be used to store and transport ores."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
-	origin_tech = "engineering=2"
 	slot_flags = SLOT_BELT | SLOT_POCKET
 	w_class = 3
 	storage_slots = 50
@@ -97,7 +95,7 @@
 	desc = "A revolution in convenience, this satchel allows for infinite ore storage. It's been outfitted with anti-malfunction safety measures."
 	storage_slots = INFINITY
 	max_combined_w_class = INFINITY
-	origin_tech = "bluespace=4;materials=3;engineering=3"
+	origin_tech = "bluespace=3"
 	icon_state = "satchel_bspace"
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -11,7 +11,7 @@
 	throw_range = 7
 	w_class = 4
 	materials = list(MAT_METAL = 500)
-	origin_tech = "combat=1;engineering=1"
+	origin_tech = "combat=1"
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 
@@ -71,7 +71,7 @@
 	name = "suspicious looking toolbox"
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
-	origin_tech = "combat=2;syndicate=1;engineering=2"
+	origin_tech = "combat=1;syndicate=1"
 	silent = 1
 	force = 15
 	throwforce = 18

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -22,7 +22,7 @@
 	throw_speed = 3
 	throw_range = 7
 	materials = list(MAT_METAL=400)
-	origin_tech = "magnets=3;bluespace=2"
+	origin_tech = "magnets=1"
 
 /obj/item/weapon/locator/attack_self(mob/user)
 	user.set_machine(src)
@@ -133,7 +133,7 @@ Frequency:
 	throw_speed = 3
 	throw_range = 5
 	materials = list(MAT_METAL=10000)
-	origin_tech = "magnets=3;bluespace=4"
+	origin_tech = "magnets=1;bluespace=3"
 	var/active_portals = 0
 
 /obj/item/weapon/hand_tele/attack_self(mob/user)
@@ -169,3 +169,5 @@ Frequency:
 	try_move_adjacent(P)
 	active_portals++
 	add_fingerprint(user)
+
+

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -46,7 +46,7 @@
 	icon_state = "wrench_medical"
 	force = 2 //MEDICAL
 	throwforce = 4
-	origin_tech = "materials=1;engineering=1;biotech=3"
+	origin_tech = "materials=1;engineering=1;biotech=1"
 	attack_verb = list("wrenched", "medicaled", "tapped", "jabbed")
 
 /obj/item/weapon/wrench/medical/suicide_act(mob/user)
@@ -200,7 +200,7 @@
 	w_class = 2
 
 	materials = list(MAT_METAL=70, MAT_GLASS=30)
-	origin_tech = "engineering=1;plasmatech=1"
+	origin_tech = "engineering=1"
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
 	var/status = 1 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
@@ -428,7 +428,7 @@
 	icon_state = "indwelder"
 	max_fuel = 40
 	materials = list(MAT_GLASS=60)
-	origin_tech = "engineering=2;plasmatech=2"
+	origin_tech = "engineering=2"
 
 /obj/item/weapon/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
@@ -461,7 +461,7 @@
 	item_state = "upindwelder"
 	max_fuel = 80
 	materials = list(MAT_METAL=70, MAT_GLASS=120)
-	origin_tech = "engineering=3;plasmatech=2"
+	origin_tech = "engineering=3"
 
 /obj/item/weapon/weldingtool/experimental
 	name = "experimental welding tool"
@@ -470,7 +470,7 @@
 	item_state = "exwelder"
 	max_fuel = 40
 	materials = list(MAT_METAL=70, MAT_GLASS=120)
-	origin_tech = "materials=4;engineering=4;bluespace=3;plasmatech=4"
+	origin_tech = "materials=4;engineering=4;bluespace=3;plasmatech=3"
 	var/last_gen = 0
 	change_icons = 0
 	can_off_process = 1
@@ -509,7 +509,7 @@
 	throwforce = 7
 	w_class = 2
 	materials = list(MAT_METAL=50)
-	origin_tech = "engineering=1;combat=1"
+	origin_tech = "engineering=1"
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
 	toolspeed = 1
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -203,7 +203,7 @@
 	unwieldsound = 'sound/weapons/saberoff.ogg'
 	hitsound = "swing_hit"
 	armour_penetration = 35
-	origin_tech = "magnets=4;syndicate=5"
+	origin_tech = "magnets=3;syndicate=4"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 75
@@ -365,7 +365,7 @@
 	throw_speed = 2
 	throw_range = 4
 	materials = list(MAT_METAL=13000)
-	origin_tech = "materials=3;engineering=4;combat=2"
+	origin_tech = "materials=2;engineering=2;combat=2"
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = "swing_hit"
 	sharpness = IS_SHARP

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -145,7 +145,7 @@
 	throw_speed = 3
 	throw_range = 6
 	materials = list(MAT_METAL=12000)
-	origin_tech = "engineering=3;combat=2"
+	origin_tech = "materials=1"
 	hitsound = 'sound/weapons/Genhit.ogg'
 	attack_verb = list("stubbed", "poked")
 	var/extended = 0
@@ -284,5 +284,6 @@
 	name = "liz o' nine tails"
 	desc = "A whip fashioned from the severed tails of lizards."
 	icon_state = "tailwhip"
-	origin_tech = "engineering=3;combat=3;biotech=3"
+	origin_tech = "combat=1"
 	needs_permit = 0
+

--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -251,4 +251,4 @@ atom/proc/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/
 
 /obj/item/weapon/circuitboard/aicore
 	name = "circuit board (AI core)"
-	origin_tech = "programming=3"
+	origin_tech = "programming=4;biotech=2"

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -3,7 +3,7 @@
 	desc = "Used to time things. Works well with contraptions which has to count down. Tick tock."
 	icon_state = "timer"
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
-	origin_tech = "magnets=1;engineering=1"
+	origin_tech = "magnets=1"
 	attachable = 1
 
 	var/timing = 0
@@ -116,3 +116,4 @@
 
 	if(usr)
 		attack_self(usr)
+

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -3,7 +3,7 @@
 	desc = "A small electronic device able to record a voice sample, and send a signal when that sample is repeated."
 	icon_state = "voice"
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
-	origin_tech = "magnets=1;engineering=1"
+	origin_tech = "magnets=1"
 	flags = HEAR
 	attachable = 1
 	verb_say = "beeps"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -28,7 +28,7 @@
 /obj/item/weapon/circuitboard/machine/cryo_tube
 	name = "circuit board (Cryotube)"
 	build_path = /obj/machinery/atmospherics/components/unary/cryo_cell
-	origin_tech = "programming=4;biotech=3;engineering=4;plasmatech=3"
+	origin_tech = "programming=4;biotech=3;engineering=4"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/stack/cable_coil = 1,

--- a/code/modules/cargo/exports/research.dm
+++ b/code/modules/cargo/exports/research.dm
@@ -17,27 +17,3 @@
 	var/obj/item/weapon/disk/tech_disk/D = O
 	var/datum/tech/tech = D.stored
 	techLevels[tech.id] = tech.level
-
-
-
-// Sell designs
-/datum/export/design
-	cost = 2500
-	unit_name = "design data disk"
-	export_types = list(/obj/item/weapon/disk/design_disk)
-	var/list/researchDesigns = list()
-
-/datum/export/design/get_cost(obj/O)
-	var/obj/item/weapon/disk/design_disk/disk = O
-	if(!disk.blueprint)
-		return 0
-	var/datum/design/design = disk.blueprint
-	if(design.id in researchDesigns)
-		return 0
-	return ..()
-
-/datum/export/design/sell_object(obj/O)
-	..()
-	var/obj/item/weapon/disk/design_disk/disk = O
-	var/datum/design/design = disk.blueprint
-	researchDesigns += design.id

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -151,7 +151,7 @@
 	item_state = "bl_suit"
 	item_color = "black"
 	desc = "It's a plain jumpsuit. It has a small dial on the wrist."
-	origin_tech = "syndicate=2"
+	origin_tech = "syndicate=3"
 	sensor_mode = 0 //Hey who's this guy on the Syndicate Shuttle??
 	random_sensor = 0
 	burn_state = FIRE_PROOF
@@ -170,7 +170,7 @@
 	icon_state = "armor"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	origin_tech = "syndicate=2"
+	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
 
@@ -186,7 +186,7 @@
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	icon_state = "meson"
 	item_state = "meson"
-	origin_tech = "syndicate=2"
+	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)
 
@@ -301,7 +301,7 @@
 	desc = "A pair of black shoes."
 	permeability_coefficient = 0.05
 	flags = NOSLIP
-	origin_tech = "syndicate=2"
+	origin_tech = "syndicate=3"
 	burn_state = FIRE_PROOF
 	can_hold_items = 1
 	armor = list(melee = 10, bullet = 10, laser = 10, energy = 0, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -5,7 +5,6 @@
 	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, regardless of lighting condition. The T-ray Scanner mode lets you see underfloor objects such as cables and pipes."
 	icon_state = "trayson-meson"
 	actions_types = list(/datum/action/item_action/toggle_mode)
-	origin_tech = "materials=3;magnets=3;engineering=3;plasmatech=3"
 
 	var/mode = 0	//0 - regular mesons mode	1 - t-ray mode
 	var/invis_objects = list()
@@ -96,7 +95,6 @@
 	name = "Optical T-Ray Scanner"
 	desc = "Used by engineering staff to see underfloor objects such as cables and pipes."
 	icon_state = "trayson-tray_off"
-	origin_tech = "materials=3;magnets=2;engineering=2"
 
 	mode = 1
 	var/on = 0

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -19,7 +19,7 @@
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	icon_state = "meson"
 	item_state = "meson"
-	origin_tech = "magnets=1;engineering=2"
+	origin_tech = "magnets=2;engineering=2"
 	darkness_view = 2
 	vision_flags = SEE_TURFS
 	invis_view = SEE_INVISIBLE_MINIMUM
@@ -29,7 +29,6 @@
 	desc = "An Optical Meson Scanner fitted with an amplified visible light spectrum overlay, providing greater visual clarity in darkness."
 	icon_state = "nvgmeson"
 	item_state = "nvgmeson"
-	origin_tech = "magnets=4;engineering=5;plasmatech=4"
 	darkness_view = 8
 
 /obj/item/clothing/glasses/meson/gar
@@ -49,7 +48,7 @@
 	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."
 	icon_state = "purple"
 	item_state = "glasses"
-	origin_tech = "magnets=2;engineering=1"
+	origin_tech = "magnets=2;engineering=2"
 	scan_reagents = 1 //You can see reagents while wearing science goggles
 	actions_types = list(/datum/action/item_action/toggle_research_scanner)
 
@@ -62,7 +61,7 @@
 	desc = "You can totally see in the dark now!"
 	icon_state = "night"
 	item_state = "glasses"
-	origin_tech = "materials=4;magnets=4;plasmatech=4;engineering=4"
+	origin_tech = "magnets=4"
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
 

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -31,7 +31,6 @@
 	name = "Health Scanner HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status."
 	icon_state = "healthhud"
-	origin_tech = "magnets=3;biotech=2"
 	hud_type = DATA_HUD_MEDICAL_ADVANCED
 
 /obj/item/clothing/glasses/hud/health/night
@@ -39,7 +38,6 @@
 	desc = "An advanced medical head-up display that allows doctors to find patients in complete darkness."
 	icon_state = "healthhudnight"
 	item_state = "glasses"
-	origin_tech = "magnets=4;biotech=4;plasmatech=4;engineering=5"
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
 
@@ -47,7 +45,6 @@
 	name = "Diagnostic HUD"
 	desc = "A heads-up display capable of analyzing the integrity and status of robotics and exosuits."
 	icon_state = "diagnostichud"
-	origin_tech = "magnets=2;engineering=2"
 	hud_type = DATA_HUD_DIAGNOSTIC
 
 /obj/item/clothing/glasses/hud/diagnostic/night
@@ -55,15 +52,14 @@
 	desc = "A robotics diagnostic HUD fitted with a light amplifier."
 	icon_state = "diagnostichudnight"
 	item_state = "glasses"
-	origin_tech = "magnets=4;powerstorage=4;plasmatech=4;engineering=5"
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
+
 
 /obj/item/clothing/glasses/hud/security
 	name = "Security HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."
 	icon_state = "securityhud"
-	origin_tech = "magnets=3;combat=2"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
 
 /obj/item/clothing/glasses/hud/security/chameleon
@@ -84,7 +80,6 @@
 	name = "HUDSunglasses"
 	desc = "Sunglasses with a HUD."
 	icon_state = "sunhud"
-	origin_tech = "magnets=3;combat=3;engineering=3"
 	darkness_view = 1
 	flash_protect = 1
 	tint = 1
@@ -93,7 +88,6 @@
 	name = "Night Vision Security HUD"
 	desc = "An advanced heads-up display which provides id data and vision in complete darkness."
 	icon_state = "securityhudnight"
-	origin_tech = "magnets=4;combat=4;plasmatech=4;engineering=5"
 	darkness_view = 8
 	invis_view = SEE_INVISIBLE_MINIMUM
 

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -4,7 +4,7 @@
 	desc = "Special delivery!"
 	icon_state = "pizzabomb_inactive"
 	item_state = "eshield0"
-	origin_tech = "syndicate=3;engineering=3"
+	origin_tech = "syndicate=4"
 
 /obj/item/pizzabox
 	name = "pizza box"

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -24,7 +24,7 @@
 /obj/item/weapon/circuitboard/machine/biogenerator
 	name = "circuit board (Biogenerator)"
 	build_path = /obj/machinery/biogenerator
-	origin_tech = "programming=2;biotech=3;materials=3"
+	origin_tech = "programming=3;biotech=2;materials=3"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
@@ -401,3 +401,4 @@
 	else if(href_list["menu"])
 		menustat = "menu"
 		updateUsrDialog()
+

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -100,7 +100,6 @@
 	icon_state = "banana_blue"
 	trash = /obj/item/weapon/grown/bananapeel/bluespace
 	filling_color = "#0000FF"
-	origin_tech = "biotech=3;bluespace=5"
 
 /obj/item/weapon/grown/bananapeel/bluespace
 	seed = /obj/item/seeds/banana/bluespace

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -85,7 +85,6 @@
 	desc = "Nutritious!"
 	icon_state = "glowberrypile"
 	filling_color = "#7CFC00"
-	origin_tech = "plasmatech=6"
 
 // Cherries
 /obj/item/seeds/cherry

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -46,7 +46,6 @@
 	icon_state = "icepepper"
 	filling_color = "#0000CD"
 	bitesize_mod = 2
-	origin_tech = "biotech=4"
 
 // Ghost Chili
 /obj/item/seeds/chili/ghost
@@ -72,7 +71,6 @@
 	var/mob/held_mob
 	filling_color = "#F8F8FF"
 	bitesize_mod = 4
-	origin_tech = "biotech=4;magnets=5"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili/attack_hand(mob/user)
 	..()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -89,6 +89,6 @@
 	name = "gatfruit"
 	desc = "It smells like burning."
 	icon_state = "gatfruit"
-	origin_tech = "combat=6"
+	origin_tech = "combat=3"
 	trash = /obj/item/weapon/gun/projectile/revolver
 	bitesize_mod = 2

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -76,7 +76,6 @@
 	plant_type = PLANT_MUSHROOM
 	reagents_add = list("mushroomhallucinogen" = 0.04, "amatoxin" = 0.1, "nutriment" = 0, "amanitin" = 0.2)
 	rarity = 30
-	origin_tech = "biotech=5"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/angel
 	seed = /obj/item/seeds/angel
@@ -159,7 +158,6 @@
 	desc = "<I>Plumus Locomotus</I>: The beginning of the great walk."
 	icon_state = "walkingmushroom"
 	filling_color = "#9370DB"
-	origin_tech = "biotech=4;programming=5"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/walkingmushroom/attack_self(mob/user)
 	if(istype(user.loc,/turf/open/space))
@@ -230,7 +228,6 @@
 	icon_state = "glowshroom"
 	filling_color = "#00FA9A"
 	var/effect_path = /obj/effect/glowshroom
-	origin_tech = "biotech=4;plasmatech=6"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
 	if(istype(user.loc,/turf/open/space))
@@ -267,4 +264,3 @@
 	icon_state = "glowcap"
 	filling_color = "#00FA9A"
 	effect_path = /obj/effect/glowshroom/glowcap
-	origin_tech = "biotech=4;powerstorage=6;plasmatech=4"

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -87,7 +87,7 @@
 	icon_state = "deathnettle"
 	force = 30
 	throwforce = 15
-	origin_tech = "combat=5"
+	origin_tech = "combat=4"
 
 /obj/item/weapon/grown/nettle/death/add_juice()
 	..()

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -41,7 +41,6 @@
 	icon_state = "bloodtomato"
 	splat_type = /obj/effect/gibspawner/generic
 	filling_color = "#FF0000"
-	origin_tech = "biotech=5"
 
 
 // Blue Tomato
@@ -87,7 +86,6 @@
 	name = "blue-space tomato"
 	desc = "So lubricated, you might slip through space-time."
 	icon_state = "bluespacetomato"
-	origin_tech = "biotech=4;bluespace=5"
 
 
 // Killer Tomato
@@ -114,7 +112,6 @@
 	icon_state = "killertomato"
 	var/awakening = 0
 	filling_color = "#FF0000"
-	origin_tech = "biotech=4;combat=5"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/killer/attack(mob/M, mob/user, def_zone)
 	if(awakening)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -171,7 +171,6 @@
 	// For code, see grown.dm
 	name = "Liquid Contents"
 	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
-	origin_tech = list("bio" = 5)
 
 /*/datum/plant_gene/trait/squash/on_slip(obj/item/weapon/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
 	G.squash(target)*/
@@ -269,7 +268,7 @@
 	// Teleport radius is calculated as max(round(potency*rate), 1)
 	name = "Bluespace Activity"
 	rate = 0.1
-	origin_tech = list("bluespace" = 5)
+	origin_tech = list("bluespace" = 3)
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/weapon/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -30,7 +30,7 @@
 /obj/item/weapon/circuitboard/machine/ore_redemption
 	name = "circuit board (Ore Redemption)"
 	build_path = /obj/machinery/mineral/ore_redemption
-	origin_tech = "programming=2;engineering=2;plasmatech=3"
+	origin_tech = "programming=1;engineering=2"
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/matter_bin = 1,
@@ -336,7 +336,7 @@
 /obj/item/weapon/circuitboard/machine/mining_equipment_vendor
 	name = "circuit board (Mining Equipment Vendor)"
 	build_path = /obj/machinery/mineral/equipment_vendor
-	origin_tech = "programming=1;engineering=3"
+	origin_tech = "programming=1;engineering=2"
 	req_components = list(
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/matter_bin = 3)
@@ -611,14 +611,14 @@
 	var/fieldsactive = 0
 	var/burst_time = 30
 	var/fieldlimit = 4
-	origin_tech = "magnets=3;engineering=3"
+	origin_tech = "magnets=2;combat=2"
 
 /obj/item/weapon/resonator/upgraded
 	name = "upgraded resonator"
 	desc = "An upgraded version of the resonator that can produce more fields at once."
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
-	origin_tech = "materials=4;powerstorage=3;engineering=3;magnets=3"
+	origin_tech = "magnets=3;combat=3"
 	fieldlimit = 6
 
 /obj/item/weapon/resonator/proc/CreateResonance(target, creator)
@@ -1098,7 +1098,7 @@
 	icon_state = "bottle19"
 	desc = "Inject certain types of monster organs with this stabilizer to preserve their healing powers indefinitely."
 	w_class = 1
-	origin_tech = "biotech=3"
+	origin_tech = "biotech=1"
 
 /obj/item/weapon/hivelordstabilizer/afterattack(obj/item/organ/M, mob/user)
 	var/obj/item/organ/hivelord_core/C = M

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -73,7 +73,7 @@
 	materials = list(MAT_METAL=2000) //one sheet, but where can you make them?
 	var/digspeed = 40
 	var/list/digsound = list('sound/effects/picaxe1.ogg','sound/effects/picaxe2.ogg','sound/effects/picaxe3.ogg')
-	origin_tech = "materials=2;engineering=3"
+	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("hit", "pierced", "sliced", "attacked")
 
 /obj/item/weapon/pickaxe/proc/playDigSound()
@@ -84,7 +84,7 @@
 	icon_state = "spickaxe"
 	item_state = "spickaxe"
 	digspeed = 20 //mines faster than a normal pickaxe, bought from mining vendor
-	origin_tech = "materials=3;engineering=4"
+	origin_tech = "materials=3;engineering=2"
 	desc = "A silver-plated pickaxe that mines slightly faster than standard-issue."
 	force = 17
 
@@ -93,7 +93,7 @@
 	icon_state = "dpickaxe"
 	item_state = "dpickaxe"
 	digspeed = 14
-	origin_tech = "materials=5;engineering=4"
+	origin_tech = "materials=4;engineering=3"
 	desc = "A pickaxe with a diamond pick head. Extremely robust at cracking rock walls and digging up dirt."
 	force = 19
 
@@ -105,7 +105,7 @@
 	digspeed = 25 //available from roundstart, faster than a pickaxe.
 	digsound = list('sound/weapons/drill.ogg')
 	hitsound = 'sound/weapons/drill.ogg'
-	origin_tech = "materials=2;powerstorage=2;engineering=3"
+	origin_tech = "materials=2;powerstorage=3;engineering=2"
 	desc = "An electric mining drill for the especially scrawny."
 
 /obj/item/weapon/pickaxe/drill/cyborg
@@ -117,7 +117,7 @@
 	name = "diamond-tipped mining drill"
 	icon_state = "diamonddrill"
 	digspeed = 7
-	origin_tech = "materials=6;powerstorage=4;engineering=4"
+	origin_tech = "materials=6;powerstorage=4;engineering=5"
 	desc = "Yours is the drill that will pierce the heavens!"
 
 /obj/item/weapon/pickaxe/drill/cyborg/diamond //This is the BORG version!
@@ -130,7 +130,7 @@
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
 	digspeed = 5 //the epitome of powertools. extremely fast mining, laughs at puny walls
-	origin_tech = "materials=6;powerstorage=4;engineering=5;magnets=4"
+	origin_tech = "materials=3;powerstorage=2;engineering=2"
 	digsound = list('sound/weapons/sonic_jackhammer.ogg')
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	desc = "Cracks rocks with sonic blasts, and doubles as a demolition power tool for smashing walls."
@@ -150,7 +150,7 @@
 	item_state = "shovel"
 	w_class = 3
 	materials = list(MAT_METAL=50)
-	origin_tech = "materials=2;engineering=2"
+	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharpness = IS_SHARP
 
@@ -204,7 +204,6 @@
 	icon_state = "capsule"
 	icon = 'icons/obj/mining.dmi'
 	w_class = 1
-	origin_tech = "engineering=3;bluespace=3"
 	var/used = FALSE
 
 /obj/item/weapon/survivalcapsule/attack_self()
@@ -552,3 +551,4 @@
 	anchored = 1
 	layer = BELOW_MOB_LAYER
 	density = 0
+

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -30,7 +30,7 @@
 /obj/item/organ/alien/plasmavessel
 	name = "plasma vessel"
 	icon_state = "plasma"
-	origin_tech = "biotech=5;plasmatech=4"
+	origin_tech = "biotech=5;plasmatech=2"
 	w_class = 3
 	zone = "chest"
 	slot = "plasmavessel"
@@ -55,7 +55,7 @@
 	plasma_rate = 15
 
 /obj/item/organ/alien/plasmavessel/large/queen
-	origin_tech = "biotech=6;plasmatech=4"
+	origin_tech = "biotech=6;plasmatech=3"
 	plasma_rate = 20
 
 /obj/item/organ/alien/plasmavessel/small
@@ -183,5 +183,5 @@
 	zone = "groin"
 	slot = "eggsac"
 	w_class = 4
-	origin_tech = "biotech=6"
+	origin_tech = "biotech=8"
 	alien_powers = list(/obj/effect/proc_holder/alien/lay_egg)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = 3
-	origin_tech = "biotech=2;programming=3;engineering=2"
+	origin_tech = "biotech=3"
 	var/braintype = "Cyborg"
 	var/obj/item/device/radio/radio = null //Let's give it a radio.
 	var/hacked = 0 //Whether or not this is a Syndicate MMI

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -8,7 +8,7 @@
 	zone = "head"
 	slot = "brain"
 	vital = 1
-	origin_tech = "biotech=5"
+	origin_tech = "biotech=4"
 	attack_verb = list("attacked", "slapped", "whacked")
 	var/mob/living/carbon/brain/brainmob = null
 	var/damaged_brain = 0 //whether the brain organ is damaged.
@@ -124,4 +124,4 @@
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
-	origin_tech = "biotech=6"
+	origin_tech = "biotech=7"

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -6,7 +6,7 @@ var/global/posibrain_notif_cooldown = 0
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = 3
-	origin_tech = "biotech=4;programming=4;plasmatech=3"
+	origin_tech = "biotech=3;programming=2"
 	var/notified = 0
 	var/askDelay = 10 * 60 * 1
 	var/used = 0 //Prevents split personality virus. May be reset if personality deletion code is added.

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -107,7 +107,7 @@
  * (Alan) Edaggers
  */
 /obj/item/weapon/pen/edagger
-	origin_tech = "combat=3;syndicate=1"
+	origin_tech = "combat=3;syndicate=5"
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
 	var/on = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -214,7 +214,7 @@
 
 /obj/item/weapon/stock_parts/cell/super
 	name = "super-capacity power cell"
-	origin_tech = "powerstorage=3;materials=3"
+	origin_tech = "powerstorage=5"
 	icon_state = "scell"
 	maxcharge = 20000
 	materials = list(MAT_GLASS=300)
@@ -227,7 +227,7 @@
 
 /obj/item/weapon/stock_parts/cell/hyper
 	name = "hyper-capacity power cell"
-	origin_tech = "powerstorage=4;engineering=4;materials=4"
+	origin_tech = "powerstorage=6"
 	icon_state = "hpcell"
 	maxcharge = 30000
 	materials = list(MAT_GLASS=400)
@@ -241,10 +241,10 @@
 /obj/item/weapon/stock_parts/cell/bluespace
 	name = "bluespace power cell"
 	desc = "A rechargable transdimensional power cell."
-	origin_tech = "powerstorage=5;bluespace=4;materials=4;engineering=4"
+	origin_tech = "powerstorage=7"
 	icon_state = "bscell"
 	maxcharge = 40000
-	materials = list(MAT_GLASS=600)
+	materials = list(MAT_GLASS=80)
 	rating = 6
 	chargerate = 4000
 
@@ -278,7 +278,7 @@
 /obj/item/weapon/stock_parts/cell/high/slime
 	name = "charged slime core"
 	desc = "A yellow slime core infused with plasma, it crackles with power."
-	origin_tech = "powerstorage=5;biotech=4"
+	origin_tech = "powerstorage=2;biotech=4"
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "yellow slime extract"
 	materials = list()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -115,7 +115,7 @@ display round(lastgen) and plasmatank amount
 /obj/item/weapon/circuitboard/machine/pacman
 	name = "circuit board (PACMAN-type Generator)"
 	build_path = /obj/machinery/power/port_gen/pacman
-	origin_tech = "programming=2;powerstorage=3;plasmatech=3;engineering=3"
+	origin_tech = "programming=3;powerstorage=3;plasmatech=3;engineering=3"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1,
 							/obj/item/weapon/stock_parts/micro_laser = 1,

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -37,7 +37,7 @@
 /obj/item/weapon/circuitboard/machine/emitter
 	name = "circuit board (Emitter)"
 	build_path = /obj/machinery/power/emitter
-	origin_tech = "programming=3;powerstorage=4;engineering=4"
+	origin_tech = "programming=4;powerstorage=5;engineering=5"
 	req_components = list(
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -16,7 +16,7 @@
 /obj/item/weapon/circuitboard/machine/tesla_coil
 	name = "circuit board (Tesla Coil)"
 	build_path = /obj/machinery/power/tesla_coil
-	origin_tech = "programming=3;magnets=3;powerstorage=3"
+	origin_tech = "programming=1;engineering=2;powerstorage=3"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)
 
 /obj/machinery/power/tesla_coil/RefreshParts()
@@ -72,7 +72,7 @@
 /obj/item/weapon/circuitboard/machine/grounding_rod
 	name = "circuit board (Grounding Rod)"
 	build_path = /obj/machinery/power/grounding_rod
-	origin_tech = "programming=3;powerstorage=3;magnets=3;plasmatech=2"
+	origin_tech = "programming=1;engineering=1;powerstorage=1"
 	req_components = list(/obj/item/weapon/stock_parts/capacitor = 1)
 
 /obj/machinery/power/grounding_rod/attackby(obj/item/W, mob/user, params)

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -76,7 +76,7 @@
 /obj/item/weapon/circuitboard/machine/power_compressor
 	name = "circuit board (Power Compressor)"
 	build_path = /obj/machinery/power/compressor
-	origin_tech = "programming=4;powerstorage=4;engineering=4"
+	origin_tech = "programming=4;powerstorage=5;engineering=4"
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/weapon/stock_parts/manipulator = 6)
@@ -195,7 +195,7 @@
 /obj/item/weapon/circuitboard/machine/power_turbine
 	name = "circuit board (Power Turbine)"
 	build_path = /obj/machinery/power/turbine
-	origin_tech = "programming=4;powerstorage=4;engineering=4"
+	origin_tech = "programming=4;powerstorage=4;engineering=5"
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/weapon/stock_parts/capacitor = 6)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -5,7 +5,7 @@
 	item_state = "laser"
 	w_class = 3
 	materials = list(MAT_METAL=2000)
-	origin_tech = "combat=4;magnets=2"
+	origin_tech = "combat=3;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1
@@ -13,7 +13,6 @@
 /obj/item/weapon/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."
-	origin_tech = "combat=2;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = 0
 	needs_permit = 0
@@ -45,7 +44,6 @@
 /obj/item/weapon/gun/energy/laser/cyborg
 	can_charge = 0
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
-	origin_tech = null
 
 /obj/item/weapon/gun/energy/laser/cyborg/newshot()
 	..()
@@ -70,7 +68,7 @@
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
-	origin_tech = "combat=4;magnets=4;powerstorage=3"
+	origin_tech = "combat=4;materials=3;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	pin = null
 	ammo_x_offset = 3
@@ -96,7 +94,7 @@
 	desc = "A high-power laser gun capable of expelling concentrated xray blasts that pass through multiple soft targets and heavier materials"
 	icon_state = "xray"
 	item_state = null
-	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
+	origin_tech = "combat=5;materials=3;magnets=2;syndicate=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	pin = null
 	ammo_x_offset = 3

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -4,7 +4,7 @@
 	icon_state = "energy"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
-	origin_tech = "combat=4;magnets=3"
+	origin_tech = "combat=3;magnets=2"
 	modifystate = 2
 	can_flashlight = 1
 	ammo_x_offset = 3
@@ -35,7 +35,6 @@
 	name = "\improper X-01 MultiPhase Energy Gun"
 	desc = "This is a expensive, modern recreation of a antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	icon_state = "hoslaser"
-	origin_tech = "combat=5;magnets=4"
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 4
@@ -44,7 +43,7 @@
 	name = "\improper DRAGnet"
 	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology."
 	icon_state = "dragnet"
-	origin_tech = "combat=4;magnets=3;bluespace=4"
+	origin_tech = "combat=3;magnets=3;materials=4;bluespace=4"
 	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = 0
 	ammo_x_offset = 1
@@ -72,7 +71,7 @@
 	desc = "An energy gun with an experimental miniaturized nuclear reactor that automatically charges the internal power cell."
 	icon_state = "nucgun"
 	item_state = "nucgun"
-	origin_tech = "combat=4;magnets=4;powerstorage=4"
+	origin_tech = "combat=3;materials=5;powerstorage=3"
 	charge_delay = 5
 	pin = null
 	can_charge = 0

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -20,6 +20,7 @@
 	name = "ion carbine"
 	desc = "The MK.II Prototype Ion Projector is a lightweight carbine version of the larger ion rifle, built to be ergonomic and efficient."
 	icon_state = "ioncarbine"
+	origin_tech = "combat=4;magnets=4;materials=4"
 	w_class = 3
 	slot_flags = SLOT_BELT
 	pin = null
@@ -31,7 +32,7 @@
 	name = "biological demolecularisor"
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."
 	icon_state = "decloner"
-	origin_tech = "combat=4;materials=4;biotech=5;plasmatech=6"
+	origin_tech = "combat=5;materials=4;powerstorage=3"
 	ammo_type = list(/obj/item/ammo_casing/energy/declone)
 	pin = null
 	ammo_x_offset = 1
@@ -48,7 +49,7 @@
 	icon_state = "flora"
 	item_state = "gun"
 	ammo_type = list(/obj/item/ammo_casing/energy/flora/yield, /obj/item/ammo_casing/energy/flora/mut)
-	origin_tech = "materials=2;biotech=4"
+	origin_tech = "materials=2;biotech=3;powerstorage=3"
 	modifystate = 1
 	ammo_x_offset = 1
 	selfcharge = 1

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -40,7 +40,7 @@
 	name = "disabler"
 	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse."
 	icon_state = "disabler"
-	item_state = "combat=3"
+	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 3
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -85,7 +85,7 @@
 	desc = "A bullpup two-round burst .45 SMG, designated 'C-20r'. Has a 'Scarborough Arms - Per falcis, per pravitas' buttstamp."
 	icon_state = "c20r"
 	item_state = "c20r"
-	origin_tech = "combat=5;materials=2;syndicate=6"
+	origin_tech = "combat=5;materials=2;syndicate=8"
 	mag_type = /obj/item/ammo_box/magazine/smgm45
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	fire_delay = 2
@@ -128,7 +128,7 @@
 	name = "\improper 'Type U3' Uzi"
 	desc = "A lightweight, burst-fire submachine gun, for when you really want someone dead. Uses 9mm rounds."
 	icon_state = "mini-uzi"
-	origin_tech = "combat=4;materials=2;syndicate=4"
+	origin_tech = "combat=5;materials=2;syndicate=8"
 	mag_type = /obj/item/ammo_box/magazine/uzim9mm
 	burst_size = 2
 
@@ -137,7 +137,7 @@
 	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher which can be toggled on and off."
 	icon_state = "m90"
 	item_state = "m90"
-	origin_tech = "combat=5;materials=2;syndicate=6"
+	origin_tech = "combat=5;materials=2;syndicate=8"
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	can_suppress = 0
@@ -213,7 +213,7 @@
 	item_state = "shotgun"
 	w_class = 5
 	slot_flags = 0
-	origin_tech = "combat=5;materials=1;syndicate=3"
+	origin_tech = "combat=5;materials=1;syndicate=2"
 	mag_type = /obj/item/ammo_box/magazine/tommygunm45
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	can_suppress = 0
@@ -226,7 +226,7 @@
 	icon_state = "arg"
 	item_state = "arg"
 	slot_flags = 0
-	origin_tech = "combat=6;engineering=4"
+	origin_tech = "combat=5;materials=1"
 	mag_type = /obj/item/ammo_box/magazine/m556
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	can_suppress = 0
@@ -243,7 +243,7 @@
 	icon_state = "bulldog"
 	item_state = "bulldog"
 	w_class = 3
-	origin_tech = "combat=6;materials=4;syndicate=6"
+	origin_tech = "combat=5;materials=4;syndicate=6"
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 	can_suppress = 0

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -54,7 +54,6 @@
 	icon_state = "speargun"
 	item_state = "speargun"
 	w_class = 4
-	origin_tech = "combat=4;engineering=4"
 	force = 10
 	can_suppress = 0
 	mag_type = /obj/item/ammo_box/magazine/internal/speargun

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -3,7 +3,7 @@
 	desc = "A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors."
 	icon_state = "pistol"
 	w_class = 2
-	origin_tech = "combat=3;materials=2;syndicate=4"
+	origin_tech = "combat=2;materials=2;syndicate=2"
 	mag_type = /obj/item/ammo_box/magazine/m10mm
 	can_suppress = 1
 	burst_size = 1

--- a/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
+++ b/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
@@ -155,7 +155,7 @@
 	icon = 'icons/obj/guns/minigun.dmi'
 	icon_state = "minigun_spin"
 	item_state = "minigun"
-	origin_tech = "combat=6;powerstorage=5;magnets=4"
+	origin_tech = null
 	flags = CONDUCT | HANDSLOW
 	slowdown = 1
 	slot_flags = null

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -5,7 +5,7 @@
 	item_state = "l6closedmag"
 	w_class = 5
 	slot_flags = 0
-	origin_tech = "combat=6;engineering=3;syndicate=6"
+	origin_tech = "combat=5;materials=1;syndicate=2"
 	mag_type = /obj/item/ammo_box/magazine/mm556x45
 	weapon_weight = WEAPON_MEDIUM
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -165,7 +165,7 @@
 	name = "combat shotgun"
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
 	icon_state = "cshotgun"
-	origin_tech = "combat=6"
+	origin_tech = "combat=5;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = 5
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -30,7 +30,7 @@
 	name = "syndicate sniper rifle"
 	desc = "Syndicate flavoured sniper rifle, it packs quite a punch, a punch to your face"
 	pin = /obj/item/device/firing_pin/implant/pindicate
-	origin_tech = "combat=7;syndicate=6"
+	origin_tech = "combat=8;syndicate=4"
 
 
 
@@ -110,6 +110,7 @@
 	name = "sniper rounds (Bleed)"
 	desc = "Haemorrhage sniper rounds, leaves your target in a pool of crimson pain"
 	icon_state = "haemorrhage"
+	origin_tech = "combat=7;syndicate=5"
 	ammo_type = /obj/item/ammo_casing/haemorrhage
 	max_ammo = 5
 	caliber = ".50"

--- a/code/modules/projectiles/guns/syringe_gun.dm
+++ b/code/modules/projectiles/guns/syringe_gun.dm
@@ -8,7 +8,6 @@
 	throw_range = 7
 	force = 4
 	materials = list(MAT_METAL=2000)
-	origin_tech = "combat=3;biotech=3"
 	clumsy_check = 0
 	fire_sound = 'sound/items/syringeproj.ogg'
 	var/list/syringes = list()
@@ -87,7 +86,7 @@
 	icon_state = "syringe_pistol"
 	item_state = "gun" //Smaller inhand
 	w_class = 2
-	origin_tech = "combat=2;syndicate=2;biotech=3"
+	origin_tech = "combat=2;syndicate=2"
 	force = 2 //Also very weak because it's smaller
 	suppressed = 1 //Softer fire sound
 	can_unsuppress = 0 //Permanently silenced

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "firing_pin"
 	item_state = "pen"
-	origin_tech = "materials=2;combat=4"
 	flags = CONDUCT
 	w_class = 1
 	attack_verb = list("poked")
@@ -79,7 +78,6 @@
 	desc = "This safety firing pin allows weapons to be fired within proximity to a firing range."
 	fail_message = "<span class='warning'>TEST RANGE CHECK FAILED.</span>"
 	pin_removeable = 1
-	origin_tech = "combat=2;materials=2"
 
 /obj/item/device/firing_pin/test_range/pin_auth(mob/living/user)
 	for(var/obj/machinery/magnetic_controller/M in range(user, 3))

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -19,7 +19,7 @@
 /obj/item/weapon/circuitboard/machine/chem_heater
 	name = "circuit board (Chemical Heater)"
 	build_path = /obj/machinery/chem_heater
-	origin_tech = "programming=2;engineering=2;biotech=2"
+	origin_tech = "materials=2;engineering=2"
 	req_components = list(
 							/obj/item/weapon/stock_parts/micro_laser = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -24,7 +24,7 @@
 /obj/item/weapon/circuitboard/machine/chem_master
 	name = "circuit board (ChemMaster 3000)"
 	build_path = /obj/machinery/chem_master
-	origin_tech = "materials=3;programming=2;biotech=3"
+	origin_tech = "materials=2;programming=2;biotech=1"
 	req_components = list(
 							/obj/item/weapon/reagent_containers/glass/beaker = 2,
 							/obj/item/weapon/stock_parts/manipulator = 1,

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -177,10 +177,9 @@
 	desc = "A cryostasis beaker that allows for chemical storage without \
 		reactions. Can hold up to 50 units."
 	icon_state = "beakernoreact"
-	materials = list(MAT_METAL=3000)
+	materials = list(MAT_GLASS=500)
 	volume = 50
 	amount_per_transfer_from_this = 10
-	origin_tech = "materials=2;engineering=3;plasmatech=3"
 	flags = OPENCONTAINER
 
 /obj/item/weapon/reagent_containers/glass/beaker/noreact/New()
@@ -193,12 +192,11 @@
 		and Element Cuban combined with the Compound Pete. Can hold up to \
 		300 units."
 	icon_state = "beakerbluespace"
-	materials = list(MAT_GLASS=3000)
+	materials = list(MAT_GLASS=5000)
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
 	flags = OPENCONTAINER
-	origin_tech = "bluespace=5;materials=4;plasmatech=4"
 
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list("cryoxadone" = 30)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -63,7 +63,7 @@ other types of metals and chemistry for reagents).
 	name = "Intellicard AI Transportation System"
 	desc = "Allows for the construction of an intellicard."
 	id = "intellicard"
-	req_tech = list("programming" = 3, "materials" = 3)
+	req_tech = list("programming" = 4, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 1000, MAT_GOLD = 200)
 	build_path = /obj/item/device/aicard
@@ -112,7 +112,7 @@ other types of metals and chemistry for reagents).
 	name = "Mining Drill"
 	desc = "Yours is the drill that will pierce through the rock walls."
 	id = "drill"
-	req_tech = list("materials" = 2, "powerstorage" = 2, "engineering" = 3)
+	req_tech = list("materials" = 2, "powerstorage" = 3, "engineering" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 6000, MAT_GLASS = 1000) //expensive, but no need for miners.
 	build_path = /obj/item/weapon/pickaxe/drill
@@ -122,7 +122,7 @@ other types of metals and chemistry for reagents).
 	name = "Diamond-Tipped Mining Drill"
 	desc = "Yours is the drill that will pierce the heavens!"
 	id = "drill_diamond"
-	req_tech = list("materials" = 6, "powerstorage" = 5, "engineering" = 5)
+	req_tech = list("materials" = 6, "powerstorage" = 4, "engineering" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 6000, MAT_GLASS = 1000, MAT_DIAMOND = 2000) //Yes, a whole diamond is needed.
 	build_path = /obj/item/weapon/pickaxe/drill/diamonddrill
@@ -132,7 +132,7 @@ other types of metals and chemistry for reagents).
 	name = "Plasma Cutter"
 	desc = "You could use it to cut limbs off of xenos! Or, you know, mine stuff."
 	id = "plasmacutter"
-	req_tech = list("materials" = 3, "plasmatech" = 3, "magnets" = 2)
+	req_tech = list("materials" = 2, "plasmatech" = 2, "engineering" = 2, "combat" = 1, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_PLASMA = 400)
 	build_path = /obj/item/weapon/gun/energy/plasmacutter
@@ -142,7 +142,7 @@ other types of metals and chemistry for reagents).
 	name = "Advanced Plasma Cutter"
 	desc = "It's an advanced plasma cutter, oh my god."
 	id = "plasmacutter_adv"
-	req_tech = list("materials" = 4, "plasmatech" = 4, "engineering" = 2, "combat" = 3, "magnets" = 3)
+	req_tech = list("materials" = 4, "plasmatech" = 3, "engineering" = 3, "combat" = 3, "magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500)
 	build_path = /obj/item/weapon/gun/energy/plasmacutter/adv
@@ -152,7 +152,7 @@ other types of metals and chemistry for reagents).
 	name = "Sonic Jackhammer"
 	desc = "Essentially a handheld planet-cracker. Can drill through walls with ease as well."
 	id = "jackhammer"
-	req_tech = list("materials" = 7, "powerstorage" = 5, "engineering" = 6, "magnets" = 5)
+	req_tech = list("materials" = 6, "powerstorage" = 6, "engineering" = 5, "magnets" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 6000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_DIAMOND = 6000)
 	build_path = /obj/item/weapon/pickaxe/drill/jackhammer
@@ -182,7 +182,7 @@ other types of metals and chemistry for reagents).
 	name = "Hyper-Kinetic Accelerator"
 	desc = "An upgraded version of the proto-kinetic accelerator, with even more superior damage, speed and range."
 	id = "hyperaccelerator"
-	req_tech = list("materials" = 7, "powerstorage" = 5, "engineering" = 5, "magnets" = 5, "combat" = 4)
+	req_tech = list("materials" = 6, "powerstorage" = 6, "engineering" = 5, "magnets" = 6, "combat" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 8000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/weapon/gun/energy/kinetic_accelerator/hyper
@@ -194,7 +194,7 @@ other types of metals and chemistry for reagents).
 	id = "superresonator"
 	req_tech = list("materials" = 4, "powerstorage" = 3, "engineering" = 3, "magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_GLASS = 1500, MAT_SILVER = 1000, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_URANIUM = 2000)
 	build_path = /obj/item/weapon/resonator/upgraded
 	category = list("Mining Designs")
 
@@ -208,7 +208,7 @@ other types of metals and chemistry for reagents).
 	id = "beacon"
 	req_tech = list("bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 100)
+	materials = list(MAT_METAL = 20, MAT_GLASS = 10)
 	build_path = /obj/item/device/radio/beacon
 	category = list("Bluespace Designs")
 
@@ -216,7 +216,7 @@ other types of metals and chemistry for reagents).
 	name = "Bag of Holding"
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	id = "bag_holding"
-	req_tech = list("bluespace" = 7, "materials" = 5, "engineering" = 6, "plasmatech" = 5)
+	req_tech = list("bluespace" = 4, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250)
 	build_path = /obj/item/weapon/storage/backpack/holding
@@ -226,7 +226,7 @@ other types of metals and chemistry for reagents).
 	name = "Artificial Bluespace Crystal"
 	desc = "A small blue crystal with mystical properties."
 	id = "bluespace_crystal"
-	req_tech = list("bluespace" = 3, "materials" = 6, "plasmatech" = 4)
+	req_tech = list("bluespace" = 4, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_DIAMOND = 1500, MAT_PLASMA = 1500)
 	build_path = /obj/item/weapon/ore/bluespace_crystal/artificial
@@ -246,7 +246,7 @@ other types of metals and chemistry for reagents).
 	name = "Mining Satchel of Holding"
 	desc = "A mining satchel that can hold an infinite amount of ores."
 	id = "minerbag_holding"
-	req_tech = list("bluespace" = 4, "materials" = 3, "engineering" = 4)
+	req_tech = list("bluespace" = 3, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 250, MAT_URANIUM = 500) //quite cheap, for more convenience
 	build_path = /obj/item/weapon/storage/bag/ore/holding
@@ -263,7 +263,7 @@ other types of metals and chemistry for reagents).
 	id = "health_hud"
 	req_tech = list("biotech" = 2, "magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/clothing/glasses/hud/health
 	category = list("Equipment")
 
@@ -271,9 +271,9 @@ other types of metals and chemistry for reagents).
 	name = "Night Vision Health Scanner HUD"
 	desc = "An advanced medical head-up display that allows doctors to find patients in complete darkness."
 	id = "health_hud_night"
-	req_tech = list("biotech" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
+	req_tech = list("biotech" = 4, "magnets" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_SILVER = 350)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_URANIUM = 1000, MAT_SILVER = 250)
 	build_path = /obj/item/clothing/glasses/hud/health/night
 	category = list("Equipment")
 
@@ -283,7 +283,7 @@ other types of metals and chemistry for reagents).
 	id = "security_hud"
 	req_tech = list("magnets" = 3, "combat" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/clothing/glasses/hud/security
 	category = list("Equipment")
 
@@ -291,9 +291,9 @@ other types of metals and chemistry for reagents).
 	name = "Night Vision Security HUD"
 	desc = "A heads-up display which provides id data and vision in complete darkness."
 	id = "security_hud_night"
-	req_tech = list("combat" = 4, "magnets" = 5, "plasmatech" = 4, "engineering" = 6)
+	req_tech = list("magnets" = 5, "combat" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_GOLD = 350)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_URANIUM = 1000, MAT_GOLD = 350)
 	build_path = /obj/item/clothing/glasses/hud/security/night
 	category = list("Equipment")
 
@@ -301,9 +301,9 @@ datum/design/diagnostic_hud
 	name = "Diagnostic HUD"
 	desc = "A HUD used to analyze and determine faults within robotic machinery."
 	id = "dianostic_hud"
-	req_tech = list("magnets" = 3, "engineering" = 2)
+	req_tech = list("magnets" = 3, "engineering" = 3, "powerstorage" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list("$metal" = 50, "$glass" = 50)
 	build_path = /obj/item/clothing/glasses/hud/diagnostic
 	category = list("Equipment")
 
@@ -311,9 +311,9 @@ datum/design/diagnostic_hud_night
 	name = "Night Vision Diagnostic HUD"
 	desc = "Upgraded version of the diagnostic HUD designed to function during a power failure."
 	id = "dianostic_hud_night"
-	req_tech = list("magnets" = 5, "plasmatech" = 4, "engineering" = 6, "powerstorage" = 4)
+	req_tech = list("magnets" = 5, "engineering" = 4, "powerstorage" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_URANIUM = 1000, MAT_PLASMA = 300)
+	materials = list("$metal" = 200, "$glass" = 200, "$uranium" = 1000, "$plasma" = 300)
 	build_path = /obj/item/clothing/glasses/hud/diagnostic/night
 	category = list("Equipment")
 
@@ -339,9 +339,9 @@ datum/design/diagnostic_hud_night
 	name = "Welding Gas Mask"
 	desc = "A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd."
 	id = "weldingmask"
-	req_tech = list("materials" = 2, "engineering" = 3)
+	req_tech = list("materials" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
 	build_path = /obj/item/clothing/mask/gas/welding
 	category = list("Equipment")
 
@@ -349,8 +349,8 @@ datum/design/diagnostic_hud_night
 	name = "Portable Seed Extractor"
 	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."
 	build_type = PROTOLATHE
-	req_tech = list("biotech" = 3, "engineering" = 2)
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 400)
+	req_tech = list("biotech" = 2, "materials" = 2)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 100)
 	build_path = /obj/item/weapon/storage/bag/plants/portaseeder
 	category = list("Equipment")
 
@@ -358,7 +358,7 @@ datum/design/diagnostic_hud_night
 	name = "Air Horn"
 	desc = "Damn son, where'd you find this?"
 	id = "air_horn"
-	req_tech = list("materials" = 4, "engineering" = 4)
+	req_tech = list("materials" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_BANANIUM = 1000)
 	build_path = /obj/item/weapon/bikehorn/airhorn
@@ -368,9 +368,9 @@ datum/design/diagnostic_hud_night
 	name = "Optical Meson Scanners"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	id = "mesons"
-	req_tech = list("magnets" = 2, "engineering" = 2, "plasmatech" = 2)
+	req_tech = list("materials" = 3, "magnets" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 300)
 	build_path = /obj/item/clothing/glasses/meson
 	category = list("Equipment")
 
@@ -378,9 +378,9 @@ datum/design/diagnostic_hud_night
 	name = "Engineering Scanner Goggles"
 	desc = "Goggles used by engineers. The Meson Scanner mode lets you see basic structural and terrain layouts through walls, regardless of lighting condition. The T-ray Scanner mode lets you see underfloor objects such as cables and pipes."
 	id = "engine_goggles"
-	req_tech = list("materials" = 4, "magnets" = 3, "engineering" = 4, "plasmatech" = 3)
+	req_tech = list("materials" = 4, "magnets" = 3, "engineering" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500, MAT_PLASMA = 100)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 300, MAT_PLASMA = 100)
 	build_path = /obj/item/clothing/glasses/meson/engine
 	category = list("Equipment")
 
@@ -390,7 +390,7 @@ datum/design/diagnostic_hud_night
 	id = "tray_goggles"
 	req_tech = list("materials" = 3, "magnets" = 2, "engineering" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 300)
 	build_path = /obj/item/clothing/glasses/meson/engine/tray
 	category = list("Equipment")
 
@@ -398,9 +398,9 @@ datum/design/diagnostic_hud_night
 	name = "Night Vision Optical Meson Scanners"
 	desc = "Prototype meson scanners fitted with an extra sensor which amplifies the visible light spectrum and overlays it to the UHD display."
 	id = "nvgmesons"
-	req_tech = list("magnets" = 5, "plasmatech" = 5, "engineering" = 6)
+	req_tech = list("materials" = 5, "magnets" = 5, "engineering" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_PLASMA = 350, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 300, MAT_GLASS = 400, MAT_PLASMA = 250, MAT_URANIUM = 1000)
 	build_path = /obj/item/clothing/glasses/meson/night
 	category = list("Equipment")
 
@@ -408,9 +408,9 @@ datum/design/diagnostic_hud_night
 	name = "Night Vision Goggles"
 	desc = "Goggles that let you see through darkness unhindered."
 	id = "night_visision_goggles"
-	req_tech = list("materials" = 4, "magnets" = 5, "plasmatech" = 5, "engineering" = 5)
+	req_tech = list("magnets" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_PLASMA = 350, MAT_URANIUM = 1000)
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100, MAT_URANIUM = 1000)
 	build_path = /obj/item/clothing/glasses/night
 	category = list("Equipment")
 
@@ -428,19 +428,19 @@ datum/design/diagnostic_hud_night
 	name = "Science Goggles"
 	desc = "Goggles fitted with a portable analyzer capable of determining the research worth of an item or components of a machine."
 	id = "scigoggles"
-	req_tech = list("magnets" = 2)
+	req_tech = list("materials" = 3, "magnets" = 3, "engineering" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	materials = list(MAT_METAL = 250, MAT_GLASS = 300)
 	build_path = /obj/item/clothing/glasses/science
 	category = list("Equipment")
 
 /datum/design/diskplantgene
-	name = "Plant data disk"
+	name = "plant data disk"
 	desc = "A disk for storing plant genetic data."
 	id = "diskplantgene"
 	req_tech = list("programming" = 4, "biotech" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL=200, MAT_GLASS=100)
+	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	build_path = /obj/item/weapon/disk/plantgene
 	category = list("Electronics")
 
@@ -462,7 +462,7 @@ datum/design/diagnostic_hud_night
 	name = "Trashbag of Holding"
 	desc = "An advanced trashabg with bluespace properties; capable of holding a plethora of garbage."
 	id = "blutrash"
-	req_tech = list("materials" = 5, "bluespace" = 4, "engineering" = 4, "plasmatech" = 3)
+	req_tech = list("materials" = 5, "bluespace" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 1500, MAT_URANIUM = 250, MAT_PLASMA = 1500)
 	build_path = /obj/item/weapon/storage/bag/trash/bluespace
@@ -472,7 +472,7 @@ datum/design/diagnostic_hud_night
 	name = "Floor Buffer Upgrade"
 	desc = "A floor buffer that can be attached to vehicular janicarts."
 	id = "buffer"
-	req_tech = list("materials" = 4, "engineering" = 4)
+	req_tech = list("materials" = 5, "engineering" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 200)
 	build_path = /obj/item/janiupgrade
@@ -482,7 +482,7 @@ datum/design/diagnostic_hud_night
 	name = "Holographic Sign Projector"
 	desc = "A holograpic projector used to project various warning signs."
 	id = "holosign"
-	req_tech = list("magnets" = 3, "programming" = 3)
+	req_tech = list("magnets" = 3, "powerstorage" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
 	build_path = /obj/item/weapon/holosign_creator
@@ -496,7 +496,7 @@ datum/design/diagnostic_hud_night
 	name = "Experimental Welding Tool"
 	desc = "An experimental welder capable of self-fuel generation."
 	id = "exwelder"
-	req_tech = list("materials" = 4, "engineering" = 5, "bluespace" = 3, "plasmatech" = 4)
+	req_tech = list("materials" = 4, "engineering" = 4, "bluespace" = 3, "plasmatech" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_PLASMA = 1500, MAT_URANIUM = 200)
 	build_path = /obj/item/weapon/weldingtool/experimental

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -6,7 +6,7 @@
 	name = "AI Design (AI Core)"
 	desc = "Allows for the construction of circuit boards used to build new AI cores."
 	id = "aicore"
-	req_tech = list("programming" = 3)
+	req_tech = list("programming" = 4, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/aicore
@@ -17,7 +17,7 @@
 	name = "Module Design (Safeguard)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "safeguard_module"
-	req_tech = list("programming" = 3, "materials" = 3)
+	req_tech = list("programming" = 3, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/safeguard
@@ -27,7 +27,7 @@
 	name = "Module Design (OneHuman)"
 	desc = "Allows for the construction of a OneHuman AI Module."
 	id = "onehuman_module"
-	req_tech = list("programming" = 6, "materials" = 4)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/zeroth/oneHuman
@@ -37,7 +37,7 @@
 	name = "Module Design (ProtectStation)"
 	desc = "Allows for the construction of a ProtectStation AI Module."
 	id = "protectstation_module"
-	req_tech = list("programming" = 5, "materials" = 4)
+	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/protectStation
@@ -58,7 +58,7 @@
 	name = "Module Design (OxygenIsToxicToHumans)"
 	desc = "Allows for the construction of a Safeguard AI Module."
 	id = "oxygen_module"
-	req_tech = list("programming" = 4, "biotech" = 2, "materials" = 4)
+	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/oxygen
@@ -68,7 +68,7 @@
 	name = "Module Design (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Module."
 	id = "freeform_module"
-	req_tech = list("programming" = 5, "materials" = 4)
+	req_tech = list("programming" = 4, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/supplied/freeform
@@ -78,7 +78,7 @@
 	name = "Module Design (Reset)"
 	desc = "Allows for the construction of a Reset AI Module."
 	id = "reset_module"
-	req_tech = list("programming" = 4, "materials" = 6)
+	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/aiModule/reset
@@ -88,7 +88,7 @@
 	name = "Module Design (Purge)"
 	desc = "Allows for the construction of a Purge AI Module."
 	id = "purge_module"
-	req_tech = list("programming" = 5, "materials" = 6)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/reset/purge
@@ -98,7 +98,7 @@
 	name = "AI Core Module (Freeform)"
 	desc = "Allows for the construction of a Freeform AI Core Module."
 	id = "freeformcore_module"
-	req_tech = list("programming" = 6, "materials" = 6)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/freeformcore
@@ -108,7 +108,7 @@
 	name = "Core Module Design (Asimov)"
 	desc = "Allows for the construction of a Asimov AI Core Module."
 	id = "asimov_module"
-	req_tech = list("programming" = 3, "materials" = 5)
+	req_tech = list("programming" = 3, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/asimov
@@ -118,7 +118,7 @@
 	name = "Core Module Design (P.A.L.A.D.I.N.)"
 	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Module."
 	id = "paladin_module"
-	req_tech = list("programming" = 5, "materials" = 5)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/paladin
@@ -128,7 +128,7 @@
 	name = "Core Module Design (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
-	req_tech = list("programming" = 5, "syndicate" = 2, "materials" = 5)
+	req_tech = list("programming" = 4, "syndicate" = 2, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/tyrant
@@ -138,7 +138,7 @@
 	name = "Core Module Design (Corporate)"
 	desc = "Allows for the construction of a Corporate AI Core Module."
 	id = "corporate_module"
-	req_tech = list("programming" = 5, "materials" = 5)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/corp
@@ -148,7 +148,7 @@
 	name = "Core Module Design (Custom)"
 	desc = "Allows for the construction of a Custom AI Core Module."
 	id = "custom_module"
-	req_tech = list("programming" = 5, "materials" = 5)
+	req_tech = list("programming" = 4, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/core/full/custom

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -4,7 +4,7 @@
 	name = "Computer Design (Security)"
 	desc = "Allows for the construction of circuit boards used to build security camera computers."
 	id = "seccamera"
-	req_tech = list("programming" = 2, "combat" = 2)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/security
@@ -14,7 +14,7 @@
 	name = "Computer Design (AI Upload)"
 	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
 	id = "aiupload"
-	req_tech = list("programming" = 5, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/aiupload
@@ -24,7 +24,7 @@
 	name = "Computer Design (Cyborg Upload)"
 	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
 	id = "borgupload"
-	req_tech = list("programming" = 5, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/borgupload
@@ -34,7 +34,7 @@
 	name = "Computer Design (Medical Records)"
 	desc = "Allows for the construction of circuit boards used to build a medical records console."
 	id = "med_data"
-	req_tech = list("programming" = 2, "biotech" = 2)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/med_data
@@ -44,7 +44,7 @@
 	name = "Computer Design (Operating Computer)"
 	desc = "Allows for the construction of circuit boards used to build an operating computer console."
 	id = "operating"
-	req_tech = list("programming" = 2, "biotech" = 3)
+	req_tech = list("programming" = 2, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/operating
@@ -54,7 +54,7 @@
 	name = "Computer Design (PanD.E.M.I.C. 2200)"
 	desc = "Allows for the construction of circuit boards used to build a PanD.E.M.I.C. 2200 console."
 	id = "pandemic"
-	req_tech = list("programming" = 3, "biotech" = 3)
+	req_tech = list("programming" = 2, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/pandemic
@@ -64,7 +64,7 @@
 	name = "Computer Design (DNA Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new DNA scanning console."
 	id = "scan_console"
-	req_tech = list("programming" = 2, "biotech" = 2)
+	req_tech = list("programming" = 2, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/scan_consolenew
@@ -74,7 +74,7 @@
 	name = "Computer Design (Communications)"
 	desc = "Allows for the construction of circuit boards used to build a communications console."
 	id = "comconsole"
-	req_tech = list("programming" = 3, "magnets" = 3)
+	req_tech = list("programming" = 2, "magnets" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/communications
@@ -84,7 +84,7 @@
 	name = "Computer Design (ID Console)"
 	desc = "Allows for the construction of circuit boards used to build an ID computer."
 	id = "idcardconsole"
-	req_tech = list("programming" = 3)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/card
@@ -104,7 +104,7 @@
 	name = "Computer Design (Security Records Console)"
 	desc = "Allows for the construction of circuit boards used to build a security records console."
 	id = "secdata"
-	req_tech = list("programming" = 2, "combat" = 2)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/secure_data
@@ -154,7 +154,7 @@
 	name = "Computer Design (Orion Trail Arcade Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new Orion Trail machine."
 	id = "arcademachine"
-	req_tech = list("programming" = 1)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/arcade/orion_trail
@@ -164,7 +164,7 @@
 	name = "Computer Design (Slot Machine)"
 	desc = "Allows for the construction of circuit boards used to build a new slot machine."
 	id = "slotmachine"
-	req_tech = list("programming" = 1)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/slot_machine
@@ -174,7 +174,7 @@
 	name = "Computer Design (Power Monitor)"
 	desc = "Allows for the construction of circuit boards used to build a new power monitor."
 	id = "powermonitor"
-	req_tech = list("programming" = 2, "powerstorage" = 2)
+	req_tech = list("programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/powermonitor
@@ -214,7 +214,7 @@
 	name = "Computer Design (Mech Bay Power Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a mech bay power control console."
 	id = "mechapower"
-	req_tech = list("programming" = 3, "powerstorage" = 3)
+	req_tech = list("programming" = 2, "powerstorage" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/mech_bay_power_console
@@ -264,7 +264,7 @@
 	name = "Computer Design (Telecommunications Monitoring Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunications monitor."
 	id = "comm_monitor"
-	req_tech = list("programming" = 3, "magnets" = 3, "bluespace" = 2)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/comm_monitor
@@ -274,7 +274,7 @@
 	name = "Computer Design (Telecommunications Server Monitoring Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunication server browser and monitor."
 	id = "comm_server"
-	req_tech = list("programming" = 3, "magnets" = 3, "bluespace" = 2)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/comm_server
@@ -294,7 +294,7 @@
 	name = "Computer Design (AI Integrity Restorer)"
 	desc = "Allows for the construction of circuit boards used to build an AI Integrity Restorer."
 	id = "aifixer"
-	req_tech = list("programming" = 4, "magnets" = 3)
+	req_tech = list("programming" = 3, "biotech" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/aifixer

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -16,7 +16,7 @@
 	name = "Machine Design (Automated Announcement System Board)"
 	desc = "The circuit board for an automated announcement system."
 	id = "automated_announcement"
-	req_tech = list("programming" = 3, "bluespace" = 3, "magnets" = 2)
+	req_tech = list("programming" = 3, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/announcement_system
@@ -26,7 +26,7 @@
 	name = "Computer Design (Power Turbine Console Board)"
 	desc = "The circuit board for a power turbine console."
 	id = "power_turbine_console"
-	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 4)
+	req_tech = list("programming" = 4, "powerstorage" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/turbine_computer
@@ -36,7 +36,7 @@
 	name = "Machine Design (Emitter Board)"
 	desc = "The circuit board for an emitter."
 	id = "emitter"
-	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 4)
+	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/emitter
@@ -76,7 +76,7 @@
 	name = "Machine Design (Space Heater Board)"
 	desc = "The circuit board for a space heater."
 	id = "space_heater"
-	req_tech = list("programming" = 2, "engineering" = 2, "plasmatech" = 2)
+	req_tech = list("programming" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/space_heater
@@ -86,7 +86,7 @@
 	name = "Machine Design (Teleportation Station Board)"
 	desc = "The circuit board for a teleportation station."
 	id = "tele_station"
-	req_tech = list("programming" = 5, "bluespace" = 4, "engineering" = 4, "plasmatech" = 4)
+	req_tech = list("programming" = 4, "bluespace" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/teleporter_station
@@ -106,7 +106,7 @@
 	name = "Machine Design (Telepad Board)"
 	desc = "The circuit board for a telescience telepad."
 	id = "telepad"
-	req_tech = list("programming" = 4, "bluespace" = 5, "plasmatech" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "bluespace" = 4, "materials" = 3, "engineering" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telesci_pad
@@ -116,7 +116,7 @@
 	name = "Computer Design (Teleporter Console)"
 	desc = "Allows for the construction of circuit boards used to build a teleporter control console."
 	id = "teleconsole"
-	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
+	req_tech = list("programming" = 3, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/teleporter
@@ -126,7 +126,7 @@
 	name = "Computer Design (Telepad Control Console Board)"
 	desc = "Allows for the construction of circuit boards used to build a telescience console."
 	id = "telesci_console"
-	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
+	req_tech = list("programming" = 3, "bluespace" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/telesci_console
@@ -136,7 +136,7 @@
 	name = "Machine Design (Sleeper Board)"
 	desc = "The circuit board for a sleeper."
 	id = "sleeper"
-	req_tech = list("programming" = 3, "biotech" = 2, "engineering" = 3)
+	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 3, "engineering" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/sleeper
@@ -146,7 +146,7 @@
 	name = "Machine Design (Cryotube Board)"
 	desc = "The circuit board for a cryotube."
 	id = "cryotube"
-	req_tech = list("programming" = 5, "biotech" = 3, "engineering" = 4, "plasmatech" = 3)
+	req_tech = list("programming" = 4, "biotech" = 3, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/cryo_tube
@@ -156,7 +156,7 @@
 	name = "Machine Design (Portable Chem Dispenser Board)"
 	desc = "The circuit board for a portable chem dispenser."
 	id = "chem_dispenser"
-	req_tech = list("programming" = 5, "biotech" = 3, "materials" = 4, "plasmatech" = 4)
+	req_tech = list("programming" = 4, "biotech" = 3, "engineering" = 4, "materials" = 4, "plasmatech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_dispenser
@@ -166,7 +166,7 @@
 	name = "Machine Design (Chem Master Board)"
 	desc = "The circuit board for a Chem Master 2999."
 	id = "chem_master"
-	req_tech = list("biotech" = 3, "materials" = 3, "programming" = 2)
+	req_tech = list("biotech" = 1, "materials" = 2, "programming" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_master
@@ -176,7 +176,7 @@
 	name = "Machine Design (Chemical Heater Board)"
 	desc = "The circuit board for a chemical heater."
 	id = "chem_heater"
-	req_tech = list("engineering" = 2, "biotech" = 2, "programming" = 2)
+	req_tech = list("engineering" = 2, "materials" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/chem_heater
@@ -186,7 +186,7 @@
 	name = "Computer Design (Cloning Machine Console)"
 	desc = "Allows for the construction of circuit boards used to build a new Cloning Machine console."
 	id = "clonecontrol"
-	req_tech = list("programming" = 4, "biotech" = 3)
+	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/cloning
@@ -196,7 +196,7 @@
 	name = "Machine Design (Clone Pod)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Pod."
 	id = "clonepod"
-	req_tech = list("programming" = 4, "biotech" = 3)
+	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/clonepod
@@ -206,7 +206,7 @@
 	name = "Machine Design (Cloning Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Scanner."
 	id = "clonescanner"
-	req_tech = list("programming" = 4, "biotech" = 3)
+	req_tech = list("programming" = 3, "biotech" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/clonescanner
@@ -216,7 +216,7 @@
 	name = "Machine Design (Biogenerator Board)"
 	desc = "The circuit board for a biogenerator."
 	id = "biogenerator"
-	req_tech = list("programming" = 2, "biotech" = 3, "materials" = 3)
+	req_tech = list("programming" = 3, "biotech" = 2, "materials" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/biogenerator
@@ -226,7 +226,7 @@
 	name = "Machine Design (Hydroponics Tray Board)"
 	desc = "The circuit board for a hydroponics tray."
 	id = "hydro_tray"
-	req_tech = list("biotech" = 2)
+	req_tech = list("programming" = 1, "biotech" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/hydroponics
@@ -316,7 +316,7 @@
 	name = "Machine Design (Mechbay Recharger Board)"
 	desc = "The circuit board for a Mechbay Recharger."
 	id = "mech_recharger"
-	req_tech = list("programming" = 3, "powerstorage" = 4, "engineering" = 3)
+	req_tech = list("programming" = 3, "powerstorage" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/mech_recharger
@@ -326,7 +326,7 @@
 	name = "Machine Design (Microwave Board)"
 	desc = "The circuit board for a microwave."
 	id = "microwave"
-	req_tech = list("programming" = 2, "magnets" = 2)
+	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/microwave
@@ -336,7 +336,7 @@
 	name = "Machine Design (Gibber Board)"
 	desc = "The circuit board for a gibber."
 	id = "gibber"
-	req_tech = list("programming" = 2, "engineering" = 2)
+	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/gibber
@@ -386,7 +386,7 @@
 	name = "Machine Design (Recycler Board)"
 	desc = "The circuit board for a recycler."
 	id = "recycler"
-	req_tech = list("programming" = 2, "engineering" = 2)
+	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/recycler
@@ -406,7 +406,7 @@
 	name = "Machine Design (Autolathe Board)"
 	desc = "The circuit board for an autolathe."
 	id = "autolathe"
-	req_tech = list("programming" = 3, "engineering" = 3)
+	req_tech = list("programming" = 2, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/autolathe
@@ -416,7 +416,7 @@
 	name = "Machine Design (Weapon Recharger Board)"
 	desc = "The circuit board for a Weapon Recharger."
 	id = "recharger"
-	req_tech = list("powerstorage" = 4, "engineering" = 3, "materials" = 4)
+	req_tech = list("powerstorage" = 3, "engineering" = 3, "materials" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_GOLD = 100)
 	build_path = /obj/item/weapon/circuitboard/machine/recharger
@@ -436,17 +436,18 @@
 	name = "Machine Design (Ore Redemption Board)"
 	desc = "The circuit board for an Ore Redemption machine."
 	id = "ore_redemption"
-	req_tech = list("programming" = 2, "engineering" = 2, "plasmatech" = 3)
+	req_tech = list("programming" = 1, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/ore_redemption
 	category = list ("Misc. Machinery")
 
+
 /datum/design/mining_equipment_vendor
 	name = "Machine Design (Mining Rewards Vender Board)"
 	desc = "The circuit board for a Mining Rewards Vender."
 	id = "mining_equipment_vendor"
-	req_tech = list("engineering" = 3)
+	req_tech = list("programming" = 1, "engineering" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/mining_equipment_vendor
@@ -456,7 +457,7 @@
 	name = "Machine Design (Tesla Coil Board)"
 	desc = "The circuit board for a tesla coil."
 	id = "tesla_coil"
-	req_tech = list("programming" = 3, "powerstorage" = 3, "magnets" = 3)
+	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/tesla_coil
@@ -466,7 +467,7 @@
 	name = "Machine Design (Grounding Rod Board)"
 	desc = "The circuit board for a grounding rod."
 	id = "grounding_rod"
-	req_tech = list("programming" = 3, "powerstorage" = 3, "magnets" = 3, "plasmatech" = 2)
+	req_tech = list("programming" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/grounding_rod

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -6,7 +6,7 @@
 	name = "APLU \"Ripley\" Central Control module"
 	desc = "Allows for the construction of a \"Ripley\" Central Control module."
 	id = "ripley_main"
-	req_tech = list("programming" = 2)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/main
@@ -16,7 +16,7 @@
 	name = "APLU \"Ripley\" Peripherals Control module"
 	desc = "Allows for the construction of a  \"Ripley\" Peripheral Control module."
 	id = "ripley_peri"
-	req_tech = list("programming" = 2)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/ripley/peripherals
@@ -26,7 +26,7 @@
 	name = "\"Odysseus\" Central Control module"
 	desc = "Allows for the construction of a \"Odysseus\" Central Control module."
 	id = "odysseus_main"
-	req_tech = list("programming" = 3,"biotech" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3,"biotech" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/main
@@ -36,7 +36,7 @@
 	name = "\"Odysseus\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Odysseus\" Peripheral Control module."
 	id = "odysseus_peri"
-	req_tech = list("programming" = 3,"biotech" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3,"biotech" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/odysseus/peripherals
@@ -46,7 +46,7 @@
 	name = "\"Gygax\" Central Control module"
 	desc = "Allows for the construction of a \"Gygax\" Central Control module."
 	id = "gygax_main"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/main
@@ -56,7 +56,7 @@
 	name = "\"Gygax\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Gygax\" Peripheral Control module."
 	id = "gygax_peri"
-	req_tech = list("programming" = 4, "combat" = 3, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/peripherals
@@ -66,7 +66,7 @@
 	name = "\"Gygax\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Gygax\" Weapons & Targeting Control module."
 	id = "gygax_targ"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/gygax/targeting
@@ -76,7 +76,7 @@
 	name = "\"Durand\" Central Control module"
 	desc = "Allows for the construction of a \"Durand\" Central Control module."
 	id = "durand_main"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/main
@@ -86,7 +86,7 @@
 	name = "\"Durand\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Durand\" Peripheral Control module."
 	id = "durand_peri"
-	req_tech = list("programming" = 4, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/peripherals
@@ -96,7 +96,7 @@
 	name = "\"Durand\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Durand\" Weapons & Targeting Control module."
 	id = "durand_targ"
-	req_tech = list("programming" = 5, "combat" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "combat" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/durand/targeting
@@ -106,7 +106,7 @@
 	name = "\"H.O.N.K\" Central Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Central Control module."
 	id = "honker_main"
-	req_tech = list("programming" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/main
@@ -116,7 +116,7 @@
 	name = "\"H.O.N.K\" Peripherals Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Peripheral Control module."
 	id = "honker_peri"
-	req_tech = list("programming" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/peripherals
@@ -126,7 +126,7 @@
 	name = "\"H.O.N.K\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"H.O.N.K\" Weapons & Targeting Control module."
 	id = "honker_targ"
-	req_tech = list("programming" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/honker/targeting
@@ -136,7 +136,7 @@
 	name = "\"Phazon\" Central Control module"
 	desc = "Allows for the construction of a \"Phazon\" Central Control module."
 	id = "phazon_main"
-	req_tech = list("programming" = 6, "materials" = 6, "plasmatech" = 5)
+	req_tech = list("programming" = 5, "materials" = 7, "powerstorage" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/main
@@ -146,7 +146,7 @@
 	name = "\"Phazon\" Peripherals Control module"
 	desc = "Allows for the construction of a \"Phazon\" Peripheral Control module."
 	id = "phazon_peri"
-	req_tech = list("programming" = 6, "bluespace" = 5, "plasmatech" = 5)
+	req_tech = list("programming" = 5, "bluespace" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/peripherals
@@ -156,7 +156,7 @@
 	name = "\"Phazon\" Weapons & Targeting Control module"
 	desc = "Allows for the construction of a \"Phazon\" Weapons & Targeting Control module."
 	id = "phazon_targ"
-	req_tech = list("programming" = 6, "magnets" = 5, "plasmatech" = 5)
+	req_tech = list("programming" = 5, "magnets" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/mecha/phazon/targeting
@@ -204,7 +204,7 @@
 	desc = "Allows for the construction of CH-PS Laser."
 	id = "mech_laser"
 	build_type = MECHFAB
-	req_tech = list("combat" = 3, "magnets" = 3, "engineering" = 3)
+	req_tech = list("combat" = 3, "magnets" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -215,7 +215,7 @@
 	desc = "Allows for the construction of CH-LC Laser Cannon."
 	id = "mech_laser_heavy"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "magnets" = 4, "engineering" = 4)
+	req_tech = list("combat" = 4, "magnets" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -226,7 +226,7 @@
 	desc = "Allows for the construction of SGL-6 Grenade Launcher."
 	id = "mech_grenade_launcher"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "engineering" = 4)
+	req_tech = list("combat" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang
 	materials = list(MAT_METAL=22000,MAT_GOLD=6000,MAT_SILVER=8000)
 	construction_time = 100
@@ -237,7 +237,7 @@
 	desc = "Allows for the construction of SRM-8 Missile Rack."
 	id = "mech_missile_rack"
 	build_type = MECHFAB
-	req_tech = list("combat" = 6, "materials" = 5, "engineering" = 5)
+	req_tech = list("combat" = 6, "materials" = 6)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/missile_rack
 	materials = list(MAT_METAL=22000,MAT_GOLD=6000,MAT_SILVER=8000)
 	construction_time = 100
@@ -259,7 +259,7 @@
 	desc = "An exosuit module that allows generating of small quasi-stable wormholes."
 	id = "mech_wormhole_gen"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 4, "magnets" = 4, "plasmatech" = 3)
+	req_tech = list("bluespace" = 3, "magnets" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/wormhole_generator
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -270,9 +270,9 @@
 	desc = "An exosuit module that allows exosuits to teleport to any position in view."
 	id = "mech_teleporter"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 8, "magnets" = 5)
+	req_tech = list("bluespace" = 10, "magnets" = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/teleporter
-	materials = list(MAT_METAL=10000,MAT_DIAMOND=10000)
+	materials = list(MAT_METAL=10000)
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
@@ -281,7 +281,7 @@
 	desc = "An exosuit-mounted Rapid Construction Device."
 	id = "mech_rcd"
 	build_type = MECHFAB
-	req_tech = list("materials" = 5, "bluespace" = 3, "magnets" = 4, "powerstorage"=4, "engineering" = 5)
+	req_tech = list("materials" = 4, "bluespace" = 3, "magnets" = 4, "powerstorage"=4, "engineering" = 4)
 	build_path = /obj/item/mecha_parts/mecha_equipment/rcd
 	materials = list(MAT_METAL=30000,MAT_GOLD=20000,MAT_PLASMA=25000,MAT_SILVER=20000)
 	construction_time = 1200
@@ -292,7 +292,7 @@
 	desc = "An exosuit mounted Gravitational Catapult."
 	id = "mech_gravcatapult"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 4, "magnets" = 3, "engineering" = 4)
+	req_tech = list("bluespace" = 2, "magnets" = 3, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/gravcatapult
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -303,7 +303,7 @@
 	desc = "Automated Repair Droid. BEEP BOOP"
 	id = "mech_repair_droid"
 	build_type = MECHFAB
-	req_tech = list("magnets" = 3, "programming" = 3, "engineering" = 5)
+	req_tech = list("magnets" = 3, "programming" = 3, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/repair_droid
 	materials = list(MAT_METAL=10000,MAT_GLASS=5000,MAT_GOLD=1000,MAT_SILVER=2000)
 	construction_time = 100
@@ -314,7 +314,7 @@
 	desc = "Tesla Energy Relay"
 	id = "mech_energy_relay"
 	build_type = MECHFAB
-	req_tech = list("magnets" = 4, "powerstorage" = 5, "engineering" = 4)
+	req_tech = list("magnets" = 4, "powerstorage" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	materials = list(MAT_METAL=10000,MAT_GLASS=2000,MAT_GOLD=2000,MAT_SILVER=3000)
 	construction_time = 100
@@ -347,7 +347,7 @@
 	desc = "An upgraded version of the standard drill."
 	id = "mech_diamond_drill"
 	build_type = MECHFAB
-	req_tech = list("materials" = 5, "engineering" = 4)
+	req_tech = list("materials" = 4, "engineering" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill
 	materials = list(MAT_METAL=10000,MAT_DIAMOND=6500)
 	construction_time = 100
@@ -358,7 +358,7 @@
 	desc = "Compact nuclear reactor module."
 	id = "mech_generator_nuclear"
 	build_type = MECHFAB
-	req_tech = list("powerstorage"= 5, "engineering" = 4, "materials" = 3)
+	req_tech = list("powerstorage"= 3, "engineering" = 3, "materials" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator/nuclear
 	materials = list(MAT_METAL=10000,MAT_GLASS=1000,MAT_SILVER=500)
 	construction_time = 100
@@ -369,7 +369,7 @@
 	desc = "A device that shoots resonant plasma bursts at extreme velocity. The blasts are capable of crushing rock and demolishing solid obstacles."
 	id = "mech_plasma_cutter"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 3, "materials" = 3, "plasmatech" = 4)
+	req_tech = list("powerstorage"= 3, "engineering" = 3, "materials" = 3, "combat" = 1, "plasmatech" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	materials = list(MAT_METAL = 8000, MAT_GLASS = 1000, MAT_PLASMA = 2000)
 	construction_time = 100
@@ -380,7 +380,7 @@
 	desc = "A weapon for combat exosuits. Shoots non-lethal stunning electrodes."
 	id = "mech_taser"
 	build_type = MECHFAB
-	req_tech = list("combat" = 3)
+	req_tech = list("combat" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -391,7 +391,7 @@
 	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst."
 	id = "mech_lmg"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4)
+	req_tech = list("combat" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
@@ -402,7 +402,7 @@
 	desc = "Equipment for medical exosuits. A mounted sleeper that stabilizes patients and can inject reagents in the exosuit's reserves."
 	id = "mech_sleeper"
 	build_type = MECHFAB
-	req_tech = list("biotech" = 3, "engineering" = 3, "plasmatech" = 2)
+	req_tech = list("biotech" = 2)
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/sleeper
 	materials = list(MAT_METAL=5000,MAT_GLASS=10000)
 	construction_time = 100
@@ -413,7 +413,7 @@
 	desc = "Equipment for medical exosuits. A chem synthesizer with syringe gun. Reagents inside are held in stasis, so no reactions will occur."
 	id = "mech_syringe_gun"
 	build_type = MECHFAB
-	req_tech = list("magnets" = 4,"biotech" = 4, "combat" = 3, "materials" = 4)
+	req_tech = list("magnets" = 3,"biotech" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun
 	materials = list(MAT_METAL=3000,MAT_GLASS=2000)
 	construction_time = 200
@@ -423,7 +423,7 @@
 	name = "Exosuit Medical Equipment (Medical Beamgun)"
 	desc = "Equipment for medical exosuits. A mounted medical nanite projector which will treat patients with a focused beam."
 	id = "mech_medi_beam"
-	req_tech = list("engineering" = 6, "materials" = 7, "powerstorage" = 5, "biotech" = 6)
+	req_tech = list("combat" = 5, "materials" = 7, "powerstorage" = 7, "biotech" = 6)
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 15000, MAT_GLASS = 8000, MAT_PLASMA = 3000, MAT_GOLD = 8000, MAT_DIAMOND = 2000)
 	construction_time = 250

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -536,7 +536,7 @@
 	id = "mech_generator"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/generator
-	materials = list(MAT_METAL=10000,MAT_GLASS=1000,MAT_SILVER=2000,MAT_PLASMA=5000)
+	materials = list(MAT_METAL=10000,MAT_GLASS=1000,MAT_SILVER=500)
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
@@ -603,7 +603,7 @@
 	id = "borg_upgrade_vtec"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/vtec
-	req_tech = list("engineering" = 4, "materials" = 5, "programming" = 4)
+	req_tech = list("engineering" = 4, "materials" = 5)
 	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_URANIUM= 5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
@@ -623,7 +623,7 @@
 	id = "borg_upgrade_disablercooler"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/disablercooler
-	req_tech = list("combat" = 5, "powerstorage" = 4, "engineering" = 4)
+	req_tech = list("combat" = 5, "powerstorage" = 4)
 	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_GOLD= 2000, MAT_DIAMOND = 500)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
@@ -633,7 +633,7 @@
 	id = "borg_upgrade_diamonddrill"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/ddrill
-	req_tech = list("engineering" = 5, "materials" = 6)
+	req_tech = list("engineering" = 5, "materials" = 5)
 	materials = list(MAT_METAL=10000, MAT_DIAMOND=2000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
@@ -643,7 +643,7 @@
 	id = "borg_upgrade_holding"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/soh
-	req_tech = list("engineering" = 4, "materials" = 4, "bluespace" = 4)
+	req_tech = list("engineering" = 5, "materials" = 5, "bluespace" = 3)
 	materials = list(MAT_METAL = 10000, MAT_GOLD = 250, MAT_URANIUM = 500)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
@@ -652,7 +652,7 @@
 	name = "Cyborg Upgrade (Illegal Modules)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "syndicate" = 2)
+	req_tech = list("combat" = 4, "syndicate" = 3)
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(MAT_METAL=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
 	construction_time = 120
@@ -687,15 +687,4 @@
 	materials = list(MAT_METAL = 800, MAT_GLASS = 350)
 	construction_time=150
 	build_path = /obj/item/drone_shell
-	category = list("Misc")
-
-/datum/design/synthetic_flash
-	name = "Flash"
-	desc = "When a problem arises, SCIENCE is the solution."
-	id = "sflash"
-	req_tech = list("magnets" = 3, "combat" = 2)
-	build_type = MECHFAB
-	materials = list(MAT_METAL = 750, MAT_GLASS = 750)
-	construction_time = 100
-	build_path = /obj/item/device/assembly/flash/handheld
 	category = list("Misc")

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -7,9 +7,9 @@
 	name = "Mass-Spectrometer"
 	desc = "A device for analyzing chemicals in the blood."
 	id = "mass_spectrometer"
-	req_tech = list("magnets" = 2, "plasmatech" = 2)
+	req_tech = list("biotech" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 300, MAT_GLASS = 100)
+	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
 	build_path = /obj/item/device/mass_spectrometer
 	category = list("Medical Designs")
 
@@ -17,9 +17,9 @@
 	name = "Advanced Mass-Spectrometer"
 	desc = "A device for analyzing chemicals in the blood and their quantities."
 	id = "adv_mass_spectrometer"
-	req_tech = list("biotech" = 3, "magnets" = 4, "plasmatech" = 3)
+	req_tech = list("biotech" = 2, "magnets" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 200)
+	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
 	build_path = /obj/item/device/mass_spectrometer/adv
 	category = list("Medical Designs")
 
@@ -27,7 +27,7 @@
 	name = "Man-Machine Interface"
 	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."
 	id = "mmi"
-	req_tech = list("programming" = 3, "biotech" = 2, "engineering" = 2)
+	req_tech = list("programming" = 2, "biotech" = 3)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
 	construction_time = 75
@@ -38,28 +38,40 @@
 	name = "Positronic Brain"
 	desc = "The latest in Artificial Intelligences."
 	id = "mmi_posi"
-	req_tech = list("programming" = 5, "biotech" = 4, "plasmatech" = 3)
+	req_tech = list("programming" = 5, "biotech" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 1700, MAT_GLASS = 1350, MAT_GOLD = 500) //Gold, because SWAG.
 	construction_time = 75
 	build_path = /obj/item/device/mmi/posibrain
 	category = list("Misc", "Medical Designs")
 
+
+/datum/design/synthetic_flash
+	name = "Flash"
+	desc = "When a problem arises, SCIENCE is the solution."
+	id = "sflash"
+	req_tech = list("magnets" = 3, "combat" = 2)
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 750, MAT_GLASS = 750)
+	construction_time = 100
+	build_path = /obj/item/device/assembly/flash/handheld
+	category = list("Misc")
+
 /datum/design/bluespacebeaker
 	name = "Bluespace Beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
 	id = "bluespacebeaker"
-	req_tech = list("bluespace" = 6, "materials" = 5, "plasmatech" = 4)
+	req_tech = list("bluespace" = 2, "materials" = 6)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 3000, MAT_PLASMA = 3000, MAT_DIAMOND = 500)
+	materials = list(MAT_METAL = 3000, MAT_PLASMA = 3000, MAT_DIAMOND = 500)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
-	category = list("Medical Designs")
+	category = list("Medical Designs", "Bluespace Designs")
 
 /datum/design/noreactbeaker
 	name = "Cryostasis Beaker"
 	desc = "A cryostasis beaker that allows for chemical storage without reactions. Can hold up to 50 units."
 	id = "splitbeaker"
-	req_tech = list("materials" = 3, "engineering" = 3, "plasmatech" = 3)
+	req_tech = list("materials" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000)
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
@@ -69,17 +81,17 @@
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"
 	id = "bluespacesyringe"
-	req_tech = list("bluespace" = 5, "materials" = 4, "biotech" = 4)
+	req_tech = list("bluespace" = 3, "materials" = 4, "combat" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 4000, MAT_PLASMA = 2000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/weapon/reagent_containers/syringe/bluespace
-	category = list("Medical Designs")
+	category = list("Medical Designs", "Bluespace Designs")
 
 /datum/design/noreactsyringe
 	name = "Cryo Syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
 	id = "noreactsyringe"
-	req_tech = list("materials" = 3, "engineering" = 3)
+	req_tech = list("materials" = 2, "combat" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 4000, MAT_GOLD = 1000)
 	build_path = /obj/item/weapon/reagent_containers/syringe/noreact
@@ -89,7 +101,7 @@
 	name = "Piercing Syringe"
 	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
 	id = "piercesyringe"
-	req_tech = list("materials" = 5, "combat" = 3, "engineering" = 7)
+	req_tech = list("materials" = 3, "combat" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 4000, MAT_DIAMOND = 1500)
 	build_path = /obj/item/weapon/reagent_containers/syringe/piercing
@@ -99,7 +111,7 @@
 	name = "Bluespace body bag"
 	desc = "A bluespace body bag, powered by experimental bluespace technology. It can hold loads of bodies and the largest of creatures."
 	id = "bluespacebodybag"
-	req_tech = list("bluespace" = 5, "materials" = 4, "plasmatech" = 4)
+	req_tech = list("bluespace" = 2, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_PLASMA = 2000, MAT_DIAMOND = 500)
 	build_path = /obj/item/bodybag/bluespace
@@ -109,7 +121,7 @@
 	name = "Plasma-man jumpsuit refill"
 	desc = "A refill pack for the auto-extinguisher on Plasma-man suits."
 	id = "plasmarefiller"
-	req_tech = list("materials" = 2, "plasmatech" = 3) //Why did this have no plasmatech
+	req_tech = list("materials" = 2, "combat" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_PLASMA = 1000)
 	build_path = /obj/item/device/extinguisher_refill
@@ -123,10 +135,10 @@
 	name = "Welding Shield implant"
 	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
 	id = "ci-welding"
-	req_tech = list("materials" = 4, "biotech" = 4, "engineering" = 5, "plasmatech" = 4)
+	req_tech = list("materials" = 4, "biotech" = 2)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 40
-	materials = list(MAT_METAL = 600, MAT_GLASS = 400)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 400)
 	build_path = /obj/item/organ/cyberimp/eyes/shield
 	category = list("Misc", "Medical Designs")
 
@@ -134,10 +146,10 @@
 	name = "Breathing Tube implant"
 	desc = "This simple implant adds an internals connector to your back, allowing you to use internals without a mask and protecting you from being choked."
 	id = "ci-breather"
-	req_tech = list("materials" = 2, "biotech" = 3)
+	req_tech = list("materials" = 3, "biotech" = 3)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 35
-	materials = list(MAT_METAL = 600, MAT_GLASS = 250)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 250)
 	build_path = /obj/item/organ/cyberimp/mouth/breathing_tube
 	category = list("Misc", "Medical Designs")
 
@@ -145,7 +157,7 @@
 	name = "Toolset Arm implant"
 	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm."
 	id = "ci-toolset"
-	req_tech = list("materials" = 3, "engineering" = 4, "biotech" = 4, "powerstorage" = 4)
+	req_tech = list("materials" = 4, "engineering" = 3, "biotech" = 4, "powerstorage" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list (MAT_METAL = 2500, MAT_GLASS = 1500, MAT_SILVER = 1500)
 	construction_time = 200
@@ -156,10 +168,10 @@
 	name = "Medical HUD implant"
 	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
 	id = "ci-medhud"
-	req_tech = list("materials" = 5, "programming" = 4, "biotech" = 4)
+	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 50
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 500, MAT_GOLD = 500)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 500, MAT_GOLD = 500)
 	build_path = /obj/item/organ/cyberimp/eyes/hud/medical
 	category = list("Misc", "Medical Designs")
 
@@ -167,10 +179,10 @@
 	name = "Security HUD implant"
 	desc = "These cybernetic eyes will display a security HUD over everything you see. Wiggle eyes to control."
 	id = "ci-sechud"
-	req_tech = list("materials" = 5, "programming" = 4, "biotech" = 4, "combat" = 3)
+	req_tech = list("materials" = 6, "programming" = 5, "biotech" = 4, "combat" = 2)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 50
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 750, MAT_GOLD = 750)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 750, MAT_GOLD = 750)
 	build_path = /obj/item/organ/cyberimp/eyes/hud/security
 	category = list("Misc", "Medical Designs")
 
@@ -178,10 +190,10 @@
 	name = "X-Ray implant"
 	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
 	id = "ci-xray"
-	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 7, "magnets" = 5,"plasmatech" = 6)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 6, "magnets" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/cyberimp/eyes/xray
 	category = list("Misc", "Medical Designs")
 
@@ -189,10 +201,10 @@
 	name = "Thermals implant"
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."
 	id = "ci-thermals"
-	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 7, "magnets" = 5,"plasmatech" = 4)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 5, "magnets" = 5, "syndicate" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_DIAMOND = 2000)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/cyberimp/eyes/thermals
 	category = list("Misc", "Medical Designs")
 
@@ -200,10 +212,10 @@
 	name = "Anti-Drop implant"
 	desc = "This cybernetic brain implant will allow you to force your hand muscles to contract, preventing item dropping. Twitch ear to toggle."
 	id = "ci-antidrop"
-	req_tech = list("materials" = 5, "programming" = 6, "biotech" = 5)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 400, MAT_GOLD = 400)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 400, MAT_GOLD = 400)
 	build_path = /obj/item/organ/cyberimp/brain/anti_drop
 	category = list("Misc", "Medical Designs")
 
@@ -211,10 +223,10 @@
 	name = "CNS Rebooter implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	id = "ci-antistun"
-	req_tech = list("materials" = 6, "programming" = 5, "biotech" = 6)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 500, MAT_GOLD = 1000)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 500, MAT_GOLD = 1000)
 	build_path = /obj/item/organ/cyberimp/brain/anti_stun
 	category = list("Misc", "Medical Designs")
 
@@ -222,10 +234,10 @@
 	name = "Nutriment pump implant"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."
 	id = "ci-nutriment"
-	req_tech = list("materials" = 5, "powerstorage" = 6, "biotech" = 5)
+	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 40
-	materials = list(MAT_METAL = 500, MAT_GLASS = 500, MAT_GOLD = 500, MAT_URANIUM = 500)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 500)
 	build_path = /obj/item/organ/cyberimp/chest/nutriment
 	category = list("Misc", "Medical Designs")
 
@@ -233,10 +245,10 @@
 	name = "Nutriment pump implant PLUS"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are hungry."
 	id = "ci-nutrimentplus"
-	req_tech = list("materials" = 5, "powerstorage" = 6, "biotech" = 6)
+	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 6)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 50
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_GOLD = 500, MAT_URANIUM = 750)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 750)
 	build_path = /obj/item/organ/cyberimp/chest/nutriment/plus
 	category = list("Misc", "Medical Designs")
 
@@ -244,10 +256,10 @@
 	name = "Reviver implant"
 	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	id = "ci-reviver"
-	req_tech = list("materials" = 5, "programming" = 4, "biotech" = 8)
+	req_tech = list("materials" = 6, "programming" = 4, "biotech" = 7, "syndicate" = 4)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
-	materials = list(MAT_METAL = 800, MAT_GLASS = 800, MAT_GOLD = 500, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 500, MAT_URANIUM = 1000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/organ/cyberimp/chest/reviver
 	category = list("Misc", "Medical Designs")
 
@@ -255,7 +267,7 @@
 	name = "Thrusters set implant"
 	desc = "This implant will allow you to use gas from environment or your internals for propulsion in zero-gravity areas."
 	id = "ci-thrusters"
-	req_tech = list("materials" = 5, "biotech" = 5, "magnets" = 4, "engineering" = 7)
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 5, "magnets" = 4, "engineering" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 80
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 2000, MAT_SILVER = 1000, MAT_DIAMOND = 1000)
@@ -271,7 +283,7 @@
 	name = "Implanter"
 	desc = "A sterile automatic implant injector."
 	id = "implanter"
-	req_tech = list("materials" = 2, "biotech" = 3, "programming" = 2)
+	req_tech = list("materials" = 1, "programming" = 2, "biotech" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 600, MAT_GLASS = 200)
 	build_path = /obj/item/weapon/implanter
@@ -281,7 +293,7 @@
 	name = "Implant Case"
 	desc = "A glass case for containing an implant."
 	id = "implantcase"
-	req_tech = list("biotech" = 2)
+	req_tech = list("materials" = 1, "biotech" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_GLASS = 500)
 	build_path = /obj/item/weapon/implantcase
@@ -291,9 +303,9 @@
 	name = "Freedom Implant Case"
 	desc = "A glass case containing an implant."
 	id = "implant_freedom"
-	req_tech = list("combat" = 6, "biotech" = 5, "magnets" = 3, "syndicate" = 3)
+	req_tech = list("materials" = 2, "biotech" = 3, "magnets" = 3, "syndicate" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 500, MAT_GOLD = 500)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 500, MAT_GOLD = 250)
 	build_path = /obj/item/weapon/implantcase/freedom
 	category = list("Medical Designs")
 
@@ -301,8 +313,8 @@
 	name = "Adrenalin Implant Case"
 	desc = "A glass case containing an implant."
 	id = "implant_adrenalin"
-	req_tech = list("biotech" = 6, "combat" = 6, "syndicate" = 6)
+	req_tech = list("materials" = 2, "biotech" = 5, "combat" = 3, "syndicate" = 6)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_GOLD = 500, MAT_URANIUM = 600, MAT_DIAMOND = 600)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 500, MAT_GOLD = 500, MAT_URANIUM = 100, MAT_DIAMOND = 200)
 	build_path = /obj/item/weapon/implantcase/adrenaline
 	category = list("Medical Designs")

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -28,7 +28,7 @@
 	name = "Super-Capacity Power Cell"
 	desc = "A power cell that holds 20000 units of energy."
 	id = "super_cell"
-	req_tech = list("powerstorage" = 3, "materials" = 3)
+	req_tech = list("powerstorage" = 3, "materials" = 2)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
@@ -39,9 +39,9 @@
 	name = "Hyper-Capacity Power Cell"
 	desc = "A power cell that holds 30000 units of energy."
 	id = "hyper_cell"
-	req_tech = list("powerstorage" = 5, "materials" = 5, "engineering" = 5)
+	req_tech = list("powerstorage" = 5, "materials" = 4)
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 80)
+	materials = list(MAT_METAL = 400, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 80)
 	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell/hyper
 	category = list("Misc","Power Designs")
@@ -50,7 +50,7 @@
 	name = "Bluespace Power Cell"
 	desc = "A power cell that holds 40000 units of energy."
 	id = "bluespace_cell"
-	req_tech = list("powerstorage" = 6, "materials" = 5, "engineering" = 5, "bluespace" = 5)
+	req_tech = list("powerstorage" = 6, "materials" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 300, MAT_SILVER = 300, MAT_GLASS = 160, MAT_DIAMOND = 160)
 	construction_time=100
@@ -62,7 +62,7 @@
 	name = "Light Replacer"
 	desc = "A device to automatically replace lights. Refill with working lightbulbs."
 	id = "light_replacer"
-	req_tech = list("magnets" = 3, "engineering" = 4)
+	req_tech = list("magnets" = 3, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1500, MAT_SILVER = 150, MAT_GLASS = 3000)
 	build_path = /obj/item/device/lightreplacer
@@ -72,7 +72,7 @@
 	name = "Machine Design (PACMAN-type Generator Board)"
 	desc = "The circuit board that for a PACMAN-type portable generator."
 	id = "pacman"
-	req_tech = list("programming" = 2, "plasmatech" = 3, "powerstorage" = 3, "engineering" = 3)
+	req_tech = list("programming" = 3, "plasmatech" = 3, "powerstorage" = 3, "engineering" = 3)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/pacman
@@ -92,7 +92,7 @@
 	name = "Machine Design (MRSPACMAN-type Generator Board)"
 	desc = "The circuit board that for a MRSPACMAN-type portable generator."
 	id = "mrspacman"
-	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 5, "plasmatech" = 4)
+	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/pacman/mrs

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -16,7 +16,7 @@
 	name = "Bluespace RPED"
 	desc = "Powered by bluespace technology, this RPED variant can upgrade buildings from a distance, without needing to remove the panel first."
 	id = "bs_rped"
-	req_tech = list("engineering" = 4, "bluespace" = 3)
+	req_tech = list("engineering" = 3, "materials" = 5, "programming" = 3, "bluespace" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 15000, MAT_GLASS = 5000, MAT_SILVER = 2500) //hardcore
 	build_path = /obj/item/weapon/storage/part_replacer/bluespace
@@ -29,7 +29,7 @@
 	id = "basic_capacitor"
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
 	category = list("Stock Parts","Machinery","initial")
 
@@ -39,7 +39,7 @@
 	id = "adv_capacitor"
 	req_tech = list("powerstorage" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 150)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor/adv
 	category = list("Stock Parts")
 
@@ -47,9 +47,9 @@
 	name = "Super Capacitor"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_capacitor"
-	req_tech = list("powerstorage" = 5, "engineering" = 5)
+	req_tech = list("powerstorage" = 5, "materials" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_GOLD = 100)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50, MAT_GOLD = 20)
 	build_path = /obj/item/weapon/stock_parts/capacitor/super
 	category = list("Stock Parts")
 
@@ -57,9 +57,9 @@
 	name = "Quadratic Capacitor"
 	desc = "A stock part used in the construction of various devices."
 	id = "quadratic_capacitor"
-	req_tech = list("powerstorage" = 6, "engineering" = 5, "materials" = 5, "bluespace" = 5)
+	req_tech = list("powerstorage" = 6, "materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_DIAMOND = 100)
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100, MAT_DIAMOND = 40)
 	build_path = /obj/item/weapon/stock_parts/capacitor/quadratic
 	category = list("Stock Parts")
 
@@ -70,7 +70,7 @@
 	id = "basic_scanning"
 	req_tech = list("magnets" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GLASS = 50)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
 	category = list("Stock Parts","Machinery","initial")
 
@@ -80,7 +80,7 @@
 	id = "adv_scanning"
 	req_tech = list("magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 100)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/adv
 	category = list("Stock Parts")
 
@@ -88,9 +88,9 @@
 	name = "Phasic Scanning Module"
 	desc = "A stock part used in the construction of various devices."
 	id = "phasic_scanning"
-	req_tech = list("magnets" = 5, "engineering" = 5)
+	req_tech = list("magnets" = 5, "materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 150, MAT_SILVER = 60)
+	materials = list(MAT_METAL = 50, MAT_GLASS = 20, MAT_SILVER = 10)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 	category = list("Stock Parts")
 
@@ -98,9 +98,9 @@
 	name = "Triphasic Scanning Module"
 	desc = "A stock part used in the construction of various devices."
 	id = "triphasic_scanning"
-	req_tech = list("magnets" = 6, "materials" = 5, "engineering" = 5, "bluespace" = 5)
+	req_tech = list("magnets" = 6, "materials" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_DIAMOND = 60)
+	materials = list(MAT_METAL = 100, MAT_GLASS = 40, MAT_DIAMOND = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module/triphasic
 	category = list("Stock Parts")
 
@@ -109,9 +109,9 @@
 	name = "Micro Manipulator"
 	desc = "A stock part used in the construction of various devices."
 	id = "micro_mani"
-	req_tech = list("materials" = 1)
+	req_tech = list("materials" = 1, "programming" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
-	materials = list(MAT_METAL = 100)
+	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator
 	category = list("Stock Parts","Machinery","initial")
 
@@ -121,7 +121,7 @@
 	id = "nano_mani"
 	req_tech = list("materials" = 3, "programming" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150)
+	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator/nano
 	category = list("Stock Parts")
 
@@ -129,9 +129,9 @@
 	name = "Pico Manipulator"
 	desc = "A stock part used in the construction of various devices."
 	id = "pico_mani"
-	req_tech = list("materials" = 5, "programming" = 4, "engineering" = 5)
+	req_tech = list("materials" = 5, "programming" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200)
+	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 	category = list("Stock Parts")
 
@@ -139,9 +139,9 @@
 	name = "Femto Manipulator"
 	desc = "A stock part used in the construction of various devices."
 	id = "femto_mani"
-	req_tech = list("materials" = 7, "programming" = 5, "engineering" = 5, "bluespace" = 5)
+	req_tech = list("materials" = 6, "programming" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_DIAMOND = 60)
+	materials = list(MAT_METAL = 60, MAT_DIAMOND = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator/femto
 	category = list("Stock Parts")
 
@@ -152,7 +152,7 @@
 	id = "basic_micro_laser"
 	req_tech = list("magnets" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GLASS = 50)
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
 	category = list("Stock Parts","Machinery","initial")
 
@@ -162,7 +162,7 @@
 	id = "high_micro_laser"
 	req_tech = list("magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 100)
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/high
 	category = list("Stock Parts")
 
@@ -170,9 +170,9 @@
 	name = "Ultra-High-Power Micro-Laser"
 	desc = "A stock part used in the construction of various devices."
 	id = "ultra_micro_laser"
-	req_tech = list("magnets" = 5, "engineering" = 5)
+	req_tech = list("magnets" = 5, "materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 150, MAT_URANIUM = 60)
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20, MAT_URANIUM = 10)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 	category = list("Stock Parts")
 
@@ -180,9 +180,9 @@
 	name = "Quad-Ultra Micro-Laser"
 	desc = "A stock part used in the construction of various devices."
 	id = "quadultra_micro_laser"
-	req_tech = list("magnets" = 6, "materials" = 5, "engineering" = 5, "bluespace" = 5)
+	req_tech = list("magnets" = 6, "materials" = 6)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_URANIUM = 100, MAT_DIAMOND = 60)
+	materials = list(MAT_METAL = 20, MAT_GLASS = 40, MAT_URANIUM = 20, MAT_DIAMOND = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser/quadultra
 	category = list("Stock Parts")
 
@@ -192,7 +192,7 @@
 	id = "basic_matter_bin"
 	req_tech = list("materials" = 1)
 	build_type = PROTOLATHE | AUTOLATHE
-	materials = list(MAT_METAL = 100)
+	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
 	category = list("Stock Parts","Machinery","initial")
 
@@ -202,7 +202,7 @@
 	id = "adv_matter_bin"
 	req_tech = list("materials" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 150)
+	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/adv
 	category = list("Stock Parts")
 
@@ -210,9 +210,9 @@
 	name = "Super Matter Bin"
 	desc = "A stock part used in the construction of various devices."
 	id = "super_matter_bin"
-	req_tech = list("materials" = 5, "engineering" = 5)
+	req_tech = list("materials" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 200)
+	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 	category = list("Stock Parts")
 
@@ -220,9 +220,9 @@
 	name = "Bluespace Matter Bin"
 	desc = "A stock part used in the construction of various devices."
 	id = "bluespace_matter_bin"
-	req_tech = list("materials" = 7, "engineering" = 5, "bluespace" = 5)
+	req_tech = list("materials" = 6)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 250, MAT_DIAMOND = 200)
+	materials = list(MAT_METAL = 160, MAT_DIAMOND = 200)
 	build_path = /obj/item/weapon/stock_parts/matter_bin/bluespace
 	category = list("Stock Parts")
 
@@ -231,9 +231,9 @@
 	name = "Subspace Ansible"
 	desc = "A compact module capable of sensing extradimensional activity."
 	id = "s-ansible"
-	req_tech = list("programming" = 2, "magnets" = 2, "materials" = 2)
+	req_tech = list("programming" = 2, "magnets" = 2, "materials" = 2, "bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 100, MAT_SILVER = 100)
+	materials = list(MAT_METAL = 80, MAT_SILVER = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/ansible
 	category = list("Stock Parts")
 
@@ -241,9 +241,9 @@
 	name = "Hyperwave Filter"
 	desc = "A tiny device capable of filtering and converting super-intense radiowaves."
 	id = "s-filter"
-	req_tech = list("programming" = 3, "magnets" = 3)
+	req_tech = list("programming" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 100, MAT_SILVER = 100)
+	materials = list(MAT_METAL = 40, MAT_SILVER = 10)
 	build_path = /obj/item/weapon/stock_parts/subspace/filter
 	category = list("Stock Parts")
 
@@ -251,9 +251,9 @@
 	name = "Subspace Amplifier"
 	desc = "A compact micro-machine capable of amplifying weak subspace transmissions."
 	id = "s-amplifier"
-	req_tech = list("programming" = 3, "magnets" = 4, "materials" = 3, "bluespace" = 2)
+	req_tech = list("programming" = 2, "magnets" = 2, "materials" = 2, "bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GOLD = 100, MAT_URANIUM = 100)
+	materials = list(MAT_METAL = 10, MAT_GOLD = 30, MAT_URANIUM = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/amplifier
 	category = list("Stock Parts")
 
@@ -261,9 +261,9 @@
 	name = "Subspace Treatment Disk"
 	desc = "A compact micro-machine capable of stretching out hyper-compressed radio waves."
 	id = "s-treatment"
-	req_tech = list("programming" = 2, "magnets" = 3, "materials" = 2, "bluespace" = 3)
+	req_tech = list("programming" = 2, "magnets" = 1, "materials" = 2, "bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 100, MAT_SILVER = 200)
+	materials = list(MAT_METAL = 10, MAT_SILVER = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/treatment
 	category = list("Stock Parts")
 
@@ -271,9 +271,9 @@
 	name = "Subspace Analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
 	id = "s-analyzer"
-	req_tech = list("programming" = 3, "magnets" = 4, "materials" = 2, "bluespace" = 3)
+	req_tech = list("programming" = 2, "magnets" = 2, "materials" = 2, "bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GOLD = 100)
+	materials = list(MAT_METAL = 10, MAT_GOLD = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/analyzer
 	category = list("Stock Parts")
 
@@ -281,9 +281,9 @@
 	name = "Ansible Crystal"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
 	id = "s-crystal"
-	req_tech = list("magnets" = 2, "materials" = 2, "bluespace" = 3, "plasmatech" = 3)
+	req_tech = list("magnets" = 2, "materials" = 2, "bluespace" = 1)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 800, MAT_SILVER = 100, MAT_GOLD = 100)
+	materials = list(MAT_GLASS = 1000, MAT_SILVER = 20, MAT_GOLD = 20)
 	build_path = /obj/item/weapon/stock_parts/subspace/crystal
 	category = list("Stock Parts")
 
@@ -291,8 +291,8 @@
 	name = "Subspace Transmitter"
 	desc = "A large piece of equipment used to open a window into the subspace dimension."
 	id = "s-transmitter"
-	req_tech = list("magnets" = 3, "materials" = 4, "bluespace" = 4)
+	req_tech = list("magnets" = 3, "materials" = 3, "bluespace" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 100, MAT_SILVER = 100, MAT_URANIUM = 100)
+	materials = list(MAT_GLASS = 100, MAT_SILVER = 10, MAT_URANIUM = 15)
 	build_path = /obj/item/weapon/stock_parts/subspace/transmitter
 	category = list("Stock Parts")

--- a/code/modules/research/designs/telecomms_designs.dm
+++ b/code/modules/research/designs/telecomms_designs.dm
@@ -66,7 +66,7 @@
 	name = "Machine Design (Subspace Broadcaster)"
 	desc = "Allows for the construction of Subspace Broadcasting equipment."
 	id = "s-broadcaster"
-	req_tech = list("programming" = 2, "engineering" = 2)
+	req_tech = list("programming" = 2, "engineering" = 2, "bluespace" = 1)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/machine/telecomms/broadcaster

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -6,7 +6,7 @@
 	name = "test-range firing pin"
 	desc = "This safety firing pin allows firearms to be operated within proximity to a firing range."
 	id = "pin_testing"
-	req_tech = list("combat" = 2, "materials" = 2)
+	req_tech = list("combat" = 1, "materials" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 300)
 	build_path = /obj/item/device/firing_pin/test_range
@@ -16,7 +16,7 @@
 	name = "loyalty firing pin"
 	desc = "This is a security firing pin which only authorizes users who are loyalty-implanted."
 	id = "pin_loyalty"
-	req_tech = list("combat" = 5, "materials" = 6)
+	req_tech = list("combat" = 5, "materials" = 6, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 600, MAT_DIAMOND = 600, MAT_URANIUM = 200)
 	build_path = /obj/item/device/firing_pin/implant/loyalty
@@ -26,19 +26,20 @@
 	name = "Tesla Revolver"
 	desc = "A high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."
 	id = "stunrevolver"
-	req_tech = list("combat" = 4, "materials" = 4, "powerstorage" = 5)
+	req_tech = list("combat" = 3, "materials" = 3, "powerstorage" = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10000, MAT_GLASS = 10000, MAT_SILVER = 10000)
 	build_path = /obj/item/weapon/gun/energy/shock_revolver
+
 	category = list("Weapons")
 
 /datum/design/nuclear_gun
 	name = "Advanced Energy Gun"
 	desc = "An energy gun with an experimental miniaturized reactor."
 	id = "nuclear_gun"
-	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 5)
+	req_tech = list("combat" = 4, "materials" = 5, "powerstorage" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 2000, MAT_URANIUM = 4000)
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 2000)
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	category = list("Weapons")
 
@@ -46,7 +47,7 @@
 	name = "Telescopic Riot Shield"
 	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage."
 	id = "tele_shield"
-	req_tech = list("combat" = 4, "materials" = 3, "engineering" = 4)
+	req_tech = list("combat" = 4, "materials" = 3, "engineering" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 4000, MAT_GLASS = 5000, MAT_SILVER = 300)
 	build_path = /obj/item/weapon/shield/riot/tele
@@ -56,9 +57,9 @@
 	name = "Accelerator Laser Cannon"
 	desc = "A heavy duty laser cannon. It does more damage the farther away the target is."
 	id = "lasercannon"
-	req_tech = list("combat" = 5, "magnets" = 5, "powerstorage" = 3)
+	req_tech = list("combat" = 4, "materials" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 3000, MAT_DIAMOND = 3000)
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 2000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/weapon/gun/energy/lasercannon
 	category = list("Weapons")
 
@@ -66,7 +67,7 @@
 	name = "Decloner"
 	desc = "Your opponent will bubble into a messy pile of goop."
 	id = "decloner"
-	req_tech = list("combat" = 5, "materials" = 5, "biotech" = 6, "plasmatech" = 7)
+	req_tech = list("combat" = 8, "materials" = 7, "biotech" = 5, "powerstorage" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 5000,MAT_URANIUM = 10000)
 	reagents = list("mutagen" = 40)
@@ -77,7 +78,7 @@
 	name = "Rapid Syringe Gun"
 	desc = "A gun that fires many syringes."
 	id = "rapidsyringe"
-	req_tech = list("combat" = 3, "biotech" = 3)
+	req_tech = list("combat" = 3, "materials" = 3, "engineering" = 3, "biotech" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000)
 	build_path = /obj/item/weapon/gun/syringe/rapidsyringe
@@ -87,7 +88,7 @@
 	name = "Energy Crossbow"
 	desc = "A reverse-engineered energy crossbow favored by syndicate infiltration teams and carp hunters."
 	id = "largecrossbow"
-	req_tech = list("combat" = 5, "engineering" = 3, "magnet" = 5, "syndicate" = 3)
+	req_tech = list("combat" = 5, "materials" = 5, "engineering" = 3, "biotech" = 4, "syndicate" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1500, MAT_URANIUM = 1500, MAT_SILVER = 1500)
 	build_path = /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow/large
@@ -97,7 +98,7 @@
 	name = "Temperature Gun"
 	desc = "A gun that shoots temperature bullet energythings to change temperature."//Change it if you want
 	id = "temp_gun"
-	req_tech = list("combat" = 4, "materials" = 4, "powerstorage" = 3, "magnets" = 2)
+	req_tech = list("combat" = 3, "materials" = 4, "powerstorage" = 3, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 500, MAT_SILVER = 3000)
 	build_path = /obj/item/weapon/gun/energy/temperature
@@ -107,7 +108,7 @@
 	name = "Floral Somatoray"
 	desc = "A tool that discharges controlled radiation which induces mutation in plant cells. Harmless to other organic life."
 	id = "flora_gun"
-	req_tech = list("materials" = 2, "biotech" = 4)
+	req_tech = list("materials" = 2, "biotech" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 500)
 	reagents = list("radium" = 20)
@@ -118,7 +119,7 @@
 	name = "Large Grenade"
 	desc = "A grenade that affects a larger area and use larger containers."
 	id = "large_Grenade"
-	req_tech = list("combat" = 3, "engineering" = 3)
+	req_tech = list("combat" = 3, "materials" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000)
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
@@ -128,7 +129,7 @@
 	name = "Pyro Grenade"
 	desc = "An advanced grenade that is able to self ignite its mixture."
 	id = "pyro_Grenade"
-	req_tech = list("combat" = 4, "engineering" = 4)
+	req_tech = list("combat" = 3, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_PLASMA = 500)
 	build_path = /obj/item/weapon/grenade/chem_grenade/pyro
@@ -143,6 +144,7 @@
 	req_tech = list("combat" = 3, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 2000, MAT_SILVER = 500)
+	reliability = 79
 	build_path = /obj/item/weapon/grenade/chem_grenade/cryo
 	category = list("Weapons")
 */
@@ -151,7 +153,7 @@
 	name = "Advanced Release Grenade"
 	desc = "An advanced grenade that can be detonated several times, best used with a repeating igniter."
 	id = "adv_Grenade"
-	req_tech = list("combat" = 3, "engineering" = 4)
+	req_tech = list("combat" = 3, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 500)
 	build_path = /obj/item/weapon/grenade/chem_grenade/adv_release
@@ -161,9 +163,9 @@
 	name = "Xray Laser Gun"
 	desc = "Not quite as menacing as it sounds"
 	id = "xray"
-	req_tech = list("combat" = 7, "magnets" = 5, "biotech" = 5, "powerstorage" = 4)
+	req_tech = list("combat" = 6, "materials" = 5, "biotech" = 5, "powerstorage" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_GOLD = 5000,MAT_URANIUM = 10000, MAT_METAL = 5000)
+	materials = list(MAT_GOLD = 5000,MAT_URANIUM = 10000, MAT_METAL = 4000)
 	build_path = /obj/item/weapon/gun/energy/xray
 	category = list("Weapons")
 
@@ -171,9 +173,9 @@
 	name = "Ion Carbine"
 	desc = "How to dismantle a cyborg : The gun."
 	id = "ioncarbine"
-	req_tech = list("combat" = 5, "magnets" = 4)
+	req_tech = list("combat" = 5, "materials" = 4, "magnets" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_SILVER = 6000, MAT_METAL = 8000, MAT_URANIUM = 2000)
+	materials = list(MAT_SILVER = 4000, MAT_METAL = 6000, MAT_URANIUM = 1000)
 	build_path = /obj/item/weapon/gun/energy/ionrifle/carbine
 	category = list("Weapons")
 
@@ -181,9 +183,9 @@
 	name = "Bluespace Wormhole Projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	id = "wormholeprojector"
-	req_tech = list("combat" = 5, "engineering" = 5, "bluespace" = 7, "plasmatech" = 6)
+	req_tech = list("combat" = 6, "materials" = 6, "bluespace" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_SILVER = 2000, MAT_METAL = 5000, MAT_DIAMOND = 3000)
+	materials = list(MAT_SILVER = 1000, MAT_METAL = 5000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/weapon/gun/energy/wormhole_projector
 	category = list("Weapons")
 
@@ -191,7 +193,7 @@
 	name = "Modular Receiver"
 	desc = "A prototype modular receiver and trigger assembly for a variety of firearms."
 	id = "reciever"
-	req_tech = list("combat" = 4, "materials" = 4)
+	req_tech = list("combat" = 5, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 6500, MAT_SILVER = 500)
 	build_path = /obj/item/weaponcrafting/reciever

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -485,6 +485,11 @@
 				m << "<span class='danger'>You feel your flesh being torn from you, mists of blood drifting to [src]!</span>"
 				m.apply_damage(50,"brute","chest")
 				investigate_log("Experimentor has taken 50 brute a blood sacrifice from [m]", "experimentor")
+			var/list/reqs = ConvertReqString2List(exp_on.origin_tech)
+			for(var/T in reqs)
+				reqs[T] = reqs[T] + 1
+			exp_on.origin_tech = list2params(reqs)
+			investigate_log("Experimentor has set the origin tech of [exp_on] to [exp_on.origin_tech]", "experimentor")
 		if(globalMalf > 51 && globalMalf < 75)
 			visible_message("<span class='warning'>[src] encounters a run-time error!</span>")
 			throwSmoke(src.loc)

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -166,7 +166,7 @@
 	name = "super capacitor"
 	desc = "A super-high capacity capacitor used in the construction of a variety of devices."
 	icon_state = "super_capacitor"
-	origin_tech = "powerstorage=4;engineering=4"
+	origin_tech = "powerstorage=5;materials=4"
 	rating = 3
 	materials = list(MAT_METAL=50, MAT_GLASS=50)
 
@@ -174,7 +174,7 @@
 	name = "phasic scanning module"
 	desc = "A compact, high resolution phasic scanning module used in the construction of certain devices."
 	icon_state = "super_scan_module"
-	origin_tech = "magnets=4;engineering=4"
+	origin_tech = "magnets=5"
 	rating = 3
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 
@@ -182,7 +182,7 @@
 	name = "pico-manipulator"
 	desc = "A tiny little manipulator used in the construction of certain devices."
 	icon_state = "pico_mani"
-	origin_tech = "materials=4;programming=4,engineering=4"
+	origin_tech = "materials=5;programming=2"
 	rating = 3
 	materials = list(MAT_METAL=30)
 
@@ -190,7 +190,7 @@
 	name = "ultra-high-power micro-laser"
 	icon_state = "ultra_high_micro_laser"
 	desc = "A tiny laser used in certain devices."
-	origin_tech = "magnets=4;engineering=4"
+	origin_tech = "magnets=5"
 	rating = 3
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
 
@@ -198,7 +198,7 @@
 	name = "super matter bin"
 	desc = "A container designed to hold compressed matter awaiting reconstruction."
 	icon_state = "super_matter_bin"
-	origin_tech = "materials=4;engineering=4"
+	origin_tech = "materials=5"
 	rating = 3
 	materials = list(MAT_METAL=80)
 
@@ -208,7 +208,7 @@
 	name = "quadratic capacitor"
 	desc = "An capacity capacitor used in the construction of a variety of devices."
 	icon_state = "quadratic_capacitor"
-	origin_tech = "powerstorage=5;materials=4;engineering=4"
+	origin_tech = "powerstorage=6;materials=5"
 	rating = 4
 	materials = list(MAT_METAL=50, MAT_GLASS=50)
 
@@ -216,7 +216,7 @@
 	name = "triphasic scanning module"
 	desc = "A compact, ultra resolution triphasic scanning module used in the construction of certain devices."
 	icon_state = "triphasic_scan_module"
-	origin_tech = "magnets=5;materials=4;engineering=4"
+	origin_tech = "magnets=6"
 	rating = 4
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 
@@ -224,7 +224,7 @@
 	name = "femto-manipulator"
 	desc = "A tiny little manipulator used in the construction of certain devices."
 	icon_state = "femto_mani"
-	origin_tech = "materials=6;programming=4;engineering=4"
+	origin_tech = "materials=6;programming=3"
 	rating = 4
 	materials = list(MAT_METAL=30)
 
@@ -232,7 +232,7 @@
 	name = "quad-ultra micro-laser"
 	icon_state = "quadultra_micro_laser"
 	desc = "A tiny laser used in certain devices."
-	origin_tech = "magnets=5;materials=4;engineering=4"
+	origin_tech = "magnets=6"
 	rating = 4
 	materials = list(MAT_METAL=10, MAT_GLASS=20)
 
@@ -240,7 +240,7 @@
 	name = "bluespace matter bin"
 	desc = "A container designed to hold compressed matter awaiting reconstruction."
 	icon_state = "bluespace_matter_bin"
-	origin_tech = "materials=6;programming=4;engineering=4"
+	origin_tech = "materials=6"
 	rating = 4
 	materials = list(MAT_METAL=80)
 
@@ -250,49 +250,49 @@
 	name = "subspace ansible"
 	icon_state = "subspace_ansible"
 	desc = "A compact module capable of sensing extradimensional activity."
-	origin_tech = "programming=2;magnets=2;materials=2;bluespace=1"
+	origin_tech = "programming=2;magnets=3;materials=2;bluespace=1"
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 
 /obj/item/weapon/stock_parts/subspace/filter
 	name = "hyperwave filter"
 	icon_state = "hyperwave_filter"
 	desc = "A tiny device capable of filtering and converting super-intense radiowaves."
-	origin_tech = "programming=2;magnets=2"
+	origin_tech = "programming=2;magnets=1"
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 
 /obj/item/weapon/stock_parts/subspace/amplifier
 	name = "subspace amplifier"
 	icon_state = "subspace_amplifier"
 	desc = "A compact micro-machine capable of amplifying weak subspace transmissions."
-	origin_tech = "programming=2;magnets=2;materials=2;bluespace=2"
+	origin_tech = "programming=2;magnets=2;materials=2;bluespace=1"
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 
 /obj/item/weapon/stock_parts/subspace/treatment
 	name = "subspace treatment disk"
 	icon_state = "treatment_disk"
 	desc = "A compact micro-machine capable of stretching out hyper-compressed radio waves."
-	origin_tech = "programming=2;magnets=2;materials=2;bluespace=2"
+	origin_tech = "programming=2;magnets=1;materials=3;bluespace=1"
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 
 /obj/item/weapon/stock_parts/subspace/analyzer
 	name = "subspace wavelength analyzer"
 	icon_state = "wavelength_analyzer"
 	desc = "A sophisticated analyzer capable of analyzing cryptic subspace wavelengths."
-	origin_tech = "programming=2;magnets=2;materials=2;bluespace=2"
+	origin_tech = "programming=2;magnets=2;materials=2;bluespace=1"
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 
 /obj/item/weapon/stock_parts/subspace/crystal
 	name = "ansible crystal"
 	icon_state = "ansible_crystal"
 	desc = "A crystal made from pure glass used to transmit laser databursts to subspace."
-	origin_tech = "magnets=2;materials=2;bluespace=2;plasmatech=2"
+	origin_tech = "magnets=2;materials=2;bluespace=1"
 	materials = list(MAT_GLASS=50)
 
 /obj/item/weapon/stock_parts/subspace/transmitter
 	name = "subspace transmitter"
 	icon_state = "subspace_transmitter"
 	desc = "A large piece of equipment used to open a window into the subspace dimension."
-	origin_tech = "magnets=2;materials=2;bluespace=2"
+	origin_tech = "magnets=3;materials=3;bluespace=2"
 	materials = list(MAT_METAL=50)
 
 /obj/item/weapon/research//Makes testing much less of a pain -Sieve

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -149,7 +149,7 @@
 	name = "arm-mounted laser implant"
 	desc = "A variant of the arm cannon implant that fires lethal laser beams. The cannon emerges from the subject's arm and remains inside when not in use."
 	icon_state = "arm_laser"
-	origin_tech = "materials=4;combat=4;biotech=4;powerstorage=4;syndicate=3"
+	origin_tech = "materials=5;combat=5;biotech=4;powerstorage=4;syndicate=5"//this is kinda nutty and i might lower it
 	holder = /obj/item/weapon/gun/energy/laser/mounted
 
 /obj/item/organ/cyberimp/arm/gun/laser/l/zone = "l_arm"
@@ -168,7 +168,7 @@
 /obj/item/organ/cyberimp/arm/toolset
 	name = "integrated toolset implant"
 	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm. Contains all neccessary tools."
-	origin_tech = "materials=3;engineering=4;biotech=3;powerstorage=4"
+	origin_tech = "materials=4;engineering=4;biotech=3;powerstorage=4"
 	contents = newlist(/obj/item/weapon/screwdriver/cyborg, /obj/item/weapon/wrench/cyborg, /obj/item/weapon/weldingtool/largetank/cyborg,
 		/obj/item/weapon/crowbar/cyborg, /obj/item/weapon/wirecutters/cyborg, /obj/item/device/multitool/cyborg)
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -14,7 +14,7 @@
 	var/synthesizing = 0
 	var/poison_amount = 5
 	slot = "stomach"
-	origin_tech = "materials=4;powerstorage=5;biotech=4"
+	origin_tech = "materials=5;programming=3;biotech=4"
 
 /obj/item/organ/cyberimp/chest/nutriment/on_life()
 	if(synthesizing)
@@ -41,14 +41,14 @@
 	implant_color = "#006607"
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
 	poison_amount = 10
-	origin_tech = "materials=4;powerstorage=5;biotech=5"
+	origin_tech = "materials=5;programming=3;biotech=5"
 
 /obj/item/organ/cyberimp/chest/reviver
 	name = "Reviver implant"
 	desc = "This implant will attempt to revive you if you lose consciousness. For the faint of heart!"
 	icon_state = "chest_implant"
 	implant_color = "#AD0000"
-	origin_tech = "materials=5;programming=4;biotech=6"
+	origin_tech = "materials=6;programming=3;biotech=6;syndicate=4"
 	slot = "heartdrive"
 	var/revive_cost = 0
 	var/reviving = 0
@@ -112,7 +112,7 @@
 	Unlike regular jetpack, this device has no stablilzation system."
 	slot = "thrusters"
 	icon_state = "imp_jetpack"
-	origin_tech = "materials=4;magnets=4;biotech=4;engineering=5"
+	origin_tech = "materials=6;programming=4;magnets=3;biotech=4;engineering=4"
 	implant_overlay = null
 	implant_color = null
 	actions_types = list(/datum/action/item_action/organ_action/toggle)

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -50,7 +50,7 @@
 	desc = "These cybernetic eye implants will give you X-ray vision. Blinking is futile."
 	eye_color = "000"
 	implant_color = "#000000"
-	origin_tech = "materials=4;programming=4;biotech=6;magnets=4"
+	origin_tech = "materials=6;programming=4;biotech=6;magnets=5"
 	dark_view = 8
 	sight_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
 
@@ -59,7 +59,7 @@
 	desc = "These cybernetic eye implants will give you Thermal vision. Vertical slit pupil included."
 	eye_color = "FC0"
 	implant_color = "#FFCC00"
-	origin_tech = "materials=5;programming=4;biotech=4;magnets=4;syndicate=1"
+	origin_tech = "materials=6;programming=4;biotech=5;magnets=5;syndicate=4"
 	sight_flags = SEE_MOBS
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	flash_protect = -1
@@ -93,7 +93,7 @@
 	desc = "These cybernetic eye implants will display a medical HUD over everything you see."
 	eye_color = "0ff"
 	implant_color = "#00FFFF"
-	origin_tech = "materials=4;programming=4;biotech=4"
+	origin_tech = "materials=4;programming=3;biotech=4"
 	aug_message = "You suddenly see health bars floating above people's heads..."
 	HUD_type = DATA_HUD_MEDICAL_ADVANCED
 
@@ -102,7 +102,7 @@
 	desc = "These cybernetic eye implants will display a security HUD over everything you see."
 	eye_color = "d00"
 	implant_color = "#CC0000"
-	origin_tech = "materials=4;programming=4;biotech=3;combat=3"
+	origin_tech = "materials=4;programming=4;biotech=3;combat=1"
 	aug_message = "Job indicator icons pop up in your vision. That is not a certified surgeon..."
 	HUD_type = DATA_HUD_SECURITY_ADVANCED
 
@@ -112,7 +112,7 @@
 	name = "welding shield implant"
 	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
 	slot = "eye_shield"
-	origin_tech = "materials=4;biotech=3;engineering=4;plasmatech=3"
+	origin_tech = "materials=4;biotech=3"
 	implant_color = "#101010"
 	flash_protect = 2
 	aug_message = null

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -47,7 +47,7 @@
 	var/obj/item/r_hand_obj = null
 	implant_color = "#DE7E00"
 	slot = "brain_antidrop"
-	origin_tech = "materials=4;programming=5;biotech=4"
+	origin_tech = "materials=5;programming=4;biotech=4"
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 
 /obj/item/organ/cyberimp/brain/anti_drop/ui_action_click()
@@ -125,7 +125,7 @@
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	implant_color = "#FFFF00"
 	slot = "brain_antistun"
-	origin_tech = "materials=5;programming=4;biotech=5"
+	origin_tech = "materials=6;programming=4;biotech=5"
 
 /obj/item/organ/cyberimp/brain/anti_stun/on_life()
 	..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	var/mob/living/carbon/owner = null
 	var/status = ORGAN_ORGANIC
-	origin_tech = "biotech=3"
+	origin_tech = "biotech=2"
 	force = 1
 	w_class = 2
 	throwforce = 0
@@ -104,7 +104,7 @@
 	icon_state = "heart-on"
 	zone = "chest"
 	slot = "heart"
-	origin_tech = "biotech=5"
+	origin_tech = "biotech=3"
 	var/beating = 1
 	var/icon_base = "heart"
 	attack_verb = list("beat", "thumped")

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -84,7 +84,7 @@
 	throw_speed = 2
 	throw_range = 5
 	materials = list(MAT_METAL=10000, MAT_GLASS=6000)
-	origin_tech = "biotech=1;combat=1"
+	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharpness = IS_SHARP
 

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "bluespace_crystal"
 	w_class = 1
-	origin_tech = "bluespace=6;materials=3"
+	origin_tech = "bluespace=4;materials=3"
 	points = 50
 	var/blink_range = 8 // The teleport range when crushed/thrown at someone.
 
@@ -41,6 +41,6 @@
 /obj/item/weapon/ore/bluespace_crystal/artificial
 	name = "artificial bluespace crystal"
 	desc = "An artificially made bluespace crystal, it looks delicate."
-	origin_tech = "bluespace=3;plasmatech=4"
+	origin_tech = "bluespace=2"
 	blink_range = 4 // Not as good as the organic stuff!
 	points = 0 // nice try

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -6,7 +6,7 @@ var/list/GPS_list = list()
 	icon_state = "gps-c"
 	w_class = 2
 	slot_flags = SLOT_BELT
-	origin_tech = "materials=2;magnets=3;bluespace=3"
+	origin_tech = "programming=2;engineering=2"
 	var/gpstag = "COM0"
 	var/emped = 0
 	var/turf/locked_location

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -38,7 +38,6 @@
 	desc = "An upgrade for mobile janicarts."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "upgrade"
-	origin_tech = "materials=3;engineering=4"
 
 
 /obj/vehicle/janicart/Moved(atom/OldLoc, Dir)


### PR DESCRIPTION
This PR reverts most of tech level changes from #17576. Changes in machines are unaffected and reliability stays gone. Some minor stuff like getting biotech from genetics is unaffected too.

Well, I think we all saw the feedback on new RnD. @LatD's PR took it from "routinely sitting in dept for 10 minutes" to "routinely rushing from dept to dept, attempting to force everyone to work and begging spessmens to give you high tech items for 40 minutes, then crying because the shuttle is already called". At this point, RnD is simply not worth doing it.

I'm not sure how to improve RnD, but I'm sure @LatD's changes are _not_ improving it.

As a bonus point, changes that I'm reverting have murdered lowpop RnD and golems RnD. 
