### PR TITLE
Makes explosions stronger against megafauna

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -56,10 +56,10 @@
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
 	switch (severity)
 		if (1)
-			adjustBruteLoss(250)
+			adjustBruteLoss(400)
 
 		if (2)
-			adjustBruteLoss(100)
+			adjustBruteLoss(200)
 
 		if(3)
-			adjustBruteLoss(50)
+			adjustBruteLoss(100)


### PR DESCRIPTION
Damage dealt to megafauna by explosions is increased from **50-100-250** to **100-200-400**. 

Roundstart KA deals 40 damage per shot, bothering with bombs or gibtonite wasn't worth it before, and probably isn't worth it even now. Keep in mind that most of the bosses come with 2500 HP - all 6 TTVs from science wouldn't be enough to kill a single boss, even if your aim is perfect.

Trying to bomb the boss is hard, especially if the boss is chasing you. Anything strong enough to make a 400 damage hit comes with risk of getting hit by explosion, and any knockdown in a boss fight equals death. The changes are aimed at making bombs high risk high reward, as opposed to current high risk low reward.

Token: #18466

:cl: CoreOverload
tweak: Megafauna is now more vulnerable to explosions.
/:cl:
