### PR TITLE
Repairs Spray Tan

### DIFF
--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -161,3 +161,5 @@
 			. = "471c18"
 		if("albino")
 			. = "fff4e6"
+		if("orange")
+			. = "ffc905"


### PR DESCRIPTION
The skin tone for orange wasn't formally defined in the helper proc, so it returned 0 (pure white)

Resolves #18479
