### PR TITLE
Bomb the Boss

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -57,8 +57,6 @@
 				charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()
-	if(health > 0)
-		return
 	if(size > 2)
 		adjustHealth(-maxHealth) //heal ourself to full in prep for splitting
 		var/mob/living/simple_animal/hostile/megafauna/legion/L = new(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -15,23 +15,8 @@
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
-	if(health > 0)
-		return
-	else
-		feedback_set_details("megafauna_kills","[initial(name)]")
-		..()
-
-/mob/living/simple_animal/hostile/megafauna/gib()
-	if(health > 0)
-		return
-	else
-		..()
-
-/mob/living/simple_animal/hostile/megafauna/dust()
-	if(health > 0)
-		return
-	else
-		..()
+	feedback_set_details("megafauna_kills","[initial(name)]")
+	..()
 
 /mob/living/simple_animal/hostile/megafauna/onShuttleMove()
 	var/turf/oldloc = loc
@@ -51,3 +36,13 @@
 			"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 		adjustBruteLoss(-L.maxHealth/2)
 		L.gib()
+
+/mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
+	switch(severity)
+		if(1)
+			adjustBruteLoss(600)
+		if(2)
+			adjustBruteLoss(300)
+		if(3)
+			adjustBruteLoss(150)
+	updatehealth()


### PR DESCRIPTION
This PR is an inverse of #18476. Instead of making bombs harmless to megafauna, I make them deal some real damage to them. You can now use ghetto gibtonite charges or real toxins bombs in boss fights, for fun and profit. Just don't explode yourself.

Gib radius: 600 damage
Heavy radius: 300 damage
Light radius: 150 damage

Keep in mind that most of the bosses have 2500 HP, and luring the boss on bomb and not getting caught in blast at the same time is hard.

**Token:** #18466
