### PR TITLE
Legion is no longer completely immune to wand of death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -57,8 +57,6 @@
 				charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()
-	if(health > 0)
-		return
 	if(size > 2)
 		adjustHealth(-maxHealth) //heal ourself to full in prep for splitting
 		var/mob/living/simple_animal/hostile/megafauna/legion/L = new(src.loc)


### PR DESCRIPTION
Bolt of death now "kills" Legion, forcing it to split. 

It's not a huge balance concern: using WoD's only charge on Legion just makes two more, and the fact that someone has a wand of death usually means that the round is FUBAR by wizards or badmins.

Smallest Legions are still immune to WoD, they share immunity of other megafauna.

Token: #18534
