### PR TITLE
Adds visible ripples indicating shuttle's transit

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -39,6 +39,7 @@
 #define SPACEVINE_LAYER 4.8
 #define SPACEVINE_MOB_LAYER 4.9
 //#define FLY_LAYER 5 //For easy recordkeeping; this is a byond define
+#define RIPPLE_LAYER 5.1
 
 #define GHOST_LAYER 6
 #define AREA_LAYER 10

--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -25,3 +25,7 @@
 #define UNLAUNCHED 0
 #define ENDGAME_LAUNCHED 1
 #define EARLY_LAUNCHED 2
+
+// Ripples, effects that signal a shuttle's arrival
+#define SHUTTLE_RIPPLE_TIME 100
+#define SHUTTLE_RIPPLE_FADEIN 50

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -259,8 +259,18 @@
 /obj/docking_port/mobile/emergency/check()
 	if(!timer)
 		return
-
 	var/time_left = timeLeft(1)
+
+	// The emergency shuttle doesn't work like others so this
+	// ripple check is slightly different
+	if(!ripples.len && (time_left <= SHUTTLE_RIPPLE_TIME) && ((mode == SHUTTLE_CALL) || (mode == SHUTTLE_ESCAPE)))
+		var/destination
+		if(mode == SHUTTLE_CALL)
+			destination = SSshuttle.getDock("emergency_home")
+		else if(mode == SHUTTLE_ESCAPE)
+			destination = SSshuttle.getDock("emergency_away")
+		create_ripples(destination)
+
 	switch(mode)
 		if(SHUTTLE_RECALL)
 			if(time_left <= 0)

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -13,3 +13,8 @@
 /obj/effect/ripple/New()
 	. = ..()
 	animate(src, alpha=255, time=SHUTTLE_RIPPLE_TIME)
+	// In case something goes wrong, delete us in a bit
+	addtimer(src, "delself", 3 * SHUTTLE_RIPPLE_TIME, FALSE)
+
+/obj/effect/ripple/proc/delself()
+	qdel(src)

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -1,6 +1,6 @@
 /obj/effect/ripple
-	name = "bluespace ripple"
-	desc = "Something is coming through bluespace, you can see the \
+	name = "hyperspace ripple"
+	desc = "Something is coming through hyperspace, you can see the \
 		visual disturbances. It's probably best not to be on top of these \
 		when whatever is tunneling comes through."
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -1,0 +1,15 @@
+/obj/effect/ripple
+	name = "bluespace ripple"
+	desc = "Something is coming through bluespace, you can see the \
+		visual disturbances. It's probably best not to be on top of these \
+		when whatever is tunneling comes through."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "medi_holo"
+	anchored = TRUE
+	density = FALSE
+	layer = RIPPLE_LAYER
+	alpha = 0
+
+/obj/effect/ripple/New()
+	. = ..()
+	animate(src, alpha=255, time=SHUTTLE_RIPPLE_TIME)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -189,6 +189,8 @@
 	// All shuttle templates are timid
 	var/timid = FALSE
 
+	var/list/ripples = list()
+
 /obj/docking_port/mobile/New()
 	..()
 	if(!timid)
@@ -296,6 +298,10 @@
 /obj/docking_port/mobile/proc/cancel()
 	if(mode != SHUTTLE_CALL)
 		return
+	if(ripples.len)
+		for(var/i in ripples)
+			qdel(i)
+		ripples.Cut()
 
 	timer = world.time - timeLeft(1)
 	mode = SHUTTLE_RECALL
@@ -365,6 +371,28 @@
 
 	qdel(src, force=TRUE)
 
+/obj/docking_port/mobile/proc/create_ripples(obj/docking_port/stationary/S1)
+	var/list/turfs = ripple_area(S1)
+	for(var/i in turfs)
+		ripples += new /obj/effect/ripple(i)
+
+/obj/docking_port/mobile/proc/ripple_area(obj/docking_port/stationary/S1)
+	var/list/L0 = return_ordered_turfs(x, y, z, dir, areaInstance)
+	var/list/L1 = return_ordered_turfs(S1.x, S1.y, S1.z, S1.dir)
+
+	var/list/ripple_turfs = list()
+
+	for(var/i=1, i<=L0.len, ++i)
+		var/turf/T0 = L0[i]
+		if(!T0)
+			continue
+		var/turf/T1 = L1[i]
+		if(!T1)
+			continue
+		if(T0.type != T0.baseturf)
+			ripple_turfs += T1
+
+	return ripple_turfs
 //this is the main proc. It instantly moves our mobile port to stationary port S1
 //it handles all the generic behaviour, such as sanity checks, closing doors on the shuttle, stunning mobs, etc
 /obj/docking_port/mobile/proc/dock(obj/docking_port/stationary/S1, force=FALSE)
@@ -417,6 +445,11 @@
 
 	//move or squish anything in the way ship at destination
 	roadkill(L1, S1.dir)
+
+	// Removes ripples
+	for(var/i in ripples)
+		qdel(i)
+	ripples.Cut()
 
 	for(var/i=1, i<=L0.len, ++i)
 		var/turf/T0 = L0[i]
@@ -597,6 +630,9 @@
 //used by shuttle subsystem to check timers
 /obj/docking_port/mobile/proc/check()
 	var/timeLeft = timeLeft(1)
+	if(!ripples.len && (timeLeft <= SHUTTLE_RIPPLE_TIME) && ((mode == SHUTTLE_CALL) || (mode == SHUTTLE_RECALL)))
+		create_ripples(destination)
+
 	if(timeLeft <= 0)
 		switch(mode)
 			if(SHUTTLE_CALL)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -402,11 +402,9 @@
 		if(status == SHUTTLE_ALREADY_DOCKED)
 			return status
 		else if(status)
-			spawn(0)
-				var/msg = "dock(): shuttle [src] cannot dock at [S1], \
-					error: [status]"
-				message_admins(msg)
-				throw EXCEPTION(msg)
+			var/msg = "dock(): shuttle [src] cannot dock at [S1], \
+				error: [status]"
+			message_admins(msg)
 			return status
 
 		if(canMove())
@@ -508,8 +506,7 @@
 	. = ..()
 	if(!.)
 		return
-	spawn(0)
-		close()
+	addtimer(src, "close", 0)
 
 /mob/onShuttleMove()
 	if(!move_on_shuttle)
@@ -578,8 +575,7 @@
 	if(T)
 		var/obj/machinery/door/Door = locate() in T
 		if(Door)
-			spawn(0)
-				Door.close()
+			addtimer(Door, "close", 0)
 
 /obj/docking_port/mobile/proc/roadkill(list/L0, list/L1, dir)
 	var/list/hurt_mobs = list()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -382,7 +382,7 @@
 
 	var/list/ripple_turfs = list()
 
-	for(var/i=1, i<=L0.len, ++i)
+	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]
 		if(!T0)
 			continue
@@ -451,7 +451,7 @@
 		qdel(i)
 	ripples.Cut()
 
-	for(var/i=1, i<=L0.len, ++i)
+	for(var/i in 1 to L0.len)
 		var/turf/T0 = L0[i]
 		if(!T0)
 			continue

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -444,7 +444,7 @@
 			A0.contents += T0
 
 	//move or squish anything in the way ship at destination
-	roadkill(L1, S1.dir)
+	roadkill(L0, L1, S1.dir)
 
 	// Removes ripples
 	for(var/i in ripples)
@@ -581,10 +581,18 @@
 			spawn(0)
 				Door.close()
 
-/obj/docking_port/mobile/proc/roadkill(list/L, dir, x, y)
+/obj/docking_port/mobile/proc/roadkill(list/L0, list/L1, dir)
 	var/list/hurt_mobs = list()
-	for(var/turf/T in L)
-		for(var/atom/movable/AM in T)
+	for(var/i in 1 to L0.len)
+		var/turf/T0 = L0[i]
+		var/turf/T1 = L1[i]
+		if(!T0 || !T1)
+			continue
+		if(T0.type == T0.baseturf)
+			continue
+		// The corresponding tile will not be changed, so no roadkill
+
+		for(var/atom/movable/AM in T1)
 			if(isliving(AM) && (!(AM in hurt_mobs)))
 				hurt_mobs |= AM
 				var/mob/living/M = AM
@@ -594,7 +602,7 @@
 					M.pulledby.stop_pulling()
 				M.stop_pulling()
 				M.visible_message("<span class='warning'>[M] is hit by \
-						a bluespace ripple[M.anchored ? "":" and is thrown clear"]!</span>",
+						a hyperspace ripple[M.anchored ? "":" and is thrown clear"]!</span>",
 						"<span class='userdanger'>You feel an immense \
 						crushing pressure as the space around you ripples.</span>")
 				if(M.anchored)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1697,6 +1697,7 @@
 #include "code\modules\shuttle\emergency.dm"
 #include "code\modules\shuttle\ferry.dm"
 #include "code\modules\shuttle\manipulator.dm"
+#include "code\modules\shuttle\ripple.dm"
 #include "code\modules\shuttle\shuttle.dm"
 #include "code\modules\shuttle\special.dm"
 #include "code\modules\shuttle\supply.dm"


### PR DESCRIPTION
:cl: coiax
rscadd: Due to budget cuts, the shuttle's hyperspace engines now create a visual distortion at their destination, a few seconds before arrival. Crewmembers are encouraged to use these "ripples" as an indication of where not to stand.
fix: Shuttles now only run over mobs in turfs they are moving into, rather than the entire rectangle.
/:cl:
- Adds a new layer RIPPLE_LAYER, above vines, below ghosts
- Ripples appear at 10 seconds (the engines online time) and fade in
  from fully transparent to fully visible during that time.
- Here is a video of the effect. https://youtu.be/K0sruhMtcjA
- I've tested it, and it works fine with shuttle rotation and non-EASTfacing docks.

Fixes #12168.
