### PR TITLE
Puts the AI in its place

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -23001,15 +23001,15 @@
 	charge = 5e+006
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/space)
 "aZU" = (
 /obj/item/device/multitool,
 /turf/open/floor/bluegrid,
@@ -54975,13 +54975,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cpS" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "SMES room APC";
-	pixel_y = -24
-	},
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "cpT" = (
@@ -58036,7 +58033,7 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 5000;
-	dir = 2;
+	dir = 1;
 	name = "AI Chamber APC";
 	pixel_y = 24
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -28132,6 +28132,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
 /turf/open/floor/plasteel,
 /area/assembly/chargebay)
 "bly" = (
@@ -32795,6 +32798,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
 	icon_state = "darkblue";
@@ -32814,6 +32820,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -58236,7 +58236,7 @@
 "cwp" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/space)
+/area/turret_protected/ai_upload)
 "cwq" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -88163,7 +88163,7 @@ aaa
 aaf
 aaa
 aaf
-aZT
+bfv
 cwp
 cwp
 cwq
@@ -88404,7 +88404,7 @@ aSu
 aTU
 cpC
 aWO
-aYt
+cvH
 aYx
 cva
 cva
@@ -88414,7 +88414,7 @@ cvY
 cva
 cva
 cva
-cva
+bfv
 cwm
 cwm
 cwm
@@ -88671,7 +88671,7 @@ bfu
 cwn
 bgO
 cvM
-cvM
+bbk
 cwo
 cws
 cwu
@@ -88928,7 +88928,7 @@ cvF
 cvl
 cvp
 cva
-cvb
+bft
 bkI
 aZR
 cwg
@@ -89433,7 +89433,7 @@ aTX
 aVk
 aWS
 cva
-aZT
+cva
 cBj
 cvy
 cvv
@@ -89956,7 +89956,7 @@ cvI
 cvl
 cvp
 cva
-cvb
+bft
 cvZ
 cwf
 cwi
@@ -90213,7 +90213,7 @@ bfx
 bij
 cwh
 cvR
-cvR
+bbp
 cwr
 cwt
 cwv
@@ -90460,7 +90460,7 @@ aSC
 aUa
 aVo
 aWW
-aYA
+cvL
 cvK
 cva
 cva
@@ -90470,7 +90470,7 @@ aYB
 cva
 cva
 cva
-cva
+bfv
 cwm
 cwm
 cwm
@@ -90733,7 +90733,7 @@ aaa
 aaf
 aaa
 aaf
-aZT
+bfv
 cwp
 cwp
 cwq

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -21665,13 +21665,13 @@
 /turf/open/floor/plasteel/blue/corner,
 /area/bridge)
 "aWQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/airalarm{
 	dir = 1;
 	icon_state = "alarm0";
 	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 0
@@ -21696,6 +21696,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge Center";
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 0
@@ -21726,15 +21733,6 @@
 	},
 /area/bridge)
 "aWV" = (
-/obj/machinery/turretid{
-	control_area = "AI Upload Chamber";
-	name = "AI Upload turret control";
-	pixel_y = -25
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge Center";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -22406,7 +22404,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/bridge)
 "aYu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22427,7 +22425,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "aYw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22448,32 +22446,37 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "aYy" = (
-/obj/machinery/ai_status_display,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "aYz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "aYA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/bridge)
 "aYB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
 "aYC" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -22963,25 +22966,54 @@
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "aZS" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
+/obj/effect/landmark{
+	name = "tripai"
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	broadcasting = 0;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = 5
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "aZT" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "aZU" = (
-/obj/machinery/porta_turret/ai{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/obj/item/device/multitool,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "aZV" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/captain)
@@ -23875,33 +23907,36 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bce" = (
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/quarantine,
-/obj/machinery/camera/motion{
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (EAST)";
+	icon_state = "greyOff";
 	dir = 4
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
-"bcf" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4";
+	d2 = 4
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"bcf" = (
+/obj/machinery/ai_slipper{
+	icon_state = "motion0";
+	uses = 10
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "bcg" = (
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/freeform,
-/obj/structure/sign/kiddieplaque{
-	pixel_x = 32
-	},
-/obj/machinery/camera/motion{
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (WEST)";
+	icon_state = "greyOff";
 	dir = 8
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "bch" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -24304,13 +24339,10 @@
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai_upload)
 "bdg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/light,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bdh" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -24734,14 +24766,15 @@
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai_upload)
 "bec" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/turret_protected/ai)
 "bed" = (
 /obj/machinery/power/apc{
 	cell_type = 5000;
@@ -24796,12 +24829,13 @@
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai_upload)
 "beh" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/turret_protected/ai)
 "bei" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -25300,7 +25334,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bft" = (
 /obj/machinery/ai_status_display,
 /turf/closed/wall/r_wall,
@@ -25309,8 +25343,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/obj/machinery/ai_slipper{
+	icon_state = "motion0";
+	uses = 10
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
@@ -25325,8 +25363,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/obj/machinery/ai_slipper{
+	icon_state = "motion0";
+	uses = 10
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "bfy" = (
 /obj/structure/table/wood,
 /obj/item/weapon/paper_bin{
@@ -25341,7 +25383,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bfA" = (
 /obj/structure/table/wood,
 /obj/item/weapon/hand_tele,
@@ -25834,8 +25876,13 @@
 /area/engine/gravity_generator)
 "bgO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "bgP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -26495,8 +26542,8 @@
 /area/engine/gravity_generator)
 "bij" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
 "bik" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -27635,12 +27682,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bkI" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/black,
-/area/engine/gravity_generator)
+/area/turret_protected/ai_upload)
 "bkJ" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
@@ -29241,18 +29289,11 @@
 /turf/open/floor/plasteel/black,
 /area/engine/gravity_generator)
 "bnV" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/porta_turret/ai{
+	icon_state = "greyOff"
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bnW" = (
 /obj/structure/grille,
 /obj/structure/sign/securearea{
@@ -29842,10 +29883,9 @@
 	},
 /area/engine/gravity_generator)
 "bph" = (
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/engine/gravity_generator)
+/obj/machinery/hologram/holopad,
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload)
 "bpi" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -30525,27 +30565,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "bqD" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
-	name = "Gravity Generator APC";
-	pixel_x = -25;
-	pixel_y = 1
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
 	},
-/obj/structure/table,
-/obj/item/weapon/paper/gravity_gen{
-	layer = 3
+/turf/open/floor/plasteel/vault{
+	dir = 8
 	},
-/obj/item/weapon/pen/blue,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -35
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/turret_protected/ai_upload)
 "bqE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30564,16 +30593,14 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bqG" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
+/turf/open/floor/plasteel/vault{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/turret_protected/ai_upload)
 "bqH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
@@ -31312,52 +31339,82 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "bsa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/light/small,
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 2;
+	name = "Upload APC";
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bsb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (EAST)";
+	icon_state = "greyOff";
+	dir = 4
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bsc" = (
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload)
 "bsd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bse" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/light/small,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Station Intercom (AI Private)";
+	pixel_y = -29
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bsf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+/obj/machinery/camera/motion{
+	c_tag = "AI Core";
+	dir = 1;
+	network = list("SS13")
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bsg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (WEST)";
+	icon_state = "greyOff";
+	dir = 8
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
 "bsh" = (
 /turf/closed/wall,
 /area/teleporter)
@@ -32073,15 +32130,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "btF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
+/obj/machinery/door/airlock/highsecurity{
+	icon_state = "closed";
+	locked = 0;
+	name = "AI Upload Access";
+	req_access_txt = "16"
 	},
-/turf/open/floor/plasteel/delivery{
-	name = "floor"
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
 	},
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload)
 "btG" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -32695,49 +32755,47 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "buP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "buQ" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Station Intercom (AI Private)";
+	pixel_x = 0;
+	pixel_y = 25
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 9
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTH)";
+	icon_state = "darkblue";
+	dir = 1
 	},
-/area/engine/gravity_generator)
+/area/turret_protected/ai_upload_foyer)
 "buR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "buS" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/machinery/turretid{
+	control_area = "AI Upload Chamber";
+	name = "AI Upload turret control";
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTH)";
+	icon_state = "darkblue";
+	dir = 1
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 5
-	},
-/area/engine/gravity_generator)
+/area/turret_protected/ai_upload_foyer)
 "buT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33259,6 +33317,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/warning{
 	dir = 1
 	},
@@ -33354,9 +33416,6 @@
 	},
 /area/hallway/primary/central)
 "bwh" = (
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33401,39 +33460,52 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads)
 "bwm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/engine/gravity_generator)
-"bwn" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/warning{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/area/engine/gravity_generator)
-"bwo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/engine/gravity_generator)
-"bwp" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
-	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 32;
-	pixel_y = 0
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
+"bwn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel/warning{
+/obj/machinery/airalarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Foyer";
+	dir = 1
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload_foyer)
+"bwo" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/area/engine/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
+"bwp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "AI Upload Access APC";
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload_foyer)
 "bwq" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plating,
@@ -34137,27 +34209,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "bxI" = (
-/obj/machinery/ai_status_display,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "bxJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "bxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/closed/wall,
-/area/engine/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai_upload_foyer)
 "bxL" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway South-East";
@@ -34683,12 +34754,24 @@
 /area/security/checkpoint/supply)
 "byU" = (
 /obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -35231,6 +35314,10 @@
 /area/hallway/primary/central)
 "bAf" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAg" = (
@@ -35803,6 +35890,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBm" = (
@@ -35836,6 +35929,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBq" = (
@@ -35862,6 +35958,12 @@
 	icon_state = "direction_evac";
 	pixel_x = -32;
 	pixel_y = -32
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -48991,12 +49093,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdk" = (
@@ -49117,12 +49213,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdw" = (
@@ -49335,7 +49425,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/warning/corner{
+	dir = 4
+	},
 /area/engine/engineering)
 "cdU" = (
 /obj/structure/table/reinforced,
@@ -49511,6 +49603,11 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ceo" = (
@@ -49567,6 +49664,11 @@
 	pixel_y = 0
 	},
 /obj/structure/window/fulltile,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cev" = (
@@ -49785,6 +49887,11 @@
 	req_one_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfa" = (
@@ -49841,17 +49948,16 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cff" = (
 /obj/machinery/vending/tool,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
@@ -50016,10 +50122,6 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50035,9 +50137,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfD" = (
@@ -50045,12 +50145,6 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
 	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -50102,11 +50196,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50118,13 +50207,14 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50439,21 +50529,6 @@
 /area/maintenance/asmaint2)
 "cgv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50670,22 +50745,22 @@
 /turf/open/floor/plating,
 /area/engine/chiefs_office)
 "cgT" = (
-/obj/machinery/door/airlock/engineering{
-	name = "SMES Room";
-	req_access_txt = "32"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Foyer";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel/delivery{
 	name = "floor"
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cgU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -50991,15 +51066,15 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "chB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chC" = (
@@ -51018,13 +51093,13 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "chD" = (
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/warning{
 	dir = 8
@@ -51032,17 +51107,18 @@
 /area/engine/engineering)
 "chE" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
@@ -51250,6 +51326,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cib" = (
@@ -51275,7 +51355,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/table,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cid" = (
@@ -51287,8 +51367,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/yellow/side,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/warning{
+	dir = 10
+	},
 /area/engine/engineering)
 "cie" = (
 /obj/structure/cable{
@@ -51299,6 +51381,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = 30
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
@@ -51311,10 +51396,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/table,
-/obj/item/weapon/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/yellow/side,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
 /area/engine/engineering)
 "cig" = (
 /turf/closed/wall,
@@ -51588,11 +51673,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
@@ -51769,7 +51849,13 @@
 /area/engine/chiefs_office)
 "cjh" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
+/obj/structure/sign/pods{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 6
+	},
 /area/engine/engineering)
 "cji" = (
 /obj/structure/cable{
@@ -51838,9 +51924,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cjp" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weapon/storage/toolbox/emergency,
 /turf/open/floor/plasteel/floorgrime,
@@ -52021,6 +52104,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjO" = (
@@ -52033,6 +52121,11 @@
 "cjP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -52303,16 +52396,18 @@
 /turf/open/floor/plasteel/black,
 /area/engine/engine_smes)
 "ckx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	dir = 1;
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 8
 	},
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cky" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52368,6 +52463,11 @@
 /obj/structure/table,
 /obj/item/weapon/book/manual/engineering_singularity_safety,
 /obj/item/clothing/gloves/color/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckH" = (
@@ -52814,18 +52914,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "clC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "clD" = (
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -52842,18 +52935,12 @@
 	},
 /area/engine/engine_smes)
 "clF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
 /turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "clG" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -53158,13 +53245,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboardsolar)
 "cmy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	dir = 8;
+	network = list("SS13");
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cmz" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -53255,6 +53344,11 @@
 /area/shuttle/syndicate)
 "cmI" = (
 /obj/machinery/vending/engivend,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -53527,18 +53621,8 @@
 	dir = 2;
 	on = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cnn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -53560,30 +53644,13 @@
 	},
 /area/engine/engine_smes)
 "cnp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "SMES Room";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	on = 1;
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cnq" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -53787,130 +53854,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboardsolar)
 "cnL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
-"cnM" = (
-/obj/machinery/door/window{
-	name = "SMES Chamber";
-	req_access_txt = "32"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
-"cnN" = (
-/obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
-"cnO" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
-"cnP" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/engine/engine_smes)
-"cnQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
-	},
-/area/engine/engine_smes)
-"cnR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
-"cnS" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "SMES Access";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 4
-	},
-/area/engine/engine_smes)
-"cnT" = (
-/obj/structure/sign/bluecross_2,
-/turf/closed/indestructible/opshuttle,
-/area/shuttle/syndicate)
-"cnU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -53919,8 +53868,104 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/turf/open/floor/plating/airless,
+/area/engine/gravity_generator)
+"cnM" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Gravity Generator Area";
+	req_access_txt = "19; 61"
+	},
+/turf/open/floor/plasteel/black,
+/area/engine/gravity_generator)
+"cnN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/gravity_generator)
+"cnO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/gravity_generator)
+"cnP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/cable{
+	tag = "icon-0-4";
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/gravity_generator)
+"cnQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 8
+	},
+/area/engine/gravity_generator)
+"cnR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"cnS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Foyer";
+	dir = 2;
+	network = list("SS13");
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/engine/gravity_generator)
+"cnT" = (
+/obj/structure/sign/bluecross_2,
+/turf/closed/indestructible/opshuttle,
+/area/shuttle/syndicate)
+"cnU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/securearea{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/loadingarea,
 /area/engine/engineering)
@@ -54010,7 +54055,12 @@
 /obj/effect/landmark/start{
 	name = "Station Engineer"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cod" = (
@@ -54177,50 +54227,51 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
+/turf/open/floor/plasteel/warning{
+	dir = 9
+	},
+/area/engine/gravity_generator)
+"cow" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/engine/gravity_generator)
+"cox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/warning{
-	dir = 9
-	},
-/area/engine/engine_smes)
-"cow" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/warning{
 	dir = 1
 	},
-/area/engine/engine_smes)
-"cox" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/warning{
-	dir = 1
-	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "coy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
 /turf/open/floor/plasteel/warning{
 	dir = 5
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "coz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54238,7 +54289,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54246,31 +54297,31 @@
 /turf/open/floor/plasteel/warning{
 	dir = 8
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "coB" = (
-/obj/machinery/door/airlock/engineering{
-	name = "SMES Room";
-	req_access_txt = "32"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
+	},
 /turf/open/floor/plasteel/delivery{
 	name = "floor"
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "coC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -54278,7 +54329,7 @@
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "coD" = (
 /obj/structure/table,
 /obj/item/weapon/wrench,
@@ -54318,13 +54369,13 @@
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/syndicate)
 "coH" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -54336,11 +54387,6 @@
 /area/shuttle/syndicate)
 "coJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -54362,11 +54408,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54499,10 +54540,10 @@
 /turf/open/floor/plasteel/shuttle/red,
 /area/shuttle/syndicate)
 "coZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cpa" = (
 /obj/machinery/light{
@@ -54579,27 +54620,47 @@
 /turf/open/space,
 /area/solar/starboard)
 "cpj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Gravity Generator APC";
+	pixel_x = -25;
+	pixel_y = 1
 	},
-/area/engine/engine_smes)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpk" = (
 /turf/open/floor/plasteel/warning/corner{
 	dir = 2
 	},
 /area/engine/engine_smes)
 "cpl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/open/floor/plasteel,
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cpm" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -54612,23 +54673,40 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/area/engine/engine_smes)
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpn" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/warning,
-/area/engine/engine_smes)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	on = 1
 	},
+/obj/machinery/light/small,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/warning{
 	dir = 8
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cpp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -54645,14 +54723,10 @@
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
-/area/engine/engine_smes)
+/area/engine/gravity_generator)
 "cpq" = (
 /obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -54901,37 +54975,32 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cpS" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "SMES room APC";
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/warning{
-	dir = 10
-	},
-/area/engine/engine_smes)
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpT" = (
 /obj/structure/table,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -35
 	},
-/obj/item/weapon/stock_parts/cell/high/plus,
-/turf/open/floor/plasteel/warning{
-	dir = 6
-	},
-/area/engine/engine_smes)
+/obj/item/weapon/pen,
+/obj/item/weapon/paper/gravity_gen,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpU" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/warning,
-/area/engine/engine_smes)
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "cpV" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -57734,108 +57803,60 @@
 /turf/open/space,
 /area/space)
 "cvG" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4;
-	installation = /obj/item/weapon/gun/energy/gun
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/blue/side{
+	dir = 0
+	},
+/area/bridge)
+"cvH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
 "cvI" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
 "cvJ" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4;
-	installation = /obj/item/weapon/gun/energy/gun
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvK" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthEast";
-	dir = 4;
-	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
-	start_active = 1
-	},
-/turf/open/space,
-/area/space)
-"cvL" = (
-/obj/structure/sign/securearea{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvM" = (
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Core Hallway";
-	dir = 4;
-	network = list("MiniSat")
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvN" = (
-/obj/structure/sign/securearea{
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvN" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/turret_protected/ai)
 "cvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57843,355 +57864,395 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "cvP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvT" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvV" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "2-4";
+	tag = ""
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvW" = (
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvU" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "cvX" = (
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	dir = 1;
+	network = list("SS13")
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "cvY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/airalarm{
+	desc = "This particular atmos control unit appears to have no access restrictions.";
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cwa" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "MiniSat Chamber Hallway APC";
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cwb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cwc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	icon_state = "alarm0";
+	locked = 0;
+	name = "all-access air alarm";
+	pixel_x = -24;
+	req_access = "0";
+	req_one_access = "0"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cwd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/area/turret_protected/ai)
+"cvZ" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 1;
+	anyai = 1;
+	broadcasting = 0;
+	freerange = 1;
 	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	freerange = 1;
 	listening = 0;
-	name = "Station Intercom (AI Private)";
+	name = "Custom Channel";
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = 5
+	},
+/obj/effect/landmark/start{
+	name = "AI"
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 28;
+	pixel_y = 28
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
 	pixel_x = -28;
-	pixel_y = -29
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/area/turret_protected/ai)
+"cwa" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cwb" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 2;
+	name = "AI Chamber APC";
+	pixel_y = 24
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	tag = "icon-0-4";
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cwc" = (
+/obj/machinery/door/window{
+	dir = 2;
+	name = "AI Core Door";
+	req_access_txt = "16"
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	tag = "icon-0-4";
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cwd" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/turretid{
+	name = "AI Chamber turret control";
+	pixel_x = -5;
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	tag = "icon-0-4";
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
 "cwe" = (
-/obj/structure/sign/securearea,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwf" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwg" = (
-/obj/machinery/airalarm{
-	frequency = 1439;
-	pixel_y = 23
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwj" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cwh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cwi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cwj" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	dir = 1;
+	network = list("SS13")
+	},
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
 "cwk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8;
-	on = 1;
-	scrub_Toxins = 0
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Core";
+	req_access_txt = "65"
 	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwm" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/folder/white,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/turret_protected/ai_upload)
 "cwn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
 "cwo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/oxygen,
+/obj/item/weapon/aiModule/zeroth/oneHuman,
+/obj/item/weapon/aiModule/reset/purge,
+/obj/item/weapon/aiModule/core/full/antimov,
+/obj/item/weapon/aiModule/supplied/protectStation,
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "High-Risk Modules";
+	req_access_txt = "20"
 	},
+/obj/structure/window/reinforced,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwp" = (
+/obj/machinery/computer/upload/borg,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwq" = (
+/obj/machinery/computer/upload/ai,
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table,
+/obj/item/weapon/aiModule/core/full/asimov,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/core/full/custom,
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Core Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cws" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/freeform,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/quarantine,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cww" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwp" = (
-/obj/structure/chair/office/dark,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwq" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cwr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
-/area/turret_protected/ai)
-"cws" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/turret_protected/ai)
-"cwt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_command{
-	name = "AI Core";
-	req_access_txt = "65"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwv" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
+/obj/structure/table,
+/obj/item/weapon/aiModule/reset,
 /turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cww" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwx" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/area/turret_protected/ai_upload)
 "cwy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -58200,88 +58261,82 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "cwz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	tag = "icon-darkblue (NORTH)";
+	icon_state = "darkblue";
+	dir = 1
+	},
+/area/turret_protected/ai_upload_foyer)
+"cwA" = (
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwA" = (
+/area/turret_protected/ai_upload_foyer)
+"cwB" = (
+/obj/machinery/door/airlock/highsecurity{
+	icon_state = "closed";
+	locked = 0;
+	name = "AI Upload Access";
+	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload_foyer)
+"cwC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cwD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwB" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = 32
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cwC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwD" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/turf/open/floor/plasteel/warning/corner{
 	dir = 8
 	},
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_x = 5;
-	pixel_y = -24
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/engine/engineering)
 "cwE" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/power/terminal{
+	icon_state = "term";
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/turf/open/floor/plasteel/warning{
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
-	name = "AI Chamber APC";
-	pixel_y = -24
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -11;
-	pixel_y = -24
-	},
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat AI Chamber North";
-	dir = 1;
-	network = list("MiniSat")
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/engine/engineering)
 "cwF" = (
 /obj/structure/chair{
 	dir = 1
@@ -59591,14 +59646,27 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cAj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/engine/engineering)
 "cAk" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -59891,139 +59959,100 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cAR" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "AI Core Door";
-	req_access_txt = "16"
+/obj/structure/cable/yellow{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/warning{
+	dir = 1
+	},
+/area/engine/engineering)
 "cAS" = (
-/obj/effect/landmark/start{
-	name = "AI"
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -9
-	},
-/obj/item/device/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 0;
-	pixel_y = -31
-	},
-/obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = -9
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -28;
-	pixel_y = -28
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 28;
-	pixel_y = -28
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cAT" = (
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cAU" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthWest";
-	dir = 8;
-	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
-	start_active = 1
-	},
-/turf/open/space,
-/area/space)
-"cAV" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/showcase{
-	density = 0;
-	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 8;
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "robot_old";
-	name = "Cyborg Statue";
-	pixel_x = 9;
-	pixel_y = 2
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cAT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cAU" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cAV" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cAW" = (
-/obj/structure/showcase{
-	density = 0;
-	desc = "An old, deactivated cyborg. Whilst once actively used to guard against intruders, it now simply intimidates them with its cold, steely gaze.";
-	dir = 4;
-	icon = 'icons/mob/robots.dmi';
-	icon_state = "robot_old";
-	name = "Cyborg Statue";
-	pixel_x = -9;
-	pixel_y = 2
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cAX" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthEast";
-	dir = 4;
-	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
-	start_active = 1
-	},
-/turf/open/space,
-/area/space)
-"cAY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+/obj/structure/cable/yellow{
 	icon_state = "4-8";
-	pixel_y = 0
+	d1 = 4;
+	d2 = 8
 	},
-/turf/closed/wall,
-/area/turret_protected/ai)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cAY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cAZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60033,61 +60062,63 @@
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
 "cBa" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cBb" = (
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat AI Chamber South";
-	dir = 2;
-	network = list("MiniSat")
+/obj/structure/cable/yellow{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cBc" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cBd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/obj/structure/cable/yellow{
+	icon_state = "4-8";
+	d1 = 4;
+	d2 = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cBe" = (
-/obj/machinery/airalarm{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+	external_pressure_bound = 101.325;
+	on = 1;
+	pressure_checks = 1
 	},
-/obj/machinery/hologram/holopad,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cBf" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat External South";
-	dir = 2;
-	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
-	start_active = 1
+/turf/open/floor/plasteel/warning{
+	dir = 5
 	},
-/turf/open/space,
-/area/space)
+/area/engine/engineering)
 "cBg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -60103,16 +60134,20 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/storage)
 "cBj" = (
-/obj/structure/table,
-/obj/item/weapon/folder/blue,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai_upload)
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "cBk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60379,17 +60414,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "cBS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -82489,16 +82516,16 @@ bLv
 cgH
 bLv
 aaf
-cAj
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
+btG
+btG
+btG
+btG
+btG
+btG
+btG
+btG
+btG
+btG
 aaa
 crn
 aaa
@@ -82746,16 +82773,16 @@ bLv
 cgH
 bLv
 aaa
-cjJ
-ckw
+btG
+bgN
 clC
-cmy
+bgN
 cnm
 cnL
 cov
 cpj
 cpS
-cjJ
+btG
 aaa
 crn
 aaa
@@ -83003,16 +83030,16 @@ bLv
 cgH
 bLv
 aaa
-cjJ
-cky
-clE
-cmA
-cno
+btG
+bih
+big
+bii
+bgN
 cnN
 cox
 cpl
 cpU
-cjJ
+btG
 aaf
 crn
 aaa
@@ -83260,16 +83287,16 @@ bLv
 cgH
 bLv
 aaf
-cjJ
+btG
 ckx
-clD
-cmz
-cnn
+big
+bkZ
+bgN
 cnM
 cow
-cpk
+bqF
 cpT
-cjJ
+btG
 aaa
 crn
 aaa
@@ -83517,16 +83544,16 @@ bLv
 cgH
 bLv
 aaa
-cjJ
-cky
-clG
-cmB
-cnq
+btG
+bii
+big
+bih
+bgN
 cnP
-coz
+cow
 cpn
-cjJ
-cjJ
+btG
+btG
 aaa
 crn
 aaa
@@ -83774,15 +83801,15 @@ bLv
 cgH
 bLv
 aaa
-cjJ
-ckz
+btG
+bgN
 clF
 cmy
 cnp
 cnO
 coy
 cpm
-cjJ
+btG
 aaf
 aaf
 crn
@@ -84031,15 +84058,15 @@ bLv
 cgH
 bLv
 aaf
-cjJ
-cjJ
-cjJ
-cjJ
-cjJ
+btG
+btG
+btG
+btG
+btG
 cnR
 coB
-cjJ
-cjJ
+btG
+btG
 aaa
 aaa
 crn
@@ -84288,15 +84315,15 @@ bCq
 cgH
 bCq
 aaa
-aaf
-aaa
-aaa
-aaf
-cjJ
+bCq
+ceY
+bHE
+cAV
+btG
 cnQ
 coA
 cpo
-cjJ
+btG
 aaa
 aaa
 crn
@@ -84546,14 +84573,14 @@ cgH
 bCq
 bCq
 bCq
-bCq
-bCq
-bCq
-cjJ
+bSs
+bHE
+cAV
+btG
 cnS
 coC
 cpp
-cjJ
+btG
 aaf
 aaf
 cig
@@ -84803,14 +84830,14 @@ cbw
 ccu
 ciT
 bCq
-bSs
-ceY
+bHE
+bHE
 ccw
-ccw
+btG
 cnR
 cgT
-cjJ
-ccw
+btG
+btG
 ccw
 ccw
 ccw
@@ -85573,9 +85600,9 @@ caz
 cby
 cdj
 cdv
-cem
-cem
-cem
+cjL
+cjL
+cjL
 cfe
 cfD
 cgv
@@ -86093,7 +86120,7 @@ ckB
 ckB
 ccw
 cnY
-coH
+cjS
 cgR
 cgR
 cqx
@@ -86350,7 +86377,7 @@ ckB
 ckC
 ccw
 cnX
-coH
+cjS
 cps
 cpX
 cqz
@@ -86864,7 +86891,7 @@ ccw
 ccw
 ccw
 cnZ
-coH
+cjS
 cpt
 cpZ
 cig
@@ -87371,15 +87398,15 @@ bVJ
 cay
 ccw
 cia
-cja
+cwD
 cgR
 ckD
 cig
 cmF
 cfG
 cgw
-coK
-cpu
+cjS
+cny
 cqa
 ccw
 ccw
@@ -87628,12 +87655,12 @@ bVJ
 cay
 ccw
 cid
-cgR
+cwE
 cen
 ckG
-clJ
+cAU
 cmI
-cgR
+cAW
 cgI
 chF
 ciO
@@ -87854,7 +87881,7 @@ bmr
 bmr
 byQ
 aJq
-aJq
+bBi
 bCs
 bDy
 bFb
@@ -87885,15 +87912,15 @@ bVJ
 cay
 ccw
 cic
-cBO
+cAj
 cjN
-cgR
+cAS
 ceu
 cff
-cgR
+cAX
 cgx
 coM
-cpv
+cnw
 cqb
 cqB
 cqU
@@ -88090,15 +88117,15 @@ aTV
 aVi
 aWP
 aYu
-aYt
-bbk
-bbk
-bbk
-bbk
+cvH
+cvM
+cvM
+cvM
+cvM
 bfs
-aZM
-aZM
-aZM
+cva
+cva
+cva
 aaf
 aaf
 aaa
@@ -88142,12 +88169,12 @@ bVJ
 caB
 ccw
 cif
-cgR
+cAR
 cjP
-ckF
+cAT
 ceZ
-ckF
-ckF
+cAT
+cAY
 cgK
 cjS
 cpv
@@ -88348,21 +88375,21 @@ cpC
 aWO
 aYt
 aYx
-bbj
+cvp
 bce
-bdf
-beb
-aYv
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+cvp
+cvl
+cvY
+cvl
+bce
+cva
+cva
+cwm
+cwm
+cwm
+bfv
+bfv
+bfv
 aaa
 aaa
 aJn
@@ -88404,7 +88431,7 @@ cnA
 cnA
 cev
 cfg
-cgU
+cBa
 cgJ
 chG
 cpv
@@ -88602,30 +88629,30 @@ aRl
 aSx
 aTX
 aVi
-aWR
+aWU
 aYv
 aZS
-aZR
-aZR
-bbm
+cvl
+cvS
+cvp
 bec
 bfu
+cwn
 bgO
-bgO
-bgO
-bmu
-bgO
-bgO
-bgO
-bgO
+cwi
+cvM
+cwo
+cws
+cwu
+cww
 bsb
-aaf
+bfv
 aaf
 aaf
 aJn
 aXf
 aJq
-aJq
+bBi
 bCs
 bFa
 bFa
@@ -88661,7 +88688,7 @@ cgR
 ckJ
 clJ
 cmL
-cgR
+cBb
 csF
 ccw
 cpy
@@ -88861,28 +88888,28 @@ aTW
 aVj
 aWQ
 aYv
-aZR
-aZR
-aZR
-aZR
-aZR
-bft
-bgN
-bgN
-bgN
-bmv
+cva
+cvN
+cvT
+cvW
+cvW
+cvW
+cwa
+cwf
+cvN
+cvb
 bkI
-bnT
-bpg
+aZR
+bdh
 bqD
 bsa
-bgO
+bbk
 buP
 bwm
 bxH
 byS
 aJq
-aMh
+cwC
 bCs
 bCs
 bCs
@@ -88918,7 +88945,7 @@ cgR
 ckI
 cig
 cmK
-cBO
+cBc
 ccw
 chV
 cpx
@@ -89118,22 +89145,22 @@ aTY
 aVl
 aWT
 aYx
-aZR
-bbm
-bbm
-bdh
-bee
-bfv
-bgN
-bih
-big
-bii
-bgN
+cvI
+cvP
+cvU
+cvp
+cvv
+cvv
+cwb
+cvp
+cwj
+cva
+cwp
 bnV
-bph
-bqF
+bbm
+aZR
 bsd
-btG
+bfv
 buQ
 bwn
 bxI
@@ -89175,7 +89202,7 @@ cgR
 ckK
 clJ
 cmL
-cnw
+cBd
 cgL
 chX
 cAO
@@ -89374,26 +89401,26 @@ aSy
 aTX
 aVk
 aWS
-aYw
+cva
 aZT
 cBj
 bcf
 bdg
-bed
-bfv
-bgN
-big
-bgN
-bkZ
-bgN
-bnU
+cvv
+cvZ
+cwc
+cvp
+bcf
+cwl
+aZR
+bbm
 bph
-bqE
+bbm
 bsc
 btF
-bph
-bsc
-btF
+cwz
+cwA
+cwB
 bvW
 bAf
 bBp
@@ -89632,22 +89659,22 @@ aTZ
 aVn
 aWV
 aYz
-aZR
-bbm
-bbm
-bdh
-bef
-bfv
-bgN
-bii
-big
-bih
-bgN
+cvJ
+cvQ
+cAZ
+cvX
+cvv
+cvv
+cwd
+cvp
+cvl
+cva
+cwq
 bnV
-bph
-bqF
+bbm
+aZR
 bsf
-btG
+bfv
 buS
 bwp
 bxK
@@ -89887,24 +89914,24 @@ aRo
 aSA
 aTX
 aVm
-aWU
+cvG
 aYy
+cva
+cvN
+cvV
+cvW
+cvW
+cvW
+cwe
+cwg
+cvN
+cvb
+bkI
 aZR
-aZR
-aZR
-aZR
-aZR
-bfw
-bgN
-bgN
-bgN
-bjy
-bmw
-bnW
-bpi
+bdh
 bqG
 bse
-bij
+bbp
 buR
 bwo
 bxJ
@@ -90144,24 +90171,24 @@ aRr
 aSD
 ceh
 aVp
-aWX
-aYB
-aZU
-aZR
-aZR
-bbm
+aWU
+aYy
+aZS
+cvl
+cvS
+cvp
 beh
 bfx
 bij
-bij
-bij
-bgR
-bij
-bij
-bij
-bij
+cwh
+cwk
+cvR
+cwr
+cwt
+cwv
+cwx
 bsg
-aaf
+bfv
 aaf
 aaf
 aJn
@@ -90403,22 +90430,22 @@ aUa
 aVo
 aWW
 aYA
-aYz
-bbn
+cvK
+cvp
 bcg
 aZU
-beg
+cvl
 aYB
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+cvl
+bcg
+cva
+cva
+cwm
+cwm
+cwm
+bfv
+bfv
+bfv
 aaa
 aaa
 aJn
@@ -90660,15 +90687,15 @@ aUc
 aVm
 aWY
 aYC
-aYA
-bbp
-bbp
-bbp
-bbp
+cvL
+cvR
+cvR
+cvR
+cvR
 bfz
-aZV
-aZV
-aZV
+cva
+cva
+cva
 aaf
 aaf
 aaa
@@ -91234,7 +91261,7 @@ cmQ
 cgR
 cgP
 cir
-cen
+cgR
 cqc
 cqC
 crc
@@ -91745,10 +91772,10 @@ cfM
 ckT
 cgU
 cfC
-cnA
-cnA
-cis
-ciV
+cBe
+ckH
+ckH
+ckH
 ckH
 cqA
 cre
@@ -92004,8 +92031,8 @@ cfd
 cfB
 cfI
 cgQ
-cjS
-cjN
+cgR
+cgR
 cqm
 cig
 crd
@@ -92261,10 +92288,10 @@ ccw
 ccw
 ccw
 ccw
-cjS
-cjN
+cBf
+cjc
 cjh
-cig
+ccw
 ccw
 ccw
 ccw
@@ -92518,16 +92545,16 @@ bOh
 bOh
 bOh
 ccw
-cjS
-cjP
-ckF
-ckF
-ckF
-cpE
-cjR
-crW
-csg
-aag
+ccw
+cpI
+ccw
+ccw
+cBS
+cig
+aaa
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92774,17 +92801,17 @@ ckV
 clU
 clU
 bOh
-ccw
+cig
 coZ
-cgU
-cgU
-cgU
-crw
-cjO
-ccw
-crX
-cfK
-aag
+ciZ
+cqp
+csg
+ciZ
+cig
+aaf
+aaf
+aaf
+aaa
 aaa
 aaa
 aaa
@@ -93031,20 +93058,20 @@ ckU
 clT
 cmU
 bOh
-ccw
-cpa
-cjc
-cqo
-ccw
-cjk
-cjm
-ccw
-ccw
 cig
-aag
-aag
-aag
-aag
+cpc
+cpJ
+cqq
+ccw
+ciZ
+cig
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93288,23 +93315,23 @@ ckW
 clU
 clU
 bOh
-ccw
-ccw
-cpI
-ccw
-ccw
-cjl
-cjQ
-cjV
 cig
-aaf
-aaf
-aaf
-aaf
-aag
+cpd
+czM
+cpd
+cig
+csg
+cig
 aaa
 aaa
-aae
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93545,20 +93572,20 @@ bOh
 bOh
 bOh
 bOh
+ccw
+cpd
+czL
+cpd
 cig
-cpb
-ciZ
-cqp
-cig
-cjT
-cgR
-crP
-cig
-aaa
-aaa
+aag
+aag
+aaf
 aaa
 aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93802,20 +93829,20 @@ ckY
 clW
 clW
 bOh
-cig
-cig
-cpI
-cig
-cig
-crh
-crA
-crR
-crY
-csi
-csL
+aaa
+cpe
+cpM
+cqr
+aaa
+aaf
 aaa
 aaf
 aag
+aaf
+aaf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94059,20 +94086,20 @@ ckX
 clV
 cmV
 bOh
-cig
-cpc
-cpJ
-cqq
-cig
-cqY
-cqY
-cqY
-cig
-csh
-csl
+aaa
+aaa
+czN
+aaa
 aaa
 aaf
-aag
+aaa
+aaf
+aaf
+aaf
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94316,20 +94343,20 @@ ckZ
 clW
 clW
 bOh
-cig
-cpd
-czM
-cpd
-cig
+aaa
+aaa
 aaa
 aaa
 aaa
 aaf
 aaf
-cso
+aaa
 aaf
 aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94573,20 +94600,20 @@ bOh
 bOh
 bOh
 bOh
-ccw
-cpd
-czL
-cpd
-ccw
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 aaf
-aaa
-csn
-aaa
+aaf
 aaf
 aag
+aaf
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94831,19 +94858,19 @@ clY
 clZ
 bOh
 aaf
-cpe
-cpM
-cqr
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaa
 aaa
 aaa
-aaf
 aaa
-csp
-aaa
-aaf
-aag
 aaa
 aaa
 aaa
@@ -95089,18 +95116,18 @@ cmW
 bOh
 aaf
 aaa
-czN
-aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
-csn
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95348,16 +95375,16 @@ aaf
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
-aaf
-cso
-aaf
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95605,16 +95632,16 @@ aaf
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
-csn
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95862,16 +95889,16 @@ apQ
 aoV
 aoV
 aoV
-apQ
+aoV
 aoV
 aaa
 aaa
-aaf
 aaa
-csp
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96119,16 +96146,16 @@ apQ
 aoV
 aoV
 aoV
-apQ
+aoV
 aoV
 aaa
 aaa
-aaf
 aaa
-csn
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96380,12 +96407,12 @@ aoV
 aoV
 aaa
 aaa
-aaf
-aaf
-cso
-aaf
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96637,12 +96664,12 @@ aoV
 aoV
 aaa
 aaa
-aaf
 aaa
-csn
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96894,12 +96921,12 @@ aoV
 aoV
 aaa
 aaa
-aaf
 aaa
-csp
 aaa
-aaf
-aag
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97135,13 +97162,13 @@ bOh
 bOh
 apQ
 apQ
-ciC
-bVu
-bVu
-bVu
-bVu
-bVu
-caJ
+aoV
+aoV
+aoV
+aoV
+aoV
+aoV
+aoV
 aoV
 aoV
 aoV
@@ -97151,33 +97178,6 @@ aoV
 aoV
 aaa
 aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-ctZ
-ctZ
-ctZ
-ctZ
-ctZ
-aaf
-aaa
-aaf
-cvF
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
 aaa
 aaa
 aaa
@@ -97185,9 +97185,36 @@ aaa
 aaa
 aaa
 aaa
-aaf
-cAU
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97392,62 +97419,62 @@ apQ
 apQ
 apQ
 cfj
-cfU
+cfj
 cfj
 cfj
 ckf
 cfj
 cfj
-bUr
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-bVu
-csw
-csw
-csw
-csw
-csM
-csw
-csw
-ctd
-csw
-csw
-csw
-csw
-ctO
-ctZ
-ctZ
-cuo
-cuA
-cuM
-ctZ
-cvk
-cvk
-cvk
-cvk
-aaf
-aaf
-aaf
-aaf
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+aoV
+aoV
+aoV
+aoV
+aoV
+aoV
+aoV
+aoV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97665,48 +97692,48 @@ aoV
 aoV
 aaa
 aaa
-aaf
-aaa
-csn
-aag
-aag
-aag
-aag
 aaa
 aaa
 aaa
-ctN
-ctY
-cuh
-cun
-cuz
-cuL
-cuY
-cvj
-cvs
-cvD
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvX
-cvX
-cvX
-cvX
-cwq
-cwq
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97906,7 +97933,7 @@ bAw
 caK
 cfj
 ciB
-ckh
+cjr
 chj
 ciA
 cjr
@@ -97922,49 +97949,49 @@ aoV
 aoV
 aaa
 aaa
-aaf
-aaa
-csn
-csD
-cta
-csD
-cua
 aaa
 aaa
 aaa
-aaf
-ctZ
-cui
-cuq
-cuC
-cuO
-cuz
-cvm
-cvt
-cvt
-cvt
-cvL
-cvQ
-cvX
-cvX
-cvX
-cvX
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cvx
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98163,7 +98190,7 @@ cfW
 cfX
 chk
 chl
-ciz
+cle
 chi
 ciz
 cjq
@@ -98179,49 +98206,49 @@ apQ
 aoV
 aaa
 aaa
-aaf
 aaa
-csn
-csD
-csX
-ctg
-cua
-cua
-cua
-cua
-cua
-ctZ
-ctZ
-cup
-cuB
-cuN
-cuZ
-cvj
-cvj
-cvj
-cvj
-cvj
-cvP
-cvj
-cvj
-cvj
-cvj
-cva
-cva
-cva
-cva
-cvp
-cwv
-cvp
-cvr
-cvl
-cvr
-cwv
-cvp
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98436,48 +98463,48 @@ bVw
 bVw
 aaa
 aaa
-aaf
-csD
-csO
-csD
-cta
-cti
-cua
-cua
-ctw
-ctH
-ctQ
-cuc
-cuj
-cuj
-cuE
-cuQ
-cuj
-cvk
-cvw
-cvw
-cvG
-cvM
-cvS
-cvZ
-cvG
-cvw
-cvw
-cvf
-cwh
-cwm
-cwr
-cvp
-cwx
-cwj
-cwu
-cAV
-cAZ
-cvl
-cvl
-cva
-cva
-cva
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98693,48 +98720,48 @@ aaa
 bVw
 aaa
 aaa
-aaf
-csD
-csN
-csV
-ctb
-cth
-cua
-ctr
-ctu
-ctG
-ctP
-cub
-cuj
-cur
-cuD
-cuP
-cvc
-cvk
-cvu
-cvu
-cvu
-cvu
-cvR
-cvY
-cwb
-cvu
-cvu
-cva
-cwg
-cwl
-cwr
-cvl
-cww
-cwD
-cvv
-cvv
-cAY
-cBb
-cBd
-cva
-cva
-cva
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98950,49 +98977,49 @@ aaa
 bVw
 aaa
 aaa
-aaf
-csD
-csU
-csW
-ctc
-ctc
-cto
-ctt
-cty
-ctJ
-ctT
-cue
-cul
-cuu
-cuG
-cuS
-cve
-cvo
-cvz
-cvz
-cvI
-cvz
-cvT
-cBS
-cwc
-cvz
-cwd
-cwf
-cwj
-cwo
-cwt
-cwu
-cwA
-cAR
-cAS
-cvv
-cBa
-cBc
-cBe
-cva
-cva
-cva
-cBf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99207,48 +99234,48 @@ aaa
 bVw
 aaa
 aaa
-aaf
-csD
-csT
-csV
-ctb
-ctj
-ctk
-cts
-ctx
-ctI
-ctS
-cud
-cuk
-cus
-cuF
-cuR
-cvd
-cvn
-cvy
-cvy
-cvH
-cvy
-cvy
-cvy
-cvy
-cvy
-cvy
-cwe
-cwi
-cwn
-cws
-cwn
-cwz
-cwE
-cvv
-cvv
-cvv
-cvp
-cvl
-cva
-cva
-cva
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99464,48 +99491,48 @@ bVw
 bVw
 aaa
 aaa
-aaf
-csD
-csD
-csD
-csD
-cti
-ctq
-cua
-ctA
-cuy
-ctV
-cug
-cuj
-cuj
-cuE
-cuU
-cuj
-cvk
-cvw
-cvw
-cvJ
-cvw
-cvV
-cwa
-cvJ
-cvw
-cvw
-cvb
-cwk
-cwp
-cwr
-cvp
-cwC
-cwn
-cAT
-cAW
-cvl
-cvl
-cvl
-cva
-cva
-cva
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99727,43 +99754,43 @@ aaa
 aaa
 aaa
 aaa
-ctp
-cua
-ctz
-ctK
-ctU
-cuf
-cuf
-cuv
-cuH
-cuT
-cvg
-cvj
-cvj
-cvj
-cvj
-cvj
-cvU
-cvj
-cvj
-cvj
-cvj
-cva
-cva
-cva
-cva
-cvp
-cwB
-cvp
-cvr
-cvl
-cvr
-cwB
-cvp
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99984,43 +100011,43 @@ aaa
 aaa
 aaa
 aaa
-aaf
-cua
-ctF
-ctM
-ctX
-cuf
-cum
-cuw
-cuJ
-cuW
-cvi
-cvq
-cvC
-cvC
-cvC
-cvN
-cvW
-cvX
-cvX
-cvX
-cvX
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cvA
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100241,42 +100268,42 @@ aaa
 aaa
 aaa
 aaa
-aaf
-cua
-ctE
-ctL
-ctW
-cuf
-cum
-cuw
-cuI
-cuV
-cvh
-cvj
-cvB
-cvE
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvX
-cvX
-cvX
-cvX
-cwq
-cwq
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100498,40 +100525,40 @@ aaa
 aaa
 aaa
 aaa
-aaf
-cua
-cua
-cua
-cua
-cuf
-cuf
-cux
-cuK
-cuX
-cuf
-cvk
-cvk
-cvk
-cvk
-aaf
-aaf
-aaf
-aaf
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100755,27 +100782,6 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-cuf
-cuf
-cuf
-cuf
-cuf
-aaf
-aaa
-aaf
-cvK
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
 aaa
 aaa
 aaa
@@ -100783,9 +100789,30 @@ aaa
 aaa
 aaa
 aaa
-aaf
-cAX
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -730,7 +730,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/item/weapon/gun/energy/ionrifle,
 /obj/item/clothing/suit/armor/laserproof,
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -22475,7 +22474,7 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/black,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai)
 "aYC" = (
 /obj/machinery/firealarm{
@@ -22963,7 +22962,9 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "aZR" = (
-/turf/open/floor/bluegrid,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 9
+	},
 /area/turret_protected/ai_upload)
 "aZS" = (
 /obj/effect/landmark{
@@ -22997,18 +22998,7 @@
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "aZT" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/plasteel/black,
+/turf/closed/wall/r_wall,
 /area/space)
 "aZU" = (
 /obj/item/device/multitool,
@@ -24771,9 +24761,7 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "bed" = (
 /obj/machinery/power/apc{
@@ -24832,9 +24820,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "bei" = (
 /obj/machinery/light{
@@ -25343,9 +25329,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (EAST)";
+	icon_state = "greyOff";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
@@ -25363,9 +25354,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0";
-	uses = 10
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (WEST)";
+	icon_state = "greyOff";
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
@@ -25876,11 +25872,6 @@
 /area/engine/gravity_generator)
 "bgO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "bgP" = (
@@ -26542,7 +26533,10 @@
 /area/engine/gravity_generator)
 "bij" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "bik" = (
 /obj/item/device/radio/intercom{
@@ -27682,12 +27676,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bkI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/freeform,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bkJ" = (
 /obj/structure/grille,
@@ -29289,10 +29280,17 @@
 /turf/open/floor/plasteel/black,
 /area/engine/gravity_generator)
 "bnV" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 0;
+	pixel_y = 24
+	},
 /obj/machinery/porta_turret/ai{
 	icon_state = "greyOff"
 	},
-/turf/open/floor/bluegrid,
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
 /area/turret_protected/ai_upload)
 "bnW" = (
 /obj/structure/grille,
@@ -30571,8 +30569,38 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 2;
+	name = "Upload APC";
+	pixel_y = -24
+	},
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "High-Risk Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/item/weapon/aiModule/supplied/oxygen,
+/obj/item/weapon/aiModule/zeroth/oneHuman,
+/obj/item/weapon/aiModule/reset/purge,
+/obj/item/weapon/aiModule/core/full/antimov,
+/obj/item/weapon/aiModule/supplied/protectStation,
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-warndarkcorners (EAST)";
+	icon_state = "warndarkcorners";
+	dir = 4
 	},
 /area/turret_protected/ai_upload)
 "bqE" = (
@@ -30597,7 +30625,33 @@
 	dir = 4;
 	on = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Station Intercom (AI Private)";
+	pixel_y = -29
+	},
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/item/weapon/aiModule/core/full/asimov,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/core/full/custom,
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Core Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/darkwarning/corner{
+	tag = "icon-warndarkcorners (WEST)";
+	icon_state = "warndarkcorners";
 	dir = 8
 	},
 /area/turret_protected/ai_upload)
@@ -31342,29 +31396,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/machinery/light/small,
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
-	name = "Upload APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "bsb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/machinery/porta_turret/ai{
-	tag = "icon-greyOff (EAST)";
-	icon_state = "greyOff";
-	dir = 4
-	},
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "bsc" = (
 /obj/structure/cable{
@@ -31386,15 +31424,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/machinery/light/small,
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_y = -29
-	},
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "bsf" = (
 /obj/machinery/camera/motion{
@@ -31402,18 +31432,13 @@
 	dir = 1;
 	network = list("SS13")
 	},
-/turf/open/floor/bluegrid,
+/turf/open/floor/plasteel/black,
 /area/turret_protected/ai_upload)
 "bsg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/porta_turret/ai{
-	tag = "icon-greyOff (WEST)";
-	icon_state = "greyOff";
-	dir = 8
-	},
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "bsh" = (
 /turf/closed/wall,
@@ -57677,296 +57702,91 @@
 	name = "AI Satellite Hallway"
 	})
 "cvx" = (
-/obj/effect/landmark{
-	name = "tripai"
+/obj/machinery/porta_turret/ai{
+	icon_state = "greyOff"
 	},
-/obj/item/device/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = 5
-	},
-/obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 0;
-	pixel_y = -25
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cvy" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvz" = (
+/obj/machinery/power/terminal{
+	icon_state = "term";
+	dir = 1
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-4";
+	d2 = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/black,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0";
+	uses = 10
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvz" = (
+/obj/machinery/airalarm{
+	desc = "This particular atmos control unit appears to have no access restrictions.";
+	dir = 8;
+	icon_state = "alarm0";
+	locked = 0;
+	name = "all-access air alarm";
+	pixel_x = 24;
+	req_access = "0";
+	req_one_access = "0"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "cvA" = (
-/obj/effect/landmark{
-	name = "tripai"
-	},
-/obj/item/device/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_x = 27;
-	pixel_y = 5
-	},
 /obj/item/device/radio/intercom{
 	anyai = 1;
 	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
-	pixel_y = -25
+	pixel_x = -5;
+	pixel_y = -27
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = -26;
+	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = -5;
+	pixel_y = 20
+	},
+/obj/effect/landmark{
+	name = "tripai"
 	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cvB" = (
-/obj/structure/rack,
-/obj/item/weapon/crowbar/red,
-/obj/item/weapon/wrench,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
 "cvC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvD" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/turret_protected/AIsatextFS{
-	name = "AI Satellite Hallway"
-	})
-"cvF" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthWest";
-	dir = 8;
-	network = list("MiniSat");
-	pixel_x = 0;
-	pixel_y = 0;
-	start_active = 1
-	},
-/turf/open/space,
-/area/space)
-"cvG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 0
-	},
-/area/bridge)
-"cvH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvI" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvJ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvN" = (
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
-/area/turret_protected/ai)
-"cvO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/asmaint2)
-"cvP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/turret_protected/ai)
-"cvS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cvX" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber North";
-	dir = 1;
-	network = list("SS13")
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cvY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	desc = "This particular atmos control unit appears to have no access restrictions.";
-	dir = 4;
-	icon_state = "alarm0";
-	locked = 0;
-	name = "all-access air alarm";
-	pixel_x = -24;
-	req_access = "0";
-	req_one_access = "0"
-	},
-/turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cvZ" = (
 /obj/item/device/radio/intercom{
 	anyai = 1;
 	broadcasting = 0;
@@ -57995,37 +57815,284 @@
 /obj/effect/landmark/start{
 	name = "AI"
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 28;
-	pixel_y = 28
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = -28;
-	pixel_y = 28
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1;
 	d2 = 2
 	},
+/obj/machinery/button/door{
+	id = "aiBlast";
+	name = "AI Chamber Blast Door Control";
+	pixel_x = -23;
+	pixel_y = 23;
+	req_access_txt = "16"
+	},
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
-"cwa" = (
+"cvD" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvE" = (
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	broadcasting = 0;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 5;
+	pixel_y = 20
+	},
+/obj/item/device/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = 5;
+	pixel_y = -26
+	},
+/obj/effect/landmark{
+	name = "tripai"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvF" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4";
 	tag = "90Curve"
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/blue/side{
+	dir = 0
+	},
+/area/bridge)
+"cvH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvJ" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	dir = 1;
+	network = list("SS13")
+	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
+"cvK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvN" = (
+/obj/machinery/porta_turret/ai{
+	icon_state = "greyOff"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"cvP" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	dir = 2;
+	network = list("SS13")
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvS" = (
+/obj/machinery/airalarm{
+	desc = "This particular atmos control unit appears to have no access restrictions.";
+	dir = 4;
+	icon_state = "alarm0";
+	locked = 0;
+	name = "all-access air alarm";
+	pixel_x = -24;
+	req_access = "0";
+	req_one_access = "0"
+	},
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cvT" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvU" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvV" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai)
+"cvX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "aiBlast";
+	name = "AI Chamber Blast Door"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/turret_protected/ai)
+"cvY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	desc = "This particular atmos control unit appears to have no access restrictions.";
+	dir = 4;
+	icon_state = "alarm0";
+	locked = 0;
+	name = "all-access air alarm";
+	pixel_x = -24;
+	req_access = "0";
+	req_one_access = "0"
+	},
+/turf/closed/wall/r_wall,
+/area/turret_protected/ai)
+"cvZ" = (
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/quarantine,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai_upload)
+"cwa" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/turret_protected/ai_upload)
 "cwb" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -58091,67 +58158,60 @@
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
 "cwe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/porta_turret/ai{
+	icon_state = "greyOff"
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/turf/open/floor/plasteel/darkwarning{
+	dir = 1
+	},
+/area/turret_protected/ai_upload)
 "cwf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/open/floor/plasteel/darkwarning{
+	dir = 5
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/turret_protected/ai_upload)
 "cwg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/open/floor/plasteel/darkwarning{
+	dir = 8
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/turret_protected/ai_upload)
 "cwh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/bluegrid,
+/area/turret_protected/ai)
+"cwi" = (
+/turf/open/floor/plasteel/darkwarning{
+	dir = 4
+	},
+/area/turret_protected/ai_upload)
+"cwj" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cwi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light,
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
-"cwj" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber South";
-	dir = 1;
-	network = list("SS13")
+/turf/open/floor/plasteel/black,
+/area/turret_protected/ai_upload)
+"cwk" = (
+/obj/structure/cable{
+	tag = "icon-1-2";
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/black,
-/area/turret_protected/ai)
-"cwk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light,
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai)
+/area/turret_protected/ai_upload)
 "cwl" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Core";
 	req_access_txt = "65"
 	},
-/turf/open/floor/bluegrid,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/turret_protected/ai)
 "cwm" = (
 /obj/structure/grille,
@@ -58160,59 +58220,33 @@
 /area/turret_protected/ai_upload)
 "cwn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/oxygen,
-/obj/item/weapon/aiModule/zeroth/oneHuman,
-/obj/item/weapon/aiModule/reset/purge,
-/obj/item/weapon/aiModule/core/full/antimov,
-/obj/item/weapon/aiModule/supplied/protectStation,
-/obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
-	name = "High-Risk Modules";
-	req_access_txt = "20"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/table,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwp" = (
-/obj/machinery/computer/upload/borg,
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
 "cwq" = (
-/obj/machinery/computer/upload/ai,
-/obj/machinery/airalarm{
-	frequency = 1439;
-	locked = 0;
-	pixel_y = 23
-	},
-/turf/open/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central)
 "cwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/table,
-/obj/item/weapon/aiModule/core/full/asimov,
-/obj/item/weapon/aiModule/core/freeformcore,
-/obj/item/weapon/aiModule/core/full/corp,
-/obj/item/weapon/aiModule/core/full/custom,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Core Modules";
-	req_access_txt = "20"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/weapon/aiModule/reset,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cws" = (
@@ -58225,30 +58259,25 @@
 /area/turret_protected/ai_upload)
 "cwu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/freeform,
+/obj/machinery/computer/upload/borg,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/quarantine,
+/obj/machinery/computer/upload/ai,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cww" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/table,
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "cwx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/weapon/aiModule/reset,
-/turf/open/floor/bluegrid,
+/turf/closed/wall/r_wall,
 /area/turret_protected/ai_upload)
 "cwy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -60054,7 +60083,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai)
@@ -60131,17 +60166,16 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/storage)
 "cBj" = (
-/obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
 	},
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
@@ -88129,10 +88163,10 @@ aaa
 aaf
 aaa
 aaf
-aaa
-aaa
-aaa
-aJn
+aZT
+cwp
+cwp
+cwq
 aXf
 aJq
 byV
@@ -88372,13 +88406,13 @@ cpC
 aWO
 aYt
 aYx
-cvp
-bce
-cvp
-cvl
+cva
+cva
+cva
+cvA
 cvY
-cvl
-bce
+cva
+cva
 cva
 cva
 cwm
@@ -88387,9 +88421,9 @@ cwm
 bfv
 bfv
 bfv
-aaa
-aaa
-aJn
+cwp
+cwp
+cwq
 aXf
 aJq
 byU
@@ -88628,15 +88662,15 @@ aTX
 aVi
 aWU
 aYv
-aZS
-cvl
+cva
+cvp
 cvS
 cvp
 bec
 bfu
 cwn
 bgO
-cwi
+cvM
 cvM
 cwo
 cws
@@ -88644,9 +88678,9 @@ cwu
 cww
 bsb
 bfv
-aaf
-aaf
-aJn
+cwp
+cwp
+cwq
 aXf
 aJq
 bBi
@@ -88889,15 +88923,15 @@ cva
 cvN
 cvT
 cvW
-cvW
-cvW
-cwa
-cwf
-cvN
+cvB
+cvF
+cvl
+cvp
+cva
 cvb
 bkI
 aZR
-bdh
+cwg
 bqD
 bsa
 bbk
@@ -89142,21 +89176,21 @@ aTY
 aVl
 aWT
 aYx
-cvI
+cva
 cvP
 cvU
-cvp
 cvv
 cvv
 cwb
+cvl
 cvp
-cwj
 cva
-cwp
+cva
+bfv
 bnV
 bbm
-aZR
-bsd
+cwj
+bbm
 bfv
 buQ
 bwn
@@ -89401,19 +89435,19 @@ aWS
 cva
 aZT
 cBj
-bcf
-bdg
+cvy
 cvv
-cvZ
+cvC
 cwc
-cvp
 bcf
+cvp
+cvX
 cwl
-aZR
-bbm
+bdh
+cwa
 bph
-bbm
 bsc
+cwk
 btF
 cwz
 cwA
@@ -89656,20 +89690,20 @@ aTZ
 aVn
 aWV
 aYz
-cvJ
+cva
 cvQ
 cAZ
-cvX
 cvv
 cvv
 cwd
-cvp
 cvl
+cvJ
 cva
-cwq
-bnV
+cva
+bfv
+cwe
 bbm
-aZR
+bbm
 bsf
 bfv
 buS
@@ -89914,18 +89948,18 @@ aVm
 cvG
 aYy
 cva
-cvN
+cvx
 cvV
 cvW
-cvW
-cvW
-cwe
-cwg
-cvN
+cvD
+cvI
+cvl
+cvp
+cva
 cvb
-bkI
-aZR
-bdh
+cvZ
+cwf
+cwi
 bqG
 bse
 bbp
@@ -90170,15 +90204,15 @@ ceh
 aVp
 aWU
 aYy
-aZS
-cvl
-cvS
+cva
 cvp
+cvz
+aZU
 beh
 bfx
 bij
 cwh
-cwk
+cvR
 cvR
 cwr
 cwt
@@ -90186,9 +90220,9 @@ cwv
 cwx
 bsg
 bfv
-aaf
-aaf
-aJn
+cwp
+cwp
+cwq
 aJq
 aJq
 bBu
@@ -90428,13 +90462,13 @@ aVo
 aWW
 aYA
 cvK
-cvp
-bcg
-aZU
-cvl
+cva
+cva
+cva
+cvE
 aYB
-cvl
-bcg
+cva
+cva
 cva
 cva
 cwm
@@ -90443,9 +90477,9 @@ cwm
 bfv
 bfv
 bfv
-aaa
-aaa
-aJn
+cwp
+cwp
+cwq
 aJq
 aJq
 bBt
@@ -90699,10 +90733,10 @@ aaa
 aaf
 aaa
 aaf
-aaa
-aaa
-aaa
-aJn
+aZT
+cwp
+cwp
+cwq
 aJq
 aJq
 aXf

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -14848,6 +14848,9 @@
 	dir = 8
 	},
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aGq" = (
@@ -27676,9 +27679,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bkI" = (
-/obj/structure/table,
-/obj/item/weapon/aiModule/supplied/freeform,
-/turf/open/floor/bluegrid,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/turret_protected/ai_upload)
 "bkJ" = (
 /obj/structure/grille,
@@ -28131,9 +28137,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Cyborg"
 	},
 /turf/open/floor/plasteel,
 /area/assembly/chargebay)
@@ -29283,17 +29286,10 @@
 /turf/open/floor/plasteel/black,
 /area/engine/gravity_generator)
 "bnV" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/machinery/porta_turret/ai{
 	icon_state = "greyOff"
 	},
-/turf/open/floor/plasteel/darkwarning{
-	dir = 1
-	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bnW" = (
 /obj/structure/grille,
@@ -30572,38 +30568,8 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
-	name = "Upload APC";
-	pixel_y = -24
-	},
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
-	name = "High-Risk Modules";
-	req_access_txt = "20"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/item/weapon/aiModule/supplied/oxygen,
-/obj/item/weapon/aiModule/zeroth/oneHuman,
-/obj/item/weapon/aiModule/reset/purge,
-/obj/item/weapon/aiModule/core/full/antimov,
-/obj/item/weapon/aiModule/supplied/protectStation,
-/turf/open/floor/plasteel/darkwarning/corner{
-	tag = "icon-warndarkcorners (EAST)";
-	icon_state = "warndarkcorners";
-	dir = 4
+/turf/open/floor/plasteel/vault{
+	dir = 8
 	},
 /area/turret_protected/ai_upload)
 "bqE" = (
@@ -30628,33 +30594,7 @@
 	dir = 4;
 	on = 1
 	},
-/obj/item/device/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_y = -29
-	},
-/obj/machinery/light/small,
-/obj/structure/table,
-/obj/item/weapon/aiModule/core/full/asimov,
-/obj/item/weapon/aiModule/core/freeformcore,
-/obj/item/weapon/aiModule/core/full/corp,
-/obj/item/weapon/aiModule/core/full/custom,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Core Modules";
-	req_access_txt = "20"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/darkwarning/corner{
-	tag = "icon-warndarkcorners (WEST)";
-	icon_state = "warndarkcorners";
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/turret_protected/ai_upload)
@@ -31399,13 +31339,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 2;
+	name = "Upload APC";
+	pixel_y = -24
+	},
+/obj/machinery/light/small,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bsb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (EAST)";
+	icon_state = "greyOff";
+	dir = 4
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bsc" = (
 /obj/structure/cable{
@@ -31427,7 +31383,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/closed/wall/r_wall,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Station Intercom (AI Private)";
+	pixel_y = -29
+	},
+/obj/machinery/light/small,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bsf" = (
 /obj/machinery/camera/motion{
@@ -31441,7 +31405,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/porta_turret/ai{
+	tag = "icon-greyOff (WEST)";
+	icon_state = "greyOff";
+	dir = 8
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bsh" = (
 /turf/closed/wall,
@@ -32798,8 +32767,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/start{
-	name = "Cyborg"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	tag = "icon-darkblue (NORTH)";
@@ -33402,6 +33371,9 @@
 	scrub_N2O = 0;
 	scrub_Toxins = 0
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/warning/corner{
 	dir = 4
 	},
@@ -33515,6 +33487,8 @@
 	c_tag = "Gravity Generator Foyer";
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/weapon/phone,
 /turf/open/floor/plasteel/black,
 /area/turret_protected/ai_upload_foyer)
 "bwo" = (
@@ -34775,6 +34749,11 @@
 "byS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 3;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/warning/corner{
 	dir = 8
@@ -57836,7 +57815,7 @@
 	pixel_y = 23;
 	req_access_txt = "16"
 	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cvD" = (
 /obj/structure/cable{
@@ -58185,33 +58164,36 @@
 	},
 /area/turret_protected/ai_upload)
 "cwg" = (
-/turf/open/floor/plasteel/darkwarning{
-	dir = 8
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start{
+	name = "Cyborg"
 	},
-/area/turret_protected/ai_upload)
+/turf/open/floor/plasteel/bot,
+/area/storage/primary)
 "cwh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai)
 "cwi" = (
-/turf/open/floor/plasteel/darkwarning{
-	dir = 4
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 0;
+	pixel_y = 24
 	},
+/obj/machinery/computer/upload/ai,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/black,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwk" = (
-/obj/structure/cable{
-	tag = "icon-1-2";
-	icon_state = "1-2"
+/obj/machinery/airalarm{
+	frequency = 1439;
+	locked = 0;
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel/black,
+/obj/machinery/computer/upload/borg,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwl" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -58236,26 +58218,53 @@
 /area/turret_protected/ai)
 "cwo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/table,
+/obj/item/weapon/aiModule/supplied/oxygen,
+/obj/item/weapon/aiModule/zeroth/oneHuman,
+/obj/item/weapon/aiModule/reset/purge,
+/obj/item/weapon/aiModule/core/full/antimov,
+/obj/item/weapon/aiModule/supplied/protectStation,
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "High-Risk Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwp" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "AI Core";
+	dir = 1;
+	network = list("SS13")
+	},
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwq" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "cwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/table,
-/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/core/full/asimov,
+/obj/item/weapon/aiModule/core/freeformcore,
+/obj/item/weapon/aiModule/core/full/corp,
+/obj/item/weapon/aiModule/core/full/custom,
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Core Modules";
+	req_access_txt = "20"
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cws" = (
@@ -58268,25 +58277,30 @@
 /area/turret_protected/ai_upload)
 "cwu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/upload/borg,
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/freeform,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/upload/ai,
+/obj/structure/table,
+/obj/item/weapon/aiModule/reset,
 /turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cww" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/item/weapon/aiModule/supplied/quarantine,
+/turf/open/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "cwy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -78122,7 +78136,7 @@ aDb
 aDo
 aFY
 aDo
-aDo
+cwg
 aKp
 aLE
 aLE
@@ -88172,9 +88186,9 @@ aaa
 aaf
 aaa
 aaf
-bfv
-cwp
-cwp
+aaa
+aaa
+aaa
 cwq
 aXf
 aJq
@@ -88430,8 +88444,8 @@ cwm
 bfv
 bfv
 bfv
-cwp
-cwp
+aaa
+aaa
 cwq
 aXf
 aJq
@@ -88687,8 +88701,8 @@ cwu
 cww
 bsb
 bfv
-cwp
-cwp
+aaf
+aaf
 cwq
 aXf
 aJq
@@ -88939,8 +88953,8 @@ cvp
 cva
 bft
 bkI
-aZR
-cwg
+cwj
+bdh
 bqD
 bsa
 bbk
@@ -89195,11 +89209,11 @@ cvl
 cvp
 cva
 cva
-bfv
+cwi
 bnV
 bbm
 cwj
-bbm
+cwp
 bfv
 buQ
 bwn
@@ -89452,11 +89466,11 @@ bcf
 cvp
 cvX
 cwl
-bdh
-cwa
+cwj
+bbm
 bph
+bbm
 bsc
-cwk
 btF
 cwz
 cwA
@@ -89709,11 +89723,11 @@ cvl
 cvJ
 cva
 cva
-bfv
-cwe
+cwk
+bnV
 bbm
-bbm
-bsf
+cwj
+cwj
 bfv
 buS
 bwp
@@ -89966,9 +89980,9 @@ cvl
 cvp
 cva
 bft
-cvZ
-cwf
-cwi
+bkI
+cwj
+bdh
 bqG
 bse
 bbp
@@ -90229,8 +90243,8 @@ cwv
 cwx
 bsg
 bfv
-cwp
-cwp
+aaf
+aaf
 cwq
 aJq
 aJq
@@ -90486,8 +90500,8 @@ cwm
 bfv
 bfv
 bfv
-cwp
-cwp
+aaa
+aaa
 cwq
 aJq
 aJq
@@ -90742,9 +90756,9 @@ aaa
 aaf
 aaa
 aaf
-bfv
-cwp
-cwp
+aaa
+aaa
+aaa
 cwq
 aJq
 aJq


### PR DESCRIPTION
:cl: Quiltyquilty
rscadd: The AI is back in the center of the station. The gravity generator is now where the SMES room used to be. The SMESes are in the equipment room.
/:cl:

Personally I don't think it's good for Box to just copy everything Meta does. Since the start the MiniSat has been massive powercreep for the AI for no reason, since Meta is basically powercreep: the map.

The new AI core is similar but not identical to the old one. I shrunk down and made the upload a bit more secure. The rest is pretty similar.

EDIT: Since people are instantly saying this is a nerf and giving a thumbs down, here's my view on this change and why it isn't really a nerf.
- The AI can no longer be killed by nuke ops/wizards instantly at roundstart without anyone noticing.
- On that same note, breaking into the ai core to steal its brain is harder as well.
- However, malf AI is quite a bit more vulnerable being onstation.
- Rogue AIs go unchanged, because the upload was already onstation.

By looking at it like that, you could argue that it's a buff with a downside, or at the least a balanced change that evens out. That's my two cents.

AI Upload/Core:
![](http://puu.sh/pxkRv/32e7b921d7.png)

Gravity Generator:
![](http://puu.sh/puWow/f727d6a941.png)

Where the MiniSat entrance used to be:
![](http://puu.sh/puWpb/57d1799143.png)

I forgot to take a picture of the equipment room, but just look at any pre-SMES room revision of Box, it's identical to that.

Merge token is #18147
