### PR TITLE
Fixes portals not disappearing

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -31,7 +31,7 @@
 		src.teleport(M)
 	if(lifespan > 0)
 		spawn(lifespan)
-			qdel(src)
+		qdel(src)
 	return
 
 /obj/effect/portal/Destroy()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -24,13 +24,13 @@
 	src.creator = creator
 	var/area/A = target.loc
 	if(A.noteleport) // No point in persisting if the target is unreachable.
+		src.visible_message("<span class='danger'>The [src] suddenly loses power and closes! The target destination is under the effects of a teleportation jammer!<span>")
 		qdel(src)
 		return
 	for(var/mob/M in src.loc)
 		src.teleport(M)
 	if(lifespan > 0)
-		spawn(lifespan)
-			qdel(src)
+		addtimer(src, "Destroy", lifespan)
 	return
 
 /obj/effect/portal/Destroy()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -24,6 +24,7 @@
 	src.creator = creator
 	var/area/A = target.loc
 	if(A.noteleport) // No point in persisting if the target is unreachable.
+		src.visible_message("<span class='danger'>The [src] suddenly loses power and closes! The target destination is under the effects of a teleportation jammer!<span>")
 		qdel(src)
 		return
 	for(var/mob/M in src.loc)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -24,13 +24,13 @@
 	src.creator = creator
 	var/area/A = target.loc
 	if(A.noteleport) // No point in persisting if the target is unreachable.
-		src.visible_message("<span class='danger'>The [src] suddenly loses power and closes! The target destination is under the effects of a teleportation jammer!<span>")
 		qdel(src)
 		return
 	for(var/mob/M in src.loc)
 		src.teleport(M)
 	if(lifespan > 0)
-		addtimer(src, "Destroy", lifespan)
+		spawn(lifespan)
+			qdel(src)
 	return
 
 /obj/effect/portal/Destroy()


### PR DESCRIPTION
Fixes hand teleporter portals not disappearing
There might be a bug where the portal is created adjacent to the mob creating it instead of on it but I'm not sure, I might not be testing correctly, but that's not the point of this PR.
Fixes #18426 
:cl:
bugfix: Hand teleporters now have more then 3 uses, and their portals are no longer indefinite.
/:cl:
