### PR TITLE
You can now repair clockwork structures with a clockwork proselytizer

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_ratvar.dm
+++ b/code/game/gamemodes/clock_cult/clock_ratvar.dm
@@ -23,6 +23,7 @@
 	icon = 'icons/effects/clockwork_effects.dmi'
 	icon_state = "nothing"
 	density = TRUE
+	can_be_repaired = FALSE
 	var/progress_in_seconds = 0 //Once this reaches GATEWAY_RATVAR_ARRIVAL, it's game over
 	var/purpose_fulfilled = FALSE
 	var/first_sound_played = FALSE

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -14,6 +14,8 @@
 	layer = BELOW_OBJ_LAYER
 	var/max_health = 100 //All clockwork structures have health that can be removed via attacks
 	var/health = 100
+	var/repair_amount = 5 //how much a proselytizer can repair each cycle
+	var/can_be_repaired = TRUE //if a proselytizer can repair it at all
 	var/takes_damage = TRUE //If the structure can be damaged
 	var/break_message = "<span class='warning'>The frog isn't a meme after all!</span>" //The message shown when a structure breaks
 	var/break_sound = 'sound/magic/clockwork/anima_fragment_death.ogg' //The sound played when a structure breaks
@@ -185,25 +187,6 @@
 		user << "<span class='notice'>You add [C] to [src].</span>"
 		user.drop_item()
 		qdel(C)
-		return 1
-	else if(istype(I, /obj/item/clockwork/clockwork_proselytizer))
-		var/obj/item/clockwork/clockwork_proselytizer/P = I
-		if(P.uses_alloy && P.stored_alloy + REPLICANT_ALLOY_UNIT <= P.max_alloy)
-			if(clockwork_component_cache["replicant_alloy"])
-				user.visible_message("<span class='notice'>[user] places the end of [P] in the hole in [src]...</span>", \
-				"<span class='notice'>You start filling [P] with liquified alloy...</span>")
-				while(P && P.uses_alloy && P.stored_alloy + REPLICANT_ALLOY_UNIT <= P.max_alloy && clockwork_component_cache["replicant_alloy"] && do_after(user, 10, target = src) \
-				&& P && P.uses_alloy &&  P.stored_alloy + REPLICANT_ALLOY_UNIT <= P.max_alloy && clockwork_component_cache["replicant_alloy"]) //hugeass check because we need to re-check after the do_after
-					P.modify_stored_alloy(REPLICANT_ALLOY_UNIT)
-					clockwork_component_cache["replicant_alloy"]--
-					playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
-				if(P && user)
-					user.visible_message("<span class='notice'>[user] removes [P] from the hole in [src], apparently satisfied.</span>", \
-					"<span class='brass'>You finish filling [P] with liquified alloy. It now contains [P.stored_alloy]/[P.max_alloy] units of liquified alloy.</span>")
-			else
-				user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
-		else
-			user << "<span class='warning'>[P]'s containers of liquified alloy are full!</span>"
 		return 1
 	else if(istype(I, /obj/item/clockwork/slab))
 		var/obj/item/clockwork/slab/S = I

--- a/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
+++ b/code/game/gamemodes/clock_cult/clockwork_proselytizer.dm
@@ -11,6 +11,7 @@
 	var/max_alloy = REPLICANT_ALLOY_UNIT * 10
 	var/uses_alloy = TRUE
 	var/metal_to_alloy = FALSE
+	var/repairing = null //what we're currently repairing, if anything
 
 /obj/item/clockwork/clockwork_proselytizer/preloaded
 	stored_alloy = REPLICANT_ALLOY_UNIT
@@ -65,42 +66,57 @@
 	proselytize(target, user)
 
 /obj/item/clockwork/clockwork_proselytizer/proc/modify_stored_alloy(amount)
-	if(ratvar_awakens) //Ratvar makes it free
+	if(can_use_alloy(0)) //Ratvar makes it free
 		amount = 0
 	stored_alloy = Clamp(stored_alloy + amount, 0, max_alloy)
 	return 1
+
+/obj/item/clockwork/clockwork_proselytizer/proc/can_use_alloy(amount)
+	if(ratvar_awakens || !uses_alloy)
+		return TRUE
+	if(!amount) //functions thus as a check for if ratvar is up/it doesn't use alloy if no amount is provided
+		return FALSE
+	if(stored_alloy - amount < 0)
+		return FALSE
+	if(stored_alloy - amount > max_alloy)
+		return FALSE
+	return TRUE
 
 /obj/item/clockwork/clockwork_proselytizer/proc/proselytize(atom/target, mob/living/user)
 	if(!target || !user)
 		return 0
 	var/target_type = target.type
 	var/list/proselytize_values = target.proselytize_vals(user, src) //relevant values for proselytizing stuff, given as an associated list
+	if(proselytize_values == TRUE) //if we get true, fail, but don't send a message for whatever reason
+		return 0
 	if(!islist(proselytize_values))
 		user << "<span class='warning'>[target] cannot be proselytized!</span>"
 		return 0
-
+	if(repairing)
+		user << "<span class='warning'>You are currently repairing [repairing] with [src]!</span>"
+		return 0
 	if(!uses_alloy)
 		proselytize_values["alloy_cost"] = 0
 
-	if(stored_alloy - proselytize_values["alloy_cost"] < 0)
-		user << "<span class='warning'>You need [proselytize_values["alloy_cost"]] liquified alloy to proselytize [target]!</span>"
-		return 0
-	if(stored_alloy - proselytize_values["alloy_cost"] > max_alloy)
-		user << "<span class='warning'>You have too much liquified alloy stored to proselytize [target]!</span>"
+	if(!can_use_alloy(proselytize_values["alloy_cost"]))
+		if(stored_alloy - proselytize_values["alloy_cost"] < 0)
+			user << "<span class='warning'>You need [proselytize_values["alloy_cost"]] liquified alloy to proselytize [target]!</span>"
+		else if(stored_alloy - proselytize_values["alloy_cost"] > max_alloy)
+			user << "<span class='warning'>You have too much liquified alloy stored to proselytize [target]!</span>"
 		return 0
 
-	if(ratvar_awakens) //Ratvar makes it faster
+	if(can_use_alloy(0)) //Ratvar makes it faster
 		proselytize_values["operation_time"] *= 0.5
 
 	user.visible_message("<span class='warning'>[user]'s [name] begins tearing apart [target]!</span>", "<span class='brass'>You begin proselytizing [target]...</span>")
 	playsound(target, 'sound/machines/click.ogg', 50, 1)
 	if(proselytize_values["operation_time"] && !do_after(user, proselytize_values["operation_time"], target = target))
 		return 0
-	if(stored_alloy - proselytize_values["alloy_cost"] < 0) //Check again to prevent bypassing via spamclick
-		return 0
-	if(stored_alloy - proselytize_values["alloy_cost"] > max_alloy)
+	if(!can_use_alloy(proselytize_values["alloy_cost"])) //Check again to prevent bypassing via spamclick
 		return 0
 	if(!target || target.type != target_type)
+		return 0
+	if(repairing)
 		return 0
 	user.visible_message("<span class='warning'>[user]'s [name] disgorges a chunk of metal and shapes it over what's left of [target]!</span>", \
 	"<span class='brass'>You proselytize [target].</span>")
@@ -122,6 +138,7 @@
 //if a valid target, returns an associated list in this format;
 //list("operation_time" = 15, "new_obj_type" = /obj/structure/window/reinforced/clockwork, "alloy_cost" = 5, "spawn_dir" = dir, "dir_in_new" = TRUE)
 //otherwise, return literally any non-list thing but preferably FALSE
+//returning TRUE won't produce the "cannot be proselytized" message and will still prevent proselytizing
 
 /atom/proc/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	return FALSE
@@ -197,6 +214,81 @@
 
 /obj/structure/grille/ratvar/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	return FALSE
+
+/obj/structure/clockwork/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
+	. = TRUE
+	if(proselytizer.repairing) //no spamclicking for fast repairs, bucko
+		user << "<span class='warning'>You are already repairing [proselytizer.repairing] with [proselytizer]!</span>"
+		return
+	if(!can_be_repaired)
+		user << "<span class='warning'>[src] cannot be repaired with a proselytizer!</span>"
+		return
+	if(health == max_health)
+		user << "<span class='warning'>[src] is at maximum integrity!</span>"
+		return
+	var/amount_to_heal = max_health - health
+	var/healing_for_cycle = min(amount_to_heal, repair_amount)
+	if(!proselytizer.can_use_alloy(0))
+		healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
+	var/proselytizer_cost = healing_for_cycle*2
+	if(!proselytizer.can_use_alloy(proselytizer_cost))
+		user << "<span class='warning'>You need more liquified alloy to repair [src]!</span>"
+		return
+	user.visible_message("<span class='notice'>[user]'s [proselytizer.name] starts covering [src] in black liquid metal...</span>", \
+	"<span class='alloy'>You start repairing [src]...</span>")
+	//hugeass while because we need to re-check after the do_after
+	proselytizer.repairing = src
+	while(proselytizer && user && src && health != max_health)
+		amount_to_heal = max_health - health
+		if(!amount_to_heal)
+			break
+		healing_for_cycle = min(amount_to_heal, repair_amount)
+		if(!proselytizer.can_use_alloy(0))
+			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
+		proselytizer_cost = healing_for_cycle*2
+		if(!proselytizer.can_use_alloy(proselytizer_cost) || !do_after(user, proselytizer_cost, target = src) || !proselytizer || !proselytizer.can_use_alloy(proselytizer_cost))
+			break
+		amount_to_heal = max_health - health
+		if(!amount_to_heal)
+			break
+		healing_for_cycle = min(amount_to_heal, repair_amount)
+		if(!proselytizer.can_use_alloy(0))
+			healing_for_cycle = min(healing_for_cycle, proselytizer.stored_alloy)
+		proselytizer_cost = healing_for_cycle*2
+		if(!proselytizer.can_use_alloy(proselytizer_cost))
+			break
+		health += healing_for_cycle
+		proselytizer.modify_stored_alloy(-proselytizer_cost)
+		playsound(src, 'sound/machines/click.ogg', 50, 1)
+
+	if(proselytizer)
+		proselytizer.repairing = null
+		if(user)
+			user.visible_message("<span class='notice'>[user]'s [proselytizer.name] stops covering [src] with black liquid metal.</span>", \
+		"<span class='alloy'>You finish repairing [src]. It is now at <b>[health]/[max_health]</b> integrity.</span>")
+	return
+
+/obj/structure/clockwork/cache/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
+	. = ..()
+	if(proselytizer.can_use_alloy(0) || proselytizer.stored_alloy + REPLICANT_ALLOY_UNIT > proselytizer.max_alloy)
+		user << "<span class='warning'>[proselytizer]'s containers of liquified alloy are full!</span>"
+		return
+	if(!clockwork_component_cache["replicant_alloy"])
+		user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
+		return
+	user.visible_message("<span class='notice'>[user] places the end of [proselytizer] in the hole in [src]...</span>", \
+	"<span class='notice'>You start filling [proselytizer] with liquified alloy...</span>")
+	//hugeass check because we need to re-check after the do_after
+	while(proselytizer && proselytizer.uses_alloy && proselytizer.stored_alloy + REPLICANT_ALLOY_UNIT <= proselytizer.max_alloy && clockwork_component_cache["replicant_alloy"] \
+	&& do_after(user, 10, target = src) \
+	&& proselytizer && proselytizer.uses_alloy &&  proselytizer.stored_alloy + REPLICANT_ALLOY_UNIT <= proselytizer.max_alloy && clockwork_component_cache["replicant_alloy"])
+		proselytizer.modify_stored_alloy(REPLICANT_ALLOY_UNIT)
+		clockwork_component_cache["replicant_alloy"]--
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, 1)
+	if(proselytizer && user)
+		user.visible_message("<span class='notice'>[user] removes [proselytizer] from the hole in [src], apparently satisfied.</span>", \
+		"<span class='brass'>You finish filling [proselytizer] with liquified alloy. It now contains [proselytizer.stored_alloy]/[proselytizer.max_alloy] units of liquified alloy.</span>")
+	return
 
 /obj/structure/clockwork/wall_gear/proselytize_vals(mob/living/user, obj/item/clockwork/clockwork_proselytizer/proselytizer)
 	return list("operation_time" = 10, "new_obj_type" = /obj/item/clockwork/component/replicant_alloy, "alloy_cost" = REPLICANT_ALLOY_UNIT-REPLICANT_WALL_MINUS_FLOOR, "spawn_dir" = SOUTH)


### PR DESCRIPTION
:cl: Joan
rscadd: You can now repair clockwork structures with a clockwork proselytizer. This is about a third as efficient as a mending motor, costing 2 liquified alloy to 1 health, and also about a third as fast.
/:cl:

Moves cache alloy gain to proselytize_values() so it happens after repair attempts
