### PR TITLE
Adds changelog reminder to pull requests

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
+[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs)


### PR DESCRIPTION
This'll add a short reminder when opening a PR [that'll](https://github.com/tgstation/tgstation/pull/18739) [hopefully](https://github.com/tgstation/tgstation/pull/18802) [help](https://github.com/tgstation/tgstation/pull/18795) [with](https://github.com/tgstation/tgstation/pull/18632) [people](https://github.com/tgstation/tgstation/pull/18585) [not](https://github.com/tgstation/tgstation/pull/18537) [making](https://github.com/tgstation/tgstation/pull/18696) [changelogs](https://github.com/tgstation/tgstation/pull/18661).

This PR dedicated to Joan, Kor and oranges.
