### PR TITLE
Deathrattle preferences fix; ignores Z2 deaths

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -60,6 +60,7 @@
 	set desc = "Toggle recieving a message in deadchat when sentient mobs \
 		die."
 	prefs.toggles ^= DISABLE_DEATHRATTLE
+	prefs.save_preferences()
 	usr << "You will \
 		[(prefs.toggles & DISABLE_DEATHRATTLE) ? "no longer" : "now"] get \
 		messages when a sentient mob dies."

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -44,8 +44,9 @@
 	unset_machine()
 	timeofdeath = world.time
 	tod = worldtime2text()
-	if(mind && mind.name && mind.active)
-		var/area/A = get_area(loc)
+	var/turf/T = get_turf(src)
+	if(mind && mind.name && mind.active && (T.z != ZLEVEL_CENTCOM))
+		var/area/A = get_area(T)
 		var/rendered = "<span class='game deadsay'><span class='name'>\
 			[mind.name]</span> has died at <span class='name'>[A.name]\
 			</span>.</span>"


### PR DESCRIPTION
Fixes #18351. Deathrattle preferences are now saved.

Deaths on Z2 are now no longer printed to deadchat.
