### PR TITLE
Adds "Analyze Air" ghost verb, and "Analyze Air Verbose" debug admin verb

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -268,7 +268,9 @@ MASS SPECTROMETER
 		return
 
 	var/datum/gas_mixture/environment = location.return_air()
+	print_environment(user, environment)
 
+/proc/print_environment(user, datum/gas_mixture/environment)
 	var/pressure = environment.return_pressure()
 	var/total_moles = environment.total_moles()
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -146,7 +146,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/create_outfits,
 	/client/proc/debug_huds,
 	/client/proc/map_template_load,
-	/client/proc/map_template_upload
+	/client/proc/map_template_upload,
+	/client/proc/analyze_air
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -735,3 +735,17 @@ var/global/list/g_fancy_list_of_types = null
 	if(!holder)
 		return
 	debug_variables(huds[i])
+
+/client/proc/analyze_air()
+	set category = "Debug"
+	set name = "Analyze Air"
+	set desc = "Displays what an air analyzer would output if used on this \
+		turf."
+	if(!holder)
+		return
+
+	var/turf/location = get_turf(usr)
+	if(!istype(location))
+		return
+	var/datum/gas_mixture/environment = location.return_air()
+	print_environment(usr, environment)


### PR DESCRIPTION
:cl: coiax
rscadd: Adds "Analyze Air" to Ghost verbs. Prints the same information as an analyzer used on your mob's turf.
rscadd: Adds "Analyze Air Verbose" to Admin debug verbs. Prints a complete breakdown of the air sample.
/:cl:
