### PR TITLE
Set dir()

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -957,19 +957,19 @@ var/global/list/humanoid_icon_cache = list()
 
 		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
 
-		body.dir = NORTH
+		body.setDir(NORTH)
 		var/icon/partial = getFlatIcon(body)
 		out_icon.Insert(partial,dir=NORTH)
 
-		body.dir = SOUTH
+		body.setDir(SOUTH)
 		partial = getFlatIcon(body)
 		out_icon.Insert(partial,dir=SOUTH)
 
-		body.dir = WEST
+		body.setDir(WEST)
 		partial = getFlatIcon(body)
 		out_icon.Insert(partial,dir=WEST)
 
-		body.dir = EAST
+		body.setDir(EAST)
 		partial = getFlatIcon(body)
 		out_icon.Insert(partial,dir=EAST)
 
@@ -985,4 +985,4 @@ var/global/list/humanoid_icon_cache = list()
 //Images have dir without being an atom, so they get their own definition.
 //Lame.
 /image/proc/setDir(newdir)
-	dir = newdir
+	setDir(newdir)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -980,3 +980,9 @@ var/global/list/humanoid_icon_cache = list()
 	else
 		return humanoid_icon_cache[icon_id]
 
+
+//Hook, override to run code on- wait this is images
+//Images have dir without being an atom, so they get their own definition.
+//Lame.
+/image/proc/setDir(newdir)
+	dir = newdir

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -985,4 +985,4 @@ var/global/list/humanoid_icon_cache = list()
 //Images have dir without being an atom, so they get their own definition.
 //Lame.
 /image/proc/setDir(newdir)
-	setDir(newdir)
+	dir = newdir

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -502,7 +502,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //The variables should be apparent enough.
 	var/atom/movable/overlay/animation = new(location)
 	if(direction)
-		animation.dir = direction
+		animation.setDir(direction)
 	animation.icon = a_icon
 	animation.layer = target:layer+1
 	if(a_icon_state)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -309,25 +309,25 @@
 	var/dy = A.y - y
 	if(!dx && !dy) // Wall items are graphically shifted but on the floor
 		if(A.pixel_y > 16)
-			dir = NORTH
+			setDir(NORTH)
 		else if(A.pixel_y < -16)
-			dir = SOUTH
+			setDir(SOUTH)
 		else if(A.pixel_x > 16)
-			dir = EAST
+			setDir(EAST)
 		else if(A.pixel_x < -16)
-			dir = WEST
+			setDir(WEST)
 		return
 
 	if(abs(dx) < abs(dy))
 		if(dy > 0)
-			dir = NORTH
+			setDir(NORTH)
 		else
-			dir = SOUTH
+			setDir(SOUTH)
 	else
 		if(dx > 0)
-			dir = EAST
+			setDir(EAST)
 		else
-			dir = WEST
+			setDir(WEST)
 
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen_gen.dmi'

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -177,7 +177,7 @@ var/const/tk_maxrange = 15
 	O.anchored = 1
 	O.density = 0
 	O.layer = FLY_LAYER
-	O.dir = pick(cardinal)
+	O.setDir(pick(cardinal))
 	O.icon = 'icons/effects/effects.dmi'
 	O.icon_state = "nothing"
 	flick("empdisable",O)

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -218,7 +218,7 @@
 		I = new /icon(icon, icon_state, dir)
 	else
 		I = new /icon(icon, icon_state)
-		dir = "default"
+		setDir("default")
 
 	var/filename = "[ckey("[icon]_[icon_state]_[dir]")].png"
 	src << browse_rsc(I, filename)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -742,9 +742,9 @@ body
 
 			switch(href_list["rotatedir"])
 				if("right")
-					A.dir = turn(A.dir, -45)
+					A.setDir(turn(A.dir, -45))
 				if("left")
-					A.dir = turn(A.dir, 45)
+					A.setDir(turn(A.dir, 45))
 			href_list["datumrefresh"] = href_list["rotatedatum"]
 
 		else if(href_list["editorgans"])

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -162,7 +162,7 @@
 	A.say("TORNADO SWEEP!")
 	spawn(0)
 		for(var/i in list(NORTH,SOUTH,EAST,WEST,EAST,SOUTH,NORTH,SOUTH,EAST,WEST,EAST,SOUTH))
-			A.dir = i
+			A.setDir(i)
 			playsound(A.loc, 'sound/weapons/punch1.ogg', 15, 1, -1)
 			sleep(1)
 	var/obj/effect/proc_holder/spell/aoe_turf/repulse/R = new(null)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -121,7 +121,7 @@
 		A << "You need to have [D] in a cinch!"
 		return
 	D.forceMove(A.loc)
-	D.dir = get_dir(D, A)
+	D.setDir(get_dir(D, A))
 
 	D.Stun(4)
 	A.visible_message("<span class = 'danger'><B>[A] starts spinning around with [D]!</B></span>")
@@ -151,12 +151,12 @@
 				A << "You can't throw [D] from here!"
 				return 0
 
-			A.dir = turn(A.dir, 90)
+			A.setDir(turn(A.dir, 90))
 			var/turf/T = get_step(A, A.dir)
 			var/turf/S = D.loc
 			if ((S && isturf(S) && S.Exit(D)) && (T && isturf(T) && T.Enter(A)))
 				D.forceMove(T)
-				D.dir = get_dir(D, A)
+				D.setDir(get_dir(D, A))
 		else
 			return 0
 
@@ -193,8 +193,8 @@
 		A << "You need to have [D] in a cinch!"
 		return
 	D.forceMove(A.loc)
-	A.dir = get_dir(A, D)
-	D.dir = get_dir(D, A)
+	A.setDir(get_dir(A, D))
+	D.setDir(get_dir(D, A))
 
 	A.visible_message("<span class = 'danger'><B>[A] lifts [D] up!</B></span>")
 
@@ -209,8 +209,8 @@
 		if (A && D)
 			A.pixel_y += 3
 			D.pixel_y += 3
-			A.dir = turn(A.dir, 90)
-			D.dir = turn(D.dir, 90)
+			A.setDir(turn(A.dir, 90))
+			D.setDir(turn(D.dir, 90))
 
 			switch (A.dir)
 				if (NORTH)
@@ -305,7 +305,7 @@
 	var/turf/T = get_turf(A)
 	if (T && isturf(T) && D && isturf(D.loc))
 		for (var/i = 0, i < 4, i++)
-			A.dir = turn(A.dir, 90)
+			A.setDir(turn(A.dir, 90))
 
 		A.forceMove(D.loc)
 		spawn (4)
@@ -322,7 +322,7 @@
 		return
 	A.emote("scream")
 	A.emote("flip")
-	A.dir = turn(A.dir, 90)
+	A.setDir(turn(A.dir, 90))
 
 	A.visible_message("<span class = 'danger'><B>[A] roundhouse-kicks [D]!</B></span>")
 	playsound(A.loc, "swing_hit", 50, 1)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -435,4 +435,4 @@ var/list/blood_splatter_icons = list()
 
 //Hook for running code when a dir change occurs
 /atom/proc/setDir(newdir)
-	setDir(newdir)
+	dir = newdir

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -435,4 +435,4 @@ var/list/blood_splatter_icons = list()
 
 //Hook for running code when a dir change occurs
 /atom/proc/setDir(newdir)
-	dir = newdir
+	setDir(newdir)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -432,3 +432,7 @@ var/list/blood_splatter_icons = list()
 			if(nutri_check.nutriment_factor >0)
 				M.reagents.remove_reagent(R.id,R.volume)
 
+
+//Hook for running code when a dir change occurs
+/atom/proc/setDir(newdir)
+	dir = newdir

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -188,7 +188,7 @@
 
 	var/old_dir = dir
 	. = step(src, direction)
-	dir = old_dir
+	setDir(old_dir)
 
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -68,6 +68,7 @@
 		Moved(oldloc, direct)
 
 	last_move = direct
+	setDir(direct)
 
 	spawn(5)	// Causes space drifting. /tg/station has no concept of speed, we just use 5
 		if(loc && direct && last_move == direct)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -24,7 +24,7 @@
 	if(Ablob.blob_allowed) //Is this area allowed for winning as blob?
 		blobs_legit += src
 	blobs += src //Keep track of the blob in the normal list either way
-	src.dir = pick(1, 2, 4, 8)
+	src.setDir(pick(1, 2, 4, 8))
 	src.update_icon()
 	..(loc)
 	ConsumeTile()

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -285,14 +285,14 @@
 			if(ratvar_awakens && target)
 				target.adjust_fire_stacks(damage_per_tick)
 				target.IgniteMob()
-			dir = get_dir(get_turf(src), get_turf(target))
+			setDir(get_dir(get_turf(src), get_turf(target)))
 	else
 		if(!acquire_nearby_target() && prob(0.5)) //Extremely low chance because of how fast the subsystem it uses processes
 			var/list/idle_messages = list("[src] sulkily glares around.", "[src] lazily drifts from side to side.", "[src] looks around for something to burn.", "[src] slowly turns in circles.")
 			if(prob(50))
 				visible_message("<span class='notice'>[pick(idle_messages)]</span>")
 			else
-				dir = pick(NORTH, EAST, SOUTH, WEST) //Random rotation
+				setDir(pick(NORTH, EAST, SOUTH, WEST) )//Random rotation
 
 /obj/structure/clockwork/ocular_warden/proc/acquire_nearby_target()
 	var/list/possible_targets = list()

--- a/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
@@ -91,7 +91,7 @@
 			new new_thing_type(get_turf(target), proselytize_values["spawn_dir"])
 		else
 			var/atom/A = new new_thing_type(get_turf(target))
-			A.dir = proselytize_values["spawn_dir"]
+			A.setDir(proselytize_values["spawn_dir"])
 		qdel(target)
 	modify_stored_alloy(-proselytize_values["alloy_cost"])
 	return 1

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -48,7 +48,7 @@
 	if(T.z != L.z)
 		icon_state = "pinonnull"
 	else
-		dir = get_dir(L, T)
+		setDir(get_dir(L, T))
 		switch(get_dist(L, T))
 			if(-1)
 				icon_state = "pinondirect"
@@ -203,7 +203,7 @@
 	if(!the_disk)
 		icon_state = "pinonnull"
 		return
-	dir = get_dir(src, the_disk)
+	setDir(get_dir(src, the_disk))
 	switch(get_dist(src, the_disk))
 		if(0)
 			icon_state = "pinondirect"
@@ -237,7 +237,7 @@
 	if(loc.z != home.z)	//If you are on a different z-level from the shuttle
 		icon_state = "pinonnull"
 	else
-		dir = get_dir(src, home)
+		setDir(get_dir(src, home))
 		switch(get_dist(src, home))
 			if(0)
 				icon_state = "pinondirect"

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -19,7 +19,7 @@
 /obj/machinery/button/New(loc, ndir = 0, built = 0)
 	..()
 	if(built)
-		dir = ndir
+		setDir(ndir)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0
 		panel_open = 1

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -156,7 +156,7 @@
 					assembly = new()
 				assembly.loc = src.loc
 				assembly.state = 1
-				assembly.dir = src.dir
+				assembly.setDir(src.dir)
 				assembly = null
 				qdel(src)
 			return
@@ -339,13 +339,13 @@
 			//If someone knows a better way to do this, let me know. -Giacom
 			switch(i)
 				if(NORTH)
-					src.dir = SOUTH
+					src.setDir(SOUTH)
 				if(SOUTH)
-					src.dir = NORTH
+					src.setDir(NORTH)
 				if(WEST)
-					src.dir = EAST
+					src.setDir(EAST)
 				if(EAST)
-					src.dir = WEST
+					src.setDir(WEST)
 			break
 
 //Return a working camera that can see a given mob

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -27,7 +27,7 @@
 /obj/machinery/camera_assembly/New(loc, ndir, building)
 	..()
 	if(building)
-		dir = ndir
+		setDir(ndir)
 
 /obj/machinery/camera_assembly/attackby(obj/item/W, mob/living/user, params)
 	switch(state)
@@ -87,7 +87,7 @@
 				var/obj/machinery/camera/C = new(src.loc)
 				src.loc = C
 				C.assembly = src
-				C.dir = src.dir
+				C.setDir(src.dir)
 
 				C.network = tempnetwork
 				var/area/A = get_area_master(src)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,7 +18,7 @@
 /obj/machinery/door/window/New(loc, set_dir)
 	..()
 	if(set_dir)
-		dir = set_dir
+		setDir(set_dir)
 	if(src.req_access && src.req_access.len)
 		src.icon_state = "[src.icon_state]"
 		src.base_state = src.icon_state
@@ -272,7 +272,7 @@
 								WA.secure = 1
 						WA.anchored = 1
 						WA.state= "02"
-						WA.dir = src.dir
+						WA.setDir(src.dir)
 						WA.ini_dir = src.dir
 						WA.update_icon()
 						WA.created_name = src.name
@@ -348,7 +348,7 @@
 	..()
 	var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/door/window, get_turf(src))
 	if(set_dir)
-		E.dir = set_dir
+		E.setDir(set_dir)
 	debris += new/obj/item/clockwork/component/vanguard_cogwheel(src)
 
 /obj/machinery/door/window/clockwork/ratvar_act()
@@ -367,65 +367,65 @@
 	return 0
 
 /obj/machinery/door/window/northleft
-	dir = NORTH
+	setDir(NORTH)
 
 /obj/machinery/door/window/eastleft
-	dir = EAST
+	setDir(EAST)
 
 /obj/machinery/door/window/westleft
-	dir = WEST
+	setDir(WEST)
 
 /obj/machinery/door/window/southleft
-	dir = SOUTH
+	setDir(SOUTH)
 
 /obj/machinery/door/window/northright
-	dir = NORTH
+	setDir(NORTH)
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/eastright
-	dir = EAST
+	setDir(EAST)
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/westright
-	dir = WEST
+	setDir(WEST)
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/southright
-	dir = SOUTH
+	setDir(SOUTH)
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/brigdoor/northleft
-	dir = NORTH
+	setDir(NORTH)
 
 /obj/machinery/door/window/brigdoor/eastleft
-	dir = EAST
+	setDir(EAST)
 
 /obj/machinery/door/window/brigdoor/westleft
-	dir = WEST
+	setDir(WEST)
 
 /obj/machinery/door/window/brigdoor/southleft
-	dir = SOUTH
+	setDir(SOUTH)
 
 /obj/machinery/door/window/brigdoor/northright
-	dir = NORTH
+	setDir(NORTH)
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/eastright
-	dir = EAST
+	setDir(EAST)
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/westright
-	dir = WEST
+	setDir(WEST)
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/southright
-	dir = SOUTH
+	setDir(SOUTH)
 	icon_state = "rightsecure"
 	base_state = "rightsecure"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -367,65 +367,65 @@
 	return 0
 
 /obj/machinery/door/window/northleft
-	setDir(NORTH)
+	dir = NORTH
 
 /obj/machinery/door/window/eastleft
-	setDir(EAST)
+	dir = EAST
 
 /obj/machinery/door/window/westleft
-	setDir(WEST)
+	dir = WEST
 
 /obj/machinery/door/window/southleft
-	setDir(SOUTH)
+	dir = SOUTH
 
 /obj/machinery/door/window/northright
-	setDir(NORTH)
+	dir = NORTH
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/eastright
-	setDir(EAST)
+	dir = EAST
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/westright
-	setDir(WEST)
+	dir = WEST
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/southright
-	setDir(SOUTH)
+	dir = SOUTH
 	icon_state = "right"
 	base_state = "right"
 
 /obj/machinery/door/window/brigdoor/northleft
-	setDir(NORTH)
+	dir = NORTH
 
 /obj/machinery/door/window/brigdoor/eastleft
-	setDir(EAST)
+	dir = EAST
 
 /obj/machinery/door/window/brigdoor/westleft
-	setDir(WEST)
+	dir = WEST
 
 /obj/machinery/door/window/brigdoor/southleft
-	setDir(SOUTH)
+	dir = SOUTH
 
 /obj/machinery/door/window/brigdoor/northright
-	setDir(NORTH)
+	dir = NORTH
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/eastright
-	setDir(EAST)
+	dir = EAST
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/westright
-	setDir(WEST)
+	dir = WEST
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
 
 /obj/machinery/door/window/brigdoor/southright
-	setDir(SOUTH)
+	dir = SOUTH
 	icon_state = "rightsecure"
 	base_state = "rightsecure"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -45,7 +45,7 @@ var/list/doppler_arrays = list()
 		return
 	if(usr.stat || usr.restrained() || !usr.canmove)
 		return
-	src.dir = turn(src.dir, 90)
+	src.setDir(turn(src.dir, 90))
 	return
 
 /obj/machinery/doppler_array/AltClick(mob/living/user)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -26,7 +26,7 @@
 /obj/machinery/firealarm/New(loc, dir, building)
 	..()
 	if(dir)
-		src.dir = dir
+		src.setDir(dir)
 	if(building)
 		buildstage = 0
 		panel_open = 1

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -25,7 +25,7 @@
 /obj/machinery/flasher/New(loc, ndir = 0, built = 0)
 	..() // ..() is EXTREMELY IMPORTANT, never forget to add it
 	if(built)
-		dir = ndir
+		setDir(ndir)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -28 : 28)
 		pixel_y = (dir & 3)? (dir ==1 ? -28 : 28) : 0
 	else

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -373,7 +373,7 @@ Class Procs:
 /obj/machinery/proc/default_change_direction_wrench(mob/user, obj/item/weapon/wrench/W)
 	if(panel_open && istype(W))
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		dir = turn(dir,-90)
+		setDir(turn(dir,-90))
 		user << "<span class='notice'>You rotate [src].</span>"
 		return 1
 	return 0

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -200,7 +200,7 @@ var/list/obj/machinery/newscaster/allCasters = list()
 /obj/machinery/newscaster/New(loc, ndir, building)
 	..()
 	if(building)
-		dir = ndir
+		setDir(ndir)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -32 : 32)
 		pixel_y = (dir & 3)? (dir ==1 ? -32 : 32) : 0
 

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -52,7 +52,7 @@ Buildable meters
 /obj/item/pipe/New(loc, pipe_type, dir, obj/machinery/atmospherics/make_from)
 	..()
 	if(make_from)
-		src.dir = make_from.dir
+		src.setDir(make_from.dir)
 		src.pipename = make_from.name
 		src.color = make_from.color
 
@@ -67,10 +67,10 @@ Buildable meters
 		var/obj/machinery/atmospherics/components/trinary/triP = make_from
 		if(istype(triP) && triP.flipped)
 			src.flipped = 1
-			src.dir = turn(src.dir, -45)
+			src.setDir(turn(src.dir, -45))
 	else
 		src.pipe_type = pipe_type
-		src.dir = dir
+		src.setDir(dir)
 
 	if(src.dir in diagonals)
 		is_bent = 1
@@ -144,7 +144,7 @@ var/global/list/pipeID2State = list(
 	if ( usr.stat || usr.restrained() || !usr.canmove )
 		return
 
-	src.dir = turn(src.dir, -90)
+	src.setDir(turn(src.dir, -90))
 
 	fixdir()
 
@@ -159,11 +159,11 @@ var/global/list/pipeID2State = list(
 		return
 
 	if (pipe_type in list(PIPE_GAS_FILTER, PIPE_GAS_MIXER))
-		src.dir = turn(src.dir, flipped ? 45 : -45)
+		src.setDir(turn(src.dir, flipped )? 45 : -45)
 		flipped = !flipped
 		return
 
-	src.dir = turn(src.dir, -180)
+	src.setDir(turn(src.dir, -180))
 
 	fixdir()
 
@@ -182,7 +182,7 @@ var/global/list/pipeID2State = list(
 /obj/item/pipe/Move()
 	var/old_dir = dir
 	..()
-	dir = old_dir //pipes changing direction when moved is just annoying and buggy
+	setDir(old_dir )//pipes changing direction when moved is just annoying and buggy
 
 /obj/item/pipe/proc/unflip(direction)
 	if(direction in diagonals)
@@ -194,9 +194,9 @@ var/global/list/pipeID2State = list(
 /obj/item/pipe/proc/fixdir()
 	if((pipe_type in list (PIPE_SIMPLE, PIPE_HE, PIPE_MVALVE, PIPE_DVALVE)) && !is_bent)
 		if(dir==SOUTH)
-			dir = NORTH
+			setDir(NORTH)
 		else if(dir==WEST)
-			dir = EAST
+			setDir(EAST)
 
 /obj/item/pipe/attack_self(mob/user)
 	return rotate()
@@ -209,10 +209,10 @@ var/global/list/pipeID2State = list(
 
 	fixdir()
 	if(pipe_type in list(PIPE_GAS_MIXER, PIPE_GAS_FILTER))
-		dir = unflip(dir)
+		setDir(unflip(dir))
 
 	var/obj/machinery/atmospherics/A = new pipe_type(src.loc)
-	A.dir = src.dir
+	A.setDir(src.dir)
 	A.SetInitDirections()
 
 	for(var/obj/machinery/atmospherics/M in src.loc)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -587,7 +587,7 @@
 	if(target)
 		spawn()
 			popUp()				//pop the turret up if it's not already up.
-		dir = get_dir(base, target)	//even if you can't shoot, follow the target
+		setDir(get_dir(base, target)	)//even if you can't shoot, follow the target
 		spawn()
 			shootAt(target)
 		return 1
@@ -701,7 +701,7 @@
 /obj/machinery/turretid/New(loc, ndir = 0, built = 0)
 	..()
 	if(built)
-		dir = ndir
+		setDir(ndir)
 		locked = 0
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -24 : 24)
 		pixel_y = (dir & 3)? (dir ==1 ? -24 : 24) : 0

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -11,7 +11,7 @@
 		var/health = max_health //The shield can only take so much beating (prevents perma-prisons)
 
 /obj/machinery/shield/New()
-	src.dir = pick(1,2,3,4)
+	src.setDir(pick(1,2,3,4))
 	..()
 	air_update_turf(1)
 
@@ -407,7 +407,7 @@
 		T2 = T
 		var/obj/machinery/shieldwall/CF = new/obj/machinery/shieldwall/(src, G) //(ref to this gen, ref to connected gen)
 		CF.loc = T
-		CF.dir = field_dir
+		CF.setDir(field_dir)
 
 
 /obj/machinery/shieldwallgen/attackby(obj/item/W, mob/user, params)

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -14,7 +14,7 @@
 	name = "mech bay power port"
 	density = 1
 	anchored = 1
-	dir = 4
+	setDir(4)
 	icon = 'icons/mecha/mech_bay.dmi'
 	icon_state = "recharge_port"
 	var/obj/mecha/recharging_mech

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -14,7 +14,7 @@
 	name = "mech bay power port"
 	density = 1
 	anchored = 1
-	setDir(4)
+	dir = EAST
 	icon = 'icons/mecha/mech_bay.dmi'
 	icon_state = "recharge_port"
 	var/obj/mecha/recharging_mech

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -520,7 +520,7 @@
 
 
 /obj/mecha/proc/mechturn(direction)
-	dir = direction
+	setDir(direction)
 	if(turnsound)
 		playsound(src,turnsound,40,1)
 	return 1
@@ -529,7 +529,7 @@
 	var/current_dir = dir
 	var/result = step(src,direction)
 	if(strafe)
-		dir = current_dir
+		setDir(current_dir)
 	if(result && stepsound)
 		playsound(src,stepsound,40,1)
 	return result
@@ -836,7 +836,7 @@
 		forceMove(loc)
 		log_append_to_last("[H] moved in as pilot.")
 		icon_state = initial(icon_state)
-		dir = dir_in
+		setDir(dir_in)
 		playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 		if(!internal_damage)
 			occupant << sound('sound/mecha/nominal.ogg',volume=50)
@@ -888,7 +888,7 @@
 		mmi_as_oc.loc = src
 		mmi_as_oc.mecha = src
 		icon_state = initial(icon_state)
-		dir = dir_in
+		setDir(dir_in)
 		log_message("[mmi_as_oc] moved in as pilot.")
 		if(!internal_damage)
 			occupant << sound('sound/mecha/nominal.ogg',volume=50)
@@ -940,7 +940,7 @@
 			mmi.update_icon()
 			L.canmove = 0
 		icon_state = initial(icon_state)+"-open"
-		dir = dir_in
+		setDir(dir_in)
 
 	if(L && L.client)
 		L.client.view = world.view

--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -5,7 +5,7 @@
 
 
 /obj/mecha/medical/mechturn(direction)
-	dir = direction
+	setDir(direction)
 	playsound(src,'sound/mecha/mechmove01.ogg',40,1)
 	return 1
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -52,7 +52,7 @@
 		return 0
 
 	M.buckled = src
-	M.dir = dir
+	M.setDir(dir)
 	buckled_mobs |= M
 	M.update_canmove()
 	post_buckle_mob(M)

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -38,7 +38,7 @@
 		if(number < 3)
 			var/obj/effect/particle_effect/steam/I = PoolOrNew(/obj/effect/particle_effect/steam, oldposition)
 			number++
-			I.dir = holder.dir
+			I.setDir(holder.dir)
 			oldposition = get_turf(holder)
 			spawn(10)
 				qdel(I)
@@ -68,7 +68,7 @@
 		if(T != oldposition)
 			if(!has_gravity(T))
 				var/obj/effect/particle_effect/ion_trails/I = PoolOrNew(effect_type, oldposition)
-				I.dir = holder.dir
+				I.setDir(holder.dir)
 				flick("ion_fade", I)
 				I.icon_state = ""
 				spawn(20)

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -79,7 +79,7 @@
 			smoke_mob(L)
 		var/obj/effect/particle_effect/smoke/S = new type(T)
 		reagents.copy_to(S, reagents.total_volume)
-		S.dir = pick(cardinal)
+		S.setDir(pick(cardinal))
 		S.amount = amount-1
 		S.color = color
 		S.lifetime = lifetime

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -26,7 +26,7 @@ obj/effect/glowshroom/glowcap
 /obj/effect/glowshroom/New()
 	..()
 	SetLuminosity(round(potency/10))
-	dir = CalcDir()
+	setDir(CalcDir())
 	var/base_icon_state = initial(icon_state)
 	if(!floor)
 		switch(dir) //offset to make it be on the wall rather than on the floor

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -33,7 +33,7 @@
 
 /obj/effect/overlay/temp/New()
 	if(randomdir)
-		dir = pick(cardinal)
+		setDir(pick(cardinal))
 	flick("[icon_state]", src) //Because we might be pulling it from a pool, flick whatever icon it uses so it starts at the start of the icon's animation.
 	spawn(duration)
 		qdel(src)
@@ -85,7 +85,7 @@
 	if(mimiced_atom)
 		name = mimiced_atom.name
 		appearance = mimiced_atom.appearance
-		dir = mimiced_atom.dir
+		setDir(mimiced_atom.dir)
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/overlay/temp/cult
@@ -105,7 +105,7 @@
 /obj/effect/overlay/temp/cult/phase/New(loc, set_dir)
 	..()
 	if(set_dir)
-		dir = set_dir
+		setDir(set_dir)
 
 /obj/effect/overlay/temp/cult/phase/out
 	icon_state = "cultout"

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -84,7 +84,7 @@
 			var/predir = AM.dir
 			step(AM, direction)
 			if(!facedir)
-				AM.dir = predir
+				AM.setDir(predir)
 
 
 

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -77,9 +77,9 @@
 		I.pixel_x = p_x - 1 //offset correction
 		I.pixel_y = p_y - 1
 		if(decaltype == DECALTYPE_SCORCH)
-			I.dir = pick(NORTH,SOUTH,EAST,WEST)// random scorch design
+			I.setDir(pick(NORTH,SOUTH,EAST,WEST))// random scorch design
 			if(P.damage >= 20 || istype(P, /obj/item/projectile/beam/practice))
-				I.dir = pick(NORTH,SOUTH,EAST,WEST)
+				I.setDir(pick(NORTH,SOUTH,EAST,WEST))
 			else
 				I.icon_state = "light_scorch"
 		else

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -101,7 +101,7 @@
 
 			var/obj/structure/window/W
 			W = new /obj/structure/window( user.loc, 0 )
-			W.dir = dir_to_set
+			W.setDir(dir_to_set)
 			W.ini_dir = W.dir
 			W.anchored = 0
 			W.air_update_turf(1)
@@ -203,7 +203,7 @@
 			var/obj/structure/window/W
 			W = new /obj/structure/window/reinforced( user.loc, 1 )
 			W.state = 0
-			W.dir = dir_to_set
+			W.setDir(dir_to_set)
 			W.ini_dir = W.dir
 			W.anchored = 0
 			W.add_fingerprint(user)
@@ -252,16 +252,16 @@
 			src.use(5)
 			switch(user.dir)
 				if(SOUTH)
-					WD.dir = SOUTH
+					WD.setDir(SOUTH)
 					WD.ini_dir = SOUTH
 				if(EAST)
-					WD.dir = EAST
+					WD.setDir(EAST)
 					WD.ini_dir = EAST
 				if(WEST)
-					WD.dir = WEST
+					WD.setDir(WEST)
 					WD.ini_dir = WEST
 				else //If the user is facing northeast. northwest, southeast, southwest or north, default to north
-					WD.dir = NORTH
+					WD.setDir(NORTH)
 					WD.ini_dir = NORTH
 		else
 			return 1

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -130,7 +130,7 @@
 				return
 
 		var/atom/O = new R.result_type( usr.loc )
-		O.dir = usr.dir
+		O.setDir(usr.dir)
 		use(R.req_amount * multiplier)
 
 		//is it a stack ?

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -32,7 +32,7 @@ RPD
 /datum/pipe_info/New(pid,direction,dt)
 	src.id=pid
 	src.icon_state=pipeID2State["[pid]"]
-	src.setDir(direction)
+	src.dir = direction
 	src.dirtype=dt
 
 /datum/pipe_info/proc/Render(dispenser,label)
@@ -70,7 +70,7 @@ var/global/list/disposalpipeID2State=list(
 /datum/pipe_info/disposal/New(var/pid,var/dt)
 	src.id=pid
 	src.icon_state=disposalpipeID2State[pid+1]
-	src.setDir(2)
+	src.dir = SOUTH
 	src.dirtype=dt
 	if(pid<DISP_END_BIN || pid>DISP_END_CHUTE)
 		icon_state = "con[icon_state]"

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -32,7 +32,7 @@ RPD
 /datum/pipe_info/New(pid,direction,dt)
 	src.id=pid
 	src.icon_state=pipeID2State["[pid]"]
-	src.dir=direction
+	src.setDir(direction)
 	src.dirtype=dt
 
 /datum/pipe_info/proc/Render(dispenser,label)
@@ -70,7 +70,7 @@ var/global/list/disposalpipeID2State=list(
 /datum/pipe_info/disposal/New(var/pid,var/dt)
 	src.id=pid
 	src.icon_state=disposalpipeID2State[pid+1]
-	src.dir=2
+	src.setDir(2)
 	src.dirtype=dt
 	if(pid<DISP_END_BIN || pid>DISP_END_CHUTE)
 		icon_state = "con[icon_state]"

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -77,22 +77,22 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 			for(var/area/chapel/main/A in world)
 				for(var/turf/T in A.contents)
 					if(T.icon_state == "carpetsymbol")
-						T.dir = 2
+						T.setDir(2)
 		if("koran")
 			for(var/area/chapel/main/A in world)
 				for(var/turf/T in A.contents)
 					if(T.icon_state == "carpetsymbol")
-						T.dir = 4
+						T.setDir(4)
 		if("scientology")
 			for(var/area/chapel/main/A in world)
 				for(var/turf/T in A.contents)
 					if(T.icon_state == "carpetsymbol")
-						T.dir = 8
+						T.setDir(8)
 		if("athiest")
 			for(var/area/chapel/main/A in world)
 				for(var/turf/T in A.contents)
 					if(T.icon_state == "carpetsymbol")
-						T.dir = 10
+						T.setDir(10)
 
 /obj/item/weapon/storage/book/bible/Topic(href, href_list)
 	if(href_list["seticon"] && ticker && !ticker.Bible_icon_state)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -234,7 +234,7 @@
 	if((wielded) && prob(50))
 		spawn(0)
 			for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2))
-				user.dir = i
+				user.setDir(i)
 				if(i == 8)
 					user.emote("flip")
 				sleep(1)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -49,7 +49,7 @@
 /obj/structure/chair/narsie_act()
 	if(prob(20))
 		var/obj/structure/chair/wood/W = new/obj/structure/chair/wood(get_turf(src))
-		W.dir = dir
+		W.setDir(dir)
 		qdel(src)
 
 /obj/structure/chair/attackby(obj/item/weapon/W, mob/user, params)
@@ -62,7 +62,7 @@
 		var/obj/item/assembly/shock_kit/SK = W
 		var/obj/structure/chair/e_chair/E = new /obj/structure/chair/e_chair(src.loc)
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		E.dir = dir
+		E.setDir(dir)
 		E.part = SK
 		SK.loc = E
 		SK.master = E
@@ -84,7 +84,7 @@
 			buckled_mob.buckled = null //Temporary, so Move() succeeds.
 			if(!direction || !buckled_mob.Move(get_step(src, direction), direction))
 				buckled_mob.buckled = src
-				dir = buckled_mob.dir
+				setDir(buckled_mob.dir)
 				return 0
 			buckled_mob.buckled = src //Restoring
 	handle_layer()
@@ -97,12 +97,12 @@
 		layer = OBJ_LAYER
 
 /obj/structure/chair/proc/spin()
-	dir = turn(dir, 90)
+	setDir(turn(dir, 90))
 	handle_layer()
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			buckled_mob.dir = dir
+			buckled_mob.setDir(dir)
 
 /obj/structure/chair/verb/rotate()
 	set name = "Rotate Chair"
@@ -249,7 +249,7 @@
 /obj/item/chair/narsie_act()
 	if(prob(20))
 		var/obj/item/chair/wood/W = new/obj/item/chair/wood(get_turf(src))
-		W.dir = dir
+		W.setDir(dir)
 		qdel(src)
 
 /obj/item/chair/attack_self(mob/user)
@@ -266,7 +266,7 @@
 
 	user.visible_message("<span class='notice'>[user] rights \the [src.name].</span>", "<span class='notice'>You right \the [name].</span>")
 	var/obj/structure/chair/C = new origin_type(get_turf(loc))
-	C.dir = dir
+	C.setDir(dir)
 	qdel(src)
 
 /obj/item/chair/proc/smash(mob/living/user)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -99,9 +99,9 @@
 		I = getFlatIcon(A)
 	else
 		var/old_dir = A.dir
-		A.dir = 2
+		A.setDir(2)
 		I = getFlatIcon(A)
-		A.dir = old_dir
+		A.setDir(old_dir)
 	return I
 
 /obj/structure/displaycase/update_icon()

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -14,7 +14,7 @@
 	if(istype(W, /obj/item/weapon/wrench))
 		var/obj/structure/chair/C = new /obj/structure/chair(loc)
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		C.dir = dir
+		C.setDir(dir)
 		part.loc = loc
 		part.master = null
 		part = null

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -11,7 +11,7 @@
 /obj/structure/extinguisher_cabinet/New(loc, ndir, building)
 	..()
 	if(building)
-		dir = ndir
+		setDir(ndir)
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -27 : 27)
 		pixel_y = (dir & 3)? (dir ==1 ? -30 : 30) : 0
 		opened = 1

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -180,7 +180,7 @@
 					WD = new/obj/structure/window/reinforced/fulltile(loc) //reinforced window
 				else
 					WD = new/obj/structure/window/fulltile(loc) //normal window
-				WD.dir = dir_to_set
+				WD.setDir(dir_to_set)
 				WD.ini_dir = dir_to_set
 				WD.anchored = 0
 				WD.state = 0

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -68,7 +68,7 @@
 			L.add_splatter_floor()
 			L.adjustBruteLoss(30)
 			L.buckled = src
-			L.dir = 2
+			L.setDir(2)
 			buckle_mob(L, force=1)
 			var/matrix/m180 = matrix(L.transform)
 			m180.Turn(180)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -118,7 +118,7 @@
 	if (src.anchored)
 		usr << "<span class='warning'>It is fastened to the floor!</span>"
 		return 0
-	src.dir = turn(src.dir, 270)
+	src.setDir(turn(src.dir, 270))
 	return 1
 
 

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -53,7 +53,7 @@
 	R.transfer_fingerprints_to(T)
 	T.add_fingerprint(user)
 	T.loc = src.loc
-	T.dir = turn(src.dir, -90)
+	T.setDir(turn(src.dir, -90))
 	user.visible_message("[user] inserts the [R].", "<span class='notice'>You insert the [R].</span>")
 	qdel(R)
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -114,14 +114,14 @@
 	icon_state = "closed"
 
 /obj/structure/c_transit_tube/station/tube_turn(var/angle)
-	src.dir = turn(src.dir, angle)
+	src.setDir(turn(src.dir, angle))
 
 /obj/structure/c_transit_tube/station/tube_flip()
 	src.tube_turn(180)
 
 /obj/structure/c_transit_tube/station/buildtube()
 	var/obj/structure/transit_tube/station/R = new/obj/structure/transit_tube/station(src.loc)
-	R.dir = src.dir
+	R.setDir(src.dir)
 	R.init_dirs()
 	return R
 
@@ -131,7 +131,7 @@
 
 /obj/structure/c_transit_tube/station/reverse/buildtube()
 	var/obj/structure/transit_tube/station/reverse/R = new/obj/structure/transit_tube/station/reverse(src.loc)
-	R.dir = src.dir
+	R.setDir(src.dir)
 	R.init_dirs()
 	return R
 
@@ -146,7 +146,7 @@
 /obj/structure/c_transit_tube/station/block/buildtube()
 	var/obj/structure/transit_tube/R = new/obj/structure/transit_tube(src.loc)
 	R.icon_state = src.icon_state
-	R.dir = src.dir
+	R.setDir(src.dir)
 	R.init_dirs()
 	return R
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -78,7 +78,7 @@
 	var/exit_delay
 
 	if(reverse_launch)
-		dir = turn(dir, 180) // Back it up
+		setDir(turn(dir, 180) )// Back it up
 
 	for(var/obj/structure/transit_tube/tube in loc)
 		if(tube.has_exit(dir))
@@ -105,13 +105,13 @@
 				break
 
 		if(current_tube == null)
-			dir = next_dir
+			setDir(next_dir)
 			Move(get_step(loc, dir), dir) // Allow collisions when leaving the tubes.
 			break
 
 		last_delay = current_tube.enter_delay(src, next_dir)
 		sleep(last_delay)
-		dir = next_dir
+		setDir(next_dir)
 		loc = next_loc // When moving from one tube to another, skip collision and such.
 		density = current_tube.density
 
@@ -200,12 +200,12 @@
 								station.open_animation()
 
 						else if(direction in station.directions())
-							dir = direction
+							setDir(direction)
 							station.launch_pod()
 					return
 
 			for(var/obj/structure/transit_tube/tube in loc)
 				if(dir in tube.directions())
 					if(tube.has_exit(direction))
-						dir = direction
+						setDir(direction)
 						return

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -16,7 +16,7 @@
 	icon_state = "l_windoor_assembly01"
 	anchored = 0
 	density = 0
-	dir = NORTH
+	setDir(NORTH)
 
 	var/ini_dir
 	var/obj/item/weapon/electronics/airlock/electronics = null
@@ -263,7 +263,7 @@
 							else
 								windoor.icon_state = "rightsecureopen"
 								windoor.base_state = "rightsecure"
-							windoor.dir = dir
+							windoor.setDir(dir)
 							windoor.density = 0
 
 							if(electronics.one_access)
@@ -286,7 +286,7 @@
 							else
 								windoor.icon_state = "rightopen"
 								windoor.base_state = "right"
-							windoor.dir = dir
+							windoor.setDir(dir)
 							windoor.density = 0
 
 							windoor.req_access = electronics.accesses
@@ -318,7 +318,7 @@
 	//if(state != "01")
 		//update_nearby_tiles(need_rebuild=1) //Compel updates before
 
-	dir = turn(dir, 270)
+	setDir(turn(dir, 270))
 
 	//if(state != "01")
 		//update_nearby_tiles(need_rebuild=1)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -312,7 +312,7 @@
 		usr << "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>"
 		return 0
 
-	dir = turn(dir, 90)
+	setDir(turn(dir, 90))
 //	updateSilicate()
 	air_update_turf(1)
 	ini_dir = dir
@@ -332,7 +332,7 @@
 		usr << "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>"
 		return 0
 
-	dir = turn(dir, 270)
+	setDir(turn(dir, 270))
 //	updateSilicate()
 	air_update_turf(1)
 	ini_dir = dir
@@ -374,7 +374,7 @@
 /obj/structure/window/Move()
 	var/turf/T = loc
 	..()
-	dir = ini_dir
+	setDir(ini_dir)
 	move_update_air(T)
 
 /obj/structure/window/CanAtmosPass(turf/T)
@@ -446,7 +446,7 @@
 /obj/structure/window/fulltile
 	icon = 'icons/obj/smooth_structures/window.dmi'
 	icon_state = "window"
-	dir = 5
+	setDir(5)
 	maxhealth = 50
 	fulltile = 1
 	smooth = SMOOTH_TRUE
@@ -455,7 +455,7 @@
 /obj/structure/window/reinforced/fulltile
 	icon = 'icons/obj/smooth_structures/reinforced_window.dmi'
 	icon_state = "r_window"
-	dir = 5
+	setDir(5)
 	maxhealth = 100
 	fulltile = 1
 	smooth = SMOOTH_TRUE
@@ -465,7 +465,7 @@
 /obj/structure/window/reinforced/tinted/fulltile
 	icon = 'icons/obj/smooth_structures/tinted_window.dmi'
 	icon_state = "tinted_window"
-	dir = 5
+	setDir(5)
 	fulltile = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile/)
@@ -483,7 +483,7 @@
 	desc = "A reinforced, air-locked pod window."
 	icon = 'icons/obj/smooth_structures/shuttle_window.dmi'
 	icon_state = "shuttle_window"
-	dir = 5
+	setDir(5)
 	maxhealth = 100
 	wtype = "shuttle"
 	fulltile = 1
@@ -512,8 +512,8 @@
 	if(!fulltile)
 		var/obj/effect/E = PoolOrNew(/obj/effect/overlay/temp/ratvar/window/single, get_turf(src))
 		if(direct)
-			dir = direct
-			E.dir = direct
+			setDir(direct)
+			E.setDir(direct)
 	else
 		PoolOrNew(/obj/effect/overlay/temp/ratvar/window, get_turf(src))
 	for(var/obj/item/I in debris)
@@ -538,5 +538,5 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	fulltile = 1
-	dir = 5
+	setDir(5)
 	maxhealth = 150

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -446,7 +446,7 @@
 /obj/structure/window/fulltile
 	icon = 'icons/obj/smooth_structures/window.dmi'
 	icon_state = "window"
-	setDir(5)
+	dir = NORTHEAST
 	maxhealth = 50
 	fulltile = 1
 	smooth = SMOOTH_TRUE
@@ -455,7 +455,7 @@
 /obj/structure/window/reinforced/fulltile
 	icon = 'icons/obj/smooth_structures/reinforced_window.dmi'
 	icon_state = "r_window"
-	setDir(5)
+	dir = NORTHEAST
 	maxhealth = 100
 	fulltile = 1
 	smooth = SMOOTH_TRUE
@@ -465,7 +465,7 @@
 /obj/structure/window/reinforced/tinted/fulltile
 	icon = 'icons/obj/smooth_structures/tinted_window.dmi'
 	icon_state = "tinted_window"
-	setDir(5)
+	dir = NORTHEAST
 	fulltile = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile/)
@@ -483,7 +483,7 @@
 	desc = "A reinforced, air-locked pod window."
 	icon = 'icons/obj/smooth_structures/shuttle_window.dmi'
 	icon_state = "shuttle_window"
-	setDir(5)
+	dir = NORTHEAST
 	maxhealth = 100
 	wtype = "shuttle"
 	fulltile = 1
@@ -538,5 +538,5 @@
 	smooth = SMOOTH_TRUE
 	canSmoothWith = null
 	fulltile = 1
-	setDir(5)
+	dir = NORTHEAST
 	maxhealth = 150

--- a/code/game/turfs/simulated/dirtystation.dm
+++ b/code/game/turfs/simulated/dirtystation.dm
@@ -21,7 +21,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old/New()
 	..()
 	icon_state += "-old"
-	dir = pick(1,2,4,8)
+	setDir(pick(1,2,4,8))
 	blood_DNA["Non-human DNA"] = "A+"
 
 /obj/effect/decal/cleanable/vomit/old

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -132,7 +132,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/old_dir = dir
 	var/turf/open/floor/W = ..()
 	W.icon_regular_floor = old_icon
-	W.dir = old_dir
+	W.setDir(old_dir)
 	W.update_icon()
 	return W
 

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -175,7 +175,7 @@
 	if(T.color != color)
 		T.color = color
 	if(T.dir != dir)
-		T.dir = dir
+		T.setDir(dir)
 	T.transform = transform
 	return T
 

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -1,10 +1,10 @@
 /turf/open/space/transit
 	icon_state = "black"
-	setDir(SOUTH)
+	dir = SOUTH
 	baseturf = /turf/open/space/transit
 
 /turf/open/space/transit/horizontal
-	setDir(WEST)
+	dir = WEST
 
 /turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
 	if(!AM)

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -1,10 +1,10 @@
 /turf/open/space/transit
 	icon_state = "black"
-	dir = SOUTH
+	setDir(SOUTH)
 	baseturf = /turf/open/space/transit
 
 /turf/open/space/transit/horizontal
-	dir = WEST
+	setDir(WEST)
 
 /turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
 	if(!AM)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -290,7 +290,7 @@
 	I.appearance = AM.appearance
 	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
 	I.loc = src
-	I.dir = AM.dir
+	I.setDir(AM.dir)
 	I.alpha = 128
 
 	if(!blueprint_data)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1943,7 +1943,7 @@
 					else
 						var/atom/O = new path(target)
 						if(O)
-							O.dir = obj_dir
+							O.setDir(obj_dir)
 							if(obj_name)
 								O.name = obj_name
 								if(istype(O,/mob))

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -52,7 +52,7 @@
 
 
 /obj/screen/buildmode/bdir/update_icon()
-	dir = bd.build_dir
+	setDir(bd.build_dir)
 	return
 
 /obj/screen/buildmode/quit
@@ -273,19 +273,19 @@
 				switch(build_dir)
 					if(NORTH)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = NORTH
+						WIN.setDir(NORTH)
 					if(SOUTH)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = SOUTH
+						WIN.setDir(SOUTH)
 					if(EAST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = EAST
+						WIN.setDir(EAST)
 					if(WEST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = WEST
+						WIN.setDir(WEST)
 					if(NORTHWEST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = NORTHWEST
+						WIN.setDir(NORTHWEST)
 				log_admin("Build Mode: [key_name(user)] built a window at ([object.x],[object.y],[object.z])")
 		if(ADV_BUILDMODE)
 			if(left_click)
@@ -295,7 +295,7 @@
 					T.ChangeTurf(objholder)
 				else
 					var/obj/A = new objholder (get_turf(object))
-					A.dir = build_dir
+					A.setDir(build_dir)
 					log_admin("Build Mode: [key_name(user)] modified [A]'s ([A.x],[A.y],[A.z]) dir to [build_dir]")
 			else if(right_click)
 				if(isobj(object))

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -68,7 +68,7 @@
 	else if(isnum(var_value))
 		usr << "Variable appears to be <b>NUM</b>."
 		default = "num"
-		dir = 1
+		setDir(1)
 
 	else if(istext(var_value))
 		usr << "Variable appears to be <b>TEXT</b>."
@@ -103,23 +103,23 @@
 	if(dir)
 		switch(var_value)
 			if(1)
-				dir = "NORTH"
+				setDir("NORTH")
 			if(2)
-				dir = "SOUTH"
+				setDir("SOUTH")
 			if(4)
-				dir = "EAST"
+				setDir("EAST")
 			if(8)
-				dir = "WEST"
+				setDir("WEST")
 			if(5)
-				dir = "NORTHEAST"
+				setDir("NORTHEAST")
 			if(6)
-				dir = "SOUTHEAST"
+				setDir("SOUTHEAST")
 			if(9)
-				dir = "NORTHWEST"
+				setDir("NORTHWEST")
 			if(10)
-				dir = "SOUTHWEST"
+				setDir("SOUTHWEST")
 			else
-				dir = null
+				setDir(null)
 		if(dir)
 			usr << "If a direction, direction is: [dir]"
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -224,7 +224,7 @@ var/list/VVckey_edit = list("key", "ckey")
 	else if(isnum(variable))
 		usr << "Variable appears to be <b>NUM</b>."
 		default = "num"
-		dir = 1
+		setDir(1)
 
 	else if(istext(variable))
 		usr << "Variable appears to be <b>TEXT</b>."
@@ -259,23 +259,23 @@ var/list/VVckey_edit = list("key", "ckey")
 	if(dir)
 		switch(variable)
 			if(1)
-				dir = "NORTH"
+				setDir("NORTH")
 			if(2)
-				dir = "SOUTH"
+				setDir("SOUTH")
 			if(4)
-				dir = "EAST"
+				setDir("EAST")
 			if(8)
-				dir = "WEST"
+				setDir("WEST")
 			if(5)
-				dir = "NORTHEAST"
+				setDir("NORTHEAST")
 			if(6)
-				dir = "SOUTHEAST"
+				setDir("SOUTHEAST")
 			if(9)
-				dir = "NORTHWEST"
+				setDir("NORTHWEST")
 			if(10)
-				dir = "SOUTHWEST"
+				setDir("SOUTHWEST")
 			else
-				dir = null
+				setDir(null)
 
 		if(dir)
 			usr << "If a direction, direction is: [dir]"
@@ -452,7 +452,7 @@ var/list/VVckey_edit = list("key", "ckey")
 			else if(isnum(var_value))
 				usr << "Variable appears to be <b>NUM</b>."
 				class = "num"
-				dir = 1
+				setDir(1)
 
 			else if(istext(var_value))
 				usr << "Variable appears to be <b>TEXT</b>."
@@ -516,7 +516,7 @@ var/list/VVckey_edit = list("key", "ckey")
 		else if(isnum(var_value))
 			usr << "Variable appears to be <b>NUM</b>."
 			default = "num"
-			dir = 1
+			setDir(1)
 
 		else if(istext(var_value))
 			usr << "Variable appears to be <b>TEXT</b>."
@@ -551,23 +551,23 @@ var/list/VVckey_edit = list("key", "ckey")
 		if(dir)
 			switch(var_value)
 				if(1)
-					dir = "NORTH"
+					setDir("NORTH")
 				if(2)
-					dir = "SOUTH"
+					setDir("SOUTH")
 				if(4)
-					dir = "EAST"
+					setDir("EAST")
 				if(8)
-					dir = "WEST"
+					setDir("WEST")
 				if(5)
-					dir = "NORTHEAST"
+					setDir("NORTHEAST")
 				if(6)
-					dir = "SOUTHEAST"
+					setDir("SOUTHEAST")
 				if(9)
-					dir = "NORTHWEST"
+					setDir("NORTHWEST")
 				if(10)
-					dir = "SOUTHWEST"
+					setDir("SOUTHWEST")
 				else
-					dir = null
+					setDir(null)
 			if(dir)
 				usr << "If a direction, direction is: [dir]"
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -68,7 +68,7 @@
 		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(T)
 		I.master = src
 		I.density = 1
-		I.dir = dir
+		I.setDir(dir)
 		first = I
 		step(I, I.dir)
 		if(first)
@@ -85,14 +85,14 @@
 /obj/item/device/assembly/infra/Move()
 	var/t = dir
 	..()
-	dir = t
+	setDir(t)
 	qdel(first)
 	return
 
 /obj/item/device/assembly/infra/holder_movement()
 	if(!holder)
 		return 0
-//	dir = holder.dir
+//	setDir(holder.dir)
 	qdel(first)
 	return 1
 
@@ -143,7 +143,7 @@
 	if(usr.incapacitated())
 		return
 
-	dir = turn(dir, 90)
+	setDir(turn(dir, 90))
 	return
 
 /obj/item/device/assembly/infra/AltClick(mob/user)
@@ -203,7 +203,7 @@
 		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(loc)
 		I.master = master
 		I.density = 1
-		I.dir = dir
+		I.setDir(dir)
 		I.previous = src
 		next = I
 		step(I, I.dir)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -61,7 +61,7 @@
 	..()
 	SSair.hotspots += src
 	perform_exposure()
-	dir = pick(cardinal)
+	setDir(pick(cardinal))
 	air_update_turf()
 
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -114,7 +114,7 @@
 	..()
 	wires = new /datum/wires/airalarm(src)
 	if(ndir)
-		dir = ndir
+		setDir(ndir)
 
 	if(nbuild)
 		buildstage = 0

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -212,7 +212,7 @@ Pipelines + Other Objects -> Pipe network
 	if(can_unwrench)
 		color = obj_color
 		pipe_color = obj_color
-		stored.dir = src.dir		  //need to define them here, because the obj directions...
+		stored.setDir(src.dir		  )//need to define them here, because the obj directions...
 		stored.pipe_type = pipe_type  //... were not set at the time the stored pipe was created
 		stored.color = obj_color
 	var/turf/T = loc

--- a/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/binary
 	icon = 'icons/obj/atmospherics/components/binary_devices.dmi'
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
 	use_power = 1
 	device_type = BINARY

--- a/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/binary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/binary
 	icon = 'icons/obj/atmospherics/components/binary_devices.dmi'
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = SOUTH|NORTH
 	use_power = 1
 	device_type = BINARY

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -39,9 +39,9 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 
 /obj/machinery/atmospherics/components/binary/valve/proc/normalize_dir()
 	if(dir==SOUTH)
-		dir = NORTH
+		setDir(NORTH)
 	else if(dir==WEST)
-		dir = EAST
+		setDir(EAST)
 
 /obj/machinery/atmospherics/components/binary/valve/attack_ai(mob/user)
 	return

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/trinary
 	icon = 'icons/obj/atmospherics/components/trinary_devices.dmi'
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = 1
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/trinary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/trinary
 	icon = 'icons/obj/atmospherics/components/trinary_devices.dmi'
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = SOUTH|NORTH|WEST
 	use_power = 1
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -5,7 +5,7 @@
 	name = "oxygen generator"
 	desc = "Generates oxygen"
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = SOUTH
 
 	var/on = 0

--- a/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/oxygen_generator.dm
@@ -5,7 +5,7 @@
 	name = "oxygen generator"
 	desc = "Generates oxygen"
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = SOUTH
 
 	var/on = 0

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/unary
 	icon = 'icons/obj/atmospherics/components/unary_devices.dmi'
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = SOUTH
 	device_type = UNARY
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/components/unary
 	icon = 'icons/obj/atmospherics/components/unary_devices.dmi'
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = SOUTH
 	device_type = UNARY
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -8,7 +8,7 @@
 	minimum_temperature_difference = 300
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = NORTH
 	initialize_directions_he = SOUTH
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -8,7 +8,7 @@
 	minimum_temperature_difference = 300
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = NORTH
 	initialize_directions_he = SOUTH
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -5,7 +5,7 @@
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes"
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions_he = EAST|NORTH|WEST
 
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -5,7 +5,7 @@
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes"
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions_he = EAST|NORTH|WEST
 
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -4,7 +4,7 @@
 	name = "pipe"
 	desc = "A one meter section of heat-exchanging pipe"
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions_he = SOUTH|NORTH
 
 	device_type = BINARY
@@ -20,9 +20,9 @@
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/proc/normalize_dir()
 	if(dir==SOUTH)
-		dir = NORTH
+		setDir(NORTH)
 	else if(dir==WEST)
-		dir = EAST
+		setDir(EAST)
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/atmosinit()
 	normalize_dir()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -4,7 +4,7 @@
 	name = "pipe"
 	desc = "A one meter section of heat-exchanging pipe"
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions_he = SOUTH|NORTH
 
 	device_type = BINARY

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -8,7 +8,7 @@
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes"
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = EAST|NORTH|WEST
 
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/pipes/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/manifold.dm
@@ -8,7 +8,7 @@
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes"
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = EAST|NORTH|WEST
 
 	device_type = TRINARY

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -10,7 +10,7 @@ The regular pipe you see everywhere, including bent ones.
 	name = "pipe"
 	desc = "A one meter section of regular pipe"
 
-	setDir(SOUTH)
+	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
 
 	device_type = BINARY

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -10,7 +10,7 @@ The regular pipe you see everywhere, including bent ones.
 	name = "pipe"
 	desc = "A one meter section of regular pipe"
 
-	dir = SOUTH
+	setDir(SOUTH)
 	initialize_directions = SOUTH|NORTH
 
 	device_type = BINARY
@@ -30,9 +30,9 @@ The regular pipe you see everywhere, including bent ones.
 
 /obj/machinery/atmospherics/pipe/simple/proc/normalize_dir()
 	if(dir==SOUTH)
-		dir = NORTH
+		setDir(NORTH)
 	else if(dir==WEST)
-		dir = EAST
+		setDir(EAST)
 
 /obj/machinery/atmospherics/pipe/simple/update_icon()
 	normalize_dir()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -145,7 +145,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 	if(awaygate.calibrated)
 		AM.forceMove(get_step(awaygate.loc, SOUTH))
-		AM.dir = SOUTH
+		AM.setDir(SOUTH)
 		if (ismob(AM))
 			var/mob/M = AM
 			if (M.client)
@@ -155,7 +155,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		var/obj/effect/landmark/dest = pick(awaydestinations)
 		if(dest)
 			AM.forceMove(get_turf(dest))
-			AM.dir = SOUTH
+			AM.setDir(SOUTH)
 			use_power(5000)
 		return
 
@@ -258,7 +258,7 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 				AM << "\black The station gate has detected your exile implant and is blocking your entry."
 				return
 	AM.forceMove(get_step(stationgate.loc, SOUTH))
-	AM.dir = SOUTH
+	AM.setDir(SOUTH)
 	if (ismob(AM))
 		var/mob/M = AM
 		if (M.client)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -368,4 +368,4 @@ var/next_external_rsc = 0
 //Hook, override it to run code when dir changes
 //Like for /atoms, but clients are their own snowflake FUCK
 /client/proc/setDir(newdir)
-	setDir(newdir)
+	dir = newdir

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -363,3 +363,9 @@ var/next_external_rsc = 0
 	spawn (10) //removing this spawn causes all clients to not get verbs.
 		//Precache the client with all other assets slowly, so as to not block other browse() calls
 		getFilesSlow(src, SSasset.cache, register_asset = FALSE)
+
+
+//Hook, override it to run code when dir changes
+//Like for /atoms, but clients are their own snowflake FUCK
+/client/proc/setDir(newdir)
+	dir = newdir

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -368,4 +368,4 @@ var/next_external_rsc = 0
 //Hook, override it to run code when dir changes
 //Like for /atoms, but clients are their own snowflake FUCK
 /client/proc/setDir(newdir)
-	dir = newdir
+	setDir(newdir)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -422,7 +422,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 			collapse()
 			continue
 		if(get_dist(src,my_target) > 1)
-			src.dir = get_dir(src,my_target)
+			src.setDir(get_dir(src,my_target))
 			step_towards(src,my_target)
 			updateimage()
 		else

--- a/code/modules/holiday/halloween.dm
+++ b/code/modules/holiday/halloween.dm
@@ -191,7 +191,7 @@
 
 /mob/living/simple_animal/shade/howling_ghost/proc/EtherealMove(direction)
 	loc = get_step(src, direction)
-	dir = direction
+	setDir(direction)
 
 /mob/living/simple_animal/shade/howling_ghost/proc/roam()
 	if(prob(80))

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -84,7 +84,7 @@
 		var/old_icon1 = T.icon
 
 		var/turf/X = new T.type(B)
-		X.dir = old_dir1
+		X.setDir(old_dir1)
 		X.icon = old_icon1
 		X.icon_state = old_icon_state1
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -228,7 +228,7 @@
 		var/obj/effect/immortality_talisman/Z = new(get_turf(src.loc))
 		Z.name = "hole in reality"
 		Z.desc = "It's shaped an awful lot like [user.name]."
-		Z.dir = user.dir
+		Z.setDir(user.dir)
 		user.forceMove(Z)
 		user.notransform = 1
 		user.status_flags |= GODMODE

--- a/code/modules/mining/lavaland/ruins/gym.dm
+++ b/code/modules/mining/lavaland/ruins/gym.dm
@@ -27,7 +27,7 @@
 	else
 		in_use = 1
 		icon_state = "fitnesslifter2"
-		user.dir = SOUTH
+		user.setDir(SOUTH)
 		user.Stun(4)
 		user.loc = src.loc
 		var/bragmessage = pick("pushing it to the limit","going into overdrive","burning with determination","rising up to the challenge", "getting strong now","getting ripped")
@@ -65,7 +65,7 @@
 	else
 		in_use = 1
 		icon_state = "fitnessweight-c"
-		user.dir = SOUTH
+		user.setDir(SOUTH)
 		user.Stun(4)
 		user.loc = src.loc
 		var/image/W = image('goon/icons/obj/fitness.dmi',"fitnessweight-w")

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -323,7 +323,7 @@
 		if(i > 2 && prob(33))
 			// We can't go a full loop though
 			next_angle = -next_angle
-			dir = angle2dir(dir2angle(dir) + next_angle)
+			setDir(angle2dir(dir2angle(dir) )+ next_angle)
 
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnFloor(turf/T)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -173,7 +173,7 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 		updatedir = 1
 	else
 		updatedir = 0	//stop updating the dir in case we want to show accessories with dirs on a ghost sprite without dirs
-		dir = 2 		//reset the dir to its default so the sprites all properly align up
+		setDir(2 		)//reset the dir to its default so the sprites all properly align up
 
 	if(ghost_accs == GHOST_ACCS_FULL && icon_state in ghost_forms_with_accessories_list) //check if this form supports accessories and if the client wants to show them
 		var/datum/sprite_accessory/S
@@ -271,7 +271,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/Move(NewLoc, direct)
 	if(updatedir)
-		dir = direct //only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
+		setDir(direct )//only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
 	if(NewLoc)
 		loc = NewLoc
 		for(var/obj/effect/step_trigger/S in NewLoc)
@@ -401,7 +401,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	orbit(target,orbitsize, FALSE, 20, rot_seg)
 
 /mob/dead/observer/orbit()
-	dir = 2 //reset dir so the right directional sprites show up
+	setDir(2 )//reset dir so the right directional sprites show up
 	..()
 	//restart our floating animation after orbit is done.
 	sleep 2  //orbit sets up a 2ds animation when it finishes, so we wait for that to end

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -180,7 +180,7 @@ Des: Removes all infected images from the alien.
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	src << "<span class='noticealien'>You begin to evolve!</span>"
 	visible_message("<span class='alertalien'>[src] begins to twist and contort!</span>")
-	new_xeno.dir = dir
+	new_xeno.setDir(dir)
 	if(!alien_name_regex.Find(name))
 		new_xeno.name = name
 		new_xeno.real_name = real_name

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -96,9 +96,9 @@
 		H = hud_used.inv_slots[slot_r_hand]
 		H.update_icon()
 	/*if (!( src.hand ))
-		src.hands.dir = NORTH
+		src.hands.setDir(NORTH)
 	else
-		src.hands.dir = SOUTH*/
+		src.hands.setDir(SOUTH)*/
 	return
 
 /mob/living/carbon/activate_hand(selhand) //0 or "r" or "right" for right hand; 1 or "l" or "left" for left hand.
@@ -326,7 +326,7 @@
 				D = SOUTH
 			if(WEST)
 				D = NORTH
-		dir = D
+		setDir(D)
 		spintime -= speed
 
 /mob/living/carbon/resist_buckle()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -276,7 +276,7 @@
 	if(!animation_length)
 		return
 	icon = 'icons/mob/robot_transformations.dmi'
-	src.dir = SOUTH
+	src.setDir(SOUTH)
 	notransform = 1
 	flick(icon_state, src)
 	sleep(animation_length+1)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -482,14 +482,14 @@ var/global/mulebot_count = 0
 						B.blood_DNA |= blood_DNA.Copy()
 						var/newdir = get_dir(next, loc)
 						if(newdir == dir)
-							B.dir = newdir
+							B.setDir(newdir)
 						else
 							newdir = newdir | dir
 							if(newdir == 3)
 								newdir = 1
 							else if(newdir == 12)
 								newdir = 4
-							B.dir = newdir
+							B.setDir(newdir)
 						bloodiness--
 
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -180,7 +180,7 @@
 						if(prob(25))
 							step_rand(item_to_add)
 						for(var/i in list(1,2,4,8,4,8,4,dir))
-							dir = i
+							setDir(i)
 							sleep(1)
 						return
 
@@ -240,7 +240,7 @@
 		if(prob(25))
 			step_rand(item_to_add)
 		for(var/i in list(1,2,4,8,4,8,4,dir))
-			dir = i
+			setDir(i)
 			sleep(1)
 
 	return valid
@@ -366,15 +366,15 @@
 
 				if(movement_target)		//Not redundant due to sleeps, Item can be gone in 6 decisecomds
 					if (movement_target.loc.x < src.x)
-						dir = WEST
+						setDir(WEST)
 					else if (movement_target.loc.x > src.x)
-						dir = EAST
+						setDir(EAST)
 					else if (movement_target.loc.y < src.y)
-						dir = SOUTH
+						setDir(SOUTH)
 					else if (movement_target.loc.y > src.y)
-						dir = NORTH
+						setDir(NORTH)
 					else
-						dir = SOUTH
+						setDir(SOUTH)
 
 					if(!Adjacent(movement_target)) //can't reach food through windows.
 						return
@@ -389,7 +389,7 @@
 			emote("me", 1, pick("dances around.","chases its tail!"))
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					dir = i
+					setDir(i)
 					sleep(1)
 
 
@@ -508,7 +508,7 @@
 			emote("me", 1, pick("dances around.","chases her tail."))
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					dir = i
+					setDir(i)
 					sleep(1)
 
 /mob/living/simple_animal/pet/dog/pug/Life()
@@ -519,7 +519,7 @@
 			emote("me", 1, pick("chases its tail."))
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2,4,8,4,2,1,2,4,8,4,2))
-					dir = i
+					setDir(i)
 					sleep(1)
 
 /mob/living/simple_animal/pet/dog/attack_hand(mob/living/carbon/human/M)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -64,7 +64,7 @@
 	contents -= drone
 	drone.loc = get_turf(src)
 	drone.reset_perspective()
-	drone.dir = SOUTH //Looks better
+	drone.setDir(SOUTH )//Looks better
 	drone.visible_message("<span class='warning'>[drone] uncurls!</span>")
 	drone = null
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -24,7 +24,7 @@
 			user.visible_message("[user] baps [name] on the nose with the rolled up [O].")
 			spawn(0)
 				for(var/i in list(1,2,4,8,4,2,1,2))
-					dir = i
+					setDir(i)
 					sleep(1)
 	else
 		..()

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -29,7 +29,7 @@
 /mob/living/simple_animal/hostile/illusion/proc/Copy_Parent(mob/living/original, life = 50, health = 100, damage = 0, replicate = 0 )
 	appearance = original.appearance
 	parent_mob = original
-	dir = original.dir
+	setDir(original.dir)
 	life_span = world.time+life
 	melee_damage_lower = damage
 	melee_damage_upper = damage

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -187,7 +187,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 
 /mob/living/simple_animal/hostile/mimic/copy/Aggro()
 	..()
-	googly_eyes.dir = get_dir(src,target)
+	googly_eyes.setDir(get_dir(src,target))
 
 
 /mob/living/simple_animal/hostile/mimic/copy/machine

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -82,7 +82,7 @@
 				L.attack_animal(src)
 			else
 				if(prob(grasp_pull_chance))
-					dir = get_dir(src,L) //staaaare
+					setDir(get_dir(src,L) )//staaaare
 					step(L,get_dir(L,src)) //reel them in
 					L.Weaken(3) //you can't get away now~
 

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -61,7 +61,7 @@
 	. = ..()
 	if(target && next_cast < world.time)
 		if((get_dir(src,target) in list(SOUTH,EAST,WEST,NORTH)) && fireball.cast_check(0,src)) //Lined up for fireball
-			src.dir = get_dir(src,target)
+			src.setDir(get_dir(src,target))
 			fireball.choose_targets(src)
 			next_cast = world.time + 10 //One spell per second
 			return .

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -701,7 +701,7 @@ var/next_mob_id = 0
 	set hidden = 1
 	if(!canface())
 		return 0
-	dir = EAST
+	setDir(EAST)
 	client.move_delay += movement_delay()
 	return 1
 
@@ -710,7 +710,7 @@ var/next_mob_id = 0
 	set hidden = 1
 	if(!canface())
 		return 0
-	dir = WEST
+	setDir(WEST)
 	client.move_delay += movement_delay()
 	return 1
 
@@ -719,7 +719,7 @@ var/next_mob_id = 0
 	set hidden = 1
 	if(!canface())
 		return 0
-	dir = NORTH
+	setDir(NORTH)
 	client.move_delay += movement_delay()
 	return 1
 
@@ -728,7 +728,7 @@ var/next_mob_id = 0
 	set hidden = 1
 	if(!canface())
 		return 0
-	dir = SOUTH
+	setDir(SOUTH)
 	client.move_delay += movement_delay()
 	return 1
 
@@ -765,7 +765,7 @@ var/next_mob_id = 0
 
 //override to avoid rotating pixel_xy on mobs
 /mob/shuttleRotate(rotation)
-	dir = angle2dir(rotation+dir2angle(dir))
+	setDir(angle2dir(rotation)+dir2angle(dir))
 
 //You can buckle on mobs if you're next to them since most are dense
 /mob/buckle_mob(mob/living/M, force = 0)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -765,7 +765,7 @@ var/next_mob_id = 0
 
 //override to avoid rotating pixel_xy on mobs
 /mob/shuttleRotate(rotation)
-	setDir(angle2dir(rotation)+dir2angle(dir))
+	setDir(angle2dir(rotation+dir2angle(dir)))
 
 //You can buckle on mobs if you're next to them since most are dense
 /mob/buckle_mob(mob/living/M, force = 0)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -83,7 +83,7 @@
 			step(mob.control_object,direct)
 			if(!mob.control_object)
 				return
-			mob.control_object.dir = direct
+			mob.control_object.setDir(direct)
 		else
 			mob.control_object.loc = get_step(mob.control_object,direct)
 	return
@@ -183,7 +183,7 @@
 	switch(L.incorporeal_move)
 		if(1)
 			L.loc = get_step(L, direct)
-			L.dir = direct
+			L.setDir(direct)
 		if(2)
 			if(prob(50))
 				var/locx
@@ -223,7 +223,7 @@
 				spawn(0)
 					anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,L.dir)
 				L.loc = get_step(L, direct)
-			L.dir = direct
+			L.setDir(direct)
 		if(3) //Incorporeal move, but blocked by holy-watered tiles
 			var/turf/open/floor/stepTurf = get_step(L, direct)
 			if(stepTurf.flags & NOJAUNT)
@@ -233,7 +233,7 @@
 					L.notransform = 0
 			else
 				L.loc = get_step(L, direct)
-				L.dir = direct
+				L.setDir(direct)
 	return 1
 
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -65,15 +65,15 @@
 	preview_icon = icon('icons/effects/effects.dmi', "nothing")
 	preview_icon.Scale(48+32, 16+32)
 
-	mannequin.dir = NORTH
+	mannequin.setDir(NORTH)
 	var/icon/stamp = getFlatIcon(mannequin)
 	preview_icon.Blend(stamp, ICON_OVERLAY, 25, 17)
 
-	mannequin.dir = WEST
+	mannequin.setDir(WEST)
 	stamp = getFlatIcon(mannequin)
 	preview_icon.Blend(stamp, ICON_OVERLAY, 1, 9)
 
-	mannequin.dir = SOUTH
+	mannequin.setDir(SOUTH)
 	stamp = getFlatIcon(mannequin)
 	preview_icon.Blend(stamp, ICON_OVERLAY, 49, 1)
 

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -15,7 +15,7 @@
 	icon_state = "shield"
 	anchored = 1
 	density = 1
-	setDir(1)
+	dir = NORTH
 	use_power = 0//Living things generally dont use power
 	idle_power_usage = 0
 	active_power_usage = 0

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -15,7 +15,7 @@
 	icon_state = "shield"
 	anchored = 1
 	density = 1
-	dir = 1
+	setDir(1)
 	use_power = 0//Living things generally dont use power
 	idle_power_usage = 0
 	active_power_usage = 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -109,9 +109,9 @@
 	// offset 24 pixels in direction of dir
 	// this allows the APC to be embedded in a wall, yet still inside an area
 	if (building)
-		dir = ndir
+		setDir(ndir)
 	src.tdir = dir		// to fix Vars bug
-	dir = SOUTH
+	setDir(SOUTH)
 
 	if(auto_name)
 		name = "[get_area(src)] APC"
@@ -153,7 +153,7 @@
 	// create a terminal object at the same position as original turf loc
 	// wires will attach to this
 	terminal = new/obj/machinery/power/terminal(src.loc)
-	terminal.dir = tdir
+	terminal.setDir(tdir)
 	terminal.master = src
 
 /obj/machinery/power/apc/proc/init()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -41,7 +41,7 @@
 /obj/machinery/light_construct/New(loc, ndir, building)
 	..()
 	if(building)
-		dir = ndir
+		setDir(ndir)
 
 /obj/machinery/light_construct/examine(mob/user)
 	..()
@@ -110,7 +110,7 @@
 						newlight = new /obj/machinery/light/built(loc)
 					if ("bulb")
 						newlight = new /obj/machinery/light/small/built(loc)
-				newlight.dir = dir
+				newlight.setDir(dir)
 				transfer_fingerprints_to(newlight)
 				qdel(src)
 				return
@@ -320,7 +320,7 @@
 				if("bulb")
 					newlight = new /obj/machinery/light_construct/small(src.loc)
 					newlight.icon_state = "bulb-construct-stage2"
-			newlight.dir = src.dir
+			newlight.setDir(src.dir)
 			newlight.stage = 2
 			transfer_fingerprints_to(newlight)
 			qdel(src)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -68,7 +68,7 @@
 	if (src.anchored)
 		usr << "<span class='warning'>It is fastened to the floor!</span>"
 		return 0
-	src.dir = turn(src.dir, 270)
+	src.setDir(turn(src.dir, 270))
 	return 1
 
 /obj/machinery/power/emitter/AltClick(mob/user)
@@ -170,7 +170,7 @@
 
 		var/obj/item/projectile/A = PoolOrNew(projectile_type,src.loc)
 
-		A.dir = src.dir
+		A.setDir(src.dir)
 		playsound(src.loc, projectile_sound, 25, 1)
 
 		if(prob(35))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -283,7 +283,7 @@ field_generator power level display
 			var/obj/machinery/field/containment/CF = new/obj/machinery/field/containment()
 			CF.set_master(src,G)
 			CF.loc = T
-			CF.dir = field_dir
+			CF.setDir(field_dir)
 			fields += CF
 			G.fields += CF
 			for(var/mob/living/L in T)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -151,7 +151,7 @@
 
 /obj/singularity/narsie/proc/narsie_spawn_animation()
 	icon = 'icons/obj/narsie_spawn_anim.dmi'
-	dir = SOUTH
+	setDir(SOUTH)
 	move_self = 0
 	flick("narsie_spawn_anim",src)
 	sleep(11)

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -22,7 +22,7 @@
 
 
 /obj/effect/accelerated_particle/New(loc, dir = 2)
-	src.dir = dir
+	src.setDir(dir)
 
 	spawn(0)
 		move(1)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -63,7 +63,7 @@
 	if (anchored)
 		usr << "It is fastened to the floor!"
 		return 0
-	dir = turn(dir, -90)
+	setDir(turn(dir, -90))
 	return 1
 
 /obj/structure/particle_accelerator/AltClick(mob/user)
@@ -86,7 +86,7 @@
 	if (anchored)
 		usr << "It is fastened to the floor!"
 		return 0
-	dir = turn(dir, 90)
+	setDir(turn(dir, 90))
 	return 1
 
 /obj/structure/particle_accelerator/attackby(obj/item/W, mob/user, params)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -10,7 +10,7 @@
 	use_power = 0
 	idle_power_usage = 500
 	active_power_usage = 10000
-	setDir(1)
+	dir = NORTH
 	var/strength_upper_limit = 2
 	var/interface_control = 1
 	var/list/obj/structure/particle_accelerator/connected_parts

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -10,7 +10,7 @@
 	use_power = 0
 	idle_power_usage = 500
 	active_power_usage = 10000
-	dir = 1
+	setDir(1)
 	var/strength_upper_limit = 2
 	var/interface_control = 1
 	var/list/obj/structure/particle_accelerator/connected_parts
@@ -166,7 +166,7 @@
 	if(!F)
 		return 0
 
-	dir = F.dir
+	setDir(F.dir)
 	connected_parts.Cut()
 
 	T = get_step(T,rdir)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -193,7 +193,7 @@
 // wires will attach to this
 /obj/machinery/power/smes/proc/make_terminal(turf/T)
 	terminal = new/obj/machinery/power/terminal(T)
-	terminal.dir = get_dir(T,src)
+	terminal.setDir(get_dir(T,src))
 	terminal.master = src
 
 /obj/machinery/power/smes/disconnect_terminal()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -114,7 +114,7 @@
 		overlays += image('icons/obj/power.dmi', icon_state = "solar_panel-b", layer = FLY_LAYER)
 	else
 		overlays += image('icons/obj/power.dmi', icon_state = "solar_panel", layer = FLY_LAYER)
-		src.dir = angle2dir(adir)
+		src.setDir(angle2dir(adir))
 	return
 
 //calculates the fraction of the sunlight that the panel recieves

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -61,7 +61,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 		pixel_x = 0
 		pixel_y = 0
 
-		dir = tesla_zap(src, 7, TESLA_DEFAULT_POWER)
+		setDir(tesla_zap(src, 7, TESLA_DEFAULT_POWER))
 
 		pixel_x = -32
 		pixel_y = -32

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -53,7 +53,7 @@
 	sun_angle = angle
 
 	//set icon dir to show sun illumination
-	dir = turn(NORTH, -angle - 22.5)	// 22.5 deg bias ensures, e.g. 67.5-112.5 is EAST
+	setDir(turn(NORTH, -angle - 22.5)	)// 22.5 deg bias ensures, e.g. 67.5-112.5 is EAST
 
 	if(powernet && (powernet == control.powernet)) //update if we're still in the same powernet
 		control.currentdir = angle

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -23,7 +23,7 @@
 		BB = new projectile_type(src)
 	pixel_x = rand(-10, 10)
 	pixel_y = rand(-10, 10)
-	dir = pick(alldirs)
+	setDir(pick(alldirs))
 	update_icon()
 
 /obj/item/ammo_casing/update_icon()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -46,7 +46,7 @@
 /obj/machinery/conveyor/New(loc, newdir)
 	..(loc)
 	if(newdir)
-		dir = newdir
+		setDir(newdir)
 	update_move_direction()
 
 /obj/machinery/conveyor/proc/update_move_direction()
@@ -126,7 +126,7 @@
 	else if(istype(I, /obj/item/weapon/wrench))
 		if(!(stat & BROKEN))
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			dir = turn(dir,-45)
+			setDir(turn(dir,-45))
 			update_move_direction()
 			user << "<span class='notice'>You rotate [src].</span>"
 

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -24,7 +24,7 @@
 	..(loc)
 	if(pipe_type)
 		ptype = pipe_type
-	dir = direction
+	setDir(direction)
 
 // update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/update_icon()
@@ -103,7 +103,7 @@
 		usr << "<span class='warning'>You must unfasten the pipe before rotating it!</span>"
 		return
 
-	dir = turn(dir, -90)
+	setDir(turn(dir, -90))
 	update_icon()
 
 /obj/structure/disposalconstruct/AltClick(mob/user)
@@ -127,7 +127,7 @@
 		usr << "<span class='warning'>You must unfasten the pipe before flipping it!</span>"
 		return
 
-	dir = turn(dir, 180)
+	setDir(turn(dir, 180))
 	switch(ptype)
 		if(DISP_JUNCTION)
 			ptype = DISP_JUNCTION_FLIP

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -8,7 +8,7 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	var/datum/gas_mixture/gas = null	// gas used to flush, will appear at exit point
 	var/active = 0	// true if the holder is moving, otherwise inactive
-	setDir(0)
+	dir = 0
 	var/count = 1000	//*** can travel 1000 steps before going inactive (in case of loops)
 	var/destinationTag = 0 // changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
@@ -134,7 +134,7 @@
 	on_blueprints = TRUE
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
-	setDir(0				)// dir will contain dominant direction for junction pipes
+	dir = 0// dir will contain dominant direction for junction pipes
 	var/health = 10 	// health points 0-10
 	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes
 	var/base_icon_state	// initial icon state on map

--- a/code/modules/recycling/disposal-structures.dm
+++ b/code/modules/recycling/disposal-structures.dm
@@ -8,7 +8,7 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	var/datum/gas_mixture/gas = null	// gas used to flush, will appear at exit point
 	var/active = 0	// true if the holder is moving, otherwise inactive
-	dir = 0
+	setDir(0)
 	var/count = 1000	//*** can travel 1000 steps before going inactive (in case of loops)
 	var/destinationTag = 0 // changes if contains a delivery container
 	var/tomail = 0 //changes if contains wrapped package
@@ -57,7 +57,7 @@
 		return
 	loc = D.trunk
 	active = 1
-	dir = DOWN
+	setDir(DOWN)
 	move()
 
 	return
@@ -134,7 +134,7 @@
 	on_blueprints = TRUE
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
-	dir = 0				// dir will contain dominant direction for junction pipes
+	setDir(0				)// dir will contain dominant direction for junction pipes
 	var/health = 10 	// health points 0-10
 	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes
 	var/base_icon_state	// initial icon state on map
@@ -146,7 +146,7 @@
 
 	if(make_from && !qdeleted(make_from))
 		base_icon_state = make_from.base_state
-		dir = make_from.dir
+		setDir(make_from.dir)
 		dpdir = make_from.dpdir
 		make_from.loc = src
 		stored = make_from
@@ -209,7 +209,7 @@
 	return transfer_to_dir(H, nextdir)
 
 /obj/structure/disposalpipe/proc/transfer_to_dir(obj/structure/disposalholder/H, nextdir)
-	H.dir = nextdir
+	H.setDir(nextdir)
 	var/turf/T = H.nextloc()
 	var/obj/structure/disposalpipe/P = H.findpipe(T)
 
@@ -298,7 +298,7 @@
 		for(var/D in cardinal)
 			if(D & dpdir)
 				var/obj/structure/disposalpipe/broken/P = new(src.loc)
-				P.dir = D
+				P.setDir(D)
 
 	src.invisibility = INVISIBILITY_MAXIMUM	// make invisible (since we won't delete the pipe immediately)
 	var/obj/structure/disposalholder/H = locate() in src
@@ -386,7 +386,7 @@
 		var/turf/T = loc
 		stored.loc = T
 		transfer_fingerprints_to(stored)
-		stored.dir = dir
+		stored.setDir(dir)
 		stored.density = 0
 		stored.anchored = 1
 		stored.update_icon()
@@ -706,7 +706,7 @@
 	..()
 
 	if(make_from)
-		dir = make_from.dir
+		setDir(make_from.dir)
 		make_from.loc = src
 		stored = make_from
 	else

--- a/code/modules/recycling/disposal-unit.dm
+++ b/code/modules/recycling/disposal-unit.dm
@@ -24,7 +24,7 @@
 	..()
 
 	if(make_from)
-		dir = make_from.dir
+		setDir(make_from.dir)
 		make_from.loc = 0
 		stored = make_from
 	else

--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -47,7 +47,7 @@
 	landing_zone.dheight = dheight
 	landing_zone.width = width
 	landing_zone.height = height
-	landing_zone.dir = lz_dir
+	landing_zone.setDir(lz_dir)
 
 	for(var/obj/machinery/computer/shuttle/S in machines)
 		if(S.shuttleId == shuttle_id)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -178,7 +178,7 @@
 	dwidth = 9
 	width = 22
 	height = 11
-	dir = 4
+	setDir(4)
 	travelDir = -90
 	roundstart_move = "emergency_away"
 	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
@@ -446,7 +446,7 @@
 	dwidth = 2
 	width = 8
 	height = 8
-	dir = 4
+	setDir(4)
 
 	roundstart_move = "backup_away"
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -178,7 +178,7 @@
 	dwidth = 9
 	width = 22
 	height = 11
-	setDir(4)
+	dir = EAST
 	travelDir = -90
 	roundstart_move = "emergency_away"
 	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
@@ -446,8 +446,7 @@
 	dwidth = 2
 	width = 8
 	height = 8
-	setDir(4)
-
+	dir = EAST
 	roundstart_move = "backup_away"
 
 /obj/docking_port/mobile/emergency/backup/New()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -12,7 +12,7 @@
 	anchored = 1
 
 	var/id
-	setDir(NORTH		)//this should point -away- from the dockingport door, ie towards the ship
+	dir = NORTH//this should point -away- from the dockingport door, ie towards the ship
 	var/width = 0	//size of covered area, perpendicular to dir
 	var/height = 0	//size of covered area, paralell to dir
 	var/dwidth = 0	//position relative to covered area, perpendicular to dir

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -12,7 +12,7 @@
 	anchored = 1
 
 	var/id
-	dir = NORTH		//this should point -away- from the dockingport door, ie towards the ship
+	setDir(NORTH		)//this should point -away- from the dockingport door, ie towards the ship
 	var/width = 0	//size of covered area, perpendicular to dir
 	var/height = 0	//size of covered area, paralell to dir
 	var/dwidth = 0	//position relative to covered area, perpendicular to dir
@@ -317,7 +317,7 @@
 //default shuttleRotate
 /atom/proc/shuttleRotate(rotation)
 	//rotate our direction
-	dir = angle2dir(rotation+dir2angle(dir))
+	setDir(angle2dir(rotation)+dir2angle(dir))
 
 	//resmooth if need be.
 	if(smooth)
@@ -388,7 +388,7 @@
 
 //		//rotate transit docking ports, so we don't need zillions of variants
 //		if(istype(S1, /obj/docking_port/stationary/transit))
-//			S1.dir = turn(NORTH, -travelDir)
+//			S1.setDir(turn(NORTH, -travelDir))
 
 	var/obj/docking_port/stationary/S0 = get_docked()
 	var/turf_type = /turf/open/space
@@ -455,7 +455,7 @@
 		SSair.add_to_active(T0,1)
 
 	loc = S1.loc
-	dir = S1.dir
+	setDir(S1.dir)
 
 /atom/movable/proc/onShuttleMove(turf/T1, rotation)
 	if(rotation)
@@ -681,5 +681,5 @@
 	if(T.color != color)
 		T.color = color
 	if(T.dir != dir)
-		T.dir = dir
+		T.setDir(dir)
 	return T

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -3,7 +3,7 @@
 	id = "supply"
 	callTime = 600
 
-	setDir(8)
+	dir = WEST
 	travelDir = 90
 	width = 12
 	dwidth = 5

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -3,7 +3,7 @@
 	id = "supply"
 	callTime = 600
 
-	dir = 8
+	setDir(8)
 	travelDir = 90
 	width = 12
 	dwidth = 5

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -111,12 +111,12 @@
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/jaunt_disappear(atom/movable/overlay/animation, mob/living/target)
 	animation.icon_state = "phase_shift"
-	animation.dir = target.dir
+	animation.setDir(target.dir)
 	flick("phase_shift",animation)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/jaunt_reappear(atom/movable/overlay/animation, mob/living/target)
 	animation.icon_state = "phase_shift2"
-	animation.dir = target.dir
+	animation.setDir(target.dir)
 	flick("phase_shift2",animation)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/jaunt_steam(mobloc)

--- a/code/modules/spells/spell_types/dumbfire.dm
+++ b/code/modules/spells/spell_types/dumbfire.dm
@@ -45,7 +45,7 @@
 				projectile = new proj_type(user)
 			projectile.icon = proj_icon
 			projectile.icon_state = proj_icon_state
-			projectile.dir = get_dir(projectile, target)
+			projectile.setDir(get_dir(projectile, target))
 			projectile.name = proj_name
 
 			var/current_loc = user.loc

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -35,7 +35,7 @@
 				projectile:linked_spells += proj_type
 			projectile.icon = proj_icon
 			projectile.icon_state = proj_icon_state
-			projectile.dir = get_dir(target,projectile)
+			projectile.setDir(get_dir(target,projectile))
 			projectile.name = proj_name
 
 			var/current_loc = user.loc
@@ -48,7 +48,7 @@
 
 				if(proj_homing)
 					if(proj_insubstantial)
-						projectile.dir = get_dir(projectile,target)
+						projectile.setDir(get_dir(projectile,target))
 						projectile.loc = get_step_to(projectile,target)
 					else
 						step_to(projectile,target)

--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -23,7 +23,7 @@
 
 /obj/effect/overlay/temp/speedbike_trail/New(loc,move_dir)
 	..()
-	dir = move_dir
+	setDir(move_dir)
 
 /obj/vehicle/space/speedbike/Move(newloc,move_dir)
 	if(has_buckled_mobs())
@@ -43,7 +43,7 @@
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			buckled_mob.dir = dir
+			buckled_mob.setDir(dir)
 			switch(dir)
 				if(NORTH)
 					buckled_mob.pixel_x = 0

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -39,7 +39,7 @@
 	if(has_buckled_mobs())
 		for(var/m in buckled_mobs)
 			var/mob/living/buckled_mob = m
-			buckled_mob.dir = dir
+			buckled_mob.setDir(dir)
 			buckled_mob.pixel_x = generic_pixel_x
 			buckled_mob.pixel_y = generic_pixel_y
 


### PR DESCRIPTION
- Adds a hook, `setDir()` that we can override to run code when an object changes dir.
- Like `loc = X` has been replaced with `forceMove(X)` in future all dir sets (where possible, eg: atoms) must now be `setDir(X)`

I used Notepad++ and regex to automatically convert the whole codebase:
<B>MATCH REGEX:</B> `(?<=[\t\.])dir\s*=\s*([\w\.\d\(\)\"\,\ \t\-\[\]\+]+)` 
<B>REPLACE REGEX:</B> `setDir\(\1\)`
<B>WARNING</B>, there are cases where a `setDir()` in an OBJECT DEFINITION would either error straight away OR were wrongly seen as proc overrides, I have manually found and fixed them, however maybe 1-2 slipped through the cracks (I'm not -that- pefect ;) ), thankfully incorrect dirs are pretty easy to spot in game so it should be fine.

<del>Incoming commit for the hilarious error of `setDir()` itself being replaced with `setDir()`!</del> - Goodbye hilarious bug.
