### PR TITLE
Borgs now get less confused over time!

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -357,9 +357,6 @@
 			AdjustSleeping(1)
 			Paralyse(5)
 
-	if(confused)
-		confused = max(0, confused - 1)
-
 	//Jitteryness
 	if(jitteriness)
 		do_jitter_animation(jitteriness)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -83,6 +83,8 @@
 		AdjustStunned(-1, 1, 1)
 	if(weakened)
 		AdjustWeakened(-1, 1, 1)
+	if(confused)
+		confused = max(0, confused - 1)
 
 /mob/living/proc/handle_disabilities()
 	//Eyes


### PR DESCRIPTION
Moves confusion reduction from living/carbon to mob/living

Note that while this fixes #18787 confusion is still defined at the /mob level so if you try to make ghosts confused or something they'll be dizzy forever (they don't process anything to begin with). Ideally the confusion var should be defined at the mob/living level but confusion movement itself is defined at client/Move() and I'm not dealing with rewriting movement code right now :V

Also here's a changelog for the thing 
:cl: Cheridan
tweak: Flashes no longer stun cyborgs, instead working almost exactly like a human, causing them to become confused and unequip their current module.
/:cl:
