### PR TITLE
Security cameras will no longer accept engiborg analyzers

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -105,7 +105,7 @@
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
 		if(!user.unEquip(W))
 			return
-		if(!drop_item()) // no eating borg items
+		if(!W.drop_item()) // no eating borg items
 			return
 		user << "<span class='notice'>You attach \the [W] into the assembly inner circuits.</span>"
 		upgrades += W

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -105,6 +105,8 @@
 	if(is_type_in_list(W, possible_upgrades) && !is_type_in_list(W, upgrades)) // Is a possible upgrade and isn't in the camera already.
 		if(!user.unEquip(W))
 			return
+		if(!drop_item()) // no eating borg items
+			return
 		user << "<span class='notice'>You attach \the [W] into the assembly inner circuits.</span>"
 		upgrades += W
 		W.loc = src


### PR DESCRIPTION
...or other such undroppable items.

Fixes https://github.com/tgstation/tgstation/issues/18501.
