### PR TITLE
Smacks clockwork component generation in the face again

### DIFF
--- a/code/game/gamemodes/clock_cult/__clock_defines.dm
+++ b/code/game/gamemodes/clock_cult/__clock_defines.dm
@@ -14,9 +14,9 @@ var/global/ratvar_awakens = FALSE //If Ratvar has been summoned
 #define SCRIPTURE_REVENANT 4
 #define SCRIPTURE_JUDGEMENT 5
 
-#define SLAB_PRODUCTION_TIME 500 //how long(deciseconds) slabs require to produce a single component; defaults to 50 seconds
+#define SLAB_PRODUCTION_TIME 600 //how long(deciseconds) slabs require to produce a single component; defaults to 1 minute
 
-#define CACHE_PRODUCTION_TIME 350 //how long(deciseconds) caches require to produce a component; defaults to 35 seconds
+#define CACHE_PRODUCTION_TIME 900 //how long(deciseconds) caches require to produce a component; defaults to 1 minute 30 seconds
 
 #define LOWER_PROB_PER_COMPONENT 10 //how much each component in the cache reduces the weight of getting another of that component type
 

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -355,7 +355,7 @@
 			target << "<span class='heavy_brass'>\"I SEE YOU!\"</span>\n<span class='userdanger'>[src]'s gaze [ratvar_awakens ? "melts you alive" : "burns you"]!</span>"
 		else if(prob(0.5)) //Extremely low chance because of how fast the subsystem it uses processes
 			if(prob(50))
-				visible_message("<span class='notice'>[src] [pick(idle_messages)]</span>")
+				visible_message("<span class='notice'>[src][pick(idle_messages)]</span>")
 			else
 				setDir(pick(cardinal))//Random rotation
 
@@ -396,7 +396,7 @@
 			return 0
 		user.visible_message("<span class='notice'>[user] places [S] in [src], where it fuses to the shell.</span>", "<span class='brass'>You place [S] in [src], fusing it to the shell.</span>")
 		var/mob/living/simple_animal/A = new mobtype(get_turf(src))
-		A.visible_message("[src][spawn_message]")
+		A.visible_message("<span class='brass'>[src][spawn_message]</span>")
 		S.brainmob.mind.transfer_to(A)
 		add_servant_of_ratvar(A, TRUE)
 		user.drop_item()


### PR DESCRIPTION
:cl: Joan
tweak: Tinkerer's Caches generate components(when near clockwork walls) every minute and a half, from every 35 seconds. Clockwork Slabs generate components once per minute, from once per 50 seconds.
/:cl:

Nerfs will continue until component generation ceases.
