### PR TITLE
Adds Drone Shells to Emergency cargo packs

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -122,6 +122,14 @@
 	contains = list(/obj/item/weapon/storage/box/metalfoam)
 	crate_name = "metal foam grenade crate"
 
+/datum/supply_pack/emergency/droneshells
+	name = "Drone Shell Crate"
+	cost = 1000
+	contains = list(/obj/item/drone_shell,
+					/obj/item/drone_shell,
+					/obj/item/drone_shell)
+	crate_name = "drone shell crate"
+
 /datum/supply_pack/emergency/specialops
 	name = "Special Ops Supplies"
 	hidden = TRUE


### PR DESCRIPTION
:cl: coiax
rscadd: Drone shells can be ordered in Emergency supplies at Cargo.
/:cl:
- 3xdrone shells for 1000 credits. Ghosts get notified as normal when
  the shuttle leaves Centcom (because that's when the items get made).
