### PR TITLE
Blast door fix and ling limb regen

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -9,6 +9,7 @@
 	user.status_flags &= ~(FAKEDEATH)
 	user.tod = null
 	user.revive(full_heal = 1)
+	user.regenerate_limbs(0, list("head")) //regenerate all limbs except the head
 	user << "<span class='notice'>We have regenerated.</span>"
 	user.mind.changeling.purchasedpowers -= src
 	feedback_add_details("changeling_powers","CR")

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -68,3 +68,7 @@
 
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
  	return
+
+obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
+	if(stat & NOPOWER)
+		open(1)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -294,11 +294,13 @@
 
 
 //Regenerates all limbs. Returns amount of limbs regenerated
-/mob/living/proc/regenerate_limbs(noheal)
+/mob/living/proc/regenerate_limbs(noheal, excluded_limbs)
 	return 0
 
-/mob/living/carbon/human/regenerate_limbs(noheal)
+/mob/living/carbon/human/regenerate_limbs(noheal, list/excluded_limbs)
 	var/list/limb_list = list("head", "chest", "r_arm", "l_arm", "r_leg", "l_leg")
+	if(excluded_limbs)
+		limb_list -= excluded_limbs
 	for(var/Z in limb_list)
 		. += regenerate_limb(Z, noheal)
 


### PR DESCRIPTION
- Fixes blast doors not being crowbarrable when out of power. Fixes #18468.
- Changeling regenerative stasis now regenerate limbs, except the head. As discussed in #17554.
