### PR TITLE
Remove exception from rule about colon operator (:)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,6 @@ The previous code made compliant:
 ###No overriding type safety checks.
 The use of the : operator to override type safety checks is strongly discouraged. You must cast the variable to the proper type.
 
-Exceptions are only made when used in loops that require the performance boost from being called ***extremely*** often. (Rule of thumb: If you aren't messing with the master controller or it's subsystems, this exception probably doesn't apply)
-
 ###Type paths must began with a /
 eg: `/datum/thing` not `datum/thing`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ The previous code made compliant:
 ```
 
 ###No overriding type safety checks.
-The use of the : operator to override type safety checks is strongly discouraged. You must cast the variable to the proper type.
+The use of the : operator to override type safety checks is not allowed. You must cast the variable to the proper type.
 
 ###Type paths must began with a /
 eg: `/datum/thing` not `datum/thing`


### PR DESCRIPTION
This isn't needed anymore because typecasting has a lot less overhead than we thought.
