### PR TITLE
Gives devil saturation on receiving a soul

### DIFF
--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -138,9 +138,12 @@ var/global/list/lawlorify = list (
 	return pick(BANISH_WATER, BANISH_COFFIN, BANISH_FORMALDYHIDE, BANISH_RUNES, BANISH_CANDLES, BANISH_DESTRUCTION, BANISH_FUNERAL_GARB)
 
 /datum/devilinfo/proc/add_soul(datum/mind/soul)
+	var/mob/living/carbon/human/H = owner.current
 	if(soulsOwned.Find(soul))
 		return
 	soulsOwned += soul
+	H.nutrition = NUTRITION_LEVEL_FULL
+	owner.current << "<span class='warning'>You feel saturated as you recieved a new soul."
 	switch(SOULVALUE)
 		if(0)
 			owner.current << "<span class='warning'>Your hellish powers have been restored."
@@ -422,3 +425,4 @@ var/global/list/lawlorify = list (
 		else
 			throw EXCEPTION("Unable to find a blobstart landmark for hellish resurrection")
 	check_regression()
+

--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -143,7 +143,7 @@ var/global/list/lawlorify = list (
 		return
 	soulsOwned += soul
 	H.nutrition = NUTRITION_LEVEL_FULL
-	owner.current << "<span class='warning'>You feel saturated as you recieved a new soul."
+	owner.current << "<span class='warning'>You feel satiated as you recieved a new soul."
 	switch(SOULVALUE)
 		if(0)
 			owner.current << "<span class='warning'>Your hellish powers have been restored."

--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -143,7 +143,7 @@ var/global/list/lawlorify = list (
 		return
 	soulsOwned += soul
 	H.nutrition = NUTRITION_LEVEL_FULL
-	owner.current << "<span class='warning'>You feel satiated as you recieved a new soul."
+	owner.current << "<span class='warning'>You feel satiated as you received a new soul.</span>"
 	switch(SOULVALUE)
 		if(0)
 			owner.current << "<span class='warning'>Your hellish powers have been restored."


### PR DESCRIPTION
Devils have high-difficulty not starving because they can only materialize near potential signers, and not food.

This PR makes him go to well fed upon buying a soul and adds a (not so) fancy message.
