### PR TITLE
Clone pods properly eject occupants when destroyed

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -48,6 +48,7 @@
 	radio.recalculateChannels()
 
 /obj/machinery/clonepod/Destroy()
+	go_out()
 	qdel(radio)
 	radio = null
 	qdel(countdown)


### PR DESCRIPTION
Fixes #18641.

This should ensure the clone's ghost is shoved back into the body.
