### PR TITLE
Invoking Sevtug is now slightly less silent for those near the invoker

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -1054,10 +1054,11 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	return ..()
 
 /datum/clockwork_scripture/targeted/invoke_sevtug/scripture_effects()
-	if(!target)
-		return 0 //wait where'd they go
+	new/obj/effect/clockwork/general_marker/sevtug(get_turf(invoker))
 	clockwork_generals_invoked["sevtug"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
-	invoker.dominate_mind(target, 300)
+	invoker.visible_message("<span class='sevtug'>[invoker]'s eyes glow bright purple!</span>")
+	if(invoker.dominate_mind(target, 300))
+		invoker.visible_message("<span class='sevtug_small'>The glow in [invoker]'s eyes dims...</span>")
 	return 1
 
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -191,6 +191,8 @@
 	mind.transfer_to(target)
 	target.mental_dominator = src
 	spawn(duration)
+		if(!target)
+			return 0
 		if(!src)
 			if(!silent)
 				target << "<span class='userdanger'>You try to return to your own body, but sense nothing! You're being forced out!</span>"


### PR DESCRIPTION
It'll produce the sevtug general marker and a visible message from the person invoking it.
Also fixes some maybe-runtimes if the target got gibbed before the mind control finished.
