### PR TITLE
Adds a ghost verb to jump between linked servers

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -57,7 +57,10 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
 
 /mob/dead/observer/New(mob/body)
 	verbs += /mob/dead/observer/proc/dead_tele
-
+	
+	if(global.cross_allowed)
+		verbs += /mob/dead/observer/proc/server_hop
+	
 	ghostimage = image(src.icon,src,src.icon_state)
 	if(icon_state in ghost_forms_with_directions_list)
 		ghostimage_default = image(src.icon,src,src.icon_state + "_nodir")
@@ -554,6 +557,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	target.key = key
 	return 1
 
+/mob/dead/observer/proc/ServerHop()
+	set category = "Ghost"
+	set name = "Server Hop!"
+	set desc= "Jump to the other server"
+	if (alert(src, "Jump to server running at [global.cross_address]?", "Server Hop", "Yes", "No") != "Yes")
+		return 0
+	if (client && global.cross_allowed) 
+		src << "<span class='notice'>Sending you to [global.cross_address]</span>"
+		client << link(global.cross_address)
+	else
+		src << "<span class='error'>There is no other server configured!</span>"
 
 //this is a mob verb instead of atom for performance reasons
 //see /mob/verb/examinate() in mob.dm for more info

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -557,7 +557,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	target.key = key
 	return 1
 
-/mob/dead/observer/proc/ServerHop()
+/mob/dead/observer/proc/server_hop()
 	set category = "Ghost"
 	set name = "Server Hop!"
 	set desc= "Jump to the other server"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -564,7 +564,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (alert(src, "Jump to server running at [global.cross_address]?", "Server Hop", "Yes", "No") != "Yes")
 		return 0
 	if (client && global.cross_allowed) 
-		src << "<span class='notice'>Sending you to [global.cross_address]</span>"
+		src << "<span class='notice'>Sending you to [global.cross_address].</span>"
+		winset(usr, null, "command=.options") //other wise the user never knows if byond is downloading resources
 		client << link(global.cross_address)
 	else
 		src << "<span class='error'>There is no other server configured!</span>"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -565,7 +565,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 	if (client && global.cross_allowed) 
 		src << "<span class='notice'>Sending you to [global.cross_address].</span>"
-		winset(usr, null, "command=.options") //other wise the user never knows if byond is downloading resources
+		winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
 		client << link(global.cross_address)
 	else
 		src << "<span class='error'>There is no other server configured!</span>"


### PR DESCRIPTION
The separation between basil and sybil is not complete, it is in fact fuzzy.

:cl:
add: Ghosts may now jump between the two linked servers using the new Server Hop verb. Rather than whine in deadchat about dieing, you can just go play a new round on the other server.
/:cl:

merge token(are we still doing those?): #18936
