### PR TITLE
Clockwork mobs language sound like Ratvar chants if you don't understand it

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -425,3 +425,46 @@ var/list/binary = list("0","1")
 	. = list()
 	for(var/x in 1 to length(t))
 		. += copytext(t,x,x+1)
+
+var/list/rot13_lookup = list()
+
+/proc/generate_rot13_lookup()
+	var/letters = alphabet.Copy()
+	for(var/c in alphabet)
+		letters += uppertext(c)
+
+	for(var/char in letters)
+		var/ascii_char = text2ascii(char, 1)
+
+		var/index
+
+		switch(ascii_char)
+			// A - Z
+			if(65 to 90)
+				index = 65
+			// a - z
+			if(97 to 122)
+				index = 97
+
+		var/d = ascii_char - index
+		d += 13
+		if(d >= 26)
+			d -= 26
+		ascii_char = index + d
+		var/translated_char = ascii2text(ascii_char)
+
+		rot13_lookup[char] = translated_char
+
+/proc/rot13(t_in)
+	if(!rot13_lookup.len)
+		generate_rot13_lookup()
+
+	var/t_out = ""
+
+	for(var/i in 1 to length(t_in))
+		if(i in rot13_lookup)
+			t_out += rot13_lookup[i]
+		else
+			t_out += i
+
+	return t_out

--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -231,9 +231,7 @@
 	\
 	The third functionality is Recollection, which will display this guide. Recollection will automatically be initiated if you have not used a slab before.<br><br>\
 	\
-	The fourth functionality is the Repository, which will display all components stored within the slab.<br><br>\
-	\
-	The fifth and final functionality is Report, which allows you to discreetly communicate with all other servants.<br><br>\
+	The fourth and final functionality is Report, which allows you to discreetly communicate with all other servants.<br><br>\
 	\
 	A complete list of scripture, its effects, and its requirements can be found below. <i>Note that anything above a driver always consumes the components listed unless otherwise \
 	specified.</i><br><br>"
@@ -536,7 +534,7 @@
 		V.recharging = TRUE //To prevent exploiting multiple visors to bypass the cooldown
 		V.update_status()
 		addtimer(V, "recharge_visor", ratvar_awakens ? 60 : 600, FALSE, user)
-	user.say("Xarry, urn'guraf!")
+	clockwork_say(user, "Xarry, urn'guraf!")
 	user.visible_message("<span class='warning'>The flame in [user]'s hand rushes to [target]!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
 	new/obj/effect/clockwork/judicial_marker(get_turf(target))
 	user.update_action_buttons_icon()

--- a/code/game/gamemodes/clock_cult/clock_machines.dm
+++ b/code/game/gamemodes/clock_cult/clock_machines.dm
@@ -554,7 +554,7 @@
 			if(!try_use_power(hierophant_cost))
 				user << "<span class='warning'>The obelisk lacks the power to broadcast!</span>"
 				return
-			user.say("Uvrebcunag Oebnqpnfg, npgvingr!")
+			clockwork_say(user, "Uvrebcunag Oebnqpnfg, npgvingr!")
 			send_hierophant_message(user, input, 1)
 		if("Spatial Gateway")
 			if(gateway_active)
@@ -564,7 +564,7 @@
 				user << "<span class='warning'>The obelisk lacks the power to open a gateway!</span>"
 				return
 			if(procure_gateway(user, 100, 5, 1))
-				user.say("Fcnpvny Tngrjnl, npgvingr!")
+				clockwork_say(user, "Fcnpvny Tngrjnl, npgvingr!")
 			else
 				return_power(gateway_cost)
 		if("Cancel")

--- a/code/game/gamemodes/clock_cult/clock_mobs.dm
+++ b/code/game/gamemodes/clock_cult/clock_mobs.dm
@@ -447,7 +447,7 @@
 	status_flags += GODMODE
 	src << "<span class='userdanger'>ASSIMILATION SUCCESSFUL.</span>"
 	H << "<span class='userdanger'>ASSIMILATION SUCCESSFUL.</span>"
-	H.say("ASSIMILATION SUCCESSFUL.")
+	clockwork_say(H, rot13("ASSIMILATION SUCCESSFUL."))
 	if(!H.mind)
 		mind.transfer_to(H)
 	return 1

--- a/code/game/gamemodes/clock_cult/clock_scripture.dm
+++ b/code/game/gamemodes/clock_cult/clock_scripture.dm
@@ -96,16 +96,10 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 			for(var/mob/living/L in range(1, invoker))
 				if(is_servant_of_ratvar(L))
 					for(var/invocation in invocations)
-						if(!whispered)
-							L.say(invocation)
-						else
-							L.whisper(invocation)
+						clockwork_say(L, invocation, whispered)
 		else
 			for(var/invocation in invocations)
-				if(!whispered)
-					invoker.say(invocation)
-				else
-					invoker.whisper(invocation)
+				clockwork_say(invoker, invocation, whispered)
 	invoker << "<span class='brass'>You [channel_time <= 0 ? "recite" : "begin reciting"] a piece of scripture entitled \"[name]\".</span>"
 	if(!channel_time)
 		return 1
@@ -113,10 +107,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 		if(!do_after(invoker, channel_time / invocations.len, target = invoker))
 			slab.busy = null
 			return 0
-		if(!whispered)
-			invoker.say(invocation)
-		else
-			invoker.whisper(invocation)
+		clockwork_say(invoker, invocation, whispered)
 	return 1
 
 /datum/clockwork_scripture/proc/scripture_effects() //The actual effects of the recital after its conclusion
@@ -134,10 +125,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 			break
 		if(!do_after(invoker, chant_interval, target = invoker))
 			break
-		if(!whispered)
-			invoker.say(pick(chant_invocations))
-		else
-			invoker.whisper(pick(chant_invocations))
+		clockwork_say(invoker, pick(chant_invocations), whispered)
 		chant_effects(i)
 	if(invoker && slab)
 		invoker << "<span class='brass'>You cease your chant.</span>"
@@ -1213,7 +1201,7 @@ Judgement: 10 servants, 100 CV, and any existing AIs are converted or destroyed
 	new/obj/effect/clockwork/general_marker/inathneq(get_turf(invoker))
 	clockwork_generals_invoked["inath-neq"] = world.time + CLOCKWORK_GENERAL_COOLDOWN
 	if(invoker.real_name == "Lucio")
-		invoker.say("Aww, let's break it DOWN!!")
+		clockwork_say(invoker, rot13("Aww, let's break it DOWN!!"))
 	var/list/affected_servants = list()
 	for(var/mob/living/L in range(7, invoker))
 		if(!is_servant_of_ratvar(L) || L.stat == DEAD)

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -121,15 +121,13 @@
 /proc/clockwork_say(atom/movable/AM, message, whisper=FALSE)
 	// When servants invoke ratvar's power, they speak in ways that non
 	// servants do not comprehend.
-	// Our ratvarian chants are stored in their ratvar forms in code
-	// this changes them to english so servants can understand.
-	// Non servants will only hear the original rot13.
-	message = rot13(message)
+	// Our ratvarian chants are stored in their ratvar forms
 
 	var/list/spans = list(SPAN_ROBOT)
 
 	var/old_languages_spoken = AM.languages_spoken
-	AM.languages_spoken = list(RATVAR)
+	AM.languages_spoken = ALL // Everyone understands
+	// In that no one does.
 	if(isliving(AM))
 		var/mob/living/L = AM
 		if(!whisper)

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -118,6 +118,28 @@
 		"replicant_alloy" = max(MAX_COMPONENTS_BEFORE_RAND - LOWER_PROB_PER_COMPONENT*clockwork_component_cache["replicant_alloy"], 1), \
 		"hierophant_ansible" = max(MAX_COMPONENTS_BEFORE_RAND - LOWER_PROB_PER_COMPONENT*clockwork_component_cache["hierophant_ansible"], 1)))
 
+/proc/clockwork_say(atom/movable/AM, message, whisper=FALSE)
+	// When servants invoke ratvar's power, they speak in ways that non
+	// servants do not comprehend.
+	// Our ratvarian chants are stored in their ratvar forms in code
+	// this changes them to english so servants can understand.
+	// Non servants will only hear the original rot13.
+	message = rot13(message)
+
+	var/list/spans = list(SPAN_ROBOT)
+
+	var/old_languages_spoken = AM.languages_spoken
+	AM.languages_spoken = list(RATVAR)
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(!whisper)
+			L.say(message, "clock", spans)
+		else
+			L.whisper(message)
+	else
+		AM.say(message)
+	AM.languages_spoken = old_languages_spoken
+
 /*
 
 The Ratvarian Language

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -103,7 +103,11 @@ var/list/freqtospan = list(
 	else if(message_langs & SWARMER)
 		return "hums."
 	else if(message_langs & RATVAR)
-		return "sounds like grinding cogs."
+		var/atom/movable/AM = speaker.GetSource()
+		if(AM)
+			return AM.say_quote(rot13(raw_message), spans)
+		else
+			return speaker.say_quote(rot13(raw_message), spans)
 	else
 		return "makes a strange sound."
 


### PR DESCRIPTION
:cl: coiax
rscadd: Clockwork mobs sound like Ratvar chants if you do not serve Ratvar.
rscadd: When servants recite, they now talk in a strange voice that is more noticable.
/:cl:

So this adds the clockwork_say() proc to clock_unsorted.dm which
modifies a speaker's language temporarily to speak all languages.
This means an invocation is never rot13'd in case it's a ratvar speaker.

If spoken outloud, invocations also use ROBOT span for that gutteral
clockwork feel and use the clockwork speech bubbles.
