### PR TITLE
Ash Drakes are now immune to their own fireball explosions

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -43,6 +43,11 @@
 	qdel(internal)
 	. = ..()
 
+/mob/living/simple_animal/hostile/megafauna/dragon/ex_act(severity, target)
+	if(severity == 3)
+		return
+	..()
+
 /mob/living/simple_animal/hostile/megafauna/dragon/adjustHealth(amount)
 	if(swooping)
 		return 0


### PR DESCRIPTION
IE; they won't take damage from their own fireball spam.
