### PR TITLE
Fixes megafauna being almost immune to explosions

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -57,8 +57,6 @@
 				charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()
-	if(health > 0)
-		return
 	if(size > 2)
 		adjustHealth(-maxHealth) //heal ourself to full in prep for splitting
 		var/mob/living/simple_animal/hostile/megafauna/legion/L = new(src.loc)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -45,4 +45,3 @@
 			adjustBruteLoss(300)
 		if(3)
 			adjustBruteLoss(150)
-	updatehealth()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -15,23 +15,8 @@
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
 
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
-	if(health > 0)
-		return
-	else
-		feedback_set_details("megafauna_kills","[initial(name)]")
-		..()
-
-/mob/living/simple_animal/hostile/megafauna/gib()
-	if(health > 0)
-		return
-	else
-		..()
-
-/mob/living/simple_animal/hostile/megafauna/dust()
-	if(health > 0)
-		return
-	else
-		..()
+	feedback_set_details("megafauna_kills","[initial(name)]")
+	..()
 
 /mob/living/simple_animal/hostile/megafauna/onShuttleMove()
 	var/turf/oldloc = loc
@@ -51,3 +36,13 @@
 			"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 		adjustBruteLoss(-L.maxHealth/2)
 		L.gib()
+
+/mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
+	switch(severity)
+		if(1)
+			adjustBruteLoss(600)
+		if(2)
+			adjustBruteLoss(300)
+		if(3)
+			adjustBruteLoss(150)
+	updatehealth()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -36,7 +36,7 @@
 	//Healable by medical stacks? Defaults to yes.
 	var/healable = 1
 
-	//Atmos effect - Yes, you can make creatures that require plasma or co2 to survive. N2O is a trace gas and handled separately, hence why it isn't here. It'd be hard to add it. Hard and me don't mix (Yes, yes make all the dick jokes you want with that.) - Errorage
+	//Atmos effect - Yes, you can make creatures that require plasma or co2 to survive.
 	var/list/atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0) //Leaving something at 0 means it's off - has no maximum
 	var/unsuitable_atmos_damage = 2	//This damage is taken when atmos doesn't fit all the requirements above
 
@@ -420,13 +420,11 @@
 		if (1)
 			gib()
 			return
-
 		if (2)
 			adjustBruteLoss(60)
 
 		if(3)
 			adjustBruteLoss(30)
-	updatehealth()
 
 /mob/living/simple_animal/proc/CanAttack(atom/the_target)
 	if(see_invisible < the_target.invisibility)


### PR DESCRIPTION
This PR is an inverse of #18476. Instead of making bombs harmless to megafauna, I make them deal some real damage to them. You can now use ghetto gibtonite charges or real toxins bombs in boss fights, for fun and profit. Just don't explode yourself.

Gib radius: 600 damage
Heavy radius: 300 damage
Light radius: 150 damage

Keep in mind that most of the bosses have 2500 HP, and luring the boss on bomb and not getting caught in blast at the same time is hard.

**Why chose this PR over #18498?**
- My numbers actually make bombing _useful_, high risk high reward.
- My PR changes only megafauna without touching all the simple animals. Kor's PR removes simple animals getting gibbed by bombs.
- I'm not a jerk who closes other people PRs _just because_.
