### PR TITLE
Fives Fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -42,7 +42,7 @@ var/list/airlock_overlays = list()
 	var/obj/machinery/door/airlock/closeOther = null
 	var/closeOtherId = null
 	var/lockdownbyai = 0
-	var/doortype = /obj/structure/door_assembly/door_assembly_0
+	assemblytype = /obj/structure/door_assembly/door_assembly_0
 	var/justzap = 0
 	normalspeed = 1
 	var/obj/item/weapon/electronics/airlock/electronics = null
@@ -854,7 +854,7 @@ var/list/airlock_overlays = list()
 			playsound(loc, 'sound/items/Welder.ogg', 40, 1)
 			if(do_after(user,40/W.toolspeed, 1, target = src))
 				if(density && !operating)//Door must be closed to weld.
-					if( !istype(src, /obj/machinery/door/airlock) || !user || !W || !W.isOn() || !user.loc )
+					if(!user || !W || !W.isOn() || !user.loc )
 						return
 					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
 					welded = !welded
@@ -887,12 +887,12 @@ var/list/airlock_overlays = list()
 							 "<span class='notice'>You start to remove electronics from the airlock assembly...</span>")
 		if(do_after(user,40/I.toolspeed, target = src))
 			if(src.loc)
-				if(src.doortype)
-					var/obj/structure/door_assembly/A = new src.doortype(src.loc)
+				if(assemblytype)
+					var/obj/structure/door_assembly/A = new assemblytype(src.loc)
 					A.heat_proof_finished = src.heat_proof //tracks whether there's rglass in
 				else
 					new /obj/structure/door_assembly/door_assembly_0(src.loc)
-					//If you come across a null doortype, it will produce the default assembly instead of disintegrating.
+					//If you come across a null assemblytype, it will produce the default assembly instead of disintegrating.
 
 				if(emagged)
 					user << "<span class='warning'>You discard the damaged electronics.</span>"
@@ -1069,51 +1069,51 @@ var/list/airlock_overlays = list()
 		if("Public")
 			icon = 'icons/obj/doors/airlocks/station/public.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_0
+			assemblytype = /obj/structure/door_assembly/door_assembly_0
 		if("Public2")
 			icon = 'icons/obj/doors/airlocks/station2/glass.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_glass
+			assemblytype = /obj/structure/door_assembly/door_assembly_glass
 		if("Engineering")
 			icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_eng
+			assemblytype = /obj/structure/door_assembly/door_assembly_eng
 		if("Atmospherics")
 			icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_atmo
+			assemblytype = /obj/structure/door_assembly/door_assembly_atmo
 		if("Security")
 			icon = 'icons/obj/doors/airlocks/station/security.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_sec
+			assemblytype = /obj/structure/door_assembly/door_assembly_sec
 		if("Command")
 			icon = 'icons/obj/doors/airlocks/station/command.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_com
+			assemblytype = /obj/structure/door_assembly/door_assembly_com
 		if("Medical")
 			icon = 'icons/obj/doors/airlocks/station/medical.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_med
+			assemblytype = /obj/structure/door_assembly/door_assembly_med
 		if("Research")
 			icon = 'icons/obj/doors/airlocks/station/research.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_research
+			assemblytype = /obj/structure/door_assembly/door_assembly_research
 		if("Mining")
 			icon = 'icons/obj/doors/airlocks/station/mining.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_min
+			assemblytype = /obj/structure/door_assembly/door_assembly_min
 		if("Maintenance")
 			icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_mai
+			assemblytype = /obj/structure/door_assembly/door_assembly_mai
 		if("External")
 			icon = 'icons/obj/doors/airlocks/external/external.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_ext
+			assemblytype = /obj/structure/door_assembly/door_assembly_ext
 		if("High Security")
 			icon = 'icons/obj/doors/airlocks/highsec/highsec.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/highsec/overlays.dmi'
-			doortype = /obj/structure/door_assembly/door_assembly_highsecurity
+			assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	update_icon()
 
 /obj/machinery/door/airlock/CanAStarPass(obj/item/weapon/card/id/ID)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -3,51 +3,51 @@
 */
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_com
+	assemblytype = /obj/structure/door_assembly/door_assembly_com
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_sec
+	assemblytype = /obj/structure/door_assembly/door_assembly_sec
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_eng
+	assemblytype = /obj/structure/door_assembly/door_assembly_eng
 
 /obj/machinery/door/airlock/medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_med
+	assemblytype = /obj/structure/door_assembly/door_assembly_med
 
 /obj/machinery/door/airlock/maintenance
 	name = "maintenance access"
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_mai
+	assemblytype = /obj/structure/door_assembly/door_assembly_mai
 
 /obj/machinery/door/airlock/mining
 	name = "mining airlock"
 	icon = 'icons/obj/doors/airlocks/station/mining.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_min
+	assemblytype = /obj/structure/door_assembly/door_assembly_min
 
 /obj/machinery/door/airlock/atmos
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_atmo
+	assemblytype = /obj/structure/door_assembly/door_assembly_atmo
 
 /obj/machinery/door/airlock/research
 	icon = 'icons/obj/doors/airlocks/station/research.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_research
+	assemblytype = /obj/structure/door_assembly/door_assembly_research
 
 /obj/machinery/door/airlock/freezer
 	name = "freezer airlock"
 	icon = 'icons/obj/doors/airlocks/station/freezer.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_fre
+	assemblytype = /obj/structure/door_assembly/door_assembly_fre
 
 /obj/machinery/door/airlock/science
 	icon = 'icons/obj/doors/airlocks/station/science.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_science
+	assemblytype = /obj/structure/door_assembly/door_assembly_science
 
 /obj/machinery/door/airlock/virology
 	icon = 'icons/obj/doors/airlocks/station/virology.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_viro
+	assemblytype = /obj/structure/door_assembly/door_assembly_viro
 
 //////////////////////////////////
 /*
@@ -57,61 +57,61 @@
 /obj/machinery/door/airlock/glass_command
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_com/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_com/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_eng/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_eng/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_sec/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_sec/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_med/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_med/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_research
 	icon = 'icons/obj/doors/airlocks/station/research.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_research/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_research/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_mining
 	icon = 'icons/obj/doors/airlocks/station/mining.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_min/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_min/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_atmos
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_atmo/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_atmo/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_science
 	icon = 'icons/obj/doors/airlocks/station/science.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_science/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_science/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_virology
 	icon = 'icons/obj/doors/airlocks/station/virology.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_viro/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_viro/glass
 	glass = 1
 
 /obj/machinery/door/airlock/glass_maintenance
 	icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_mai/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_mai/glass
 	glass = 1
 
 //////////////////////////////////
@@ -123,25 +123,25 @@
 	name = "gold airlock"
 	icon = 'icons/obj/doors/airlocks/station/gold.dmi'
 	var/mineral = "gold"
-	doortype = /obj/structure/door_assembly/door_assembly_gold
+	assemblytype = /obj/structure/door_assembly/door_assembly_gold
 
 /obj/machinery/door/airlock/silver
 	name = "silver airlock"
 	icon = 'icons/obj/doors/airlocks/station/silver.dmi'
 	var/mineral = "silver"
-	doortype = /obj/structure/door_assembly/door_assembly_silver
+	assemblytype = /obj/structure/door_assembly/door_assembly_silver
 
 /obj/machinery/door/airlock/diamond
 	name = "diamond airlock"
 	icon = 'icons/obj/doors/airlocks/station/diamond.dmi'
 	var/mineral = "diamond"
-	doortype = /obj/structure/door_assembly/door_assembly_diamond
+	assemblytype = /obj/structure/door_assembly/door_assembly_diamond
 
 /obj/machinery/door/airlock/uranium
 	name = "uranium airlock"
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi'
 	var/mineral = "uranium"
-	doortype = /obj/structure/door_assembly/door_assembly_uranium
+	assemblytype = /obj/structure/door_assembly/door_assembly_uranium
 	var/last_event = 0
 
 /obj/machinery/door/airlock/uranium/process()
@@ -160,7 +160,7 @@
 	desc = "No way this can end badly."
 	icon = 'icons/obj/doors/airlocks/station/plasma.dmi'
 	var/mineral = "plasma"
-	doortype = /obj/structure/door_assembly/door_assembly_plasma
+	assemblytype = /obj/structure/door_assembly/door_assembly_plasma
 
 /obj/machinery/door/airlock/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
@@ -184,20 +184,20 @@
 	icon = 'icons/obj/doors/airlocks/station/bananium.dmi'
 	var/mineral = "bananium"
 	doorOpen = 'sound/items/bikehorn.ogg'
-	doortype = /obj/structure/door_assembly/door_assembly_clown
+	assemblytype = /obj/structure/door_assembly/door_assembly_clown
 
 /obj/machinery/door/airlock/sandstone
 	name = "sandstone airlock"
 	icon = 'icons/obj/doors/airlocks/station/sandstone.dmi'
 	var/mineral = "sandstone"
-	doortype = /obj/structure/door_assembly/door_assembly_sandstone
+	assemblytype = /obj/structure/door_assembly/door_assembly_sandstone
 
 
 /obj/machinery/door/airlock/wood
 	name = "wooden airlock"
 	icon = 'icons/obj/doors/airlocks/station/wood.dmi'
 	var/mineral = "wood"
-	doortype = /obj/structure/door_assembly/door_assembly_wood
+	assemblytype = /obj/structure/door_assembly/door_assembly_wood
 
 //////////////////////////////////
 /*
@@ -209,7 +209,7 @@
 	icon = 'icons/obj/doors/airlocks/station2/glass.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_glass
 	glass = 1
 
 //////////////////////////////////
@@ -221,13 +221,13 @@
 	name = "external airlock"
 	icon = 'icons/obj/doors/airlocks/external/external.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_ext
+	assemblytype = /obj/structure/door_assembly/door_assembly_ext
 
 /obj/machinery/door/airlock/glass_external
 	name = "external airlock"
 	icon = 'icons/obj/doors/airlocks/external/external.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_ext/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_ext/glass
 	opacity = 0
 	glass = 1
 
@@ -240,7 +240,7 @@
 	icon = 'icons/obj/doors/airlocks/centcom/centcom.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/centcom/overlays.dmi'
 	opacity = 1
-	doortype = /obj/structure/door_assembly/door_assembly_centcom
+	assemblytype = /obj/structure/door_assembly/door_assembly_centcom
 
 //////////////////////////////////
 /*
@@ -252,7 +252,7 @@
 	icon = 'icons/obj/doors/airlocks/vault/vault.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/vault/overlays.dmi'
 	opacity = 1
-	doortype = /obj/structure/door_assembly/door_assembly_vault
+	assemblytype = /obj/structure/door_assembly/door_assembly_vault
 	explosion_block = 2
 
 //////////////////////////////////
@@ -265,14 +265,14 @@
 	icon = 'icons/obj/doors/airlocks/hatch/centcom.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	opacity = 1
-	doortype = /obj/structure/door_assembly/door_assembly_hatch
+	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
 
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "maintenance hatch"
 	icon = 'icons/obj/doors/airlocks/hatch/maintenance.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	opacity = 1
-	doortype = /obj/structure/door_assembly/door_assembly_mhatch
+	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
 
 //////////////////////////////////
 /*
@@ -283,7 +283,7 @@
 	name = "high tech security airlock"
 	icon = 'icons/obj/doors/airlocks/highsec/highsec.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/highsec/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_highsecurity
+	assemblytype = /obj/structure/door_assembly/door_assembly_highsecurity
 	explosion_block = 2
 
 //////////////////////////////////
@@ -295,14 +295,14 @@
 	name = "shuttle airlock"
 	icon = 'icons/obj/doors/airlocks/shuttle/shuttle.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/shuttle/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_shuttle
+	assemblytype = /obj/structure/door_assembly/door_assembly_shuttle
 
 /obj/machinery/door/airlock/abductor
 	name = "alien airlock"
 	desc = "With humanity's current technological level, it could take years to hack this advanced airlock... or maybe we should give a screwdriver a try?"
 	icon = 'icons/obj/doors/airlocks/abductor/abductor_airlock.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/abductor/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_abductor
+	assemblytype = /obj/structure/door_assembly/door_assembly_abductor
 	opacity = 1
 	explosion_block = 3
 	hackProof = 1
@@ -317,7 +317,7 @@
 	name = "cult airlock"
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_cult
+	assemblytype = /obj/structure/door_assembly/door_assembly_cult
 	hackProof = 1
 	aiControlDisabled = 1
 	var/openingoverlaytype = /obj/effect/overlay/temp/cult/door
@@ -360,7 +360,7 @@
 	friendly = TRUE
 
 /obj/machinery/door/airlock/cult/glass
-	doortype = /obj/structure/door_assembly/door_assembly_cult/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_cult/glass
 	glass = 1
 	opacity = 0
 
@@ -370,14 +370,14 @@
 /obj/machinery/door/airlock/cult/unruned
 	icon = 'icons/obj/doors/airlocks/cult/unruned/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/unruned/overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_cult/unruned
+	assemblytype = /obj/structure/door_assembly/door_assembly_cult/unruned
 	openingoverlaytype = /obj/effect/overlay/temp/cult/door/unruned
 
 /obj/machinery/door/airlock/cult/unruned/friendly
 	friendly = TRUE
 
 /obj/machinery/door/airlock/cult/unruned/glass
-	doortype = /obj/structure/door_assembly/door_assembly_cult/unruned/glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_cult/unruned/glass
 	glass = 1
 	opacity = 0
 
@@ -508,7 +508,7 @@
 	icon = 'icons/obj/doors/airlocks/glass_large/glass_large.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/glass_large/overlays.dmi'
 	opacity = 0
-	doortype = null
+	assemblytype = null
 	glass = 1
 	bound_width = 64 // 2x1
 

--- a/code/game/machinery/doors/alarmlock.dm
+++ b/code/game/machinery/doors/alarmlock.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/doors/airlocks/station2/glass.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
 	opacity = 0
-	doortype = /obj/structure/door_assembly/door_assembly_glass
+	assemblytype = /obj/structure/door_assembly/door_assembly_glass
 	glass = 1
 
 	var/datum/radio_frequency/air_connection

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -23,7 +23,7 @@
 	var/autoclose = 0 //does it automatically close after some time
 	var/safe = 1 //whether the door detects things and mobs in its way and reopen or crushes them.
 	var/locked = 0 //whether the door is bolted or not.
-
+	var/assemblytype //the type of door frame to drop during deconstruction
 	var/auto_close //TO BE REMOVED, no longer used, it's just preventing a runtime with a map var edit.
 
 /obj/machinery/door/New()

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -69,7 +69,7 @@
 				P.add_fingerprint(user)
 				I.add_fingerprint(user)
 				user.put_in_hands(P)
-			I.loc = P
+			I.forceMove(P)
 			var/size = round(I.w_class)
 			P.w_class = size
 			size = min(size, 5)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -321,14 +321,14 @@
 	name = "airlock"
 	icon = 'icons/obj/doors/airlocks/survival/horizontal/survival.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/survival/horizontal/survival_overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_pod
+	assemblytype = /obj/structure/door_assembly/door_assembly_pod
 	opacity = 0
 	glass = 1
 
 /obj/machinery/door/airlock/survival_pod/vertical
 	icon = 'icons/obj/doors/airlocks/survival/vertical/survival.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/survival/vertical/survival_overlays.dmi'
-	doortype = /obj/structure/door_assembly/door_assembly_pod/vertical
+	assemblytype = /obj/structure/door_assembly/door_assembly_pod/vertical
 
 /obj/structure/door_assembly/door_assembly_pod
 	name = "pod airlock assembly"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -26,6 +26,8 @@
 /mob/proc/put_in_l_hand(obj/item/W)
 	if(!put_in_hand_check(W))
 		return 0
+	if(!has_left_hand())
+		return 0
 	if(!l_hand)
 		W.loc = src		//TODO: move to equipped?
 		l_hand = W
@@ -43,6 +45,8 @@
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_r_hand(obj/item/W)
 	if(!put_in_hand_check(W))
+		return 0
+	if(!has_right_hand())
 		return 0
 	if(!r_hand)
 		W.loc = src

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1233,8 +1233,12 @@
 			H.adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
 
 		H.failed_last_breath = 1
-		H.throw_alert("oxy", /obj/screen/alert/oxy)
-
+		if(safe_oxygen_min)
+			H.throw_alert("oxy", /obj/screen/alert/oxy)
+		else if(safe_toxins_min)
+			H.throw_alert("not_enough_tox", /obj/screen/alert/not_enough_tox)
+		else if(safe_co2_min)
+			H.throw_alert("not_enough_co2", /obj/screen/alert/not_enough_co2)
 		return 0
 
 	var/gas_breathed = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -563,6 +563,9 @@ Sorry Giacom. Please don't be mad :(
 	var/atom/movable/pullee = pulling
 	if(pullee && get_dist(src, pullee) > 1)
 		stop_pulling()
+	if(pullee && !isturf(pullee.loc) && pullee.loc != loc) //to be removed once all code that changes an object's loc uses forceMove().
+		log_game("DEBUG:[src]'s pull on [pullee] wasn't broken despite [pullee] being in [pullee.loc]. Pull stopped manually.")
+		stop_pulling()
 	var/turf/T = loc
 	. = ..()
 	if(. && pulling && pulling == pullee) //we were pulling a thing and didn't lose it during our move.

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -4,6 +4,7 @@
 	desc = "why is it detached..."
 	force = 3
 	throwforce = 3
+	icon_state = ""
 	var/mob/living/carbon/human/owner = null
 	var/status = ORGAN_ORGANIC
 	var/body_zone //"chest", "l_arm", etc , used for def_zone
@@ -266,7 +267,6 @@
 /obj/item/bodypart/chest
 	name = "chest"
 	desc = "It's impolite to stare at a person's chest."
-	icon_state = "chest"
 	max_damage = 200
 	body_zone = "chest"
 	body_part = CHEST
@@ -285,7 +285,6 @@
 		Latin 'sinestra' (left hand), because the left hand was supposed to \
 		be possessed by the devil? This arm appears to be possessed by no \
 		one though."
-	icon_state = "l_arm"
 	attack_verb = list("slapped", "punched")
 	max_damage = 50
 	body_zone ="l_arm"
@@ -297,7 +296,6 @@
 	name = "right arm"
 	desc = "Over 87% of humans are right handed. That figure is much lower \
 		among humans missing their right arm."
-	icon_state = "r_arm"
 	attack_verb = list("slapped", "punched")
 	max_damage = 50
 	body_zone = "r_arm"
@@ -309,7 +307,6 @@
 	name = "left leg"
 	desc = "Some athletes prefer to tie their left shoelaces first for good \
 		luck. In this instance, it probably would not have helped."
-	icon_state = "l_leg"
 	attack_verb = list("kicked", "stomped")
 	max_damage = 50
 	body_zone = "l_leg"
@@ -323,7 +320,6 @@
 		shake it all about. And apparently then it detaches.\n\
 		The hokey pokey has certainly changed a lot since space colonisation."
 	// alternative spellings of 'pokey' are availible
-	icon_state = "r_leg"
 	attack_verb = list("kicked", "stomped")
 	max_damage = 50
 	body_zone = "r_leg"

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -1,7 +1,6 @@
 /obj/item/bodypart/head
 	name = "head"
 	desc = "Didn't make sense not to live for fun, your brain gets smart but your head gets dumb."
-	icon_state = "head"
 	max_damage = 200
 	body_zone = "head"
 	body_part = HEAD

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -24,7 +24,7 @@
 		return 0
 	return 1
 
-/mob/living/carbon/proc/has_left_hand()
+/mob/proc/has_left_hand()
 	return 1
 
 /mob/living/carbon/human/has_left_hand()
@@ -34,7 +34,7 @@
 		return 0
 	return 1
 
-/mob/living/carbon/proc/has_right_hand()
+/mob/proc/has_right_hand()
 	return 1
 
 /mob/living/carbon/human/has_right_hand()

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -36,6 +36,7 @@
 			var/obj/item/device/multitool/M = I
 			M.buffer = src
 			user << "<span class='caution'>You save the data in the [I.name]'s buffer.</span>"
+			return 1
 
 	if(exchange_parts(user, I))
 		return

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -80,7 +80,7 @@
 		playsound(src.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 		A.audible_message("<span class='danger'>With a screech, [A] is torn \
 			apart!</span>")
-		var/obj/structure/door_assembly/door = new A.doortype(get_turf(A))
+		var/obj/structure/door_assembly/door = new A.assemblytype(get_turf(A))
 		door.density = 0
 		door.anchored = 1
 		door.name = "ravaged [door]"


### PR DESCRIPTION
- Using a multitool on telepad with open panel to save data no longer hits the machine. Fixes #18290
- Packagewrapping a pulled item now properly stops the pulling. Fixes #18343 .
  I added a check to living/Move() to catch all future instances of this bug (changing the loc of the pulled item without breaking the pull), this way people won't freak out and we'll just have to look at the logs to find out the when this bug happens and in which circumstances.
- Using put_in_hands() procs now properly checks if the mob has a hand. Fixes #18127
  bodyparts icon_state is now "" like it should be.
- You can no longer build a firelock on top of another firelock. Fixes #10750
  You can reinforce a firelock assembly to build a heavy firlock.
- Human species who breath something other than oxygen now get the proper alert when in crit, and I fixed the alert not being removed when healed. Fixes #17794

:cl: phil235
rscadd: Firelock assemblies can be reinforced with plasteel to construct heavy firelocks.
/:cl:
