### PR TITLE
Adds a debug verb to trigger the BYOND world.Repop proc

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -132,6 +132,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_debug_del_all,
 	/client/proc/restart_controller,
 	/client/proc/enable_debug_verbs,
+	/client/proc/world_repop,
 	/client/proc/callproc,
 	/client/proc/callproc_datum,
 	/client/proc/SDQL2_query,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -735,3 +735,21 @@ var/global/list/g_fancy_list_of_types = null
 	if(!holder)
 		return
 	debug_variables(huds[i])
+
+
+/client/proc/world_repop()
+	set category = "Debug"
+	set name = "Repopulate world"
+	set desc = "Remakes any object or mob (NOT TURF) that was destroyed to the initial state."
+
+	if(!check_rights(R_DEBUG)) return
+
+	if(alert("Are you sure? This will NOT remake any turfs or anything not defined in the map itself. It will also cause lag",,"Yes","No") != "Yes")
+		return
+
+	world.Repop()
+
+	log_admin("[key_name(usr)] triggered a world  repopulation.")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] triggered a world repopulation.</span>")
+	feedback_add_details("admin_verb","REPOPW") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+


### PR DESCRIPTION
The verb will cause any object or mob defined in the map file that was destroyed to be remade to its initial state.
This will NOT remake turfs, players, or any object not defined in the map.
It will also cause some lag for remaking large amounts of objects.

Note, that since turfs are not remade, this may cause strange behaviors with stuff like pipes and wires if they are remade on top of space.
