### PR TITLE
Fixes Infinitely Generating Exotic Blood

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -542,7 +542,10 @@ var/const/INJECT = 5 //injection
 		add_reagent(r_id, amt, data)
 
 /datum/reagents/proc/remove_reagent(reagent, amount, safety)//Added a safety check for the trans_id_to
-
+	
+	if(isnull(amount))
+		amount = INFINITY
+		
 	if(!isnum(amount))
 		return 1
 


### PR DESCRIPTION
You would think that if you called remove_reagent() with just a reagent id it'd assume you just wanted to remove it all.

But nope it just does nothing instead, failing silently. Good design.

The only time this was used was in the recent blood refactor, which, due to it not actually removing reagent when converting exotic blood to the blood total, allowed it to be infinitely duped. If you saw any slime people with 30 bodies, this was why.
