### PR TITLE
[wip] Syndrones have nuke ops access, syndicomms

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -1,5 +1,5 @@
 
-/obj/item/device/encryptionkey/
+/obj/item/device/encryptionkey
 	name = "standard encryption key"
 	desc = "An encryption key for a radio headset.  Has no special codes in it.  WHY DOES IT EXIST?  ASK NANOTRASEN."
 	icon = 'icons/obj/radio.dmi'

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -297,5 +297,3 @@
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, radiochannels[ch_name])
-
-	return

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -84,7 +84,7 @@
 		equip_to_slot_or_del(I, slot_head)
 	if(default_radio)
 		radio = new default_radio(src)
-		radio |= NODROP
+		radio.flags |= NODROP
 
 	access_card.flags |= NODROP
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -55,10 +55,15 @@
 	var/light_on = 0
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())
+
 	var/obj/item/internal_storage //Drones can store one item, of any size/type in their body
 	var/obj/item/head
+	var/obj/item/device/radio/radio
+
 	var/obj/item/default_storage = /obj/item/weapon/storage/backpack/dufflebag/drone //If this exists, it will spawn in internal storage
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
+	var/obj/item/device/radio/default_radio
+
 	var/seeStatic = 1 //Whether we see static instead of mobs
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = 0 //If we have laws to destroy the station
@@ -77,6 +82,9 @@
 	if(default_hatmask)
 		var/obj/item/I = new default_hatmask(src)
 		equip_to_slot_or_del(I, slot_head)
+	if(default_radio)
+		radio = new default_radio(src)
+		radio |= NODROP
 
 	access_card.flags |= NODROP
 
@@ -108,6 +116,9 @@
 
 /mob/living/simple_animal/drone/Destroy()
 	qdel(access_card) //Otherwise it ends up on the floor!
+	if(radio)
+		qdel(radio)
+	radio = null
 	return ..()
 
 /mob/living/simple_animal/drone/Login()

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -14,8 +14,8 @@
 	icon_state = "drone_synd"
 	icon_living = "drone_synd"
 	picked = TRUE //the appearence of syndrones is static, you don't get to change it.
-	health = 30
-	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
+	health = 50
+	maxHealth = 50
 	faction = list("syndicate")
 	speak_emote = list("hisses")
 	bubble_icon = "syndibot"
@@ -26,15 +26,14 @@
 	"3. Destroy."
 	default_storage = /obj/item/device/radio/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
+	default_radio = /obj/item/device/radio/headset/syndicate
 	seeStatic = 0 //Our programming is superior.
 
 /mob/living/simple_animal/drone/syndrone/New()
 	..()
 	internal_storage.hidden_uplink.telecrystals = 10
-
-/mob/living/simple_animal/drone/syndrone/Login()
-	..()
-	src << "<span class='notice'>You can kill and eat other drones to increase your health!</span>" //Inform the evil lil guy
+	access_card.access |= access_syndicate
+	access_card.access |= access_syndicate_leader
 
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -244,7 +244,6 @@
 
 /mob/living/simple_animal/blob_act(obj/effect/blob/B)
 	adjustBruteLoss(20)
-	return
 
 /mob/living/simple_animal/say_quote(input)
 	var/ending = copytext(input, length(input))
@@ -337,8 +336,6 @@
 			visible_message("<span class='notice'>[M.name] [response_help] [src].</span>")
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-	return
-
 /mob/living/simple_animal/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if(..()) //if harm or disarm intent.
 		if(M.a_intent == "disarm")
@@ -418,14 +415,11 @@
 
 /mob/living/simple_animal/ex_act(severity, target)
 	..()
-	switch (severity)
-		if (1)
+	switch(severity)
+		if(1)
 			gib()
-			return
-
-		if (2)
+		if(2)
 			adjustBruteLoss(60)
-
 		if(3)
 			adjustBruteLoss(30)
 


### PR DESCRIPTION
- Minor cleaning of encryptionkey.dm and headset.dm
- Drones now can have default radios that spawns inside of them, which
  is deleted when they are destroyed (like their ID card)
- Removes syndrone cannibalism because current implementation is bugged because they can just repair themselves with a screwdriver anyway

:cl: coiax
rscadd: Syndrones now have Syndicate access on their internal ID cards, along with access to Syndicate communications.
/:cl:
- [ ] Test to see if they can talk and listen on their radios
