### PR TITLE
Removes spawn() from things I

### DIFF
--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -46,14 +46,22 @@
 	density = TRUE
 
 /obj/structure/cursed_money/New()
-	spawn(600)
-		if(src)
-			visible_message("<span class='warning'>[src] falls in on itself, canvas rotting away and contents vanishing.</span>")
-			qdel(src)
+	. = ..()
+	addtimer(src, "collapse", 600)
+
+/obj/structure/cursed_money/proc/collapse()
+	visible_message("<span class='warning'>[src] falls in on itself, \
+		canvas rotting away and contents vanishing.</span>")
+	qdel(src)
 
 /obj/structure/cursed_money/attack_hand(mob/living/user)
-	user.visible_message("<span class='boldwarning'>You open the bag...!</span>\n<span class='danger'>And see a bag full of dice. Confused, you take one... and the bag vanishes.</span>")
-	var/obj/item/weapon/dice/d20/fate/one_use/critical_fail = new(get_turf(user))
+	user.visible_message("<span class='warning'>[user] opens the bag and \
+		and removes a die. The bag then vanishes.</span>",
+		"<span class='boldwarning'>You open the bag...!</span>\n\
+		<span class='danger'>And see a bag full of dice. Confused, \
+		you take one... and the bag vanishes.</span>")
+	var/turf/T = get_turf(user)
+	var/obj/item/weapon/dice/d20/fate/one_use/critical_fail = new(T)
 	user.put_in_hands(critical_fail)
 	qdel(src)
 

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -20,5 +20,7 @@
 		cooldown = 1
 		usr << "<span class='notice'>Your request has been recieved by Centcom.</span>"
 		admins << "<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) (<A HREF='?_src_=holder;secrets=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>"
-		spawn(600) //One minute cooldown
-			cooldown = 0
+		addtimer(src, "reset_cooldown", 600)
+
+/obj/machinery/computer/shuttle/ferry/request/proc/reset_cooldown()
+	cooldown = FALSE

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -8,19 +8,16 @@
 /obj/machinery/computer/shuttle/ferry/request
 	name = "ferry console"
 	circuit = /obj/item/weapon/circuitboard/computer/ferry/request
-	var/cooldown //prevents spamming admins
+	var/last_request //prevents spamming admins
+	var/cooldown = 600
 	possible_destinations = "ferry_home"
 	admin_controlled = 1
 
 /obj/machinery/computer/shuttle/ferry/request/Topic(href, href_list)
 	..()
 	if(href_list["request"])
-		if(cooldown)
+		if(last_request && (last_request + cooldown > world.time))
 			return
-		cooldown = 1
+		last_request = world.time
 		usr << "<span class='notice'>Your request has been recieved by Centcom.</span>"
 		admins << "<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) (<A HREF='?_src_=holder;secrets=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>"
-		addtimer(src, "reset_cooldown", 600)
-
-/obj/machinery/computer/shuttle/ferry/request/proc/reset_cooldown()
-	cooldown = FALSE

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -16,13 +16,16 @@
 	user << sound("sound/magic/Knock.ogg")
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
-			spawn(1)
-				if(istype(door,/obj/machinery/door/airlock))
-					door:locked = 0
-				door.open()
+			addtimer(src, "open_door", 1, FALSE, door)
 		for(var/obj/structure/closet/C in T.contents)
-			spawn(1)
-				C.locked = 0
-				C.open()
+			addtimer(src, "open_closet", 1, FALSE, C)
 
-	return
+/obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_door(var/obj/machinery/door/door)
+	if(istype(door, /obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/A = door
+		A.locked = FALSE
+	door.open()
+
+/obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_closet(var/obj/structure/closet/C)
+	C.locked = FALSE
+	C.open()

--- a/code/modules/spells/spell_types/knock.dm
+++ b/code/modules/spells/spell_types/knock.dm
@@ -16,9 +16,9 @@
 	user << sound("sound/magic/Knock.ogg")
 	for(var/turf/T in targets)
 		for(var/obj/machinery/door/door in T.contents)
-			addtimer(src, "open_door", 1, FALSE, door)
+			addtimer(src, "open_door", 0, FALSE, door)
 		for(var/obj/structure/closet/C in T.contents)
-			addtimer(src, "open_closet", 1, FALSE, C)
+			addtimer(src, "open_closet", 0, FALSE, C)
 
 /obj/effect/proc_holder/spell/aoe_turf/knock/proc/open_door(var/obj/machinery/door/door)
 	if(istype(door, /obj/machinery/door/airlock))


### PR DESCRIPTION
- Removes from Sin of Greed slot machine (also cleans up the visible
  message to make a difference between viewer and user)
- Removes from ferry request cooldown
- Removes from knock opening doors and closets
