### PR TITLE
Judicial Visors now tell the user how many targets were affected

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_items.dm
+++ b/code/game/gamemodes/clock_cult/clock_items.dm
@@ -469,12 +469,10 @@
 		user.update_action_buttons_icon()
 
 /obj/item/clothing/glasses/judicial_visor/proc/update_status(change_to)
-	if(recharging)
+	if(recharging || !isliving(loc))
 		icon_state = "judicial_visor_0"
 		return 0
 	if(active == change_to)
-		return 0
-	if(!isliving(loc))
 		return 0
 	var/mob/living/L = loc
 	if(!is_servant_of_ratvar(L) || L.stat)
@@ -482,6 +480,7 @@
 	active = change_to
 	icon_state = "judicial_visor_[active]"
 	L.update_action_buttons_icon()
+	L.update_inv_glasses()
 	switch(active)
 		if(TRUE)
 			L << "<span class='notice'>As you put on [src], its lens begins to glow, information flashing before your eyes.</span>\n\
@@ -494,10 +493,13 @@
 	if(!src || !user)
 		return 0
 	recharging = FALSE
+	if(src == user.get_item_by_slot(slot_glasses))
+		user << "<span class='brass'>Your [name] hums. It is ready.</span>"
+	else
+		active = FALSE
 	icon_state = "judicial_visor_[active]"
 	user.update_action_buttons_icon()
-	if(loc == user)
-		user << "<span class='brass'>Your [name] hums. It is ready.</span>"
+	user.update_inv_glasses()
 
 /obj/item/weapon/ratvars_flame //Used by the judicial visor
 	name = "Ratvar's flame"
@@ -536,8 +538,9 @@
 		addtimer(V, "recharge_visor", ratvar_awakens ? 60 : 600, FALSE, user)
 	clockwork_say(user, "Xarry, urn'guraf!")
 	user.visible_message("<span class='warning'>The flame in [user]'s hand rushes to [target]!</span>", "<span class='heavy_brass'>You direct [visor]'s power to [target]. You must wait for some time before doing this again.</span>")
-	new/obj/effect/clockwork/judicial_marker(get_turf(target))
+	new/obj/effect/clockwork/judicial_marker(get_turf(target), user)
 	user.update_action_buttons_icon()
+	user.update_inv_glasses()
 	addtimer(visor, "recharge_visor", ratvar_awakens ? 30 : 300, FALSE, user)//Cooldown is reduced by 10x if Ratvar is up
 	qdel(src)
 	return 1

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -460,7 +460,7 @@
 	..()
 	desc = initial(desc)
 
-/obj/effect/clockwork/judicial_marker //Judicial marker: Created by the judicial visor. After four seconds, stuns any non-servants nearby and damages Nar-Sian cultists.
+/obj/effect/clockwork/judicial_marker //Judicial marker: Created by the judicial visor. After three seconds, stuns any non-servants nearby and damages Nar-Sian cultists.
 	name = "judicial marker"
 	desc = "You get the feeling that you shouldn't be standing here."
 	clockwork_desc = "A sigil that will soon erupt and smite any unenlightened nearby."
@@ -468,34 +468,48 @@
 	pixel_x = -32
 	pixel_y = -32
 	layer = BELOW_MOB_LAYER
+	var/mob/user
 
-/obj/effect/clockwork/judicial_marker/New()
+/obj/effect/clockwork/judicial_marker/New(loc, caster)
 	..()
+	user = caster
+	playsound(src, 'sound/magic/MAGIC_MISSILE.ogg', 50, 1, 1, 1)
 	flick("judicial_marker", src)
-	spawn(16) //Utilizes spawns due to how it works with Ratvar's flame
-		layer = ABOVE_ALL_MOB_LAYER
-		flick("judicial_explosion", src)
-		spawn(14)
-			for(var/mob/living/L in range(1, src))
-				if(is_servant_of_ratvar(L))
-					continue
-				if(L.null_rod_check())
-					var/obj/item/I = L.null_rod_check()
-					L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
-					"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
-				else if(!iscultist(L))
-					L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
-					"<span class='userdanger'>[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]</span>")
-					L.Weaken(8)
-				else
-					L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
-					"<span class='heavy_brass'>\"Keep an eye out, filth.\"</span>\n<span class='userdanger'>A burst of heat crushes you against the ground!</span>")
-					L.Weaken(4) //half the stun, but sets cultists on fire
-					L.adjust_fire_stacks(2)
-					L.IgniteMob()
-				L.adjustBruteLoss(10)
-			qdel(src)
-			return 1
+	addtimer(src, "burstanim", 16, FALSE)
+
+/obj/effect/clockwork/judicial_marker/proc/burstanim()
+	layer = ABOVE_ALL_MOB_LAYER
+	flick("judicial_explosion", src)
+	addtimer(src, "judicialblast", 13, FALSE)
+
+/obj/effect/clockwork/judicial_marker/proc/judicialblast()
+	var/targetsjudged = 0
+	playsound(src, 'sound/effects/explosionfar.ogg', 100, 1, 1, 1)
+	for(var/mob/living/L in range(1, src))
+		if(is_servant_of_ratvar(L))
+			continue
+		if(L.null_rod_check())
+			var/obj/item/I = L.null_rod_check()
+			L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
+			"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
+			continue
+		if(!iscultist(L))
+			L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
+			"<span class='userdanger'>[!issilicon(L) ? "An unseen force slams you into the ground!" : "ERROR: Motor servos disabled by external source!"]</span>")
+			L.Weaken(8)
+		else
+			L.visible_message("<span class='warning'>[L] is struck by a judicial explosion!</span>", \
+			"<span class='heavy_brass'>\"Keep an eye out, filth.\"</span>\n<span class='userdanger'>A burst of heat crushes you against the ground!</span>")
+			L.Weaken(4) //half the stun, but sets cultists on fire
+			L.adjust_fire_stacks(2)
+			L.IgniteMob()
+		targetsjudged++
+		L.adjustBruteLoss(10)
+	user << "<span class='brass'><b>[targetsjudged ? "Successfully judged <span class='neovgre'>[targetsjudged]</span>":"Judged no"] heretic[targetsjudged > 1 ? "s":""].</b></span>"
+	QDEL_IN(src, 3) //so the animation completes properly
+
+/obj/effect/clockwork/judicial_marker/ex_act(severity)
+	return
 
 /obj/effect/clockwork/spatial_gateway //Spatial gateway: A usually one-way rift to another location.
 	name = "spatial gateway"

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -505,7 +505,7 @@
 			L.IgniteMob()
 		targetsjudged++
 		L.adjustBruteLoss(10)
-	user << "<span class='brass'><b>[targetsjudged ? "Successfully judged <span class='neovgre'>[targetsjudged]</span>":"Judged no"] heretic[targetsjudged > 1 ? "s":""].</b></span>"
+	user << "<span class='brass'><b>[targetsjudged ? "Successfully judged <span class='neovgre'>[targetsjudged]</span>":"Judged no"] heretic[!targetsjudged || targetsjudged > 1 ? "s":""].</b></span>"
 	QDEL_IN(src, 3) //so the animation completes properly
 
 /obj/effect/clockwork/judicial_marker/ex_act(severity)


### PR DESCRIPTION
:cl: Joan
rscadd: Judicial Visors now tell the user how many targets the Judicial Blast struck.
soundadd: Judicial Markers now have sounds when appearing and exploding.
/:cl:

Properly updates the icon; it should always be darkened if the visor is not ready or is not in the glasses slot.
