### PR TITLE
Megafauna are now totally immune to explosions

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -21,6 +21,9 @@
 		feedback_set_details("megafauna_kills","[initial(name)]")
 		..()
 
+/mob/living/simple_animal/hostile/megafauna/ex_act(severity)
+	return
+
 /mob/living/simple_animal/hostile/megafauna/gib()
 	if(health > 0)
 		return


### PR DESCRIPTION
:cl: Joan
rscdel: Megafauna are now totally immune to explosions.
/:cl:

Bombs could either do 30 damage, at light range, 60, at medium, or 0, at devastation, due to the gib override, and really bombs are not a good choice.
