### PR TITLE
Adds "plants" and "vines" factions to pod people

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -35,6 +35,8 @@
 					blood_type = bloodSample.data["blood_type"]
 					features = bloodSample.data["features"]
 					factions = bloodSample.data["factions"]
+					factions |= "plants"
+					factions |= "vines"
 					W.reagents.clear_reagents()
 					user << "<span class='notice'>You inject the contents of the syringe into the seeds.</span>"
 					contains_sample = 1

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -35,8 +35,6 @@
 					blood_type = bloodSample.data["blood_type"]
 					features = bloodSample.data["features"]
 					factions = bloodSample.data["factions"]
-					factions |= "plants"
-					factions |= "vines"
 					W.reagents.clear_reagents()
 					user << "<span class='notice'>You inject the contents of the syringe into the seeds.</span>"
 					contains_sample = 1

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -148,6 +148,11 @@
 		if(/obj/item/projectile/energy/florayield)
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 	return
+	
+/datum/species/pod/on_species_gain(mob/living/carbon/C)
+	..()
+	C.faction |= "plants"
+	C.faction |= "vines"
 
 /*
  SHADOWPEOPLE


### PR DESCRIPTION
Pod people now have the "plants" and "vines" factions added to them when they become podpeople. The main point of this is to make deliberately unleashing Kudzu Hell onto the station a more viable option for traitor botanists- Mutant kudzu doesn't crop up often, but it's really cool, as I learned in a recent round. Hopefully this will encourage botanists to use it a little more often, since they can protect themselves from it if they plan ahead.
