### PR TITLE
[s] Safer input for the station charter

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -24,6 +24,7 @@
 #define MAX_MESSAGE_LEN			1024
 #define MAX_NAME_LEN			26
 #define MAX_BROADCAST_LEN		512
+#define MAX_CHARTER_LEN			50
 
 //MINOR TWEAKS/MISC
 #define AGE_MIN				17	//youngest a character can be

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -14,7 +14,7 @@
 		user << "The crew has already settled into the shift. It probably wouldn't be good to rename the station right now."
 		return
 
-	var/new_name = input(user, "What do you want to name [station_name()]? Keep in mind particularly terrible names may attract the attention of your employers.")  as text|null
+	var/new_name = stripped_input(user, message="What do you want to name [station_name()]? Keep in mind particularly terrible names may attract the attention of your employers.", max_length=MAX_CHARTER_LEN)
 	if(new_name)
 		world.name = new_name
 		station_name = new_name


### PR DESCRIPTION
Prevents html entities and sets a maximum length of 30
