### PR TITLE
makes legless scootering a feature

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -24,22 +24,20 @@
 	if(buckled_mobs.len)
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			if(iscarbon(buckled_mob))
-				var/mob/living/carbon/buckled_carbon = buckled_mob
-				if(buckled_carbon.get_num_legs() < 2)
-					switch(buckled_carbon.dir)
-						if(NORTH)
-							buckled_carbon.pixel_x = 0
-							buckled_carbon.pixel_y = -4
-						if(EAST)
-							buckled_carbon.pixel_x = -2
-							buckled_carbon.pixel_y = -4
-						if(SOUTH)
-							buckled_carbon.pixel_x = 0
-							buckled_carbon.pixel_y = -4
-						if(WEST)
-							buckled_carbon.pixel_x = 2
-							buckled_carbon.pixel_y = -4
+			if(buckled_mobs.get_num_legs() <= 0)
+				switch(buckled_mobs.dir)
+					if(NORTH)
+						buckled_mobs.pixel_x = 0
+						buckled_mobs.pixel_y = -4
+					if(EAST)
+						buckled_mobs.pixel_x = -2
+						buckled_mobs.pixel_y = -4
+					if(SOUTH)
+						buckled_mobs.pixel_x = 0
+						buckled_mobs.pixel_y = -4
+					if(WEST)
+						buckled_mobs.pixel_x = 2
+						buckled_mobs.pixel_y = -4
 			else
 				switch(buckled_mob.dir)
 					if(NORTH)
@@ -58,11 +56,11 @@
 /obj/vehicle/scooter/post_buckle_mob(mob/living/M)
 	vehicle_move_delay = initial(vehicle_move_delay)
 	..()
-	if(!iscarbon(M))
-		return
-	var/mob/living/carbon/C = M
-	if(C.get_num_legs() < 2)
-		vehicle_move_delay = initial(vehicle_move_delay) + 1
+	if(M.get_num_legs() < 2)
+		vehicle_move_delay ++
+		if(M.get_num_arms() <= 0)
+			unbuckle_mob(M)
+			M << "<span class='warning'>Your limbless body flops off \the [src].</span>"
 
 /obj/vehicle/scooter/skateboard
 	name = "skateboard"

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -24,22 +24,8 @@
 	if(buckled_mobs.len)
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			if(buckled_mobs.get_num_legs() <= 0)
+			if(buckled_mobs.get_num_legs() > 0)
 				switch(buckled_mobs.dir)
-					if(NORTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
-					if(EAST)
-						buckled_mobs.pixel_x = -2
-						buckled_mobs.pixel_y = -4
-					if(SOUTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
-					if(WEST)
-						buckled_mobs.pixel_x = 2
-						buckled_mobs.pixel_y = -4
-			else
-				switch(buckled_mob.dir)
 					if(NORTH)
 						buckled_mob.pixel_x = 0
 						buckled_mob.pixel_y = 4
@@ -52,6 +38,20 @@
 					if(WEST)
 						buckled_mob.pixel_x = 2
 						buckled_mob.pixel_y = 4
+			else
+				switch(buckled_mob.dir)
+					if(NORTH)
+						buckled_mobs.pixel_x = 0
+						buckled_mobs.pixel_y = -4
+					if(EAST)
+						buckled_mobs.pixel_x = -2
+						buckled_mobs.pixel_y = -4
+					if(SOUTH)
+						buckled_mobs.pixel_x = 0
+						buckled_mobs.pixel_y = -4
+					if(WEST)
+						buckled_mobs.pixel_x = 2
+						buckled_mobs.pixel_y = -4
 
 /obj/vehicle/scooter/post_buckle_mob(mob/living/M)
 	vehicle_move_delay = initial(vehicle_move_delay)
@@ -59,8 +59,9 @@
 	if(M.get_num_legs() < 2)
 		vehicle_move_delay ++
 		if(M.get_num_arms() <= 0)
+			if(buckled_mobs.len)//to prevent the message displaying twice due to unbuckling
+				M << "<span class='warning'>Your limbless body flops off \the [src].</span>"
 			unbuckle_mob(M)
-			M << "<span class='warning'>Your limbless body flops off \the [src].</span>"
 
 /obj/vehicle/scooter/skateboard
 	name = "skateboard"

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -24,34 +24,19 @@
 	if(buckled_mobs.len)
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			if(buckled_mobs.get_num_legs() > 0)
-				switch(buckled_mob.dir)
-					if(NORTH)
-						buckled_mob.pixel_x = 0
-						buckled_mob.pixel_y = 4
-					if(EAST)
-						buckled_mob.pixel_x = -2
-						buckled_mob.pixel_y = 4
-					if(SOUTH)
-						buckled_mob.pixel_x = 0
-						buckled_mob.pixel_y = 4
-					if(WEST)
-						buckled_mob.pixel_x = 2
-						buckled_mob.pixel_y = 4
+			switch(buckled_mob.dir)
+				if(NORTH)
+					buckled_mob.pixel_x = 0
+				if(EAST)
+					buckled_mob.pixel_x = -2
+				if(SOUTH)
+					buckled_mob.pixel_x = 0
+				if(WEST)
+					buckled_mob.pixel_x = 2
+			if(buckled_mob.get_num_legs() > 0)
+				buckled_mob.pixel_y = 4
 			else
-				switch(buckled_mob.dir)
-					if(NORTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
-					if(EAST)
-						buckled_mobs.pixel_x = -2
-						buckled_mobs.pixel_y = -4
-					if(SOUTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
-					if(WEST)
-						buckled_mobs.pixel_x = 2
-						buckled_mobs.pixel_y = -4
+				buckled_mob.pixel_y = -4
 
 /obj/vehicle/scooter/post_buckle_mob(mob/living/M)
 	vehicle_move_delay = initial(vehicle_move_delay)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -24,20 +24,20 @@
 	if(buckled_mobs.len)
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			if(buckled_mobs.get_num_legs() <= 0)
-				switch(buckled_mobs.dir)
+			if(buckled_mob.get_num_legs() <= 0)
+				switch(buckled_mob.dir)
 					if(NORTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
+						buckled_mob.pixel_x = 0
+						buckled_mob.pixel_y = -4
 					if(EAST)
-						buckled_mobs.pixel_x = -2
-						buckled_mobs.pixel_y = -4
+						buckled_mob.pixel_x = -2
+						buckled_mob.pixel_y = -4
 					if(SOUTH)
-						buckled_mobs.pixel_x = 0
-						buckled_mobs.pixel_y = -4
+						buckled_mob.pixel_x = 0
+						buckled_mob.pixel_y = -4
 					if(WEST)
-						buckled_mobs.pixel_x = 2
-						buckled_mobs.pixel_y = -4
+						buckled_mob.pixel_x = 2
+						buckled_mob.pixel_y = -4
 			else
 				switch(buckled_mob.dir)
 					if(NORTH)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -24,19 +24,45 @@
 	if(buckled_mobs.len)
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			switch(buckled_mob.dir)
-				if(NORTH)
-					buckled_mob.pixel_x = 0
-					buckled_mob.pixel_y = 4
-				if(EAST)
-					buckled_mob.pixel_x = -2
-					buckled_mob.pixel_y = 4
-				if(SOUTH)
-					buckled_mob.pixel_x = 0
-					buckled_mob.pixel_y = 4
-				if(WEST)
-					buckled_mob.pixel_x = 2
-					buckled_mob.pixel_y = 4
+			if(iscarbon(buckled_mob))
+				var/mob/living/carbon/buckled_carbon = buckled_mob
+				if(buckled_carbon.get_num_legs() < 2)
+					switch(buckled_carbon.dir)
+						if(NORTH)
+							buckled_carbon.pixel_x = 0
+							buckled_carbon.pixel_y = -4
+						if(EAST)
+							buckled_carbon.pixel_x = -2
+							buckled_carbon.pixel_y = -4
+						if(SOUTH)
+							buckled_carbon.pixel_x = 0
+							buckled_carbon.pixel_y = -4
+						if(WEST)
+							buckled_carbon.pixel_x = 2
+							buckled_carbon.pixel_y = -4
+			else
+				switch(buckled_mob.dir)
+					if(NORTH)
+						buckled_mob.pixel_x = 0
+						buckled_mob.pixel_y = 4
+					if(EAST)
+						buckled_mob.pixel_x = -2
+						buckled_mob.pixel_y = 4
+					if(SOUTH)
+						buckled_mob.pixel_x = 0
+						buckled_mob.pixel_y = 4
+					if(WEST)
+						buckled_mob.pixel_x = 2
+						buckled_mob.pixel_y = 4
+
+/obj/vehicle/scooter/post_buckle_mob(mob/living/M)
+	vehicle_move_delay = initial(vehicle_move_delay)
+	..()
+	if(!iscarbon(M))
+		return
+	var/mob/living/carbon/C = M
+	if(C.get_num_legs() < 2)
+		vehicle_move_delay = initial(vehicle_move_delay) + 1
 
 /obj/vehicle/scooter/skateboard
 	name = "skateboard"
@@ -50,6 +76,7 @@
 		density = 1
 	else
 		density = 0
+	..()
 
 /obj/vehicle/scooter/skateboard/Bump(atom/A)
 	..()


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/18283

Now instead of hovering and controlling your sweet ride with telekinesis, you scoot along the floor with your hands. You go slightly slower this way.

Issues to deal with:
- ~~I fucked up the pixel shift check apparently. It looks fine for legless people, but applies to everybody, even those with legs. **Not sure how to fix send help** EDIT: I made it worse no pixel shifts apply to anybody now~~
- ~~Leg check on the pixel shift should check for exactly 0 legs, not less than 2~~
- ~~Need to make a check if the subject has any arms on buckle. If they have no legs _and_ no arms then they truly cannot ride a skateboard/scooter.~~
- ~~Add a check to the "body flops off the [src]" message so it only appears on buckling, not unbuckling~~

![ye](http://vignette1.wikia.nocookie.net/pixar/images/3/38/57656r.png/revision/latest?cb=20111206025400)
