### PR TITLE
[s] makes disguised rune desc match fake rune desc

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -198,7 +198,7 @@
 	user.visible_message("<span class='warning'>Dust flows from [user]s hand.</span>", \
 						 "<span class='cultitalic'>You speak the words of the talisman, making nearby runes appear fake.</span>")
 	for(var/obj/effect/rune/R in orange(6,user))
-		R.desc = "A rune drawn in crayon."
+		R.desc = "A rune vandalizing the station."
 
 
 //Rite of Disruption: Weaker than rune


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/18547

[s] because this bug relies on metaknowledge, meaning it shouldn't be announced to the server
