### PR TITLE
Fixes non-human carbons without DNA being shock immune

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -50,9 +50,9 @@
 
 
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, override = 0, tesla_shock = 0)
-	CHECK_DNA_AND_SPECIES(src)
-
-	shock_damage *= (siemens_coeff * dna.species.siemens_coeff)
+	shock_damage *= siemens_coeff
+	if(dna && dna.species)
+		shock_damage *= dna.species.siemens_coeff
 	if(shock_damage<1 && !override)
 		return 0
 	if(reagents.has_reagent("teslium"))


### PR DESCRIPTION
The CHECK_DNA_AND_SPECIES define was causing the /carbon/electrocute_act() proc to terminate silently, with no runtime or returned value.
This is what made certain mobs, like Xenos, who have no `dna` set to be entirely impervious to tesla and other electrical attacks.
Fixes https://github.com/tgstation/tgstation/issues/18304.
