### PR TITLE
You can now call global procs with addtimer()

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -41,3 +41,6 @@
 //	This flag overrides SS_KEEP_TIMING
 #define SS_POST_FIRE_TIMING 128
 
+
+//Timing subsystem
+#define GLOBAL_PROC	"some_magic_bullshit"

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -36,7 +36,7 @@ var/datum/subsystem/timer/SStimer
 
 /datum/subsystem/timer/proc/runevent(datum/timedevent/event)
 	set waitfor = 0
-	if(event.thingToCall == GLOBAL_PROC)
+	if(event.thingToCall == GLOBAL_PROC && istext(event.procToCall))
 		call("/proc/[event.procToCall]")(arglist(event.argList))
 	else
 		call(event.thingToCall, event.procToCall)(arglist(event.argList))

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -36,7 +36,10 @@ var/datum/subsystem/timer/SStimer
 
 /datum/subsystem/timer/proc/runevent(datum/timedevent/event)
 	set waitfor = 0
-	call(event.thingToCall, event.procToCall)(arglist(event.argList))
+	if(event.thingToCall == GLOBAL_PROC)
+		call("/proc/[event.procToCall]")(arglist(event.argList))
+	else
+		call(event.thingToCall, event.procToCall)(arglist(event.argList))
 
 /datum/subsystem/timer/Recover()
 	processing |= SStimer.processing


### PR DESCRIPTION
- You can now call global procs with addtimer(), by supplying the object as `GLOBAL_PROC`, a special define that tells the timing subsystem to use a different call()() syntax (the syntax that supports global procs)
- Yes it's a hack, @MrStonedOne cry.

for example:

```
var/mob/living/simple_animal/pet/dog/corgi/Ian/I = new(get_turf(src))   
addtimer(GLOBAL_PROC, "qdel", 50, FALSE, I)
```

This deletes Ian after 5 seconds
