### PR TITLE
Fixes countdown moving in space wind

### DIFF
--- a/code/modules/countdown/countdown.dm
+++ b/code/modules/countdown/countdown.dm
@@ -11,6 +11,7 @@
 	var/text_size = 4
 	var/started = FALSE
 	invisibility = INVISIBILITY_OBSERVER
+	anchored = TRUE
 	layer = GHOST_LAYER
 
 /obj/effect/countdown/New(atom/A)


### PR DESCRIPTION
The countdown was being blown about by atmos stuff, and then moved back
each tick. It was amusing to look at, but ultimately, is a bug that
needs fixing.
