### PR TITLE
Pylons pulse cult floors when finished conversion

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -2496,7 +2496,7 @@
 	desc = "A altar dedicated to the Wizard's Federation"
 	},
 /obj/item/weapon/kitchen/knife/ritual,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "hM" = (
 /obj/structure/flora/bush,
@@ -3066,7 +3066,7 @@
 	},
 /area/wizard_station)
 "jx" = (
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult/airless,
 /area/wizard_station)
 "jy" = (
 /obj/item/clothing/head/collectable/paper,
@@ -3183,7 +3183,7 @@
 /area/wizard_station)
 "jQ" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult/airless,
 /area/wizard_station)
 "jR" = (
 /turf/closed/indestructible/riveted,
@@ -3311,7 +3311,7 @@
 /area/wizard_station)
 "kk" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult/airless,
 /area/wizard_station)
 "kl" = (
 /obj/structure/showcase{
@@ -3320,9 +3320,7 @@
 	icon_state = "nim";
 	name = "wizard of yendor showcase"
 	},
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage4"
-	},
+/turf/open/floor/engine/cult/airless,
 /area/wizard_station)
 "km" = (
 /turf/closed/indestructible/fakeglass{
@@ -3446,12 +3444,10 @@
 /area/wizard_station)
 "kF" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "kG" = (
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "kH" = (
 /turf/closed/indestructible/fakeglass,
@@ -3536,7 +3532,7 @@
 /area/wizard_station)
 "kT" = (
 /obj/effect/forcefield,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "kU" = (
 /turf/open/floor/plasteel/cult{
@@ -3781,9 +3777,7 @@
 /area/wizard_station)
 "lJ" = (
 /obj/machinery/vending/snack,
-/turf/open/floor/plasteel/cult{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lK" = (
 /turf/open/floor/plasteel/darkblue/side{
@@ -3814,14 +3808,14 @@
 	anchored = 1;
 	name = "Break Room"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lR" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Break Room"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lS" = (
 /turf/open/floor/plasteel/blue,
@@ -3844,12 +3838,12 @@
 /obj/structure/table/wood,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lY" = (
 /obj/structure/table/wood,
 /obj/item/weapon/retractor,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "lZ" = (
 /obj/structure/table/wood,
@@ -3859,26 +3853,24 @@
 /obj/structure/mirror/magic{
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "ma" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/wizrobe/magusred,
 /obj/item/clothing/head/wizard/magus,
 /obj/item/weapon/staff,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mb" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/space/hardsuit/wizard,
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mc" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "md" = (
 /obj/effect/forcefield,
@@ -3974,7 +3966,7 @@
 /obj/item/clothing/head/wizard/red,
 /obj/item/weapon/staff,
 /obj/item/clothing/shoes/sandal,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "ms" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -3982,9 +3974,7 @@
 	health = 9999
 	},
 /obj/item/clothing/suit/space/hardsuit/wizard,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mt" = (
 /turf/open/floor/plasteel/cult,
@@ -4041,7 +4031,7 @@
 /area/wizard_station)
 "mA" = (
 /obj/structure/bookcase,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mB" = (
 /obj/structure/grille/broken{
@@ -4057,14 +4047,14 @@
 /obj/item/clothing/suit/wizrobe/marisa,
 /obj/item/clothing/head/wizard/marisa,
 /obj/item/weapon/staff/broom,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /mob/living/simple_animal/hostile/creature{
 	name = "Experiment 35b"
 	},
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mF" = (
 /obj/machinery/door/poddoor/preopen,
@@ -4156,7 +4146,7 @@
 "mR" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/cult/airless,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mS" = (
 /turf/open/floor/plasteel/cult,
@@ -4183,19 +4173,17 @@
 	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mW" = (
 /obj/structure/cult/pylon,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mX" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/rack,
 /obj/item/weapon/staff,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "mY" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -4207,9 +4195,7 @@
 "mZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/forcefield,
-/turf/open/floor/plasteel/cult/airless{
-	icon_state = "cultdamage"
-	},
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "na" = (
 /turf/open/floor/plasteel/cult/airless{
@@ -4221,14 +4207,14 @@
 	anchored = 1;
 	name = "Corridor A"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "nc" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Corridor A"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "nd" = (
 /obj/structure/barricade/security,
@@ -4358,7 +4344,7 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
 	name = "Personal Quarters"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "nz" = (
 /turf/closed/indestructible/riveted,
@@ -4491,7 +4477,7 @@
 /area/centcom/holding)
 "nV" = (
 /obj/structure/table/wood,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "nW" = (
 /obj/structure/table/wood,
@@ -4500,7 +4486,7 @@
 	max_charges = 0;
 	name = "wand of emergency engine ignition"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "nX" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -4614,7 +4600,7 @@
 	desc = "A engine used in powering the wizards ship";
 	name = "magma engine"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/engine/cult,
 /area/wizard_station)
 "op" = (
 /obj/structure/table,
@@ -5797,19 +5783,20 @@
 	},
 /turf/open/floor/plasteel/delivery,
 /area/centcom/ferry)
+"sa" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"sb" = (
+/obj/structure/cult/tome,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"sc" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "sd" = (
 /obj/structure/flora/tree/pine,
-/turf/open/floor/holofloor/snow/cold,
-/area/holodeck/rec_center/winterwonderland)
-"sc" = (
-/obj/structure/flora/grass/brown,
-/turf/open/floor/holofloor/snow/cold,
-/area/holodeck/rec_center/winterwonderland)
-"sb" = (
-/obj/structure/flora/bush,
-/turf/open/floor/holofloor/snow/cold,
-/area/holodeck/rec_center/winterwonderland)
-"sa" = (
 /turf/open/floor/holofloor/snow/cold,
 /area/holodeck/rec_center/winterwonderland)
 
@@ -10616,10 +10603,10 @@ aa
 aa
 aa
 jc
-lW
-mp
+sa
+sb
 mA
-mp
+sb
 mV
 jc
 aa
@@ -11902,7 +11889,7 @@ lx
 ju
 jc
 lX
-mq
+kF
 lz
 lI
 mW
@@ -12159,7 +12146,7 @@ ly
 lG
 jc
 lY
-mq
+kF
 ln
 kG
 kG
@@ -12664,7 +12651,7 @@ aa
 ja
 jw
 jP
-jQ
+sc
 kv
 kF
 kU
@@ -13458,7 +13445,7 @@ nL
 jP
 jc
 jc
-ok
+sc
 jc
 jc
 jc
@@ -14218,7 +14205,7 @@ mc
 mt
 mF
 mS
-mY
+mc
 jc
 aa
 aa
@@ -14728,7 +14715,7 @@ aa
 aa
 aa
 ju
-me
+kF
 lx
 mH
 mT

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -44,6 +44,8 @@
 
 #define isconstruct(A) (istype(A, /mob/living/simple_animal/hostile/construct))
 
+#define isshade(A) (istype(A, /mob/living/simple_animal/shade))
+
 #define isbear(A) (istype(A, /mob/living/simple_animal/hostile/bear))
 
 #define iscarp(A) (istype(A, /mob/living/simple_animal/hostile/carp))

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -155,7 +155,7 @@ var/list/blacklisted_pylon_turfs = typecacheof(list(
 		else
 			var/turf/open/floor/engine/cult/F = safepick(cultturfs)
 			if(F)
-				F.pulse()
+				PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, F)
 			else
 				// Are we in space or something? No cult turfs or
 				// convertable turfs?

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -92,6 +92,13 @@
 		user << "<span class='cultitalic'>You work the forge as dark knowledge guides your hands, creating [N]!</span>"
 
 
+var/list/blacklisted_pylon_turfs = typecacheof(list(
+	/turf/closed,
+	/turf/open/floor/engine/cult,
+	/turf/open/space,
+	/turf/open/floor/plating/lava,
+	/turf/open/chasm))
+
 /obj/structure/cult/pylon
 	name = "pylon"
 	desc = "A floating crystal that slowly heals those faithful to Nar'Sie."
@@ -116,30 +123,43 @@
 	if(last_heal <= world.time)
 		last_heal = world.time + heal_delay
 		for(var/mob/living/L in range(5, src))
-			if(iscultist(L) || istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
+			if(iscultist(L) || isshade(L) || isconstruct(L))
 				if(L.health != L.maxHealth)
 					PoolOrNew(/obj/effect/overlay/temp/heal, list(get_turf(src), "#960000"))
 					if(ishuman(L))
 						L.adjustBruteLoss(-1, 0)
 						L.adjustFireLoss(-1, 0)
 						L.updatehealth()
-					if(istype(L, /mob/living/simple_animal/shade) || istype(L, /mob/living/simple_animal/hostile/construct))
+					if(isshade(L) || isconstruct(L))
 						var/mob/living/simple_animal/M = L
 						if(M.health < M.maxHealth)
 							M.adjustHealth(-1)
 			CHECK_TICK
 	if(last_corrupt <= world.time)
 		var/list/validturfs = list()
+		var/list/cultturfs = list()
 		for(var/T in circleviewturfs(src, 5))
-			if(istype(T, /turf/closed) || istype(T, /turf/open/floor/engine/cult) || istype(T, /turf/open/space) || istype(T, /turf/open/floor/plating/lava))
+			if(istype(T, /turf/open/floor/engine/cult))
+				cultturfs |= T
 				continue
-			validturfs |= T
+			if(is_type_in_typecache(T, blacklisted_pylon_turfs))
+				continue
+			else
+				validturfs |= T
+
+		last_corrupt = world.time + corrupt_delay
+
 		var/turf/T = safepick(validturfs)
 		if(T)
 			T.ChangeTurf(/turf/open/floor/engine/cult)
-			last_corrupt = world.time + corrupt_delay
 		else
-			last_corrupt = world.time + corrupt_delay*2
+			var/turf/open/floor/engine/cult/F = safepick(cultturfs)
+			if(F)
+				F.pulse()
+			else
+				// Are we in space or something? No cult turfs or
+				// convertable turfs?
+				last_corrupt = world.time + corrupt_delay*2
 
 /obj/structure/cult/tome
 	name = "archives"

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -153,11 +153,8 @@
 	icon_state = "cult"
 
 /turf/open/floor/engine/cult/New()
-	pulse()
-	..()
-
-/turf/open/floor/engine/cult/proc/pulse()
 	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)
+	..()
 
 /turf/open/floor/engine/cult/narsie_act()
 	return

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -178,6 +178,9 @@
 		else if(prob(30))
 			ReplaceWithLattice()
 
+/turf/open/floor/engine/cult/airless
+	initial_gas_mix = "TEMP=2.7"
+
 /turf/open/floor/engine/vacuum
 	name = "vacuum floor"
 	icon_state = "engine"

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -153,8 +153,11 @@
 	icon_state = "cult"
 
 /turf/open/floor/engine/cult/New()
-	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)
+	pulse()
 	..()
+
+/turf/open/floor/engine/cult/proc/pulse()
+	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)
 
 /turf/open/floor/engine/cult/narsie_act()
 	return


### PR DESCRIPTION
Once a cult pylon has converted everything it can, it then starts
picking random cult floors and pulsing them like they were just created.

Fixes #18539 by making it intended behaviour. The wizard's den is now mostly converted cult tiles.
