### PR TITLE
Nerfs ghosts

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -14,7 +14,7 @@
 
 	// Otherwise jump
 	else if(A.loc)
-		loc = get_turf(A)
+		Move(get_turf(A.loc))
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)
 

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -56,6 +56,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/has_gravity = 0
 	var/noteleport = 0			//Are you forbidden from teleporting to the area? (centcomm, mobs, wizard, hand teleporter)
 	var/safe = 0 				//Is the area teleport-safe: no space / radiation / aggresive mobs / other dangers
+	var/no_observers = 0 		//Stop ghosts from moving freely around the area
 
 	var/no_air = null
 	var/area/master				// master area used for power calcluations

--- a/code/modules/mining/lavaland/lavaland_areas.dm
+++ b/code/modules/mining/lavaland/lavaland_areas.dm
@@ -23,7 +23,8 @@
 	power_light = 0
 	ambientsounds = list('sound/ambience/ambimine.ogg')
 
-
 /area/lavaland/surface/outdoors
 	name = "Lavaland Wastes"
 	outdoors = 1
+	no_observers = 1
+

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -273,11 +273,20 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(updatedir)
 		setDir(direct )//only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
 	if(NewLoc)
-		loc = NewLoc
-		for(var/obj/effect/step_trigger/S in NewLoc)
-			S.Crossed(src)
+		var/area/new_area = get_area(NewLoc)
+		if(new_area.no_observers)
+			src << "You can't move around here!"
+			var/area/old_area = get_area(loc)
+			if(old_area.no_observers)
+				loc = pick(latejoin)
+			else
+				return
+		else
+			loc = NewLoc
+			for(var/obj/effect/step_trigger/S in NewLoc)
+				S.Crossed(src)
+			return
 
-		return
 	loc = get_turf(src) //Get out of closets and such as a ghost
 	if((direct & NORTH) && y < world.maxy)
 		y++
@@ -350,6 +359,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	A = input("Area to jump to", "BOOYEA", A) as null|anything in sortedAreas
 	var/area/thearea = A
 	if(!thearea)
+		return
+
+	if(thearea.no_observers)
+		usr << "This area does not allow ghosts!"
 		return
 
 	var/list/L = list()


### PR DESCRIPTION
Ghosts can't move around on lavaland to avoid letting them scout out all the sick loot before spawning as an ash lizard.
