### PR TITLE
Removes a superfluous addition of the "slime" faction to slimepeople.

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -35,6 +35,8 @@
 					blood_type = bloodSample.data["blood_type"]
 					features = bloodSample.data["features"]
 					factions = bloodSample.data["factions"]
+					factions |= "plants"
+					factions |= "vines"
 					W.reagents.clear_reagents()
 					user << "<span class='notice'>You inject the contents of the syringe into the seeds.</span>"
 					contains_sample = 1

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -35,8 +35,6 @@
 					blood_type = bloodSample.data["blood_type"]
 					features = bloodSample.data["features"]
 					factions = bloodSample.data["factions"]
-					factions |= "plants"
-					factions |= "vines"
 					W.reagents.clear_reagents()
 					user << "<span class='notice'>You inject the contents of the syringe into the seeds.</span>"
 					contains_sample = 1

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -36,7 +36,6 @@
 		H << "<span class='danger'>Your flesh rapidly mutates!</span>"
 		H.set_species(/datum/species/jelly/slime)
 		H.reagents.del_reagent(chem.type)
-		H.faction |= "slime"
 		return 1
 
 //Curiosity killed the cat's wagging tail.
@@ -149,10 +148,6 @@
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 	return
 	
-/datum/species/pod/on_species_gain(mob/living/carbon/C)
-	..()
-	C.faction |= "plants"
-	C.faction |= "vines"
 
 /*
  SHADOWPEOPLE

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -148,6 +148,11 @@
 		if(/obj/item/projectile/energy/florayield)
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 	return
+	
+/datum/species/pod/on_species_gain(mob/living/carbon/C)
+	..()
+	C.faction |= "plants"
+	C.faction |= "vines"
 
 /*
  SHADOWPEOPLE


### PR DESCRIPTION
Slimepeople were getting the slime faction added to them twice for no good reason- once in handle_chemicals for slime mutation toxin, and again in the on_species_gain for the slimeperson mutantrace. After this, it is done exclusively through the on_species_gain.

ps ignore the superfluous commits that's because I put previous stuff direct to master like a doof.
