### PR TITLE
Support guardian beacons are now structures

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -11,7 +11,7 @@
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! You caught a support carp. It's a kleptocarp!</span>"
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Support modules active. Holoparasite swarm online.</span>"
 	toggle_button_type = /obj/screen/guardian/ToggleMode
-	var/turf/open/floor/beacon
+	var/obj/structure/recieving_pad/beacon
 	var/beacon_cooldown = 0
 	var/toggle = FALSE
 
@@ -68,58 +68,89 @@
 /mob/living/simple_animal/hostile/guardian/healer/verb/Beacon()
 	set name = "Place Bluespace Beacon"
 	set category = "Guardian"
-	set desc = "Mark a floor as your beacon point, allowing you to warp targets to it. Your beacon will not work at extreme distances."
-	if(beacon_cooldown<world.time)
-		var/turf/beacon_loc = get_turf(src.loc)
-		if(istype(beacon_loc, /turf/open/floor))
-			var/turf/open/floor/F = beacon_loc
-			F.icon = 'icons/turf/floors.dmi'
-			F.name = "bluespace recieving pad"
-			F.desc = "A recieving zone for bluespace teleportations. Building a wall over it should disable it."
-			F.icon_state = "light_on-w"
-			F.luminosity = 1
-			if(namedatum)
-				F.color = namedatum.colour
-			src << "<span class='danger'><B>Beacon placed! You may now warp targets to it, including your user, via Alt+Click. </span></B>"
-			if(beacon)
-				beacon.ChangeTurf(/turf/open/floor/plating)
-			beacon = F
-			beacon_cooldown = world.time+3000
+	set desc = "Mark a floor as your beacon point, allowing you to warp \
+		targets to it. Your beacon will not work at extreme distances."
 
-	else
+	if(beacon_cooldown >= world.time)
 		src << "<span class='danger'><B>Your power is on cooldown. You must wait five minutes between placing beacons.</span></B>"
+		return
+
+	var/turf/beacon_loc = get_turf(src.loc)
+	if(!istype(beacon_loc, /turf/open/floor))
+		return
+
+	if(beacon)
+		beacon.disappear()
+		beacon = null
+
+	beacon = new(beacon_loc, src)
+
+	src << "<span class='danger'><B>Beacon placed! You may now warp targets \
+		to it, including your user, via Alt+Click.</span></B>"
+
+	beacon_cooldown = world.time + 3000
+
+/obj/structure/recieving_pad
+	name = "bluespace recieving pad"
+	icon = 'icons/turf/floors.dmi'
+	desc = "A recieving zone for bluespace teleportations."
+	icon_state = "light_on-w"
+	luminosity = 1
+	density = FALSE
+	anchored = TRUE
+	layer = ABOVE_OPEN_TURF_LAYER
+
+/obj/structure/recieving_pad/New(loc, mob/living/simple_animal/hostile/guardian/healer/G)
+	. = ..()
+	if(G.namedatum)
+		color = G.namedatum.colour
+
+/obj/structure/recieving_pad/proc/disappear()
+	visible_message("[src] vanishes!")
+	qdel(src)
 
 /mob/living/simple_animal/hostile/guardian/healer/AltClickOn(atom/movable/A)
 	if(!istype(A))
 		return
 	if(src.loc == summoner)
-		src << "<span class='danger'><B>You must be manifested to warp a target!</span></B>"
+		src << "<span class='danger'><B>You must be manifested to warp a \
+			target!</span></B>"
 		return
 	if(!beacon)
-		src << "<span class='danger'><B>You need a beacon placed to warp things!</span></B>"
+		src << "<span class='danger'><B>You need a beacon placed to warp \
+			things!</span></B>"
 		return
 	if(!Adjacent(A))
-		src << "<span class='danger'><B>You must be adjacent to your target!</span></B>"
+		src << "<span class='danger'><B>You must be adjacent to your \
+			target!</span></B>"
 		return
-	if((A.anchored))
-		src << "<span class='danger'><B>Your target cannot be anchored!</span></B>"
+	if(A.anchored)
+		src << "<span class='danger'><B>Your target cannot be \
+			anchored!</span></B>"
 		return
 
 	var/turf/T = get_turf(A)
-	if(beacon.z == T.z)
-		src << "<span class='danger'><B>You begin to warp [A].</span></B>"
-		A.visible_message("<span class='danger'>[A] starts to glow faintly!</span>", "<span class='userdanger'>You start to faintly glow, and you feel strangely weightless!</span>")
-		do_attack_animation(A)
-		if(do_mob(src, A, 60)) //now start the channel
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, T)
-			if(isliving(A))
-				var/mob/living/L = A
-				L.flash_eyes()
-			A.visible_message("<span class='danger'>[A] disappears in a flash of light!</span>", "<span class='userdanger'>Your vision is obscured by a flash of light!</span>")
-			do_teleport(A, beacon, 0)
-			PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))
-		else
-			src << "<span class='danger'><B>You need to hold still!</span></B>"
+	if(beacon.z != T.z)
+		src << "<span class='danger'><B>The beacon is too far away to warp \
+			to!</span></B>"
+		return
 
-	else
-		src << "<span class='danger'><B>The beacon is too far away to warp to!</span></B>"
+	src << "<span class='danger'><B>You begin to warp [A].</span></B>"
+	A.visible_message("<span class='danger'>[A] starts to glow faintly!\
+		</span>", "<span class='userdanger'>You start to faintly glow, and \
+		you feel strangely weightless!</span>")
+	do_attack_animation(A)
+
+	if(!do_mob(src, A, 60)) //now start the channel
+		src << "<span class='danger'><B>You need to hold still!</span></B>"
+		return
+
+	PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, T)
+	if(isliving(A))
+		var/mob/living/L = A
+		L.flash_eyes()
+	A.visible_message("<span class='danger'>[A] disappears in a flash of \
+		light!</span>", "<span class='userdanger'>Your vision is obscured \
+		by a flash of light!</span>")
+	do_teleport(A, beacon, 0)
+	PoolOrNew(/obj/effect/overlay/temp/guardian/phase, get_turf(A))


### PR DESCRIPTION
- Now they'll no longer eat the turf to place themselves.
- Also tidied up the code a little.

:cl: coiax
tweak: The beacons from support guardians are now structures, rather than replacing the floor tile. In practice, this will change little, aside from not leaving empty plating when a beacon is removed because a new one has been placed.
/:cl:
