### PR TITLE
Lowers GC priority of qdel'd living mobs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -46,7 +46,7 @@ Sorry Giacom. Please don't be mad :(
 			qdel(I)
 	staticOverlays.len = 0
 	remove_from_all_data_huds()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL
 
 
 /mob/living/proc/OpenCraftingMenu()


### PR DESCRIPTION
@MrStonedOne
- Changes the qdel hint from QDEL_HINT_HARDDEL_NOW to QDEL_HINT_HARDDEL.
