### PR TITLE
(☞ﾟ∀ﾟ)☞ SECURITY CHANGE!! ~*Detective Can No Longer Be A Traitor!!*~ SECURITY CHANGE!! ᕙ(⇀‸↼‶)ᕗ

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -10,7 +10,7 @@
 	config_tag = "traitor"
 	antag_flag = ROLE_TRAITOR
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
This PR brings the Detective back into the fold by removing his chance of being a round start traitor.

The Detective being a traitor is a wild inconsistency and a bad decision. Aside from the Detective spawning with arguable the best gun on offer at round start, but he also has intimate access to Security and its personal, this is in addition to him by all intents and purposes spawning with a Mindshield Implant and being immune to other station antag roles.

Relevant Thread Discussion: https://tgstation13.org/phpBB/viewtopic.php?f=9&t=6920 
