### PR TITLE
Fixes bot interfaces reopening for all previous users.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -757,7 +757,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	dat = get_controls(M)
 	var/datum/browser/popup = new(M,window_id,window_name,350,600)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(use_onclose = 0)
 	onclose(M,window_id,ref=src)
 	return
 


### PR DESCRIPTION
Fixes #16847

onclose was being called twice, with the second one, built into open, having a null reference, preventing the close topic from being called.
