### PR TITLE
Brings back CE's hardsuit jetpack

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -11,6 +11,7 @@
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
+	new /obj/item/hardsuit_jetpack(src)
 	new /obj/item/weapon/cartridge/ce(src)
 	new /obj/item/device/radio/headset/heads/ce(src)
 	new /obj/item/weapon/storage/toolbox/mechanical(src)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -83,6 +83,11 @@
 	var/helmettype = /obj/item/clothing/head/helmet/space/hardsuit
 	var/obj/item/weapon/tank/jetpack/suit/jetpack = null
 
+/obj/item/clothing/suit/space/hardsuit/New()
+	if(jetpack && ispath(jetpack))
+		jetpack = new jetpack(src)
+	..()
+
 /obj/item/clothing/suit/space/hardsuit/equipped(mob/user, slot)
 	..()
 	if(jetpack)
@@ -162,6 +167,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
+	jetpack = /obj/item/weapon/tank/jetpack/suit
 
 
 	//Mining hardsuit
@@ -276,10 +282,7 @@
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank/internals)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi
-
-/obj/item/clothing/suit/space/hardsuit/syndi/New()
-	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
-	..()
+	jetpack = /obj/item/weapon/tank/jetpack/suit
 
 
 //Elite Syndie suit

--- a/code/modules/mining/equipment.dm
+++ b/code/modules/mining/equipment.dm
@@ -448,6 +448,8 @@
 	name = "hardsuit jetpack upgrade"
 	icon_state = "jetpack_upgrade"
 	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It is fueled by a tank inserted into the suit's storage compartment."
+	origin_tech = "materials=4;magnets=4;engineering=5"
+	// Same as jetpack implant minus biotech, makes sense.
 
 
 /obj/item/hardsuit_jetpack/afterattack(var/obj/item/clothing/suit/space/hardsuit/S, mob/user)


### PR DESCRIPTION
CE's hardsuit spawns with integrated jetpack once again. Atmos tech and engineer hardsuits still don't spawn with jetpacks, but CE has one hardsuit jetpack upgrade in his locker. He can hand it out to the most useful dept member.

> Why engineers need jetpacks? 
Jetpacking around the station is the quickest way to check it for meteor/space dust damage, and nobody likes meteor damage. Jetpacks are also extremely useful for external repairs or any space construction tasks. And that's what engineers do when they are not busy with stopping toxin fires and patching up bomb holes.

**Token:** #18428
