### PR TITLE
Tweaks clockwork structure health

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -120,6 +120,8 @@
 	active_icon = "mending_motor"
 	inactive_icon = "mending_motor_inactive"
 	construction_value = 20
+	max_health = 150
+	health = 150
 	break_message = "<span class='warning'>The prism collapses with a heavy thud!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards, /obj/item/clockwork/component/vanguard_cogwheel)
 	var/stored_alloy = 0 //250W = 1 alloy
@@ -223,6 +225,8 @@
 	active_icon = "mania_motor"
 	inactive_icon = "mania_motor_inactive"
 	construction_value = 20
+	max_health = 80
+	health = 80
 	break_message = "<span class='warning'>The antenna break off, leaving a pile of shards!</span>"
 	debris = list(/obj/item/clockwork/alloy_shards, /obj/item/clockwork/component/guvax_capacitor/antennae)
 	var/mania_cost = 150
@@ -428,6 +432,8 @@
 	active_icon = "obelisk"
 	inactive_icon = "obelisk_inactive"
 	construction_value = 20
+	max_health = 200
+	health = 200
 	break_message = "<span class='warning'>The obelisk falls to the ground, undamaged!</span>"
 	debris = list(/obj/item/clockwork/component/hierophant_ansible/obelisk)
 	var/hierophant_cost = 50 //how much it costs to broadcast with large text

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -140,6 +140,8 @@
 	icon_state = "tinkerers_cache"
 	construction_value = 10
 	break_message = "<span class='warning'>The cache's fire winks out before it falls in on itself!</span>"
+	max_health = 80
+	health = 80
 	var/wall_generation_cooldown
 	var/wall_found = FALSE //if we've found a wall and finished our windup delay
 
@@ -412,6 +414,8 @@
 	name = "massive gear"
 	icon_state = "wall_gear"
 	climbable = TRUE
+	max_health = 50
+	health = 50
 	desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, or just climb over it."
 	clockwork_desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, just climb over it, or proselytize it into replicant alloy."
 	break_message = "<span class='warning'>The gear breaks apart into shards of alloy!</span>"


### PR DESCRIPTION
Mania Motors, Tinkerer's Caches, and Wall Gears have less health; 80, from 100, for motors and caches and 50, from 100, for gears.
Mending Motors and Clockwork Obelisks have more health; 150, from 100, for motors and 200, from 100, for obelisks.
