### PR TITLE
Clockwork structures are now slightly more resistant to lava

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -898,6 +898,7 @@
 	name = "meme component"
 	desc = "A piece of a famous meme."
 	clockwork_desc = null
+	burn_state = LAVA_PROOF
 	var/component_id //What the component is identified as
 	var/cultist_message = "You are not worthy of this meme." //Showed to Nar-Sian cultists if they pick up the component in addition to chaplains
 	var/list/servant_of_ratvar_messages = list("ayy", "lmao") //Fluff, shown to servants of Ratvar on a low chance
@@ -1017,3 +1018,4 @@
 	desc = "Broken shards of some oddly malleable metal. They occasionally move and seem to glow."
 	clockwork_desc = "Broken shards of replicant alloy. Could probably be proselytized into replicant alloy, though there's not much left."
 	icon_state = "alloy_shards"
+	burn_state = LAVA_PROOF

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -15,6 +15,8 @@
 	attacktext = "crushes"
 	attack_sound = 'sound/magic/clockwork/anima_fragment_attack.ogg'
 	loot = list(/obj/item/clockwork/component/replicant_alloy/smashed_anima_fragment, /obj/item/device/mmi/posibrain/soul_vessel)
+	weather_immunities = list("lava")
+	flying = 1
 	del_on_death = TRUE
 	death_sound = 'sound/magic/clockwork/anima_fragment_death.ogg'
 	var/playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you have low health, do decent damage, and move at \
@@ -75,6 +77,8 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	environment_smash = 1
 	unique_name = 1
+	weather_immunities = list("lava")
+	flying = 1
 	var/true_name = "Meme Master 69" //Required to call forth the marauder
 	var/list/possible_true_names = list("Xaven", "Melange", "Ravan", "Kel", "Rama", "Geke", "Peris", "Vestra", "Skiwa") //All fairly short and easy to pronounce
 	var/fatigue = 0 //Essentially what determines the marauder's power

--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -3,6 +3,7 @@
 	desc = "A very large construction."
 	layer = MASSIVE_OBJ_LAYER
 	density = FALSE
+	burn_state = LAVA_PROOF
 
 /obj/structure/clockwork/massive/New()
 	..()

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -42,9 +42,10 @@
 
 /obj/structure/clockwork/burn()
 	SSobj.burning -= src
-	if(take_damage(rand(50, 100), BURN))
+	if(takes_damage)
 		playsound(src 'sound/items/Welder.ogg', 100, 1)
 		visible_message("<span class='warning'>[src] is warped by the heat!</span>")
+		take_damage(rand(50, 100), BURN)
 
 /obj/structure/clockwork/proc/take_damage(amount, damage_type)
 	if(!amount || !damage_type || !damage_type in list(BRUTE, BURN))

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -40,6 +40,13 @@
 	qdel(src)
 	return 1
 
+/obj/structure/clockwork/burn()
+	SSobj.burning -= src
+	playsound(src 'sound/items/Welder.ogg', 100, 1)
+	visible_message("<span class='warning'>[src] is warped by the heat!</span>")
+	if(!take_damage(rand(50, 100), BURN))
+		burn_state = LAVA_PROOF
+
 /obj/structure/clockwork/proc/take_damage(amount, damage_type)
 	if(!amount || !damage_type || !damage_type in list(BRUTE, BURN))
 		return 0
@@ -239,6 +246,7 @@
 	layer = HIGH_OBJ_LAYER
 	break_message = "<span class='warning'>The warden's eye gives a glare of utter hate before falling dark!</span>"
 	debris = list(/obj/item/clockwork/component/belligerent_eye/blind_eye)
+	burn_state = LAVA_PROOF
 	var/damage_per_tick = 3
 	var/sight_range = 3
 	var/mob/living/target
@@ -359,6 +367,7 @@
 	anchored = 1
 	density = 0
 	opacity = 0
+	burn_state = LAVA_PROOF
 
 /obj/effect/clockwork/New()
 	..()
@@ -582,6 +591,8 @@
 	icon_state = "sigil"
 	layer = LOW_OBJ_LAYER
 	alpha = 50
+	burn_state = FIRE_PROOF
+	burntime = 1
 	var/affects_servants = FALSE
 	var/affects_stat = FALSE
 

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -43,7 +43,7 @@
 /obj/structure/clockwork/burn()
 	SSobj.burning -= src
 	if(takes_damage)
-		playsound(src 'sound/items/Welder.ogg', 100, 1)
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		visible_message("<span class='warning'>[src] is warped by the heat!</span>")
 		take_damage(rand(50, 100), BURN)
 

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -42,10 +42,9 @@
 
 /obj/structure/clockwork/burn()
 	SSobj.burning -= src
-	playsound(src 'sound/items/Welder.ogg', 100, 1)
-	visible_message("<span class='warning'>[src] is warped by the heat!</span>")
-	if(!take_damage(rand(50, 100), BURN))
-		burn_state = LAVA_PROOF
+	if(take_damage(rand(50, 100), BURN))
+		playsound(src 'sound/items/Welder.ogg', 100, 1)
+		visible_message("<span class='warning'>[src] is warped by the heat!</span>")
 
 /obj/structure/clockwork/proc/take_damage(amount, damage_type)
 	if(!amount || !damage_type || !damage_type in list(BRUTE, BURN))
@@ -312,6 +311,7 @@
 	anchored = 0
 	density = 0
 	takes_damage = FALSE
+	burn_state = LAVA_PROOF
 
 /obj/structure/clockwork/anima_fragment/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/device/mmi/posibrain/soul_vessel))


### PR DESCRIPTION
Ratvar, the Ark, components, and all non-sigil clockwork effects are immune to lava.
Structures that take damage will take damage when burnt via lava instead of being outright deleted.
Ocular Wardens, Anima Fragments, and Clockwork Marauders will ignore lava because wow guess what they fly.
