### PR TITLE
Refactors slime names; altered slime, xeno names kept when evolving

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -75,7 +75,8 @@
 	owner << "<span class='warning'>You feel nauseous!</span>"
 	owner.vomit(20)
 
-	var/mob/living/simple_animal/slime/Slime = new/mob/living/simple_animal/slime(get_turf(owner))
+	var/mob/living/simple_animal/slime/Slime
+	Slime = new(get_turf(owner), "grey")
 	Slime.Friends = list(owner)
 	Slime.Leader = owner
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -2,6 +2,7 @@
 #define HEAT_DAMAGE_LEVEL_2 3 //Amount of damage applied when your body temperature passes the 400K point
 #define HEAT_DAMAGE_LEVEL_3 8 //Amount of damage applied when your body temperature passes the 460K point and you are on fire
 
+
 /mob/living/carbon/alien
 	name = "alien"
 	voice_name = "alien"
@@ -28,6 +29,8 @@
 	var/leaping = 0
 	gib_type = /obj/effect/decal/cleanable/xenoblood/xgibs
 	unique_name = 1
+
+	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
 
 /mob/living/carbon/alien/New()
 	verbs += /mob/living/proc/mob_sleep
@@ -177,6 +180,10 @@ Des: Removes all infected images from the alien.
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	src << "<span class='noticealien'>You begin to evolve!</span>"
 	visible_message("<span class='alertalien'>[src] begins to twist and contort!</span>")
+	new_xeno.dir = dir
+	if(!alien_name_regex.Find(name))
+		new_xeno.name = name
+		new_xeno.real_name = real_name
 	if(mind)
 		mind.transfer_to(new_xeno)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -3,11 +3,11 @@
 		return
 	if(!gibbed)
 		if(is_adult)
-			var/mob/living/simple_animal/slime/M = new /mob/living/simple_animal/slime(loc)
-			M.colour = colour
-			M.rabid = 1
+			var/mob/living/simple_animal/slime/M = new(loc, colour)
+			M.rabid = TRUE
 			M.regenerate_icons()
-			is_adult = 0
+
+			is_adult = FALSE
 			maxHealth = 150
 			for(var/datum/action/innate/slime/reproduce/R in actions)
 				R.Remove(src)
@@ -15,8 +15,7 @@
 			E.Grant(src)
 			revive(full_heal = 1)
 			regenerate_icons()
-			number = rand(1, 1000)
-			name = "[colour] [is_adult ? "adult" : "baby"] slime ([number])"
+			update_name()
 			return
 
 	if(buckled)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -80,8 +80,8 @@
 	M.unbuckle_all_mobs(force=1) //Slimes rip other mobs (eg: shoulder parrots) off (Slimes Vs Slimes is already handled in CanFeedon())
 	if(M.buckle_mob(src, force=1))
 		layer = M.layer+0.01 //appear above the target mob
-		M.visible_message("<span class='danger'>The [name] has latched onto [M]!</span>", \
-						"<span class='userdanger'>The [name] has latched onto [M]!</span>")
+		M.visible_message("<span class='danger'>[name] has latched onto [M]!</span>", \
+						"<span class='userdanger'>[name] has latched onto [M]!</span>")
 	else
 		src << "<span class='warning'><i>I have failed to latch onto the subject</i></span>"
 
@@ -113,7 +113,7 @@
 			for(var/datum/action/innate/slime/evolve/E in actions)
 				E.Remove(src)
 			regenerate_icons()
-			name = text("[colour] [is_adult ? "adult" : "baby"] slime ([number])")
+			update_name()
 		else
 			src << "<i>I am not ready to evolve yet...</i>"
 	else
@@ -149,13 +149,15 @@
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)
 			for(var/i=1,i<=4,i++)
-				var/mob/living/simple_animal/slime/M = new /mob/living/simple_animal/slime/(loc)
+				var/child_colour
 				if(mutation_chance >= 100)
-					M.colour = "rainbow"
+					child_colour = "rainbow"
 				else if(prob(mutation_chance))
-					M.colour = slime_mutation[rand(1,4)]
+					child_colour = slime_mutation[rand(1,4)]
 				else
-					M.colour = colour
+					child_colour = colour
+				var/mob/living/simple_animal/slime/M
+				M = new(loc, child_colour)
 				if(ckey)
 					M.nutrition = new_nutrition //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -3,8 +3,9 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 	"gold", "green", "adamantine", "oil", "light pink", "bluespace",
 	"cerulean", "sepia", "black", "pyrite")
 
+
 /mob/living/simple_animal/slime
-	name = "baby slime"
+	name = "grey baby slime (123)"
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "grey baby slime"
 	pass_flags = PASSTABLE
@@ -68,15 +69,19 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 	var/mutator_used = FALSE //So you can't shove a dozen mutators into a single slime
 	var/force_stasis = FALSE
 
+	var/static/regex/slime_name_regex = new("\\w+ (baby|adult) slime \\(\\d+\\)")
 	///////////TIME FOR SUBSPECIES
 
 	var/colour = "grey"
 	var/coretype = /obj/item/slime_extract/grey
 	var/list/slime_mutation[4]
 
-/mob/living/simple_animal/slime/New()
+/mob/living/simple_animal/slime/New(loc, new_colour="grey", new_is_adult=FALSE)
 	var/datum/action/innate/slime/feed/F = new
 	F.Grant(src)
+
+	is_adult = new_is_adult
+
 	if(is_adult)
 		var/datum/action/innate/slime/reproduce/R = new
 		R.Grant(src)
@@ -86,20 +91,22 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 		var/datum/action/innate/slime/evolve/E = new
 		E.Grant(src)
 	create_reagents(100)
-	spawn(0)
-		set_colour(colour)
+	set_colour(new_colour)
 	..()
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)
 	colour = new_colour
-
-	number = rand(1, 1000)
-	name = "[colour] [is_adult ? "adult" : "baby"] slime ([number])"
-	real_name = name
+	update_name()
 	slime_mutation = mutation_table(colour)
 	var/sanitizedcolour = replacetext(colour, " ", "")
 	coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	regenerate_icons()
+
+/mob/living/simple_animal/slime/proc/update_name()
+	if(slime_name_regex.Find(name))
+		number = rand(1, 1000)
+		name = "[colour] [is_adult ? "adult" : "baby"] slime ([number])"
+		real_name = name
 
 /mob/living/simple_animal/slime/proc/random_colour()
 	set_colour(pick(slime_colours))
@@ -181,7 +188,7 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 				stat(null, "You can evolve!")
 
 		if(stat == UNCONSCIOUS)
-			stat(null,"You are knocked out by high levels of CO2!")
+			stat(null,"You are knocked out by high levels of BZ!")
 		else
 			stat(null,"Power Level: [powerlevel]")
 
@@ -410,3 +417,6 @@ var/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 /mob/living/simple_animal/slime/get_mob_buckling_height(mob/seat)
 	if(..())
 		return 3
+
+/mob/living/simple_animal/slime/random/New(loc, new_colour, new_is_adult)
+	. = ..(loc, pick(slime_colours), new_is_adult)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -182,11 +182,9 @@
 					else
 						new_mob.languages |= HUMAN
 				if("slime")
-					new_mob = new /mob/living/simple_animal/slime(M.loc)
-					var/mob/living/simple_animal/slime/slimey = new_mob
-					if(prob(50))
-						slimey.is_adult = 1
-					slimey.random_colour()
+					var/mob/living/simple_animal/slime/random/slimey
+					slimey = new(get_turf(M), null, new_is_adult=prob(50))
+					new_mob = slimey
 					new_mob.languages |= HUMAN
 				if("xeno")
 					if(prob(50))

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -11,9 +11,11 @@
 
 /datum/chemical_reaction/slimespawn/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
-	S.loc = get_turf(holder.my_atom)
-	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
+	var/mob/living/simple_animal/slime/S
+	S = new(get_turf(holder.my_atom), "grey")
+	S.visible_message("<span class='danger'>Infused with plasma, the \
+		core begins to quiver and grow, and soon a new baby slime \
+		emerges from it!</span>")
 
 /datum/chemical_reaction/slimeinaprov
 	name = "Slime epinephrine"
@@ -683,10 +685,11 @@
 
 /datum/chemical_reaction/slimeRNG/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime
-	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
-	S.loc = get_turf(holder.my_atom)
-	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
+	var/mob/living/simple_animal/slime/random/S
+	S = new(get_turf(holder.my_atom))
+	S.visible_message("<span class='danger'>Infused with plasma, the \
+		core begins to quiver and grow, and soon a new baby slime emerges \
+		from it!</span>")
 
 /datum/chemical_reaction/slime_transfer
 	name = "Transfer Potion"


### PR DESCRIPTION
Also fixes #18352.

Slime colour and adulthood are specified in New(), which is a lot better
than having an ugly spawn(0) in the middle of a New(). Slimes also only
update their names when growing or shrinking when it matches their
existing name format.

So if you happen to be a slime called Carl Lagerfield, it won't change
your name if you grow up to adulthood.

In addition non-standard xeno names are preserved while evolving.
And it also applies your old dir to the new xeno, because that looks
slightly better

:cl: coiax
tweak: Slimes and aliens with custom names now retain those names when changing forms.
/:cl:
