### PR TITLE
Fixes changelog generator's handling of odd names in author field

### DIFF
--- a/tools/github_webhook_processor.php
+++ b/tools/github_webhook_processor.php
@@ -251,7 +251,7 @@ function checkchangelog($payload, $merge = false) {
 	if (!count($changelogbody))
 		return;
 
-	$file = 'author: '.trim(str_replace(array("\\", '"'), array("\\\\", "\\\""), $username))."\n";
+	$file = 'author: "'.trim(str_replace(array("\\", '"'), array("\\\\", "\\\""), $username)).'"'."\n";
 	$file .= "delete-after: True\n";
 	$file .= "changes: \n";
 	foreach ($changelogbody as $changelogitem) {


### PR DESCRIPTION
tested and works with :, its escaped so it will work with " and \ too
