### PR TITLE
Changes default shuttle transit time to 15 seconds

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -176,7 +176,7 @@
 
 	var/timer						//used as a timer (if you want time left to complete move, use timeLeft proc)
 	var/mode = SHUTTLE_IDLE			//current shuttle mode (see /__DEFINES/stat.dm)
-	var/callTime = 50				//time spent in transit (deciseconds)
+	var/callTime = 150				//time spent in transit (deciseconds)
 	var/roundstart_move				//id of port to send shuttle to at roundstart
 	var/travelDir = 0				//direction the shuttle would travel in
 


### PR DESCRIPTION
:cl: coiax
rscdel: The default shuttle transit time is now 15 seconds.
/:cl:
- Fixes shuttle movement spam to spam stun
- Guarantees that all shuttles produce the full
  ten second ripple effect before appearing
