### PR TITLE
Fixes infinite buckling, removes unnecessary list init.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -40,9 +40,7 @@
 /atom/movable/proc/buckle_mob(mob/living/M, force = 0)
 	if(!buckled_mobs)
 		buckled_mobs = list()
-	if(!M.buckled_mobs)
-		M.buckled_mobs = list()
-	if((!can_buckle && !force) || !istype(M) || (M.loc != loc) || M.buckled || (M.buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if((!can_buckle && !force) || !istype(M) || (M.loc != loc) || M.buckled || (buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return 0
 	if(!M.can_buckle() && !force)
 		if(M == usr)


### PR DESCRIPTION
We were checking if `M` had more mobs buckled to it than `src` allowed, usually this is 0 so it allows atoms to have infinite mobs on them, which is getting fixed because it's too fun.
