### PR TITLE
Only things that can understand HUMAN will be able to parse ratvarian chanting

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -126,8 +126,7 @@
 	var/list/spans = list(SPAN_ROBOT)
 
 	var/old_languages_spoken = AM.languages_spoken
-	AM.languages_spoken = ALL // Everyone understands
-	// In that no one does.
+	AM.languages_spoken = HUMAN //anyone who can understand HUMAN will hear weird shitty ratvar speak, otherwise it'll get starred out
 	if(isliving(AM))
 		var/mob/living/L = AM
 		if(!whisper)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -86,12 +86,16 @@ var/list/freqtospan = list(
 			return AM.say_quote(raw_message, spans)
 		else
 			return speaker.say_quote(raw_message, spans)
-	else if(message_langs & HUMAN)
+	else if((message_langs & HUMAN) || (message_langs & RATVAR)) //it's human or ratvar language
 		var/atom/movable/AM = speaker.GetSource()
+		if(message_langs & HUMAN)
+			raw_message = stars(raw_message), spans)
+		if(message_langs & RATVAR)
+			raw_message = rot13(raw_message)
 		if(AM)
-			return AM.say_quote(stars(raw_message), spans)
+			return AM.say_quote(raw_message, spans)
 		else
-			return speaker.say_quote(stars(raw_message), spans)
+			return speaker.say_quote(raw_message, spans)
 	else if(message_langs & MONKEY)
 		return "chimpers."
 	else if(message_langs & ALIEN)
@@ -102,12 +106,6 @@ var/list/freqtospan = list(
 		return "chitters."
 	else if(message_langs & SWARMER)
 		return "hums."
-	else if(message_langs & RATVAR)
-		var/atom/movable/AM = speaker.GetSource()
-		if(AM)
-			return AM.say_quote(rot13(raw_message), spans)
-		else
-			return speaker.say_quote(rot13(raw_message), spans)
 	else
 		return "makes a strange sound."
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -89,7 +89,7 @@ var/list/freqtospan = list(
 	else if((message_langs & HUMAN) || (message_langs & RATVAR)) //it's human or ratvar language
 		var/atom/movable/AM = speaker.GetSource()
 		if(message_langs & HUMAN)
-			raw_message = stars(raw_message), spans)
+			raw_message = stars(raw_message)
 		if(message_langs & RATVAR)
 			raw_message = rot13(raw_message)
 		if(AM)


### PR DESCRIPTION
Otherwise, it'll get asterisked out like normal.

Tweaked the 'lacks language' code so that if something that doesn't understand both HUMAN and RATVAR gets an asterisked-out, rot13'd message instead of just an asterisked-out message.
