### PR TITLE
Ashwalkers can get homesick from being away from home too long

### DIFF
--- a/code/datums/diseases/homesickness.dm
+++ b/code/datums/diseases/homesickness.dm
@@ -1,0 +1,57 @@
+/datum/disease/homesickness
+	name = "Homesickness"
+	max_stages = 5
+	spread_text = "None"
+	spread_flags = NON_CONTAGIOUS
+	cure_text = "A trip home."
+	agent = "Saudade"
+	viable_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	desc = "The patient is longing for their homeland, interfering with their ability to fight."
+	severity = MEDIUM
+	stage_prob = 5
+	visibility_flags = HIDDEN_PANDEMIC
+	disease_flags = null
+	var/message_shown = 0
+
+/datum/disease/homesickness/stage_act()
+	if(prob(stage_prob))
+		switch(stage)
+			if(1)
+				affected_mob << "<span class='notice'>You feel like it's been a little too long since you've seen the wastes.</span>"
+			if(2)
+				affected_mob << "<span class='notice'>You wonder how the village is doing without you...</span>"
+			if(3)
+				affected_mob << "<span class='danger'>You miss home. This place sucks. Not enough lava.</span>"
+				get_sad(stage)
+			if(4)
+				affected_mob << "<span class='danger'>You feel numb. What is all this? What are you even doing here?</span>"
+				get_sad(stage)
+			if(5)
+				affected_mob << "<span class='danger'>You need to get out of here!</span>"
+				get_sad(stage)
+		stage = min(stage + 1,max_stages)
+	check_surroundings()
+
+/datum/disease/homesickness/proc/get_sad(stage)
+	if(prob(50))
+		affected_mob.visible_message("<span class='notice'>[affected_mob] stops and sighs loudly.</span>","<span class='notice'>You stop and sigh loudly.</span>")
+		affected_mob.Stun(1)
+	else
+		affected_mob << "<span class='notice'>You feel very tense.</span>"
+		affected_mob.jitteriness += rand(2,4)
+	if(stage >= 4)
+		if(prob(50))
+			affected_mob.visible_message("<span class='notice'>[affected_mob] looks shellshocked.</span>","<span class='danger'>Your mind goes blank for a moment, lost in thought.</span>")
+			affected_mob.Stun(5)
+	if(stage == 5)
+		affected_mob.jitteriness += 10
+		if(prob(50))
+			affected_mob.visible_message("<span class='notice'>[affected_mob] falls to the floor in tears!</span>","<span class='userdanger'>You can't take this!</span>")
+			affected_mob.Paralyse(10)
+		else
+			affected_mob.visible_message("<span class='notice'>[affected_mob] looks profoundly uncomfortable.</span>","<span class='danger'>You can't take much more of this!</span>")
+
+/datum/disease/homesickness/proc/check_surroundings()
+	if(istype(get_area(affected_mob),/area/lavaland))
+		affected_mob << "<span class='notice'>You take a deep breath of the acrid air of your homeland. It's good to be back!</span>"
+		cure()

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -87,6 +87,22 @@
 	name = "Ash Walker"
 	id = "lizard"
 	specflags = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS)
+	var/time_home = 0
+	var/time_away = 0
+
+/datum/species/lizard/ashwalker/spec_life(mob/living/carbon/human/H)
+	if(H.stat == DEAD)
+		return
+	if(H.z != ZLEVEL_LAVALAND)
+		if(time_away > time_home)
+			return //Just so an ashwalker who comes home can't end up in homesickness debt
+		time_away++
+		if(time_away == time_home)
+			H.ForceContractDisease(new /datum/disease/homesickness(0))
+	else
+		time_home++
+
+
 /*
  PODPEOPLE
 */

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -186,6 +186,7 @@
 #include "code\datums\diseases\flu.dm"
 #include "code\datums\diseases\fluspanish.dm"
 #include "code\datums\diseases\gbs.dm"
+#include "code\datums\diseases\homesickness.dm"
 #include "code\datums\diseases\magnitis.dm"
 #include "code\datums\diseases\pierrot_throat.dm"
 #include "code\datums\diseases\retrovirus.dm"


### PR DESCRIPTION
Ash walkers who spend a long time away from lavaland will eventually start to show symptoms of homesickness. How long an ash walker can spend away from lavaland depends on how long they initially remain on lavaland. This means that "first generation" ash walkers that did some hunting before going to the station can spend a long time there, but newly hatched lizards that just rush the shuttle will all too quickly succumb.

Symptoms of homesickness include various low grade stuns (only at high stages) intended to trip up the combat heavy ash walkers in inconvenient moments. Visiting lavaland instantly cures the illness, though obviously more time should be spent on lavaland to build up more tolerance to the station before going back to the station.

The illness itself has a very low stage progression, so depending on RNG a fresh ash walker can still exist on the station for quite a while before stuns start to manifest.

:cl:
rscadd: Ash walkers now have an intrinsic affinity for their lavaland home. Those that spend more time away from their homeland than on it will start to act strangely, and can seize up at unfortunate moments.
/:cl:
