### PR TITLE
AI hostile lockdown power now re-opens doors

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -150,22 +150,11 @@
 	if(!canUseTopic())
 		return
 
-	var/obj/machinery/door/airlock/AL
 	for(var/obj/machinery/door/D in airlocks)
 		if(D.z != ZLEVEL_STATION)
 			continue
-		spawn()
-			if(istype(D, /obj/machinery/door/airlock))
-				AL = D
-				if(AL.canAIControl(src) && !AL.stat) //Must be powered and have working AI wire.
-					AL.locked = 0 //For airlocks that were bolted open.
-					AL.safe = 0 //DOOR CRUSH
-					AL.close()
-					AL.bolt() //Bolt it!
-					AL.secondsElectrified = -1  //Shock it!
-					AL.shockedby += "\[[time_stamp()]\][src](ckey:[src.ckey])"
-			else if(!D.stat) //So that only powered doors are closed.
-				D.close() //Close ALL the doors!
+		addtimer(D, "hostile_lockdown", 0, FALSE, src)
+		addtimer(D, "disable_lockdown", 900)
 
 	var/obj/machinery/computer/communications/C = locate() in machines
 	if(C)
@@ -174,28 +163,9 @@
 	verbs -= /mob/living/silicon/ai/proc/lockdown
 	minor_announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 1)
 	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
-	addtimer(src, "disablelockdown", 900)
-
-/mob/living/silicon/ai/proc/disablelockdown()
-	set category = "Malfunction"
-	set name = "Disable Lockdown"
-
-	var/obj/machinery/door/airlock/AL
-	for(var/obj/machinery/door/D in airlocks)
-		if(D.z != ZLEVEL_STATION)
-			continue
-		spawn()
-			if(istype(D, /obj/machinery/door/airlock))
-				AL = D
-				if(AL.canAIControl(src) && !AL.stat) //Must be powered and have working AI wire.
-					AL.unbolt()
-					AL.secondsElectrified = 0
-					AL.open()
-					AL.safe = 1
-			else if(!D.stat) //Opens only powered doors.
-				D.open() //Open everything!
-
-	minor_announce("Automatic system reboot complete. Have a secure day.","Network reset:")
+	addtimer(GLOBAL_PROC, "minor_announce", 900, FALSE,
+		"Automatic system reboot complete. Have a secure day.",
+		"Network reset:")
 
 /datum/AI_Module/large/destroy_rcd
 	module_name = "Destroy RCDs"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1159,3 +1159,23 @@ var/list/airlock_overlays = list()
 	if(do_after(user, time_to_open, target = src))
 		if(density && !open(2)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
 			user << "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>"
+
+/obj/machinery/door/airlock/hostile_lockdown(mob/origin)
+	// Must be powered and have working AI wire.
+	if(canAIControl(src) && !stat)
+		locked = FALSE //For airlocks that were bolted open.
+		safe = FALSE //DOOR CRUSH
+		close()
+		bolt() //Bolt it!
+		secondsElectrified = -1  //Shock it!
+		if(origin)
+			shockedby += "\[[time_stamp()]\][origin](ckey:[origin.ckey])"
+
+
+/obj/machinery/door/airlock/disable_lockdown()
+	// Must be powered and have working AI wire.
+	if(canAIControl(src) && !stat)
+		unbolt()
+		secondsElectrified = 0
+		open()
+		safe = TRUE

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -335,3 +335,11 @@ obj/machinery/door/proc/try_to_crowbar(obj/item/I, mob/user)
 
 /obj/machinery/door/proc/unlock()
 	return
+
+/obj/machinery/door/proc/hostile_lockdown(mob/origin)
+	if(!stat) //So that only powered doors are closed.
+		close() //Close ALL the doors!
+
+/obj/machinery/door/proc/disable_lockdown()
+	if(!stat) //Opens only powered doors.
+		open() //Open everything!


### PR DESCRIPTION
:cl: coiax
fix: The AI malfunction "Hostile Lockdown" power now restores the station doors to normal after 90 seconds, rather than keeping everything shut forever.
/:cl:
Fixes #18985.

A side effect is that when the mass door opening happens, it's not
instant like it was before. I did consider making a global proc to call
to do that instead, but it made more sense to have the timer attached to
the doors themselves, rather than the AI or a global proc.
