### PR TITLE
Adds proper cleanbot bug detection.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1391,3 +1391,22 @@ proc/pick_closest_path(value)
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
 #define QDEL_IN(item, time) addtimer(GLOBAL_PROC, "qdel", time, FALSE, item)
+
+/proc/check_for_cleanbot_bug()
+	var/static/admins_warned //bet you didn't know you could do this!
+	var/icon/Icon_test = icon('icons/BadAss.dmi')
+	if(!istype(Icon_test))
+		var/msg = "Cleanbot bug detected in icons! Icons are mapping to [Icon_test]"
+		if (!admins_warned)
+			admins_warned = 1
+			spawn(25)
+				message_admins(msg)
+		stack_trace(msg)
+	var/sound/Sound_test = sound('sound/misc/null.ogg')
+	if(!istype(Sound_test))
+		var/msg = "Cleanbot bug detected in sounds! Sounds are mapping to [Sound_test]"
+		if (!admins_warned)
+			admins_warned = 1
+			spawn(25)
+				message_admins(msg)
+		stack_trace(msg)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -50,6 +50,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 /datum/controller/master/New()
 	// Highlander-style: there can only be one! Kill off the old and replace it with the new.
+	check_for_cleanbot_bug()
 	subsystems = list()
 	if (Master != src)
 		if (istype(Master))
@@ -112,6 +113,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 // Please don't stuff random bullshit here,
 // 	Make a subsystem, give it the SS_NO_FIRE flag, and do your work in it's Initialize()
 /datum/controller/master/proc/Setup()
+	check_for_cleanbot_bug()
 	world << "<span class='boldannounce'>Initializing subsystems...</span>"
 
 	// Sort subsystems by init_order, so they initialize in the correct order.
@@ -131,13 +133,13 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
-
+	check_for_cleanbot_bug()
 	// Set world options.
 	world.sleep_offline = 1
 	world.fps = config.fps
-
+	check_for_cleanbot_bug()
 	sleep(1)
-
+	check_for_cleanbot_bug()
 	// Loop.
 	Master.StartProcessing()
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -9,6 +9,7 @@
 var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 
 /world/New()
+	check_for_cleanbot_bug()
 	map_ready = 1
 
 #if (PRELOAD_RSC == 0)


### PR DESCRIPTION
Lets admins know (so they can act) and logs a stack trace to the runtime logs.

Part of this is also to help me and lummox figure out what point in world init the bug starts. (does the world start in a bugged state, or is it after New() is called, or after the map is loaded, or after the mc enables pausing processing when no connected players are active, etc)
