### PR TITLE
Slows down clockwork component generation slightly

### DIFF
--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -14,9 +14,9 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 #define SCRIPTURE_REVENANT 4
 #define SCRIPTURE_JUDGEMENT 5
 
-#define SLAB_PRODUCTION_TIME 400 //how long(deciseconds) slabs require to produce a single component; defaults to 40 seconds
+#define SLAB_PRODUCTION_TIME 500 //how long(deciseconds) slabs require to produce a single component; defaults to 45 seconds
 
-#define CACHE_PRODUCTION_TIME 300 //how long(deciseconds) caches require to produce a component; defaults to 30 seconds
+#define CACHE_PRODUCTION_TIME 350 //how long(deciseconds) caches require to produce a component; defaults to 35 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -14,7 +14,7 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 #define SCRIPTURE_REVENANT 4
 #define SCRIPTURE_JUDGEMENT 5
 
-#define SLAB_PRODUCTION_TIME 500 //how long(deciseconds) slabs require to produce a single component; defaults to 45 seconds
+#define SLAB_PRODUCTION_TIME 500 //how long(deciseconds) slabs require to produce a single component; defaults to 50 seconds
 
 #define CACHE_PRODUCTION_TIME 350 //how long(deciseconds) caches require to produce a component; defaults to 35 seconds
 

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -792,7 +792,6 @@
 			component_to_generate = get_weighted_component_id() //more likely to generate components that we have less of
 		clockwork_component_cache[component_to_generate]++
 		production_time = world.time + production_cooldown + (clockwork_component_cache[component_to_generate] * component_slowdown_mod) //Start it over
-		generate_cache_component(specific_component)
 		cache.visible_message("<span class='warning'>[cache] hums as the tinkerer's daemon within it produces a component.</span>")
 
 /obj/item/clockwork/tinkerers_daemon/attack_hand(mob/user)

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -762,6 +762,7 @@
 	var/obj/structure/clockwork/cache/cache //The cache the daemon is feeding
 	var/production_time = 0 //Progress towards production of the next component in seconds
 	var/production_cooldown = 200 //How many deciseconds it takes to produce a new component
+	var/component_slowdown_mod = 2 //how many deciseconds are added to the cooldown when producing a component for each of that component type
 
 /obj/item/clockwork/tinkerers_daemon/New()
 	..()
@@ -786,7 +787,11 @@
 	if(servants * 0.2 < clockwork_daemons)
 		return 0
 	if(production_time <= world.time)
-		production_time = world.time + production_cooldown //Start it over
+		var/component_to_generate = specific_component
+		if(!component_to_generate)
+			component_to_generate = get_weighted_component_id() //more likely to generate components that we have less of
+		clockwork_component_cache[component_to_generate]++
+		production_time = world.time + production_cooldown + (clockwork_component_cache[component_to_generate] * component_slowdown_mod) //Start it over
 		generate_cache_component(specific_component)
 		cache.visible_message("<span class='warning'>[cache] hums as the tinkerer's daemon within it produces a component.</span>")
 


### PR DESCRIPTION
:cl: Joan
tweak: Clockwork slabs now produce a component every 50 seconds, from 40, Tinkerer's Caches now produce(if near a clockwork wall) a component every 35 seconds, from 30.
experiment: Tinkerer's daemons have a slightly higher cooldown for each component of the type they chose to produce that's already in the cache: This is very slight, but it'll add up if you have a lot of one component type and are trying to get more of it with daemons; 5 of a component type will add a second of delay.
/:cl:
