### PR TITLE
Nuke ops can no longer get free noslips with their camo kit

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -633,6 +633,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!"
 	item = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_tools/chameleon/nuke
+	cost = 6
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	name = "No-Slip Chameleon Shoes"


### PR DESCRIPTION
The camo kit costs 4 TC and contains chameleon noslips.
Nuke op noslips cost 4 TC. Take a guess what the obvious path was there.

The nuke op chameleon kit now costs 6 TC, 4 for noslips plus 2 for the kit itself, like the normal camo kit does.
