### PR TITLE
[WIP]Cyborg Riding and Spinning

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -312,23 +312,6 @@
 		show_message("<span class='userdanger'>The blob attacks!</span>")
 		adjustBruteLoss(10)
 
-/mob/living/carbon/proc/spin(spintime, speed)
-	set waitfor = 0
-	var/D = dir
-	while(spintime >= speed)
-		sleep(speed)
-		switch(D)
-			if(NORTH)
-				D = EAST
-			if(SOUTH)
-				D = WEST
-			if(EAST)
-				D = SOUTH
-			if(WEST)
-				D = NORTH
-		dir = D
-		spintime -= speed
-
 /mob/living/carbon/resist_buckle()
 	if(restrained())
 		changeNext_move(CLICK_CD_BREAKOUT)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1037,3 +1037,20 @@ Sorry Giacom. Please don't be mad :(
 		G.Recall()
 		G << "<span class='holoparasite'>Your summoner has changed \
 			form to [new_mob]!</span>"
+
+/mob/living/proc/spin(spintime, speed)
+	set waitfor = 0
+	var/D = dir
+	while(spintime >= speed)
+		sleep(speed)
+		switch(D)
+			if(NORTH)
+				D = EAST
+			if(SOUTH)
+				D = WEST
+			if(EAST)
+				D = SOUTH
+			if(WEST)
+				D = NORTH
+		dir = D
+		spintime -= speed

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -236,13 +236,17 @@
 			src.spin(24,1)
 			for(var/mob/living/T in buckled_mobs)
 				if(prob(70))
-					T.visible_message("<span class='warning'>[T] tries to hang on, but couldn't, and is thrown off [src]!<span>")
+					T.visible_message("<span class='warning'>[T] tries to hang on, but couldn't, and is sent flying by [src]!<span>")
 					unbuckle_mob(T,1)
+					var/atom/A = get_edge_target_turf(T, pick(cardinal))
+					T.throw_at_fast(A, 6, 1)
 					T.Weaken(3)
 					T.Dizzy(5)
+					playsound(src, 'sound/effects/bang.ogg', 50, 1)
 				else
 					T.visible_message("<span class='warning'>[T] hangs on to [src] as it spins around dizzily!<span>")
 					T.Dizzy(5)
+				spawn(5)
 
 		if ("help")
 			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob,buzz2,chime, clap, custom, deathgasp, flap, glare-(none)/mob, honk, look-(none)/mob, me, nod, ping-(none)/mob, sad, \nsalute-(none)/mob, twitch, twitch_s, warn,"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -231,26 +231,18 @@
 			m_type = 2
 
 		if ("spin")
-			if(buckled_mobs.len)
-				message = "<B>[src]</B> spins in place, and throws [english_list(buckled_mobs)] clear of itself!"
-			else
-				message = "<B>[src]</B> spins in place!"
+			message = "<B>[src]</B> spins in place!"
 			m_type = 1
 			src.spin(24,1)
-			src.unbuckle_all_mobs(1)
 			for(var/mob/living/T in buckled_mobs)
-				var/r_dir = NORTH
-				var/r_dir_number = rand(1,4)
-				switch(r_dir_number)
-					if(1)
-						r_dir = NORTH
-					if(2)
-						r_dir = EAST
-					if(3)
-						r_dir = SOUTH
-					if(4)
-						r_dir = WEST
-				T.throw_at(get_edge_target_turf(T, r_dir),6,1)
+				if(prob(70))
+					T.visible_message("<span class='warning'>[T] tries to hang on, but couldn't, and is thrown off [src]!<span>")
+					unbuckle_mob(T,1)
+					T.Weaken(3)
+					T.Dizzy(5)
+				else
+					T.visible_message("<span class='warning'>[T] hangs on to [src] as it spins around dizzily!<span>")
+					T.Dizzy(5)
 
 		if ("help")
 			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob,buzz2,chime, clap, custom, deathgasp, flap, glare-(none)/mob, honk, look-(none)/mob, me, nod, ping-(none)/mob, sad, \nsalute-(none)/mob, twitch, twitch_s, warn,"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -231,15 +231,26 @@
 			m_type = 2
 
 		if ("spin")
-			if(buckled_mobs)
+			if(buckled_mobs.len)
 				message = "<B>[src]</B> spins in place, and throws [english_list(buckled_mobs)] clear of itself!"
 			else
 				message = "<B>[src]</B> spins in place!"
 			m_type = 1
-			src.SpinAnimation(32,2)
+			src.spin(24,1)
 			src.unbuckle_all_mobs(1)
 			for(var/mob/living/T in buckled_mobs)
-				T.throwat(get_edge_target_turf(user, get_dir(user, get_step_away(T, user))),6,1)
+				var/r_dir = NORTH
+				var/r_dir_number = rand(1,4)
+				switch(r_dir_number)
+					if(1)
+						r_dir = NORTH
+					if(2)
+						r_dir = EAST
+					if(3)
+						r_dir = SOUTH
+					if(4)
+						r_dir = WEST
+				T.throw_at(get_edge_target_turf(T, r_dir),6,1)
 
 		if ("help")
 			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob,buzz2,chime, clap, custom, deathgasp, flap, glare-(none)/mob, honk, look-(none)/mob, me, nod, ping-(none)/mob, sad, \nsalute-(none)/mob, twitch, twitch_s, warn,"

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -230,6 +230,17 @@
 			playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, 0)
 			m_type = 2
 
+		if ("spin")
+			if(buckled_mobs)
+				message = "<B>[src]</B> spins in place, and throws [english_list(buckled_mobs)] clear of itself!"
+			else
+				message = "<B>[src]</B> spins in place!"
+			m_type = 1
+			src.SpinAnimation(32,2)
+			src.unbuckle_all_mobs(1)
+			for(var/mob/living/T in buckled_mobs)
+				T.throwat(get_edge_target_turf(user, get_dir(user, get_step_away(T, user))),6,1)
+
 		if ("help")
 			src << "Help for cyborg emotes. You can use these emotes with say \"*emote\":\n\naflap, beep-(none)/mob, bow-(none)/mob, buzz-(none)/mob,buzz2,chime, clap, custom, deathgasp, flap, glare-(none)/mob, honk, look-(none)/mob, me, nod, ping-(none)/mob, sad, \nsalute-(none)/mob, twitch, twitch_s, warn,"
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -10,7 +10,12 @@
 	bubble_icon = "robot"
 	designation = "Default" //used for displaying the prefix & getting the current module of cyborg
 	has_limbs = 1
-
+	can_buckle = 1
+	max_buckled_mobs = 3
+	buckle_lying = 0
+	var/mob/living/buckled_mob_1 = null
+	var/mob/living/buckled_mob_2 = null
+	var/mob/living/buckled_mob_3 = null
 	var/custom_name = ""
 	var/braintype = "Cyborg"
 	var/modtype = "robot"
@@ -935,6 +940,7 @@
 
 #define BORG_CAMERA_BUFFER 30
 /mob/living/silicon/robot/Move(a, b, flag)
+	handle_buckled_mobs()
 	var/oldLoc = src.loc
 	. = ..()
 	if(.)
@@ -1311,3 +1317,90 @@
 			locked = 1
 		notify_ai(1)
 		. = 1
+
+/mob/living/silicon/robot/buckle_mob(mob/living/M, force = 0)
+	if(M.restrained())
+		return 0
+	if(isrobot(M)) //No cyborg stacking.
+		return 0
+	if(!buckled_mob_1)
+		buckled_mob_1 = M
+	else if(!buckled_mob_2)
+		buckled_mob_2 = M
+	else if(!buckled_mob_3)
+		buckled_mob_3 = M
+	else
+		return 0
+	.=..()
+
+/mob/living/silicon/robot/unbuckle_mob(mob/living/buckled_mob, force = 0)
+	.=..()
+
+/mob/living/silicon/robot/post_buckle_mob(mob/living/M)
+	handle_buckled_mobs()
+
+/mob/living/silicon/robot/proc/handle_buckled_mobs()
+	if(buckled_mobs.len)
+		layer = ABOVE_MOB_LAYER
+	else
+		layer = MOB_LAYER
+		return
+	for(var/mob/living/L in buckled_mobs)
+		L.pixel_x = 0
+		L.pixel_y = 0
+	if(buckled_mob_1 in buckled_mobs)
+		switch(dir)
+			if(NORTH)
+				buckled_mob_1.pixel_x = 0
+				buckled_mob_1.pixel_y = -7
+			if(SOUTH)
+				buckled_mob_1.pixel_x = 0
+				buckled_mob_1.pixel_y = 7
+			if(WEST)
+				buckled_mob_1.pixel_x = 7
+				buckled_mob_1.pixel_y = 0
+			if(EAST)
+				buckled_mob_1.pixel_x = -7
+				buckled_mob_1.pixel_y = 0
+	else
+		buckled_mob_1.pixel_x = 0
+		buckled_mob_1.pixel_y = 0
+		buckled_mob_1 = null
+
+	if(buckled_mob_2 in buckled_mobs)
+		switch(dir)
+			if(NORTH)
+				buckled_mob_2.pixel_x = 7
+				buckled_mob_2.pixel_y = 0
+			if(SOUTH)
+				buckled_mob_2.pixel_x = -7
+				buckled_mob_2.pixel_y = 0
+			if(WEST)
+				buckled_mob_2.pixel_x = 0
+				buckled_mob_2.pixel_y = 7
+			if(EAST)
+				buckled_mob_2.pixel_x = 0
+				buckled_mob_2.pixel_y = -7
+	else
+		buckled_mob_2.pixel_x = 0
+		buckled_mob_2.pixel_y = 0
+		buckled_mob_2 = null
+
+	if(buckled_mob_3 in buckled_mobs)
+		switch(dir)
+			if(NORTH)
+				buckled_mob_3.pixel_x = -7
+				buckled_mob_3.pixel_y = 0
+			if(SOUTH)
+				buckled_mob_3.pixel_x = 7
+				buckled_mob_3.pixel_y = 0
+			if(WEST)
+				buckled_mob_3.pixel_x = 0
+				buckled_mob_3.pixel_y = -7
+			if(EAST)
+				buckled_mob_3.pixel_x = 0
+				buckled_mob_3.pixel_y = 7
+	else
+		buckled_mob_3.pixel_x = 0
+		buckled_mob_3.pixel_y = 0
+		buckled_mob_3 = null

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -9,6 +9,9 @@
 	verb_yell = "alarms"
 	see_in_dark = 8
 	bubble_icon = "machine"
+	can_buckle = 1
+	max_buckled_mobs = 3
+	buckle_lying = 0
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/list/alarms_to_show = list()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -496,6 +496,6 @@
 	return 1
 
 /mob/living/silicon/buckle_mob(mob/living/M, force = 0)
-	if(M.restrained)
+	if(M.restrained())
 		return 0
 	.=..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -9,9 +9,6 @@
 	verb_yell = "alarms"
 	see_in_dark = 8
 	bubble_icon = "machine"
-	can_buckle = 1
-	max_buckled_mobs = 3
-	buckle_lying = 0
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/list/alarms_to_show = list()
@@ -494,8 +491,3 @@
 
 /mob/living/silicon/is_literate()
 	return 1
-
-/mob/living/silicon/buckle_mob(mob/living/M, force = 0)
-	if(M.restrained())
-		return 0
-	.=..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -494,3 +494,8 @@
 
 /mob/living/silicon/is_literate()
 	return 1
+
+/mob/living/silicon/buckle_mob(mob/living/M, force = 0)
+	if(M.restrained)
+		return 0
+	.=..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -14,6 +14,7 @@
 	has_unlimited_silicon_privilege = 1
 	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = NONE //no default canpush
+	can_buckle = 0
 
 	speak_emote = list("states")
 	bubble_icon = "machine"


### PR DESCRIPTION
TODO: 
FIND A WAY TO LET PEOPLE PULL YOU OFF THE CYBORG

You can now ride on a cyborg by buckling yourself to it. Cyborgs can also buckle people to itself.
Cyborgs now have the _spin emote that lets them spin around quickly, likely throwing off anyone riding on it.
You can not buckle simple bots to it like Beepsky due to balance reasons, immershuns reasons, meme reasons, and most of all, BUGGED REASONS.
You can not buckle handcuffed mobs to it as that would be pretty overpowered.
:cl:
rscadd: Cyborgs have been equipped with handgrips. Why Nanotrasen did this, no one will ever know. You can now buckle yourself to a cyborg to ride them.
rscadd: Cyborgs now have programming to spin in place. This is likely defence to assistants using them as sentient skateboards. (_spin to most likely throw off anyone riding you as a cyborg)
rscdel: The addition of handgrips has made Cyborgs too bulky to be buckled in
rscdel: A recent firmware update has rendered more simple robots like Securitrons, Cleanbots, and others unable to be buckled to anything. 
/:cl:
