### PR TITLE
Birdboat: atmos split and small tweaks

### DIFF
--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -11708,9 +11708,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	icon_state = "manifold";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/sleep)
@@ -12119,7 +12119,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/warning/corner,
 /area/maintenance/asmaint2)
 "aDW" = (
@@ -12353,10 +12352,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aEy" = (
 /obj/structure/closet/emcloset,
+/obj/item/weapon/storage/box/metalfoam,
 /turf/open/floor/plating,
 /area/maintenance/maintcentral{
 	name = "Central Maintenance"
@@ -12395,7 +12396,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aEE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aEF" = (
@@ -12446,7 +12447,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
@@ -13051,7 +13051,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/warning/corner{
 	dir = 8
 	},
@@ -14011,11 +14010,11 @@
 /obj/docking_port/stationary{
 	dheight = 0;
 	dir = 8;
-	dwidth = 6;
-	height = 18;
+	dwidth = 10;
+	height = 51;
 	id = "emergency_home";
 	name = "emergency evac bay";
-	width = 14
+	width = 21
 	},
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/escape)
@@ -14395,7 +14394,6 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /mob/living/simple_animal/mouse/brown,
 /turf/open/floor/plasteel/white,
 /area/toxins/xenobiology)
@@ -16073,9 +16071,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	icon_state = "manifold";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/toxins/xenobiology)
@@ -18064,7 +18062,6 @@
 /area/security/brig)
 "aSA" = (
 /obj/structure/table,
-/obj/item/weapon/wrench,
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_y = 7
 	},
@@ -18083,18 +18080,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aSB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	icon_state = "intact";
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/warnwhite{
 	dir = 4
 	},
 /area/medical/medbay)
 "aSC" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/black,
 /area/medical/medbay)
 "aSD" = (
@@ -18491,6 +18489,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/warnwhite/corner{
 	dir = 8
 	},
@@ -18817,6 +18816,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "aUn" = (
@@ -18825,6 +18828,9 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -18835,6 +18841,10 @@
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
@@ -19046,6 +19056,10 @@
 "aUR" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	icon_state = "intact";
+	dir = 9
 	},
 /turf/open/floor/plasteel/warnwhite/corner,
 /area/medical/medbay)
@@ -21295,8 +21309,11 @@
 /turf/closed/wall,
 /area/medical/morgue)
 "bav" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baw" = (
@@ -21344,10 +21361,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bay" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
 /obj/structure/sign/directions/science{
 	pixel_x = 32;
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	icon_state = "manifold";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21500,9 +21520,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	icon_state = "intact";
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	icon_state = "manifold";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/fore{
@@ -21512,7 +21532,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/closet/cardboard,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore{
 	name = "Security Maintenance"
@@ -21773,7 +21796,10 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	icon_state = "manifold";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore{
 	name = "Security Maintenance"
@@ -22062,7 +22088,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint2)
 "bbX" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint2)
 "bbY" = (
@@ -22213,7 +22239,10 @@
 	name = "Security Maintenance"
 	})
 "bcu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	icon_state = "manifold";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint)
 "bcv" = (
@@ -22246,6 +22275,7 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bcA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /mob/living/simple_animal/mouse/brown,
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
@@ -23233,6 +23263,188 @@
 /area/maintenance/fore{
 	name = "Security Maintenance"
 	})
+"ZzT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/toy/crayon/spraycan/mimecan,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"ZzU" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hallway shutter";
+	name = "hallway shutter"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzX" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzY" = (
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzZ" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"ZAa" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "science maintenance door";
+	req_one_access_txt = "47;12;29"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/asmaint2)
+"ZAb" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/toxins/xenobiology)
+"ZAc" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/warning{
+	tag = "icon-warningcorner";
+	icon_state = "warningcorner";
+	dir = 2
+	},
+/area/maintenance/asmaint2)
+"ZAd" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/warning,
+/area/maintenance/asmaint2)
+"ZAe" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/wrench/medical,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay)
+"ZAf" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/maintenance/asmaint2)
+"ZAg" = (
+/obj/machinery/droneDispenser,
+/turf/open/floor/plasteel,
+/area/maintenance/asmaint2)
+"ZAh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	tag = "icon-intact (WEST)";
+	icon_state = "intact";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/medbay)
+"ZAi" = (
+/obj/machinery/shieldwallgen{
+	req_access = null
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/aft{
+	name = "\improper South Hallway"
+	})
+"ZAj" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore{
+	name = "Security Maintenance"
+	})
+"ZAk" = (
+/obj/structure/cable/cyan{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore{
+	name = "Security Maintenance"
+	})
+"ZAl" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	icon_state = "connector_map";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/fore{
+	name = "Security Maintenance"
+	})
+"ZAm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/maintenance/asmaint2)
+"ZAn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"ZAo" = (
+/obj/machinery/atmospherics/components/binary/valve/open,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"ZAp" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/asmaint)
+"ZAq" = (
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating,
+/area/maintenance/asmaint)
+"ZAr" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"ZAs" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/asmaint2)
+"ZAt" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"ZAu" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
 "ZAv" = (
 /obj/item/weapon/coin/gold,
 /turf/open/floor/wood,
@@ -50131,8 +50343,8 @@ aNf
 aDo
 aaa
 aaa
-aay
-aay
+aaa
+aaa
 aay
 aaB
 aay
@@ -50388,7 +50600,7 @@ aEf
 aHj
 aaa
 aaa
-aay
+aaa
 aaa
 aaa
 aaB
@@ -50644,9 +50856,9 @@ aEX
 aFK
 aGx
 aaa
-aay
-aay
-aay
+aaa
+aaa
+aaa
 aPH
 aPH
 aPH
@@ -57055,7 +57267,7 @@ axh
 axh
 aCJ
 axh
-axh
+ZzX
 axh
 axh
 aGD
@@ -57310,13 +57522,13 @@ aww
 aAL
 aww
 azs
-azl
-aww
-aww
-aww
-aww
-aww
-aww
+ZzU
+atT
+ZzY
+atT
+atT
+atT
+atT
 bav
 aJh
 aJX
@@ -57601,8 +57813,8 @@ aZh
 aPK
 bac
 aQp
-aRk
-aRn
+ZAj
+ZAk
 bbJ
 aPH
 aay
@@ -57859,7 +58071,7 @@ aPK
 bad
 bad
 baR
-aQq
+ZAl
 bbK
 aPH
 aaa
@@ -59386,10 +59598,10 @@ aaa
 aaa
 aaa
 aay
-aaa
-aaa
-aaa
-aaa
+aeQ
+afj
+afj
+afB
 aay
 aaa
 aaa
@@ -59643,10 +59855,10 @@ aPc
 aPc
 aPc
 aKj
-aay
-aay
-aay
-aay
+aeT
+afB
+aeQ
+afk
 aVV
 aVW
 aVW
@@ -59900,10 +60112,10 @@ aPT
 aQJ
 aRB
 aKj
-aaa
-aaa
-aaa
-aaa
+aeQ
+afk
+aeT
+afB
 aVW
 aWy
 aXf
@@ -60157,10 +60369,10 @@ aKX
 aKX
 aRC
 aKj
-aaa
-aaa
-aaa
-aaa
+aeT
+afB
+aeQ
+afk
 aVW
 aWz
 aXf
@@ -60415,8 +60627,8 @@ aMv
 aRD
 aKj
 aKj
-aPc
-aPc
+ZAh
+ZAh
 aKj
 aVX
 aVX
@@ -60690,8 +60902,8 @@ bbu
 bbQ
 bch
 bcq
-baS
-baS
+ZAp
+ZAq
 aZr
 aaJ
 aaJ
@@ -60907,7 +61119,7 @@ azo
 axr
 aAO
 aAl
-aCj
+ZzT
 aCk
 aCk
 aEv
@@ -61180,7 +61392,7 @@ aLM
 aMt
 aNv
 aOn
-aKX
+ZAe
 aPU
 aQM
 aRF
@@ -62963,14 +63175,14 @@ azs
 ave
 aww
 aBC
-azl
-aAL
-axw
-aww
-aww
-aww
-aBC
-aww
+ZzU
+ZzV
+ZzW
+ZzY
+atT
+atT
+atU
+atT
 bay
 baX
 aKl
@@ -63002,10 +63214,10 @@ aRR
 azL
 bbU
 aLY
-aAx
+bbZ
 aAx
 aDi
-aAx
+ZAt
 azL
 aaJ
 aaJ
@@ -63519,7 +63731,7 @@ aNE
 aNE
 aHG
 bcI
-aAx
+ZAu
 aBR
 aaa
 aay
@@ -64543,10 +64755,10 @@ bez
 aSJ
 azL
 bbX
-aBb
-aAx
+ZAm
+ZAo
 bcA
-aDi
+bcI
 bcj
 azL
 aaa
@@ -64799,11 +65011,11 @@ aTK
 bez
 aSJ
 azL
-bbY
-aAx
-aAx
-aAx
-aDi
+bbX
+ZAn
+ZAo
+aHG
+ZAr
 bcY
 azL
 aaa
@@ -65053,14 +65265,14 @@ aXp
 aXp
 aWG
 aTK
-beA
+ZAi
 beD
 azL
-bbZ
-bcj
-aAx
-aBb
-aDj
+bbX
+ZAn
+ZAo
+aNE
+ZAs
 bcZ
 azL
 aaa
@@ -65536,7 +65748,7 @@ awK
 aCt
 aCX
 aDL
-aED
+ZzZ
 aED
 aED
 aGU
@@ -65792,11 +66004,11 @@ axA
 aBH
 axA
 aCY
-aDM
+avo
 aEE
-aEE
-aEE
-aGV
+aHu
+aHu
+aGW
 aHC
 aAl
 aAl
@@ -67347,8 +67559,8 @@ aQV
 aHG
 aML
 aNE
-aOB
-aNE
+ZAc
+ZAf
 bdT
 bdV
 aRY
@@ -67604,8 +67816,8 @@ bdF
 aCy
 aCy
 aNF
-aDU
-aBb
+ZAd
+ZAg
 aBR
 bdU
 aRZ
@@ -67846,7 +68058,7 @@ awN
 alA
 akk
 aBK
-aCu
+avm
 aDc
 avo
 aEH
@@ -69131,7 +69343,7 @@ azH
 anN
 akk
 aBP
-aCu
+avm
 aDc
 avo
 aEH
@@ -70160,7 +70372,7 @@ akL
 azM
 aBR
 azL
-aDh
+aDk
 aDS
 aCy
 aFy
@@ -70417,7 +70629,7 @@ aAv
 aBb
 aBS
 aCx
-aDi
+aAx
 aDR
 aCy
 aFu
@@ -70674,7 +70886,7 @@ aos
 aBc
 aAx
 aBR
-aDj
+aBb
 aDT
 aCy
 aFz
@@ -70931,7 +71143,7 @@ aAw
 aBd
 aBT
 aBR
-aDj
+aBb
 aDU
 aCy
 aCy
@@ -71188,7 +71400,7 @@ azL
 azL
 azL
 azL
-aDj
+aBb
 aDU
 aBb
 aFA
@@ -71445,16 +71657,16 @@ aAx
 aBe
 aAx
 azM
-aDk
+aAx
 aDV
 aEK
-aFB
+aXw
 aGn
-aHe
-aJF
+ZAa
+ZAb
 aJH
-aKy
-aKy
+aHI
+aHI
 aNQ
 aKy
 aOV

--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -23263,7 +23263,7 @@
 /area/maintenance/fore{
 	name = "Security Maintenance"
 	})
-"ZzT" = (
+"ZzR" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -23271,24 +23271,35 @@
 /obj/item/toy/crayon/spraycan/mimecan,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"ZzU" = (
+"ZzS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	icon_state = "intact";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ZzV" = (
+"ZzT" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hallway shutter";
 	name = "hallway shutter"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ZzW" = (
+"ZzU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzV" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ZzW" = (
+/obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ZzX" = (
@@ -23297,19 +23308,8 @@
 	},
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ZzY" = (
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ZzZ" = (
-/obj/structure/cable/cyan{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"ZAa" = (
+"ZzY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "science maintenance door";
 	req_one_access_txt = "47;12;29"
@@ -23319,13 +23319,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint2)
-"ZAb" = (
+"ZzZ" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/toxins/xenobiology)
-"ZAc" = (
+"ZAa" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -23336,28 +23336,28 @@
 	dir = 2
 	},
 /area/maintenance/asmaint2)
-"ZAd" = (
+"ZAb" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/warning,
 /area/maintenance/asmaint2)
-"ZAe" = (
+"ZAc" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/wrench/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
-"ZAf" = (
+"ZAd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
 /area/maintenance/asmaint2)
-"ZAg" = (
+"ZAe" = (
 /obj/machinery/droneDispenser,
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint2)
-"ZAh" = (
+"ZAf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	tag = "icon-intact (WEST)";
@@ -23366,7 +23366,7 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay)
-"ZAi" = (
+"ZAg" = (
 /obj/machinery/shieldwallgen{
 	req_access = null
 	},
@@ -23374,7 +23374,7 @@
 /area/hallway/primary/aft{
 	name = "\improper South Hallway"
 	})
-"ZAj" = (
+"ZAh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	on = 1
@@ -23383,7 +23383,7 @@
 /area/maintenance/fore{
 	name = "Security Maintenance"
 	})
-"ZAk" = (
+"ZAi" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
 	},
@@ -23395,7 +23395,7 @@
 /area/maintenance/fore{
 	name = "Security Maintenance"
 	})
-"ZAl" = (
+"ZAj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	icon_state = "connector_map";
 	dir = 8
@@ -23404,18 +23404,29 @@
 /area/maintenance/fore{
 	name = "Security Maintenance"
 	})
-"ZAm" = (
+"ZAk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/asmaint2)
-"ZAn" = (
+"ZAl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
-"ZAo" = (
+"ZAm" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating{
+	icon_plating = "asteroidplating";
+	icon_state = "asteroidplating"
+	},
+/area/maintenance/asmaint2)
+"ZAn" = (
 /obj/machinery/atmospherics/components/binary/valve/open,
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"ZAo" = (
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "ZAp" = (
@@ -57267,7 +57278,7 @@ axh
 axh
 aCJ
 axh
-ZzX
+ZzV
 axh
 axh
 aGD
@@ -57522,9 +57533,9 @@ aww
 aAL
 aww
 azs
-ZzU
+ZzS
 atT
-ZzY
+ZzW
 atT
 atT
 atT
@@ -57813,8 +57824,8 @@ aZh
 aPK
 bac
 aQp
-ZAj
-ZAk
+ZAh
+ZAi
 bbJ
 aPH
 aay
@@ -58071,7 +58082,7 @@ aPK
 bad
 bad
 baR
-ZAl
+ZAj
 bbK
 aPH
 aaa
@@ -60627,8 +60638,8 @@ aMv
 aRD
 aKj
 aKj
-ZAh
-ZAh
+ZAf
+ZAf
 aKj
 aVX
 aVX
@@ -61119,7 +61130,7 @@ azo
 axr
 aAO
 aAl
-ZzT
+ZzR
 aCk
 aCk
 aEv
@@ -61392,7 +61403,7 @@ aLM
 aMt
 aNv
 aOn
-ZAe
+ZAc
 aPU
 aQM
 aRF
@@ -63175,10 +63186,10 @@ azs
 ave
 aww
 aBC
+ZzS
+ZzT
 ZzU
-ZzV
 ZzW
-ZzY
 atT
 atT
 atU
@@ -64755,8 +64766,8 @@ bez
 aSJ
 azL
 bbX
-ZAm
-ZAo
+ZAk
+ZAn
 bcA
 bcI
 bcj
@@ -65012,8 +65023,8 @@ bez
 aSJ
 azL
 bbX
+ZAl
 ZAn
-ZAo
 aHG
 ZAr
 bcY
@@ -65265,12 +65276,12 @@ aXp
 aXp
 aWG
 aTK
-ZAi
+ZAg
 beD
 azL
 bbX
+ZAl
 ZAn
-ZAo
 aNE
 ZAs
 bcZ
@@ -65748,7 +65759,7 @@ awK
 aCt
 aCX
 aDL
-ZzZ
+ZzX
 aED
 aED
 aGU
@@ -66298,7 +66309,7 @@ aBb
 aBb
 aBb
 aBe
-aRZ
+ZAo
 bcB
 aDj
 azL
@@ -66555,7 +66566,7 @@ aWM
 aXq
 aWM
 aBb
-aRZ
+ZAo
 bcB
 aDj
 azL
@@ -66811,7 +66822,7 @@ aWb
 aWb
 aWb
 aWM
-aAx
+aRZ
 aBR
 aAx
 aDi
@@ -67068,7 +67079,7 @@ aWK
 aWK
 aWb
 aWM
-aWK
+ZAm
 azL
 bcz
 bcI
@@ -67559,8 +67570,8 @@ aQV
 aHG
 aML
 aNE
-ZAc
-ZAf
+ZAa
+ZAd
 bdT
 bdV
 aRY
@@ -67816,8 +67827,8 @@ bdF
 aCy
 aCy
 aNF
-ZAd
-ZAg
+ZAb
+ZAe
 aBR
 bdU
 aRZ
@@ -71662,8 +71673,8 @@ aDV
 aEK
 aXw
 aGn
-ZAa
-ZAb
+ZzY
+ZzZ
 aJH
 aHI
 aHI


### PR DESCRIPTION
- Birdboat has a drone shell dispenser
- Supply loop is separated into a north and south loop, which
  are not connected, south loop has its own supply tanks. Both loops
  are also separated by new airlocks.
- Expanded shuttle dock numbers (no change physically, but updated
  numbers to inform what can dock successfully)
- Medical has an experimental space cooling system for cryo
- Moved disused medical freezer into maint
- Added mime can to Theatre, metal foam grenades to maint
- Wooden barricades have been added between the spider pen room and the nearest vent

:cl: coiax
rscadd: Birdboat's supply loop has been split into two unconnected halves, to maintain award winning air quality.
/:cl:
