### PR TITLE
Clockwork marauders will now die when their host does

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -221,7 +221,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/clockwork_marauder/proc/adjust_fatigue(amount) //Adds or removes the given amount of fatigue
-	if(!ratvar_awakens || amount > 0)
+	if(!ratvar_awakens || amount < 0)
 		fatigue = Clamp(fatigue + amount, 0, fatigue_recall_threshold)
 		update_fatigue()
 	else

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -166,7 +166,7 @@
 					recovering = TRUE
 					return_to_host()
 				else
-					qdel(src) //Shouldn't ever happen, but...
+					death() //Shouldn't ever happen, but...
 
 /mob/living/simple_animal/hostile/clockwork_marauder/death(gibbed)
 	..(TRUE)
@@ -339,7 +339,7 @@
 	else
 		host << "<span class='heavy_brass'>[true_name] emerges from your body to protect you!</span>"
 	forceMove(get_turf(host))
-	visible_message("<span class='warning'>[host]'s skin glows red as a [name] emerges from their body!</span>", "<span class='brass'>You exit the safety of [host]'s body!</span>")
+	visible_message("<span class='warning'>[host]'s skin glows red as [name] emerges from their body!</span>", "<span class='brass'>You exit the safety of [host]'s body!</span>")
 	return 1
 
 /mob/living/simple_animal/hostile/clockwork_marauder/proc/is_in_host() //Checks if the marauder is inside of their host


### PR DESCRIPTION
Kill bugs before they get reported today.

Fixes failing to emerge if recovering when dying.
Fixes marauders not dying ever and being able to just drag their dead host corpse around murderboning.
