### PR TITLE
Attempts to subdue metastation's xenobio power cost

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -88194,6 +88194,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/power/apc{
+	cell_type = 10000;
 	dir = 1;
 	name = "Xenobiology APC";
 	pixel_x = 0;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -87878,10 +87878,6 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -87889,6 +87885,9 @@
 	c_tag = "Xenobiology Lab - Airlock";
 	dir = 8;
 	network = list("SS13","RD")
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel/warnwhite{
 	dir = 4
@@ -88671,10 +88670,6 @@
 	},
 /area/toxins/xenobiology)
 "cVq" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/delivery{
 	name = "floor"
@@ -89052,11 +89047,10 @@
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "cVZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/warnwhite{
 	dir = 8
 	},
@@ -89346,9 +89340,6 @@
 	},
 /area/toxins/xenobiology)
 "cWy" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	id = "xenobio1";
 	name = "Containment Blast Doors";
@@ -89703,6 +89694,9 @@
 	dir = 4;
 	network = list("SS13","RD")
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/warning{
 	dir = 4
 	},
@@ -89748,10 +89742,6 @@
 	},
 /area/toxins/xenobiology)
 "cWZ" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -89765,6 +89755,9 @@
 	c_tag = "Xenobiology Lab - Aft-Starboard";
 	dir = 8;
 	network = list("SS13","RD")
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel/warning{
 	dir = 8
@@ -93461,9 +93454,7 @@
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "deL" = (
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/toxins/xenobiology)
 "deM" = (
@@ -93847,9 +93838,8 @@
 /turf/open/floor/engine/vacuum,
 /area/atmos)
 "dfz" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small,
 /turf/open/floor/bluegrid{
 	name = "Killroom Floor";
 	initial_gas_mix = "n2=500;TEMP=80"
@@ -125015,7 +125005,7 @@ cVB
 cTC
 bxW
 cTC
-dfz
+dds
 dfA
 cTC
 aaf
@@ -125530,8 +125520,8 @@ cTC
 deR
 deS
 deW
-deW
-deX
+dfz
+cTC
 cXl
 aaa
 aaa
@@ -126043,7 +126033,7 @@ deN
 cTC
 cXs
 cTC
-dfz
+dds
 dds
 cTC
 aaa


### PR DESCRIPTION
:cl: MMMiracles
tweak: Metastation xenobiology's lights and cell have been modified so it won't drain 5 minutes into the round.
/:cl:

Resolves #18672

21 lights, most of them large lights, now reduced to 18 and mostly small lights.

4364 to 3644, or about a 720 difference in power usage. 

I mean come on @Metacide the freezer room doesn't need 2 large lights dedicated solely for it that's just crazy.
