### PR TITLE
Rebalances radioactive microlaser

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -80,15 +80,15 @@ MASS SPECTROMETER
 	materials = list(MAT_METAL=200)
 	origin_tech = "magnets=1;biotech=1"
 	var/mode = 1
-	var/scanchems = 0
+	var/scanmode = 0
 
 /obj/item/device/healthanalyzer/attack_self(mob/user)
-	if(!scanchems)
+	if(!scanmode)
 		user << "<span class='notice'>You switch the health analyzer to scan chemical contents.</span>"
-		scanchems = 1
+		scanmode = 1
 	else
 		user << "<span class='notice'>You switch the health analyzer to check physical health.</span>"
-		scanchems = 0
+		scanmode = 0
 
 /obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/carbon/human/user)
 
@@ -104,9 +104,9 @@ MASS SPECTROMETER
 
 	user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>")
 
-	if(!scanchems)
+	if(scanmode == 0)
 		healthscan(user, M, mode)
-	else
+	else if(scanmode == 1)
 		chemscan(user, M)
 
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -69,7 +69,6 @@ effective or pretty fucking useless.
 */
 
 /obj/item/device/healthanalyzer/rad_laser
-	desc = "A hand-held body scanner able to distinguish vital signs of the subject. It has a strange device hooked up to its scanning end."
 	materials = list(MAT_METAL=400)
 	origin_tech = "magnets=3;biotech=5;syndicate=3"
 	var/irradiate = 1
@@ -88,7 +87,7 @@ effective or pretty fucking useless.
 		icon_state = "health1"
 		handle_cooldown(cooldown) // splits off to handle the cooldown while handling wavelength
 		user << "<span class='warning'>Successfully irradiated [M].</span>"
-		spawn((wavelength+(intensity*4))*10)
+		spawn((wavelength+(intensity*4))*5)
 			if(M)
 				if(intensity >= 5)
 					M.apply_effect(round(intensity/1.5), PARALYZE)
@@ -151,7 +150,7 @@ effective or pretty fucking useless.
 	else if(href_list["radint"])
 		var/amount = text2num(href_list["radint"])
 		amount += intensity
-		intensity = max(1,(min(15,amount)))
+		intensity = max(1,(min(20,amount)))
 
 	else if(href_list["radwav"])
 		var/amount = text2num(href_list["radwav"])

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -68,31 +68,26 @@ effective or pretty fucking useless.
 		Wavelength is also slightly increased by the intensity as well.
 */
 
-/obj/item/device/rad_laser
-	name = "health analyzer"
-	icon_state = "health"
-	item_state = "analyzer"
-	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
-	flags = CONDUCT
-	slot_flags = SLOT_BELT
-	throwforce = 3
-	w_class = 1
-	throw_speed = 3
-	throw_range = 7
+/obj/item/device/healthanalyzer/rad_laser
+	desc = "A hand-held body scanner able to distinguish vital signs of the subject. It has a strange device hooked up to it's scanning end."
 	materials = list(MAT_METAL=400)
 	origin_tech = "magnets=3;biotech=5;syndicate=3"
-	var/intensity = 5 // how much damage the radiation does
+	var/irradiate = 1
+	var/intensity = 10 // how much damage the radiation does
 	var/wavelength = 10 // time it takes for the radiation to kick in, in seconds
 	var/used = 0 // is it cooling down?
 
-/obj/item/device/rad_laser/attack(mob/living/M, mob/living/user)
+/obj/item/device/healthanalyzer/rad_laser/attack(mob/living/M, mob/living/user)
+	..()
+	if(!irradiate)
+		return
 	if(!used)
 		add_logs(user, M, "irradiated", src)
-		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>")
-		var/cooldown = round(max(100,(((intensity*8)-(wavelength/2))+(intensity*2))*10))
+		var/cooldown = round(max(10, (intensity*5 - wavelength/4))) * 10
 		used = 1
 		icon_state = "health1"
 		handle_cooldown(cooldown) // splits off to handle the cooldown while handling wavelength
+		user << "<span class='warning'>Successfully irradiated [M].</span>"
 		spawn((wavelength+(intensity*4))*10)
 			if(M)
 				if(intensity >= 5)
@@ -101,22 +96,38 @@ effective or pretty fucking useless.
 	else
 		user << "<span class='warning'>The radioactive microlaser is still recharging.</span>"
 
-/obj/item/device/rad_laser/proc/handle_cooldown(cooldown)
+/obj/item/device/healthanalyzer/rad_laser/proc/handle_cooldown(cooldown)
 	spawn(cooldown)
 		used = 0
 		icon_state = "health"
 
-/obj/item/device/rad_laser/attack_self(mob/user)
-	..()
+/obj/item/device/healthanalyzer/rad_laser/attack_self(mob/user)
 	interact(user)
 
-/obj/item/device/rad_laser/interact(mob/user)
+/obj/item/device/healthanalyzer/rad_laser/interact(mob/user)
 	user.set_machine(src)
 
-	var/cooldown = round(max(10,((intensity*8)-(wavelength/2))+(intensity*2)))
-	var/dat = {"
-	Radiation Intensity: <A href='?src=\ref[src];radint=-5'>-</A><A href='?src=\ref[src];radint=-1'>-</A> [intensity] <A href='?src=\ref[src];radint=1'>+</A><A href='?src=\ref[src];radint=5'>+</A><BR>
-	Radiation Wavelength: <A href='?src=\ref[src];radwav=-5'>-</A><A href='?src=\ref[src];radwav=-1'>-</A> [(wavelength+(intensity*4))] <A href='?src=\ref[src];radwav=1'>+</A><A href='?src=\ref[src];radwav=5'>+</A><BR>
+	var/cooldown = round(max(10, (intensity*5 - wavelength/4)))
+	var/dat = "Irradiation: <A href='?src=\ref[src];rad=1'>[irradiate ? "On" : "Off"]</A><br>"
+	dat += "Scan Mode: <a href='?src=\ref[src];mode=1'>"
+	if(!scanmode)
+		dat += "Scan Health"
+	else if(scanmode == 1)
+		dat += "Scan Reagents"
+	else
+		dat += "Disabled"
+	dat += "</a><br><br>"
+
+	dat += {"
+	Radiation Intensity:
+	<A href='?src=\ref[src];radint=-5'>-</A><A href='?src=\ref[src];radint=-1'>-</A>
+	[intensity]
+	<A href='?src=\ref[src];radint=1'>+</A><A href='?src=\ref[src];radint=5'>+</A><BR>
+
+	Radiation Wavelength:
+	<A href='?src=\ref[src];radwav=-5'>-</A><A href='?src=\ref[src];radwav=-1'>-</A>
+	[(wavelength+(intensity*4))]
+	<A href='?src=\ref[src];radwav=1'>+</A><A href='?src=\ref[src];radwav=5'>+</A><BR>
 	Laser Cooldown: [cooldown] Seconds<BR>
 	"}
 
@@ -124,21 +135,28 @@ effective or pretty fucking useless.
 	popup.set_content(dat)
 	popup.open()
 
-/obj/item/device/rad_laser/Topic(href, href_list)
+/obj/item/device/healthanalyzer/rad_laser/Topic(href, href_list)
 	if(!usr.canUseTopic(src))
 		return 1
 
 	usr.set_machine(src)
+	if(href_list["rad"])
+		irradiate = !irradiate
 
-	if(href_list["radint"])
+	else if(href_list["mode"])
+		scanmode += 1
+		if(scanmode > 2)
+			scanmode = 0
+
+	else if(href_list["radint"])
 		var/amount = text2num(href_list["radint"])
 		amount += intensity
-		intensity = max(1,(min(10,amount)))
+		intensity = max(1,(min(15,amount)))
 
 	else if(href_list["radwav"])
 		var/amount = text2num(href_list["radwav"])
 		amount += wavelength
-		wavelength = max(1,(min(120,amount)))
+		wavelength = max(0,(min(120,amount)))
 
 	attack_self(usr)
 	add_fingerprint(usr)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -69,7 +69,7 @@ effective or pretty fucking useless.
 */
 
 /obj/item/device/healthanalyzer/rad_laser
-	desc = "A hand-held body scanner able to distinguish vital signs of the subject. It has a strange device hooked up to it's scanning end."
+	desc = "A hand-held body scanner able to distinguish vital signs of the subject. It has a strange device hooked up to its scanning end."
 	materials = list(MAT_METAL=400)
 	origin_tech = "magnets=3;biotech=5;syndicate=3"
 	var/irradiate = 1

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -78,7 +78,6 @@
 		/obj/item/device/flashlight/pen,
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/reagent_containers/hypospray,
-		/obj/item/device/rad_laser,
 		/obj/item/device/sensor_device,
 		/obj/item/device/radio,
 		/obj/item/clothing/gloves/,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -18,7 +18,7 @@
 		if("stealth")
 			new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow(src)
 			new /obj/item/weapon/pen/sleepy(src)
-			new /obj/item/device/rad_laser(src)
+			new /obj/item/device/healthanalyzer/rad_laser(src)
 			new /obj/item/device/chameleon(src)
 			new /obj/item/weapon/soap/syndie(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)

--- a/code/modules/surgery/organs/autoimplanter.dm
+++ b/code/modules/surgery/organs/autoimplanter.dm
@@ -6,14 +6,12 @@
 	icon_state = "autoimplanter"
 	item_state = "walkietalkie"//left as this so as to intentionally not have inhands
 	w_class = 2
-	var/obj/item/organ/cyberimp/storedorgan
+	var/obj/item/organ/storedorgan
+	var/organ_type = /obj/item/organ/cyberimp
 	var/uses = INFINITE
-	var/one_use = 0//separate var, as a 2-use device can have 1 use remaining if used once but not be a single-use device
 
 /obj/item/device/autoimplanter/New()
 	..()
-	if(one_use)
-		uses = 1
 	if(storedorgan)
 		storedorgan.loc = src
 
@@ -21,7 +19,7 @@
 	if(!uses)
 		user << "<span class='warning'>[src] has already been used. The tools are dull and won't reactivate.</span>"
 		return
-	if(!storedorgan)
+	else if(!storedorgan)
 		user << "<span class='notice'>[src] currently has no implant stored.</span>"
 		return
 	storedorgan.Insert(user)//insert stored organ into the user
@@ -29,17 +27,17 @@
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
 	storedorgan = null
 	if(uses != INFINITE)
-		uses --
+		uses--
 	if(!uses)
 		desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/device/autoimplanter/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/organ/cyberimp))
-		if(one_use && !storedorgan)
-			user << "<span class='notice'>[src] doesn't accept implants. It must be a single-use device.</span>"
-			return//prevents removing the intended implant to insert your own
+	if(istype(I, organ_type))
 		if(storedorgan)
 			user << "<span class='notice'>[src] already has an implant stored.</span>"
+			return
+		else if(!uses)
+			user << "<span class='notice'>[src] has already been used up.</span>"
 			return
 		if(!user.drop_item())
 			return
@@ -55,9 +53,13 @@
 			user << "<span class='notice'>You remove the [storedorgan] from [src].</span>"
 			playsound(get_turf(user), 'sound/items/Screwdriver.ogg', 50, 1)
 			storedorgan = null
+			if(uses != INFINITE)
+				uses--
+			if(!uses)
+				desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/device/autoimplanter/cmo
 	name = "medical HUD autoimplanter"
 	desc = "A single use autoimplanter that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	storedorgan = new/obj/item/organ/cyberimp/eyes/hud/medical()
-	one_use = 1
+	uses = 1

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -909,7 +909,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			powerful burst of radiation, which, after a short delay, can incapitate all but the most protected \
 			of humanoids. It has two settings: intensity, which controls the power of the radiation, \
 			and wavelength, which controls how long the radiation delay is."
-	item = /obj/item/device/rad_laser
+	item = /obj/item/device/healthanalyzer/rad_laser
 	cost = 3
 
 /datum/uplink_item/device_tools/assault_pod


### PR DESCRIPTION
This PR is aimed at making radioactive microlaser less useless.
- Radioactive microlaser is now a subtype of health analyzer. Using it on someone would print out target's health status. Useful for stealth. You can disable this in microlaser's menu.
- You can disable microlaser's irradiation in the same menu. Just in case you want to check your own health without carrying a real health analyzer.
- Radioactive microlaser has it's max rad output increased 200%.
- Radioactive microlaser cooldown is cut in two.

**Token:** #18534 
