### PR TITLE
Burnt and broken floors can have cabling

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -184,9 +184,6 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	if(prob(20))
 		ChangeTurf(/turf/open/floor/clockwork)
 
-/turf/open/floor/can_have_cabling()
-	return !burnt && !broken
-
 /turf/open/floor/initialize()
 	..()
 	MakeDirty()


### PR DESCRIPTION
This made no sense at all. Really, none of the 'it's "broken" you can't place anything on it' does, but cables especially so because they're not even secured to the floor like pipes are.
