### PR TITLE
Runtimes now crash the server (blame oranges and hg)

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -230,6 +230,9 @@ var/inerror = 0
 			split[i] = "\[[time2text(world.timeofday,"hh:mm:ss")]\][split[i]]"
 	e.desc = jointext(split, "\n")
 	inerror = 0
+	spawn()
+		world << "<span class='boldannounce'>Runtime detected! Crashing the server because coderbus is a bunch of idiots who think crashing the server on minor errors is a good thing."
+		del(world)
 	return ..(e)
 
 /world/proc/load_mode()


### PR DESCRIPTION
(I think this is a stupid idea, but oranges and hg like it)

:cl: Oranges and HG
fix: All minor errors and runtime errors now cause the server to flat out crash.
/:cl:
