### PR TITLE
Rejecting charter names is now visible

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -68,7 +68,7 @@
 		return
 	if(!response_timer_id)
 		return
-	var/turf/T = get_turf(user)
+	var/turf/T = get_turf(src)
 	T.visible_message("<span class='warning'>The proposed changes disappear \
 		from [src]; it looks like they've been rejected.</span>")
 	var/m = "[key_name(user)] has rejected the proposed station name."


### PR DESCRIPTION
Before it'd make a visual message at the user's location (ie. the admin
that rejected it).

Now it makes a message at the charter's location.
