### PR TITLE
Removes venus map traps

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -319,20 +319,6 @@
 		else
 			. = 8
 
-/datum/spacevine_mutation/flowering
-	name = "flowering"
-	hue = "#0A480D"
-	quality = NEGATIVE
-	severity = 10
-
-/datum/spacevine_mutation/flowering/on_grow(obj/effect/spacevine/holder)
-	if(holder.energy == 2 && prob(severity) && !locate(/obj/structure/alien/resin/flower_bud_enemy) in range(5,holder))
-		new/obj/structure/alien/resin/flower_bud_enemy(get_turf(holder))
-
-/datum/spacevine_mutation/flowering/on_cross(obj/effect/spacevine/holder, mob/living/crosser)
-	holder.entangle(crosser)
-
-
 // SPACE VINES (Note that this code is very similar to Biomass code)
 /obj/effect/spacevine
 	name = "space vines"


### PR DESCRIPTION
yes I'm salty I got chainstunned through a wall for ~10 minutes along with 5 other people and told it was a feature via ahelps

> fix it don't remove it!

If someone wants to fix them so they don't just AoE stun people with no way to save them then go for it, they're completely broken and unplayable right now.
