### PR TITLE
Wizard Spell: Spacetime Distortion

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -5,6 +5,8 @@
     locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
   )
 
+#define Z_TURFS(ZLEVEL) block(locate(1,1,ZLEVEL), locate(world.maxx, world.maxy, ZLEVEL))
+
 /proc/get_area(atom/A)
 	if (!istype(A))
 		return

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -92,3 +92,5 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 	"CMO Office", "Chemistry", "Research", "RD Office",
 	"Robotics", "HoP Office", "Library", "Chapel", "Theatre",
 	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics")
+
+var/list/guitar_notes = flist("sound/guitar/")

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -93,4 +93,4 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 	"Robotics", "HoP Office", "Library", "Chapel", "Theatre",
 	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics")
 
-var/list/guitar_notes = flist("sound/guitar/")
+var/global/list/guitar_notes = flist("sound/guitar/")

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -232,6 +232,13 @@
 	category = "Assistance"
 	cost = 1
 
+/datum/spellbook_entry/spacetime_dist
+	name = "Spacetime Distortion"
+	spell_type = /obj/effect/proc_holder/spell/spacetime_dist
+	log_name = "STD"
+	category = "Defensive"
+	cost = 1
+
 /datum/spellbook_entry/item
 	name = "Buy Item"
 	refundable = 0

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -65,15 +65,17 @@
 	var/obj/effect/cross_action/spacetime_dist/linked_dist
 	var/busy = FALSE
 	var/sound
+	var/walks_left = 50 //prevents the game from hanging in extreme cases (such as minigun fire)
 
 /obj/effect/cross_action/spacetime_dist/New()
 	..()
 	sound = "sound/guitar/[safepick(guitar_notes)]"
 
 /obj/effect/cross_action/spacetime_dist/proc/walk_link(atom/movable/AM)
-	if(linked_dist)
+	if(linked_dist && walks_left > 0)
 		flick("purplesparkles", src)
 		linked_dist.get_walker(AM)
+		walks_left--
 
 /obj/effect/cross_action/spacetime_dist/proc/get_walker(atom/movable/AM)
 	busy = TRUE

--- a/code/modules/spells/spell_types/spacetime_distortion.dm
+++ b/code/modules/spells/spell_types/spacetime_distortion.dm
@@ -1,0 +1,105 @@
+/obj/effect/proc_holder/spell/spacetime_dist
+	name = "Spacetime Distortion"
+	desc = "Entangle the strings of spacetime to deny easy movement around you. The strings vibrate..."
+	charge_max = 300
+	var/duration = 150
+	range = 7
+	var/list/effects
+	var/ready = TRUE
+	centcom_cancast = FALSE
+	sound = "sound/effects/magic.ogg"
+
+/obj/effect/proc_holder/spell/spacetime_dist/can_cast(mob/user = usr)
+	if(ready)
+		return ..()
+	return FALSE
+
+/obj/effect/proc_holder/spell/spacetime_dist/choose_targets(mob/user = usr)
+	var/list/turfs = spiral_range_turfs(range, user)
+	if(!turfs.len)
+		revert_cast()
+		return
+
+	ready = FALSE
+	var/list/turf_steps = list()
+	var/length = round(turfs.len * 0.5)
+	for(var/i in 1 to length)
+		turf_steps[pick_n_take(turfs)] = pick_n_take(turfs)
+	if(turfs.len > 0)
+		var/turf/loner = pick(turfs)
+		turf_steps[loner] = pick(Z_TURFS(user.z))
+
+	perform(turf_steps,user=user)
+
+/obj/effect/proc_holder/spell/spacetime_dist/after_cast(list/targets)
+	addtimer(src, "clean_turfs", duration)
+
+/obj/effect/proc_holder/spell/spacetime_dist/cast(list/targets, mob/user = usr)
+	effects = list()
+	for(var/V in targets)
+		var/turf/T0 = V
+		var/turf/T1 = targets[V]
+		var/obj/effect/cross_action/spacetime_dist/STD0 = new /obj/effect/cross_action/spacetime_dist(T0)
+		var/obj/effect/cross_action/spacetime_dist/STD1 = new /obj/effect/cross_action/spacetime_dist(T1)
+		STD0.linked_dist = STD1
+		STD1.linked_dist = STD0
+		effects += STD0
+		effects += STD1
+
+/obj/effect/proc_holder/spell/spacetime_dist/proc/clean_turfs()
+	for(var/effect in effects)
+		qdel(effect)
+	effects.Cut()
+	effects = null
+	ready = TRUE
+
+/obj/effect/cross_action
+	name = "cross me"
+	desc = "for crossing"
+
+/obj/effect/cross_action/spacetime_dist
+	name = "spacetime distortion"
+	desc = "A distortion in spacetime. You can hear faint music..."
+	icon_state = "wave1"
+	color = "#8A2BE2"
+	var/obj/effect/cross_action/spacetime_dist/linked_dist
+	var/busy = FALSE
+	var/sound
+
+/obj/effect/cross_action/spacetime_dist/New()
+	..()
+	sound = "sound/guitar/[safepick(guitar_notes)]"
+
+/obj/effect/cross_action/spacetime_dist/proc/walk_link(atom/movable/AM)
+	if(linked_dist)
+		flick("purplesparkles", src)
+		linked_dist.get_walker(AM)
+
+/obj/effect/cross_action/spacetime_dist/proc/get_walker(atom/movable/AM)
+	busy = TRUE
+	if(linked_dist)
+		flick("purplesparkles", src)
+		AM.forceMove(get_turf(src))
+		playsound(get_turf(src),sound,70,0)
+	busy = FALSE
+
+/obj/effect/cross_action/spacetime_dist/Crossed(atom/movable/AM)
+	if(!busy)
+		walk_link(AM)
+
+/obj/effect/cross_action/spacetime_dist/attackby(obj/item/W, mob/user, params)
+	if(user.unEquip(W))
+		walk_link(W)
+	else
+		walk_link(user)
+
+/obj/effect/cross_action/spacetime_dist/attack_hand(mob/user)
+	walk_link(user)
+
+/obj/effect/cross_action/spacetime_dist/attack_paw(mob/user)
+	walk_link(user)
+
+/obj/effect/cross_action/spacetime_dist/Destroy()
+	busy = TRUE
+	linked_dist = null
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1715,6 +1715,7 @@
 #include "code\modules\spells\spell_types\rightandwrong.dm"
 #include "code\modules\spells\spell_types\santa.dm"
 #include "code\modules\spells\spell_types\shapeshift.dm"
+#include "code\modules\spells\spell_types\spacetime_distortion.dm"
 #include "code\modules\spells\spell_types\summonitem.dm"
 #include "code\modules\spells\spell_types\touch_attacks.dm"
 #include "code\modules\spells\spell_types\trigger.dm"


### PR DESCRIPTION
This spell will distort spacetime around the wizard to make movement within it difficult, every step taking you into a different tile than the one you were expecting.

Using placeholder sprites, which don't look too bad but I'd rather something more appropriate if someone is willing to sprite.

:cl:
rscadd: New wizard spell: Spacetime Distortion.
/:cl:

Merge token: https://github.com/tgstation/tgstation/pull/18254