### PR TITLE
Ghosts can click to use transition space turfs

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -17,7 +17,6 @@
 		loc = get_turf(A)
 
 /mob/dead/observer/ClickOn(var/atom/A, var/params)
-
 	if(client.click_intercept)
 		if(call(client.click_intercept,"InterceptClickOn")(src,params,A))
 			return
@@ -52,7 +51,6 @@
 			attack_ai(user)
 		if(user.client.prefs.inquisitive_ghost)
 			user.examinate(src)
-	return
 
 // ---------------------------------------
 // And here are some good things for free:

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -25,6 +25,11 @@
 	else
 		return QDEL_HINT_LETMELIVE
 
+/turf/open/space/attack_ghost(mob/dead/observer/user)
+	if(destination_z)
+		var/turf/T = locate(destination_x, destination_y, destination_z)
+		user.forceMove(T)
+
 /turf/open/space/Initalize_Atmos(times_fired)
 	return
 


### PR DESCRIPTION
:cl:
rscadd: If you are an observer, you can click on transition edges of a Z-level in order to move as a mob would.
/:cl:

Also removed some trailing returns.
