### PR TITLE
Changes flashes vs. borgs

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -112,10 +112,13 @@
 		return 1
 
 	else if(issilicon(M))
-		add_logs(user, M, "flashed", src)
+		var/mob/living/silicon/robot/R = M
+		add_logs(user, R, "flashed", src)
 		update_icon(1)
-		M.Weaken(rand(5,10))
-		user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the flash!</span>", "<span class='danger'>You overload [M]'s sensors with the flash!</span>")
+		R.confused += 5
+		R.uneq_active()
+		R.flash_eyes(affect_silicon = 1)
+		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return 1
 
 	user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")


### PR DESCRIPTION
Instead of being stunned, flashes on cyborgs causes a confused effect, a blind screen overlay, and the unequipping of the current module. Basically, the exact same effect as against humans.

Now that borgs aren't invincible stuntanks it seems fair to soften up their hard counters. Especially because I despise hard counters.

Cons: Harder for traitors to emag them since they can't disable them as easily? (is this even a con?) if it's a problem we can just make emagging easier but I don't really see non-roboticists doing so often as it is now.
