### PR TITLE
Fix destroying comms console extending shuttle timer

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -177,7 +177,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			break
 
 	if(callShuttle)
-		if(!EMERGENCY_IDLE_OR_RECALLED)
+		if(EMERGENCY_IDLE_OR_RECALLED)
 			emergency.request(null, 2.5)
 			log_game("There is no means of calling the shuttle anymore. Shuttle automatically called.")
 			message_admins("All the communications consoles were destroyed and all AIs are inactive. Shuttle called.")


### PR DESCRIPTION
Fixes #18369
~~This doesn't call if the shuttle is on the recall state, not sure if it was the original intent of this.~~
nevermind it works fine.
