### PR TITLE
Fixes tinker's cache exploit

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -118,11 +118,21 @@
 
 /obj/structure/clockwork/cache/New()
 	..()
+	SSobj.processing += src
 	clockwork_caches++
 
 /obj/structure/clockwork/cache/Destroy()
 	clockwork_caches--
+	SSobj.processing -= src
 	return ..()
+
+/obj/structure/clockwork/cache/process()
+	if(prob(2))
+		playsound(src, 'sound/magic/clockwork/fellowship_armory.ogg', rand(1, 5), 1, -4, 1, 1)
+	for(var/turf/closed/wall/clockwork/C in orange(1, get_turf(src)))
+		if(prob(5))
+			clockwork_component_cache[pick("belligerent_eye", "vanguard_cogwheel", "guvax_capacitor", "replicant_alloy", "hierophant_ansible")]++
+			playsound(src, 'sound/magic/clockwork/fellowship_armory.ogg', rand(15, 20), 1, -3, 1, 1)
 
 /obj/structure/clockwork/cache/attackby(obj/item/I, mob/living/user, params)
 	if(!is_servant_of_ratvar(user))

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -53,21 +53,11 @@
 	..()
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/wall, src)
 	PoolOrNew(/obj/effect/overlay/temp/ratvar/beam, src)
-	SSobj.processing += src
 	clockwork_construction_value += 5
 
 /turf/closed/wall/clockwork/Destroy()
-	SSobj.processing -= src
 	clockwork_construction_value -= 5
 	..()
-
-/turf/closed/wall/clockwork/process()
-	if(prob(2))
-		playsound(src, 'sound/magic/clockwork/fellowship_armory.ogg', rand(1, 5), 1, -4, 1, 1)
-	for(var/obj/structure/clockwork/cache/C in range(1, src))
-		if(prob(5))
-			clockwork_component_cache[pick("belligerent_eye", "vanguard_cogwheel", "guvax_capacitor", "replicant_alloy", "hierophant_ansible")]++
-			playsound(src, 'sound/magic/clockwork/fellowship_armory.ogg', rand(15, 20), 1, -3, 1, 1)
 
 /turf/closed/wall/clockwork/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))


### PR DESCRIPTION
First, clock walls are no longer processing, it was a bad idea. Processing functions are moved to tinker's cache. And tinker's cache uses `orange` with `get_turf` to check for surrounding walls.

Fixes #18309.
