### PR TITLE
Exports no longer need to be inside storage containers

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -63,6 +63,7 @@
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
 /proc/is_type_in_typecache(atom/A, list/L)
 	if(!L || !L.len || !A)
+
 		return 0
 	return L[A.type]
 

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -33,15 +33,10 @@
 		user << "<span class='notice'>Scanned [O].</span>"
 
 		// Before you fix it: yes, checking manifests is a part of intended functionality.
-		var/exported = FALSE
-		for(var/a in supply.exports)
-			var/datum/export/E = a
-			if(E.applies_to(O, cargo_console.contraband, cargo_console.emagged))
-				var/cost = E.get_cost(O, cargo_console.contraband, cargo_console.emagged)
-				user << "<span class='notice'>Export cost: [cost] credits.</span>"
-				if(is_type_in_list(O, supply.storage_objects) && O.contents.len)
-					user << "<span class='notice'>(contents not included)</span>"
-				exported = TRUE
-				break
-		if(!exported)
-			user << "<span class='notice'>The object is unexportable.</span>"
+		var/price = export_item_and_contents(O, supply.exports, cargo_console.contraband, cargo_console.emagged, dry_run=TRUE)
+	
+		if(price)	
+			user << "<span class='notice'>Export value: [price] \
+				credits.</span>"
+			if(O.contents.len)
+				user << "<span class='notice'>(contents included)</span>"

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -25,18 +25,13 @@
 	else if(!istype(cargo_console))
 		user << "<span class='warning'>You must link [src] to a cargo console first!</span>"
 	else
-		var/obj/docking_port/mobile/supply/supply = SSshuttle.supply
-		if(!supply)
-			user << "<span class='warning'>Falied to connect to exports database!</span>"
-			return
+		// Before you fix it:
+		// yes, checking manifests is a part of intended functionality.
+		var/price = export_item_and_contents(O, cargo_console.contraband, cargo_console.emagged, dry_run=TRUE)
 
-		user << "<span class='notice'>Scanned [O].</span>"
-
-		// Before you fix it: yes, checking manifests is a part of intended functionality.
-		var/price = export_item_and_contents(O, supply.exports, cargo_console.contraband, cargo_console.emagged, dry_run=TRUE)
-	
-		if(price)	
-			user << "<span class='notice'>Export value: [price] \
-				credits.</span>"
-			if(O.contents.len)
-				user << "<span class='notice'>(contents included)</span>"
+		if(price)
+			user << "<span class='notice'>Scanned [O], value: <b>[price]</b> \
+				credits[O.contents.len ? " (contents included)" : ""].</span>"
+		else
+			user << "<span class='warning'>Scanned [O], no export value. \
+				</span>"

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -26,7 +26,32 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
  then the player gets the profit from selling his own wasted time.
 */
+/proc/export_item_and_contents(atom/movable/AM, exports, contraband, emagged, dry_run=FALSE)
+	var/sold_str = ""
+	var/cost = 0
 
+	var/list/contents = AM.GetAllContents()
+
+	// We go backwards, so it'll be innermost objects sold first
+	for(var/i in reverseRange(contents))
+		var/atom/movable/thing
+		for(var/datum/export/E in exports)
+			if(!E)
+				continue
+			if(E.applies_to(thing, contraband, emagged))
+				if(dry_run)
+					cost += E.get_cost(thing, contraband, emagged)
+				else
+					E.sell_object(thing, contraband, emagged)
+					sold_str += " [thing.name]"
+				break
+		if(!dry_run)
+			qdel(thing)
+
+	if(dry_run)
+		return cost
+	else
+		return sold_str
 
 /datum/export
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
@@ -37,7 +62,6 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
 	var/include_subtypes = TRUE		// Set to FALSE to make the datum apply only to a strict type.
 	var/list/exclude_types = list()	// Types excluded from export
-	var/shuttle_floor = FALSE 		// TRUE if the item can be sold on the floor, not only in crates.
 
 	// Used by print-out
 	var/total_cost = 0
@@ -104,3 +128,11 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 /datum/export/proc/export_end()
 	total_cost = 0
 	total_amount = 0
+
+var/list/exports_list = list()
+
+/proc/setupExports()
+	for(var/subtype in subtypesof(/datum/export))
+		var/datum/export/E = new subtype
+		if(E.export_types && E.export_types.len) // Exports without a type are invalid/base types
+			exports += E

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -26,7 +26,10 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
  then the player gets the profit from selling his own wasted time.
 */
-/proc/export_item_and_contents(atom/movable/AM, exports, contraband, emagged, dry_run=FALSE)
+/proc/export_item_and_contents(atom/movable/AM, contraband, emagged, dry_run=FALSE)
+	if(!exports_list.len)
+		setupExports()
+
 	var/sold_str = ""
 	var/cost = 0
 
@@ -34,8 +37,8 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 	// We go backwards, so it'll be innermost objects sold first
 	for(var/i in reverseRange(contents))
-		var/atom/movable/thing
-		for(var/datum/export/E in exports)
+		var/atom/movable/thing = i
+		for(var/datum/export/E in exports_list)
 			if(!E)
 				continue
 			if(E.applies_to(thing, contraband, emagged))
@@ -135,4 +138,4 @@ var/list/exports_list = list()
 	for(var/subtype in subtypesof(/datum/export))
 		var/datum/export/E = new subtype
 		if(E.export_types && E.export_types.len) // Exports without a type are invalid/base types
-			exports += E
+			exports_list += E

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -1,9 +1,5 @@
 // Large objects that don't fit in crates, but must be sellable anyway.
 
-/datum/export/large
-	shuttle_floor = TRUE
-
-
 // Crates, boxes, lockers.
 /datum/export/large/crate
 	cost = 500

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,8 +26,6 @@ var/list/blacklisted_cargo_types = typecacheof(list(
 	height = 7
 	roundstart_move = "supply_away"
 
-	var/list/exports = list()
-
 	// When TRUE, these vars allow exporting emagged/contraband items, and add some special interactions to existing exports.
 	var/contraband = FALSE
 	var/emagged = FALSE
@@ -41,10 +39,12 @@ var/list/blacklisted_cargo_types = typecacheof(list(
 		return check_blacklist(areaInstance)
 	return ..()
 
-/obj/docking_port/mobile/supply/proc/check_blacklist(atom/A)
-	for(var/thing in list(A) | A.GetAllContents())
-		if(is_type_in_typecache(thing, blacklisted_cargo_types))
-			return TRUE
+/obj/docking_port/mobile/supply/proc/check_blacklist(areaInstance)
+	for(var/trf in areaInstance)
+		var/turf/T = trf
+		for(var/a in T.GetAllContents())
+			if(is_type_in_typecache(a, blacklisted_cargo_types))
+				return TRUE
 	return FALSE
 
 /obj/docking_port/mobile/supply/request()
@@ -96,7 +96,8 @@ var/list/blacklisted_cargo_types = typecacheof(list(
 /obj/docking_port/mobile/supply/proc/sell()
 	var/presale_points = SSshuttle.points
 
-	if(!exports.len) // No exports list? Generate it!
+	if(!exports_list.len) // No exports list? Generate it!
+		setupExports()
 
 	var/msg = ""
 	var/sold_atoms = ""
@@ -104,12 +105,12 @@ var/list/blacklisted_cargo_types = typecacheof(list(
 	for(var/atom/movable/AM in areaInstance)
 		if(AM.anchored)
 			continue
-		sold_atoms += export_item_and_contents(AM, exports, contraband, emagged, dry_run = FALSE)
+		sold_atoms += export_item_and_contents(AM, contraband, emagged, dry_run = FALSE)
 
 	if(sold_atoms)
 		sold_atoms += "."
 
-	for(var/a in exports)
+	for(var/a in exports_list)
 		var/datum/export/E = a
 		var/export_text = E.total_printout()
 		if(!export_text)


### PR DESCRIPTION
:cl: coiax
add: All items inside the supply shuttle will now be sold, regardless of whether they're inside a container or not.
/:cl:
- Also makes blacklisted cargo types use typecaches, because they're good I guess
