### PR TITLE
Talisman creation runes now require that the target paper doesn't move and still exists

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -223,7 +223,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(!do_after(user, 100, target = paper_to_imbue))
 		rune_in_use = 0
 		return
-	new talisman_type(get_turf(src))
+	new talisman_type(T)
 	visible_message("<span class='warning'>[src] glows with power, and bloody images form themselves on [paper_to_imbue].</span>")
 	qdel(paper_to_imbue)
 	rune_in_use = 0

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -231,7 +231,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/imbue/proc/checkpapers()
 	. = list()
 	for(var/obj/item/weapon/paper/P in get_turf(src))
-		if(!P.info && !istype(P, obj/item/weapon/paper/talisman))
+		if(!P.info && !istype(P, /obj/item/weapon/paper/talisman))
 			. |= P
 
 var/list/teleport_runes = list()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -186,13 +186,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/imbue/invoke(var/list/invokers)
 	var/mob/living/user = invokers[1] //the first invoker is always the user
 	var/turf/T = get_turf(src)
-	var/list/papers_on_rune = list()
+	var/list/papers_on_rune = checkpapers()
 	var/entered_talisman_name
 	var/obj/item/weapon/paper/talisman/talisman_type
 	var/list/possible_talismans = list()
-	for(var/obj/item/weapon/paper/P in T)
-		if(!P.info)
-			papers_on_rune.Add(P)
 	if(!papers_on_rune.len)
 		user << "<span class='cultitalic'>There must be a blank paper on top of [src]!</span>"
 		fail_invoke()
@@ -203,7 +200,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		log_game("Talisman Creation rune failed - already in use")
 		return
-	var/obj/item/weapon/paper/paper_to_imbue = pick(papers_on_rune)
+
 	for(var/I in subtypesof(/obj/item/weapon/paper/talisman) - /obj/item/weapon/paper/talisman/malformed - /obj/item/weapon/paper/talisman/supply - /obj/item/weapon/paper/talisman/supply/weak)
 		var/obj/item/weapon/paper/talisman/J = I
 		var/talisman_cult_name = initial(J.cultist_name)
@@ -213,16 +210,29 @@ structure_check() searches for nearby cultist structures required for the invoca
 	talisman_type = possible_talismans[entered_talisman_name]
 	if(!Adjacent(user) || !src || qdeleted(src) || user.incapacitated() || rune_in_use || !talisman_type)
 		return
+	papers_on_rune = checkpapers()
+	if(!papers_on_rune.len)
+		user << "<span class='cultitalic'>There must be a blank paper on top of [src]!</span>"
+		fail_invoke()
+		log_game("Talisman Creation rune failed - no blank papers on rune")
+		return
+	var/obj/item/weapon/paper/paper_to_imbue = pick(papers_on_rune)
 	..()
 	visible_message("<span class='warning'>Dark power begins to channel into the paper!</span>")
 	rune_in_use = 1
-	if(!do_after(user, 100, target = get_turf(user)))
+	if(!do_after(user, 100, target = paper_to_imbue))
 		rune_in_use = 0
 		return
 	new talisman_type(get_turf(src))
 	visible_message("<span class='warning'>[src] glows with power, and bloody images form themselves on [paper_to_imbue].</span>")
 	qdel(paper_to_imbue)
 	rune_in_use = 0
+
+/obj/effect/rune/imbue/proc/checkpapers()
+	. = list()
+	for(var/obj/item/weapon/paper/P in get_turf(src))
+		if(!P.info && !istype(P, obj/item/weapon/paper/talisman))
+			. |= P
 
 var/list/teleport_runes = list()
 /obj/effect/rune/teleport

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -185,7 +185,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/imbue/invoke(var/list/invokers)
 	var/mob/living/user = invokers[1] //the first invoker is always the user
-	var/turf/T = get_turf(src)
 	var/list/papers_on_rune = checkpapers()
 	var/entered_talisman_name
 	var/obj/item/weapon/paper/talisman/talisman_type
@@ -216,14 +215,14 @@ structure_check() searches for nearby cultist structures required for the invoca
 		fail_invoke()
 		log_game("Talisman Creation rune failed - no blank papers on rune")
 		return
-	var/obj/item/weapon/paper/paper_to_imbue = pick(papers_on_rune)
+	var/obj/item/weapon/paper/paper_to_imbue = papers_on_rune[1]
 	..()
 	visible_message("<span class='warning'>Dark power begins to channel into the paper!</span>")
 	rune_in_use = 1
 	if(!do_after(user, 100, target = paper_to_imbue))
 		rune_in_use = 0
 		return
-	new talisman_type(T)
+	new talisman_type(get_turf(src))
 	visible_message("<span class='warning'>[src] glows with power, and bloody images form themselves on [paper_to_imbue].</span>")
 	qdel(paper_to_imbue)
 	rune_in_use = 0


### PR DESCRIPTION
Instead of allowing a nonexistent paper as target or working when the rune was clear of papers.
Also fixes allowing talismans as target papers.
