### PR TITLE
Flashes now once again stun borgs

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -94,7 +94,7 @@
 			M << "<span class='userdanger'>[user] blinds you with the flash!</span>"
 			if(M.weakeyes)
 				M.Stun(2)
-				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shields your eyes!</span>")
+				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shield your eyes!</span>")
 		else
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
 			user << "<span class='warning'>You fail to blind [M] with the flash!</span>"
@@ -115,6 +115,7 @@
 		var/mob/living/silicon/robot/R = M
 		add_logs(user, R, "flashed", src)
 		update_icon(1)
+		M.Weaken(3)
 		R.confused += 5
 		R.uneq_active()
 		R.flash_eyes(affect_silicon = 1)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -117,7 +117,6 @@
 		update_icon(1)
 		M.Weaken(3)
 		R.confused += 5
-		R.uneq_active()
 		R.flash_eyes(affect_silicon = 1)
 		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return 1


### PR DESCRIPTION
:cl: Joan
rscadd: Flashes will once again stun borgs, but for a much shorter time than they previously did; average stun time is reduced from the previous average of 15 seconds to about 6 seconds. The confusion remains, but it will no longer unequip borg modules.
/:cl:

Note; stun time previously was random between 10-20 seconds.

Pros; borgs can be dealt with more easily, i fixed an unrelated typo

Cons; stun combat, hard counters, people coming out of the woodwork to meme me
