### PR TITLE
New Standard Cyborg Module Gear

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -125,16 +125,26 @@
 
 /obj/item/weapon/robot_module/standard/New()
 	..()
-	modules += new /obj/item/weapon/melee/baton/loaded(src)
-	modules += new /obj/item/weapon/extinguisher(src)
+	modules += new /obj/item/weapon/reagent_containers/borghypo/epi(src)
+	modules += new /obj/item/device/healthanalyzer(src)
+
+	modules += new /obj/item/weapon/weldingtool/largetank/cyborg(src)
 	modules += new /obj/item/weapon/wrench/cyborg(src)
 	modules += new /obj/item/weapon/crowbar/cyborg(src)
-	modules += new /obj/item/device/healthanalyzer(src)
-	modules += new /obj/item/toy/crayon/spraycan/borg(src)
+	add_module(new /obj/item/stack/sheet/metal/cyborg())
+	modules += new /obj/item/weapon/extinguisher(src)
+
+	modules += new /obj/item/weapon/pickaxe(src)
+	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
+
+	modules += new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src)
+
+	modules += new /obj/item/weapon/soap/nanotrasen(src)
+
 	modules += new /obj/item/borg/cyborghug(src)
+
 	emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
 	fix_modules()
-
 
 
 /obj/item/weapon/robot_module/medical

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -25,7 +25,6 @@ Borg Hypospray
 
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "antitoxin", "epinephrine", "spaceacillin")
-	//var/list/reagent_ids = list("salbutamol", "salglu_solution", "salglu_solution", "charcoal", "ephedrine", "spaceacillin")
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
 
@@ -219,3 +218,8 @@ Borg Shaker
 	desc = "Everything's peaceful in death!"
 	icon_state = "borghypo_s"
 	reagent_ids = list("dizzysolution","tiresolution","tirizene","sulfonal","sodium_thiopental","cyanide","neurotoxin2")
+
+/obj/item/weapon/reagent_containers/borghypo/epi
+	name = "epinephrine injector"
+	desc = "An advanced chemical synthesizer and injection system, designed to stabilize patients.."
+	reagent_ids = list("epinephrine")


### PR DESCRIPTION
Previously it had:

Baton, extinguisher, wrench, crowbar, health analyzer, spraycan. Basically useless outside the baton.

It couldln't really do anything other than be a sad imitation of security cyborg. I've tried to redesign it as a jack of all trades that isn't really good at any one task, but can assist others doing those tasks.

It now has:

Epi hypo and medical analyzer to stabilize patients and get them to medbay

Welding tool/wrench/crowbar/metal for minor repairs

Extinguisher because everyone has one of those 

Pickaxe/mineral bag for really inefficient mining

Cable ties to assist security (it can't stun people on its own long enough to cuff them though)

Soap for slow cleaning

Hopefully this compromise addresses concerns about the borg having a baton while making the module actually worth playing. A borg that is good at everything but  great at nothing is kind of reversed from the design goals of other cyborgs though.

token: #18221
