### PR TITLE
Fixes changeling HUD being added for round-start changelings.  ( Fixes #18806 )

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -54,10 +54,11 @@
 
 /datum/game_mode/traitor/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)
-		changeling.current.make_changeling(changeling.current)
+		changeling.current.make_changeling()
 		changeling.special_role = "Changeling"
 		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
+		ticker.mode.update_changeling_icons_added(changeling)
 	..()
 	return
 


### PR DESCRIPTION
fixes #18806

:cl: SnipeDragon
fix: Changelings created at round start now correctly receive their Antag HUD.
/:cl:
