### PR TITLE
Buffs anima fragments

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -40,10 +40,10 @@ This file's folder contains:
 	return M && istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.servants_of_ratvar)
 
 /proc/is_eligible_servant(mob/M)
-	return M && istype(M) && M.mind && !is_servant_of_ratvar(M) && !iscultist(M) && !isconstruct(M) && !isloyal(M)
+	return M && istype(M) && M.mind && !iscultist(M) && !isconstruct(M) && !isloyal(M)
 
 /proc/add_servant_of_ratvar(mob/M, silent = FALSE)
-	if(!ticker || !ticker.mode)
+	if(is_servant_of_ratvar(M) || !ticker || !ticker.mode)
 		return 0
 	if(iscarbon(M))
 		if(!silent)

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -40,10 +40,10 @@ This file's folder contains:
 	return M && istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.servants_of_ratvar)
 
 /proc/is_eligible_servant(mob/M)
-	return M && istype(M) && M.mind && !M.mind.special_role && !isloyal(M)
+	return M && istype(M) && M.mind && !is_servant_of_ratvar(M) && !iscultist(M) && !isconstruct(M) && !isloyal(M)
 
 /proc/add_servant_of_ratvar(mob/M, silent = FALSE)
-	if(!is_eligible_servant(M) || !ticker || !ticker.mode)
+	if(!ticker || !ticker.mode)
 		return 0
 	if(iscarbon(M))
 		if(!silent)
@@ -59,6 +59,11 @@ This file's folder contains:
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] whirs as it resists an outside influence!</span>", \
 			"<span class='warning'><b>Corrupt data purged. Resetting cortex chip to factory defaults... complete.</b></span>")
+			return 0
+	else if(!silent)
+		M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar lies in exile, derelict and forgotten in an unseen realm.</span>"
+		if(!is_eligible_servant(M))
+			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
 			return 0
 	if(!silent)
 		M.visible_message("<span class='heavy_brass'>[M]'s eyes glow a blazing yellow!</span>", \

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -48,7 +48,7 @@ This file's folder contains:
 	if(iscarbon(M))
 		if(!silent)
 			M << "<span class='heavy_brass'>Your mind is racing! Your body feels incredibly light! Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork \
-			Justiciar lies in exile, derelict and forgotten in an unseen realm.</span>"
+			Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
 			return 0
@@ -61,7 +61,7 @@ This file's folder contains:
 			"<span class='warning'><b>Corrupt data purged. Resetting cortex chip to factory defaults... complete.</b></span>")
 			return 0
 	else if(!silent)
-		M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar lies in exile, derelict and forgotten in an unseen realm.</span>"
+		M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
 			return 0

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -51,6 +51,7 @@ This file's folder contains:
 			Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
+			return 0
 	else if(issilicon(M))
 		if(!silent)
 			M << "<span class='heavy_brass'>You are unable to compute this truth. Your vision glows a brilliant yellow, and all at once it comes to you. Ratvar, the Clockwork Justiciar, lies in \
@@ -58,12 +59,13 @@ This file's folder contains:
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] whirs as it resists an outside influence!</span>", \
 			"<span class='warning'><b>Corrupt data purged. Resetting cortex chip to factory defaults... complete.</b></span>")
-	else if(!silent)
-		M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
+			return 0
+	else
+		if(!silent)
+			M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
-	if(!is_eligible_servant(M))
-		return 0
+			return 0
 	if(!silent)
 		M.visible_message("<span class='heavy_brass'>[M]'s eyes glow a blazing yellow!</span>", \
 		"<span class='heavy_brass'>Assist your new companions in their righteous efforts. Your goal is theirs, and theirs yours. You serve the Clockwork Justiciar above all else. Perform his every \

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -51,7 +51,6 @@ This file's folder contains:
 			Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
-			return 0
 	else if(issilicon(M))
 		if(!silent)
 			M << "<span class='heavy_brass'>You are unable to compute this truth. Your vision glows a brilliant yellow, and all at once it comes to you. Ratvar, the Clockwork Justiciar, lies in \
@@ -59,12 +58,12 @@ This file's folder contains:
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] whirs as it resists an outside influence!</span>", \
 			"<span class='warning'><b>Corrupt data purged. Resetting cortex chip to factory defaults... complete.</b></span>")
-			return 0
 	else if(!silent)
 		M << "<span class='heavy_brass'>Your world glows a brilliant yellow! All at once it comes to you. Ratvar, the Clockwork Justiciar, lies in exile, derelict and forgotten in an unseen realm.</span>"
 		if(!is_eligible_servant(M))
 			M.visible_message("<span class='warning'>[M] seems to resist an unseen force!</span>", "<span class='warning'><b>And yet, you somehow push it all away.</b></span>")
-			return 0
+	if(!is_eligible_servant(M))
+		return 0
 	if(!silent)
 		M.visible_message("<span class='heavy_brass'>[M]'s eyes glow a blazing yellow!</span>", \
 		"<span class='heavy_brass'>Assist your new companions in their righteous efforts. Your goal is theirs, and theirs yours. You serve the Clockwork Justiciar above all else. Perform his every \

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -490,6 +490,6 @@
 				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
 				return
 			if(procure_gateway(user, 100, 5, 1))
-				user.say("Fcnpvny tngrjnl, npgvingr!")
+				user.say("Fcnpvny Tngrjnl, npgvingr!")
 		if("Cancel")
 			return

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -468,8 +468,14 @@
 	var/choice = alert(user,"You place your hand on the obelisk...",,"Hierophant Broadcast","Spatial Gateway","Cancel")
 	switch(choice)
 		if("Hierophant Broadcast")
+			if(gateway_active)
+				user << "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>"
+				return
 			var/input = stripped_input(usr, "Please choose a message to send over the Hierophant Network.", "Hierophant Broadcast", "")
 			if(!input || !user.canUseTopic(src, be_close = 1))
+				return
+			if(gateway_active)
+				user << "<span class='warning'>The obelisk is sustaining a gateway and cannot broadcast!</span>"
 				return
 			if(!try_use_power(hierophant_cost))
 				user << "<span class='warning'>The obelisk lacks the power to broadcast!</span>"
@@ -477,11 +483,11 @@
 			user.say("Uvrebcunag Oebnqpnfg, npgvingr!")
 			send_hierophant_message(user, input, 1)
 		if("Spatial Gateway")
-			if(!try_use_power(gateway_cost))
-				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
-				return
 			if(gateway_active)
 				user << "<span class='warning'>The obelisk is already sustaining a gateway!</span>"
+				return
+			if(!try_use_power(gateway_cost))
+				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
 				return
 			if(procure_gateway(user, 100, 5, 1))
 				user.say("Fcnpvny tngrjnl, npgvingr!")

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -95,7 +95,7 @@
 	while(sigilpower && amount >= 50)
 		for(var/S in sigils_in_range)
 			var/obj/effect/clockwork/sigil/transmission/T = S
-			if(T.modify_charge(50))
+			if(amount >= 50 && T.modify_charge(50))
 				sigilpower -= 50
 				amount -= 50
 	var/apcpower = accessable_apc_power()
@@ -448,7 +448,7 @@
 /obj/structure/clockwork/powered/clockwork_obelisk/examine(mob/user)
 	..()
 	if(is_servant_of_ratvar(user) || isobserver(user))
-		user << "<span class='nzcrentr'>It requires [hierophant_cost]W to broadcast over the Hierophant Network, and [gateway_cost]W to open a Spatial Gateway.</span>"
+		user << "<span class='nzcrentr_small'>It requires [hierophant_cost]W to broadcast over the Hierophant Network, and [gateway_cost]W to open a Spatial Gateway.</span>"
 
 /obj/structure/clockwork/powered/clockwork_obelisk/process()
 	if(locate(/obj/effect/clockwork/spatial_gateway) in loc)

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -440,6 +440,7 @@
 	debris = list(/obj/item/clockwork/component/hierophant_ansible/obelisk)
 	var/hierophant_cost = 50 //how much it costs to broadcast with large text
 	var/gateway_cost = 2000 //how much it costs to open a gateway
+	var/gateway_active = FALSE
 
 /obj/structure/clockwork/powered/clockwork_obelisk/New()
 	..()
@@ -454,9 +455,11 @@
 	if(locate(/obj/effect/clockwork/spatial_gateway) in loc)
 		icon_state = active_icon
 		density = 0
+		gateway_active = TRUE
 	else
 		icon_state = inactive_icon
 		density = 1
+		gateway_active = FALSE
 
 /obj/structure/clockwork/powered/clockwork_obelisk/attack_hand(mob/living/user)
 	if(!is_servant_of_ratvar(user) || !total_accessable_power() >= hierophant_cost)
@@ -466,18 +469,21 @@
 	switch(choice)
 		if("Hierophant Broadcast")
 			var/input = stripped_input(usr, "Please choose a message to send over the Hierophant Network.", "Hierophant Broadcast", "")
-			if(user.canUseTopic(src, be_close = 1))
-				if(try_use_power(hierophant_cost))
-					user.say("Uvrebcunag Oebnqpnfg, npgvingr!")
-					send_hierophant_message(user, input, 1)
-				else
-					user <<  "<span class='warning'>The obelisk lacks the power to broadcast!</span>"
+			if(!input || !user.canUseTopic(src, be_close = 1))
+				return
+			if(!try_use_power(hierophant_cost))
+				user << "<span class='warning'>The obelisk lacks the power to broadcast!</span>"
+				return
+			user.say("Uvrebcunag Oebnqpnfg, npgvingr!")
+			send_hierophant_message(user, input, 1)
 		if("Spatial Gateway")
-			if(total_accessable_power() >= gateway_cost)
-				if(procure_gateway(user, 100, 5, 1))
-					user.say("Fcnpvny tngrjnl, npgvingr!")
-					try_use_power(gateway_cost)
-			else
-				user <<  "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
+			if(!try_use_power(gateway_cost))
+				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
+				return
+			if(gateway_active)
+				user << "<span class='warning'>The obelisk is already sustaining a gateway!</span>"
+				return
+			if(procure_gateway(user, 100, 5, 1))
+				user.say("Fcnpvny tngrjnl, npgvingr!")
 		if("Cancel")
 			return

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -1,11 +1,12 @@
-/mob/living/simple_animal/hostile/anima_fragment //Anima fragment: Low health but high melee power. Created by inserting a soul vessel into an empty fragment.
+/mob/living/simple_animal/hostile/anima_fragment //Anima fragment: High health and high melee damage, but slows down when struck. Created by inserting a soul vessel into an empty fragment.
 	name = "anima fragment"
 	desc = "An ominous humanoid shell with a spinning cogwheel as its head, lifted by a jet of blazing red flame."
 	faction = list("ratvar")
 	icon = 'icons/mob/clockwork_mobs.dmi'
 	icon_state = "anime_fragment"
-	health = 75 //Glass cannon
-	maxHealth = 75
+	health = 120
+	maxHealth = 120
+	speed = -1
 	minbodytemp = 0
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0) //Robotic
 	healable = FALSE
@@ -13,9 +14,13 @@
 	melee_damage_upper = 25
 	attacktext = "crushes"
 	attack_sound = 'sound/magic/clockwork/anima_fragment_attack.ogg'
-	var/playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you are weak but possess powerful melee capabilities \
-	in addition to being immune to extreme temperatures and pressures. Your goal is to serve the Justiciar and his servants in any way you can. You yourself are one of these servants, and will \
-	be able to utilize anything they can, assuming it doesn't require opposable thumbs.</b>"
+	loot = list(/obj/item/clockwork/component/replicant_alloy/smashed_anima_fragment, /obj/item/device/mmi/posibrain/soul_vessel)
+	del_on_death = TRUE
+	death_sound = 'sound/magic/clockwork/anima_fragment_death.ogg'
+	var/playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you have medium health, do decent damage, and move at \
+	extreme speed in addition to being immune to extreme temperatures and pressures. Taking damage will temporarily slow you down, however. Your goal is to serve the Justiciar and his servants \
+	in any way you can. You yourself are one of these servants, and will be able to utilize anything they can, assuming it doesn't require opposable thumbs.</b>"
+	var/movement_delay_time //how long the fragment is slowed after being hit
 
 /mob/living/simple_animal/hostile/anima_fragment/New()
 	..()
@@ -24,16 +29,32 @@
 		real_name = name
 		desc = "I-it's not like I want to show you the light of the Justiciar or anything, B-BAKA!"
 
+/mob/living/simple_animal/hostile/anima_fragment/Stat()
+	..()
+	if(statpanel("Status") && movement_delay_time > world.time && !ratvar_awakens)
+		stat(null, "Movement delay(seconds): [max(round((movement_delay_time - world.time)*0.1, 0.1), 0)]")
+
 /mob/living/simple_animal/hostile/anima_fragment/death(gibbed)
 	..(TRUE)
 	visible_message("<span class='warning'>[src]'s flame jets cut out as it falls to the floor with a tremendous crash. A cube of metal tumbles out, whirring and sputtering.</span>", \
 	"<span class='userdanger'>Your gears seize up. Your flame jets flicker. Your soul vessel belches smoke as you helplessly crash down.</span>")
-	playsound(src, 'sound/magic/clockwork/anima_fragment_death.ogg', 100, 1)
-	new/obj/item/clockwork/component/replicant_alloy/smashed_anima_fragment(get_turf(src))
-	new/obj/item/device/mmi/posibrain/soul_vessel(get_turf(src)) //Notice the lack of transfer - it's a standard soul vessel with no mind in it!
-	qdel(src)
 	return 1
 
+/mob/living/simple_animal/hostile/anima_fragment/Process_Spacemove(movement_dir = 0)
+	return 1
+
+/mob/living/simple_animal/hostile/anima_fragment/movement_delay()
+	. = ..()
+	if(movement_delay_time > world.time && !ratvar_awakens)
+		. += min((movement_delay_time - world.time) * 0.1, 10) //the more delay we have, the slower we go
+
+/mob/living/simple_animal/hostile/anima_fragment/adjustHealth(amount)
+	. = ..()
+	if(!ratvar_awakens) //if ratvar is up we ignore movement delay
+		if(movement_delay_time > world.time)
+			movement_delay_time = movement_delay_time + amount*2
+		else
+			movement_delay_time = world.time + amount*2
 
 
 /mob/living/simple_animal/hostile/clockwork_marauder //Clockwork marauder: Slow but with high damage, resides inside of a servant. Created via the Memory Allocation scripture.

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -37,7 +37,7 @@
 /mob/living/simple_animal/hostile/anima_fragment/death(gibbed)
 	..(TRUE)
 	visible_message("<span class='warning'>[src]'s flame jets cut out as it falls to the floor with a tremendous crash. A cube of metal tumbles out, whirring and sputtering.</span>", \
-	"<span class='userdanger'>Your gears seize up. Your flame jets flicker. Your soul vessel belches smoke as you helplessly crash down.</span>")
+	"<span class='userdanger'>Your gears seize up. Your flame jets flicker out. Your soul vessel belches smoke as you helplessly crash down.</span>")
 	return 1
 
 /mob/living/simple_animal/hostile/anima_fragment/Process_Spacemove(movement_dir = 0)
@@ -176,6 +176,7 @@
 			resulthealth = round((abs(config.health_threshold_dead - host.health) / abs(config.health_threshold_dead - host.maxHealth)) * 100)
 			stat(null, "Host Health: [resulthealth]%")
 		stat(null, "You are [recovering ? "too weak" : "able"] to deploy!")
+		stat(null, "You do [melee_damage_upper] on melee attacks.")
 
 /mob/living/simple_animal/hostile/clockwork_marauder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
 	..()
@@ -313,7 +314,10 @@
 	if(!is_in_host())
 		return 0
 	if(recovering)
-		host << "<span class='heavy_brass'>[true_name] is too weak to come forth!</span>"
+		if(hostchosen)
+			host << "<span class='heavy_brass'>[true_name] is too weak to come forth!</span>"
+		else
+			host << "<span class='heavy_brass'>[true_name] tries to emerge to protect you, but it's too weak!</span>"
 		src << "<span class='userdanger'>You try to come forth, but you're too weak!</span>"
 		return 0
 	if(hostchosen) //marauder approved

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -645,7 +645,8 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 /datum/clockwork_scripture/create_object/anima_fragment //Anima Fragment: Creates an empty anima fragment
 	name = "Anima Fragment"
-	desc = "Creates a large shell fitted for soul vessels. The result is a powerful construct with low damage tolerance but exceptional melee power."
+	desc = "Creates a large shell fitted for soul vessels. Adding an active sould vessel to it results in a powerful construct with decent health, notable melee power, \
+	and exceptional speed, though taking damage will temporarily slow it down."
 	invocations = list("Pnyy sbegu...", "...gur fbyqvref-bs Nezbere.")
 	channel_time = 50
 	required_components = list("belligerent_eye" = 2, "guvax_capacitor" = 1, "replicant_alloy" = 2)
@@ -731,14 +732,14 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		return 0
 	invoker.notransform = FALSE
 	slab.busy = null
-	var/list/marauder_candidates = get_candidates(ROLE_SERVANT_OF_RATVAR)
+	var/list/marauder_candidates = pollCandidates("Do you want to play as the clockwork marauder of [invoker.real_name]?", ROLE_SERVANT_OF_RATVAR, null, FALSE, 100)
 	if(!marauder_candidates.len)
 		invoker.visible_message("<span class='warning'>The tendril retracts from [invoker]'s head, sealing the entry wound as it does so!</span>", \
 		"<span class='warning'>The tendril was unsuccessful! Perhaps you should try again another time.</span>")
 		return 0
-	var/client/new_marauder = pick(marauder_candidates)
+	var/mob/dead/observer/theghost = pick(marauder_candidates)
 	var/mob/living/simple_animal/hostile/clockwork_marauder/M = new(invoker)
-	M.client = new_marauder
+	M.key = theghost.key
 	M.host = invoker
 	M << M.playstyle_string
 	M << "<b>Your true name is \"[M.true_name]\". You can change this <i>once</i> by using the Change True Name verb in your Marauder tab.</b>"

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -732,6 +732,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		return 0
 	invoker.notransform = FALSE
 	slab.busy = null
+	invoker << "<span class='warning'>The tendril shivers slightly as it selects a marauder...</span>"
 	var/list/marauder_candidates = pollCandidates("Do you want to play as the clockwork marauder of [invoker.real_name]?", ROLE_SERVANT_OF_RATVAR, null, FALSE, 100)
 	if(!marauder_candidates.len)
 		invoker.visible_message("<span class='warning'>The tendril retracts from [invoker]'s head, sealing the entry wound as it does so!</span>", \

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -529,7 +529,7 @@
 	animate(src, alpha = 0, time = 10)
 	addtimer(src, "selfdel", 10)
 
-/obj/effect/clockwerk/general_marker/proc/selfdel()
+/obj/effect/clockwork/general_marker/proc/selfdel()
 	qdel(src)
 
 /obj/effect/clockwork/general_marker/nezbere

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -481,7 +481,7 @@
 		qdel(src)
 		return 1
 	if(user.drop_item())
-		user.visible_message("<span class='warning'>[user] drops [I] into [src]!</span>", "<span class='danger'>You drop [I] into [src]!</span>"
+		user.visible_message("<span class='warning'>[user] drops [I] into [src]!</span>", "<span class='danger'>You drop [I] into [src]!</span>")
 		pass_through_gateway(I)
 	..()
 

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -481,6 +481,7 @@
 		qdel(src)
 		return 1
 	if(user.drop_item())
+		user.visible_message("<span class='warning'>[user] drops [I] into [src]!</span>", "<span class='danger'>You drop [I] into [src]!</span>"
 		pass_through_gateway(I)
 	..()
 

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -447,6 +447,7 @@
 	else
 		sender = TRUE
 		gatewayB.sender = FALSE
+		gatewayB.density = FALSE
 	lifetime = set_duration
 	gatewayB.lifetime = set_duration
 	uses = set_uses


### PR DESCRIPTION
:cl: Joan
tweak: Anima Fragments have slightly more health and move faster, but slow down temporarily when taking damage. Also they can move in space now.
/:cl:

Fixes #18211
Actually two bugs; first was that simple animals have, by default, a special role, so they didn't count as a servant. Second was, I am reasonably sure, marauders lacked a mind due to how they were created.
Fixes a bug where machines could use negative sigil power and would fail to work. ha ha whoops
Fixes a bug where you could use an obelisk if you managed to click it under a gateway.
Fixes a bug where no hierophant input would still try to message.
Fixes a bug where the receiver gateway would be dense and thus block entering an obelisk gateway if you aimed a non-obelisk gateway at an obelisk sustaining a gateway. This is a convoluted issue but very easy to fix.
Fixes a bug where general markers were permanent.
