### PR TITLE
Removes Dementia Doctrine, moves Sigil of Submission to Scripts tier

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -119,7 +119,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 
 /datum/clockwork_scripture/channeled //Channeled scripture begins instantly but runs constantly
-	var/list/chant_invocations = list("NYY YZNB") //"AYY LAMO"
+	var/list/chant_invocations = list("NLL YZNB") //"AYY LAMO"
 	var/chant_amount = 5 //Times the chant is spoken
 	var/chant_interval = 10 //Amount of deciseconds between times the chant is actually spoken aloud
 
@@ -149,9 +149,15 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	var/creator_message = "<span class='brass'>You create a meme.</span>" //Shown to the invoker
 	var/observer_message
 	var/one_per_tile = FALSE
+	var/prevent_path
+
+/datum/clockwork_scripture/create_object/New()
+	..()
+	if(!prevent_path)
+		prevent_path = object_path
 
 /datum/clockwork_scripture/create_object/check_special_requirements()
-	if(one_per_tile && (locate(object_path) in get_turf(invoker)))
+	if(one_per_tile && (locate(prevent_path) in get_turf(invoker)))
 		invoker << "<span class='warning'>You can only place one of this object on each tile!</span>"
 		return 0
 	return 1
@@ -717,6 +723,25 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	observer_message = "<span class='warning'>The slab disgorges a puddle of black metal that expands and forms into a strange shell!</span>"
 	usage_tip = "Useless without a soul vessel and should not be created without one."
 	tier = SCRIPTURE_APPLICATION
+
+
+
+/datum/clockwork_scripture/create_object/sigil_of_accession //Sigil of Accession: Creates a sigil of accession.
+	descname = "Permenant Conversion Trap"
+	name = "Sigil of Accession"
+	desc = "Places a luminous sigil much like a Sigil of Submission, but it will remain even after successfully converting a non-implanted target. \
+	It will penetrate mindshield implants once before disappearing."
+	invocations = list("Qvivavgl, rafynir...", "...nyy jub gerfcnff urer!")
+	channel_time = 100
+	required_components = list("belligerent_eye" = 2, "guvax_capacitor" = 2, "hierophant_ansible" = 2)
+	consumed_components = list("belligerent_eye" = 1, "guvax_capacitor" = 1, "hierophant_ansible" = 1)
+	whispered = TRUE
+	object_path = /obj/effect/clockwork/sigil/submission/accession
+	prevent_path = /obj/effect/clockwork/sigil/submission
+	creator_message = "<span class='brass'>A luminous sigil appears below you. All non-servants to cross it will be enslaved after a brief time if they do not move.</span>"
+	usage_tip = "It will remain after converting a target, unless that target has a mindshield implant, which it will break to convert them, but consume itself in the process."
+	tier = SCRIPTURE_APPLICATION
+	one_per_tile = TRUE
 
 
 

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -33,7 +33,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	var/list/used_cache_components = list("belligerent_eye" = 0, "vanguard_cogwheel" = 0, "guvax_capacitor" = 0, "replicant_alloy" = 0, "hierophant_ansible" = 0)
 
 /datum/clockwork_scripture/proc/run_scripture()
-	if(can_recite() && check_special_requirements())
+	if(can_recite() && has_requirements() && check_special_requirements())
 		if(slab.busy)
 			invoker << "<span class='warning'>[slab] refuses to work, displaying the message: \"[slab.busy]!\"</span>"
 			return 0
@@ -67,6 +67,9 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	if(!invoker.can_speak_vocal())
 		invoker << "<span class='warning'>You are unable to speak the words of the scripture!</span>"
 		return 0
+	return 1
+
+/datum/clockwork_scripture/proc/has_requirements() //if we have the components and invokers to do it
 	if(!ratvar_awakens && !slab.no_cost)
 		for(var/i in required_components)
 			if(slab.stored_components[i] + clockwork_component_cache[i] < required_components[i])
@@ -805,8 +808,6 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	return create_marauder()
 
 /datum/clockwork_scripture/memory_allocation/proc/create_marauder()
-	if(!can_recite())
-		return 0
 	invoker.visible_message("<span class='warning'>A yellow tendril appears from [invoker]'s [slab.name] and impales itself in their forehead!</span>", \
 	"<span class='heavy_brass'>A tendril flies from [slab] into your forehead. You begin waiting while it painfully rearranges your thought pattern...</span>")
 	invoker.notransform = TRUE //Vulnerable during the process

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -689,8 +689,8 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	desc = "Places a luminous sigil that will enslave any valid beings standing on it after a time."
 	invocations = list("Qvivavgl, rayvtugra...", "...gubfr jub gerfcnff urer!")
 	channel_time = 60
-	required_components = list("belligerent_eye" = 1, "guvax_capacitor" = 1)
-	consumed_components = list("belligerent_eye" = 1, "guvax_capacitor" = 1)
+	required_components = list("guvax_capacitor" = 2)
+	consumed_components = list("guvax_capacitor" = 1)
 	whispered = TRUE
 	object_path = /obj/effect/clockwork/sigil/submission
 	creator_message = "<span class='brass'>A luminous sigil appears below you. The next non-servant to cross it will be enslaved after a brief time if they do not move.</span>"

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -122,7 +122,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 
 
 /datum/clockwork_scripture/channeled //Channeled scripture begins instantly but runs constantly
-	var/list/chant_invocations = list("NLL YZNB") //"AYY LAMO"
+	var/list/chant_invocations = list("NLL YZNB") //"AYY LMAO"
 	var/chant_amount = 5 //Times the chant is spoken
 	var/chant_interval = 10 //Amount of deciseconds between times the chant is actually spoken aloud
 

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -383,6 +383,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	var/starttime = world.time
 	progbar = new(invoker, flee_time, invoker)
 	progbar.bar.color = "#AF0AAF"
+	animate(progbar.bar, color = initial(progbar.bar.color), time = flee_time+grace_period)
 	while(world.time < endtime)
 		sleep(1)
 		progbar.update(world.time - starttime)

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -234,13 +234,13 @@
 /obj/effect/overlay/temp/ratvar/sigil/transgression
 	color = "#FAE48C"
 	layer = ABOVE_MOB_LAYER
-	duration = 38
+	duration = 50
 
 /obj/effect/overlay/temp/ratvar/sigil/transgression/New()
 	..()
 	var/oldtransform = transform
 	animate(src, transform = matrix()*2, time = 5)
-	animate(transform = oldtransform, alpha = 0, time = 33)
+	animate(transform = oldtransform, alpha = 0, time = 45)
 
 /obj/effect/overlay/temp/ratvar/sigil/vitality
 	color = "#1E8CE1"

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -247,6 +247,13 @@
 	icon_state = "sigilactivepulse"
 	layer = BELOW_MOB_LAYER
 
+/obj/effect/overlay/temp/ratvar/sigil/accession
+	color = "#AF0AAF"
+	layer = ABOVE_MOB_LAYER
+	duration = 50
+	icon_state = "sigilactiveoverlay"
+	alpha = 0
+
 
 /obj/effect/overlay/temp/revenant
 	name = "spooky lights"


### PR DESCRIPTION
:cl: Joan
rscdel: Removed Dementia Doctrine, replacing it with an Application sigil.
rscadd: Adds the Sigil of Accession, the previously-mentioned Application sigil, which is much like a Sigil of Submission, except it isn't removed on converting un-mindshielded targets and will disappear after converting a mindshielded target.
tweak: Sigil of Submission is now a Script instead of a Driver; It's unlocked one tier up, so you have to rely on the Drivers you have until you get Scripts, instead of spamming both Driver sigils for free converts.
rscadd: To replace Sigil of Submission in the Driver tier; Added Taunting Tirade, which is a chanted scripture with a very fast invocation, which, on chanting, confuses, dizzies, and briefly stuns nearby non-servants and allows the invoker a brief time to relocate before continuing the chant.
/:cl:

Fixes having too few components interrupting chanting.
