### PR TITLE
Removes stands from uplink

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -303,15 +303,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	surplus = 35
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/guardian
-	name = "Holoparasites"
-	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
-			organic host as a home base and source of fuel."
-	item = /obj/item/weapon/storage/box/syndie_kit/guardian
-	cost = 12
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-	player_minimum = 25
-
 // Ammunition
 /datum/uplink_item/ammo
 	category = "Ammunition"


### PR DESCRIPTION
:cl: Kor
del: Holoparasites are no longer in the uplink
/:cl:

Thematically inappropriate and they've consistently been a source of complaints.
