### PR TITLE
fixes shuttle rotation

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -317,7 +317,7 @@
 //default shuttleRotate
 /atom/proc/shuttleRotate(rotation)
 	//rotate our direction
-	setDir(angle2dir(rotation)+dir2angle(dir))
+	setDir(angle2dir(rotation+dir2angle(dir)))
 
 	//resmooth if need be.
 	if(smooth)


### PR DESCRIPTION
fixes #18526

@RemieRichards's pr added the `)` to the wrong spot. https://github.com/tgstation/tgstation/commit/fda2c699fceba79e93a2fa3d62e5c5c7e2596f79#diff-8d50796c8e2b4ec669f94278cf488abdL320
