### PR TITLE
Nerfs anima fragments again

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -30,12 +30,18 @@
 	var/busy //If the slab is currently being used by something
 	var/production_time = 0
 	var/no_cost = FALSE //If the slab is admin-only and needs no components and has no scripture locks
+	var/produces_components = TRUE //if it produces components at all
 
 /obj/item/clockwork/slab/starter
 	stored_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "guvax_capacitor" = 1, "replicant_alloy" = 1, "hierophant_ansible" = 1)
 
 /obj/item/clockwork/slab/debug
 	no_cost = TRUE
+
+/obj/item/clockwork/slab/internal
+	name = "scripture motor"
+	no_cost = TRUE
+	produces_components = FALSE
 
 /obj/item/clockwork/slab/debug/attack_hand(mob/living/user)
 	..()
@@ -52,7 +58,7 @@
 	return ..()
 
 /obj/item/clockwork/slab/process()
-	if(production_time > world.time)
+	if(!produces_components || production_time > world.time)
 		return
 	production_time = world.time + SLAB_PRODUCTION_TIME
 	var/mob/living/L

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -35,13 +35,13 @@
 /obj/item/clockwork/slab/starter
 	stored_components = list("belligerent_eye" = 1, "vanguard_cogwheel" = 1, "guvax_capacitor" = 1, "replicant_alloy" = 1, "hierophant_ansible" = 1)
 
-/obj/item/clockwork/slab/debug
-	no_cost = TRUE
-
-/obj/item/clockwork/slab/internal
+/obj/item/clockwork/slab/internal //an internal motor for mobs running scripture
 	name = "scripture motor"
 	no_cost = TRUE
 	produces_components = FALSE
+
+/obj/item/clockwork/slab/debug
+	no_cost = TRUE
 
 /obj/item/clockwork/slab/debug/attack_hand(mob/living/user)
 	..()
@@ -58,7 +58,10 @@
 	return ..()
 
 /obj/item/clockwork/slab/process()
-	if(!produces_components || production_time > world.time)
+	if(!produces_components)
+		SSobj.processing -= src
+		return
+	if(production_time > world.time)
 		return
 	production_time = world.time + SLAB_PRODUCTION_TIME
 	var/mob/living/L

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -159,28 +159,21 @@
 		toggle()
 		return
 	for(var/atom/movable/M in range(5, src))
-		if(istype(M, /mob/living/simple_animal/hostile/clockwork_marauder))
-			var/mob/living/simple_animal/hostile/clockwork_marauder/E = M
+		if(istype(M, /mob/living/simple_animal/hostile/clockwork/marauder))
+			var/mob/living/simple_animal/hostile/clockwork/marauder/E = M
 			if((E.health == E.maxHealth && !E.fatigue) || E.stat)
 				continue
 			if(!try_use_power(mob_cost))
 				break
 			E.adjustBruteLoss(-E.maxHealth) //Instant because marauders don't usually take health damage
 			E.fatigue = max(0, E.fatigue - 15)
-		else if(istype(M, /mob/living/simple_animal/hostile/anima_fragment))
-			var/mob/living/simple_animal/hostile/anima_fragment/F = M
-			if(F.health == F.maxHealth || F.stat)
+		else if(istype(M, /mob/living/simple_animal/hostile/clockwork))
+			var/mob/living/simple_animal/hostile/clockwork/W = M
+			if(W.health == W.maxHealth || W.stat)
 				continue
 			if(!try_use_power(mob_cost))
 				break
-			F.adjustBruteLoss(-15)
-		else if(istype(M, /mob/living/simple_animal/hostile/clockwork_reclaimer))
-			var/mob/living/simple_animal/hostile/clockwork_reclaimer/R = M
-			if(R.health == R.maxHealth || R.stat)
-				continue
-			if(!try_use_power(mob_cost))
-				break
-			R.adjustBruteLoss(-15)
+			W.adjustBruteLoss(-15)
 		else if(istype(M, /obj/structure/clockwork))
 			var/obj/structure/clockwork/C = M
 			if(C.health == C.max_health)

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -15,6 +15,11 @@
 	..()
 	internalslab = new/obj/item/clockwork/slab/internal(src)
 
+/mob/living/simple_animal/hostile/clockwork/Destroy()
+	qdel(internalslab)
+	internalslab = null
+	return ..()
+
 /mob/living/simple_animal/hostile/clockwork/fragment //Anima fragment: Low health and high melee damage, but slows down when struck. Created by inserting a soul vessel into an empty fragment.
 	name = "anima fragment"
 	desc = "An ominous humanoid shell with a spinning cogwheel as its head, lifted by a jet of blazing red flame."

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -52,7 +52,7 @@
 		stat(null, "Movement delay(seconds): [max(round((movement_delay_time - world.time)*0.1, 0.1), 0)]")
 
 /mob/living/simple_animal/hostile/clockwork/fragment/death(gibbed)
-	visible_message("<span class='warning'>[src]'s flame jets cut out as it falls to the floor with a tremendous crash. A cube of metal tumbles out, whirring and sputtering.</span>", \
+	visible_message("<span class='warning'>[src]'s flame jets cut out as it falls to the floor with a tremendous crash.</span>", \
 	"<span class='userdanger'>Your gears seize up. Your flame jets flicker out. Your soul vessel belches smoke as you helplessly crash down.</span>")
 	..(TRUE)
 	return 1

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -68,7 +68,7 @@
 		else
 			movement_delay_time = world.time + amount*3
 
-/mob/living/simple_animal/hostile/clockwork/fragment/update_health()
+/mob/living/simple_animal/hostile/clockwork/fragment/updatehealth()
 	..()
 	if(health == maxHealth)
 		speed = initial(speed)

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -1,57 +1,66 @@
-/mob/living/simple_animal/hostile/anima_fragment //Anima fragment: Low health and high melee damage, but slows down when struck. Created by inserting a soul vessel into an empty fragment.
-	name = "anima fragment"
-	unique_name = 1
-	desc = "An ominous humanoid shell with a spinning cogwheel as its head, lifted by a jet of blazing red flame."
+
+/mob/living/simple_animal/hostile/clockwork
 	faction = list("ratvar")
 	icon = 'icons/mob/clockwork_mobs.dmi'
+	unique_name = 1
+	minbodytemp = 0
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0) //Robotic
+	healable = FALSE
+	del_on_death = TRUE
+	death_sound = 'sound/magic/clockwork/anima_fragment_death.ogg'
+	var/playstyle_string = "<span class='heavy_brass'>You are a bug, yell at whoever spawned you!</span>"
+	var/obj/item/clockwork/slab/internalslab //an internal slab for running scripture
+
+/mob/living/simple_animal/hostile/clockwork/New()
+	..()
+	internalslab = new/obj/item/clockwork/slab/internal(src)
+
+/mob/living/simple_animal/hostile/clockwork/fragment //Anima fragment: Low health and high melee damage, but slows down when struck. Created by inserting a soul vessel into an empty fragment.
+	name = "anima fragment"
+	desc = "An ominous humanoid shell with a spinning cogwheel as its head, lifted by a jet of blazing red flame."
 	icon_state = "anime_fragment"
 	health = 90
 	maxHealth = 90
 	speed = -1
-	minbodytemp = 0
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0) //Robotic
-	healable = FALSE
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attacktext = "crushes"
 	attack_sound = 'sound/magic/clockwork/anima_fragment_attack.ogg'
-	loot = list(/obj/item/clockwork/component/replicant_alloy/smashed_anima_fragment, /obj/item/device/mmi/posibrain/soul_vessel)
+	loot = list(/obj/item/clockwork/component/replicant_alloy/smashed_anima_fragment)
 	weather_immunities = list("lava")
 	flying = 1
-	del_on_death = TRUE
-	death_sound = 'sound/magic/clockwork/anima_fragment_death.ogg'
-	var/playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you have low health, do decent damage, and move at \
+	playstyle_string = "<span class='heavy_brass'>You are an anima fragment</span><b>, a clockwork creation of Ratvar. As a fragment, you have low health, do decent damage, and move at \
 	extreme speed in addition to being immune to extreme temperatures and pressures. Taking damage will temporarily slow you down, however. Your goal is to serve the Justiciar and his servants \
 	in any way you can. You yourself are one of these servants, and will be able to utilize anything they can, assuming it doesn't require opposable thumbs.</b>"
 	var/movement_delay_time //how long the fragment is slowed after being hit
 
-/mob/living/simple_animal/hostile/anima_fragment/New()
+/mob/living/simple_animal/hostile/clockwork/fragment/New()
 	..()
 	if(prob(1))
 		name = "anime fragment"
 		real_name = name
 		desc = "I-it's not like I want to show you the light of the Justiciar or anything, B-BAKA!"
 
-/mob/living/simple_animal/hostile/anima_fragment/Stat()
+/mob/living/simple_animal/hostile/clockwork/fragment/Stat()
 	..()
 	if(statpanel("Status") && movement_delay_time > world.time && !ratvar_awakens)
 		stat(null, "Movement delay(seconds): [max(round((movement_delay_time - world.time)*0.1, 0.1), 0)]")
 
-/mob/living/simple_animal/hostile/anima_fragment/death(gibbed)
+/mob/living/simple_animal/hostile/clockwork/fragment/death(gibbed)
 	visible_message("<span class='warning'>[src]'s flame jets cut out as it falls to the floor with a tremendous crash. A cube of metal tumbles out, whirring and sputtering.</span>", \
 	"<span class='userdanger'>Your gears seize up. Your flame jets flicker out. Your soul vessel belches smoke as you helplessly crash down.</span>")
 	..(TRUE)
 	return 1
 
-/mob/living/simple_animal/hostile/anima_fragment/Process_Spacemove(movement_dir = 0)
+/mob/living/simple_animal/hostile/clockwork/fragment/Process_Spacemove(movement_dir = 0)
 	return 1
 
-/mob/living/simple_animal/hostile/anima_fragment/movement_delay()
+/mob/living/simple_animal/hostile/clockwork/fragment/movement_delay()
 	. = ..()
 	if(movement_delay_time > world.time && !ratvar_awakens)
 		. += min((movement_delay_time - world.time) * 0.1, 10) //the more delay we have, the slower we go
 
-/mob/living/simple_animal/hostile/anima_fragment/adjustHealth(amount)
+/mob/living/simple_animal/hostile/clockwork/fragment/adjustHealth(amount)
 	. = ..()
 	if(!ratvar_awakens) //if ratvar is up we ignore movement delay
 		if(movement_delay_time > world.time)
@@ -59,45 +68,46 @@
 		else
 			movement_delay_time = world.time + amount*3
 
+/mob/living/simple_animal/hostile/clockwork/fragment/update_health()
+	..()
+	if(health == maxHealth)
+		speed = initial(speed)
+	else
+		speed = 0 //slow down if damaged at all
 
-/mob/living/simple_animal/hostile/clockwork_marauder //Clockwork marauder: Slow but with high damage, resides inside of a servant. Created via the Memory Allocation scripture.
+/mob/living/simple_animal/hostile/clockwork/marauder //Clockwork marauder: Slow but with high damage, resides inside of a servant. Created via the Memory Allocation scripture.
 	name = "clockwork marauder"
 	desc = "A stalwart apparition of a soldier, blazing with crimson flames. It's armed with a gladius and shield."
-	faction = list("ratvar")
-	icon = 'icons/mob/clockwork_mobs.dmi'
 	icon_state = "clockwork_marauder"
 	health = 25 //Health is governed by fatigue, but can be directly reduced by the presence of certain objects
 	maxHealth = 25
 	speed = 1
-	minbodytemp = 0
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	healable = FALSE
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	environment_smash = 1
-	unique_name = 1
 	weather_immunities = list("lava")
 	flying = 1
+	loot = list(/obj/item/clockwork/component/replicant_alloy/fallen_armor)
 	var/true_name = "Meme Master 69" //Required to call forth the marauder
 	var/list/possible_true_names = list("Xaven", "Melange", "Ravan", "Kel", "Rama", "Geke", "Peris", "Vestra", "Skiwa") //All fairly short and easy to pronounce
 	var/fatigue = 0 //Essentially what determines the marauder's power
 	var/fatigue_recall_threshold = 100 //In variable form due to changed effects once Ratvar awakens
 	var/mob/living/host //The mob that the marauder is living inside of
 	var/recovering = FALSE //If the marauder is recovering from a large amount of fatigue
-	var/playstyle_string = "<span class='heavy_brass'>You are a clockwork marauder</span><b>, a living extension of Ratvar's will. As a marauder, you are slow but sturdy and decently powerful \
+	playstyle_string = "<span class='heavy_brass'>You are a clockwork marauder</span><b>, a living extension of Ratvar's will. As a marauder, you are slow but sturdy and decently powerful \
 	in addition to being immune to extreme temperatures and pressures. Your primary goal is to serve the creature that you are now a part of. You can use the Linked Minds ability in your \
 	Marauder tab to communicate silently with your master, but can only exit if your master calls your true name.\n\n\
 	\
 	Taking damage and remaining outside of your master will cause <i>fatigue</i>, which hinders your movement speed and attacks, in addition to forcing you back into your master if it grows \
 	too high. As a final note, you should probably avoid harming any fellow servants of Ratvar.</span>"
 
-/mob/living/simple_animal/hostile/clockwork_marauder/New()
+/mob/living/simple_animal/hostile/clockwork/marauder/New()
 	..()
 	true_name = pick(possible_true_names)
 
-/mob/living/simple_animal/hostile/clockwork_marauder/Life()
+/mob/living/simple_animal/hostile/clockwork/marauder/Life()
 	..()
 	if(is_in_host())
 		if(!ratvar_awakens && host.stat == DEAD)
@@ -127,7 +137,7 @@
 					else //right next to or on top of host
 						adjust_fatigue(-1)
 
-/mob/living/simple_animal/hostile/clockwork_marauder/proc/update_fatigue()
+/mob/living/simple_animal/hostile/clockwork/marauder/proc/update_fatigue()
 	if(!ratvar_awakens && host && host.stat == DEAD)
 		death()
 		return
@@ -169,17 +179,14 @@
 				else
 					death() //Shouldn't ever happen, but...
 
-/mob/living/simple_animal/hostile/clockwork_marauder/death(gibbed)
+/mob/living/simple_animal/hostile/clockwork/marauder/death(gibbed)
 	..(TRUE)
 	emerge_from_host(0, 1)
 	visible_message("<span class='warning'>[src]'s equipment clatters lifelessly to the ground as the red flames within dissipate.</span>", \
 	"<span class='userdanger'>Your equipment falls away. You feel a moment of confusion before your fragile form is annihilated.</span>")
-	playsound(src, 'sound/magic/clockwork/anima_fragment_death.ogg', 100, 1)
-	new/obj/item/clockwork/component/replicant_alloy/fallen_armor(get_turf(src))
-	qdel(src)
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_marauder/Stat()
+/mob/living/simple_animal/hostile/clockwork/marauder/Stat()
 	..()
 	if(statpanel("Status"))
 		stat(null, "Fatigue: [fatigue]/[fatigue_recall_threshold]")
@@ -192,7 +199,7 @@
 		stat(null, "You are [recovering ? "too weak" : "able"] to deploy!")
 		stat(null, "You do [melee_damage_upper] on melee attacks.")
 
-/mob/living/simple_animal/hostile/clockwork_marauder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
+/mob/living/simple_animal/hostile/clockwork/marauder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
 	..()
 	if(findtext(message, true_name) && is_in_host()) //Called or revealed by hearing their true name
 		if(speaker == host)
@@ -201,7 +208,7 @@
 			src << "<span class='warning'><b>You hear your true name and partially emerge before you can stop yourself!</b></span>"
 			host.visible_message("<span class='warning'>[host]'s skin flashes crimson!</span>", "<span class='warning'><b>Your marauder instinctively reacts to its true name!</b></span>")
 
-/mob/living/simple_animal/hostile/clockwork_marauder/say(message)
+/mob/living/simple_animal/hostile/clockwork/marauder/say(message)
 	if(is_in_host())
 		message = "<span class='heavy_brass'>Marauder [true_name]:</span> <span class='brass'>\"[message]\"</span>" //Automatic linked minds
 		src << message
@@ -209,19 +216,19 @@
 		return 1
 	..()
 
-/mob/living/simple_animal/hostile/clockwork_marauder/adjustHealth(amount) //Fatigue damage
+/mob/living/simple_animal/hostile/clockwork/marauder/adjustHealth(amount) //Fatigue damage
 	for(var/mob/living/L in range(1, src))
 		if(L.null_rod_check()) //Null rods allow direct damage
 			src << "<span class='userdanger'>The power of a holy artifact bypasses your armor and wounds you directly!</span>"
 			return ..()
 	return adjust_fatigue(amount)
 
-/mob/living/simple_animal/hostile/clockwork_marauder/AttackingTarget()
+/mob/living/simple_animal/hostile/clockwork/marauder/AttackingTarget()
 	if(is_in_host())
 		return 0
 	..()
 
-/mob/living/simple_animal/hostile/clockwork_marauder/proc/adjust_fatigue(amount) //Adds or removes the given amount of fatigue
+/mob/living/simple_animal/hostile/clockwork/marauder/proc/adjust_fatigue(amount) //Adds or removes the given amount of fatigue
 	if(!ratvar_awakens || amount < 0)
 		fatigue = Clamp(fatigue + amount, 0, fatigue_recall_threshold)
 		update_fatigue()
@@ -229,7 +236,7 @@
 		amount = 0
 	return amount
 
-/mob/living/simple_animal/hostile/clockwork_marauder/verb/linked_minds() //Discreet communications between a marauder and its host
+/mob/living/simple_animal/hostile/clockwork/marauder/verb/linked_minds() //Discreet communications between a marauder and its host
 	set name = "Linked Minds"
 	set desc = "Silently communicates with your master."
 	set category = "Marauder"
@@ -252,10 +259,10 @@
 	set name = "Linked Minds"
 	set desc = "Silently communicates with your marauder."
 	set category = "Clockwork"
-	var/mob/living/simple_animal/hostile/clockwork_marauder/marauder
+	var/mob/living/simple_animal/hostile/clockwork/marauder/marauder
 
 	if(!marauder)
-		for(var/mob/living/simple_animal/hostile/clockwork_marauder/C in living_mob_list)
+		for(var/mob/living/simple_animal/hostile/clockwork/marauder/C in living_mob_list)
 			if(C.host == src)
 				marauder = C
 		if(!marauder) //Double-check afterwards
@@ -273,18 +280,18 @@
 	marauder << message
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_marauder/verb/change_true_name()
+/mob/living/simple_animal/hostile/clockwork/marauder/verb/change_true_name()
 	set name = "Change True Name (One-Use)"
 	set desc = "Changes your true name, used to be called forth."
 	set category = "Marauder"
 
-	verbs -= /mob/living/simple_animal/hostile/clockwork_marauder/verb/change_true_name
+	verbs -= /mob/living/simple_animal/hostile/clockwork/marauder/verb/change_true_name
 	var/new_name = stripped_input(usr, "Enter a new true name (20-character limit).", "Change True Name")// as null|anything
 	if(!usr)
 		return 0
 	if(!new_name)
 		usr << "<span class='notice'>You decide against changing your true name for now.</span>"
-		verbs += /mob/living/simple_animal/hostile/clockwork_marauder/verb/change_true_name //If they decide against it, let them have another opportunity
+		verbs += /mob/living/simple_animal/hostile/clockwork/marauder/verb/change_true_name //If they decide against it, let them have another opportunity
 		return 0
 	new_name = dd_limittext(new_name, 20)
 	true_name = new_name
@@ -293,7 +300,7 @@
 		host << "<span class='userdanger'>Your clockwork marauder has changed their true name to \"[new_name]\"!</span>"
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_marauder/verb/return_to_host()
+/mob/living/simple_animal/hostile/clockwork/marauder/verb/return_to_host()
 	set name = "Return to Host"
 	set desc = "Recalls yourself to your host, assuming you aren't already there."
 	set category = "Marauder"
@@ -302,21 +309,21 @@
 		return 0
 	if(!host)
 		src << "<span class='warning'>You don't have a host!</span>"
-		verbs -= /mob/living/simple_animal/hostile/clockwork_marauder/verb/return_to_host
+		verbs -= /mob/living/simple_animal/hostile/clockwork/marauder/verb/return_to_host
 		return 0
 	host << "<span class='heavy_brass'>You feel [true_name]'s consciousness settle in your mind.</span>"
 	visible_message("<span class='warning'>[src] is yanked into [host]'s body!</span>", "<span class='brass'>You return to [host].</span>")
 	forceMove(host)
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_marauder/verb/try_emerge()
+/mob/living/simple_animal/hostile/clockwork/marauder/verb/try_emerge()
 	set name = "Attempt to Emerge from Host"
 	set desc = "Attempts to emerge from your host, likely to only work if your host is very heavily damaged."
 	set category = "Marauder"
 
 	if(!host)
 		src << "<span class='warning'>You don't have a host!</span>"
-		verbs -= /mob/living/simple_animal/hostile/clockwork_marauder/verb/try_emerge
+		verbs -= /mob/living/simple_animal/hostile/clockwork/marauder/verb/try_emerge
 		return 0
 	var/resulthealth
 	resulthealth = round((abs(config.health_threshold_dead - host.health) / abs(config.health_threshold_dead - host.maxHealth)) * 100)
@@ -325,7 +332,7 @@
 		return
 	return emerge_from_host(0)
 
-/mob/living/simple_animal/hostile/clockwork_marauder/proc/emerge_from_host(hostchosen, force) //Notice that this is a proc rather than a verb - marauders can NOT exit at will, but they CAN return
+/mob/living/simple_animal/hostile/clockwork/marauder/proc/emerge_from_host(hostchosen, force) //Notice that this is a proc rather than a verb - marauders can NOT exit at will, but they CAN return
 	if(!is_in_host())
 		return 0
 	if(!force && recovering)
@@ -343,32 +350,26 @@
 	visible_message("<span class='warning'>[host]'s skin glows red as [name] emerges from their body!</span>", "<span class='brass'>You exit the safety of [host]'s body!</span>")
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_marauder/proc/is_in_host() //Checks if the marauder is inside of their host
+/mob/living/simple_animal/hostile/clockwork/marauder/proc/is_in_host() //Checks if the marauder is inside of their host
 	return host && loc == host
 
 
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer
+/mob/living/simple_animal/hostile/clockwork/reclaimer
 	name = "clockwork reclaimer"
 	desc = "A tiny clockwork arachnid with a single cogwheel spinning quickly in its head. Its legs blur, too fast to be seen clearly."
-	faction = list("ratvar")
-	icon = 'icons/mob/clockwork_mobs.dmi'
 	icon_state = "clockwork_reclaimer"
 	health = 50
 	maxHealth = 50
-	minbodytemp = 0
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0) //Robotic
-	healable = FALSE
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	attacktext = "slams into"
 	attack_sound = 'sound/magic/clockwork/anima_fragment_attack.ogg'
 	ventcrawler = 2
-	unique_name = 1
-	var/playstyle_string = "<span class='heavy_brass'>You are a clockwork reclaimer</span><b>, a harbringer of the Justiciar's light. You can crawl through vents to move more swiftly. Your \
+	playstyle_string = "<span class='heavy_brass'>You are a clockwork reclaimer</span><b>, a harbringer of the Justiciar's light. You can crawl through vents to move more swiftly. Your \
 	goal: purge all untruths and honor Ratvar. You may alt-click a valid target to break yourself apart and convert the target to a servant of Ratvar.</b>"
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer/New()
+/mob/living/simple_animal/hostile/clockwork/reclaimer/New()
 	..()
 	if(prob(1))
 		real_name = "jehovah's witness"
@@ -379,21 +380,21 @@
 		add_servant_of_ratvar(src, TRUE)
 		src << playstyle_string
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer/Life()
+/mob/living/simple_animal/hostile/clockwork/reclaimer/Life()
 	..()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/L = loc
 		if(L.stat || !L.client)
 			disengage()
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer/death()
+/mob/living/simple_animal/hostile/clockwork/reclaimer/death()
 	..(1)
 	visible_message("<span class='warning'>[src] bursts into deadly shrapnel!</span>")
 	for(var/mob/living/carbon/C in range(2, src))
 		C.adjustBruteLoss(rand(3, 5))
 	qdel(src)
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer/AltClickOn(atom/movable/A)
+/mob/living/simple_animal/hostile/clockwork/reclaimer/AltClickOn(atom/movable/A)
 	if(!ishuman(A))
 		return ..()
 	var/mob/living/carbon/human/H = A
@@ -431,7 +432,7 @@
 		mind.transfer_to(H)
 	return 1
 
-/mob/living/simple_animal/hostile/clockwork_reclaimer/verb/disengage()
+/mob/living/simple_animal/hostile/clockwork/reclaimer/verb/disengage()
 	set name = "Disgengage From Host"
 	set desc = "Jumps off of your host if you have one, freeing their mind but allowing you movement."
 	set category = "Clockwork"

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -67,7 +67,7 @@
 
 /mob/living/simple_animal/hostile/clockwork/fragment/adjustHealth(amount)
 	. = ..()
-	if(!ratvar_awakens) //if ratvar is up we ignore movement delay
+	if(!ratvar_awakens && amount > 0) //if ratvar is up we ignore movement delay
 		if(movement_delay_time > world.time)
 			movement_delay_time = movement_delay_time + amount*3
 		else
@@ -174,7 +174,7 @@
 				melee_damage_lower = 5
 				melee_damage_upper = 5
 				attacktext = "weakly slashes"
-			if(99 to 100)
+			if(99 to fatigue_recall_threshold)
 				src << "<span class='userdanger'>The fatigue becomes too much!</span>"
 				if(host)
 					src << "<span class='userdanger'>You retreat to [host] - you will have to wait before being deployed again.</span>"

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -142,6 +142,9 @@
 					else //right next to or on top of host
 						adjust_fatigue(-1)
 
+/mob/living/simple_animal/hostile/clockwork/marauder/Process_Spacemove(movement_dir = 0)
+	return 1
+
 /mob/living/simple_animal/hostile/clockwork/marauder/proc/update_fatigue()
 	if(!ratvar_awakens && host && host.stat == DEAD)
 		death()
@@ -201,7 +204,10 @@
 			var/resulthealth
 			resulthealth = round((abs(config.health_threshold_dead - host.health) / abs(config.health_threshold_dead - host.maxHealth)) * 100)
 			stat(null, "Host Health: [resulthealth]%")
-		stat(null, "You are [recovering ? "too weak" : "able"] to deploy!")
+			if(resulthealth > 60)
+				stat(null, "You are [recovering ? "unable to deploy" : "can deploy on hearing True Name"]!")
+			else
+				stat(null, "You are [recovering ? "unable to deploy" : "can deploy to protect your host"]!")
 		stat(null, "You do [melee_damage_upper] on melee attacks.")
 
 /mob/living/simple_animal/hostile/clockwork/marauder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)

--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -205,7 +205,7 @@
 /obj/structure/clockwork/massive/ratvar/attack_ghost(mob/dead/observer/O)
 	if(alert(O, "Embrace the Justiciar's light? You can no longer be cloned!",,"Yes", "No") == "No" || !O)
 		return 0
-	var/mob/living/simple_animal/hostile/clockwork_reclaimer/R = new(get_turf(src))
+	var/mob/living/simple_animal/hostile/clockwork/reclaimer/R = new(get_turf(src))
 	R.visible_message("<span class='warning'>[R] forms and hums to life!</span>")
 	R.key = O.key
 

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -757,7 +757,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	tier = SCRIPTURE_APPLICATION
 
 /datum/clockwork_scripture/memory_allocation/check_special_requirements()
-	for(var/mob/living/simple_animal/hostile/clockwork_marauder/M in living_mob_list)
+	for(var/mob/living/simple_animal/hostile/clockwork/marauder/M in living_mob_list)
 		if(M.host == invoker)
 			invoker << "<span class='warning'>You can only house one marauder at a time!</span>"
 			return 0
@@ -791,7 +791,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		"<span class='warning'>The tendril was unsuccessful! Perhaps you should try again another time.</span>")
 		return 0
 	var/mob/dead/observer/theghost = pick(marauder_candidates)
-	var/mob/living/simple_animal/hostile/clockwork_marauder/M = new(invoker)
+	var/mob/living/simple_animal/hostile/clockwork/marauder/M = new(invoker)
 	M.key = theghost.key
 	M.host = invoker
 	M << M.playstyle_string

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -393,8 +393,9 @@
 		if(S.brainmob && (!S.brainmob.client || !S.brainmob.mind))
 			user << "<span class='warning'>[S]'s trapped spirit appears inactive!</span>"
 			return 0
-		user.visible_message("<span class='notice'>[user] clicks [S] into place on [src].</span>", "<span class='brass'>You insert [S] into [src]. It whirs and begins to rise.</span>")
-		var/mob/living/simple_animal/hostile/anima_fragment/A = new(get_turf(src))
+		user.visible_message("<span class='notice'>[user] places [S] in [src], where it fuses to the shell.</span>", "<span class='brass'>You place [S] in [src], fusing it to the shell.</span>")
+		var/mob/living/simple_animal/hostile/clockwork/fragment/A = new(get_turf(src))
+		A.visible_message("[src] whirs and rises from the ground on a flickering jet of reddish fire.")
 		S.brainmob.mind.transfer_to(A)
 		add_servant_of_ratvar(A, TRUE)
 		A << A.playstyle_string


### PR DESCRIPTION
:cl: Joan
tweak: Anima Fragments are now slightly slower if not at maximum health and no longer drop a soul vessel when destroyed.
/:cl:

Bunch of background changes, here; all clockwork mobs are a subtype of one mob.
That one mob has an internal slab so it can easily run scripture/etc and makes it way easier to give clockwork mobs the ability to use comms, though it's currently unused.
