### PR TITLE
Cult can only use runes on station and on mining

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -178,7 +178,7 @@ This file contains the arcane tome files.
 		user << "<span class='cult'>There is already a rune here.</span>"
 		return
 
-	if(Turf != ZLEVEL_STATION && Turf != ZLEVEL_MINING)
+	if(Turf.z != ZLEVEL_STATION && Turf.z != ZLEVEL_MINING)
 		user << "<span class='warning'>The veil is not weak enough here."
 		return
 	if(istype(A, /area/shuttle))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -172,9 +172,17 @@ This file contains the arcane tome files.
 	var/entered_rune_name
 	var/list/possible_runes = list()
 	var/list/shields = list()
+	var/area/A = get_area(src)
+
 	if(locate(/obj/effect/rune) in Turf)
 		user << "<span class='cult'>There is already a rune here.</span>"
 		return
+
+	if(Turf != ZLEVEL_STATION && Turf != ZLEVEL_MINING)
+		user << "<span class='warning'>The veil is not weak enough here."
+		return
+	if(istype(A, /area/shuttle))
+		user << "<span class='warning'>Interference from hyperspace engines disrupts the Geometer's power on shuttles.</span>"
 	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed)
 		var/obj/effect/rune/R = T
 		if(initial(R.cultist_name))
@@ -217,16 +225,10 @@ This file contains the arcane tome files.
 			else if(!cult_mode.eldergod)
 				user << "<span class='cultlarge'>\"I am already here. There is no need to try to summon me now.\"</span>"
 				return
-			var/area/A = get_area(src)
 			var/locname = initial(A.name)
 			if(loc.z && loc.z != ZLEVEL_STATION)
 				user << "<span class='warning'>The Geometer is not interested \
 					in lesser locations; the station is the prize!</span>"
-				return
-			if(istype(A, /area/shuttle))
-				user << "<span class='warning'>Interference from hyperspace \
-					engines prevents the Geometer from entering our world on \
-					a shuttle.</span>"
 				return
 			var/confirm_final = alert(user, "This is the FINAL step to summon Nar-Sie, it is a long, painful ritual and the crew will be alerted to your presence", "Are you prepared for the final battle?", "My life for Nar-Sie!", "No")
 			if(confirm_final == "No")


### PR DESCRIPTION
I'm not sure this is a good idea but the best way to get attention for a bad idea is to open a PR

Cult runes can only be used on the station z level or the mining z level.

Why?

Because it's effectively impossible for security to fight cultists on the white ship, or who have their base in some other random bit of space debris. Hiding in an unassailable base on another z level for 30-40 minutes is bad.

> but then why'd you let them keep building on mining

Because I realize that there are not many good places to build a base in maint (hey maybe making multiple game modes about  base building in ss13 wasn't a great idea). Mining however

-Can support security running about on it. You don't need suits for lavaland.

-Is thematically appropriate for the veil being weak

-Is possible to actually navigate unlike 6 z levels of emptiness and random transitions.

-Leaves a trail when you dig out into it. So they can hide a base there, but not forever.

Organizing a raid to go shoot cultists in hell sounds more fun to me than "well I guess we should call the shuttle because they're in their mobile fortress we can't attack again"

Anyway tell me why it's a bad idea please so I can close this PR instead of being responsible for tanking the cult winrate.

:cl: Kor
rscadd: Cult runes can only be scribed on station and on mining.
/:cl:
