### PR TITLE
Patch nerf

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -241,12 +241,12 @@
 			var/many = params["many"]
 			if(reagents.total_volume == 0) return
 			var/amount = 1
-			var/vol_each = min(reagents.total_volume, 50)
+			var/vol_each = min(reagents.total_volume, 40)
 			if(text2num(many))
 				amount = min(max(round(input(usr, "Max 10. Buffer content will be split evenly.", "How many patches?", amount) as num|null), 0), 10)
 				if(!amount)
 					return
-				vol_each = min(reagents.total_volume / amount, 50)
+				vol_each = min(reagents.total_volume / amount, 40)
 			var/name = stripped_input(usr,"Name:","Name your patch!", "[reagents.get_master_reagent_name()] ([vol_each]u)", MAX_NAME_LEN)
 			if(!name || !reagents.total_volume)
 				return

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -5,7 +5,7 @@
 	icon_state = "bandaid"
 	item_state = "bandaid"
 	possible_transfer_amounts = list()
-	volume = 50
+	volume = 40
 	apply_type = PATCH
 	apply_method = "apply"
 	self_delay = 30		// three seconds
@@ -21,11 +21,11 @@
 /obj/item/weapon/reagent_containers/pill/patch/styptic
 	name = "brute patch"
 	desc = "Helps with brute injuries."
-	list_reagents = list("styptic_powder" = 50)
+	list_reagents = list("styptic_powder" = 20)
 	icon_state = "bandaid_brute"
 
 /obj/item/weapon/reagent_containers/pill/patch/silver_sulf
 	name = "burn patch"
 	desc = "Helps with burn injuries."
-	list_reagents = list("silver_sulfadiazine" = 50)
+	list_reagents = list("silver_sulfadiazine" = 20)
 	icon_state = "bandaid_burn"


### PR DESCRIPTION
:cl: Quiltyquilty
rscdel: Patches now hold only 40u.
rscdel: Patches in first aid kits now only contain 20u of chemicals.
/:cl:

Goof was supposed to do this in his pr but he never did. He approves of this change though.
Patches now only hold 40u. This is 1:1 with goon and makes them less of a direct upgrade from pills with a tiny delay.
Medkit patches now only hold 20u by default. As they are now, patches will heal you to full health with like one or two. That means a medkit is more useful than a doctor. This fixes that and is also 1:1 with goon.

My merge token is #18383
